### PR TITLE
chore(governance): refresh ledger pentest attestation

### DIFF
--- a/openbank-libs/governance/attestations.yaml
+++ b/openbank-libs/governance/attestations.yaml
@@ -36,7 +36,7 @@
 
 ledger:
   restore_drill: { date: 2026-07-26, ttl_days: 180, by: jiri, ref: runbook-0003 }
-  pentest:       { date: 2026-07-26, ttl_days: 21, by: ci-zap-baseline, ref: https://github.com/JiRaska/open-bank-oss/actions/runs/30192274904 }
+  pentest:       { date: 2026-08-18, ttl_days: 21, by: ci-zap-baseline, ref: https://github.com/JiRaska/open-bank-oss/actions/runs/32173390301 }
 
 consent:
   pentest:       { date: 2026-07-28, ttl_days: 21, by: ci-schemathesis, ref: https://github.com/JiRaska/open-bank-oss/actions/runs/30340495749 }


### PR DESCRIPTION
## Summary
- Ledger pentest attestation (`openbank-libs/governance/attestations.yaml`) expired today (2026-08-18, TTL 21d from 2026-07-26).
- Re-ran `dast-zap-baseline.yml` against `ledger-service` (workflow_dispatch, run 32173390301, completed success).
- Bumped `ledger.pentest` date + ref to the fresh run.

## Linked issues
N/A — routine attestation refresh, not tied to a filed issue.

## Test plan
- [x] `python3 .github/scripts/check-readiness-attestations.py` — format OK, only the expected freshness warnings.
- [x] Fresh ZAP baseline run against ledger-service completed `success`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
