### PR TITLE
fix(security-scanner): renumber Flyway V4 -> V6, service down 4h+

### DIFF
--- a/openbank-security-scanner/src/main/resources/db/migration/V6__drop_security_outbox.sql
+++ b/openbank-security-scanner/src/main/resources/db/migration/V6__drop_security_outbox.sql
@@ -1,5 +1,15 @@
 -- Drops the transactional outbox that never had a producer (#4709).
 --
+-- Renumbered V4 -> V6 (issue #5628): this migration's own PR (#4940) merged AFTER
+-- V5__create_ict_incidents.sql's PR (#4939) had already deployed and applied V5 to the
+-- live database. A migration numbered lower than the highest already-applied version
+-- fails Flyway's default validateOnMigrate the moment both are on the same classpath --
+-- "Detected resolved migration not applied to database: 4" -- and crash-loops the whole
+-- service on boot, which is what happened: security-scanner-service was down for 4+
+-- hours. Safe to renumber: this migration had never been applied anywhere (absent from
+-- flyway_schema_history on the only environment that runs this service), so no checksum
+-- is at risk -- the checksum-immutability rule only protects an APPLIED migration.
+--
 -- V2 created `security_outbox` and V3 gave it the Panache `_seq` sequence. The port, entity,
 -- repository, @Scheduled dispatcher, backlog gauge, Kafka publisher, the `security-events-out`
 -- channel and the `openbank.security.scan.event` topic were all built and wired correctly —


### PR DESCRIPTION
## What

Fixes #5628 — `security-scanner-service` has been in `CrashLoopBackOff` (0/1 ready) since ~16:47Z, 4+ hours down, every boot dying with:

```
Caused by: org.flywaydb.core.api.exception.FlywayValidateException: Validate failed: Migrations have failed validation
Detected resolved migration not applied to database: 4.
```

## Root cause

Live `flyway_schema_history`:

```
installed_rank | version | description             | success | installed_on
1               | 2       | create security outbox  | t       | 2026-08-02 22:24:54
2               | 3       | hibernate sequences      | t       | 2026-08-02 22:24:54
3               | 5       | create ict incidents     | t       | 2026-08-16 20:52:54
```

`V4__drop_security_outbox.sql`'s own PR (#4940) merged **after** `V5__create_ict_incidents.sql`'s PR (#4939) had already deployed and applied V5 to the live database. Flyway's default `validateOnMigrate` refuses to start once a lower-numbered migration than the highest already-applied one shows up on the classpath — the mirror image of the "two branches claim the same version" collision this repo has hit before: here one PR claimed a version number a sibling PR had already passed in deployed reality.

## Fix

`git mv V4__drop_security_outbox.sql V6__drop_security_outbox.sql` (next free version) + a comment explaining why, in the same commit.

Safe: `flyway_schema_history` confirms V4 was never applied anywhere (ranks are 2, 3, 5 — no 4), so this repo's checksum-immutability rule doesn't apply — that rule only protects an *applied* migration.

## Verified

`compileKotlin`, `ktlintCheck`, `detekt` all clean. No Kotlin source touched — pure SQL migration renumber.

After merge/deploy: will confirm live that the pod actually boots and clears `CrashLoopBackOff`.

Refs #5628
