### PR TITLE
fix(infra): declare admin-cli explicitly so its tokens carry realm_access

### DIFF
--- a/openbank-infra/docker/keycloak/realm/openbank-realm.json
+++ b/openbank-infra/docker/keycloak/realm/openbank-realm.json
@@ -41,6 +41,23 @@
   },
   "clients": [
     {
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "protocol": "openid-connect",
+      "fullScopeAllowed": true,
+      "defaultClientScopes": [
+        "profile",
+        "email",
+        "roles"
+      ],
+      "attributes": {}
+    },
+    {
       "clientId": "openbank-services",
       "name": "OpenBank Services",
       "enabled": true,

--- a/openbank-infra/gitops/components/keycloak/realm-template.json
+++ b/openbank-infra/gitops/components/keycloak/realm-template.json
@@ -94,6 +94,23 @@
   },
   "clients": [
     {
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "description": "Keycloak's built-in CLI/direct-grant client, declared explicitly so operator password-grant tokens carry realm_access — left to Keycloak's auto-created default (fullScopeAllowed=false, no scope mappings), it mints no realm roles at all (#5498).",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "protocol": "openid-connect",
+      "fullScopeAllowed": true,
+      "defaultClientScopes": [
+        "profile",
+        "email",
+        "roles"
+      ]
+    },
+    {
       "clientId": "openbank-admin-ui",
       "name": "OpenBank Admin UI",
       "enabled": true,


### PR DESCRIPTION
## Summary

- Declares Keycloak's built-in `admin-cli` client explicitly in
  `openbank-infra/docker/keycloak/realm/openbank-realm.json` and
  `openbank-infra/gitops/components/keycloak/realm-template.json`, matching
  the other role-bearing clients already declared there
  (`openbank-services`, `openbank-admin-ui`).
- Root cause (verified locally, not from the issue's live-cluster
  hypothesis): neither template previously declared `admin-cli` at all, so
  Keycloak auto-creates it on import via its hardened built-in defaults —
  `fullScopeAllowed=false` and zero `clientScopeMappings`. With no scope
  granted, its password-grant tokens can **never** carry any realm role, no
  matter which roles the authenticating user actually holds. This is a
  different, template-level defect than the issue's own investigation
  comment describes for the *live* sandbox (which additionally has
  `fullScopeAllowed=true` plus a lightweight-access-token flag with no
  matching mapper opt-in) — both produce the same missing-`realm_access`
  symptom, but only the one fixed here is reproducible from the committed
  template.

## Verification

Reproduced and fixed locally via Docker (no live cluster touched):

1. Booted `quay.io/keycloak/keycloak:24.0.5` (the docker-compose pin) with
   `--import-realm` against the **unmodified** `openbank-realm.json`, minted
   a password-grant token for `admin@openbank.local` via `admin-cli` — the
   decoded JWT had no `realm_access` at all (`scope: "profile email"` only).
2. Applied this fix, re-ran the same import + token mint — decoded JWT now
   carries `realm_access.roles: [ROLE_OPERATOR, ROLE_VIEWER, ROLE_ADMIN]`.
3. Repeated against `quay.io/keycloak/keycloak:26.6.3` (the sandbox's
   actual pinned version per `keycloak.yaml`), using this repo's own
   `openbank-infra/scripts/render-verify-keycloak-realm-import.sh --out`
   recipe (dummy secret values, since this is a boot-only structural test)
   against `realm-template.json` — same result: `realm_access.roles`
   present after the fix.
4. Ran `.github/scripts/check-realm-template-importable.py` — passes (it
   initially caught the client `description` exceeding Keycloak's 255-char
   import cap; shortened it).

## Out of scope

This is a **template-only** fix. It does not touch:
- The live sandbox realm, which per the issue's own comment has separately
  drifted (`admin-cli` there has `fullScopeAllowed=true` plus a
  lightweight-access-token attribute with no per-mapper opt-in for the
  `roles` scope's realm-role mapper) — a live-config decision, not
  something this PR can or should flip.
- The Vault-sourced `keycloak-realm-import` / `keycloak-customers-realm-import`
  Secrets, which runbook `docs/runbooks/0009-keycloak-realm-import-reconcile.md`
  already documents as a stale ancestor of the committed template, reconciled
  only by an owner-gated Vault write.

`--import-realm` runs on Keycloak's cold start only, so this change has no
effect on anything currently running — it only fixes what a future rebuild
(or the Vault reconcile in runbook 0009) will import.

Refs #5498 — does not close it, since the live-cluster drift piece the
issue also describes is intentionally left for a separate, deliberate
policy decision.

## Test plan

- [x] `python3 .github/scripts/check-realm-template-importable.py` passes
- [x] Local Docker import + token-mint verification on Keycloak 24.0.5 (docker realm)
- [x] Local Docker import + token-mint verification on Keycloak 26.6.3 (sandbox's pinned version, via `render-verify-keycloak-realm-import.sh`)
- [ ] Live sandbox drift reconciliation (owner-gated, out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
