### PR TITLE
test(security-scanner): prove DORA ICT incident producer publishes end to end

### DIFF
--- a/openbank-security-scanner/src/test/kotlin/com/openbank/securityscanner/integration/IctIncidentDurabilityIT.kt
+++ b/openbank-security-scanner/src/test/kotlin/com/openbank/securityscanner/integration/IctIncidentDurabilityIT.kt
@@ -13,6 +13,7 @@ import io.restassured.module.kotlin.extensions.Extract
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
+import io.smallrye.reactive.messaging.kafka.Record
 import io.smallrye.reactive.messaging.memory.InMemoryConnector
 import jakarta.inject.Inject
 import org.assertj.core.api.Assertions.assertThat
@@ -59,6 +60,10 @@ class IctIncidentDurabilityIT {
 
     @Inject
     lateinit var dataSource: DataSource
+
+    @jakarta.enterprise.inject.Any
+    @Inject
+    lateinit var connector: InMemoryConnector
 
     private fun reportIncident(title: String): UUID {
         val body = """
@@ -187,6 +192,37 @@ class IctIncidentDurabilityIT {
             jsonPath().getList<String>("id")
         }
         assertThat(none).doesNotContain(id.toString())
+    }
+
+    /**
+     * Issue #4942: `openbank.security.ict.incident` sat at end offset 0 in every real
+     * environment, and the durability tests above never once looked at the channel — they wired
+     * up `InMemoryConnector.switchOutgoingChannelsToInMemory("ict-incident-events-out")` in
+     * [InMemoryKafkaResource] but only ever asserted the JDBC row, never the sink. That leaves
+     * "the producer fires" and "nobody has ever called the endpoint" indistinguishable from the
+     * test suite alone — exactly the ambiguity #4942 asks to resolve. This test closes that gap:
+     * it reports an incident through the real REST endpoint and asserts a corresponding record
+     * landed on the (in-memory) outgoing channel, with the eventType and incident id `emitter.send`
+     * actually put on the wire in [IctIncidentService.publishEvent]. It cannot prove a human has
+     * ever exercised the path in production — only a live topic read could — but it does prove
+     * the producer is not dead code: reachable REST endpoint -> service -> emitter -> channel,
+     * exercised end to end exactly the way a real call would drive it.
+     */
+    @Test
+    @TestSecurity(user = "operator", roles = ["ROLE_OPERATOR"])
+    fun `reporting an incident actually publishes to the ict-incident-events-out channel`() {
+        val id = reportIncident("kafka broker unreachable ${UUID.randomUUID()}")
+
+        // The emitter is Emitter<Record<String, String>> (IctIncidentService.publishEvent), so the
+        // in-memory sink's payload type is io.smallrye.reactive.messaging.kafka.Record, not String
+        // directly -- the JSON body lives in Record.value(), the incident id in Record.key().
+        val sink = connector.sink<Record<String, String>>("ict-incident-events-out")
+        val mine = sink.received().filter { it.payload.key() == id.toString() }
+
+        assertThat(mine)
+            .describedAs("reportIncident must publish an ICT_INCIDENT_REPORTED record, not just persist the row")
+            .isNotEmpty
+        assertThat(mine.last().payload.value()).contains("\"eventType\":\"ICT_INCIDENT_REPORTED\"")
     }
 
     private companion object {


### PR DESCRIPTION
## Summary

Investigation of #4942 (`openbank.security.ict.incident` at end offset 0): the producer path
is **not broken**. `IctIncidentResource` (`@Path("/api/v1/ict-incidents")`) is a normal
class-level JAX-RS annotation (no stray top-level function stealing it), `IctIncidentService`
injects `@Channel("ict-incident-events-out")` correctly, the channel is configured in
`application.yaml` (`topic: openbank.security.ict.incident`), and `openbank-audit-service`
already lists that topic among the ones it consumes
(`EventAttribution.kt`, `application.yaml`). `IctIncidentDurabilityIT` already drives the
real REST endpoint through RestAssured against a real Postgres and gets 200/201s back, which
would not happen if the resource were unreachable (the McpEndpoint-style `@Path`-binds-to-
wrong-declaration bug this repo has seen before).

So the topic sitting at offset 0 is the **"never exercised" reading from the issue, not the
"unreachable" one**: nobody has called `POST /api/v1/ict-incidents` in any real environment
yet. That's consistent with this being a manual/analyst-driven DORA incident-reporting path —
a low/no-traffic path is not itself a defect.

## What this PR does

The one real gap: `IctIncidentDurabilityIT` already wires
`InMemoryConnector.switchOutgoingChannelsToInMemory("ict-incident-events-out")` but never
once asserted against the sink -- every existing test only checks the JDBC row. That means
even the test suite couldn't previously distinguish "the producer fires" from "the producer
is dead code", the exact ambiguity the issue calls out.

Adds one test that reports an incident through the real REST endpoint and reads the message
back off the in-memory Kafka sink, asserting `IctIncidentService.publishEvent` actually calls
`emitter.send()` with the incident id as the record key and `eventType: ICT_INCIDENT_REPORTED`
in the payload. It's a real assertion, not a decoration -- it fails if the sink assertion is
against the wrong channel, and it caught two real bugs while being written (see below).

## What it does not do

It cannot prove a human has ever exercised the path in a live environment -- only reading the
real topic could do that, and that (plus confirming a consumer exists, which it does --
audit-service) is explicitly out of scope for a code change and requires the sandbox
measurement the issue itself asks for. This PR only closes the "is the producer wired
correctly" half of the ambiguity.

## Notes from writing the test

- `import jakarta.enterprise.inject.Any` (needed to `@Inject @Any InMemoryConnector`, the
  fleet convention for injecting the raw connector in an IT) shadows Kotlin's own `Any` type
  for the whole file -- it broke `Map<String, Any?>` return types elsewhere in the same file
  with a nonsensical "Return type mismatch" error. Fixed by using the fully-qualified
  `@jakarta.enterprise.inject.Any` annotation instead of importing it.
- `IctIncidentService`'s emitter is `Emitter<Record<String, String>>`
  (`io.smallrye.reactive.messaging.kafka.Record`), so the in-memory sink's payload type is
  `Record<String, String>`, not `String` -- an initial cast straight to
  `Message<String>`/`.payload as String` threw `ClassCastException` at runtime. Typed the sink
  as `InMemorySink<Record<String, String>>` and read `.key()`/`.value()` off the record.

## Test plan

- [x] `./gradlew :openbank-security-scanner:compileTestKotlin :openbank-security-scanner:ktlintCheck :openbank-security-scanner:detekt` -- all green
- [x] `./gradlew :openbank-security-scanner:test --tests "com.openbank.securityscanner.integration.IctIncidentDurabilityIT"` -- 5/5 pass, including the new one, against a real Testcontainers Postgres + Kafka-shaped in-memory channel

Refs #4942

🤖 Generated with [Claude Code](https://claude.com/claude-code)
