### PR TITLE
fix(billing): escape billing_outbox JSON payloads via Jackson

### DIFF
--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/outbox/AssessedFeeOutboxPayloads.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/outbox/AssessedFeeOutboxPayloads.kt
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.billing.infrastructure.outbox
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.billing.infrastructure.persistence.entity.AssessedFeeEntity
+
+/**
+ * Serializes an [AssessedFeeEntity] into the `billing.fee.post-intent.v1` /
+ * `billing.fee.reversal-intent.v1` `billing_outbox` payload shapes (ADR-0143 steps 2/2e).
+ *
+ * **Uses Jackson, not hand-built string concatenation (#4701).** `fee_name` (`feeName`, wired
+ * into `description` below) is free text sourced from the product catalog — no length or
+ * character constraint on the column (`BillingEntities.kt`'s `@Column(name = "fee_name",
+ * nullable = false)`) — and can contain a double quote or backslash. The previous version of
+ * this object hand-built the JSON string, embedding `feeName` with no escaping at all; a fee
+ * name containing either character produced malformed JSON that
+ * [LedgerOutboxEventPublisher.publish] could never parse. That failure is deterministic, not
+ * transient — `OutboxDispatch.dispatchOnce` re-claims and re-attempts the same row every tick,
+ * `mapper.readValue` throws the same `JsonParseException` every time, and after
+ * `OutboxFailurePolicy.DEFAULT_MAX_ATTEMPTS` (10) the row is parked `DEAD` with no alert (#4701:
+ * two `billing.fee.post-intent.v1` rows found dead at `attempt_count = 10`). This is the exact
+ * trap [AnnualFeeSummaryOutboxPayloads]'s own KDoc already named for the same reason ("fee
+ * names/categories carry free text ... possibly quotes, so hand-rolled string escaping is the
+ * wrong tool here") — that object was migrated to Jackson under ADR-0248, this one was not.
+ *
+ * `internal`, own file (mirrors [AnnualFeeSummaryOutboxPayloads]): this is the exact payload
+ * shape [LedgerOutboxEventPublisher] deserializes against, so it needs a payload-shape unit test
+ * with no database in the loop — impossible while nested `private` inside
+ * `BillingAssessmentRepositoryImpl`.
+ *
+ * Monetary fields stay JSON STRINGS (`amount.toPlainString()`), matching the previous wire
+ * format and every other money-carrying event in this fleet ("never a float").
+ */
+internal object AssessedFeeOutboxPayloads {
+
+    private val mapper = jacksonObjectMapper().findAndRegisterModules()
+
+    fun postIntent(fee: AssessedFeeEntity): String = mapper.writeValueAsString(
+        FeePostIntentWirePayload(
+            idempotencyKey = fee.idempotencyKey,
+            cycleId = fee.cycleId,
+            accountId = fee.accountId,
+            feeId = fee.feeId,
+            amount = fee.chargedAmount.toPlainString(),
+            currency = fee.currency,
+            description = "Fee charge: ${fee.feeName}",
+        ),
+    )
+
+    fun reversalIntent(fee: AssessedFeeEntity, reason: String): String = mapper.writeValueAsString(
+        FeeReversalIntentWirePayload(
+            idempotencyKey = fee.reversalIdempotencyKey(),
+            originalIdempotencyKey = fee.idempotencyKey,
+            cycleId = fee.cycleId,
+            accountId = fee.accountId,
+            feeId = fee.feeId,
+            amount = fee.chargedAmount.toPlainString(),
+            currency = fee.currency,
+            reason = reason,
+        ),
+    )
+
+    private fun AssessedFeeEntity.reversalIdempotencyKey(): String = "fee-reversal-$cycleId-$accountId-$feeId-$currency"
+}
+
+/**
+ * The `billing.fee.post-intent.v1` outbox payload shape — mirrors
+ * `LedgerOutboxEventPublisher`'s private `FeePostIntentWirePayload` deserialization target field
+ * for field, so a rename on either side must be made on both (no shared module boundary here;
+ * this repo's per-service outbox payloads intentionally don't share a wire-contract type).
+ */
+private data class FeePostIntentWirePayload(
+    val schemaVersion: Int = 1,
+    val idempotencyKey: String,
+    val cycleId: String,
+    val accountId: String,
+    val feeId: String,
+    val amount: String,
+    val currency: String,
+    val description: String,
+)
+
+/** The `billing.fee.reversal-intent.v1` outbox payload shape — see [FeePostIntentWirePayload]. */
+private data class FeeReversalIntentWirePayload(
+    val schemaVersion: Int = 1,
+    val idempotencyKey: String,
+    val originalIdempotencyKey: String,
+    val cycleId: String,
+    val accountId: String,
+    val feeId: String,
+    val amount: String,
+    val currency: String,
+    val reason: String,
+)

--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/persistence/repository/BillingAssessmentRepositoryImpl.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/persistence/repository/BillingAssessmentRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.openbank.billing.domain.AssessedFee
 import com.openbank.billing.domain.BillingAssessment
 import com.openbank.billing.domain.PostingStatus
 import com.openbank.billing.infrastructure.outbox.AnnualFeeSummaryOutboxPayloads
+import com.openbank.billing.infrastructure.outbox.AssessedFeeOutboxPayloads
 import com.openbank.billing.infrastructure.persistence.entity.AssessedFeeEntity
 import com.openbank.billing.infrastructure.persistence.entity.BillingCycleAssessmentEntity
 import com.openbank.billing.infrastructure.persistence.entity.BillingOutboxEntity
@@ -327,31 +328,6 @@ class BillingAssessmentRepositoryImpl(private val sf: Mutiny.SessionFactory, pri
         private fun aggregateIdFor(accountId: String, year: Int): UUID =
             UUID.nameUUIDFromBytes("annual-fee-summary:$accountId:$year".toByteArray(StandardCharsets.UTF_8))
     }
-}
-
-/**
- * Serializes an [AssessedFeeEntity] into the two `billing_outbox` payload shapes (ADR-0143 steps
- * 2/2e). Split out of [BillingAssessmentRepositoryImpl] (detekt `TooManyFunctions`, threshold 11):
- * this is pure payload-mapping logic with no reactive/transactional concern of its own — the same
- * "mapper lives at file scope, not on the persistence class" convention this file already used for
- * [BillingCycleAssessmentEntity.toDomain]/[AssessedFeeEntity.toDomain] below.
- */
-private object AssessedFeeOutboxPayloads {
-
-    fun postIntent(fee: AssessedFeeEntity): String = "{\"schemaVersion\":1," +
-        "\"idempotencyKey\":\"${fee.idempotencyKey}\",\"cycleId\":\"${fee.cycleId}\"," +
-        "\"accountId\":\"${fee.accountId}\",\"feeId\":\"${fee.feeId}\"," +
-        "\"amount\":\"${fee.chargedAmount}\",\"currency\":\"${fee.currency}\"," +
-        "\"description\":\"Fee charge: ${fee.feeName}\"}"
-
-    fun reversalIntent(fee: AssessedFeeEntity, reason: String): String = "{\"schemaVersion\":1," +
-        "\"idempotencyKey\":\"${fee.reversalIdempotencyKey()}\"," +
-        "\"originalIdempotencyKey\":\"${fee.idempotencyKey}\",\"cycleId\":\"${fee.cycleId}\"," +
-        "\"accountId\":\"${fee.accountId}\",\"feeId\":\"${fee.feeId}\"," +
-        "\"amount\":\"${fee.chargedAmount}\",\"currency\":\"${fee.currency}\"," +
-        "\"reason\":\"${reason.replace('\n', ' ').replace('\r', ' ').replace("\"", "'")}\"}"
-
-    private fun AssessedFeeEntity.reversalIdempotencyKey(): String = "fee-reversal-$cycleId-$accountId-$feeId-$currency"
 }
 
 private fun BillingCycleAssessmentEntity.toDomain(fees: List<AssessedFeeEntity>): BillingAssessment = BillingAssessment(

--- a/openbank-billing-service/src/test/kotlin/com/openbank/billing/AssessedFeeOutboxPayloadsTest.kt
+++ b/openbank-billing-service/src/test/kotlin/com/openbank/billing/AssessedFeeOutboxPayloadsTest.kt
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.billing
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.openbank.billing.domain.PostingStatus
+import com.openbank.billing.infrastructure.outbox.AssessedFeeOutboxPayloads
+import com.openbank.billing.infrastructure.persistence.entity.AssessedFeeEntity
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+/**
+ * Locks the `billing.fee.post-intent.v1` / `billing.fee.reversal-intent.v1` outbox payload shape
+ * (ADR-0143) — the exact contract [com.openbank.billing.infrastructure.outbox.LedgerOutboxEventPublisher]
+ * deserializes against.
+ *
+ * The whole point of this suite (#4701): a `fee_name` containing a double quote or a backslash
+ * previously produced MALFORMED JSON — `postIntent`/`reversalIntent` hand-built the string and
+ * embedded `feeName` with no escaping. That JSON never parsed, `LedgerOutboxEventPublisher.publish`
+ * threw the same `JsonParseException` on every dispatch attempt (a permanent failure, not a
+ * transient one — `OutboxDispatch.isTransportUnavailable` does not cover it, so every attempt
+ * counted), and after 10 attempts the row was parked `DEAD` with no alert. Two
+ * `billing.fee.post-intent.v1` rows were found in exactly that state. These tests prove the
+ * Jackson-based replacement produces valid, round-trippable JSON for fee names carrying the
+ * characters that broke it.
+ */
+class AssessedFeeOutboxPayloadsTest {
+
+    private val mapper = ObjectMapper()
+
+    private fun fee(feeName: String = "Maintenance", idempotencyKey: String = "fee-2026-07-acc-1-f1-CZK") =
+        AssessedFeeEntity().apply {
+            assessmentId = java.util.UUID.randomUUID()
+            cycleId = "2026-07"
+            accountId = "acc-1"
+            feeId = "f1"
+            this.feeName = feeName
+            currency = "CZK"
+            chargedAmount = BigDecimal("150.00")
+            waived = false
+            waiveReason = "NOT_WAIVABLE"
+            this.idempotencyKey = idempotencyKey
+            postingStatus = PostingStatus.PENDING
+        }
+
+    @Test
+    fun `postIntent serializes the exact contract fields as valid JSON`() {
+        val json = AssessedFeeOutboxPayloads.postIntent(fee())
+        val node = mapper.readTree(json) as ObjectNode
+
+        assertThat(node.get("schemaVersion").asInt()).isEqualTo(1)
+        assertThat(node.get("idempotencyKey").asText()).isEqualTo("fee-2026-07-acc-1-f1-CZK")
+        assertThat(node.get("cycleId").asText()).isEqualTo("2026-07")
+        assertThat(node.get("accountId").asText()).isEqualTo("acc-1")
+        assertThat(node.get("feeId").asText()).isEqualTo("f1")
+        assertThat(node.get("amount").isTextual).isTrue()
+        assertThat(node.get("amount").asText()).isEqualTo("150.00")
+        assertThat(node.get("currency").asText()).isEqualTo("CZK")
+        assertThat(node.get("description").asText()).isEqualTo("Fee charge: Maintenance")
+    }
+
+    @Test
+    fun `a fee name containing a double quote produces valid JSON, not the old malformed payload`() {
+        val json = AssessedFeeOutboxPayloads.postIntent(fee(feeName = """Fee for "Premium" tier"""))
+
+        val node = mapper.readTree(json) as ObjectNode // throws on malformed JSON — the #4701 failure mode
+
+        assertThat(node.get("description").asText()).isEqualTo("""Fee charge: Fee for "Premium" tier""")
+    }
+
+    @Test
+    fun `a fee name containing a backslash produces valid JSON`() {
+        val json = AssessedFeeOutboxPayloads.postIntent(fee(feeName = """Fee \ surcharge"""))
+
+        val node = mapper.readTree(json) as ObjectNode
+
+        assertThat(node.get("description").asText()).isEqualTo("""Fee charge: Fee \ surcharge""")
+    }
+
+    @Test
+    fun `a fee name with Czech diacritics round-trips unchanged`() {
+        val json = AssessedFeeOutboxPayloads.postIntent(fee(feeName = "Vedení účtu"))
+
+        val node = mapper.readTree(json) as ObjectNode
+
+        assertThat(node.get("description").asText()).isEqualTo("Fee charge: Vedení účtu")
+    }
+
+    @Test
+    fun `reversalIntent serializes the exact contract fields, including a reason with quotes and newlines`() {
+        val reason = "waiver \"bug\"\nreverting"
+        val json = AssessedFeeOutboxPayloads.reversalIntent(fee(), reason)
+        val node = mapper.readTree(json) as ObjectNode
+
+        assertThat(node.get("schemaVersion").asInt()).isEqualTo(1)
+        assertThat(node.get("idempotencyKey").asText()).isEqualTo("fee-reversal-2026-07-acc-1-f1-CZK")
+        assertThat(node.get("originalIdempotencyKey").asText()).isEqualTo("fee-2026-07-acc-1-f1-CZK")
+        assertThat(node.get("reason").asText()).isEqualTo(reason)
+    }
+}


### PR DESCRIPTION
## What

Fixes the code defect behind the two `billing_outbox` rows that reached `DEAD` at
`attempt_count = 10` (#4701).

`AssessedFeeOutboxPayloads.postIntent` / `.reversalIntent` (used by
`BillingAssessmentRepositoryImpl` to write the `billing.fee.post-intent.v1` /
`billing.fee.reversal-intent.v1` outbox rows) hand-built the JSON payload by string
interpolation, embedding `fee.feeName` with **no escaping**. `feeName` is free text sourced
from the product catalog — the `fee_name` column has no length or charset constraint
(`BillingEntities.kt`). A fee name containing a double quote or backslash therefore produced
**malformed JSON**.

`LedgerOutboxEventPublisher.publish` deserializes that payload with Jackson before calling the
ledger; malformed JSON throws a parse exception on every single dispatch attempt — a
deterministic failure, not a transient one (`OutboxDispatch.isTransportUnavailable` correctly
excludes circuit-breaker/bulkhead faults from the attempt count, but a real per-row exception
like this counts every time). After `OutboxFailurePolicy`'s max-attempts threshold (10), the row
is parked `DEAD` — a terminal, non-alerting state (that half of the issue — making `DEAD` rows
alertable — is explicitly out of scope here and left to #4701's own follow-up).

Notably, this exact trap was already documented in the repo: `AnnualFeeSummaryOutboxPayloads`'s
own KDoc says it uses Jackson "unlike `BillingAssessmentRepositoryImpl`'s `AssessedFeeOutboxPayloads`
hand-built string concatenation ... fee names/categories carry free text (Czech diacritics,
possibly quotes), so hand-rolled string escaping is the wrong tool here" — that migration
(ADR-0248) covered the annual-summary payload but never circled back to fix the charge/reversal
leg it was calling out.

## Fix

- `AssessedFeeOutboxPayloads` moved out of `BillingAssessmentRepositoryImpl.kt` into its own file
  (mirrors `AnnualFeeSummaryOutboxPayloads`'s convention) and rewritten to serialize via
  `jacksonObjectMapper()` instead of string concatenation. Monetary fields stay JSON strings
  (`amount.toPlainString()`), matching the previous wire format and the fleet's "never a float"
  convention.
- Added `AssessedFeeOutboxPayloadsTest` — a standalone payload-shape unit test (no DB) proving a
  fee name containing a double quote, a backslash, or Czech diacritics now round-trips as valid
  JSON, plus contract-field coverage for both `postIntent` and `reversalIntent`. The previous
  hand-rolled `reversalIntent` also mangled the reversal `reason` (stripped newlines, swapped `"`
  for `'`) to dodge this same bug for one field only — the new version preserves it verbatim,
  correctly JSON-escaped.

## Scope / what this does NOT do

- Does **not** touch the 2 existing `DEAD` rows — replaying or deleting them is a live-data
  decision for a human, out of scope for this PR (per #4701 "What needs deciding" #3).
- Does **not** add `DEAD`-row alerting (#4701 "What needs deciding" #2) — that's a separate,
  broader change (a metric/alert already exists via `DomainMetrics.outboxDead`, but making it
  paged is a different PR).
- `openbank.outbox.dispatch-enabled` was already confirmed `true` in the issue; not implicated.
- No Kafka dotted-key or `runBlocking`-in-`@Scheduled` issue found — `BillingOutboxDispatcher.dispatch()`
  is already a `suspend fun`, and this outbox posts to ledger-service directly (not Kafka) for the
  charge/reversal legs.

## Test plan

- [x] `:openbank-billing-service:test` — new `AssessedFeeOutboxPayloadsTest` plus existing
      `LedgerOutboxEventPublisherTest` / `BillingOutboxDispatcherTest` all green.
- [x] `:openbank-billing-service:ktlintCheck :openbank-billing-service:detekt` — clean.
- [ ] The 2 dead rows in the sandbox need a human's live-DB remediation (replay/delete decision) —
      unaffected by this PR, tracked separately in #4701.

Closes #4701
