### PR TITLE
fix(transaction): pin TransactionServiceTest clock to stop weekend flake

### DIFF
--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/application/usecase/TransactionServiceTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/application/usecase/TransactionServiceTest.kt
@@ -50,7 +50,13 @@ class TransactionServiceTest {
 
     private lateinit var service: TransactionService
 
-    private val clock: Clock = Clock.systemUTC()
+    // Fixed instead of Clock.systemUTC(): several tests derive `requested = today.plusMonths(1)`
+    // and assert it passes through SettlementDateResolver UNCHANGED. That only holds when the
+    // resulting date is a CERTIS business day — on a real clock it silently flakes whenever
+    // `today.plusMonths(1)` lands on a weekend (or a CZK bank holiday), because the resolver
+    // correctly rolls a non-business-day value date forward (#5652). 2026-03-16 -> +1 month is
+    // 2026-04-16, a Thursday, clear of Easter (2026-04-03/04-06) and every other CERTIS holiday.
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-03-16T09:00:00Z"), SettlementDateResolver.BANK_ZONE)
     private var lastSaved: Transaction? = null
 
     @BeforeEach
@@ -71,6 +77,7 @@ class TransactionServiceTest {
             fxRatePort,
             temporalConfig,
             workflowClient,
+            clock,
         )
     }
 


### PR DESCRIPTION
## Summary
- `TransactionServiceTest` computed `today` from `Clock.systemUTC()` and asserted a requested value date one month out passes through `SettlementDateResolver` **unchanged**. That only holds when `today.plusMonths(1)` lands on a CERTIS business day — on a weekend (or a CZK bank holiday) the resolver correctly rolls the value date forward, and the assertion flakes.
- Reproduced locally on 2026-08-19 (a Wednesday): `today.plusMonths(1)` = 2026-09-19 (Saturday) → resolver correctly returns 2026-09-21 (Monday), while the test expected the unrolled Saturday date.
- Fixed by pinning the test's `clock` field to `Clock.fixed(Instant.parse("2026-03-16T09:00:00Z"), SettlementDateResolver.BANK_ZONE)`, chosen so `today.plusMonths(1)` = 2026-04-16 (Thursday), clear of Easter and every other CERTIS holiday.
- Also fixed a related latent bug: the test's `clock` field was declared but never passed into the `TransactionService` under test (`setUp()` used the `@Inject`-style secondary constructor, which defaults to its own `Clock.systemUTC()`). Wired `clock` through to the primary constructor so the test's fixed clock actually governs production date derivation.
- No production code changed — `SettlementDateResolver`'s weekend/holiday rolling behavior is correct; the test's expectation was wrong.

Closes #5652

## Test plan
- [x] `./gradlew :openbank-transaction-service:test --tests "*TransactionServiceTest*"` — 25/25 pass (was 6 failing pre-fix on a real weekend-adjacent date)
- [x] `./gradlew :openbank-transaction-service:test` (full module) — 138 tests, 0 failures, 0 errors, 1 pre-existing skip
- [x] `./gradlew :openbank-transaction-service:ktlintCheck :openbank-transaction-service:detekt` — clean
