### PR TITLE
feat(notification): wire ADR-0232 delegation lifecycle into notifications

### DIFF
--- a/openbank-infra/gitops/components/notifications/kafka-notification-mtls.yaml
+++ b/openbank-infra/gitops/components/notifications/kafka-notification-mtls.yaml
@@ -3,7 +3,7 @@
 # secret is projected into `notifications` via ExternalSecret (kafka-messaging-certs
 # ClusterSecretStore). The cluster-CA truststore is shared and also projected.
 #
-# ACLs: notification-service reads from two topics using two separate consumer
+# ACLs: notification-service reads from three topics using three separate consumer
 # groups, and — since ADR-0239 D2 — WRITES delivery outcomes onto one topic. That
 # Write grant is the whole of its producer surface; it is not a general producer.
 ---
@@ -37,6 +37,14 @@ spec:
           patternType: literal
         operations: [Read, Describe]
         host: "*"
+      # ADR-0232 delegated-access lifecycle notifications (DelegationNotificationConsumer) — a
+      # second consumer of the topic account-service and audit-service already read.
+      - resource:
+          type: topic
+          name: openbank.delegation.events
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
       # ADR-0239 D2: emit delivery outcomes so a producer can tell an accepted handoff
       # from a delivered, suppressed or failed message (issue #3663).
       - resource:
@@ -54,6 +62,12 @@ spec:
       - resource:
           type: group
           name: notification-service-party
+          patternType: literal
+        operations: [Read]
+        host: "*"
+      - resource:
+          type: group
+          name: notification-service-delegation
           patternType: literal
         operations: [Read]
         host: "*"

--- a/openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml
@@ -54,3 +54,6 @@ data:
     mp.messaging.incoming.party-events-in.client.id=notification-service-party-${quarkus.uuid}
     mp.messaging.incoming.party-events-in.group.id=notification-service-party
     mp.messaging.incoming.party-events-in.auto.offset.reset=earliest
+    mp.messaging.incoming.delegation-events-in.client.id=notification-service-delegation-${quarkus.uuid}
+    mp.messaging.incoming.delegation-events-in.group.id=notification-service-delegation
+    mp.messaging.incoming.delegation-events-in.auto.offset.reset=earliest

--- a/openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml
@@ -54,6 +54,3 @@ data:
     mp.messaging.incoming.party-events-in.client.id=notification-service-party-${quarkus.uuid}
     mp.messaging.incoming.party-events-in.group.id=notification-service-party
     mp.messaging.incoming.party-events-in.auto.offset.reset=earliest
-    mp.messaging.incoming.delegation-events-in.client.id=notification-service-delegation-${quarkus.uuid}
-    mp.messaging.incoming.delegation-events-in.group.id=notification-service-delegation
-    mp.messaging.incoming.delegation-events-in.auto.offset.reset=earliest

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -991,6 +991,26 @@ class NotificationConsumer @Inject constructor(
                     "<p><b>${vars.v("ctaText")}</b></p>" +
                     "<p style=\"font-size:small;color:#666\">You are receiving this because you opted in to " +
                     "marketing emails. Manage your preferences in the app.</p>"
+            NotificationTemplate.DELEGATION_OFFERED ->
+                "You have a delegated access offer to review" to
+                    "<h2>Delegated Access Offer</h2><p>Someone has offered you delegated access to their " +
+                    "<b>${vars.v("resourceType")}</b>. Open the OpenBank app to accept or decline.</p>"
+            NotificationTemplate.DELEGATION_ACCEPTED ->
+                "Your delegated access offer was accepted" to
+                    "<h2>Offer Accepted</h2><p>Your delegated access offer for your " +
+                    "<b>${vars.v("resourceType")}</b> was accepted and is now active.</p>"
+            NotificationTemplate.DELEGATION_DECLINED ->
+                "Your delegated access offer was declined" to
+                    "<h2>Offer Declined</h2><p>Your delegated access offer for your " +
+                    "<b>${vars.v("resourceType")}</b> was declined. No access was granted.</p>"
+            NotificationTemplate.DELEGATION_REVOKED ->
+                "Your delegated access was revoked" to
+                    "<h2>Access Revoked</h2><p>Delegated access to a <b>${vars.v("resourceType")}</b> " +
+                    "granted to you has been revoked. You can no longer act on it.</p>"
+            NotificationTemplate.DELEGATION_EXPIRED ->
+                "A delegated access grant has expired" to
+                    "<h2>Grant Expired</h2><p>A delegated access grant for a <b>${vars.v("resourceType")}</b> " +
+                    "has reached the end of its validity period and is no longer active.</p>"
         }
 }
 

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OversightWebhook.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OversightWebhook.kt
@@ -35,6 +35,9 @@ object OversightWebhook {
         NotificationTemplate.KYC_REJECTED,
         NotificationTemplate.ACCOUNT_FROZEN,
         NotificationTemplate.CONSENT_REVOKED,
+        // ADR-0232 delegated-access grant pulled back — same risk shape as CONSENT_REVOKED
+        // (an access grant ending), not a routine lifecycle step like OFFERED/ACCEPTED.
+        NotificationTemplate.DELEGATION_REVOKED,
     )
 
     fun isOversight(template: NotificationTemplate): Boolean = template in OVERSIGHT_TEMPLATES
@@ -44,6 +47,7 @@ object OversightWebhook {
         NotificationTemplate.KYC_REJECTED -> "🚫" // 🚫
         NotificationTemplate.ACCOUNT_FROZEN -> "❄️" // ❄️
         NotificationTemplate.CONSENT_REVOKED -> "🔓" // 🔓
+        NotificationTemplate.DELEGATION_REVOKED -> "🔒" // 🔒
         else -> "ℹ️" // ℹ️
     }
 

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
@@ -56,6 +56,28 @@ enum class NotificationTemplate(val variables: Set<String>) {
      * discipline — a campaign supplies values, never free-form body text.
      */
     MARKETING_PRODUCT_OFFER(setOf("offerTitle", "offerText", "ctaText")),
+
+    // ── ADR-0232 delegated-access lifecycle — sent to the party actionable on each transition.
+    // `resourceType` is the only detail carried on `openbank.delegation.events` that is safe to
+    // put in a template: neither party's display name rides the wire (DelegationEvents.kt has no
+    // name field — delegation-service's own counterparty-names table is a read-model local to that
+    // service), so DelegationNotificationConsumer cannot render one without an extra cross-service
+    // call this fan-out deliberately does not make (see its KDoc).
+
+    /** A grantee has an offer waiting to accept or decline (DelegationOffered). */
+    DELEGATION_OFFERED(setOf("resourceType")),
+
+    /** The grantor's offer was accepted and the grant is now active (DelegationActivated). */
+    DELEGATION_ACCEPTED(setOf("resourceType")),
+
+    /** The grantee declined the grantor's offer (DelegationDeclined). */
+    DELEGATION_DECLINED(setOf("resourceType")),
+
+    /** The grantor revoked an active grant; the grantee's access ends now (DelegationRevoked). */
+    DELEGATION_REVOKED(setOf("resourceType")),
+
+    /** A grant's validity window ended on its own; sent to both parties (DelegationExpired). */
+    DELEGATION_EXPIRED(setOf("resourceType")),
     ;
 
     /** Keys in [vars] that this template does not accept. Empty = the request is well-formed. */
@@ -71,6 +93,8 @@ enum class NotificationTemplate(val variables: Set<String>) {
             OTP_CODE, PASSWORD_RESET, ACCOUNT_FROZEN, SCA_APPROVAL,
             KYC_APPROVED, KYC_REJECTED, KYC_DOCUMENT_REQUIRED,
             CONSENT_GRANTED, CONSENT_REVOKED,
+            DELEGATION_OFFERED, DELEGATION_ACCEPTED, DELEGATION_DECLINED,
+            DELEGATION_REVOKED, DELEGATION_EXPIRED,
             -> NotificationCategory.SECURITY
             TRANSACTION_COMPLETED, TRANSACTION_FAILED -> NotificationCategory.PAYMENTS
             ACCOUNT_OPENED, ACCOUNT_CLOSED, WELCOME -> NotificationCategory.PRODUCT

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/kafka/DelegationNotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/kafka/DelegationNotificationConsumer.kt
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.notification.application.NotificationConsumer
+import com.openbank.notification.domain.model.NotificationChannel
+import com.openbank.notification.domain.model.NotificationRequest
+import com.openbank.notification.domain.model.NotificationTemplate
+import io.smallrye.mutiny.Uni
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.jboss.logging.Logger
+import java.util.UUID
+
+/**
+ * Wires ADR-0232 delegated-access lifecycle events into customer notifications.
+ *
+ * `openbank-delegation-service` already publishes the full lifecycle onto
+ * `openbank.delegation.events` (DelegationEvents.kt) via its transactional outbox; today
+ * `openbank-account-service` (its enforcement projection, ADR-0232 D3) and `openbank-audit-service`
+ * (its `onBehalfOf` audit trail) are the only consumers. Neither party is told anything — this is
+ * a SECOND consumer of the same, already-live topic, not a new event contract.
+ *
+ * **Which party, per event** — the party who has something to act on, or who is affected:
+ *  - `DelegationOffered` -> the **grantee**: they have an offer to accept or decline.
+ *  - `DelegationActivated` -> the **grantor**: their offer was accepted.
+ *  - `DelegationDeclined` -> the **grantor**: their offer was turned down.
+ *  - `DelegationRevoked` -> the **grantee**: their access just ended.
+ *  - `DelegationExpired` -> **both**: the grant is gone either way.
+ *  - Everything else (`DelegationSuspended`, `DelegationReinstated`, `DelegationRenounced`, and any
+ *    future/unknown type) is deliberately not notified here — out of this fan-out's stated scope,
+ *    not silently dropped by accident; add it as its own reviewed branch when it is in scope.
+ *
+ * **Delivery reuses the real pipeline, in-process.** Rather than re-implement rendering, the
+ * consent gate, push/email preference checks, persistence and the outcome-event write, this builds
+ * the exact [NotificationRequest] wire shape every other producer sends on
+ * `openbank.notification.requests` (see `KafkaNotificationRequestPublisher`,
+ * `LoggingNotificationSender`) and hands it to [NotificationConsumer.consume] directly — the same
+ * entry point a real Kafka delivery on that topic would reach. That also means the closed
+ * variable-schema check (ADR-0176 D1) and the deep-link allow-list still run for every notification
+ * built here, exactly as they would for an external producer.
+ *
+ * **No name in the copy.** [DelegationEvents][com.openbank.delegation.domain.event] carries
+ * `grantorPartyId`/`granteePartyId` as UUIDs only — no display name rides the wire (delegation-
+ * service's own counterparty-names table, V3, is a read model local to that service). Resolving a
+ * name would mean a synchronous cross-service call from an event consumer for a non-critical field,
+ * which this fan-out deliberately does not add; the templates read `resourceType` only.
+ *
+ * **Idempotency**: none, deliberately, matching [NotificationConsumer.consume]'s own documented
+ * position — delivery is at-least-once and a redelivery re-persists a fresh notification row, which
+ * is "acceptable for notifications (no money path)". A DLQ'd/retried delegation event can therefore
+ * produce a duplicate notification on redelivery, same as every other channel into this service.
+ *
+ * **Failure handling**: a malformed/unparseable record is a poison pill — logged and swallowed so
+ * it can never wedge the partition (mirrors [PartyErasureConsumer]). No `dead-letter-queue`
+ * `failure-strategy` is configured, matching this service's other two channels
+ * (`notification-events-in`, `party-events-in`): [NotificationConsumer.consume] already recovers
+ * every failure internally (JSON parse, closed-schema rejection, and `dispatch`'s own
+ * `.onFailure().recoverWithUni`) and always completes its `Uni`, so there is nothing left here that
+ * would reach a failure-strategy.
+ */
+@ApplicationScoped
+class DelegationNotificationConsumer @Inject constructor(
+    private val notificationConsumer: NotificationConsumer,
+    private val objectMapper: ObjectMapper,
+) {
+    private val log = Logger.getLogger(DelegationNotificationConsumer::class.java)
+
+    /**
+     * Reactive `Uni`, not `suspend` — same reasoning as [NotificationConsumer.consume]'s own KDoc:
+     * this method's only real work is delegating into that `Uni`-returning method, and a `suspend`
+     * wrapper here would reintroduce exactly the Vert.x-context hazard that method's KDoc documents.
+     */
+    @Incoming("delegation-events-in")
+    // Mirrors PartyErasureConsumer/NotificationConsumer.consume: any malformed record is a poison
+    // pill and must be swallowed, not just the JsonProcessingException Jackson usually throws.
+    @Suppress("TooGenericExceptionCaught")
+    fun consume(payload: String): Uni<Void> {
+        val node = try {
+            objectMapper.readTree(payload)
+        } catch (e: Exception) {
+            log.warnf(
+                e,
+                "Dropping unprocessable delegation event (poison pill): %s",
+                payload.take(MAX_LOGGED_PAYLOAD_CHARS),
+            )
+            return Uni.createFrom().voidItem()
+        }
+        val requests = requestsFor(node, payload)
+        if (requests.isEmpty()) return Uni.createFrom().voidItem()
+        return requests
+            .map { req -> notificationConsumer.consume(objectMapper.writeValueAsString(req)) }
+            .reduce { a, b -> a.chain { _: Void? -> b } }
+    }
+
+    /** The [NotificationRequest]s this event should raise — zero, one, or two (EXPIRED). */
+    private fun requestsFor(node: JsonNode, payload: String): List<NotificationRequest> {
+        val eventType = node.path("eventType").asText("")
+        val template = TEMPLATE_BY_EVENT_TYPE[eventType]
+        if (template == null) {
+            // Not an error: DelegationSuspended/Reinstated/Renounced and any future type are
+            // in-scope for other consumers of this topic, just not for this fan-out (see class KDoc).
+            log.debugf("delegation event %s not in notification scope, skipping", eventType.ifBlank { "?" })
+            return emptyList()
+        }
+        val grantId = node.path("aggregateId").asText(null)?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+        val grantor = node.path("grantorPartyId").asText(null)?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+        val grantee = node.path("granteePartyId").asText(null)?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+        if (grantId == null || grantor == null || grantee == null) {
+            log.warnf(
+                "Dropping delegation event %s with missing/unparseable identifiers: %s",
+                eventType,
+                payload.take(MAX_LOGGED_PAYLOAD_CHARS),
+            )
+            return emptyList()
+        }
+        val resourceType = node.path("resourceType").asText("")
+        val targets = TARGETS_BY_EVENT_TYPE.getValue(eventType)(grantor, grantee)
+        return targets.map { partyId ->
+            NotificationRequest(
+                partyId = partyId,
+                channel = NotificationChannel.PUSH,
+                template = template,
+                recipient = partyId.toString(),
+                variables = mapOf("resourceType" to resourceType),
+                // The grant id, not a freshly minted one: it is the stable identifier a producer
+                // owns for this business event (ADR-0239 D1), letting a later outcome event be
+                // joined back to the delegation grant that caused it.
+                correlationId = grantId,
+            )
+        }
+    }
+
+    private companion object {
+        /** Cap on the producer-supplied payload echoed into a poison-pill warning (untrusted input). */
+        const val MAX_LOGGED_PAYLOAD_CHARS = 300
+
+        val TEMPLATE_BY_EVENT_TYPE: Map<String, NotificationTemplate> = mapOf(
+            "DelegationOffered" to NotificationTemplate.DELEGATION_OFFERED,
+            "DelegationActivated" to NotificationTemplate.DELEGATION_ACCEPTED,
+            "DelegationDeclined" to NotificationTemplate.DELEGATION_DECLINED,
+            "DelegationRevoked" to NotificationTemplate.DELEGATION_REVOKED,
+            "DelegationExpired" to NotificationTemplate.DELEGATION_EXPIRED,
+        )
+
+        /** Recipient party id(s) per event type, given (grantor, grantee) — see class KDoc. */
+        val TARGETS_BY_EVENT_TYPE: Map<String, (UUID, UUID) -> List<UUID>> = mapOf(
+            "DelegationOffered" to { _, grantee -> listOf(grantee) },
+            "DelegationActivated" to { grantor, _ -> listOf(grantor) },
+            "DelegationDeclined" to { grantor, _ -> listOf(grantor) },
+            "DelegationRevoked" to { _, grantee -> listOf(grantee) },
+            "DelegationExpired" to { grantor, grantee -> listOf(grantor, grantee) },
+        )
+    }
+}

--- a/openbank-notification-service/src/main/resources/application.yaml
+++ b/openbank-notification-service/src/main/resources/application.yaml
@@ -155,6 +155,15 @@ mp:
         # set via the gitops ConfigMap instead (issue #686).
         topic: openbank.party.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      # ADR-0232 delegated-access lifecycle notifications (DelegationNotificationConsumer) — a
+      # second consumer of the topic account-service (enforcement projection) and audit-service
+      # (onBehalfOf trail) already read.
+      delegation-events-in:
+        connector: smallrye-kafka
+        # client.id / group.id / auto.offset.reset: same dotted-key YAML bug as above —
+        # set via the gitops ConfigMap instead (issue #686).
+        topic: openbank.delegation.events
+        value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
 # ADR-0155 four-eyes, opted into by opsmessage.compose (ADR-0176 D5). Default false, matching
 # every other four-eyes-wired service (lending, balance, sepa-payment, sepa-instant, account) —

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
@@ -31,18 +31,34 @@ class NotificationModelTest {
 
     @Test
     fun `NotificationTemplate has all expected templates`() {
-        assertThat(NotificationTemplate.values()).hasSize(15)
+        assertThat(NotificationTemplate.values()).hasSize(20)
         assertThat(NotificationTemplate.values()).contains(
             NotificationTemplate.ACCOUNT_OPENED,
             NotificationTemplate.OTP_CODE,
             NotificationTemplate.WELCOME,
             NotificationTemplate.SCA_APPROVAL,
             NotificationTemplate.MARKETING_PRODUCT_OFFER,
+            NotificationTemplate.DELEGATION_OFFERED,
+            NotificationTemplate.DELEGATION_ACCEPTED,
+            NotificationTemplate.DELEGATION_DECLINED,
+            NotificationTemplate.DELEGATION_REVOKED,
+            NotificationTemplate.DELEGATION_EXPIRED,
         )
         // SCA_APPROVAL is SECURITY so the #2 push-preference gate never suppresses it.
         assertThat(NotificationTemplate.SCA_APPROVAL.category).isEqualTo(NotificationCategory.SECURITY)
         // ADR-0200/0198: the campaign template is MARKETING so the consent gate always applies.
         assertThat(NotificationTemplate.MARKETING_PRODUCT_OFFER.category).isEqualTo(NotificationCategory.MARKETING)
+        // ADR-0232: the whole delegated-access lifecycle is SECURITY — a customer can never mute
+        // being told someone else can now act on their account, same as CONSENT_GRANTED/REVOKED.
+        assertThat(
+            listOf(
+                NotificationTemplate.DELEGATION_OFFERED,
+                NotificationTemplate.DELEGATION_ACCEPTED,
+                NotificationTemplate.DELEGATION_DECLINED,
+                NotificationTemplate.DELEGATION_REVOKED,
+                NotificationTemplate.DELEGATION_EXPIRED,
+            ),
+        ).allSatisfy { assertThat(it.category).isEqualTo(NotificationCategory.SECURITY) }
     }
 
     @Test

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/kafka/DelegationNotificationConsumerTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/kafka/DelegationNotificationConsumerTest.kt
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.notification.application.NotificationConsumer
+import com.openbank.notification.domain.model.NotificationChannel
+import com.openbank.notification.domain.model.NotificationRequest
+import com.openbank.notification.domain.model.NotificationTemplate
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.smallrye.mutiny.Uni
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class DelegationNotificationConsumerTest {
+
+    private val notificationConsumer = mockk<NotificationConsumer>()
+    private val objectMapper: ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    private lateinit var consumer: DelegationNotificationConsumer
+
+    private val grantId = UUID.randomUUID()
+    private val grantorPartyId = UUID.randomUUID()
+    private val granteePartyId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        consumer = DelegationNotificationConsumer(notificationConsumer, objectMapper)
+        every { notificationConsumer.consume(any()) } returns Uni.createFrom().voidItem()
+    }
+
+    /** Captures the [NotificationRequest] JSON(s) handed to [NotificationConsumer.consume]. */
+    private fun capturedRequests(): List<NotificationRequest> {
+        val slot = mutableListOf<String>()
+        verify { notificationConsumer.consume(capture(slot)) }
+        return slot.map { objectMapper.readValue(it, NotificationRequest::class.java) }
+    }
+
+    private fun eventPayload(
+        eventType: String,
+        resourceType: String = "ACCOUNT",
+        aggregateId: UUID = grantId,
+        grantor: UUID? = grantorPartyId,
+        grantee: UUID? = granteePartyId,
+    ): String {
+        val fields = mutableListOf(
+            "\"eventType\":\"$eventType\"",
+            "\"aggregateId\":\"$aggregateId\"",
+            "\"resourceType\":\"$resourceType\"",
+            "\"occurredAt\":\"${Instant.parse("2026-08-19T10:00:00Z")}\"",
+        )
+        grantor?.let { fields += "\"grantorPartyId\":\"$it\"" }
+        grantee?.let { fields += "\"granteePartyId\":\"$it\"" }
+        return "{${fields.joinToString(",")}}"
+    }
+
+    @Test
+    fun `DelegationOffered notifies the grantee to accept or decline`() {
+        consumer.consume(eventPayload("DelegationOffered", resourceType = "CARD"))
+            .subscribe().with({}, {})
+
+        val requests = capturedRequests()
+        assertThat(requests).hasSize(1)
+        val req = requests.single()
+        assertThat(req.partyId).isEqualTo(granteePartyId)
+        assertThat(req.template).isEqualTo(NotificationTemplate.DELEGATION_OFFERED)
+        assertThat(req.channel).isEqualTo(NotificationChannel.PUSH)
+        assertThat(req.variables).isEqualTo(mapOf("resourceType" to "CARD"))
+        assertThat(req.correlationId).isEqualTo(grantId)
+    }
+
+    @Test
+    fun `DelegationActivated notifies the grantor that their offer was accepted`() {
+        consumer.consume(eventPayload("DelegationActivated")).subscribe().with({}, {})
+
+        val req = capturedRequests().single()
+        assertThat(req.partyId).isEqualTo(grantorPartyId)
+        assertThat(req.template).isEqualTo(NotificationTemplate.DELEGATION_ACCEPTED)
+    }
+
+    @Test
+    fun `DelegationDeclined notifies the grantor`() {
+        consumer.consume(eventPayload("DelegationDeclined")).subscribe().with({}, {})
+
+        val req = capturedRequests().single()
+        assertThat(req.partyId).isEqualTo(grantorPartyId)
+        assertThat(req.template).isEqualTo(NotificationTemplate.DELEGATION_DECLINED)
+    }
+
+    @Test
+    fun `DelegationRevoked notifies the grantee that access just ended`() {
+        consumer.consume(eventPayload("DelegationRevoked")).subscribe().with({}, {})
+
+        val req = capturedRequests().single()
+        assertThat(req.partyId).isEqualTo(granteePartyId)
+        assertThat(req.template).isEqualTo(NotificationTemplate.DELEGATION_REVOKED)
+    }
+
+    @Test
+    fun `DelegationExpired notifies BOTH grantor and grantee`() {
+        consumer.consume(eventPayload("DelegationExpired")).subscribe().with({}, {})
+
+        val requests = capturedRequests()
+        assertThat(requests).hasSize(2)
+        assertThat(requests.map { it.partyId }).containsExactlyInAnyOrder(grantorPartyId, granteePartyId)
+        assertThat(requests).allSatisfy { assertThat(it.template).isEqualTo(NotificationTemplate.DELEGATION_EXPIRED) }
+    }
+
+    @Test
+    fun `out-of-scope lifecycle types are not notified`() {
+        for (type in listOf("DelegationSuspended", "DelegationReinstated", "DelegationRenounced", "SomethingElse")) {
+            consumer.consume(eventPayload(type)).subscribe().with({}, {})
+        }
+
+        verify(exactly = 0) { notificationConsumer.consume(any()) }
+    }
+
+    @Test
+    fun `malformed JSON is a poison pill, swallowed without throwing`() {
+        consumer.consume("not json").subscribe().with({}, {})
+
+        verify(exactly = 0) { notificationConsumer.consume(any()) }
+    }
+
+    @Test
+    fun `missing party identifiers are dropped rather than notified with a bad target`() {
+        consumer.consume(eventPayload("DelegationOffered", grantee = null)).subscribe().with({}, {})
+        consumer.consume(eventPayload("DelegationActivated", grantor = null)).subscribe().with({}, {})
+        // aggregateId present but not a parseable UUID.
+        consumer.consume(
+            """{"eventType":"DelegationRevoked","aggregateId":"not-a-uuid",""" +
+                """"grantorPartyId":"$grantorPartyId","granteePartyId":"$granteePartyId","resourceType":"ACCOUNT"}""",
+        ).subscribe().with({}, {})
+
+        verify(exactly = 0) { notificationConsumer.consume(any()) }
+    }
+}


### PR DESCRIPTION
feat(notification): wire ADR-0232 delegation lifecycle into notifications

openbank-delegation-service has published DelegationOffered/Activated/
Declined/Revoked/Expired onto openbank.delegation.events since ADR-0232
shipped; account-service (enforcement projection) and audit-service
(onBehalfOf trail) already consume it. Neither party in a delegated-access
grant was ever notified — this adds notification-service as a second
consumer of the same, already-live topic.

- DelegationNotificationConsumer (new @Incoming("delegation-events-in")):
  maps each lifecycle event to the party who has something to act on or
  is affected (offered -> grantee, accepted/declined -> grantor,
  revoked -> grantee, expired -> both), builds the same NotificationRequest
  wire shape every other producer sends, and hands it to
  NotificationConsumer.consume() in-process — reusing rendering, the
  consent gate, push/email preferences, persistence and the outcome-event
  write instead of re-implementing any of it. DelegationSuspended/
  Reinstated/Renounced stay out of scope, not silently dropped.
- Five new NotificationTemplate constants (DELEGATION_OFFERED/ACCEPTED/
  DECLINED/REVOKED/EXPIRED), all NotificationCategory.SECURITY like
  CONSENT_GRANTED/REVOKED, rendered in NotificationConsumer.renderTemplate.
  Templates carry resourceType only: DelegationEvents.kt puts no display
  name on the wire, so a name would need an extra cross-service call this
  fan-out deliberately doesn't add.
- DELEGATION_REVOKED added to the ADR-0059 oversight allow-list, same risk
  shape as CONSENT_REVOKED.
- Kafka wiring follows this service's own established shape for its other
  two channels exactly: topic/deserializer in application.yaml, group.id/
  client.id/auto.offset.reset via the gitops override ConfigMap (the
  dotted-key YAML bug, issue #686), and a Read/Describe + consumer-group
  ACL on the KafkaUser.
- Unit tests for the new consumer (mockk, mirrors PartyErasureConsumerTest):
  each lifecycle event -> correct target + template, EXPIRED fans out to
  both parties, poison pills and missing identifiers are dropped without
  throwing. Existing NotificationModelTest's exhaustive template-count
  assertion updated for the five new constants.

:openbank-notification-service:build (compile, detekt, full test suite
incl. Testcontainers ITs, quarkusBuild) passes clean.

Signed-off-by: jiri.raska <jiri@iraska.cz>
Signed-off-by: Jiri Raska <jiri@iraska.cz>

