### PR TITLE
test(transaction): stop TransactionServiceTest asking the calendar a new question each day

### DIFF
--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/application/usecase/TransactionServiceTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/application/usecase/TransactionServiceTest.kt
@@ -38,6 +38,7 @@ import java.math.BigDecimal
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.UUID
 
 class TransactionServiceTest {
@@ -50,7 +51,27 @@ class TransactionServiceTest {
 
     private lateinit var service: TransactionService
 
-    private val clock: Clock = Clock.systemUTC()
+    /**
+     * FIXED, and that is the whole point. Six tests below build a requested value date as
+     * `today.plusMonths(1)`, and [SettlementDateResolver] rolls a requested date to a business day
+     * (FOLLOWING). Under a system clock this file is a calendar time-bomb in two directions:
+     *
+     *  - the two tests that assert the requested date survives verbatim fail whenever today + 1
+     *    month lands on a weekend or holiday — on 2026-08-19 that was Saturday 2026-09-19, and
+     *    `a SEPA settlement booked as TRANSFER still honours the requested value date` and
+     *    `a domestic payment leaving the bank still honours the resolver` both went red;
+     *  - the four that assert the same-day branch (`isEqualTo(today)`) are exposed whenever
+     *    *today itself* is not a business day, i.e. every weekend run.
+     *
+     * Nothing here was wrong on the day it was written; the test simply asked the calendar a
+     * different question each morning. Path-scoped CI hid it — the module builds only when
+     * something touches it, so the failure surfaced on an unrelated docs-only PR.
+     *
+     * 2026-01-06 is a Tuesday, 09:00Z = 10:00 Europe/Prague (before the 16:00 cut-off), and
+     * 2026-02-06 is a Friday. Both ends of every `plusMonths(1)` below are business days by
+     * construction, on every future run.
+     */
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-01-06T09:00:00Z"), ZoneOffset.UTC)
     private var lastSaved: Transaction? = null
 
     @BeforeEach
@@ -65,12 +86,16 @@ class TransactionServiceTest {
         every {
             workflowClient.newWorkflowStub(PaymentWorkflow::class.java, any<WorkflowOptions>())
         } returns workflowStub
+        // The clock is passed EXPLICITLY: the @Inject constructor defaults to Clock.systemUTC(),
+        // so a fixed clock held only by the test would describe a different day from the one the
+        // service resolves settlement dates against — expectations and subject must share it.
         service = TransactionService(
             transactionRepository,
             eventPublisher,
             fxRatePort,
             temporalConfig,
             workflowClient,
+            clock,
         )
     }
 


### PR DESCRIPTION
## The failure

Two tests went red on 2026-08-19 with nothing in the module changed:

```
TransactionServiceTest > a SEPA settlement booked as TRANSFER still honours the requested value date
TransactionServiceTest > a domestic payment leaving the bank still honours the resolver
expected: 2026-09-19 but was: 2026-09-21
```

Both build a requested value date as `today.plusMonths(1)` under `Clock.systemUTC()` and assert it survives verbatim. `SettlementDateResolver` rolls a requested date to a business day (FOLLOWING), and **2026-08-19 + 1 month is Saturday 2026-09-19** — so the resolver correctly answered Monday 2026-09-21.

The production code is right. The test asked the calendar a different question each morning and happened to be wrong that day.

## The exposure is wider than the two that fired

Four sibling tests assert the same-day branch with `isEqualTo(today)`. Those break whenever **today itself** is not a business day — every weekend run. Six date-dependent tests in one file, all green by luck rather than by construction.

## The fix

Clock fixed at `2026-01-06T09:00:00Z`: a Tuesday, 10:00 Europe/Prague (before the 16:00 cut-off), whose +1 month is Friday 2026-02-06. Both ends of every `plusMonths(1)` are business days by construction, on every future run.

The clock is now **passed explicitly** into `TransactionService`. Its `@Inject` constructor defaults to `Clock.systemUTC()`, so a fixed clock held only by the test describes a different day from the one the service resolves against — which is precisely what the first attempt produced: **6 failures instead of 2**, expectations moved and the subject did not. Worth stating because that shape looks like progress and is a regression.

## Why nobody saw it coming

CI is path-scoped, so this module builds only when something touches it. The failure surfaced on a **docs-only PR** (#5662) that changed this service's `02-architecture.md` and nothing else — the first build it had had on a day the bomb was live. The module's own last real change (`b83799b06`) was green, because that day's +1 month was a weekday.

## Verification

- `:openbank-transaction-service:test` — **137/137 green** (was 137 / 2 failed)
- `:openbank-transaction-service:ktlintCheck :openbank-transaction-service:detekt` — clean
- Red case is not hypothetical: it is the CI failure this PR was cut to fix, reproduced twice (initial run and a rerun, same two tests, same assertion).

## Not covered here

Four other test files combine a system clock with date arithmetic (`openbank-lending-service` ×3, `openbank-tpp-registry-service`). None is proven date-sensitive — they may not touch a business-day calendar at all — so this PR does not touch them. Worth a separate sweep.

Refs #5662
