### PR TITLE
fix(balance): grant OPERATOR/ADMIN balance.approval.decide (money-path authz gap)

### DIFF
--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/infrastructure/rest/BalanceResourceAuthzTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/infrastructure/rest/BalanceResourceAuthzTest.kt
@@ -127,4 +127,29 @@ class BalanceResourceAuthzTest {
             statusCode(404)
         }
     }
+
+    // Regression coverage for the `balance.approval.decide` money-path authz gap found by PR
+    // #5686's OPA verification: the action was missing from rules.yaml's role_action_matrix, so
+    // real OPA evaluation resolved allow=false for every OPERATOR and the four-eyes checker
+    // endpoint 403'd in any AUTHZ_ENFORCE=true environment. This test profile never runs a real
+    // OPA sidecar (authz.enforce defaults to false here, same as every other test above) so it
+    // cannot itself prove the grant — that is what
+    // openbank-infra/gitops/components/balances/balance_rest_ext_test.rego's
+    // test_operator_may_decide_approval / test_edge_may_not_decide_approval_despite_matrix_grant
+    // assert against the real regenerated bundle. What this test DOES prove: the interceptor is
+    // a correct no-op for balance.approval.decide in advisory mode, matching every other
+    // endpoint in this class, so the endpoint's own behavior (unknown approval id -> 404) is
+    // reachable and not masked by the authz layer.
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `advisory mode does not block approval decide - unknown approval id 404s from the handler`() {
+        Given {
+            contentType("application/json")
+            body("""{"approve":true}""")
+        } When {
+            patch("/api/v1/balances/approvals/${UUID.randomUUID()}")
+        } Then {
+            statusCode(404)
+        }
+    }
 }

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "ad9610f36137b763"
+    openbank.tech/policy-checksum: "c3d7e704ddadbb54"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1356,6 +1356,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ad9610f36137b763"
+        openbank.tech/policy-checksum: "c3d7e704ddadbb54"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "c285dea134c86f80"
+    openbank.tech/policy-checksum: "7ffa16e0665a8b30"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1307,6 +1307,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c285dea134c86f80"
+        openbank.tech/policy-checksum: "7ffa16e0665a8b30"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "d6740b35d9dbccb0"
+    openbank.tech/policy-checksum: "9f5300aa9e5eacb2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1290,6 +1290,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d6740b35d9dbccb0"
+        openbank.tech/policy-checksum: "9f5300aa9e5eacb2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "25942f13f92bd234"
+    openbank.tech/policy-checksum: "9901d2fdbeedc4ea"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1245,6 +1245,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "25942f13f92bd234"
+        openbank.tech/policy-checksum: "9901d2fdbeedc4ea"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "bfd13983ec3af561"
+    openbank.tech/policy-checksum: "d7681cc600be0856"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1289,6 +1289,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bfd13983ec3af561"
+        openbank.tech/policy-checksum: "d7681cc600be0856"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "994db3f0b56df007"
+    openbank.tech/policy-checksum: "cf3271b39beec249"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -534,7 +534,7 @@ data:
     # Extends openbank.rest with balance-store allow reasons.
     # Mounted alongside rest.rego in the same OPA bundle — OPA merges same-package rules.
     #
-    # Actions gated (BalanceResource / ReconciliationResource):
+    # Actions gated (BalanceResource / ReconciliationResource / ApprovalResource):
     #   balance.read                — get one/all currency balances (#accountId)
     #   balance.hold                — place a hold on funds (#accountId)
     #   balance.holdRelease         — release a hold (#holdId)
@@ -544,12 +544,25 @@ data:
     #   balance.overdraftLimit      — set the arranged overdraft limit (#accountId, supervisor-only)
     #   balance.reconciliation.read — latest control-account tie-out report
     #   balance.reconciliation.run  — on-demand tie-out re-run
+    #   balance.approval.decide     — a DIFFERENT operator decides a paused credit/debit four-eyes
+    #                                 approval (#id, ADR-0155). Granted via rules.yaml's
+    #                                 role_action_matrix (ROLE_OPERATOR/ROLE_ADMIN) + base rest.rego's
+    #                                 matrix-allows — same mechanism as sanctions.approval.decide /
+    #                                 lending.approval.decide, no dedicated allowed_reasons rule
+    #                                 needed here. It DOES need the edge veto below (matrix-allows is
+    #                                 role-only and would otherwise also admit the customer-facing
+    #                                 edge M2M identity, which carries ROLE_OPERATOR in the deployed
+    #                                 realm template) — same reasoning as every other write action in
+    #                                 this file.
     #
     # balance-service is the most-called money-primitive in the fleet: ledger/settlement/transaction
-    # all post through balance.credit/balance.debit. None of the verbs above is in rules.yaml's
-    # four_eyes.verbs list (transfer/post/reverse/freeze/release/flip) — the four-eyes gate lives on
-    # the payment RAILS (domestic-payment.transitionStatus etc.), not on this shared primitive, so no
-    # four-eyes logic belongs here.
+    # all post through balance.credit/balance.debit. None of the credit/debit/hold/etc verbs above is
+    # in rules.yaml's four_eyes.verbs list (transfer/post/reverse/freeze/release/flip) — the four-eyes
+    # gate on THOSE lives on the payment RAILS (domestic-payment.transitionStatus etc.), not on this
+    # shared primitive. balance.approval.decide is a different mechanism: ApprovalResource is the
+    # checker-facing side of ApprovalStore's own maker/checker four-eyes gate (ADR-0155), separate
+    # from OPA's four_eyes_required attribute, so no allowed_reasons rule for it belongs here — only
+    # the matrix grant plus the edge prohibition.
     #
     # Base rest.rego already grants: operator-read-any / compliance-read-any for *.read (covers
     # balance.read + balance.reconciliation.read for OPERATOR/ADMIN/COMPLIANCE).
@@ -699,6 +712,7 @@ data:
     		"balance.initialize",
     		"balance.reconciliation.run",
     		"balance.overdraftLimit",
+    		"balance.approval.decide",
     	}
     }
   agents.rego: |
@@ -1418,6 +1432,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "994db3f0b56df007"
+        openbank.tech/policy-checksum: "cf3271b39beec249"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance_rest_ext.rego
+++ b/openbank-infra/gitops/components/balances/balance_rest_ext.rego
@@ -3,7 +3,7 @@
 # Extends openbank.rest with balance-store allow reasons.
 # Mounted alongside rest.rego in the same OPA bundle — OPA merges same-package rules.
 #
-# Actions gated (BalanceResource / ReconciliationResource):
+# Actions gated (BalanceResource / ReconciliationResource / ApprovalResource):
 #   balance.read                — get one/all currency balances (#accountId)
 #   balance.hold                — place a hold on funds (#accountId)
 #   balance.holdRelease         — release a hold (#holdId)
@@ -13,12 +13,25 @@
 #   balance.overdraftLimit      — set the arranged overdraft limit (#accountId, supervisor-only)
 #   balance.reconciliation.read — latest control-account tie-out report
 #   balance.reconciliation.run  — on-demand tie-out re-run
+#   balance.approval.decide     — a DIFFERENT operator decides a paused credit/debit four-eyes
+#                                 approval (#id, ADR-0155). Granted via rules.yaml's
+#                                 role_action_matrix (ROLE_OPERATOR/ROLE_ADMIN) + base rest.rego's
+#                                 matrix-allows — same mechanism as sanctions.approval.decide /
+#                                 lending.approval.decide, no dedicated allowed_reasons rule
+#                                 needed here. It DOES need the edge veto below (matrix-allows is
+#                                 role-only and would otherwise also admit the customer-facing
+#                                 edge M2M identity, which carries ROLE_OPERATOR in the deployed
+#                                 realm template) — same reasoning as every other write action in
+#                                 this file.
 #
 # balance-service is the most-called money-primitive in the fleet: ledger/settlement/transaction
-# all post through balance.credit/balance.debit. None of the verbs above is in rules.yaml's
-# four_eyes.verbs list (transfer/post/reverse/freeze/release/flip) — the four-eyes gate lives on
-# the payment RAILS (domestic-payment.transitionStatus etc.), not on this shared primitive, so no
-# four-eyes logic belongs here.
+# all post through balance.credit/balance.debit. None of the credit/debit/hold/etc verbs above is
+# in rules.yaml's four_eyes.verbs list (transfer/post/reverse/freeze/release/flip) — the four-eyes
+# gate on THOSE lives on the payment RAILS (domestic-payment.transitionStatus etc.), not on this
+# shared primitive. balance.approval.decide is a different mechanism: ApprovalResource is the
+# checker-facing side of ApprovalStore's own maker/checker four-eyes gate (ADR-0155), separate
+# from OPA's four_eyes_required attribute, so no allowed_reasons rule for it belongs here — only
+# the matrix grant plus the edge prohibition.
 #
 # Base rest.rego already grants: operator-read-any / compliance-read-any for *.read (covers
 # balance.read + balance.reconciliation.read for OPERATOR/ADMIN/COMPLIANCE).
@@ -168,5 +181,6 @@ prohibited if {
 		"balance.initialize",
 		"balance.reconciliation.run",
 		"balance.overdraftLimit",
+		"balance.approval.decide",
 	}
 }

--- a/openbank-infra/gitops/components/balances/balance_rest_ext_test.rego
+++ b/openbank-infra/gitops/components/balances/balance_rest_ext_test.rego
@@ -31,6 +31,7 @@ rules_mock := {
 		"balance.debit",
 		"balance.initialize",
 		"balance.reconciliation.run",
+		"balance.approval.decide",
 	]}}},
 	"money_path_services": [],
 	"money_path_action_prefixes": {},
@@ -74,6 +75,22 @@ test_edge_may_not_run_reconciliation_despite_matrix_grant if {
 		with data.rules as rules_mock
 }
 
+# Regression for the money-path authz gap found by PR #5686's OPA verification: real OPA
+# evaluation (not just the CI unit tests) showed balance.approval.decide resolving allow=false
+# for a real OPERATOR because the action was missing from rules.yaml's role_action_matrix — the
+# four-eyes checker endpoint (ApprovalResource.decide) 403'd for every operator in an
+# AUTHZ_ENFORCE=true environment. Fixed by adding the matrix grant; this asserts the fix AND
+# that it does not reopen the edge-escalation gap the rest of this file exists to prevent.
+test_edge_may_not_decide_approval_despite_matrix_grant if {
+	rest.allow == false with input as {"principal": edge, "action": "balance.approval.decide"}
+		with data.rules as rules_mock
+}
+
+test_prohibition_fires_for_edge_on_approval_decide if {
+	rest.prohibited with input as {"principal": edge, "action": "balance.approval.decide"}
+		with data.rules as rules_mock
+}
+
 test_prohibition_fires_for_edge_on_write if {
 	rest.prohibited with input as {"principal": edge, "action": "balance.credit"}
 		with data.rules as rules_mock
@@ -107,6 +124,13 @@ test_operator_may_credit if {
 	decision.allow == true
 	"operator-balance-write" in rest.allowed_reasons with input as {"principal": operator, "action": "balance.credit"}
 		with data.rules as rules_mock
+}
+
+test_operator_may_decide_approval if {
+	decision := rest.allow with input as {"principal": operator, "action": "balance.approval.decide"}
+		with data.rules as rules_mock
+	decision.allow == true
+	decision.reason == "matrix-allows"
 }
 
 test_supervisor_may_set_overdraft_limit if {

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "c8fbf1638366ea9c"
+    openbank.tech/policy-checksum: "00eab878623febc9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1304,6 +1304,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -36,7 +36,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c8fbf1638366ea9c"
+        openbank.tech/policy-checksum: "00eab878623febc9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: campaign-service
     app.kubernetes.io/part-of: campaign
   annotations:
-    openbank.tech/policy-checksum: "9b8c966ad54148db"
+    openbank.tech/policy-checksum: "85472f1eff53706e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1314,6 +1314,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-campaign-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9b8c966ad54148db"
+        openbank.tech/policy-checksum: "85472f1eff53706e"
       labels:
         app.kubernetes.io/name: campaign-service
         app.kubernetes.io/part-of: campaign

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "65729028d61775d3"
+    openbank.tech/policy-checksum: "b87f0d32d4567dd2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1390,6 +1390,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "65729028d61775d3"
+        openbank.tech/policy-checksum: "b87f0d32d4567dd2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "bb70b4b774e3a026"
+    openbank.tech/policy-checksum: "eed18bb0b17c7eea"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1369,6 +1369,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bb70b4b774e3a026"
+        openbank.tech/policy-checksum: "eed18bb0b17c7eea"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "46effa788909c54c"
+    openbank.tech/policy-checksum: "57ced8e58fb25190"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -962,6 +962,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "46effa788909c54c"
+        openbank.tech/policy-checksum: "57ced8e58fb25190"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: delegation-service
     app.kubernetes.io/part-of: delegation
   annotations:
-    openbank.tech/policy-checksum: "28e6a00340db4e61"
+    openbank.tech/policy-checksum: "beeacf806fb4b42f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1333,6 +1333,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/delegation/delegation-service.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-delegation-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "28e6a00340db4e61"
+        openbank.tech/policy-checksum: "beeacf806fb4b42f"
       labels:
         app.kubernetes.io/name: delegation-service
         app.kubernetes.io/part-of: delegation

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "af4599acf83b7064"
+    openbank.tech/policy-checksum: "83dd3e093fff7f52"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1419,6 +1419,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -24,7 +24,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "af4599acf83b7064"
+        openbank.tech/policy-checksum: "83dd3e093fff7f52"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "46effa788909c54c"
+    openbank.tech/policy-checksum: "57ced8e58fb25190"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -962,6 +962,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -52,7 +52,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "46effa788909c54c"
+        openbank.tech/policy-checksum: "57ced8e58fb25190"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/engagement/engagement-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/engagement/engagement-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: engagement-service
     app.kubernetes.io/part-of: engagement
   annotations:
-    openbank.tech/policy-checksum: "46effa788909c54c"
+    openbank.tech/policy-checksum: "57ced8e58fb25190"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -962,6 +962,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/engagement/engagement-service.yaml
+++ b/openbank-infra/gitops/components/engagement/engagement-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-engagement-opa-bundle.sh.
-        openbank.tech/policy-checksum: "46effa788909c54c"
+        openbank.tech/policy-checksum: "57ced8e58fb25190"
       labels:
         app.kubernetes.io/name: engagement-service
         app.kubernetes.io/part-of: engagement

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "f6f2bfb27633315a"
+    openbank.tech/policy-checksum: "0fd2590c84951823"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1326,6 +1326,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f6f2bfb27633315a"
+        openbank.tech/policy-checksum: "0fd2590c84951823"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "46891668e3f55b54"
+    openbank.tech/policy-checksum: "c1b982bc2c98b14a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1362,6 +1362,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "46891668e3f55b54"
+        openbank.tech/policy-checksum: "c1b982bc2c98b14a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "3a5ea4dc0777b81e"
+    openbank.tech/policy-checksum: "94c97fa656270d33"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1341,6 +1341,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3a5ea4dc0777b81e"
+        openbank.tech/policy-checksum: "94c97fa656270d33"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "36619134e8d81025"
+    openbank.tech/policy-checksum: "519a0afc146a7af7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1307,6 +1307,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "36619134e8d81025"
+        openbank.tech/policy-checksum: "519a0afc146a7af7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "e45f9fff60e5b399"
+    openbank.tech/policy-checksum: "2cb8af7812dacb60"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1423,6 +1423,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e45f9fff60e5b399"
+        openbank.tech/policy-checksum: "2cb8af7812dacb60"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "ddcca992d30aba03"
+    openbank.tech/policy-checksum: "93b925e2ab422b8c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1412,6 +1412,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -41,7 +41,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ddcca992d30aba03"
+        openbank.tech/policy-checksum: "93b925e2ab422b8c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "25942f13f92bd234"
+    openbank.tech/policy-checksum: "9901d2fdbeedc4ea"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1245,6 +1245,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "25942f13f92bd234"
+        openbank.tech/policy-checksum: "9901d2fdbeedc4ea"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "46effa788909c54c"
+    openbank.tech/policy-checksum: "57ced8e58fb25190"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -962,6 +962,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "46effa788909c54c"
+        openbank.tech/policy-checksum: "57ced8e58fb25190"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "e6cb9dddd43ad0de"
+    openbank.tech/policy-checksum: "204ca8f28fc57ace"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1316,6 +1316,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e6cb9dddd43ad0de"
+        openbank.tech/policy-checksum: "204ca8f28fc57ace"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8be68585f4128ca8"
+    openbank.tech/policy-checksum: "438cb7e5a4c4c426"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1300,6 +1300,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1fda16ac541a2d85"
+    openbank.tech/policy-checksum: "e7b947367c2b3b2d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1337,6 +1337,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f3e3076f88cd4d1d"
+    openbank.tech/policy-checksum: "501621da0770c9ef"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1322,6 +1322,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "b7e762c77801da1f" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "ca4d63f55e886dbd" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -378,7 +378,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9ec9017df9886e22"
+        openbank.tech/policy-checksum: "7a8b70909ac1f61b"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -741,7 +741,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "f3e3076f88cd4d1d" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "501621da0770c9ef" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1078,7 +1078,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "65bb22269c6c5145"
+        openbank.tech/policy-checksum: "37ab19ee85715bf4"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1399,7 +1399,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "1fda16ac541a2d85" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "e7b947367c2b3b2d" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1697,7 +1697,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "d2dc7f34692d768d" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "9bc86ab3c6babbb5" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1974,7 +1974,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8be68585f4128ca8"
+        openbank.tech/policy-checksum: "438cb7e5a4c4c426"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2252,7 +2252,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "85b8ff7cc423d640" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "5a71a6a8bae98cb9" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2678,7 +2678,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a41d4f3d0d202e38"
+        openbank.tech/policy-checksum: "cc40e28c89210505"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2992,7 +2992,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3621490a70c48d9a"
+        openbank.tech/policy-checksum: "cac502569edfc815"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "65bb22269c6c5145"
+    openbank.tech/policy-checksum: "37ab19ee85715bf4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1295,6 +1295,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "9ec9017df9886e22"
+    openbank.tech/policy-checksum: "7a8b70909ac1f61b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1341,6 +1341,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "85b8ff7cc423d640"
+    openbank.tech/policy-checksum: "5a71a6a8bae98cb9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1296,6 +1296,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d2dc7f34692d768d"
+    openbank.tech/policy-checksum: "9bc86ab3c6babbb5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1317,6 +1317,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a41d4f3d0d202e38"
+    openbank.tech/policy-checksum: "cc40e28c89210505"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1299,6 +1299,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b7e762c77801da1f"
+    openbank.tech/policy-checksum: "ca4d63f55e886dbd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1352,6 +1352,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3621490a70c48d9a"
+    openbank.tech/policy-checksum: "cac502569edfc815"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1317,6 +1317,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "4cebe9c2ff67524f"
+    openbank.tech/policy-checksum: "717aeddc4af4dbd7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1333,6 +1333,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4cebe9c2ff67524f"
+        openbank.tech/policy-checksum: "717aeddc4af4dbd7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "84031ccff59e455f"
+    openbank.tech/policy-checksum: "1c191c44e9ef4516"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1378,6 +1378,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "84031ccff59e455f"
+        openbank.tech/policy-checksum: "1c191c44e9ef4516"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "dff0fb5cdb6c59cc"
+    openbank.tech/policy-checksum: "ab20aba5d0530a0c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1283,6 +1283,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "dff0fb5cdb6c59cc"
+        openbank.tech/policy-checksum: "ab20aba5d0530a0c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "319e0fcfaffcc227"
+    openbank.tech/policy-checksum: "3873e6a51337db5f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1338,6 +1338,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "319e0fcfaffcc227"
+        openbank.tech/policy-checksum: "3873e6a51337db5f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sdd/sdd-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sdd/sdd-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sdd-service
     app.kubernetes.io/part-of: sdd
   annotations:
-    openbank.tech/policy-checksum: "b53ee870e162e783"
+    openbank.tech/policy-checksum: "f8f7bebe78fb0132"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1363,6 +1363,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/sdd/sdd-service.yaml
+++ b/openbank-infra/gitops/components/sdd/sdd-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sdd-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b53ee870e162e783"
+        openbank.tech/policy-checksum: "f8f7bebe78fb0132"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "9f4f49138210b205"
+    openbank.tech/policy-checksum: "9eaf5692af94840a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1349,6 +1349,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -35,7 +35,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9f4f49138210b205"
+        openbank.tech/policy-checksum: "9eaf5692af94840a"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "0f721db9ec4019f8"
+    openbank.tech/policy-checksum: "f359d78bd560b096"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1286,6 +1286,7 @@ data:
             - account.search
             - account.unfreeze
             - account.update
+            - balance.approval.decide
             - balance.credit
             - balance.debit
             - balance.hold

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0f721db9ec4019f8"
+        openbank.tech/policy-checksum: "f359d78bd560b096"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules-opa-data.yaml
+++ b/openbank-libs/governance/rules-opa-data.yaml
@@ -251,6 +251,7 @@ authz:
         - account.search
         - account.unfreeze
         - account.update
+        - balance.approval.decide
         - balance.credit
         - balance.debit
         - balance.hold

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -2570,6 +2570,7 @@ authz:
         - account.search
         - account.unfreeze
         - account.update
+        - balance.approval.decide
         - balance.credit
         - balance.debit
         - balance.hold
@@ -2807,6 +2808,7 @@ shared_m2m_matrix_write_grants:
     - account.search
     - account.unfreeze
     - account.update
+    - balance.approval.decide
     - balance.credit
     - balance.debit
     - balance.hold


### PR DESCRIPTION
## Summary

- `openbank-balance-service`'s four-eyes checker endpoint, `PATCH /api/v1/balances/approvals/{id}` (`ApprovalResource.decide`, `@RolesAllowed(OPERATOR, ADMIN)`, `@Authorize(action = "balance.approval.decide")`), is where a different operator approves or rejects a paused `balance.credit`/`balance.debit` request (ADR-0155).
- `balance.approval.decide` was **missing** from `rules.yaml`'s `authz.role_action_matrix`, and `balance_rest_ext.rego` has no rule for it either. The only path that can admit the action is base `rest.rego`'s `matrix-allows`, which reads the matrix directly — with the action absent, real OPA evaluation resolves `allow=false` for every OPERATOR/ADMIN.
- `openbank-balance-service` runs `AUTHZ_ENFORCE=true` in production (unlike `sanctions-service`, which is shadow-mode), so this endpoint has been 403ing for every real operator trying to clear a paused credit/debit — a live, silent, money-path authorization defect.
- Found via real OPA-bundle evaluation while verifying PR #5686 (issue #5679). Not caused by that work — pre-existing. No issue number was pre-filed for this specific gap, so it's fully described here and in the commit message.

## Root cause and fix

Mirrors how `sanctions.approval.decide` / `lending.approval.decide` are already granted:

1. Added `balance.approval.decide` to `role_action_matrix.ROLE_OPERATOR.grant` in `openbank-libs/governance/rules.yaml` (`ROLE_ADMIN` inherits via the existing `inherits: ROLE_OPERATOR`). No new `allowed_reasons` rule needed — `matrix-allows` alone is sufficient, same mechanism as sanctions/lending's equivalent actions.
2. Added `balance.approval.decide` to the enforced `shared_m2m_matrix_write_grants.declared` list (gate: `check-matrix-write-grants.py`) — every matrix write grant must be explicitly declared there as a reviewable security decision.
3. **The trap**: `matrix-allows` is role-only. Granting the action to `ROLE_OPERATOR` would, without a further guard, also admit `service-account-openbank-edge` — the customer-facing M2M identity, which carries `ROLE_OPERATOR` in the deployed realm template. `balance_rest_ext.rego` already vetoes that identity from every other balance write for exactly this reason (issue #3734); extended the same `prohibited` block to cover `balance.approval.decide`.
4. Regenerated the derived OPA artifacts this change touches: `rules-opa-data.yaml` (`role_action_matrix` is in OPA's read set) and **every** service's OPA bundle ConfigMap + pod-roll checksum annotation (`find openbank-infra/gitops/components -name 'gen-*opa-bundle*.sh' | sort | xargs -n1 bash`) — required because a `rules.yaml` key OPA reads changed, and `.github/workflows/opa-policy.yml` re-runs every generator and diffs the whole `openbank-infra/gitops/components` tree. This is why the diff touches 74 files under `gitops/components` even though only `balances/` has a substantive rule change — every other bundle only got a re-stamped checksum from the shared `rules-data.yaml` input, confirmed byte-for-byte reproducible (regenerated twice, identical output).

## Verification — by effect, not by appearance

Ran `opa eval` against the actual regenerated `balance-opa-bundle.yaml` ConfigMap contents (extracted to the sidecar's own directory layout: `rules-data.yaml` → `rules/data.yaml`, `agents-data.yaml` → `agents/data.yaml`):

| Principal | Action | Result | Reason |
|---|---|---|---|
| `HUMAN` + `ROLE_OPERATOR` | `balance.approval.decide` | `allow=true` | `matrix-allows` |
| `HUMAN` + `ROLE_VIEWER` (deny control) | `balance.approval.decide` | `allow=false` | — |
| `service-account-openbank-edge` + `ROLE_OPERATOR` (escalation control) | `balance.approval.decide` | `allow=false` | `prohibited` fires |

Also reproduced the bug on the **unmodified** bundle from `origin/main`: the same OPERATOR input resolves `allow=false` there, confirming this PR closes a real, currently-live gap rather than a hypothetical one.

`opa test` on `rest.rego` + `balance_rest_ext.rego` + `balance_rest_ext_test.rego`: **15/15 pass**, including 4 new cases (`test_operator_may_decide_approval`, `test_edge_may_not_decide_approval_despite_matrix_grant`, `test_prohibition_fires_for_edge_on_approval_decide`) mirroring the exact structure of this file's existing edge/M2M-tightening regression tests.

`check-matrix-write-grants.py`, `gen-rules-opa-data.py --check`, `check-opa-bundle-parses.py`, `check-opa-sidecar-bundle-shape.py`: all pass.

Kotlin: `BalanceResourceAuthzTest` gained one advisory-mode case for the endpoint, documented in the test comment as unable to exercise the real grant itself (the test profile runs no OPA sidecar) — the rego suite above is the actual regression coverage for the grant. `compileTestKotlin`, `ktlintCheck`, `detekt` all pass; the full `test` task could not be run to completion in this environment (a pre-existing, unrelated `Failed to create OidcClientImpl` Dev Services failure reproduces identically on unmodified `origin/main` for this same test class — confirmed by stashing this change and re-running).

## Test plan

- [x] `opa eval` allow/deny/escalation controls against the regenerated bundle (see table above)
- [x] `opa eval` against the pre-fix `origin/main` bundle reproduces the reported 403
- [x] `opa test` on the balance rego suite (15/15)
- [x] `check-matrix-write-grants.py`, `gen-rules-opa-data.py --check`, `check-opa-bundle-parses.py`, `check-opa-sidecar-bundle-shape.py`
- [x] `ktlintCheck` / `detekt` / `compileTestKotlin` for `openbank-balance-service`
- [ ] Full `openbank-balance-service` Gradle `test` task (blocked locally by an unrelated Dev Services OIDC connectivity issue reproducible on `origin/main`; CI should run it cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
