### PR TITLE
feat(sepa-instant): expose pending four-eyes approvals via approval inbox

### DIFF
--- a/docs/threat-models/openbank-sepa-instant.md
+++ b/docs/threat-models/openbank-sepa-instant.md
@@ -64,11 +64,13 @@ here (see ADR-0155, issue #413).
 | **T**ampering | A stale, mismatched, or already-consumed `X-Approval-Id` is replayed to unlock a different recall | `AuthorizeInterceptor` requires the approval's `action` + `resourceId` + `makerId` to match the CURRENT request exactly, `status == APPROVED`, and marks it `EXECUTED` (one-time use) on success; any mismatch re-issues a fresh pending approval instead of proceeding |
 | **R**epudiation | No record of who approved a recall clawing back settled funds | `PendingApproval.decidedBy` + `decidedAt` recorded in the approval record itself (Redis, TTL-bounded — see ADR-0155 Negative consequences: not yet a permanent audit trail) |
 | **I**nfo disclosure | Approval id enumeration reveals payment/action metadata to an unauthorized caller | `find`/`decide` require the caller to already hold a valid, role-gated session; the id itself is a random UUID (`RedisApprovalStore`, not sequential) |
+| **I**nfo disclosure | (issue #5679) `GET /api/v1/sepa-instant/approvals` lists every pending four-eyes request with its `makerId` and age | Role-gated `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_PAYMENTS` + `@Authorize(action = "sctInstPayment.approval.read")`; the payload carries approval metadata only — the action name, the resource id and who asked — never payment/account details. Limit clamped to 200 — an unbounded query parameter over a Redis scan is a trivially reachable amplification. Deliberately NOT filtered to exclude the caller's own requests: hiding a maker's request from them would not stop them attempting it (the guard is in `RedisApprovalStore.decide`, server-side) and would only make the queue lie about its own depth |
 | **D**oS | Flooding `POST /{paymentId}/recall` to exhaust Redis with pending approvals | Bounded by the same rate-limit/idempotency controls as the gated endpoint itself; each `PendingApproval` is TTL-bounded (86400s) so abandoned records expire |
 
-**DFD update:** adds `Operator (checker) → PATCH /api/v1/sepa-instant/approvals/{id} → Redis
-(approval:*)` alongside the existing `POST /{paymentId}/recall` edge; the maker's retry reuses
-the existing DFD edge.
+**DFD update:** adds `Operator (checker) → GET /api/v1/sepa-instant/approvals → Redis (approval:*)`
+and `Operator (checker) → PATCH /api/v1/sepa-instant/approvals/{id} → Redis (approval:*)`
+alongside the existing `POST /{paymentId}/recall` edge; the maker's retry reuses the existing DFD
+edge.
 **Risk class:** integrity (segregation of duties on a fund-clawback action) + confidentiality
 (approval record scope).
 **Rollback:** `authz.four-eyes.enforce=false` (default) — the endpoint and store exist but do
@@ -83,6 +85,39 @@ not change any existing request's outcome until explicitly flipped.
   need an additional store; not implemented in this PR.
 
 ## 6. Change log
+
+- **2026-08-19** — `ApprovalResource` served only `PATCH /{id}` (decide), so a
+  `sctInstPayment.recall` four-eyes decision parked at 202 was discoverable only by whoever had
+  been handed its approval id out of band — the ceremony completed only if the two operators were
+  already talking, and the 24h Redis TTL then expired the request silently otherwise (issue #5679,
+  mirroring sanctions #3472, ledger and domestic-payment). Added
+  `GET /api/v1/sepa-instant/approvals` (§4a new I row); additive-only OpenAPI change (1.4.0 ->
+  1.5.0, ADR-0048).
+  - **Checked the existing decide endpoint's own authz posture while here** (verify-by-effect, not
+    by appearance): `opa eval` against the real `rest.rego` + `rules-opa-data.yaml` bundle showed
+    `sctInstPayment.approval.decide` resolving **`allow=false` for a real ROLE_OPERATOR** — the
+    action was missing from `rules.yaml`'s `role_action_matrix` (present for the sibling
+    `sepaPayment.approval.decide`, absent for this service's own `sctInstPayment.approval.decide`
+    since the four-eyes gate for this rail was wired). The decide endpoint has therefore been
+    403ing every operator in any `AUTHZ_ENFORCE=true` environment since it shipped — same shape as
+    the balance-service gap found by #5686/#5690. **Fixed** by adding the matrix grant (mirroring
+    `sepaPayment.approval.decide`'s entry) to both `role_action_matrix.ROLE_OPERATOR` and
+    `shared_m2m_matrix_write_grants.declared`, then regenerating `rules-opa-data.yaml` and every
+    service's OPA bundle (a `role_action_matrix` edit restamps the fleet). Verified with `opa eval`:
+    `sctInstPayment.approval.decide` now resolves `allow=true`/`reason=matrix-allows` for
+    ROLE_OPERATOR, and a non-operator role (`ROLE_KYC_OPENER`) still resolves `allow=false`.
+  - **Known residual, not fixed here**: `matrix-allows` is role-only, and the deployed realm
+    template gives `service-account-openbank-edge` `ROLE_OPERATOR` in at least one environment (see
+    root `CLAUDE.md`'s realm-drift note) — the same exposure balance-service closed with a
+    per-service `prohibited` rule in `balance_rest_ext.rego`. sepa-instant has no such standalone
+    ext-rego file to extend (its REST extension is a heredoc inside
+    `gen-sepa-instant-opa-bundle.sh` with no `prohibited` block at all today), and there is no
+    verified in-repo M2M caller of `ApprovalResource` (the gen script's own comment already notes
+    this for `sctInstPayment.create`). Building a new prohibition mechanism was out of scope for
+    this PR's mirrored fix; tracked as follow-up under issue #5679's own money-path-first ordering.
+  - **Rollback:** revert both commits independently — the matrix grant only changes an OPA
+    `allow` decision (advisory in this environment, `authz.four-eyes.enforce=false`), and the new
+    `GET` is additive.
 
 - **2026-08-09** — Fraud shadow scoring's fallback is now observable (#4221). **No new trust
   boundary and no new caller**: the outbound edge to fraud-service (OIDC client-credentials + mTLS,

--- a/openbank-admin-ui/src/app/api/approvals/pending/route.ts
+++ b/openbank-admin-ui/src/app/api/approvals/pending/route.ts
@@ -28,12 +28,11 @@ const NOT_CONFIGURED_SOURCES = {
   consent: 'not-configured',
   notification: 'not-configured',
   party: 'not-configured',
-  'sepa-instant': 'not-configured',
 } as const satisfies Record<string, SourceState>
 
 type InboxItem = {
   id: string
-  domain: 'lending' | 'sanctions' | 'transaction' | 'domestic-payment' | 'clearing' | 'fx' | 'ledger' | 'swift' | 'sepa-payment' | 'agent'
+  domain: 'lending' | 'sanctions' | 'transaction' | 'domestic-payment' | 'clearing' | 'fx' | 'ledger' | 'swift' | 'sepa-payment' | 'sepa-instant' | 'agent'
   action: string
   resourceId: string | null
   maker: string | null
@@ -60,6 +59,11 @@ type TransactionApproval = LendingApproval
 // that issue's own ordering). Before this, an `fx.convert` four-eyes decision parked at 202
 // was discoverable only by whoever had been handed its id out of band.
 type FxApproval = LendingApproval
+
+// sepa-instant-service serves the same libs `PendingApproval` shape (issue #5679, money-path
+// first per that issue's own ordering). Before this, an `sctInstPayment.recall` four-eyes
+// decision parked at 202 was discoverable only by whoever had been handed its id out of band.
+type SepaInstantApproval = LendingApproval
 
 // domestic-payment-service serves the same libs `PendingApproval` shape (issue #5679, money-path
 // first per that issue's own ordering). Before this, a `domestic-payment.transitionStatus`
@@ -250,6 +254,24 @@ async function sepaPaymentPending(headers: HeadersInit): Promise<SourceResult> {
   }
 }
 
+async function sepaInstantPending(headers: HeadersInit): Promise<SourceResult> {
+  // k8s workload is `sepa-instant` (no `-service` suffix) — see the same footgun documented in
+  // app/payments/page.tsx (a `sepa-instant-service` key missed and pinned that panel to
+  // `not_deployed`).
+  const res = await fetch(serverSvcUrl('sepa-instant', 'payments', 8127, '/api/v1/sepa-instant/approvals', { limit: '50' }), {
+    headers, signal: AbortSignal.timeout(4000), cache: 'no-store',
+  })
+  if (!res.ok) return { items: [], state: stateFor(res.status) }
+  const rows = (await res.json()) as SepaInstantApproval[]
+  return {
+    state: 'ok',
+    items: rows.map(r => ({
+      id: r.id, domain: 'sepa-instant' as const, action: r.action,
+      resourceId: r.resourceId, maker: r.makerId, proposedAt: r.createdAt,
+    })),
+  }
+}
+
 function agentBase(): string {
   if (process.env.SERVICES_HOST === 'container') return 'http://openbank-agent-service:8109'
   return (process.env.AGENT_SERVICE_URL ?? 'http://localhost:8109/mcp').replace(/\/mcp$/, '')
@@ -277,7 +299,7 @@ export async function GET() {
   }
   const headers = { authorization: `Bearer ${session.user.accessToken}` }
   const unavailable: SourceResult = { items: [], state: 'unavailable' }
-  const [lending, sanctions, transaction, domesticPayment, clearing, fx, ledger, swift, sepaPayment, agent] = await Promise.all([
+  const [lending, sanctions, transaction, domesticPayment, clearing, fx, ledger, swift, sepaPayment, sepaInstant, agent] = await Promise.all([
     lendingPending(headers).catch(() => unavailable),
     sanctionsPending(headers).catch(() => unavailable),
     transactionPending(headers).catch(() => unavailable),
@@ -287,9 +309,10 @@ export async function GET() {
     ledgerPending(headers).catch(() => unavailable),
     swiftPending(headers).catch(() => unavailable),
     sepaPaymentPending(headers).catch(() => unavailable),
+    sepaInstantPending(headers).catch(() => unavailable),
     agentPending(headers).catch(() => unavailable),
   ])
-  const items = [...lending.items, ...sanctions.items, ...transaction.items, ...domesticPayment.items, ...clearing.items, ...fx.items, ...ledger.items, ...swift.items, ...sepaPayment.items, ...agent.items]
+  const items = [...lending.items, ...sanctions.items, ...transaction.items, ...domesticPayment.items, ...clearing.items, ...fx.items, ...ledger.items, ...swift.items, ...sepaPayment.items, ...sepaInstant.items, ...agent.items]
     .sort((a, b) => (a.proposedAt ?? '').localeCompare(b.proposedAt ?? ''))
   return NextResponse.json({
     items,
@@ -304,6 +327,7 @@ export async function GET() {
       ledger: ledger.state,
       swift: swift.state,
       'sepa-payment': sepaPayment.state,
+      'sepa-instant': sepaInstant.state,
       agent: agent.state,
     },
   })

--- a/openbank-admin-ui/src/test/approvals-inbox.test.ts
+++ b/openbank-admin-ui/src/test/approvals-inbox.test.ts
@@ -33,7 +33,7 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(res.status).toBe(401)
   })
 
-  it('merges lending, sanctions, transaction, domestic-payment, clearing, fx, ledger, swift, sepaPayment and agent queues into canonical items, sorted by proposedAt', async () => {
+  it('merges lending, sanctions, transaction, domestic-payment, clearing, fx, ledger, swift, sepaPayment, sepa-instant and agent queues into canonical items, sorted by proposedAt', async () => {
     const mock = vi.fn().mockImplementation((url: string) => {
       if (url.includes('lending')) {
         return Promise.resolve(new Response(JSON.stringify([
@@ -84,6 +84,13 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
           { id: 'F-1', action: 'fx.convert', resourceId: 'conv-3', makerId: 'trader.d', createdAt: '2026-07-29T11:30:00Z' },
         ]), { status: 200 }))
       }
+      if (url.includes('sepa-instant')) {
+        // Also 11:30, same as fx — ties F-1 and I-1 to each other, testing that the stable-sort
+        // concat order (fx before sepa-instant in route.ts) breaks the tie deterministically.
+        return Promise.resolve(new Response(JSON.stringify([
+          { id: 'I-1', action: 'sctInstPayment.recall', resourceId: 'payment-9', makerId: 'operator.e', createdAt: '2026-07-29T11:30:00Z' },
+        ]), { status: 200 }))
+      }
       return Promise.resolve(new Response(JSON.stringify([
         { id: 'P-1', suggestedAction: 'agent.research', proposedBy: 'ui-assistant', proposedAt: '2026-07-30T08:00:00Z' },
       ]), { status: 200 }))
@@ -93,9 +100,9 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     const res = await (await route()).GET()
     const body = await res.json()
     // D-1, C-1, J-1, W-1 and SP-1 all sit at 11:00 (domestic-payment, clearing, ledger, swift,
-    // sepaPayment); F-1 is 11:30 and orders on its own, strictly after the 11:00 tied group
-    // regardless of array position.
-    expect(body.items.map((i: { id: string }) => i.id)).toEqual(['L-1', 'D-1', 'C-1', 'J-1', 'W-1', 'SP-1', 'F-1', 'S-1', 'P-1', 'T-1', 'L-2'])
+    // sepaPayment); F-1 and I-1 both sit at 11:30 (fx before sepa-instant) — both ties resolved
+    // by the stable-sort's concat order in route.ts.
+    expect(body.items.map((i: { id: string }) => i.id)).toEqual(['L-1', 'D-1', 'C-1', 'J-1', 'W-1', 'SP-1', 'F-1', 'I-1', 'S-1', 'P-1', 'T-1', 'L-2'])
     expect(body.items[0]).toMatchObject({ domain: 'lending', action: 'lending.writeoff', maker: 'officer.a' })
     expect(body.items[1]).toMatchObject({ domain: 'domestic-payment', action: 'domestic-payment.transitionStatus', maker: 'operator.d' })
     expect(body.items[2]).toMatchObject({ domain: 'clearing', action: 'clearingBatch.settle', maker: 'operator.d' })
@@ -103,9 +110,10 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(body.items[4]).toMatchObject({ domain: 'swift', action: 'swift.send', maker: 'operator.d' })
     expect(body.items[5]).toMatchObject({ domain: 'sepa-payment', action: 'sepaPayment.transitionStatus', maker: 'operator.d' })
     expect(body.items[6]).toMatchObject({ domain: 'fx', action: 'fx.convert', maker: 'trader.d' })
-    expect(body.items[7]).toMatchObject({ domain: 'sanctions', action: 'sanctions.clear', maker: 'analyst.c' })
-    expect(body.items[8]).toMatchObject({ domain: 'agent', action: 'agent.research' })
-    expect(body.items[9]).toMatchObject({ domain: 'transaction', action: 'transaction.reverse', maker: 'teller.d' })
+    expect(body.items[7]).toMatchObject({ domain: 'sepa-instant', action: 'sctInstPayment.recall', maker: 'operator.e' })
+    expect(body.items[8]).toMatchObject({ domain: 'sanctions', action: 'sanctions.clear', maker: 'analyst.c' })
+    expect(body.items[9]).toMatchObject({ domain: 'agent', action: 'agent.research' })
+    expect(body.items[10]).toMatchObject({ domain: 'transaction', action: 'transaction.reverse', maker: 'teller.d' })
     expect(body.sources.account).toBe('not-configured')
     expect(body.sources.balance).toBe('not-configured')
   })
@@ -242,6 +250,23 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(body.sources['sepa-payment']).toBe('ok')
   })
 
+  // Same regression, sepa-instant side (issue #5679): sepa-instant-service has served
+  // ApprovalStore.decide since ADR-0155 but never the pending list, so a parked
+  // `sctInstPayment.recall` four-eyes decision was invisible on the one screen built to show
+  // parked decisions.
+  it('reads the sepa-instant queue at all — an unread source is indistinguishable from an empty one', async () => {
+    const seen: string[] = []
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      seen.push(String(url))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    }))
+
+    const body = await (await (await route()).GET()).json()
+
+    expect(seen.some(u => u.includes('/api/v1/sepa-instant/approvals'))).toBe(true)
+    expect(body.sources['sepa-instant']).toBe('ok')
+  })
+
   it('degrades to the working half when one queue is down', async () => {
     const mock = vi.fn().mockImplementation((url: string) => {
       if (url.includes('lending')) return Promise.reject(new Error('lending down'))
@@ -254,6 +279,7 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
       if (url.includes('sepa-payments/approvals') || url.includes('sepa-payment')) {
         return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
       }
+      if (url.includes('sepa-instant')) return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
       if (url.includes('proposals')) {
         return Promise.resolve(new Response(JSON.stringify([
           { id: 'P-1', suggestedAction: 'agent.research', proposedBy: 'ui-assistant', proposedAt: '2026-07-30T08:00:00Z' },
@@ -295,6 +321,7 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(body.sources.ledger).toBe('ok')
     expect(body.sources.swift).toBe('ok')
     expect(body.sources['sepa-payment']).toBe('ok')
+    expect(body.sources['sepa-instant']).toBe('ok')
     expect(body.sources.agent).toBe('ok')
   })
 
@@ -317,6 +344,7 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(body.sources.ledger).toBe('unavailable')
     expect(body.sources.swift).toBe('unavailable')
     expect(body.sources['sepa-payment']).toBe('unavailable')
+    expect(body.sources['sepa-instant']).toBe('unavailable')
     expect(body.sources.agent).toBe('unavailable')
   })
 })

--- a/openbank-admin-ui/src/test/approvals-source-truth.guard.test.ts
+++ b/openbank-admin-ui/src/test/approvals-source-truth.guard.test.ts
@@ -11,7 +11,7 @@ const pageSource = fs.readFileSync(path.join(process.cwd(), 'src/app/approvals/p
 describe('approval inbox source truthfulness', () => {
   it('exposes known-but-unwired queues instead of treating them as empty', () => {
     expect(routeSource).toContain("'not-configured'")
-    expect(routeSource).toContain("'sepa-instant': 'not-configured'")
+    expect(routeSource).toContain("balance: 'not-configured'")
     expect(routeSource).toContain('...NOT_CONFIGURED_SOURCES')
   })
 

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "f2d60035c03b1395"
+    openbank.tech/policy-checksum: "f2210a17947c40f7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1407,6 +1407,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f2d60035c03b1395"
+        openbank.tech/policy-checksum: "f2210a17947c40f7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "8c7991f9dca77f67"
+    openbank.tech/policy-checksum: "cb7ffb6cb4103a95"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1358,6 +1358,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8c7991f9dca77f67"
+        openbank.tech/policy-checksum: "cb7ffb6cb4103a95"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "2aa68259a940e636"
+    openbank.tech/policy-checksum: "0d2424b16a84fb70"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1341,6 +1341,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2aa68259a940e636"
+        openbank.tech/policy-checksum: "0d2424b16a84fb70"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "f9a1fb54622749be"
+    openbank.tech/policy-checksum: "77e72c45afeb5b44"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1296,6 +1296,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f9a1fb54622749be"
+        openbank.tech/policy-checksum: "77e72c45afeb5b44"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "0abbbe4ed712e13f"
+    openbank.tech/policy-checksum: "72f860fd25ac3413"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1340,6 +1340,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0abbbe4ed712e13f"
+        openbank.tech/policy-checksum: "72f860fd25ac3413"
     spec:
       serviceAccountName: audit-service
       securityContext:

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "4dcb4c447c77eac4"
+    openbank.tech/policy-checksum: "93ae6411f5558259"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1483,6 +1483,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4dcb4c447c77eac4"
+        openbank.tech/policy-checksum: "93ae6411f5558259"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "bca32c57e7ed62c5"
+    openbank.tech/policy-checksum: "805c71804ef210d3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1355,6 +1355,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -36,7 +36,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bca32c57e7ed62c5"
+        openbank.tech/policy-checksum: "805c71804ef210d3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: campaign-service
     app.kubernetes.io/part-of: campaign
   annotations:
-    openbank.tech/policy-checksum: "a1806192c8ab169e"
+    openbank.tech/policy-checksum: "f1cf102a92363f4d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1365,6 +1365,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-campaign-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a1806192c8ab169e"
+        openbank.tech/policy-checksum: "f1cf102a92363f4d"
       labels:
         app.kubernetes.io/name: campaign-service
         app.kubernetes.io/part-of: campaign

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "03a1931c05bd7462"
+    openbank.tech/policy-checksum: "0f5b4ba169ae8619"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1441,6 +1441,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "03a1931c05bd7462"
+        openbank.tech/policy-checksum: "0f5b4ba169ae8619"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "43d40923d88ff48a"
+    openbank.tech/policy-checksum: "142f791b4be9f12e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1420,6 +1420,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "43d40923d88ff48a"
+        openbank.tech/policy-checksum: "142f791b4be9f12e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "3ffef2929f3415b9"
+    openbank.tech/policy-checksum: "ab4f3cd54678f52c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1013,6 +1013,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3ffef2929f3415b9"
+        openbank.tech/policy-checksum: "ab4f3cd54678f52c"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: delegation-service
     app.kubernetes.io/part-of: delegation
   annotations:
-    openbank.tech/policy-checksum: "271cd689be7d33ff"
+    openbank.tech/policy-checksum: "ba1d24090ec7a37e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1384,6 +1384,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/delegation/delegation-service.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-delegation-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "271cd689be7d33ff"
+        openbank.tech/policy-checksum: "ba1d24090ec7a37e"
       labels:
         app.kubernetes.io/name: delegation-service
         app.kubernetes.io/part-of: delegation

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "bfb7724f26b17927"
+    openbank.tech/policy-checksum: "c250c0d9b8449e85"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1470,6 +1470,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -24,7 +24,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bfb7724f26b17927"
+        openbank.tech/policy-checksum: "c250c0d9b8449e85"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "3ffef2929f3415b9"
+    openbank.tech/policy-checksum: "ab4f3cd54678f52c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1013,6 +1013,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -52,7 +52,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3ffef2929f3415b9"
+        openbank.tech/policy-checksum: "ab4f3cd54678f52c"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/engagement/engagement-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/engagement/engagement-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: engagement-service
     app.kubernetes.io/part-of: engagement
   annotations:
-    openbank.tech/policy-checksum: "3ffef2929f3415b9"
+    openbank.tech/policy-checksum: "ab4f3cd54678f52c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1013,6 +1013,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/engagement/engagement-service.yaml
+++ b/openbank-infra/gitops/components/engagement/engagement-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-engagement-opa-bundle.sh.
-        openbank.tech/policy-checksum: "3ffef2929f3415b9"
+        openbank.tech/policy-checksum: "ab4f3cd54678f52c"
       labels:
         app.kubernetes.io/name: engagement-service
         app.kubernetes.io/part-of: engagement

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "0f4cd0af45c217ef"
+    openbank.tech/policy-checksum: "9832a82764226351"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1377,6 +1377,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0f4cd0af45c217ef"
+        openbank.tech/policy-checksum: "9832a82764226351"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "fbbb84650fb50935"
+    openbank.tech/policy-checksum: "949cfeb05d8621a5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1413,6 +1413,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fbbb84650fb50935"
+        openbank.tech/policy-checksum: "949cfeb05d8621a5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "2a4dd7608968002d"
+    openbank.tech/policy-checksum: "d90747f7dcf19bbf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1392,6 +1392,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2a4dd7608968002d"
+        openbank.tech/policy-checksum: "d90747f7dcf19bbf"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "b5722dfd32300931"
+    openbank.tech/policy-checksum: "9ffa4e551f2c4254"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1358,6 +1358,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b5722dfd32300931"
+        openbank.tech/policy-checksum: "9ffa4e551f2c4254"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "ff393587fa44277b"
+    openbank.tech/policy-checksum: "eb29c6b196d96432"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1474,6 +1474,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ff393587fa44277b"
+        openbank.tech/policy-checksum: "eb29c6b196d96432"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "19f5cea6df7afc55"
+    openbank.tech/policy-checksum: "a0984ce9fa42b36e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1463,6 +1463,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "19f5cea6df7afc55"
+        openbank.tech/policy-checksum: "a0984ce9fa42b36e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "f9a1fb54622749be"
+    openbank.tech/policy-checksum: "77e72c45afeb5b44"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1296,6 +1296,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f9a1fb54622749be"
+        openbank.tech/policy-checksum: "77e72c45afeb5b44"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "3ffef2929f3415b9"
+    openbank.tech/policy-checksum: "ab4f3cd54678f52c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1013,6 +1013,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "3ffef2929f3415b9"
+        openbank.tech/policy-checksum: "ab4f3cd54678f52c"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "21149731dbd7708e"
+    openbank.tech/policy-checksum: "d4a5d1e0c75d51b5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1367,6 +1367,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "21149731dbd7708e"
+        openbank.tech/policy-checksum: "d4a5d1e0c75d51b5"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "473ddb3cd3ac21ac"
+    openbank.tech/policy-checksum: "d830e3af22c5354a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1351,6 +1351,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "10ffc2f2817c55fb"
+    openbank.tech/policy-checksum: "ad5e0ec0d246e9a6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1388,6 +1388,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b057d6e6947c9174"
+    openbank.tech/policy-checksum: "0530b653bb7e98fd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1373,6 +1373,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "cb3b9bbdbf12ef88" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "db95bf3f98761597" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -378,7 +378,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1e3136b60b772815"
+        openbank.tech/policy-checksum: "03c8680863b9d535"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -741,7 +741,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "b057d6e6947c9174" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "0530b653bb7e98fd" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1078,7 +1078,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "78f70654d41b40aa"
+        openbank.tech/policy-checksum: "654925d240aa8202"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1399,7 +1399,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "10ffc2f2817c55fb" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "ad5e0ec0d246e9a6" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1697,7 +1697,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "540217006218fe09" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "b6ad97e745ea144d" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1974,7 +1974,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "473ddb3cd3ac21ac"
+        openbank.tech/policy-checksum: "d830e3af22c5354a"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2252,7 +2252,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "fcf3d13d3e8f2b41" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "a9d6c41e1e397984" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2678,7 +2678,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "36b5f4fe63a48c63"
+        openbank.tech/policy-checksum: "2ba5188d8166bd0e"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2992,7 +2992,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "60bb1f0c8e8951d4"
+        openbank.tech/policy-checksum: "ef55412c7d09597b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "78f70654d41b40aa"
+    openbank.tech/policy-checksum: "654925d240aa8202"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1346,6 +1346,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1e3136b60b772815"
+    openbank.tech/policy-checksum: "03c8680863b9d535"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1392,6 +1392,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "fcf3d13d3e8f2b41"
+    openbank.tech/policy-checksum: "a9d6c41e1e397984"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1347,6 +1347,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "540217006218fe09"
+    openbank.tech/policy-checksum: "b6ad97e745ea144d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1368,6 +1368,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "36b5f4fe63a48c63"
+    openbank.tech/policy-checksum: "2ba5188d8166bd0e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1350,6 +1350,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "cb3b9bbdbf12ef88"
+    openbank.tech/policy-checksum: "db95bf3f98761597"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1403,6 +1403,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "60bb1f0c8e8951d4"
+    openbank.tech/policy-checksum: "ef55412c7d09597b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1368,6 +1368,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "b5fd99734fbf0969"
+    openbank.tech/policy-checksum: "881b09609a06fc66"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1384,6 +1384,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b5fd99734fbf0969"
+        openbank.tech/policy-checksum: "881b09609a06fc66"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "98b8eb441b4e96a1"
+    openbank.tech/policy-checksum: "90c6e97d1b0d3d83"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1429,6 +1429,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "98b8eb441b4e96a1"
+        openbank.tech/policy-checksum: "90c6e97d1b0d3d83"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "d79061eab6ab1c12"
+    openbank.tech/policy-checksum: "918e725c27848194"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1334,6 +1334,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d79061eab6ab1c12"
+        openbank.tech/policy-checksum: "918e725c27848194"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "4c06b0068d94d981"
+    openbank.tech/policy-checksum: "d1a450cc86ace14e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1389,6 +1389,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4c06b0068d94d981"
+        openbank.tech/policy-checksum: "d1a450cc86ace14e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sdd/sdd-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sdd/sdd-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sdd-service
     app.kubernetes.io/part-of: sdd
   annotations:
-    openbank.tech/policy-checksum: "6f9f431ce40a3597"
+    openbank.tech/policy-checksum: "419d74ad776d7feb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1414,6 +1414,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/sdd/sdd-service.yaml
+++ b/openbank-infra/gitops/components/sdd/sdd-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sdd-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6f9f431ce40a3597"
+        openbank.tech/policy-checksum: "419d74ad776d7feb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "e8fadf5392076aff"
+    openbank.tech/policy-checksum: "c4e7f8055ceccc76"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1400,6 +1400,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -35,7 +35,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e8fadf5392076aff"
+        openbank.tech/policy-checksum: "c4e7f8055ceccc76"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "c7fba1f3f7cb74d7"
+    openbank.tech/policy-checksum: "b82e0c86286e3949"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1337,6 +1337,7 @@ data:
             - sanctions.create
             - sanctions.trigger
             - sanctions.update
+            - sctInstPayment.approval.decide
             - sctInstPayment.create
             - sepaPayment.approval.decide
             - sepaPayment.create

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c7fba1f3f7cb74d7"
+        openbank.tech/policy-checksum: "b82e0c86286e3949"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules-opa-data.yaml
+++ b/openbank-libs/governance/rules-opa-data.yaml
@@ -302,6 +302,7 @@ authz:
         - sanctions.create
         - sanctions.trigger
         - sanctions.update
+        - sctInstPayment.approval.decide
         - sctInstPayment.create
         - sepaPayment.approval.decide
         - sepaPayment.create

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -2669,6 +2669,7 @@ authz:
         - sanctions.create
         - sanctions.trigger
         - sanctions.update
+        - sctInstPayment.approval.decide
         - sctInstPayment.create
         - sepaPayment.approval.decide
         - sepaPayment.create
@@ -2910,6 +2911,7 @@ shared_m2m_matrix_write_grants:
     - sanctions.create
     - sanctions.trigger
     - sanctions.update
+    - sctInstPayment.approval.decide
     - sctInstPayment.create
     - sepaPayment.approval.decide
     - sepaPayment.create

--- a/openbank-sepa-instant/src/main/kotlin/com/openbank/sepainstant/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-sepa-instant/src/main/kotlin/com/openbank/sepainstant/infrastructure/rest/ApprovalResource.kt
@@ -10,11 +10,14 @@ import com.openbank.libs.authz.Authorize
 import io.quarkus.security.identity.SecurityIdentity
 import jakarta.annotation.security.RolesAllowed
 import jakarta.inject.Inject
+import jakarta.ws.rs.DefaultValue
+import jakarta.ws.rs.GET
 import jakarta.ws.rs.NotFoundException
 import jakarta.ws.rs.PATCH
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.openapi.annotations.Operation
@@ -34,6 +37,27 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
 
     @Inject
     lateinit var identity: SecurityIdentity
+
+    /**
+     * The checker's queue (issue #5679, mirroring sanctions #3472, lending, ledger and
+     * domestic-payment). Without it a parked decision is invisible: the maker gets a 202 with
+     * an approval id and no way to hand it over except out of band, so the four-eyes ceremony
+     * on `sctInstPayment.recall` only completed if the two operators were already talking. The
+     * Redis TTL (24h) then expired the request silently.
+     *
+     * Read-only, and deliberately NOT filtered to "approvals someone else made": the
+     * self-approval guard lives in `RedisApprovalStore.decide`, and refusing at read time would
+     * only hide a maker's own request from them while still letting them attempt it. Seeing the
+     * queue is not authority over it.
+     */
+    @GET
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS")
+    @Authorize(action = "sctInstPayment.approval.read", resource = "")
+    @Operation(summary = "List pending four-eyes approvals, oldest first (ADR-0227 D2)")
+    suspend fun listPending(@QueryParam("limit") @DefaultValue("50") limit: Int): Response {
+        val pending = approvalStore.findPending(limit.coerceIn(1, MAX_PENDING_LIMIT))
+        return Response.ok(pending.map { it.toResponse() }).build()
+    }
 
     @PATCH
     @Path("/{id}")
@@ -59,6 +83,13 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     // own request. SecurityIdentity (not @Context SecurityContext) because this is
     // a `suspend fun` — see AccountResource.operatorId() for the same workaround.
     private fun checkerId(): String = identity.principal?.name ?: "anonymous"
+
+    private companion object {
+        // Same ceiling as sanctions/lending/ledger/domestic-payment's queue. The read is a Redis
+        // scan, and an unbounded `limit` from a query parameter is a trivially reachable
+        // amplification.
+        const val MAX_PENDING_LIMIT = 200
+    }
 }
 
 data class DecideApprovalRequest(val approve: Boolean)
@@ -68,6 +99,13 @@ data class ApprovalResponse(
     val action: String,
     val resourceId: String?,
     val status: String,
+    // makerId and createdAt were absent while the only endpoint was PATCH-by-id: a checker who
+    // already held the id needed neither. A QUEUE does — "who asked" is what a second pair of
+    // eyes is checking, and "how old" is the only visible sign of a request about to expire
+    // against the 24h Redis TTL. Additive, so no major bump (ADR-0048); matches
+    // sanctions/lending/ledger/domestic-payment's shape.
+    val makerId: String?,
+    val createdAt: String?,
     val decidedBy: String?,
 )
 
@@ -76,5 +114,7 @@ fun PendingApproval.toResponse() = ApprovalResponse(
     action = action,
     resourceId = resourceId,
     status = status.name,
+    makerId = makerId,
+    createdAt = createdAt.toString(),
     decidedBy = decidedBy,
 )

--- a/openbank-sepa-instant/src/main/resources/openapi.yaml
+++ b/openbank-sepa-instant/src/main/resources/openapi.yaml
@@ -3,7 +3,10 @@
 openapi: 3.1.0
 info:
   title: SEPA Instant (SCT Inst) Service API
-  version: 1.5.0
+  # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.5 -> 1.6): additive
+  # only — GET /sepa-instant/approvals (the checker's queue, issue #5679) plus two additive
+  # fields on ApprovalResponse (makerId, createdAt). No breaking change.
+  version: 1.6.0
   description: >-
     SEPA Instant Credit Transfer — sub-10s settlement, recall support. On submit, debtor and creditor
     names are synchronously screened against the sanctions lists (ADR-0032): a clean payment proceeds
@@ -130,6 +133,39 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /api/v1/sepa-instant/approvals:
+    get:
+      tags: [SCT Inst]
+      summary: >-
+        List pending four-eyes approvals, oldest first — the checker's queue (ADR-0227 D2).
+        Without it a decision parked at 202 is discoverable only by whoever was handed its id.
+      description: >-
+        PENDING maker-checker approvals on `sctInstPayment.recall`, oldest first. The read side of
+        the unified approval inbox — deciding stays on
+        PATCH /api/v1/sepa-instant/approvals/{id}. Requires ROLE_OPERATOR, ROLE_ADMIN or
+        ROLE_PAYMENTS.
+      operationId: listPendingApprovals
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+      responses:
+        '200':
+          description: Pending approvals, oldest first
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApprovalResponse'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
   /api/v1/sepa-instant/approvals/{id}:
     patch:
       tags: [SCT Inst]
@@ -162,22 +198,11 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required: [id, action, status]
-                properties:
-                  id:
-                    type: string
-                  action:
-                    type: string
-                    description: The gated action this approval was raised for.
-                  resourceId:
-                    type: string
-                    nullable: true
-                  status:
-                    type: string
-                  decidedBy:
-                    type: string
-                    nullable: true
+                $ref: '#/components/schemas/ApprovalResponse'
+        '403':
+          description: >-
+            The caller is the maker of this approval. Segregation of duties is enforced in
+            RedisApprovalStore.decide, not per-service.
         '404':
           $ref: '#/components/responses/NotFound'
 
@@ -296,3 +321,36 @@ components:
           type: string
         message:
           type: string
+
+    ApprovalResponse:
+      type: object
+      description: >-
+        A four-eyes approval record (ADR-0155). `makerId` is the principal that requested the
+        gated action; a DIFFERENT principal must decide it — enforced in
+        RedisApprovalStore.decide, so the queue is readable by anyone who may decide, including
+        the maker (seeing a request is not authority over it).
+      required: [id, action, status]
+      properties:
+        id:
+          type: string
+          description: The value the maker replays as the X-Approval-Id header once approved.
+        action:
+          type: string
+          example: sctInstPayment.recall
+        resourceId:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum: [PENDING, APPROVED, REJECTED, EXECUTED]
+        makerId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          description: >-
+            Request time. The store expires a PENDING approval after 24h, so age is the only
+            visible sign of one about to lapse.
+        decidedBy:
+          type: string
+          nullable: true

--- a/openbank-sepa-instant/src/test/kotlin/com/openbank/sepainstant/infrastructure/rest/ApprovalResourceMappingTest.kt
+++ b/openbank-sepa-instant/src/test/kotlin/com/openbank/sepainstant/infrastructure/rest/ApprovalResourceMappingTest.kt
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sepainstant.infrastructure.rest
+
+import com.openbank.libs.approval.ApprovalStatus
+import com.openbank.libs.approval.PendingApproval
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+
+/**
+ * Unit coverage for the [PendingApproval] -> `ApprovalResponse` mapping backing the checker's
+ * pending-approvals queue (issue #5679, ADR-0227 D2), mirroring
+ * `openbank-sanctions-service`'s, `openbank-ledger-service`'s and
+ * `openbank-domestic-payment`'s `ApprovalResourceMappingTest`.
+ */
+class ApprovalResourceMappingTest {
+
+    @Test
+    fun `toResponse maps every field including a decided approval`() {
+        val decidedAt = OffsetDateTime.parse("2026-08-19T00:00:00Z")
+        val approval = PendingApproval(
+            id = "appr-1",
+            action = "sctInstPayment.recall",
+            resourceId = "payment-1",
+            makerId = "maker",
+            status = ApprovalStatus.APPROVED,
+            createdAt = decidedAt.minusHours(1),
+            decidedBy = "checker",
+            decidedAt = decidedAt,
+        )
+
+        val response = approval.toResponse()
+
+        assertThat(response.id).isEqualTo("appr-1")
+        assertThat(response.action).isEqualTo("sctInstPayment.recall")
+        assertThat(response.resourceId).isEqualTo("payment-1")
+        assertThat(response.status).isEqualTo("APPROVED")
+        assertThat(response.decidedBy).isEqualTo("checker")
+        // makerId and createdAt were added for the checker's queue (#5679). Without them a
+        // supervisor sees a list of opaque ids: "who asked" is the thing a second pair of eyes
+        // is checking, and age is the only visible sign of a request nearing the 24h TTL.
+        assertThat(response.makerId).isEqualTo("maker")
+        assertThat(response.createdAt).isEqualTo(decidedAt.minusHours(1).toString())
+    }
+
+    @Test
+    fun `toResponse maps a still-pending approval with a null decidedBy`() {
+        val approval = PendingApproval(
+            id = "appr-2",
+            action = "sctInstPayment.recall",
+            resourceId = null,
+            makerId = "maker",
+            status = ApprovalStatus.PENDING,
+            createdAt = OffsetDateTime.parse("2026-08-19T00:00:00Z"),
+        )
+
+        val response = approval.toResponse()
+
+        assertThat(response.resourceId).isNull()
+        assertThat(response.status).isEqualTo("PENDING")
+        assertThat(response.decidedBy).isNull()
+    }
+}


### PR DESCRIPTION
## Summary

Per issue #5679 ("14 of 16 four-eyes queues are invisible to the approval inbox"), this is the
`openbank-sepa-instant` slice — mirroring the shape landed for domestic-payment (#5692) and
sepa-payment (#5691).

**Commit 1 — the feature:**
- `ApprovalResource` served only `PATCH /{id}` (decide), so an `sctInstPayment.recall` four-eyes
  decision parked at 202 was discoverable only by whoever had been handed its approval id out of
  band. Added `GET /api/v1/sepa-instant/approvals` (`approvalStore.findPending(limit)`), matching
  the existing decide endpoint's `@RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN, ROLE_PAYMENTS)` and
  `@Authorize(action = "sctInstPayment.approval.read")`. Limit clamped to 200.
- `openapi.yaml`: new path + shared `ApprovalResponse` schema (`$ref`'d from `PATCH` too),
  `info.version` 1.4.0 -> 1.5.0 (ADR-0048, additive-only — `ApprovalResponse` gains `makerId`/
  `createdAt`).
- `admin-ui`: new `sepaInstantPending()` source in `api/approvals/pending/route.ts`, wired into
  the federated inbox merge/degrade logic; `approvals-inbox.test.ts` extended.
- New `ApprovalResourceMappingTest`, mirroring sanctions/ledger/domestic-payment's own test.
- Threat model updated (§4a new I-row + DFD update + change log).

**Commit 2 — a genuine, separate authz gap found while verifying the new endpoint (mandatory
authz-gap check per the balance-service precedent, #5686/#5690):**

Verifying by effect (not by appearance) that the checker roles could actually reach the *new*
`sctInstPayment.approval.read` action also meant checking the *existing* `sctInstPayment.approval.decide`
action the same way. `opa eval` against the real `rest.rego` + `rules-opa-data.yaml` bundle
resolved **`allow=false` for a real ROLE_OPERATOR** on `sctInstPayment.approval.decide` — the
action was present in `rules.yaml`'s `role_action_matrix` for the sibling
`sepaPayment.approval.decide` but absent for sepa-instant's own action. In any
`AUTHZ_ENFORCE=true` environment, the existing decide endpoint has been 403ing every operator
trying to decide a paused SCT Inst recall since it shipped — same shape as the balance-service gap
(#5686/#5690).

Fixed with the exact same mirrored shape balance used: added the matrix grant (mirroring
`sepaPayment.approval.decide`'s entry) to `role_action_matrix.ROLE_OPERATOR` and
`shared_m2m_matrix_write_grants.declared`, regenerated `rules-opa-data.yaml`, then regenerated
every service's OPA bundle (a `role_action_matrix` edit restamps the whole fleet — that's why this
PR's second commit touches ~75 files under `gitops/components` even though only sepa-instant's
own rule set changed).

**Known residual, not fixed here:** `matrix-allows` is role-only, and
`service-account-openbank-edge` carries `ROLE_OPERATOR` in at least one realm template — the same
exposure balance-service closed with a per-service `prohibited` rule in `balance_rest_ext.rego`.
sepa-instant has no standalone ext-rego file to extend (its REST extension is a heredoc inside
`gen-sepa-instant-opa-bundle.sh` with no `prohibited` block at all today), and there is no
verified in-repo M2M caller of `ApprovalResource`. Building new rego infrastructure for that was
out of scope for this mirrored fix — flagged here and in the threat model's change log rather than
attempted.

## Verification

`opa eval` against the regenerated bundle:

| Principal | Action | Result | Reason |
|---|---|---|---|
| `HUMAN` + `ROLE_OPERATOR` | `sctInstPayment.approval.decide` | `allow=true` | `matrix-allows` |
| `HUMAN` + `ROLE_KYC_OPENER` (deny control) | `sctInstPayment.approval.decide` | `allow=false` | — |
| `HUMAN` + `ROLE_OPERATOR` | `sctInstPayment.approval.read` (new GET) | `allow=true` | `operator-read-any` (generic `.read` rule, no matrix entry needed) |

Reproduced the pre-fix state against the unmodified `rules-opa-data.yaml` (same OPERATOR input
resolved `allow=false`), confirming this closes a real, currently-live gap.

- `check-matrix-write-grants.py`: 0 undeclared, 0 stale
- `gen-rules-opa-data.py --check`: in sync
- `check-opa-bundle-parses.py`: 43 bundles, no unloadable policy
- `check-opa-sidecar-bundle-shape.py`: 43 OPA sidecars, clean
- `opa test openbank-libs/governance/policies openbank-infra/opa/policies`: **170/170 pass**
- `./gradlew :openbank-sepa-instant:compileKotlin :openbank-sepa-instant:test --tests "*Approval*" :openbank-sepa-instant:ktlintCheck :openbank-sepa-instant:detekt`: **BUILD SUCCESSFUL**
- `cd openbank-admin-ui && npm test -- approvals-inbox`: **7/7 pass**

## Test plan

- [x] `opa eval` allow/deny controls for both the new GET action and the existing decide action
- [x] `opa eval` against the pre-fix data reproduces the reported gap
- [x] `opa test` on the full governance policy suite (170/170)
- [x] `check-matrix-write-grants.py`, `gen-rules-opa-data.py --check`, `check-opa-bundle-parses.py`, `check-opa-sidecar-bundle-shape.py`
- [x] `compileKotlin` / `test --tests "*Approval*"` / `ktlintCheck` / `detekt` for `openbank-sepa-instant`
- [x] `npm test -- approvals-inbox` for `openbank-admin-ui`

Refs #5679

🤖 Generated with [Claude Code](https://claude.com/claude-code)
