### PR TITLE
fix(kyc): rethrow a failed party event instead of acking the work away

### DIFF
--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/kafka/PartyEventConsumer.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/kafka/PartyEventConsumer.kt
@@ -11,6 +11,7 @@ import com.openbank.kyc.application.PepScreeningService
 import com.openbank.kyc.application.port.out.KycCaseRepository
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
+import kotlinx.coroutines.delay
 import org.eclipse.microprofile.reactive.messaging.Incoming
 import org.jboss.logging.Logger
 import java.time.Clock
@@ -24,9 +25,27 @@ import java.util.UUID
  * Quarkus dispatches suspend handlers on the Vert.x event loop with a duplicated context, so the
  * downstream reactive persistence inside [KycService] runs correctly.
  *
- * Poison-pill protection: any parse or domain failure is caught, logged and the message is acked
- * (the method returns normally). A single malformed event must not wedge the consumer group; the
- * canonical party stream can be replayed, and [KycService.openCaseForParty] is idempotent.
+ * Failure handling distinguishes two things the original version conflated (#5698).
+ *
+ * A **malformed event** is unretryable — replaying it produces the same parse failure forever — so
+ * it is logged and acked. That is the poison-pill case, and it is the only one.
+ *
+ * A **transient failure of a dependency** is the opposite: the event is fine, the infrastructure is
+ * not, and the work must happen once it recovers. Acking there loses the event silently. That is
+ * what happened on 2026-08-19: kyc-db was down for a few seconds, a PARTY_CREATED arrived, the
+ * catch-all logged `Failed to auto-open/screen KYC case` and acked. No case was ever opened, so the
+ * party stayed PENDING_KYC forever; its two accounts stayed PENDING_ACTIVATION; and the welcome
+ * bonus, which fires only on activation, never ran. The pooled sequence proves no insert was ever
+ * retried (`kyc_cases_seq.last_value` did not advance past the block in use). Ten of 73 parties in
+ * sandbox were in that state — 13.7% of the onboarding funnel, silently.
+ *
+ * So domain and infrastructure failures now go through [withBoundedRetry] and, if they still fail,
+ * are RETHROWN — the connector then retries and ultimately dead-letters, which is a signal someone
+ * can see. Same shape as card-issuance's CardDelegationEventConsumer and account-service's
+ * DelegationEventConsumer.
+ *
+ * A single such event can no longer be quietly dropped; it can still wedge nothing, because the
+ * retry is bounded and the failure moves to the DLQ rather than blocking the partition forever.
  */
 @ApplicationScoped
 class PartyEventConsumer {
@@ -71,7 +90,7 @@ class PartyEventConsumer {
             log.warnf("[party-events-in] PARTY_CREATED without a valid partyId, skipping: %.200s", payload)
             return
         }
-        try {
+        withBoundedRetry("PARTY_CREATED", partyId) {
             val (case, created) = kycService.openCaseForParty(partyId)
             if (created) {
                 log.infof("[party-events-in] Auto-opened KYC case %s for party %s", case.id, partyId)
@@ -92,8 +111,6 @@ class PartyEventConsumer {
                 pepScreeningService.screenCase(case.id, legalName)
                 log.infof("[party-events-in] PEP-screened KYC case %s for party %s", case.id, partyId)
             }
-        } catch (e: Exception) {
-            log.errorf(e, "[party-events-in] Failed to auto-open/screen KYC case for party %s", partyId)
         }
     }
 
@@ -102,11 +119,59 @@ class PartyEventConsumer {
             log.warnf("[party-events-in] PARTY_ERASED without valid partyId, skipping: %.200s", payload)
             return
         }
-        try {
+        // Same rule, and here the cost of swallowing is a compliance breach rather than a stalled
+        // funnel: an acked-but-failed erasure leaves PII in place while the log claims otherwise.
+        // anonymizeByPartyId is idempotent, so a retry or a redelivery is safe.
+        withBoundedRetry("PARTY_ERASED", partyId) {
             kycCaseRepository.anonymizeByPartyId(partyId, clock.instant())
             log.infof("[party-events-in] GDPR Art. 17: anonymised KYC PII for erased party %s", partyId)
-        } catch (e: Exception) {
-            log.errorf(e, "[party-events-in] Failed to anonymise KYC PII for party %s", partyId)
         }
+    }
+
+    /**
+     * Retry [block] a bounded number of times, then RETHROW so the connector dead-letters.
+     *
+     * The rethrow is the point. A caught-and-logged failure acks the message, and an acked message
+     * that did no work is indistinguishable from one that succeeded — from Kafka, from the consumer
+     * lag metric, and from every dashboard built on either. The only trace is an ERROR line nobody
+     * is alerting on, which is exactly how ten parties sat un-KYC'd for months.
+     */
+    private suspend fun withBoundedRetry(eventType: String, partyId: UUID, block: suspend () -> Unit) {
+        var attempt = 1
+        while (true) {
+            try {
+                block()
+                return
+            } catch (e: Exception) {
+                if (attempt >= MAX_ATTEMPTS) {
+                    log.errorf(
+                        e,
+                        "[party-events-in] %s for party %s failed after %d attempts (%s: %s) — dead-lettering",
+                        eventType,
+                        partyId,
+                        attempt,
+                        e.javaClass.simpleName,
+                        e.message,
+                    )
+                    throw e
+                }
+                log.warnf(
+                    "[party-events-in] %s for party %s failed (attempt %d/%d, %s: %s) — retrying",
+                    eventType,
+                    partyId,
+                    attempt,
+                    MAX_ATTEMPTS,
+                    e.javaClass.simpleName,
+                    e.message,
+                )
+                delay(RETRY_BACKOFF_MS * attempt)
+                attempt++
+            }
+        }
+    }
+
+    private companion object {
+        const val MAX_ATTEMPTS = 3
+        const val RETRY_BACKOFF_MS = 500L
     }
 }

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/infrastructure/kafka/PartyEventConsumerTest.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/infrastructure/kafka/PartyEventConsumerTest.kt
@@ -19,8 +19,12 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.Instant
 import java.util.UUID
+
+/** Named so detekt's TooGenericExceptionThrown does not have to be suppressed at the throw site. */
+private class TransientDbFailure : RuntimeException("connection refused")
 
 class PartyEventConsumerTest {
 
@@ -108,17 +112,6 @@ class PartyEventConsumerTest {
     }
 
     @Test
-    fun `PARTY_ERASED anonymisation failure is swallowed to protect the consumer group`(): Unit = runBlocking {
-        val partyId = UUID.randomUUID()
-        val now = fixedClock.instant()
-        coEvery { kycCaseRepository.anonymizeByPartyId(partyId, now) } throws RuntimeException("db down")
-
-        consumer.consume("""{"eventType":"PARTY_ERASED","partyId":"$partyId"}""")
-
-        coVerify(exactly = 1) { kycCaseRepository.anonymizeByPartyId(partyId, now) }
-    }
-
-    @Test
     fun `unknown party events are ignored`(): Unit = runBlocking {
         val partyId = UUID.randomUUID()
 
@@ -143,15 +136,51 @@ class PartyEventConsumerTest {
         coVerify(exactly = 0) { kycCaseRepository.anonymizeByPartyId(any(), any()) }
     }
 
+    /**
+     * This test replaces one that asserted the OPPOSITE — that a domain failure is swallowed "so
+     * the consumer group is not wedged", on the stated assumption that "the party stream can
+     * replay". Nothing replays it: the message was acked, and the only trace of the lost work was
+     * an ERROR line. That is how a few seconds of kyc-db downtime on 2026-08-19 left a party
+     * un-KYC'd, two accounts stuck in PENDING_ACTIVATION and a welcome bonus unpaid, with ten such
+     * parties in sandbox (#5698). The green test was the defect's own documentation.
+     */
     @Test
-    fun `a domain failure is swallowed so the consumer group is not wedged`(): Unit = runBlocking {
+    fun `a persistent infrastructure failure is RETHROWN so the connector dead-letters`(): Unit = runBlocking {
         val partyId = UUID.randomUUID()
         coEvery { kycService.openCaseForParty(partyId) } throws RuntimeException("db down")
 
-        // Must not throw — the message is acked and the party stream can replay.
+        assertThrows<RuntimeException> {
+            runBlocking { consumer.consume("""{"eventType":"PARTY_CREATED","partyId":"$partyId"}""") }
+        }
+
+        coVerify(exactly = 3) { kycService.openCaseForParty(partyId) }
+    }
+
+    @Test
+    fun `a TRANSIENT failure is retried and the case is opened without dead-lettering`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        val case = caseFor(partyId)
+        var calls = 0
+        coEvery { kycService.openCaseForParty(partyId) } answers {
+            calls++
+            if (calls == 1) throw TransientDbFailure() else KycCaseResult(case, created = true)
+        }
+
         consumer.consume("""{"eventType":"PARTY_CREATED","partyId":"$partyId"}""")
 
-        coVerify(exactly = 1) { kycService.openCaseForParty(partyId) }
+        coVerify(exactly = 2) { kycService.openCaseForParty(partyId) }
+    }
+
+    @Test
+    fun `a failed GDPR erasure is RETHROWN rather than logged as done`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        coEvery { kycCaseRepository.anonymizeByPartyId(partyId, any()) } throws RuntimeException("db down")
+
+        assertThrows<RuntimeException> {
+            runBlocking { consumer.consume("""{"eventType":"PARTY_ERASED","partyId":"$partyId"}""") }
+        }
+
+        coVerify(exactly = 3) { kycCaseRepository.anonymizeByPartyId(partyId, any()) }
     }
 
     private fun caseFor(partyId: UUID) = KycCase(


### PR DESCRIPTION
Closes the first box of #5698.

## The incident

`PARTY_CREATED` for a real onboarding customer arrived at 12:56:15 on 2026-08-19 while `kyc-db-rw` was refusing connections. `PartyEventConsumer.handleCreated` caught the exception, logged `Failed to auto-open/screen KYC case`, and returned normally — **which acks the message**.

No KYC case ⇒ party stays `PENDING_KYC` ⇒ no `PARTY status=ACTIVE` ⇒ `account-service` never activates ⇒ `grantWelcomeBonus`, which lives inside the activation branch, never fires. The customer had two `PENDING_ACTIVATION` accounts and no money.

Nothing retried, and that is measured rather than assumed: `kyc_cases_seq.last_value` never advanced past the block already in use, so no INSERT was attempted after the failure (the repo's pooled-sequence diagnostic).

**10 of 73 parties in sandbox are in this state** — 13.7% of the onboarding funnel, silently, the oldest since 2026-06-07.

## The conflation

The class KDoc called the catch-all "poison-pill protection". Two opposite failures were sharing one handler:

- a **malformed event** is unretryable — replaying it fails identically forever, so log-and-ack is right. That is the only poison pill, and it is unchanged.
- a **transient dependency failure** is the opposite: the event is fine, the infrastructure is not, and the work must still happen. Acking loses it with no trace but an ERROR line nobody alerts on.

Domain and infrastructure failures now go through `withBoundedRetry` (3 attempts, linear backoff) and are **rethrown** if they still fail, so the connector retries and ultimately dead-letters. Same shape as `CardDelegationEventConsumer` (card-issuance) and `DelegationEventConsumer` (account-service).

`PARTY_ERASED` gets the same treatment, where swallowing is worse than a stalled funnel: an acked-but-failed erasure leaves PII in place while the log records the erasure as done. `account-service`'s equivalent handler already propagates deliberately and says why.

## Two green tests asserted the defect

```
a domain failure is swallowed so the consumer group is not wedged
PARTY_ERASED anonymisation failure is swallowed to protect the consumer group
```

The first justified itself with *"the message is acked and the party stream can replay"*. **Nothing replays it.** Both are replaced. Worth stating plainly: the test suite documented the bug as intended behaviour, so no amount of test-reading would have found this — only the live DB did.

## Falsification

| | tests |
|---|---|
| fix reverted, new tests in place | **3 failed / 11** |
| fix applied | **14 / 14 green** |

The new tests assert the retry **count**, not just that something throws — so a rethrow with no retries, and a retry that never gives up, are both red. `ktlintCheck` + `detekt` clean.

## Live remediation (already done, before this PR)

The customer was unstuck through the real event path, not a hand-written DB row: delete the manually-opened `OPEN` case, re-drive the `party_outbox` row for `PARTY_CREATED`, let the sandbox straight-through path run. Result: case `APPROVED` (`reviewedBy=sandbox-auto-approval`), party `ACTIVE`, both accounts `ACTIVE`, **100 000 CZK booked** on the CURRENT account at 13:26:19.

## Not in this PR (tracked in #5698)

- the 9 older orphaned parties
- detection — nothing notices a party that never got a case; today's answer is "a human sees an account that does not work"
- fleet sweep for the same catch-and-ack shape in other consumers
