### PR TITLE
fix(gitops): restore delegation-events-in override now that the image is live

### DIFF
--- a/openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml
@@ -54,3 +54,6 @@ data:
     mp.messaging.incoming.party-events-in.client.id=notification-service-party-${quarkus.uuid}
     mp.messaging.incoming.party-events-in.group.id=notification-service-party
     mp.messaging.incoming.party-events-in.auto.offset.reset=earliest
+    mp.messaging.incoming.delegation-events-in.client.id=notification-service-delegation-${quarkus.uuid}
+    mp.messaging.incoming.delegation-events-in.group.id=notification-service-delegation
+    mp.messaging.incoming.delegation-events-in.auto.offset.reset=earliest


### PR DESCRIPTION
## Summary
Follow-up to #5661 (merged, deployed as `sandbox-e3d9339b`). The gitops-sequencing split (deferring the override to a follow-up PR) worked exactly as intended: `kubectl logs` on the live pod confirms the channel connects cleanly, no SRMSG00071 boot failure.

But every poll now fails:
```
GroupAuthorizationException: Not authorized to access group: openbank-notification-service
```
SmallRye falls back to an auto-generated default group id (the Quarkus app name) since the deterministic `group.id` override was deferred. `kafka-notification-mtls.yaml` already grants `Read` on group `notification-service-delegation` — added alongside the deferred override in #5661, anticipating exactly this — it was just never active because nothing set the consumer to actually use that group id.

This restores the override (`client.id`/`group.id`/`auto.offset.reset`), same shape as the other two channels (`notification-events-in`, `party-events-in`).

## Verification
- [x] Confirmed via `kubectl logs -n notifications` that the channel connects without a boot failure (proving the earlier sequencing split was correct).
- [x] Confirmed the specific failure mode (`GroupAuthorizationException` on the SmallRye-default group, not the granted `notification-service-delegation` group) directly from live pod logs, not guessed.
- [x] `kafka-notification-mtls.yaml`'s group ACL for `notification-service-delegation` already exists and needs no change — this PR only restores the property that makes the consumer actually use it.