### PR TITLE
fix(admin-ui): reconcile the two production-readiness collectors

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -395,6 +395,27 @@ gates:
     run: |
       python3 .github/scripts/check-network-policy-code-edges.py
 
+  # Two implementations of the production-readiness scorecard both ship — the Python one via
+  # build-push-admin-ui.sh, the Node one via `prebuild`/admin-ui-deploy.yml, because the admin-ui
+  # build image has no python3. They drifted to 20-of-44 services scored differently (17 GO vs
+  # 11 GO for the same repo on the same day), each side carrying corrections the other lacked,
+  # and nothing compared them. The equivalence is what gets enforced, since the duplicate cannot
+  # be deleted and hand-auditing it is exactly what failed. ENFORCED.
+  - id: readiness-collectors-agree
+    name: "prod-readiness collectors agree (Python vs Node, enforced)"
+    group: gitops
+    mode: enforced
+    rationale: >-
+      Two implementations of the readiness scorecard both ship and cannot be merged into one
+      (no python3 in the admin-ui build image); they had already drifted to 20 of 44 services
+      scored differently, so their equivalence is enforced rather than hand-audited.
+    review_after: 2027-02-19
+    selftest: |
+      python3 .github/scripts/check-readiness-collectors-agree.py --self-test
+    min_subjects: 40   # 44 services scored today (2026-08-19)
+    run: |
+      python3 .github/scripts/check-readiness-collectors-agree.py
+
   - id: podmonitor-namespace-coverage
     name: "PodMonitor namespace coverage (issue #2255, enforced)"
     group: gitops

--- a/.github/scripts/check-readiness-collectors-agree.py
+++ b/.github/scripts/check-readiness-collectors-agree.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""
+Assert the two production-readiness collectors score the fleet identically.
+
+There are two implementations of the C1-C9 scorecard and BOTH ship:
+
+  * openbank-infra/scripts/prod-readiness-collector.py — run by build-push-admin-ui.sh
+  * openbank-admin-ui/scripts/collect-prod-readiness.mjs — run by `npm run prebuild` and by
+    admin-ui-deploy.yml, because the admin-ui build image is node:26-alpine and has no python3
+
+A second implementation of a scorer is a second copy of a list, and it drifted exactly the way
+CLAUDE.md says a second copy always does. Measured on 2026-08-19, before this gate existed:
+
+    20 of 44 services scored differently — 17 GO from the Python collector against 11 GO
+    from the Node one, for the same repo, on the same day.
+
+Every one of the differences was a correction that had landed on one side only. The Python
+collector had #2255's namespace-resolved C8, #2364's `<short>-service` shapes, the
+artifact-based (not prose-based) contract-test probe and the stateless C4/C5 handling; the Node
+collector had the exact-calendar TTL arithmetic (#2365) the Python one lacked, so an expired
+21-day pentest attestation still scored consent C7=Bank-grade there. Neither side was uniformly
+right, which is why "just delete one" was not available and why nobody had noticed: each
+collector looked correct on its own, and no artifact anywhere compared them.
+
+Deleting the duplicate is not possible (no python3 in the build image) and hand-auditing it is
+what already failed, so the equivalence itself is the thing that gets enforced. The gate runs
+both collectors over the real repo at a FIXED date and requires byte-identical scores, evidence
+strings and gates for every service.
+
+Usage:
+    check-readiness-collectors-agree.py             # gate (exit 1 on any divergence)
+    check-readiness-collectors-agree.py --self-test # prove the gate can fail
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import gatelib  # noqa: E402  (path must be set before the import)
+
+REPO = Path(__file__).resolve().parents[2]
+PY_COLLECTOR = REPO / "openbank-infra" / "scripts" / "prod-readiness-collector.py"
+NODE_COLLECTOR = REPO / "openbank-admin-ui" / "scripts" / "collect-prod-readiness.mjs"
+
+# A fixed date, so the TTL decay of attestations.yaml cannot make this gate flap: an
+# attestation expiring between two runs would otherwise look like a collector divergence.
+# Both collectors read it the same way (--today / READINESS_TODAY).
+FIXED_TODAY = "2026-01-15"
+
+
+def run_python(repo: Path, out: Path) -> list[dict]:
+    subprocess.run(
+        [sys.executable, str(repo / "openbank-infra" / "scripts" / "prod-readiness-collector.py"),
+         "--all", "--today", FIXED_TODAY, "--json", str(out)],
+        cwd=repo, check=True, capture_output=True, text=True,
+    )
+    return json.loads(out.read_text())["services"]
+
+
+def run_node(repo: Path, out: Path) -> list[dict]:
+    env = dict(os.environ, READINESS_TODAY=FIXED_TODAY)
+    subprocess.run(
+        ["node", str(repo / "openbank-admin-ui" / "scripts" / "collect-prod-readiness.mjs"),
+         "--repo", str(repo), "--out", str(out)],
+        cwd=repo, check=True, capture_output=True, text=True, env=env,
+    )
+    return json.loads(out.read_text())["services"]
+
+
+def compare(repo: Path, count: list[int] | None = None) -> list[str]:
+    """-> human-readable differences; empty when the two collectors agree.
+
+    `count`, when given, receives the number of services compared, so the caller can declare it
+    as the gate's subject count even on the failure path.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        py = {s["service"]: s for s in run_python(repo, Path(tmp) / "py.json")}
+        node = {s["service"]: s for s in run_node(repo, Path(tmp) / "node.json")}
+
+    diffs: list[str] = []
+    for only_in, missing in (("python", set(py) - set(node)), ("node", set(node) - set(py))):
+        for svc in sorted(missing):
+            diffs.append(f"{svc}: scored only by the {only_in} collector")
+
+    if count is not None:
+        count.append(len(set(py) & set(node)))
+    for svc in sorted(set(py) & set(node)):
+        a, b = py[svc], node[svc]
+        if a["gate"] != b["gate"]:
+            diffs.append(f"{svc}: gate python={a['gate']} node={b['gate']}")
+        if a["money_path"] != b["money_path"]:
+            diffs.append(f"{svc}: money_path python={a['money_path']} node={b['money_path']}")
+        for dim in sorted(set(a["scores"]) | set(b["scores"])):
+            pa, nb = a["scores"].get(dim), b["scores"].get(dim)
+            if pa != nb:
+                diffs.append(f"{svc}: {dim} score python={pa} node={nb}")
+            ea, eb = a["evidence"].get(dim, ""), b["evidence"].get(dim, "")
+            if ea != eb:
+                diffs.append(f"{svc}: {dim} evidence\n      python: {ea}\n      node:   {eb}")
+    return diffs
+
+
+def self_test() -> int:
+    """Prove the gate can fail: perturb one scorer in a throwaway copy and require a diff.
+
+    A gate that only ever runs against a repo where the two agree cannot distinguish "they
+    agree" from "the comparison never happened" — the failure this repo keeps finding. So the
+    self-test breaks the Node collector's C6 scorer on purpose and requires the comparison to
+    report it.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        work = Path(tmp) / "repo"
+        # A full copy is too slow; the collectors only read these trees.
+        work.mkdir()
+        for rel in ("openbank-infra/scripts", "openbank-admin-ui/scripts",
+                    "openbank-libs/governance", "docs/runbooks", "docs/threat-models"):
+            src = REPO / rel
+            if src.exists():
+                dst = work / rel
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copytree(src, dst)
+        # Enough of the fleet for both collectors to produce a non-empty, comparable population.
+        for svc in sorted(REPO.glob("openbank-*-service")):
+            if (svc / "governance.yaml").exists():
+                shutil.copytree(svc, work / svc.name,
+                                ignore=shutil.ignore_patterns("build", ".gradle", "node_modules"))
+        shutil.copytree(REPO / "openbank-infra" / "gitops", work / "openbank-infra" / "gitops")
+
+        clean = compare(work)
+        if clean:
+            print("SELF-TEST FAILED: the untouched copy already diverges:", file=sys.stderr)
+            for d in clean:
+                print(f"  {d}", file=sys.stderr)
+            return 1
+
+        node = work / "openbank-admin-ui" / "scripts" / "collect-prod-readiness.mjs"
+        text = node.read_text()
+        marker = "function scoreC6Dr(short) {"
+        assert marker in text, "self-test needs updating: scoreC6Dr no longer exists"
+        node.write_text(text.replace(
+            marker, marker + "\n  return { score: 0, evidence: 'self-test perturbation' }", 1))
+
+        broken = compare(work)
+        if not broken:
+            print("SELF-TEST FAILED: a deliberately broken C6 scorer produced NO divergence — "
+                  "the comparison is not reaching the collectors", file=sys.stderr)
+            return 1
+        print(f"self-test: perturbing the Node C6 scorer produced {len(broken)} divergence(s) — "
+              f"the gate can fail")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+
+    if not PY_COLLECTOR.exists() or not NODE_COLLECTOR.exists():
+        print(f"ERROR: expected both collectors to exist:\n  {PY_COLLECTOR}\n  {NODE_COLLECTOR}",
+              file=sys.stderr)
+        return 1
+
+    compared: list[int] = []
+    diffs = compare(REPO, compared)
+    # Unconditional, including on the failure path: a gate that found its corpus and then failed
+    # on it must not also be reported as having lost its corpus.
+    gatelib.subjects(compared[0] if compared else 0, "services scored by both collectors")
+    if diffs:
+        print("Production-readiness collectors DISAGREE — the scorecard the deploy bakes into the "
+              "admin-ui image depends on which of the two ran:\n", file=sys.stderr)
+        for d in diffs:
+            print(f"  {d}", file=sys.stderr)
+        print(f"\n{len(diffs)} divergence(s). Fix the scorer on whichever side is wrong — both "
+              f"have been the wrong one. Do not silence this by deleting a collector: the "
+              f"admin-ui build image (node:26-alpine) has no python3, and build-push-admin-ui.sh "
+              f"has no node guarantee.", file=sys.stderr)
+        return 1
+
+    print("readiness collectors agree: identical scores, evidence and gates for every service")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/openbank-admin-ui/scripts/collect-prod-readiness.mjs
+++ b/openbank-admin-ui/scripts/collect-prod-readiness.mjs
@@ -154,43 +154,27 @@ function grepAny(dir, needles) {
   return false
 }
 
-/** Gitops component dir for a given service short-name. */
-function gitopsComponentDir(short) {
-  const aliases = [
-    short,
-    short.replace(/-service$/, ''),
-    short === 'account'          ? 'accounts'      : null,
-    short === 'balance'          ? 'balances'       : null,
-    short === 'notification'     ? 'notifications'  : null,
-    short === 'sepa-payment'     ? 'payments'       : null,
-    short === 'sepa-instant'     ? 'payments'       : null,
-    short === 'domestic-payment' ? 'payments'       : null,
-    short === 'swift'            ? 'payments'       : null,
-    short === 'clearing'         ? 'payments'       : null,
-    short === 'sdd'              ? 'payments'       : null,
-    short === 'transaction'      ? 'statements'     : null,
-    short === 'standing-order'   ? 'statements'     : null,
-    short === 'statement'        ? 'statements'     : null,
-    short === 'tpp-registry'     ? 'registry-cache' : null,
-  ].filter(Boolean)
-
-  const components = path.join(REPO, 'openbank-infra', 'gitops', 'components')
-  for (const c of aliases) {
-    const d = path.join(components, c)
-    if (existsSync(d)) return d
-  }
-  return null
-}
-
-function gitopsYamlsFor(short) {
-  const dir = gitopsComponentDir(short)
-  if (!dir) return []
-  return findFiles(dir, (e) => e.endsWith('.yaml') || e.endsWith('.yml'))
-}
-
+/**
+ * gitops manifests that mention the service AND declare the given kind.
+ *
+ * This used to walk a hand-kept alias map of component directory names, which listed `short` and
+ * `short` minus a `-service` suffix but never `<short>-service` — the shape half the fleet
+ * actually uses (`components/dispute-service`, `components/fraud-service`, `components/psd2-service`).
+ * Eight services therefore resolved to no component dir at all and scored C5=0 "no CNPG cluster"
+ * against a `postgres.yaml` sitting right there, while the Python collector — which does exactly
+ * what this now does — scored them 2. Mirrors prod-readiness-collector.gitops_files_for.
+ */
 function gitopsFilesWithKind(short, kind) {
-  return gitopsYamlsFor(short).filter(f => readText(f).includes(`kind: ${kind}`))
+  const comp = path.join(GITOPS, 'components', short)
+  const scoped = existsSync(comp)
+  const root = scoped ? comp : GITOPS
+  if (!existsSync(root)) return []
+  return findFiles(root, e => e.endsWith('.yaml')).filter(f => {
+    const text = readText(f)
+    return text.includes(`kind: ${kind}`) && (scoped || text.includes(short))
+  })
 }
+
 
 // ---------------------------------------------------------------------------
 // Attestations (M-dimensions) with TTL decay
@@ -236,6 +220,102 @@ function attestFresh(svc, key) {
 }
 
 // ---------------------------------------------------------------------------
+// gitops facts — the Node mirror of openbank-infra/scripts/gitops_facts.py
+//
+// These five helpers are why this file kept disagreeing with the Python collector: the Node
+// copy answered "is this service scraped", "does it declare ports", "does it ship a contract
+// test" and "does it have a datastore" with cheaper probes that had ALREADY been corrected on
+// the Python side (#2255, #2364). The two collectors then scored 20 of 44 services differently
+// and produced 11 GO against 17 GO — for the same repo, on the same day, both shipping (this
+// one via `prebuild`/admin-ui-deploy.yml, the Python one via build-push-admin-ui.sh).
+//
+// check-readiness-collectors-agree.py now fails the build when they diverge, so this mirror
+// cannot silently rot again.
+// ---------------------------------------------------------------------------
+const GITOPS = path.join(REPO, 'openbank-infra', 'gitops')
+
+/** Every name this module is known by — both directory shapes and their bare workload names. */
+function moduleNames(short) {
+  return new Set([`openbank-${short}-service`, `openbank-${short}`, `${short}-service`, short])
+}
+
+/** The `namespace:` of the closest kustomization.yaml at or above the manifest. */
+function nearestKustomizeNamespace(manifest) {
+  let dir = path.dirname(manifest)
+  while (dir.startsWith(GITOPS)) {
+    const m = readText(path.join(dir, 'kustomization.yaml')).match(/^namespace:\s*(\S+)/m)
+    if (m) return m[1]
+    const parent = path.dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  return null
+}
+
+/**
+ * Every namespace in which a Deployment/Rollout for this service is declared.
+ *
+ * A manifest that merely MENTIONS the service does not count — a NetworkPolicy naming it as a
+ * peer or an env var holding its URL would otherwise resolve to some caller's namespace. The
+ * workload's own `metadata.name` must be the service.
+ */
+function workloadNamespaces(short) {
+  const names = moduleNames(short)
+  const haystacks = [`openbank-${short}-service`, `openbank-${short}`]
+  const found = new Set()
+  for (const f of findFiles(GITOPS, e => e.endsWith('.yaml')).sort()) {
+    const text = readText(f)
+    if (!haystacks.some(h => text.includes(h))) continue
+    for (const doc of text.split('\n---')) {
+      const kind = doc.match(/^kind:\s*(\S+)/m)
+      if (!kind || !['Deployment', 'Rollout'].includes(kind[1])) continue
+      const name = doc.match(/^\s{2}name:\s*(\S+)/m)
+      if (!name || !names.has(name[1])) continue
+      const explicit = doc.match(/^\s{2}namespace:\s*(\S+)/m)
+      if (explicit) { found.add(explicit[1]); continue }
+      const inherited = nearestKustomizeNamespace(f)
+      if (inherited) found.add(inherited)
+    }
+  }
+  return found
+}
+
+/** The single namespace this service runs in, or null when it is not deployed. */
+function serviceNamespace(short) {
+  const ns = [...workloadNamespaces(short)].sort()
+  return ns.length ? ns[0] : null
+}
+
+/** `namespaceSelector.matchNames` of the fleet PodMonitor — the namespaces Prometheus scrapes. */
+let _podmonNs = null
+function podmonitorNamespaces() {
+  if (_podmonNs) return _podmonNs
+  const file = path.join(GITOPS, 'components', 'observability', 'podmonitor-openbank-services.yaml')
+  const text = readText(file)
+  const out = new Set()
+  if (text.includes('matchNames:')) {
+    for (const line of text.split('matchNames:')[1].split('\n')) {
+      const m = line.match(/^(\s+)-\s+(\S+)\s*$/)
+      if (m) { out.add(m[2]); continue }
+      if (line.trim()) break // dedented back out of the list
+    }
+  }
+  _podmonNs = out
+  return out
+}
+
+/** `primaryDatastore` from the service's governance.yaml (ADR-0071), '' when undeclared. */
+function declaredDatastore(short) {
+  const m = readText(path.join(svcDir(short), 'governance.yaml')).match(/^primaryDatastore:\s*(.+?)\s*$/m)
+  return m ? m[1].trim() : ''
+}
+
+/** True when the service declares no primary datastore at all. */
+function isStateless(datastore) {
+  return ['', 'none', 'n/a', '\u2014', '-'].includes((datastore || '').trim().toLowerCase())
+}
+
+// ---------------------------------------------------------------------------
 // Per-dimension scorers  (short: string) → { score, evidence }
 // ---------------------------------------------------------------------------
 
@@ -243,7 +323,13 @@ function scoreC1Code(short) {
   const main = path.join(svcDir(short), 'src', 'main')
   if (!existsSync(main)) return { score: 0, evidence: 'no src/main' }
   const kt = countFiles(main, e => e.endsWith('.kt'))
-  const hasPortFiles = countFiles(main, e => e.includes('Port') && e.endsWith('.kt')) > 0
+  // Ports are declared by the PACKAGE (`application/port/{in,out}`), not by a filename
+  // containing "Port" — anacredit and onboarding carry a textbook port package whose files are
+  // named *Repository.kt / *UseCases.kt / *Queries.kt and were scored as having no ports at all.
+  // The fix for a false negative here must never be to rename a file so the probe is satisfied.
+  const hasPortFiles = findFiles(main, e => e.endsWith('.kt'))
+    .some(f => path.relative(main, f).split(path.sep).some(seg => seg === 'port' || seg === 'ports')
+      || path.basename(f).includes('Port'))
   const hasGov = existsSync(path.join(svcDir(short), 'governance.yaml'))
   if (kt < 8) return { score: 1, evidence: `skeleton (${kt} kt files)` }
   let s = (hasPortFiles && hasGov) ? 2 : 1
@@ -266,32 +352,89 @@ function scoreC2Tests(short) {
   return { score: s, evidence: `${unit} unit, ${it} IT, kover=${kover ? 'y' : 'n'}` }
 }
 
+/**
+ * True when the service ships an ACTUAL contract test, with what proves it.
+ *
+ * This used to be `grepAny(src/test, ['Pact', 'ContractTest', 'contract'])` — a substring scan
+ * that counted the word "contract" anywhere, comments included. Three services scored C3=Verified
+ * purely on a sentence like `// the mark-and-sweep reconciliation contract`, and ap2 flipped 1->2
+ * the moment an unrelated PR added `// Cardinality + evidence contract: …`, which nobody wrote
+ * with a score in mind. Prose must never be evidence — ask for artifacts a contract test cannot
+ * exist without: the pact library imported, or the fleet's test-class naming.
+ */
+function hasContractTest(short) {
+  const test = path.join(svcDir(short), 'src', 'test')
+  if (!existsSync(test)) return { ok: false, how: '' }
+  const byImport = []
+  const byName = []
+  for (const f of findFiles(test, e => e.endsWith('.kt'))) {
+    const base = path.basename(f)
+    if (readText(f).includes('au.com.dius.pact')) byImport.push(base)
+    else if (base.includes('Pact') || base.endsWith('ContractTest.kt')) byName.push(base)
+  }
+  if (byImport.length) return { ok: true, how: `${byImport.length} pact test(s)` }
+  if (byName.length) return { ok: true, how: `${byName.length} contract test(s) by naming` }
+  return { ok: false, how: '' }
+}
+
+/** Pact files in the repo-root `pacts/` dir naming this service on either side (ADR-0063). */
+function committedPacts(short) {
+  const dir = path.join(REPO, 'pacts')
+  if (!existsSync(dir)) return []
+  const token = path.basename(svcDir(short))
+  try {
+    return readdirSync(dir).filter(f => f.endsWith('.json') && f.includes(token)).sort()
+  } catch { return [] }
+}
+
 function scoreC3Api(short) {
   const openapiPath = path.join(svcDir(short), 'src', 'main', 'resources', 'openapi.yaml')
   if (!existsSync(openapiPath)) return { score: 0, evidence: 'no openapi.yaml' }
-  const testDir = path.join(svcDir(short), 'src', 'test')
-  const contract = grepAny(testDir, ['Pact', 'ContractTest', 'contract'])
-  const buildGradle = readText(path.join(svcDir(short), 'build.gradle.kts'))
-  const diffGate = buildGradle.includes('oasdiff') || buildGradle.includes('spectral')
-  let s = 1
-  if (contract) s = 2
+  const { ok: contract, how } = hasContractTest(short)
+  const pacts = committedPacts(short)
+  let s = contract ? 2 : 1
   if (attestFresh(short, 'contract_verified')) s = 3
-  return {
-    score: s,
-    evidence: `openapi=y, contract=${contract ? 'y' : 'n'}, diffgate=${diffGate ? 'y' : 'n'}`,
-  }
+  const ev = ['openapi=y', contract ? how : 'NO contract test in src/test']
+  if (pacts.length) ev.push(`${pacts.length} committed pact(s)`)
+  return { score: s, evidence: ev.join(', ') }
 }
 
 function scoreC4Data(short) {
-  const migs = findFiles(svcDir(short), e => /^V\d+.*\.sql$/.test(e))
-  if (migs.length === 0) return { score: 1, evidence: 'no flyway (stateless?)' }
+  const d = svcDir(short)
+  const migs = findFiles(d, (e, full) => /^V\d+.*\.sql$/.test(e) && full.includes(`${path.sep}db${path.sep}migration${path.sep}`))
+  const datastore = declaredDatastore(short)
+  const stateless = isStateless(datastore)
+  if (stateless && migs.length === 0) {
+    // A service that declares no datastore has no migrations to review and no rollback note to
+    // write, so the old hardcoded `1, 'no flyway (stateless?)'` made 2 UNREACHABLE for it — the
+    // matrix asked ap2, copilot, finrep and mcp for an artifact it would be wrong to produce.
+    return { score: 2, evidence: 'n/a — declares no datastore (stateless)' }
+  }
+  if (stateless && migs.length) {
+    // Declared facts and shipped code disagree. Whichever is wrong, nobody can review a data
+    // dimension described two different ways, so this is a finding, not a pass.
+    return {
+      score: 1,
+      evidence: `CONTRADICTION: governance.yaml says datastore '${datastore || 'none'}' but ${migs.length} migration(s) exist`,
+    }
+  }
+  if (migs.length === 0) {
+    return { score: 1, evidence: `declares datastore '${datastore}' but has no Flyway migration` }
+  }
   const rollback = migs.some(m => readText(m).toLowerCase().includes('rollback'))
-    || grepAny(svcDir(short), ['rollback'])
-  const s = rollback ? 2 : 1
-  return { score: s, evidence: `${migs.length} migrations, rollback_note=${rollback ? 'y' : 'n'}` }
+    || findFiles(d, e => e.endsWith('.md')).some(f => readText(f).toLowerCase().includes('rollback'))
+  return {
+    score: rollback ? 2 : 1,
+    evidence: `${migs.length} migrations, rollback_note=${rollback ? 'y' : 'n'}`,
+  }
 }
 
 function scoreC5Backup(short) {
+  if (isStateless(declaredDatastore(short))) {
+    // No datastore, nothing to back up. finrep scored 0 ('no CNPG cluster') for the absence of a
+    // cluster it must not have — an unachievable 0 that read like a missing backup.
+    return { score: 2, evidence: 'n/a — declares no datastore (stateless), nothing to back up' }
+  }
   const clusters = gitopsFilesWithKind(short, 'Cluster')
   const cnpg = clusters.filter(f => f.includes('postgres') || readText(f).toLowerCase().includes('cnpg'))
   if (cnpg.length === 0) return { score: 0, evidence: 'no CNPG cluster' }
@@ -328,7 +471,10 @@ function hasVexTriage(short) {
 }
 
 function scoreC7Security(short) {
-  const tm = existsSync(path.join(REPO, 'docs', 'threat-models', `openbank-${short}-service.md`))
+  // The threat model is named after the MODULE DIRECTORY, which drops the `-service` suffix for
+  // openbank-sepa-payment, openbank-sepa-instant and openbank-domestic-payment — the `-service`
+  // form missed all three money-path payment modules' threat models.
+  const tm = existsSync(path.join(REPO, 'docs', 'threat-models', `${path.basename(svcDir(short))}.md`))
   const netpol = gitopsFilesWithKind(short, 'NetworkPolicy').length > 0
   const sectest = grepAny(
     path.join(svcDir(short), 'src', 'test'),
@@ -350,11 +496,16 @@ function scoreC7Security(short) {
 }
 
 function scoreC8Observability(short) {
-  const podmonFile = path.join(
-    REPO, 'openbank-infra', 'gitops', 'components', 'observability',
-    'podmonitor-openbank-services.yaml',
-  )
-  const monitored = readText(podmonFile).includes(short)
+  // The fleet PodMonitor scrapes by namespaceSelector.matchNames, so "is this service scraped"
+  // is a question about its NAMESPACE. This used to ask `short in read(podmonitor.yaml)` — a
+  // substring match over the whole file, comments included. A comment asserting sdd-service was
+  // covered "via `payments`" was simply false (sdd runs in namespace `sdd`), and that false claim
+  // scored sdd as scraped while its metrics reached nothing; meanwhile ap2, mcp, card-issuance,
+  // settlement, standing-order and the sepa/domestic payment modules ARE scraped via
+  // `platform`/`payments`/`statements` and scored as if they were not, because their names appear
+  // nowhere in the file (#2255).
+  const ns = serviceNamespace(short)
+  const monitored = ns !== null && podmonitorNamespaces().has(ns)
   const alerts = gitopsFilesWithKind(short, 'PrometheusRule').length > 0
   const metrics = grepAny(
     path.join(svcDir(short), 'src', 'main'),
@@ -364,8 +515,16 @@ function scoreC8Observability(short) {
   let s = 1
   if (monitored && metrics) s = 2
   if (attestFresh(short, 'slo_defined')) s = 3
-  const ev = [monitored && 'scraped', metrics && 'metrics', alerts && 'alerts'].filter(Boolean)
-  return { score: s, evidence: ev.join(', ') || 'none' }
+  // Evidence names the namespace and the specific missing half, so a 0 or 1 is actionable without
+  // re-deriving it: "add the namespace to the PodMonitor" and "instrument the domain" are
+  // different pieces of work and used to be reported identically as "not scraped".
+  const ev = []
+  if (ns === null) ev.push('not deployed (no Deployment/Rollout in gitops)')
+  else if (monitored) ev.push(`scraped (ns ${ns})`)
+  else ev.push(`NOT scraped — ns '${ns}' absent from PodMonitor matchNames`)
+  ev.push(metrics ? 'domain metrics' : 'NO domain metrics in src/main')
+  if (alerts) ev.push('alerts')
+  return { score: s, evidence: ev.join(', ') }
 }
 
 function scoreC9Ops(short) {

--- a/openbank-infra/scripts/prod-readiness-collector.py
+++ b/openbank-infra/scripts/prod-readiness-collector.py
@@ -165,10 +165,18 @@ def attest_fresh(att: dict, svc: str, key: str, today: str) -> bool:
         ttl = int(rec.get("ttl_days", "365"))
     except ValueError:
         ttl = 365
-    # crude date diff (YYYY-MM-DD) — good enough for decay flag
-    d = [int(x) for x in rec["date"].split("-")]
-    t = [int(x) for x in today.split("-")]
-    days = (t[0] - d[0]) * 365 + (t[1] - d[1]) * 30 + (t[2] - d[2])
+    # Exact calendar arithmetic. The previous form approximated a year as 365 days and a month
+    # as 30, which let a TTL run PAST its own expiry — the one thing this mechanism exists to
+    # prevent. consent's 21-day pentest, dated 2026-07-28, is 22 real days old on 2026-08-19 and
+    # the approximation scored it (19-28)+... = 21 days, i.e. still fresh, so consent read
+    # C7=Bank-grade off an expired attestation. The Node collector already used exact dates
+    # (#2365); this is the same correction on the copy that had not received it.
+    try:
+        d = date.fromisoformat(rec["date"])
+        t = date.fromisoformat(today)
+    except ValueError:
+        return False
+    days = (t - d).days
     return 0 <= days <= ttl
 
 


### PR DESCRIPTION
## What

The C1–C9 production-readiness scorecard has **two implementations, and both ship**:

| Collector | Runs from |
|---|---|
| `openbank-infra/scripts/prod-readiness-collector.py` | `build-push-admin-ui.sh` |
| `openbank-admin-ui/scripts/collect-prod-readiness.mjs` | `npm run prebuild`, `admin-ui-deploy.yml` |

The Node copy exists because the admin-ui build image is `node:26-alpine` and has no `python3`. Nothing anywhere compared the two, and they had drifted:

```
20 of 44 services scored differently — 17 GO (Python) vs 11 GO (Node),
same repo, same day.
```

Neither side was uniformly right, which is why this is a two-way fix and why nobody had noticed: each collector looked correct on its own.

## Corrections the Node collector was missing

- **C8** asked `short in read(podmonitor.yaml)` — a substring match over the whole file, comments included. The fleet PodMonitor selects by **namespace**, so `ap2`, `mcp`, `card-issuance`, `settlement`, `standing-order` and the sepa/domestic payment modules — all genuinely scraped via `platform`/`payments`/`statements` — scored as unscraped, because their names appear nowhere in that file. Now resolved from the workload manifests, as #2255 already did on the Python side. (Verified against `check-podmonitor-namespace-coverage.py`: real coverage is `38 namespaces scraped, 0 unscraped`.)
- **Component-directory resolution** walked a hand-kept alias map listing `<short>` and `<short>` minus a `-service` suffix, but never `<short>-service` — the shape half the fleet uses. Eight services scored `C5=0 "no CNPG cluster"` against a `postgres.yaml` sitting in `components/<short>-service/`.
- **C3** counted the word "contract" anywhere under `src/test`, comments included. Now requires an artifact a contract test cannot exist without: the `au.com.dius.pact` import, or the fleet's `*Pact*Test.kt` / `*ContractTest.kt` naming.
- **C1** required a *filename* containing `Port`; the fleet declares ports by **package** (`application/port/{in,out}`), so `onboarding` read as having none.
- **C4/C5** had no stateless case, so a service declaring no datastore was asked for a migration rollback note and a database backup it must not have — an unachievable 0.
- **Threat-model path** assumed the `-service` suffix, missing all three payment modules' threat models.

## Correction the Python collector was missing

- `attest_fresh` approximated a year as 365 days and a month as 30, so a TTL could run **past its own expiry**. `consent`'s 21-day pentest attestation, 22 real days old on 2026-08-19, still scored `C7=Bank-grade` off an expired attestation. Exact calendar arithmetic now, as the Node collector already had (#2365).

## The gate

Both collectors now produce **identical scores, evidence strings and gates for all 44 services**. `check-readiness-collectors-agree.py` enforces that (`readiness-collectors-agree`, enforced, `min_subjects: 40`), because the duplicate cannot be deleted and hand-auditing it is precisely what failed.

Its self-test perturbs the Node C6 scorer in a throwaway copy and requires the comparison to report it — the negative case, not the green one:

```
self-test: perturbing the Node C6 scorer produced 99 divergence(s) — the gate can fail
SUBJECTS=44  # services scored by both collectors
readiness collectors agree: identical scores, evidence and gates for every service
```

The comparison runs at a fixed `READINESS_TODAY`, so an attestation expiring between two runs cannot flap the gate.

## What this does NOT do

**No service's real posture changed.** This fixes what the matrix *reports*, not what it *measures*. The 27 NO-GO services stay NO-GO: the money-path gate requires C1/C5/C7 at Bank-grade, and Bank-grade is granted only by a fresh `code_complete`, `restore_drill` and `pentest` attestation — real-world facts that a code change must never manufacture.

## Verification

- `python3 .github/scripts/check-readiness-collectors-agree.py` → 0 divergences, 44 subjects
- `python3 .github/scripts/check-readiness-collectors-agree.py --self-test` → falsifiable
- `python3 openbank-infra/scripts/prod_readiness_collector_test.py` → 29 tests OK
- `npm test` (admin-ui, with `pretest` artifacts) → 190 files / 1470 tests passed
- `npm run lint` → 0 errors (91 pre-existing warnings)
- `run-gates.py --all` → the 6 other failures reproduce identically on clean `origin/main` (they require `PR_DIFF_BASE`, which is empty locally)

## Linked issues

Refs #5705
Refs #5706
