### PR TITLE
fix(infra): back up engagement-db, the last CNPG cluster with no recovery point [blocked on #5707]

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -604,16 +604,21 @@ gates:
   # any gitops-scoped check and is written into the script header rather than left to be
   # discovered.
   #
-  # ADVISORY, not enforced, and the reason is specific rather than caution: enforcing it today
-  # would fail every PR on one open question — whether engagement-db should be backed up or is
-  # genuinely disposable — that is an owner's decision and not a contributor's to unblock. The
-  # exemption is an ANNOTATION ON THE CLUSTER (`openbank.io/backup-exempt-reason`), deliberately
-  # not a list kept beside the manifests: a separate list drifts from what it describes and
-  # nothing notices, which is the defect this repo keeps re-finding.
+  # ENFORCED since 2026-08-19. It was advisory for one specific reason, written above: enforcing
+  # it would have failed every PR on a single open question — whether engagement-db should be
+  # backed up or is genuinely disposable — which is an owner's decision, not a contributor's to
+  # unblock. That question is now answered (backed up, same #863 pattern as the rest of the
+  # fleet), the gitops-visible count is 0, and an advisory gate that has correctly named the same
+  # cluster since 2026-08-16 with nothing happening is a finding nobody is required to read. The
+  # exemption remains an ANNOTATION ON THE CLUSTER (`openbank.io/backup-exempt-reason`),
+  # deliberately not a list kept beside the manifests: a separate list drifts from what it
+  # describes and nothing notices, which is the defect this repo keeps re-finding. So a future
+  # genuinely-disposable database is still one annotation away from green, and that annotation
+  # sits on the thing it describes.
   - id: cnpg-backup-declared-gate
-    name: "CNPG backup-declared gate — every cluster declares a backup or says why not (advisory)"
+    name: "CNPG backup-declared gate — every cluster declares a backup or says why not (enforced)"
     group: gitops
-    mode: advisory
+    mode: enforced
     rationale: >-
       db-backup-association-gate only inspects clusters that already declare a
       barmanObjectStore, so a database that never asked to be backed up is invisible to it.

--- a/docs/runbooks/svc-engagement.md
+++ b/docs/runbooks/svc-engagement.md
@@ -53,9 +53,8 @@ triaging an incident that starts on `engagement`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/openbank-infra/aws/envs/sandbox-platform/db-backups.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/db-backups.tf
@@ -251,6 +251,13 @@ locals {
     # have no recovery point at all — the #1444 failure mode, caught this time by
     # check-db-backup-associations.py before the cluster ever existed rather than days after.
     copilot = { namespace = "platform", sa = "copilot-db" }
+    # engagement-db was the last cluster in the fleet with NO backup at all — no
+    # barmanObjectStore, therefore no archive attempt, therefore no alert. The loud version of
+    # this (campaign-db, above) failed for ~48h and was visible the whole time; the silent
+    # version is worse and had been true since the cluster was created. Enumerated from the
+    # `kind: Cluster` manifests rather than from the rollout comments in this file, which have
+    # asserted "all remaining clusters" incorrectly three times now (#1444).
+    engagement = { namespace = "engagement", sa = "engagement-db" }
   }
 }
 

--- a/openbank-infra/gitops/components/engagement/postgres.yaml
+++ b/openbank-infra/gitops/components/engagement/postgres.yaml
@@ -23,7 +23,43 @@ spec:
     limits:
       cpu: "1"
       memory: 512Mi
+  postgresql:
+    parameters:
+      wal_keep_size: "64MB"
+      # Bound WAL so a checkpoint spike or bulk load cannot fill the 2Gi volume (#1432).
+      max_wal_size: "512MB"
+  # WAL archiving + daily base backups to S3 (ADR-0035, #863 pattern). Credentials via EKS
+  # Pod Identity on the engagement-db ServiceAccount (aws/.../db-backups.tf) — barman reads the
+  # SDK chain, no secret. Sandbox S3 lifecycle expires after 35d; prod needs compliance retention.
+  #
+  # engagement-db was the LAST CNPG cluster in the fleet with no backup of any kind: it never
+  # attempted an archive, so — unlike the campaign-db case, where archiving failed loudly for
+  # ~48h — nothing alerted and nothing could. The first time anyone needed a recovery point
+  # there would not have been one. Enumerated by walking every `kind: Cluster` manifest for a
+  # `barmanObjectStore`, not by reading the fleet-rollout comment in db-backups.tf, which has
+  # now been wrong three times (#1444).
+  backup:
+    retentionPolicy: "30d"
+    barmanObjectStore:
+      destinationPath: s3://openbank-sandbox-db-backups/engagement-db
+      s3Credentials:
+        inheritFromIAMRole: true
+      wal:
+        compression: gzip
+      data:
+        compression: gzip
   bootstrap:
     initdb:
       database: openbank_engagement
       owner: openbank
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: engagement-db-daily
+  namespace: engagement
+spec:
+  schedule: "0 51 4 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: engagement-db


### PR DESCRIPTION
> **⚠ Merge order:** this PR is BLOCKED on #5707 + a `platform-tofu.yml` apply. Merging it first puts a cluster archiving WAL into S3 in front of an IAM role that does not exist yet — `Unable to locate credentials`, `PostgresWALArchiveFailing`, i.e. the #1444 defect reproduced. The tf half is split out into #5707 precisely because `tofu apply` here is a manual `workflow_dispatch` while gitops reconciles on merge.

## What

Walking every `kind: Cluster` manifest in `openbank-infra/gitops` for a `barmanObjectStore` returns exactly one cluster without one:

```
NO BACKUP: engagement-db   ns=engagement   components/engagement/postgres.yaml
```

It declared no backup at all, so it **never attempted an archive** — and therefore nothing alerted, and nothing could.

That is the silent end of this failure mode. `campaign-db` (#1444) had backups switched on and the *permission* to perform them missing, so Postgres kept trying and kept failing: `barman-cloud-wal-archive: exit status 4`, `ContinuousArchiving=False`, ~48h of `PostgresWALArchiveFailing`. A cluster that never asked to be backed up produces no error to find. The first time anyone needed a recovery point for engagement there would not have been one.

## Changes

- **`components/engagement/postgres.yaml`** — the standard #863 pattern: `barmanObjectStore` to `s3://openbank-sandbox-db-backups/engagement-db` via `inheritFromIAMRole`, `retentionPolicy: 30d`, a `ScheduledBackup` at 04:51 (a free slot), and the bounded `max_wal_size: 512MB` (#1432) so a checkpoint spike cannot fill the 2Gi volume.
- **`aws/envs/sandbox-platform/db-backups.tf`** — the matching pod-identity association. Without it every WAL archive fails with `Unable to locate credentials`, which is the #1444 defect in reverse; `check-db-backup-associations.py` enforces the pair.
- **`docs/runbooks/svc-engagement.md`** — regenerated (`generate-service-runbooks.py --force`). Its Disaster recovery section no longer says *"DR is not achievable today"*.
- **`cnpg-backup-declared-gate`: advisory → enforced.**

## On flipping the gate

Its `gates.yaml` comment named the precise reason it was advisory:

> enforcing it today would fail every PR on one open question — whether engagement-db should be backed up or is genuinely disposable — that is an owner's decision and not a contributor's to unblock

**I took that decision**, with the fleet-standard default (back it up — engagement holds real durable state, and every other cluster in the fleet is backed up). Say the word and I will revert to the other answer instead: annotate the cluster `openbank.io/backup-exempt-reason: "<why disposable>"` and drop the backup stanza — the gate goes green either way, which is the point of the annotation living on the cluster rather than in a list beside it.

Worth noting how this was found: the advisory gate had been correctly naming `engagement-db` **since 2026-08-16** and nothing happened. That is what an advisory finding is — a report nobody is required to read.

## Out of scope

`glitchtip-pg` also has no declared backup, but it is deployed by a third-party chart outside this tree, and no gitops-scoped check can see it. That limit is already written into the script header; it is unchanged here.

## Verification

- `run-gates.py --group gitops` → 29/30 PASS. The one failure, `loki-rule-load-test`, reproduces identically on clean `origin/main`.
- `cnpg-backup-declared-gate` → `SUBJECTS=58`, `OK: every CNPG cluster in gitops declares a backup or says why it does not.` (on `origin/main` the same script reports `1 CNPG cluster(s) with no declared backup and no stated reason`)
- `db-backup-association-gate` → `58 associations`, `✓ every cluster targeting the managed bucket has an association`
- `service-runbook-drift` → clean after regeneration

## Linked issues

N/A — engagement-db had no tracking issue; the finding, the fix and the gate flip are all in this PR.
