### PR TITLE
test(campaign,engagement): add the kover coverage floors the modules were missing

### DIFF
--- a/openbank-campaign-service/build.gradle.kts
+++ b/openbank-campaign-service/build.gradle.kts
@@ -54,3 +54,23 @@ dependencies {
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
 }
+
+// Coverage is ratchet-only (never lower). Without this block koverVerify has no rule to check,
+// so the module's coverage was measured by nobody — and the production-readiness collector
+// scores C2 off the presence of a ratchet, not off a number, which is the honest signal: a
+// floor that cannot go down is a guarantee, a percentage in a report is not.
+// Measured on 2026-08-19: 72.9% LINE. The bound is the fleet-standard 60, i.e. below
+// today's level on purpose — a floor is a floor, not a target, and one set at the current
+// reading turns every unrelated refactor into a red build.
+kover {
+    reports {
+        verify {
+            rule {
+                bound {
+                    minValue = 60
+                    coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
+                }
+            }
+        }
+    }
+}

--- a/openbank-engagement-service/build.gradle.kts
+++ b/openbank-engagement-service/build.gradle.kts
@@ -44,3 +44,23 @@ dependencies {
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.wiremock.standalone)
 }
+
+// Coverage is ratchet-only (never lower). Without this block koverVerify has no rule to check,
+// so the module's coverage was measured by nobody — and the production-readiness collector
+// scores C2 off the presence of a ratchet, not off a number, which is the honest signal: a
+// floor that cannot go down is a guarantee, a percentage in a report is not.
+// Measured on 2026-08-19: 75.6% LINE. The bound is the fleet-standard 60, i.e. below
+// today's level on purpose — a floor is a floor, not a target, and one set at the current
+// reading turns every unrelated refactor into a red build.
+kover {
+    reports {
+        verify {
+            rule {
+                bound {
+                    minValue = 60
+                    coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

`openbank-campaign-service` and `openbank-engagement-service` ship kover reports with **no verification rule**, so `koverVerify` had nothing to check and the modules' coverage was measured by nobody. A coverage report with no bound is a number, not a guarantee — which is also why the production-readiness collector scores C2 off the presence of a *ratchet* rather than off a percentage.

| Module | Measured LINE (2026-08-19) | Floor set |
|---|---|---|
| campaign | 72.9 % (1747/2396) | 60 |
| engagement | 75.6 % (558/738) | 60 |

The bound is deliberately **below** today's reading. A floor is a floor, not a target; one set at the current level turns every unrelated refactor into a red build. Coverage here is ratchet-only (never lower), so raising it later is a separate, deliberate act.

## Falsified, not assumed

Per the house rule that a guard is proven by what it *prevents*, not by what it prints — with `minValue` temporarily raised to 99:

```
> Rule violated: lines covered percentage is 75.609800, but expected minimum is 99
exit=1
```

Restored to 60, `koverVerify` passes for both modules.

## Verification

- `./gradlew :openbank-campaign-service:koverVerify :openbank-engagement-service:koverVerify` → BUILD SUCCESSFUL
- `./gradlew :openbank-campaign-service:ktlintCheck :openbank-engagement-service:ktlintCheck :openbank-campaign-service:detekt :openbank-engagement-service:detekt` → exit 0

## Note on scope

`openbank-tax-reporting-service` is the third module with no kover block and is **deliberately excluded**: it sits at 31.4 % LINE across 2 unit tests, so any floor I could set today would either fail the build or be low enough to certify nothing. Setting one there would move its C2 to "Verified" for a service that is not. That is a real gap, not a config omission — filed separately.

## Linked issues

Refs #5706
