### PR TITLE
fix(infra): add the engagement-db pod-identity association ahead of its backup

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/db-backups.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/db-backups.tf
@@ -251,6 +251,13 @@ locals {
     # have no recovery point at all — the #1444 failure mode, caught this time by
     # check-db-backup-associations.py before the cluster ever existed rather than days after.
     copilot = { namespace = "platform", sa = "copilot-db" }
+    # engagement-db was the last cluster in the fleet with NO backup at all — no
+    # barmanObjectStore, therefore no archive attempt, therefore no alert. The loud version of
+    # this (campaign-db, above) failed for ~48h and was visible the whole time; the silent
+    # version is worse and had been true since the cluster was created. Enumerated from the
+    # `kind: Cluster` manifests rather than from the rollout comments in this file, which have
+    # asserted "all remaining clusters" incorrectly three times now (#1444).
+    engagement = { namespace = "engagement", sa = "engagement-db" }
   }
 }
 


### PR DESCRIPTION
## What

The IAM half of the engagement-db backup (#5703), split out so the two halves land in the only order that cannot break.

## Why split

`tofu apply` in this repo is a **manual `workflow_dispatch`** (`platform-tofu.yml`), while gitops reconciles on merge through ArgoCD. Landing both halves in one PR would put a cluster that archives WAL into S3 in front of a role that does not exist yet: every archive would fail with `Unable to locate credentials`, `ContinuousArchiving=False`, and `PostgresWALArchiveFailing` would page — until someone remembered to dispatch the apply. That is exactly the #1444 defect, reproduced on purpose.

Order:

1. **this PR** — merge, then dispatch `platform-tofu.yml` → apply
2. **#5703** — merge the `barmanObjectStore` + `ScheduledBackup` + gate flip

This half is inert on its own: an association for a ServiceAccount that no cluster is yet archiving under grants a permission nobody exercises.

## Verification

- `db-backup-association-gate` with **only** this half applied → `✓ every cluster targeting the managed bucket has an association` (the gate fails on the other ordering — a cluster declaring a destination with no association behind it — which is what makes this split safe rather than merely tidy)
- `cnpg-backup-declared-gate` → still reports `1 CNPG cluster(s) with no declared backup`, correctly: engagement-db is not backed up until #5703 lands.

## Linked issues

Refs #5703
