### PR TITLE
fix(consent): map SuppressionEntity to the columns V6 actually created

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -415,6 +415,35 @@ gates:
     min_subjects: 40   # 44 services scored today (2026-08-19)
     run: |
       python3 .github/scripts/check-readiness-collectors-agree.py
+  # A JPA property in a service with no physical-naming-strategy maps to a column that is the
+  # property name folded to lower case — `createdAt` -> `createdat` — while every migration in this
+  # repo writes `created_at`. The mapping is then wrong for every multi-word property and right for
+  # every single-word one, so the class looks internally consistent and reviews clean.
+  #
+  # consent-service's SuppressionEntity shipped that way: six of ten columns wrong, and
+  # GET /api/v1/suppressions/party/{partyId} answered 500 on EVERY call from the day it shipped.
+  # Nothing could see it — unit tests mock the repository so no SQL is issued, health probes do not
+  # touch the table, and the two sibling entities in the same package do name their columns. It was
+  # found by schemathesis fuzzing the running service, which is not a control that runs on a PR.
+  #
+  # Scope note: this enforces the CONVENTION (a multi-word property names its column), not a diff
+  # against the DDL. Deriving "does this column exist" needs real DDL parsing — partitioned tables,
+  # custom enum types, ALTER/RENAME chains — and two attempts at it produced 12 and then ~40 false
+  # findings against correct code. A gate that cries wolf gets ignored. ENFORCED.
+  - id: entity-column-names
+    name: "JPA entity columns are named explicitly where nothing converts them (enforced)"
+    group: gitops
+    mode: enforced
+    rationale: >-
+      In a service with no physical-naming-strategy an implicit column name is the property name
+      folded to lower case, which no migration in this repo ever creates; the resulting 500 is
+      invisible to unit tests, health probes and review.
+    review_after: 2027-02-19
+    min_subjects: 100   # 147 entity classes in strategy-less services today (2026-08-19)
+    selftest: |
+      python3 .github/scripts/check-entity-column-names.py --self-test
+    run: |
+      python3 .github/scripts/check-entity-column-names.py
 
   - id: podmonitor-namespace-coverage
     name: "PodMonitor namespace coverage (issue #2255, enforced)"

--- a/.github/scripts/check-entity-column-names.py
+++ b/.github/scripts/check-entity-column-names.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""
+Assert every JPA entity property resolves to a column its migrations actually created.
+
+Hibernate's IMPLICIT column name for a property is the property name verbatim, and Postgres
+folds an unquoted identifier to lower case. So in a service that configures no
+`physical-naming-strategy`, a property called `createdAt` resolves to the column `createdat`,
+while every migration in this repo writes `created_at`. The mapping is wrong for every
+multi-word property and right for every single-word one, which is exactly why it survives
+review: the class looks consistent.
+
+Found live in consent-service's `SuppressionEntity` (2026-08-19). Six of its ten columns were
+wrong — party_id, reason_code, created_by, created_at, revoked_at, revoked_by — and
+`GET /api/v1/suppressions/party/{partyId}` answered `500 INTERNAL_ERROR` on EVERY call since the
+endpoint shipped:
+
+    SQLGrammarException: column se1_0.createdat does not exist (42703)
+
+Nothing caught it. A unit test that mocks the repository never issues the SQL; the service had no
+integration test driving that route against a real database; the pod is Ready because health
+probes do not touch the table; and the sibling entities in the same package (ConsentEntity,
+ConsentOutboxEntity) spell every column out, so the file next door looked like the convention was
+being followed. It was found only when schemathesis fuzzed the running service.
+
+THE SPLIT THIS ENFORCES
+-----------------------
+Six services set `hibernate-orm.physical-naming-strategy: CamelCaseToUnderscoresNamingStrategy`
+(campaign, engagement, fx and friends). There, `createdAt` -> `created_at` is derived and a bare
+property is CORRECT. Everywhere else the column name must be explicit. Both spellings are fine;
+mixing them per-service is what breaks, so the rule is per-service and derived from that service's
+own config — never a list kept here.
+
+Usage:
+    check-entity-column-names.py             # gate (exit 1 on a bare camelCase column)
+    check-entity-column-names.py --self-test # prove the gate can fail
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import gatelib  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[2]
+STRATEGY = "CamelCaseToUnderscoresNamingStrategy"
+
+CAMEL = re.compile(r"[a-z][A-Z]")
+
+# One `@Entity ... class X { ... }` body. Kotlin binds an annotation to the NEXT declaration, so an
+# annotation block sits immediately above the thing it annotates — the same rule that lets a stray
+# top-level function between `@Path` and its class steal the annotation (CLAUDE.md). Scanning a
+# whole FILE instead of a class body is how a first cut of this check reported five findings in
+# openbank-audit-service against a plain result-holder that merely shares a file with an entity.
+ENTITY_CLASS = re.compile(
+    r"@Entity\b(?P<anns>(?:[^\n]*\n)*?)\s*class\s+(?P<name>\w+)[^{]*\{(?P<body>.*?)\n\}",
+    re.S,
+)
+TABLE_NAME = re.compile(r'@Table\(\s*name\s*=\s*"([^"]+)"')
+PROPERTY = re.compile(
+    r"((?:^[ \t]*@(?:\w+:)?[\w.]+(?:\((?:[^()]|\([^()]*\))*\))?[ \t]*\n)*)"
+    r"^[ \t]*(?:lateinit\s+)?(?:var|val)\s+(\w+)\s*:",
+    re.M,
+)
+# `@field:Column` / `@get:Column` are the same annotation with a Kotlin use-site target, and
+# roughly half the fleet writes them that way. A first cut of this regex required a bare `@Column`
+# and therefore reported all of openbank-sanctions-service — every column of which IS named
+# explicitly, as `@field:Column(name = "checked_at")`. Twenty-three findings, none real.
+EXPLICIT_NAME = re.compile(r'@(?:\w+:)?Column\((?:[^()]|\([^()]*\))*?name\s*=\s*"([^"]+)"')
+# Associations and computed/ignored members carry their own naming rules and are not columns.
+NOT_A_COLUMN = ("Transient", "OneToMany", "ManyToMany", "OneToOne", "ManyToOne",
+                "JoinColumn", "Embedded", "ElementCollection", "Formula")
+
+def service_uses_strategy(module: Path) -> bool:
+    for cfg in (module / "src" / "main" / "resources").glob("application*.y*ml"):
+        if STRATEGY in gatelib.read_text(cfg):
+            return True
+    return False
+
+
+def audit(repo: Path) -> tuple[list[str], int]:
+    """-> ([findings], entity classes examined)
+
+    The rule is the CONVENTION, not a diff against the DDL, and that is a deliberate narrowing.
+    Deriving "does this column exist" from the migrations needs real DDL parsing — this repo has
+    partitioned tables (`) PARTITION BY RANGE (booking_date);`), custom enum types
+    (`settlement_type settlement_type NOT NULL`), ALTER/RENAME chains and quoted identifiers — and
+    every shortcut produced false findings against code that was fine: twelve from a type-restricted
+    column pattern, then the whole of transaction-service from a closing-paren pattern. A gate that
+    cries wolf about correct code gets ignored, and then it is worth less than nothing.
+
+    So this asks the decidable question instead: in a service that converts nothing, does a
+    multi-word property say which column it means? Both spellings are fine — explicit names, or the
+    naming strategy — and mixing them per service is what breaks.
+    """
+    findings: list[str] = []
+    examined = 0
+    for module in sorted(repo.glob("openbank-*")):
+        if not (module / "src" / "main").is_dir():
+            continue
+        if service_uses_strategy(module):
+            continue  # the strategy derives the snake_case name; a bare property is correct
+        for f in sorted((module / "src" / "main").rglob("*.kt")):
+            text = gatelib.read_text(f)
+            if "@Entity" not in text:
+                continue
+            for cls in ENTITY_CLASS.finditer(text):
+                examined += 1
+                for annotations, prop in PROPERTY.findall(cls.group("body")):
+                    if any(marker in annotations for marker in NOT_A_COLUMN):
+                        continue
+                    if not CAMEL.search(prop):
+                        continue  # single word: the implicit name and the folded identifier agree
+                    if EXPLICIT_NAME.search(annotations):
+                        continue
+                    findings.append(
+                        f"{f.relative_to(repo)}: {cls.group('name')}.{prop} has no explicit "
+                        f"@Column(name = ...), and {module.name} sets no physical-naming-strategy, "
+                        f"so Hibernate asks for the column `{prop.lower()}` — every migration in "
+                        f"this repo writes `{_snake(prop)}`"
+                    )
+    return findings, examined
+
+
+def _snake(prop: str) -> str:
+    return re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", prop).lower()
+
+
+def self_test() -> int:
+    """Prove the gate fires on the real defect shape and stays silent on the two correct ones."""
+    # (label, strategy, expect a finding, expected subject count). The subject count matters:
+    # the strategy case is silent because the MODULE IS SKIPPED, not because the entity passed, and
+    # a self-test that only checked "no finding" could not tell those apart — which is the exact
+    # failure mode this repo names most often.
+    cases = [
+        ("bare camelCase, no strategy -> MUST fire", None, True, 1),
+        ("explicit @Column(name) -> silent", None, False, 1),
+        ("bare camelCase WITH strategy -> skipped, 0 subjects", STRATEGY, False, 0),
+        ("single-word property, no strategy -> silent", None, False, 1),
+    ]
+    bodies = [
+        "    @Column(nullable = false)\n    lateinit var createdAt: String\n",
+        '    @Column(name = "created_at", nullable = false)\n    lateinit var createdAt: String\n',
+        "    @Column(nullable = false)\n    lateinit var createdAt: String\n",
+        "    @Column(nullable = false)\n    lateinit var source: String\n",
+    ]
+    failures = 0
+    for (label, strategy, want_finding, want_subjects), body in zip(cases, bodies):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            module = repo / "openbank-probe-service"
+            src = module / "src" / "main" / "kotlin"
+            src.mkdir(parents=True)
+            (module / "src" / "main" / "resources").mkdir(parents=True)
+            (module / "src" / "main" / "resources" / "application.yaml").write_text(
+                f"quarkus:\n  hibernate-orm:\n    physical-naming-strategy: {strategy}\n"
+                if strategy else "quarkus:\n  hibernate-orm: {}\n"
+            )
+            (src / "E.kt").write_text(f"@Entity\n@Table(name = \"t\")\nclass E {{\n{body}}}\n")
+            got, examined = audit(repo)
+            ok = bool(got) == want_finding and examined == want_subjects
+            print(f"  {'ok  ' if ok else 'FAIL'}  {label}")
+            if not ok:
+                failures += 1
+                for g in got:
+                    print(f"        got: {g}")
+    if failures:
+        print(f"SELF-TEST FAILED: {failures} case(s)", file=sys.stderr)
+        return 1
+    print("self-test: PASS — the gate fires on the defect and is silent on both correct spellings")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+
+    findings, examined = audit(REPO)
+    gatelib.subjects(examined, "entity source files in services with no naming strategy")
+    if findings:
+        print("JPA properties that map to a column no migration creates:\n", file=sys.stderr)
+        for f in findings:
+            print(f"  {f}", file=sys.stderr)
+        print(
+            f"\n{len(findings)} finding(s). Add `@Column(name = \"<snake_case>\")`, matching the "
+            f"migration. Do NOT 'fix' this by adding a physical-naming-strategy to a service whose "
+            f"other entities already spell their columns out — that changes their mapping too.",
+            file=sys.stderr,
+        )
+        return 1
+    print("OK: every entity property in a strategy-less service names its column explicitly.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check-entity-column-names.py
+++ b/.github/scripts/check-entity-column-names.py
@@ -150,7 +150,7 @@ def self_test() -> int:
         "    @Column(nullable = false)\n    lateinit var source: String\n",
     ]
     failures = 0
-    for (label, strategy, want_finding, want_subjects), body in zip(cases, bodies):
+    for (label, strategy, want_finding, want_subjects), body in zip(cases, bodies, strict=True):
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp)
             module = repo / "openbank-probe-service"

--- a/.github/scripts/check-entity-column-names.py
+++ b/.github/scripts/check-entity-column-names.py
@@ -45,7 +45,7 @@ import tempfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-import gatelib  # noqa: E402
+import gatelib
 
 REPO = Path(__file__).resolve().parents[2]
 STRATEGY = "CamelCaseToUnderscoresNamingStrategy"
@@ -59,13 +59,13 @@ CAMEL = re.compile(r"[a-z][A-Z]")
 # openbank-audit-service against a plain result-holder that merely shares a file with an entity.
 ENTITY_CLASS = re.compile(
     r"@Entity\b(?P<anns>(?:[^\n]*\n)*?)\s*class\s+(?P<name>\w+)[^{]*\{(?P<body>.*?)\n\}",
-    re.S,
+    re.DOTALL,
 )
 TABLE_NAME = re.compile(r'@Table\(\s*name\s*=\s*"([^"]+)"')
 PROPERTY = re.compile(
     r"((?:^[ \t]*@(?:\w+:)?[\w.]+(?:\((?:[^()]|\([^()]*\))*\))?[ \t]*\n)*)"
     r"^[ \t]*(?:lateinit\s+)?(?:var|val)\s+(\w+)\s*:",
-    re.M,
+    re.MULTILINE,
 )
 # `@field:Column` / `@get:Column` are the same annotation with a Kotlin use-site target, and
 # roughly half the fleet writes them that way. A first cut of this regex required a bare `@Column`
@@ -111,12 +111,12 @@ def audit(repo: Path) -> tuple[list[str], int]:
                 continue
             for cls in ENTITY_CLASS.finditer(text):
                 examined += 1
-                for annotations, prop in PROPERTY.findall(cls.group("body")):
-                    if any(marker in annotations for marker in NOT_A_COLUMN):
+                for anns, prop in PROPERTY.findall(cls.group("body")):
+                    if any(marker in anns for marker in NOT_A_COLUMN):
                         continue
                     if not CAMEL.search(prop):
                         continue  # single word: the implicit name and the folded identifier agree
-                    if EXPLICIT_NAME.search(annotations):
+                    if EXPLICIT_NAME.search(anns):
                         continue
                     findings.append(
                         f"{f.relative_to(repo)}: {cls.group('name')}.{prop} has no explicit "

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/persistence/entity/SuppressionEntity.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/persistence/entity/SuppressionEntity.kt
@@ -11,35 +11,58 @@ import jakarta.persistence.Table
 import java.time.OffsetDateTime
 import java.util.UUID
 
+/**
+ * Row mapping for `suppressions` (V6__suppressions.sql).
+ *
+ * EVERY column name is explicit, and that is load-bearing rather than stylistic: consent-service
+ * configures **no** `physical-naming-strategy`, so Hibernate's implicit name for a property is the
+ * property name verbatim, and Postgres folds an unquoted identifier to lower case. `createdAt`
+ * therefore resolved to `createdat` while the migration created `created_at`, and every read of
+ * this table answered `500 INTERNAL_ERROR` —
+ * `SQLGrammarException: column se1_0.createdat does not exist (42703)`. Six of the ten columns
+ * were wrong the same way (party_id, reason_code, created_by, created_at, revoked_at, revoked_by);
+ * the four that "worked" — id, scope, value, source — are single words, which is why the class
+ * looked fine.
+ *
+ * Its two siblings in this package, ConsentEntity and ConsentOutboxEntity, both spell every
+ * column out. This one did not, and nothing noticed until schemathesis fuzzed the route (#5705
+ * follow-up): a unit test that mocks SuppressionRepository never issues the SQL, and the service
+ * had no integration test driving the endpoint against a real database.
+ *
+ * Only the six services that set `CamelCaseToUnderscoresNamingStrategy` may omit the name;
+ * consent is not one of them. `check-entity-column-names.py` now enforces that split.
+ */
 @Entity
 @Table(name = "suppressions")
 class SuppressionEntity {
     @Id
-    @Column(nullable = false, updatable = false)
+    @Column(name = "id", nullable = false, updatable = false)
     lateinit var id: UUID
 
-    @Column(nullable = false)
+    @Column(name = "party_id", nullable = false)
     lateinit var partyId: UUID
 
-    @Column(nullable = false, length = 10)
+    @Column(name = "scope", nullable = false, length = 10)
     lateinit var scope: String
 
-    @Column(length = 255)
+    @Column(name = "value", length = 255)
     var value: String? = null
 
-    @Column(nullable = false, length = 30)
+    @Column(name = "reason_code", nullable = false, length = 30)
     lateinit var reasonCode: String
 
-    @Column(nullable = false, length = 100)
+    @Column(name = "source", nullable = false, length = 100)
     lateinit var source: String
 
-    @Column(nullable = false)
+    @Column(name = "created_by", nullable = false)
     lateinit var createdBy: String
 
-    @Column(nullable = false)
+    @Column(name = "created_at", nullable = false)
     lateinit var createdAt: OffsetDateTime
 
+    @Column(name = "revoked_at")
     var revokedAt: OffsetDateTime? = null
 
+    @Column(name = "revoked_by")
     var revokedBy: String? = null
 }

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/integration/SuppressionPersistenceIT.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/integration/SuppressionPersistenceIT.kt
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.consent.integration
+
+import com.openbank.consent.it.ConsentPostgresRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Extract
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import javax.sql.DataSource
+
+/**
+ * ADR-0219 D3 suppressions, driven over real HTTP against a real Postgres.
+ *
+ * WHY THIS EXISTS: `SuppressionEntity` mapped six of its ten columns to names no migration
+ * creates. consent-service configures no `physical-naming-strategy`, so Hibernate's implicit
+ * column name is the property name verbatim and Postgres folds it to lower case — `createdAt`
+ * asked for `createdat` while V6 created `created_at`. Every call to
+ * `GET /api/v1/suppressions/party/{partyId}` answered 500 with
+ * `SQLGrammarException: column se1_0.createdat does not exist (42703)`, from the day the endpoint
+ * shipped, and `POST` failed the same way one layer down.
+ *
+ * Nothing in the suite could see it. The unit tests mock `SuppressionRepository`, so no SQL is
+ * ever issued; the pod is Ready because health probes do not touch the table; and the sibling
+ * entities in the same package spell every column out, so the file next door looked like the
+ * convention was being followed. It took schemathesis fuzzing the running service to find it.
+ *
+ * So this test asserts the one thing a mock cannot: that the SQL Hibernate generates matches the
+ * schema Flyway built. It is deliberately a round trip through the endpoints plus a plain JDBC
+ * read — the JDBC assertion is what pins the physical column names, and it would go red again the
+ * moment a property loses its `@Column(name = ...)`.
+ *
+ * Reactive-Panache repositories cannot be called from a bare @QuarkusTest thread ("No current
+ * Vertx context found"); only a real HTTP request carries one. Same shape as
+ * ConsentRevocationOutboxIT and LendingOutboxWriteIT.
+ */
+@QuarkusTest
+@QuarkusTestResource(SuppressionPersistenceIT.InMemoryKafkaResource::class)
+@QuarkusTestResource(ConsentPostgresRedisTestResource::class)
+class SuppressionPersistenceIT {
+
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> {
+            val props = InMemoryConnector.switchOutgoingChannelsToInMemory("consent-events-out").toMutableMap()
+            props["openbank.outbox.dispatch-enabled"] = "false"
+            return props
+        }
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    @Test
+    @TestSecurity(user = "it-operator", roles = ["ROLE_OPERATOR"])
+    fun `listing suppressions for a party with none returns an empty list, not a 500`() {
+        // The exact request schemathesis failed on. A party with no rows still forces Hibernate to
+        // build and execute the SELECT, which is where the column names are resolved — so this
+        // case, with no fixture at all, is the one that catches a broken mapping.
+        When {
+            get("/api/v1/suppressions/party/${UUID.randomUUID()}")
+        } Then {
+            statusCode(200)
+            body("size()", org.hamcrest.Matchers.equalTo(0))
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "it-operator", roles = ["ROLE_OPERATOR"])
+    fun `a created suppression round-trips through the physical columns V6 created`() {
+        val partyId = UUID.randomUUID()
+        val id = Given {
+            contentType("application/json")
+            body(
+                """
+                {"partyId":"$partyId","scope":"ALL","value":null,
+                 "reason":"CUSTOMER_OPTOUT","source":"suppression-persistence-it"}
+                """.trimIndent(),
+            )
+        } When {
+            post("/api/v1/suppressions")
+        } Then {
+            statusCode(201)
+        } Extract {
+            UUID.fromString(jsonPath().getString("id"))
+        }
+
+        // Read the row by its SNAKE_CASE column names. This is the assertion that pins the
+        // mapping: it cannot pass against an entity that writes `createdat`, and it does not
+        // depend on the entity class to name the columns for it.
+        dataSource.connection.use { c ->
+            c.prepareStatement(
+                """
+                SELECT party_id, scope, reason_code, source, created_by, created_at,
+                       revoked_at, revoked_by
+                  FROM suppressions
+                 WHERE id = ?
+                """.trimIndent(),
+            ).use { st ->
+                st.setObject(1, id)
+                st.executeQuery().use { rs ->
+                    assertThat(rs.next()).describedAs("suppression row committed").isTrue()
+                    assertThat(rs.getObject("party_id")).isEqualTo(partyId)
+                    assertThat(rs.getString("scope")).isEqualTo("ALL")
+                    assertThat(rs.getString("reason_code")).isEqualTo("CUSTOMER_OPTOUT")
+                    assertThat(rs.getString("source")).isEqualTo("suppression-persistence-it")
+                    assertThat(rs.getString("created_by")).isNotBlank()
+                    assertThat(rs.getTimestamp("created_at")).isNotNull()
+                    assertThat(rs.getTimestamp("revoked_at")).isNull()
+                    assertThat(rs.getString("revoked_by")).isNull()
+                }
+            }
+        }
+
+        // And the read path returns it — the half that was 500 in production.
+        When {
+            get("/api/v1/suppressions/party/$partyId")
+        } Then {
+            statusCode(200)
+            body("size()", org.hamcrest.Matchers.equalTo(1))
+            body("[0].id", org.hamcrest.Matchers.equalTo(id.toString()))
+            body("[0].scope", org.hamcrest.Matchers.equalTo("ALL"))
+            body("[0].reason", org.hamcrest.Matchers.equalTo("CUSTOMER_OPTOUT"))
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "it-operator", roles = ["ROLE_OPERATOR"])
+    fun `revoking a suppression drops it out of the active list`() {
+        val partyId = UUID.randomUUID()
+        val id = Given {
+            contentType("application/json")
+            body(
+                """
+                {"partyId":"$partyId","scope":"TOPIC","value":"loans",
+                 "reason":"COMPLAINT","source":"suppression-persistence-it"}
+                """.trimIndent(),
+            )
+        } When {
+            post("/api/v1/suppressions")
+        } Then {
+            statusCode(201)
+        } Extract {
+            jsonPath().getString("id")
+        }
+
+        When {
+            post("/api/v1/suppressions/$id/revoke")
+        } Then {
+            statusCode(200)
+        }
+
+        // `revoked_at IS NULL` is the active predicate the contact-policy gate reads, and it is one
+        // of the columns that was mismapped — so asserting the row is GONE from the active list
+        // exercises the filter against the physical column, not just the entity's idea of it.
+        When {
+            get("/api/v1/suppressions/party/$partyId")
+        } Then {
+            statusCode(200)
+            body("size()", org.hamcrest.Matchers.equalTo(0))
+        }
+
+        dataSource.connection.use { c ->
+            c.prepareStatement("SELECT revoked_at, revoked_by FROM suppressions WHERE id = ?").use { st ->
+                st.setObject(1, UUID.fromString(id))
+                st.executeQuery().use { rs ->
+                    assertThat(rs.next()).isTrue()
+                    assertThat(rs.getTimestamp("revoked_at")).isNotNull()
+                    assertThat(rs.getString("revoked_by")).isNotBlank()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## The defect

`GET /api/v1/suppressions/party/{partyId}` has answered **500 on every call since the endpoint shipped**:

```
SQLGrammarException: column se1_0.createdat does not exist (42703)
[select se1_0.id,se1_0.createdAt,se1_0.createdBy,se1_0.partyId,se1_0.reasonCode,
        se1_0.revokedAt,se1_0.revokedBy,se1_0.scope,se1_0.source,se1_0.value
   from suppressions se1_0 where se1_0.partyId=$1 and se1_0.revokedAt is null]
```

consent-service configures **no** `physical-naming-strategy`, so Hibernate's implicit column name is the property name verbatim, and Postgres folds an unquoted identifier to lower case. `createdAt` asked for `createdat`; `V6__suppressions.sql` created `created_at`.

| entity property | asked for | migration created |
|---|---|---|
| `partyId` | `partyid` | `party_id` |
| `reasonCode` | `reasoncode` | `reason_code` |
| `createdBy` | `createdby` | `created_by` |
| `createdAt` | `createdat` | `created_at` |
| `revokedAt` | `revokedat` | `revoked_at` |
| `revokedBy` | `revokedby` | `revoked_by` |
| `id`, `scope`, `value`, `source` | ✅ | ✅ |

Six of ten wrong. The four that worked are single words — which is exactly why the class reads as internally consistent. Both siblings in the same package (`ConsentEntity`, `ConsentOutboxEntity`) spell every column out; this one did not.

## Why nothing caught it

- The unit tests **mock `SuppressionRepository`**, so no SQL is ever issued.
- Health probes do not touch the table, so the pod is Ready and ArgoCD is Healthy.
- The endpoint had **no integration test**.
- The file next door followed the convention, so review had nothing to catch on.

It was found by **schemathesis fuzzing the running service** in the weekly API-fuzz lane — a control that does not run on a PR. That is the whole story of this PR: the only thing that could see it ran once a week, after merge.

## Verified against a real Postgres, both directions

```
before:  GET /api/v1/suppressions/party/<uuid>  ->  500 {"code":"INTERNAL_ERROR"}
after:   GET /api/v1/suppressions/party/<uuid>  ->  200 []
```

`SuppressionPersistenceIT` drives create / list / revoke over real HTTP and reads the row back **by its snake_case column names via plain JDBC**. The JDBC assertion is the part that pins the mapping: it cannot pass against an entity that writes `createdat`, and it does not ask the entity class what the columns are called.

Falsified, not assumed — with the entity reverted:

```
ERROR: column se1_0.createdat does not exist (42703)
3 tests completed, 3 failed
```

and with the fix in place, 3 passed.

## The gate

`entity-column-names` (**enforced**): in a service that sets no `physical-naming-strategy`, a multi-word entity property must carry an explicit `@Column(name = ...)`.

- against the **unfixed** entity: 6 findings — exactly the 6 broken columns
- against the fixed tree: clean across **147 entity classes**
- self-test covers all four cases, including *"bare camelCase WITH a naming strategy → 0 subjects"* — that one is silent because the module is **skipped**, not because the entity passed, and the self-test asserts the subject count so those two cannot be confused

### Why it enforces the convention and not the DDL

Deriving *"does this column actually exist"* from the migrations needs real DDL parsing, and this repo has partitioned tables (`) PARTITION BY RANGE (booking_date);`), custom enum types (`settlement_type settlement_type NOT NULL`), ALTER/RENAME chains and quoted identifiers. Two attempts at that produced **12** and then **~40 false findings against correct code** — including the whole of sanctions-service, whose columns *are* named explicitly, in the Kotlin use-site form `@field:Column(name = "checked_at")` that the first regex could not match. A gate that cries wolf about correct code gets ignored, and then it is worth less than nothing. Both spellings remain valid; mixing them within one service is what breaks.

## Verification

- `./gradlew :openbank-consent-service:test --tests '*SuppressionPersistenceIT*'` → BUILD SUCCESSFUL (3/3), and 3/3 FAILED with the entity reverted
- `./gradlew :openbank-consent-service:ktlintCheck :openbank-consent-service:detekt` → exit 0
- `run-gates.py --only entity-column-names` → PASS, `SUBJECTS=147`
- live reproduction against `postgres:16.3-alpine` + `quarkusDev`, before and after

## Linked issues

Refs #5705
