### PR TITLE
fix(ci): make the API-fuzz lane actually reach six money-path services

### DIFF
--- a/.github/workflows/api-fuzz.yml
+++ b/.github/workflows/api-fuzz.yml
@@ -180,6 +180,18 @@ jobs:
             PORT="$(grep -m1 -A3 '^  http:' "$APP_YAML" | grep -m1 'port:' | grep -oE '[0-9]+')"
             DB="$(grep -m1 -E 'postgresql://' "$APP_YAML" | sed -E 's|.*/([A-Za-z0-9_]+).*|\1|')"
             DBUSER="$(grep -m1 '^    username:' "$APP_YAML" | awk '{print $2}')"
+            # The username is often a Quarkus config EXPRESSION, not a literal:
+            # `${POSTGRES_USER:openbank}` (vop) or `"${QUARKUS_DATASOURCE_USERNAME:openbank_settlement}"`
+            # (settlement). Taken verbatim, that string was handed to `docker run -e POSTGRES_USER=`
+            # and then to `pg_isready -U`, which can never succeed — so both services died on
+            # "postgres never became ready" and had NEVER been fuzzed, silently, while the job list
+            # showed them as covered. Resolve the expression to its default, which is exactly what
+            # the %dev profile resolves it to here (none of these vars are set in this job).
+            DBUSER="$(printf '%s' "$DBUSER" | tr -d "\"'" | sed -E 's/^\$\{[A-Za-z_][A-Za-z0-9_]*:?-?([^}]*)\}$/\1/')"
+            if [ -z "$DBUSER" ] || printf '%s' "$DBUSER" | grep -q '[^A-Za-z0-9_]'; then
+              echo "::error::[${svc}] could not resolve a usable datasource username from ${APP_YAML} (got '${DBUSER}') — skip"
+              OVERALL=1; continue
+            fi
             echo "==> [${svc}] port=${PORT} db=${DB} user=${DBUSER}"
 
             # Job-local postgres on the localhost:5432 the %dev profile
@@ -207,9 +219,39 @@ jobs:
             # Quarkus dev mode: %dev disables OIDC; Flyway migrates at start.
             # Kafka producers are lazy — no broker needed for the HTTP surface
             # (the transactional outbox keeps brokers out of the request path).
+            # Temporal worker OFF for the fuzz run. Six services register a Temporal worker at
+            # StartupEvent and there is no Temporal here, so the gRPC channel to
+            # temporal-frontend:7233 is refused: transaction-service failed outright
+            # ("Failed to start quarkus", Caused by StatusRuntimeException UNAVAILABLE) while
+            # lending, sepa-payment and domestic-payment retried past the boot deadline. Four
+            # money-path services were reported as fuzz failures for an absent dependency, which
+            # is not a finding about their HTTP surface — and it drowned the ONE real finding in
+            # the same run (consent-service, #5711).
+            #
+            # Every registrar already has the switch, because @QuarkusTest needs it too. What they
+            # do NOT have is a shared name for it: openbank.transaction.worker.enabled,
+            # openbank.domestic.worker.enabled, openbank.sepa.worker.enabled,
+            # openbank.campaign.worker.enabled, openbank.settlement.worker.enabled — and
+            # lending's is `lending.origination.worker.enabled`, not even under `openbank.`. So the
+            # property is DERIVED from the registrar's own @ConfigProperty rather than listed here;
+            # a hand-kept table of six names is the thing this repo keeps finding rotted.
+            # An ARRAY, not a string: an unquoted string here would rely on word splitting to
+            # become separate flags, which is the one shell behaviour that silently does the wrong
+            # thing the day a property name gains a space or the variable is empty.
+            # An ARRAY, not a string: an unquoted string at the use site would rely on word
+            # splitting to become separate flags, which is the one shell behaviour that silently
+            # does the wrong thing the day the variable is empty.
+            WORKER_FLAGS=()
+            WORKER_PROPS="$(grep -rhoE '"[A-Za-z0-9._-]*worker\.enabled"' "${svc}/src/main" 2>/dev/null | tr -d '"' | sort -u || true)"
+            for prop in ${WORKER_PROPS}; do
+              WORKER_FLAGS+=("-D${prop}=false")
+              echo "==> [${svc}] disabling Temporal worker via ${prop}=false"
+            done
+
             echo "==> [${svc}] starting quarkusDev"
             ./gradlew ":${svc}:quarkusDev" \
               -Dquarkus.datasource.jdbc.url="jdbc:postgresql://localhost:5432/${DB}" \
+              "${WORKER_FLAGS[@]}" \
               -Dquarkus.console.basic=true \
               --console=plain --quiet \
               > "fuzz-reports/${svc}-boot.log" 2>&1 &


### PR DESCRIPTION
## What the last fuzz run actually said

The 2026-08-18 run ([32103867665](https://github.com/JiRaska/open-bank-oss/actions/runs/32103867665)) reported **7 failures of 23**. Exactly **one** was a finding about a service's HTTP surface — consent-service, a real 500 on every call, fixed in #5711.

The other six never sent a request. The job list showed them as covered the whole time.

| service | reported | actually |
|---|---|---|
| consent | ❌ | **real finding** — 500 on `GET /suppressions/party/{id}` (#5711) |
| vop | ❌ | postgres never started — username was a config expression |
| settlement | ❌ | same |
| transaction | ❌ | `Failed to start quarkus` ← Temporal gRPC refused |
| lending | ❌ | retried Temporal past the boot deadline |
| sepa-payment | ❌ | same |
| domestic-payment | ❌ | same |

Six money-path services have never been adversarially tested by anything in this repo, and the failure looked identical to a genuine one.

## Defect 1 — the username is an expression, not a literal

```
DBUSER="$(grep -m1 '^    username:' "$APP_YAML" | awk '{print $2}')"
```

gives `${POSTGRES_USER:openbank}` for vop and `"${QUARKUS_DATASOURCE_USERNAME:openbank_settlement}"` for settlement. That string went straight to `docker run -e POSTGRES_USER=` and `pg_isready -U`, which can never succeed:

```
==> [openbank-vop-service] port=8149 db=openbank_vop user=${POSTGRES_USER:openbank}
::error::[openbank-vop-service] postgres never became ready — skip
```

Now resolved to the default — which is exactly what the `%dev` profile resolves it to in this job, since none of those variables are set — with a **loud skip** if the result is not a usable identifier. Falsified both ways:

```
'${POSTGRES_USER:openbank}'                              -> ok 'openbank'
'"${QUARKUS_DATASOURCE_USERNAME:openbank_settlement}"'   -> ok 'openbank_settlement'
'openbank'                                               -> ok 'openbank'
'${UNRESOLVED'                                           -> SKIP (loud)
''                                                       -> SKIP (loud)
```

## Defect 2 — the Temporal worker is a boot dependency

Six services register a Temporal worker at `StartupEvent`, and there is no Temporal here:

```
ERROR [io.qu.ru.Application] Failed to start application: Failed to start quarkus
Caused by: io.grpc.StatusRuntimeException: UNAVAILABLE: io exception
Caused by: ...ConnectException: finishConnect(..) failed with error(-111): Connection refused: localhost:7233
```

transaction-service failed outright; lending, sepa-payment and domestic-payment retried the name resolution past the boot deadline. That is not a finding about their HTTP surface — and it buried the one real finding in the same run.

Every registrar **already has the switch** (`@QuarkusTest` needs it). What they do not have is a shared name:

```
openbank.transaction.worker.enabled
openbank.domestic.worker.enabled
openbank.sepa.worker.enabled
openbank.campaign.worker.enabled
openbank.settlement.worker.enabled
lending.origination.worker.enabled     <- not even under `openbank.`
```

So the property is **derived from each registrar's own `@ConfigProperty`**, not listed in the workflow. A hand-kept table of six names is exactly the shape this repo keeps finding rotted — and the sixth name is the one a table would have got wrong.

## Verified by running it, not by reading it

The changed fragments, executed against the real tree:

```
openbank-transaction-service: user=openbank            flags=-Dopenbank.transaction.worker.enabled=false
openbank-lending-service:     user=openbank            flags=-Dlending.origination.worker.enabled=false
openbank-settlement-service:  user=openbank_settlement flags=-Dopenbank.settlement.worker.enabled=false
openbank-vop-service:         user=openbank            flags=none
openbank-consent-service:     user=openbank            flags=none
```

`actionlint` reports the same single pre-existing `SC2034` as `origin/main` — no new findings. The use site takes an **array**, `"${WORKER_FLAGS[@]}"`, not an unquoted string: relying on word splitting to turn one variable into several flags is the shell behaviour that silently does the wrong thing the day the variable is empty (and it is what `SC2086` was pointing at).

## Why this matters beyond the lane

The `pentest` attestation in `attestations.yaml` is earned by `ci-schemathesis` — this workflow — with the run URL as its `ref`. While six money-path services could not be fuzzed, C7=Bank-grade was blocked on an event that could not happen for them. This does not grant any attestation; it makes the one that grants them capable of running.

## Linked issues

Refs #5705
