### PR TITLE
fix(interest): stop acking event-consumer failures that a retry could fix (#5698)

### DIFF
--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/kafka/WithholdingRemittanceSettlementConsumer.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/kafka/WithholdingRemittanceSettlementConsumer.kt
@@ -13,6 +13,7 @@ import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.ws.rs.core.Response
+import kotlinx.coroutines.delay
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.eclipse.microprofile.reactive.messaging.Incoming
@@ -58,6 +59,23 @@ import java.util.UUID
  * by transaction-service's own idempotencyKey field and this consumer's dedup key, so a Kafka
  * redelivery replays the same booking instead of double-remitting.
  *
+ * ## Failure handling — a bad payload and a bad rail call are not the same thing (#5698)
+ *
+ * A **malformed payload** is unretryable: a redelivery decodes identically and fails identically
+ * forever. It is logged and ACKED, and that is the only poison-pill case here.
+ *
+ * A **failed downstream call** is the opposite — the event is fine, the rail or the database is
+ * not, and a due regulatory tax remittance must still be booked once it recovers. This boundary
+ * used to swallow that too: the outer catch wrapped the whole of [bookAndSettle], so a transient
+ * transaction-service failure was logged and the message ACKED, stranding the batch PENDING
+ * forever with the event gone. Nothing re-drives it — there is no endpoint, only SQL. So every
+ * downstream call now goes through [withBoundedRetry] and, if it still fails, is RETHROWN, letting
+ * the connector dead-letter it into something a human can see. Same shape as kyc-service's
+ * `PartyEventConsumer` (#5698/#5699).
+ *
+ * The idempotency key below is what makes both a retry and a redelivery safe: transaction-service
+ * answers 409 for a batch already booked, and this consumer treats that as success.
+ *
  * **Scope note (deliberate, tracked as follow-up — see issue #999):** this consumer books the cash
  * leg only. It does NOT assemble or file the statutory §38d *Vyúčtování daně vybírané srážkou* XML
  * with the finanční úřad — that is a separate regulatory-reporting concern (issue #999 flags
@@ -78,30 +96,92 @@ class WithholdingRemittanceSettlementConsumer(
     private val log = Logger.getLogger(WithholdingRemittanceSettlementConsumer::class.java)
 
     @Incoming("interest-withholding-remitted-in")
-    // Poison-pill safety: this boundary must swallow ANY failure (parse, rail call) and ack, so
-    // one bad event cannot wedge the consumer group.
+    // Only the DECODE below is allowed to swallow-and-ack (a malformed payload can never succeed on
+    // a redelivery). Every downstream call is retried and then rethrown — see the class KDoc.
     @Suppress("TooGenericExceptionCaught")
     suspend fun consume(record: ConsumerRecord<String, String>) {
-        try {
-            // ADR-0050 N3: the event type travels ONLY as the ce-type header — the payload has no
-            // eventType field (see KafkaInterestOutboxEventPublisher), so filter on the header.
-            val eventType = record.headers().lastHeader(OutboxKafkaHeaders.HEADER_EVENT_TYPE)
-                ?.let { String(it.value(), StandardCharsets.UTF_8) }
-            if (eventType != EVENT_WITHHOLDING_REMITTED) return
+        // ADR-0050 N3: the event type travels ONLY as the ce-type header — the payload has no
+        // eventType field (see KafkaInterestOutboxEventPublisher), so filter on the header.
+        val eventType = record.headers().lastHeader(OutboxKafkaHeaders.HEADER_EVENT_TYPE)
+            ?.let { String(it.value(), StandardCharsets.UTF_8) }
+        if (eventType != EVENT_WITHHOLDING_REMITTED) return
 
-            val node = objectMapper.readTree(record.value())
-            val remittanceId = UUID.fromString(node.path("remittanceId").asText())
-            val totalTaxAmount = decimalOf(node.path("totalTaxAmount"))
-            val itemCount = node.path("itemCount").asInt()
-
-            if (totalTaxAmount.signum() <= 0) {
-                settleNilOrRefuse(remittanceId, totalTaxAmount, itemCount)
-                return
-            }
-
-            bookAndSettle(remittanceId, debitRequestFor(node, remittanceId, totalTaxAmount))
+        val batch = try {
+            decode(record.value())
         } catch (e: Exception) {
-            log.errorf(e, "[withholding-remittance] failed to handle remitted event: %.300s", record.value())
+            // Unretryable: log and ack. This is the ONLY swallowed failure in this consumer.
+            log.errorf(e, "[withholding-remittance] undecodable remitted event, acking: %.300s", record.value())
+            return
+        }
+
+        withBoundedRetry(batch.remittanceId) {
+            if (batch.totalTaxAmount.signum() <= 0) {
+                settleNilOrRefuse(batch.remittanceId, batch.totalTaxAmount, batch.itemCount)
+            } else {
+                bookAndSettle(
+                    batch.remittanceId,
+                    debitRequestFor(batch.node, batch.remittanceId, batch.totalTaxAmount),
+                )
+            }
+        }
+    }
+
+    /** The fields this consumer needs off the event; throws on anything unparsable (see [decimalOf]). */
+    private data class RemittedBatch(
+        val node: JsonNode,
+        val remittanceId: UUID,
+        val totalTaxAmount: BigDecimal,
+        val itemCount: Int,
+    )
+
+    private fun decode(payload: String): RemittedBatch {
+        val node = objectMapper.readTree(payload)
+        return RemittedBatch(
+            node = node,
+            remittanceId = UUID.fromString(node.path("remittanceId").asText()),
+            totalTaxAmount = decimalOf(node.path("totalTaxAmount")),
+            itemCount = node.path("itemCount").asInt(),
+        )
+    }
+
+    /**
+     * Retry [block] a bounded number of times, then RETHROW so the connector dead-letters.
+     *
+     * The rethrow is the point. A caught-and-logged failure acks the message, and an acked message
+     * that did no work is indistinguishable from one that succeeded — from Kafka, from the consumer
+     * lag metric, and from every dashboard built on either. The only trace was an ERROR line nobody
+     * alerts on, while a due tax remittance sat PENDING with no event left to re-drive it (#5698).
+     */
+    @Suppress("TooGenericExceptionCaught") // the retry is deliberately type-agnostic; it rethrows
+    private suspend fun withBoundedRetry(remittanceId: UUID, block: suspend () -> Unit) {
+        var attempt = 1
+        while (true) {
+            try {
+                block()
+                return
+            } catch (e: Exception) {
+                if (attempt >= MAX_ATTEMPTS) {
+                    log.errorf(
+                        e,
+                        "[withholding-remittance] batch %s failed after %d attempts (%s: %s) — dead-lettering",
+                        remittanceId,
+                        attempt,
+                        e.javaClass.simpleName,
+                        e.message,
+                    )
+                    throw e
+                }
+                log.warnf(
+                    "[withholding-remittance] batch %s failed (attempt %d/%d, %s: %s) — retrying",
+                    remittanceId,
+                    attempt,
+                    MAX_ATTEMPTS,
+                    e.javaClass.simpleName,
+                    e.message,
+                )
+                delay(RETRY_BACKOFF_MS * attempt)
+                attempt++
+            }
         }
     }
 
@@ -157,7 +237,14 @@ class WithholdingRemittanceSettlementConsumer(
             instructionType = "ONE_OFF",
         )
 
-    /** Books the debit and advances the batch to SETTLED; a 409 is an idempotent success (#999). */
+    /**
+     * Books the debit and advances the batch to SETTLED; a 409 is an idempotent success (#999).
+     *
+     * Any other non-2xx THROWS — a due tax remittance that did not move money must reach the DLQ,
+     * not a log line. A 4xx (e.g. the unconfigured all-zero source account 404ing) cannot succeed
+     * on retry, but dead-lettering it is still the loud failure this consumer's KDoc asks for, and
+     * strictly louder than the silent ack it replaces.
+     */
     private suspend fun bookAndSettle(remittanceId: UUID, request: InitiateTransactionRequest) {
         val response = transactionClient.initiateTransaction(request).awaitSuspending()
         when {
@@ -173,13 +260,11 @@ class WithholdingRemittanceSettlementConsumer(
                 )
             }
             else -> {
-                log.errorf(
-                    "[withholding-remittance] batch %s FAILED to book (HTTP %d) — a due tax remittance " +
-                        "did not move money. This requires manual investigation; the batch stays PENDING " +
-                        "for retry (a redelivery of this event, or an operator re-driving it).",
-                    remittanceId,
-                    response.status,
-                )
+                // Throwing is what makes the retry real. This branch used to log and return, which
+                // ACKED the message — so the "stays PENDING for retry (a redelivery of this event)"
+                // the old comment promised could never happen: the event was already gone, and no
+                // endpoint re-drives a batch. Now the caller retries and then dead-letters (#5698).
+                throw RemittanceBookingFailedException(remittanceId, response.status)
             }
         }
     }
@@ -188,7 +273,8 @@ class WithholdingRemittanceSettlementConsumer(
      * The producer serializes BigDecimal fields as JSON *strings* (`"totalTaxAmount":"1234.00"`,
      * see `WithholdingRemittanceService.remittedEvent`), and Jackson's `decimalValue()` silently
      * returns `BigDecimal.ZERO` for a TextNode — the original zero-booking bug. Accept both the
-     * string and a plain numeric encoding; anything unparsable throws (caught + logged upstream).
+     * string and a plain numeric encoding; anything unparsable throws, which
+     * [consume] logs and ACKS — a malformed payload is the one failure a redelivery cannot fix.
      */
     private fun decimalOf(node: JsonNode): BigDecimal =
         if (node.isNumber) node.decimalValue() else BigDecimal(node.asText())
@@ -196,5 +282,18 @@ class WithholdingRemittanceSettlementConsumer(
     private companion object {
         const val EVENT_WITHHOLDING_REMITTED = "interest.withholding.remitted.v1"
         const val HTTP_CONFLICT = 409
+        const val MAX_ATTEMPTS = 3
+        const val RETRY_BACKOFF_MS = 500L
     }
 }
+
+/**
+ * The rail refused to book a due withholding-tax remittance. Named (rather than a bare
+ * RuntimeException) so the retry/dead-letter path is greppable and detekt's TooGenericExceptionThrown
+ * does not need suppressing.
+ */
+class RemittanceBookingFailedException(remittanceId: UUID, status: Int) :
+    RuntimeException(
+        "[withholding-remittance] batch $remittanceId FAILED to book (HTTP $status) — a due tax " +
+            "remittance did not move money; requires manual investigation",
+    )

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/kafka/WithholdingRemittanceSettlementConsumerTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/kafka/WithholdingRemittanceSettlementConsumerTest.kt
@@ -19,7 +19,11 @@ import kotlinx.coroutines.runBlocking
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.util.UUID
+
+/** Named so detekt's TooGenericExceptionThrown does not fire at the throw site in a mockk answer. */
+private class TransientRailFailure : RuntimeException("connection reset")
 
 class WithholdingRemittanceSettlementConsumerTest {
 
@@ -114,15 +118,53 @@ class WithholdingRemittanceSettlementConsumerTest {
         verify(exactly = 1) { remitUseCase.settle(remittanceId) }
     }
 
+    /**
+     * Replaces a test that asserted the OPPOSITE — "does not settle the batch and does not throw".
+     * Not throwing ACKS the message, so a due regulatory tax remittance was stranded PENDING with
+     * the event gone and nothing left to re-drive it, while the code comment right there promised
+     * "the batch stays PENDING for retry (a redelivery of this event)". That redelivery could never
+     * happen (#5698). The batch must still not settle — but the message must now reach the DLQ.
+     */
     @Test
-    fun `a non-2xx-non-409 response does not settle the batch and does not throw`(): Unit = runBlocking {
+    fun `a persistent non-2xx-non-409 response is RETHROWN so the connector dead-letters`(): Unit = runBlocking {
         every { transactionClient.initiateTransaction(any()) } returns
             Uni.createFrom().item(Response.status(500).build())
 
+        assertThrows<RemittanceBookingFailedException> { runBlocking { consumer.consume(record()) } }
+
+        verify(exactly = 3) { transactionClient.initiateTransaction(any()) }
+        verify(exactly = 0) { remitUseCase.settle(any()) }
+    }
+
+    @Test
+    fun `a TRANSIENT rail failure is retried and the batch settles without dead-lettering`(): Unit = runBlocking {
+        var calls = 0
+        every { transactionClient.initiateTransaction(any()) } answers {
+            calls++
+            if (calls == 1) throw TransientRailFailure() else Uni.createFrom().item(Response.status(201).build())
+        }
+        every { remitUseCase.settle(remittanceId) } returns Uni.createFrom().item(Unit)
+
         consumer.consume(record())
 
-        verify(exactly = 1) { transactionClient.initiateTransaction(any()) }
-        verify(exactly = 0) { remitUseCase.settle(any()) }
+        verify(exactly = 2) { transactionClient.initiateTransaction(any()) }
+        verify(exactly = 1) { remitUseCase.settle(remittanceId) }
+    }
+
+    /**
+     * The settle() leg is a downstream call too: booking the money and then silently failing to
+     * advance the batch would leave it PENDING against a rail that already moved the cash.
+     */
+    @Test
+    fun `a persistent settle failure after a successful booking is RETHROWN`(): Unit = runBlocking {
+        every { transactionClient.initiateTransaction(any()) } returns
+            Uni.createFrom().item(Response.status(201).build())
+        every { remitUseCase.settle(remittanceId) } returns
+            Uni.createFrom().failure(TransientRailFailure())
+
+        assertThrows<TransientRailFailure> { runBlocking { consumer.consume(record()) } }
+
+        verify(exactly = 3) { remitUseCase.settle(remittanceId) }
     }
 
     @Test
@@ -176,10 +218,30 @@ class WithholdingRemittanceSettlementConsumerTest {
         verify(exactly = 1) { remitUseCase.settle(remittanceId) }
     }
 
+    /**
+     * The other half of the split, and the reason the fix is not a blanket rethrow: a payload that
+     * cannot be decoded fails identically on every redelivery, so it is the one genuinely
+     * unretryable case and must still ACK. A suite that only proved the rethrow could not tell this
+     * fix from "throw on everything", which would wedge the partition on the first bad event.
+     */
     @Test
-    fun `a malformed payload is swallowed, not thrown`(): Unit = runBlocking {
+    fun `a malformed payload still ACKS and never reaches the rail`(): Unit = runBlocking {
         consumer.consume(record(payload = "{bad-json"))
 
         verify(exactly = 0) { transactionClient.initiateTransaction(any()) }
+        verify(exactly = 0) { remitUseCase.settle(any()) }
+    }
+
+    /**
+     * A NEGATIVE total is an upstream data defect, not an infrastructure blip — no
+     * WithholdingTaxPolicy path produces one, so a redelivery decodes the same negative amount
+     * forever. It must be refused and ACKED, never retried onto the rail.
+     */
+    @Test
+    fun `a negative amount ACKS without retrying the rail`(): Unit = runBlocking {
+        consumer.consume(record(payload = remittedPayload(totalTaxAmount = "\"-5\"", itemCount = 3)))
+
+        verify(exactly = 0) { transactionClient.initiateTransaction(any()) }
+        verify(exactly = 0) { remitUseCase.settle(any()) }
     }
 }


### PR DESCRIPTION
## What

Two more instances of the #5698 catch-and-ack shape, in the two **money-path** services. Same fix shape as PR #5699 (kyc-service): bounded retry then rethrow for downstream calls, keep the ack for genuinely unretryable payloads.

A sibling PR covers the non-money-path consumers; this PR deliberately touches only `openbank-interest-service` and `openbank-fraud-service`.

## The split, which is the whole fix

| failure | before | after |
|---|---|---|
| malformed / undecodable payload | logged, acked | **unchanged** — logged, acked |
| upstream data defect (negative tax total) | logged, acked | **unchanged** — logged, acked |
| downstream call (REST rail, DB write) | logged, **acked** | 3 attempts, linear backoff, then **rethrown** so the connector dead-letters |
| ADR-0140 feature store (shadow plane) | logged, acked | **unchanged**, and the KDoc now says why |

A redelivery of a malformed payload decodes identically and fails identically forever, so acking it is correct; blanket-rethrowing would wedge the partition on the first bad event.

## 1. `openbank-interest-service` — `WithholdingRemittanceSettlementConsumer` (highest severity)

The outer `try` wrapped the entire `consume()`, including `bookAndSettle()` -> `transactionClient.initiateTransaction(...)` — the REST call that books the cash leg of a due withholding-tax remittance to the finanční úřad. A transient transaction-service failure was logged and the message acked, stranding a **regulatory tax remittance PENDING forever** with the event gone and no endpoint to re-drive it.

Two comments asserted behaviour the code did not have, which is how it survived review:

- the handler comment: the boundary `"must swallow ANY failure (parse, rail call) and ack"`;
- `bookAndSettle`'s non-2xx branch: `"the batch stays PENDING for retry (a redelivery of this event, or an operator re-driving it)"` — a redelivery that could never arrive, because that branch also returned normally and acked.

Both corrected; the class KDoc now states the split. A non-2xx-non-409 response throws `RemittanceBookingFailedException` rather than logging, and `remitUseCase.settle()` is covered too — booking the money and then silently failing to advance the batch leaves it PENDING against a rail that already moved cash.

## 2. `openbank-fraud-service` — `TransactionSignalConsumer`

The class KDoc claimed `"Failures are DLQ'd"`. Nothing rethrew, so nothing was: three individually-swallowed calls inside `runBlocking`, handler returns normally, message acked. Consumer lag and every dashboard built on it reported the event as processed. An undercounted velocity window is a fraud rule that quietly does not fire — `"scoring degrades gracefully"` is true of a *missing* aggregate, not a licence to create one silently.

`recordTransaction()` and `recordPayment()` now retry-then-rethrow. **`FeatureOnlineUpdater` is deliberately still swallowed** — it is the ADR-0140 shadow plane feeding no live decision, so dead-lettering a real velocity signal for a shadow-plane write would trade a working control for an experimental one. The KDoc now says that specifically instead of a blanket claim that was false for all three.

Trade-off recorded in the KDoc because it is real: `payee_history` upserts guard on `last_transaction_id` and are redelivery-safe, but `velocity_aggregates` has no dedup, so a redelivery re-adds the amount. Over-counting makes fraud rules fire *more* readily; under-counting makes them silently not fire — which is the bug being fixed.

## Tests — and the negative case

Four green tests across the two services asserted the swallow **as intended behaviour** (`"is caught and does not propagate"`, `"does not settle the batch and does not throw"`). As the issue notes, reading them would have confirmed the bug as a feature. All four are replaced.

Added per service: a persistent-failure test asserting the rethrow **and** the attempt count, a transient-failure test proving one blip is retried and the work still completes, and explicit ACK tests for the malformed/unretryable paths — so the suite can distinguish this fix from a blanket rethrow.

**Verified by effect, not appearance.** Each new suite was run against the pre-fix consumer:

- fraud — exactly the 3 new behaviour tests FAIL; the malformed-ACK and feature-store tests PASS on both sides.
- interest — exactly the 3 new behaviour tests FAIL; the malformed-payload and negative-amount ACK tests PASS on both sides.

(For interest this needed a throwaway shim so the new tests compiled against the old consumer, isolating behaviour from compilation. Not committed.)

## Verification

`ktlintCheck`, `detekt` and `test` all green for both modules, confirmed by reading which tasks actually appear in the output rather than the final status line:

```
./gradlew :openbank-interest-service:ktlintCheck :openbank-interest-service:detekt :openbank-interest-service:test
./gradlew :openbank-fraud-service:ktlintCheck :openbank-fraud-service:detekt :openbank-fraud-service:test
```

No API change, so no `openapi.yaml` bump. No DB or event-schema change. `version.txt` untouched — release-please cuts both from the `fix` type plus the `src/main` paths.

`openbank-interest-service` is money-path, so this needs 2 approvals per ADR-0030. **Not merging.**

Refs #5698
