### PR TITLE
feat(settlement): emit domain metrics and alert on them (#5705)

### DIFF
--- a/openbank-infra/gitops/components/payments/prometheus-rules.yaml
+++ b/openbank-infra/gitops/components/payments/prometheus-rules.yaml
@@ -406,3 +406,141 @@ spec:
               balance compensation was attempted and refused, so funds moved and were not returned —
               this does not resolve itself. Identify the settlement, confirm which leg is
               outstanding, and start the collections/dispute path.
+---
+# ─────────────────────────────────────────────────────────────────────────────
+# settlement-service (issue #5705)
+#
+# settlement-service is a declared money-path service that, until #5705, emitted no application
+# metric of any kind: the pod was scraped, the Rollout was Healthy, ArgoCD was Green, and there was
+# simply no series to query. Nothing here could distinguish "settlement is running normally" from
+# "settlement has booked nothing for six hours".
+#
+# Every series below is registered EAGERLY by SettlementMetricsAdapter.bindTo() at @PostConstruct
+# (the bean is @Startup because @ApplicationScoped is lazy), so it exists at 0.0 from the first
+# scrape. That is load-bearing, not tidiness: Micrometer does not create a counter until its first
+# increment, so `increase(openbank_settlement_terminal_total[6h]) == 0` written against a lazily
+# created counter matches NOTHING on a service that has never booked anything — precisely the state
+# these alerts exist to catch. SettlementMetricsAdapterTest asserts the rendered scrape text, so the
+# exact strings below (dot->underscore, the `_total` suffix, tag order) come from Micrometer rather
+# than from this file's idea of them.
+# ─────────────────────────────────────────────────────────────────────────────
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-settlement-alerts
+  namespace: payments
+  labels:
+    app.kubernetes.io/part-of: openbank
+    app.kubernetes.io/name: settlement-service
+spec:
+  groups:
+    - name: openbank.settlement.health
+      rules:
+        - alert: SettlementSagaNotCompleting
+          # THE alert for this service. Self-normalising by construction: it compares work accepted
+          # against work finished, so it needs no business-hours guard and no uptime guard — a
+          # freshly started pod has no originations either, making the first conjunct 0 and the
+          # rule silent, rather than firing 15m after every deploy the way an unguarded
+          # `increase(...) == 0` gauge alert does (the boot-time fourth state this repo has already
+          # paid for once, ADR-0237 / #4208).
+          #
+          # This is the shape of the failure the saga makes invisible: originate() answers 202 with
+          # a PENDING row and hands off to Temporal, so a worker that never picks work up (worker
+          # not registered, wrong task queue, Temporal frontend unreachable) leaves every settlement
+          # PENDING forever and produces no HTTP errors, no latency change and no log line anyone
+          # is watching. Money is accepted and nothing settles.
+          expr: |
+            increase(openbank_settlement_originated_total{outcome="created"}[1h]) > 0
+            and
+            increase(openbank_settlement_terminal_total[1h]) == 0
+          for: 15m
+          labels:
+            severity: critical
+            service: settlement
+          annotations:
+            # Subject: incremented on the settlement request/activity path
+            # (SettlementMetricsAdapter), not by any scheduler — no period to compare against.
+            subject_period: continuous
+            summary: "settlement-service accepted settlements but completed none"
+            description: >-
+              {{ $value }} settlement(s) were accepted in the last hour and not one reached a
+              terminal state (booked or rejected). Suspect the Temporal worker: check that the
+              settlement worker is registered on task queue `openbank-settlement` and that
+              temporal-frontend.temporal.svc:7233 is reachable. Rows will be sitting in PENDING.
+
+        - alert: SettlementNoBookingsInBusinessHours
+          # The issue's literal ask — "settlement has processed nothing for six hours".
+          #
+          # The `> 0` guard is what separates "was settling and went quiet" from "has not settled
+          # yet since it started", and it is required, not decorative. The counter is eagerly
+          # registered, so on a fresh pod the series EXISTS and reads 0; without the guard
+          # `increase(...) == 0` is true for every pod for the first six hours of its life and this
+          # warning fires after every deploy during business hours. Same guard, same reason, as
+          # AuditChainVerificationStale in components/observability/prometheus-rules-audit-chain.yaml.
+          #
+          # What the guard deliberately gives up: a pod that has NEVER booked anything since restart
+          # is not covered here. That case is SettlementSagaNotCompleting's, which catches it within
+          # the hour and at `critical` — so nothing is left uncovered by keeping this one narrow.
+          expr: |
+            increase(openbank_settlement_terminal_total{outcome="booked"}[6h]) == 0
+            and openbank_settlement_terminal_total{outcome="booked"} > 0
+            and on() hour() >= 6 and on() hour() <= 18
+          for: 30m
+          labels:
+            severity: warning
+            service: settlement
+          annotations:
+            # Subject: incremented on the settlement request/activity path
+            # (SettlementMetricsAdapter), not by any scheduler — no period to compare against.
+            subject_period: continuous
+            summary: "No settlements booked in 6h (business hours)"
+            description: >-
+              settlement-service has booked nothing to the ledger for 6h during business hours,
+              having booked normally earlier in this pod's life. Either upstream stopped
+              originating settlements, or the saga is failing short of the ledger — cross-check
+              openbank_settlement_saga_steps_total{outcome="failed"}.
+
+        - alert: SettlementSagaStepsFailing
+          # Temporal RETRIES a failing activity before it compensates, so a non-zero failure rate is
+          # not by itself an incident — a sustained one is the only warning before customer money
+          # gets moved and moved back. Warning, not critical: the compensation is the safety net
+          # working, and SettlementCompensationsElevated below is what pages if it is actually used.
+          expr: |
+            sum by (step) (rate(openbank_settlement_saga_steps_total{outcome="failed"}[15m])) > 0
+          for: 20m
+          labels:
+            severity: warning
+            service: settlement
+          annotations:
+            # Subject: incremented on the settlement request/activity path
+            # (SettlementMetricsAdapter), not by any scheduler — no period to compare against.
+            subject_period: continuous
+            summary: "settlement saga step {{ $labels.step }} is failing repeatedly"
+            description: >-
+              The `{{ $labels.step }}` activity has been failing continuously for 20m. Temporal is
+              still retrying; once the attempts are exhausted the saga compensates and the
+              settlement ends REJECTED. Check the downstream this step calls (balance-service for
+              debit/credit, ledger-service for ledger_book).
+
+        - alert: SettlementCompensationsElevated
+          # A compensated saga MOVES CUSTOMER MONEY AND MOVES IT BACK, then ends in REJECTED — a
+          # perfectly healthy-looking terminal state that no error rate and no HTTP status reports.
+          # This is the one alert that reads that outcome as the incident it is.
+          expr: |
+            sum(rate(openbank_settlement_terminal_total{outcome="rejected"}[1h]))
+              /
+            clamp_min(sum(rate(openbank_settlement_terminal_total[1h])), 1e-9)
+              > 0.1
+          for: 30m
+          labels:
+            severity: critical
+            service: settlement
+          annotations:
+            # Subject: incremented on the settlement request/activity path
+            # (SettlementMetricsAdapter), not by any scheduler — no period to compare against.
+            subject_period: continuous
+            summary: "Over 10% of settlements are being rejected after compensation"
+            description: >-
+              {{ $value | humanizePercentage }} of settlements reaching a terminal state in the last
+              hour were REJECTED after their compensations ran — each one debited and credited real
+              accounts and then reversed them. Treat as a money-path incident, not a error-rate blip.

--- a/openbank-settlement-service/build.gradle.kts
+++ b/openbank-settlement-service/build.gradle.kts
@@ -41,16 +41,17 @@ dependencies {
     testImplementation(libs.quarkus.test.security)
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
-    // Test-only (#5705): SettlementStrandedGaugeTest and SettlementActivitiesImplTest assert the
-    // alert expressions in gitops/components/payments/prometheus-rules.yaml against a real
-    // Prometheus scrape, so the dot->underscore mapping, the counter's `_total` suffix and the tag
-    // ordering come from Micrometer rather than from these tests' idea of them. Runtime already
-    // ships the registry via quarkus-micrometer-registry-prometheus, but as the `-simpleclient`
-    // variant (package io.micrometer.prometheus); only the compile classpath needs the
-    // io.micrometer.prometheusmetrics one. Same version, same rationale and same CVE pin as
-    // openbank-campaign-service's and openbank-domestic-payment's copies: 1.14.5 -> 1.17.0 for
-    // GHSA-g3pr-3p32-fp23 / CVE-2026-40984 (HIGH DoS; the 1.14.x line has no fix), and this
-    // literal — not quarkus-bom's constraint — is what dependency-review scans.
+    // Test-only (#5705): SettlementStrandedGaugeTest, SettlementActivitiesImplTest and
+    // SettlementMetricsAdapterTest assert the alert expressions in
+    // gitops/components/payments/prometheus-rules.yaml against a real Prometheus scrape, so the
+    // dot->underscore mapping, the counter's `_total` suffix and the tag ordering come from
+    // Micrometer rather than from these tests' idea of them. Runtime already ships the registry via
+    // quarkus-micrometer-registry-prometheus, but as the `-simpleclient` variant (package
+    // io.micrometer.prometheus); only the compile classpath needs the io.micrometer.prometheusmetrics
+    // one. Same version, same rationale and same CVE pin as openbank-campaign-service's and
+    // openbank-domestic-payment's copies: 1.14.5 -> 1.17.0 for GHSA-g3pr-3p32-fp23 /
+    // CVE-2026-40984 (HIGH DoS; the 1.14.x line has no fix), and this literal — not quarkus-bom's
+    // constraint — is what dependency-review scans.
     testImplementation("io.micrometer:micrometer-registry-prometheus:1.17.0")
     testImplementation(libs.rest.assured.kotlin)
     testImplementation(libs.testcontainers)

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/port/out/SettlementMetricsPort.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/port/out/SettlementMetricsPort.kt
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.application.port.out
+
+import java.math.BigDecimal
+import java.time.Duration
+
+/**
+ * Outbound observability port (ADR-0002 / ADR-0077, issue #5705). settlement-service is a declared
+ * money-path service that emitted **no application metric of any kind** — the pod was scraped, the
+ * workload was Ready, and there was simply no series to query. Nothing could distinguish
+ * "settlement is running normally" from "settlement has booked nothing for six hours".
+ *
+ * The failure modes these meters make visible are all silent by construction:
+ *
+ *  - the saga is driven by Temporal, which **retries** a failing activity and only then compensates;
+ *    a debit that keeps failing shows up as neither an HTTP error nor a latency change on this
+ *    service, because the originating request already returned 202 with the PENDING row;
+ *  - a compensated saga *moves customer money and moves it back*, ending in REJECTED — a perfectly
+ *    healthy-looking terminal state that no error rate reports;
+ *  - a worker that never picks work up at all (no Temporal worker registered, wrong task queue)
+ *    leaves every settlement in PENDING forever, and produces no errors whatsoever.
+ *
+ * Kept as a port rather than a direct `MeterRegistry` dependency so the application layer stays free
+ * of the metrics framework, and so the counters are exercised through the real adapter (over a real
+ * Prometheus registry) in unit tests.
+ *
+ * Implemented by [com.openbank.settlement.infrastructure.observability.SettlementMetricsAdapter].
+ */
+interface SettlementMetricsPort {
+
+    /**
+     * Record one origination request. [outcome] separates a genuinely new PENDING row from an
+     * idempotent replay of a key already seen — the name says *accepted*, not settled: at this
+     * point no money has moved and the saga has only just been asked to start.
+     */
+    fun settlementOriginated(currency: String, outcome: OriginationOutcome)
+
+    /**
+     * Record one settlement-saga activity attempt. [outcome] is `FAILED` for an attempt that threw —
+     * Temporal will retry it, so a non-zero failure rate is not by itself an incident, but a
+     * sustained one is the only warning before compensation runs.
+     */
+    fun sagaStep(step: SettlementStep, outcome: SettlementStepOutcome)
+
+    /**
+     * Record a settlement that reached BOOKED. [cycleDuration] is measured from origination to the
+     * ledger booking, i.e. the whole customer-visible settlement latency, not one activity's.
+     */
+    fun settlementBooked(currency: String, amount: BigDecimal, cycleDuration: Duration)
+
+    /** Record a settlement that reached REJECTED after its compensations ran. */
+    fun settlementRejected(currency: String, cycleDuration: Duration)
+}
+
+/** What an origination request actually did. A bounded set — safe as a metric tag. */
+enum class OriginationOutcome {
+    /** The idempotency key was not yet stored when the request arrived, so a row was created. */
+    CREATED,
+
+    /** The idempotency key resolved to an existing settlement; nothing new was created. */
+    REPLAYED,
+}
+
+/**
+ * The settlement-saga activities, forward legs and compensations alike. A bounded set — safe as a
+ * metric tag, and deliberately mirrors the method names on
+ * [com.openbank.settlement.application.workflow.SettlementActivities] so a series can be traced
+ * back to exactly one call site.
+ */
+enum class SettlementStep {
+    DEBIT,
+    CREDIT,
+    LEDGER_BOOK,
+    REVERSE_DEBIT,
+    REVERSE_CREDIT,
+    REVERSE_LEDGER_BOOK,
+    REJECT,
+}
+
+/** Terminal outcome of one activity attempt. */
+enum class SettlementStepOutcome {
+    /** The activity completed and the status transition was persisted. */
+    COMPLETED,
+
+    /** The activity threw. Temporal will retry it, and compensate once the attempts are exhausted. */
+    FAILED,
+}

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/usecase/SettlementService.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/usecase/SettlementService.kt
@@ -7,6 +7,8 @@ package com.openbank.settlement.application.usecase
 import com.openbank.libs.temporal.TemporalConfig
 import com.openbank.settlement.application.port.`in`.OriginateSettlementCommand
 import com.openbank.settlement.application.port.`in`.SettlementUseCase
+import com.openbank.settlement.application.port.out.OriginationOutcome
+import com.openbank.settlement.application.port.out.SettlementMetricsPort
 import com.openbank.settlement.application.port.out.SettlementRepository
 import com.openbank.settlement.application.workflow.SettlementWorkflow
 import com.openbank.settlement.domain.model.Settlement
@@ -27,6 +29,7 @@ class SettlementService(
     private val settlementRepository: SettlementRepository,
     private val temporalConfig: TemporalConfig,
     private val workflowClient: WorkflowClient,
+    private val metrics: SettlementMetricsPort,
     private val clock: Clock,
 ) : SettlementUseCase {
 
@@ -35,10 +38,12 @@ class SettlementService(
         settlementRepository: SettlementRepository,
         temporalConfig: TemporalConfig,
         workflowClient: WorkflowClient,
+        metrics: SettlementMetricsPort,
     ) : this(
         settlementRepository,
         temporalConfig,
         workflowClient,
+        metrics,
         Clock.systemUTC(),
     )
 
@@ -53,7 +58,14 @@ class SettlementService(
         // retried request resolves to the same row (the UUID primary key is the hard duplicate
         // guard even under a concurrent double-submit).
         val id = UUID.nameUUIDFromBytes("settlement:${command.idempotencyKey}".toByteArray())
-        val settlement = settlementRepository.findById(id) ?: createPending(command, id)
+        val existing = settlementRepository.findById(id)
+        val settlement = existing ?: createPending(command, id)
+        // `created` vs `replayed` on the ACCEPTANCE of a request — nothing has moved yet at this
+        // point, so the metric deliberately does not claim a settlement.
+        metrics.settlementOriginated(
+            settlement.currency,
+            if (existing == null) OriginationOutcome.CREATED else OriginationOutcome.REPLAYED,
+        )
 
         // (Re)start the settlement whenever it is not yet terminal: a fresh PENDING, OR an orphaned
         // PENDING left behind if a prior request created the row but failed before/while starting

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImpl.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImpl.kt
@@ -12,7 +12,10 @@ import com.openbank.settlement.application.port.out.DebitPort
 import com.openbank.settlement.application.port.out.LedgerPort
 import com.openbank.settlement.application.port.out.ReverseCreditPort
 import com.openbank.settlement.application.port.out.ReverseDebitPort
+import com.openbank.settlement.application.port.out.SettlementMetricsPort
 import com.openbank.settlement.application.port.out.SettlementRepository
+import com.openbank.settlement.application.port.out.SettlementStep
+import com.openbank.settlement.application.port.out.SettlementStepOutcome
 import com.openbank.settlement.domain.model.Settlement
 import com.openbank.settlement.domain.model.SettlementStatus
 import io.quarkus.vertx.VertxContextSupport
@@ -23,6 +26,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import org.jboss.logging.Logger
+import java.time.Duration
 import java.util.UUID
 
 /**
@@ -36,6 +40,11 @@ import java.util.UUID
  * succeed so a thrown activity exception (Temporal will retry) never records a false SUCCESS.
  */
 @ApplicationScoped
+// TooManyFunctions fires AT its threshold of 11, not above it. This class is the seven activities
+// SettlementActivities declares — one method each, not decomposable — plus `compensate`, `audit`,
+// `step` and `runOnVertxContext`. `cycleDuration` is already top-level for the same reason. Same
+// rationale as CampaignJourneyActivitiesImpl, the fleet's other Temporal activities implementation.
+@Suppress("TooManyFunctions")
 open class SettlementActivitiesImpl(
     private val settlementRepository: SettlementRepository,
     private val debitPort: DebitPort,
@@ -44,11 +53,12 @@ open class SettlementActivitiesImpl(
     private val auditPublisher: AuditEventPublisher,
     private val reverseDebitPort: ReverseDebitPort,
     private val reverseCreditPort: ReverseCreditPort,
+    private val metrics: SettlementMetricsPort,
 ) : SettlementActivities {
 
     private val log = Logger.getLogger(SettlementActivitiesImpl::class.java)
 
-    override fun debitPayer(settlementId: UUID): Unit = runOnVertxContext {
+    override fun debitPayer(settlementId: UUID): Unit = step(SettlementStep.DEBIT) {
         log.infof("Debiting payer for settlement %s", settlementId)
         debitPort.debit(settlementId)
         val settlement = settlementRepository.updateStatus(settlementId, SettlementStatus.DEBITED)
@@ -56,7 +66,7 @@ open class SettlementActivitiesImpl(
         Unit
     }
 
-    override fun creditPayee(settlementId: UUID): Unit = runOnVertxContext {
+    override fun creditPayee(settlementId: UUID): Unit = step(SettlementStep.CREDIT) {
         log.infof("Crediting payee for settlement %s", settlementId)
         creditPort.credit(settlementId)
         val settlement = settlementRepository.updateStatus(settlementId, SettlementStatus.CREDITED)
@@ -64,15 +74,17 @@ open class SettlementActivitiesImpl(
         Unit
     }
 
-    override fun bookToLedger(settlementId: UUID): Unit = runOnVertxContext {
+    override fun bookToLedger(settlementId: UUID): Unit = step(SettlementStep.LEDGER_BOOK) {
         log.infof("Booking settlement %s to ledger", settlementId)
         ledgerPort.book(settlementId)
         val settlement = settlementRepository.updateStatus(settlementId, SettlementStatus.BOOKED)
         audit("settlement.ledger-book", settlement)
-        Unit
+        // The saga's only success terminus. Recorded here, after the ledger write and the status
+        // transition, so the counter can never claim a booking that did not happen.
+        metrics.settlementBooked(settlement.currency, settlement.amount, settlement.cycleDuration())
     }
 
-    override fun reverseDebit(settlementId: UUID): Unit = runOnVertxContext {
+    override fun reverseDebit(settlementId: UUID): Unit = step(SettlementStep.REVERSE_DEBIT) {
         compensate(
             settlementId = settlementId,
             operation = "settlement.reverse-debit",
@@ -80,7 +92,7 @@ open class SettlementActivitiesImpl(
         ) { reverseDebitPort.reverseDebit(settlementId) }
     }
 
-    override fun reverseCredit(settlementId: UUID): Unit = runOnVertxContext {
+    override fun reverseCredit(settlementId: UUID): Unit = step(SettlementStep.REVERSE_CREDIT) {
         compensate(
             settlementId = settlementId,
             operation = "settlement.reverse-credit",
@@ -117,7 +129,7 @@ open class SettlementActivitiesImpl(
      * [SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED] — an operator sees *which* half of the unwind
      * did not happen — rather than the old `LEDGER_REVERSED`, which claimed it had.
      */
-    override fun reverseBookToLedger(settlementId: UUID): Unit = runOnVertxContext {
+    override fun reverseBookToLedger(settlementId: UUID): Unit = step(SettlementStep.REVERSE_LEDGER_BOOK) {
         log.errorf(
             "Ledger booking for settlement %s was NOT reversed: settlement-service cannot reverse a " +
                 "journal (ledger.reverse is maker-checker gated and no journal id is retained). " +
@@ -169,11 +181,30 @@ open class SettlementActivitiesImpl(
         audit(operation, settlement)
     }
 
-    override fun rejectSettlement(settlementId: UUID): Unit = runOnVertxContext {
+    override fun rejectSettlement(settlementId: UUID): Unit = step(SettlementStep.REJECT) {
         log.warnf("Rejecting settlement %s after compensation", settlementId)
         val settlement = settlementRepository.updateStatus(settlementId, SettlementStatus.REJECTED)
         audit("settlement.reject", settlement, result = AuditResult.FAILURE)
-        Unit
+        metrics.settlementRejected(settlement.currency, settlement.cycleDuration())
+    }
+
+    /**
+     * Run one activity [block] on a Vert.x context and record its attempt against [step].
+     *
+     * A failure is recorded and **rethrown**: Temporal owns the retry/compensation decision, so the
+     * meter must not change the saga's behaviour — it only makes the attempt visible. `Throwable`
+     * rather than `Exception` because a failure originating in native or static-initializer code
+     * arrives as an `Error`, and an attempt that fails that way must not be counted as completed.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private fun step(step: SettlementStep, block: suspend () -> Unit): Unit = runOnVertxContext {
+        try {
+            block()
+            metrics.sagaStep(step, SettlementStepOutcome.COMPLETED)
+        } catch (ex: Throwable) {
+            metrics.sagaStep(step, SettlementStepOutcome.FAILED)
+            throw ex
+        }
     }
 
     /**
@@ -220,3 +251,18 @@ open class SettlementActivitiesImpl(
         CoroutineScope(Dispatchers.Unconfined).async { block() }.asUni()
     }
 }
+
+/**
+ * Wall-clock duration of the settlement cycle, measured from the row's own audit columns.
+ *
+ * `updatedAt` is set by the repository on the status transition that just committed, so no clock is
+ * needed here and the value cannot drift from what the database recorded. Clamped at zero by the
+ * adapter.
+ *
+ * Top-level rather than a member: detekt's `TooManyFunctions` fires AT the threshold of 11, not
+ * above it, and the seven activities plus `step`, `compensate`, `audit` and `runOnVertxContext`
+ * already reach it. Declared **after** the class on purpose — a Kotlin annotation binds to the next
+ * declaration, so a top-level function placed above an annotated class silently steals its
+ * annotation (the `@Path`/McpEndpoint 404 this repo has already shipped once).
+ */
+private fun Settlement.cycleDuration(): Duration = Duration.between(createdAt, updatedAt)

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/observability/SettlementMetricsAdapter.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/observability/SettlementMetricsAdapter.kt
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.infrastructure.observability
+
+import com.openbank.settlement.application.port.out.OriginationOutcome
+import com.openbank.settlement.application.port.out.SettlementMetricsPort
+import com.openbank.settlement.application.port.out.SettlementStep
+import com.openbank.settlement.application.port.out.SettlementStepOutcome
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import io.quarkus.runtime.Startup
+import jakarta.annotation.PostConstruct
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+import java.math.BigDecimal
+import java.time.Duration
+
+/**
+ * Micrometer adapter for [SettlementMetricsPort] (issue #5705). Emits, all tagged
+ * `service="settlement"`:
+ *
+ *  - `openbank_settlement_originated_total{currency,outcome}` — acceptance rate, split
+ *    `created` / `replayed`.
+ *  - `openbank_settlement_saga_steps_total{step,outcome}` — every activity attempt of the saga,
+ *    forward legs and compensations, `completed` / `failed`.
+ *  - `openbank_settlement_terminal_total{outcome}` — settlements that reached `booked` or
+ *    `rejected`. This is the series the "nothing has settled" alert reads.
+ *  - `openbank_settlement_cycle_duration_seconds{outcome}` — origination → terminal latency.
+ *  - `openbank_settlement_booked_amount{currency}` — amount distribution of booked settlements.
+ *
+ * ### Why the counters are registered eagerly, and why that is the point
+ *
+ * Micrometer does not create a counter until its first increment, so
+ * `increase(openbank_settlement_terminal_total{outcome="booked"}[6h]) == 0` written against a
+ * lazily-created counter matches **nothing at all** on a service that has never booked anything —
+ * which is exactly the state the alert exists to catch. Every series an alert reads is therefore
+ * bound in [bindTo] at `@PostConstruct`, present at `0.0` from the first scrape. `@Startup` because
+ * `@ApplicationScoped` is lazy: without it the bean, and so the meters, would not exist until the
+ * first settlement request.
+ *
+ * The per-currency amount summary is the one meter left to lazy registration: its label set is not
+ * knowable at boot, and no alert reads it.
+ *
+ * Service-local `MeterRegistry` via [Instance] exactly like libs `DomainMetrics` and the fleet's
+ * other per-service adapters: settlement-saga shape is settlement-specific, so adding it to the
+ * shared libs facade would force a fleet-wide rebuild for a one-service concern.
+ *
+ * Field injection of `Instance<MeterRegistry>` rather than a nullable constructor parameter: a
+ * nullable parameter needs a second `@Inject` constructor, and ArC registers no bean at all when it
+ * sees two plain constructors.
+ */
+@Startup
+@ApplicationScoped
+class SettlementMetricsAdapter : SettlementMetricsPort {
+
+    @Inject
+    lateinit var registryInstance: Instance<MeterRegistry>
+
+    private var registry: MeterRegistry? = null
+
+    @PostConstruct
+    fun register() {
+        if (registryInstance.isResolvable) bindTo(registryInstance.get())
+    }
+
+    /**
+     * Bind the meters to [registry]. Called once at startup by [register]; exposed so a test can
+     * bind a real Prometheus registry and assert the rendered series names and label sets, rather
+     * than assuming how Micrometer maps them.
+     */
+    fun bindTo(registry: MeterRegistry) {
+        this.registry = registry
+        // Everything an alert expression reads is created here, before any traffic.
+        SettlementStep.entries.forEach { step ->
+            SettlementStepOutcome.entries.forEach { outcome -> sagaStepCounter(registry, step, outcome) }
+        }
+        TERMINAL_OUTCOMES.forEach { outcome ->
+            terminalCounter(registry, outcome)
+            cycleTimer(registry, outcome)
+        }
+    }
+
+    override fun settlementOriginated(currency: String, outcome: OriginationOutcome) {
+        registry?.let { r ->
+            Counter.builder(ORIGINATED_METRIC)
+                .tag("service", SERVICE)
+                .tag("currency", currency)
+                .tag("outcome", outcome.name.lowercase())
+                .description("Settlement origination requests accepted, split new vs idempotent replay")
+                .register(r)
+                .increment()
+        }
+    }
+
+    override fun sagaStep(step: SettlementStep, outcome: SettlementStepOutcome) {
+        registry?.let { r -> sagaStepCounter(r, step, outcome).increment() }
+    }
+
+    override fun settlementBooked(currency: String, amount: BigDecimal, cycleDuration: Duration) {
+        registry?.let { r ->
+            terminalCounter(r, OUTCOME_BOOKED).increment()
+            cycleTimer(r, OUTCOME_BOOKED).record(cycleDuration.coerceAtLeast(Duration.ZERO))
+            DistributionSummary.builder(BOOKED_AMOUNT_METRIC)
+                .tag("service", SERVICE)
+                .tag("currency", currency)
+                .publishPercentiles(P50, P95, P99)
+                .publishPercentileHistogram()
+                .description("Amount of settlements booked to the ledger")
+                .register(r)
+                .record(amount.toDouble())
+        }
+    }
+
+    override fun settlementRejected(currency: String, cycleDuration: Duration) {
+        registry?.let { r ->
+            terminalCounter(r, OUTCOME_REJECTED).increment()
+            cycleTimer(r, OUTCOME_REJECTED).record(cycleDuration.coerceAtLeast(Duration.ZERO))
+        }
+    }
+
+    private fun sagaStepCounter(
+        registry: MeterRegistry,
+        step: SettlementStep,
+        outcome: SettlementStepOutcome,
+    ): Counter = Counter.builder(SAGA_STEPS_METRIC)
+        .tag("service", SERVICE)
+        .tag("step", step.name.lowercase())
+        .tag("outcome", outcome.name.lowercase())
+        .description("Settlement saga activity attempts, forward legs and compensations")
+        .register(registry)
+
+    private fun terminalCounter(registry: MeterRegistry, outcome: String): Counter = Counter.builder(TERMINAL_METRIC)
+        .tag("service", SERVICE)
+        .tag("outcome", outcome)
+        .description("Settlements that reached a terminal state")
+        .register(registry)
+
+    private fun cycleTimer(registry: MeterRegistry, outcome: String): Timer = Timer.builder(CYCLE_DURATION_METRIC)
+        .tag("service", SERVICE)
+        .tag("outcome", outcome)
+        .publishPercentiles(P50, P95, P99)
+        .publishPercentileHistogram()
+        .description("Time from settlement origination to its terminal state")
+        .register(registry)
+
+    companion object {
+        const val SERVICE = "settlement"
+
+        const val ORIGINATED_METRIC = "openbank.settlement.originated"
+        const val SAGA_STEPS_METRIC = "openbank.settlement.saga.steps"
+        const val TERMINAL_METRIC = "openbank.settlement.terminal"
+        const val CYCLE_DURATION_METRIC = "openbank.settlement.cycle.duration"
+        const val BOOKED_AMOUNT_METRIC = "openbank.settlement.booked.amount"
+
+        const val OUTCOME_BOOKED = "booked"
+        const val OUTCOME_REJECTED = "rejected"
+
+        private val TERMINAL_OUTCOMES = listOf(OUTCOME_BOOKED, OUTCOME_REJECTED)
+
+        // The fleet-standard percentile set (libs DomainMetrics publishes the same three).
+        // Declared as constants: detekt MagicNumber fires on each literal in publishPercentiles.
+        private const val P50 = 0.5
+        private const val P95 = 0.95
+        private const val P99 = 0.99
+    }
+}

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceOriginateTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceOriginateTest.kt
@@ -11,6 +11,8 @@ import com.openbank.settlement.application.workflow.SettlementActivities
 import com.openbank.settlement.application.workflow.SettlementWorkflowImpl
 import com.openbank.settlement.domain.model.Settlement
 import com.openbank.settlement.domain.model.SettlementStatus
+import com.openbank.settlement.infrastructure.observability.SettlementMetricsAdapter
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -42,6 +44,16 @@ class SettlementServiceOriginateTest {
     private lateinit var worker: Worker
     private lateinit var service: SettlementService
 
+    // A REAL metrics adapter over a real registry, not a mock: the point of these two assertions is
+    // that originate() actually moves a counter, which a verified mock cannot establish.
+    private val registry = SimpleMeterRegistry()
+    private val metrics = SettlementMetricsAdapter().apply { bindTo(registry) }
+
+    private fun originatedCount(outcome: String): Double = registry.find(SettlementMetricsAdapter.ORIGINATED_METRIC)
+        .tag("outcome", outcome)
+        .counter()
+        ?.count() ?: 0.0
+
     private companion object {
         const val TASK_QUEUE = "openbank-settlement"
     }
@@ -54,7 +66,7 @@ class SettlementServiceOriginateTest {
         worker.registerActivitiesImplementations(RelaxedActivities())
         env.start()
         every { temporalConfig.taskQueue() } returns TASK_QUEUE
-        service = SettlementService(repo, temporalConfig, env.workflowClient)
+        service = SettlementService(repo, temporalConfig, env.workflowClient, metrics)
     }
 
     @AfterEach
@@ -85,6 +97,10 @@ class SettlementServiceOriginateTest {
         assertThat(created.captured.status).isEqualTo(SettlementStatus.PENDING)
         assertThat(result.id).isEqualTo(created.captured.id)
         coVerify { repo.create(any()) }
+        // A new row is `created`, and specifically NOT `replayed` — the pair is what makes the
+        // outcome tag load-bearing rather than a constant.
+        assertThat(originatedCount("created")).isEqualTo(1.0)
+        assertThat(originatedCount("replayed")).isEqualTo(0.0)
     }
 
     @Test
@@ -110,6 +126,8 @@ class SettlementServiceOriginateTest {
 
         assertThat(result.id).isEqualTo(existing.id)
         coVerify(exactly = 0) { repo.create(any()) }
+        assertThat(originatedCount("replayed")).isEqualTo(1.0)
+        assertThat(originatedCount("created")).isEqualTo(0.0)
     }
 
     /** Activities stub that never throws — originate coverage only exercises settle() dispatch. */

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceSettleTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceSettleTest.kt
@@ -28,7 +28,7 @@ class SettlementServiceSettleTest {
     @Test
     fun `settle throws when the settlement does not exist`() {
         val workflowClient: WorkflowClient = mockk(relaxed = true)
-        val service = SettlementService(repo, temporalConfig, workflowClient)
+        val service = SettlementService(repo, temporalConfig, workflowClient, mockk(relaxed = true))
         val id = UUID.randomUUID()
         coEvery { repo.findById(id) } returns null
 

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceTemporalSettleTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceTemporalSettleTest.kt
@@ -52,7 +52,7 @@ class SettlementServiceTemporalSettleTest {
         worker.registerActivitiesImplementations(RelaxedActivities())
         env.start()
         every { temporalConfig.taskQueue() } returns TASK_QUEUE
-        service = SettlementService(repo, temporalConfig, env.workflowClient)
+        service = SettlementService(repo, temporalConfig, env.workflowClient, mockk(relaxed = true))
     }
 
     @AfterEach

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImplTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImplTest.kt
@@ -12,6 +12,7 @@ import com.openbank.settlement.application.port.out.DebitPort
 import com.openbank.settlement.application.port.out.LedgerPort
 import com.openbank.settlement.application.port.out.ReverseCreditPort
 import com.openbank.settlement.application.port.out.ReverseDebitPort
+import com.openbank.settlement.application.port.out.SettlementMetricsPort
 import com.openbank.settlement.application.port.out.SettlementRepository
 import com.openbank.settlement.domain.model.Settlement
 import com.openbank.settlement.domain.model.SettlementStatus
@@ -42,6 +43,7 @@ class SettlementActivitiesImplTest {
     private val auditPublisher: AuditEventPublisher = mockk(relaxed = true)
     private val reverseDebitPort: ReverseDebitPort = mockk(relaxed = true)
     private val reverseCreditPort: ReverseCreditPort = mockk(relaxed = true)
+    private val metrics: SettlementMetricsPort = mockk(relaxed = true)
 
     private lateinit var activities: SettlementActivitiesImpl
 
@@ -68,6 +70,7 @@ class SettlementActivitiesImplTest {
             auditPublisher,
             reverseDebitPort,
             reverseCreditPort,
+            metrics,
         )
         coEvery { settlementRepository.updateStatus(any(), any()) } answers {
             settlement(firstArg(), secondArg())
@@ -237,6 +240,7 @@ private class TestableActivities(
     auditPublisher: AuditEventPublisher,
     reverseDebitPort: ReverseDebitPort,
     reverseCreditPort: ReverseCreditPort,
+    metrics: SettlementMetricsPort,
 ) : SettlementActivitiesImpl(
     settlementRepository,
     debitPort,
@@ -245,6 +249,7 @@ private class TestableActivities(
     auditPublisher,
     reverseDebitPort,
     reverseCreditPort,
+    metrics,
 ) {
     override fun <T> runOnVertxContext(block: suspend () -> T): T = runBlocking { block() }
 }

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesMetricsTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesMetricsTest.kt
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.application.workflow
+
+import com.openbank.libs.audit.AuditEventPublisher
+import com.openbank.settlement.application.port.out.CreditPort
+import com.openbank.settlement.application.port.out.DebitPort
+import com.openbank.settlement.application.port.out.LedgerPort
+import com.openbank.settlement.application.port.out.ReverseCreditPort
+import com.openbank.settlement.application.port.out.ReverseDebitPort
+import com.openbank.settlement.application.port.out.SettlementMetricsPort
+import com.openbank.settlement.application.port.out.SettlementRepository
+import com.openbank.settlement.domain.model.Settlement
+import com.openbank.settlement.infrastructure.observability.SettlementMetricsAdapter
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.temporal.failure.ApplicationFailure
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.data.Offset.offset
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+/**
+ * Proves the settlement meters record **on the saga path that claims to move them**, using a real
+ * [SettlementMetricsAdapter] over a real registry rather than a verified mock.
+ *
+ * The distinction matters here more than usual. A mock verification shows the activity *called* the
+ * port; it cannot show that the counter the alert reads actually moved, nor that the forward legs
+ * are separated from the compensations, nor — the case this service was silent about — that a
+ * settlement which was compensated all the way back to REJECTED is counted as `rejected` and not as
+ * a success. Every test below therefore carries its negative control: the counter that must NOT
+ * have moved is asserted alongside the one that must.
+ */
+class SettlementActivitiesMetricsTest {
+
+    private val settlementRepository: SettlementRepository = mockk(relaxed = true)
+    private val debitPort: DebitPort = mockk(relaxed = true)
+    private val creditPort: CreditPort = mockk(relaxed = true)
+    private val ledgerPort: LedgerPort = mockk(relaxed = true)
+    private val auditPublisher: AuditEventPublisher = mockk(relaxed = true)
+    private val reverseDebitPort: ReverseDebitPort = mockk(relaxed = true)
+    private val reverseCreditPort: ReverseCreditPort = mockk(relaxed = true)
+
+    private val registry = SimpleMeterRegistry()
+    private val metrics = SettlementMetricsAdapter().apply { bindTo(registry) }
+
+    private lateinit var activities: SettlementActivitiesImpl
+
+    private fun terminal(outcome: String): Double =
+        registry.find(SettlementMetricsAdapter.TERMINAL_METRIC).tag("outcome", outcome).counter()?.count() ?: 0.0
+
+    private fun sagaStep(step: String, outcome: String): Double =
+        registry.find(SettlementMetricsAdapter.SAGA_STEPS_METRIC)
+            .tag("step", step)
+            .tag("outcome", outcome)
+            .counter()
+            ?.count() ?: 0.0
+
+    @BeforeEach
+    fun setUp() {
+        activities = MetricsTestableActivities(
+            settlementRepository,
+            debitPort,
+            creditPort,
+            ledgerPort,
+            auditPublisher,
+            reverseDebitPort,
+            reverseCreditPort,
+            metrics,
+        )
+        // The row carries a 30s-old createdAt so the cycle timer has something non-zero to record —
+        // a duration of exactly zero would pass even if the timer never saw the real timestamps.
+        coEvery { settlementRepository.updateStatus(any(), any()) } answers {
+            val now = Instant.now()
+            Settlement(
+                id = firstArg(),
+                payerAccountId = UUID.randomUUID(),
+                payeeAccountId = UUID.randomUUID(),
+                amount = BigDecimal("250.00"),
+                currency = "CZK",
+                status = secondArg(),
+                createdAt = now.minusSeconds(THIRTY_SECONDS),
+                updatedAt = now,
+            )
+        }
+    }
+
+    @Test
+    fun `bookToLedger records a booked settlement, its cycle duration and its amount`() {
+        activities.bookToLedger(UUID.randomUUID())
+
+        assertThat(terminal("booked")).isEqualTo(1.0)
+        // The saga's only success terminus — a booking must never also read as a rejection.
+        assertThat(terminal("rejected")).isEqualTo(0.0)
+        assertThat(sagaStep("ledger_book", "completed")).isEqualTo(1.0)
+        assertThat(sagaStep("ledger_book", "failed")).isEqualTo(0.0)
+
+        val timer = registry.find(SettlementMetricsAdapter.CYCLE_DURATION_METRIC).tag("outcome", "booked").timer()
+        assertThat(timer!!.count()).isEqualTo(1L)
+        // Origination -> booking, read off the row: proves the timer saw the real timestamps and is
+        // not recording a constant zero.
+        assertThat(timer.totalTime(TimeUnit.SECONDS)).isCloseTo(THIRTY_SECONDS_D, offset(ONE_SECOND))
+
+        val amounts = registry.find(SettlementMetricsAdapter.BOOKED_AMOUNT_METRIC).tag("currency", "CZK").summary()
+        assertThat(amounts!!.totalAmount()).isEqualTo(250.0)
+    }
+
+    @Test
+    fun `the forward legs before booking record their step but no terminal outcome`() {
+        val id = UUID.randomUUID()
+
+        activities.debitPayer(id)
+        activities.creditPayee(id)
+
+        assertThat(sagaStep("debit", "completed")).isEqualTo(1.0)
+        assertThat(sagaStep("credit", "completed")).isEqualTo(1.0)
+        // Money has moved but the settlement is not done. Counting these as terminal is exactly the
+        // "success that never left the process" shape this repo has shipped before.
+        assertThat(terminal("booked")).isEqualTo(0.0)
+        assertThat(terminal("rejected")).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `a compensated saga ending in rejectSettlement is counted as rejected, never as booked`() {
+        val id = UUID.randomUUID()
+
+        activities.reverseDebit(id)
+        activities.reverseCredit(id)
+        // Ledger reversal is NOT implemented and fails loudly on purpose (#6037): settlement-service
+        // cannot reverse a journal, so the activity records LEDGER_REVERSAL_UNSUPPORTED and throws
+        // rather than claiming an unwind that did not happen. The step meter must therefore show it
+        // as FAILED — counting it as completed would restore exactly the false-success the status
+        // change was made to remove. SettlementWorkflowImpl catches this per compensation, so the
+        // saga still reaches rejectSettlement.
+        assertThatThrownBy { activities.reverseBookToLedger(id) }
+            .isInstanceOf(ApplicationFailure::class.java)
+        activities.rejectSettlement(id)
+
+        assertThat(terminal("rejected")).isEqualTo(1.0)
+        assertThat(terminal("booked")).isEqualTo(0.0)
+        assertThat(sagaStep("reverse_debit", "completed")).isEqualTo(1.0)
+        assertThat(sagaStep("reverse_credit", "completed")).isEqualTo(1.0)
+        assertThat(sagaStep("reverse_ledger_book", "failed")).isEqualTo(1.0)
+        assertThat(sagaStep("reverse_ledger_book", "completed")).isEqualTo(0.0)
+        assertThat(sagaStep("reject", "completed")).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `a failing activity is counted as failed, is not counted as completed, and still throws`() {
+        // Temporal owns the retry/compensation decision — the meter must observe the attempt, never
+        // swallow it, or instrumenting the saga would silently change its behaviour.
+        coEvery { debitPort.debit(any()) } throws IllegalStateException("balance-service unavailable")
+
+        assertThatThrownBy { activities.debitPayer(UUID.randomUUID()) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("balance-service unavailable")
+
+        assertThat(sagaStep("debit", "failed")).isEqualTo(1.0)
+        assertThat(sagaStep("debit", "completed")).isEqualTo(0.0)
+        assertThat(terminal("booked")).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `a booking that fails at the ledger records no booked settlement`() {
+        coEvery { ledgerPort.book(any()) } throws IllegalStateException("ledger rejected the journal")
+
+        assertThatThrownBy { activities.bookToLedger(UUID.randomUUID()) }
+            .isInstanceOf(IllegalStateException::class.java)
+
+        assertThat(sagaStep("ledger_book", "failed")).isEqualTo(1.0)
+        // The whole point of recording the counter after the ledger write: a failed booking must
+        // not appear in the series the "nothing has settled" alert reads.
+        assertThat(terminal("booked")).isEqualTo(0.0)
+    }
+
+    private companion object {
+        const val THIRTY_SECONDS = 30L
+        const val ONE_SECOND = 1.0
+        const val THIRTY_SECONDS_D = 30.0
+    }
+}
+
+/** Runs the activity bodies synchronously, bypassing the real Vert.x-context bridge. */
+private class MetricsTestableActivities(
+    settlementRepository: SettlementRepository,
+    debitPort: DebitPort,
+    creditPort: CreditPort,
+    ledgerPort: LedgerPort,
+    auditPublisher: AuditEventPublisher,
+    reverseDebitPort: ReverseDebitPort,
+    reverseCreditPort: ReverseCreditPort,
+    metrics: SettlementMetricsPort,
+) : SettlementActivitiesImpl(
+    settlementRepository,
+    debitPort,
+    creditPort,
+    ledgerPort,
+    auditPublisher,
+    reverseDebitPort,
+    reverseCreditPort,
+    metrics,
+) {
+    override fun <T> runOnVertxContext(block: suspend () -> T): T = runBlocking { block() }
+}

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/observability/SettlementMetricsAdapterTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/observability/SettlementMetricsAdapterTest.kt
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.infrastructure.observability
+
+import com.openbank.settlement.application.port.out.OriginationOutcome
+import com.openbank.settlement.application.port.out.SettlementStep
+import com.openbank.settlement.application.port.out.SettlementStepOutcome
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+/**
+ * Asserts the adapter against a **real** [PrometheusMeterRegistry] and, for the alert-bearing
+ * series, against the rendered scrape text — not against a mock and not against Micrometer's
+ * in-memory meter names. The alert expressions in
+ * `openbank-infra/gitops/components/payments/prometheus-rules.yaml` (the
+ * `openbank-settlement-alerts` document) are written over the
+ * *scraped* names (`openbank_settlement_terminal_total`), and only the rendered output can show
+ * that Micrometer's dot-to-underscore mapping plus the `_total` suffix produce exactly those.
+ *
+ * The load-bearing case is [`the alert-bearing series exist at zero before any settlement happens`]:
+ * Micrometer creates a counter on first increment, so a lazily-registered
+ * `openbank_settlement_terminal_total{outcome="booked"}` is **absent** — not zero — on a service
+ * that has never booked anything, and `increase(...[6h]) == 0` then matches nothing at all. That is
+ * precisely the state the alert exists to catch, so a lazy counter would make the alert silent in
+ * the only case it is for. Deleting the `bindTo` body must turn that test red.
+ */
+class SettlementMetricsAdapterTest {
+
+    private val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+    private val adapter = SettlementMetricsAdapter().apply { bindTo(registry) }
+
+    private fun counter(name: String, vararg tags: Pair<String, String>): Double? = registry.find(name)
+        .let { search -> tags.fold(search) { s, (k, v) -> s.tag(k, v) } }
+        .counter()
+        ?.count()
+
+    @Test
+    fun `the alert-bearing series exist at zero before any settlement happens`() {
+        // Rendered scrape output, i.e. what Prometheus would actually store and the alert query.
+        val scrape = registry.scrape()
+
+        assertThat(scrape)
+            .contains("openbank_settlement_terminal_total")
+            .contains("""openbank_settlement_terminal_total{outcome="booked",service="settlement"} 0.0""")
+            .contains("""openbank_settlement_terminal_total{outcome="rejected",service="settlement"} 0.0""")
+
+        // Every saga step/outcome combination too — a `failed` series that only appears once
+        // something has already failed cannot support a "failures are climbing" query either.
+        SettlementStep.entries.forEach { step ->
+            SettlementStepOutcome.entries.forEach { outcome ->
+                assertThat(
+                    counter(
+                        SettlementMetricsAdapter.SAGA_STEPS_METRIC,
+                        "step" to step.name.lowercase(),
+                        "outcome" to outcome.name.lowercase(),
+                    ),
+                ).describedAs("saga step %s/%s must be registered eagerly", step, outcome)
+                    .isEqualTo(0.0)
+            }
+        }
+    }
+
+    @Test
+    fun `every series the settlement alerts read renders under the name the alert uses`() {
+        // The alert expressions in gitops/components/payments/prometheus-rules.yaml are written over
+        // these exact strings. Micrometer's dot->underscore mapping and the `_total` suffix on a
+        // counter are the things that could silently drift, and a rule referencing a name that
+        // renders differently is a rule that matches nothing while looking perfectly correct.
+        adapter.settlementOriginated("CZK", OriginationOutcome.CREATED)
+        adapter.settlementBooked("CZK", BigDecimal.ONE, Duration.ofSeconds(1))
+
+        val scrape = registry.scrape()
+
+        // SettlementSagaNotCompleting reads these two.
+        assertThat(scrape).contains("openbank_settlement_originated_total")
+        assertThat(scrape).contains("openbank_settlement_terminal_total")
+        // SettlementSagaStepsFailing reads this one.
+        assertThat(scrape).contains("openbank_settlement_saga_steps_total")
+        // And the outcome tag values the expressions filter on must render as written.
+        assertThat(scrape).contains("""outcome="created"""")
+        assertThat(scrape).contains("""outcome="booked"""")
+        assertThat(scrape).contains("""outcome="rejected"""")
+        assertThat(scrape).contains("""outcome="failed"""")
+    }
+
+    @Test
+    fun `booking records the terminal counter, the cycle timer and the amount summary`() {
+        adapter.settlementBooked("CZK", BigDecimal("250.00"), Duration.ofSeconds(12))
+
+        assertThat(counter(SettlementMetricsAdapter.TERMINAL_METRIC, "outcome" to "booked")).isEqualTo(1.0)
+        // Negative control: booking must not move the rejected leg.
+        assertThat(counter(SettlementMetricsAdapter.TERMINAL_METRIC, "outcome" to "rejected")).isEqualTo(0.0)
+
+        val timer = registry.find(SettlementMetricsAdapter.CYCLE_DURATION_METRIC).tag("outcome", "booked").timer()
+        assertThat(timer).isNotNull
+        assertThat(timer!!.count()).isEqualTo(1L)
+        assertThat(timer.totalTime(TimeUnit.SECONDS)).isEqualTo(12.0)
+
+        val amounts = registry.find(SettlementMetricsAdapter.BOOKED_AMOUNT_METRIC).tag("currency", "CZK").summary()
+        assertThat(amounts).isNotNull
+        assertThat(amounts!!.totalAmount()).isEqualTo(250.0)
+    }
+
+    @Test
+    fun `rejection records the rejected terminal counter and its own cycle timer`() {
+        adapter.settlementRejected("EUR", Duration.ofSeconds(3))
+
+        assertThat(counter(SettlementMetricsAdapter.TERMINAL_METRIC, "outcome" to "rejected")).isEqualTo(1.0)
+        assertThat(counter(SettlementMetricsAdapter.TERMINAL_METRIC, "outcome" to "booked")).isEqualTo(0.0)
+        assertThat(
+            registry.find(SettlementMetricsAdapter.CYCLE_DURATION_METRIC).tag("outcome", "rejected").timer()?.count(),
+        ).isEqualTo(1L)
+    }
+
+    @Test
+    fun `a negative cycle duration is clamped to zero rather than corrupting the timer`() {
+        // createdAt/updatedAt come from two different rows' clocks; a small backwards skew is
+        // possible and Micrometer would otherwise record a negative sample.
+        adapter.settlementBooked("CZK", BigDecimal.ONE, Duration.ofSeconds(-5))
+
+        val timer = registry.find(SettlementMetricsAdapter.CYCLE_DURATION_METRIC).tag("outcome", "booked").timer()
+        assertThat(timer!!.totalTime(TimeUnit.SECONDS)).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `origination separates a created row from an idempotent replay`() {
+        adapter.settlementOriginated("CZK", OriginationOutcome.CREATED)
+        adapter.settlementOriginated("CZK", OriginationOutcome.REPLAYED)
+        adapter.settlementOriginated("CZK", OriginationOutcome.REPLAYED)
+
+        assertThat(counter(SettlementMetricsAdapter.ORIGINATED_METRIC, "outcome" to "created")).isEqualTo(1.0)
+        assertThat(counter(SettlementMetricsAdapter.ORIGINATED_METRIC, "outcome" to "replayed")).isEqualTo(2.0)
+    }
+
+    @Test
+    fun `an unbound adapter records nothing and throws nothing`() {
+        // No MeterRegistry bean resolvable (a profile with micrometer disabled): the adapter must
+        // stay inert rather than NPE on the money path.
+        val unbound = SettlementMetricsAdapter()
+
+        unbound.settlementBooked("CZK", BigDecimal.ONE, Duration.ofSeconds(1))
+        unbound.settlementRejected("CZK", Duration.ofSeconds(1))
+        unbound.settlementOriginated("CZK", OriginationOutcome.CREATED)
+        unbound.sagaStep(SettlementStep.DEBIT, SettlementStepOutcome.COMPLETED)
+
+        // And nothing leaked into the bound registry either.
+        assertThat(counter(SettlementMetricsAdapter.TERMINAL_METRIC, "outcome" to "booked")).isEqualTo(0.0)
+        assertThat(counter(SettlementMetricsAdapter.TERMINAL_METRIC, "outcome" to "rejected")).isEqualTo(0.0)
+        assertThat(counter(SettlementMetricsAdapter.ORIGINATED_METRIC, "outcome" to "created")).isNull()
+    }
+}


### PR DESCRIPTION
## What

`openbank-settlement-service` — a declared money-path service — emitted **no application metric of any kind** and had **no PrometheusRule of its own**. The pod was scraped, the Rollout was Healthy, ArgoCD was Green, and there was simply no series to query. Nothing could distinguish *"settlement is running normally"* from *"settlement has booked nothing for six hours"*.

This adds the metrics and the alerts that read them.

### Metrics (commit 1)

`SettlementMetricsPort` (application) + `SettlementMetricsAdapter` (infrastructure), following the fleet convention — `P50/P95/P99` constants in the companion object for detekt `MagicNumber`, field injection of `Instance<MeterRegistry>` so a missing registry leaves the adapter inert rather than breaking the money path.

| Series (all tagged `service="settlement"`) | What it makes visible |
| --- | --- |
| `openbank_settlement_originated_total{currency,outcome}` | acceptance rate, `created` vs idempotent `replayed` |
| `openbank_settlement_saga_steps_total{step,outcome}` | every activity attempt, forward legs and compensations |
| `openbank_settlement_terminal_total{outcome}` | `booked` / `rejected` — the series the alerts read |
| `openbank_settlement_cycle_duration_seconds{outcome}` | origination → terminal latency |
| `openbank_settlement_booked_amount{currency}` | amount distribution of booked settlements |

Two naming decisions worth stating explicitly:

- **Origination counts as *accepted*, never as settled.** At that point `originate()` has only persisted a PENDING row and asked Temporal to start; no money has moved.
- **A compensated saga is counted as `rejected` on its own terminal leg**, never sharing a flag with success — the shape that previously shipped a push adapter reporting deliveries that never left the process.

### Alerts (commit 2)

`openbank-settlement-alerts` in `components/payments/prometheus-rules.yaml`, five rules. The two interesting ones are about the **boot-time** state rather than the steady state:

- **`SettlementSagaNotCompleting`** (critical) — the primary alert. Compares work *accepted* against work *finished* (`originations > 0 and terminals == 0`), which makes it self-normalising: a freshly started pod has no originations either, so the first conjunct is `0` and the rule stays silent instead of firing 15m after every deploy. It catches the failure the saga makes invisible — `originate()` answers 202 and hands off to Temporal, so a worker that never picks work up leaves every settlement PENDING forever with no HTTP error, no latency change and no log line.
- **`SettlementNoBookingsInBusinessHours`** (warning) — the issue's literal ask, with an explicit `> 0` guard. Because the counter is registered eagerly the series *exists and reads 0* on a fresh pod, so without the guard this is true for every pod for the first six hours of its life. Same guard, same reason, as `AuditChainVerificationStale`. What it gives up (a pod that has never booked since restart) is covered by `SettlementSagaNotCompleting` within the hour and at `critical`.

Plus `SettlementSagaStepsFailing` (Temporal retries before compensating, so a sustained failure rate is the only warning before customer money moves and moves back), and `SettlementCompensationsElevated` (critical — a compensated saga ends REJECTED, a healthy-looking terminal state no error rate reports).

## Why the counters are registered eagerly

Micrometer does not create a counter until its first increment, so `increase(openbank_settlement_terminal_total[6h]) == 0` written against a lazily created counter matches **nothing at all** on a service that has never booked anything — precisely the state the alert exists to catch. Every series an alert reads is bound in `bindTo()` at `@PostConstruct`, and the bean is `@Startup` because `@ApplicationScoped` is lazy.

## Tests — proven by mutation, not by inspection

11 new tests, all using a **real adapter over a real registry** rather than a verified mock, each with its negative control (the counter that must *not* have moved is asserted alongside the one that must).

Both halves were falsified before being trusted:

| Mutation | Result |
| --- | --- |
| gut the eager-registration body of `bindTo()` | **4 tests red** — the scrape renders empty and `openbank_settlement_terminal_total` is absent, i.e. exactly the alert's blind spot |
| drop the `metrics.settlementBooked(...)` call from `bookToLedger` | **1 test red** — `expected: 1.0 but was: 0.0` |

`SettlementMetricsAdapterTest` additionally asserts the **rendered Prometheus scrape text**, so the dot→underscore mapping, the `_total` suffix and the tag ordering come from Micrometer rather than from this repo's idea of them — a rule referencing a name that renders differently cannot pass as correct while matching nothing.

## Verification

```
:openbank-settlement-service:compileKotlin :test :ktlintCheck :detekt :koverVerify  -> BUILD SUCCESSFUL
53 tests, 0 failures, 0 skipped
```

Gates run locally, all green: `check-critical-alert-egress.py`, `check-gitops-duplicate-resources.py`, `check-gitops-secret-refs.py`, `check-podmonitor-namespace-coverage.py`. The alert YAML round-trips through `yaml.safe_load_all` (6 documents).

Two detekt/ktlint traps hit and fixed along the way, both of the "fires AT the threshold" family: `TooManyFunctions` tripped at exactly 11 once the `step()` helper landed (`cycleDuration()` moved to a top-level function, declared **after** the class so it cannot steal the class annotation), and the new test dep needed the `io.micrometer.prometheusmetrics` artifact because Quarkus ships the `-simpleclient` variant — same explicit `testImplementation` and same CVE pin as `openbank-domestic-payment` already carries.

## Deliberately left out

**campaign-service.** The issue's suggested-work item 4 asks for the same treatment there, and this PR does not do it — hence `Refs`, not `Closes`. campaign-service is in the identical state (scraped, zero domain metrics) and deserves its own PR rather than being bolted onto a money-path change.

## Merge note

PR #4308 also appends a document to `components/payments/prometheus-rules.yaml`. The added alerts are disjoint (`openbank-card-issuance-alerts` vs `openbank-settlement-alerts`, no shared alert names), but both append at EOF, so whichever lands second needs a textual resolution — and per this repo's history a "clean" merge of two neighbouring additions can silently keep only one. Worth counting the documents after merging (`yaml.safe_load_all` should yield 7).

Refs #5705



---

**Note (rebase onto current `main`):** `SettlementServiceDown` was **dropped** during the conflict resolution. The progress half of #5705 merged to `main` first, and its document rejects that rule explicitly — `PaymentServiceDown` in `prometheus-rules-tier1.yaml` already owns `up{job="observability/openbank-services", namespace="payments"}`, so a second rule over the same target would page twice for one outage. The other four rules in this PR are unchanged, and this PR's document (`openbank-settlement-alerts`) is appended alongside `main`'s (`openbank-settlement-progress-alerts`) with disjoint rule, metric and object names — which is how `main`'s own comment says the two halves were meant to land.
