### PR TITLE
fix: stop swallowing transient event-consumer failures as an ack across 4 services (#5698)

### DIFF
--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/kafka/PartyErasureConsumer.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/kafka/PartyErasureConsumer.kt
@@ -9,6 +9,7 @@ import com.openbank.copilot.application.port.out.ConversationStore
 import com.openbank.copilot.infrastructure.observability.CopilotMetricsAdapter
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
+import kotlinx.coroutines.delay
 import org.eclipse.microprofile.reactive.messaging.Incoming
 import org.jboss.logging.Logger
 import java.util.UUID
@@ -24,8 +25,24 @@ import java.util.UUID
  *
  * Shape is copied from the seven services that already consume this event (notification-service's
  * `PartyErasureConsumer` is the closest sibling): `suspend @Incoming` so Quarkus dispatches on a
- * Vert.x duplicated context and the reactive Panache delete below runs correctly; poison-pill safe,
- * so any parse or delete failure is logged and the message acked rather than wedging the group.
+ * Vert.x duplicated context and the reactive Panache delete below runs correctly.
+ *
+ * ## Failure handling — a malformed event and a broken database are not the same thing (#5698)
+ *
+ * This consumer used to log-and-ack BOTH, which reads as poison-pill safety and is not. A malformed
+ * payload is unretryable: replaying it produces the same parse failure forever, so acking it is the
+ * only sane outcome and it stays that way below. [ConversationStore.deleteForParty] is a reactive
+ * Panache call, and a connection-refused there is the opposite case — the event is fine, the
+ * database is not, and the work must still happen once it recovers. Acking that lost a GDPR Art. 17
+ * erasure permanently: the only trace was an ERROR line nobody alerts on, and the transcripts the
+ * consumer exists to delete stayed on disk while the log claimed the erasure was handled. That is
+ * the exact shape that left ten of 73 sandbox parties without a KYC case for months (#5698).
+ *
+ * So the delete now runs under [withBoundedRetry] and, if it still fails, is RETHROWN — the
+ * connector retries and ultimately dead-letters, which is a signal someone can see. The retry is
+ * bounded and the failure moves to the DLQ, so a single bad event still cannot wedge the group.
+ * [ConversationStore.deleteForParty] is idempotent (a second delete matches nothing), so both the
+ * retry and a connector redelivery are safe.
  *
  * ## Identity — why the delete is not keyed on the storage key (#3881)
  *
@@ -73,7 +90,7 @@ class PartyErasureConsumer {
             return
         }
 
-        try {
+        withBoundedRetry(partyId) {
             val erased = conversationStore.deleteForParty(partyId.toString())
             if (erased == 0L) {
                 // Not necessarily a defect — a party that never chatted holds nothing. But it is
@@ -94,8 +111,53 @@ class PartyErasureConsumer {
                     partyId,
                 )
             }
-        } catch (e: Exception) {
-            log.errorf(e, "[party-events-in] Failed to erase copilot conversations for party %s", partyId)
         }
+    }
+
+    /**
+     * Retry [block] a bounded number of times, then RETHROW so the connector dead-letters.
+     *
+     * The rethrow is the point. A caught-and-logged failure acks the message, and an acked message
+     * that did no work is indistinguishable from one that succeeded — from Kafka, from the consumer
+     * lag metric, and from every dashboard built on either. Neither erasure counter is incremented
+     * on this path either, so a failed erasure is invisible in the metric as well as in the log.
+     */
+    @Suppress("TooGenericExceptionCaught") // the retry is type-agnostic on purpose: any failure of the
+    // delete is a failure to erase, and the bounded rethrow (not a swallow) is what keeps it visible.
+    private suspend fun withBoundedRetry(partyId: UUID, block: suspend () -> Unit) {
+        var attempt = 1
+        while (true) {
+            try {
+                block()
+                return
+            } catch (e: Exception) {
+                if (attempt >= MAX_ATTEMPTS) {
+                    log.errorf(
+                        e,
+                        "[party-events-in] Erasure for party %s failed after %d attempts (%s: %s) — dead-lettering",
+                        partyId,
+                        attempt,
+                        e.javaClass.simpleName,
+                        e.message,
+                    )
+                    throw e
+                }
+                log.warnf(
+                    "[party-events-in] Erasure for party %s failed (attempt %d/%d, %s: %s) — retrying",
+                    partyId,
+                    attempt,
+                    MAX_ATTEMPTS,
+                    e.javaClass.simpleName,
+                    e.message,
+                )
+                delay(RETRY_BACKOFF_MS * attempt)
+                attempt++
+            }
+        }
+    }
+
+    private companion object {
+        const val MAX_ATTEMPTS = 3
+        const val RETRY_BACKOFF_MS = 500L
     }
 }

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/kafka/PartyErasureConsumerTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/kafka/PartyErasureConsumerTest.kt
@@ -14,7 +14,11 @@ import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.util.UUID
+
+/** Named so detekt's UseCheckOrError does not fire at the throw site inside a mockk `answers` block. */
+private class TransientStoreFailure : IllegalStateException("connection refused")
 
 /**
  * Routing/robustness cover for the PARTY_ERASED consumer (#3870). That the delete actually removes
@@ -71,7 +75,9 @@ class PartyErasureConsumerTest {
         val partyId = UUID.randomUUID()
         coEvery { conversationStore.deleteForParty(partyId.toString()) } throws IllegalStateException("db down")
 
-        consumer.consume("""{"eventType":"PARTY_ERASED","partyId":"$partyId"}""")
+        assertThrows<IllegalStateException> {
+            runBlocking { consumer.consume("""{"eventType":"PARTY_ERASED","partyId":"$partyId"}""") }
+        }
 
         verify(exactly = 0) { metrics.recordPartyErasure(any()) }
     }
@@ -103,13 +109,40 @@ class PartyErasureConsumerTest {
         coVerify(exactly = 0) { conversationStore.deleteForParty(any()) }
     }
 
+    /**
+     * Replaces a test that asserted the OPPOSITE — that a store failure is swallowed "so one bad
+     * message cannot wedge the consumer group". Nothing replays an acked message, so that swallow
+     * silently dropped a GDPR Art. 17 erasure while the log claimed it was handled (#5698). The
+     * green test was the defect's own documentation.
+     *
+     * The pair below is what makes this non-decoration: a DOWNSTREAM failure must escape (the
+     * connector can then dead-letter it), while a MALFORMED payload must still be acked. A test
+     * that cannot tell those two apart proves nothing about either.
+     */
     @Test
-    fun `a store failure is swallowed so one bad message cannot wedge the consumer group`(): Unit = runBlocking {
+    fun `a persistent store failure is RETHROWN so the connector can dead-letter`(): Unit = runBlocking {
         val partyId = UUID.randomUUID()
         coEvery { conversationStore.deleteForParty(partyId.toString()) } throws IllegalStateException("db down")
 
+        assertThrows<IllegalStateException> {
+            runBlocking { consumer.consume("""{"eventType":"PARTY_ERASED","partyId":"$partyId"}""") }
+        }
+
+        coVerify(exactly = 3) { conversationStore.deleteForParty(partyId.toString()) }
+    }
+
+    @Test
+    fun `a TRANSIENT store failure is retried and the erasure completes`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        var calls = 0
+        coEvery { conversationStore.deleteForParty(partyId.toString()) } answers {
+            calls++
+            if (calls == 1) throw TransientStoreFailure() else 2L
+        }
+
         consumer.consume("""{"eventType":"PARTY_ERASED","partyId":"$partyId"}""")
 
-        coVerify(exactly = 1) { conversationStore.deleteForParty(partyId.toString()) }
+        coVerify(exactly = 2) { conversationStore.deleteForParty(partyId.toString()) }
+        verify(exactly = 1) { metrics.recordPartyErasure(CopilotMetricsAdapter.OUTCOME_ERASED) }
     }
 }

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/onboarding/OnboardingResumeService.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/onboarding/OnboardingResumeService.kt
@@ -25,8 +25,28 @@ import org.eclipse.microprofile.reactive.messaging.Incoming
  *   - DISTINCT_NEW     → create the party + register the (no-RČ) identity into pid.
  *   - REJECT           → audit only; the applicant is not onboarded.
  *
- * Best-effort and idempotent-ish (the pending record is deleted after handling). Flag-gated off by
- * default. The plaintext RČ is never available here (never stored) — resume uses name + birthdate.
+ * Flag-gated off by default. The plaintext RČ is never available here (never stored) — resume uses
+ * name + birthdate.
+ *
+ * ## Failure handling — the pending record must outlive a failed attempt (#5698)
+ *
+ * This used to be `try { resume(...) } catch (e: Exception) { Log.error(...) } finally { delete }`,
+ * which is the catch-and-ack defect of #5698 with an extra turn of the screw. [resume] fans out to
+ * `upstream.post` (party-service, pid-service) and `keycloakAdmin.setPartyIdAttribute`; a connection
+ * refused from any of them was logged and the handler returned normally, acking the Kafka message —
+ * and the `finally` then deleted the [PendingOnboarding] anyway. So even a manual replay of the
+ * decision event found nothing to resume: the applicant was stranded with an operator verdict
+ * recorded in pid and no party ever created, and the only trace was one ERROR line.
+ *
+ * Now the attempt is bounded-retried and, if it still fails, RETHROWN — the connector dead-letters,
+ * which is a signal someone can see — and the pending record is deleted **only on success**, so a
+ * redelivery or a replay has something to work with. `resume` is safe to repeat: the party create
+ * carries the idempotency key `onboarding-resume-<caseId>`, the Keycloak sub link is idempotent by
+ * construction, and the pid identity registration is keyed on the party id.
+ *
+ * A malformed or foreign event still returns early without deleting anything (nothing was written),
+ * and an unknown verdict is treated as handled — replaying it produces the same unknown verdict
+ * forever, so it is the poison-pill case and the record is cleared.
  */
 @ApplicationScoped
 @Suppress("LongParameterList") // CDI-injected collaborators + two service URLs + the feature flag
@@ -46,9 +66,11 @@ class OnboardingResumeService(
 
     @Incoming("party-events-in")
     @Blocking
-    @Suppress("TooGenericExceptionCaught") // a consumer must never die on a single bad/foreign event
     fun onPartyEvent(payload: String) {
         if (!resumeEnabled) return
+        // Everything down to `linkPartyId` is parsing/routing: a malformed or foreign event returns
+        // early and is acked, because replaying it can only fail the same way. Nothing was written,
+        // so nothing is deleted either.
         val node = runCatching { objectMapper.readTree(payload) }.getOrNull() ?: return
         if (node["eventType"]?.asText() != DECIDED_EVENT) return
         val caseId = node["aggregateId"]?.asText()?.takeIf { it.isNotBlank() } ?: return
@@ -56,12 +78,48 @@ class OnboardingResumeService(
         val p = node["payload"]
         val verdict = p?.get("verdict")?.asText() ?: return
         val linkPartyId = p?.get("linkPartyId")?.takeIf { !it.isNull }?.asText()
-        try {
-            resume(pending, verdict, linkPartyId)
-        } catch (e: Exception) {
-            Log.error("onboarding resume failed for case=$caseId verdict=$verdict: ${e.message}", e)
-        } finally {
-            pendingStore.delete(caseId)
+
+        // The downstream half. On success the pending record is cleared; on a persistent failure the
+        // exception escapes so the connector dead-letters AND the record survives for the replay.
+        withBoundedRetry(caseId, verdict) { resume(pending, verdict, linkPartyId) }
+        pendingStore.delete(caseId)
+    }
+
+    /**
+     * Retry [block] a bounded number of times, then RETHROW so the connector dead-letters.
+     *
+     * The rethrow is the point. A caught-and-logged failure acks the message, and an acked message
+     * that did no work is indistinguishable from one that succeeded — from Kafka, from the consumer
+     * lag metric, and from every dashboard built on either.
+     *
+     * The sleep is a plain [Thread.sleep] because this handler is `@Blocking`: Quarkus dispatches it
+     * on a worker thread, never on the event loop, so blocking it delays only this partition.
+     */
+    @Suppress("TooGenericExceptionCaught") // the retry is type-agnostic on purpose: any failure of
+    // the fan-out is a failure to resume, and the bounded rethrow (not a swallow) keeps it visible.
+    private fun withBoundedRetry(caseId: String, verdict: String, block: () -> Unit) {
+        var attempt = 1
+        while (true) {
+            try {
+                block()
+                return
+            } catch (e: Exception) {
+                if (attempt >= MAX_ATTEMPTS) {
+                    Log.error(
+                        "onboarding resume failed for case=$caseId verdict=$verdict after $attempt " +
+                            "attempts (${e.javaClass.simpleName}: ${e.message}) — dead-lettering, " +
+                            "the pending record is kept so a replay can resume it",
+                        e,
+                    )
+                    throw e
+                }
+                Log.warn(
+                    "onboarding resume failed for case=$caseId verdict=$verdict " +
+                        "(attempt $attempt/$MAX_ATTEMPTS, ${e.javaClass.simpleName}: ${e.message}) — retrying",
+                )
+                Thread.sleep(RETRY_BACKOFF_MS * attempt)
+                attempt++
+            }
         }
     }
 
@@ -172,5 +230,7 @@ class OnboardingResumeService(
 
     companion object {
         private const val DECIDED_EVENT = "IdentityVerificationCaseDecided"
+        private const val MAX_ATTEMPTS = 3
+        private const val RETRY_BACKOFF_MS = 500L
     }
 }

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/infrastructure/onboarding/OnboardingResumeServiceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/infrastructure/onboarding/OnboardingResumeServiceTest.kt
@@ -16,6 +16,10 @@ import jakarta.ws.rs.core.Response
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/** Named so detekt's TooGenericExceptionThrown does not fire at the throw site. */
+private class UpstreamDown : RuntimeException("connection refused")
 
 class OnboardingResumeServiceTest {
 
@@ -131,5 +135,55 @@ class OnboardingResumeServiceTest {
         every { store.find(caseId) } returns null
         svc.onPartyEvent(decidedEvent("DISTINCT_NEW", null))
         verify(exactly = 0) { upstream.post(any(), any(), any(), any()) }
+    }
+
+    /**
+     * The #5698 pair. Before this fix the handler caught every downstream failure, logged it, and
+     * returned normally — acking the Kafka message — while a `finally` deleted the pending record
+     * regardless. So a few seconds of party-service downtime stranded the applicant permanently:
+     * the event was gone AND the record a replay would have needed was gone with it.
+     *
+     * Both halves are asserted, because a test that cannot tell a transient downstream failure from
+     * a malformed payload proves nothing about either.
+     */
+    @Test
+    fun `a persistent upstream failure is RETHROWN and the pending record is KEPT for a replay`() {
+        every { upstream.post("http://party/api/v1/parties", any(), any(), any()) } throws UpstreamDown()
+
+        assertThrows<UpstreamDown> { svc.onPartyEvent(decidedEvent("DISTINCT_NEW", null)) }
+
+        verify(exactly = 3) { upstream.post("http://party/api/v1/parties", any(), any(), any()) }
+        verify(exactly = 0) { store.delete(any()) }
+    }
+
+    @Test
+    fun `a transient upstream failure is retried, succeeds, and then clears the pending record`() {
+        var calls = 0
+        every { upstream.post("http://party/api/v1/parties", any(), any(), any()) } answers {
+            calls++
+            if (calls == 1) throw UpstreamDown() else Response.ok("{}").build()
+        }
+
+        svc.onPartyEvent(decidedEvent("DISTINCT_NEW", null))
+
+        verify(exactly = 2) { upstream.post("http://party/api/v1/parties", any(), any(), any()) }
+        verify(exactly = 1) { store.delete(caseId) }
+    }
+
+    @Test
+    fun `a malformed payload is acked, touching neither upstream nor the pending store`() {
+        svc.onPartyEvent("not json")
+        svc.onPartyEvent("""{"eventType":"IdentityVerificationCaseDecided"}""") // no aggregateId
+
+        verify(exactly = 0) { upstream.post(any(), any(), any(), any()) }
+        verify(exactly = 0) { store.delete(any()) }
+    }
+
+    @Test
+    fun `an unknown verdict is acked and clears the pending record`() {
+        svc.onPartyEvent(decidedEvent("SOMETHING_ELSE", null))
+
+        verify(exactly = 0) { upstream.post(any(), any(), any(), any()) }
+        verify(exactly = 1) { store.delete(caseId) }
     }
 }

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/kafka/AccountCreatedConsumer.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/kafka/AccountCreatedConsumer.kt
@@ -22,6 +22,10 @@ import java.util.UUID
  *
  * Poison-pill safe (an unparseable payload is logged and skipped, never crashes the consumer) and
  * idempotent (delegated to [OnboardingDocumentUseCase], which no-ops on replay).
+ *
+ * Issuance failures are split by kind (#5698) — see [withBoundedRetry]. A deterministic failure for
+ * one account is still acked, exactly as ADR-0086's off-the-money-path trade-off intends; a
+ * transient one is retried and then rethrown, so it dead-letters instead of vanishing.
  */
 @ApplicationScoped
 class AccountCreatedConsumer(
@@ -56,23 +60,39 @@ class AccountCreatedConsumer(
         }
 
         try {
-            onboardingUseCase.issueOnboardingDocument(
-                IssueOnboardingDocumentCommand(
-                    accountId = accountId,
-                    partyRef = partyId.toString(),
-                    productId = productId,
-                ),
-            )
-        } catch (e: Exception) {
-            // Poison-pill safety: onboarding is best-effort and off the money path (ADR-0086), so a
-            // deterministic downstream failure for ONE account (e.g. a documentTemplateCode with no
-            // PUBLISHED template) must not throw out of the stream and, under smallrye-kafka's default
-            // fail-strategy, wedge onboarding for EVERY subsequent account. Log and ack; a missed
-            // onboarding document is re-triggerable, not a money error. This deliberately trades
-            // at-least-once retry on a transient error for consumer liveness — a bounded retry / DLQ
-            // is a possible follow-up if transient-loss ever proves material.
-            log.errorf(e, "Onboarding-document issuance failed for account %s; skipping (event acked).", accountId)
+            withBoundedRetry(log, "Onboarding-document issuance for account $accountId") {
+                onboardingUseCase.issueOnboardingDocument(
+                    IssueOnboardingDocumentCommand(
+                        accountId = accountId,
+                        partyRef = partyId.toString(),
+                        productId = productId,
+                    ),
+                )
+            }
+        } catch (e: IllegalStateException) {
+            ackDeterministic(e, accountId)
+        } catch (e: IllegalArgumentException) {
+            ackDeterministic(e, accountId)
         }
+        // Anything else has already been retried and is deliberately NOT caught: it propagates so
+        // smallrye-kafka can dead-letter the record. Swallowing it acked an event that did no work,
+        // which is indistinguishable from success on every dashboard there is (#5698).
+    }
+
+    /**
+     * Ack a failure that is a property of THIS account rather than of the infrastructure — e.g. a
+     * product whose `documentTemplateCode` has no PUBLISHED template. Onboarding is best-effort and
+     * off the money path (ADR-0086), so such an event must not throw out of the stream and, under
+     * smallrye-kafka's default fail-strategy, wedge onboarding for EVERY subsequent account. It also
+     * cannot be fixed by a retry or by a DLQ: the next delivery fails identically. A missed
+     * onboarding document is re-triggerable, not a money error.
+     */
+    private fun ackDeterministic(e: RuntimeException, accountId: UUID) {
+        log.errorf(
+            e,
+            "Onboarding-document issuance failed deterministically for account %s; skipping (event acked).",
+            accountId,
+        )
     }
 
     private companion object {

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/kafka/AnnualFeeSummaryReadyConsumer.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/kafka/AnnualFeeSummaryReadyConsumer.kt
@@ -23,6 +23,10 @@ import java.util.UUID
  * a required field is logged and skipped, never crashes the consumer) and delegates to an
  * idempotent use case, so a deterministic downstream failure for one account never wedges delivery
  * for every subsequent one.
+ *
+ * Delivery failures are split by kind (#5698) — see [withBoundedRetry]. A deterministic failure for
+ * one account is still acked; a transient one is retried and then rethrown, so it dead-letters
+ * instead of vanishing.
  */
 @ApplicationScoped
 class AnnualFeeSummaryReadyConsumer(
@@ -52,20 +56,33 @@ class AnnualFeeSummaryReadyConsumer(
         }
 
         try {
-            deliveryUseCase.deliverAnnualStatement(cmd)
-        } catch (e: Exception) {
-            // Poison-pill safety: statement delivery is best-effort event-driven work, so a
-            // deterministic downstream failure for ONE account (e.g. no PUBLISHED template) must
-            // not throw out of the stream and, under smallrye-kafka's default fail-strategy, wedge
-            // delivery for EVERY subsequent account. Log and ack; a missed statement is
-            // re-triggerable by billing-service re-draining its outbox, not a money error.
-            log.errorf(
-                e,
-                "Annual statement delivery failed for account %s year %d; skipping (event acked).",
-                cmd.accountId,
-                cmd.year,
-            )
+            withBoundedRetry(log, "Annual statement delivery for account ${cmd.accountId} year ${cmd.year}") {
+                deliveryUseCase.deliverAnnualStatement(cmd)
+            }
+        } catch (e: IllegalStateException) {
+            ackDeterministic(e, cmd)
+        } catch (e: IllegalArgumentException) {
+            ackDeterministic(e, cmd)
         }
+        // Anything else has already been retried and is deliberately NOT caught: it propagates so
+        // smallrye-kafka can dead-letter the record rather than acking work that never happened.
+    }
+
+    /**
+     * Ack a failure that is a property of THIS account rather than of the infrastructure — e.g. no
+     * PUBLISHED template for the statement. Statement delivery is best-effort event-driven work, so
+     * such an event must not throw out of the stream and, under smallrye-kafka's default
+     * fail-strategy, wedge delivery for EVERY subsequent account; and a retry or a DLQ cannot help,
+     * since the next delivery fails identically. A missed statement is re-triggerable by
+     * billing-service re-draining its outbox, not a money error.
+     */
+    private fun ackDeterministic(e: RuntimeException, cmd: AnnualFeeSummaryReadyCommand) {
+        log.errorf(
+            e,
+            "Annual statement delivery failed deterministically for account %s year %d; skipping (event acked).",
+            cmd.accountId,
+            cmd.year,
+        )
     }
 
     // ReturnCount: deliberate -- each required field is validated independently (poison-pill

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/kafka/ConsumerRetry.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/kafka/ConsumerRetry.kt
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.infrastructure.kafka
+
+import kotlinx.coroutines.delay
+import org.jboss.logging.Logger
+
+/**
+ * Bounded retry shared by this service's two document-issuance consumers (#5698).
+ *
+ * Both used to catch `Exception` around the use-case call, log, and return normally — which acks
+ * the Kafka message. The comment framed that as a deliberate trade-off: onboarding is off the money
+ * path (ADR-0086), and a deterministic failure for ONE account (a product whose
+ * `documentTemplateCode` has no PUBLISHED template) must not wedge issuance for every subsequent
+ * account. That reasoning is sound and is preserved. What it could not do is tell a deterministic
+ * failure from a transient one — the same generic catch swallowed a connection-refused from
+ * Postgres, and an acked message that did no work is indistinguishable from one that succeeded.
+ *
+ * The split is by exception type, and it is not arbitrary: the deterministic per-event failures in
+ * this service are raised as [IllegalStateException] (`DocumentRenderService`'s
+ * `error("No published template for …")`) or [IllegalArgumentException] (a value the event itself
+ * carries). Those can never succeed on retry, so they are rethrown immediately and the CALLER acks
+ * them, keeping the documented behaviour. Everything else — a `PersistenceException`, a socket
+ * failure, a timeout — is retried [MAX_ATTEMPTS] times and then rethrown, so the connector
+ * dead-letters rather than losing the event.
+ */
+internal const val MAX_ATTEMPTS = 3
+
+/** Linear backoff base: attempt N waits N * this. */
+internal const val RETRY_BACKOFF_MS = 500L
+
+/**
+ * True for failures that are a property of the EVENT rather than of the infrastructure, and so
+ * produce the identical failure on every redelivery. Retrying them burns attempts for nothing and
+ * dead-lettering them buys nothing either — the caller acks them instead.
+ */
+internal fun Throwable.isDeterministicForThisEvent(): Boolean =
+    this is IllegalStateException || this is IllegalArgumentException
+
+/**
+ * Run [block], retrying a transient failure up to [MAX_ATTEMPTS] times and then RETHROWING.
+ *
+ * The rethrow is the point: it is the only thing that turns a lost event into a visible one. A
+ * deterministic failure ([isDeterministicForThisEvent]) is rethrown on the first attempt without a
+ * retry, so the caller can distinguish it and ack.
+ */
+@Suppress("TooGenericExceptionCaught") // the classification below IS the specific-exception handling
+internal suspend fun withBoundedRetry(log: Logger, what: String, block: suspend () -> Unit) {
+    var attempt = 1
+    while (true) {
+        try {
+            block()
+            return
+        } catch (e: Exception) {
+            if (e.isDeterministicForThisEvent()) throw e
+            if (attempt >= MAX_ATTEMPTS) {
+                log.errorf(
+                    e,
+                    "%s failed after %d attempts (%s: %s) — rethrowing so the connector dead-letters",
+                    what,
+                    attempt,
+                    e.javaClass.simpleName,
+                    e.message,
+                )
+                throw e
+            }
+            log.warnf(
+                "%s failed (attempt %d/%d, %s: %s) — retrying",
+                what,
+                attempt,
+                MAX_ATTEMPTS,
+                e.javaClass.simpleName,
+                e.message,
+            )
+            delay(RETRY_BACKOFF_MS * attempt)
+            attempt++
+        }
+    }
+}

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/kafka/AccountCreatedConsumerTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/kafka/AccountCreatedConsumerTest.kt
@@ -12,7 +12,11 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.util.UUID
+
+/** Named so detekt's TooGenericExceptionThrown does not fire at the throw site. */
+private class TransientDbFailure : RuntimeException("connection refused")
 
 /** Poison-pill safety + field-presence guards for [AccountCreatedConsumer] (mirrors BalanceInitConsumer). */
 class AccountCreatedConsumerTest {
@@ -62,7 +66,7 @@ class AccountCreatedConsumerTest {
     }
 
     @Test
-    fun `swallows a downstream failure so one bad account never wedges the consumer`(): Unit = runBlocking {
+    fun `acks a DETERMINISTIC downstream failure so one bad account never wedges the consumer`(): Unit = runBlocking {
         val accountId = UUID.randomUUID()
         val partyId = UUID.randomUUID()
         val productId = UUID.randomUUID()
@@ -73,7 +77,44 @@ class AccountCreatedConsumerTest {
         // halt the stream (poison-pill safety). runBlocking would rethrow if consume() let it escape.
         consumer.consume(accountCreatedPayload(accountId, partyId, productId))
 
+        // Exactly once: a failure that fails identically on every delivery must not burn retries.
         coVerify(exactly = 1) { onboardingUseCase.issueOnboardingDocument(any()) }
+    }
+
+    /**
+     * The other half of #5698, and the reason the test above is not enough on its own. The original
+     * catch was `catch (e: Exception)`, so a connection-refused from Postgres was acked exactly like
+     * the no-template case — an event that did no work, indistinguishable from one that succeeded.
+     */
+    @Test
+    fun `a TRANSIENT downstream failure is retried and then RETHROWN so the connector dead-letters`(): Unit =
+        runBlocking {
+            val accountId = UUID.randomUUID()
+            val partyId = UUID.randomUUID()
+            val productId = UUID.randomUUID()
+            coEvery { onboardingUseCase.issueOnboardingDocument(any()) } throws TransientDbFailure()
+
+            assertThrows<TransientDbFailure> {
+                runBlocking { consumer.consume(accountCreatedPayload(accountId, partyId, productId)) }
+            }
+
+            coVerify(exactly = 3) { onboardingUseCase.issueOnboardingDocument(any()) }
+        }
+
+    @Test
+    fun `a transient failure that recovers is retried to success, not dead-lettered`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val partyId = UUID.randomUUID()
+        val productId = UUID.randomUUID()
+        var calls = 0
+        coEvery { onboardingUseCase.issueOnboardingDocument(any()) } answers {
+            calls++
+            if (calls == 1) throw TransientDbFailure() else Unit
+        }
+
+        consumer.consume(accountCreatedPayload(accountId, partyId, productId))
+
+        coVerify(exactly = 2) { onboardingUseCase.issueOnboardingDocument(any()) }
     }
 
     private fun accountCreatedPayload(accountId: UUID, partyId: UUID, productId: UUID) = """

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/kafka/AnnualFeeSummaryReadyConsumerTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/kafka/AnnualFeeSummaryReadyConsumerTest.kt
@@ -13,8 +13,12 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
 import java.util.UUID
+
+/** Named so detekt's TooGenericExceptionThrown does not fire at the throw site. */
+private class AnnualTransientDbFailure : RuntimeException("connection refused")
 
 /** Poison-pill safety + field-presence guards for [AnnualFeeSummaryReadyConsumer] (mirrors AccountCreatedConsumerTest). */
 class AnnualFeeSummaryReadyConsumerTest {
@@ -137,7 +141,7 @@ class AnnualFeeSummaryReadyConsumerTest {
     }
 
     @Test
-    fun `swallows a downstream failure so one bad account never wedges the consumer`(): Unit = runBlocking {
+    fun `acks a DETERMINISTIC downstream failure so one bad account never wedges the consumer`(): Unit = runBlocking {
         val accountId = UUID.randomUUID()
         val partyId = UUID.randomUUID()
         coEvery { deliveryUseCase.deliverAnnualStatement(any()) } throws
@@ -147,7 +151,38 @@ class AnnualFeeSummaryReadyConsumerTest {
         // halt the stream (poison-pill safety). runBlocking would rethrow if consume() let it escape.
         consumer.consume(annualFeeSummaryPayload(accountId, partyId))
 
+        // Exactly once: a failure that fails identically on every delivery must not burn retries.
         coVerify(exactly = 1) { deliveryUseCase.deliverAnnualStatement(any()) }
+    }
+
+    /** The #5698 half the generic `catch (e: Exception)` could not express — see the sibling test. */
+    @Test
+    fun `a TRANSIENT downstream failure is retried and then RETHROWN so the connector dead-letters`(): Unit =
+        runBlocking {
+            val accountId = UUID.randomUUID()
+            val partyId = UUID.randomUUID()
+            coEvery { deliveryUseCase.deliverAnnualStatement(any()) } throws AnnualTransientDbFailure()
+
+            assertThrows<AnnualTransientDbFailure> {
+                runBlocking { consumer.consume(annualFeeSummaryPayload(accountId, partyId)) }
+            }
+
+            coVerify(exactly = 3) { deliveryUseCase.deliverAnnualStatement(any()) }
+        }
+
+    @Test
+    fun `a transient failure that recovers is retried to success, not dead-lettered`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val partyId = UUID.randomUUID()
+        var calls = 0
+        coEvery { deliveryUseCase.deliverAnnualStatement(any()) } answers {
+            calls++
+            if (calls == 1) throw AnnualTransientDbFailure() else Unit
+        }
+
+        consumer.consume(annualFeeSummaryPayload(accountId, partyId))
+
+        coVerify(exactly = 2) { deliveryUseCase.deliverAnnualStatement(any()) }
     }
 
     private fun annualFeeSummaryPayload(accountId: UUID, partyId: UUID) = """

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/CampaignBannerPlacementConsumer.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/CampaignBannerPlacementConsumer.kt
@@ -22,11 +22,24 @@ class CampaignBannerPlacementConsumer(
     private val log = Logger.getLogger(CampaignBannerPlacementConsumer::class.java)
 
     @Incoming("campaign-banner-placements-in")
-    @Suppress("TooGenericExceptionCaught")
     suspend fun consume(payload: String) {
+        // Parse first, and ack a malformed command: campaign's send log remains the durable audit
+        // trail, and a replay of an unparseable command fails identically forever.
+        val placement = parse(payload) ?: return
+
+        // The write is the opposite case — a DB failure here is transient and the placement must
+        // still land once it recovers, so it is retried and then rethrown for the DLQ (#5698).
+        withBoundedRetry(log, "campaign banner placement for interaction ${placement.interactionRef}") {
+            placements.save(placement)
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught") // any parse/field failure on an untrusted payload is the
+    // same unretryable poison pill, whatever Jackson or the enum lookup happens to throw.
+    private fun parse(payload: String): CampaignBannerPlacement? =
         try {
             val node = mapper.readTree(payload)
-            val placement = CampaignBannerPlacement(
+            CampaignBannerPlacement(
                 interactionRef = UUID.fromString(node.requiredText("interactionRef")),
                 partyId = UUID.fromString(node.requiredText("partyId")),
                 campaignId = UUID.fromString(node.requiredText("campaignId")),
@@ -43,13 +56,12 @@ class CampaignBannerPlacementConsumer(
                         ?: error("unknown inAppSurface")
                 } ?: SurfaceSlot.HOME_BANNER,
             )
-            placements.save(placement)
         } catch (e: Exception) {
             // A malformed command cannot wedge the consumer group; campaign's send log remains
             // the durable audit trail and the error is visible for reconciliation.
-            log.errorf(e, "Failed to place campaign banner: %.300s", payload)
+            log.errorf(e, "Failed to parse campaign banner placement command: %.300s", payload)
+            null
         }
-    }
 
     private fun com.fasterxml.jackson.databind.JsonNode.requiredText(name: String): String =
         required(name).asText().takeIf { it.isNotBlank() } ?: error("$name is required")

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/ConsumerRetry.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/ConsumerRetry.kt
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.engagement.infrastructure.kafka
+
+import kotlinx.coroutines.delay
+import org.jboss.logging.Logger
+
+/**
+ * Bounded retry shared by this service's five event consumers (#5698).
+ *
+ * All five had the same shape: ONE `try` wrapping both the JSON/field parsing and the
+ * `AdverseStateRepository` (or `CampaignBannerPlacementRepository`) write, with a single
+ * `catch (e: Exception)` that logged and returned normally — which acks the Kafka message. Each
+ * carried a comment justifying it as poison-pill safety, "the producer's outbox remains the source
+ * of truth and can be replayed". Nothing replays it: the message was acked, and the only trace of
+ * the lost work was an ERROR line nobody alerts on.
+ *
+ * The justification is right about parsing and wrong about the write. A malformed payload is
+ * unretryable — replaying it produces the same parse failure forever — so each consumer still parses
+ * in its own `catch` and acks. The repository write is the opposite case: the event is fine, the
+ * database is not, and the work must still happen once it recovers. It now runs here, is retried
+ * [MAX_ATTEMPTS] times with linear backoff, and is RETHROWN if it still fails, so the connector
+ * dead-letters rather than silently dropping a targeting-exclusion signal (a fraud hold, an arrears
+ * flag, a dispute, or a GDPR erasure that ADR-0220 D3.5 treats as terminal and never re-derives).
+ *
+ * Every write behind this helper is idempotent — `setActive`/`clearActive` are keyed by
+ * (party, state) and `save` upserts by interaction ref — so both the retry and a connector
+ * redelivery are safe.
+ */
+internal const val MAX_ATTEMPTS = 3
+
+/** Linear backoff base: attempt N waits N * this. */
+internal const val RETRY_BACKOFF_MS = 500L
+
+/**
+ * Run [block], retrying a failure up to [MAX_ATTEMPTS] times and then RETHROWING.
+ *
+ * The rethrow is the point. A caught-and-logged failure acks the message, and an acked message that
+ * did no work is indistinguishable from one that succeeded — from Kafka, from the consumer lag
+ * metric, and from every dashboard built on either. The retry stays bounded and the failure moves to
+ * the DLQ, so one bad event still cannot wedge the consumer group.
+ */
+@Suppress("TooGenericExceptionCaught") // the retry is type-agnostic on purpose: any failure of the
+// write is a failure to apply the signal, and the bounded rethrow (not a swallow) keeps it visible.
+internal suspend fun withBoundedRetry(log: Logger, what: String, block: suspend () -> Unit) {
+    var attempt = 1
+    while (true) {
+        try {
+            block()
+            return
+        } catch (e: Exception) {
+            if (attempt >= MAX_ATTEMPTS) {
+                log.errorf(
+                    e,
+                    "%s failed after %d attempts (%s: %s) — rethrowing so the connector dead-letters",
+                    what,
+                    attempt,
+                    e.javaClass.simpleName,
+                    e.message,
+                )
+                throw e
+            }
+            log.warnf(
+                "%s failed (attempt %d/%d, %s: %s) — retrying",
+                what,
+                attempt,
+                MAX_ATTEMPTS,
+                e.javaClass.simpleName,
+                e.message,
+            )
+            delay(RETRY_BACKOFF_MS * attempt)
+            attempt++
+        }
+    }
+}

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/DisputeOpenedEventConsumer.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/DisputeOpenedEventConsumer.kt
@@ -33,8 +33,9 @@ import java.util.UUID
  * fewer suppressed marketing surfaces rather than towards a state that can never be cleared, and
  * matching the existing FRAUD_HOLD/ARREARS shape rather than introducing a second one.
  *
- * Poison-pill safe: parse/handle failures are logged and swallowed so one bad event cannot wedge
- * the consumer group — dispute-service's outbox remains the source of truth and can be replayed.
+ * Poison-pill safe for a MALFORMED event: an unparseable payload or a missing partyId is logged and
+ * acked, because replaying it fails identically forever. A failure of the `adverseState` write is
+ * the opposite case and is retried, then rethrown for the DLQ — see [withBoundedRetry] (#5698).
  */
 @ApplicationScoped
 class DisputeOpenedEventConsumer(
@@ -44,27 +45,47 @@ class DisputeOpenedEventConsumer(
     private val log = Logger.getLogger(DisputeOpenedEventConsumer::class.java)
 
     @Incoming("dispute-events-in")
-    @Suppress("TooGenericExceptionCaught")
     suspend fun consume(payload: String) {
+        val signal = parse(payload) ?: return
+        withBoundedRetry(log, "dispute exclusion for party ${signal.partyId} (${signal.eventType})") {
+            if (signal.opened) {
+                adverseState.setActive(signal.partyId, AdverseState.DISPUTE_OPENED, Instant.now())
+                log.infof("ADR-0220 D3.5: excluded party %s from targeting (dispute.opened)", signal.partyId)
+            } else {
+                adverseState.clearActive(signal.partyId, AdverseState.DISPUTE_OPENED)
+                log.infof(
+                    "ADR-0220 D3.5: lifted dispute exclusion for party %s (dispute.resolved)",
+                    signal.partyId,
+                )
+            }
+        }
+    }
+
+    /** Parsing + routing only — every outcome here is unretryable, so a null means "ack and move on". */
+    @Suppress("TooGenericExceptionCaught") // whatever Jackson or UUID.fromString throws, a malformed
+    // payload is the same unretryable poison pill.
+    private fun parse(payload: String): DisputeSignal? =
         try {
             val node = objectMapper.readTree(payload)
             val eventType = node.path("eventType").asText()
-            if (eventType != EVENT_OPENED && eventType != EVENT_RESOLVED) return
-
-            val partyId = node.path("partyId").asText(null)?.let(UUID::fromString) ?: run {
-                log.warnf("%s missing/unparseable partyId, skipping: %.300s", eventType, payload)
-                return
-            }
-            if (eventType == EVENT_OPENED) {
-                adverseState.setActive(partyId, AdverseState.DISPUTE_OPENED, Instant.now())
-                log.infof("ADR-0220 D3.5: excluded party %s from targeting (dispute.opened)", partyId)
+            if (eventType != EVENT_OPENED && eventType != EVENT_RESOLVED) {
+                null
             } else {
-                adverseState.clearActive(partyId, AdverseState.DISPUTE_OPENED)
-                log.infof("ADR-0220 D3.5: lifted dispute exclusion for party %s (dispute.resolved)", partyId)
+                val partyId = node.path("partyId").asText(null)?.let(UUID::fromString)
+                if (partyId == null) {
+                    log.warnf("%s missing/unparseable partyId, skipping: %.300s", eventType, payload)
+                    null
+                } else {
+                    DisputeSignal(partyId, eventType)
+                }
             }
         } catch (e: Exception) {
-            log.errorf(e, "Failed to handle dispute lifecycle event: %.300s", payload)
+            log.errorf(e, "Failed to parse dispute lifecycle event: %.300s", payload)
+            null
         }
+
+    private data class DisputeSignal(val partyId: UUID, val eventType: String) {
+        val opened: Boolean get() = eventType == EVENT_OPENED
     }
 
     private companion object {

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/FraudHoldEventConsumer.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/FraudHoldEventConsumer.kt
@@ -21,8 +21,10 @@ import java.util.UUID
  * fraud-service's side (its own scheduled sweep, no manual clear), so this consumer must honour
  * `active: false` and actually clear the state rather than only ever setting it.
  *
- * Poison-pill safe: parse/handle failures are logged and swallowed so one bad event cannot wedge
- * the consumer group — fraud-service's outbox remains the source of truth and can be replayed.
+ * Poison-pill safe for a MALFORMED event: an unparseable payload or a missing partyId is logged and
+ * acked, because replaying it fails identically forever. A failure of the `adverseState` write is
+ * the opposite case and is retried, then rethrown for the DLQ — see [withBoundedRetry] (#5698).
+ * Losing this signal silently is the worst of the four: it is the fraud-hold marketing exclusion.
  */
 @ApplicationScoped
 class FraudHoldEventConsumer(
@@ -32,22 +34,34 @@ class FraudHoldEventConsumer(
     private val log = Logger.getLogger(FraudHoldEventConsumer::class.java)
 
     @Incoming("fraud-hold-events-in")
-    @Suppress("TooGenericExceptionCaught")
     suspend fun consume(payload: String) {
-        try {
-            val node = objectMapper.readTree(payload)
-            val partyId = node.path("partyId").asText(null)?.let(UUID::fromString) ?: run {
-                log.warnf("fraud.hold_changed missing/unparseable partyId, skipping: %.300s", payload)
-                return
-            }
-            val active = node.path("active").asBoolean(false)
-            if (active) {
-                adverseState.setActive(partyId, AdverseState.FRAUD_HOLD, Instant.now())
+        val signal = parse(payload) ?: return
+        withBoundedRetry(log, "fraud-hold exclusion for party ${signal.partyId} (active=${signal.active})") {
+            if (signal.active) {
+                adverseState.setActive(signal.partyId, AdverseState.FRAUD_HOLD, Instant.now())
             } else {
-                adverseState.clearActive(partyId, AdverseState.FRAUD_HOLD)
+                adverseState.clearActive(signal.partyId, AdverseState.FRAUD_HOLD)
             }
-        } catch (e: Exception) {
-            log.errorf(e, "Failed to handle fraud.hold_changed event: %.300s", payload)
         }
     }
+
+    /** Parsing only — every outcome here is unretryable, so a null means "ack and move on". */
+    @Suppress("TooGenericExceptionCaught") // whatever Jackson or UUID.fromString throws, a malformed
+    // payload is the same unretryable poison pill.
+    private fun parse(payload: String): FraudHoldSignal? =
+        try {
+            val node = objectMapper.readTree(payload)
+            val partyId = node.path("partyId").asText(null)?.let(UUID::fromString)
+            if (partyId == null) {
+                log.warnf("fraud.hold_changed missing/unparseable partyId, skipping: %.300s", payload)
+                null
+            } else {
+                FraudHoldSignal(partyId, node.path("active").asBoolean(false))
+            }
+        } catch (e: Exception) {
+            log.errorf(e, "Failed to parse fraud.hold_changed event: %.300s", payload)
+            null
+        }
+
+    private data class FraudHoldSignal(val partyId: UUID, val active: Boolean)
 }

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/LendingArrearsEventConsumer.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/LendingArrearsEventConsumer.kt
@@ -28,8 +28,10 @@ import java.util.UUID
  * coarse "as of the last stage change" signal, not a continuously fresh DPD feed. Good enough for
  * a targeting exclusion; do not read it as a live delinquency metric.
  *
- * Poison-pill safe: parse/handle failures are logged and swallowed so one bad event cannot wedge
- * the consumer group — lending-service's outbox remains the source of truth and can be replayed.
+ * Poison-pill safe for a MALFORMED event: an unparseable payload, a missing partyId or a missing
+ * daysPastDue is logged and acked, because replaying it fails identically forever. A failure of the
+ * `adverseState` write is the opposite case and is retried, then rethrown for the DLQ — see
+ * [withBoundedRetry] (#5698).
  */
 @ApplicationScoped
 class LendingArrearsEventConsumer(
@@ -39,32 +41,44 @@ class LendingArrearsEventConsumer(
     private val log = Logger.getLogger(LendingArrearsEventConsumer::class.java)
 
     @Incoming("lending-events-in")
-    @Suppress("TooGenericExceptionCaught") // poison-pill safety, same convention as
-    // MarketingConsentEventConsumer/PartyEventConsumer across the fleet.
     suspend fun consume(payload: String) {
-        try {
-            val node = objectMapper.readTree(payload)
-            if (node.path("eventType") // topic carries only loan.stage_changed today, but check
-                    .asText() != "loan.stage_changed"
-            ) {
-                return
-            }
-            val partyId = node.path("partyId").asText(null)?.let(UUID::fromString) ?: run {
-                log.warnf("loan.stage_changed missing/unparseable partyId, skipping: %.300s", payload)
-                return
-            }
-            val daysPastDue = node.path("daysPastDue").asInt(-1)
-            if (daysPastDue < 0) {
-                log.warnf("loan.stage_changed missing/unparseable daysPastDue, skipping: %.300s", payload)
-                return
-            }
-            if (daysPastDue > 0) {
-                adverseState.setActive(partyId, AdverseState.ARREARS, Instant.now())
+        val signal = parse(payload) ?: return
+        withBoundedRetry(log, "arrears exclusion for party ${signal.partyId} (dpd=${signal.daysPastDue})") {
+            if (signal.daysPastDue > 0) {
+                adverseState.setActive(signal.partyId, AdverseState.ARREARS, Instant.now())
             } else {
-                adverseState.clearActive(partyId, AdverseState.ARREARS)
+                adverseState.clearActive(signal.partyId, AdverseState.ARREARS)
             }
-        } catch (e: Exception) {
-            log.errorf(e, "Failed to handle loan.stage_changed event: %.300s", payload)
         }
     }
+
+    /** Parsing + routing only — every outcome here is unretryable, so a null means "ack and move on". */
+    // TooGenericExceptionCaught: whatever Jackson or UUID.fromString throws, a malformed payload is
+    // the same unretryable poison pill. ReturnCount: one guard per required field reads far better
+    // than folding four conditions together.
+    @Suppress("TooGenericExceptionCaught", "ReturnCount")
+    private fun parse(payload: String): ArrearsSignal? {
+        val node = try {
+            objectMapper.readTree(payload)
+        } catch (e: Exception) {
+            log.errorf(e, "Failed to parse loan.stage_changed event: %.300s", payload)
+            return null
+        }
+        // topic carries only loan.stage_changed today, but check
+        if (node.path("eventType").asText() != "loan.stage_changed") return null
+
+        val partyId = runCatching { node.path("partyId").asText(null)?.let(UUID::fromString) }.getOrNull()
+        if (partyId == null) {
+            log.warnf("loan.stage_changed missing/unparseable partyId, skipping: %.300s", payload)
+            return null
+        }
+        val daysPastDue = node.path("daysPastDue").asInt(-1)
+        if (daysPastDue < 0) {
+            log.warnf("loan.stage_changed missing/unparseable daysPastDue, skipping: %.300s", payload)
+            return null
+        }
+        return ArrearsSignal(partyId, daysPastDue)
+    }
+
+    private data class ArrearsSignal(val partyId: UUID, val daysPastDue: Int)
 }

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/PartyErasureConsumer.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/PartyErasureConsumer.kt
@@ -20,27 +20,42 @@ import java.util.UUID
  * exclusion. Deliberately never cleared: there is no "un-erase" event anywhere in this fleet —
  * erasure is terminal, so once set this state is permanent for the party.
  *
- * Poison-pill safe: failures are logged and acked.
+ * Poison-pill safe for a MALFORMED event: an unparseable payload or a missing partyId is logged and
+ * acked, because replaying it fails identically forever. A failure of the `adverseState` write is
+ * the opposite case and is retried, then rethrown for the DLQ — see [withBoundedRetry] (#5698).
+ * There is no compensating path here at all: erasure is terminal and never re-derived, so a write
+ * that was acked without happening leaves the party permanently targetable with nothing to notice.
  */
 @ApplicationScoped
 class PartyErasureConsumer(private val adverseState: AdverseStateRepository, private val objectMapper: ObjectMapper) {
     private val log = Logger.getLogger(PartyErasureConsumer::class.java)
 
     @Incoming("party-events-in")
-    @Suppress("TooGenericExceptionCaught")
     suspend fun consume(payload: String) {
-        try {
-            val node = objectMapper.readTree(payload)
-            if (node.path("eventType").asText() != "PARTY_ERASED") return
-
-            val partyId = node.path("partyId").asText(null)?.let(UUID::fromString) ?: run {
-                log.warnf("PARTY_ERASED without valid partyId, skipping: %.300s", payload)
-                return
-            }
+        val partyId = parse(payload) ?: return
+        withBoundedRetry(log, "erasure exclusion for party $partyId") {
             adverseState.setActive(partyId, AdverseState.ERASURE_REQUESTED, Instant.now())
             log.infof("ADR-0220 D3.5: excluded party %s from targeting (PARTY_ERASED)", partyId)
-        } catch (e: Exception) {
-            log.errorf(e, "Failed to handle PARTY_ERASED event: %.300s", payload)
         }
     }
+
+    /** Parsing + routing only — every outcome here is unretryable, so a null means "ack and move on". */
+    @Suppress("TooGenericExceptionCaught") // whatever Jackson or UUID.fromString throws, a malformed
+    // payload is the same unretryable poison pill.
+    private fun parse(payload: String): UUID? =
+        try {
+            val node = objectMapper.readTree(payload)
+            if (node.path("eventType").asText() != "PARTY_ERASED") {
+                null
+            } else {
+                node.path("partyId").asText(null)?.let(UUID::fromString)
+                    ?: run {
+                        log.warnf("PARTY_ERASED without valid partyId, skipping: %.300s", payload)
+                        null
+                    }
+            }
+        } catch (e: Exception) {
+            log.errorf(e, "Failed to parse PARTY_ERASED event: %.300s", payload)
+            null
+        }
 }

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/infrastructure/kafka/CampaignBannerPlacementConsumerTest.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/infrastructure/kafka/CampaignBannerPlacementConsumerTest.kt
@@ -8,12 +8,14 @@ import com.openbank.engagement.application.port.out.CampaignBannerPlacementRepos
 import com.openbank.engagement.domain.model.CampaignBannerPlacement
 import com.openbank.engagement.domain.model.SurfaceContentType
 import com.openbank.engagement.domain.model.SurfaceSlot
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.util.UUID
 
 class CampaignBannerPlacementConsumerTest {
@@ -44,4 +46,39 @@ class CampaignBannerPlacementConsumerTest {
         assertThat(placement.captured.slot).isEqualTo(SurfaceSlot.STORIES)
         assertThat(placement.captured.toSurfaceContent().type).isEqualTo(SurfaceContentType.STORY)
     }
+
+    @Test
+    fun `a malformed command is acked without saving anything or throwing`(): Unit = runBlocking {
+        val consumer = CampaignBannerPlacementConsumer(repository, ObjectMapper())
+
+        consumer.consume("not json")
+        consumer.consume("""{"interactionRef":"not-a-uuid"}""")
+        consumer.consume(bannerCommand(UUID.randomUUID()).replace("openbank://products", ""))
+
+        coVerify(exactly = 0) { repository.save(any()) }
+    }
+
+    /**
+     * The #5698 half the single wrapping `try` could not express: parsing and `repository.save`
+     * shared one catch, so a DB failure was acked exactly like a malformed command — an event that
+     * did no work, indistinguishable from one that succeeded.
+     */
+    @Test
+    fun `a transient save failure is retried and RETHROWN so the connector dead-letters`(): Unit = runBlocking {
+        val consumer = CampaignBannerPlacementConsumer(repository, ObjectMapper())
+        coEvery { repository.save(any()) } throws TransientDbFailure()
+
+        assertThrows<TransientDbFailure> {
+            runBlocking { consumer.consume(bannerCommand(UUID.randomUUID())) }
+        }
+
+        coVerify(exactly = 3) { repository.save(any()) }
+    }
+
+    private fun bannerCommand(interactionRef: UUID) =
+        """{"interactionRef":"$interactionRef","partyId":"${UUID.randomUUID()}",""" +
+            """"campaignId":"${UUID.randomUUID()}","stepOrder":1,""" +
+            """"template":"MARKETING_PRODUCT_OFFER_BANNER",""" +
+            """"variables":{"offerTitle":"Offer","offerText":"Details","ctaText":"Open"},""" +
+            """"deepLink":"openbank://products"}"""
 }

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/infrastructure/kafka/ConsumerRetryTest.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/infrastructure/kafka/ConsumerRetryTest.kt
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.engagement.infrastructure.kafka
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.jboss.logging.Logger
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * A named type so detekt's TooGenericExceptionThrown does not fire at the throw sites, and so the
+ * consumer tests can assert on the exact exception that escaped rather than on `RuntimeException`.
+ *
+ * Shared by every consumer test in this package: the five consumers all had the same catch-and-ack
+ * defect (#5698) and are all fixed the same way, so one transient-failure type keeps the assertions
+ * comparable.
+ */
+internal class TransientDbFailure : RuntimeException("connection refused")
+
+/**
+ * Direct cover for the retry helper, so each consumer test can assert the consumer's WIRING
+ * (parse acks, write escapes) without also re-deriving the backoff semantics.
+ */
+class ConsumerRetryTest {
+
+    private val log = Logger.getLogger(ConsumerRetryTest::class.java)
+
+    @Test
+    fun `a persistent failure is retried MAX_ATTEMPTS times and then RETHROWN`(): Unit = runBlocking {
+        var calls = 0
+
+        assertThrows<TransientDbFailure> {
+            runBlocking {
+                withBoundedRetry(log, "unit test") {
+                    calls++
+                    throw TransientDbFailure()
+                }
+            }
+        }
+
+        assertThat(calls).isEqualTo(MAX_ATTEMPTS)
+    }
+
+    @Test
+    fun `a failure that recovers is retried to success and nothing escapes`(): Unit = runBlocking {
+        var calls = 0
+
+        withBoundedRetry(log, "unit test") {
+            calls++
+            if (calls < 2) throw TransientDbFailure()
+        }
+
+        assertThat(calls).isEqualTo(2)
+    }
+
+    @Test
+    fun `a block that succeeds first time runs exactly once`(): Unit = runBlocking {
+        var calls = 0
+
+        withBoundedRetry(log, "unit test") { calls++ }
+
+        assertThat(calls).isEqualTo(1)
+    }
+}

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/infrastructure/kafka/DisputeOpenedEventConsumerTest.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/infrastructure/kafka/DisputeOpenedEventConsumerTest.kt
@@ -7,10 +7,12 @@ package com.openbank.engagement.infrastructure.kafka
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.engagement.application.port.out.AdverseStateRepository
 import com.openbank.engagement.domain.model.AdverseState
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.util.UUID
 
 /**
@@ -67,5 +69,26 @@ class DisputeOpenedEventConsumerTest {
         consumer.consume("""{"eventType":"dispute.opened","partyId":"not-a-uuid"}""")
         coVerify(exactly = 0) { adverseState.setActive(any(), any(), any()) }
         coVerify(exactly = 0) { adverseState.clearActive(any(), any()) }
+    }
+
+    /** The #5698 half a malformed-payload test can never reach — the write must ESCAPE. */
+    @Test
+    fun `a transient write failure is retried and RETHROWN so the connector dead-letters`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        coEvery { adverseState.setActive(any(), any(), any()) } throws TransientDbFailure()
+
+        assertThrows<TransientDbFailure> { runBlocking { consumer.consume(opened(partyId)) } }
+
+        coVerify(exactly = 3) { adverseState.setActive(partyId, AdverseState.DISPUTE_OPENED, any()) }
+    }
+
+    @Test
+    fun `a transient failure lifting the exclusion is also RETHROWN`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        coEvery { adverseState.clearActive(any(), any()) } throws TransientDbFailure()
+
+        assertThrows<TransientDbFailure> { runBlocking { consumer.consume(resolved(partyId)) } }
+
+        coVerify(exactly = 3) { adverseState.clearActive(partyId, AdverseState.DISPUTE_OPENED) }
     }
 }

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/infrastructure/kafka/FraudHoldEventConsumerTest.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/infrastructure/kafka/FraudHoldEventConsumerTest.kt
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.engagement.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.engagement.application.port.out.AdverseStateRepository
+import com.openbank.engagement.domain.model.AdverseState
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID
+
+/**
+ * First cover for [FraudHoldEventConsumer] — it had none, which is why the catch-and-ack defect of
+ * #5698 lived here undisturbed on the fraud-hold marketing-exclusion signal.
+ */
+class FraudHoldEventConsumerTest {
+
+    private val adverseState = mockk<AdverseStateRepository>(relaxed = true)
+    private val consumer = FraudHoldEventConsumer(adverseState, ObjectMapper())
+
+    private fun holdChanged(partyId: UUID, active: Boolean) =
+        """{"eventType":"fraud.hold_changed","partyId":"$partyId","active":$active}"""
+
+    @Test
+    fun `an active hold sets FRAUD_HOLD active`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        consumer.consume(holdChanged(partyId, active = true))
+        coVerify(exactly = 1) { adverseState.setActive(partyId, AdverseState.FRAUD_HOLD, any()) }
+    }
+
+    @Test
+    fun `a released hold clears FRAUD_HOLD`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        consumer.consume(holdChanged(partyId, active = false))
+        coVerify(exactly = 1) { adverseState.clearActive(partyId, AdverseState.FRAUD_HOLD) }
+        coVerify(exactly = 0) { adverseState.setActive(any(), any(), any()) }
+    }
+
+    @Test
+    fun `malformed payload is acked without applying anything or throwing`(): Unit = runBlocking {
+        consumer.consume("not json")
+        consumer.consume("""{"eventType":"fraud.hold_changed"}""") // no partyId
+        consumer.consume("""{"eventType":"fraud.hold_changed","partyId":"not-a-uuid"}""")
+        coVerify(exactly = 0) { adverseState.setActive(any(), any(), any()) }
+        coVerify(exactly = 0) { adverseState.clearActive(any(), any()) }
+    }
+
+    /**
+     * The #5698 half a malformed-payload test can never reach: the write must ESCAPE so the
+     * connector dead-letters. Before the fix the same generic catch swallowed both, and an acked
+     * message that did no work is indistinguishable from one that succeeded.
+     */
+    @Test
+    fun `a transient write failure is retried and RETHROWN so the connector dead-letters`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        coEvery { adverseState.setActive(any(), any(), any()) } throws TransientDbFailure()
+
+        assertThrows<TransientDbFailure> {
+            runBlocking { consumer.consume(holdChanged(partyId, active = true)) }
+        }
+
+        coVerify(exactly = 3) { adverseState.setActive(partyId, AdverseState.FRAUD_HOLD, any()) }
+    }
+}

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/infrastructure/kafka/LendingArrearsEventConsumerTest.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/infrastructure/kafka/LendingArrearsEventConsumerTest.kt
@@ -7,10 +7,12 @@ package com.openbank.engagement.infrastructure.kafka
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.engagement.application.port.out.AdverseStateRepository
 import com.openbank.engagement.domain.model.AdverseState
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.util.UUID
 
 class LendingArrearsEventConsumerTest {
@@ -56,5 +58,23 @@ class LendingArrearsEventConsumerTest {
         ) // no daysPastDue
         coVerify(exactly = 0) { adverseState.setActive(any(), any(), any()) }
         coVerify(exactly = 0) { adverseState.clearActive(any(), any()) }
+    }
+
+    /** The #5698 half a malformed-payload test can never reach — the write must ESCAPE. */
+    @Test
+    fun `a transient write failure is retried and RETHROWN so the connector dead-letters`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        coEvery { adverseState.setActive(any(), any(), any()) } throws TransientDbFailure()
+
+        assertThrows<TransientDbFailure> {
+            runBlocking {
+                consumer.consume(
+                    """{"eventType":"loan.stage_changed","loanId":"${UUID.randomUUID()}","partyId":"$partyId",""" +
+                        """"previousStage":"STAGE_1","newStage":"STAGE_2","daysPastDue":45}""",
+                )
+            }
+        }
+
+        coVerify(exactly = 3) { adverseState.setActive(partyId, AdverseState.ARREARS, any()) }
     }
 }

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/infrastructure/kafka/PartyErasureConsumerTest.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/infrastructure/kafka/PartyErasureConsumerTest.kt
@@ -7,10 +7,12 @@ package com.openbank.engagement.infrastructure.kafka
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.engagement.application.port.out.AdverseStateRepository
 import com.openbank.engagement.domain.model.AdverseState
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.util.UUID
 
 class PartyErasureConsumerTest {
@@ -37,5 +39,23 @@ class PartyErasureConsumerTest {
         consumer.consume("""{"eventType":"PARTY_ERASED"}""") // no partyId
         consumer.consume("""{"eventType":"PARTY_ERASED","partyId":"not-a-uuid"}""")
         coVerify(exactly = 0) { adverseState.setActive(any(), any(), any()) }
+    }
+
+    /**
+     * The #5698 half a malformed-payload test can never reach. This consumer's state is TERMINAL —
+     * ADR-0220 D3.5 never re-derives ERASURE_REQUESTED and there is no un-erase event — so a write
+     * that was acked without happening leaves the party permanently targetable, with nothing
+     * anywhere to notice. The write must escape so the connector dead-letters.
+     */
+    @Test
+    fun `a transient write failure is retried and RETHROWN so the connector dead-letters`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        coEvery { adverseState.setActive(any(), any(), any()) } throws TransientDbFailure()
+
+        assertThrows<TransientDbFailure> {
+            runBlocking { consumer.consume("""{"eventType":"PARTY_ERASED","partyId":"$partyId"}""") }
+        }
+
+        coVerify(exactly = 3) { adverseState.setActive(partyId, AdverseState.ERASURE_REQUESTED, any()) }
     }
 }


### PR DESCRIPTION
Fleet sweep for the catch-and-ack defect of #5698, following the shape #5699 established in
`openbank-kyc-service`: bounded retry with backoff and then a **rethrow** so the connector can
dead-letter, while genuine poison pills (malformed payloads, unretryable per-event failures) keep
acking because they can never succeed on a retry. That split is the whole change.

The sibling PR for the money-path services (`openbank-interest-service`, `openbank-fraud-service`)
is on `fix/event-consumer-catch-and-ack-sweep`; this PR deliberately does not touch them.

## Sites fixed (9 of 9 examined, all confirmed genuine)

### `openbank-copilot-service`
1. `infrastructure/kafka/PartyErasureConsumer.kt` — `conversationStore.deleteForParty` is a reactive
   Panache call and shared a generic `catch (e: Exception)` with everything else. A connection
   refused lost a **GDPR Art. 17 erasure permanently**: the transcripts stayed on disk, neither
   erasure metric was incremented, and the log claimed the erasure was handled. Now bounded-retried
   and rethrown; parse and partyId validation still ack.

### `openbank-customer-edge`
2. `infrastructure/onboarding/OnboardingResumeService.kt` — worse than the original bug, as noted in
   the issue: `try { resume(...) } catch { Log.error } finally { pendingStore.delete(caseId) }`.
   `resume()` fans out to party-service, pid-service and Keycloak, so a transient failure was acked
   **and** the pending record was deleted anyway, leaving even a manual replay with nothing to
   resume. Both halves fixed: the fan-out is bounded-retried then rethrown, and the record is
   deleted **only on success**. The retry is safe — the party create carries the idempotency key
   `onboarding-resume-<caseId>`. Backoff uses `Thread.sleep` because the handler is `@Blocking`
   (worker thread, never the event loop).

### `openbank-document-service`
3. `infrastructure/kafka/AccountCreatedConsumer.kt`
4. `infrastructure/kafka/AnnualFeeSummaryReadyConsumer.kt`

   Both framed the swallow as a deliberate ADR-0086 trade-off (off the money path; one bad account
   must not wedge issuance for every subsequent one) and both named "a bounded retry / DLQ is a
   possible follow-up". The reasoning is sound for a *deterministic* failure and could not be
   applied selectively, because the same `catch (e: Exception)` also swallowed a connection refused.

   The catch is now narrowed by type, and the boundary is not arbitrary: the deterministic per-event
   failures in this service surface as `IllegalStateException` (`DocumentRenderService`'s
   `error("No published template for …")`) or `IllegalArgumentException`. Those are rethrown without
   a retry and the consumer acks them — documented behaviour preserved. Everything else is retried
   and rethrown. Both comments were rewritten to describe what the code now does.

### `openbank-engagement-service`
5. `infrastructure/kafka/CampaignBannerPlacementConsumer.kt` — parse + `placements.save` shared one `try`
6. `infrastructure/kafka/DisputeOpenedEventConsumer.kt` — parse + `adverseState.setActive/clearActive`
7. `infrastructure/kafka/FraudHoldEventConsumer.kt` — the fraud-hold exclusion signal
8. `infrastructure/kafka/LendingArrearsEventConsumer.kt`
9. `infrastructure/kafka/PartyErasureConsumer.kt`

   Near-identical, so they share one small helper (`infrastructure/kafka/ConsumerRetry.kt`) rather
   than five copies of the loop; each consumer keeps its own `parse(...)` because the fields differ.
   Parsing acks, the write retries then rethrows. Site 9 is the worst of the five: ADR-0220 D3.5
   treats `ERASURE_REQUESTED` as terminal and never re-derives it, so an acked-but-failed write left
   the party permanently targetable with no compensating path anywhere.

## Sites examined and NOT changed

- `openbank-interest-service`, `openbank-fraud-service` — out of scope by instruction; owned by the
  sibling money-path PR on `fix/event-consumer-catch-and-ack-sweep`.
- `OnboardingResumeService.resumeCreate` non-2xx from party-service — this does **not** throw; it
  emits a `CUSTOMER_ONBOARDING_RESUMED_CREATED` audit event with `result=ERROR` and returns. It is a
  silent-ish path, but unlike the sites above it leaves a durable audit record rather than only an
  ERROR log line, and converting it to a throw would re-emit that audit event on each retry.
  Deliberately left alone; flagging it here rather than changing it in this PR.
- `openbank-notification-service/.../PartyErasureConsumer.kt` — the "closest sibling" the copilot
  consumer's KDoc cites. Not in the assigned scope, and not touched here; worth a look in a
  follow-up sweep since the shape is the same family.

## Tests

Every site gets a **pair**, because a test that cannot separate a transient downstream failure from
a malformed payload proves nothing about either:

- transient/persistent downstream failure ⇒ **rethrown** after exactly `MAX_ATTEMPTS` (3) calls, so
  the connector can dead-letter;
- a transient failure that recovers ⇒ retried to success, not dead-lettered;
- malformed payload ⇒ still acked, downstream never called.

`FraudHoldEventConsumer` had **no test at all**, which is part of why the defect survived there; it
gets a first one. `ConsumerRetryTest` covers the engagement helper's semantics directly. Tests that
asserted the swallow as intended behaviour (copilot's
`a store failure is swallowed so one bad message cannot wedge the consumer group`, both
document-service `swallows a downstream failure …`) are replaced or renamed to match reality — same
class of green-test-as-defect-documentation the issue calls out.

## Verification (local, per module)

`test` + `ktlintCheck` + `detekt` green on all four modules (`test` implies `compileKotlin`):

| module | tests | failures | skipped |
|---|---|---|---|
| `:openbank-copilot-service` | 141 | 0 | 0 |
| `:openbank-customer-edge` | 380 | 0 | 1 (pre-existing broker-gated pact provider test) |
| `:openbank-document-service` | 141 | 0 | 0 |
| `:openbank-engagement-service` | 100 | 0 | 0 |

Refs #5698
