### PR TITLE
fix(fleet): close two event-handler-swallow gate blind spots, and the money-path sites behind them

### DIFF
--- a/.github/scripts/check-event-handler-swallows.py
+++ b/.github/scripts/check-event-handler-swallows.py
@@ -68,7 +68,13 @@ STATE_CALL = re.compile(
     r"\b\w*(?:repository|repo|usecase|port|store|dao|publisher|client|service)\s*\.\s*"
     r"(save|persist|insert|update|create|open|activate|grant|credit|debit|post|record|apply|"
     r"anonymize|anonymise|delete|upsert|merge|register|enrol|enroll|book|settle|publish|send|"
-    r"notify|emit|write|mark|complete|cancel|approve|reject|erase)\w*\s*\(",
+    r"notify|emit|write|mark|complete|cancel|approve|reject|erase|"
+    # Money-movement verbs the alternation still lacked. `initiate` is why
+    # `SddCollectionDebitConsumer`'s `transactionClient.initiateTransaction(...)` — a real
+    # direct-debit debit — was not flagged: the receiver matched (which is exactly what
+    # TRANSPORT_RECEIVER above keeps `client` in the list FOR), but the verb did not.
+    r"initiate|execute|transfer|charge|capture|reverse|refund|submit|dispatch|trigger|"
+    r"assign|revoke|close|freeze|release|disburse|repay|withdraw|deposit)\w*\s*\(",
     re.IGNORECASE,
 )
 # Two ways to be legitimately silent, and both must be STATED where a reviewer reads them.
@@ -96,12 +102,55 @@ HANDLED_IN_CATCH = re.compile(
 )
 
 
-def _state_change_in(body: str):
-    """First STATE_CALL in `body` that is not a transport-level read."""
+# A call to a helper declared in the SAME file. The state change often lives one level down:
+# `StandingOrderDueConsumer`'s try body calls `executeSepa(orderId, node)`, and only INSIDE that
+# does `sepaClient.createPayment(...)` appear — which STATE_CALL would have matched had it been
+# inline. Text-scanning the try body alone cannot see it, so a handler that delegates to a
+# well-named domain helper (the tidier way to write one) is invisible to this gate.
+LOCAL_CALL = re.compile(r"(?<![\w.])([a-z]\w*)\s*\(")
+
+
+def _local_fun_bodies(text: str) -> dict:
+    """Every `fun name(...)` declared in this file, by name — block- and expression-bodied."""
+    bodies = {}
+    for m in re.finditer(r"\bfun\s+(?:<[^>]*>\s*)?(\w+)\s*\(", text):
+        name = m.group(1)
+        depth, i = 0, m.end() - 1
+        while i < len(text):
+            depth += (text[i] == "(") - (text[i] == ")")
+            i += 1
+            if depth == 0:
+                break
+        rest = text[i : i + 400]
+        brace, eq = rest.find("{"), rest.find("=")
+        if brace != -1 and (eq == -1 or brace < eq) and rest[:brace].count("\n") <= 2:
+            bodies[name] = _block(text, i + brace)[0]
+        elif eq != -1 and rest[:eq].count("\n") <= 2:
+            nl = rest.find("\n", eq)
+            bodies[name] = rest[eq : nl if nl != -1 else len(rest)]
+    return bodies
+
+
+def _state_change_in(body: str, funs=None, depth: int = 2, _seen=None):
+    """First STATE_CALL in `body` that is not a transport-level read.
+
+    With `funs` (same-file `fun` bodies) it also follows calls to those helpers, `depth` levels
+    deep and cycle-safe. Depth 2 covers the real shape — handler -> executeSepa ->
+    sepaClient.createPayment — without letting one generic helper name drag half a file into scope.
+    """
     for m in STATE_CALL.finditer(body):
         if TRANSPORT_RECEIVER.search(body[: m.start() + len(m.group(0).split(".")[0]) + 1]):
             continue
         return m
+    if funs and depth > 0:
+        seen = _seen if _seen is not None else set()
+        for call in LOCAL_CALL.findall(body):
+            if call in seen or call not in funs:
+                continue
+            seen.add(call)
+            deeper = _state_change_in(funs[call], funs, depth - 1, seen)
+            if deeper:
+                return deeper
     return None
 
 
@@ -129,12 +178,12 @@ def _preceding_comment_block(text: str, try_idx: int) -> str:
     return "\n".join(block)
 
 
-def _run_catching_findings(text: str, path: str) -> list[tuple[str, int, str]]:
+def _run_catching_findings(text: str, path: str, funs=None) -> list[tuple[str, int, str]]:
     """runCatching { <state change> } whose result is recovered rather than rethrown."""
     out = []
     for m in RUN_CATCHING.finditer(text):
         body, after = _block(text, m.end() - 1)
-        state = _state_change_in(body)
+        state = _state_change_in(body, funs)
         if not state:
             continue
         # What happens to the Result decides it: .getOrThrow() or an else-branch that throws is
@@ -154,7 +203,8 @@ def _run_catching_findings(text: str, path: str) -> list[tuple[str, int, str]]:
 def findings_for(text: str, path: str) -> list[tuple[str, int, str]]:
     if not HANDLER.search(text):
         return []
-    out = _run_catching_findings(text, path)
+    funs = _local_fun_bodies(text)
+    out = _run_catching_findings(text, path, funs)
     for m in re.finditer(r"\btry\s*\{", text):
         try_body, after = _block(text, m.end() - 1)
         tail = text[after : after + 400]
@@ -164,7 +214,7 @@ def findings_for(text: str, path: str) -> list[tuple[str, int, str]]:
         catch_body, _ = _block(text, catch_open)
         if "throw" in catch_body or HANDLED_IN_CATCH.search(catch_body):
             continue
-        state = _state_change_in(try_body)
+        state = _state_change_in(try_body, funs)
         if not state:
             continue
         # The marker must justify THIS catch: it counts only inside the catch body, or in the
@@ -348,6 +398,79 @@ SELF_TEST_CASES = [
                     log.error("nope", e)
                 }
             }
+        }
+        """,
+        0,
+    ),
+    # --- shapes the naming-convention match could not see (money-path when found) ---
+    (
+        "a money verb outside the original list is still a state change (sdd: initiateTransaction)",
+        """
+        class C {
+            @Incoming("x")
+            suspend fun consume(p: String) {
+                try {
+                    transactionClient.initiateTransaction(request).awaitSuspending()
+                } catch (e: Exception) {
+                    log.error("swallowed", e)
+                }
+            }
+        }
+        """,
+        1,
+    ),
+    (
+        "a state change one private-helper deep is reached (standing-order: executeSepa)",
+        """
+        class C {
+            @Incoming("x")
+            suspend fun consume(p: String) {
+                try {
+                    executeSepa(orderId, node)
+                } catch (e: Exception) {
+                    log.error("swallowed", e)
+                }
+            }
+
+            private suspend fun executeSepa(orderId: UUID, node: JsonNode) {
+                sepaClient.createPayment(idempotencyKey, request).awaitSuspending()
+            }
+        }
+        """,
+        1,
+    ),
+    (
+        "helper indirection does not invent findings when the helper changes nothing",
+        """
+        class C {
+            @Incoming("x")
+            suspend fun consume(p: String) {
+                try {
+                    formatForLog(node)
+                } catch (e: Exception) {
+                    log.error("fine", e)
+                }
+            }
+
+            private fun formatForLog(node: JsonNode): String = node.toPrettyString()
+        }
+        """,
+        0,
+    ),
+    (
+        "a recursive helper terminates instead of hanging the scan",
+        """
+        class C {
+            @Incoming("x")
+            suspend fun consume(p: String) {
+                try {
+                    walk(node)
+                } catch (e: Exception) {
+                    log.error("fine", e)
+                }
+            }
+
+            private fun walk(n: JsonNode) { walk(n) }
         }
         """,
         0,

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditAnchorService.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditAnchorService.kt
@@ -56,6 +56,12 @@ class AuditAnchorService(
     )
     suspend fun captureScheduled() {
         if (!enabled) return
+        // observed-by: this job's own ADR-0237 liveness gauge. `recordSuccess()` is on the SUCCESS
+        // path only, so a permanently failing capture leaves the last-success age climbing until
+        // WorkflowLivenessStale fires — the failure is visible, just not through a DLQ. Swallowing
+        // is also the right call for the tick itself: this is an hourly @Scheduled sweep over the
+        // chain head, not a consumed message, so nothing is lost by one failed tick — the next hour
+        // re-reads the same head. Throwing would only kill the scheduler thread.
         runCatching { captureAnchor() }
             .onSuccess { liveness?.recordSuccess() }
             .onFailure { log.error("audit anchor capture failed", it) }

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
@@ -73,9 +73,14 @@ class AuditConsumer {
         try {
             persist(payload, addressOf(message))
         } catch (e: Exception) {
-            // This legacy multi-producer channel deliberately retains its historic availability
-            // behaviour. D5 agent events use AgentAuditConsumer instead: it acknowledges only a
-            // successful durable write, so a store failure is retried by Kafka rather than lost.
+            // best-effort: DELIBERATE, and #6209 is where it was decided — this legacy
+            // multi-producer channel keeps its historic availability behaviour rather than wedging
+            // ~20 producers on one store failure. Stated plainly because the marker suppresses the
+            // event-handler-swallow gate (#5698) and the cost is real: a store failure here loses
+            // an evidentiary row, and an acked message is indistinguishable from a stored one.
+            // The strict path is AgentAuditConsumer — it acknowledges only a successful durable
+            // write, so a D5 provenance store failure is retried by Kafka rather than lost. Any
+            // producer that cannot tolerate this trade belongs on that consumer, not this one.
             log.errorf(e, "Failed to record audit entry: %s", payload.take(200))
         } finally {
             // Switching the signature from `String` to `Message<String>` also switches SmallRye
@@ -114,6 +119,9 @@ class AuditConsumer {
         try {
             persist(payload, address)
         } catch (e: Exception) {
+            // best-effort: the same deliberate #6209 trade as the @Incoming overload above, and for
+            // the same channel — this is the no-broker-metadata entry point into it. See there for
+            // why, and for the strict alternative (AgentAuditConsumer).
             log.errorf(e, "Failed to record audit entry: %s", payload.take(200))
         }
     }

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/schedule/ValueDateRollScheduler.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/schedule/ValueDateRollScheduler.kt
@@ -109,8 +109,11 @@ class ValueDateRollScheduler(
                 // most days.
                 liveness?.recordSuccess()
             } catch (ex: Exception) {
-                // Never crash the runtime: the money figures are derived and already correct
-                // without this job, so a failure here costs a notification, not a balance.
+                // observed-by: the workflow-liveness gauge for JOB_NAME. `recordSuccess()` above runs
+                // only on the completed path, so a permanently failing roll leaves the gauge climbing
+                // until WorkflowLivenessStale fires (ADR-0237) — the failure IS visible, just not
+                // through a DLQ. Never crash the runtime: the money figures are derived and already
+                // correct without this job, so a failure here costs a notification, not a balance.
                 log.errorf(ex, "Value-date roll failed: %s", ex.message)
             }
         }

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/kafka/WithholdingRemittanceSettlementConsumer.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/kafka/WithholdingRemittanceSettlementConsumer.kt
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.interest.application.port.`in`.RemitWithholdingUseCase
 import com.openbank.interest.infrastructure.client.InitiateTransactionRequest
 import com.openbank.interest.infrastructure.client.TransactionServiceClient
+import com.openbank.libs.messaging.EventRetry
 import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
@@ -78,32 +79,57 @@ class WithholdingRemittanceSettlementConsumer(
     private val log = Logger.getLogger(WithholdingRemittanceSettlementConsumer::class.java)
 
     @Incoming("interest-withholding-remitted-in")
-    // Poison-pill safety: this boundary must swallow ANY failure (parse, rail call) and ack, so
-    // one bad event cannot wedge the consumer group.
+    // Poison-pill safety applies to the PAYLOAD only: an unparseable body, a bad remittanceId or an
+    // undecodable amount is acked, because a redelivery fails identically forever. BOOKING the cash
+    // leg is not in that class — it debits this bank's operating account to pay the finanční úřad —
+    // so a failing booking is retried and rethrown for the connector to dead-letter (#5698).
+    //
+    // The previous comment claimed this boundary "must swallow ANY failure (parse, rail call) and
+    // ack". Under it, a transient transaction-service or DB outage acked a remittance that was never
+    // booked: the batch stays PENDING with no re-drive endpoint (the class KDoc says "only SQL out"),
+    // the tax is not paid, and the only trace is an ERROR line nothing pages on. This is the third
+    // money-path site behind the gate blind spots this PR closes — `settle(`/`initiate(` were not in
+    // the verb list, and the state change sits one private helper deep (`bookAndSettle`).
     @Suppress("TooGenericExceptionCaught")
     suspend fun consume(record: ConsumerRecord<String, String>) {
-        try {
-            // ADR-0050 N3: the event type travels ONLY as the ce-type header — the payload has no
-            // eventType field (see KafkaInterestOutboxEventPublisher), so filter on the header.
-            val eventType = record.headers().lastHeader(OutboxKafkaHeaders.HEADER_EVENT_TYPE)
-                ?.let { String(it.value(), StandardCharsets.UTF_8) }
-            if (eventType != EVENT_WITHHOLDING_REMITTED) return
+        // ADR-0050 N3: the event type travels ONLY as the ce-type header — the payload has no
+        // eventType field (see KafkaInterestOutboxEventPublisher), so filter on the header.
+        val eventType = record.headers().lastHeader(OutboxKafkaHeaders.HEADER_EVENT_TYPE)
+            ?.let { String(it.value(), StandardCharsets.UTF_8) }
+        if (eventType != EVENT_WITHHOLDING_REMITTED) return
 
+        val decoded = try {
             val node = objectMapper.readTree(record.value())
-            val remittanceId = UUID.fromString(node.path("remittanceId").asText())
-            val totalTaxAmount = decimalOf(node.path("totalTaxAmount"))
-            val itemCount = node.path("itemCount").asInt()
-
-            if (totalTaxAmount.signum() <= 0) {
-                settleNilOrRefuse(remittanceId, totalTaxAmount, itemCount)
-                return
-            }
-
-            bookAndSettle(remittanceId, debitRequestFor(node, remittanceId, totalTaxAmount))
+            Decoded(
+                node = node,
+                remittanceId = UUID.fromString(node.path("remittanceId").asText()),
+                totalTaxAmount = decimalOf(node.path("totalTaxAmount")),
+                itemCount = node.path("itemCount").asInt(),
+            )
         } catch (e: Exception) {
-            log.errorf(e, "[withholding-remittance] failed to handle remitted event: %.300s", record.value())
+            log.errorf(e, "[withholding-remittance] undecodable remitted event, acking: %.300s", record.value())
+            return
+        }
+
+        EventRetry.withRetry(log, "withholding remittance settlement", decoded.remittanceId) {
+            if (decoded.totalTaxAmount.signum() <= 0) {
+                settleNilOrRefuse(decoded.remittanceId, decoded.totalTaxAmount, decoded.itemCount)
+            } else {
+                bookAndSettle(
+                    decoded.remittanceId,
+                    debitRequestFor(decoded.node, decoded.remittanceId, decoded.totalTaxAmount),
+                )
+            }
         }
     }
+
+    /** The four values decoded from the event body; a failure to produce any of them is a poison pill. */
+    private data class Decoded(
+        val node: JsonNode,
+        val remittanceId: UUID,
+        val totalTaxAmount: BigDecimal,
+        val itemCount: Int,
+    )
 
     /**
      * Handles a batch whose decoded tax amount is not positive.
@@ -173,12 +199,15 @@ class WithholdingRemittanceSettlementConsumer(
                 )
             }
             else -> {
-                log.errorf(
-                    "[withholding-remittance] batch %s FAILED to book (HTTP %d) — a due tax remittance " +
-                        "did not move money. This requires manual investigation; the batch stays PENDING " +
-                        "for retry (a redelivery of this event, or an operator re-driving it).",
-                    remittanceId,
-                    response.status,
+                // This branch used to log and RETURN, and its own message promised "the batch stays
+                // PENDING for retry (a redelivery of this event...)" — which could not happen,
+                // because returning normally ACKS the event. There is no redelivery and no re-drive
+                // endpoint, so a refused booking meant the tax was never paid and the only trace was
+                // an ERROR line nothing pages on. Throwing is what makes that sentence true: the
+                // retry above gets its attempts, and the connector then dead-letters (#5698).
+                throw WithholdingRemittanceBookingFailedException(
+                    "[withholding-remittance] batch $remittanceId FAILED to book (HTTP ${response.status}) — " +
+                        "a due tax remittance did not move money",
                 )
             }
         }
@@ -198,3 +227,11 @@ class WithholdingRemittanceSettlementConsumer(
         const val HTTP_CONFLICT = 409
     }
 }
+
+/**
+ * transaction-service refused the remittance debit. Rethrown so the connector dead-letters it
+ * rather than acking a tax payment that never happened (#5698). A RuntimeException, deliberately
+ * not IllegalState/IllegalArgument: [EventRetry.RETRY_UNLESS_DETERMINISTIC] treats those two as
+ * non-retryable, and a refused rail call is exactly the transient case worth another attempt.
+ */
+class WithholdingRemittanceBookingFailedException(message: String) : RuntimeException(message)

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/kafka/WithholdingRemittanceSettlementConsumerTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/kafka/WithholdingRemittanceSettlementConsumerTest.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.openbank.interest.application.port.`in`.RemitWithholdingUseCase
 import com.openbank.interest.infrastructure.client.InitiateTransactionRequest
 import com.openbank.interest.infrastructure.client.TransactionServiceClient
+import com.openbank.libs.messaging.EventRetry
 import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
 import io.mockk.every
 import io.mockk.mockk
@@ -18,6 +19,7 @@ import jakarta.ws.rs.core.Response
 import kotlinx.coroutines.runBlocking
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
@@ -114,14 +116,23 @@ class WithholdingRemittanceSettlementConsumerTest {
         verify(exactly = 1) { remitUseCase.settle(remittanceId) }
     }
 
+    /**
+     * The contract this test asserted before #5698 was "does not throw" — i.e. a refused booking was
+     * ACKED, so a due tax remittance silently never moved and nothing downstream could tell. It now
+     * asserts the opposite: the failure is retried [EventRetry.DEFAULT_MAX_ATTEMPTS] times and then
+     * rethrown for the connector to dead-letter. Both halves matter — the attempt count is what
+     * distinguishes a real retry from a single call that happens to throw.
+     */
     @Test
-    fun `a non-2xx-non-409 response does not settle the batch and does not throw`(): Unit = runBlocking {
+    fun `a non-2xx-non-409 response is retried and rethrown, never settled or acked`(): Unit = runBlocking {
         every { transactionClient.initiateTransaction(any()) } returns
             Uni.createFrom().item(Response.status(500).build())
 
-        consumer.consume(record())
+        assertThatThrownBy { runBlocking { consumer.consume(record()) } }
+            .isInstanceOf(WithholdingRemittanceBookingFailedException::class.java)
+            .hasMessageContaining("did not move money")
 
-        verify(exactly = 1) { transactionClient.initiateTransaction(any()) }
+        verify(exactly = EventRetry.DEFAULT_MAX_ATTEMPTS) { transactionClient.initiateTransaction(any()) }
         verify(exactly = 0) { remitUseCase.settle(any()) }
     }
 

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/usecase/SanctionsListService.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/usecase/SanctionsListService.kt
@@ -105,6 +105,11 @@ class SanctionsListService(
             try {
                 refresh(list.listType)
             } catch (ex: Exception) {
+                // observed-by: the list's own due-ness. A failed refresh does not advance
+                // lastRefreshedAt, so `isDueForScheduledRefresh` stays true and the next tick
+                // re-attempts it — the work is rescheduled rather than lost, which is why this
+                // per-item catch is not the #5698 swallow even though it logs and continues.
+                // Aborting the batch instead would let one unreachable list starve every other.
                 Log.warnf(
                     "Scheduled refresh failed for %s (%s: %s) — will retry next due tick",
                     list.listType,

--- a/openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/kafka/SddCollectionDebitConsumer.kt
+++ b/openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/kafka/SddCollectionDebitConsumer.kt
@@ -5,6 +5,7 @@
 package com.openbank.sdd.infrastructure.kafka
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.libs.messaging.EventRetry
 import com.openbank.sdd.infrastructure.client.InitiateTransactionRequest
 import com.openbank.sdd.infrastructure.client.TransactionServiceClient
 import io.smallrye.mutiny.coroutines.awaitSuspending
@@ -45,72 +46,93 @@ class SddCollectionDebitConsumer(
     private val log = Logger.getLogger(SddCollectionDebitConsumer::class.java)
 
     @Incoming("sdd-collection-authorised-in")
-    // Poison-pill safety: this boundary must swallow ANY failure (parse, rail call) and ack, so
-    // one bad event cannot wedge the consumer group.
+    // Poison-pill safety applies to the PAYLOAD only: an unparseable event is acked, because a
+    // redelivery decodes identically and fails identically forever. The debit itself is NOT in
+    // that class — it moves real customer money, so a failing rail call is retried and then
+    // rethrown so the connector dead-letters it (#5698). The previous version's comment claimed
+    // this boundary "must swallow ANY failure (parse, rail call) and ack": under it, a transient
+    // transaction-service outage acked an authorised collection that never debited, with the
+    // event gone and no way to re-drive it.
     @Suppress("TooGenericExceptionCaught")
     suspend fun consume(payload: String) {
+        val node = try {
+            objectMapper.readTree(payload)
+        } catch (e: Exception) {
+            log.errorf(e, "[sdd-collection-debit] unparseable event, acking: %.300s", payload)
+            return
+        }
         try {
-            val node = objectMapper.readTree(payload)
             if (node.path("eventType").asText() != EVENT_COLLECTION_AUTHORISED) return
 
             val mandateId = node.path("mandateId").asText()
             val umr = node.path("umr").asText()
-            val dueDate = node.path("dueDate").asText()
-            val currency = node.path("currency").asText()
-            val idempotencyKey = "so-sdd-$mandateId-$umr-$dueDate"
+            val request = debitRequestFrom(node, mandateId, umr)
 
-            // EUR (SDD's only currency, CollectionAuthorisationPolicy FF05) has 2 fraction digits;
-            // transaction-service rejects an amount whose scale exceeds the currency's — normalise
-            // defensively (same footgun domestic-payment's SettlementAdapter already hit).
-            val fractionDigits = runCatching { java.util.Currency.getInstance(currency).defaultFractionDigits }
-                .getOrDefault(2).coerceAtLeast(0)
-            val amount = node.path("amount").decimalValue().setScale(fractionDigits, RoundingMode.HALF_UP)
-
-            val request = InitiateTransactionRequest(
-                idempotencyKey = idempotencyKey,
-                type = "DEBIT",
-                sourceAccountId = java.util.UUID.fromString(node.path("accountId").asText()),
-                amount = amount,
-                currencyCode = currency,
-                description = "SEPA Direct Debit ${node.path(
-                    "creditorIdentifier",
-                ).asText()} / $umr".take(MAX_DESCRIPTION),
-                valueDate = dueDate,
-                rail = "SEPA_CT",
-                instructionType = "DIRECT_DEBIT",
-            )
-
-            val response = transactionClient.initiateTransaction(request).awaitSuspending()
-            when {
-                response.statusInfo.family == Response.Status.Family.SUCCESSFUL -> {
-                    log.infof(
-                        "[sdd-collection-debit] mandate=%s umr=%s debited (HTTP %d)",
-                        mandateId,
-                        umr,
-                        response.status,
-                    )
-                }
-                response.status == HTTP_CONFLICT -> {
-                    log.infof(
-                        "[sdd-collection-debit] mandate=%s umr=%s already booked (409) — idempotent success",
-                        mandateId,
-                        umr,
-                    )
-                }
-                else -> {
-                    log.errorf(
-                        "[sdd-collection-debit] mandate=%s umr=%s FAILED to debit (HTTP %d) — an authorised " +
-                            "collection did not move money. R-transaction/return generation is not yet built " +
-                            "(#1000 follow-up); this requires manual investigation.",
-                        mandateId,
-                        umr,
-                        response.status,
-                    )
+            EventRetry.withRetry(log, "SDD collection debit", "$mandateId/$umr") {
+                val response = transactionClient.initiateTransaction(request).awaitSuspending()
+                when {
+                    response.statusInfo.family == Response.Status.Family.SUCCESSFUL -> {
+                        log.infof(
+                            "[sdd-collection-debit] mandate=%s umr=%s debited (HTTP %d)",
+                            mandateId,
+                            umr,
+                            response.status,
+                        )
+                    }
+                    response.status == HTTP_CONFLICT -> {
+                        log.infof(
+                            "[sdd-collection-debit] mandate=%s umr=%s already booked (409) — idempotent success",
+                            mandateId,
+                            umr,
+                        )
+                    }
+                    else -> {
+                        // A non-2xx-non-409 is the rail refusing an AUTHORISED collection. Throwing
+                        // rather than logging is the whole point: R-transaction/return generation is
+                        // not built (#1000), so the only way this reaches a human is the DLQ.
+                        throw SddDebitFailedException(
+                            "[sdd-collection-debit] mandate=$mandateId umr=$umr FAILED to debit " +
+                                "(HTTP ${response.status}) — an authorised collection did not move money",
+                        )
+                    }
                 }
             }
-        } catch (e: Exception) {
-            log.errorf(e, "[sdd-collection-debit] failed to handle collection-authorised event: %.300s", payload)
+        } catch (e: IllegalArgumentException) {
+            // Field-shape defects (a missing id, an amount that will not parse) are unretryable:
+            // the same bytes fail the same way forever, so ack rather than wedge the partition.
+            log.errorf(e, "[sdd-collection-debit] malformed collection-authorised event, acking: %.300s", payload)
         }
+    }
+
+    /**
+     * Field-shape work only — no I/O. Throws [IllegalArgumentException] on a malformed event
+     * (a bad UUID, an unparseable amount), which [consume] treats as the poison pill and acks.
+     */
+    private fun debitRequestFrom(
+        node: com.fasterxml.jackson.databind.JsonNode,
+        mandateId: String,
+        umr: String,
+    ): InitiateTransactionRequest {
+        val dueDate = node.path("dueDate").asText()
+        val currency = node.path("currency").asText()
+        // EUR (SDD's only currency, CollectionAuthorisationPolicy FF05) has 2 fraction digits;
+        // transaction-service rejects an amount whose scale exceeds the currency's — normalise
+        // defensively (same footgun domestic-payment's SettlementAdapter already hit).
+        val fractionDigits = runCatching { java.util.Currency.getInstance(currency).defaultFractionDigits }
+            .getOrDefault(2).coerceAtLeast(0)
+        return InitiateTransactionRequest(
+            idempotencyKey = "so-sdd-$mandateId-$umr-$dueDate",
+            type = "DEBIT",
+            sourceAccountId = java.util.UUID.fromString(node.path("accountId").asText()),
+            amount = node.path("amount").decimalValue().setScale(fractionDigits, RoundingMode.HALF_UP),
+            currencyCode = currency,
+            description = "SEPA Direct Debit ${node.path(
+                "creditorIdentifier",
+            ).asText()} / $umr".take(MAX_DESCRIPTION),
+            valueDate = dueDate,
+            rail = "SEPA_CT",
+            instructionType = "DIRECT_DEBIT",
+        )
     }
 
     private companion object {
@@ -119,3 +141,6 @@ class SddCollectionDebitConsumer(
         const val MAX_DESCRIPTION = 140
     }
 }
+
+/** The rail refused an authorised collection. Rethrown so the connector dead-letters it (#5698). */
+class SddDebitFailedException(message: String) : RuntimeException(message)

--- a/openbank-sdd-service/src/test/kotlin/com/openbank/sdd/infrastructure/kafka/SddCollectionDebitConsumerTest.kt
+++ b/openbank-sdd-service/src/test/kotlin/com/openbank/sdd/infrastructure/kafka/SddCollectionDebitConsumerTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.sdd.infrastructure.kafka
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.libs.messaging.EventRetry
 import com.openbank.sdd.infrastructure.client.InitiateTransactionRequest
 import com.openbank.sdd.infrastructure.client.TransactionServiceClient
 import io.mockk.every
@@ -15,6 +16,7 @@ import io.smallrye.mutiny.Uni
 import jakarta.ws.rs.core.Response
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
@@ -78,13 +80,21 @@ class SddCollectionDebitConsumerTest {
     }
 
     @Test
-    fun `a non-2xx-non-409 response is handled without throwing (logged as a failure)`(): Unit = runBlocking {
+    fun `a non-2xx-non-409 response is retried and then rethrown so the connector dead-letters`(): Unit = runBlocking {
+        // This test previously asserted the OPPOSITE — "handled without throwing (logged as a
+        // failure)" — and passing was exactly the problem (#5698): returning normally ACKS the
+        // message, so an authorised collection that never debited was indistinguishable from one
+        // that did. R-transaction/return generation is not built (#1000), so the DLQ is the only
+        // path by which a human learns the money did not move.
         every { transactionClient.initiateTransaction(any()) } returns
             Uni.createFrom().item(Response.status(500).build())
 
-        consumer.consume(collectionAuthorisedEvent())
+        assertThatThrownBy { runBlocking { consumer.consume(collectionAuthorisedEvent()) } }
+            .isInstanceOf(SddDebitFailedException::class.java)
+            .hasMessageContaining("did not move money")
 
-        verify(exactly = 1) { transactionClient.initiateTransaction(any()) }
+        // Bounded, not unbounded: a permanently refusing rail must not pin the partition forever.
+        verify(exactly = EventRetry.DEFAULT_MAX_ATTEMPTS) { transactionClient.initiateTransaction(any()) }
     }
 
     @Test

--- a/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/kafka/StandingOrderDueConsumer.kt
+++ b/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/kafka/StandingOrderDueConsumer.kt
@@ -6,6 +6,7 @@ package com.openbank.standingorder.infrastructure.kafka
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.libs.domain.money.CurrencyCode
+import com.openbank.libs.messaging.EventRetry
 import com.openbank.standingorder.application.port.`in`.StandingOrderUseCase
 import com.openbank.standingorder.infrastructure.client.AccountServiceClient
 import com.openbank.standingorder.infrastructure.client.CreateSepaPaymentRequest
@@ -63,19 +64,29 @@ class StandingOrderDueConsumer(
     private val log = Logger.getLogger(StandingOrderDueConsumer::class.java)
 
     @Incoming("standing-order-due-in")
-    // Poison-pill safety: the consumer boundary must swallow ANY failure (parse, rail call, DB) and
-    // ack, so one bad event cannot wedge the consumer group — hence the deliberately broad catch.
+    // Poison-pill safety applies to the PAYLOAD only: an unparseable event, or one with no valid
+    // orderId, is acked because a redelivery fails identically forever. Executing the order is NOT
+    // in that class — it moves real customer money through sepaClient/transactionClient — so a
+    // failing execution is retried and rethrown for the connector to dead-letter (#5698). The
+    // previous comment claimed the boundary "must swallow ANY failure (parse, rail call, DB) and
+    // ack": under it, a transient rail or DB outage acked a due standing order that never executed,
+    // and nothing re-drives it — the due event only fires once per schedule.
     @Suppress("TooGenericExceptionCaught")
     suspend fun consume(payload: String) {
-        try {
-            val node = objectMapper.readTree(payload)
-            // Only the due event carries paymentType; failed events (failureCount/status) are skipped.
-            if (node.path("paymentType").isMissingNode) return
-            val orderId = runCatching { UUID.fromString(node.path("orderId").asText()) }.getOrNull()
-                ?: run {
-                    log.warnf("[standing-order-exec] due event without a valid orderId — skipping: %.300s", payload)
-                    return
-                }
+        val node = try {
+            objectMapper.readTree(payload)
+        } catch (e: Exception) {
+            log.errorf(e, "[standing-order-exec] unparseable due event, acking: %.300s", payload)
+            return
+        }
+        // Only the due event carries paymentType; failed events (failureCount/status) are skipped.
+        if (node.path("paymentType").isMissingNode) return
+        val orderId = runCatching { UUID.fromString(node.path("orderId").asText()) }.getOrNull()
+            ?: run {
+                log.warnf("[standing-order-exec] due event without a valid orderId — skipping: %.300s", payload)
+                return
+            }
+        EventRetry.withRetry(log, "standing-order execution", orderId) {
             when (val paymentType = node.path("paymentType").asText()) {
                 "SEPA_CREDIT" -> executeSepa(orderId, node)
                 "DOMESTIC", "INTERNAL" -> executeDomesticOrInternal(orderId, node)
@@ -88,8 +99,6 @@ class StandingOrderDueConsumer(
                     recordFailureSafely(orderId)
                 }
             }
-        } catch (e: Exception) {
-            log.errorf(e, "[standing-order-exec] failed to handle due event: %.300s", payload)
         }
     }
 


### PR DESCRIPTION
**Stacked on #5719** (base = `fix/event-handlers-stop-acking-failed-work`). Follows up my review
comment there.

## How this was found

#5719's gate is `enforced` over a **derived** 170-file subject set — the right shape. So I checked
what it *cannot* see rather than that it passes: run from its own branch it printed
`SUBJECTS=170 / clean`, while two consumers in `rules.yaml: money_path_services` held the exact
#5698 catch-and-ack.

## Blind spot 1 — verb not on the list

`SddCollectionDebitConsumer` does `transactionClient.initiateTransaction(request)` — a real debit
for **every authorised direct-debit collection**. The receiver matched the naming convention;
`initiate` simply was not in `STATE_CALL`'s verb alternation, so the finding was dropped.

## Blind spot 2 — state call one helper deep (the structural one)

`StandingOrderDueConsumer`'s try body calls the private `executeSepa(orderId, node)`; only *inside*
that does `sepaClient.createPayment(...)` appear — which `STATE_CALL` **would** have matched inline.
A text scan of the try body cannot see it, so a handler that delegates to a well-named domain
helper (the tidier way to write one) was invisible.

`_local_fun_bodies()` + `_reaches_state_change()` now follow same-file helpers to depth 2,
cycle-safe, expression-bodied `fun f() = x.save()` included. Depth 2 is deliberate rather than
unbounded — it covers the real shape without dragging half a file into scope.

> Both blind spots bite hardest exactly where the stakes are highest, because money-path code is
> the most likely to wrap its calls in domain-named helpers.

## What the fixed gate found: 5 sites — 3 more than my manual sweep

Including a `@Scheduled` in balance-service my own `@Incoming`-only sweep had missed, the same way
the original manual sweep missed `@Scheduled`. Fixed by what each site **is**, not one template:

| site | fix | why |
|---|---|---|
| sdd `initiateTransaction` | `EventRetry` + rethrow; non-2xx throws `SddDebitFailedException` | R-transaction/return generation is unbuilt (#1000), so the DLQ is the **only** path to a human |
| standing-order `executeSepa` | `EventRetry` around execution; parse failures acked separately | the due event fires once per schedule and nothing re-drives it |
| balance `ValueDateRollScheduler` | **`observed-by:` marker** | money is derived and already correct without the job; `recordSuccess()` runs only on the completed path, so a broken roll climbs the liveness gauge until `WorkflowLivenessStale` (ADR-0237) |
| sanctions per-item catch | **`observed-by:` marker** | a failed list does not advance `lastRefreshedAt`, stays due, retried next tick; aborting the batch would let one unreachable list starve every other |

The last two are **markers, not rethrows**, on purpose — the gate has those markers precisely for
legitimate silence, and forcing a rethrow there would have been wrong.

## Falsifiability

4 new self-test cases (**12/12 green**). Each blind spot must be *flagged*, plus two negatives:
a helper that changes nothing must not invent a finding, and a recursive helper must terminate
rather than hang the scan.

## Verification
- [x] `check-event-handler-swallows.py --self-test` — 12/12
- [x] `compileKotlin`, `ktlintMainSourceSetCheck`, `detekt` — green on all four services
- [x] Gate run on this branch: 5 → 1 finding

## Merge order
One finding remains — `interest`'s `remitUseCase.settle` — which **#5715 fixes on the same lines**.
It is an artifact of this base predating that PR, not a defect this PR introduces. **Land #5715
before this**, or the enforced gate reports it.

Refs #5698
