### PR TITLE
feat(settlement): instrument the settlement saga and alert on its success state

### DIFF
--- a/openbank-infra/gitops/components/payments/prometheus-rules.yaml
+++ b/openbank-infra/gitops/components/payments/prometheus-rules.yaml
@@ -45,6 +45,81 @@ spec:
             summary: "Payment sagas are stuck in transaction-service"
             description: "{{ $value }} payment saga(s) have been in an incomplete state for >5m — manual triage required."
 ---
+# settlement-service emitted NO metric of any kind until #5705 — 20 Kotlin files, not one reference
+# to MeterRegistry — and had no PrometheusRule of its own. The only alert whose name contains
+# "Settlement" is ClearingSettlementWindowMissed below, which belongs to clearing-service and
+# queries a clearing series. So nothing could distinguish "settlement is running normally" from
+# "settlement has booked nothing for six hours": the pod is Ready, the namespace is scraped, and
+# the series did not exist.
+#
+# These alert on the SUCCESS STATE, not on an error rate. A settlement path that quietly does
+# nothing — a worker that never polls, an orchestrator that never starts a run — produces no
+# errors at all, so an error-rate alert is silent in exactly the outage that matters. That is the
+# lesson the disabled push adapter cost (ADR-0252 phase 0) and the one the dead schedulers cost
+# (#2148): alert on the absence of the thing that should be happening.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-settlement-alerts
+  namespace: payments
+  labels:
+    app.kubernetes.io/part-of: openbank
+    prometheus: openbank
+spec:
+  groups:
+    - name: settlement
+      rules:
+        - alert: SettlementNoBookingsDuringBusinessHours
+          # `transitions_total{status="BOOKED"}` is what settlement-service observed itself commit.
+          # Deliberately not called "settled": whether money moved is a claim only the ledger can
+          # make, and naming a metric for more than it establishes is how an accepted push became
+          # a reported delivery.
+          expr: |
+            increase(openbank_settlement_transitions_total{service="settlement",status="BOOKED"}[2h]) == 0
+            and on() hour() >= 6 and on() hour() <= 18
+          for: 30m
+          labels:
+            severity: warning
+            service: settlement
+          annotations:
+            summary: "No settlement booked in 2h (business hours)"
+            description: >-
+              settlement-service has not committed a BOOKED transition in 2h during business hours.
+              A stalled Temporal worker or an orchestrator that never starts a run looks exactly
+              like this and produces no errors — check the worker is polling
+              (openbank_settlement_workflow_starts_total) before assuming there is simply no volume.
+        - alert: SettlementCompensationsSpiking
+          # Compensations have their own status values rather than folding into a failure count, so
+          # a burst of reversals is visible as itself — a debit that had to be unwound is a
+          # different operational event from a settlement that was rejected before moving anything.
+          expr: |
+            sum(increase(openbank_settlement_transitions_total{service="settlement",status=~"REVERSED|CREDITED_REVERSED|LEDGER_REVERSED"}[15m])) > 5
+          for: 10m
+          labels:
+            severity: critical
+            service: settlement
+          annotations:
+            summary: "Settlement compensations spiking"
+            description: >-
+              {{ $value }} compensating transitions in 15m. Each one means money was moved and then
+              unwound, so a downstream port (debit, credit or ledger) is failing mid-saga.
+        - alert: SettlementWorkflowStartsAllNoOps
+          # An idempotent no-op start is a CORRECT outcome and a different one from a real start.
+          # If every start becomes ALREADY_RUNNING, runs are being created and never completing —
+          # a state that a success rate reports as 100% healthy.
+          expr: |
+            sum(increase(openbank_settlement_workflow_starts_total{service="settlement",outcome="STARTED"}[1h])) == 0
+            and sum(increase(openbank_settlement_workflow_starts_total{service="settlement",outcome="ALREADY_RUNNING"}[1h])) > 0
+          for: 15m
+          labels:
+            severity: warning
+            service: settlement
+          annotations:
+            summary: "Every settlement workflow start is an idempotent no-op"
+            description: >-
+              settlement-service started no new workflow run in 1h while still receiving retries
+              for in-flight ones — runs are being created and not completing.
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/port/out/SettlementMetricsPort.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/port/out/SettlementMetricsPort.kt
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.application.port.out
+
+import com.openbank.settlement.domain.model.SettlementStatus
+
+/**
+ * Outbound observability port (ADR-0002 / ADR-0084 §1) for the settlement saga.
+ *
+ * WHY IT EXISTS: settlement-service is money-path and emitted **nothing** — 20 Kotlin files, not one
+ * reference to `MeterRegistry`, `DomainMetrics`, `@Counted` or `@Timed`, and no PrometheusRule of
+ * its own. The one alert whose name contains "Settlement", `ClearingSettlementWindowMissed`, belongs
+ * to clearing-service and queries `openbank_clearing_settlements_completed_total`. So there was no
+ * signal anywhere that could distinguish "settlement is running normally" from "settlement has
+ * booked nothing for six hours" — the pod is Ready, the namespace is scraped, and the series simply
+ * did not exist (#5705).
+ *
+ * Kept as a port, not a direct `MeterRegistry` dependency in the saga, so the application layer
+ * stays free of the metrics framework and the counters are exercised through a fake in unit tests.
+ */
+interface SettlementMetricsPort {
+
+    /**
+     * Record one settlement state transition. Every transition the saga performs passes through
+     * here, compensations included, so `REVERSED` / `CREDITED_REVERSED` / `LEDGER_REVERSED` are
+     * visible as their own series rather than folded into a failure count.
+     */
+    fun recordTransition(status: SettlementStatus)
+
+    /** Record the outcome of an originate request. */
+    fun recordOriginated(outcome: OriginateOutcome)
+
+    /** Record the outcome of starting the settlement workflow. */
+    fun recordWorkflowStart(outcome: WorkflowStartOutcome)
+}
+
+/**
+ * What an originate request actually did.
+ *
+ * These are three distinct values on purpose, not a boolean. A "successful no-op" and a real
+ * success sharing one flag is how a disabled push adapter reported every notification as delivered
+ * (ADR-0252 phase 0): the row committed SENT, the outcome event announced a delivery that never
+ * left the process, and no signal anywhere disagreed. An idempotent hit here is a *correct* outcome
+ * and a *different* one — a sudden shift from CREATED to IDEMPOTENT_HIT means callers are retrying,
+ * which is worth seeing and which a success rate cannot show.
+ */
+enum class OriginateOutcome {
+    /** A new PENDING settlement row was written. */
+    CREATED,
+
+    /** The idempotency key resolved to an existing row; nothing was written. */
+    IDEMPOTENT_HIT,
+
+    /** A concurrent same-key create lost the primary-key race and adopted the winner's row. */
+    CONCURRENT_RACE,
+}
+
+/** What starting the settlement workflow actually did. */
+enum class WorkflowStartOutcome {
+    /** A workflow run was started. */
+    STARTED,
+
+    /** A run for this settlement id was already in flight; the call was an idempotent no-op. */
+    ALREADY_RUNNING,
+
+    /** The row was already terminal, so no workflow was started. */
+    NOT_STARTED_TERMINAL,
+}

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/usecase/SettlementService.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/usecase/SettlementService.kt
@@ -7,7 +7,10 @@ package com.openbank.settlement.application.usecase
 import com.openbank.libs.temporal.TemporalConfig
 import com.openbank.settlement.application.port.`in`.OriginateSettlementCommand
 import com.openbank.settlement.application.port.`in`.SettlementUseCase
+import com.openbank.settlement.application.port.out.OriginateOutcome
+import com.openbank.settlement.application.port.out.SettlementMetricsPort
 import com.openbank.settlement.application.port.out.SettlementRepository
+import com.openbank.settlement.application.port.out.WorkflowStartOutcome
 import com.openbank.settlement.application.workflow.SettlementWorkflow
 import com.openbank.settlement.domain.model.Settlement
 import com.openbank.settlement.domain.model.SettlementStatus
@@ -27,6 +30,7 @@ class SettlementService(
     private val settlementRepository: SettlementRepository,
     private val temporalConfig: TemporalConfig,
     private val workflowClient: WorkflowClient,
+    private val metrics: SettlementMetricsPort,
     private val clock: Clock,
 ) : SettlementUseCase {
 
@@ -35,10 +39,12 @@ class SettlementService(
         settlementRepository: SettlementRepository,
         temporalConfig: TemporalConfig,
         workflowClient: WorkflowClient,
+        metrics: SettlementMetricsPort,
     ) : this(
         settlementRepository,
         temporalConfig,
         workflowClient,
+        metrics,
         Clock.systemUTC(),
     )
 
@@ -53,7 +59,13 @@ class SettlementService(
         // retried request resolves to the same row (the UUID primary key is the hard duplicate
         // guard even under a concurrent double-submit).
         val id = UUID.nameUUIDFromBytes("settlement:${command.idempotencyKey}".toByteArray())
-        val settlement = settlementRepository.findById(id) ?: createPending(command, id)
+        val existing = settlementRepository.findById(id)
+        if (existing != null) {
+            // A correct outcome and a DIFFERENT one from a fresh create. A shift in this ratio means
+            // callers are retrying, which a success rate cannot show.
+            metrics.recordOriginated(OriginateOutcome.IDEMPOTENT_HIT)
+        }
+        val settlement = existing ?: createPending(command, id)
 
         // (Re)start the settlement whenever it is not yet terminal: a fresh PENDING, OR an orphaned
         // PENDING left behind if a prior request created the row but failed before/while starting
@@ -62,6 +74,7 @@ class SettlementService(
         if (settlement.status == SettlementStatus.PENDING) {
             settle(settlement.id)
         } else {
+            metrics.recordWorkflowStart(WorkflowStartOutcome.NOT_STARTED_TERMINAL)
             log.infof("Settlement %s already %s; returning without re-settling", id, settlement.status)
         }
         return settlement
@@ -82,12 +95,14 @@ class SettlementService(
         )
         return try {
             settlementRepository.create(settlement).also {
+                metrics.recordOriginated(OriginateOutcome.CREATED)
                 log.infof("Originated settlement %s (%s %s)", it.id, it.amount, it.currency)
             }
         } catch (ex: Exception) {
             // Lost a concurrent same-key create race: the UUID primary key rejected the duplicate.
             // The winner's row exists — return it (idempotent), don't surface a 500.
             settlementRepository.findById(id)?.also {
+                metrics.recordOriginated(OriginateOutcome.CONCURRENT_RACE)
                 log.infof(
                     "Concurrent create for idempotencyKey '%s' (%s); using the winner's row",
                     command.idempotencyKey.sanitizeForLog(),
@@ -122,7 +137,9 @@ class SettlementService(
         )
         try {
             WorkflowClient.start(stub::settle, settlementId)
+            metrics.recordWorkflowStart(WorkflowStartOutcome.STARTED)
         } catch (alreadyRunning: WorkflowExecutionAlreadyStarted) {
+            metrics.recordWorkflowStart(WorkflowStartOutcome.ALREADY_RUNNING)
             // Idempotent: the settlement workflow for this id is already in flight (a retry of
             // an orphaned PENDING). Nothing to do — Temporal owns its lifecycle from here.
             log.infof(

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImpl.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImpl.kt
@@ -10,6 +10,7 @@ import com.openbank.libs.audit.AuditResult
 import com.openbank.settlement.application.port.out.CreditPort
 import com.openbank.settlement.application.port.out.DebitPort
 import com.openbank.settlement.application.port.out.LedgerPort
+import com.openbank.settlement.application.port.out.SettlementMetricsPort
 import com.openbank.settlement.application.port.out.SettlementRepository
 import com.openbank.settlement.domain.model.Settlement
 import com.openbank.settlement.domain.model.SettlementStatus
@@ -39,6 +40,7 @@ open class SettlementActivitiesImpl(
     private val creditPort: CreditPort,
     private val ledgerPort: LedgerPort,
     private val auditPublisher: AuditEventPublisher,
+    private val metrics: SettlementMetricsPort,
 ) : SettlementActivities {
 
     private val log = Logger.getLogger(SettlementActivitiesImpl::class.java)
@@ -112,6 +114,10 @@ open class SettlementActivitiesImpl(
      * event is reconstructable on its own (Art. 17), without a join back to the settlements table.
      */
     private suspend fun audit(operation: String, settlement: Settlement, result: AuditResult = AuditResult.SUCCESS) {
+        // Counted here rather than at each call site: every transition this saga performs already
+        // funnels through audit(), compensations included, so a transition cannot be added without
+        // also being counted. The metric records the status the row was just moved TO.
+        metrics.recordTransition(settlement.status)
         auditPublisher.publish(
             AuditEvent(
                 actorId = "settlement-service",

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/observability/SettlementMetricsAdapter.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/observability/SettlementMetricsAdapter.kt
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.infrastructure.observability
+
+import com.openbank.settlement.application.port.out.OriginateOutcome
+import com.openbank.settlement.application.port.out.SettlementMetricsPort
+import com.openbank.settlement.application.port.out.WorkflowStartOutcome
+import com.openbank.settlement.domain.model.SettlementStatus
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+
+/**
+ * Micrometer adapter for [SettlementMetricsPort]. Emits three counters, all tagged
+ * `service="settlement"`:
+ *
+ *  * `openbank_settlement_transitions_total{status}` — every saga state transition
+ *  * `openbank_settlement_originations_total{outcome}` — CREATED / IDEMPOTENT_HIT / CONCURRENT_RACE
+ *  * `openbank_settlement_workflow_starts_total{outcome}` — STARTED / ALREADY_RUNNING / NOT_STARTED_TERMINAL
+ *
+ * Name them for what they establish. `transitions_total{status="BOOKED"}` is what the service
+ * observed itself commit — not "money settled", which is a claim only the ledger can make. The
+ * distinction is the one the push-notification adapter got wrong by calling an accepted request a
+ * delivery (ADR-0252 phase 0).
+ *
+ * Service-local `MeterRegistry`, null-safe via [Instance] exactly like `FraudMetricsAdapter`: these
+ * are settlement-specific series, so putting them in the shared libs facade would force a
+ * fleet-wide rebuild for a one-service concern. The explicit `@Inject` constructor is required —
+ * without it ArC sees two constructors, registers no bean, and every injection point of this class
+ * is unsatisfied at build time.
+ */
+@ApplicationScoped
+class SettlementMetricsAdapter(private val registry: MeterRegistry?) : SettlementMetricsPort {
+
+    @Inject
+    constructor(registryInstance: Instance<MeterRegistry>) : this(
+        if (registryInstance.isResolvable) registryInstance.get() else null,
+    )
+
+    override fun recordTransition(status: SettlementStatus) =
+        increment("openbank.settlement.transitions", "status", status.name)
+
+    override fun recordOriginated(outcome: OriginateOutcome) =
+        increment("openbank.settlement.originations", "outcome", outcome.name)
+
+    override fun recordWorkflowStart(outcome: WorkflowStartOutcome) =
+        increment("openbank.settlement.workflow.starts", "outcome", outcome.name)
+
+    private fun increment(name: String, tag: String, value: String) {
+        registry?.let { r ->
+            Counter.builder(name)
+                .tag("service", SERVICE)
+                .tag(tag, value)
+                .register(r)
+                .increment()
+        }
+    }
+
+    companion object {
+        private const val SERVICE = "settlement"
+    }
+}

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceOriginateTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceOriginateTest.kt
@@ -6,11 +6,14 @@ package com.openbank.settlement.application.usecase
 
 import com.openbank.libs.temporal.TemporalConfig
 import com.openbank.settlement.application.port.`in`.OriginateSettlementCommand
+import com.openbank.settlement.application.port.out.OriginateOutcome
 import com.openbank.settlement.application.port.out.SettlementRepository
+import com.openbank.settlement.application.port.out.WorkflowStartOutcome
 import com.openbank.settlement.application.workflow.SettlementActivities
 import com.openbank.settlement.application.workflow.SettlementWorkflowImpl
 import com.openbank.settlement.domain.model.Settlement
 import com.openbank.settlement.domain.model.SettlementStatus
+import com.openbank.settlement.support.RecordingSettlementMetrics
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -40,6 +43,7 @@ class SettlementServiceOriginateTest {
 
     private lateinit var env: TestWorkflowEnvironment
     private lateinit var worker: Worker
+    private lateinit var metrics: RecordingSettlementMetrics
     private lateinit var service: SettlementService
 
     private companion object {
@@ -54,7 +58,8 @@ class SettlementServiceOriginateTest {
         worker.registerActivitiesImplementations(RelaxedActivities())
         env.start()
         every { temporalConfig.taskQueue() } returns TASK_QUEUE
-        service = SettlementService(repo, temporalConfig, env.workflowClient)
+        metrics = RecordingSettlementMetrics()
+        service = SettlementService(repo, temporalConfig, env.workflowClient, metrics)
     }
 
     @AfterEach
@@ -110,6 +115,11 @@ class SettlementServiceOriginateTest {
 
         assertThat(result.id).isEqualTo(existing.id)
         coVerify(exactly = 0) { repo.create(any()) }
+        // The distinction the port exists for: an idempotent hit is a correct outcome and a
+        // DIFFERENT one from a fresh create. Counting both as "success" is how a no-op path
+        // becomes indistinguishable from a working one (ADR-0252 phase 0).
+        assertThat(metrics.originations).containsExactly(OriginateOutcome.IDEMPOTENT_HIT)
+        assertThat(metrics.workflowStarts).containsExactly(WorkflowStartOutcome.NOT_STARTED_TERMINAL)
     }
 
     /** Activities stub that never throws — originate coverage only exercises settle() dispatch. */

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceSettleTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceSettleTest.kt
@@ -6,6 +6,7 @@ package com.openbank.settlement.application.usecase
 
 import com.openbank.libs.temporal.TemporalConfig
 import com.openbank.settlement.application.port.out.SettlementRepository
+import com.openbank.settlement.support.RecordingSettlementMetrics
 import io.mockk.coEvery
 import io.mockk.mockk
 import io.temporal.client.WorkflowClient
@@ -28,7 +29,8 @@ class SettlementServiceSettleTest {
     @Test
     fun `settle throws when the settlement does not exist`() {
         val workflowClient: WorkflowClient = mockk(relaxed = true)
-        val service = SettlementService(repo, temporalConfig, workflowClient)
+        val metrics = RecordingSettlementMetrics()
+        val service = SettlementService(repo, temporalConfig, workflowClient, metrics)
         val id = UUID.randomUUID()
         coEvery { repo.findById(id) } returns null
 

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceTemporalSettleTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceTemporalSettleTest.kt
@@ -10,6 +10,7 @@ import com.openbank.settlement.application.workflow.SettlementActivities
 import com.openbank.settlement.application.workflow.SettlementWorkflowImpl
 import com.openbank.settlement.domain.model.Settlement
 import com.openbank.settlement.domain.model.SettlementStatus
+import com.openbank.settlement.support.RecordingSettlementMetrics
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -38,6 +39,7 @@ class SettlementServiceTemporalSettleTest {
 
     private lateinit var env: TestWorkflowEnvironment
     private lateinit var worker: Worker
+    private lateinit var metrics: RecordingSettlementMetrics
     private lateinit var service: SettlementService
 
     private companion object {
@@ -52,7 +54,8 @@ class SettlementServiceTemporalSettleTest {
         worker.registerActivitiesImplementations(RelaxedActivities())
         env.start()
         every { temporalConfig.taskQueue() } returns TASK_QUEUE
-        service = SettlementService(repo, temporalConfig, env.workflowClient)
+        metrics = RecordingSettlementMetrics()
+        service = SettlementService(repo, temporalConfig, env.workflowClient, metrics)
     }
 
     @AfterEach

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImplTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImplTest.kt
@@ -10,9 +10,11 @@ import com.openbank.libs.audit.AuditResult
 import com.openbank.settlement.application.port.out.CreditPort
 import com.openbank.settlement.application.port.out.DebitPort
 import com.openbank.settlement.application.port.out.LedgerPort
+import com.openbank.settlement.application.port.out.SettlementMetricsPort
 import com.openbank.settlement.application.port.out.SettlementRepository
 import com.openbank.settlement.domain.model.Settlement
 import com.openbank.settlement.domain.model.SettlementStatus
+import com.openbank.settlement.support.RecordingSettlementMetrics
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -36,6 +38,8 @@ class SettlementActivitiesImplTest {
     private val ledgerPort: LedgerPort = mockk(relaxed = true)
     private val auditPublisher: AuditEventPublisher = mockk(relaxed = true)
 
+    private lateinit var metrics: RecordingSettlementMetrics
+
     private lateinit var activities: SettlementActivitiesImpl
 
     private fun settlement(id: UUID, status: SettlementStatus) = Settlement(
@@ -53,7 +57,9 @@ class SettlementActivitiesImplTest {
     fun setUp() {
         // TestableActivities overrides runOnVertxContext to run synchronously — the production impl
         // needs a real Vert.x context (VertxContextSupport), which a plain unit test does not have.
-        activities = TestableActivities(settlementRepository, debitPort, creditPort, ledgerPort, auditPublisher)
+        metrics = RecordingSettlementMetrics()
+        activities =
+            TestableActivities(settlementRepository, debitPort, creditPort, ledgerPort, auditPublisher, metrics)
         coEvery { settlementRepository.updateStatus(any(), any()) } answers {
             settlement(firstArg(), secondArg())
         }
@@ -133,6 +139,33 @@ class SettlementActivitiesImplTest {
         coVerify(exactly = 0) { debitPort.debit(any()) }
         coVerify(exactly = 0) { creditPort.credit(any()) }
         coVerify { settlementRepository.updateStatus(id, SettlementStatus.REJECTED) }
+        assertThat(metrics.transitions).containsExactly(SettlementStatus.REJECTED)
+    }
+
+    @Test
+    fun `every saga transition is counted, compensations included`() {
+        // settlement-service emitted no metric of any kind before #5705, so there was no series
+        // that could tell "running normally" from "has booked nothing for six hours". The
+        // compensating transitions get their own status values rather than folding into a failure
+        // count — a reversal is a distinct thing to alert on from a rejection.
+        val id = UUID.randomUUID()
+        activities.debitPayer(id)
+        activities.creditPayee(id)
+        activities.bookToLedger(id)
+        activities.reverseBookToLedger(id)
+        activities.reverseCredit(id)
+        activities.reverseDebit(id)
+        activities.rejectSettlement(id)
+
+        assertThat(metrics.transitions).containsExactly(
+            SettlementStatus.DEBITED,
+            SettlementStatus.CREDITED,
+            SettlementStatus.BOOKED,
+            SettlementStatus.LEDGER_REVERSED,
+            SettlementStatus.CREDITED_REVERSED,
+            SettlementStatus.REVERSED,
+            SettlementStatus.REJECTED,
+        )
     }
 
     @Test
@@ -158,6 +191,7 @@ private class TestableActivities(
     creditPort: CreditPort,
     ledgerPort: LedgerPort,
     auditPublisher: AuditEventPublisher,
-) : SettlementActivitiesImpl(settlementRepository, debitPort, creditPort, ledgerPort, auditPublisher) {
+    metrics: SettlementMetricsPort,
+) : SettlementActivitiesImpl(settlementRepository, debitPort, creditPort, ledgerPort, auditPublisher, metrics) {
     override fun <T> runOnVertxContext(block: suspend () -> T): T = runBlocking { block() }
 }

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/support/RecordingSettlementMetrics.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/support/RecordingSettlementMetrics.kt
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.support
+
+import com.openbank.settlement.application.port.out.OriginateOutcome
+import com.openbank.settlement.application.port.out.SettlementMetricsPort
+import com.openbank.settlement.application.port.out.WorkflowStartOutcome
+import com.openbank.settlement.domain.model.SettlementStatus
+
+/**
+ * Recording fake for [SettlementMetricsPort]. The port exists so the application layer never sees
+ * Micrometer; this is the other half of that — the counters are assertable without a registry.
+ *
+ * A mock returning Unit would satisfy the compiler and prove nothing. These lists are what let a
+ * test say "an idempotent hit was counted as an idempotent hit, not as a fresh create", which is
+ * the distinction the port was introduced to preserve.
+ */
+class RecordingSettlementMetrics : SettlementMetricsPort {
+    val transitions = mutableListOf<SettlementStatus>()
+    val originations = mutableListOf<OriginateOutcome>()
+    val workflowStarts = mutableListOf<WorkflowStartOutcome>()
+
+    override fun recordTransition(status: SettlementStatus) {
+        transitions += status
+    }
+    override fun recordOriginated(outcome: OriginateOutcome) {
+        originations += outcome
+    }
+    override fun recordWorkflowStart(outcome: WorkflowStartOutcome) {
+        workflowStarts += outcome
+    }
+}


### PR DESCRIPTION
## The gap

`openbank-settlement-service` is a declared money-path service and emitted **nothing**. Measured on `origin/main`:

```
grep -rl "micrometer|MeterRegistry|Counter|Gauge|Timer" openbank-settlement-service/src/main
  -> (nothing; 20 .kt files)
```

It also had **no PrometheusRule of its own**. The only alert whose name contains "Settlement" — `ClearingSettlementWindowMissed` — belongs to clearing-service and queries `openbank_clearing_settlements_completed_total`, `service: clearing`.

So there was no signal anywhere that could distinguish *"settlement is running normally"* from *"settlement has booked nothing for six hours"*. The pod is Ready, the namespace is scraped (`payments` is in the fleet PodMonitor), ArgoCD is Healthy, and the series simply did not exist — the repo's recurring shape, one layer earlier than the scrape-coverage sweeps that came before.

## What this adds

`SettlementMetricsPort` (application layer, framework-free) + `SettlementMetricsAdapter` (Micrometer, null-safe via `Instance` like `FraudMetricsAdapter`):

| metric | tags |
|---|---|
| `openbank_settlement_transitions_total` | `status` — every saga transition, compensations included |
| `openbank_settlement_originations_total` | `outcome` — `CREATED` / `IDEMPOTENT_HIT` / `CONCURRENT_RACE` |
| `openbank_settlement_workflow_starts_total` | `outcome` — `STARTED` / `ALREADY_RUNNING` / `NOT_STARTED_TERMINAL` |

### Two naming decisions, both deliberate

**A no-op outcome gets its own enum value, never a shared success flag.** `IDEMPOTENT_HIT` and `ALREADY_RUNNING` are *correct* outcomes and *different* ones from a real create or start. Folding them into a success rate is exactly how a feature-flagged-off push adapter reported every notification as delivered (ADR-0252 phase 0): the row committed `SENT`, the outcome event announced a delivery that never left the process, and nothing disagreed. A shift from `CREATED` to `IDEMPOTENT_HIT` means callers are retrying — visible here, invisible in a success rate.

**The metric is `transitions{status="BOOKED"}`, not `settled`.** That is what settlement-service observed itself commit. Whether money moved is a claim only the ledger can make, and naming a metric for more than it establishes is the same defect as calling an accepted APNs request a delivery.

The counter lives inside the existing `audit(...)` helper, which every transition already funnels through — so a new transition cannot be added without also being counted.

## Alerts, on the success state

Three rules in `components/payments/prometheus-rules.yaml`, all keyed on the *absence of the thing that should be happening* rather than on an error rate. A settlement path that quietly does nothing — a worker that never polls, an orchestrator that never starts a run — produces **no errors at all**, so an error-rate alert is silent in exactly the outage that matters (#2148, five schedulers that had never run).

- `SettlementNoBookingsDuringBusinessHours` — no `BOOKED` transition in 2h during business hours
- `SettlementCompensationsSpiking` — >5 compensating transitions in 15m; money moved and then unwound is a different event from a settlement rejected before moving anything, which is why compensations get their own status values
- `SettlementWorkflowStartsAllNoOps` — every start is `ALREADY_RUNNING` and none is `STARTED`: runs are being created and never completing, a state a success rate reports as 100% healthy

## Verified, and falsified

```
./gradlew :openbank-settlement-service:test   -> 42 tests, 0 failures
```

Falsification — with `metrics.recordTransition(...)` commented out:

```
SettlementActivitiesImplTest > every saga transition is counted, compensations included() FAILED
SettlementActivitiesImplTest > rejectSettlement sets REJECTED status without port calls() FAILED
10 tests completed, 2 failed
```

Exactly the two assertions that claim the metric, and no others. The test double is a **recording** fake, not a mock returning `Unit` — a mock would satisfy the compiler and prove nothing, and could not express "an idempotent hit was counted as an idempotent hit, not as a fresh create", which is the distinction the port exists to preserve.

`ktlintCheck` + `detekt` clean.

## Note on the test call sites

Four tests construct `SettlementService` / `SettlementActivitiesImpl` by hand and needed the new parameter — the shape CLAUDE.md flags as a shared namespace that breaks every hand-instantiating test at once. They were updated to pass the recording fake **and to assert on it**, rather than being given a mock to keep them compiling.

## Linked issues

Closes #5705
