### PR TITLE
fix(infra): seed script must PUT the first write, PATCH every later one

### DIFF
--- a/openbank-infra/scripts/seed-ai-stack-secrets.sh
+++ b/openbank-infra/scripts/seed-ai-stack-secrets.sh
@@ -44,6 +44,23 @@ has_field() { # kv_path field
   bao_exec bao kv get -field="$2" "$1" >/dev/null 2>&1
 }
 
+has_path() { # kv_path
+  bao_exec bao kv get "$1" >/dev/null 2>&1
+}
+
+# `kv patch` MERGES do existujícího tajemství — a na neexistující cestě vrátí 404. `kv put` cestu
+# založí, ale REPLACES všechno, co tam je. Takže první zápis na čerstvou cestu musí být put a každý
+# další patch. Samotný put by při každém běhu smazal sourozenecké klíče; samotný patch spadne na
+# úplně prvním běhu (změřeno 2026-08-19, první ostré spuštění tohohle skriptu):
+#   Error writing data to openbank/data/langfuse: Code: 404
+kv_write() { # kv_path field value
+  if has_path "$1"; then
+    bao_exec bao kv patch "$1" "$2=$3" >/dev/null
+  else
+    bao_exec bao kv put "$1" "$2=$3" >/dev/null
+  fi
+}
+
 if [[ -z "${VAULT_TOKEN:-}" ]]; then
   if [[ -n "${BAO_TOKEN:-}" ]]; then VAULT_TOKEN="$BAO_TOKEN"
   elif [[ -n "${RT:-}" ]]; then VAULT_TOKEN="$RT"; fi
@@ -82,8 +99,7 @@ seed_langfuse_field() { # field generator_command
   fi
   local value
   value="$(eval "$gen")"
-  # kv patch, ne kv put: put přepíše CELÝ secret a shodil by ostatní klíče na téže cestě.
-  bao_exec bao kv patch "$KV_LANGFUSE" "$field=$value" >/dev/null
+  kv_write "$KV_LANGFUSE" "$field" "$value"
   unset value
   echo "   $field: zapsáno"
 }
@@ -103,7 +119,7 @@ if [[ "$ROTATE" -eq 0 ]] && has_field "$KV_LANGFUSE" INIT_USER_EMAIL; then
 else
   read -r -p "   INIT_USER_EMAIL (operátorský e-mail pro login do Langfuse): " LF_EMAIL
   [[ -n "$LF_EMAIL" ]] || { echo "prázdný e-mail — Langfuse by uživatele nezaložil"; exit 1; }
-  bao_exec bao kv patch "$KV_LANGFUSE" "INIT_USER_EMAIL=$LF_EMAIL" >/dev/null
+  kv_write "$KV_LANGFUSE" INIT_USER_EMAIL "$LF_EMAIL"
   echo "   INIT_USER_EMAIL: zapsáno"
 fi
 


### PR DESCRIPTION
Found by running it: the first real invocation against a fresh KV path failed with

```
Error writing data to openbank/data/langfuse: Code: 404
```

`bao kv patch` merges into an **existing** secret and 404s on a path that does not exist yet.
`bao kv put` creates the path but **replaces** everything on it — which is the failure the original
comment was guarding against (wiping sibling keys), so swapping patch for put everywhere would just
trade one defect for a worse, silent one.

The write now branches on whether the path exists: `put` to create, `patch` thereafter.

Verified with `bash -n` and shellcheck (clean). Not verified end-to-end against the cluster from
here — that needs the operator token, which I do not handle; the owner is running it.

## Linked issues

Refs #5671
