### PR TITLE
fix(notification): wire the DLQ the #5698 sweep assumes

### DIFF
--- a/openbank-infra/gitops/components/notifications/kafka-notification-mtls.yaml
+++ b/openbank-infra/gitops/components/notifications/kafka-notification-mtls.yaml
@@ -45,6 +45,18 @@ spec:
           patternType: literal
         operations: [Read, Describe]
         host: "*"
+      # #5698: SmallRye dead-letter topic for the party-events-in channel. Without Write here
+      # the DLQ send itself fails and the consumer wedges on the very failure it was meant to
+      # park — the same ANONYMOUS-vs-ACL lockout class that took party-service down (#1476), and
+      # the reason account-service's own ACL carries the identical grant. The name is set
+      # explicitly in notification-service-msg-override.yaml rather than left to SmallRye's
+      # `dead-letter-topic-<channel>` default, which account-service already owns.
+      - resource:
+          type: topic
+          name: openbank.party.events.notification.dlq
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
       # ADR-0239 D2: emit delivery outcomes so a producer can tell an accepted handoff
       # from a delivered, suppressed or failed message (issue #3663).
       - resource:

--- a/openbank-infra/gitops/components/notifications/kafka-topic.yaml
+++ b/openbank-infra/gitops/components/notifications/kafka-topic.yaml
@@ -47,3 +47,36 @@ spec:
   config:
     retention.ms: 604800000
     cleanup.policy: delete
+---
+# #5698: dead-letter topic for notification-service's party-events-in channel (SmallRye
+# failure-strategy: dead-letter-queue, set in the service's application.yaml). A PARTY_ERASED
+# event whose GDPR Art. 17 erasure survives PartyErasureConsumer's bounded retry is parked here
+# for inspection/replay instead of being acked and lost.
+#
+# Explicitly named (openbank.party.events.notification.dlq) rather than left to SmallRye's default
+# `dead-letter-topic-<channel>`, because account-service already owns that name for its OWN
+# party-events-in channel — the two would otherwise share one topic and be misattributed by the
+# existing AccountPartyEventDeadLettered alert. The name is supplied via the msg-override
+# ConfigMap, since `dead-letter-queue.topic` is a dotted leaf key SmallRye's YAML source would
+# silently mis-quote (issue #686).
+#
+# A CR is required, not optional: this cluster does not auto-create topics, so without it the
+# DLQ send fails and the consumer wedges on the failure it was meant to park.
+#
+# Longer retention than the source topic: a dead-lettered erasure is a real compliance incident
+# that may outlive a 7-day window before someone replays it. No consumer by design — it is a
+# quarantine, invisible to the event-consumer-liveness gate (that gate reads `outgoing:` channels,
+# and this producer is the connector's implicit DLQ, not a declared channel).
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.party.events.notification.dlq
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete

--- a/openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml
@@ -54,6 +54,14 @@ data:
     mp.messaging.incoming.party-events-in.client.id=notification-service-party-${quarkus.uuid}
     mp.messaging.incoming.party-events-in.group.id=notification-service-party
     mp.messaging.incoming.party-events-in.auto.offset.reset=earliest
+    # #5698: explicit DLQ topic for the party-events-in channel (failure-strategy:
+    # dead-letter-queue, set in application.yaml). Explicit rather than implicit because
+    # SmallRye's default name is dead-letter-topic-<channel>, and account-service already owns
+    # `dead-letter-topic-party-events-in` for ITS party-events-in channel — sharing it would put
+    # two services' dead letters in one topic and misattribute them in the existing
+    # AccountPartyEventDeadLettered alert. Dotted leaf key, so it MUST live here and not in
+    # application.yaml (issue #686, same reason as group.id above).
+    mp.messaging.incoming.party-events-in.dead-letter-queue.topic=openbank.party.events.notification.dlq
     mp.messaging.incoming.delegation-events-in.client.id=notification-service-delegation-${quarkus.uuid}
     mp.messaging.incoming.delegation-events-in.group.id=notification-service-delegation
     mp.messaging.incoming.delegation-events-in.auto.offset.reset=earliest

--- a/openbank-notification-service/src/main/resources/application.yaml
+++ b/openbank-notification-service/src/main/resources/application.yaml
@@ -155,6 +155,20 @@ mp:
         # set via the gitops ConfigMap instead (issue #686).
         topic: openbank.party.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        # #5698: PartyErasureConsumer now RETHROWS a failed GDPR Art. 17 erasure instead of
+        # acking it. That is only an improvement if the connector parks the record — SmallRye's
+        # DEFAULT failure-strategy is `fail`, which STOPS the channel, so a rethrow without this
+        # line trades silent data loss for a wedged consumer. `dead-letter-queue` is what makes
+        # the consumer's KDoc true by effect rather than by assertion.
+        #
+        # The DLQ TOPIC NAME is set in the gitops msg-override ConfigMap, not here: the key is
+        # `dead-letter-queue.topic`, a dotted leaf key, and SmallRye's YAML source would register
+        # it quoted and never read it (issue #686 — the same footgun as group.id above). Left
+        # implicit it would default to `dead-letter-topic-party-events-in`, which account-service
+        # ALREADY owns for its own channel of the same name — two services' dead letters in one
+        # topic, misattributed by the existing AccountPartyEventDeadLettered alert. Hence the
+        # explicit per-service name, mirroring fraud-service's `transaction-signal` channel.
+        failure-strategy: dead-letter-queue
       # ADR-0232 delegated-access lifecycle notifications (DelegationNotificationConsumer) — a
       # second consumer of the topic account-service (enforcement projection) and audit-service
       # (onBehalfOf trail) already read.


### PR DESCRIPTION
Stacked on **#5719** (merged into this branch so CI is green independently; those files drop out of
the diff once #5719 lands). `Refs #5698`

## What this PR is, after subtraction

I started on the site #5725 flagged and left out of scope — notification-service's
`PartyErasureConsumer` — then found **#5719 had already fixed the same file**, with a shared
`EventRetry` in `openbank-libs-runtime` rather than the per-service `ConsumerRetry.kt` copy #5725
established and I had mirrored. Theirs is the better form, so I deleted mine and took theirs.

What is left is the part no PR in this sweep has:

| file | why it is here |
|---|---|
| `openbank-notification-service/src/main/resources/application.yaml` | `failure-strategy: dead-letter-queue` — **without it the rethrow does not dead-letter** |
| `…/notifications/notification-service-msg-override.yaml` | explicit DLQ topic name |
| `…/notifications/kafka-topic.yaml` | the `KafkaTopic` CR (cluster does not auto-create) |
| `…/notifications/kafka-notification-mtls.yaml` | KafkaUser `Write` ACL on the DLQ topic |
| `…/kafka/PartyErasureConsumerTest.kt` | #5719 changed this consumer with **no test**; these are its tests |

## ⚠️ The whole sweep asserts a DLQ that four services have

Every PR in this family rethrows "so the connector dead-letters". `EventRetry`'s own KDoc says it
"hands the decision to the connector's own failure strategy (retry, then dead-letter)".

**SmallRye's default `failure-strategy` is `fail`, which stops the channel.** It does not
dead-letter. Fleet-wide, exactly four services configure one:

| service / channel | `failure-strategy` |
|---|---|
| fraud `transaction-signal`, transaction `payment-scheme-accepted` | `dead-letter-queue` |
| account `party-events-in` + `delegation-events-in`, card-issuance `delegation-events-in` | `dead-letter-queue` |
| **every other incoming channel in the monorepo** | **unset → `fail`** |

So of the sites across #5715 / #5719 / #5725 / #5726, only the ones on those four channels behave as
documented. The rest stop the data loss by **halting the consumer** — the exact "one bad event wedges
the group" outcome the original swallow comments were written to avoid. That is arguably still the
better trade for a GDPR erasure, but it is not what the KDocs say, and nobody has decided it
deliberately. The repo already knows the mechanism; account-service's own ACL manifest says it:

> Without Write here, the DLQ send itself fails and the consumer wedges on the very failure it was
> meant to park.

This PR therefore wires the DLQ for `party-events-in` rather than asserting one. Explicit topic name,
because `dead-letter-queue.topic` is a dotted leaf key SmallRye's YAML source mis-quotes (#686), and
the implicit default `dead-letter-topic-party-events-in` is **already owned by account-service's
channel of the same name** — leaving it implicit would merge two services' dead letters into one
topic and misattribute them in the existing `AccountPartyEventDeadLettered` alert.

I have not touched the other PRs' branches. Flagged on each.

## Tests, and their falsification

#5719 changed `PartyErasureConsumer` without a test. These are the tests, and they were falsified
against the **pre-fix** consumer:

| test | pre-fix | post-fix |
|---|---|---|
| a persistent erasure failure is RETHROWN | 🔴 | 🟢 |
| a TRANSIENT erasure failure is retried and completes | 🔴 | 🟢 |
| a failure of the SECOND delete also escapes | 🔴 | 🟢 |
| malformed payload is acked without throwing | 🟢 | 🟢 |
| non-PARTY_ERASED events are ignored | 🟢 | 🟢 |
| PARTY_ERASED deletes device tokens and notifications | 🟢 | 🟢 |

Exactly the behaviour tests discriminate; the ack tests hold on both sides, which is what stops a
blanket rethrow from passing them. They now run against #5719's `EventRetry`, so they double as the
first independent check on it. Module gate on the merged state: `ktlintCheck` 0, `detekt` 0,
`quarkusBuild` 0, `test` 41 classes / 184 tests / 0 failures / **0 skipped**.

## The enumeration — every reactive-messaging consumer in the monorepo

The two earlier audits were sampled by service, so absence of findings was not yet evidence.
Searched structurally (the annotation), not by catch-block text: **59** `@Incoming` mentions under
`*/src/main/**.kt`, of which **44** are real annotation sites (15 are KDoc references) across 40
files. Other shapes were checked and none exists — `@Blocking` without `@Incoming` is 16 JAX-RS
resources/filters; the only `Multi<>` declaration is copilot's SSE endpoint (it *produces*); every
`subscribe` is awaited; no direct `KafkaConsumer`; all 60 `@Observes` are Startup/Shutdown; both
`@ConsumeEvent` are a local Vert.x kill-switch; all ~50 `@Channel` injections are outgoing emitters.

**44 sites = 31 genuine · 13 clean or deliberate-and-correct.** Of the 31 genuine, **21 are covered
by a PR** (11 in #5715/#5725, 7 in #5719, 1 here, 2 in #5726) and **10 are not covered by anything.**

### Genuine, covered

| PR | sites |
|---|---|
| #5715 | fraud `TransactionSignal`, interest `WithholdingRemittanceSettlement` |
| #5725 | copilot `PartyErasure`, customer-edge `OnboardingResume`, document ×2, engagement ×5 |
| #5719 | aml `PartyEvent`, audit `AuditConsumer`, card-issuance `PartyEvent`, kyc `PartyEvent`, party `KycAml` ×2, party `MarketingConsent` |
| #5726 | sdd `SddCollectionDebit`, standing-order `StandingOrderDue` |
| this | notification `PartyErasure` (code from #5719; DLQ + tests here) |

### Genuine, covered by NOTHING (10)

| service | consumer | swallowed call | signal lost |
|---|---|---|---|
| anacredit | `LoanStageEventConsumer` | `projections.applyIfNewer` | IFRS 9 stage / DPD frozen → stale AnaCredit regulatory exposure |
| analytics-sink | `AnalyticsConsumer` | `ClickHouseAnalyticsSink.write` | bronze row lost from the ≥10y log of record; the only `DeadLetterSink` binding is a `log.warnf`, so "quarantined" means logged |
| campaign | `EnrolmentTriggerConsumer` (2 channels) | `TriggeredEnrolmentService.enrol` — DB + Temporal `startJourney` | party never enrolled; `reset: latest` rules out replay; can leave a running journey with no enrolment row |
| campaign | `NotificationOutcomeConsumer` | `sendLog.applyDeliveryOutcome` | send row stays `PENDING` forever — the exact ADR-0239 D3 defect it was built to fix |
| notification | `NotificationConsumer` | `dispatch` — persist, contact lookup, email/push send | the notification itself; this channel carries transactional and security templates |
| onboarding | `OnboardingEventConsumer` (3 channels) | `projection.eraseParty`, `projection.applyEvent` | Art. 17 erasure of the read model; KYC/SCA transitions never reach the funnel |
| tax-reporting | `WithholdingRemittedConsumer` | `filingRepository.openIfAbsent`, `remittanceRepository.record` | a remittance missing from the §38d statutory return — silently understated tax withheld |

### Clean or deliberate-and-correct (13)

account `DelegationEvent` + `PartyEvent` (already retry+rethrow) · agent `OversightEvent` (no catch) ·
balance `BalanceInit` · balance `LedgerProjection` (money-path, checked closely — `projection.apply`
unwrapped, so a DB failure nacks) · campaign `CampaignEngagement`, `ConsentEvent`, `Conversion` ×2 ·
card-issuance `CardDelegationEvent` · notification `DelegationNotification` (parse-only; the swallow
it inherits is counted under `NotificationConsumer`) · statement `AccountRegistry` (`upsertOpen`
returned as a `Uni`) · transaction `SchemeAccepted` (catch narrowed to `JacksonException`).

## #5719's gate reports clean, and 10 genuine sites are why that is not evidence

`check-event-handler-swallows.py` prints `clean: 170 handler files, no swallowed state changes` on
this branch. Measured against its own `findings_for`, with a positive control that does fire:

| shape (a real site above) | gate |
|---|---|
| `repo.save(e)` in a plain catch — **positive control** | 🚩 flagged |
| `projections.applyIfNewer` — receiver not in the name list (anacredit) | missed |
| `sink.write` (analytics-sink) | missed |
| `sendLog.applyDeliveryOutcome` (campaign) | missed |
| `projection.applyEvent` (onboarding) | missed |
| `taxFilingService.observe` — receiver matches, **verb** not listed (tax-reporting) | missed |
| `.onFailure().recoverWithUni {}` — Mutiny, no `catch` keyword (notification) | missed |
| swallow in a helper class whose file has no `@Incoming` (campaign `enrol`) | missed |

`STATE_CALL` matches on the receiver's *name* and a closed verb list, and `CATCH` requires a literal
`catch (x: Exception|Throwable)`. Both are reasonable heuristics; neither is a proof of absence, so
the gate's green is about the subset it can express. #5726 closes two of these — worth widening it to
the rest, or the next occurrence of this bug class ships under a green gate.

## Not in scope here

The 10 uncovered sites are not folded in: several are money-path (2 approvals + a threat model by
rule), each needs its own discriminating tests and, per the section above, its own DLQ wiring — and a
ten-service rethrow landing at once is an operational change, not a tidy-up. Filed separately.

Three hedges the audit recorded and deliberately did **not** promote to findings, so nobody
rediscovers them: account-service's `grantWelcomeBonus` (sandbox-only, flag off by default);
`LedgerProjectionService.releaseCoverHolds` (documented best-effort, TTL-compensated);
`ConversionConsumer`'s unconditional `finally { message.ack() }` (needs runtime verification of
SmallRye's commit-vs-shutdown ordering, which I did not run anything to establish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
