### PR TITLE
ci(gates): pin the gates shard to Node 26, and make the deps lock wait for a finished install

### DIFF
--- a/.github/scripts/ensure-admin-ui-deps.sh
+++ b/.github/scripts/ensure-admin-ui-deps.sh
@@ -30,35 +30,36 @@
 # Usage:  source "$(dirname "$0")/ensure-admin-ui-deps.sh"; ensure_admin_ui_deps "<label>"
 
 ensure_admin_ui_deps() {
-  local label="${1:-deps}"
-  local script_dir repo_root ui_dir lock waited
+  local label="${1:-deps}" script_dir repo_root ui_dir lock marker waited
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   repo_root="$(cd "$script_dir/../.." && pwd)"
   ui_dir="$repo_root/openbank-admin-ui"
   lock="$ui_dir/.node_modules.gate-lock"
+  # A COMPLETION marker, not a resolve check. npm writes node_modules progressively, so a waiter
+  # that probes with require.resolve can see a half-installed tree as ready and then fail on a
+  # package npm has not unpacked yet — which is how the first version of this helper still let the
+  # two gates trip over each other, just later and less obviously (the gate reported UNFALSIFIED,
+  # not a clean failure). The marker is written only after `npm ci` returns 0.
+  marker="$ui_dir/node_modules/.openbank-gate-deps-ok"
 
-  _deps_present() {
-    node -e "for (const m of ['yaml','zod','mermaid','jsdom']) require.resolve(m,{paths:['$ui_dir']})" \
-      >/dev/null 2>&1
-  }
-
-  if _deps_present; then return 0; fi
+  if [ -f "$marker" ]; then return 0; fi
 
   waited=0
-  # 600s: a cold `npm ci` here is ~50s, so this only trips when the holder died mid-install.
+  # 900s: a cold `npm ci` here is ~50s, so this only trips when the holder died mid-install.
   while ! mkdir "$lock" 2>/dev/null; do
-    if [ "$waited" -ge 600 ]; then
+    if [ "$waited" -ge 900 ]; then
       echo "[$label] stale lock at $lock after ${waited}s — removing and retrying" >&2
       rm -rf "$lock"
       continue
     fi
     sleep 2
     waited=$((waited + 2))
-    if _deps_present; then return 0; fi
+    if [ -f "$marker" ]; then return 0; fi
   done
   trap 'rm -rf "$lock"' EXIT
 
-  if _deps_present; then
+  # Re-check under the lock: the holder we queued behind has usually just finished.
+  if [ -f "$marker" ]; then
     rm -rf "$lock"
     trap - EXIT
     return 0
@@ -69,6 +70,7 @@ ensure_admin_ui_deps() {
   # A half-written tree left by a killed peer makes npm ci itself fail, so clear it first.
   rm -rf "$ui_dir/node_modules"
   ( cd "$ui_dir" && npm ci --ignore-scripts --no-audit --no-fund >/dev/null )
+  touch "$marker"
 
   rm -rf "$lock"
   trap - EXIT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,6 +266,23 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Node 26, for the same reason ui-build pins it: it is what openbank-admin-ui's
+      # dependency tree is resolved against (Dockerfile: node:26-alpine). The gates shard
+      # had no setup-node at all, so it ran on whatever the runner image ships, and the
+      # mermaid-parses gate — which imports admin-ui's own mermaid — died there while
+      # passing everywhere else:
+      #
+      #   ERR_UNSUPPORTED_DIR_IMPORT: Directory import '.../node_modules/es-toolkit/compat'
+      #   is not supported resolving ES modules imported from .../mermaid/dist/mermaid.core.mjs
+      #
+      # es-toolkit declares a correct "./compat" exports entry, so this is the older Node
+      # failing to apply it, not a broken package. The gate reported UNFALSIFIED rather than
+      # passing — its own self-test could not run — which is how a runtime mismatch that
+      # reproduces nowhere else got caught at all.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "26"
+
       # PyYAML is a prerequisite of run-gates.py itself, and of most checkers. It used to
       # be installed inside the gen-network-policies gate, which happened to be the first
       # step that needed it; now that gates run concurrently there is no "first step", so


### PR DESCRIPTION
Fixes two defects in the `mermaid-parses` gate landed by #5662. Both currently make `gates (lint)` **red on `main`**, which also blocks the deploy PRs.

Both showed up as **UNFALSIFIED**, not as a pass — the gate's own self-test could not run, so `run-gates.py` refused to call it green. That is the machinery working exactly as intended.

## 1. The gates shard had no `setup-node`

It ran on whatever Node the runner image ships, while `openbank-admin-ui`'s dependency tree is resolved against **Node 26** (`Dockerfile: node:26-alpine`, and `ui-build` pins it for the same reason, with its own war-story comment about jsdom 30).

Importing admin-ui's own mermaid there died with:

```
ERR_UNSUPPORTED_DIR_IMPORT: Directory import '.../node_modules/es-toolkit/compat'
is not supported resolving ES modules imported from .../mermaid/dist/mermaid.core.mjs
```

`es-toolkit` declares a correct `"./compat"` exports entry, so this is the older Node failing to apply it, not a broken package — and **not something my earlier "import by bare specifier" commit could have fixed**, because the failing import is inside mermaid, not in the gate. Green on Node 26 locally, red on the runner: the worst split a checker can have, and the reason the gate now pins its runtime.

## 2. The lock was not actually a barrier

`ensure-admin-ui-deps.sh` serialises the two gates that install into `openbank-admin-ui/node_modules` (`governance-manifest` and `mermaid-parses`, both in the `lint` shard, which `run-gates.py` runs concurrently). But the waiter probed readiness with `require.resolve`.

npm writes `node_modules` progressively, so the waiter could see a **half-installed tree as ready** and then fail on a package npm had not unpacked yet. The first version of this helper therefore still let the two gates trip over each other — just later, and less obviously.

Readiness is now a **completion marker** written only after `npm ci` returns 0.

## Verification

Reproduced the way the bug appears — `node_modules` deleted, so both gates take the install path concurrently:

| | result |
|---|---|
| before | 19 PASS + **1 UNFALSIFIED** |
| after | **20/20 PASS** |

`shellcheck` clean on the changed script.

## Note

Touches `.github/workflows/ci.yml`, so it needs a human merge by the repo's own rule.
