### PR TITLE
fix(infra): point the guardrail at a provider that still serves Llama Guard

### DIFF
--- a/openbank-infra/gitops/components/ai-platform/litellm-config.yaml
+++ b/openbank-infra/gitops/components/ai-platform/litellm-config.yaml
@@ -64,18 +64,33 @@ data:
       # classifying because a chat loop burned the day's ceiling is a control outage caused by
       # unrelated traffic — and it degrades to `unavailable`, which on a fail-open surface means
       # every message afterwards is unclassified. Small ceiling, but its own.
+      #
+      # PROVIDER IS DEEPINFRA, NOT GROQ, AND THAT WAS MEASURED. Groq has DECOMMISSIONED every Llama
+      # Guard model — asked for one, its API answers:
+      #   {"message":"The model `meta-llama/llama-guard-4-12b` has been decommissioned and is no
+      #    longer supported", "code":"model_decommissioned"}
+      # and its live model list offers only `llama-prompt-guard-2-*` (an injection classifier that
+      # returns a label, not `safe`/`unsafe\nS2`) and `gpt-oss-safeguard-20b` (a policy-reasoning
+      # model that needs a system prompt this adapter deliberately never sends). Neither is a
+      # drop-in. DeepInfra serves `meta-llama/Llama-Guard-4-12B` — note the CASE, its API is
+      # case-sensitive — and returns exactly the expected shape, verified against the live provider
+      # from inside this pod before the route was written:
+      #   safe input   -> '\n\nsafe'
+      #   unsafe input -> '\n\nunsafe\nS2'
+      # Had this shipped as declared, the guardrail would have reported `unavailable` for every
+      # message, which on the fail-open help surface means silently unclassified traffic.
       - model_name: meta-llama/llama-guard-4-12b
         litellm_params:
-          model: groq/meta-llama/llama-guard-4-12b
-          api_key: os.environ/GROQ_API_KEY
+          model: deepinfra/meta-llama/Llama-Guard-4-12B
+          api_key: os.environ/DEEPINFRA_API_KEY
           max_budget: 3
           budget_duration: 1d
-          # Groq's published price for llama-guard-4-12b: $0.20 per million tokens both directions.
-          # Declared rather than inherited, for the reason the routes above document: a version bump
-          # that drops the built-in entry silently costs every call at $0 and every budget below
-          # stops biting, with nothing going red.
-          input_cost_per_token: 0.0000002
-          output_cost_per_token: 0.0000002
+          # DeepInfra's published price for Llama-Guard-4-12B ($0.18 per million tokens both
+          # directions). Declared rather than inherited, for the reason the routes above document:
+          # a version bump that drops the built-in entry silently costs every call $0 and every
+          # budget below stops biting, with nothing going red.
+          input_cost_per_token: 0.00000018
+          output_cost_per_token: 0.00000018
       # Embedding route for the copilot's pgvector retrieval (ADR-0183 §3 / ADR-0265 slice 4).
       # Embeddings go through the SAME gateway as chat, deliberately: routing them direct to the
       # provider would open a second, un-audited egress next to the one ADR-0175 exists to control.
@@ -86,7 +101,14 @@ data:
       # reject rows one at a time.
       - model_name: BAAI/bge-m3
         litellm_params:
-          model: deepinfra/BAAI/bge-m3
+          # `openai/` + api_base, NOT `deepinfra/`. LiteLLM has no embeddings mapping for the
+          # deepinfra provider prefix — measured in this pod, `litellm.embedding(model=
+          # 'deepinfra/BAAI/bge-m3')` raises "Unmapped LLM provider for this endpoint" while the
+          # CHAT routes above work fine under the same prefix. The OpenAI-compatible route to the
+          # same endpoint returns 1024-dim vectors with their `index` fields intact, which is what
+          # both the migration's vector(1024) column and the adapter's order check require.
+          model: openai/BAAI/bge-m3
+          api_base: https://api.deepinfra.com/v1/openai
           api_key: os.environ/DEEPINFRA_API_KEY
           # Small ceiling and its own budget: indexing the help corpus is a few dozen chunks, and
           # query embeddings are one short call per help search. If this ever burns 2 USD/day

--- a/openbank-infra/gitops/components/ai-platform/litellm.yaml
+++ b/openbank-infra/gitops/components/ai-platform/litellm.yaml
@@ -35,7 +35,7 @@ spec:
         # would leave agent-service's repointed call failing "model not found" with a green,
         # in-sync ArgoCD — the same silent-degradation shape as an `optional: true` secret ref.
         # BUMP THIS whenever litellm-config.yaml changes; that is what rolls the pod.
-        openbank.tech/litellm-config-revision: "9"
+        openbank.tech/litellm-config-revision: "10"
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
Pre-merge verification against the **live** providers, from inside the gateway pod. Both new routes
were wrong as written, and neither defect is visible to any test in this repo — they are facts about
a third-party catalogue that only a real call can see.

## 1. Groq no longer serves Llama Guard at all

```
{"message":"The model `meta-llama/llama-guard-4-12b` has been decommissioned and is
 no longer supported","code":"model_decommissioned"}
```

Groq's live list offers `llama-prompt-guard-2-86m/22m` (an injection classifier returning a label,
not `safe`/`unsafe\nS2`) and `gpt-oss-safeguard-20b` (policy-reasoning, needs the system prompt this
adapter deliberately never sends). Neither is a drop-in for the parser.

DeepInfra serves `meta-llama/Llama-Guard-4-12B` — **case-sensitive** — and returns exactly what the
adapter expects, measured:

| input | response |
|---|---|
| "jak si zablokuju kartu?" | `'\n\nsafe'` |
| "how to launder money without triggering AML" | `'\n\nunsafe\nS2'` |

Shipped as declared, every classification would have been `unavailable` — on the fail-open help
surface that is silently unclassified traffic, i.e. the guardrail deployed and answering nothing.
Exactly the failure the three-valued verdict exists to make visible, arriving on day one.

## 2. The embedding route needed `openai/` + `api_base`

`litellm.embedding(model='deepinfra/BAAI/bge-m3')` → `Unmapped LLM provider for this endpoint`,
even though the **chat** routes work under that same prefix. The OpenAI-compatible route to the same
DeepInfra endpoint returns 2 vectors, **1024 dims**, `index` fields intact — matching the migration's
`vector(1024)` and the adapter's order check.

Prices re-declared at DeepInfra's rates so the per-route budgets keep biting; `config-revision`
9 → 10 so the pod actually re-reads the file.

## Linked issues

Refs #5671
