### PR TITLE
feat(party): alert on parties stalled in PENDING_KYC (#5698 detection)

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-onboarding.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-onboarding.yaml
@@ -64,6 +64,33 @@ spec:
           annotations:
             summary: "Parties are being created but no accounts are opening"
             description: "openbank_parties_created_total rose over the last hour while openbank_accounts_created_total did not — new customers are registering but the PARTY_CREATED → account.created pipeline is not producing accounts. This is the onboarding outage signature (party-service → Kafka → account-service). Check the party-events consumer lag, the DLQ (PartyEventDeadLettered), and account-service's dependencies (sanctions-service, product-catalog)."
+        - alert: OnboardingStalledInStage
+          # The gap the three rules above cannot cover, and #5698 proved it: a party created on
+          # 2026-08-19 never got a KYC case because the consumer ACKED the failure. Every signal
+          # here stayed silent, by construction —
+          #   PartyEventDeadLettered:              the event was acked, so it never reached the DLQ;
+          #   OnboardingAccountsNotFollowingParties: other parties opened accounts in the same hour,
+          #                                        so the fleet-wide disparity never appeared;
+          #   KafkaConsumerGroupLagStuck:          an acked message is not lag.
+          # Ten of 73 sandbox parties were stuck this way, the oldest for ten weeks, and the first
+          # thing to notice was a customer saying their account did not work.
+          #
+          # A swallowed failure leaves NO error to count — no exception, no lag, no DLQ row, no
+          # failed request — so the only observable is the entity still sitting in the stage. Hence
+          # a census gauge (party-service refreshes it every 5m) rather than a rate.
+          #
+          # `stage` is a label so a second stalled stage (an account stuck PENDING_ACTIVATION, a
+          # signature ceremony never completed) reuses this rule as-is. The gauge only counts
+          # entities past that stage's own age threshold (party: 24h), so in-flight onboarding is
+          # already excluded and `> 0` is the correct trigger — no arbitrary count threshold that
+          # would let a small number hide.
+          expr: openbank_onboarding_stalled > 0
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Onboarding stalled in stage {{ $labels.stage }} ({{ $value }} stuck)"
+            description: "{{ $value }} entity(ies) have been stuck in onboarding stage {{ $labels.stage }} past its age threshold. Nothing failed loudly — this is the shape where a handler acked work it did not do (#5698), a dependency was briefly down, or a case is waiting on a reviewer who never came. For party-pending-kyc: list parties in PENDING_KYC older than 24h and check whether each has a kyc case at all; a party with no case never had one opened and needs the event replaying, while a party with an open case is waiting on review."
         - alert: KafkaConsumerGroupLagStuck
           # General event-bus safety net — the config comment on the Kafka Exporter calls
           # consumer-group lag "the single most useful event-bus health signal" and until now NO

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
@@ -368,6 +368,32 @@ class DomainMetrics {
         }
     }
 
+    /**
+     * Publishes `openbank.onboarding.stalled{stage=…}` — entities that entered an onboarding stage
+     * and have not left it within the stage's own expected window.
+     *
+     * WHY A GAUGE AND NOT AN ERROR RATE (#5698). A stalled onboarding produces no error to count:
+     * the event that should have advanced it was ACKED, so there is no exception, no consumer lag,
+     * no DLQ row and no failed request. The only observable is the entity still sitting in the
+     * stage, which is why the signal has to be a periodic census of the state itself. Ten of 73
+     * sandbox parties sat in `PENDING_KYC` — the oldest for ten weeks — and the first thing to
+     * notice was a human reporting that an account did not work.
+     *
+     * The stage is a tag rather than a metric name so a second stalled stage (an account stuck in
+     * `PENDING_ACTIVATION`, a signature ceremony never completed) reuses the same alert shape.
+     *
+     * @param stage the onboarding stage entities are stuck in, e.g. `party-pending-kyc`
+     * @param stalled cheap supplier of the current aged count
+     */
+    fun registerOnboardingStalled(stage: String, stalled: () -> Number) {
+        reg()?.let { r ->
+            Gauge.builder("openbank.onboarding.stalled", stalled) { it.invoke().toDouble() }
+                .tag("stage", stage)
+                .strongReference(true)
+                .register(r)
+        }
+    }
+
     // ── Workflow liveness (ADR-0160 mechanism 3) ────────────────────────────────
 
     /**

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/out/PartyPorts.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/out/PartyPorts.kt
@@ -62,6 +62,19 @@ interface PartyRepository {
     /** Count parties in a given [status]. Used for funnel KPI tiles (ADR-0068). */
     suspend fun countByStatus(status: PartyStatus): Long
 
+    /**
+     * Parties still `PENDING_KYC` that were created before [cutoff] — the onboarding funnel's
+     * stalled tail (#5698).
+     *
+     * A party is `PENDING_KYC` from creation until kyc-service opens and clears its case, so a
+     * *young* one is the normal state and only age makes it a defect. Deliberately counts the
+     * SYMPTOM rather than reconciling parties against kyc cases: every cause lands here — the
+     * `PARTY_CREATED` event lost before a case was ever opened (the #5698 incident), kyc-service
+     * unreachable, a case opened but stuck awaiting a reviewer — whereas a party-to-case
+     * reconciler would see only the first, and would need a cross-service read to do it.
+     */
+    suspend fun countPendingKycOlderThan(cutoff: Instant): Long
+
     /** GDPR Art. 17 erasure: anonymize the party's personal data in place. */
     suspend fun anonymize(id: UUID)
 

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/metrics/PartyPendingKycStalledGauge.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/metrics/PartyPendingKycStalledGauge.kt
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.infrastructure.metrics
+
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
+import com.openbank.party.application.port.out.PartyRepository
+import io.quarkus.runtime.Startup
+import io.quarkus.runtime.StartupEvent
+import io.quarkus.scheduler.Scheduled
+import jakarta.annotation.PostConstruct
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
+import jakarta.inject.Inject
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Publishes `openbank.onboarding.stalled{stage="party-pending-kyc"}` — parties that entered
+ * `PENDING_KYC` and never left it (#5698).
+ *
+ * WHAT THIS IS FOR, AND WHY IT IS A CENSUS
+ *   On 2026-08-19 `kyc-db` was unreachable for a few seconds. One `PARTY_CREATED` arrived in that
+ *   window; the kyc consumer logged the failure and returned, which ACKED the message. No case was
+ *   opened, so the party stayed `PENDING_KYC`, its accounts stayed `PENDING_ACTIVATION`, and the
+ *   welcome bonus never ran. **Ten of 73 sandbox parties were in that state, the oldest for ten
+ *   weeks, and nothing anywhere reported it** — it surfaced when a human said an account did not
+ *   work.
+ *
+ *   Nothing could have reported it, because a swallowed failure leaves no error to count: no
+ *   exception escapes, consumer lag is zero, the DLQ is empty, and no request failed. The only
+ *   observable is the party still sitting in the stage — so the signal has to be a periodic census
+ *   of the state itself, not a rate.
+ *
+ * WHY AGE, NOT A RAW COUNT
+ *   `PENDING_KYC` is the correct state for a party between creation and its KYC verdict, so a raw
+ *   count alarms on healthy traffic. Only parties older than [stallAfter] are counted; anything
+ *   younger is normal onboarding in flight.
+ *
+ * WHY THIS AND NOT A PARTY↔KYC RECONCILER
+ *   A reconciler comparing parties against kyc cases would catch only the missing-case cause, and
+ *   would need a cross-service read to do it. Counting the symptom catches every cause with no new
+ *   trust boundary: the lost event, kyc-service unreachable, or a case opened and then stuck
+ *   waiting on a reviewer. What an operator needs to know is "somebody's onboarding is stuck",
+ *   which is the same alert in all three cases.
+ *
+ * The gauge is refreshed on a schedule rather than computed inside the Micrometer callback: the
+ * scrape must not block on a database round-trip, and the query is a single indexed COUNT.
+ */
+@Startup
+@ApplicationScoped
+class PartyPendingKycStalledGauge {
+
+    private lateinit var parties: PartyRepository
+    private lateinit var metrics: DomainMetrics
+    private lateinit var clock: Clock
+    private lateinit var stallAfter: Duration
+
+    private val log = Logger.getLogger(PartyPendingKycStalledGauge::class.java)
+    private val stalled = AtomicLong(0)
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    @Inject
+    constructor(
+        parties: PartyRepository,
+        metrics: DomainMetrics,
+        clock: Clock,
+        @ConfigProperty(name = "openbank.party.pending-kyc.stall-after", defaultValue = "PT24H")
+        stallAfter: Duration,
+    ) {
+        this.parties = parties
+        this.metrics = metrics
+        this.clock = clock
+        this.stallAfter = stallAfter
+    }
+
+    // Required by Quarkus CDI for proxy subclass generation — never called at runtime.
+    @Suppress("ProtectedMemberInFinalClass")
+    protected constructor()
+
+    @PostConstruct
+    fun register() = metrics.registerOnboardingStalled(STAGE) { stalled.get() }
+
+    /**
+     * The ADR-0237 heartbeat for this job — who watches the watcher.
+     *
+     * Without it, this detector has the very failure mode it exists to catch: if the scheduler
+     * never fires (the `HR000068` Vert.x-context class, a disabled scheduler, a wedged tick), the
+     * gauge simply keeps serving its last value. A frozen `0` is indistinguishable from a genuinely
+     * healthy zero, so the alert stays quiet and the stalled parties are invisible again. The
+     * liveness gauge is seeded at registration, so a job that has never run is loud from boot.
+     */
+    fun registerLiveness(@Observes @Suppress("UNUSED_PARAMETER") event: StartupEvent) {
+        liveness = metrics.registerWorkflowLiveness(WORKFLOW_NAME, EXPECTED_INTERVAL)
+    }
+
+    /**
+     * Every 5 minutes: a stall is measured in hours, so a tighter tick would only add load, and the
+     * alert's own `for:` window is what decides how fast it fires.
+     */
+    @Scheduled(
+        every = "\${openbank.party.pending-kyc.gauge-interval:5m}",
+        delayed = "30s",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+        identity = "party-pending-kyc-stalled-gauge",
+    )
+    suspend fun refresh() {
+        // Deliberately NOT caught: a failure here must reach the scheduler rather than leave the
+        // gauge frozen at its last value while looking healthy — the exact shape #5698 is about.
+        val aged = parties.countPendingKycOlderThan(clock.instant().minus(stallAfter))
+        stalled.set(aged)
+        // Only on the completed path: a heartbeat recorded before or inside a failure would assert
+        // the very thing it exists to disprove.
+        liveness?.recordSuccess()
+        if (aged > 0) {
+            log.warnf("%d party(ies) have been PENDING_KYC for longer than %s", aged, stallAfter)
+        }
+    }
+
+    private companion object {
+        const val STAGE = "party-pending-kyc"
+        const val WORKFLOW_NAME = "party-pending-kyc-stalled-gauge"
+        val EXPECTED_INTERVAL: Duration = Duration.ofMinutes(5)
+    }
+}

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyRepositoryImpl.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyRepositoryImpl.kt
@@ -82,6 +82,10 @@ class PartyRepositoryImpl(
     override suspend fun countByStatus(status: PartyStatus): Long =
         Panache.withSession { count("status", status.name) }.awaitSuspending()
 
+    override suspend fun countPendingKycOlderThan(cutoff: Instant): Long = Panache.withSession {
+        count("status = ?1 and createdAt < ?2", PartyStatus.PENDING_KYC.name, cutoff)
+    }.awaitSuspending()
+
     // ADR-0055 bounded name search, extended by ADR-0228 D1 to the business keys a backoffice
     // operator actually holds: email, phone, tax id and company registration number alongside
     // legal/trading name. Case-insensitive substring over all six (lower(...) + the V7

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/metrics/PartyPendingKycStalledGaugeTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/metrics/PartyPendingKycStalledGaugeTest.kt
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.party.infrastructure.metrics
+
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.party.application.port.out.PartyRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+
+/**
+ * #5698: parties stranded in `PENDING_KYC` were invisible because a swallowed failure produces no
+ * error to count. These tests assert the three properties that make the gauge a usable signal —
+ * it reports the aged count, it EXCLUDES healthy in-flight onboarding, and it refuses to report a
+ * stale value when the query fails.
+ */
+class PartyPendingKycStalledGaugeTest {
+
+    private val now = Instant.parse("2026-08-19T12:00:00Z")
+    private val clock = Clock.fixed(now, ZoneOffset.UTC)
+    private val stallAfter = Duration.ofHours(24)
+
+    private fun gauge(repo: PartyRepository, metrics: DomainMetrics) =
+        PartyPendingKycStalledGauge(repo, metrics, clock, stallAfter)
+
+    @Test
+    fun `the registered supplier tracks the refreshed count`(): Unit = runBlocking {
+        val repo = mockk<PartyRepository>()
+        val metrics = mockk<DomainMetrics>()
+        val supplier = slot<() -> Number>()
+        val stage = slot<String>()
+        every { metrics.registerOnboardingStalled(capture(stage), capture(supplier)) } returns Unit
+        coEvery { repo.countPendingKycOlderThan(any()) } returns 10L
+
+        val g = gauge(repo, metrics)
+        g.register()
+
+        assertThat(stage.captured).isEqualTo("party-pending-kyc")
+        // Micrometer reads the cached value, so before any refresh it must be 0 rather than blocking.
+        assertThat(supplier.captured().toLong()).isZero()
+        g.refresh()
+        assertThat(supplier.captured().toLong()).isEqualTo(10L)
+    }
+
+    @Test
+    fun `the cutoff excludes parties younger than the stall window`(): Unit = runBlocking {
+        // The property that stops this alarming on healthy traffic: PENDING_KYC is the CORRECT
+        // state for a freshly created party, so only the age cutoff separates a stall from normal
+        // onboarding in flight. Asserts the exact instant handed to the query.
+        val repo = mockk<PartyRepository>()
+        val metrics = mockk<DomainMetrics>()
+        every { metrics.registerOnboardingStalled(any(), any()) } returns Unit
+        val cutoff = slot<Instant>()
+        coEvery { repo.countPendingKycOlderThan(capture(cutoff)) } returns 0L
+
+        gauge(repo, metrics).refresh()
+
+        assertThat(cutoff.captured).isEqualTo(now.minus(stallAfter))
+        assertThat(cutoff.captured).isBefore(now)
+    }
+
+    @Test
+    fun `a failing query propagates instead of freezing the gauge at a healthy-looking value`(): Unit = runBlocking {
+        // The #5698 shape applied to the detector itself: if the refresh swallowed its own failure,
+        // the gauge would hold its last value — most likely 0 — and read as healthy forever while
+        // measuring nothing. The scheduler must see the throw.
+        val repo = mockk<PartyRepository>()
+        val metrics = mockk<DomainMetrics>()
+        val supplier = slot<() -> Number>()
+        every { metrics.registerOnboardingStalled(any(), capture(supplier)) } returns Unit
+        coEvery { repo.countPendingKycOlderThan(any()) } returnsMany listOf(7L) andThenThrows
+            IllegalStateException("db down")
+
+        val g = gauge(repo, metrics)
+        g.register()
+        g.refresh()
+        assertThat(supplier.captured().toLong()).isEqualTo(7L)
+
+        assertThatThrownBy { runBlocking { g.refresh() } }
+            .isInstanceOf(IllegalStateException::class.java)
+        // and the last good value is still what is served — not silently reset to a healthy 0
+        assertThat(supplier.captured().toLong()).isEqualTo(7L)
+        coVerify(exactly = 2) { repo.countPendingKycOlderThan(any()) }
+    }
+}


### PR DESCRIPTION
Closes the **detection** box #5698 left unchecked: *"nothing today notices a party that never got a
case."* #5699/#5715/#5719 fixed the cause; this makes the next occurrence visible.

Ten of 73 sandbox parties were stranded in `PENDING_KYC`, the oldest for ten weeks, and the first
thing to notice was a customer saying their account did not work.

## Why a census gauge, not a rate

A swallowed failure produces **no error to count**: no exception escapes, consumer lag is zero, the
DLQ is empty, no request failed. The only observable is the party still sitting in the stage — so
the signal has to be a periodic census of the state itself.

Checked that all three existing onboarding alerts stay silent for this incident, **by
construction**:

| existing alert | why it was silent |
|---|---|
| `PartyEventDeadLettered` | the event was **acked** — it never reached the DLQ |
| `OnboardingAccountsNotFollowingParties` | other parties opened accounts that hour, so the fleet-wide disparity never appeared |
| `KafkaConsumerGroupLagStuck` | an acked message is not lag |

## Design choices, and what each rules out

**Age, not a raw count.** `PENDING_KYC` is the *correct* state between creation and the KYC verdict,
so a raw count alarms on healthy traffic. Only parties older than the stall window (default 24h,
configurable) are counted — which is why `> 0` is the right trigger and no arbitrary count threshold
is needed to let a small number hide.

**Symptom, not a party↔kyc reconciler.** A reconciler would catch only the missing-case cause and
would need a cross-service read to do it. Counting the symptom catches every cause with no new trust
boundary: the lost event, kyc-service unreachable, or a case opened and then stuck waiting on a
reviewer. *"Somebody's onboarding is stuck"* is the same alert in all three.

**`stage` is a metric label, not part of the name** — a second stalled stage (an account stuck
`PENDING_ACTIVATION`, a signature ceremony never completed) reuses `openbank_onboarding_stalled`
and the alert as-is.

## Who watches the watcher

The `scheduler-liveness-adoption` gate (ADR-0237) **caught this PR's first version**, and was right
to: a detector whose own tick can die silently has the exact failure mode it exists to catch — a
frozen gauge reads as a healthy zero. Now registers `registerWorkflowLiveness` (recorded only on the
completed path), and `refresh()` deliberately does **not** catch its own exception.

## Verification
- [x] `:openbank-party-service:test --tests "*PartyPendingKycStalledGaugeTest*"` — **3 tests, 0 skipped** (read from the JUnit XML, not the task status)
- [x] `ktlintCheck`, `detekt`, `compileKotlin`, `compileTestKotlin` — green
- [x] `run-gates.py --group gitops` — **PASS=30**, same as clean `main` (the one `UNFALSIFIED` loki entry is pre-existing, confirmed by stashing)

Tests assert the three properties that make the gauge usable: it reports the aged count, it
**excludes** parties younger than the window (the anti-false-alarm property), and a failing query
**propagates** instead of freezing the gauge at a healthy-looking value.

## Minor, noted not fixed
`gen-network-policies-drift-gate` runs `git diff --exit-code openbank-infra/gitops/components/` —
the whole directory rather than the generated `network-policies.yaml` files — so **any** uncommitted
change under `components/` fails it locally. Harmless on CI (the tree is clean there); it cost a few
minutes of diagnosis locally. Left alone rather than scope-creeping this PR.

Refs #5698
