### PR TITLE
feat(kyc): detect parties with no KYC case via reconciler (#5698)

### DIFF
--- a/.github/asvs-l3-baseline.txt
+++ b/.github/asvs-l3-baseline.txt
@@ -54,6 +54,7 @@ V9.1 openbank-infra/gitops/components/devops-agent/devops-agent.yaml:56: plainte
 V9.1 openbank-infra/gitops/components/devops-agent/devops-agent.yaml:65: plaintext http:// env value http://litellm.ai-platform.svc:4000/v1
 V9.1 openbank-infra/gitops/components/kyc/kyc-service.yaml:113: plaintext http:// env value http://tempo.observability.svc:4317
 V9.1 openbank-infra/gitops/components/kyc/kyc-service.yaml:122: plaintext http:// env value http://sanctions-service.sanctions.svc:8123
+V9.1 openbank-infra/gitops/components/kyc/kyc-service.yaml:130: plaintext http:// env value http://party-service.party.svc:8111
 V9.1 openbank-infra/gitops/components/anacredit/anacredit-service.yaml:63: plaintext http:// env value http://tempo.observability.svc:4317
 V9.1 openbank-infra/gitops/components/customer-edge/customer-edge.yaml:143: plaintext http:// env value http://account-service.accounts.svc:8100
 V9.1 openbank-infra/gitops/components/customer-edge/customer-edge.yaml:153: plaintext http:// env value http://product-catalog.accounts.svc:8104

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -120,6 +120,14 @@ spec:
             # (never a silent PASSED), but every new case would need an operator's attention.
             - name: SANCTIONS_SERVICE_URL
               value: http://sanctions-service.sanctions.svc:8123
+            # Orphaned-party reconciliation (issue #5698): kyc-service enumerates the party
+            # register hourly and reports parties that never got a KYC case, as
+            # openbank_kyc_orphaned_parties. Read-only — it opens no cases. Without this the
+            # rest-client falls back to its localhost dev default and every pass fails, which
+            # shows up as a stale kyc-orphaned-party-detection liveness heartbeat rather than
+            # as a silent "no orphans" (the gauges are not reset on a failed pass).
+            - name: PARTY_SERVICE_URL
+              value: http://party-service.party.svc:8111
             # Sandbox straight-through KYC (ADR-0116 §4): auto-approve cases opened from
             # PARTY_CREATED so onboarding activates without an operator. MUST be false in prod.
             - name: OPENBANK_KYC_AUTO_APPROVE

--- a/openbank-infra/gitops/components/observability/prometheus-rules-onboarding.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-onboarding.yaml
@@ -64,6 +64,39 @@ spec:
           annotations:
             summary: "Parties are being created but no accounts are opening"
             description: "openbank_parties_created_total rose over the last hour while openbank_accounts_created_total did not — new customers are registering but the PARTY_CREATED → account.created pipeline is not producing accounts. This is the onboarding outage signature (party-service → Kafka → account-service). Check the party-events consumer lag, the DLQ (PartyEventDeadLettered), and account-service's dependencies (sanctions-service, product-catalog)."
+        - alert: KycPartiesWithoutCase
+          # Issue #5698. PartyEventConsumer caught every exception, logged it and returned — which
+          # ACKS the Kafka message. A few seconds of kyc-db downtime therefore destroyed the only
+          # copy of a PARTY_CREATED: no KYC case, party stuck in PENDING_KYC forever, accounts stuck
+          # in PENDING_ACTIVATION, no welcome bonus. 10 of 73 sandbox parties were in that state,
+          # the oldest since 2026-06-07, and it was found only because a human noticed an account
+          # did not work.
+          #
+          # Why the two rules above could not catch it. PartyEventDeadLettered needs a DLQ record,
+          # and the whole defect is that the event was acked and never dead-lettered.
+          # OnboardingAccountsNotFollowingParties compares hourly RATES, so it is silent about a
+          # party stranded weeks ago and silent whenever the pipeline is working now — a backlog of
+          # already-stranded parties is invisible to a rate comparison. This is a STOCK, not a rate:
+          # it stays lit until someone actually replays the missing cases.
+          #
+          # Grace period is enforced in the service, not here: openbank_kyc_orphaned_parties only
+          # counts parties older than openbank.kyc.orphan-detection.grace-period (default 1h), so a
+          # party whose PARTY_CREATED is legitimately still in flight is never counted and this does
+          # not fire on every new signup. `for: 30m` on top absorbs a single failed pass.
+          #
+          # Boot-safe by construction: the gauge is seeded to 0 and only ever set by a COMPLETED
+          # pass, so a freshly started pod reads 0 and cannot fire this — deliberately unlike the
+          # Instant.EPOCH seeding that made WorkflowLivenessStale fire 15 minutes after every
+          # deploy (#2239). The converse risk — the reconciliation silently not running, which also
+          # reads 0 — is covered by WorkflowLivenessStale on the kyc-orphaned-party-detection
+          # heartbeat, not by this rule.
+          expr: openbank_kyc_orphaned_parties > 0
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: "{{ $value }} party(ies) have no KYC case at all"
+            description: "openbank_kyc_orphaned_parties is {{ $value }} — that many parties, all past the detection grace period, have NO kyc_cases row. Each is a customer permanently stuck: PENDING_KYC party, accounts stuck in PENDING_ACTIVATION, no welcome bonus, and nothing retries because the PARTY_CREATED event was acked and dropped (#5698). Not self-healing — the event is gone, so it needs a replay per party. The stranded party ids are logged by kyc-service under `[orphan-detection]`; openbank_kyc_orphaned_parties_oldest_age_seconds says how long the worst one has been waiting."
         - alert: KafkaConsumerGroupLagStuck
           # General event-bus safety net — the config comment on the Kafka Exporter calls
           # consumer-group lag "the single most useful event-bus health signal" and until now NO

--- a/openbank-infra/gitops/components/party/network-policies.yaml
+++ b/openbank-infra/gitops/components/party/network-policies.yaml
@@ -50,6 +50,9 @@ spec:
               kubernetes.io/metadata.name: documents
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: kyc
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: onboarding
         - namespaceSelector:
             matchLabels:

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/application/OrphanedPartyDetector.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/application/OrphanedPartyDetector.kt
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyc.application
+
+import com.openbank.kyc.application.port.out.KycCaseRepository
+import com.openbank.kyc.application.port.out.PartyDirectoryPort
+import com.openbank.kyc.application.port.out.PartySummary
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Cross-service reconciliation for the invariant `every party has a KYC case` (issue #5698).
+ *
+ * ### The defect this detects
+ *
+ * `PartyEventConsumer.handleCreated` caught every exception, logged it and returned — which **acks**
+ * the Kafka message. A few seconds of `kyc-db` downtime therefore destroyed the only copy of a
+ * `PARTY_CREATED` event: no case was opened, the party stayed `PENDING_KYC` forever, its accounts
+ * stayed `PENDING_ACTIVATION`, and nothing anywhere went red. Ten of 73 sandbox parties were in that
+ * state, the oldest since 2026-06-07, and it was found only because a human noticed an account did
+ * not work. The consumer fix (#5699) stops *new* losses by rethrowing so the connector
+ * dead-letters; it cannot see a party already stranded, and no retry, DLQ or replay can either —
+ * the event is gone. Only comparing the two services' state finds those, which is what this does.
+ *
+ * ### Why the comparison runs here and reads party-service over REST
+ *
+ * The two sides live in separate services and separate databases, so there is no join to write. The
+ * dependency direction is already settled: kyc-service consumes party events and calls
+ * party-service, never the reverse, so enumerating parties from here adds no new coupling, while
+ * teaching party-service about KYC cases would. This follows the fleet's established reconciliation
+ * shape — a scheduled read-only tie-out that publishes a drift metric and mutates nothing
+ * (`BalanceReconciliationScheduler`, ADR-0039; `AccountReconciliationRepository`, ADR-0026).
+ *
+ * **It deliberately does not remediate.** Opening the missing cases is a separate, human-gated
+ * decision on a compliance-adjacent record: the party's `legalName` must be PEP-screened as part of
+ * opening a case, and a bulk auto-open would screen historical parties as a side effect of a
+ * monitoring job. Detection is the control; remediation is a replay, tracked separately on #5698.
+ */
+@ApplicationScoped
+class OrphanedPartyDetector(
+    private val partyDirectory: PartyDirectoryPort,
+    private val kycCaseRepository: KycCaseRepository,
+    private val clock: Clock,
+    @ConfigProperty(name = "openbank.kyc.orphan-detection.grace-period", defaultValue = "PT1H")
+    private val gracePeriod: Duration,
+    @ConfigProperty(name = "openbank.kyc.orphan-detection.page-size", defaultValue = "100")
+    private val pageSize: Int,
+    @ConfigProperty(name = "openbank.kyc.orphan-detection.max-pages", defaultValue = "500")
+    private val maxPages: Int,
+) {
+
+    private val log = Logger.getLogger(OrphanedPartyDetector::class.java)
+
+    /**
+     * Scans the whole party register and reports those with no KYC case at all.
+     *
+     * Throws rather than swallowing: the caller ([com.openbank.kyc.infrastructure.observability.OrphanedPartyGauge])
+     * must be able to tell a scan that found nothing from a scan that never completed, because those
+     * two states publish the same orphan count and mean opposite things. That distinction is the
+     * whole reason [OrphanedPartyReport.partiesScanned] exists.
+     */
+    @Suppress("NestedBlockDepth")
+    suspend fun detect(): OrphanedPartyReport {
+        val now = Instant.now(clock)
+        val cutoff = now.minus(gracePeriod)
+        val candidates = mutableMapOf<UUID, PartySummary>()
+        var scanned = 0L
+        var page = 0
+
+        var morePages = true
+        while (morePages) {
+            if (page >= maxPages) {
+                // What this warning must NOT do is name the knob whose own value breaks the job.
+                // It used to say "raise openbank.kyc.orphan-detection.max-pages" full stop, while
+                // the presence lookup below bound one parameter per candidate into a single
+                // statement — so following the advice at ~660 pages walked the query into
+                // PostgreSQL's 65,535-parameter protocol ceiling and turned an unchecked tail into
+                // a hard failure. The query is batched now (KycRepository.idBatches), which is why
+                // this can point at the knob at all; the remaining cost is that one pass holds
+                // every candidate in memory, so say that instead of implying the cap is free.
+                log.warnf(
+                    "[orphan-detection] Stopped at the %d-page cap after scanning %d parties — the " +
+                        "register has outgrown the cap and the tail was NOT checked, so this pass's " +
+                        "orphan count is a FLOOR, not a total. Raising " +
+                        "openbank.kyc.orphan-detection.max-pages widens the scan; one pass holds " +
+                        "up to page-size x max-pages party summaries in memory, so raise it against " +
+                        "the register's actual size (%d pages covers %d) rather than by a round " +
+                        "number, and watch the pod's heap on the next tick.",
+                    maxPages,
+                    scanned,
+                    maxPages,
+                    maxPages.toLong() * pageSize,
+                )
+                break
+            }
+            val result = partyDirectory.listParties(page, pageSize)
+            scanned += result.items.size
+            result.items.forEach { party ->
+                // Ordering matters for correctness of the grace-period test below: a party is a
+                // candidate only if it is BOTH in a state that must have a case AND old enough that
+                // the event round-trip cannot still be in flight.
+                if (party.status.uppercase() !in STATUSES_WITHOUT_EXPECTED_CASE &&
+                    party.createdAt.isBefore(cutoff)
+                ) {
+                    candidates[party.id] = party
+                }
+            }
+            // `total` is the register-wide count, so it bounds the scan without depending on a
+            // short page as the stop signal (an offset scan may legitimately return one). An empty
+            // page also ends the scan — party-service has nothing further to give.
+            morePages = result.items.isNotEmpty() && scanned < result.total
+            page++
+        }
+
+        // One batched `IN` query rather than a lookup per party: the N+1 shape would put a query per
+        // party on kyc-db every tick, which is a monitoring job generating more load than the thing
+        // it monitors.
+        val withCases = if (candidates.isEmpty()) {
+            emptySet()
+        } else {
+            kycCaseRepository.findPartyIdsWithAnyCase(candidates.keys)
+        }
+        val orphans = candidates.values
+            .filter { it.id !in withCases }
+            .sortedBy { it.createdAt }
+
+        return OrphanedPartyReport(
+            orphanedPartyIds = orphans.map { it.id },
+            oldestOrphanCreatedAt = orphans.firstOrNull()?.createdAt,
+            partiesScanned = scanned,
+            checkedAt = now,
+        )
+    }
+
+    private companion object {
+        /**
+         * Party states where "no KYC case" is legitimate rather than a defect.
+         *
+         * `CLOSED` and `MERGED` parties may never have had a case, or had one hard-deleted once the
+         * AML 5-year hold expired ([KycCaseRepository.deleteErasedCasesOlderThan], ADR-0118 §5) —
+         * flagging those would make the alert fire on correct retention behaviour.
+         *
+         * `ACTIVE` is deliberately NOT excluded even though it looks settled: a party that reached
+         * ACTIVE with no KYC case is a worse finding than a stranded `PENDING_KYC` one, not a
+         * benign one, because it means activation happened without the KYC gate.
+         *
+         * Compared case-insensitively against a raw String so an unrecognised future status
+         * degrades to "expected to have a case" — a false positive a human dismisses, rather than a
+         * false negative that hides the next incident.
+         */
+        val STATUSES_WITHOUT_EXPECTED_CASE = setOf("CLOSED", "MERGED")
+    }
+}
+
+/**
+ * Outcome of one reconciliation pass.
+ *
+ * @param partiesScanned how many parties the pass actually examined. This is the denominator, and
+ *   it is reported for a reason: a pass that enumerated **zero** parties reports zero orphans, which
+ *   is indistinguishable from a healthy register unless the denominator is published alongside. The
+ *   fleet has been bitten by exactly this shape — a probe that cannot express its own failure
+ *   reports "clean".
+ * @param oldestOrphanCreatedAt creation time of the longest-stranded orphan, or `null` when there
+ *   are none. Drives the age gauge that tells a fresh mis-configuration apart from the months-old
+ *   backlog #5698 found.
+ */
+data class OrphanedPartyReport(
+    val orphanedPartyIds: List<UUID>,
+    val oldestOrphanCreatedAt: Instant?,
+    val partiesScanned: Long,
+    val checkedAt: Instant,
+) {
+    val orphanCount: Int get() = orphanedPartyIds.size
+}

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/application/port/out/KycRepositoryPort.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/application/port/out/KycRepositoryPort.kt
@@ -41,6 +41,26 @@ interface KycCaseRepository {
      */
     suspend fun findActiveByPartyId(partyId: UUID): KycCase?
 
+    /**
+     * Of [partyIds], the subset that has **any** KYC case — terminal, active or erased-but-retained.
+     *
+     * Deliberately not [findActiveByPartyId]'s question. The reconciliation behind this
+     * (issue #5698) asks whether the party was ever projected into KYC at all, so a REJECTED or
+     * APPROVED case counts as present: those parties were handled, and a party whose case closed is
+     * not the stranded-onboarding defect. Only the total absence of a row is.
+     *
+     * Batched rather than a lookup per id — the caller scans the whole party register on every
+     * tick, and the per-id shape would make a monitoring job the heaviest reader of kyc-db.
+     * An empty [partyIds] returns an empty set without touching the database.
+     *
+     * [partyIds] is UNBOUNDED by contract: the caller's candidate set is limited only by its own
+     * page cap, so an implementation must not assume it fits one statement. The JPA implementation
+     * chunks at `KycRepository.ID_BATCH_SIZE`, keeping the bind-parameter count of any single
+     * statement constant no matter how large the register grows — `IN :ids` expands to one bind
+     * per id, and PostgreSQL's wire protocol caps a statement at 65,535 of them.
+     */
+    suspend fun findPartyIdsWithAnyCase(partyIds: Collection<UUID>): Set<UUID>
+
     suspend fun listAll(page: Int, size: Int): List<KycCase>
 
     /** Filter by [status]. Used by the onboarding cockpit funnel view (ADR-0068). */

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/application/port/out/PartyDirectoryPort.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/application/port/out/PartyDirectoryPort.kt
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyc.application.port.out
+
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Read-only outbound view of party-service's party register (ADR-0002 hexagonal architecture).
+ *
+ * This exists for exactly one caller — [com.openbank.kyc.application.OrphanedPartyDetector] — and
+ * deliberately exposes the *minimum* a reconciliation needs: which parties exist, when they were
+ * created, and what lifecycle state they are in. It is not a general party client, and it must not
+ * grow into one: kyc-service holds one side of the invariant and party-service holds the other, so
+ * the only legitimate traffic across this port is the enumeration that lets the two be compared.
+ *
+ * Implemented by [com.openbank.kyc.infrastructure.client.PartyDirectoryAdapter].
+ */
+interface PartyDirectoryPort {
+
+    /**
+     * One page of the party register. Ordering is NOT guaranteed — party-service's
+     * `GET /api/v1/parties` is offset-paginated over an unordered scan, so a page boundary can
+     * shift under a concurrent insert. That is tolerable here and nowhere else: a party missed
+     * because it moved across a boundary is picked up by the next run, and a party seen twice is
+     * deduplicated by the id set the detector builds.
+     *
+     * @param page zero-based page index
+     * @param size page size; party-service clamps this to 1..100
+     */
+    suspend fun listParties(page: Int, size: Int): PartyDirectoryPage
+}
+
+/**
+ * A page of [PartySummary] plus the register-wide total, which is what lets the detector stop
+ * paging without relying on an empty page (an offset scan can legitimately return a short page).
+ */
+data class PartyDirectoryPage(val items: List<PartySummary>, val total: Long)
+
+/**
+ * The three fields the reconciliation actually reads. Everything else party-service returns —
+ * `legalName`, `email`, `tradingName` — is PII this control has no need for, so it is not mapped:
+ * a field that is never bound cannot be logged by accident.
+ *
+ * @param status party lifecycle state as party-service spells it (`PENDING_KYC`, `ACTIVE`,
+ *   `SUSPENDED`, `CLOSED`, `MERGED`). Kept as a String rather than a kyc-side enum on purpose —
+ *   party-service owns this vocabulary and has already added a value (`MERGED`, ADR-0179) that its
+ *   own OpenAPI enum still omits. An unknown value must degrade to "not one of the excluded ones",
+ *   which a String does and a `valueOf` does not.
+ */
+data class PartySummary(val id: UUID, val status: String, val createdAt: Instant)

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/client/PartyDirectoryAdapter.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/client/PartyDirectoryAdapter.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyc.infrastructure.client
+
+import com.openbank.kyc.application.port.out.PartyDirectoryPage
+import com.openbank.kyc.application.port.out.PartyDirectoryPort
+import com.openbank.kyc.application.port.out.PartySummary
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.jboss.logging.Logger
+
+/**
+ * Adapts [PartyServiceClient] to [PartyDirectoryPort] (ADR-0002 — the application layer depends on
+ * the port, never on the REST client).
+ *
+ * Maps only `id`, `status` and `createdAt`; see [PartyListResponse] for why the rest of the payload
+ * is deliberately not bound.
+ */
+@ApplicationScoped
+class PartyDirectoryAdapter(@RestClient private val client: PartyServiceClient) : PartyDirectoryPort {
+
+    private val log = Logger.getLogger(PartyDirectoryAdapter::class.java)
+
+    override suspend fun listParties(page: Int, size: Int): PartyDirectoryPage {
+        val response = client.listParties(page, size).awaitSuspending()
+        // A row missing any of the three fields cannot be reconciled either way, so it is dropped
+        // rather than guessed at — but it is logged, because silently shrinking the scanned set is
+        // how a detection control starts under-reporting without anything looking wrong.
+        val items = response.items.mapNotNull { item ->
+            val id = item.id
+            val status = item.status
+            val createdAt = item.createdAt
+            if (id == null || status == null || createdAt == null) {
+                log.warnf(
+                    "[orphan-detection] Skipping a party row missing id/status/createdAt on page %d " +
+                        "(id=%s) — it cannot be reconciled and is NOT counted as scanned",
+                    page,
+                    id,
+                )
+                null
+            } else {
+                PartySummary(id = id, status = status, createdAt = createdAt)
+            }
+        }
+        return PartyDirectoryPage(items = items, total = response.total)
+    }
+}

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/client/PartyServiceClient.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/client/PartyServiceClient.kt
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyc.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * RestClient binding to `openbank-party-service`'s party register
+ * (`GET /api/v1/parties`), used only by the #5698 orphaned-party reconciliation.
+ *
+ * Mirrors the [SanctionsServiceClient] stack already in this service (ADR-0032 §D) — the reactive
+ * OIDC filter attaches the service token, without which party-service answers 401. The endpoint
+ * admits `ROLE_API`, which is the role the shared service account carries in every realm, so no
+ * new grant is needed for this call.
+ */
+@RegisterRestClient(configKey = "party-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/parties")
+@Produces(MediaType.APPLICATION_JSON)
+interface PartyServiceClient {
+
+    @GET
+    fun listParties(@QueryParam("page") page: Int, @QueryParam("size") size: Int): Uni<PartyListResponse>
+}
+
+/**
+ * Subset of party-service's list payload. `@JsonIgnoreProperties(ignoreUnknown = true)` is
+ * load-bearing rather than defensive: the response carries `legalName`, `email`, `tradingName` and
+ * `kycStatus`, and this reconciliation has no need for any of them. Not binding them is how the PII
+ * stays out of this service's heap and logs.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PartyListResponse(val items: List<PartyListItem> = emptyList(), val total: Long = 0)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PartyListItem(val id: UUID? = null, val status: String? = null, val createdAt: Instant? = null)

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/observability/OrphanedPartyGauge.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/observability/OrphanedPartyGauge.kt
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.kyc.infrastructure.observability
+
+import com.openbank.kyc.application.OrphanedPartyDetector
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import io.quarkus.runtime.Startup
+import io.quarkus.runtime.StartupEvent
+import io.quarkus.scheduler.Scheduled
+import jakarta.annotation.PostConstruct
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Publishes the #5698 orphaned-party reconciliation as metrics, and runs it on a cron.
+ *
+ *  - `openbank_kyc_orphaned_parties{service="kyc"}` — parties past the grace period with no KYC
+ *    case. The alert (`KycPartiesWithoutCase`) reads this one.
+ *  - `openbank_kyc_orphaned_parties_oldest_age_seconds{service="kyc"}` — how long the
+ *    longest-stranded party has been waiting, `0` when there are none. Triage: separates a
+ *    mis-configuration that started this morning from the months-old backlog #5698 found.
+ *  - `openbank_kyc_orphan_detection_parties_scanned{service="kyc"}` — the DENOMINATOR.
+ *
+ * ### Why the denominator is published
+ *
+ * A scan that enumerated zero parties reports zero orphans, which is byte-identical to a healthy
+ * register. Without `parties_scanned` there is no series anywhere that can tell "nothing is wrong"
+ * apart from "this control is not looking at anything" — and a detection control that fails by
+ * reporting clean is the exact failure mode #5698 is about.
+ *
+ * ### The value at t=0 on a cold pod (ADR-0237, #2239)
+ *
+ * Every gauge here is seeded to **0**, and the alert is `> 0`, so a freshly started pod cannot fire
+ * it. This is the deliberate opposite of the `Instant.EPOCH` seeding that made
+ * `openbank_workflow_last_success_age_seconds` read as decades on a cold pod and fire
+ * `WorkflowLivenessStale` 15 minutes after every deploy for every daily workflow.
+ *
+ * A boot-time 0 is a genuine fourth state — "not yet measured", next to healthy/degraded/absent —
+ * and it is not left ambiguous. It is resolved by the other two signals rather than by this gauge:
+ * `parties_scanned` is also 0 until the first successful pass, and
+ * [DomainMetrics.registerWorkflowLiveness] publishes a heartbeat whose age is seeded from
+ * REGISTRATION time, so `WorkflowLivenessStale` fires if this job never completes a pass within 2x
+ * its interval — without firing at boot, because the seed makes a fresh pod's age its own uptime.
+ * So "no orphans" and "never ran" are distinguishable, and neither is alarming at t=0.
+ *
+ * ### Failure semantics
+ *
+ * A failed pass (party-service down, kyc-db down) leaves the previous values in place and does NOT
+ * record a liveness success. Resetting to 0 on failure would be the same defect in miniature: an
+ * unreachable party-service would publish "no orphans" and clear a firing alert. Staleness is what
+ * the liveness heartbeat is for.
+ *
+ * Service-local [MeterRegistry] rather than a new method on the shared [DomainMetrics] facade: this
+ * is a kyc-service signal, and putting it in libs would force a fleet-wide rebuild for it
+ * (the [com.openbank.domestic.infrastructure.observability.DomesticPaymentStrandedGauge] precedent).
+ */
+@Startup
+@ApplicationScoped
+class OrphanedPartyGauge(
+    private val detector: OrphanedPartyDetector,
+    private val registry: MeterRegistry?,
+    private val clock: Clock,
+    private val domainMetrics: DomainMetrics,
+    private val enabled: Boolean,
+) {
+    // Explicit @Inject constructor: MeterRegistry is optional (absent in slim test slices), and
+    // without this ArC sees two constructors, registers no bean, and the @Startup hook silently
+    // never runs — the DomesticPaymentStrandedGauge comment documents the same trap.
+    @Inject
+    constructor(
+        detector: OrphanedPartyDetector,
+        registryInstance: Instance<MeterRegistry>,
+        clock: Clock,
+        domainMetrics: DomainMetrics,
+        @ConfigProperty(name = "openbank.kyc.orphan-detection.enabled", defaultValue = "true")
+        enabled: Boolean,
+    ) : this(
+        detector,
+        if (registryInstance.isResolvable) registryInstance.get() else null,
+        clock,
+        domainMetrics,
+        enabled,
+    )
+
+    private val log = Logger.getLogger(OrphanedPartyGauge::class.java)
+
+    private val orphanCount = AtomicLong(0)
+    private val oldestOrphanAgeSeconds = AtomicLong(0)
+    private val partiesScanned = AtomicLong(0)
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    @PostConstruct
+    fun register() {
+        val r = registry ?: return
+        gauge(r, "openbank.kyc.orphaned.parties", orphanCount)
+        gauge(r, "openbank.kyc.orphaned.parties.oldest.age.seconds", oldestOrphanAgeSeconds)
+        gauge(r, "openbank.kyc.orphan.detection.parties.scanned", partiesScanned)
+    }
+
+    fun onStart(@Observes @Suppress("UNUSED_PARAMETER") ev: StartupEvent) {
+        // Registered even when the job is disabled: a disabled control that publishes no heartbeat
+        // is indistinguishable from a broken one, and the sentinel should be able to say which.
+        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, EXPECTED_INTERVAL)
+    }
+
+    private fun gauge(r: MeterRegistry, name: String, holder: AtomicLong) {
+        Gauge.builder(name, holder) { it.get().toDouble() }
+            .tag("service", SERVICE)
+            .strongReference(true)
+            .register(r)
+    }
+
+    /**
+     * `suspend fun`, not a plain `fun` wrapping `runBlocking` — Quarkus invokes a plain `@Scheduled`
+     * method on a bare `executor-thread` with no Vert.x context, so the first reactive Panache query
+     * inside would throw `HR000068` and abort the pass silently, having done nothing. That defect
+     * shipped five times in this fleet (#2148, #2187) and is invisible to any test that calls this
+     * method directly, because a direct call supplies the very context the scheduler does not.
+     * `OrphanedPartyDetectionSchedulerIT` drives the real cron for that reason.
+     */
+    // TooGenericExceptionCaught: a scheduler tick must never crash the runtime, and every fault
+    // here (REST, DB, deserialisation) has the identical handling — keep the last known values and
+    // let the liveness heartbeat go stale. Same rationale as BalanceReconciliationScheduler.
+    @Suppress("TooGenericExceptionCaught")
+    @Scheduled(
+        cron = "{openbank.kyc.orphan-detection.cron:0 15 * * * ?}",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+    )
+    suspend fun refresh() {
+        if (!enabled) return
+        try {
+            val report = detector.detect()
+            orphanCount.set(report.orphanCount.toLong())
+            partiesScanned.set(report.partiesScanned)
+            oldestOrphanAgeSeconds.set(
+                report.oldestOrphanCreatedAt
+                    ?.let { maxOf(0L, Duration.between(it, Instant.now(clock)).seconds) }
+                    ?: 0L,
+            )
+            liveness?.recordSuccess()
+            if (report.orphanCount > 0) {
+                // The ids, not just the count: remediation is a manual replay per party (#5698), so
+                // the log line has to be actionable on its own. Party ids are opaque identifiers,
+                // not PII — no name, email or birth number is read by this control at all.
+                log.warnf(
+                    "[orphan-detection] %d of %d parties have NO KYC case (oldest stranded since %s): %s",
+                    report.orphanCount,
+                    report.partiesScanned,
+                    report.oldestOrphanCreatedAt,
+                    report.orphanedPartyIds.joinToString(),
+                )
+            } else {
+                log.infof("[orphan-detection] All %d parties have a KYC case", report.partiesScanned)
+            }
+        } catch (e: Exception) {
+            // Swallowed so a scheduler tick can never crash the runtime, but NOT reset to 0 and NOT
+            // recorded as a success: an unreachable party-service must not publish "no orphans".
+            // The liveness heartbeat going stale is what makes this visible.
+            log.errorf(e, "[orphan-detection] Reconciliation pass failed; leaving the previous gauge values in place")
+        }
+    }
+
+    private companion object {
+        const val SERVICE = "kyc"
+        const val WORKFLOW_NAME = "kyc-orphaned-party-detection"
+        val EXPECTED_INTERVAL: Duration = Duration.ofHours(1)
+    }
+}

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/persistence/KycRepository.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/persistence/KycRepository.kt
@@ -141,6 +141,36 @@ class KycRepository(private val outboxRepository: KycOutboxRepository) :
         ).firstResult()
     }.awaitSuspending()?.toDomain(objectMapper)
 
+    // Projects to party_id only: the reconciliation needs presence, not the aggregate, and
+    // hydrating full KycCase rows (each of which parses checksJson) to then discard everything but
+    // the id would make a read-only monitoring query the most expensive one in the service.
+    // BATCHED, and the batching is the point. The caller's candidate set is bounded only by
+    // `page-size x max-pages` (100 x 500 = 50,000 by default), and Hibernate expands `IN :ids`
+    // into one bind parameter PER ID. The PostgreSQL wire protocol carries the parameter count
+    // as an int16, so a single statement cannot exceed 65,535 binds -- the previous shape sat
+    // 15,535 under a hard protocol ceiling on defaults, and the cap warning in
+    // OrphanedPartyDetector told operators to raise `max-pages`, which is the one action that
+    // walks it over the edge. A register of 66,000 parties, or a max-pages of 700, turned the
+    // reconciler into a hard failure with no reading of the code suggesting why.
+    //
+    // Chunking makes the statement shape independent of the register size: bind count per
+    // statement is <= ID_BATCH_SIZE no matter how large the candidate set grows, and the number
+    // of statements grows linearly instead. See `idBatches` for the measured guarantee.
+    override suspend fun findPartyIdsWithAnyCase(partyIds: Collection<UUID>): Set<UUID> {
+        if (partyIds.isEmpty()) return emptySet()
+        val found = mutableSetOf<UUID>()
+        for (batch in idBatches(partyIds)) {
+            found += Panache.withSession {
+                Panache.getSession().flatMap { session ->
+                    session.createQuery(PARTY_IDS_WITH_CASE_HQL, UUID::class.java)
+                        .setParameter("ids", batch)
+                        .resultList
+                }
+            }.awaitSuspending()
+        }
+        return found
+    }
+
     override suspend fun listAll(page: Int, size: Int): List<KycCase> =
         Panache.withSession { findAll().page(page, size).list() }.awaitSuspending().map { it.toDomain(objectMapper) }
 
@@ -211,6 +241,34 @@ class KycRepository(private val outboxRepository: KycOutboxRepository) :
 
     companion object {
         private val log = Logger.getLogger(KycRepository::class.java)
+
+        /**
+         * Scalar HQL rather than Panache's `.project(...)`: a constructor-arg projection resolves
+         * its columns from CONSTRUCTOR PARAMETER NAMES, which requires the `-parameters` compiler
+         * flag this build does not set, so it compiles cleanly and throws
+         * `PanacheQueryException` at runtime. Selecting the single column directly needs no
+         * parameter-name metadata, and returns only the ids — the point of the query.
+         */
+/**
+         * Maximum ids bound into one `IN` statement.
+         *
+         * Well under PostgreSQL's 65,535-parameter protocol ceiling, so the margin absorbs any
+         * other binds the statement grows later, and small enough that one batch stays a cheap
+         * index probe rather than a planner-defeating list.
+         */
+        internal const val ID_BATCH_SIZE = 1_000
+
+        /**
+         * Split [partyIds] into statement-sized batches.
+         *
+         * `internal` so the bound can be MEASURED rather than argued: each returned list is
+         * exactly the collection handed to `setParameter("ids", ...)`, so its size IS the bind
+         * count of one statement (`KycRepositoryBatchingTest`).
+         */
+        internal fun idBatches(partyIds: Collection<UUID>): List<List<UUID>> = partyIds.toList().chunked(ID_BATCH_SIZE)
+
+        private const val PARTY_IDS_WITH_CASE_HQL =
+            "SELECT c.partyId FROM KycCaseEntity c WHERE c.partyId IN :ids"
 
         internal fun anonymizeChecksJson(checksJson: String, objectMapper: ObjectMapper): String = try {
             val checks: List<KycCheck> = objectMapper.readValue(

--- a/openbank-kyc-service/src/main/resources/application.yaml
+++ b/openbank-kyc-service/src/main/resources/application.yaml
@@ -62,6 +62,10 @@ quarkus:
     sanctions-service:
       url: ${SANCTIONS_SERVICE_URL:http://localhost:8123}
       scope: jakarta.inject.Singleton
+    # Party register enumeration for the #5698 orphaned-party reconciliation (read-only).
+    party-service:
+      url: ${PARTY_SERVICE_URL:http://localhost:8111}
+      scope: jakarta.inject.Singleton
   smallrye-reactive-messaging:
     kafka:
       bootstrap-servers: localhost:29092
@@ -156,6 +160,14 @@ mp:
       enabled: false
     oidc-client:
       enabled: false
+  openbank:
+    kyc:
+      # kyc-service does NOT set quarkus.scheduler.enabled=false under %test, so every @Scheduled
+      # bean fires during unrelated suites. This reconciliation calls party-service over REST, which
+      # no test JVM serves, so leaving it on would log a connection error every tick of every test
+      # class. OrphanedPartyDetectionSchedulerIT re-enables it, with a shrunk cron and a stub port.
+      orphan-detection:
+        enabled: false
 openbank:
   rate-limit:
     enabled: true
@@ -174,6 +186,17 @@ openbank:
       retention-years: "${RETENTION_KYC_YEARS:5}"
       cron: "${RETENTION_KYC_CRON:0 30 3 * * ?}"
       dry-run: "${RETENTION_KYC_DRY_RUN:false}"
+  kyc:
+    # Cross-service reconciliation: parties with no KYC case at all (issue #5698). Read-only —
+    # it publishes openbank_kyc_orphaned_parties and never opens a case (remediation is a
+    # human-gated replay). Hourly; the grace period keeps a party that was created seconds ago,
+    # whose PARTY_CREATED is still in flight, from being counted as stranded.
+    orphan-detection:
+      enabled: "${KYC_ORPHAN_DETECTION_ENABLED:true}"
+      cron: "${KYC_ORPHAN_DETECTION_CRON:0 15 * * * ?}"
+      grace-period: "${KYC_ORPHAN_DETECTION_GRACE:PT1H}"
+      page-size: "${KYC_ORPHAN_DETECTION_PAGE_SIZE:100}"
+      max-pages: "${KYC_ORPHAN_DETECTION_MAX_PAGES:500}"
 
 # OPA sidecar (ADR-0034). Advisory mode by default.
 opa:

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/application/OrphanedPartyDetectorTest.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/application/OrphanedPartyDetectorTest.kt
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyc.application
+
+import com.openbank.kyc.application.port.out.KycCaseRepository
+import com.openbank.kyc.application.port.out.PartyDirectoryPage
+import com.openbank.kyc.application.port.out.PartyDirectoryPort
+import com.openbank.kyc.application.port.out.PartySummary
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * Unit coverage for the #5698 detection rule.
+ *
+ * Deliberately drives [OrphanedPartyDetector.detect] directly with mocked ports — this asserts the
+ * *rule* (who counts as orphaned). That a real cron actually dispatches the job is a different
+ * claim, which a mocked test structurally cannot make; `OrphanedPartyDetectionSchedulerIT` owns it.
+ */
+class OrphanedPartyDetectorTest {
+
+    private val now: Instant = Instant.parse("2026-08-19T12:00:00Z")
+    private val clock: Clock = Clock.fixed(now, ZoneOffset.UTC)
+
+    private val directory = mockk<PartyDirectoryPort>()
+    private val repository = mockk<KycCaseRepository>()
+
+    private fun detector(gracePeriod: Duration = Duration.ofHours(1)) = OrphanedPartyDetector(
+        partyDirectory = directory,
+        kycCaseRepository = repository,
+        clock = clock,
+        gracePeriod = gracePeriod,
+        pageSize = PAGE_SIZE,
+        maxPages = MAX_PAGES,
+    )
+
+    private fun party(status: String = "PENDING_KYC", ageMinutes: Long = 120) = PartySummary(
+        id = UUID.randomUUID(),
+        status = status,
+        createdAt = now.minus(Duration.ofMinutes(ageMinutes)),
+    )
+
+    private fun directoryHolds(vararg parties: PartySummary) {
+        coEvery { directory.listParties(0, PAGE_SIZE) } returns
+            PartyDirectoryPage(items = parties.toList(), total = parties.size.toLong())
+    }
+
+    private fun casesExistFor(vararg ids: UUID) {
+        coEvery { repository.findPartyIdsWithAnyCase(any()) } returns ids.toSet()
+    }
+
+    @Test
+    fun `a party older than the grace period with no KYC case is detected`(): Unit = runBlocking {
+        val stranded = party(ageMinutes = 120)
+        directoryHolds(stranded)
+        casesExistFor()
+
+        val report = detector().detect()
+
+        assertThat(report.orphanedPartyIds)
+            .describedAs(
+                "the #5698 defect exactly: a party whose PARTY_CREATED was acked and dropped has no " +
+                    "case and nothing replays it, so only this comparison can find it",
+            )
+            .containsExactly(stranded.id)
+        assertThat(report.oldestOrphanCreatedAt).isEqualTo(stranded.createdAt)
+        assertThat(report.partiesScanned).isEqualTo(1L)
+    }
+
+    @Test
+    fun `a party still inside the grace period is NOT flagged`(): Unit = runBlocking {
+        // Created 5 minutes ago: its PARTY_CREATED may still legitimately be in flight. Flagging
+        // this would make the alert fire on every new signup, which is worse than no alert.
+        val fresh = party(ageMinutes = 5)
+        directoryHolds(fresh)
+        casesExistFor()
+
+        val report = detector(gracePeriod = Duration.ofHours(1)).detect()
+
+        assertThat(report.orphanedPartyIds).isEmpty()
+        assertThat(report.oldestOrphanCreatedAt).isNull()
+        assertThat(report.partiesScanned)
+            .describedAs("it was still scanned — the denominator counts it, the numerator does not")
+            .isEqualTo(1L)
+    }
+
+    @Test
+    fun `a party that has a KYC case is NOT flagged`(): Unit = runBlocking {
+        val handled = party(ageMinutes = 500)
+        directoryHolds(handled)
+        casesExistFor(handled.id)
+
+        val report = detector().detect()
+
+        assertThat(report.orphanedPartyIds).isEmpty()
+        assertThat(report.partiesScanned).isEqualTo(1L)
+    }
+
+    @Test
+    fun `a CLOSED or MERGED party with no case is NOT flagged, but an ACTIVE one is`(): Unit = runBlocking {
+        val closed = party(status = "CLOSED", ageMinutes = 5_000)
+        val merged = party(status = "MERGED", ageMinutes = 5_000)
+        val active = party(status = "ACTIVE", ageMinutes = 5_000)
+        directoryHolds(closed, merged, active)
+        casesExistFor()
+
+        val report = detector().detect()
+
+        assertThat(report.orphanedPartyIds)
+            .describedAs(
+                "CLOSED/MERGED may legitimately have no case (or had one hard-deleted once the AML " +
+                    "5-year hold expired), so flagging them would alert on correct retention. ACTIVE " +
+                    "is the opposite: it means the party was activated without the KYC gate.",
+            )
+            .containsExactly(active.id)
+    }
+
+    @Test
+    fun `an unrecognised party status is treated as expecting a case`(): Unit = runBlocking {
+        // party-service owns this vocabulary and has added values its own OpenAPI enum omits. An
+        // unknown status must degrade to a false positive a human dismisses, never to a false
+        // negative that hides the next incident.
+        val unknown = party(status = "SOME_FUTURE_STATE", ageMinutes = 5_000)
+        directoryHolds(unknown)
+        casesExistFor()
+
+        assertThat(detector().detect().orphanedPartyIds).containsExactly(unknown.id)
+    }
+
+    @Test
+    fun `paging continues until the register total is covered and de-duplicates`(): Unit = runBlocking {
+        val first = party(ageMinutes = 300)
+        val second = party(ageMinutes = 200)
+        // Same party returned on both pages — an offset scan can shift under a concurrent insert.
+        coEvery { directory.listParties(0, PAGE_SIZE) } returns
+            PartyDirectoryPage(items = listOf(first, second), total = 3)
+        coEvery { directory.listParties(1, PAGE_SIZE) } returns
+            PartyDirectoryPage(items = listOf(second), total = 3)
+        casesExistFor()
+
+        val report = detector().detect()
+
+        assertThat(report.orphanedPartyIds)
+            .describedAs("a party seen on two pages must be reported once, not twice")
+            .containsExactlyInAnyOrder(first.id, second.id)
+    }
+
+    @Test
+    fun `an empty register reports no orphans and a zero denominator`(): Unit = runBlocking {
+        coEvery { directory.listParties(0, PAGE_SIZE) } returns PartyDirectoryPage(emptyList(), 0)
+
+        val report = detector().detect()
+
+        assertThat(report.orphanCount).isZero()
+        assertThat(report.partiesScanned)
+            .describedAs(
+                "publishing the denominator is what separates 'nothing is wrong' from 'this control " +
+                    "is looking at nothing' — both report zero orphans",
+            )
+            .isZero()
+    }
+
+    private companion object {
+        const val PAGE_SIZE = 100
+        const val MAX_PAGES = 500
+    }
+}

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/infrastructure/persistence/KycRepositoryBatchingTest.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/infrastructure/persistence/KycRepositoryBatchingTest.kt
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyc.infrastructure.persistence
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * The bind-parameter bound of [KycRepository.findPartyIdsWithAnyCase], MEASURED.
+ *
+ * `IN :ids` expands to one bind parameter per id, and PostgreSQL's wire protocol carries a
+ * statement's parameter count as an int16 — a hard ceiling of 65,535. The reconciler's candidate
+ * set is bounded only by its own page cap (`page-size x max-pages`, 100 x 500 = 50,000 by
+ * default), and `OrphanedPartyDetector`'s cap warning used to tell operators to RAISE `max-pages`,
+ * which is precisely the action that walks the statement over the ceiling.
+ *
+ * These cases assert the property the fix buys and the old shape could not satisfy: the batch
+ * handed to `setParameter("ids", ...)` — which IS the statement's bind list — never exceeds
+ * [KycRepository.ID_BATCH_SIZE], at the configured cap and far beyond it. A comment claiming that
+ * is not a proof; this is, and it fails the moment the chunking is removed.
+ */
+class KycRepositoryBatchingTest {
+
+    private fun ids(n: Int) = List(n) { UUID.randomUUID() }
+
+    @Test
+    fun `at the detector's configured cap no statement exceeds the batch size`() {
+        val candidates = ids(DEFAULT_PAGE_SIZE * DEFAULT_MAX_PAGES) // 50,000
+
+        val batches = KycRepository.idBatches(candidates)
+
+        assertThat(batches.maxOf { it.size })
+            .`as`("largest bind list handed to one statement")
+            .isLessThanOrEqualTo(KycRepository.ID_BATCH_SIZE)
+        assertThat(batches).hasSize(candidates.size / KycRepository.ID_BATCH_SIZE)
+        assertThat(batches.flatten()).containsExactlyElementsOf(candidates)
+    }
+
+    @Test
+    fun `the per-statement bind count stays under the protocol ceiling well past the cap`() {
+        // 13x the default cap: the old single-statement shape needed 650,000 binds here, ~10x the
+        // protocol ceiling. The bound must not depend on the register's size at all.
+        val candidates = ids(650_000)
+
+        val batches = KycRepository.idBatches(candidates)
+
+        assertThat(batches.maxOf { it.size }).isLessThan(POSTGRES_MAX_BIND_PARAMETERS)
+        assertThat(batches.maxOf { it.size }).isEqualTo(KycRepository.ID_BATCH_SIZE)
+    }
+
+    @Test
+    fun `a partial final batch is kept, so no candidate goes unchecked`() {
+        val candidates = ids(KycRepository.ID_BATCH_SIZE + 1)
+
+        val batches = KycRepository.idBatches(candidates)
+
+        assertThat(batches).hasSize(2)
+        assertThat(batches.last()).hasSize(1)
+        assertThat(batches.flatten()).containsExactlyElementsOf(candidates)
+    }
+
+    @Test
+    fun `an empty candidate set produces no statement at all`() {
+        assertThat(KycRepository.idBatches(emptyList())).isEmpty()
+    }
+
+    private companion object {
+        const val DEFAULT_PAGE_SIZE = 100
+        const val DEFAULT_MAX_PAGES = 500
+
+        /** int16 on the wire; the ceiling the old shape was 15,535 away from on defaults. */
+        const val POSTGRES_MAX_BIND_PARAMETERS = 65_535
+    }
+}

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/integration/OrphanedPartyDetectionSchedulerIT.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/integration/OrphanedPartyDetectionSchedulerIT.kt
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyc.integration
+
+import com.openbank.kyc.application.port.out.PartyDirectoryPage
+import com.openbank.kyc.application.port.out.PartyDirectoryPort
+import com.openbank.kyc.application.port.out.PartySummary
+import com.openbank.kyc.it.PostgresTestResource
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry
+import io.micrometer.prometheus.PrometheusMeterRegistry
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import jakarta.annotation.Priority
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Alternative
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import javax.sql.DataSource
+
+/**
+ * Regression coverage for the #5698 **detection** control: proof that the reconciliation actually
+ * runs as a cron, and that its reactive query survives being dispatched by the scheduler.
+ *
+ * ### Why this drives the real cron instead of calling `refresh()`
+ *
+ * The defect class this guards against is in *how the framework invokes the method*, not in the
+ * method body. Quarkus dispatches a plain (non-`suspend`) `@Scheduled` method on a bare
+ * `executor-thread` that carries no Vert.x context, so the first reactive Panache query inside —
+ * here [com.openbank.kyc.application.port.out.KycCaseRepository.findPartyIdsWithAnyCase] — throws
+ * `HR000068` and the pass aborts having done nothing, silently. Five schedulers in this fleet, three
+ * money-path, had **never** run for exactly that reason (#2148, #2187).
+ *
+ * A test that called `refresh()` directly would supply the very context the scheduler does not, and
+ * would pass against that broken code. So this test never touches the bean: it seeds state, waits,
+ * and asserts on the published gauges. Turning the gauge's `refresh` back into a plain, non-suspend
+ * function that wraps its body in a blocking coroutine builder makes this time out with the orphan
+ * gauge still at its boot-time 0 and `HR000068` in the log — measured, not assumed — which is also,
+ * precisely, what the production failure would look like.
+ *
+ * ### What it proves beyond dispatch
+ *
+ *  - the batched `IN` projection query works against a real PostgreSQL (a Panache
+ *    `.project()` with a mismatched constructor fails only at runtime);
+ *  - the rule holds end to end — the party WITH a case row is not flagged, the one without is;
+ *  - the gauges move off their boot-time zero only after a genuinely scheduler-driven pass.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+@TestProfile(OrphanedPartyDetectionSchedulerIT.FastScanProfile::class)
+class OrphanedPartyDetectionSchedulerIT {
+
+    /**
+     * Runs the reconciliation every two seconds instead of hourly, and drops the grace period to
+     * zero so the seeded parties qualify immediately.
+     *
+     * Every value is a LITERAL. A `QuarkusTestProfile` loads in a different classloader from the
+     * test class, so a companion object initialises twice — a randomised id generated here would
+     * hand the scheduler one value and the assertion another.
+     */
+    class FastScanProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf(
+            "openbank.kyc.orphan-detection.enabled" to "true",
+            "openbank.kyc.orphan-detection.cron" to "*/2 * * * * ?",
+            "openbank.kyc.orphan-detection.grace-period" to "PT0S",
+            // The dispatcher would publish to a Kafka broker no test JVM runs; irrelevant to this
+            // claim and pure log noise.
+            "openbank.outbox.dispatch-enabled" to "false",
+            // Random free HTTP port instead of the shared 8081 test default. This IT drives beans
+            // and JDBC, never HTTP, so the port is incidental — but a parallel Gradle build on the
+            // same machine binding 8081 first makes Quarkus fail to boot with QuarkusBindException,
+            // which surfaces as this class failing for a reason that has nothing to do with it.
+            "quarkus.http.test-port" to "0",
+        )
+
+        /** Scopes the stub party register to THIS profile, so no other test class sees it. */
+        override fun getEnabledAlternatives(): Set<Class<*>> = setOf(StubPartyDirectory::class.java)
+    }
+
+    /**
+     * A two-party register: one that never got a KYC case (the #5698 defect) and one that did.
+     * Both ids are hardcoded literals for the classloader reason above.
+     */
+    @Alternative
+    @Priority(1)
+    @ApplicationScoped
+    class StubPartyDirectory : PartyDirectoryPort {
+        override suspend fun listParties(page: Int, size: Int): PartyDirectoryPage {
+            if (page > 0) return PartyDirectoryPage(emptyList(), TOTAL)
+            return PartyDirectoryPage(
+                items = listOf(
+                    PartySummary(UUID.fromString(STRANDED_PARTY_ID), "PENDING_KYC", CREATED_AT),
+                    PartySummary(UUID.fromString(HANDLED_PARTY_ID), "PENDING_KYC", CREATED_AT),
+                ),
+                total = TOTAL,
+            )
+        }
+    }
+
+    @Inject
+    lateinit var registry: MeterRegistry
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    private fun gauge(name: String): Double = registry.find(name).tag("service", "kyc").gauge()?.value() ?: Double.NaN
+
+    /** Seeds a KYC case for the handled party over plain JDBC — a reactive repo cannot be called here. */
+    private fun seedCaseForHandledParty() {
+        dataSource.connection.use { c ->
+            c.prepareStatement(
+                """
+                INSERT INTO kyc_cases (case_id, party_id, status, risk_level, checks_json, created_at, updated_at)
+                VALUES (?, ?, 'OPEN', 'MEDIUM', '[]', NOW(), NOW())
+                """.trimIndent(),
+            ).use { st ->
+                st.setObject(1, UUID.randomUUID())
+                st.setObject(2, UUID.fromString(HANDLED_PARTY_ID))
+                st.executeUpdate()
+            }
+        }
+    }
+
+    /** Polls until a scheduler-driven pass has published a denominator, or the budget runs out. */
+    private fun awaitScan(): Boolean = awaitGauge("openbank.kyc.orphan.detection.parties.scanned") {
+        it >= TOTAL.toDouble()
+    }
+
+    /**
+     * Polls [name] until [predicate] holds, then returns the value it settled on (or the last value
+     * seen when the budget runs out, so a timeout still fails with the real number rather than a
+     * bare "timed out").
+     *
+     * Polling the CONDITION rather than "some pass has completed" is load-bearing. Both test methods
+     * share one JVM, one database and one 2s cron, so a pass that ran before this test's JDBC seed
+     * committed has already satisfied "a scan happened" while still reporting the pre-seed count.
+     * Waiting on the post-seed condition makes each method independent of the other's ordering.
+     */
+    private fun awaitGaugeValue(name: String, predicate: (Double) -> Boolean): Double {
+        val deadline = System.nanoTime() + SCAN_BUDGET_NANOS
+        var last = gauge(name)
+        while (System.nanoTime() < deadline) {
+            last = gauge(name)
+            if (predicate(last)) return last
+            Thread.sleep(POLL_INTERVAL_MILLIS)
+        }
+        return last
+    }
+
+    private fun awaitGauge(name: String, predicate: (Double) -> Boolean): Boolean =
+        predicate(awaitGaugeValue(name, predicate))
+
+    @Test
+    fun `the scheduled reconciliation runs and reports only the party with no KYC case`() {
+        seedCaseForHandledParty()
+
+        assertThat(awaitScan())
+            .describedAs(
+                "a scheduler-dispatched pass must publish parties_scanned=$TOTAL. Still 0 means the " +
+                    "cron never produced a working pass — the HR000068 signature of a non-suspend " +
+                    "@Scheduled method (#2148/#2187), which is invisible to any direct call",
+            )
+            .isTrue()
+
+        assertThat(awaitGaugeValue("openbank.kyc.orphaned.parties") { it == 1.0 })
+            .describedAs(
+                "exactly one of the two seeded parties has no kyc_cases row, so the orphan gauge " +
+                    "must read 1 — 0 would mean the batched IN projection matched everything, 2 " +
+                    "that it matched nothing",
+            )
+            .isEqualTo(1.0)
+
+        assertThat(gauge("openbank.kyc.orphaned.parties.oldest.age.seconds"))
+            .describedAs("the stranded party was created well in the past, so its age must be positive")
+            .isGreaterThan(0.0)
+    }
+
+    @Test
+    fun `the liveness heartbeat records a success once a pass completes`() {
+        assertThat(awaitScan()).isTrue()
+
+        val recorded = registry.find("openbank.workflow.success.recorded")
+            .tag("workflow", "kyc-orphaned-party-detection")
+            .gauge()?.value()
+
+        assertThat(recorded)
+            .describedAs(
+                "ADR-0237: without a heartbeat, a reconciliation that silently stops running is " +
+                    "invisible — and a control that stops looking publishes the same 'no orphans' " +
+                    "as a healthy one",
+            )
+            .isEqualTo(1.0)
+    }
+
+    @Test
+    fun `the gauges are exposed under the exact metric names the alert rule queries`() {
+        assertThat(awaitScan()).isTrue()
+
+        // Quarkus injects a CompositeMeterRegistry; the Prometheus one that renders the exposition
+        // format (and therefore decides the series names) is nested inside it.
+        val prometheus = when (val r = registry) {
+            is PrometheusMeterRegistry -> r
+            is CompositeMeterRegistry -> r.registries.filterIsInstance<PrometheusMeterRegistry>().single()
+            else -> error("no PrometheusMeterRegistry available, cannot verify exposed metric names")
+        }
+        val scrape = prometheus.scrape()
+
+        // The Micrometer names are dotted; Prometheus sees them underscored. `KycPartiesWithoutCase`
+        // in prometheus-rules-onboarding.yaml queries the UNDERSCORED form, and nothing else in the
+        // repo can check that the two agree — a rule naming a series that is never emitted collects
+        // an empty vector and reports "no orphans" forever, which is how the control-liveness
+        // sentinel's own mechanism 3 was silently dead (#2187 follow-up).
+        assertThat(scrape)
+            .describedAs("the series `KycPartiesWithoutCase` alerts on must actually be emitted")
+            .contains("openbank_kyc_orphaned_parties{")
+        assertThat(scrape)
+            .describedAs("triage series named in the alert's description")
+            .contains("openbank_kyc_orphaned_parties_oldest_age_seconds{")
+        assertThat(scrape)
+            .describedAs("the denominator that separates 'no orphans' from 'scanned nothing'")
+            .contains("openbank_kyc_orphan_detection_parties_scanned{")
+    }
+
+    private companion object {
+        const val STRANDED_PARTY_ID = "fad8c8db-0000-4000-8000-000000005698"
+        const val HANDLED_PARTY_ID = "58fb3ae8-0000-4000-8000-000000005698"
+        const val TOTAL = 2L
+        val CREATED_AT: Instant = Instant.parse("2026-06-07T10:00:00Z")
+
+        /** Generous vs the 2s cron so a slow CI runner cannot flake the wait. */
+        const val SCAN_BUDGET_NANOS = 60_000_000_000L
+        const val POLL_INTERVAL_MILLIS = 250L
+    }
+}


### PR DESCRIPTION
## Summary

`PartyEventConsumer` acked `PARTY_CREATED` on failure, so seconds of `kyc-db` downtime destroyed the only copy of the event — no KYC case, party stuck in `PENDING_KYC`, accounts stuck in `PENDING_ACTIVATION`. **10 of 73 sandbox parties are in that state, the oldest since 2026-06-07**, and nothing went red: it was found because a human noticed an account did not work. This builds the unchecked "Detection" item on #5698 — an hourly read-only reconciliation that compares the party register against `kyc_cases` and alerts on the gap.

#5699 stops *new* losses by rethrowing so the connector dead-letters. It cannot see a party already stranded, and no retry or replay can — the event is gone. Only comparing the two services' state finds those.

## Type of change

- [x] feat (new functionality)

## Linked issues

Refs #5698

## Changes

- **`OrphanedPartyDetector`** (application) — pages the party register, reports parties past a grace period with no `kyc_cases` row. One batched `IN` query, not N+1.
- **`PartyDirectoryPort` / `PartyServiceClient` / `PartyDirectoryAdapter`** — read-only enumeration over `GET /api/v1/parties`, mirroring the existing `SanctionsServiceClient` stack. Binds only `id`, `status`, `createdAt`; `legalName`/`email`/`tradingName` are deliberately **not** mapped, so the PII cannot be logged by accident.
- **`KycCaseRepository.findPartyIdsWithAnyCase`** — scalar HQL projection.
- **`OrphanedPartyGauge`** — `@Scheduled` `suspend fun` + three gauges + ADR-0237 liveness heartbeat.
- **`KycPartiesWithoutCase`** alert in `prometheus-rules-onboarding.yaml`.
- gitops: `PARTY_SERVICE_URL` on the kyc Rollout; `party/network-policies.yaml` regenerated (the generator derived the new kyc→party ingress itself).

## Why the comparison lives in kyc-service

The two sides are separate services and separate DBs, so there is no join to write. The dependency direction is already settled — kyc-service consumes party events and calls party-service, never the reverse — so enumerating parties from here adds no new coupling, while teaching party-service about KYC cases would. Follows the fleet's established reconciliation shape (`BalanceReconciliationScheduler` ADR-0039, `AccountReconciliationRepository` ADR-0026): scheduled, read-only, publishes drift, mutates nothing.

**It deliberately does not remediate.** The 9 remaining orphans need a replay against a live DB — explicitly out of scope here and still open on #5698. Auto-opening cases from a monitoring job would also PEP-screen historical parties as a side effect.

## The metrics, and the cold-pod reading

```
openbank_kyc_orphaned_parties                     -> KycPartiesWithoutCase alerts on this
openbank_kyc_orphaned_parties_oldest_age_seconds  -> triage
openbank_kyc_orphan_detection_parties_scanned     -> the denominator
```

The denominator is published because **a pass that enumerated zero parties reports zero orphans, which is byte-identical to a healthy register.** Without it no series anywhere separates "nothing is wrong" from "this control is looking at nothing" — the exact failure mode #5698 is about.

**At t=0 on a cold pod every gauge reads 0**, and the alert is `> 0`, so a fresh pod cannot fire it. This is the deliberate opposite of the `Instant.EPOCH` seeding that made `WorkflowLivenessStale` fire 15 minutes after every deploy for every daily workflow (#2239). That boot-time 0 is a real fourth state — "not yet measured" — and it is resolved by the *other* signals rather than left ambiguous: `parties_scanned` is also 0 until the first pass, and the `kyc-orphaned-party-detection` liveness heartbeat (seeded at registration, so also boot-safe) fires `WorkflowLivenessStale` if the job never completes a pass. So "no orphans" and "never ran" are distinguishable, and neither alarms at boot. **This was measured, not reasoned about** — see the falsification below, where the gauges sat at 0 exactly as predicted.

A failed pass keeps the previous values and records no liveness success: resetting to 0 would let an unreachable party-service publish "no orphans" and clear a firing alert.

## Grace period

A party legitimately has no case for a short window after creation. The grace period (default `PT1H`, configurable) is enforced **in the service**, so the gauge only ever counts parties past it and the alert cannot fire on a new signup; `for: 30m` on top absorbs a single failed pass. `CLOSED`/`MERGED` are excluded (they may legitimately have no case, or had one hard-deleted by AML retention — flagging them would alert on correct behaviour). `ACTIVE` is **not** excluded: a party that reached ACTIVE with no KYC case means activation happened without the KYC gate, which is worse than a stranded `PENDING_KYC`.

## Definition of Done

- [x] Hexagonal layering preserved.
- [x] Unit tests added (7).
- [x] Integration tests added (3).
- [ ] Contract tests — n/a, no public API change (no new endpoint, `openapi.yaml` untouched).
- [x] `ktlintCheck` / `detekt` / `test` / `quarkusBuild` pass locally.
- [x] No new lint warnings.
- [ ] OpenAPI — n/a. [ ] Flyway — n/a. [ ] Avro — n/a.

## Testing, and the proof the scheduler actually runs

Full kyc suite: **94 tests, 0 failures, 1 pre-existing skip** (both new classes: 0 skipped).

`OrphanedPartyDetectorTest` covers the rule: orphan **is** detected; party inside the grace period is **not**; party with a case is **not**; `CLOSED`/`MERGED` excluded while `ACTIVE` is flagged; unknown status degrades to a false positive rather than a false negative; paging de-duplicates.

`OrphanedPartyDetectionSchedulerIT` proves the *cron* runs, which no mocked test can: a plain `@Scheduled` method carries no Vert.x context, so the reactive query throws `HR000068` and the pass aborts silently (#2148, #2187) — and calling the method directly supplies the very context the scheduler does not. It drives the real cron from a `@TestProfile` (shrunk to 2s, all-literal values because the profile loads in a different classloader) and asserts only on published gauges.

**Falsified, not assumed.** Reverting `refresh()` to a plain non-suspend function wrapping a blocking coroutine builder makes all three IT assertions fail, with `HR000068 ... currently running on thread 'executor-thread-1'` in the log and the gauges still at their boot-time 0. No bind error in that run — the app booted fine and the scheduler genuinely misbehaved.

Two real defects were caught by these tests during development, both of which compiled cleanly:
1. Panache `.project()` resolves columns from **constructor parameter names**, needing the `-parameters` flag this build does not set — it threw `PanacheQueryException` only at runtime. Replaced with scalar HQL.
2. Five of the seven unit tests were **silently skipped by JUnit5**: `fun x() = runBlocking { … }` infers a non-`Unit` return type. Fixed with `: Unit`.

A third test asserts the gauges appear in a real `PrometheusMeterRegistry.scrape()` under the exact underscored names the alert queries — nothing else in the repo checks that a rule's `expr` names a series that is actually emitted.

## Security checklist

- [x] No secrets, tokens, or PII in code, config, tests, logs. The reconciliation reads no name, email, or birth number; only opaque party ids are logged.
- [x] `@Suppress("TooGenericExceptionCaught")` on `refresh()` — justified: a scheduler tick must never crash the runtime and every fault has identical handling (keep last values, let the heartbeat go stale). Same rationale as `BalanceReconciliationScheduler`, which carries the equivalent detekt baseline entry.
- [x] No new third-party dependency (every needed lib was already on kyc-service's dependency list).
- [ ] Auth / crypto / payment code — unchanged.
- [ ] PII path — not changed; PII exposure is *reduced* relative to a naive client by not binding those fields.

## Compliance impact

- [x] AML / 5AMLD — this is a detection control over KYC case coverage. It **adds** assurance (a party with no KYC case was previously undetectable) and weakens nothing. It opens, closes, and modifies no case, and the AML 5-year retention path is untouched — `CLOSED`/`MERGED` exclusion exists precisely so correct retention behaviour is not reported as drift.
- [ ] PCI DSS / DORA / GDPR / PSD2 / CNB — none.

## Rollout / Rollback

- Deployment strategy: rolling (existing Argo Rollout).
- Rollback plan: revert the PR, or set `KYC_ORPHAN_DETECTION_ENABLED=false` to disable the job without a deploy. Read-only, so there is no state to unwind.
- Data migration reversible: N/A — no schema change.

## Reviewer notes

- **One ASVS baseline line added** (`.github/asvs-l3-baseline.txt`): `PARTY_SERVICE_URL` is a plaintext in-cluster `http://` edge, the same shape as all 232 existing entries — including kyc-service's own `SANCTIONS_SERVICE_URL` two lines above it in the same file. In-cluster plaintext is the fleet's declared architecture, so this is consistent treatment of an existing category rather than new debt of a novel kind. Flagging it explicitly in case you disagree.
- **`party/network-policies.yaml` is derived** — regenerated with `openbank-infra/scripts/gen-network-policies.py`, not hand-edited. The generator picked up the new kyc→party edge from the Rollout env var on its own; the drift gate passes.
- Gate status: `run-gates.py --all` gives **147/153 PASS with zero new failures** — the remaining ones fail identically on clean `origin/main` (verified in a separate worktree) and are environmental: `api-contract` wants `sudo` to install `oasdiff`, `release-scope` needs `PR_TITLE`, `loki-rule-load-test` is unfalsified upstream. Re-run with a real `PR_DIFF_BASE`, the enforced **threat-model, db-migration and schema-compat gates all pass**.
- The party-register scan is capped at `max-pages` (default 500 x 100 = 50k parties) and logs loudly if it ever hits the cap, rather than silently truncating.
