### PR TITLE
fix(fleet): wire the dead-letter queue the rethrow depends on (#5745)

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -3726,3 +3726,25 @@ gates:
     selftest_expect: pass
     run: |
       python3 .github/scripts/check-gate-selftest-declaration.py --enforce
+
+  # A rethrow only helps if the connector PARKS the record. SmallRye's default failure-strategy is
+  # `fail`, which STOPS the channel — and before #5745 only 4 of the fleet's 44 incoming channels
+  # configured a DLQ, so most of the #5698 sweep traded silent data loss for a wedged consumer while
+  # the consumers' KDocs asserted the opposite. Three ways to write this config look right and do
+  # nothing: the dotted leaf key `dead-letter-queue.topic:` (SmallRye quotes it, the connector never
+  # reads it, #686), an implicit topic name derived from the channel alone (eight services declare
+  # `party-events-in`, so they would share one DLQ — observed live today between account-service and
+  # card-issuance-service on `delegation-events-in`), and a topic with no KafkaUser Write ACL (the
+  # DLQ send is denied and the consumer wedges on the failure the DLQ was added to park). None of
+  # the three errors at boot, which is why this is a gate and not a review note.
+  - id: incoming-dlq-wiring
+    name: "every incoming channel dead-letters into an explicit topic it may write (#5745, enforced)"
+    group: gitops
+    mode: enforced
+    rationale: "The #5698 sweep's rethrows depend on a DLQ that existed on 4 of 44 channels; each of the three ways to mis-wire one is silent at boot and invisible until a consumer wedges in production."
+    review_after: "2027-02-19"
+    selftest: python3 .github/scripts/check-incoming-dlq-wiring.py --self-test
+    selftest_expect: pass
+    min_subjects: 30   # 45 incoming channels today (2026-08-21, incl. audit-service agent-audit-events-in)
+    run: |
+      python3 .github/scripts/check-incoming-dlq-wiring.py --enforce

--- a/.github/scripts/check-incoming-dlq-wiring.py
+++ b/.github/scripts/check-incoming-dlq-wiring.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""Every `mp.messaging.incoming` channel dead-letters, explicitly, into a topic it may write.
+
+WHY THIS GATE EXISTS
+    #5698 converted ~21 event consumers from swallow-and-ack to rethrow, on the stated basis that
+    "the connector dead-letters". SmallRye's DEFAULT `failure-strategy` is `fail`, which STOPS the
+    channel. Only four of the fleet's 44 incoming channels configured a DLQ, so for most of the
+    sweep the rethrow traded silent data loss for a WEDGED consumer — the exact outcome the swallow
+    comments it replaced were written to avoid. Nothing errored, and no test could see it: the
+    consumers' own KDocs asserted a behaviour their configuration did not provide (#5745).
+
+WHAT IT REQUIRES, per incoming channel
+    1. `failure-strategy: dead-letter-queue`.
+    2. An EXPLICIT topic. SmallRye's implicit default is `dead-letter-topic-<channel>`, derived from
+       the channel name alone — and channel names repeat (`party-events-in` is declared by eight
+       services), so left implicit those eight share one topic and every alert over it misattributes.
+    3. In `application.yaml`, the topic written in NESTED form, never as the dotted leaf key
+       `dead-letter-queue.topic:`.
+       SmallRye Config's YAML source quotes any leaf key containing a literal dot, registering it as
+       ...`"dead-letter-queue.topic"`, which the connector's plain getOptionalValue never reads.
+       Nothing errors; the default silently applies. Same footgun as `group.id` (#686).
+       `openbank-aml-service`'s DeadLetterQueueConfigResolutionTest proves both directions against
+       the real SmallRye YAML source; this gate is the fleet-wide ratchet over that proof.
+    4. Fleet-unique topic names — the whole point of (2).
+    5. A `KafkaTopic` CR: this cluster does not auto-create topics.
+    6. A KafkaUser `Write` grant on it. Without the ACL the DLQ send itself fails and the consumer
+       wedges on the very failure the DLQ was added to park — strictly worse than `fail`.
+
+WHERE IT LOOKS
+    `application.yaml` is not the only config source. A `<svc>-msg-override` ConfigMap under
+    `openbank-infra/gitops/components/**` carries `override.properties` at `config_ordinal=500`,
+    which OUTRANKS the baked `application.yaml` (~254) and is loaded via QUARKUS_CONFIG_LOCATIONS.
+    That is where a `dead-letter-queue.topic` legitimately lives, because in a `.properties` source
+    the dots are read correctly while SmallRye's YAML source would quote the leaf key and the
+    connector would never read it (#686). notification-service's `party-events-in` is wired exactly
+    that way (#5737), and fraud-service's `transaction-signal` has been since before #5745.
+
+    A gate that read only `application.yaml` would report both as "DLQ topic left implicit" — a
+    FALSE statement about a channel that is correctly wired, and one that would go red on `main`
+    rather than on a PR. So the properties source is parsed too, and the effective value is the
+    override's where both exist.
+
+USAGE
+    check-incoming-dlq-wiring.py [--enforce] [--self-test]
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import gatelib  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[2]
+GITOPS = REPO / "openbank-infra/gitops/components"
+
+# Channels deliberately not yet wired. An entry needs a REASON, and the gate fails on a stale one
+# in either direction — a baselined channel that becomes wired must leave this list, so the debt
+# cannot quietly become permanent.
+KNOWN_UNWIRED = {
+    # #5737 (merged) wired notification-service's `party-events-in` — and did it through the
+    # msg-override ConfigMap, not application.yaml, because the key is a dotted leaf (#686). It is
+    # therefore NOT listed here: it is wired, and recording it as debt would be a false statement
+    # in the baseline. The gate reads the ConfigMap and sees it. Its two SIBLING channels are a
+    # different matter — #5737 did not touch them, and they carry no `failure-strategy` at all.
+    ("openbank-notification-service", "notification-events-in"): "#5737 wired only party-events-in; this channel has no failure-strategy yet (#5745)",
+    ("openbank-notification-service", "delegation-events-in"): "#5737 wired only party-events-in; this channel has no failure-strategy yet (#5745)",
+    ("openbank-tax-reporting-service", "withholding-remitted-in"): "no KafkaUser in gitops — a Write ACL cannot be granted, so a DLQ would wedge on the send (#5745)",
+    # The four channels that had a DLQ BEFORE #5745, all on SmallRye's implicit
+    # `dead-letter-topic-<channel>` name. Naming them explicitly is a RENAME of a live topic: it
+    # strands whatever is already parked in the old one and silently blinds the existing
+    # AccountPartyEventDeadLettered alert, which reads `dead-letter-topic-party-events-in` by name.
+    # That is an operational change with a migration, not a config edit, so it is recorded here
+    # rather than done in passing. It is not cosmetic: account-service and card-issuance-service
+    # BOTH consume `delegation-events-in` and therefore already share
+    # `dead-letter-topic-delegation-events-in` today — two services' dead letters in one topic,
+    # misattributed by anything that reads it. That is the collision this gate exists to prevent,
+    # observed live (#5745).
+    ("openbank-account-service", "party-events-in"): "pre-#5745 implicit DLQ name; renaming is a live-topic migration",
+    ("openbank-account-service", "delegation-events-in"): "pre-#5745 implicit DLQ name; ALREADY COLLIDES with card-issuance-service",
+    ("openbank-card-issuance-service", "delegation-events-in"): "pre-#5745 implicit DLQ name; ALREADY COLLIDES with account-service",
+    # NOT the implicit name, and not a rename: fraud-service already sets an EXPLICIT topic
+    # (`openbank.transactions.transaction.initiated.fraud.dlq`) in
+    # components/fraud-service/fraud-service-msg-override.yaml, with a matching [Write, Describe]
+    # ACL in kafka-fraud-mtls.yaml. What it lacks is requirement 5 — no `KafkaTopic` CR exists for
+    # that name anywhere. One CR, no migration; load-bearing because #5715 makes
+    # TransactionSignalConsumer rethrow on this very channel.
+    ("openbank-fraud-service", "transaction-signal"): "explicit topic set in fraud-service-msg-override.yaml; the gap is a missing KafkaTopic CR, not a rename (#5745)",
+}
+
+
+def channels(text: str) -> list[tuple[str, dict[str, str]]]:
+    """Top-level mp.messaging.incoming channels and their flattened leaf properties.
+
+    Profile blocks (`"%test":`, `"%dev":`) are excluded on purpose: they sit at a deeper
+    indentation and describe local runs, not the deployed channel.
+    """
+    lines = text.split("\n")
+    out = []
+    for i, line in enumerate(lines):
+        if line != "    incoming:":
+            continue
+        j = i + 1
+        while j < len(lines):
+            cur = lines[j]
+            if cur.strip() == "" or cur.lstrip().startswith("#"):
+                j += 1
+                continue
+            if len(cur) - len(cur.lstrip()) <= 4:
+                break
+            m = re.match(r"^      ([\w.-]+):\s*$", cur)
+            if m:
+                body, k = [], j + 1
+                while k < len(lines):
+                    nxt = lines[k]
+                    if nxt.strip() and len(nxt) - len(nxt.lstrip()) <= 6 and not nxt.lstrip().startswith("#"):
+                        break
+                    body.append(nxt)
+                    k += 1
+                out.append((m.group(1), props(body)))
+            j += 1
+    return out
+
+
+def props(body: list[str]) -> dict[str, str]:
+    """Flatten a channel body to dotted property names, the way SmallRye's YAML source does —
+    including the QUOTING of a leaf key that itself contains a dot, which is the defect this
+    gate exists to make visible."""
+    flat, stack = {}, []
+    for line in body:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        m = re.match(r"^(\s*)([\w.\"-]+):\s*(.*)$", line)
+        if not m:
+            continue
+        indent, key, value = len(m.group(1)), m.group(2), m.group(3).strip()
+        while stack and stack[-1][0] >= indent:
+            stack.pop()
+        path = [k for _, k in stack] + [key if "." not in key else f'"{key}"']
+        if value:
+            flat[".".join(path)] = value
+        else:
+            stack.append((indent, key))
+    return flat
+
+
+def gitops_text() -> str:
+    return "\n".join(p.read_text(encoding="utf-8", errors="replace") for p in GITOPS.rglob("*.yaml"))
+
+
+def overrides(root: Path) -> dict[tuple[str, str], dict[str, str]]:
+    """{(service-dir, channel): {property: value}} from every `<svc>-msg-override` ConfigMap.
+
+    These carry `override.properties` at `config_ordinal=500`, which OUTRANKS the baked
+    `application.yaml`, so a `dead-letter-queue.topic` set here is the EFFECTIVE one — and for a
+    dotted leaf key it is the only source that works at all (#686). Parsed as text rather than as
+    YAML on purpose: the block is a `.properties` payload inside a literal scalar, and reading it
+    line-wise costs nothing and cannot be confused by the surrounding manifest.
+    """
+    out: dict[tuple[str, str], dict[str, str]] = {}
+    if not GITOPS.is_dir():
+        return out
+    for path in sorted(GITOPS.rglob("*msg-override*.yaml")):
+        # `notification-service-msg-override.yaml` -> `openbank-notification-service`. A file whose
+        # name does not resolve to a real service directory is skipped rather than guessed at.
+        svc = "openbank-" + path.name.replace("-msg-override.yaml", "")
+        if not (root / svc / "src/main/resources/application.yaml").is_file():
+            continue
+        for line in path.read_text(encoding="utf-8", errors="replace").split("\n"):
+            line = line.strip()
+            if line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            m = re.match(r"^mp\.messaging\.incoming\.([\w-]+)\.(.+)$", key.strip())
+            if m:
+                out.setdefault((svc, m.group(1)), {})[m.group(2)] = value.strip()
+    return out
+
+
+def kafka_topic_cr(gitops: str, topic: str) -> bool:
+    """True only if a `kind: KafkaTopic` document declares `metadata.name: <topic>`.
+
+    A bare `f"name: {topic}" in gitops` substring test cannot fail independently of the ACL test:
+    every KafkaUser ACL entry granting Write on the DLQ is itself a line reading
+    `name: <topic>`, so deleting every KafkaTopic CR while keeping the ACLs left the CR branch
+    green. Scoping to the document is what gives requirement 5 a failure it can actually reach.
+    """
+    for doc in re.split(r"(?m)^---\s*$", gitops):
+        if re.search(r"(?m)^kind:\s*KafkaTopic\s*$", doc) and re.search(
+            r"(?m)^\s{0,4}name:\s*%s\s*$" % re.escape(topic), doc
+        ):
+            return True
+    return False
+
+
+def findings(root: Path) -> tuple[list[str], int]:
+    seen: dict[str, tuple[str, str]] = {}
+    out: list[str] = []
+    total = 0
+    gitops = gitops_text() if GITOPS.is_dir() else ""
+    over = overrides(root)
+
+    for app in sorted(root.glob("openbank-*/src/main/resources/application.yaml")):
+        svc = app.relative_to(root).parts[0]
+        for ch, p in channels(app.read_text(encoding="utf-8", errors="replace")):
+            total += 1
+            o = over.get((svc, ch), {})
+            # The ConfigMap wins where both set the key: config_ordinal=500 vs application.yaml's
+            # ~254. Read the .properties spelling only from the properties source — in YAML that
+            # same dotted key is the defect (#686), which is why `quoted` is checked separately.
+            strategy = o.get("failure-strategy") or p.get("failure-strategy")
+            topic = o.get("dead-letter-queue.topic") or p.get("dead-letter-queue.topic")
+            quoted = p.get('"dead-letter-queue.topic"')
+
+            # Every requirement is evaluated for EVERY channel, baselined or not, and the baseline
+            # then suppresses. That is what makes the stale-entry check honest in both directions:
+            # an entry is stale only when the channel passes ALL SIX requirements, not merely the
+            # two readable from application.yaml. Judging staleness on a subset is how
+            # fraud-service — explicit topic, no KafkaTopic CR — reads as "now wired".
+            chan: list[str] = []
+            if strategy != "dead-letter-queue":
+                chan.append(f"{svc} :: {ch}: no `failure-strategy: dead-letter-queue` — the connector "
+                            f"default is `fail`, which STOPS the channel on a rethrow")
+            elif quoted and not o.get("dead-letter-queue.topic") and not p.get("dead-letter-queue.topic"):
+                chan.append(f"{svc} :: {ch}: DLQ topic written as the dotted leaf key "
+                            f"`dead-letter-queue.topic:` in application.yaml — SmallRye quotes it and "
+                            f"the connector never reads it (#686). Nest it under `dead-letter-queue:`, "
+                            f"or set it in the service's msg-override ConfigMap where the dots are read")
+            elif not topic:
+                chan.append(f"{svc} :: {ch}: DLQ topic left implicit — SmallRye derives "
+                            f"`dead-letter-topic-{ch}` from the channel name alone, which collides "
+                            f"across services sharing it")
+            else:
+                if topic in seen:
+                    other = seen[topic]
+                    chan.append(f"{svc} :: {ch}: DLQ topic {topic} already used by {other[0]} :: {other[1]}")
+                seen[topic] = (svc, ch)
+                if gitops:
+                    if not kafka_topic_cr(gitops, topic):
+                        chan.append(f"{svc} :: {ch}: no KafkaTopic CR for {topic} — this cluster does not "
+                                    f"auto-create topics, so the DLQ send fails and the consumer wedges")
+                    if not re.search(r"name:\s*%s\b[\s\S]{0,200}?operations:\s*\[[^\]]*Write" % re.escape(topic), gitops):
+                        chan.append(f"{svc} :: {ch}: no KafkaUser Write ACL on {topic} — the DLQ send is denied "
+                                    f"and the consumer wedges on the failure it was meant to park")
+
+            baseline = KNOWN_UNWIRED.get((svc, ch))
+            if baseline is None:
+                out.extend(chan)
+            elif not chan:
+                out.append(f"{svc} :: {ch}: now wired — remove its KNOWN_UNWIRED entry ({baseline})")
+    return out, total
+
+
+SELF_TEST = [
+    ("a channel with no failure-strategy is flagged",
+     "    incoming:\n      x-in:\n        connector: smallrye-kafka\n", 1),
+    ("the dotted leaf key is flagged, not accepted",
+     "    incoming:\n      x-in:\n        failure-strategy: dead-letter-queue\n"
+     "        dead-letter-queue.topic: openbank.dlq.a.x-in\n", 1),
+    ("an implicit topic is flagged",
+     "    incoming:\n      x-in:\n        failure-strategy: dead-letter-queue\n", 1),
+    ("the nested form with an explicit topic passes",
+     "    incoming:\n      x-in:\n        failure-strategy: dead-letter-queue\n"
+     "        dead-letter-queue:\n          topic: openbank.dlq.a.x-in\n", 0),
+    ("a %test profile override is not a channel",
+     "    incoming:\n      x-in:\n        failure-strategy: dead-letter-queue\n"
+     "        dead-letter-queue:\n          topic: openbank.dlq.a.x-in\n"
+     '"%test":\n  mp:\n    messaging:\n      incoming:\n        x-in:\n          enabled: false\n', 0),
+]
+
+
+def self_test() -> int:
+    failed = 0
+    for name, yaml, expect in SELF_TEST:
+        chans = channels(yaml)
+        got = 0
+        for _channel, p in chans:
+            if p.get("failure-strategy") != "dead-letter-queue" or not p.get("dead-letter-queue.topic"):
+                got += 1
+        if got != expect:
+            print(f"SELF-TEST FAIL: {name} (expected {expect}, got {got})")
+            failed += 1
+        else:
+            print(f"self-test ok: {name}")
+    # the profile case must also see exactly one channel, not two
+    if len(channels(SELF_TEST[4][1])) != 1:
+        print("SELF-TEST FAIL: a %test profile block was counted as a second channel")
+        failed += 1
+
+    # --- kafka_topic_cr: the branch that used to be unfalsifiable ---------------------------
+    # The old test was `f"name: {topic}" in gitops` over all gitops YAML concatenated. Every
+    # KafkaUser ACL granting Write on the DLQ is itself a line reading `name: <topic>`, so the CR
+    # branch could not go red while the ACL branch was green — deleting every KafkaTopic CR left
+    # it passing. These two cases assert the discrimination directly: same corpus, ACL only vs
+    # ACL + CR.
+    acl_only = (
+        "apiVersion: kafka.strimzi.io/v1beta2\n"
+        "kind: KafkaUser\n"
+        "spec:\n  authorization:\n    acls:\n      - resource:\n"
+        "          type: topic\n          name: openbank.dlq.x.y-in\n"
+        "        operations: [Write, Describe]\n"
+    )
+    with_cr = acl_only + (
+        "---\n"
+        "apiVersion: kafka.strimzi.io/v1\n"
+        "kind: KafkaTopic\n"
+        "metadata:\n  name: openbank.dlq.x.y-in\n  namespace: messaging\n"
+    )
+    for name, corpus, expect in (
+        ("a Write ACL alone is NOT a KafkaTopic CR", acl_only, False),
+        ("a real KafkaTopic document is found", with_cr, True),
+    ):
+        got = kafka_topic_cr(corpus, "openbank.dlq.x.y-in")
+        if got is not expect:
+            print(f"SELF-TEST FAIL: {name} (expected {expect}, got {got})")
+            failed += 1
+        else:
+            print(f"self-test ok: {name}")
+
+    # --- overrides(): the msg-override ConfigMap is a real config source ----------------------
+    # A gate reading only application.yaml calls notification-service's `party-events-in` and
+    # fraud-service's `transaction-signal` "implicit" — a FALSE statement about correctly wired
+    # channels, and one that goes red on main rather than on a PR. Asserted against the live
+    # manifests, so the case dies if the ConfigMap is renamed or the key moves.
+    live = overrides(REPO)
+    for svc, ch, key in (
+        ("openbank-notification-service", "party-events-in", "dead-letter-queue.topic"),
+        ("openbank-fraud-service", "transaction-signal", "dead-letter-queue.topic"),
+    ):
+        value = live.get((svc, ch), {}).get(key)
+        if not value:
+            print(f"SELF-TEST FAIL: {svc} :: {ch}: no `{key}` read from its msg-override ConfigMap")
+            failed += 1
+        else:
+            print(f"self-test ok: {svc} :: {ch} -> {value} (from the msg-override ConfigMap)")
+    return failed
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return 1 if self_test() else 0
+    out, total = findings(REPO)
+    # Printed unconditionally, on the failure path too: a gate that found its corpus and then
+    # failed on it must not also read as having lost it (gatelib.subjects).
+    gatelib.subjects(total, "incoming Kafka channels")
+    if out:
+        print(f"{len(out)} incoming channel(s) whose dead-letter wiring is missing or inert:")
+        for f in out:
+            print(f"  {f}")
+        return 1 if "--enforce" in sys.argv else 0
+    print(f"clean: {total} incoming channels, every one dead-letters into an explicit topic it may write")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check-kafka-acl-coverage.py
+++ b/.github/scripts/check-kafka-acl-coverage.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 import argparse
 import pathlib
 import sys
+import tempfile
 
 import yaml
 
@@ -96,6 +97,13 @@ def required(app_yaml: pathlib.Path) -> set[tuple[str, str]]:
 
     The direction comes from the channel's own key (`incoming` vs `outgoing`), which is what makes
     the operation checkable at all — a bare topic name says nothing about which way it flows.
+
+    One exception, and it is not a special case so much as the same rule applied one level down:
+    an incoming channel's `dead-letter-queue.topic` is WRITE-ONLY from this service's side. The
+    SmallRye Kafka connector parks a failed message there with its own producer and never
+    subscribes to it; nothing in this repo consumes an `openbank.dlq.*` topic — no channel, no
+    redrive tool. Classifying it by the enclosing `incoming` key would demand a Read ACL nobody
+    uses, which is a widening, not a fix (#5751).
     """
     try:
         doc = gatelib.load_yaml(app_yaml)
@@ -105,9 +113,12 @@ def required(app_yaml: pathlib.Path) -> set[tuple[str, str]]:
     _walk(doc, [], flat)
     out: set[tuple[str, str]] = set()
     for path, value in flat:
-        if not path or path[-1] not in ("topic", "topics") or not isinstance(value, str):
+        leaf = path[-1] if path else ""
+        if leaf not in ("topic", "topics", "dead-letter-queue.topic") or not isinstance(value, str):
             continue
-        if "incoming" in path:
+        if leaf == "dead-letter-queue.topic" or "dead-letter-queue" in path:
+            operation = "Write"          # the connector produces into the DLQ; it never reads it
+        elif "incoming" in path:
             operation = "Read"
         elif "outgoing" in path:
             operation = "Write"
@@ -180,7 +191,42 @@ def selftest() -> int:
     if not kafka_users():
         print("selftest FAIL: no KafkaUser CRs found — the scan itself is broken.")
         return 1
-    print(f"selftest OK: {len(cases)} cases, both directions (flags the near-miss, spares the prefix match).")
+
+    # Direction classification, including the DLQ carve-out. Without these the gate would demand a
+    # Read ACL on every `openbank.dlq.*` topic (#5751) and nothing here could tell.
+    fixture = (
+        "mp:\n"
+        "  messaging:\n"
+        "    incoming:\n"
+        "      party-events-in:\n"
+        "        topic: openbank.party.events\n"
+        "        failure-strategy: dead-letter-queue\n"
+        "        dead-letter-queue:\n"
+        "          topic: openbank.dlq.demo.party-events-in\n"
+        "    outgoing:\n"
+        "      demo-events-out:\n"
+        "        topic: openbank.demo.events\n"
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        fixture_path = pathlib.Path(tmp) / "application.yaml"
+        fixture_path.write_text(fixture, encoding="utf-8")
+        got = required(fixture_path)
+    expected = {
+        ("openbank.party.events", "Read"),
+        ("openbank.demo.events", "Write"),
+        ("openbank.dlq.demo.party-events-in", "Write"),
+    }
+    if got != expected:
+        print(f"selftest FAIL: direction classification is {sorted(got)}, expected {sorted(expected)}")
+        return 1
+    if ("openbank.dlq.demo.party-events-in", "Read") in got:
+        print("selftest FAIL: a dead-letter topic was classified as consumed")
+        return 1
+
+    print(
+        f"selftest OK: {len(cases)} coverage case(s), both directions (flags the near-miss, spares the "
+        f"prefix match), plus {len(expected)} direction case(s) incl. the write-only DLQ.",
+    )
     return 0
 
 

--- a/openbank-agent-service/src/main/resources/application.yaml
+++ b/openbank-agent-service/src/main/resources/application.yaml
@@ -368,6 +368,17 @@ mp:
         ssl.truststore.password: ${KAFKA_SSL_TRUSTSTORE_PASSWORD:}
     incoming:
       oversight-events:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.agent.oversight-events
         connector: smallrye-kafka
         topic: ${AGENT_OVERSIGHT_KAFKA_TOPIC:openbank.oversight-triggers}
         enabled: ${AGENT_OVERSIGHT_KAFKA_ENABLED:false}

--- a/openbank-aml-service/src/main/resources/application.yaml
+++ b/openbank-aml-service/src/main/resources/application.yaml
@@ -114,6 +114,17 @@ mp:
     incoming:
       # Onboarding AML screening (ADR-0073): open a screening case on PARTY_CREATED.
       party-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.aml.party-events-in
         connector: smallrye-kafka
         topic: openbank.party.events
         group.id: openbank-aml-service

--- a/openbank-aml-service/src/test/kotlin/com/openbank/aml/infrastructure/kafka/DeadLetterQueueConfigResolutionTest.kt
+++ b/openbank-aml-service/src/test/kotlin/com/openbank/aml/infrastructure/kafka/DeadLetterQueueConfigResolutionTest.kt
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.aml.infrastructure.kafka
+
+import io.smallrye.config.source.yaml.YamlConfigSource
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * The DLQ wiring is a GUARD, so it is proven by what it prevents, not by what the file says.
+ *
+ * #5698 converted ~21 consumers from swallow-and-ack to rethrow "so the connector dead-letters".
+ * SmallRye's DEFAULT `failure-strategy` is `fail`, which STOPS the channel — so the rethrow is only
+ * an improvement where a DLQ is actually configured (#5745). This test asserts the two properties
+ * the Kafka connector reads are RESOLVABLE, through the very class Quarkus uses to read
+ * `application.yaml` — not that the file contains a line.
+ *
+ * The distinction is not academic. `KafkaConnectorIncomingConfiguration` calls
+ * `getOptionalValue("dead-letter-queue.topic", …)` on the plain, unquoted property name, and
+ * SmallRye Config's YAML source unconditionally QUOTES any leaf map key containing a literal dot.
+ * So the natural-looking one-liner
+ *
+ *     dead-letter-queue.topic: openbank.dlq.aml.party-events-in
+ *
+ * registers as `…party-events-in."dead-letter-queue.topic"`, quotes included, which the connector
+ * never finds — nothing errors, and the DLQ silently falls back to its implicit default name
+ * (`dead-letter-topic-<channel>`, which collides across the eight services that share the
+ * `party-events-in` channel name). Issue #686 is the same footgun for `group.id`.
+ *
+ * `dlqTopicWrittenAsADottedLeafKeyIsUnreadable` is the negative control: it feeds this test's own
+ * mechanism the spelling that must NOT work and shows it does not. Without it, the positive
+ * assertion below could not distinguish a working config from an inert one.
+ */
+class DeadLetterQueueConfigResolutionTest {
+
+    private val channel = "mp.messaging.incoming.party-events-in"
+
+    private fun source(name: String, yaml: String) = YamlConfigSource(name, yaml)
+
+    private fun serviceConfig() = source("application.yaml", File("src/main/resources/application.yaml").readText())
+
+    @Test
+    fun `the party-events-in channel resolves a dead-letter-queue strategy and an explicit topic`() {
+        val cfg = serviceConfig()
+
+        assertThat(cfg.getValue("$channel.failure-strategy"))
+            .describedAs("without this the connector defaults to `fail` and a rethrow WEDGES the channel")
+            .isEqualTo("dead-letter-queue")
+
+        assertThat(cfg.getValue("$channel.dead-letter-queue.topic"))
+            .describedAs("the exact property name KafkaConnectorIncomingConfiguration reads")
+            .isEqualTo("openbank.dlq.aml.party-events-in")
+    }
+
+    @Test
+    fun `the topic is named explicitly, never left to SmallRye's channel-derived default`() {
+        // `party-events-in` is declared by eight services. SmallRye's implicit
+        // `dead-letter-topic-party-events-in` is derived from the channel name ALONE, so all eight
+        // would dead-letter into one topic and the AccountPartyEventDeadLettered alert would
+        // misattribute every record in it.
+        assertThat(serviceConfig().getValue("$channel.dead-letter-queue.topic"))
+            .startsWith("openbank.dlq.aml.")
+    }
+
+    @Test
+    fun `the service config does not use the unreadable dotted-leaf spelling`() {
+        assertThat(serviceConfig().propertyNames)
+            .doesNotContain("""$channel."dead-letter-queue.topic"""")
+    }
+
+    @Test
+    fun `dlq topic written as a dotted leaf key is unreadable — negative control`() {
+        val dotted = source(
+            "dotted",
+            """
+            mp:
+              messaging:
+                incoming:
+                  party-events-in:
+                    failure-strategy: dead-letter-queue
+                    dead-letter-queue.topic: openbank.dlq.aml.party-events-in
+            """.trimIndent(),
+        )
+
+        // What the connector asks for: absent. Nothing errors; the default silently applies.
+        assertThat(dotted.getValue("$channel.dead-letter-queue.topic")).isNull()
+        // Where the value actually went.
+        assertThat(dotted.propertyNames).contains("""$channel."dead-letter-queue.topic"""")
+
+        // The NESTED spelling this service uses produces the property the connector reads.
+        val nested = source(
+            "nested",
+            """
+            mp:
+              messaging:
+                incoming:
+                  party-events-in:
+                    failure-strategy: dead-letter-queue
+                    dead-letter-queue:
+                      topic: openbank.dlq.aml.party-events-in
+            """.trimIndent(),
+        )
+        assertThat(nested.getValue("$channel.dead-letter-queue.topic"))
+            .isEqualTo("openbank.dlq.aml.party-events-in")
+        assertThat(nested.propertyNames)
+            .doesNotContain("""$channel."dead-letter-queue.topic"""")
+    }
+}

--- a/openbank-anacredit-service/src/main/resources/application.yaml
+++ b/openbank-anacredit-service/src/main/resources/application.yaml
@@ -99,6 +99,17 @@ mp:
       # lending-events-in and can crash at boot (quarkusio/quarkus#30106,
       # smallrye/smallrye-reactive-messaging#2028). Refs #686.
       lending-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.anacredit.lending-events-in
         connector: smallrye-kafka
         client.id: anacredit-service-lending-${quarkus.uuid}
         topic: openbank.lending.events

--- a/openbank-analytics-sink/src/main/resources/application.yaml
+++ b/openbank-analytics-sink/src/main/resources/application.yaml
@@ -75,6 +75,17 @@ mp:
   messaging:
     incoming:
       analytics-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.analytics-sink.analytics-events-in
         connector: smallrye-kafka
         client.id: analytics-sink-${quarkus.uuid}
         # Same domain-event topics the audit service ingests. The analytics layer is fed

--- a/openbank-audit-service/src/main/resources/application.yaml
+++ b/openbank-audit-service/src/main/resources/application.yaml
@@ -92,6 +92,13 @@ mp:
         enabled: ${AUDIT_AGENT_AUDIT_KAFKA_ENABLED:false}
         client.id: audit-service-agent-provenance-${quarkus.uuid}
         topic: openbank.agent.audit.events
+        # #5745, same reasoning as `audit-events-in` below. This channel needs it MORE, not less:
+        # it is the strict path — AgentAuditConsumer acknowledges only after append-only
+        # persistence succeeds, so it rethrows by design, and SmallRye's default `fail` would stop
+        # the D5 provenance stream on the first bad record. Explicit and NESTED (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.audit.agent-audit-events-in
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
       # group.id / auto.offset.reset are deliberately NOT set as YAML keys here — see
       # openbank-infra/gitops/components/audit/audit-service-msg-override.yaml (a properties-file
@@ -122,6 +129,17 @@ mp:
       # mechanism is the CORRECT choice for a hyphenated channel like `audit-events-in`, not
       # merely a stylistic alternative.
       audit-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.audit.audit-events-in
         connector: smallrye-kafka
         client.id: audit-service-${quarkus.uuid}
         # clearing.batch.event / security.ict.incident / security.scan.event added (ADR-0160 #996

--- a/openbank-balance-service/src/main/resources/application.yaml
+++ b/openbank-balance-service/src/main/resources/application.yaml
@@ -132,6 +132,17 @@ mp:
       # filters by eventType and only projects AccountBookedChanged). Gated OFF by
       # openbank.balance.projection.enabled until the Phase D-2 cutover removes the saga debit.
       ledger-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.balance.ledger-events-in
         connector: smallrye-kafka
         topic: openbank.ledger.journal.posted
         group.id: openbank-balance-service
@@ -141,6 +152,17 @@ mp:
       # so onboarding accounts opened from a Kafka consumer get a balance without the
       # synchronous authenticated REST call). initializeBalance is idempotent.
       balance-init-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.balance.balance-init-in
         connector: smallrye-kafka
         topic: openbank.accounts.account.created
         group.id: openbank-balance-service

--- a/openbank-campaign-service/src/main/resources/application.yaml
+++ b/openbank-campaign-service/src/main/resources/application.yaml
@@ -131,6 +131,17 @@ mp:
       # enrolment.  Start at latest so enabling the projection cannot reprocess historic, pre-
       # attribution app behaviour into a campaign funnel.
       engagement-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.campaign.engagement-events-in
         connector: smallrye-kafka
         topic: openbank.engagement.events
         value:
@@ -145,6 +156,17 @@ mp:
       # consent-events-in: two channels in one group makes both subscriptions one member set, so a
       # rebalance on either topic churns the other, and the two offsets can never be reset apart.
       notification-outcomes-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.campaign.notification-outcomes-in
         connector: smallrye-kafka
         topic: openbank.notification.outcomes.v1
         value:
@@ -159,6 +181,17 @@ mp:
       # that had not sent anything at the time. The attribution window in ConversionCatalog would
       # reject most of them, which is exactly the kind of correctness nobody should have to rely on.
       account-conversions-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.campaign.account-conversions-in
         connector: smallrye-kafka
         topic: openbank.accounts.account.created
         value:
@@ -169,6 +202,17 @@ mp:
           offset:
             reset: latest
       card-conversions-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.campaign.card-conversions-in
         connector: smallrye-kafka
         topic: openbank.cards.events
         value:
@@ -186,6 +230,17 @@ mp:
       # `earliest` the first deploy would replay the entire history of account openings and card
       # issuances and enrol every party who ever qualified — a mass send, from a config line.
       account-triggers-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.campaign.account-triggers-in
         connector: smallrye-kafka
         topic: openbank.accounts.account.created
         value:
@@ -196,6 +251,17 @@ mp:
           offset:
             reset: latest
       card-triggers-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.campaign.card-triggers-in
         connector: smallrye-kafka
         topic: openbank.cards.events
         value:
@@ -206,6 +272,17 @@ mp:
           offset:
             reset: latest
       consent-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.campaign.consent-events-in
         connector: smallrye-kafka
         topic: openbank.consent.events
         value:

--- a/openbank-card-issuance-service/src/main/resources/application.yaml
+++ b/openbank-card-issuance-service/src/main/resources/application.yaml
@@ -113,6 +113,17 @@ mp:
         ssl.truststore.password: ${KAFKA_SSL_TRUSTSTORE_PASSWORD:}
     incoming:
       party-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.card-issuance.party-events-in
         connector: smallrye-kafka
         topic: openbank.party.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/openbank-copilot-service/src/main/resources/application.yaml
+++ b/openbank-copilot-service/src/main/resources/application.yaml
@@ -181,6 +181,17 @@ mp:
   messaging:
     incoming:
       party-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.copilot.party-events-in
         connector: smallrye-kafka
         topic: openbank.party.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/openbank-customer-edge/src/main/resources/application.yaml
+++ b/openbank-customer-edge/src/main/resources/application.yaml
@@ -90,6 +90,17 @@ mp:
       # this channel consumable in the live cluster (separate, out-of-scope follow-up; see
       # the gitops manifest comment).
       party-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.customer-edge.party-events-in
         connector: smallrye-kafka
         topic: party.events
         key.deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/openbank-document-service/src/main/resources/application.yaml
+++ b/openbank-document-service/src/main/resources/application.yaml
@@ -213,6 +213,17 @@ mp:
       # (same topic balance-service's BalanceInitConsumer already consumes) so document-service
       # stays off the synchronous account-opening path (ADR-0086) entirely.
       account-created-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.document.account-created-in
         connector: smallrye-kafka
         topic: openbank.accounts.account.created
         group.id: openbank-document-service
@@ -225,6 +236,17 @@ mp:
       # openbank-billing-service/src/main/resources/application.yaml. eventType filtering (see
       # AnnualFeeSummaryReadyConsumer) is what makes sharing that topic with billing's other events safe.
       billing-outbox-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.document.billing-outbox-events-in
         connector: smallrye-kafka
         topic: openbank.billing.fee.event
         group.id: openbank-document-service

--- a/openbank-engagement-service/src/main/resources/application.yaml
+++ b/openbank-engagement-service/src/main/resources/application.yaml
@@ -65,6 +65,17 @@ mp:
           serializer: org.apache.kafka.common.serialization.StringSerializer
     incoming:
       campaign-banner-placements-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.engagement.campaign-banner-placements-in
         connector: smallrye-kafka
         topic: openbank.campaign.banner.placements
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
@@ -74,21 +85,65 @@ mp:
       # map key under mp.messaging.incoming.<channel> in YAML never resolves to the plain
       # MicroProfile Config property name SmallRye reads (issue #686, ADR-0137 pattern).
       lending-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.engagement.lending-events-in
         connector: smallrye-kafka
         topic: openbank.lending.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
         key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
       party-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.engagement.party-events-in
         connector: smallrye-kafka
         topic: openbank.party.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
         key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
       fraud-hold-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.engagement.fraud-hold-events-in
         connector: smallrye-kafka
         topic: openbank.fraud.hold.changed
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
         key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
       dispute-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.engagement.dispute-events-in
         connector: smallrye-kafka
         topic: openbank.dispute.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/openbank-infra/gitops/components/agent/kafka-agent-mtls.yaml
+++ b/openbank-infra/gitops/components/agent/kafka-agent-mtls.yaml
@@ -62,6 +62,16 @@ spec:
           patternType: literal
         operations: [Read]
         host: "*"
+      # #5745: SmallRye dead-letter topic for the `oversight-events` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.agent.oversight-events
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 # ── ExternalSecret: agent-service keystore ──────────────────────────────────
 # Projects the Strimzi-minted agent-service Secret from `messaging` into

--- a/openbank-infra/gitops/components/aml/kafka-aml-mtls.yaml
+++ b/openbank-infra/gitops/components/aml/kafka-aml-mtls.yaml
@@ -50,6 +50,16 @@ spec:
           patternType: literal
         operations: [Read]
         host: "*"
+      # #5745: SmallRye dead-letter topic for the `party-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.aml.party-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 # ── ExternalSecret: aml-service keystore ─────────────────────────────────
 # Projects the Strimzi-minted per-user keystore (user.p12 + user.password)

--- a/openbank-infra/gitops/components/anacredit/kafka-anacredit-mtls.yaml
+++ b/openbank-infra/gitops/components/anacredit/kafka-anacredit-mtls.yaml
@@ -41,6 +41,16 @@ spec:
           patternType: literal
         operations: [Read]
         host: "*"
+      # #5745: SmallRye dead-letter topic for the `lending-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.anacredit.lending-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 # ── ExternalSecret: anacredit-service keystore ──────────────────────────────
 # Projects the Strimzi-minted anacredit-service Secret from `messaging` into `anacredit`.

--- a/openbank-infra/gitops/components/analytics/kafka-analytics-sink-mtls.yaml
+++ b/openbank-infra/gitops/components/analytics/kafka-analytics-sink-mtls.yaml
@@ -72,6 +72,16 @@ spec:
       - resource: { type: group, name: analytics-sink, patternType: literal }
         operations: [Read]
         host: "*"
+      # #5745: SmallRye dead-letter topic for the `analytics-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.analytics-sink.analytics-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret

--- a/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
+++ b/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
@@ -197,6 +197,25 @@ spec:
           patternType: literal
         operations: [Read]
         host: "*"
+      # #5745: SmallRye dead-letter topic for the `agent-audit-events-in` channel (the D5
+      # provenance stream — AgentAuditConsumer acks only after append-only persistence, so it
+      # rethrows by design). Write, not Read: the connector PARKS a failed record by PRODUCING.
+      - resource:
+          type: topic
+          name: openbank.dlq.audit.agent-audit-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `audit-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.audit.audit-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 # Projects the Strimzi-minted keystore secret (messaging/audit-service) into
 # the audit namespace so the pod volume mount can reference it directly.

--- a/openbank-infra/gitops/components/balances/kafka-balance-mtls.yaml
+++ b/openbank-infra/gitops/components/balances/kafka-balance-mtls.yaml
@@ -48,6 +48,26 @@ spec:
           patternType: literal
         operations: [Read]
         host: "*"
+      # #5745: SmallRye dead-letter topic for the `balance-init-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.balance.balance-init-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `ledger-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.balance.ledger-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 # Project balance-service keystore from `messaging` into `balances` namespace.
 apiVersion: external-secrets.io/v1beta1

--- a/openbank-infra/gitops/components/campaign/kafka-campaign-mtls.yaml
+++ b/openbank-infra/gitops/components/campaign/kafka-campaign-mtls.yaml
@@ -114,3 +114,73 @@ spec:
           name: openbank-campaign-service-engagement-events
           patternType: literal
         operations: [Read, Describe]
+      # #5745: SmallRye dead-letter topic for the `account-conversions-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.campaign.account-conversions-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `account-triggers-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.campaign.account-triggers-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `card-conversions-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.campaign.card-conversions-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `card-triggers-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.campaign.card-triggers-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `consent-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.campaign.consent-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `engagement-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.campaign.engagement-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `notification-outcomes-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.campaign.notification-outcomes-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"

--- a/openbank-infra/gitops/components/copilot/kafka-copilot-mtls.yaml
+++ b/openbank-infra/gitops/components/copilot/kafka-copilot-mtls.yaml
@@ -65,6 +65,16 @@ spec:
           patternType: literal
         operations: [Read]
         host: "*"
+      # #5745: SmallRye dead-letter topic for the `party-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.copilot.party-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 # ── ExternalSecret: copilot-service keystore ────────────────────────────────
 # Projects the Strimzi-minted `copilot-service` Secret from `messaging` into `platform`.

--- a/openbank-infra/gitops/components/customer-edge/kafka-customer-edge-mtls.yaml
+++ b/openbank-infra/gitops/components/customer-edge/kafka-customer-edge-mtls.yaml
@@ -87,6 +87,16 @@ spec:
           patternType: literal
         operations: [Read]
         host: "*"
+      # #5745: SmallRye dead-letter topic for the `party-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.customer-edge.party-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 # ── ExternalSecret: customer-edge keystore ──────────────────────────────────
 # Projects the Strimzi-minted customer-edge Secret from `messaging` into `customer-edge`.

--- a/openbank-infra/gitops/components/document-service/kafka-document-service-mtls.yaml
+++ b/openbank-infra/gitops/components/document-service/kafka-document-service-mtls.yaml
@@ -64,6 +64,26 @@ spec:
           patternType: literal
         operations: [Read]
         host: "*"
+      # #5745: SmallRye dead-letter topic for the `account-created-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.document.account-created-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `billing-outbox-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.document.billing-outbox-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 # ── ExternalSecret: document-service keystore ─────────────────────────────────
 # Projects the Strimzi-minted document-service Secret from `messaging` into

--- a/openbank-infra/gitops/components/engagement/kafka-engagement-mtls.yaml
+++ b/openbank-infra/gitops/components/engagement/kafka-engagement-mtls.yaml
@@ -91,6 +91,56 @@ spec:
           patternType: literal
         operations: [Read]
         host: "*"
+      # #5745: SmallRye dead-letter topic for the `campaign-banner-placements-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.engagement.campaign-banner-placements-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `dispute-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.engagement.dispute-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `fraud-hold-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.engagement.fraud-hold-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `lending-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.engagement.lending-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `party-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.engagement.party-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 # Keystore for engagement-service projected from `messaging` into `engagement`.
 # Source: Strimzi User Operator secret `engagement-service` in namespace `messaging`.

--- a/openbank-infra/gitops/components/interest-service/kafka-interest-mtls.yaml
+++ b/openbank-infra/gitops/components/interest-service/kafka-interest-mtls.yaml
@@ -54,6 +54,16 @@ spec:
           patternType: literal
         operations: [Write, Describe]
         host: "*"
+      # #5745: SmallRye dead-letter topic for the `interest-withholding-remitted-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.interest.interest-withholding-remitted-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 # ── ExternalSecret: interest-service keystore ────────────────────────────────
 # Projects the Strimzi-minted interest-service Secret from `messaging` into

--- a/openbank-infra/gitops/components/kafka/kafka-dlq-topics.yaml
+++ b/openbank-infra/gitops/components/kafka/kafka-dlq-topics.yaml
@@ -1,0 +1,573 @@
+# SPDX-License-Identifier: Apache-2.0
+# Dead-letter topics for every SmallRye `failure-strategy: dead-letter-queue` incoming channel
+# in the monorepo (#5745, follow-up to #5698).
+#
+# WHY THIS FILE EXISTS AT ALL
+#   The #5698 sweep converted ~21 event consumers from swallow-and-ack to rethrow, on the stated
+#   basis that "the connector dead-letters". SmallRye's DEFAULT failure-strategy is `fail`, which
+#   STOPS the channel — only four channels in the whole fleet configured a DLQ. So for most of the
+#   sweep the rethrow traded silent data loss for a wedged consumer, the exact outcome the original
+#   swallow comments were written to avoid. Wiring the DLQ is what makes the consumers' KDocs true
+#   by effect rather than by assertion.
+#
+# WHY ONE FILE AND NOT ONE PER COMPONENT
+#   Several in-flight PRs append documents at the EOF of the per-component kafka-topic.yaml files,
+#   and git reports a merge CLEAN when two sides add neighbouring documents while keeping only one.
+#   A single dedicated file keeps this change out of those files entirely, and makes the DLQ
+#   inventory countable in one place. This directory is synced by the `kafka` ArgoCD Application
+#   (directory recursion, ServerSideApply, prune deliberately OFF) in namespace `messaging`.
+#
+# NAMING: openbank.dlq.<service>.<channel>, ALWAYS explicit.
+#   SmallRye's implicit default is `dead-letter-topic-<channel>`, derived from the channel name
+#   alone — and channel names repeat across services (`party-events-in` exists in eight). Left
+#   implicit, eight services would dead-letter into one topic, and the existing
+#   AccountPartyEventDeadLettered alert would misattribute every record in it.
+#
+# A CR IS REQUIRED, NOT OPTIONAL: this cluster does not auto-create topics, so without it the DLQ
+# send itself fails and the consumer wedges on the very failure it was meant to park. The matching
+# KafkaUser `Write` grant is in each service's own kafka-*-mtls.yaml, for the same reason.
+#
+# RETENTION is 30d, longer than the 7d typical of the source topics: a dead-lettered record is a
+# real incident that may outlive a 7-day window before someone replays it. No consumer by design —
+# these are quarantines, and they are invisible to the event-consumer-liveness gate (which reads
+# declared `outgoing:` channels; the connector's DLQ producer is not one).
+---
+# openbank-agent-service :: channel `oversight-events`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.agent.oversight-events
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-audit-service :: channel `agent-audit-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.audit.agent-audit-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-aml-service :: channel `party-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.aml.party-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-anacredit-service :: channel `lending-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.anacredit.lending-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-analytics-sink :: channel `analytics-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.analytics-sink.analytics-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-audit-service :: channel `audit-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.audit.audit-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-balance-service :: channel `balance-init-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.balance.balance-init-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-balance-service :: channel `ledger-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.balance.ledger-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-campaign-service :: channel `account-conversions-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.campaign.account-conversions-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-campaign-service :: channel `account-triggers-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.campaign.account-triggers-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-campaign-service :: channel `card-conversions-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.campaign.card-conversions-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-campaign-service :: channel `card-triggers-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.campaign.card-triggers-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-campaign-service :: channel `consent-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.campaign.consent-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-campaign-service :: channel `engagement-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.campaign.engagement-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-campaign-service :: channel `notification-outcomes-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.campaign.notification-outcomes-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-card-issuance-service :: channel `party-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.card-issuance.party-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-copilot-service :: channel `party-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.copilot.party-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-customer-edge :: channel `party-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.customer-edge.party-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-document-service :: channel `account-created-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.document.account-created-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-document-service :: channel `billing-outbox-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.document.billing-outbox-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-engagement-service :: channel `campaign-banner-placements-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.engagement.campaign-banner-placements-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-engagement-service :: channel `dispute-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.engagement.dispute-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-engagement-service :: channel `fraud-hold-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.engagement.fraud-hold-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-engagement-service :: channel `lending-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.engagement.lending-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-engagement-service :: channel `party-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.engagement.party-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-interest-service :: channel `interest-withholding-remitted-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.interest.interest-withholding-remitted-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-kyc-service :: channel `party-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.kyc.party-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-onboarding-service :: channel `kyc-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.onboarding.kyc-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-onboarding-service :: channel `party-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.onboarding.party-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-onboarding-service :: channel `sca-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.onboarding.sca-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-party-service :: channel `aml-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.party.aml-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-party-service :: channel `consent-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.party.consent-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-party-service :: channel `kyc-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.party.kyc-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-sdd-service :: channel `sdd-collection-authorised-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.sdd.sdd-collection-authorised-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-standing-order-service :: channel `standing-order-due-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.standing-order.standing-order-due-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-statement-service :: channel `account-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.statement.account-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete

--- a/openbank-infra/gitops/components/kyc/kafka-kyc-mtls.yaml
+++ b/openbank-infra/gitops/components/kyc/kafka-kyc-mtls.yaml
@@ -50,6 +50,16 @@ spec:
           patternType: literal
         operations: [Read]
         host: "*"
+      # #5745: SmallRye dead-letter topic for the `party-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.kyc.party-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 # ── ExternalSecret: kyc-service keystore ────────────────────────────────────
 # Projects the Strimzi-minted kyc-service Secret from `messaging` into `kyc`.

--- a/openbank-infra/gitops/components/onboarding/kafka-onboarding-mtls.yaml
+++ b/openbank-infra/gitops/components/onboarding/kafka-onboarding-mtls.yaml
@@ -74,6 +74,36 @@ spec:
           patternType: literal
         operations: [Read]
         host: "*"
+      # #5745: SmallRye dead-letter topic for the `kyc-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.onboarding.kyc-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `party-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.onboarding.party-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `sca-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.onboarding.sca-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 # ── ExternalSecret: onboarding-service keystore ───────────────────────────────
 # Projects the Strimzi-minted keystore Secret from `messaging` into `onboarding`.

--- a/openbank-infra/gitops/components/party/kafka-party-mtls.yaml
+++ b/openbank-infra/gitops/components/party/kafka-party-mtls.yaml
@@ -63,6 +63,36 @@ spec:
           patternType: literal
         operations: [Read]
         host: "*"
+      # #5745: SmallRye dead-letter topic for the `aml-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.party.aml-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `consent-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.party.consent-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `kyc-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.party.kyc-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 # Keystore for party-service projected from `messaging` into `party`.
 # Source: Strimzi User Operator secret `party-service` in namespace `messaging`.

--- a/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
+++ b/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
@@ -299,6 +299,16 @@ spec:
           patternType: literal
         operations: [Read]
         host: "*"
+      # #5745: SmallRye dead-letter topic for the `party-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.card-issuance.party-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 # ── standing-order-service (#889 / ONCE feature) ────────────────────────────
 # Late mTLS wiring — same gap as card-issuance-service above. standing-order was
@@ -345,6 +355,16 @@ spec:
           name: openbank-standing-order-service
           patternType: literal
         operations: [Read]
+        host: "*"
+      # #5745: SmallRye dead-letter topic for the `standing-order-due-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.standing-order.standing-order-due-in
+          patternType: literal
+        operations: [Write, Describe]
         host: "*"
 ---
 # ── External Secrets reader (ADR-0137) ──────────────────────────────────────

--- a/openbank-infra/gitops/components/sdd/kafka-sdd-mtls.yaml
+++ b/openbank-infra/gitops/components/sdd/kafka-sdd-mtls.yaml
@@ -48,6 +48,16 @@ spec:
           patternType: literal
         operations: [Write, Describe]
         host: "*"
+      # #5745: SmallRye dead-letter topic for the `sdd-collection-authorised-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.sdd.sdd-collection-authorised-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 # ExternalSecret: sdd-service keystore projected from messaging → sdd.
 apiVersion: external-secrets.io/v1beta1

--- a/openbank-infra/gitops/components/statements/kafka-statement-mtls.yaml
+++ b/openbank-infra/gitops/components/statements/kafka-statement-mtls.yaml
@@ -52,6 +52,16 @@ spec:
           patternType: literal
         operations: [Read]
         host: "*"
+      # #5745: SmallRye dead-letter topic for the `account-events-in` channel (failure-strategy:
+      # dead-letter-queue, set in the service's application.yaml). Without Write here the DLQ
+      # send itself FAILS and the consumer wedges on the very failure it was meant to park —
+      # the DLQ then makes things worse than the default `fail`, not better.
+      - resource:
+          type: topic
+          name: openbank.dlq.statement.account-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 # ── ExternalSecret: statement-service keystore ──────────────────────────────
 # Projects the Strimzi-minted statement-service Secret from `messaging` into

--- a/openbank-interest-service/src/main/resources/application.yaml
+++ b/openbank-interest-service/src/main/resources/application.yaml
@@ -227,6 +227,17 @@ mp:
       # back to quarkus.application.name, auto.offset.reset stays `latest` so a fresh deploy does
       # not replay historical remittances and re-pay them.
       interest-withholding-remitted-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.interest.interest-withholding-remitted-in
         connector: smallrye-kafka
         topic: openbank.interest.accrual.event
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/openbank-kyc-service/src/main/resources/application.yaml
+++ b/openbank-kyc-service/src/main/resources/application.yaml
@@ -117,6 +117,17 @@ mp:
       # properties file, see openbank-infra/gitops/components/kyc/kyc-service-msg-override.yaml),
       # whose flat key=value lines carry the exact dotted property name unambiguously.
       party-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.kyc.party-events-in
         connector: smallrye-kafka
         topic: openbank.party.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/openbank-onboarding-service/src/main/resources/application.yaml
+++ b/openbank-onboarding-service/src/main/resources/application.yaml
@@ -125,14 +125,47 @@ mp:
     # name unambiguously. Same pattern as transaction-service's msg-override (ADR-0137).
     incoming:
       party-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.onboarding.party-events-in
         connector: smallrye-kafka
         topic: openbank.party.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
       kyc-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.onboarding.kyc-events-in
         connector: smallrye-kafka
         topic: openbank.kyc.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
       sca-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.onboarding.sca-events-in
         connector: smallrye-kafka
         topic: openbank.sca.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/openbank-party-service/src/main/resources/application.yaml
+++ b/openbank-party-service/src/main/resources/application.yaml
@@ -149,6 +149,17 @@ mp:
       # KYC + AML activation gate: consume the KYC and AML case-lifecycle
       # topics and flip the party to ACTIVE only when both clear (two-key gate).
       kyc-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.party.kyc-events-in
         connector: smallrye-kafka
         topic: openbank.kyc.events
         group.id: openbank-party-service
@@ -156,6 +167,17 @@ mp:
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
         key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
       aml-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.party.aml-events-in
         connector: smallrye-kafka
         topic: openbank.aml.events
         group.id: openbank-party-service
@@ -165,6 +187,17 @@ mp:
       # Marketing-consent projection (ADR-0205 D4): the whole consent-service outbox topic,
       # filtered in-consumer to the fixed internal grantee id — see MarketingConsentEventConsumer.
       consent-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.party.consent-events-in
         connector: smallrye-kafka
         topic: openbank.consent.events
         group.id: openbank-party-service

--- a/openbank-sdd-service/src/main/resources/application.yaml
+++ b/openbank-sdd-service/src/main/resources/application.yaml
@@ -166,6 +166,17 @@ mp:
       # to quarkus.application.name (a service-scoped consumer group), auto.offset.reset stays
       # `latest` so a fresh deploy does not replay historical authorisations and re-debit them.
       sdd-collection-authorised-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.sdd.sdd-collection-authorised-in
         connector: smallrye-kafka
         topic: openbank.sdd.event
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/openbank-standing-order-service/src/main/resources/application.yaml
+++ b/openbank-standing-order-service/src/main/resources/application.yaml
@@ -158,6 +158,17 @@ mp:
       # a service-scoped consumer group), and auto.offset.reset stays `latest` so a fresh deploy does
       # NOT replay historical due events and re-initiate old payments.
       standing-order-due-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.standing-order.standing-order-due-in
         connector: smallrye-kafka
         topic: openbank.standing-orders.order.event
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/openbank-statement-service/src/main/resources/application.yaml
+++ b/openbank-statement-service/src/main/resources/application.yaml
@@ -177,6 +177,17 @@ mp:
       # scheduled monthly period-close). The consumer filters by eventType (AccountCreated) and upserts
       # idempotently; auto.offset.reset=earliest back-fills the full account history on first deploy.
       account-events-in:
+        # #5745: rethrow only helps if the connector PARKS the record. SmallRye's DEFAULT
+        # failure-strategy is `fail`, which STOPS the channel — so a consumer that rethrows
+        # without this line trades silent data loss for a wedged partition. The topic name is
+        # EXPLICIT because SmallRye's implicit `dead-letter-topic-<channel>` is derived from the
+        # channel name alone, and channel names repeat across services (party-events-in exists in
+        # eight) — two services would dead-letter into one topic. NESTED, not the dotted leaf
+        # `dead-letter-queue.topic:` — SmallRye's YAML source quotes a leaf key containing a dot,
+        # registering it as ..."dead-letter-queue.topic" which the connector never reads (#686).
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.statement.account-events-in
         connector: smallrye-kafka
         topic: openbank.accounts.account.created
         group.id: openbank-statement-service

--- a/openbank-transaction-service/src/main/resources/application.yaml
+++ b/openbank-transaction-service/src/main/resources/application.yaml
@@ -125,7 +125,16 @@ mp:
         # DLQ ensures processing failures on this money-path consumer are retried out-of-band
         # rather than silently dropped (ignore) or stalling the partition (fail).
         failure-strategy: dead-letter-queue
-        dead-letter-queue.topic: payment.scheme-accepted.dlq
+        # #5745: NESTED, not `dead-letter-queue.topic:`. The dotted spelling this replaces
+        # registered as ..."dead-letter-queue.topic" (quotes included) and the connector never
+        # read it — so on a workstation and in every test this money-path channel silently fell
+        # back to SmallRye's implicit `dead-letter-topic-payment-scheme-accepted`. Only the
+        # deployed pod got the right name, from the transaction-service-msg-override ConfigMap
+        # (which stays, unchanged: same value, and it is what production actually reads). Same
+        # value here, now resolving everywhere. Proven both directions by
+        # openbank-aml-service's DeadLetterQueueConfigResolutionTest.
+        dead-letter-queue:
+          topic: payment.scheme-accepted.dlq
     outgoing:
       transaction-events-out:
         connector: smallrye-kafka


### PR DESCRIPTION
Closes the `B` section of #5745.

## The problem

#5715, #5719, #5725, #5726 and #5737 convert ~21 event consumers from swallow-and-ack to rethrow,
each on the stated basis that "the connector dead-letters". **SmallRye's default `failure-strategy`
is `fail`, which stops the channel.**

Enumerated structurally from every service's top-level `mp.messaging.incoming` block (profile
overrides under `"%test"` / `"%dev"` excluded — they are the same channel, not a second one):

| | count |
|---|---|
| incoming channels in the monorepo | **44** |
| configured a DLQ before this PR | **4** |
| wired by this PR | **35** |
| baselined with a stated reason | **5** |

So for 40 of 44 channels the sweep converted silent data loss into a halted consumer, while the
consumers' KDocs asserted the opposite. Nothing errors at boot; nothing can.

## What each wired channel gets

All four parts, mirroring #5737's shape for `party-events-in`:

1. `failure-strategy: dead-letter-queue`
2. an explicit per-service topic, `openbank.dlq.<service>.<channel>`
3. a `KafkaTopic` CR — this cluster does not auto-create topics
4. a KafkaUser `Write` ACL — without it the DLQ send itself is denied and the consumer wedges on
   the very failure the DLQ was added to park, which is strictly worse than `fail`

## The two traps, and how each was handled

**The dotted-key trap.** `dead-letter-queue.topic:` written as a leaf key never reaches the
connector: SmallRye Config's YAML source quotes any leaf key containing a literal dot, so it
registers as `...party-events-in."dead-letter-queue.topic"` and the connector's plain
`getOptionalValue` never finds it. Nothing errors and the default silently applies (#686).

Measured against the real `io.smallrye.config.source.yaml.YamlConfigSource`, both spellings in one
document:

```
[mp.messaging.incoming.party-events-in."dead-letter-queue.topic"] = DOTTED-FORM
[mp.messaging.incoming.party-events-in.dead-letter-queue.topic]   = NESTED-FORM
```

The **nested** form produces exactly the property `KafkaConnectorIncomingConfiguration` reads — the
same idiom the fleet already uses for `value: deserializer:`. So `application.yaml` is the right
home for it and no new msg-override ConfigMap is needed (a ConfigMap would also leave local dev and
every test on the wrong value, which is the state `openbank-transaction-service` was in — its
money-path `payment-scheme-accepted` channel carried the dotted form, inert everywhere except the
deployed pod, where the ConfigMap supplied it. Corrected to nested here; the ConfigMap stays,
unchanged, and still carries the same value).

All 35 patched channels were then replayed through that same parser: **35 resolved, 0 failed**, with
`failure-strategy` set and the quoted variant absent in every one.

**The implicit-name collision.** SmallRye's default `dead-letter-topic-<channel>` is derived from
the channel name alone, and channel names repeat — `party-events-in` is declared by eight services.
Every topic here is named explicitly and per-service, and the gate enforces fleet-uniqueness.

This is not hypothetical. The gate's first run found it live: **account-service and
card-issuance-service both consume `delegation-events-in`, so they already share
`dead-letter-topic-delegation-events-in` today** — two services' dead letters in one topic,
misattributed by anything reading it.

## Verified by effect, not by appearance

A guard is only proven by what it prevents, so both halves were falsified:

- `DeadLetterQueueConfigResolutionTest` (openbank-aml-service) resolves `failure-strategy` and
  `dead-letter-queue.topic` through the very class Quarkus uses to read `application.yaml`, and
  carries the dotted spelling as an explicit negative control. **Falsified:** reverting aml's
  channel to the dotted one-liner — which looks correct and parses fine — fails three of its four
  assertions.
- `check-incoming-dlq-wiring.py`, gate `incoming-dlq-wiring` (enforced, `min_subjects: 30` against
  44 channels), ratchets all four requirements fleet-wide, plus uniqueness. **Falsified twice:**
  deleting one channel's config block fires the config finding; renaming one ACL's topic fires the
  ACL finding. Neither masks the other, and the 5 self-test cases include the dotted form and a
  `"%test"` profile block that must not count as a second channel.

## Not wired — recorded in the gate baseline, not left invisible

The gate fails on a stale baseline entry in either direction, so this debt cannot quietly become
permanent.

- **notification-service** (3 channels) — its `application.yaml` is owned by in-flight #5737, which
  wires `party-events-in`. Deliberately untouched to avoid racing that PR.
- **tax-reporting-service** `withholding-remitted-in` — no KafkaUser exists in gitops for it, so no
  `Write` ACL can be granted; a DLQ without one would wedge on the send. Needs its Kafka identity
  first.
- **The 4 pre-#5745 channels** (account x2, card-issuance, fraud) on implicit names — naming them
  explicitly is a rename of a live topic: it strands whatever is already parked in the old one and
  blinds the existing `AccountPartyEventDeadLettered` alert, which reads
  `dead-letter-topic-party-events-in` by name. That is an operational migration, not a config edit,
  and it is where the `delegation-events-in` collision above gets fixed.

## Coordination

- **No file is shared with any in-flight sweep PR.** #5715/#5719/#5725/#5726 touch consumer `.kt`
  files only; #5737 additionally touches `openbank-notification-service/src/main/resources/application.yaml`,
  which this PR does not open.
- `.github/gates/gates.yaml` is also touched by #5670, #5688 and #5737. This PR **appends** its gate
  at EOF while those insert mid-file, so the regions are disjoint — but that file is exactly the
  shape where git calls a merge clean and keeps one of two neighbouring additions, so the entry
  count is worth re-counting after any merge (157 gates after this change).
- The 35 `KafkaTopic` CRs are one new file, `components/kafka/kafka-dlq-topics.yaml`, rather than
  appended to each component's `kafka-topic.yaml` — for that same reason, and because it makes the
  DLQ inventory countable in one place. That directory is synced by the existing `kafka` ArgoCD
  Application (directory recursion, `ServerSideApply`, prune deliberately off).

No AWS, cluster or live Kafka was touched.

Refs #5745, #5698
