### PR TITLE
fix(campaign,onboarding): stop swallowing transient consumer failures as an ack (#5745)

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/TriggeredEnrolmentService.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/TriggeredEnrolmentService.kt
@@ -60,9 +60,24 @@ class TriggeredEnrolmentService(
         if (!segmentEvaluation.matches(segment, partyId)) return TriggeredEnrolment.NOT_IN_SEGMENT
 
         // Same order as the sweep, for the same reason (#2953): start the journey first, persist on
-        // success. A crash between the two costs a duplicate start, which the workflow id makes a
-        // no-op; the reverse order costs the party forever, because the committed row makes every
-        // later attempt skip them.
+        // success. The reverse order costs the party forever, because the committed row makes
+        // every later attempt skip them.
+        //
+        // A failure between the two leaves a running journey with no enrolment row, and is repaired
+        // by REDELIVERY: the caller nacks, the record comes back, `findByCampaignAndParty` still
+        // finds nothing, and `startJourney` runs again against the same workflow id. Until #5745
+        // that redelivery could not happen — `EnrolmentTriggerConsumer` acked the failure — so this
+        // comment described a recovery that was structurally unreachable.
+        //
+        // The idempotency it relies on is real but CONDITIONAL, and the condition is worth naming:
+        // `TemporalJourneySignaller` catches `WorkflowExecutionAlreadyStarted`, which Temporal
+        // raises only while an execution with that id is still RUNNING. No `WorkflowIdReusePolicy`
+        // is set, so the default `ALLOW_DUPLICATE` applies and a start against a COMPLETED journey
+        // opens a second execution. For a campaign with no steps the journey completes at once, so
+        // that window is not hypothetical. It is not tightened to `REJECT_DUPLICATE` here because
+        // that would also block a legitimate later re-enrolment of the same party into the same
+        // campaign; the bounded cost is a repeat of a journey whose sends are still gated by the
+        // ADR-0219 contact rules (suppression, caps, quiet hours, live consent).
         journeys.startJourney(campaignId, partyId, campaign.journeyType())
         enrolments.save(
             Enrolment(

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/EnrolmentTriggerConsumer.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/EnrolmentTriggerConsumer.kt
@@ -64,13 +64,14 @@ class EnrolmentTriggerConsumer(
      * or a Temporal outage meant the party was never enrolled and never would be — `reset: latest`
      * rules out replay and nothing in lag, the DLQ or any dashboard showed a thing.
      *
-     * **What a nack does on THESE two channels today.** `account-triggers-in` and
-     * `card-triggers-in` configure no `failure-strategy`, so SmallRye's default `fail` applies:
-     * the nack STOPS the channel rather than dead-lettering. That is deliberate and it is the
-     * lesser evil — a stopped channel is loud and recoverable, a silently un-enrolled party is
-     * neither — but it is a real trade, and this KDoc will not claim a dead-letter that does not
-     * exist. Wiring `failure-strategy` + an explicit DLQ topic + the `KafkaTopic` CR + the
-     * KafkaUser `Write` ACL for these channels is #5745 section B.
+     * **What the nack does next is the CONNECTOR's decision, not this class's.** The handler's
+     * contract ends at "the work did not happen, and the platform was told". What follows depends
+     * entirely on the channel's configured `failure-strategy`: `dead-letter-queue` parks the record
+     * on the channel's DLQ topic for replay, while SmallRye's default `fail` stops the channel
+     * instead. Both are better than an ack, which loses the party silently; they are not the same
+     * incident, so read the channel's config in `application.yaml` before predicting one.
+     * (#5751 wires `failure-strategy: dead-letter-queue` for `account-triggers-in` and
+     * `card-triggers-in`, with explicit `openbank.dlq.campaign.<channel>` topics.)
      */
     @Suppress("TooGenericExceptionCaught")
     private suspend fun handle(message: Message<String>, topic: String) {

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/EnrolmentTriggerConsumer.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/EnrolmentTriggerConsumer.kt
@@ -9,6 +9,7 @@ import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.usecase.TriggeredEnrolment
 import com.openbank.campaign.application.usecase.TriggeredEnrolmentService
 import com.openbank.campaign.domain.model.TriggerCatalog
+import com.openbank.libs.messaging.EventRetry
 import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata
 import jakarta.enterprise.context.ApplicationScoped
 import org.eclipse.microprofile.reactive.messaging.Incoming
@@ -50,65 +51,114 @@ class EnrolmentTriggerConsumer(
     @Incoming("card-triggers-in")
     suspend fun onCardEvent(message: Message<String>) = handle(message, "openbank.cards.events")
 
+    /**
+     * Ack is now the SUCCESS path, not the only path.
+     *
+     * The record is acked when the work is done, and when the payload is a poison pill no
+     * redelivery could ever fix (unparseable JSON, no usable `partyId`, no matching trigger) —
+     * those are dropped deliberately and named as such. Anything else is a dependency failing, not
+     * the event: [EventRetry] retries it a bounded number of times and then rethrows, and the
+     * record is NACKED so the platform, rather than a log line nobody pages on, owns the outcome.
+     *
+     * The previous `finally { message.ack() }` acked every one of those, so a campaigns-DB blip
+     * or a Temporal outage meant the party was never enrolled and never would be — `reset: latest`
+     * rules out replay and nothing in lag, the DLQ or any dashboard showed a thing.
+     *
+     * **What a nack does on THESE two channels today.** `account-triggers-in` and
+     * `card-triggers-in` configure no `failure-strategy`, so SmallRye's default `fail` applies:
+     * the nack STOPS the channel rather than dead-lettering. That is deliberate and it is the
+     * lesser evil — a stopped channel is loud and recoverable, a silently un-enrolled party is
+     * neither — but it is a real trade, and this KDoc will not claim a dead-letter that does not
+     * exist. Wiring `failure-strategy` + an explicit DLQ topic + the `KafkaTopic` CR + the
+     * KafkaUser `Write` ACL for these channels is #5745 section B.
+     */
     @Suppress("TooGenericExceptionCaught")
     private suspend fun handle(message: Message<String>, topic: String) {
-        try {
-            val event = try {
-                mapper.readTree(message.payload)
-            } catch (e: Exception) {
-                log.errorf(e, "Unparseable %s event — dropped", topic)
-                return
-            }
-
-            val partyId = event.path("partyId").takeIf { !it.isMissingNode && !it.isNull }
-                ?.let { runCatching { UUID.fromString(it.asText()) }.getOrNull() }
-                ?: return
-
-            // Header first, payload second — the two producers put the type in different places
-            // (see TriggerCatalog). `openbank.cards.events` is shared, so without this a limit
-            // change would enrol the party into a card-issuance campaign.
-            val eventType = headerEventType(message) ?: event.path("eventType").asText().ifBlank { null }
-            val triggers = TriggerCatalog.matching(topic, eventType)
-            if (triggers.isEmpty()) return
-
-            for (trigger in triggers) {
-                for (campaign in campaigns.findActiveByTrigger(trigger)) {
-                    enrol(campaign.id, partyId, trigger)
-                }
-            }
-        } finally {
-            // Acked in every case, including the failures logged below. A poison event that cannot
-            // enrol anyone would otherwise be redelivered forever and stall the partition, blocking
-            // every later party's trigger behind it. The cost of the alternative is worse than the
-            // event being lost: this consumer starts journeys, so a wedged partition is silent
-            // non-delivery for everyone.
+        val event = try {
+            mapper.readTree(message.payload)
+        } catch (e: Exception) {
+            // Poison pill: replaying it fails identically forever, so acking is the right answer.
+            log.errorf(e, "Unparseable %s event — dropped", topic)
             message.ack()
+            return
         }
+
+        val partyId = event.path("partyId").takeIf { !it.isMissingNode && !it.isNull }
+            ?.let { runCatching { UUID.fromString(it.asText()) }.getOrNull() }
+        if (partyId == null) {
+            // Nothing to enrol. Not a fault: the shared topics carry records with no party at all.
+            message.ack()
+            return
+        }
+
+        // Header first, payload second — the two producers put the type in different places
+        // (see TriggerCatalog). `openbank.cards.events` is shared, so without this a limit
+        // change would enrol the party into a card-issuance campaign.
+        val eventType = headerEventType(message) ?: event.path("eventType").asText().ifBlank { null }
+        val triggers = TriggerCatalog.matching(topic, eventType)
+        if (triggers.isEmpty()) {
+            message.ack()
+            return
+        }
+
+        try {
+            enrolAll(triggers, partyId)
+        } catch (e: Exception) {
+            message.nack(e)
+            return
+        }
+        message.ack()
+    }
+
+    /**
+     * Attempts every (trigger, campaign) pair for this party, then rethrows the FIRST transient
+     * failure once they have all been tried.
+     *
+     * The original per-campaign catch existed so one campaign's failure did not cost the others
+     * their enrolment of the same party; that intent is kept by continuing the loop. What changes
+     * is the ending: the failure is no longer discarded. Redelivery is safe because
+     * `TriggeredEnrolmentService.enrol` returns `ALREADY_ENROLLED` for anything that did succeed.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun enrolAll(triggers: Collection<String>, partyId: UUID) {
+        var firstFailure: Exception? = null
+        for (trigger in triggers) {
+            for (campaign in campaigns.findActiveByTrigger(trigger)) {
+                val failure = enrolOrFailure(campaign.id, partyId, trigger)
+                if (firstFailure == null) firstFailure = failure
+            }
+        }
+        firstFailure?.let { throw it }
     }
 
     @Suppress("TooGenericExceptionCaught")
+    private suspend fun enrolOrFailure(campaignId: UUID, partyId: UUID, trigger: String): Exception? = try {
+        enrol(campaignId, partyId, trigger)
+        null
+    } catch (e: Exception) {
+        e
+    }
+
     private suspend fun enrol(campaignId: UUID, partyId: UUID, trigger: String) {
-        try {
-            when (val outcome = triggered.enrol(campaignId, partyId)) {
-                TriggeredEnrolment.ENROLLED ->
-                    log.infof("Trigger %s enrolled party=%s into campaign=%s", trigger, partyId, campaignId)
-                // The ordinary answers. A product event arrives for every party in the bank and
-                // almost none are in any given segment, so these are logged at debug — at info they
-                // would be the loudest thing in the service and would bury the enrolments.
-                TriggeredEnrolment.NOT_IN_SEGMENT,
-                TriggeredEnrolment.ALREADY_ENROLLED,
-                TriggeredEnrolment.NOT_ACTIVE,
-                ->
-                    log.debugf("Trigger %s: campaign=%s party=%s -> %s", trigger, campaignId, partyId, outcome)
-                // These two mean the definition is broken rather than the party unqualified.
-                TriggeredEnrolment.SEGMENT_GONE,
-                TriggeredEnrolment.CAMPAIGN_GONE,
-                ->
-                    log.warnf("Trigger %s: campaign=%s party=%s -> %s", trigger, campaignId, partyId, outcome)
-            }
-        } catch (e: Exception) {
-            // One campaign's failure must not cost the others their enrolment of this same party.
-            log.errorf(e, "Trigger %s failed for campaign=%s party=%s", trigger, campaignId, partyId)
+        val outcome = EventRetry.withRetry(log, "Triggered enrolment", "campaign=$campaignId party=$partyId") {
+            triggered.enrol(campaignId, partyId)
+        }
+        when (outcome) {
+            TriggeredEnrolment.ENROLLED ->
+                log.infof("Trigger %s enrolled party=%s into campaign=%s", trigger, partyId, campaignId)
+            // The ordinary answers. A product event arrives for every party in the bank and
+            // almost none are in any given segment, so these are logged at debug — at info they
+            // would be the loudest thing in the service and would bury the enrolments.
+            TriggeredEnrolment.NOT_IN_SEGMENT,
+            TriggeredEnrolment.ALREADY_ENROLLED,
+            TriggeredEnrolment.NOT_ACTIVE,
+            ->
+                log.debugf("Trigger %s: campaign=%s party=%s -> %s", trigger, campaignId, partyId, outcome)
+            // These two mean the definition is broken rather than the party unqualified.
+            TriggeredEnrolment.SEGMENT_GONE,
+            TriggeredEnrolment.CAMPAIGN_GONE,
+            ->
+                log.warnf("Trigger %s: campaign=%s party=%s -> %s", trigger, campaignId, partyId, outcome)
         }
     }
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/NotificationOutcomeConsumer.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/NotificationOutcomeConsumer.kt
@@ -6,6 +6,7 @@ package com.openbank.campaign.infrastructure.kafka
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.campaign.application.port.out.SendLogRepository
+import com.openbank.libs.messaging.EventRetry
 import jakarta.enterprise.context.ApplicationScoped
 import org.eclipse.microprofile.reactive.messaging.Incoming
 import org.jboss.logging.Logger
@@ -34,10 +35,21 @@ class NotificationOutcomeConsumer(private val sendLog: SendLogRepository, privat
      * consumer thread that carries no Vert.x context, so the first reactive Panache call throws and
      * the message is nacked fail-stop, taking the whole channel down with it.
      *
-     * Every failure below is swallowed after logging. A poison record must not wedge the partition,
-     * and the cost of dropping one is bounded and visible: a send-log row stays `PENDING`, which is
-     * the state that already means "no outcome arrived". The alternative — nacking — stops the
-     * channel and leaves EVERY row pending.
+     * **An unparseable record is still dropped; a failing repository is not.** The old KDoc argued
+     * that leaving a row `PENDING` was "bounded and visible" because `PENDING` already means "no
+     * outcome arrived". It is not visible: `PENDING` is exactly what the console shows for a send
+     * whose outcome is merely in flight, so a lost outcome is indistinguishable from a pending one
+     * and the row stays that way forever — which is precisely the ADR-0239 D3 / #3663 defect this
+     * consumer was built to close. The consumer reintroduced it through the ack.
+     *
+     * So a write failure is retried a bounded number of times by [EventRetry] and then RETHROWN.
+     * A `suspend @Incoming` method that throws is nacked by the connector.
+     *
+     * **What that does on `notification-outcomes-in` today: it stops the channel.** No
+     * `failure-strategy` is configured here, so SmallRye's default `fail` applies and there is no
+     * dead-letter topic to land in. That is the deliberate trade — a halted channel is loud and its
+     * backlog survives, where the ack was silent and the outcome did not — but nothing below
+     * dead-letters, and this KDoc will not say it does. Wiring the DLQ is #5745 section B.
      */
     @Suppress("TooGenericExceptionCaught")
     @Incoming("notification-outcomes-in")
@@ -60,14 +72,11 @@ class NotificationOutcomeConsumer(private val sendLog: SendLogRepository, privat
         val occurredAt = runCatching { Instant.parse(event.path("occurredAt").asText()) }
             .getOrElse { Instant.now() }
 
-        try {
-            val moved = sendLog.applyDeliveryOutcome(sendId, outcome, reason, occurredAt)
-            if (moved) {
-                log.infof("Send %s delivery outcome=%s reason=%s", sendId, outcome, reason ?: "-")
-            }
-        } catch (e: Exception) {
-            // Swallowed on purpose — see the KDoc. The row stays PENDING; the channel keeps draining.
-            log.errorf(e, "Failed to apply delivery outcome for send %s — row left PENDING", sendId)
+        val moved = EventRetry.withRetry(log, "Delivery outcome", sendId) {
+            sendLog.applyDeliveryOutcome(sendId, outcome, reason, occurredAt)
+        }
+        if (moved) {
+            log.infof("Send %s delivery outcome=%s reason=%s", sendId, outcome, reason ?: "-")
         }
     }
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/NotificationOutcomeConsumer.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/NotificationOutcomeConsumer.kt
@@ -45,11 +45,12 @@ class NotificationOutcomeConsumer(private val sendLog: SendLogRepository, privat
      * So a write failure is retried a bounded number of times by [EventRetry] and then RETHROWN.
      * A `suspend @Incoming` method that throws is nacked by the connector.
      *
-     * **What that does on `notification-outcomes-in` today: it stops the channel.** No
-     * `failure-strategy` is configured here, so SmallRye's default `fail` applies and there is no
-     * dead-letter topic to land in. That is the deliberate trade — a halted channel is loud and its
-     * backlog survives, where the ack was silent and the outcome did not — but nothing below
-     * dead-letters, and this KDoc will not say it does. Wiring the DLQ is #5745 section B.
+     * **What happens to the nacked record is the CONNECTOR's decision.** This class's contract
+     * ends at "the outcome was not applied, and the platform was told". The channel's configured
+     * `failure-strategy` decides the rest: `dead-letter-queue` parks it for replay, the default
+     * `fail` stops the channel instead. Either is louder than the ack it replaces — read
+     * `application.yaml` for what `notification-outcomes-in` does today rather than assuming.
+     * (#5751 wires it to `dead-letter-queue`, topic `openbank.dlq.campaign.notification-outcomes-in`.)
      */
     @Suppress("TooGenericExceptionCaught")
     @Incoming("notification-outcomes-in")

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/temporal/TemporalJourneySignaller.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/temporal/TemporalJourneySignaller.kt
@@ -17,7 +17,14 @@ import java.util.UUID
 
 /**
  * Temporal-backed journey control (ADR-0200 D1/D2). The workflow id is the idempotency key:
- * starting an already-running id is a no-op for Temporal, which is what makes re-enrolment safe.
+ * starting an already-RUNNING id is a no-op, which is what makes a redelivered enrolment safe.
+ *
+ * Read the qualifier literally. [WorkflowExecutionAlreadyStarted] is raised only against a live
+ * execution, and no [io.temporal.api.enums.v1.WorkflowIdReusePolicy] is set, so the default
+ * `ALLOW_DUPLICATE` applies: the same id started again AFTER the first journey completed begins a
+ * second execution. The policy is left alone on purpose — `REJECT_DUPLICATE` would also refuse a
+ * legitimate later re-enrolment — so the guarantee here is "no duplicate while it runs", not
+ * "never a duplicate" (#5745).
  */
 @ApplicationScoped
 class TemporalJourneySignaller(

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/NotificationOutcomeConsumerTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/NotificationOutcomeConsumerTest.kt
@@ -12,8 +12,10 @@ import com.openbank.campaign.domain.model.DeliveryStatus
 import com.openbank.campaign.domain.model.SendOutcome
 import com.openbank.campaign.domain.model.SendRecord
 import com.openbank.campaign.infrastructure.kafka.NotificationOutcomeConsumer
+import com.openbank.libs.messaging.EventRetry
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.util.UUID
@@ -23,8 +25,8 @@ import java.util.UUID
  *
  * The transition rule it delegates to is covered by `DeliveryTransitionTest`; what is asserted here
  * is everything between a record on a SHARED topic and the repository call: which records reach the
- * send log at all, and that the ones that must not reach it fail quietly rather than wedging the
- * channel.
+ * send log at all, that a malformed one is dropped quietly rather than wedging the channel, and
+ * that a FAILING repository is not confused with either (#5745).
  */
 class NotificationOutcomeConsumerTest {
 
@@ -38,12 +40,23 @@ class NotificationOutcomeConsumerTest {
         val applied = mutableListOf<Applied>()
         var throwOnApply: RuntimeException? = null
 
+        /** How many times the repository was ASKED, including the calls that threw. */
+        var attempts = 0
+
+        /** Fail this many times, then succeed — the transient failure the retry exists for. */
+        var failuresBeforeSuccess = 0
+
         override suspend fun applyDeliveryOutcome(
             sendId: UUID,
             outcome: String,
             reason: String?,
             occurredAt: Instant,
         ): Boolean {
+            attempts++
+            if (failuresBeforeSuccess > 0) {
+                failuresBeforeSuccess--
+                throw DownstreamDown("connection reset")
+            }
             throwOnApply?.let { throw it }
             applied += Applied(sendId, outcome, reason, occurredAt)
             return true
@@ -143,18 +156,56 @@ class NotificationOutcomeConsumerTest {
     }
 
     /**
-     * A repository failure is swallowed for the same reason. The row stays PENDING — which already
-     * means "no outcome arrived" — rather than the channel stopping and EVERY row staying pending.
+     * The defect this consumer was written to close, reintroduced through the ack (#5745, #5698).
+     *
+     * A persistent repository failure must reach the platform. Acking it leaves the send row
+     * `PENDING` forever, which is indistinguishable from an outcome still in flight — the exact
+     * ADR-0239 D3 / #3663 state the consumer exists to settle.
+     *
+     * Asserts the retry is BOUNDED as well as present: an unbounded in-handler retry would block
+     * the partition through a long outage, which is what the swallow was written against.
      */
     @Test
-    fun `a repository failure leaves the channel draining`(): Unit = runBlocking {
-        sendLog.throwOnApply = IllegalStateException("connection reset")
-        consumer.onOutcome(outcomeJson(UUID.randomUUID().toString(), "SENT", null))
+    fun `a persistent repository failure is rethrown after bounded attempts`(): Unit = runBlocking {
+        sendLog.throwOnApply = DownstreamDown("connection reset")
 
-        sendLog.throwOnApply = null
+        assertThatThrownBy {
+            runBlocking { consumer.onOutcome(outcomeJson(UUID.randomUUID().toString(), "SENT", null)) }
+        }.isInstanceOf(DownstreamDown::class.java).hasMessage("connection reset")
+
+        assertThat(sendLog.attempts).isEqualTo(EventRetry.DEFAULT_MAX_ATTEMPTS)
+        assertThat(sendLog.applied).isEmpty()
+    }
+
+    /**
+     * The other half, and the reason the retry is there at all: a blip must NOT cost a nack. A test
+     * that only asserted the rethrow would pass against a consumer that rethrew on the first
+     * failure, turning every transient hiccup into a stopped channel.
+     */
+    @Test
+    fun `a transient repository failure that recovers is retried to success`(): Unit = runBlocking {
+        sendLog.failuresBeforeSuccess = EventRetry.DEFAULT_MAX_ATTEMPTS - 1
         val sendId = UUID.randomUUID()
+
         consumer.onOutcome(outcomeJson(sendId.toString(), "SENT", null))
 
         assertThat(sendLog.applied.map { it.sendId }).containsExactly(sendId)
+        assertThat(sendLog.attempts).isEqualTo(EventRetry.DEFAULT_MAX_ATTEMPTS)
+    }
+
+    /**
+     * A malformed payload is still acked, and the repository is never asked. This is the assertion
+     * that must hold on BOTH sides of the fix — a blanket rethrow would break it, and the poison
+     * pill is the one case a nack cannot help, because replaying it fails identically forever.
+     */
+    @Test
+    fun `a malformed payload is still acked and never reaches the repository`(): Unit = runBlocking {
+        consumer.onOutcome("{not json at all")
+        consumer.onOutcome("""{"correlationId":"not-a-uuid","outcome":"SENT"}""")
+
+        assertThat(sendLog.attempts).isZero()
     }
 }
+
+/** A downstream dependency failing — the transient case, named so the tests read as intent. */
+private class DownstreamDown(message: String) : RuntimeException(message)

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/EnrolmentTriggerConsumerTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/EnrolmentTriggerConsumerTest.kt
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.usecase.TriggeredEnrolment
+import com.openbank.campaign.application.usecase.TriggeredEnrolmentService
+import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignState
+import com.openbank.campaign.domain.model.CampaignStep
+import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.SegmentRef
+import com.openbank.libs.messaging.EventRetry
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.reactive.messaging.Message
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+/**
+ * The ack is the assertion (#5745, #5698).
+ *
+ * This consumer used to ack in a `finally`, so every outcome — enrolled, dropped, or "the campaigns
+ * DB was unreachable" — told Kafka the same thing. With `reset: latest` there is no replay, so a
+ * party who qualified for a campaign and hit a blip was never enrolled and never would be, with
+ * nothing in lag, the DLQ or any dashboard to say so.
+ *
+ * Each test below asks the one question the old code could not answer: was this record ACKED or
+ * NACKED. A test that only asserted "the consumer did not throw" passes against the broken version.
+ */
+class EnrolmentTriggerConsumerTest {
+
+    private val partyId = UUID.randomUUID()
+    private val campaignId = UUID.randomUUID()
+
+    private val campaigns = mockk<CampaignRepository>()
+    private val triggered = mockk<TriggeredEnrolmentService>()
+
+    private fun consumer() = EnrolmentTriggerConsumer(campaigns, triggered, ObjectMapper())
+
+    /** Records how the connector was told to settle the record — the whole point of the fix. */
+    private class Settlement {
+        var acked = false
+        var nacked: Throwable? = null
+
+        private fun done(): CompletionStage<Void> = CompletableFuture.completedFuture(null)
+
+        fun message(payload: String): Message<String> = Message.of(
+            payload,
+            {
+                acked = true
+                done()
+            },
+            { t ->
+                nacked = t
+                done()
+            },
+        )
+    }
+
+    private fun accountCreated() =
+        """{"partyId":"$partyId","eventType":"AccountCreated","occurredAt":"${Instant.EPOCH}"}"""
+
+    private fun campaign() = Campaign(
+        id = campaignId,
+        name = "account activation",
+        goal = "open an account",
+        segmentRef = SegmentRef("eligible", 1),
+        steps = listOf(CampaignStep(0, "MARKETING_PRODUCT_OFFER", Channel.EMAIL, emptyMap(), 0)),
+        conversionRule = "ACCOUNT_OPENED",
+        trigger = "ACCOUNT_OPENED",
+        state = CampaignState.ACTIVE,
+        createdBy = "maker",
+        approvedBy = "checker",
+        createdAt = Instant.EPOCH,
+        updatedAt = Instant.EPOCH,
+    )
+
+    /**
+     * A persistent downstream failure — the campaigns DB, or Temporal refusing a `startJourney` —
+     * must be NACKED. `TriggeredEnrolmentService.enrol` writes a row and starts a workflow, so an
+     * acked failure is a party who silently never entered the campaign.
+     */
+    @Test
+    fun `a persistent enrolment failure is nacked after bounded attempts`(): Unit = runBlocking {
+        coEvery { campaigns.findActiveByTrigger("ACCOUNT_OPENED") } returns listOf(campaign())
+        var attempts = 0
+        coEvery { triggered.enrol(campaignId, partyId) } answers {
+            attempts++
+            throw DownstreamDown("temporal unavailable")
+        }
+        val settlement = Settlement()
+
+        consumer().onAccountEvent(settlement.message(accountCreated()))
+
+        assertThat(attempts).isEqualTo(EventRetry.DEFAULT_MAX_ATTEMPTS)
+        assertThat(settlement.nacked).isInstanceOf(DownstreamDown::class.java)
+        assertThat(settlement.acked).isFalse()
+    }
+
+    /**
+     * The other half. Without this, rethrowing on the first failure would also pass the test above
+     * while turning every transient hiccup into a stopped channel — the outcome the original
+     * swallow was written to avoid.
+     */
+    @Test
+    fun `a transient enrolment failure that recovers is retried to success and acked`(): Unit = runBlocking {
+        coEvery { campaigns.findActiveByTrigger("ACCOUNT_OPENED") } returns listOf(campaign())
+        var attempts = 0
+        coEvery { triggered.enrol(campaignId, partyId) } answers {
+            attempts++
+            if (attempts < EventRetry.DEFAULT_MAX_ATTEMPTS) throw DownstreamDown("connection reset")
+            TriggeredEnrolment.ENROLLED
+        }
+        val settlement = Settlement()
+
+        consumer().onAccountEvent(settlement.message(accountCreated()))
+
+        assertThat(attempts).isEqualTo(EventRetry.DEFAULT_MAX_ATTEMPTS)
+        assertThat(settlement.acked).isTrue()
+        assertThat(settlement.nacked).isNull()
+    }
+
+    /**
+     * The poison pill stays acked, and nothing downstream is asked. This must hold on BOTH sides of
+     * the fix — replaying a payload that cannot parse fails identically forever, so a nack would
+     * wedge the partition on a record no dead-letter replay could ever drain.
+     */
+    @Test
+    fun `a malformed payload is still acked and never reaches the enrolment service`(): Unit = runBlocking {
+        val settlement = Settlement()
+
+        consumer().onAccountEvent(settlement.message("{not json at all"))
+
+        assertThat(settlement.acked).isTrue()
+        assertThat(settlement.nacked).isNull()
+    }
+
+    /**
+     * The overwhelmingly normal case on a shared topic: a well-formed event matching no trigger.
+     * It is acked without a repository call — this is the record type that arrives for every party
+     * in the bank, and turning it into a lookup would be the expensive kind of correct.
+     */
+    @Test
+    fun `an event matching no trigger is acked without asking the campaign repository`(): Unit = runBlocking {
+        val settlement = Settlement()
+
+        consumer().onAccountEvent(
+            settlement.message("""{"partyId":"$partyId","eventType":"SomethingElse"}"""),
+        )
+
+        assertThat(settlement.acked).isTrue()
+        assertThat(settlement.nacked).isNull()
+    }
+
+    /**
+     * One campaign failing must not cost the OTHERS their enrolment of the same party — the intent
+     * of the original per-campaign catch, kept. What changes is the ending: the failure is still
+     * reported, so the record comes back and `ALREADY_ENROLLED` makes the succeeded one a no-op.
+     */
+    @Test
+    fun `a failing campaign does not stop the others, and is still nacked at the end`(): Unit = runBlocking {
+        val otherId = UUID.randomUUID()
+        coEvery { campaigns.findActiveByTrigger("ACCOUNT_OPENED") } returns
+            listOf(campaign(), campaign().copy(id = otherId))
+        coEvery { triggered.enrol(campaignId, partyId) } throws DownstreamDown("campaign one is broken")
+        var otherEnrolled = false
+        coEvery { triggered.enrol(otherId, partyId) } answers {
+            otherEnrolled = true
+            TriggeredEnrolment.ENROLLED
+        }
+        val settlement = Settlement()
+
+        consumer().onAccountEvent(settlement.message(accountCreated()))
+
+        assertThat(otherEnrolled).isTrue()
+        assertThat(settlement.nacked).isInstanceOf(DownstreamDown::class.java)
+        assertThat(settlement.acked).isFalse()
+    }
+}
+
+/** A downstream dependency failing — the transient case, named so the tests read as intent. */
+private class DownstreamDown(message: String) : RuntimeException(message)

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/messaging/EventRetry.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/messaging/EventRetry.kt
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.messaging
+
+import kotlinx.coroutines.delay
+import org.jboss.logging.Logger
+
+/**
+ * Bounded retry for an event handler, ending in a RETHROW so the platform can see the failure.
+ *
+ * WHY THIS EXISTS
+ *   A `suspend @Incoming` handler that returns normally ACKS its message. So a handler that catches
+ *   its own failures and logs them tells Kafka the work is done — and an acked message that did no
+ *   work is indistinguishable from a successful one: not in consumer lag, not on any dashboard built
+ *   on lag, not in the DLQ, which stays empty. The only trace is an ERROR line, and nothing pages on
+ *   ERROR lines.
+ *
+ *   On 2026-08-19 kyc-db was unreachable for a few seconds. One PARTY_CREATED arrived in that
+ *   window, the handler logged `Failed to auto-open/screen KYC case` and acked. No KYC case was
+ *   opened, so the party stayed PENDING_KYC, its two accounts stayed PENDING_ACTIVATION, and the
+ *   welcome bonus — which fires only on activation — never ran. The customer had accounts that did
+ *   not work and no money in them, and nothing anywhere was reporting it (#5698).
+ *
+ *   ONE confirmed instance, not the ten first reported. Of the nine other sandbox parties with no
+ *   KYC case, six predate the auto-open consumer (added 2026-06-26) and three are e2e fixtures with
+ *   no accounts at all. The bigger number was the alarming one and it was wrong; the defect is the
+ *   same either way, which is why it is worth stating rather than quietly keeping.
+ *
+ * THE DISTINCTION THIS ENCODES
+ *   A **malformed event** is unretryable: replaying it fails identically forever, so log-and-ack is
+ *   right. That is the poison pill, and it is the ONLY case that may be acked on failure. Callers
+ *   handle it before calling this — parse, validate, return.
+ *
+ *   Everything else is a dependency failing, not the event. Hexagonal architecture is precisely why
+ *   that must not be logged away: a database or cache being down is a NORMAL event for an adapter,
+ *   and the port contract is "the work happens, or somebody finds out".
+ *
+ * WHY BOUNDED, AND WHY IT ENDS IN A THROW
+ *   Unbounded in-handler retry blocks the partition through a long outage, which is the fear the
+ *   swallowing versions were written against. Bounding it and rethrowing hands the decision to the
+ *   connector's own failure strategy (retry, then dead-letter): the work is preserved somewhere a
+ *   human can find it, and the partition moves on.
+ *
+ * SCOPE
+ *   Not for side effects that are genuinely optional — a push notification when the money is already
+ *   booked. Those may be caught, but give them their own catch with a comment saying why the event
+ *   is complete without them, rather than sharing a catch with the state change.
+ */
+object EventRetry {
+
+    const val DEFAULT_MAX_ATTEMPTS = 3
+    const val DEFAULT_BACKOFF_MS = 500L
+
+    /**
+     * Run [block], retrying transient failures, then rethrow.
+     *
+     * @param log the caller's logger, so the message names the real handler rather than this class.
+     * @param what short description of the work — appears in both the retry and dead-letter lines.
+     * @param key the entity the event is about (party id, account id, …), for grepping later.
+     */
+    @Suppress("TooGenericExceptionCaught") // The point of this helper: ANY failure is transient until proven otherwise.
+    suspend fun <T> withRetry(
+        log: Logger,
+        what: String,
+        key: Any?,
+        maxAttempts: Int = DEFAULT_MAX_ATTEMPTS,
+        backoffMs: Long = DEFAULT_BACKOFF_MS,
+        block: suspend () -> T,
+    ): T {
+        require(maxAttempts >= 1) { "maxAttempts must be >= 1, was $maxAttempts" }
+        var attempt = 1
+        while (true) {
+            try {
+                return block()
+            } catch (e: Exception) {
+                if (attempt >= maxAttempts) {
+                    log.errorf(
+                        e,
+                        "%s for %s failed after %d attempt(s) (%s: %s) — rethrowing so the connector dead-letters",
+                        what,
+                        key,
+                        attempt,
+                        e.javaClass.simpleName,
+                        e.message,
+                    )
+                    throw e
+                }
+                log.warnf(
+                    "%s for %s failed (attempt %d/%d, %s: %s) — retrying",
+                    what,
+                    key,
+                    attempt,
+                    maxAttempts,
+                    e.javaClass.simpleName,
+                    e.message,
+                )
+                delay(backoffMs * attempt)
+                attempt++
+            }
+        }
+    }
+}

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/messaging/EventRetryTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/messaging/EventRetryTest.kt
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.messaging
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.jboss.logging.Logger
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+private class TransientFailure : RuntimeException("connection refused")
+
+class EventRetryTest {
+
+    private val log = Logger.getLogger(EventRetryTest::class.java)
+
+    @Test
+    fun `a successful block runs once and returns its value`(): Unit = runBlocking {
+        var calls = 0
+        val result = EventRetry.withRetry(log, "TEST_EVENT", "key-1", backoffMs = 1) {
+            calls++
+            "done"
+        }
+
+        assertThat(result).isEqualTo("done")
+        assertThat(calls).isEqualTo(1)
+    }
+
+    @Test
+    fun `a transient failure is retried and then succeeds`(): Unit = runBlocking {
+        var calls = 0
+        val result = EventRetry.withRetry(log, "TEST_EVENT", "key-1", backoffMs = 1) {
+            calls++
+            if (calls < 3) throw TransientFailure()
+            "done"
+        }
+
+        assertThat(result).isEqualTo("done")
+        assertThat(calls).isEqualTo(3)
+    }
+
+    /**
+     * The assertion that matters. Swallowing here is what acked a real customer's onboarding into
+     * nothing (#5698); a version of this helper that logged and returned would leave every caller
+     * with the same defect while looking like a fix.
+     */
+    @Test
+    fun `a persistent failure is RETHROWN after the bounded attempts`(): Unit = runBlocking {
+        var calls = 0
+
+        assertThrows<TransientFailure> {
+            runBlocking {
+                EventRetry.withRetry(log, "TEST_EVENT", "key-1", backoffMs = 1) {
+                    calls++
+                    throw TransientFailure()
+                }
+            }
+        }
+
+        assertThat(calls).isEqualTo(EventRetry.DEFAULT_MAX_ATTEMPTS)
+    }
+
+    @Test
+    fun `maxAttempts of 1 means no retry, and still rethrows`(): Unit = runBlocking {
+        var calls = 0
+
+        assertThrows<TransientFailure> {
+            runBlocking {
+                EventRetry.withRetry(log, "TEST_EVENT", "key-1", maxAttempts = 1, backoffMs = 1) {
+                    calls++
+                    throw TransientFailure()
+                }
+            }
+        }
+
+        assertThat(calls).isEqualTo(1)
+    }
+
+    @Test
+    fun `maxAttempts below 1 is rejected rather than silently running zero times`(): Unit = runBlocking {
+        assertThrows<IllegalArgumentException> {
+            runBlocking {
+                EventRetry.withRetry(log, "TEST_EVENT", "key-1", maxAttempts = 0, backoffMs = 1) { "never" }
+            }
+        }
+        Unit
+    }
+}

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumer.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumer.kt
@@ -6,6 +6,7 @@ package com.openbank.onboarding.infrastructure.kafka
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.libs.messaging.EventRetry
 import com.openbank.onboarding.application.usecase.OnboardingProjectionService
 import com.openbank.onboarding.domain.model.KycStage
 import com.openbank.onboarding.domain.model.OnboardingEvent
@@ -26,9 +27,23 @@ import java.util.UUID
  * Quarkus dispatches suspend @Incoming handlers on the Vert.x event loop with a proper
  * duplicated context, so awaitSuspending() inside the projection service works correctly.
  *
- * Poison-pill protection: any parse or projection failure is caught, logged, and the message
- * is acked (return). This is correct for a read-model projection: a single bad event must not
- * wedge the consumer group; the canonical source of truth (party/kyc/sca) can be replayed.
+ * **Poison pills are acked; failing dependencies are not (#5745, #5698).** A parse or mapping
+ * failure is still caught, logged and acked — replaying that record fails identically forever, so
+ * it is the one case where dropping is right. A *projection* failure is a different thing: the
+ * database or the read-model service is down, the event is fine, and returning normally tells Kafka
+ * the work is done. Those are retried a bounded number of times by [EventRetry] and then rethrown,
+ * which nacks the record.
+ *
+ * The old KDoc justified acking projection failures with "the canonical source of truth
+ * (party/kyc/sca) can be replayed". Nothing replays it: no re-seed job exists in this service, and
+ * the two things being lost are not cosmetic — a dropped `PARTY_ERASED` leaves personal data in the
+ * onboarding read model after an Art. 17 erasure was executed everywhere else (a compliance breach,
+ * not a stale tile), and a dropped KYC/SCA transition means the funnel never sees the party move.
+ *
+ * **None of these three channels configures a `failure-strategy`,** so SmallRye's default `fail`
+ * applies and a nack STOPS the channel instead of dead-lettering. That is the deliberate trade —
+ * a halted channel is loud and its backlog survives on the topic — but there is no DLQ behind
+ * these three today and this KDoc does not pretend otherwise; wiring one is #5745 section B.
  */
 @ApplicationScoped
 class OnboardingEventConsumer(private val clock: Clock) {
@@ -64,16 +79,12 @@ class OnboardingEventConsumer(private val clock: Clock) {
                 log.warnf("[party-events-in] PARTY_ERASED without valid partyId, skipping: %.200s", payload)
                 return
             }
-            try {
+            // Rethrows after the bounded attempts. An erasure that is acked without happening is a
+            // GDPR Art. 17 breach that no later process notices, and `PARTY_ERASED` is emitted once.
+            EventRetry.withRetry(log, "[party-events-in] GDPR Art. 17 erasure", partyId) {
                 projection.eraseParty(partyId)
-                log.infof("[party-events-in] GDPR Art. 17: erased onboarding read-model for party %s", partyId)
-            } catch (e: Exception) {
-                log.errorf(
-                    e,
-                    "[party-events-in] GDPR Art. 17: failed to erase onboarding read-model for party %s",
-                    partyId,
-                )
             }
+            log.infof("[party-events-in] GDPR Art. 17: erased onboarding read-model for party %s", partyId)
             return
         }
 
@@ -199,19 +210,38 @@ class OnboardingEventConsumer(private val clock: Clock) {
         return event
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private suspend fun project(event: OnboardingEvent, topic: String) {
         try {
-            projection.applyEvent(event)
-            metrics.record(topic, ProjectionOutcomeMetrics.Outcome.PROJECTED)
+            EventRetry.withRetry(log, "[$topic] Projection of ${event::class.simpleName}", partyIdOf(event)) {
+                projection.applyEvent(event)
+            }
         } catch (e: Exception) {
+            // The FAILED counter is still recorded — it is the series the funnel dashboards read —
+            // and then the failure is rethrown so the record is nacked rather than acked as done.
             metrics.record(topic, ProjectionOutcomeMetrics.Outcome.FAILED)
-            log.errorf(e, "[%s] Projection failed for event type %s", topic, event::class.simpleName)
-            // Ack the message (don't rethrow) — the read-model can be re-seeded from events if needed.
+            throw e
         }
+        metrics.record(topic, ProjectionOutcomeMetrics.Outcome.PROJECTED)
     }
 
     // ── JSON helpers ─────────────────────────────────────────────────────────
 
     private fun JsonNode.asUuid(): UUID? = runCatching { UUID.fromString(asText()) }.getOrNull()
     private fun JsonNode.asInstant(): Instant? = runCatching { Instant.parse(asText()) }.getOrNull()
+}
+
+/**
+ * The sealed base declares only `occurredAt`; every subtype carries its own party id.
+ *
+ * Top-level on purpose: as a member it would put the class AT detekt's `TooManyFunctions`
+ * threshold of 11, which fires at the limit rather than above it. It carries no annotation, so the
+ * next-declaration binding trap does not apply here.
+ */
+private fun partyIdOf(event: OnboardingEvent): UUID = when (event) {
+    is OnboardingEvent.PartyCreated -> event.partyId
+    is OnboardingEvent.PartyStatusChanged -> event.partyId
+    is OnboardingEvent.KycCaseOpened -> event.partyId
+    is OnboardingEvent.KycStatusChanged -> event.partyId
+    is OnboardingEvent.DeviceEnrolled -> event.partyId
 }

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumer.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumer.kt
@@ -40,10 +40,13 @@ import java.util.UUID
  * onboarding read model after an Art. 17 erasure was executed everywhere else (a compliance breach,
  * not a stale tile), and a dropped KYC/SCA transition means the funnel never sees the party move.
  *
- * **None of these three channels configures a `failure-strategy`,** so SmallRye's default `fail`
- * applies and a nack STOPS the channel instead of dead-lettering. That is the deliberate trade —
- * a halted channel is loud and its backlog survives on the topic — but there is no DLQ behind
- * these three today and this KDoc does not pretend otherwise; wiring one is #5745 section B.
+ * **What becomes of a nacked record is the CONNECTOR's decision, not this class's.** The handler's
+ * contract ends at "the projection did not happen, and the platform was told". Each channel's
+ * configured `failure-strategy` decides the rest: `dead-letter-queue` parks the record on that
+ * channel's DLQ topic for replay, SmallRye's default `fail` stops the channel instead. Both beat an
+ * ack that loses an Art. 17 erasure silently, but they are different incidents — read
+ * `application.yaml` per channel rather than assuming either. (#5751 wires all three to
+ * `dead-letter-queue`, with explicit `openbank.dlq.onboarding.<channel>` topics.)
  */
 @ApplicationScoped
 class OnboardingEventConsumer(private val clock: Clock) {

--- a/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumerTest.kt
+++ b/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumerTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.onboarding.infrastructure.kafka
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.libs.messaging.EventRetry
 import com.openbank.onboarding.application.usecase.OnboardingProjectionService
 import com.openbank.onboarding.domain.model.KycStage
 import com.openbank.onboarding.domain.model.OnboardingEvent
@@ -17,6 +18,9 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
@@ -185,4 +189,104 @@ class OnboardingEventConsumerTest {
                 )
             }
         }
+
+    // ── Transient failure vs poison pill (#5745, #5698) ───────────────────────
+
+    /**
+     * The compliance case. `PARTY_ERASED` is emitted once, nothing in this service re-seeds the read
+     * model, and acking a failed erasure leaves personal data in a projection after Art. 17 erasure
+     * was executed everywhere else. So a persistent failure must reach the platform, not a log line.
+     */
+    @Test
+    fun `a persistent eraseParty failure is rethrown after bounded attempts`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        var attempts = 0
+        coEvery { projection.eraseParty(partyId) } answers {
+            attempts++
+            throw DownstreamDown("read-model DB unreachable")
+        }
+
+        assertThatThrownBy {
+            runBlocking { consumer.consumePartyEvent("""{"eventType":"PARTY_ERASED","partyId":"$partyId"}""") }
+        }.isInstanceOf(DownstreamDown::class.java).hasMessage("read-model DB unreachable")
+
+        assertThat(attempts).isEqualTo(EventRetry.DEFAULT_MAX_ATTEMPTS)
+    }
+
+    /** A blip must not cost a nack — otherwise every hiccup becomes a stopped channel. */
+    @Test
+    fun `a transient eraseParty failure that recovers is retried to success`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        var attempts = 0
+        coEvery { projection.eraseParty(partyId) } answers {
+            attempts++
+            if (attempts < EventRetry.DEFAULT_MAX_ATTEMPTS) throw DownstreamDown("connection reset")
+        }
+
+        consumer.consumePartyEvent("""{"eventType":"PARTY_ERASED","partyId":"$partyId"}""")
+
+        assertThat(attempts).isEqualTo(EventRetry.DEFAULT_MAX_ATTEMPTS)
+    }
+
+    /**
+     * The projection half: a KYC/SCA transition lost here never reaches the funnel, and the record
+     * is acked as done. Also asserts the FAILED counter still fires — the dashboards read it, and a
+     * rethrow that skipped it would trade one silent failure for another.
+     */
+    @Test
+    fun `a persistent applyEvent failure is rethrown after bounded attempts`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        var attempts = 0
+        coEvery { projection.applyEvent(any()) } answers {
+            attempts++
+            throw DownstreamDown("read-model DB unreachable")
+        }
+        val payload = """{"eventType":"DEVICE_ENROLLED","partyId":"$partyId","credentialId":"c1"}"""
+
+        assertThatThrownBy { runBlocking { consumer.consumeScaEvent(payload) } }
+            .isInstanceOf(DownstreamDown::class.java)
+
+        assertThat(attempts).isEqualTo(EventRetry.DEFAULT_MAX_ATTEMPTS)
+        verify { metrics.record("sca-events-in", ProjectionOutcomeMetrics.Outcome.FAILED) }
+    }
+
+    /** Same channel, recovering dependency: retried, projected, no nack. */
+    @Test
+    fun `a transient applyEvent failure that recovers is retried to success`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        var attempts = 0
+        coEvery { projection.applyEvent(any()) } answers {
+            attempts++
+            if (attempts < EventRetry.DEFAULT_MAX_ATTEMPTS) throw DownstreamDown("connection reset")
+        }
+
+        consumer.consumeScaEvent("""{"eventType":"DEVICE_ENROLLED","partyId":"$partyId","credentialId":"c1"}""")
+
+        assertThat(attempts).isEqualTo(EventRetry.DEFAULT_MAX_ATTEMPTS)
+        verify { metrics.record("sca-events-in", ProjectionOutcomeMetrics.Outcome.PROJECTED) }
+    }
+
+    /**
+     * Poison pills stay acked on all three channels, and the projection is never asked. This must
+     * hold on BOTH sides of the fix: a blanket rethrow would break it, and no redelivery can help a
+     * payload that fails to parse identically forever.
+     */
+    @Test
+    fun `a malformed payload is still acked on every channel and never reaches the projection`(): Unit = runBlocking {
+        assertThatCode {
+            runBlocking {
+                consumer.consumePartyEvent("{not json at all")
+                consumer.consumeKycEvent("{not json at all")
+                consumer.consumeScaEvent("{not json at all")
+                // Well-formed JSON, no usable partyId: also unretryable.
+                consumer.consumePartyEvent("""{"eventType":"PARTY_ERASED","partyId":"nope"}""")
+            }
+        }.doesNotThrowAnyException()
+
+        coVerify(exactly = 0) { projection.eraseParty(any()) }
+        coVerify(exactly = 0) { projection.applyEvent(any()) }
+    }
 }
+
+/** A downstream dependency failing — the transient case, named so the tests read as intent. */
+private class DownstreamDown(message: String) : RuntimeException(message)


### PR DESCRIPTION
## What

Three consumers from #5745 section A stop acking work they did not do. Scope is **campaign (2 consumers, 3 channels)** and **onboarding (1 consumer, 3 channels)** only — notification, anacredit, analytics-sink and tax-reporting are other agents' PRs.

| service | consumer | was swallowed | now |
|---|---|---|---|
| campaign | `EnrolmentTriggerConsumer` (`account-triggers-in`, `card-triggers-in`) | `TriggeredEnrolmentService.enrol` — a DB write **and** a Temporal `startJourney` | bounded retry, then **nack**. Poison pills and no-trigger records still acked |
| campaign | `NotificationOutcomeConsumer` (`notification-outcomes-in`) | `sendLog.applyDeliveryOutcome` | bounded retry, then rethrow |
| onboarding | `OnboardingEventConsumer` (`party-events-in`, `kyc-events-in`, `sca-events-in`) | `projection.eraseParty`, `projection.applyEvent` | bounded retry, then rethrow; parse/mapping failures still acked |

`EnrolmentTriggerConsumer` acked in a `finally`, so every outcome told Kafka the same thing, and `reset: latest` rules out replay — the party was never enrolled and never would be, with nothing in lag, the DLQ or any dashboard to say so. `NotificationOutcomeConsumer` is worth naming separately: **the consumer written to close ADR-0239 D3 / #3663 reintroduced that exact defect through its ack.** Its KDoc argued the cost was "bounded and visible" because the row stays `PENDING`; `PENDING` is also what the console shows for an outcome merely in flight, so a lost one is invisible by construction. In onboarding the lost signals are a **GDPR Art. 17 erasure of the read model** (a compliance breach, not a stale tile) and KYC/SCA transitions that never reach the funnel — and the old KDoc's justification, "the canonical source of truth can be replayed", has no mechanism behind it: no re-seed job exists in this service.

Poison pills are still acked everywhere. This is deliberately not a blanket rethrow.

## The DLQ these six channels rethrow into: wired by #5751, not by this PR

**Corrected after review.** My first version of this PR asserted that none of these six channels had a `failure-strategy`, so the rethrow would halt them. That was true of `origin/main` when I checked, and #5751 (`fix/kafka-incoming-dlq-wiring`, open) had not yet appeared on the remote. It has since, and I read its diff rather than a summary: it wires **all six** of the channels this PR touches — four-part, per #5745 section B, with an explicit per-service topic name (the implicit `dead-letter-topic-<channel>` would collide across the eight services that share a channel name):

| service | channel | DLQ topic | KafkaTopic CR + Write ACL |
|---|---|---|---|
| campaign | `account-triggers-in` | `openbank.dlq.campaign.account-triggers-in` | yes |
| campaign | `card-triggers-in` | `openbank.dlq.campaign.card-triggers-in` | yes |
| campaign | `notification-outcomes-in` | `openbank.dlq.campaign.notification-outcomes-in` | yes |
| onboarding | `party-events-in` | `openbank.dlq.onboarding.party-events-in` | yes |
| onboarding | `kyc-events-in` | `openbank.dlq.onboarding.kyc-events-in` | yes |
| onboarding | `sca-events-in` | `openbank.dlq.onboarding.sca-events-in` | yes |

None of the six is among the channels #5751 baselines rather than wires.

**So the KDocs in this PR assert neither.** Claiming the dead-letter as a present fact would depend on a PR that has not merged; claiming its absence goes stale the moment it does. They state the mechanism instead — the record is nacked, and the channel's configured `failure-strategy` decides what follows, `dead-letter-queue` parking it for replay and the default `fail` stopping the channel — with a pointer to #5751 for what these six are being wired to. True on either side of that merge.

That correction is itself the bug class this PR is about: a comment that outlives the behaviour it describes. It is the same defect as `NotificationOutcomeConsumer`'s "bounded and visible" and `OnboardingEventConsumer`'s "can be replayed".

**Ordering note for whoever merges:** if this lands before #5751, the six channels rethrow into SmallRye's default `fail` until #5751 follows — loud and recoverable, but a halted channel rather than a parked record. That is a strictly better failure than the silent ack it replaces, so it does not block, but the two PRs are better merged close together.

## The Temporal workflow-id claim: it holds, but only while the journey RUNS

`TriggeredEnrolmentService` starts the journey first and persists second, arguing that a crash between the two "costs a duplicate start, which the workflow id makes a no-op". Two corrections, both now in the code:

1. **That argument assumed a redelivery this very catch-and-ack guaranteed could never happen.** Fixing the swallow makes the comment true for the first time.
2. **The idempotency is conditional and the condition was not stated.** `TemporalJourneySignaller` catches `WorkflowExecutionAlreadyStarted`, which Temporal raises only against a **running** execution. No `WorkflowIdReusePolicy` is set, so the default `ALLOW_DUPLICATE` applies and a start against a **completed** journey opens a second execution. For a campaign with no steps `runLinear` reaches `markCompleted` immediately, so that window is not hypothetical.

I did not tighten it to `REJECT_DUPLICATE`: that would also refuse a legitimate later re-enrolment of the same party into the same campaign. The bounded cost is a repeated journey whose sends are still gated by the ADR-0219 contact rules. Both KDocs now say "no duplicate while it runs", not "never a duplicate".

## `EventRetry` — reused, not reimplemented

#5719 is still open, so its shared `openbank-libs-runtime` `EventRetry` is not on `main`. I took `EventRetry.kt` and `EventRetryTest.kt` **verbatim from #5719's branch** so the two merge as an identical add/add, with **one line of divergence**: a `@Suppress("TooGenericExceptionCaught")` on `withRetry`, without which `:openbank-libs-runtime:detekt` fails locally. #5719's own CI was still running when I checked, so it may hit the same finding. That single line is the only thing that can conflict; whichever lands second should keep it. No third retry implementation was introduced.

## Overlap with #5744

#5744 (campaign metrics) is open against the same module and edits `TriggeredEnrolmentService`. I read its diff before starting. The overlap is **the same file, different hunks**: #5744 adds a `CampaignMetricsPort` constructor parameter and a `metrics.enrolmentRecorded(...)` call after `enrolments.save`; this PR only rewrites the comment block above `journeys.startJourney`. It should merge textually clean either way round, but they are not independent by review — flagging it here rather than resolving it silently. #5744 also touches `CampaignService.enrol` and `CampaignJourneyActivitiesImpl`, neither of which this PR touches. It adds ~27 lines to `CampaignEnrolmentFailureTest` and ~17 to `TriggeredEnrolmentTest`; this PR touches neither.

## Tests, and the falsification

Per site: persistent downstream failure ⇒ rethrown/nacked after bounded attempts; transient failure that recovers ⇒ retried to success; malformed payload ⇒ still acked, downstream never called. The `EnrolmentTriggerConsumer` tests assert **which way the record was settled** (a `Message.of(payload, ack, nack)` recording both) — "the consumer did not throw" passes against the broken version, so it is not an assertion.

`NotificationOutcomeConsumerTest`'s `a repository failure leaves the channel draining` asserted the swallow as intended behaviour and was replaced. That is the shape #5745 section C describes: green tests documenting the bug.

**Falsified** by reverting the three consumers to `origin/main` with the new tests in place. Exactly the 9 behaviour tests went red and both poison-pill/ack tests stayed green on both sides:

```
RED  campaign    a persistent enrolment failure is nacked after bounded attempts
RED  campaign    a transient enrolment failure that recovers is retried to success and acked
RED  campaign    a failing campaign does not stop the others, and is still nacked at the end
RED  campaign    a persistent repository failure is rethrown after bounded attempts
RED  campaign    a transient repository failure that recovers is retried to success
RED  onboarding  a persistent eraseParty failure is rethrown after bounded attempts
RED  onboarding  a transient eraseParty failure that recovers is retried to success
RED  onboarding  a persistent applyEvent failure is rethrown after bounded attempts
RED  onboarding  a transient applyEvent failure that recovers is retried to success
GREEN (both sides)  the two `a malformed payload is still acked …` tests
```

## Local gate

`ktlintCheck` + `detekt` + `test` for all three modules, each read for the tasks that actually ran and for the **skipped** count, not just failures:

| module | tests | failed | skipped |
|---|---|---|---|
| openbank-campaign-service | 217 | 0 | 0 |
| openbank-onboarding-service | 42 | 0 | 0 |
| openbank-libs-runtime | 239 | 0 | 0 |

`ktlintCheck`/`detekt` for all three exit 0 (run separately from `test`, after it).

Refs #5745, #5698
