### PR TITLE
fix(transaction): make TransactionSagaStuck able to fire — instrument the gauge it needs

### DIFF
--- a/openbank-infra/gitops/components/payments/prometheus-rules.yaml
+++ b/openbank-infra/gitops/components/payments/prometheus-rules.yaml
@@ -35,15 +35,32 @@ spec:
             summary: "transaction outbox backlog stuck"
             description: "transaction-service outbox has >100 unrelayed rows for >15m — payment events are not being dispatched."
         - alert: TransactionSagaStuck
-          # A saga stuck >5m = payment is in a terminal-unknown state.
-          expr: openbank_transaction_sagas_stuck_total > 0
+          # A saga stuck past its expected completion = payment in a terminal-unknown state.
+          #
+          # This rule spent its whole life unable to fire (#5733): it was written against
+          # `openbank_transaction_sagas_stuck_total`, which nothing has ever emitted. It loaded,
+          # promtool accepted it, Alertmanager routed it, and Prometheus reported it `inactive`
+          # forever -- indistinguishable from a correctly-quiet critical alert. It now reads the
+          # gauge TransactionStrandedGauge actually publishes.
+          #
+          # Age, not count: a wedged saga answered 2xx, emitted no error span, took normal latency
+          # and sits on a healthy pod, so age is the only layer at which it differs from a healthy
+          # one -- the same reason DomesticPaymentStrandedBeforeClearing is written this way
+          # (#3273). The `> 300` IS the "stuck >5m" the old comment claimed, expressed against a
+          # series that exists; `for: 5m` then requires it to persist rather than catching one
+          # slow saga mid-flight.
+          #
+          # PENDING only. PROCESSING is mid-saga and legitimately takes seconds to low minutes;
+          # holding both to a 5m bound would page on normal traffic, and holding both to the
+          # loosest bound is the same as not alerting on PENDING at all.
+          expr: max(openbank_transactions_non_terminal_oldest_age_seconds{status="PENDING"}) > 300
           for: 5m
           labels:
             severity: critical
             service: transaction
           annotations:
             summary: "Payment sagas are stuck in transaction-service"
-            description: "{{ $value }} payment saga(s) have been in an incomplete state for >5m — manual triage required."
+            description: "Oldest PENDING payment saga is {{ $value | humanizeDuration }} old (>5m) — manual triage required."
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/port/out/StrandedSagaQueryPort.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/port/out/StrandedSagaQueryPort.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.application.port.out
+
+import com.openbank.transaction.domain.model.TransactionStatus
+import java.time.Instant
+
+/**
+ * Read-only backlog queries for the stranded-saga gauge (issue #5733).
+ *
+ * Deliberately its OWN port rather than two more methods on [TransactionRepository]. That
+ * interface is the transaction aggregate's persistence contract on a money-path service — every
+ * method on it participates in the transactional-outbox invariant, and widening it for an
+ * observability read would put a diagnostic in the same review surface as the write path. These
+ * two never mutate, never take an [com.openbank.libs.persistence.outbox.OutboxMessage], and their
+ * only consumer is a gauge.
+ */
+interface StrandedSagaQueryPort {
+
+    /** How many transactions sit in [status] right now. */
+    suspend fun countByStatus(status: TransactionStatus): Long
+
+    /**
+     * When the oldest transaction in [status] was initiated, or `null` when none are.
+     *
+     * `null` must be rendered as an age of zero, not as a stale previous reading: "no saga is
+     * stuck" and "the last stuck one just cleared" are the same healthy state, and carrying the
+     * old age forward would make `TransactionSagaStuck` fire forever after one resolved incident.
+     */
+    suspend fun oldestInitiatedAt(status: TransactionStatus): Instant?
+}

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/observability/TransactionStrandedGauge.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/observability/TransactionStrandedGauge.kt
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.transaction.infrastructure.observability
+
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
+import com.openbank.transaction.application.port.out.StrandedSagaQueryPort
+import com.openbank.transaction.domain.model.TransactionStatus
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import io.quarkus.runtime.Startup
+import io.quarkus.runtime.StartupEvent
+import io.quarkus.scheduler.Scheduled
+import jakarta.annotation.PostConstruct
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Publishes how long payment sagas have been sitting in a **non-terminal** state (issue #5733).
+ *
+ *  - `openbank_transactions_non_terminal{service="transaction",status="..."}` — how many
+ *    transactions are in that state right now.
+ *  - `openbank_transactions_non_terminal_oldest_age_seconds{service="transaction",status="..."}`
+ *    — age of the oldest one, or `0` when there are none.
+ *
+ * ### Why this exists
+ *
+ * `TransactionSagaStuck` — `severity: critical`, money-path, whose whole job is to page a human
+ * when a saga wedges — was written against `openbank_transaction_sagas_stuck_total`, a metric
+ * **nothing has ever emitted**. The rule loaded, `promtool` accepted it, Alertmanager routed it,
+ * and Prometheus reported it `inactive` forever, which is exactly what a correctly-quiet alert
+ * also looks like. It could not fire, and nothing anywhere disagreed (#5733).
+ *
+ * This is the observable the alert always needed, and it is deliberately the same shape as
+ * [com.openbank.domestic.infrastructure.observability.DomesticPaymentStrandedGauge] in
+ * domestic-payment (#3273), which was built for the identical failure: a payment held
+ * fail-closed answers 2xx, emits no error span, takes normal latency and sits on a healthy pod,
+ * so every rule that measures whether the service *answers* stays green while work it accepted
+ * stops *progressing*. Age is the only layer at which the two differ.
+ *
+ * Terminal states ([TransactionStatus.COMPLETED], `FAILED`, `REVERSED`) are not published: their
+ * age only grows and would alert forever.
+ *
+ * Per-status series rather than one aggregate, because the thresholds differ — `PROCESSING` is
+ * mid-saga and legitimately takes seconds to low minutes, while `PENDING` means the saga was
+ * accepted and has not started. One number could only carry the loosest of the two.
+ *
+ * Micrometer samples a gauge supplier synchronously on the Prometheus scrape (worker) thread, but
+ * these come from reactive queries — so a scheduled `suspend` tick refreshes cached [AtomicLong]s
+ * on the right context and the suppliers read those caches cheaply and lock-free. That is also why
+ * the scheduled method is `suspend` and not `runBlocking`: a plain `@Scheduled` carries no Vert.x
+ * context and a blocking bridge around reactive Panache throws HR000068, aborting the job silently
+ * (#2148/#2187, enforced by check-no-runblocking-in-scheduled.py).
+ *
+ * The refresh registers its own liveness (ADR-0160 mechanism 3), so a gauge that silently stops
+ * updating — the failure that would make this control quietly useless — is itself alertable via
+ * `WorkflowLivenessStale`, rather than freezing at its last value and reading as healthy.
+ */
+@Startup
+@ApplicationScoped
+class TransactionStrandedGauge(
+    private val strandedSagaQuery: StrandedSagaQueryPort,
+    private val registry: MeterRegistry?,
+    private val clock: Clock,
+    private val domainMetrics: DomainMetrics,
+) {
+    // CDI constructor: MeterRegistry is optional (absent when no Prometheus registry is on the
+    // classpath, e.g. in slim test slices). Without an explicit @Inject constructor, ArC sees two
+    // constructors, registers no bean, and the @Startup hook silently never runs.
+    @Inject
+    constructor(
+        strandedSagaQuery: StrandedSagaQueryPort,
+        registryInstance: Instance<MeterRegistry>,
+        clock: Clock,
+        domainMetrics: DomainMetrics,
+    ) : this(
+        strandedSagaQuery,
+        if (registryInstance.isResolvable) registryInstance.get() else null,
+        clock,
+        domainMetrics,
+    )
+
+    private val counts: Map<TransactionStatus, AtomicLong> = NON_TERMINAL.associateWith { AtomicLong(0) }
+    private val oldestAgeSeconds: Map<TransactionStatus, AtomicLong> = NON_TERMINAL.associateWith { AtomicLong(0) }
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    @PostConstruct
+    fun register() {
+        val r = registry ?: return
+        NON_TERMINAL.forEach { status ->
+            gauge(r, "openbank.transactions.non_terminal", status, counts.getValue(status))
+            gauge(
+                r,
+                "openbank.transactions.non_terminal.oldest.age.seconds",
+                status,
+                oldestAgeSeconds.getValue(status),
+            )
+        }
+    }
+
+    fun onStart(@Observes @Suppress("UNUSED_PARAMETER") ev: StartupEvent) {
+        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, Duration.ofSeconds(REFRESH_INTERVAL_SECONDS))
+    }
+
+    private fun gauge(r: MeterRegistry, name: String, status: TransactionStatus, holder: AtomicLong) {
+        Gauge.builder(name, holder) { it.get().toDouble() }
+            .tag("service", SERVICE)
+            .tag("status", status.name)
+            .strongReference(true)
+            .register(r)
+    }
+
+    @Scheduled(
+        every = "30s",
+        delayed = "15s",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+    )
+    suspend fun refresh() {
+        val now = Instant.now(clock)
+        NON_TERMINAL.forEach { status ->
+            counts.getValue(status).set(strandedSagaQuery.countByStatus(status))
+            // Absent oldest row means the state is empty — report 0, not a stale previous age.
+            val oldest = strandedSagaQuery.oldestInitiatedAt(status)
+            oldestAgeSeconds.getValue(status).set(
+                oldest?.let { maxOf(0L, Duration.between(it, now).seconds) } ?: 0L,
+            )
+        }
+        liveness?.recordSuccess()
+    }
+
+    companion object {
+        private const val SERVICE = "transaction"
+        private const val WORKFLOW_NAME = "transaction-stranded-gauge"
+        private const val REFRESH_INTERVAL_SECONDS = 30L
+
+        /**
+         * States a saga must move out of. A transaction in either has been accepted and is still
+         * owed an outcome, so age is meaningful; in a terminal state it is not.
+         */
+        val NON_TERMINAL: List<TransactionStatus> = listOf(
+            TransactionStatus.PENDING,
+            TransactionStatus.PROCESSING,
+        )
+    }
+}

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/persistence/repository/PanacheStrandedSagaQuery.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/persistence/repository/PanacheStrandedSagaQuery.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.infrastructure.persistence.repository
+
+import com.openbank.transaction.application.port.out.StrandedSagaQueryPort
+import com.openbank.transaction.domain.model.TransactionStatus
+import com.openbank.transaction.infrastructure.persistence.entity.TransactionEntity
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import java.time.Instant
+
+/**
+ * Panache adapter for [StrandedSagaQueryPort] (issue #5733).
+ *
+ * Ordering is on `initiatedAt`, the only timestamp every transaction carries from creation —
+ * `completedAt` and `failedAt` are null precisely for the rows this gauge is about.
+ */
+@ApplicationScoped
+class PanacheStrandedSagaQuery :
+    StrandedSagaQueryPort,
+    PanacheRepository<TransactionEntity> {
+
+    override suspend fun countByStatus(status: TransactionStatus): Long =
+        Panache.withSession { count("status", status.name) }.awaitSuspending()
+
+    override suspend fun oldestInitiatedAt(status: TransactionStatus): Instant? = Panache.withSession {
+        find("status = ?1 order by initiatedAt asc", status.name).firstResult()
+    }.awaitSuspending()?.initiatedAt
+}

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/observability/TransactionStrandedGaugeTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/observability/TransactionStrandedGaugeTest.kt
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.transaction.infrastructure.observability
+
+import com.openbank.transaction.application.port.out.StrandedSagaQueryPort
+import com.openbank.transaction.domain.model.TransactionStatus
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+
+/**
+ * Unit cover for the #5733 stranded-saga gauges.
+ *
+ * A wedged saga is invisible to every other signal this service has — it answered 2xx, emitted no
+ * error span, took normal latency and sits on a healthy pod — so the ONLY thing separating it from
+ * a healthy one is age. These assertions are therefore on the age arithmetic and the empty-state
+ * behaviour, never on "a gauge was registered": the alert this feeds
+ * (`TransactionSagaStuck`, severity critical) spent its whole life registered and unable to fire,
+ * which is precisely the failure a registration-only assertion would have agreed with.
+ */
+class TransactionStrandedGaugeTest {
+
+    private val now: Instant = Instant.parse("2026-08-19T12:00:00Z")
+    private val clock: Clock = Clock.fixed(now, ZoneOffset.UTC)
+
+    /** Repository stub: only the two methods the gauge uses are meaningful.
+     *
+     * Mutable, so a single gauge instance can be ticked across a CHANGING database. Handing the
+     * second state to a second gauge object would not exercise anything: the registry holds a
+     * strong reference to the first instance's AtomicLong, so the new object's refresh updates a
+     * holder nothing reads — a test that passes against a production bug it cannot see. */
+    private class StubRepository(
+        var counts: Map<TransactionStatus, Long>,
+        var oldest: Map<TransactionStatus, Instant>,
+    ) : StrandedSagaQueryPort {
+        override suspend fun countByStatus(status: TransactionStatus): Long = counts[status] ?: 0L
+        override suspend fun oldestInitiatedAt(status: TransactionStatus): Instant? = oldest[status]
+    }
+
+    private fun gaugeValue(registry: SimpleMeterRegistry, name: String, status: TransactionStatus): Double =
+        registry.get(name).tag("service", "transaction").tag("status", status.name).gauge().value()
+
+    private fun newGauge(repo: StrandedSagaQueryPort, registry: SimpleMeterRegistry) =
+        TransactionStrandedGauge(repo, registry, clock, domainMetrics = mockk(relaxed = true))
+
+    @Test
+    fun `publishes the age of the oldest saga in each non-terminal state`(): Unit = runBlocking {
+        val registry = SimpleMeterRegistry()
+        val repo = StubRepository(
+            counts = mapOf(TransactionStatus.PENDING to 4L, TransactionStatus.PROCESSING to 2L),
+            oldest = mapOf(
+                TransactionStatus.PENDING to now.minus(Duration.ofHours(3)),
+                TransactionStatus.PROCESSING to now.minus(Duration.ofMinutes(7)),
+            ),
+        )
+        val gauge = newGauge(repo, registry)
+        gauge.register()
+
+        gauge.refresh()
+
+        assertThat(gaugeValue(registry, "openbank.transactions.non_terminal", TransactionStatus.PENDING))
+            .isEqualTo(4.0)
+        assertThat(gaugeValue(registry, "openbank.transactions.non_terminal", TransactionStatus.PROCESSING))
+            .isEqualTo(2.0)
+        // The age is the whole signal: 3h and 7m must be distinguishable, so this asserts the
+        // arithmetic, not merely that the series is non-zero.
+        assertThat(
+            gaugeValue(registry, "openbank.transactions.non_terminal.oldest.age.seconds", TransactionStatus.PENDING),
+        ).isEqualTo(Duration.ofHours(3).seconds.toDouble())
+        assertThat(
+            gaugeValue(registry, "openbank.transactions.non_terminal.oldest.age.seconds", TransactionStatus.PROCESSING),
+        ).isEqualTo(Duration.ofMinutes(7).seconds.toDouble())
+    }
+
+    @Test
+    fun `an empty state reports age zero, and does not keep the previous incident's age`(): Unit = runBlocking {
+        val registry = SimpleMeterRegistry()
+        // One gauge, one registry, a database that CHANGES between ticks — which is the only
+        // arrangement that exercises the cached holder the registry actually reads.
+        val repo = StubRepository(
+            counts = mapOf(TransactionStatus.PENDING to 1L),
+            oldest = mapOf(TransactionStatus.PENDING to now.minus(Duration.ofDays(2))),
+        )
+        val gauge = newGauge(repo, registry)
+        gauge.register()
+        gauge.refresh()
+        assertThat(
+            gaugeValue(registry, "openbank.transactions.non_terminal.oldest.age.seconds", TransactionStatus.PENDING),
+        ).isEqualTo(Duration.ofDays(2).seconds.toDouble())
+
+        // The stuck saga clears: the repository now reports nothing in that state.
+        repo.counts = emptyMap()
+        repo.oldest = emptyMap()
+        gauge.refresh()
+
+        // Falsifying assertion: a wiring that leaves the cached AtomicLong untouched when the query
+        // returns null would still read two days here, and `TransactionSagaStuck` would then fire
+        // forever after a single resolved incident — alert fatigue on the one control that exists
+        // to be believed.
+        assertThat(
+            gaugeValue(registry, "openbank.transactions.non_terminal.oldest.age.seconds", TransactionStatus.PENDING),
+        ).isEqualTo(0.0)
+        assertThat(gaugeValue(registry, "openbank.transactions.non_terminal", TransactionStatus.PENDING))
+            .isEqualTo(0.0)
+    }
+
+    @Test
+    fun `terminal states are never published — their age only grows`() {
+        val registry = SimpleMeterRegistry()
+        newGauge(StubRepository(counts = emptyMap(), oldest = emptyMap()), registry).register()
+
+        // COMPLETED/FAILED/REVERSED are outcomes, not backlog. Publishing them would produce a
+        // series that rises forever and an alert nobody can ever clear.
+        listOf(TransactionStatus.COMPLETED, TransactionStatus.FAILED, TransactionStatus.REVERSED).forEach { st ->
+            assertThat(
+                registry.find("openbank.transactions.non_terminal").tag("status", st.name).gauge(),
+            ).describedAs("terminal status %s must not be published", st).isNull()
+        }
+        assertThat(TransactionStrandedGauge.NON_TERMINAL)
+            .containsExactly(TransactionStatus.PENDING, TransactionStatus.PROCESSING)
+    }
+}


### PR DESCRIPTION
## What

Makes `TransactionSagaStuck` — `severity: critical`, money-path — actually able to fire. It never has been.

The rule was written against `openbank_transaction_sagas_stuck_total`, a metric **nothing has ever emitted** (#5733).

## Why nothing caught it

A dead alert is invisible from every angle you would normally check: it loads, `promtool` accepts the PromQL, Alertmanager routes it, and Prometheus reports it `inactive` forever — **which is exactly what a correctly-quiet critical alert also looks like**.

Confirmed two independent ways:
- The live sandbox's Prometheus holds 59 `openbank_*` metric names; that is not one of them.
- A comment-stripped scan of every `openbank-*/src/main` finds no instrumentation for it in any of this repo's three metric-naming idioms.

## The fix

`TransactionStrandedGauge`, deliberately the same shape as domestic-payment's `DomesticPaymentStrandedGauge` (#3273), which exists for the identical failure:

> a wedged saga answered 2xx, emitted no error span, took normal latency and sits on a healthy pod — so every rule measuring whether the service **answers** stays green while work it accepted stops **progressing**. Age is the only layer at which the two differ.

```
openbank_transactions_non_terminal{service,status}
openbank_transactions_non_terminal_oldest_age_seconds{service,status}
```

`PENDING` and `PROCESSING` only — a terminal state's age only grows and would alert forever. Per-status rather than one aggregate because the thresholds genuinely differ: `PROCESSING` is mid-saga and legitimately takes seconds to low minutes, while `PENDING` means the saga was accepted and never started. One number could only carry the looser of the two.

The rewritten alert reads `PENDING > 300s` — the "stuck >5m" the old comment always claimed, now expressed against a series that exists.

## Design note: its own port

The two read-only queries live on a new `StrandedSagaQueryPort`, not as two more methods on `TransactionRepository`. That interface is the aggregate's persistence contract on a money-path service — every method participates in the transactional-outbox invariant — and a diagnostic read does not belong in the same review surface as the write path. It also keeps `PanacheTransactionRepository` under detekt's `TooManyFunctions` threshold, which fires **at** 11, not above it.

## Verified

- `TransactionStrandedGaugeTest` **3/3**. The empty-state test is falsifying and earned it: the first version handed the cleared data to a *second* gauge object while asserting on a registry gauge still bound to the **first** instance's `AtomicLong` — it would have agreed with a production bug it could not see. Rewritten to one instance over a mutable stub, the only arrangement that exercises the cached holder the registry actually reads.
- `ktlint`, `detekt`, `quarkusBuild` (CDI wiring) green.
- `check-scheduler-liveness`: **51/51** with liveness, the new gauge included. `check-no-runblocking-in-scheduled` clean.
- **Decisive check, by effect rather than assertion**: ran #5739's new `check-alert-metric-emitted` gate against this branch with `TransactionSagaStuck` **removed from its baseline** → clean, **214** emitted metric names (up from 212) and **3** baselined instead of 4. The gate that flagged this alert as dead no longer can.

## Merge order with #5739

#5739 baselines four dead alerts including this one. Merging **this** PR first is the clean order: #5739's branch has already been updated to drop the `TransactionSagaStuck` entry, so its baseline lands at three. If #5739 merges first instead, its baseline correctly still covers this alert and nothing breaks — the entry simply becomes stale on the next run and gets reported, which is the ratchet working as designed.

## Money path

`openbank-transaction-service` is in `rules.yaml: money_path_services` — 2 approvals. The diff adds only a read-only gauge and its port: no write path, no aggregate, no outbox touched.

## Still open in #5733

The other three (`ClearingSettlementWindowMissed`, `SwiftMtMessageProcessingStalled`, `LendingRepaymentProcessingStalled`) are all `warning`, all event-driven rather than scheduled, and all written as `increase(...) == 0` — a shape that is blind to absence even once the metric exists. They need a decision about whether that alert shape should exist at all before instrumenting three more counters across three money-path services; documented in #5733 rather than rushed here.

Refs #5733
