### PR TITLE
fix: stop the three regulatory event consumers acking work they did not do (#5745)

### DIFF
--- a/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/infrastructure/kafka/LoanStageEventConsumer.kt
+++ b/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/infrastructure/kafka/LoanStageEventConsumer.kt
@@ -8,6 +8,7 @@ import com.openbank.anacredit.application.port.out.AnaCreditMetricsPort
 import com.openbank.anacredit.application.port.out.LoanStageEventOutcome
 import com.openbank.anacredit.application.port.out.LoanStageProjectionRepository
 import com.openbank.anacredit.domain.model.LoanStageProjection
+import com.openbank.libs.messaging.EventRetry
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.eclipse.microprofile.reactive.messaging.Incoming
@@ -24,14 +25,33 @@ import java.util.UUID
  *
  * Same shape as `kyc-service`/`aml-service`'s `PartyEventConsumer`: `suspend @Incoming` (Quarkus
  * dispatches on the Vert.x event loop with a duplicated context, so the reactive-Panache write inside
- * [LoanStageProjectionRepository] runs correctly), poison-pill safe (a parse/domain failure is caught,
- * logged, and the message is acked — one malformed event must not wedge the consumer group; the
- * canonical lending stream can be replayed).
+ * [LoanStageProjectionRepository] runs correctly).
  *
- * Every consumption reports its terminal outcome to [AnaCreditMetricsPort]. That is the point of the
- * meter rather than a nicety: acking a bad event is the correct behaviour, so a broken producer, a
- * schema change or a wedged projection write leaves the stage projection frozen with nothing but an
- * INFO/ERROR line to show for it. `outcome=parse_error|malformed|apply_error` is that population.
+ * **Failure handling separates two things this consumer used to conflate (#5698/#5745).**
+ *
+ * A **malformed event** — unparseable JSON, no `loanId`, no `newStage` — is unretryable: replaying it
+ * fails identically forever. It is logged, counted and acked. That is the genuine poison pill, and it
+ * is the only case that may be acked on failure.
+ *
+ * A **failed projection write** is the opposite: the event is fine, the database is not, and the work
+ * must happen once it recovers. Acking there froze the loan's IFRS 9 stage and DPD at their previous
+ * values with nothing but an ERROR line to show for it — and AnaCredit exposure is a *regulatory*
+ * return, so a stage that silently stops advancing is a wrong number on a filed report, not a stale
+ * dashboard. `applyIfNewer` is idempotent and ordering-safe, so a retry or a redelivery is free.
+ * Those failures now go through [EventRetry.withRetry] and are RETHROWN.
+ *
+ * **What the rethrow does, and what it deliberately does not promise.** The mechanism this handler
+ * controls is the rethrow: the record is not acknowledged as done. What follows is the connector's
+ * `failure-strategy` for `lending-events-in` — `dead-letter-queue` parks the record in the configured
+ * topic, SmallRye's default `fail` stops the channel. That is configuration, not a property of this
+ * code, so this KDoc does not state today's value: #5745 section B found the whole family of #5698
+ * fixes asserting a dead-letter that only four channels fleet-wide actually had, and #5751 is wiring
+ * this one to `openbank.dlq.anacredit.lending-events-in`. Read the channel's config, or the
+ * `check-incoming-dlq-wiring` gate, for the current answer.
+ *
+ * Every consumption still reports its terminal outcome to [AnaCreditMetricsPort], `apply_error`
+ * included — the counter is incremented *before* the rethrow, so the population survives whichever
+ * failure-strategy the channel is configured with.
  *
  * Idempotent + ordering-safe: [LoanStageProjectionRepository.applyIfNewer] only writes when the
  * incoming event's timestamp is strictly newer than the projection's current value, so an out-of-order
@@ -102,32 +122,41 @@ class LoanStageEventConsumer {
     }
 
     /**
-     * Write the projection and report the terminal outcome. A write failure is logged, counted and
-     * swallowed — the message is acked so one bad row cannot wedge the consumer group, and the
-     * canonical lending stream can be replayed.
+     * Write the projection and report the terminal outcome.
+     *
+     * A write failure is a dependency being down, not a bad event: it is retried a bounded number of
+     * times and then RETHROWN, so the platform sees a failure instead of an ack that did nothing. The
+     * `apply_error` counter is still incremented first, so the metric records every terminal failure
+     * regardless of which failure-strategy the channel is configured with.
      */
-    @Suppress("TooGenericExceptionCaught") // any write failure means the same thing: ack and count it
+    @Suppress("TooGenericExceptionCaught") // count the terminal outcome for ANY failure, then rethrow
     private suspend fun apply(projection: LoanStageProjection) {
         try {
-            if (projections.applyIfNewer(projection)) {
-                log.infof(
-                    "[lending-events-in] Applied stage projection for loan %s: %s (DPD %d)",
-                    projection.loanId,
-                    projection.stage,
-                    projection.daysPastDue,
-                )
-                metrics.loanStageEvent(LoanStageEventOutcome.APPLIED)
-            } else {
-                log.infof(
-                    "[lending-events-in] Ignored stale/duplicate loan.stage_changed for loan %s " +
-                        "(existing projection is already at least as recent)",
-                    projection.loanId,
-                )
-                metrics.loanStageEvent(LoanStageEventOutcome.STALE)
+            EventRetry.withRetry(log, "loan.stage_changed projection", projection.loanId) {
+                applyOnce(projection)
             }
         } catch (e: Exception) {
-            log.errorf(e, "[lending-events-in] Failed to apply stage projection for loan %s", projection.loanId)
             metrics.loanStageEvent(LoanStageEventOutcome.APPLY_ERROR)
+            throw e
+        }
+    }
+
+    private suspend fun applyOnce(projection: LoanStageProjection) {
+        if (projections.applyIfNewer(projection)) {
+            log.infof(
+                "[lending-events-in] Applied stage projection for loan %s: %s (DPD %d)",
+                projection.loanId,
+                projection.stage,
+                projection.daysPastDue,
+            )
+            metrics.loanStageEvent(LoanStageEventOutcome.APPLIED)
+        } else {
+            log.infof(
+                "[lending-events-in] Ignored stale/duplicate loan.stage_changed for loan %s " +
+                    "(existing projection is already at least as recent)",
+                projection.loanId,
+            )
+            metrics.loanStageEvent(LoanStageEventOutcome.STALE)
         }
     }
 }

--- a/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/infrastructure/kafka/LoanStageEventConsumerTest.kt
+++ b/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/infrastructure/kafka/LoanStageEventConsumerTest.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.anacredit.application.port.out.LoanStageProjectionRepository
 import com.openbank.anacredit.domain.model.LoanStageProjection
 import com.openbank.anacredit.infrastructure.observability.AnaCreditMetricsAdapter
+import com.openbank.libs.messaging.EventRetry
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -15,11 +16,15 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.Clock
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
+
+/** A named transient failure, so the tests below never `throw RuntimeException` (detekt). */
+private class ProjectionUnavailable(message: String) : RuntimeException(message)
 
 class LoanStageEventConsumerTest {
 
@@ -81,6 +86,7 @@ class LoanStageEventConsumerTest {
         coVerify(exactly = 0) { projections.applyIfNewer(any()) }
     }
 
+    /** Unchanged by the #5745 fix, and deliberately so: a malformed event is the genuine poison pill. */
     @Test
     fun `malformed payload is acked without applying a projection or throwing`(): Unit = runBlocking {
         consumer.consume("not json")
@@ -90,18 +96,54 @@ class LoanStageEventConsumerTest {
         coVerify(exactly = 0) { projections.applyIfNewer(any()) }
     }
 
+    /**
+     * The assertion this file used to get backwards (#5698/#5745).
+     *
+     * It previously asserted the OPPOSITE — "a repository failure is swallowed so the consumer group
+     * is not wedged" — and passed, which is how the defect shipped with a green test certifying it as
+     * intended behaviour. A projection write that fails and acks freezes the loan's IFRS 9 stage and
+     * DPD at their previous values, and AnaCredit exposure is a regulatory return, so nothing
+     * downstream distinguishes "no transition happened" from "the transition was lost".
+     */
     @Test
-    fun `a repository failure is swallowed so the consumer group is not wedged`(): Unit = runBlocking {
+    fun `a persistent repository failure is RETHROWN after the bounded attempts`(): Unit = runBlocking {
         val loanId = UUID.randomUUID()
-        coEvery { projections.applyIfNewer(any()) } throws RuntimeException("db down")
+        coEvery { projections.applyIfNewer(any()) } throws ProjectionUnavailable("db down")
 
-        // Must not throw — the message is acked and the lending stream can replay.
+        assertThrows<ProjectionUnavailable> {
+            runBlocking {
+                consumer.consume(
+                    """{"eventType":"loan.stage_changed","loanId":"$loanId","previousStage":"STAGE_1",""" +
+                        """"newStage":"STAGE_2","daysPastDue":35,"asOf":"2026-07-01"}""",
+                )
+            }
+        }
+
+        // Bounded, not unbounded: the partition must move on rather than block through a long outage.
+        coVerify(exactly = EventRetry.DEFAULT_MAX_ATTEMPTS) { projections.applyIfNewer(any()) }
+        assertThat(outcome("apply_error")).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `a transient repository failure is retried and then succeeds without throwing`(): Unit = runBlocking {
+        val loanId = UUID.randomUUID()
+        var calls = 0
+        coEvery { projections.applyIfNewer(any()) } answers {
+            calls++
+            if (calls == 1) throw ProjectionUnavailable("connection refused")
+            true
+        }
+
         consumer.consume(
             """{"eventType":"loan.stage_changed","loanId":"$loanId","previousStage":"STAGE_1",""" +
                 """"newStage":"STAGE_2","daysPastDue":35,"asOf":"2026-07-01"}""",
         )
 
-        coVerify(exactly = 1) { projections.applyIfNewer(any()) }
+        assertThat(calls).isEqualTo(2)
+        assertThat(outcome("applied")).isEqualTo(1.0)
+        // A recovered retry is a success, not a failure: no apply_error counter is even registered.
+        assertThat(registry.find("openbank.anacredit.loan_stage.events").tag("outcome", "apply_error").counter())
+            .isNull()
     }
 
     @Test
@@ -124,13 +166,17 @@ class LoanStageEventConsumerTest {
     @Test
     fun `every terminal branch reports its outcome to the metrics port`(): Unit = runBlocking {
         val loanId = UUID.randomUUID()
-        coEvery { projections.applyIfNewer(any()) } returns true andThen false andThenThrows RuntimeException("db down")
+        // After the two seeded answers every later call throws, which is what the retry then exhausts.
+        coEvery { projections.applyIfNewer(any()) } returns true andThen
+            false andThenThrows ProjectionUnavailable("db down")
         val applied = """{"eventType":"loan.stage_changed","loanId":"$loanId","newStage":"STAGE_2",""" +
             """"daysPastDue":40,"asOf":"2026-07-01"}"""
 
         consumer.consume(applied) // -> applied
         consumer.consume(applied) // -> stale (applyIfNewer answers false)
-        consumer.consume(applied) // -> apply_error (the repository throws)
+        // apply_error now RETHROWS after the bounded retries (see above), so the outcome has to be
+        // collected from a throwing call rather than a silently-swallowed one.
+        assertThrows<ProjectionUnavailable> { runBlocking { consumer.consume(applied) } }
         consumer.consume("""{"eventType":"loan.provisioned","loanId":"$loanId"}""") // -> ignored
         consumer.consume("not json") // -> parse_error
         consumer.consume("""{"eventType":"loan.stage_changed"}""") // -> malformed (no loanId)

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/AnalyticsConsumer.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/AnalyticsConsumer.kt
@@ -11,6 +11,7 @@ import com.openbank.analytics.application.port.out.DeadLetterRecord
 import com.openbank.analytics.application.port.out.DeadLetterSink
 import com.openbank.libs.analytics.AnalyticsEnvelope
 import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.libs.messaging.EventRetry
 import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
 import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
@@ -35,10 +36,31 @@ import java.util.UUID
  * bronze layer is retained ≥10 years and must never hold raw identifiers.
  *
  * Delivery is at-least-once; the envelope's [AnalyticsEnvelope.eventId] is the dedupe key and the
- * sink (and ClickHouse `ReplacingMergeTree`) collapse duplicates. A malformed event is **quarantined**
- * to the [DeadLetterSink] (not silently swallowed) so it is visible, counted and replayable once the
- * producer is fixed — a dropped event would be an invisible gap in the log of record.
+ * sink (and ClickHouse `ReplacingMergeTree`) collapse duplicates.
+ *
+ * **Two failures, two different answers (#5698/#5745).**
+ *
+ * A **malformed or un-projectable event** cannot be fixed by replaying it, so it is handed to the
+ * [DeadLetterSink] and ACKED. Read [DeadLetterSink] for what that actually buys today: the only
+ * binding is `LoggingDeadLetterSink`, a WARN line. The message is recoverable from the log pipeline
+ * for as long as logs are retained (Loki, 1 week here) — that is a far weaker guarantee than the
+ * "visible, counted and replayable" this KDoc used to claim. The ClickHouse `dead_letter_events`
+ * table exists but nothing writes to it — see [DeadLetterSink].
+ *
+ * A **failed sink write** is the opposite: the event is fine, ClickHouse is not. This used to take
+ * the same branch — the bronze row was dropped, a WARN was logged, and the message was acked. Bronze
+ * is the ≥10-year log of record and the sole extraction path, so a dropped row is a permanent,
+ * unreconstructable hole in it, and nothing downstream reports one: consumer lag is zero (the message
+ * was acked) and the row simply is not there. Sink writes now go through [EventRetry.withRetry] and,
+ * on persistent failure, the message is **NACKed** — see [consume] for why nack rather than a rethrow,
+ * and for why neither KDoc names the channel's current `failure-strategy`.
  */
+// TooManyFunctions: 11, i.e. exactly AT detekt's threshold, which it reports. The class was at 10
+// and the #5745 fix adds exactly one — [settle] — because manual acknowledgement now has two
+// possible outcomes instead of the single `finally { ack() }` it replaces. Splitting the envelope
+// mapping out to buy headroom would move a dozen attribution fallbacks away from the KDocs that
+// explain why their ORDER is load-bearing, which is a worse trade than one suppression.
+@Suppress("TooManyFunctions")
 @ApplicationScoped
 class AnalyticsConsumer {
 
@@ -69,36 +91,14 @@ class AnalyticsConsumer {
      * UNKNOWN/UNKNOWN/unknown with nothing erroring.
      */
     @Incoming("analytics-events-in")
+    @Suppress("TooGenericExceptionCaught") // the two catches below mean opposite things; see the KDoc
     suspend fun consume(message: Message<String>) {
         val payload = message.payload
         val address = addressOf(message)
-        try {
-            val node: JsonNode = objectMapper.readTree(payload)
-            val envelope = toEnvelope(node, address)
-            // F7: schema governance — an unknown/newer-than-known schema is quarantined (when strict),
-            // never silently written into the 10-year log of record.
-            if (::schemaGovernance.isInitialized &&
-                !schemaGovernance.accept(
-                    envelope.eventType,
-                    envelope.schemaVersion,
-                )
-            ) {
-                deadLetters.quarantine(
-                    DeadLetterRecord(
-                        contentHash = sha256(payload),
-                        rawPayload = payload,
-                        error = "unknown schema ${envelope.eventType}:${envelope.schemaVersion}",
-                        failedAt = Instant.now(clock),
-                    ),
-                )
-                return
-            }
-            sink.write(envelope)
-            // #2598 ask 2: a row that lands without attribution must be counted and logged, or
-            // the broken state stays indistinguishable from the healthy one.
-            if (::attribution.isInitialized) attribution.record(envelope, address.topic)
-            // F8: record ingest lag (now - occurredAt) so freshness/RPO can be alerted on.
-            if (::freshness.isInitialized) freshness.recordIngest(envelope.occurredAt)
+
+        // ---- Un-projectable payload: the poison pill. Quarantine and ACK; a replay fails the same.
+        val envelope = try {
+            toEnvelope(objectMapper.readTree(payload), address)
         } catch (e: Exception) {
             log.errorf(e, "Quarantining un-projectable analytics message: %s", payload.take(200))
             deadLetters.quarantine(
@@ -110,12 +110,70 @@ class AnalyticsConsumer {
                 ),
             )
             if (::freshness.isInitialized) freshness.recordDeadLetter()
-        } finally {
-            // Switching the signature from `String` to `Message<String>` also switches SmallRye
-            // from auto-ack to manual, so the ack has to be explicit — and in a `finally`, or a
-            // quarantined message would stall the partition forever.
-            Uni.createFrom().completionStage(message.ack()).awaitSuspending()
+            settle(message)
+            return
         }
+
+        // F7: schema governance — an unknown/newer-than-known schema is quarantined (when strict),
+        // never silently written into the 10-year log of record. Also a producer-side problem a
+        // replay cannot fix, so it acks too.
+        if (::schemaGovernance.isInitialized && !schemaGovernance.accept(envelope.eventType, envelope.schemaVersion)) {
+            deadLetters.quarantine(
+                DeadLetterRecord(
+                    contentHash = sha256(payload),
+                    rawPayload = payload,
+                    error = "unknown schema ${envelope.eventType}:${envelope.schemaVersion}",
+                    failedAt = Instant.now(clock),
+                ),
+            )
+            settle(message)
+            return
+        }
+
+        // ---- Sink write: a dependency failure, NOT a bad event. Retry, then nack.
+        try {
+            EventRetry.withRetry(log, "analytics bronze write", envelope.eventId) {
+                sink.write(envelope)
+            }
+        } catch (e: Exception) {
+            // NACK rather than rethrow, because this handler took manual ack the moment its
+            // signature became `Message<String>`: acknowledgement is this method's job, and nack is
+            // how it says "I did not do this work". A bare rethrow past a manual-ack handler leaves
+            // the outcome to the framework rather than stating it here.
+            //
+            // What the nack buys is the connector's `failure-strategy` for `analytics-events-in`,
+            // which is CONFIGURATION and not a property of this code: `dead-letter-queue` parks the
+            // record in the configured topic, SmallRye's default `fail` stops the channel. This
+            // comment deliberately does not state today's value — #5745 section B found the whole
+            // #5698 family asserting a dead-letter that only four channels fleet-wide actually had,
+            // and #5751 is wiring this one to `openbank.dlq.analytics-sink.analytics-events-in`.
+            // Either outcome beats the old behaviour, which was to ack: a halted channel or a parked
+            // record is recoverable, a silent hole in a ≥10-year log of record is not.
+            log.errorf(e, "Bronze write failed after retries, nacking: %s", payload.take(200))
+            settle(message, e)
+            return
+        }
+
+        // #2598 ask 2: a row that lands without attribution must be counted and logged, or
+        // the broken state stays indistinguishable from the healthy one.
+        if (::attribution.isInitialized) attribution.record(envelope, address.topic)
+        // F8: record ingest lag (now - occurredAt) so freshness/RPO can be alerted on.
+        if (::freshness.isInitialized) freshness.recordIngest(envelope.occurredAt)
+        settle(message)
+    }
+
+    /**
+     * Settle the message: ACK when [cause] is null, NACK otherwise.
+     *
+     * Switching the signature from `String` to `Message<String>` switched SmallRye from auto-ack to
+     * manual, so every terminal path in [consume] must state its own outcome — exactly once, and
+     * never both. That is why this is no longer a `finally`: a `finally` acked the failed write too,
+     * which is the whole defect. One function rather than an `ack`/`nack` pair so the class stays
+     * under detekt's TooManyFunctions threshold without splitting the mapping apart.
+     */
+    private suspend fun settle(message: Message<String>, cause: Throwable? = null) {
+        val stage = if (cause == null) message.ack() else message.nack(cause)
+        Uni.createFrom().completionStage(stage).awaitSuspending()
     }
 
     /** Lifts the broker metadata this consumer used to discard. Absent metadata is not an error. */

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/port/out/DeadLetterSink.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/port/out/DeadLetterSink.kt
@@ -10,10 +10,15 @@ import java.time.Instant
  * A message that could not be projected into an [com.openbank.libs.analytics.AnalyticsEnvelope]
  * (malformed JSON, missing required field, mapping failure).
  *
- * [contentHash] is a stable digest of [rawPayload] so the DLQ is **idempotent** — the same poison
- * message re-delivered (at-least-once) or hit again on replay does not create duplicate quarantine
- * rows. Once the producer bug is fixed, an operator replays the quarantined payloads through the
- * normal mapping path; until then they are visible and counted, never silently lost.
+ * [contentHash] is a stable digest of [rawPayload], so a durable sink can make quarantine idempotent
+ * — the same poison message re-delivered (at-least-once) or hit again on replay would not create
+ * duplicate rows.
+ *
+ * **No such sink is bound today.** The only implementation is
+ * [com.openbank.analytics.infrastructure.sink.LoggingDeadLetterSink], one `log.warnf`. So the hash is
+ * currently a grep key rather than a dedupe key, "quarantined" means "logged at WARN", and a
+ * quarantined payload survives exactly as long as the log pipeline retains it. Operator replay is
+ * whatever can be reconstructed from those lines by hand.
  */
 data class DeadLetterRecord(val contentHash: String, val rawPayload: String, val error: String, val failedAt: Instant)
 
@@ -30,6 +35,10 @@ data class DeadLetterRecord(val contentHash: String, val rawPayload: String, val
  * "quarantined" then means **logged**: recoverable for as long as log retention holds, not from the
  * table. Read a `quarantine()` that returns normally as proof of nothing — the two are
  * indistinguishable at the call site (#5761).
+ *
+ * This port also covers only the *unretryable* case. A transient sink failure is no longer quarantined
+ * at all — [com.openbank.analytics.application.AnalyticsConsumer] retries it and then nacks, because
+ * a ClickHouse outage is not a bad event and parking it here would lose it just as thoroughly.
  */
 interface DeadLetterSink {
     suspend fun quarantine(record: DeadLetterRecord)

--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/AnalyticsConsumerFailureTest.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/AnalyticsConsumerFailureTest.kt
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.analytics.application
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.analytics.application.port.out.AnalyticsSink
+import com.openbank.analytics.application.port.out.DeadLetterRecord
+import com.openbank.analytics.application.port.out.DeadLetterSink
+import com.openbank.libs.analytics.AnalyticsEnvelope
+import com.openbank.libs.messaging.EventRetry
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.reactive.messaging.Message
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+/**
+ * The ack/nack contract of [AnalyticsConsumer] (#5698/#5745).
+ *
+ * This consumer takes MANUAL acknowledgement (its signature is `Message<String>`), and it used to ack
+ * in a `finally` — so a ClickHouse write that failed was logged, quarantined to a WARN line, and
+ * ACKED. Bronze is the ≥10-year log of record and the only extraction path, so that is a permanent
+ * hole that nothing reports: consumer lag is zero because the message was acked, and the row simply
+ * is not there.
+ *
+ * The split under test: a sink failure is retried and then NACKed; an un-projectable payload is still
+ * quarantined and ACKed, because replaying it fails identically forever.
+ */
+/** A named transient failure, so the fakes below never `throw RuntimeException` (detekt). */
+private class SinkUnavailable(message: String) : RuntimeException(message)
+
+class AnalyticsConsumerFailureTest {
+
+    private val mapper = ObjectMapper()
+
+    private class CapturingDlq : DeadLetterSink {
+        val records = mutableListOf<DeadLetterRecord>()
+        override suspend fun quarantine(record: DeadLetterRecord) {
+            records += record
+        }
+    }
+
+    private class FailingSink(private val failures: Int) : AnalyticsSink {
+        var attempts = 0
+        val written = mutableListOf<AnalyticsEnvelope>()
+        override suspend fun write(envelope: AnalyticsEnvelope) {
+            attempts++
+            if (attempts <= failures) throw SinkUnavailable("clickhouse unreachable")
+            written += envelope
+        }
+    }
+
+    /** A [Message] that records which acknowledgement the consumer actually chose. */
+    private class Outcome(payload: String) {
+        var acked = false
+        var nacked: Throwable? = null
+        val message: Message<String> = Message.of(
+            payload,
+            {
+                acked = true
+                CompletableFuture.completedFuture(null) as CompletionStage<Void>
+            },
+            { t: Throwable ->
+                nacked = t
+                CompletableFuture.completedFuture(null) as CompletionStage<Void>
+            },
+        )
+    }
+
+    private fun consumerWith(sink: AnalyticsSink, dlq: DeadLetterSink) = AnalyticsConsumer().apply {
+        this.sink = sink
+        this.deadLetters = dlq
+        objectMapper = mapper
+        clock = Clock.systemUTC()
+    }
+
+    private val goodPayload = """{"eventId":"11111111-1111-1111-1111-111111111111","aggregateType":"ACCOUNT",""" +
+        """"aggregateId":"acc-1","eventType":"account.opened","occurredAt":"2026-01-01T00:00:00Z"}"""
+
+    /**
+     * The assertion that matters: a persistent sink failure must NOT ack. Against the pre-fix
+     * consumer this fails on both counts — the `finally` acked and nothing was ever nacked.
+     */
+    @Test
+    fun `a persistent sink failure is retried and then NACKED, never acked`(): Unit = runBlocking {
+        val sink = FailingSink(failures = Int.MAX_VALUE)
+        val dlq = CapturingDlq()
+        val outcome = Outcome(goodPayload)
+
+        consumerWith(sink, dlq).consume(outcome.message)
+
+        assertThat(sink.attempts).isEqualTo(EventRetry.DEFAULT_MAX_ATTEMPTS)
+        assertThat(outcome.nacked).isInstanceOf(SinkUnavailable::class.java)
+        assertThat(outcome.acked).isFalse()
+        // A transient dependency failure is NOT a poison pill: quarantining it here would lose the
+        // row just as thoroughly, since the only DLQ binding is a log line.
+        assertThat(dlq.records).isEmpty()
+    }
+
+    @Test
+    fun `a transient sink failure is retried, written, and acked`(): Unit = runBlocking {
+        val sink = FailingSink(failures = 1)
+        val dlq = CapturingDlq()
+        val outcome = Outcome(goodPayload)
+
+        consumerWith(sink, dlq).consume(outcome.message)
+
+        assertThat(sink.attempts).isEqualTo(2)
+        assertThat(sink.written).hasSize(1)
+        assertThat(outcome.acked).isTrue()
+        assertThat(outcome.nacked).isNull()
+    }
+
+    /**
+     * The other half of the split, unchanged by the fix and deliberately so. A blanket rethrow here
+     * would wedge the partition on a payload that can never succeed.
+     */
+    @Test
+    fun `an un-projectable payload is quarantined and still ACKED, and never reaches the sink`(): Unit = runBlocking {
+        val sink = FailingSink(failures = 0)
+        val dlq = CapturingDlq()
+        val outcome = Outcome("{ this is not valid json")
+
+        consumerWith(sink, dlq).consume(outcome.message)
+
+        assertThat(sink.attempts).isZero()
+        assertThat(dlq.records).hasSize(1)
+        assertThat(outcome.acked).isTrue()
+        assertThat(outcome.nacked).isNull()
+    }
+
+    @Test
+    fun `a healthy event is written once and acked`(): Unit = runBlocking {
+        val sink = FailingSink(failures = 0)
+        val dlq = CapturingDlq()
+        val outcome = Outcome(goodPayload)
+
+        consumerWith(sink, dlq).consume(outcome.message)
+
+        assertThat(sink.written).hasSize(1)
+        assertThat(dlq.records).isEmpty()
+        assertThat(outcome.acked).isTrue()
+    }
+}

--- a/openbank-tax-reporting-service/src/main/kotlin/com/openbank/tax/infrastructure/kafka/WithholdingRemittedConsumer.kt
+++ b/openbank-tax-reporting-service/src/main/kotlin/com/openbank/tax/infrastructure/kafka/WithholdingRemittedConsumer.kt
@@ -6,6 +6,7 @@ package com.openbank.tax.infrastructure.kafka
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.libs.messaging.EventRetry
 import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
 import com.openbank.tax.application.usecase.TaxFilingService
 import com.openbank.tax.domain.model.FilingPeriod
@@ -38,6 +39,40 @@ import java.util.UUID
  * (`WithholdingRemittanceService.remittedEvent`) and the existing self-consumer rather than assumed.
  *
  * A record with no such header is ignored: it cannot have come from the compliant outbox relay.
+ *
+ * **Failure handling separates two things this consumer used to conflate (#5698/#5745).**
+ *
+ * A **malformed event** — unparseable JSON, an unparsable `totalTaxAmount`, a missing `dueDate` — is
+ * unretryable: replaying it fails identically forever, so it is counted and acked. That is the
+ * genuine poison pill and the only case that may be acked on failure.
+ *
+ * A **failed write** ([TaxFilingService.observe] → `openIfAbsent` + `record`) is the opposite: the
+ * event is fine, the database is not. Acking there was the worst variant of this bug class in the
+ * fleet, because nothing downstream can tell. `assemble` totals only what was *observed*, so a lost
+ * remittance does not surface as an error or a gap — it silently **understates the tax withheld on a
+ * §38d return that then gets filed**, and the correction is a `dodatečné vyúčtování` after the fact.
+ * `auto.offset.reset: latest` also rules out recovering it by replay. Those failures now go through
+ * [EventRetry.withRetry] and are RETHROWN.
+ *
+ * **This channel HALTS on a persistent failure, and that is currently unavoidable — say so rather
+ * than call it a dead-letter.** The mechanism this handler controls is the rethrow: the record is not
+ * acknowledged as done. What follows is the connector's `failure-strategy` for
+ * `withholding-remitted-in`, and unlike its siblings this one cannot yet be given a DLQ. #5751 wires
+ * the fleet's incoming channels to explicit dead-letter topics and deliberately BASELINES this one:
+ * `openbank-tax-reporting-service` has no `KafkaUser` manifest anywhere under
+ * `openbank-infra/gitops/components/`, so no `Write` ACL can be granted for a dead-letter topic, and
+ * a DLQ configured without the ACL wedges on the DLQ send itself — parking the record on the very
+ * failure it was meant to park. So SmallRye's default `fail` applies and the channel stops.
+ *
+ * That is a real operational property of a statutory filing path, not a footnote: a §38d remittance
+ * arriving during a tax-db outage stops this consumer group until someone intervenes. It is still the
+ * right trade against the alternative — a halted channel is loud and its backlog is intact, whereas
+ * the old ack silently understated a return that then got filed — but it is a trade someone must
+ * know about while operating this service. Creating a KafkaUser for tax-reporting is what unblocks
+ * the DLQ; until then, this consumer wedging IS the alert.
+ *
+ * `observe` is idempotent on the remittance id (that is what the `duplicate` outcome is), so a retry
+ * or a redelivery cannot double-count a batch into the return.
  */
 @ApplicationScoped
 class WithholdingRemittedConsumer(
@@ -49,24 +84,35 @@ class WithholdingRemittedConsumer(
     private val log = Logger.getLogger(WithholdingRemittedConsumer::class.java)
 
     @Incoming("withholding-remitted-in")
-    // Poison-pill safety: this boundary must swallow ANY failure and ack, so one malformed event
-    // cannot wedge the consumer group and stall every later filing period behind it.
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught") // the two catches below mean opposite things; see the KDoc
     suspend fun consume(record: ConsumerRecord<String, String>) {
-        try {
-            val eventType = record.headers().lastHeader(OutboxKafkaHeaders.HEADER_EVENT_TYPE)
-                ?.let { String(it.value(), StandardCharsets.UTF_8) }
-            if (eventType != EVENT_WITHHOLDING_REMITTED) {
-                count(OUTCOME_IGNORED)
-                return
-            }
+        val eventType = record.headers().lastHeader(OutboxKafkaHeaders.HEADER_EVENT_TYPE)
+            ?.let { String(it.value(), StandardCharsets.UTF_8) }
+        if (eventType != EVENT_WITHHOLDING_REMITTED) {
+            count(OUTCOME_IGNORED)
+            return
+        }
 
-            val remittance = parse(objectMapper.readTree(record.value()))
-            val recorded = taxFilingService.observe(remittance)
+        // Poison pill: an event this consumer cannot decode fails identically on every replay, so it
+        // is counted and acked rather than wedging the group and stalling every later filing period.
+        val remittance = try {
+            parse(objectMapper.readTree(record.value()))
+        } catch (e: Exception) {
+            count(OUTCOME_MALFORMED)
+            log.errorf(e, "[withholding-filing] unparseable remitted event, acking: %.300s", record.value())
+            return
+        }
+
+        try {
+            val recorded = EventRetry.withRetry(log, "§38d remittance observation", remittance.remittanceId) {
+                taxFilingService.observe(remittance)
+            }
             count(if (recorded) OUTCOME_RECORDED else OUTCOME_DUPLICATE)
         } catch (e: Exception) {
+            // Counted BEFORE the rethrow so the `failed` population survives whichever
+            // failure-strategy the channel is configured with — today, a halt (see the KDoc).
             count(OUTCOME_FAILED)
-            log.errorf(e, "[withholding-filing] failed to handle remitted event: %.300s", record.value())
+            throw e
         }
     }
 
@@ -101,6 +147,7 @@ class WithholdingRemittedConsumer(
         private const val OUTCOME_RECORDED = "recorded"
         private const val OUTCOME_DUPLICATE = "duplicate"
         private const val OUTCOME_IGNORED = "ignored_event_type"
+        private const val OUTCOME_MALFORMED = "malformed"
         private const val OUTCOME_FAILED = "failed"
     }
 }

--- a/openbank-tax-reporting-service/src/test/kotlin/com/openbank/tax/infrastructure/kafka/WithholdingRemittedConsumerTest.kt
+++ b/openbank-tax-reporting-service/src/test/kotlin/com/openbank/tax/infrastructure/kafka/WithholdingRemittedConsumerTest.kt
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.tax.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.libs.messaging.EventRetry
+import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
+import com.openbank.tax.application.usecase.TaxFilingService
+import com.openbank.tax.domain.model.ObservedRemittance
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.header.internals.RecordHeader
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.nio.charset.StandardCharsets
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * The §38d filing consumer's failure contract (#5698/#5745).
+ *
+ * This consumer had no test at all, and the untested branch was the one that matters: a failed
+ * `TaxFilingService.observe` was counted and acked. `assemble` totals only what was *observed*, so a
+ * lost remittance never shows up as an error or a gap — it silently understates the tax withheld on
+ * a return that then gets filed, and `auto.offset.reset: latest` rules out recovering it by replay.
+ *
+ * Each test below is written to discriminate, not to describe: run them against the pre-fix consumer
+ * and the two behaviour tests go red while the malformed-payload test stays green on both sides.
+ */
+/** A named transient failure, so the tests below never `throw RuntimeException` (detekt). */
+private class FilingStoreUnavailable(message: String) : RuntimeException(message)
+
+class WithholdingRemittedConsumerTest {
+
+    private val filings = mockk<TaxFilingService>()
+    private val registry = SimpleMeterRegistry()
+    private val clock = Clock.fixed(Instant.parse("2026-08-05T09:00:00Z"), ZoneOffset.UTC)
+    private val consumer = WithholdingRemittedConsumer(filings, ObjectMapper(), registry, clock)
+
+    private val remittanceId = UUID.randomUUID()
+
+    private fun record(
+        value: String,
+        eventType: String? = "interest.withholding.remitted.v1",
+    ): ConsumerRecord<String, String> {
+        val r = ConsumerRecord("openbank.interest.accrual.event", 0, 0L, "key", value)
+        if (eventType != null) {
+            r.headers().add(
+                RecordHeader(OutboxKafkaHeaders.HEADER_EVENT_TYPE, eventType.toByteArray(StandardCharsets.UTF_8)),
+            )
+        }
+        return r
+    }
+
+    private fun payload(id: UUID = remittanceId) = """
+        {"remittanceId":"$id","periodYear":2026,"periodMonth":7,"currency":"CZK",
+         "totalTaxAmount":"1234.56","itemCount":9,"dueDate":"2026-08-20"}
+    """.trimIndent()
+
+    private fun outcome(value: String): Double =
+        registry.counter("openbank.tax.withholding_events", "outcome", value).count()
+
+    @Test
+    fun `a remitted event is observed into the filing period`(): Unit = runBlocking {
+        coEvery { filings.observe(any()) } returns true
+
+        consumer.consume(record(payload()))
+
+        coVerify(exactly = 1) {
+            filings.observe(
+                match<ObservedRemittance> {
+                    it.remittanceId == remittanceId && it.totalTaxAmount.toPlainString() == "1234.56"
+                },
+            )
+        }
+        assertThat(outcome("recorded")).isEqualTo(1.0)
+    }
+
+    /**
+     * The assertion that matters. A `filingRepository.openIfAbsent` / `remittanceRepository.record`
+     * failure is a database being down, not a bad event — the remittance must reach the return once
+     * it recovers, or the return understates the tax withheld.
+     */
+    @Test
+    fun `a persistent write failure is RETHROWN after the bounded attempts`(): Unit = runBlocking {
+        coEvery { filings.observe(any()) } throws FilingStoreUnavailable("tax-db down")
+
+        assertThrows<FilingStoreUnavailable> { runBlocking { consumer.consume(record(payload())) } }
+
+        // Bounded, so one outage cannot block the partition indefinitely.
+        coVerify(exactly = EventRetry.DEFAULT_MAX_ATTEMPTS) { filings.observe(any()) }
+        // Counted before the rethrow, so the `failed` population survives the connector's decision.
+        assertThat(outcome("failed")).isEqualTo(1.0)
+        assertThat(outcome("recorded")).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `a transient write failure is retried and then succeeds without throwing`(): Unit = runBlocking {
+        var calls = 0
+        coEvery { filings.observe(any()) } answers {
+            calls++
+            if (calls == 1) throw FilingStoreUnavailable("connection refused")
+            true
+        }
+
+        consumer.consume(record(payload()))
+
+        assertThat(calls).isEqualTo(2)
+        assertThat(outcome("recorded")).isEqualTo(1.0)
+        assertThat(outcome("failed")).isEqualTo(0.0)
+    }
+
+    private suspend fun consumeAllMalformed() {
+        consumer.consume(record("not json"))
+        consumer.consume(record("""{"remittanceId":"not-a-uuid"}"""))
+        // A strictly-decoded amount: a silent zero here would file a return understating the tax.
+        consumer.consume(
+            record(
+                """{"remittanceId":"$remittanceId","periodYear":2026,"periodMonth":7,"currency":"CZK",""" +
+                    """"totalTaxAmount":"twelve","itemCount":9,"dueDate":"2026-08-20"}""",
+            ),
+        )
+    }
+
+    /**
+     * The other half of the split, and the reason this is not a blanket rethrow: an event this
+     * consumer cannot decode fails identically on every replay, so acking it is correct. Nothing
+     * downstream is called, so nothing is silently half-done.
+     *
+     * This one is deliberately GREEN against the pre-fix consumer too — that is what makes the three
+     * behaviour tests above meaningful rather than merely different. The poison-pill branch is the
+     * part of the old design that was right, and this asserts the fix did not take it away.
+     */
+    @Test
+    fun `a malformed payload is still acked and never reaches the filing service`(): Unit = runBlocking {
+        consumeAllMalformed()
+
+        coVerify(exactly = 0) { filings.observe(any()) }
+    }
+
+    /**
+     * Separate from the ack assertion above on purpose: `malformed` is a NEW outcome label. Folding
+     * it into the previous test would have made that test go red against the pre-fix consumer for a
+     * reason that has nothing to do with acknowledgement, and the "green on both sides" claim above
+     * would have been false.
+     */
+    @Test
+    fun `a malformed payload is counted apart from a failed write`(): Unit = runBlocking {
+        consumeAllMalformed()
+
+        assertThat(outcome("malformed")).isEqualTo(3.0)
+        // The distinction that matters operationally: `failed` now means "a write we gave up on and
+        // rethrew", so it can be alerted on. Before, it meant that OR a bad payload, indiscriminately.
+        assertThat(outcome("failed")).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `a record with another or no event type is ignored without decoding it`(): Unit = runBlocking {
+        consumer.consume(record(payload(), eventType = "interest.accrual.posted.v1"))
+        consumer.consume(record("not json at all", eventType = null))
+
+        coVerify(exactly = 0) { filings.observe(any()) }
+        assertThat(outcome("ignored_event_type")).isEqualTo(2.0)
+    }
+
+    @Test
+    fun `an already-recorded batch is counted as a duplicate, not re-added to the return`(): Unit = runBlocking {
+        coEvery { filings.observe(any()) } returns false
+
+        consumer.consume(record(payload()))
+
+        assertThat(outcome("duplicate")).isEqualTo(1.0)
+        assertThat(outcome("recorded")).isEqualTo(0.0)
+    }
+}


### PR DESCRIPTION
Fixes the three **regulatory** consumers from #5745 section A — the ones where a lost event means a
wrong number on a filed statutory return.

Stacked on #5719: this branch merges `fix/event-handlers-stop-acking-failed-work` so it can reuse
the shared `EventRetry` in `openbank-libs-runtime` rather than introduce a third retry
implementation. **The PR base is that branch**, so the diff shown here is only this work. #5719 was
still OPEN when this was written; if it merges first the base collapses to `main` on its own.

## What changed, per service

| service | swallowed call | now |
|---|---|---|
| `anacredit` | `projections.applyIfNewer` | retried, then **rethrown**; `apply_error` counted first |
| `analytics-sink` | `ClickHouseAnalyticsSink.write` | retried, then **nacked** (manual-ack consumer) |
| `tax-reporting` | `TaxFilingService.observe` | retried, then **rethrown**; `failed` counted first |

The split is the whole point and it is not a blanket rethrow: a **malformed payload** still acks in
all three, because replaying it fails identically forever. Only a **transient downstream failure**
is retried and re-raised.

`analytics-sink` nacks rather than rethrows because its signature is `Message<String>`, which took
it off auto-ack. It used to ack in a `finally`, so a failed write was acked along with everything
else; every terminal path now states its own outcome exactly once.

## ⚠️ DLQ status — two of three get one, the third cannot yet

**Corrected after review: my first version of this section said none of the three had a DLQ.** That
was true when measured and went stale inside the same session, because #5751
(`fix/kafka-incoming-dlq-wiring`, open) is wiring them while this branch is open — the same failure
mode #5757 hit. Verified against `gh pr diff 5751`:

| channel | after #5751 |
|---|---|
| anacredit `lending-events-in` | **wired** — `openbank.dlq.anacredit.lending-events-in` (config + `KafkaTopic` CR + Write ACL) |
| analytics-sink `analytics-events-in` | **wired** — `openbank.dlq.analytics-sink.analytics-events-in` |
| tax-reporting `withholding-remitted-in` | **deliberately baselined** — no DLQ |

So once #5751 lands, two of these three rethrows genuinely park the record.

**tax-reporting cannot have one, and that is the operationally important part.** #5751 baselines it
with the reason *"no KafkaUser in gitops — a Write ACL cannot be granted, so a DLQ would wedge on the
send"*. Confirmed independently: `openbank-tax-reporting-service` has no `KafkaUser` manifest
anywhere under `openbank-infra/gitops/components/` — in fact no gitops presence at all. So SmallRye's
default `fail` applies and **the channel halts on a persistent failure**: a §38d remittance arriving
during a tax-db outage stops the consumer group until someone intervenes.

That is still the right trade — a halted channel is loud and its backlog is intact, where the old ack
silently understated a return that then got filed — but it is a real property of a statutory filing
path, so the KDoc states it plainly rather than burying it: until a KafkaUser exists for that service,
**this consumer wedging IS the alert**. Creating one is the unblock, and is out of scope here.

**What the KDocs now assert.** Not the config value of the moment — that is exactly what went stale.
Each states the mechanism the handler controls (the record is not acknowledged as done) and names the
connector's `failure-strategy` as the thing that decides what follows: `dead-letter-queue` parks it,
the default `fail` stops the channel. They point at #5751 and the `check-incoming-dlq-wiring` gate for
the current answer. tax-reporting is the one exception, stated concretely, because there the halt is
not a transient state of the config.

Worth sequencing #5751 before this merges.

## analytics-sink: what "quarantined" actually means

#5745 flagged that the only `DeadLetterSink` binding is `LoggingDeadLetterSink`, one `log.warnf`,
while the KDoc promised a "visible, counted and replayable" quarantine and a ClickHouse
`dead_letter_events` adapter "landing with the warehouse adapter". Resolved by fixing the KDocs, in
all three places that made the claim.

The sharper finding while checking it: **the table exists.** `clickhouse/V1__analytics_bronze_silver.sql`
creates `openbank_analytics.dead_letter_events`, the ClickHouse init ConfigMap ships the same DDL,
and `dashboard-openbank-business-warehouse.yaml` has a panel selecting from it. No Kotlin anywhere
inserts into it. So the table is structurally present and permanently empty, and that panel reads
zero for a reason that has nothing to do with the DLQ rate — a green-looking "no dead letters" that
is really "no writer". Documented in place; implementing the adapter is not in this PR.

## Falsification

Every new behaviour test was run against the **pre-fix** consumer (restored from `origin/main`) to
confirm it can detect the absence of what it tests.

**Red pre-fix, green post-fix**
- anacredit — persistent failure rethrows; transient failure recovers; every-terminal-branch outcomes
- analytics-sink — persistent sink failure nacked and never acked; transient sink failure recovers
- tax-reporting — persistent write rethrows; transient write recovers; new `malformed` counter

**Green on BOTH sides** (this is what makes the above meaningful rather than merely different)
- anacredit — malformed payload is acked, projection never called
- analytics-sink — un-projectable payload quarantined and still acked; healthy event written + acked
- tax-reporting — malformed payload acked and never reaches the filing service; ignored event type;
  duplicate batch; happy path

The tax malformed-payload case is deliberately **two** tests. Folding the new `malformed` counter
into the ack assertion made that test go red pre-fix for a reason unrelated to acknowledgement,
which would have made the "green on both sides" claim false.

Also worth recording: anacredit's existing test asserted the **opposite** — *"a repository failure
is swallowed so the consumer group is not wedged"* — and passed. That is how this shipped under a
green test certifying the defect as intended behaviour.

## Verification

`ktlintCheck`, `detekt` and `test` per module, tasks confirmed present in the output rather than
inferred from a green exit:

| module | tests | skipped | failures |
|---|---|---|---|
| `openbank-anacredit-service` | 44 | 12 (`@QuarkusTest` ITs, Docker-gated) | 0 |
| `openbank-analytics-sink` | 85 | 0 | 0 |
| `openbank-tax-reporting-service` | 32 | 0 | 0 |

One anacredit IT (`PostgresCreditExposureRepositoryIT`, "Failed to start quarkus") failed on a run
with a second Gradle build active and passes in isolation — the documented concurrent-build boot
flake, in a Postgres repository IT with no consumer involvement.

`check-event-handler-swallows.py --enforce` (the gate from #5719) is clean over all 170 handler
files. Note it would have been clean before this PR too: `applyIfNewer` and `sink.write` are two of
the six shapes #5745 section C measured it as blind to. Widening the gate is tracked there and is
not attempted here.

## Governance

`openbank-tax-reporting-service` is **not** in `rules.yaml: money_path_services`, so ADR-0030's
2-approval + threat-model requirement does not apply, and there is no
`docs/threat-models/openbank-tax-reporting-service.md` to update. Both threat-model gates are scoped
to money-path services; `check-threat-models.py` passes (23/23). No trust boundary moves in this
diff — no REST surface, no new outbound edge, no authn/listener keys, no NetworkPolicy or Deployment
change.

Refs #5745, #5698

