### PR TITLE
fix(fraud): dedupe velocity_aggregates on redelivery (#5716)

### DIFF
--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/application/port/out/VelocityAggregateRepository.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/application/port/out/VelocityAggregateRepository.kt
@@ -12,10 +12,18 @@ import java.util.UUID
 /** Stores and queries per-account rolling velocity aggregates (ADR-0084 §2). */
 interface VelocityAggregateRepository {
     /**
-     * Records a new transaction signal for [accountId]. Upserts all three windows (H1/H24/D7)
-     * in a single call — incrementing the count and sum within each window's time bucket.
+     * Records a new transaction signal for [accountId], identified by [transactionId] (the signal's
+     * `aggregateId`). Upserts all three windows (H1/H24/D7) in a single call — incrementing the
+     * count and sum within each window's time bucket.
+     *
+     * Idempotent per window (#5716): each window row carries the id of the last signal applied to
+     * it, and a signal whose [transactionId] matches is skipped. So a redelivered Kafka message does
+     * not double-count, and a retry after a partial failure re-applies only the windows that were
+     * not applied — the windows converge independently rather than as one transaction. A null
+     * [transactionId] carries no identity and is therefore never deduplicated (same contract as
+     * [PayeeHistoryRepository.recordPayment]).
      */
-    suspend fun recordTransaction(accountId: UUID, amount: BigDecimal, currency: String)
+    suspend fun recordTransaction(accountId: UUID, amount: BigDecimal, currency: String, transactionId: UUID?)
 
     /**
      * Returns the current aggregate for [accountId] in [window] for [currency], or null.

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/messaging/TransactionSignalConsumer.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/messaging/TransactionSignalConsumer.kt
@@ -73,7 +73,7 @@ class TransactionSignalConsumer(
         @Suppress("TooGenericExceptionCaught") // DB / reactive layer exceptions have no common base
         runBlocking {
             try {
-                velocityRepo.recordTransaction(accountId, amount, currency)
+                velocityRepo.recordTransaction(accountId, amount, currency, signal.aggregateId)
                 log.debugf("Velocity aggregate updated for account %s amount=%s %s", accountId, amount, currency)
             } catch (ex: Exception) {
                 log.warnf(ex, "Failed to record velocity aggregate for account %s", accountId)

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImpl.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImpl.kt
@@ -23,12 +23,24 @@ import java.util.UUID
 class VelocityAggregateRepositoryImpl(private val pool: PgPool, private val clock: Clock) :
     VelocityAggregateRepository {
 
-    override suspend fun recordTransaction(accountId: UUID, amount: BigDecimal, currency: String) {
+    override suspend fun recordTransaction(
+        accountId: UUID,
+        amount: BigDecimal,
+        currency: String,
+        transactionId: UUID?,
+    ) {
         val now = Instant.now(clock)
         VelocityWindow.entries.forEach { window ->
             val start = window.bucketStart(now).toOffsetDateTime()
             pool.preparedQuery(UPSERT_SQL).execute(
-                Tuple.of(accountId.toString(), window.name, currency, start, amount),
+                Tuple.of(
+                    accountId.toString(),
+                    window.name,
+                    currency,
+                    start,
+                    amount,
+                    transactionId?.toString(),
+                ),
             ).awaitSuspending()
         }
     }
@@ -55,16 +67,27 @@ class VelocityAggregateRepositoryImpl(private val pool: PgPool, private val cloc
     }
 
     companion object {
+        // Redelivery guard (#5716), mirroring payee_history's: only apply when the incoming
+        // transaction id is either absent (NULL — the signal carries no aggregateId, so it cannot be
+        // deduplicated) or genuinely different from the one this row last applied. A redelivered
+        // Kafka message for the SAME aggregateId makes the WHERE false, so the DO UPDATE is skipped
+        // entirely and Postgres leaves the row untouched — no double-count of either the count or
+        // the amount. The marker is per row, so the three window statements converge independently:
+        // a retry after a partial failure re-applies only the windows it had not reached.
         private const val UPSERT_SQL =
             """
             INSERT INTO velocity_aggregates
-                (account_id, velocity_window, currency, window_start, transaction_count, total_amount, updated_at)
-            VALUES ($1::uuid, $2, $3, $4, 1, $5, NOW())
+                (account_id, velocity_window, currency, window_start, transaction_count, total_amount,
+                 last_transaction_id, updated_at)
+            VALUES ($1::uuid, $2, $3, $4, 1, $5, $6::uuid, NOW())
             ON CONFLICT (account_id, velocity_window, currency, window_start)
             DO UPDATE SET
-                transaction_count = velocity_aggregates.transaction_count + 1,
-                total_amount      = velocity_aggregates.total_amount + EXCLUDED.total_amount,
-                updated_at        = NOW()
+                transaction_count   = velocity_aggregates.transaction_count + 1,
+                total_amount        = velocity_aggregates.total_amount + EXCLUDED.total_amount,
+                last_transaction_id = EXCLUDED.last_transaction_id,
+                updated_at          = NOW()
+            WHERE EXCLUDED.last_transaction_id IS NULL
+               OR velocity_aggregates.last_transaction_id IS DISTINCT FROM EXCLUDED.last_transaction_id
             """
 
         private const val SELECT_SQL =

--- a/openbank-fraud-service/src/main/resources/db/migration/V5__velocity_aggregates_redelivery_dedup.sql
+++ b/openbank-fraud-service/src/main/resources/db/migration/V5__velocity_aggregates_redelivery_dedup.sql
@@ -1,0 +1,28 @@
+-- Issue #5716: velocity_aggregates had no redelivery dedup, so a retried/redelivered
+-- transaction.initiated event re-added the amount and re-incremented the count. This did not
+-- matter while TransactionSignalConsumer swallowed every failure and acked (#5698) — nothing was
+-- ever redelivered — but #5715 makes transient failures rethrow so the connector can dead-letter
+-- and redeliver, which makes the gap reachable.
+--
+-- The guard mirrors payee_history (V3): last_transaction_id records the aggregateId of the last
+-- signal actually applied to THIS row, and the upsert's DO UPDATE ... WHERE skips the increment
+-- when the incoming aggregateId matches it. NULL (a signal with no aggregateId) is never
+-- deduplicated — it carries no identity to deduplicate by — exactly as in payee_history.
+--
+-- Partial-failure decision: the marker is PER ROW, i.e. per (account, window, currency,
+-- window_start), not per event. recordTransaction issues one statement per window, and the three
+-- are deliberately NOT wrapped in one transaction: each window converges independently, so a retry
+-- after a partial failure re-applies only the windows that had not been applied and skips the ones
+-- that had. Wrapping the set in a transaction would still need this marker (a retry after a
+-- committed set must not re-apply), so the marker is the load-bearing part either way.
+--
+-- Known bound, same as payee_history: this is a LAST-writer marker, not an applied-event set, so it
+-- deduplicates a redelivery that arrives before any other event for the same bucket. An out-of-order
+-- replay (A, B, A) would still double-count A. Covering that needs an applied-event ledger, which is
+-- a larger change than this defect warrants; recorded here so the limit is not rediscovered as a
+-- surprise.
+--
+-- Rollback: ALTER TABLE velocity_aggregates DROP COLUMN last_transaction_id;
+-- (Backfill note: existing rows get NULL, which means "no signal recorded yet" — the first signal
+-- after the migration is applied normally, so no counter is lost or double-applied.)
+ALTER TABLE velocity_aggregates ADD COLUMN last_transaction_id UUID;

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/messaging/TransactionSignalConsumerTest.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/messaging/TransactionSignalConsumerTest.kt
@@ -49,7 +49,31 @@ class TransactionSignalConsumerTest {
 
         consumer.onTransactionInitiated(payload)
 
-        coVerify(exactly = 1) { velocityRepo.recordTransaction(accountId, BigDecimal("250.00"), "CZK") }
+        coVerify(exactly = 1) { velocityRepo.recordTransaction(accountId, BigDecimal("250.00"), "CZK", any()) }
+    }
+
+    @Test
+    fun `forwards the signal aggregateId to the velocity repository as the dedup key`() {
+        val accountId = UUID.randomUUID()
+        val aggregateId = UUID.randomUUID()
+        val transactionIdSlot = slot<UUID>()
+        coEvery {
+            velocityRepo.recordTransaction(any(), any(), any(), capture(transactionIdSlot))
+        } returns Unit
+        val payload = """
+            {
+              "aggregateId": "$aggregateId",
+              "sourceAccountId": "$accountId",
+              "amount": "250.00",
+              "currencyCode": "CZK"
+            }
+        """.trimIndent()
+
+        consumer.onTransactionInitiated(payload)
+
+        // #5716: without this the redelivery guard has no key to compare and every signal is treated
+        // as new — the guard would exist in SQL and never fire.
+        assertThat(transactionIdSlot.captured).isEqualTo(aggregateId)
     }
 
     @Test
@@ -84,7 +108,7 @@ class TransactionSignalConsumerTest {
     fun `bad JSON is dropped without calling repository`() {
         consumer.onTransactionInitiated("not-valid-json{{{")
 
-        coVerify(exactly = 0) { velocityRepo.recordTransaction(any(), any(), any()) }
+        coVerify(exactly = 0) { velocityRepo.recordTransaction(any(), any(), any(), any()) }
     }
 
     @Test
@@ -93,14 +117,14 @@ class TransactionSignalConsumerTest {
 
         consumer.onTransactionInitiated(payload)
 
-        coVerify(exactly = 0) { velocityRepo.recordTransaction(any(), any(), any()) }
+        coVerify(exactly = 0) { velocityRepo.recordTransaction(any(), any(), any(), any()) }
     }
 
     @Test
     fun `missing amount defaults to zero`() {
         val accountId = UUID.randomUUID()
         val amountSlot = slot<BigDecimal>()
-        coEvery { velocityRepo.recordTransaction(any(), capture(amountSlot), any()) } returns Unit
+        coEvery { velocityRepo.recordTransaction(any(), capture(amountSlot), any(), any()) } returns Unit
 
         val payload = """{"sourceAccountId": "$accountId", "currencyCode": "CZK"}"""
         consumer.onTransactionInitiated(payload)
@@ -112,7 +136,7 @@ class TransactionSignalConsumerTest {
     fun `missing currencyCode defaults to CZK`() {
         val accountId = UUID.randomUUID()
         val currencySlot = slot<String>()
-        coEvery { velocityRepo.recordTransaction(any(), any(), capture(currencySlot)) } returns Unit
+        coEvery { velocityRepo.recordTransaction(any(), any(), capture(currencySlot), any()) } returns Unit
 
         val payload = """{"sourceAccountId": "$accountId", "amount": "50.00"}"""
         consumer.onTransactionInitiated(payload)
@@ -123,7 +147,7 @@ class TransactionSignalConsumerTest {
     @Test
     fun `repository exception is caught and does not propagate`() {
         val accountId = UUID.randomUUID()
-        coEvery { velocityRepo.recordTransaction(any(), any(), any()) } throws RuntimeException("DB down")
+        coEvery { velocityRepo.recordTransaction(any(), any(), any(), any()) } throws RuntimeException("DB down")
 
         val payload = """{"sourceAccountId": "$accountId", "amount": "100.00", "currencyCode": "CZK"}"""
 
@@ -207,6 +231,6 @@ class TransactionSignalConsumerTest {
         // Must not throw, and must not prevent the velocity path from running
         consumer.onTransactionInitiated(payload)
 
-        coVerify(exactly = 1) { velocityRepo.recordTransaction(accountId, BigDecimal("100.00"), "CZK") }
+        coVerify(exactly = 1) { velocityRepo.recordTransaction(accountId, BigDecimal("100.00"), "CZK", any()) }
     }
 }

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplIT.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplIT.kt
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.fraud.infrastructure.persistence
+
+import com.openbank.fraud.application.port.out.VelocityAggregateRepository
+import com.openbank.fraud.domain.model.VelocityWindow
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.vertx.mutiny.pgclient.PgPool
+import io.vertx.mutiny.sqlclient.Tuple
+import jakarta.inject.Inject
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Real-Postgres acceptance test for the #5716 redelivery guard on `velocity_aggregates`
+ * (V5__velocity_aggregates_redelivery_dedup.sql + [VelocityAggregateRepositoryImpl]). The sibling
+ * [VelocityAggregateRepositoryImplTest] mocks `PgPool` and can only assert that a query was issued —
+ * it cannot tell an upsert that double-counts from one that does not. Only the real upsert SQL
+ * against a real database can, which is why this class exists alongside it (same reason
+ * [PayeeHistoryRepositoryImplIT] exists for the V3 guard).
+ *
+ * Each test uses a fresh random account id, so the three window rows it touches are its own — no
+ * cross-test interference and no cleanup needed.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.fraud.it.PostgresRedisTestResource::class)
+class VelocityAggregateRepositoryImplIT {
+
+    @Inject
+    lateinit var repository: VelocityAggregateRepository
+
+    @Inject
+    lateinit var pool: PgPool
+
+    private suspend fun assertAllWindows(accountId: UUID, count: Long, total: String) {
+        VelocityWindow.entries.forEach { window ->
+            val aggregate = repository.findAggregate(accountId, window, CURRENCY)
+            assertThat(aggregate)
+                .describedAs("aggregate for window %s", window)
+                .isNotNull
+            assertThat(aggregate!!.transactionCount).describedAs("count for window %s", window).isEqualTo(count)
+            assertThat(aggregate.totalAmount).describedAs("total for window %s", window).isEqualByComparingTo(total)
+        }
+    }
+
+    @Test
+    fun `a first signal is recorded in every window`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, UUID.randomUUID())
+
+        assertAllWindows(accountId, count = 1L, total = "100.00")
+    }
+
+    @Test
+    fun `a redelivered signal does not double-count the amount or the count`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val transactionId = UUID.randomUUID()
+
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId)
+        // Redelivery of the exact same Kafka message (same aggregateId) — must be a no-op.
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId)
+
+        assertAllWindows(accountId, count = 1L, total = "100.00")
+    }
+
+    @Test
+    fun `a genuinely new signal after a redelivery still counts`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val firstTransactionId = UUID.randomUUID()
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, firstTransactionId)
+        // Replay of the first signal — must not count.
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, firstTransactionId)
+
+        // A genuinely different transaction — must count.
+        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, UUID.randomUUID())
+
+        assertAllWindows(accountId, count = 2L, total = "140.00")
+    }
+
+    /**
+     * The per-window partial-failure case — the half of #5716 that the guard alone does not settle.
+     * `recordTransaction` writes one row per window and the three are deliberately NOT one
+     * transaction, so a crash between them leaves some windows applied and others not. That state is
+     * built here directly through [PgPool] (the port cannot express "apply to one window only"):
+     * only the H1 row is written, carrying the signal's id, as if the process died before reaching
+     * H24 and D7. The retry then re-runs the full loop and must converge — H1 skipped because it
+     * already applied this id, H24 and D7 applied for the first time — leaving exactly one
+     * application in every window.
+     */
+    @Test
+    fun `a retry after a partial per-window failure converges to the correct total`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val transactionId = UUID.randomUUID()
+        val h1Start = VelocityWindow.H1.bucketStart(Instant.now(Clock.systemUTC()))
+
+        // The interrupted first attempt: H1 applied, H24 and D7 never reached.
+        pool.preparedQuery(
+            """
+            INSERT INTO velocity_aggregates
+                (account_id, velocity_window, currency, window_start, transaction_count, total_amount,
+                 last_transaction_id, updated_at)
+            VALUES ($1::uuid, 'H1', $2, $3, 1, $4, $5::uuid, NOW())
+            """,
+        ).execute(
+            Tuple.of(
+                accountId.toString(),
+                CURRENCY,
+                h1Start.toOffsetDateTime(),
+                BigDecimal("70.00"),
+                transactionId.toString(),
+            ),
+        ).awaitSuspending()
+
+        // The redelivery re-runs the full per-window loop.
+        repository.recordTransaction(accountId, BigDecimal("70.00"), CURRENCY, transactionId)
+
+        assertAllWindows(accountId, count = 1L, total = "70.00")
+    }
+
+    @Test
+    fun `a signal without a transaction id is never deduplicated`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+
+        // No aggregateId on the wire means no identity to deduplicate by — the pre-#5716 behaviour
+        // is preserved rather than silently dropping the second signal. Same contract as
+        // payee_history.
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, null)
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, null)
+
+        assertAllWindows(accountId, count = 2L, total = "20.00")
+    }
+
+    @Test
+    fun `currencies are deduplicated independently`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val transactionId = UUID.randomUUID()
+
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId)
+        // A different currency is a different row, so the same id does not suppress it.
+        repository.recordTransaction(accountId, BigDecimal("100.00"), "EUR", transactionId)
+
+        assertAllWindows(accountId, count = 1L, total = "100.00")
+        val eur = repository.findAggregate(accountId, VelocityWindow.H1, "EUR")
+        assertThat(eur!!.transactionCount).isEqualTo(1L)
+        assertThat(eur.totalAmount).isEqualByComparingTo("100.00")
+    }
+
+    private companion object {
+        const val CURRENCY = "CZK"
+    }
+}

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplTest.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplTest.kt
@@ -67,7 +67,7 @@ class VelocityAggregateRepositoryImplTest {
         val pq = mockPreparedQuery(rowSet)
         every { pool.preparedQuery(any<String>()) } returns pq
 
-        repository.recordTransaction(UUID.randomUUID(), BigDecimal("100.00"), "CZK")
+        repository.recordTransaction(UUID.randomUUID(), BigDecimal("100.00"), "CZK", UUID.randomUUID())
 
         // recordTransaction calls upsert once per window (H1, H24, D7)
         verify(exactly = 3) { pool.preparedQuery(any<String>()) }


### PR DESCRIPTION
Closes #5716

## What

`velocity_aggregates` had no redelivery dedup: a retried `transaction.initiated` event re-added the amount and re-incremented the count. `payee_history` (V3) already guards on `last_transaction_id`; this gives `velocity_aggregates` the same guard.

This was unreachable while `TransactionSignalConsumer` swallowed every failure and acked (#5698) — nothing was ever redelivered. #5715 makes transient failures rethrow so the connector can dead-letter and redeliver, which makes it reachable.

## The shape, mirrored not reinvented

`V5__velocity_aggregates_redelivery_dedup.sql` adds `last_transaction_id UUID`, and the upsert gains the same `DO UPDATE ... WHERE` guard `PayeeHistoryRepositoryImpl` already carries:

- incoming id `IS NULL` (no `aggregateId` on the wire, nothing to deduplicate by) → apply, as before;
- incoming id `IS DISTINCT FROM` the row's `last_transaction_id` → apply;
- otherwise the `DO UPDATE` is skipped entirely and Postgres leaves the row untouched.

`recordTransaction` takes the `transactionId` and the consumer passes `signal.aggregateId`.

## Partial-failure decision: per-window idempotence, not one transaction

`recordTransaction` issues one statement per window (H1/H24/D7), and the marker is **per row** — per `(account, window, currency, window_start)` — not per event. The three statements stay deliberately un-wrapped: each window converges independently, so a retry after a crash between windows re-applies only the windows that had not been applied and skips the ones that had. Wrapping the set in a transaction would still need this marker (a retry after a committed set must not re-apply), so the marker is the load-bearing half either way, and the per-row form additionally survives the interrupted case.

## Known bound, stated rather than left to be rediscovered

This is a **last-writer marker, not an applied-event set** — exactly what `payee_history` has. It deduplicates a redelivery arriving before any other event for the same bucket; an out-of-order replay (A, B, A) would still double-count A. Covering that needs an applied-event ledger, a larger change than this defect warrants. Recorded in the migration comment and the repository KDoc.

## Tests, and the falsification

New `VelocityAggregateRepositoryImplIT` (6 tests) runs the real upsert SQL against real Postgres, mirroring `PayeeHistoryRepositoryImplIT`. The sibling `VelocityAggregateRepositoryImplTest` mocks `PgPool` and can only assert that a query was issued — it structurally cannot tell a double-counting upsert from a guarded one, which is why the IT exists.

Falsified by removing the `WHERE` guard from the upsert and the `aggregateId` from the consumer call, then re-running:

| test | guard removed | guard present |
| --- | --- | --- |
| a redelivered signal does not double-count | RED | green |
| a genuinely new signal after a redelivery still counts | RED | green |
| a retry after a partial per-window failure converges | RED | green |
| forwards the signal aggregateId as the dedup key | RED | green |
| a first signal is recorded in every window | green | green |
| a signal without a transaction id is never deduplicated | green | green |
| currencies are deduplicated independently | green | green |
| `VelocityAggregateRepositoryImplTest` (mocked, 6 tests) | green | green |

The partial-failure test builds genuine partial state through `PgPool` — only the H1 row written, carrying the signal's id, as if the process died before H24 and D7 — then asserts the retry leaves exactly one application in every window.

## Gates run locally

- `check-db-migration.py --base origin/main --enforce` → rc=0, forward-only with a rollback note
- `check-flyway-default-datasource.py` → clean
- `check-threat-model-diff.py --base origin/main --enforce` → rc=0. Measured, not assumed: the gate's boundary criteria are inbound REST surface, outbound client edge, authn/listener keys, NetworkPolicy, and Deployment port/identity/privilege hunks. A column addition plus a repository/consumer change moves none of them, so `docs/threat-models/openbank-fraud-service.md` needs no update.
- `:openbank-fraud-service:ktlintCheck detekt test` → all three tasks present in the output, BUILD SUCCESSFUL, 168 tests / 0 failures / 1 skipped (the broker-gated `FraudPactProviderVerificationTest`, pre-existing).

Migration version V5 checked free against live `origin/main` (V1–V4 there), and no other open PR adds a fraud migration — #5715 touches only consumer Kotlin.

**Money-path: needs 2 approvals per ADR-0030.**
