### PR TITLE
fix: make TransactionSagaStuck able to fire, delete 3 alerts that never could

### DIFF
--- a/openbank-infra/gitops/components/lending/prometheus-rules.yaml
+++ b/openbank-infra/gitops/components/lending/prometheus-rules.yaml
@@ -48,16 +48,14 @@ spec:
           annotations:
             summary: "High error rate on lending-service"
             description: ">10% of spans on lending-service are erroring at >0.5 err/s."
-        - alert: LendingRepaymentProcessingStalled
-          # Repayment events must be processed promptly; a stall means accounts
-          # may be incorrectly reported as overdue to the credit bureau.
-          expr: |
-            increase(openbank_lending_repayments_processed_total[30m]) == 0
-            and on() hour() >= 6 and on() hour() <= 22
-          for: 30m
-          labels:
-            severity: warning
-            service: lending
-          annotations:
-            summary: "No repayments processed in 30m (business hours)"
-            description: "lending-service has not processed any repayment events in 30m during business hours — check Kafka consumer lag."
+        # LendingRepaymentProcessingStalled was REMOVED in #5733. It watched
+        # `openbank_lending_repayments_processed_total`, which nothing emits, and its premise was
+        # wrong in two further ways that instrumenting the metric would not have fixed. There are no
+        # "repayment events": LendingService.recordRepayment is a REST operation and lending-service
+        # has no `@Incoming` consumer at all, so the description's "check Kafka consumer lag" points
+        # at a consumer that does not exist. And repayments are due per installment, i.e. monthly —
+        # a 30-minute window with none is the overwhelmingly common case, so the rule would have
+        # paged constantly rather than detecting anything.
+        # The real risk it named — an account wrongly reported overdue to the credit bureau — is a
+        # per-loan correctness property. It belongs on loan state (a count of loans past due whose
+        # repayment was accepted but not applied), not on a service-wide throughput floor.

--- a/openbank-infra/gitops/components/payments/prometheus-rules.yaml
+++ b/openbank-infra/gitops/components/payments/prometheus-rules.yaml
@@ -36,7 +36,14 @@ spec:
             description: "transaction-service outbox has >100 unrelayed rows for >15m — payment events are not being dispatched."
         - alert: TransactionSagaStuck
           # A saga stuck >5m = payment is in a terminal-unknown state.
-          expr: openbank_transaction_sagas_stuck_total > 0
+          #
+          # The series is `openbank_transaction_sagas_stuck` — a GAUGE, no `_total` suffix. It read
+          # `openbank_transaction_sagas_stuck_total` until #5733: nothing has ever emitted that
+          # name, so this critical money-path alert could not fire, and an alert that cannot fire
+          # looks exactly like one that is correctly quiet. StuckSagaGauge in transaction-service
+          # now emits it, registered eagerly at startup so the series exists at 0 rather than being
+          # absent (an absent series makes this comparison match nothing, not zero).
+          expr: openbank_transaction_sagas_stuck > 0
           for: 5m
           labels:
             severity: critical
@@ -75,17 +82,16 @@ spec:
           annotations:
             summary: "clearing outbox backlog stuck"
             description: "clearing-service outbox has >100 unrelayed rows for >15m — settlement confirmations may be delayed."
-        - alert: ClearingSettlementWindowMissed
-          expr: |
-            increase(openbank_clearing_settlements_completed_total[1h]) == 0
-            and on() hour() >= 6 and on() hour() <= 18
-          for: 30m
-          labels:
-            severity: warning
-            service: clearing
-          annotations:
-            summary: "No settlements completed in 1h (business hours)"
-            description: "clearing-service has not completed any settlement cycles in 1h during business hours."
+        # ClearingSettlementWindowMissed was REMOVED in #5733. It watched
+        # `openbank_clearing_settlements_completed_total`, which nothing emits, and instrumenting it
+        # would not have made the alert meaningful: clearing cycles are not scheduled here.
+        # `triggerClearingCycle` and `settleBatch` are on-demand REST operations (ClearingService)
+        # and the service has no `@Scheduled` sweep and no `@Incoming` consumer, so "no settlement
+        # completed in the last hour" is the NORMAL resting state, not a fault. The rule asserted a
+        # cadence the code does not have.
+        # If a scheduled clearing cycle is ever added, the right mechanism is the fleet-wide one:
+        # register it with DomainMetrics.registerWorkflowLiveness (ADR-0160) and let the existing
+        # WorkflowLivenessStale rule cover it — not a bespoke throughput alert per service.
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -117,18 +123,13 @@ spec:
           annotations:
             summary: "swift outbox backlog stuck"
             description: "swift-service outbox has >50 unrelayed rows for >15m — SWIFT confirmations are not being dispatched."
-        - alert: SwiftMtMessageProcessingStalled
-          # SWIFT MT messages must be acknowledged within SWIFT cut-off times.
-          expr: |
-            increase(openbank_swift_messages_processed_total[1h]) == 0
-            and on() hour() >= 7 and on() hour() <= 17
-          for: 30m
-          labels:
-            severity: warning
-            service: swift
-          annotations:
-            summary: "No SWIFT messages processed in 1h (business hours)"
-            description: "swift-service has not processed any MT/MX messages in 1h during business hours."
+        # SwiftMtMessageProcessingStalled was REMOVED in #5733, for the same reason as
+        # ClearingSettlementWindowMissed above. It watched `openbank_swift_messages_processed_total`,
+        # which nothing emits, and swift-service does not ingest messages on a cadence: every entry
+        # point on SwiftService (send / acknowledge / reject) is REST-driven, with no `@Scheduled`
+        # sweep and no `@Incoming` consumer. An hour with no MT/MX traffic is ordinary, so the rule
+        # could only ever have been noise had the metric existed. Cut-off adherence is a per-message
+        # property and belongs on a per-message age or latency signal, not on a throughput floor.
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
@@ -54,6 +54,15 @@ class DomainMetrics {
 
     private fun reg(): MeterRegistry? = if (registryInstance.isResolvable) registryInstance.get() else null
 
+    companion object {
+        /**
+         * Gauge name for [registerStuckPaymentSagas]. Exposed so the emitting service and its
+         * tests name the same series the alert rule does — a metric name repeated as a literal in
+         * two places is how a rule ends up watching a series nothing emits (#5733).
+         */
+        const val STUCK_PAYMENT_SAGAS = "openbank.transaction.sagas.stuck"
+    }
+
     // ── Payments ─────────────────────────────────────────────────────────────
 
     /**
@@ -363,6 +372,40 @@ class DomainMetrics {
         reg()?.let { r ->
             Gauge.builder("openbank.outbox.backlog", backlog) { it.invoke().toDouble() }
                 .tag("service", service)
+                .strongReference(true)
+                .register(r)
+        }
+    }
+
+    /**
+     * Register the **stuck payment saga** gauge: how many payment sagas have sat in a
+     * non-terminal state (`PENDING` / `PROCESSING`) for longer than the service's stuck
+     * threshold. A payment saga that wedges leaves money in a terminal-unknown state, so this
+     * is the money-path signal `TransactionSagaStuck` (severity `critical`) pages on.
+     *
+     * **Registered eagerly, at startup, not on first non-zero reading.** A lazily created meter
+     * publishes no series at all while the value is zero, and an absent series makes every
+     * comparison in a rule match *nothing* rather than match zero — the alert would then be
+     * silent in exactly the healthy-looking case it must distinguish from a dead scraper. Call
+     * this once from a `@Startup` bean's `@PostConstruct`; re-registration with the same name is
+     * a no-op, as for [registerOutboxBacklog].
+     *
+     * **What a fresh pod reports (the t=0 question).** `0` — a truthful healthy reading, because
+     * "no saga is stuck" is genuinely what a pod with no observed stuck sagas knows. That is the
+     * opposite of a sentinel like [java.time.Instant.EPOCH], which reads as a maximal *bad* value
+     * at t=0 and fired `WorkflowLivenessStale` fleet-wide 15 minutes after every deploy (#2239).
+     * Because the gauge only ever crosses `> 0` on a real observation, and the caller's supplier
+     * is refreshed from the database on a schedule, a boot-time reading can under-report for one
+     * refresh interval but can never over-report — the safe direction for a paging alert.
+     *
+     * @param stuck cheap, lock-free supplier of the current stuck-saga count (read from a cached
+     *              value refreshed by a scheduled query — Micrometer samples this on the scrape
+     *              thread and must not block on a reactive database call)
+     */
+    fun registerStuckPaymentSagas(stuck: () -> Number) {
+        reg()?.let { r ->
+            Gauge.builder(STUCK_PAYMENT_SAGAS, stuck) { it.invoke().toDouble() }
+                .description("Payment sagas in a non-terminal state past the stuck threshold")
                 .strongReference(true)
                 .register(r)
         }

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/port/out/TransactionRepository.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/port/out/TransactionRepository.kt
@@ -6,6 +6,7 @@ package com.openbank.transaction.application.port.out
 
 import com.openbank.libs.persistence.outbox.OutboxMessage
 import com.openbank.transaction.domain.model.Transaction
+import java.time.Instant
 import java.util.UUID
 
 /**
@@ -31,4 +32,11 @@ interface TransactionRepository {
 
     /** Update a transaction and enqueue a domain-event outbox message, atomically. */
     suspend fun update(transaction: Transaction, outboxMessage: OutboxMessage): Transaction
+
+    /**
+     * Count payment sagas wedged in a non-terminal state: rows still `PENDING` or `PROCESSING`
+     * that were initiated at or before [olderThan]. Feeds the `openbank.transaction.sagas.stuck`
+     * gauge that `TransactionSagaStuck` (critical, money path) pages on.
+     */
+    suspend fun countStuckSagas(olderThan: Instant): Long
 }

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/observability/StuckSagaGauge.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/observability/StuckSagaGauge.kt
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.transaction.infrastructure.observability
+
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.transaction.application.port.out.TransactionRepository
+import io.quarkus.runtime.Startup
+import io.quarkus.scheduler.Scheduled
+import jakarta.annotation.PostConstruct
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import java.time.Clock
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Publishes `openbank.transaction.sagas.stuck` — payment sagas wedged in a non-terminal state
+ * (`PENDING` / `PROCESSING`) for longer than [stuckAfter] (issue #5733).
+ *
+ * `TransactionSagaStuck` (severity `critical`, money path) has always read this series, and until
+ * this bean existed nothing emitted it: the rule loaded, `promtool` accepted it and Prometheus
+ * listed it `inactive` forever, which is indistinguishable from a correctly quiet alert.
+ *
+ * ### Why a cached value rather than a query on scrape
+ * Micrometer samples a gauge supplier synchronously on the Prometheus scrape thread, and the count
+ * is a reactive Panache query that needs a Vert.x context. So a scheduled `suspend` tick refreshes
+ * an [AtomicLong] on the right context and the supplier reads that cache lock-free — the same
+ * split [com.openbank.libs.persistence.outbox.AbstractOutboxBacklogGauge] uses. The `@Scheduled`
+ * method is a `suspend fun` deliberately: a plain one carries no Vert.x context and the reactive
+ * call would abort with `HR000068` on every tick, silently.
+ *
+ * ### What a fresh pod reports
+ * `0`, from registration until the first refresh completes. That is the healthy reading, and the
+ * error direction is one refresh interval of under-reporting — never a spurious page. The
+ * registration is eager (`@Startup` + `@PostConstruct`, not first-use) precisely so the series
+ * exists while the value is zero: an absent series makes a rule's comparison match nothing at all,
+ * so a lazily created meter would leave the alert silent in the very case it exists for.
+ */
+@Startup
+@ApplicationScoped
+class StuckSagaGauge {
+    @Inject
+    lateinit var repository: TransactionRepository
+
+    @Inject
+    lateinit var metrics: DomainMetrics
+
+    @Inject
+    lateinit var clock: Clock
+
+    /** How long a saga may stay non-terminal before it counts as stuck. */
+    @ConfigProperty(name = "openbank.transaction.saga.stuck-after", defaultValue = "PT5M")
+    lateinit var stuckAfter: Duration
+
+    private val cached = AtomicLong(0)
+
+    /** Current cached count — the value the gauge publishes. Visible for tests. */
+    val current: Long get() = cached.get()
+
+    @PostConstruct
+    fun register() {
+        metrics.registerStuckPaymentSagas { cached.get() }
+    }
+
+    @Scheduled(
+        every = "30s",
+        delayed = "30s",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+    )
+    suspend fun refresh() {
+        cached.set(repository.countStuckSagas(clock.instant().minus(stuckAfter)))
+    }
+}

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/persistence/repository/PanacheTransactionRepository.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/persistence/repository/PanacheTransactionRepository.kt
@@ -19,6 +19,7 @@ import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
@@ -74,6 +75,14 @@ class PanacheTransactionRepository(private val outboxRepository: TransactionOutb
                 .replaceWith(transaction.copy(version = transaction.version + 1))
         }.awaitSuspending()
     }
+
+    override suspend fun countStuckSagas(olderThan: Instant): Long = Panache.withSession {
+        count(
+            "status in ?1 and initiatedAt <= ?2",
+            NON_TERMINAL_STATUSES,
+            olderThan,
+        )
+    }.awaitSuspending()
 
     // Truly simultaneous writers both pass the version-matched read before either commits; the
     // loser's flush then fails the @Version check (0 rows). Same conflict, same 409 (#465).
@@ -133,6 +142,15 @@ class PanacheTransactionRepository(private val outboxRepository: TransactionOutb
                 .range(query.offset, query.offset + query.limit - 1)
                 .list()
         }.awaitSuspending().map { it.toDomain() }
+    }
+
+    private companion object {
+        /**
+         * The saga is still in flight in exactly these two states; COMPLETED / FAILED / REVERSED
+         * are terminal. Stored as the enum *names* because `TransactionEntity.status` is a String
+         * column.
+         */
+        val NON_TERMINAL_STATUSES = listOf(TransactionStatus.PENDING.name, TransactionStatus.PROCESSING.name)
     }
 }
 

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/integration/StuckSagaGaugeIT.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/integration/StuckSagaGaugeIT.kt
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.transaction.integration
+
+import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.libs.domain.money.CurrencyCode
+import com.openbank.libs.domain.money.Money
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.persistence.outbox.OutboxMessage
+import com.openbank.transaction.domain.model.Transaction
+import com.openbank.transaction.domain.model.TransactionStatus
+import com.openbank.transaction.domain.model.TransactionType
+import com.openbank.transaction.infrastructure.observability.StuckSagaGauge
+import com.openbank.transaction.infrastructure.persistence.repository.PanacheTransactionRepository
+import com.openbank.transaction.it.PostgresRedpandaTestResource
+import io.micrometer.core.instrument.MeterRegistry
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+/**
+ * Proves `openbank.transaction.sagas.stuck` — the series the critical, money-path
+ * `TransactionSagaStuck` alert reads — is actually EMITTED, against a real database and a real
+ * Micrometer registry (issue #5733: the rule watched a name nothing produced).
+ *
+ * It asserts three separate things, because the alert needs all three and the first two are the
+ * ones a mocked test cannot see:
+ *
+ *  1. **The series exists at zero on a fresh pod.** `sagaGaugeValue()` is `0.0`, not absent. An
+ *     absent series makes `openbank_transaction_sagas_stuck > 0` match nothing at all, which is
+ *     indistinguishable from a healthy match of zero — so eager registration is the property that
+ *     makes the rule able to be quiet *and* able to fire.
+ *  2. **It rises on the real path.** A `PENDING` transaction older than the stuck threshold, read
+ *     back by the real Panache query, moves the gauge above zero.
+ *  3. **It only counts what it claims.** A recent `PENDING` saga and an old `COMPLETED` one are
+ *     both excluded, so the alert cannot page on healthy traffic.
+ *
+ * ### Falsification (recorded so the next reader does not have to redo it)
+ * Removing the `metrics.registerStuckPaymentSagas { … }` call from [StuckSagaGauge.register] makes
+ * assertion 1 fail (`sagaGaugeValue()` returns null — the meter is gone); removing the
+ * `cached.set(...)` from `refresh()` makes assertion 2 fail (the gauge stays at 0.0). Both were run
+ * red before this test was committed.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedpandaTestResource::class)
+class StuckSagaGaugeIT {
+
+    @Inject
+    lateinit var gauge: StuckSagaGauge
+
+    @Inject
+    lateinit var repository: PanacheTransactionRepository
+
+    @Inject
+    lateinit var registry: MeterRegistry
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    private fun sagaGaugeValue(): Double? = registry.find(DomainMetrics.STUCK_PAYMENT_SAGAS).gauge()?.value()
+
+    @BeforeEach
+    fun clearTransactions() {
+        onEventLoop {
+            Panache.withTransaction { repository.deleteAll() }.awaitSuspending()
+        }
+        onEventLoop { gauge.refresh() }
+    }
+
+    private fun seed(status: TransactionStatus, initiatedAt: Instant) {
+        val id = Ids.newId()
+        val czk = CurrencyCode("CZK")
+        val tx = Transaction(
+            id = id,
+            referenceNumber = "TX-$id",
+            type = TransactionType.TRANSFER,
+            sourceAccountId = Ids.newId(),
+            targetAccountId = Ids.newId(),
+            amount = Money(BigDecimal("100.00"), czk),
+            fxRate = null,
+            baseAmount = Money(BigDecimal("100.00"), czk),
+            status = status,
+            description = "stuck-saga gauge fixture",
+            valueDate = LocalDate.now(),
+            bookingDate = LocalDate.now(),
+            initiatedAt = initiatedAt,
+            completedAt = if (status == TransactionStatus.COMPLETED) initiatedAt else null,
+            failedAt = null,
+            failureReason = null,
+            idempotencyKey = "idem-$id",
+            version = 0,
+        )
+        val outbox = OutboxMessage(
+            aggregateId = id,
+            eventType = "test.event.stuck-saga",
+            payload = """{"id":"$id"}""",
+            createdAt = initiatedAt,
+        )
+        onEventLoop { repository.save(tx, outbox) }
+    }
+
+    @Test
+    fun `the gauge is registered at zero before any saga is stuck`() {
+        assertThat(sagaGaugeValue())
+            .describedAs("the series must EXIST at 0, not be absent — an absent series makes the alert match nothing")
+            .isEqualTo(0.0)
+    }
+
+    @Test
+    fun `a pending saga older than the threshold raises the gauge`() {
+        seed(TransactionStatus.PENDING, Instant.now().minus(1, ChronoUnit.HOURS))
+        onEventLoop { gauge.refresh() }
+
+        assertThat(sagaGaugeValue()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `a processing saga older than the threshold raises the gauge`() {
+        seed(TransactionStatus.PROCESSING, Instant.now().minus(1, ChronoUnit.HOURS))
+        onEventLoop { gauge.refresh() }
+
+        assertThat(sagaGaugeValue()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `a recent pending saga and an old completed one leave the gauge at zero`() {
+        seed(TransactionStatus.PENDING, Instant.now())
+        seed(TransactionStatus.COMPLETED, Instant.now().minus(1, ChronoUnit.HOURS))
+        onEventLoop { gauge.refresh() }
+
+        assertThat(sagaGaugeValue())
+            .describedAs("healthy traffic must not page: only non-terminal sagas past the threshold count")
+            .isEqualTo(0.0)
+    }
+}


### PR DESCRIPTION
## What

All four alert rules from #5733 are addressed: one is made able to fire, three are deleted.

| Alert | Verdict | Why |
|---|---|---|
| `TransactionSagaStuck` (**critical**, money path) | **emit** | The condition is real, measurable and the emission is small — `StuckSagaGauge` publishes `openbank.transaction.sagas.stuck`, and the rule now reads it. |
| `ClearingSettlementWindowMissed` | **delete** | Clearing cycles are on-demand REST operations; no `@Scheduled`, no `@Incoming`. "No settlement in 1h" is the normal resting state. |
| `SwiftMtMessageProcessingStalled` | **delete** | Same shape — every `SwiftService` entry point is REST-driven; there is no periodic ingestion to stall. |
| `LendingRepaymentProcessingStalled` | **delete** | Its description said "check Kafka consumer lag" for a consumer that does not exist, and installments are monthly, so 30m of silence is the common case. |

Instrumenting the three warning metrics was considered and rejected: each rule asserts a throughput cadence the code has no scheduler for, so the metric would have existed and the alert would still have been wrong — noise instead of silence. Each deletion leaves a comment naming the mechanism to use if a scheduler is ever added: `DomainMetrics.registerWorkflowLiveness` (ADR-0160) plus the existing `WorkflowLivenessStale` rule, rather than a bespoke per-service throughput alert. Deleting them also disposes of the `increase(x[window]) == 0` problem the issue notes — an absent series matches nothing, so those rules were blind to total absence, the most severe form of what they watched.

## The metric

`StuckSagaGauge` counts payment sagas still `PENDING` or `PROCESSING` past a configurable threshold (`openbank.transaction.saga.stuck-after`, default `PT5M`), refreshed from the database by a scheduled `suspend` tick and read lock-free from a cached `AtomicLong` on the scrape thread — the split `AbstractOutboxBacklogGauge` already uses, because Micrometer samples a gauge synchronously while the count is a reactive Panache query. The `@Scheduled` method is a `suspend fun` deliberately; a plain one carries no Vert.x context and would abort every tick with `HR000068`.

The rule drops the `_total` suffix: the value was always a gauge, so the old name said counter while the rule compared it as a level.

### t=0 and eager registration

Registration is eager (`@Startup` + `@PostConstruct`), not on first non-zero value. A lazily created meter publishes no series while healthy, and an absent series makes the rule's comparison match nothing rather than match zero — the alert would then be silent in exactly the case it exists for. A fresh pod reports `0`, which is the truthful healthy reading; the only error a boot-time reading can make is one refresh interval of under-reporting, never a spurious page. That is the opposite direction from the `Instant.EPOCH` seed that fired `WorkflowLivenessStale` fleet-wide 15 minutes after every deploy (#2239).

## Verification

`StuckSagaGaugeIT` runs against a real Postgres and a real Micrometer registry (4 tests, 0 skipped) and asserts the series exists at zero, rises on a `PENDING` saga past the threshold, rises on a `PROCESSING` one, and stays at zero for a recent `PENDING` plus an old `COMPLETED`.

Falsified before committing, both directions:

- remove the `metrics.registerStuckPaymentSagas { … }` call → **4 of 4 fail**
- remove the `cached.set(...)` in `refresh()` → **2 of 2 rise-assertions fail**

Module gates, run serially: `:openbank-libs-runtime:ktlintCheck detekt test` and `:openbank-transaction-service:ktlintCheck detekt test quarkusBuild` all green — transaction-service 144 tests, 0 failures, 1 skipped (the pre-existing broker-gated `TransactionPactProviderVerificationTest`). `quarkusBuild` included so the new CDI bean is actually validated.

Both `prometheus-rules.yaml` files re-parse and no rule group is left empty. The `openbank_transaction_sagas_stuck` series is asserted from the emitting code and its test, not from a live Prometheus — no cluster was read for this PR.

Closes #5733
