### PR TITLE
test(engagement): contract-test the in-app marketing consent check

### DIFF
--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/contract/ConsentPactProviderVerificationTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/contract/ConsentPactProviderVerificationTest.kt
@@ -205,6 +205,33 @@ class ConsentPactProviderVerificationTest {
         }
     }
 
+    /**
+     * State for engagement-service's `EngagementToConsentPactConsumerTest`. Distinct from the
+     * campaign one on purpose: engagement gates promotional impressions on MARKETING_COMMS_INAPP,
+     * a separate grant from the EMAIL scope campaign's pact pins, so seeding one would not satisfy
+     * the other.
+     */
+    @State("an ACTIVE MARKETING_COMMS_INAPP consent covers the pact engagement party")
+    fun activeInAppConsentExists() {
+        dataSource.connection.use { c ->
+            c.autoCommit = false
+            if (!rowExists(c, "SELECT 1 FROM consents WHERE id = ?::uuid", PACT_INAPP_CONSENT_ID)) {
+                c.prepareStatement(INSERT_MARKETING_CONSENT_SQL).use { ps ->
+                    ps.setString(1, PACT_INAPP_CONSENT_ID)
+                    ps.setString(2, PACT_ENGAGEMENT_PARTY_ID)
+                    ps.setString(3, PACT_MARKETING_GRANTEE_ID)
+                    ps.executeUpdate()
+                }
+                c.prepareStatement("INSERT INTO consent_scopes (consent_id, scope) VALUES (?::uuid, ?)").use { ps ->
+                    ps.setString(1, PACT_INAPP_CONSENT_ID)
+                    ps.setString(2, "MARKETING_COMMS_INAPP")
+                    ps.executeUpdate()
+                }
+                c.commit()
+            }
+        }
+    }
+
     private fun rowExists(c: Connection, sql: String, id: String): Boolean = c.prepareStatement(sql).use { ps ->
         ps.setString(1, id)
         ps.executeQuery().use { rs -> rs.next() }
@@ -259,5 +286,9 @@ class ConsentPactProviderVerificationTest {
         const val PACT_CONSENTED_PARTY_ID = "c2c2c2c2-c2c2-c2c2-c2c2-c2c2c2c2c2c2"
         const val PACT_MARKETING_CONSENT_ID = "c4c4c4c4-c4c4-4c4c-8c4c-c4c4c4c4c4c4"
         const val PACT_MARKETING_GRANTEE_ID = "party-service:marketing-comms"
+
+        /** Must equal the ids in openbank-engagement-service's EngagementToConsentPactConsumerTest. */
+        const val PACT_INAPP_CONSENT_ID = "e2e2e2e2-e2e2-4e2e-8e2e-e2e2e2e2e2e2"
+        const val PACT_ENGAGEMENT_PARTY_ID = "e1e1e1e1-e1e1-e1e1-e1e1-e1e1e1e1e1e1"
     }
 }

--- a/openbank-engagement-service/build.gradle.kts
+++ b/openbank-engagement-service/build.gradle.kts
@@ -38,6 +38,9 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.rest.assured.kotlin)
+    // Consumer-driven contract against consent-service (ADR-0063). engagement-service gates every
+    // promotional impression on this call, and it was verified nowhere.
+    testImplementation(libs.pact.consumer)
     testImplementation(libs.smallrye.reactive.messaging.inmemory)
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/contract/EngagementToConsentPactConsumerTest.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/contract/EngagementToConsentPactConsumerTest.kt
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.engagement.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import io.restassured.RestAssured.given
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Consumer contract for the consent check engagement-service gates every promotional impression on
+ * (ADR-0219 D4, `ContactClass.PROMOTIONAL_IMPRESSION`).
+ *
+ * This is NOT a copy of campaign-service's interaction, and the difference is the point: engagement
+ * asks for **MARKETING_COMMS_INAPP** — the in-app banner and personalised-challenge surface — where
+ * campaign asks per channel (EMAIL / PUSH / INAPP). The consent scopes are separate grants, so a
+ * party may hold one and not the other; a contract verified only for EMAIL says nothing about the
+ * route engagement actually takes. Each consumer declares what it actually sends, which is the
+ * whole reason pacts are consumer-driven.
+ *
+ * The grantee is `party-service:marketing-comms` — `openbank.engagement.marketing-grantee`, which
+ * happens to share campaign's default. Read from the config rather than assumed: a pact written
+ * against a plausible-looking grantee pins a request this service never makes.
+ *
+ * Path written as a **literal**. Deriving it from the client's `@Path` moves expectation and
+ * request together, so the test stays green against a route that does not exist (#2290).
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-consent-service", pactVersion = PactSpecVersion.V3)
+class EngagementToConsentPactConsumerTest {
+
+    // Must match the @State seed in ConsentPactProviderVerificationTest.
+    private val partyId = "e1e1e1e1-e1e1-e1e1-e1e1-e1e1e1e1e1e1"
+    private val granteeId = "party-service:marketing-comms"
+
+    @Pact(consumer = "openbank-engagement-service", provider = "openbank-consent-service")
+    fun inAppConsentPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("an ACTIVE MARKETING_COMMS_INAPP consent covers the pact engagement party")
+        .uponReceiving("GET whether an in-app marketing consent covers a party")
+        .path("/api/v1/consents/party/$partyId/grantee/$granteeId/active")
+        .query("scope=MARKETING_COMMS_INAPP")
+        .method("GET")
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                // booleanValue, not booleanType: `granted` IS the decision, and
+                // ConsentCheckResponse defaults it to false on an absent field — so a matcher
+                // accepting any boolean would let a provider that stopped sending it pass here
+                // and suppress every impression in production.
+                o.booleanValue("granted", true)
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "inAppConsentPact")
+    fun `hasActiveConsent returns the in-app marketing decision`(mockServer: MockServer) {
+        val granted = given()
+            .baseUri(mockServer.getUrl())
+            // The grantee contains a colon. RestAssured percent-encodes it by default, which a
+            // path segment does not require (RFC 3986 lists `:` as a pchar) and which makes the
+            // request miss the pact. Measured on the campaign pact in the parent commit; the
+            // provider replay is what establishes the form consent-service actually serves.
+            .urlEncodingEnabled(false)
+            .queryParam("scope", "MARKETING_COMMS_INAPP")
+            .get("/api/v1/consents/party/$partyId/grantee/$granteeId/active")
+            .then()
+            .statusCode(200)
+            .extract().jsonPath().getBoolean("granted")
+
+        assertThat(granted).isTrue()
+    }
+}

--- a/pacts/openbank-engagement-service-openbank-consent-service.json
+++ b/pacts/openbank-engagement-service-openbank-consent-service.json
@@ -1,0 +1,44 @@
+{
+  "consumer": {
+    "name": "openbank-engagement-service"
+  },
+  "interactions": [
+    {
+      "description": "GET whether an in-app marketing consent covers a party",
+      "providerStates": [
+        {
+          "name": "an ACTIVE MARKETING_COMMS_INAPP consent covers the pact engagement party"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/consents/party/e1e1e1e1-e1e1-e1e1-e1e1-e1e1e1e1e1e1/grantee/party-service:marketing-comms/active",
+        "query": {
+          "scope": [
+            "MARKETING_COMMS_INAPP"
+          ]
+        }
+      },
+      "response": {
+        "body": {
+          "granted": true
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-consent-service"
+  }
+}


### PR DESCRIPTION
> **Stacked on #5788.** Base is `test/campaign-consent-pact`, not `main` — both PRs add `@State` handlers to the same `ConsentPactProviderVerificationTest`, and stacking is CLAUDE.md's rule for that rather than racing for the file. Merge #5788 first; this diff then reduces to the engagement half.

## What

Consumer contract for the consent check engagement-service gates every `PROMOTIONAL_IMPRESSION` on (ADR-0219 D4), plus the provider state that verifies it.

Closes the `C3=1` half of #5706 for engagement-service.

## Not a copy of campaign's interaction

engagement asks for **`MARKETING_COMMS_INAPP`** — the in-app banner and personalised-challenge surface — where campaign asks per channel (`EMAIL` / `PUSH` / `INAPP`).

Those are **separate grants**. A party may hold the EMAIL one and not the INAPP one, so a contract verified only for EMAIL says nothing about the route engagement actually takes. Each consumer declaring what it actually sends is the whole reason pacts are consumer-driven, and it is why the provider gets a second state rather than the two consumers sharing one.

The grantee is read from `openbank.engagement.marketing-grantee` rather than assumed. It happens to share campaign's default — which is exactly the kind of coincidence worth not relying on.

## Verification

Provider replay, read from the **JUnit XML** rather than the console — pact-jvm prints `Not all of the N were verified` even on fully green runs, and `@IgnoreNoPactsToVerify` can turn a missing pact into a silent skip:

```
tests=5 failures=0 errors=0 skipped=0
  ok   openbank-campaign-service   - GET whether an active consent covers a party for a grantee and scope
  ok   openbank-campaign-service   - GET the active suppressions for a party
  ok   openbank-engagement-service - GET whether an in-app marketing consent covers a party
  ok   openbank-mcp-service        - POST validate an ACTIVE ACCOUNTS_READ consent covering the requested IBAN
  ok   openbank-mcp-service        - POST validate an unknown consent id — the fail-closed deny
```

- consumer test → 1 interaction, pact committed
- `ktlintCheck` + `detekt` on both modules → BUILD SUCCESSFUL
- `derive-pact-drift-scope.sh` picks the pact up from the `@Pact` annotations; the drift gate's scope is derived, not hand-kept

`granted` is pinned with `booleanValue(true)`, not `booleanType`: it **is** the decision, and `ConsentCheckResponse` defaults it to `false` on an absent field — so a matcher accepting any boolean would let a provider that stopped sending it pass here and suppress every impression in production.

## Linked issues

Refs #5706
