### PR TITLE
fix(ci): give the pact drift check a heap that matches its growing scope

### DIFF
--- a/.github/workflows/pact-drift-check.yml
+++ b/.github/workflows/pact-drift-check.yml
@@ -30,6 +30,27 @@ jobs:
     name: Regenerate consumer pacts and diff against committed
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # This job regenerates EVERY consumer pact in one Gradle invocation, and the scope is derived
+    # from the @Pact annotations — so it grows by one module each time anyone adds a pact, while
+    # the heap did not grow at all. It set no GRADLE_OPTS, so the daemon ran on Gradle's default,
+    # and at 31 modules it tipped over:
+    #
+    #   * What went wrong:
+    #   Execution failed for task ':openbank-onboarding-service:quarkusGenerateTestAppModel'
+    #   > Java heap space
+    #
+    # onboarding-service is not the problem and is not even a subject of the change that hit this
+    # (`:openbank-onboarding-service:quarkusGenerateTestAppModel` builds in 6s on its own) — it was
+    # simply the module the daemon happened to be on when memory ran out. That is what makes the
+    # failure so misleading: it names an innocent module, on a PR that touched a different one.
+    #
+    # The number to watch is the derived scope, not this heap. `derive-pact-drift-scope.sh` will
+    # keep adding modules; if this OOMs again, split the regeneration into batches rather than
+    # raising the ceiling a second time. 6g matches the fleet's heaviest lanes rather than the
+    # 3g eight other workflows use, because this one invocation configures every module those
+    # lanes handle one at a time.
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 


### PR DESCRIPTION
## The failure

`Pact drift check` went red on #5788 with:

```
* What went wrong:
Execution failed for task ':openbank-onboarding-service:quarkusGenerateTestAppModel'
> Java heap space
```

**It is not a pact drift, and onboarding-service is not the problem.** That module builds on its own in 6 seconds:

```
$ ./gradlew :openbank-onboarding-service:quarkusGenerateTestAppModel
BUILD SUCCESSFUL in 6s
```

It was simply the module the Gradle daemon happened to be configuring when memory ran out.

## Why it happened now

The job regenerates **every** consumer pact in **one** Gradle invocation, and the scope is derived from the `@Pact` annotations by `derive-pact-drift-scope.sh`. So it grows by a module each time anyone adds a pact — while the heap did not grow at all. The workflow set **no `GRADLE_OPTS`**, so the daemon ran on Gradle's default. At 31 modules it tipped.

Adding `openbank-campaign-service` (#5788) made it 32. Nothing about that PR is special except the number: it would have tipped for whoever added the next pact.

## What makes this worth a written-down comment rather than a silent bump

The message names an **innocent module, on a PR that touched a different one**. Read literally it sends you to debug onboarding-service — a module that is fine, on a change that never went near it. That is a lot of wasted time available to the next person, so the reasoning lives in the workflow next to the setting.

## The fix, and its limit

`-Xmx6g -XX:MaxMetaspaceSize=1g` — the fleet's heaviest lane setting, rather than the `3g` eight other workflows use, because this single invocation configures every module those lanes handle one at a time.

The number to watch is **the derived scope, not this heap**. It will keep growing. If this OOMs again, the answer is to split the regeneration into batches, not to raise the ceiling a second time — written into the workflow so the next person reads it before reaching for the easy knob.

## Note

Touches `.github/workflows`, so the merge guard requires human review regardless of size. #5788 and #5790 stay red on this check until it lands; their pact content is unaffected and their provider replays are green.

## Linked issues

Refs #5788
