### PR TITLE
fix(admin-ui): prevent stale party name in account opening

### DIFF
--- a/openbank-admin-ui/src/app/accounts/new/page.tsx
+++ b/openbank-admin-ui/src/app/accounts/new/page.tsx
@@ -12,7 +12,8 @@ import { accountApi } from '@/lib/api'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader } from '@/components/ui/PageHeader'
 import { AuthGuard } from '@/components/auth/AuthGuard'
-import { PartySearch, partyDisplayName, type PartyHit } from '@/components/party/PartySearch'
+import { PartySearch, type PartyHit } from '@/components/party/PartySearch'
+import { accountPartySelection } from '@/lib/accounts/partySelection'
 
 
 const ACCOUNT_TYPES = ['CURRENT', 'SAVINGS', 'NOSTRO', 'GL_ASSET', 'GL_LIABILITY', 'GL_INCOME', 'GL_EXPENSE']
@@ -43,13 +44,14 @@ export default function NewAccountPage() {
   }
 
   function selectParty(party: PartyHit) {
+    const selection = accountPartySelection(party)
     setForm(prev => ({
       ...prev,
-      partyId: party.id,
+      partyId: selection.partyId,
       // The selected party is the source of truth for sanctions screening. Keep
       // the field editable for exceptional legal-name corrections, but never
-      // make an operator retype a name after selecting an existing party.
-      ...(party.legalName || party.tradingName ? { legalName: partyDisplayName(party) } : {}),
+      // never retain a name from a different party after an id-only selection.
+      legalName: selection.legalName,
     }))
     setErrors(prev => ({ ...prev, partyId: '', legalName: '' }))
   }

--- a/openbank-admin-ui/src/lib/accounts/partySelection.ts
+++ b/openbank-admin-ui/src/lib/accounts/partySelection.ts
@@ -1,0 +1,13 @@
+export type AccountPartySelection = {
+  id: string
+  legalName?: string | null
+  tradingName?: string | null
+}
+
+/** Keep account sanctions screening aligned with the selected party. */
+export function accountPartySelection(party: AccountPartySelection) {
+  return {
+    partyId: party.id,
+    legalName: party.legalName?.trim() || party.tradingName?.trim() || '',
+  }
+}

--- a/openbank-admin-ui/src/test/account-party-selection.test.ts
+++ b/openbank-admin-ui/src/test/account-party-selection.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { accountPartySelection } from '@/lib/accounts/partySelection'
+
+describe('account party selection', () => {
+  it('uses the verified legal name', () => {
+    expect(accountPartySelection({ id: 'a', legalName: '  Alice  ', tradingName: 'A' })).toEqual({ partyId: 'a', legalName: 'Alice' })
+  })
+
+  it('clears a stale name when only a UUID is selected', () => {
+    expect(accountPartySelection({ id: 'b' })).toEqual({ partyId: 'b', legalName: '' })
+  })
+
+  it('falls back to the trading name', () => {
+    expect(accountPartySelection({ id: 'c', tradingName: '  Company  ' })).toEqual({ partyId: 'c', legalName: 'Company' })
+  })
+})

--- a/openbank-admin-ui/src/test/accounts-new-accessibility.guard.test.ts
+++ b/openbank-admin-ui/src/test/accounts-new-accessibility.guard.test.ts
@@ -26,11 +26,12 @@ describe('new account form accessibility', () => {
   })
 
   it('resolves an existing party before the money-path submit', () => {
-    expect(page).toContain("import { PartySearch, partyDisplayName, type PartyHit } from '@/components/party/PartySearch'")
+    expect(page).toContain("import { PartySearch, type PartyHit } from '@/components/party/PartySearch'")
     expect(page).toContain('<PartySearch')
     expect(page).toContain('onSelect={selectParty}')
-    expect(page).toContain('partyId: party.id')
-    expect(page).toContain('legalName: partyDisplayName(party)')
+    expect(page).toContain('accountPartySelection(party)')
+    expect(page).toContain('partyId: selection.partyId')
+    expect(page).toContain('legalName: selection.legalName')
     expect(page).toContain('accountApi.open({')
     expect(page).toContain('partyId:     form.partyId.trim()')
     expect(page).toContain('legalName:   form.legalName.trim()')


### PR DESCRIPTION
Follow-up to #5609.

Fixes the UUID-only party selection path so it clears any previously selected legal name before account opening and sanctions screening. Adds focused selection tests and updates the accessibility guard.

Refs #5609