### PR TITLE
docs(security): add ADR-0146 key ceremony runbooks

### DIFF
--- a/docs/runbooks/key-ceremonies/README.md
+++ b/docs/runbooks/key-ceremonies/README.md
@@ -1,0 +1,21 @@
+# Key-ceremony runbooks
+
+These procedures are deliberately provider-neutral. Operators must use the deployment's
+approved secret manager and record the ceremony in the ICT incident register as a P3
+(scheduled resilience exercise), never in this repository. Never paste key material, recovery
+shares, tokens, or production identifiers into tickets, chat, or command output.
+
+Each ceremony has four phases: pre-check, two-person execution, verification, and evidence.
+The operator records the register entry ID, approvers, start/end timestamps, result, and any
+rollback action. A failed pre-check stops the ceremony; it is not a reason to improvise a
+break-glass procedure.
+
+Runbooks:
+
+- [OpenBao unseal](openbao-unseal.md)
+- [Cosign KMS signing-key rotation](cosign-kms-rotation.md)
+- [Keycloak realm signing-key renewal](keycloak-signing-key-renewal.md)
+- [cert-manager PKI recovery](cert-manager-pki-recovery.md)
+
+Annual dry-runs must use a non-production namespace and synthetic keys. A dry-run proves the
+procedure and evidence capture, not production access or recovery time.

--- a/docs/runbooks/key-ceremonies/cert-manager-pki-recovery.md
+++ b/docs/runbooks/key-ceremonies/cert-manager-pki-recovery.md
@@ -1,0 +1,23 @@
+# cert-manager PKI recovery
+
+This is the manual-intervention path when automatic renewal or issuance fails. It does not
+replace cert-manager's normal automated rotation and never includes private keys.
+
+## Pre-check
+
+Create a P3 exercise entry, inspect Certificate/CertificateRequest status and controller events,
+confirm the issuer and trust bundle are healthy, and identify the affected namespace. Do not
+delete a Certificate or Secret before a verified backup and rollback plan exist.
+
+## Execute
+
+Repair the underlying issuer or approval condition using the approved platform procedure, then
+reconcile the Certificate resource. If a replacement certificate is required, create it through
+the issuer rather than applying a hand-generated secret. Preserve the previous certificate until
+all consumers reload successfully.
+
+## Verify and evidence
+
+Check Ready/NotAfter conditions, TLS handshake and trust validation from a separate client, and
+controller events showing successful issuance. Record resource names (not secret contents), key
+IDs if applicable, timestamps, approvers, and the rollback outcome in the register.

--- a/docs/runbooks/key-ceremonies/cosign-kms-rotation.md
+++ b/docs/runbooks/key-ceremonies/cosign-kms-rotation.md
@@ -1,0 +1,23 @@
+# Cosign KMS signing-key rotation
+
+Rotate the configured KMS alias (currently documented as `alias/openbank-cosign-signing`) using
+the provider's approved two-person change process. The alias and account are deployment config,
+not credentials; never commit key ARNs or private material.
+
+## Pre-check
+
+Open a P3 exercise entry, confirm the current verifier trusts the existing public key, and stage
+a new key in the KMS/HSM without changing the alias. Ensure the image-signing and verification
+pipelines have a tested rollback to the previous alias target.
+
+## Execute
+
+With two approvers present, create the successor key, publish its public certificate through the
+approved trust-distribution path, then atomically move the alias. Do not destroy or disable the
+previous key until the retention window and verification checks pass.
+
+## Verify and evidence
+
+Sign and verify a synthetic non-production artifact, inspect the admission/policy check, and
+confirm an artifact signed before rotation remains verifiable. Record register ID, key version
+metadata (not material), approvers, timestamps, and rollback decision.

--- a/docs/runbooks/key-ceremonies/keycloak-signing-key-renewal.md
+++ b/docs/runbooks/key-ceremonies/keycloak-signing-key-renewal.md
@@ -1,0 +1,22 @@
+# Keycloak realm signing-key renewal
+
+Use the realm's approved rotation mechanism and change window. Do not export private keys or
+client secrets.
+
+## Pre-check
+
+Create a P3 exercise entry, identify the realm and relying services, confirm JWKS reachability,
+and verify that at least one client can refresh a token in a non-production environment. Keep the
+previous signing key available for the configured overlap period.
+
+## Execute
+
+Generate the successor signing key in Keycloak, publish it through JWKS, and wait for the cache
+overlap before making it the active signing key. Coordinate clients that pin a key and require
+two-person approval for any manual setting change.
+
+## Verify and evidence
+
+Obtain a synthetic token, validate its issuer/audience/signature from a separate client, and
+confirm a token issued before rotation remains accepted during overlap. Record only realm name,
+key IDs, timestamps, approvers, and result in the register.

--- a/docs/runbooks/key-ceremonies/openbao-unseal.md
+++ b/docs/runbooks/key-ceremonies/openbao-unseal.md
@@ -1,0 +1,24 @@
+# OpenBao unseal ceremony
+
+Use after a planned restart or when the OpenBao seal state is confirmed. Recovery shares stay in
+the approved external secret manager; this runbook contains no shares.
+
+## Pre-check
+
+1. Create a P3 scheduled-exercise entry in the ICT incident register and name the two operators.
+2. Confirm the target namespace, OpenBao health endpoint, maintenance window, and a tested backup.
+3. Confirm both operators can retrieve their assigned share through the approved break-glass
+   workflow. Do not copy or log the share.
+
+## Execute
+
+1. Operator A verifies the seal status and records the timestamp and response code.
+2. Operators A and B submit their shares independently through the approved control plane.
+3. Stop when the threshold is reached; never submit extra shares “to be safe”.
+
+## Verify and evidence
+
+Confirm the health endpoint reports unsealed, a read-only canary succeeds, and audit logs contain
+the ceremony actor IDs. Record only the register ID, timestamps, result, and verification checks.
+If unseal fails, reseal/restore according to the platform recovery procedure and escalate as P1/P2;
+do not troubleshoot by exposing shares.

--- a/openbank-security-scanner/src/main/resources/docs/04-data.cs.md
+++ b/openbank-security-scanner/src/main/resources/docs/04-data.cs.md
@@ -4,25 +4,53 @@
 
 Vlastní PostgreSQL schema `openbank_security` v databázi `openbank` (sdílený cluster, izolace schema-per-service).
 
-**Služba nepersistuje nic provozního.** Po migraci `V4` obsahuje schema `flyway_schema_history` a
-žádnou další tabulku. Ve službě neexistuje žádná entita, repozitář ani JPA mapování — databáze
-existuje výhradně proto, aby si Flyway měl kam zapisovat vlastní historii migrací a aby měla
-readiness sonda co kontrolovat.
+**Služba persistuje jednu tabulku: `ict_incidents`.** Po migraci `V5` obsahuje schema
+`flyway_schema_history` a `ict_incidents`. Pro cokoli jiného ve službě neexistuje žádná entita,
+repozitář ani JPA mapování — výsledky skenů zůstávají pouze in-memory.
 
 Z toho plyne:
 
 - **Výsledky skenů** (`ServiceScanResult`, `PlatformSecurityReport`) žijí v `SecurityScannerService`
   v polích typu `ConcurrentHashMap` (`lastResults`, `lastReport`). S restartem podu zanikají a obnoví
   je až další naplánovaný sken (až o 30 minut později, na studeném podu 2 minuty po startu).
-- **ICT incidenty** žijí v `IctIncidentService` v `ConcurrentHashMap` (`store`). S restartem podu
-  zanikají a **nelze je obnovit** — jedinou jejich kopií je Kafka event vyslaný v okamžiku vzniku.
+- **ICT incidenty** jsou trvalé v tabulce `ict_incidents` (issue #4728). Dříve žily v
+  `IctIncidentService` v `ConcurrentHashMap` (`store`) a s restartem podu zanikaly; to je opraveno —
+  incident, jeho časy zvládnutí/vyřešení a stav `reported_to_regulator`/`regulatory_report_id` nyní
+  restart podu přežijí.
 - Historie skenů neexistuje. `GET /api/v1/security/report` vrací pouze poslední in-memory report.
 
-Není co nakreslit jako ER diagram: služba nevlastní žádné tabulky.
+`ict_incidents` je jediná tabulka, kterou tato služba vlastní:
 
-> Do #4709 tato stránka popisovala tabulku `security_outbox` a tabulku `ict_incidents`. Outbox sice
-> existoval, ale nikdy do něj nikdo nezapsal (0 řádků za celou dobu a 0 záznamů kdy vyprodukovaných
-> do jeho topicu) a byl odstraněn migrací `V4`; tabulka `ict_incidents` neexistovala nikdy.
+```
+ict_incidents
+├── id                      UUID PRIMARY KEY  (přiděluje aplikace, UUID.randomUUID())
+├── title                   TEXT NOT NULL
+├── description             TEXT NOT NULL
+├── category                VARCHAR(64) NOT NULL
+├── severity                VARCHAR(32) NOT NULL
+├── status                  VARCHAR(32) NOT NULL
+├── affected_services       TEXT NOT NULL   (názvy služeb spojené čárkou)
+├── detected_at             TIMESTAMPTZ NOT NULL
+├── reported_at             TIMESTAMPTZ NOT NULL
+├── contained_at            TIMESTAMPTZ
+├── resolved_at             TIMESTAMPTZ
+├── rto_minutes             INTEGER
+├── rpo_minutes             INTEGER
+├── reported_to_regulator   BOOLEAN NOT NULL DEFAULT FALSE
+├── regulatory_report_id    TEXT
+├── assigned_to             TEXT
+├── created_at              TIMESTAMPTZ NOT NULL
+└── updated_at              TIMESTAMPTZ NOT NULL
+```
+
+Žádná jiná tabulka na ni neodkazuje a ona neodkazuje na nic jiného — jednouzlový diagram, není proč
+kreslit jako graf.
+
+> Do #4709 tato stránka popisovala tabulku `security_outbox` a tabulku `ict_incidents` a obě
+> označovala za fiktivní. Outbox sice existoval, ale nikdy do něj nikdo nezapsal (0 řádků za celou
+> dobu a 0 záznamů kdy vyprodukovaných do jeho topicu) a byl odstraněn migrací `V4`; `ict_incidents`
+> v tu chvíli také neexistovala. Migrace `V5` (issue #4728) pak vytvořila skutečnou tabulku
+> `ict_incidents` popsanou výše — tato stránka je aktualizována, aby odpovídala.
 
 ## Migrace
 
@@ -30,12 +58,20 @@ Není co nakreslit jako ER diagram: služba nevlastní žádné tabulky.
 |---|---|---|
 | `V2__create_security_outbox.sql` | Vytvořila `security_outbox` s indexy na `(status, created_at)` a `aggregate_id` | Aplikována na živé DB; nahrazena V4 |
 | `V3__hibernate_sequences.sql` | Vytvořila Hibernate/Panache sekvenci pro surrogate klíč outboxu | Aplikována; sekvenci ruší V4 |
-| `V4__drop_security_outbox.sql` | `DROP TABLE security_outbox` + `DROP SEQUENCE security_outbox_seq` — outbox neměl producenta (#4709) | Aktuální hlava |
+| `V4__drop_security_outbox.sql` | `DROP TABLE security_outbox` + `DROP SEQUENCE security_outbox_seq` — outbox neměl producenta (#4709) | Aplikována mimo pořadí (#5628) |
+| `V5__create_ict_incidents.sql` | Vytvořila `ict_incidents` (sloupce výše) + indexy na `created_at`, `status`, `severity` — přesouvá registr ICT incidentů dle DORA z in-memory mapy do DB (#4728) | Aktuální hlava |
 
 > V1 chybí — scanner byl v první iteraci bezestavový a V2 je první migrací, která vznikla. V2 a V3
 > jsou záměrně ponechány jako soubory a nesmazány: obě jsou zaznamenány jako aplikované v živé
 > `flyway_schema_history` a odstranění souboru aplikované migrace selže na validaci Flyway stejně
 > jistě, jako její editace selže na checksumu.
+
+> `ict_incidents` nemá Hibernate sekvenci: její id přiděluje aplikace (`UUID.randomUUID()` v
+> `IctIncidentService.reportIncident`), ne `@GeneratedValue` — entita je proto
+> `PanacheEntityBase` s explicitním `@Id`, ne `PanacheEntity`. Update jde přes
+> `Panache.getSession().flatMap { it.merge(entity) }` — `persist()` na přiděleném id by u každého
+> uložení naplánoval INSERT a každý přechod stavu po prvním by selhal na duplicitním klíči (viz
+> `IctIncidentEntity`, `IctIncidentRepositoryImpl.save`).
 
 ## Kde který stav žije
 
@@ -44,20 +80,30 @@ Není co nakreslit jako ER diagram: služba nevlastní žádné tabulky.
 | `ServiceScanResult` (na službu) | In-memory `ConcurrentHashMap` | Do restartu podu; obnoví další sken |
 | `PlatformSecurityReport` | In-memory (pouze poslední výsledek) | Do restartu podu; obnoví další sken |
 | `SecurityFinding` | In-memory (součást výsledků) | Do restartu podu |
-| `IctIncident` | In-memory `ConcurrentHashMap` | Do restartu podu — **neobnovitelné** |
+| `IctIncident` | Tabulka `ict_incidents` (PostgreSQL) | Trvalé — přežije restart podu |
 
 ## Indexy
 
-Žádné — služba nemá vlastní tabulky.
+`ict_incidents` má tři, podle toho, jak `GET /api/v1/ict-incidents` filtruje a řadí:
+
+| Index | Sloupec(e) | Proč |
+|---|---|---|
+| `idx_ict_incidents_created_at` | `created_at DESC` | List endpoint řadí podle `created_at DESC` |
+| `idx_ict_incidents_status` | `status` | List endpoint filtruje podle statusu |
+| `idx_ict_incidents_severity` | `severity` | List endpoint filtruje podle severity |
+
+Žádná jiná tabulka neexistuje, takže tyto jsou jediné indexy služby.
 
 ## Retence
 
-V databázi této služby není co uchovávat. Jedinou trvalou stopou její činnosti je Kafka topic
+Řádky v `ict_incidents` se uchovávají bez omezení — služba nemá TTL, archivační job ani mazací
+cestu. Jedinou další trvalou stopou činnosti kolem ICT incidentů je Kafka topic
 `openbank.security.ict.incident` a to, co si z něj uloží `audit-service`; tuto retenci vlastní
 audit-service, ne tato služba.
 
-Kdo potřebuje trvalý registr ICT incidentů — což evidence dle DORA čl. 17 reálně vyžaduje — měl by
-současné in-memory úložiště považovat za mezeru, ne za kontrolu.
+Evidence dle DORA čl. 17 vyžaduje trvalý registr ICT incidentů; `ict_incidents` (od #4728, `V5`) je
+tímto registrem. Před `V5` byla in-memory úložiště na této stránce správně označena jako mezera, ne
+kontrola — tato mezera je uzavřena.
 
 ## PII úvahy
 
@@ -66,11 +112,11 @@ současné in-memory úložiště považovat za mezeru, ne za kontrolu.
 - `assignedTo` — email/jméno přiřazeného inženýra (data interního zaměstnance)
 - `description` — volný text, který může odkazovat na systémy zákazníků
 
-Jde o data interního operátora, ne zákaznické PII, a zde se nikdy nezapisují do databáze. Putují ale
-v Kafka eventu.
+Jde o data interního operátora, ne zákaznické PII. Zapisují se do `ict_incidents` (sloupce
+`assigned_to`, `description`) a zároveň putují v Kafka eventu.
 
 ## Odhady velikosti
 
-- Databáze: pouze `flyway_schema_history` — 3 řádky.
+- Databáze: `flyway_schema_history` (4 řádky) + `ict_incidents`, očekávány desítky řádků měsíčně,
+  každý pod 1 KB mimo `description` — nízké stovky KB ročně, pro vlastní schema triviální.
 - In-memory výsledky skenů: 27 služeb × ~5 KB každá = ~135 KB (triviální).
-- In-memory ICT incidenty: omezené pouze životností podu; očekávány desítky měsíčně.

--- a/openbank-security-scanner/src/main/resources/docs/04-data.en.md
+++ b/openbank-security-scanner/src/main/resources/docs/04-data.en.md
@@ -4,26 +4,53 @@
 
 Dedicated PostgreSQL schema `openbank_security` in the `openbank` database (shared cluster, schema-per-service isolation).
 
-**The service persists nothing operational.** After `V4` the schema holds `flyway_schema_history`
-and no other table. There is no entity, no repository and no JPA mapping anywhere in the service —
-the database exists solely so Flyway has somewhere to record its own migration history and so the
-readiness probe has a datasource to check.
+**The service persists one table: `ict_incidents`.** After `V5` the schema holds
+`flyway_schema_history` and `ict_incidents`. There is no entity, repository or JPA mapping for
+anything else in the service — scan results are still in-memory only.
 
 Consequently:
 
 - **Scan results** (`ServiceScanResult`, `PlatformSecurityReport`) live in `SecurityScannerService`
   in `ConcurrentHashMap` fields (`lastResults`, `lastReport`). They are lost on pod restart and
   rebuilt by the next scheduled scan (up to 30 minutes later, 2 minutes after startup on a cold pod).
-- **ICT incidents** live in `IctIncidentService` in a `ConcurrentHashMap` (`store`). They are lost on
-  pod restart and are **not** recoverable — nothing else holds a copy except the Kafka event that was
-  emitted at the time.
+- **ICT incidents** are durable in the `ict_incidents` table (issue #4728). They used to live in
+  `IctIncidentService`'s `ConcurrentHashMap` (`store`) and were lost on every pod restart; that is
+  fixed — an incident, its containment/resolution timestamps and its
+  `reported_to_regulator`/`regulatory_report_id` state now survive a restart.
 - There is no scan history. `GET /api/v1/security/report` returns the last in-memory report only.
 
-There is no ER diagram to draw: the service owns no tables.
+`ict_incidents` is the one table this service owns:
 
-> Until #4709 this page described a `security_outbox` table and an `ict_incidents` table. The outbox
-> existed but was never written to (0 rows ever, and 0 records ever produced to its topic) and has
-> been dropped by `V4`; the `ict_incidents` table never existed at all.
+```
+ict_incidents
+├── id                      UUID PRIMARY KEY  (app-assigned, UUID.randomUUID())
+├── title                   TEXT NOT NULL
+├── description             TEXT NOT NULL
+├── category                VARCHAR(64) NOT NULL
+├── severity                VARCHAR(32) NOT NULL
+├── status                  VARCHAR(32) NOT NULL
+├── affected_services       TEXT NOT NULL   (comma-joined service names)
+├── detected_at             TIMESTAMPTZ NOT NULL
+├── reported_at             TIMESTAMPTZ NOT NULL
+├── contained_at            TIMESTAMPTZ
+├── resolved_at             TIMESTAMPTZ
+├── rto_minutes             INTEGER
+├── rpo_minutes             INTEGER
+├── reported_to_regulator   BOOLEAN NOT NULL DEFAULT FALSE
+├── regulatory_report_id    TEXT
+├── assigned_to             TEXT
+├── created_at              TIMESTAMPTZ NOT NULL
+└── updated_at              TIMESTAMPTZ NOT NULL
+```
+
+No other table references it and it references nothing else — a single-node diagram, not worth
+drawing as a graph.
+
+> Until #4709 this page described a `security_outbox` table and an `ict_incidents` table, and
+> claimed both were fictional. The outbox existed but was never written to (0 rows ever, and 0
+> records ever produced to its topic) and was dropped by `V4`; `ict_incidents` did not exist at that
+> point either. `V5` (issue #4728) then created the real `ict_incidents` table described above —
+> this page is updated to match.
 
 ## Migrations
 
@@ -31,12 +58,20 @@ There is no ER diagram to draw: the service owns no tables.
 |---|---|---|
 | `V2__create_security_outbox.sql` | Created `security_outbox` with indexes on `(status, created_at)` and `aggregate_id` | Applied on the live database; superseded by V4 |
 | `V3__hibernate_sequences.sql` | Created the Hibernate/Panache sequence used for the outbox surrogate key | Applied; the sequence is dropped by V4 |
-| `V4__drop_security_outbox.sql` | `DROP TABLE security_outbox` + `DROP SEQUENCE security_outbox_seq` — the outbox had no producer (#4709) | The current head |
+| `V4__drop_security_outbox.sql` | `DROP TABLE security_outbox` + `DROP SEQUENCE security_outbox_seq` — the outbox had no producer (#4709) | Applied out of order (#5628) |
+| `V5__create_ict_incidents.sql` | Created `ict_incidents` (columns above) + indexes on `created_at`, `status`, `severity` — moves the DORA ICT incident register out of the in-memory map (#4728) | The current head |
 
 > V1 is absent — the scanner was stateless in its first iteration and V2 is the first migration that
 > landed. V2 and V3 are deliberately kept as files rather than deleted: both are recorded as applied
 > in the live `flyway_schema_history`, and removing an applied migration's file fails Flyway
 > validation exactly as editing one fails the checksum.
+
+> `ict_incidents` has no Hibernate sequence: its id is application-assigned (`UUID.randomUUID()` in
+> `IctIncidentService.reportIncident`), not `@GeneratedValue`, so the entity is
+> `PanacheEntityBase` with an explicit `@Id` rather than `PanacheEntity`. Updates go through
+> `Panache.getSession().flatMap { it.merge(entity) }` — `persist()` on an assigned id would schedule
+> an INSERT for every save and fail every status transition after the first with a duplicate-key
+> error (see `IctIncidentEntity`, `IctIncidentRepositoryImpl.save`).
 
 ## Where each piece of state lives
 
@@ -45,20 +80,30 @@ There is no ER diagram to draw: the service owns no tables.
 | `ServiceScanResult` (per service) | In-memory `ConcurrentHashMap` | Until pod restart; rebuilt by next scan |
 | `PlatformSecurityReport` | In-memory (last result only) | Until pod restart; rebuilt by next scan |
 | `SecurityFinding` | In-memory (part of results) | Until pod restart |
-| `IctIncident` | In-memory `ConcurrentHashMap` | Until pod restart — **not recoverable** |
+| `IctIncident` | `ict_incidents` table (PostgreSQL) | Durable — survives pod restart |
 
 ## Indexes
 
-None — the service has no tables of its own.
+`ict_incidents` carries three, matching how `GET /api/v1/ict-incidents` filters and sorts:
+
+| Index | Column(s) | Why |
+|---|---|---|
+| `idx_ict_incidents_created_at` | `created_at DESC` | The list endpoint orders by `created_at DESC` |
+| `idx_ict_incidents_status` | `status` | The list endpoint filters by status |
+| `idx_ict_incidents_severity` | `severity` | The list endpoint filters by severity |
+
+No other table exists, so these are the service's only indexes.
 
 ## Retention
 
-There is nothing to retain in this service's database. The only durable trace of its activity is the
+`ict_incidents` rows are retained indefinitely — there is no TTL, archival job or delete path in the
+service. The only other durable trace of ICT-incident activity is the
 `openbank.security.ict.incident` Kafka topic and whatever `audit-service` stores from it; that
 retention is owned by audit-service, not here.
 
-Anyone needing a durable ICT incident register — which DORA Art. 17 evidence realistically requires —
-should treat the current in-memory store as a gap, not as a control.
+DORA Art. 17 evidence needs a durable ICT incident register; `ict_incidents` (since #4728, `V5`) is
+that register. Before `V5`, the in-memory store was correctly flagged here as a gap, not a control —
+that gap is closed.
 
 ## PII considerations
 
@@ -67,11 +112,12 @@ An `IctIncident` may carry:
 - `assignedTo` — email/name of the assigned engineer (internal employee data)
 - `description` — free text that could reference customer-facing systems
 
-These fields are internal operator data, not customer PII, and are never written to a database here.
-They do travel on the Kafka event.
+These fields are internal operator data, not customer PII. They are written to `ict_incidents`
+(`assigned_to`, `description` columns) and also travel on the Kafka event.
 
 ## Size estimates
 
-- Database: `flyway_schema_history` only — 3 rows.
+- Database: `flyway_schema_history` (4 rows) + `ict_incidents`, expected tens of rows per month,
+  each row well under 1 KB outside of `description` — low hundreds of KB per year, trivial for a
+  dedicated schema.
 - In-memory scan results: 27 services × ~5 KB each = ~135 KB (trivial).
-- In-memory ICT incidents: bounded only by pod lifetime; expected tens per month.


### PR DESCRIPTION
Closes #4939

Adds provider-neutral runbooks for the four ADR-0146 key ceremonies. Documents pre-check, two-person execution, verification, rollback, and evidence capture without secrets or production claims. Keeps ADR-0146 partial: admin UI and live annual drill evidence remain open.