### PR TITLE
fix(admin-ui): expose unwired approval queues

### DIFF
--- a/openbank-admin-ui/src/app/api/approvals/pending/route.ts
+++ b/openbank-admin-ui/src/app/api/approvals/pending/route.ts
@@ -15,7 +15,22 @@ import { serverSvcUrl } from '@/lib/services/bff'
 
 export const dynamic = 'force-dynamic'
 
-type SourceState = 'ok' | 'forbidden' | 'unavailable'
+type SourceState = 'ok' | 'forbidden' | 'unavailable' | 'not-configured'
+
+// These domains already persist maker-checker decisions, but do not yet expose the
+// pending-list read required by ADR-0227 D2. Keep them in the response explicitly so
+// the inbox can distinguish "not wired" from an empty queue. Omitting them would make
+// the most dangerous state look healthy to an operator.
+const NOT_CONFIGURED_SOURCES = {
+  account: 'not-configured',
+  balance: 'not-configured',
+  billing: 'not-configured',
+  consent: 'not-configured',
+  notification: 'not-configured',
+  party: 'not-configured',
+  'sepa-instant': 'not-configured',
+  'sepa-payment': 'not-configured',
+} as const satisfies Record<string, SourceState>
 
 type InboxItem = {
   id: string
@@ -259,6 +274,7 @@ export async function GET() {
   return NextResponse.json({
     items,
     sources: {
+      ...NOT_CONFIGURED_SOURCES,
       lending: lending.state,
       sanctions: sanctions.state,
       transaction: transaction.state,

--- a/openbank-admin-ui/src/app/approvals/page.tsx
+++ b/openbank-admin-ui/src/app/approvals/page.tsx
@@ -109,8 +109,12 @@ export default function ApprovalsPage() {
   const decided = useMemo(() => rows.filter(r => r.state !== 'PROPOSED'), [rows])
   // Sources that answered anything other than 200 — a 403 here is ordinary (lending's list is
   // desk-role gated while this page is not), and it must never look like an empty queue.
-  const degradedSources = useMemo(
-    () => Object.entries(domainSources).filter(([, v]) => v !== 'ok').map(([k]) => k),
+  const unavailableSources = useMemo(
+    () => Object.entries(domainSources).filter(([, v]) => v === 'unavailable' || v === 'forbidden').map(([k]) => k),
+    [domainSources],
+  )
+  const notConfiguredSources = useMemo(
+    () => Object.entries(domainSources).filter(([, v]) => v === 'not-configured').map(([k]) => k),
     [domainSources],
   )
 
@@ -137,18 +141,29 @@ export default function ApprovalsPage() {
       <div style={{ fontSize: 12, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-secondary)', margin: '4px 0 10px' }}>
         {t('Doménová schvalování (money-path)', 'Domain approvals (money-path)')} ({domainItems.filter(i => i.domain !== 'agent').length})
       </div>
-      {degradedSources.length > 0 && (
+      {unavailableSources.length > 0 && (
         <div className="card" style={{
           padding: 14, marginBottom: 16, fontSize: 13,
           color: '#92400e', background: '#fffbeb', border: '1px solid #fcd34d',
         }}>
           {t(
-            `Fronta není úplná — nepodařilo se načíst: ${degradedSources.join(', ')}. Prázdný seznam neznamená, že nic nečeká.`,
-            `This queue is incomplete — could not read: ${degradedSources.join(', ')}. An empty list does not mean nothing is pending.`,
+            `Fronta není úplná — nepodařilo se načíst: ${unavailableSources.join(', ')}. Prázdný seznam neznamená, že nic nečeká.`,
+            `This queue is incomplete — could not read: ${unavailableSources.join(', ')}. An empty list does not mean nothing is pending.`,
           )}
         </div>
       )}
-      {!loading && degradedSources.length === 0 && domainItems.filter(i => i.domain !== 'agent').length === 0 && (
+      {notConfiguredSources.length > 0 && (
+        <div className="card" style={{
+          padding: 14, marginBottom: 16, fontSize: 13,
+          color: '#475569', background: '#f8fafc', border: '1px solid #cbd5e1',
+        }}>
+          {t(
+            `Část fronty zatím není napojená: ${notConfiguredSources.join(', ')}. Rozhodnutí z těchto domén se zde nezobrazí, dokud jejich read endpoint nebude dostupný.`,
+            `Some queues are not connected yet: ${notConfiguredSources.join(', ')}. Decisions from these domains will not appear here until their read endpoint is available.`,
+          )}
+        </div>
+      )}
+      {!loading && unavailableSources.length === 0 && notConfiguredSources.length === 0 && domainItems.filter(i => i.domain !== 'agent').length === 0 && (
         <div className="card" style={{ padding: 16, marginBottom: 16, color: 'var(--text-secondary)', fontSize: 13 }}>
           {t('Žádná doménová schvalování nečekají.', 'No domain approvals pending.')}
         </div>

--- a/openbank-admin-ui/src/test/approvals-inbox.test.ts
+++ b/openbank-admin-ui/src/test/approvals-inbox.test.ts
@@ -100,6 +100,8 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(body.items[6]).toMatchObject({ domain: 'sanctions', action: 'sanctions.clear', maker: 'analyst.c' })
     expect(body.items[7]).toMatchObject({ domain: 'agent', action: 'agent.research' })
     expect(body.items[8]).toMatchObject({ domain: 'transaction', action: 'transaction.reverse', maker: 'teller.d' })
+    expect(body.sources.account).toBe('not-configured')
+    expect(body.sources['sepa-payment']).toBe('not-configured')
   })
 
   // The regression this file exists to prevent, stated as a test for the transaction slice of

--- a/openbank-admin-ui/src/test/approvals-source-truth.guard.test.ts
+++ b/openbank-admin-ui/src/test/approvals-source-truth.guard.test.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const routeSource = fs.readFileSync(path.join(process.cwd(), 'src/app/api/approvals/pending/route.ts'), 'utf8')
+const pageSource = fs.readFileSync(path.join(process.cwd(), 'src/app/approvals/page.tsx'), 'utf8')
+
+describe('approval inbox source truthfulness', () => {
+  it('exposes known-but-unwired queues instead of treating them as empty', () => {
+    expect(routeSource).toContain("'not-configured'")
+    expect(routeSource).toContain("'sepa-payment': 'not-configured'")
+    expect(routeSource).toContain('...NOT_CONFIGURED_SOURCES')
+  })
+
+  it('does not render an empty-state claim while a source is not configured', () => {
+    expect(pageSource).toContain('const notConfiguredSources = useMemo(')
+    expect(pageSource).toContain('notConfiguredSources.length === 0 && domainItems.filter')
+    expect(pageSource).toContain('Decisions from these domains will not appear here until their read endpoint is available.')
+  })
+})


### PR DESCRIPTION
## Summary
- distinguish known-but-unwired maker-checker queues from empty or unavailable sources
- show an explicit localized coverage notice in the approval inbox
- add route and source-truth regression guards

This is a UI/BFF truthfulness slice for #5679; it does not add write paths or alter service RBAC.

Refs #5679
Closes #4841