### PR TITLE
feat(admin-ui): distinguish governance controls from autonomy

### DIFF
--- a/.github/scripts/gen-ai-governance-snapshot.py
+++ b/.github/scripts/gen-ai-governance-snapshot.py
@@ -78,7 +78,7 @@ def sha256_short(path: pathlib.Path) -> str:
 def validate_curated(curated: dict) -> None:
     if not isinstance(curated, dict):
         fail("ai-rollout.yaml must be a mapping")
-    for key in ["adrRef", "adrStatus", "phase", "decisions", "compliance", "auditTrail"]:
+    for key in ["adrRef", "adrStatus", "phase", "controlMaturity", "decisions", "compliance", "auditTrail"]:
         if key not in curated:
             fail(f"ai-rollout.yaml missing required key: {key}")
 
@@ -116,6 +116,26 @@ def validate_curated(curated: dict) -> None:
     if any(item["status"] == "complete" for item in roadmap if item["number"] > current):
         fail("no phase after phase.current may be marked complete")
 
+    control_maturity = curated["controlMaturity"]
+    if not isinstance(control_maturity, dict):
+        fail("controlMaturity must be a mapping")
+    for key in ["current", "total", "label", "achieved", "remaining"]:
+        if key not in control_maturity:
+            fail(f"controlMaturity missing required key: {key}")
+    maturity_current = control_maturity["current"]
+    maturity_total = control_maturity["total"]
+    if type(maturity_current) is not int or type(maturity_total) is not int or not 1 <= maturity_current <= maturity_total:
+        fail("controlMaturity.current must be an integer between 1 and controlMaturity.total")
+    if not isinstance(control_maturity["label"], str) or not control_maturity["label"].strip():
+        fail("controlMaturity.label must be a non-empty string")
+    achieved = control_maturity["achieved"]
+    if not isinstance(achieved, list) or len(achieved) != maturity_current or not all(isinstance(item, str) and re.fullmatch(r"D[1-9]", item) for item in achieved):
+        fail("controlMaturity.achieved must contain one D1–D9 decision id per completed control")
+    if len(set(achieved)) != len(achieved):
+        fail("controlMaturity.achieved must not contain duplicate decision ids")
+    if not isinstance(control_maturity["remaining"], str) or not control_maturity["remaining"].strip():
+        fail("controlMaturity.remaining must be a non-empty string")
+
     decisions = curated["decisions"]
     if not isinstance(decisions, list):
         fail("decisions must be a list")
@@ -130,6 +150,11 @@ def validate_curated(curated: dict) -> None:
                 fail(f"decision {item!r} missing required key: {key}")
         if item["status"] not in ALLOWED_D_STATUSES:
             fail(f"decision {item['id']} has invalid status {item['status']!r}")
+
+    decision_statuses = {item["id"]: item["status"] for item in decisions}
+    for decision_id in achieved:
+        if decision_statuses.get(decision_id) != "built":
+            fail(f"controlMaturity.achieved {decision_id} must reference a built decision")
 
     for row_name in ["compliance"]:
         rows = curated[row_name]
@@ -326,6 +351,7 @@ def build_snapshot() -> dict:
         "phaseLabel": curated["phase"]["label"],
         "agentsActing": curated["phase"]["agentsActing"],
         "phaseRoadmap": curated["phase"]["roadmap"],
+        "controlMaturity": curated["controlMaturity"],
         "decisions": decisions,
         "decisionSummary": decision_summary,
         "compliance": curated["compliance"],
@@ -386,6 +412,10 @@ def self_test() -> int:
                 {"number": 5, "status": "planned", "title": "five", "outcome": "later"},
             ],
         },
+        "controlMaturity": {
+            "current": 4, "total": 5, "label": "four controls built",
+            "achieved": ["D1", "D2", "D3", "D4"], "remaining": "D5 evidence",
+        },
         "decisions": [
             {"id": f"D{i}", "title": f"t{i}", "status": "built", "detail": f"d{i}"}
             for i in range(1, 10)
@@ -416,7 +446,7 @@ def self_test() -> int:
         fails.append(f"a well-formed curated document was rejected: {sink.getvalue().strip()}")
 
     # Top-level keys: each one absent means a section of the published page has no source.
-    for key in ("adrRef", "adrStatus", "phase", "decisions", "compliance", "auditTrail"):
+    for key in ("adrRef", "adrStatus", "phase", "controlMaturity", "decisions", "compliance", "auditTrail"):
         rejects(f"a missing top-level {key!r}", lambda d, k=key: d.pop(k))
 
     # The phase block drives the headline number on the page.
@@ -428,6 +458,17 @@ def self_test() -> int:
     rejects("an inactive current phase", lambda d: d["phase"]["roadmap"][1].update(status="blocked"))
     rejects("an incomplete prior phase", lambda d: d["phase"]["roadmap"][0].update(status="blocked"))
     rejects("a complete phase after current", lambda d: d["phase"]["roadmap"][2].update(status="complete"))
+
+    # This is a separate ruler from release autonomy. It must not become a free-form, unvalidated
+    # score that renders a stronger governance claim than its input supports.
+    for key in ("current", "total", "label", "achieved", "remaining"):
+        rejects(f"a missing controlMaturity.{key}", lambda d, k=key: d["controlMaturity"].pop(k))
+    rejects("a non-mapping controlMaturity", lambda d: d.update(controlMaturity=["not", "a", "map"]))
+    rejects("a control maturity above total", lambda d: d["controlMaturity"].update(current=6))
+    rejects("a control maturity with too few achieved controls", lambda d: d["controlMaturity"].update(achieved=["D1"]))
+    rejects("a control maturity with duplicate achieved controls", lambda d: d["controlMaturity"].update(achieved=["D1", "D1", "D3", "D4"]))
+    rejects("a control maturity citing a partial decision", lambda d: d["decisions"][2].update(status="partial"))
+    rejects("a control maturity with a blank remaining statement", lambda d: d["controlMaturity"].update(remaining=""))
 
     # D1-D9 must appear EXACTLY, in order. A dropped decision is the failure that matters most
     # here: the page renders eight rows and reads as complete, because a row that is not there
@@ -449,6 +490,10 @@ def self_test() -> int:
     for ok_status in sorted(ALLOWED_D_STATUSES):
         doc = copy.deepcopy(good)
         doc["decisions"][0]["status"] = ok_status
+        if ok_status != "built":
+            # This loop exercises the documented decision-status vocabulary, not a contradictory
+            # maturity claim. A non-built D1 cannot remain in the achieved-controls list.
+            doc["controlMaturity"].update(current=3, achieved=["D2", "D3", "D4"])
         sink = io.StringIO()
         try:
             with contextlib.redirect_stderr(sink):

--- a/openbank-admin-ui/ai-governance-snapshot.json
+++ b/openbank-admin-ui/ai-governance-snapshot.json
@@ -37,6 +37,18 @@
       "outcome": "Needs asymmetric third-party-verifiable audit anchors and AI attribution in release evidence."
     }
   ],
+  "controlMaturity": {
+    "current": 4,
+    "total": 5,
+    "label": "Four core governance control families are built; independently verifiable provenance remains partial.",
+    "achieved": [
+      "D1",
+      "D2",
+      "D3",
+      "D4"
+    ],
+    "remaining": "D5 still needs asymmetric, third-party-verifiable audit anchors and AI-attribution in release evidence."
+  },
   "decisions": [
     {
       "id": "D1",
@@ -346,7 +358,7 @@
     "provenance": {
       "curated": {
         "source": "openbank-libs/governance/ai-rollout.yaml",
-        "sha256": "8535fbf8aa2a09ab"
+        "sha256": "0fa2e67d34cc0ff7"
       },
       "generatedBy": ".github/scripts/gen-ai-governance-snapshot.py"
     }

--- a/openbank-admin-ui/src/app/iaops/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/page.tsx
@@ -35,10 +35,12 @@ interface Agent {
 interface Decision { id: string; title: string; status: DStatus; detail: string }
 interface Compliance { framework: string; requirement: string; control: string; status: DStatus }
 interface PhaseRoadmap { number: number; status: PhaseStatus; title: string; outcome: string }
+interface ControlMaturity { current: number; total: number; label: string; achieved: string[]; remaining: string }
 interface GovData {
   adrRef: string; adrStatus: string; phase: number; totalPhases: number; phaseLabel: string
   enforcement: string; policyDefault: string; agentsActing: number
   phaseRoadmap: PhaseRoadmap[]
+  controlMaturity: ControlMaturity
   chartersAvailable: boolean; agentCount: number; agents: Agent[]
   toolTiers: Record<string, string[]>
   decisions: Decision[]; decisionSummary: { built: number; partial: number; planned: number; total: number }
@@ -338,7 +340,7 @@ function IAOpsContent() {
                 { label: t('Fáze roadmapy (ADR-0031)', 'Roadmap phase (ADR-0031)'), value: `${data.phase}/${data.totalPhases}`, sub: t(`${data.phaseLabel} · není živá runtime atestace`, `${data.phaseLabel} · not live runtime evidence`), color: '#6366f1' },
                 { label: t('Vynucování', 'Enforcement'), value: data.enforcement === 'advisory' ? t('Advisory (audit)', 'Advisory (audit)') : data.enforcement, sub: t(`Default: ${data.policyDefault} (deny-by-default)`, `Default: ${data.policyDefault} (deny-by-default)`), color: '#d97706' },
                 { label: t('Autonomní změnoví agenti', 'Autonomous state-changing agents'), value: String(data.agentsActing), sub: t(`${data.agentCount} charterů definováno · není to živé počítadlo aktivity`, `${data.agentCount} charters defined · not a live activity count`), color: '#16a34a' },
-                { label: t('Roadmapa D1–D9', 'Roadmap D1–D9'), value: `${data.decisionSummary.built}/${data.decisionSummary.total}`, sub: t(`${data.decisionSummary.partial} částečně · ${data.decisionSummary.planned} plánováno`, `${data.decisionSummary.partial} partial · ${data.decisionSummary.planned} planned`), color: '#0891b2' },
+                { label: t('Governance kontroly', 'Governance controls'), value: `${data.controlMaturity.current}/${data.controlMaturity.total}`, sub: t('Kontroly, ne oprávnění k autonomní změně', 'Controls, not authority for autonomous change'), color: '#0891b2' },
               ].map(k => (
                 <div key={k.label} className="stat-card">
                   <div style={{ fontSize: '22px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em', marginBottom: '2px' }}>{k.value}</div>
@@ -346,6 +348,21 @@ function IAOpsContent() {
                   <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', marginTop: '2px' }}>{k.sub}</div>
                 </div>
               ))}
+            </div>
+
+            <div style={{ marginTop: '14px', padding: '12px 14px', borderRadius: '10px', background: 'rgba(8,145,178,0.06)', border: '1px solid rgba(8,145,178,0.18)' }}>
+              <div style={{ fontSize: '12px', fontWeight: 750, color: 'var(--text-primary)' }}>
+                {t(
+                  `${data.controlMaturity.current} z ${data.controlMaturity.total} ochranných pilířů je postavených.`,
+                  `${data.controlMaturity.current} of ${data.controlMaturity.total} protective control families are built.`,
+                )}
+              </div>
+              <p style={{ fontSize: '11px', color: 'var(--text-secondary)', lineHeight: 1.55, margin: '4px 0 0' }}>
+                {t(
+                  `${data.controlMaturity.label} To není povolení k autonomní změně — ta zůstává na ${data.phase}/${data.totalPhases}, dokud neexistuje nezávisle ověřený provozní důkaz.`,
+                  `${data.controlMaturity.label} This is not permission for autonomous change — that remains at ${data.phase}/${data.totalPhases} until independently verified operational evidence exists.`,
+                )}
+              </p>
             </div>
 
             {/* What / Why / How */}

--- a/openbank-admin-ui/src/lib/governance/aiGovernanceSnapshot.ts
+++ b/openbank-admin-ui/src/lib/governance/aiGovernanceSnapshot.ts
@@ -33,6 +33,14 @@ export interface AiGovernancePhaseRoadmapEntry {
   outcome: string
 }
 
+export interface AiGovernanceControlMaturity {
+  current: number
+  total: number
+  label: string
+  achieved: string[]
+  remaining: string
+}
+
 export interface AiGovernanceSnapshot {
   adrRef: string
   adrStatus: string
@@ -41,6 +49,7 @@ export interface AiGovernanceSnapshot {
   phaseLabel: string
   agentsActing: number
   phaseRoadmap: AiGovernancePhaseRoadmapEntry[]
+  controlMaturity: AiGovernanceControlMaturity
   decisions: AiGovernanceDecision[]
   decisionSummary: { built: number; partial: number; planned: number; total: number }
   compliance: AiGovernanceComplianceRow[]

--- a/openbank-admin-ui/src/test/iaops-agent-card.test.tsx
+++ b/openbank-admin-ui/src/test/iaops-agent-card.test.tsx
@@ -24,6 +24,7 @@ const FINOPS_AGENT = {
 
 const GOVERNANCE = {
   adrRef: 'ADR-0031', adrStatus: 'accepted', phase: 2, totalPhases: 5, phaseLabel: 'Read-only oversight active',
+  controlMaturity: { current: 4, total: 5, label: 'Four core controls are built.', achieved: ['D1', 'D2', 'D3', 'D4'], remaining: 'D5 needs independent provenance.' },
   enforcement: 'block', policyDefault: 'deny', agentsActing: 0, chartersAvailable: true,
   agentCount: 1, agents: [FINOPS_AGENT], toolTiers: {}, decisions: [],
   decisionSummary: { built: 0, partial: 0, planned: 0, total: 0 }, compliance: [],
@@ -54,6 +55,29 @@ describe('AIOps agent card interactions', () => {
     expect(screen.getByText(/A PDP outage degrades the gate to advisory/i)).toBeVisible()
     expect(screen.getByText(/Phase 2 remains read-only and proposal-only/i)).toBeVisible()
     expect(screen.queryByText(/enforcement \(OPA block\) is not yet live/i)).not.toBeInTheDocument()
+  })
+
+  it('distinguishes mature protective controls from permission for autonomous change', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => response(GOVERNANCE)))
+
+    render(<IAOpsPage />)
+
+    expect(await screen.findByText('Governance controls')).toBeVisible()
+    expect(screen.getByText('4/5')).toBeVisible()
+    expect(screen.getByText(/Controls, not authority for autonomous change/i)).toBeVisible()
+    expect(screen.getByText(/This is not permission for autonomous change/i)).toBeVisible()
+  })
+
+  it('renders the declared control maturity instead of hard-coding four of five', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => response({
+      ...GOVERNANCE,
+      controlMaturity: { current: 3, total: 5, label: 'Three core controls are built.', achieved: ['D1', 'D2', 'D3'], remaining: 'D4 and D5 need evidence.' },
+    })))
+
+    render(<IAOpsPage />)
+
+    expect(await screen.findByText('3 of 5 protective control families are built.')).toBeVisible()
+    expect(screen.queryByText('4 of 5 protective control families are built.')).not.toBeInTheDocument()
   })
 
   it.each(['ai-swarm', 'ai-mesh', 'agent-roster'])('scrolls to the %s fragment after governance data loads', async fragment => {

--- a/openbank-admin-ui/src/test/iaops-governance-route.test.ts
+++ b/openbank-admin-ui/src/test/iaops-governance-route.test.ts
@@ -26,6 +26,10 @@ describe('GET /api/iaops/governance', () => {
       totalPhases: 5,
       phaseLabel: 'Read-only oversight active — HITL proposal queue live; HolmesGPT + copilot deployed (proposal-only, no autonomous state-changing action)',
       agentsActing: 0,
+      controlMaturity: {
+        current: 4, total: 5, label: 'Four core controls are built.',
+        achieved: ['D1', 'D2', 'D3', 'D4'], remaining: 'D5 needs independent provenance.',
+      },
       phaseRoadmap: [
         { number: 1, status: 'complete', title: 'Safety foundations', outcome: 'Enforced.' },
         { number: 2, status: 'active', title: 'Read-only oversight', outcome: 'Human decides.' },
@@ -55,6 +59,7 @@ describe('GET /api/iaops/governance', () => {
     expect(body.phase).toBe(2)
     expect(body.phaseLabel).toContain('Read-only oversight active')
     expect(body.phaseRoadmap[1]).toMatchObject({ number: 2, status: 'active' })
+    expect(body.controlMaturity).toMatchObject({ current: 4, total: 5 })
     expect(body.enforcement).toBe('block')
     expect(body.policyDefault).toBe('deny')
     expect(body.chartersAvailable).toBe(true)

--- a/openbank-libs/governance/ai-rollout.yaml
+++ b/openbank-libs/governance/ai-rollout.yaml
@@ -45,6 +45,21 @@ phase:
       title: Independently verifiable provenance
       outcome: Needs asymmetric third-party-verifiable audit anchors and AI attribution in release evidence.
 
+# This is deliberately a DIFFERENT ruler from phase.current. It measures whether the
+# protective governance control families exist; it never grants an agent permission to
+# change state. Keeping both numbers visible prevents the usual false choice between
+# "the platform is only at 2/5" and "agents may autonomously act".
+controlMaturity:
+  current: 4
+  total: 5
+  label: Four core governance control families are built; independently verifiable provenance remains partial.
+  achieved:
+    - D1
+    - D2
+    - D3
+    - D4
+  remaining: D5 still needs asymmetric, third-party-verifiable audit anchors and AI-attribution in release evidence.
+
 decisions:
   - id: D1
     title: Agents as code (agents.yaml + charter)


### PR DESCRIPTION
## Summary

- publish a separately validated 4/5 governance-control maturity based on built D1–D4 controls, including OpenBao proof-of-possession identity
- keep the autonomous change authority explicitly at the independently evidenced ADR-0031 phase (currently 2/5)
- reject missing, duplicate, or non-built control evidence in the generated governance snapshot

## Verification

- `/private/tmp/openbank-governance-venv/bin/python .github/scripts/gen-ai-governance-snapshot.py --self-test`
- `/private/tmp/openbank-governance-venv/bin/python .github/scripts/gen-ai-governance-snapshot.py --check`
- `npm test -- --run src/test/iaops-agent-card.test.tsx src/test/iaops-governance-route.test.ts`
- `npm run type-check`

Refs #5261