### PR TITLE
fix(admin-ui): respect locale in shared displays

### DIFF
--- a/openbank-admin-ui/e2e/delegations-console.spec.ts
+++ b/openbank-admin-ui/e2e/delegations-console.spec.ts
@@ -97,6 +97,9 @@ test.beforeEach(async ({ context, baseURL }) => {
 })
 
 test('finds a party through entity resolution and renders its grants', async ({ page }) => {
+  // Keep the fixture language explicit: the display is intentionally locale-aware now,
+  // while this assertion exercises the Czech copy and formatting contract.
+  await page.addInitScript(() => window.localStorage.setItem('openbank-admin-lang', 'cs'))
   const seen = await stubBff(page)
   await page.goto('/delegations')
 

--- a/openbank-admin-ui/src/app/delegations/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/delegations/[id]/page.tsx
@@ -35,6 +35,7 @@ type CheckOutcome = { granted: boolean; reason?: string | null; code?: string | 
 
 export default function DelegationDetailPage() {
   const { t, language } = useLanguage()
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const params = useParams<{ id: string }>()
   const id = params?.id
 
@@ -98,13 +99,13 @@ export default function DelegationDetailPage() {
               <dd>{grant.approvalPolicy ?? '—'}</dd>
 
               <dt style={{ color: 'var(--text-tertiary)' }}>{t('Strop na transakci', 'Per-transaction cap')}</dt>
-              <dd>{formatCeiling(grant.perTransactionLimit)}</dd>
+              <dd>{formatCeiling(grant.perTransactionLimit, numberLocale)}</dd>
 
               <dt style={{ color: 'var(--text-tertiary)' }}>{t('Denní strop', 'Daily cap')}</dt>
-              <dd>{formatCeiling(grant.dailyLimit)}</dd>
+              <dd>{formatCeiling(grant.dailyLimit, numberLocale)}</dd>
 
               <dt style={{ color: 'var(--text-tertiary)' }}>{t('Měsíční strop', 'Monthly cap')}</dt>
-              <dd>{formatCeiling(grant.monthlyLimit)}</dd>
+              <dd>{formatCeiling(grant.monthlyLimit, numberLocale)}</dd>
 
               <dt style={{ color: 'var(--text-tertiary)' }}>{t('Platnost od', 'Valid from')}</dt>
               <dd>{grant.validFrom ?? '—'}</dd>

--- a/openbank-admin-ui/src/app/delegations/page.tsx
+++ b/openbank-admin-ui/src/app/delegations/page.tsx
@@ -228,7 +228,8 @@ export default function DelegationsPage() {
 function GrantTable({
   title, subtitle, grants, state,
 }: { title: string; subtitle: string; grants: Grant[]; state: DirectionState }) {
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
 
   return (
     <div className="card" style={{ padding: '16px', marginBottom: '20px' }}>
@@ -272,7 +273,7 @@ function GrantTable({
                   <td><EntityChip type="party" id={g.granteePartyId} label={counterpartyLabel(g.granteeName)} /></td>
                   <td style={{ fontSize: '12px' }}>{g.resourceType}</td>
                   <td style={{ fontSize: '12px' }}>{capabilityLabels(g.capabilities)}</td>
-                  <td style={{ fontSize: '12px' }}>{formatCeiling(g.perTransactionLimit)}</td>
+                  <td style={{ fontSize: '12px' }}>{formatCeiling(g.perTransactionLimit, numberLocale)}</td>
                   <td style={{ fontSize: '12px' }}>{g.validTo ? g.validTo.slice(0, 10) : '—'}</td>
                   <td>
                     <Link href={`/delegations/${g.id}`} className="btn btn-secondary" style={{ fontSize: '12px' }}>

--- a/openbank-admin-ui/src/app/infrastructure/page.tsx
+++ b/openbank-admin-ui/src/app/infrastructure/page.tsx
@@ -283,7 +283,7 @@ export default function InfrastructurePage() {
                   )}
 
                   {lifecycle[comp.id] && (
-                    <LifecycleStrip data={lifecycle[comp.id]} name={comp.name} t={t} />
+                    <LifecycleStrip data={lifecycle[comp.id]} name={comp.name} t={t} dateLocale={dateLocale} />
                   )}
                 </div>
               )

--- a/openbank-admin-ui/src/components/delegations/GrantView.tsx
+++ b/openbank-admin-ui/src/components/delegations/GrantView.tsx
@@ -80,7 +80,7 @@ export function counterpartyLabel(name: string | null | undefined): string | und
 }
 
 /** A ceiling of `null` means UNCAPPED for that window — never render it as zero. */
-export function formatCeiling(limit: Money | null | undefined): string {
+export function formatCeiling(limit: Money | null | undefined, locale = 'en-GB'): string {
   if (!limit || typeof limit.amount !== 'number') return '—'
-  return `${limit.amount.toLocaleString('cs-CZ')} ${limit.currency}`
+  return `${limit.amount.toLocaleString(locale)} ${limit.currency}`
 }

--- a/openbank-admin-ui/src/components/infra/LifecycleStrip.tsx
+++ b/openbank-admin-ui/src/components/infra/LifecycleStrip.tsx
@@ -48,11 +48,11 @@ const URGENCY: Record<Urgency, { cs: string; en: string; color: string; bg: stri
 
 type T = (cs: string, en: string) => string
 
-function fmtDate(iso: string): string {
-  return new Date(iso).toLocaleDateString('cs-CZ', { year: 'numeric', month: 'short' })
+function fmtDate(iso: string, locale: string): string {
+  return new Date(iso).toLocaleDateString(locale, { year: 'numeric', month: 'short' })
 }
 
-export function LifecycleStrip({ data, name, t }: { data: CompLifecycle; name: string; t: T }) {
+export function LifecycleStrip({ data, name, t, dateLocale = 'en-GB' }: { data: CompLifecycle; name: string; t: T; dateLocale?: string }) {
   const [draft, setDraft] = useState<'idle' | 'busy' | 'done' | 'err'>('idle')
   const u = URGENCY[data.urgency]
   const lc = data.lifecycle
@@ -122,7 +122,7 @@ export function LifecycleStrip({ data, name, t }: { data: CompLifecycle; name: s
               <Clock size={12} />
               {lc.eolPassed
                 ? t('Po EoL', 'Past EoL')
-                : `${t('Podpora do', 'Supported to')} ${fmtDate(lc.eol)}${lc.eolDaysLeft != null ? ` · ~${lc.eolDaysLeft} ${t('dní', 'days')}` : ''}`}
+                : `${t('Podpora do', 'Supported to')} ${fmtDate(lc.eol, dateLocale)}${lc.eolDaysLeft != null ? ` · ~${lc.eolDaysLeft} ${t('dní', 'days')}` : ''}`}
             </span>
           ) : (
             <span style={{ color: 'var(--text-tertiary)' }}>{t('EoL nestanoveno', 'No EoL set')}</span>

--- a/openbank-admin-ui/src/test/shared-locale-formatting.guard.test.ts
+++ b/openbank-admin-ui/src/test/shared-locale-formatting.guard.test.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (file: string) => fs.readFileSync(path.join(process.cwd(), file), 'utf8')
+const grant = read('src/components/delegations/GrantView.tsx')
+const lifecycle = read('src/components/infra/LifecycleStrip.tsx')
+const delegations = read('src/app/delegations/page.tsx')
+const detail = read('src/app/delegations/[id]/page.tsx')
+const infrastructure = read('src/app/infrastructure/page.tsx')
+
+describe('shared display components use the active locale', () => {
+  it('does not hard-code Czech formatting in shared components', () => {
+    expect(grant).not.toContain("toLocaleString('cs-CZ'")
+    expect(lifecycle).not.toContain("toLocaleDateString('cs-CZ'")
+    expect(grant).toContain('toLocaleString(locale)')
+    expect(lifecycle).toContain('toLocaleDateString(locale')
+  })
+
+  it('passes page language into every shared formatter consumer', () => {
+    expect(delegations).toContain('formatCeiling(g.perTransactionLimit, numberLocale)')
+    expect(detail).toContain('formatCeiling(grant.monthlyLimit, numberLocale)')
+    expect(infrastructure).toContain('dateLocale={dateLocale}')
+  })
+})


### PR DESCRIPTION
## Summary
- render delegation ceilings using the active operator locale
- render infrastructure lifecycle dates using the active operator locale
- add source guards for shared display formatters

Presentation-only: no endpoints, payloads, mutations or RBAC changed.

Refs #4841