### PR TITLE
fix(admin-ui): expose FX tab state

### DIFF
--- a/openbank-admin-ui/src/app/fx/page.tsx
+++ b/openbank-admin-ui/src/app/fx/page.tsx
@@ -389,7 +389,14 @@ export default function FxPage() {
         <div className="card" style={{ marginBottom: '24px' }}>
           <div style={{ padding: '12px 20px', borderBottom: '1px solid var(--border)', display: 'flex', alignItems: 'center', gap: '8px' }}>
             {(['bank', 'cnb', 'ecb'] as const).map(tab => (
-              <button key={tab} style={tabStyle(tab)} onClick={() => setActiveTab(tab)}>
+              <button
+                key={tab}
+                type="button"
+                style={tabStyle(tab)}
+                aria-pressed={activeTab === tab}
+                aria-label={tab === 'bank' ? t('Bankovní lístek', 'Bank rate sheet') : tab === 'cnb' ? t('Kurzy ČNB', 'CNB rates') : t('Kurzy ECB', 'ECB rates')}
+                onClick={() => setActiveTab(tab)}
+              >
                 {tab === 'bank' ? `🏦 ${t('Bankovní lístek', 'Bank Rate Sheet')}` : tab === 'cnb' ? `🇨🇿 ${t('ČNB Kurzy', 'CNB Rates')}` : `🇪🇺 ${t('ECB Kurzy', 'ECB Rates')}`}
               </button>
             ))}

--- a/openbank-admin-ui/src/test/fx-tab-semantics.guard.test.ts
+++ b/openbank-admin-ui/src/test/fx-tab-semantics.guard.test.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = fs.readFileSync(path.join(process.cwd(), 'src/app/fx/page.tsx'), 'utf8')
+
+describe('FX rate-sheet tab semantics', () => {
+  it('keeps the mutually exclusive rate-sheet controls named and stateful', () => {
+    expect(source).toContain('type="button"')
+    expect(source).toContain('aria-pressed={activeTab === tab}')
+    expect(source).toContain("t('Bankovní lístek', 'Bank rate sheet')")
+    expect(source).toContain("t('Kurzy ČNB', 'CNB rates')")
+    expect(source).toContain("t('Kurzy ECB', 'ECB rates')")
+  })
+})


### PR DESCRIPTION
## Summary
- name the FX rate-sheet controls for assistive technology
- expose the active rate-sheet choice with aria-pressed
- add a focused regression guard

Presentation-only: no FX fetch, quote, mutation, BFF or RBAC behavior changed.

Refs #4841