### PR TITLE
ci(liveness): retire healed scheduler test baseline

### DIFF
--- a/.github/scripts/check-scheduler-exercised.py
+++ b/.github/scripts/check-scheduler-exercised.py
@@ -57,14 +57,12 @@ TEST_BLOCK = re.compile(r'^"?%test"?\s*:\s*\n(.*?)(?=^\S|\Z)', re.M | re.S)
 # anywhere. Measured 2026-07-26 (#2204). This list may only SHRINK.
 BASELINE = {
     "openbank-aml-service",
-    "openbank-balance-service",
     "openbank-card-issuance-service",
     "openbank-interest-service",
     "openbank-notification-service",
     "openbank-onboarding-service",
     "openbank-sanctions-service",
     "openbank-sdd-service",
-    "openbank-statement-service",
 }
 
 


### PR DESCRIPTION
Refs #2204

Retires the two stale D4 baseline entries for balance and statement: both now re-enable the Quarkus scheduler in integration tests. The scan and self-test pass; eight genuinely uncovered services remain baselined.