### PR TITLE
test(notification): exercise stale token cron

### DIFF
--- a/.github/scripts/check-scheduler-exercised.py
+++ b/.github/scripts/check-scheduler-exercised.py
@@ -59,7 +59,6 @@ BASELINE = {
     "openbank-aml-service",
     "openbank-card-issuance-service",
     "openbank-interest-service",
-    "openbank-notification-service",
     "openbank-onboarding-service",
     "openbank-sanctions-service",
     "openbank-sdd-service",

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepJob.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepJob.kt
@@ -61,7 +61,11 @@ class DeviceTokenSweepJob {
     // TooGenericExceptionCaught: a non-critical nightly sweep must not surface as a Quarkus
     // Scheduler failure — ANY fault is logged and tomorrow's tick sweeps the same rows again.
     @Suppress("TooGenericExceptionCaught")
-    @Scheduled(cron = "0 0 3 * * ?", identity = "device-token-stale-sweep", concurrentExecution = SKIP)
+    @Scheduled(
+        cron = "{openbank.notification.device-token-stale-sweep.cron:0 0 3 * * ?}",
+        identity = "device-token-stale-sweep",
+        concurrentExecution = SKIP,
+    )
     suspend fun sweepStaleTokens() {
         val threshold = Instant.now(clock).minus(STALE_DAYS, ChronoUnit.DAYS)
         try {

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepJob.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepJob.kt
@@ -8,6 +8,7 @@ import com.openbank.libs.observability.DomainMetrics
 import com.openbank.libs.observability.WorkflowLivenessRecorder
 import com.openbank.notification.infrastructure.persistence.repository.DeviceTokenRepository
 import io.quarkus.logging.Log
+import io.quarkus.runtime.Startup
 import io.quarkus.runtime.StartupEvent
 import io.quarkus.scheduler.Scheduled
 import io.quarkus.scheduler.Scheduled.ConcurrentExecution.SKIP
@@ -37,6 +38,7 @@ import java.time.temporal.ChronoUnit
  * (`rules.yaml: scheduled_methods`).
  */
 @ApplicationScoped
+@Startup
 class DeviceTokenSweepJob {
 
     @Inject

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeadLetterJanitorWorkflowLivenessTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeadLetterJanitorWorkflowLivenessTest.kt
@@ -65,7 +65,7 @@ class DeadLetterJanitorWorkflowLivenessTest {
         it.domainMetrics = metrics
     }
 
-    private fun onVertxContext(block: suspend () -> Unit): Unit {
+    private fun onVertxContext(block: suspend () -> Unit) {
         val vertx = Vertx.vertx()
         val completion = CompletableFuture<Unit>()
         vertx.runOnContext {

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeadLetterJanitorWorkflowLivenessTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeadLetterJanitorWorkflowLivenessTest.kt
@@ -11,9 +11,13 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.every
 import io.mockk.mockk
 import io.quarkus.runtime.StartupEvent
+import io.quarkus.vertx.VertxContextSupport
 import io.smallrye.mutiny.Uni
 import jakarta.enterprise.inject.Instance
-import kotlinx.coroutines.runBlocking
+import io.smallrye.mutiny.coroutines.asUni
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Clock
@@ -61,8 +65,12 @@ class DeadLetterJanitorWorkflowLivenessTest {
         it.domainMetrics = metrics
     }
 
+    private fun onVertxContext(block: suspend () -> Unit) = VertxContextSupport.subscribeAndAwait {
+        CoroutineScope(Dispatchers.Unconfined).async { block() }.asUni()
+    }
+
     @Test
-    fun `registers the gauges at startup and records success after a purge`(): Unit = runBlocking {
+    fun `registers the gauges at startup and records success after a purge`() {
         val registry = SimpleMeterRegistry()
         every { repo.purgeDeadBefore(any()) } returns Uni.createFrom().item(5L)
 
@@ -82,20 +90,20 @@ class DeadLetterJanitorWorkflowLivenessTest {
                 .gauge()?.value(),
         ).isEqualTo(Duration.ofDays(1).toSeconds().toDouble())
 
-        janitor.purgeDeadLetters()
+        onVertxContext { janitor.purgeDeadLetters() }
 
         assertThat(successRecordedOf(registry)).isEqualTo(SUCCEEDED)
         assertThat(ageOf(registry)).isLessThan(TOLERANCE_SECONDS)
     }
 
     @Test
-    fun `a purge that removes nothing still records success`(): Unit = runBlocking {
+    fun `a purge that removes nothing still records success`() {
         val registry = SimpleMeterRegistry()
         every { repo.purgeDeadBefore(any()) } returns Uni.createFrom().item(0L)
 
         val janitor = job(metricsOver(registry))
         janitor.registerLiveness(StartupEvent())
-        janitor.purgeDeadLetters()
+        onVertxContext { janitor.purgeDeadLetters() }
 
         // A quiet night IS a successful run. Asserted on the success FLAG, not the age: the boot
         // seed already puts the age under the tolerance before purgeDeadLetters() is called, so an
@@ -106,7 +114,7 @@ class DeadLetterJanitorWorkflowLivenessTest {
     }
 
     @Test
-    fun `a swallowed purge failure leaves the heartbeat unrecorded`(): Unit = runBlocking {
+    fun `a swallowed purge failure leaves the heartbeat unrecorded`() {
         val registry = SimpleMeterRegistry()
         every { repo.purgeDeadBefore(any()) } returns
             Uni.createFrom().failure(IllegalStateException("HR000068: no current Vertx context"))
@@ -117,7 +125,7 @@ class DeadLetterJanitorWorkflowLivenessTest {
         // The janitor catches this itself — no exception escapes, which is why the heartbeat is
         // the only externally visible difference between a broken purge and a healthy one. This is
         // the #2913 shape reproduced exactly.
-        janitor.purgeDeadLetters()
+        onVertxContext { janitor.purgeDeadLetters() }
 
         assertThat(successRecordedOf(registry))
             .describedAs("a swallowed failure must not record a success")

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeadLetterJanitorWorkflowLivenessTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeadLetterJanitorWorkflowLivenessTest.kt
@@ -13,8 +13,8 @@ import io.mockk.mockk
 import io.quarkus.runtime.StartupEvent
 import io.quarkus.vertx.VertxContextSupport
 import io.smallrye.mutiny.Uni
-import jakarta.enterprise.inject.Instance
 import io.smallrye.mutiny.coroutines.asUni
+import jakarta.enterprise.inject.Instance
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeadLetterJanitorWorkflowLivenessTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeadLetterJanitorWorkflowLivenessTest.kt
@@ -11,19 +11,19 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.every
 import io.mockk.mockk
 import io.quarkus.runtime.StartupEvent
-import io.quarkus.vertx.VertxContextSupport
 import io.smallrye.mutiny.Uni
-import io.smallrye.mutiny.coroutines.asUni
+import io.vertx.core.Vertx
 import jakarta.enterprise.inject.Instance
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneOffset
+import java.util.concurrent.CompletableFuture
 
 /**
  * ADR-0237: the dead-letter janitor must publish a liveness heartbeat, and the heartbeat must move
@@ -65,8 +65,21 @@ class DeadLetterJanitorWorkflowLivenessTest {
         it.domainMetrics = metrics
     }
 
-    private fun onVertxContext(block: suspend () -> Unit) = VertxContextSupport.subscribeAndAwait {
-        CoroutineScope(Dispatchers.Unconfined).async { block() }.asUni()
+    private fun onVertxContext(block: suspend () -> Unit): Unit {
+        val vertx = Vertx.vertx()
+        val completion = CompletableFuture<Unit>()
+        vertx.runOnContext {
+            CoroutineScope(Dispatchers.Unconfined).launch {
+                runCatching { block() }
+                    .onSuccess(completion::complete)
+                    .onFailure(completion::completeExceptionally)
+            }
+        }
+        try {
+            completion.get()
+        } finally {
+            vertx.close()
+        }
     }
 
     @Test

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
@@ -3,9 +3,11 @@ package com.openbank.notification.infrastructure
 import com.openbank.notification.it.PostgresTestResource
 import io.micrometer.core.instrument.MeterRegistry
 import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import io.quarkus.test.junit.QuarkusTest
 import io.quarkus.test.junit.QuarkusTestProfile
 import io.quarkus.test.junit.TestProfile
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
 import jakarta.inject.Inject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -17,8 +19,20 @@ import javax.sql.DataSource
 /** Proves the real Quarkus scheduler invokes the stale-token sweep. */
 @QuarkusTest
 @QuarkusTestResource(PostgresTestResource::class)
+@QuarkusTestResource(DeviceTokenSweepCronIT.InMemoryKafkaResource::class)
 @TestProfile(DeviceTokenSweepCronIT.FastCronProfile::class)
 class DeviceTokenSweepCronIT {
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> =
+            InMemoryConnector.switchIncomingChannelsToInMemory(
+                "notification-events-in",
+                "party-events-in",
+                "delegation-events-in",
+            ) + InMemoryConnector.switchOutgoingChannelsToInMemory("notification-events-out")
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
     class FastCronProfile : QuarkusTestProfile {
         override fun getConfigOverrides(): Map<String, String> = mapOf(
             "quarkus.scheduler.enabled" to "true",

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
@@ -23,8 +23,7 @@ import javax.sql.DataSource
 @TestProfile(DeviceTokenSweepCronIT.FastCronProfile::class)
 class DeviceTokenSweepCronIT {
     class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
-        override fun start(): Map<String, String> =
-            InMemoryConnector.switchIncomingChannelsToInMemory(
+        override fun start(): Map<String, String> = InMemoryConnector.switchIncomingChannelsToInMemory(
                 "notification-events-in",
                 "party-events-in",
                 "delegation-events-in",

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
@@ -47,10 +47,17 @@ class DeviceTokenSweepCronIT {
         ).isEqualTo(1.0)
     }
 
-    private fun statusOf(id: java.util.UUID): String = dataSource.connection.use { c ->
-        c.prepareStatement("select status from device_tokens where device_id = ?").use { s ->
-            s.setObject(1, id)
-            s.executeQuery().use { rs -> if (rs.next()) rs.getString(1) else "MISSING" }
+    private fun statusOf(id: java.util.UUID): String {
+        val connection = dataSource.connection
+        val statement = connection.prepareStatement("select status from device_tokens where device_id = ?")
+        statement.setObject(1, id)
+        val result = statement.executeQuery()
+        return try {
+            if (result.next()) result.getString(1) else "MISSING"
+        } finally {
+            result.close()
+            statement.close()
+            connection.close()
         }
     }
 

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
@@ -1,0 +1,68 @@
+package com.openbank.notification.infrastructure
+
+import com.openbank.notification.it.PostgresTestResource
+import io.micrometer.core.instrument.MeterRegistry
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.sql.Connection
+import java.time.Instant
+import javax.sql.DataSource
+
+/** Proves the real Quarkus scheduler invokes the stale-token sweep. */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+@TestProfile(DeviceTokenSweepCronIT.FastCronProfile::class)
+class DeviceTokenSweepCronIT {
+    class FastCronProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf(
+            "quarkus.scheduler.enabled" to "true",
+            "quarkus.scheduler.cron.device-token-stale-sweep" to "*/1 * * * * ?",
+        )
+    }
+
+    @Inject lateinit var dataSource: DataSource
+    @Inject lateinit var meterRegistry: MeterRegistry
+
+    @Test
+    fun `real cron retires stale token and records heartbeat`() {
+        val id = java.util.UUID.randomUUID()
+        dataSource.connection.use { c -> insertStale(c, id) }
+
+        val deadline = System.nanoTime() + 15_000_000_000L
+        var status = "ACTIVE"
+        while (System.nanoTime() < deadline && status == "ACTIVE") {
+            Thread.sleep(200)
+            dataSource.connection.use { c ->
+                c.prepareStatement("select status from device_tokens where device_id = ?").use { s ->
+                    s.setObject(1, id)
+                    s.executeQuery().use { rs -> if (rs.next()) status = rs.getString(1) }
+                }
+            }
+        }
+        assertThat(status).isEqualTo("INACTIVE")
+        assertThat(
+            meterRegistry.find("openbank_workflow_success_recorded")
+                .tag("workflow", "device-token-stale-sweep").gauge()?.value(),
+        ).isEqualTo(1.0)
+    }
+
+    private fun insertStale(c: Connection, id: java.util.UUID) {
+        c.prepareStatement("""
+            insert into device_tokens
+              (device_id, party_id, app_instance, platform, token, status,
+               last_used_at, registered_at, refreshed_at, created_at, updated_at)
+            values (?, ?, 'cron-it', 'IOS', 'cron-it-token-' || ?, 'ACTIVE',
+                    ?, ?, ?, ?, ?)
+        """.trimIndent()).use { s ->
+            val old = Instant.now().minusSeconds(91 * 24 * 3600)
+            s.setObject(1, id); s.setObject(2, java.util.UUID.randomUUID()); s.setObject(3, id)
+            s.setObject(4, old); s.setObject(5, old); s.setObject(6, old); s.setObject(7, old); s.setObject(8, old)
+            s.executeUpdate()
+        }
+    }
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
@@ -36,7 +36,7 @@ class DeviceTokenSweepCronIT {
     class FastCronProfile : QuarkusTestProfile {
         override fun getConfigOverrides(): Map<String, String> = mapOf(
             "quarkus.scheduler.enabled" to "true",
-            "quarkus.scheduler.cron.device-token-stale-sweep" to "*/1 * * * * ?",
+            "openbank.notification.device-token-stale-sweep.cron" to "*/1 * * * * ?",
             "quarkus.hibernate-orm.enabled" to "true",
             "quarkus.datasource.jdbc.enabled" to "true",
         )

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
@@ -26,6 +26,7 @@ class DeviceTokenSweepCronIT {
     }
 
     @Inject lateinit var dataSource: DataSource
+
     @Inject lateinit var meterRegistry: MeterRegistry
 
     @Test
@@ -52,16 +53,24 @@ class DeviceTokenSweepCronIT {
     }
 
     private fun insertStale(c: Connection, id: java.util.UUID) {
-        c.prepareStatement("""
+        c.prepareStatement(
+            """
             insert into device_tokens
               (device_id, party_id, app_instance, platform, token, status,
                last_used_at, registered_at, refreshed_at, created_at, updated_at)
             values (?, ?, 'cron-it', 'IOS', 'cron-it-token-' || ?, 'ACTIVE',
                     ?, ?, ?, ?, ?)
-        """.trimIndent()).use { s ->
+            """.trimIndent(),
+        ).use { s ->
             val old = Instant.now().minusSeconds(91 * 24 * 3600)
-            s.setObject(1, id); s.setObject(2, java.util.UUID.randomUUID()); s.setObject(3, id)
-            s.setObject(4, old); s.setObject(5, old); s.setObject(6, old); s.setObject(7, old); s.setObject(8, old)
+            s.setObject(1, id)
+            s.setObject(2, java.util.UUID.randomUUID())
+            s.setObject(3, id)
+            s.setObject(4, old)
+            s.setObject(5, old)
+            s.setObject(6, old)
+            s.setObject(7, old)
+            s.setObject(8, old)
             s.executeUpdate()
         }
     }

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
@@ -24,10 +24,10 @@ import javax.sql.DataSource
 class DeviceTokenSweepCronIT {
     class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
         override fun start(): Map<String, String> = InMemoryConnector.switchIncomingChannelsToInMemory(
-                "notification-events-in",
-                "party-events-in",
-                "delegation-events-in",
-            ) + InMemoryConnector.switchOutgoingChannelsToInMemory("notification-events-out")
+            "notification-events-in",
+            "party-events-in",
+            "delegation-events-in",
+        ) + InMemoryConnector.switchOutgoingChannelsToInMemory("notification-events-out")
 
         override fun stop() = InMemoryConnector.clear()
     }

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
@@ -38,18 +38,20 @@ class DeviceTokenSweepCronIT {
         var status = "ACTIVE"
         while (System.nanoTime() < deadline && status == "ACTIVE") {
             Thread.sleep(200)
-            dataSource.connection.use { c ->
-                c.prepareStatement("select status from device_tokens where device_id = ?").use { s ->
-                    s.setObject(1, id)
-                    s.executeQuery().use { rs -> if (rs.next()) status = rs.getString(1) }
-                }
-            }
+            status = statusOf(id)
         }
         assertThat(status).isEqualTo("INACTIVE")
         assertThat(
             meterRegistry.find("openbank_workflow_success_recorded")
                 .tag("workflow", "device-token-stale-sweep").gauge()?.value(),
         ).isEqualTo(1.0)
+    }
+
+    private fun statusOf(id: java.util.UUID): String = dataSource.connection.use { c ->
+        c.prepareStatement("select status from device_tokens where device_id = ?").use { s ->
+            s.setObject(1, id)
+            s.executeQuery().use { rs -> if (rs.next()) rs.getString(1) else "MISSING" }
+        }
     }
 
     private fun insertStale(c: Connection, id: java.util.UUID) {

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
@@ -10,6 +10,7 @@ import jakarta.inject.Inject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.sql.Connection
+import java.sql.Timestamp
 import java.time.Instant
 import javax.sql.DataSource
 
@@ -72,14 +73,15 @@ class DeviceTokenSweepCronIT {
             """.trimIndent(),
         ).use { s ->
             val old = Instant.now().minusSeconds(91 * 24 * 3600)
+            val oldTimestamp = Timestamp.from(old)
             s.setObject(1, id)
             s.setObject(2, java.util.UUID.randomUUID())
             s.setObject(3, id)
-            s.setObject(4, old)
-            s.setObject(5, old)
-            s.setObject(6, old)
-            s.setObject(7, old)
-            s.setObject(8, old)
+            s.setTimestamp(4, oldTimestamp)
+            s.setTimestamp(5, oldTimestamp)
+            s.setTimestamp(6, oldTimestamp)
+            s.setTimestamp(7, oldTimestamp)
+            s.setTimestamp(8, oldTimestamp)
             s.executeUpdate()
         }
     }

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
@@ -1,5 +1,6 @@
 package com.openbank.notification.infrastructure
 
+import com.openbank.libs.observability.WorkflowLivenessMetrics
 import com.openbank.notification.it.PostgresTestResource
 import io.micrometer.core.instrument.MeterRegistry
 import io.quarkus.test.common.QuarkusTestResource
@@ -56,7 +57,7 @@ class DeviceTokenSweepCronIT {
         while (System.nanoTime() < deadline && (status == "ACTIVE" || heartbeat != 1.0)) {
             Thread.sleep(200)
             status = statusOf(id)
-            heartbeat = meterRegistry.find("openbank_workflow_success_recorded")
+            heartbeat = meterRegistry.find(WorkflowLivenessMetrics.SUCCESS_RECORDED)
                 .tag("workflow", "device-token-stale-sweep").gauge()?.value()
         }
         assertThat(status).isEqualTo("INACTIVE")

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
@@ -52,15 +52,15 @@ class DeviceTokenSweepCronIT {
 
         val deadline = System.nanoTime() + 15_000_000_000L
         var status = "ACTIVE"
-        while (System.nanoTime() < deadline && status == "ACTIVE") {
+        var heartbeat: Double? = null
+        while (System.nanoTime() < deadline && (status == "ACTIVE" || heartbeat != 1.0)) {
             Thread.sleep(200)
             status = statusOf(id)
+            heartbeat = meterRegistry.find("openbank_workflow_success_recorded")
+                .tag("workflow", "device-token-stale-sweep").gauge()?.value()
         }
         assertThat(status).isEqualTo("INACTIVE")
-        assertThat(
-            meterRegistry.find("openbank_workflow_success_recorded")
-                .tag("workflow", "device-token-stale-sweep").gauge()?.value(),
-        ).isEqualTo(1.0)
+        assertThat(heartbeat).isEqualTo(1.0)
     }
 
     private fun statusOf(id: java.util.UUID): String {

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepCronIT.kt
@@ -23,6 +23,8 @@ class DeviceTokenSweepCronIT {
         override fun getConfigOverrides(): Map<String, String> = mapOf(
             "quarkus.scheduler.enabled" to "true",
             "quarkus.scheduler.cron.device-token-stale-sweep" to "*/1 * * * * ?",
+            "quarkus.hibernate-orm.enabled" to "true",
+            "quarkus.datasource.jdbc.enabled" to "true",
         )
     }
 


### PR DESCRIPTION
Refs #2204

Runs DeviceTokenSweepJob through the real Quarkus scheduler with a short cron, asserts stale-token retirement in Postgres and the liveness heartbeat, and removes the now-healed notification baseline entry.