### PR TITLE
fix(admin-ui): complete settings tab semantics

### DIFF
--- a/openbank-admin-ui/src/app/settings/page.tsx
+++ b/openbank-admin-ui/src/app/settings/page.tsx
@@ -3,7 +3,7 @@
 
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { User, Bell, Shield, Globe, Key, Info } from 'lucide-react'
 import { useSession } from 'next-auth/react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -15,6 +15,7 @@ type Tab = 'profile' | 'notifications' | 'security' | 'api' | 'regional'
 
 export default function SettingsPage() {
   const [tab, setTab] = useState<Tab>('profile')
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([])
   const { t } = useLanguage()
   const tabs: { id: Tab; label: string; icon: React.ReactNode }[] = [
     { id: 'profile', label: t('Profil', 'Profile'), icon: <User size={14} aria-hidden="true" /> },
@@ -23,6 +24,19 @@ export default function SettingsPage() {
     { id: 'api', label: t('API klíče', 'API Keys'), icon: <Key size={14} aria-hidden="true" /> },
     { id: 'regional', label: t('Jazyk', 'Language'), icon: <Globe size={14} aria-hidden="true" /> },
   ]
+
+  const moveTabFocus = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    const next = event.key === 'ArrowDown' || event.key === 'ArrowRight'
+      ? (index + 1) % tabs.length
+      : event.key === 'ArrowUp' || event.key === 'ArrowLeft'
+        ? (index - 1 + tabs.length) % tabs.length
+        : event.key === 'Home' ? 0
+          : event.key === 'End' ? tabs.length - 1 : -1
+    if (next < 0) return
+    event.preventDefault()
+    setTab(tabs[next].id)
+    tabRefs.current[next]?.focus()
+  }
 
   return <AuthGuard permission="settings:view"><div>
     <PageHeader
@@ -33,14 +47,14 @@ export default function SettingsPage() {
     />
     <div style={{ display: 'flex', gap: '20px', alignItems: 'flex-start' }}>
       <div role="tablist" aria-label={t('Sekce nastavení', 'Settings sections')} className="card" style={{ width: '200px', flexShrink: 0, padding: '8px' }}>
-        {tabs.map(item => <button key={item.id} id={`settings-tab-${item.id}`} role="tab" type="button" onClick={() => setTab(item.id)} aria-selected={tab === item.id} aria-controls={`settings-panel-${item.id}`} style={{ width: '100%', display: 'flex', alignItems: 'center', gap: '9px', padding: '8px 10px', borderRadius: '6px', border: 'none', borderLeft: tab === item.id ? '2px solid var(--accent)' : '2px solid transparent', background: tab === item.id ? 'var(--accent-light)' : 'transparent', color: tab === item.id ? 'var(--accent)' : 'var(--text-secondary)', fontWeight: tab === item.id ? 600 : 400, fontSize: '13px', cursor: 'pointer', textAlign: 'left', fontFamily: 'inherit' }}>{item.icon}{item.label}</button>)}
+        {tabs.map((item, index) => <button key={item.id} ref={element => { tabRefs.current[index] = element }} id={`settings-tab-${item.id}`} role="tab" type="button" tabIndex={tab === item.id ? 0 : -1} onKeyDown={event => moveTabFocus(event, index)} onClick={() => setTab(item.id)} aria-selected={tab === item.id} aria-controls={`settings-panel-${item.id}`} style={{ width: '100%', display: 'flex', alignItems: 'center', gap: '9px', padding: '8px 10px', borderRadius: '6px', border: 'none', borderLeft: tab === item.id ? '2px solid var(--accent)' : '2px solid transparent', background: tab === item.id ? 'var(--accent-light)' : 'transparent', color: tab === item.id ? 'var(--accent)' : 'var(--text-secondary)', fontWeight: tab === item.id ? 600 : 400, fontSize: '13px', cursor: 'pointer', textAlign: 'left', fontFamily: 'inherit' }}>{item.icon}{item.label}</button>)}
       </div>
-      <div id={`settings-panel-${tab}`} role="tabpanel" aria-labelledby={`settings-tab-${tab}`} style={{ flex: 1 }}>
-        {tab === 'profile' && <ProfileTab />}
-        {tab === 'notifications' && <UnavailableSettings title={t('Předvolby oznámení', 'Notification preferences')} detail={t('Osobní předvolby zatím nemají podporovaný backendový kontrakt. Konzole proto nezobrazuje falešné přepínače ani neukládá zdánlivé změny.', 'Personal notification preferences do not yet have a supported backend contract. This console therefore does not show fake switches or pretend to save changes.')} />}
-        {tab === 'security' && <UnavailableSettings title={t('Zabezpečení a relace', 'Security and sessions')} detail={t('Hesla, relace a odvolání přístupu spravuje Keycloak SSO. Konzole zobrazuje skutečnou přihlášenou identitu a nebude simulovat změnu hesla ani odvolání relace.', 'Passwords, sessions and access revocation are managed by Keycloak SSO. The console shows only the real signed-in identity and does not simulate password changes or session revocation.')} />}
-        {tab === 'api' && <UnavailableSettings title={t('API klíče', 'API keys')} detail={t('Správa API klíčů není v tomto admin UI integrována s autoritativním systémem identit. Nezobrazujeme proto vzorové klíče ani akce generovat či odvolat.', 'API-key management is not integrated with the authoritative identity system in this admin UI. Sample keys and generate/revoke actions are therefore not displayed.')} />}
-        {tab === 'regional' && <RegionalTab />}
+      <div style={{ flex: 1 }}>
+        <div id="settings-panel-profile" role="tabpanel" aria-labelledby="settings-tab-profile" hidden={tab !== 'profile'}><ProfileTab /></div>
+        <div id="settings-panel-notifications" role="tabpanel" aria-labelledby="settings-tab-notifications" hidden={tab !== 'notifications'}><UnavailableSettings title={t('Předvolby oznámení', 'Notification preferences')} detail={t('Osobní předvolby zatím nemají podporovaný backendový kontrakt. Konzole proto nezobrazuje falešné přepínače ani neukládá zdánlivé změny.', 'Personal notification preferences do not yet have a supported backend contract. This console therefore does not show fake switches or pretend to save changes.')} /></div>
+        <div id="settings-panel-security" role="tabpanel" aria-labelledby="settings-tab-security" hidden={tab !== 'security'}><UnavailableSettings title={t('Zabezpečení a relace', 'Security and sessions')} detail={t('Hesla, relace a odvolání přístupu spravuje Keycloak SSO. Konzole zobrazuje skutečnou přihlášenou identitu a nebude simulovat změnu hesla ani odvolání relace.', 'Passwords, sessions and access revocation are managed by Keycloak SSO. The console shows only the real signed-in identity and does not simulate password changes or session revocation.')} /></div>
+        <div id="settings-panel-api" role="tabpanel" aria-labelledby="settings-tab-api" hidden={tab !== 'api'}><UnavailableSettings title={t('API klíče', 'API keys')} detail={t('Správa API klíčů není v tomto admin UI integrována s autoritativním systémem identit. Nezobrazujeme proto vzorové klíče ani akce generovat či odvolat.', 'API-key management is not integrated with the authoritative identity system in this admin UI. Sample keys and generate/revoke actions are therefore not displayed.')} /></div>
+        <div id="settings-panel-regional" role="tabpanel" aria-labelledby="settings-tab-regional" hidden={tab !== 'regional'}><RegionalTab /></div>
       </div>
     </div>
   </div></AuthGuard>

--- a/openbank-admin-ui/src/test/settings-tabs-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/settings-tabs-a11y.guard.test.ts
@@ -1,0 +1,22 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = fs.readFileSync(path.join(process.cwd(), 'src/app/settings/page.tsx'), 'utf8')
+
+describe('settings tabs accessibility', () => {
+  it('keeps every tab target mounted and keyboard navigable', () => {
+    expect(page).toContain('role="tablist"')
+    expect(page).toContain('role="tab"')
+    expect(page).toContain('role="tabpanel"')
+    expect(page).toContain('tabIndex={tab === item.id ? 0 : -1}')
+    expect(page).toContain("event.key === 'ArrowDown'")
+    expect(page).toContain("event.key === 'ArrowUp'")
+    expect(page).toContain("event.key === 'Home'")
+    expect(page).toContain("event.key === 'End'")
+    for (const id of ['profile', 'notifications', 'security', 'api', 'regional']) {
+      expect(page).toContain(`id="settings-panel-${id}"`)
+      expect(page).toContain(`hidden={tab !== '${id}'}`)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- keep every settings tabpanel mounted so aria-controls targets remain valid
- add roving focus with Arrow/Home/End keyboard navigation
- add a focused accessibility source guard

## Safety
- presentation/a11y only; settings:view/AuthGuard, session reads and language persistence unchanged
- Closes #4841
