### PR TITLE
docs(balance): cite the ADR that actually decided this (#5785)

### DIFF
--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/kafka/BalanceInitConsumer.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/kafka/BalanceInitConsumer.kt
@@ -14,7 +14,7 @@ import org.jboss.logging.Logger
 import java.util.UUID
 
 /**
- * Event-driven balance initialization (ADR-0073).
+ * Event-driven balance initialization (ADR-0267 §3).
  *
  * Creates a zero balance row when an account is created, by consuming
  * openbank.accounts.account.created. This replaces the synchronous REST init for the

--- a/openbank-balance-service/src/main/resources/application.yaml
+++ b/openbank-balance-service/src/main/resources/application.yaml
@@ -137,7 +137,7 @@ mp:
         group.id: openbank-balance-service
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
         auto.offset.reset: earliest
-      # ADR-0073: create a zero balance row when an account is created (event-driven init,
+      # ADR-0267 §3: create a zero balance row when an account is created (event-driven init,
       # so onboarding accounts opened from a Kafka consumer get a balance without the
       # synchronous authenticated REST call). initializeBalance is idempotent.
       balance-init-in:

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/AccountCreatedMessagePactConsumerTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/AccountCreatedMessagePactConsumerTest.kt
@@ -21,7 +21,7 @@ import java.util.UUID
 
 /**
  * Consumer-driven MESSAGE contract for the `AccountCreated` event balance-service consumes to
- * initialize a zero balance (ADR-0073, [com.openbank.balance.infrastructure.kafka.BalanceInitConsumer]).
+ * initialize a zero balance (ADR-0267 §3, [com.openbank.balance.infrastructure.kafka.BalanceInitConsumer]).
  *
  * This is the first async (message) pact in the repo — it asserts the event carries the three fields
  * the consumer actually reads (`eventType`, `aggregateId`, `currency`); the producer (account-service)


### PR DESCRIPTION
## What

Three sites in `openbank-balance-service` cited **ADR-0073** for event-driven balance
initialization. ADR-0073 is *"Hardware-backed credential storage for the customer app"*
(Android Keystore / iOS Keychain, PINs as salted KDF verifiers) — an unrelated subject.

The behaviour these sites describe — `BalanceInitConsumer` consuming
`openbank.accounts.account.created` and creating the zero balance row instead of a synchronous
authenticated REST init — is decided by **ADR-0266 §3** ("Balance initialization is
event-driven"), written in #5784.

| site | old | new |
|---|---|---|
| `infrastructure/kafka/BalanceInitConsumer.kt` | ADR-0073 | ADR-0266 §3 |
| `src/main/resources/application.yaml` (`account-created-in` channel) | ADR-0073 | ADR-0266 §3 |
| `contract/AccountCreatedMessagePactConsumerTest.kt` | ADR-0073 | ADR-0266 §3 |

`CHANGELOG.md`'s "ADR-0073 phase" entries are release-please-derived and immutable — left alone.

Comment-only change; no behaviour, no API, no schema.

**Depends on #5784**, which adds `docs/adr/0266-event-driven-onboarding-account-lifecycle.md`.
Merge that first so the citation resolves.

Refs #5785
