### PR TITLE
docs(kyc): cite the ADR that actually decided this (#5785)

### DIFF
--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/application/KycService.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/application/KycService.kt
@@ -83,7 +83,7 @@ class KycService {
     // the series is still collected; revisit once the case gains an individual|business field.
     private val caseType = "unknown"
 
-    // Sandbox-only straight-through processing (ADR-0073): when true, a case opened from a
+    // Sandbox-only straight-through processing (ADR-0116 §4): when true, a case opened from a
     // PARTY_CREATED event is auto-evaluated (all checks PASSED) and approved, so onboarding
     // activates without an operator. MUST stay false in production (four-eyes, ADR-0068).
     @org.eclipse.microprofile.config.inject.ConfigProperty(name = "openbank.kyc.auto-approve", defaultValue = "false")

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/infrastructure/kafka/PartyEventConsumerTest.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/infrastructure/kafka/PartyEventConsumerTest.kt
@@ -74,7 +74,7 @@ class PartyEventConsumerTest {
     @Test
     fun `PARTY_CREATED skips PEP screening when the sandbox auto-approve path already settled the case`(): Unit =
         runBlocking {
-            // openbank.kyc.auto-approve=true (sandbox STP, ADR-0073) settles the case to APPROVED
+            // openbank.kyc.auto-approve=true (sandbox STP, ADR-0116 §4) settles the case to APPROVED
             // before this consumer ever sees it — re-screening a terminal case here would race the
             // already-closed state rather than extend it.
             val partyId = UUID.randomUUID()


### PR DESCRIPTION
## What

Two sites in `openbank-kyc-service` cited **ADR-0073** for `openbank.kyc.auto-approve`.
ADR-0073 is *"Hardware-backed credential storage for the customer app"* — unrelated.

Sandbox straight-through KYC is decided by **ADR-0116 §4** ("Sandbox straight-through processing
(STP)"), which names the property, its `false` default, the auto-evaluate-and-approve behaviour on
a case opened from `PARTY_CREATED`, and the "MUST remain false in production" constraint. It is a
verbatim match for what both comments claim.

Note these are **not** ADR-0266: unlike the rest of the #5785 sweep, the kyc-service sites describe
the KYC engine's own sandbox mode, not the account lifecycle.

| site | old | new |
|---|---|---|
| `application/KycService.kt` | ADR-0073 | ADR-0116 §4 |
| `infrastructure/kafka/PartyEventConsumerTest.kt` | ADR-0073 | ADR-0116 §4 |

`CHANGELOG.md`'s ADR-0073 entries are release-please-derived and immutable — left alone.

Comment-only change; no behaviour, no API, no schema. No dependency on any unmerged PR (ADR-0116
is on `main`).

Refs #5785
