### PR TITLE
docs(aml): cite the ADR that actually decided this (#5785)

### DIFF
--- a/openbank-aml-service/src/main/kotlin/com/openbank/aml/infrastructure/kafka/PartyEventConsumer.kt
+++ b/openbank-aml-service/src/main/kotlin/com/openbank/aml/infrastructure/kafka/PartyEventConsumer.kt
@@ -19,10 +19,11 @@ import org.jboss.logging.Logger
 import java.util.UUID
 
 /**
- * Opens an onboarding AML screening case when a party is created (ADR-0073), and — in the
- * sandbox — auto-clears it so the party clears the AML key of the activation gate without an
- * analyst. Emits aml.case.status_changed.v1 (CLEARED) on openbank.aml.events, which
- * party-service consumes for its KYC+AML two-key gate.
+ * Opens an onboarding AML screening case when a party is created (ADR-0267 §2 — the AML
+ * outcome is the second key of the party activation gate), and — in the sandbox — auto-clears
+ * it so the party clears the AML key of that gate without an analyst. Emits
+ * aml.case.status_changed.v1 (CLEARED) on openbank.aml.events, which party-service consumes
+ * for its KYC+AML two-key gate.
  *
  * Idempotent: the case idempotency key is "<partyId>:CUSTOMER_ONBOARDING", so a redelivered
  * PARTY_CREATED reuses the existing case; the auto-clear is skipped once the case is terminal.
@@ -34,7 +35,9 @@ import java.util.UUID
  * Poison-pill safe: failures are logged and acked.
  *
  * Auto-clear is sandbox-only (openbank.aml.auto-clear, default false). Production keeps the
- * four-eyes decision endpoint as the only path to CLEARED/BLOCKED.
+ * four-eyes decision endpoint as the only path to CLEARED/BLOCKED. No ADR decides this flag:
+ * ADR-0116 §4 decides only the KYC equivalent (openbank.kyc.auto-approve); the AML side is
+ * recorded in this service's docs/ only (#5785).
  */
 @ApplicationScoped
 class PartyEventConsumer(

--- a/openbank-aml-service/src/main/resources/application.yaml
+++ b/openbank-aml-service/src/main/resources/application.yaml
@@ -112,7 +112,8 @@ mp:
         key.serializer: org.apache.kafka.common.serialization.StringSerializer
         value.serializer: org.apache.kafka.common.serialization.StringSerializer
     incoming:
-      # Onboarding AML screening (ADR-0073): open a screening case on PARTY_CREATED.
+      # Onboarding AML screening (ADR-0267 §2): open a screening case on PARTY_CREATED; the
+      # AML outcome is the second key of the party activation gate.
       party-events-in:
         connector: smallrye-kafka
         topic: openbank.party.events


### PR DESCRIPTION
## What

Two sites in `openbank-aml-service` cited **ADR-0073** for onboarding AML screening. ADR-0073 is
*"Hardware-backed credential storage for the customer app"* — unrelated.

| site | old | new | why |
|---|---|---|---|
| `infrastructure/kafka/PartyEventConsumer.kt` (KDoc) | ADR-0073 | **ADR-0266 §2** | the case-open on `PARTY_CREATED` and the AML outcome as the second key of the party activation gate is exactly what ADR-0266 §2 decides |
| `src/main/resources/application.yaml` (`party-events-in`) | ADR-0073 | **ADR-0266 §2** | same |

### One claim here has no ADR behind it — and this PR says so rather than picking a number

`openbank.aml.auto-clear` (sandbox straight-through AML) is **decided by no ADR**. ADR-0116 §4
decides only the KYC equivalent, `openbank.kyc.auto-approve`; ADR-0266 decides the activation gate
but not this flag. The only written record is this service's own
`src/main/resources/docs/02-architecture.*.md` and `06-compliance.*.md`.

Rather than stretch ADR-0266 to cover it, the KDoc now states the gap explicitly and points at the
KYC sibling. Worth an ADR of its own (or a §-addition to 0116) — it is a flag that bypasses
four-eyes on a compliance control, which is precisely the class of thing that should have a
decision record.

`CHANGELOG.md`'s ADR-0073 entries are release-please-derived and immutable — left alone.

Comment-only change; no behaviour, no API, no schema.

**Depends on #5784**, which adds `docs/adr/0266-event-driven-onboarding-account-lifecycle.md`.

Refs #5785
