### PR TITLE
docs(onboarding): cite the ADR that actually decided this (#5785)

### DIFF
--- a/openbank-onboarding-service/governance.yaml
+++ b/openbank-onboarding-service/governance.yaml
@@ -26,7 +26,7 @@ lineage:
   # No account-service downstream edge: onboarding-service is a passive funnel-tracking read model
   # (OnboardingEventConsumer projects party/kyc/sca events), not an orchestrator — it has
   # no AccountServiceClient and opens no account. Account opening is driven directly by
-  # account-service's PartyEventConsumer on PARTY_CREATED (ADR-0073); the real edge is
+  # account-service's PartyEventConsumer on PARTY_CREATED (ADR-0267 §1); the real edge is
   # party-service --topic--> account-service, declared on party-service's own downstream.
   # The former `account-service (api, "opens account")` edge here was fabricated boilerplate
   # with no backing @RegisterRestClient (issue #1501, found by check-governance-lineage.py).


### PR DESCRIPTION
## What

One site in `openbank-onboarding-service/governance.yaml` cited **ADR-0073** for account opening
being driven by account-service's `PartyEventConsumer` on `PARTY_CREATED`. ADR-0073 is
*"Hardware-backed credential storage for the customer app"* — unrelated.

That mechanism is decided by **ADR-0266 §1** ("`PARTY_CREATED` opens inert accounts").

| site | old | new |
|---|---|---|
| `governance.yaml` (downstream-edge rationale comment) | ADR-0073 | ADR-0266 §1 |

Comment-only change inside the curatorial manifest; no declared edge, service, datastore or
lineage fact changes, so the derived `governance.json` is unaffected.

**Depends on #5784**, which adds `docs/adr/0266-event-driven-onboarding-account-lifecycle.md`.

Refs #5785
