### PR TITLE
docs(customer-edge): cite the ADR that actually decided this (#5785)

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -409,7 +409,7 @@ class CustomerEdgeResource(
         return Response.ok(body).type(MediaType.APPLICATION_JSON).build()
     }
 
-    // --- KYC / identity verification status (AML Act §8, ADR-0073) ---
+    // --- KYC / identity verification status (AML Act §8, ADR-0116) ---
 
     /**
      * The caller's OWN identity-verification (KYC) status. No path param — the party is taken from


### PR DESCRIPTION
## What

One site in `openbank-customer-edge` cited **ADR-0073** on the section header for the customer's
own KYC / identity-verification status endpoint. ADR-0073 is *"Hardware-backed credential storage
for the customer app"* — unrelated.

`GET /kyc` projects **kyc-service's case** (status, `reviewedAt`, per-check outcomes) down to a
customer-safe shape. The case lifecycle, the five-check set and the AML Act §8 audit-trail
requirement the comment already names are decided by **ADR-0116** — not by ADR-0266 (which decides
the *account* lifecycle, not the KYC case).

| site | old | new |
|---|---|---|
| `infrastructure/rest/CustomerEdgeResource.kt` (KYC section header) | ADR-0073 | ADR-0116 |

Comment-only change; no behaviour, no API, no schema. No dependency on any unmerged PR (ADR-0116
is on `main`).

Refs #5785
