### PR TITLE
fix(admin-ui): name document row actions

### DIFF
--- a/openbank-admin-ui/src/app/document-templates/page.tsx
+++ b/openbank-admin-ui/src/app/document-templates/page.tsx
@@ -551,16 +551,16 @@ export default function DocumentTemplatesPage() {
                       <td style={{ fontFamily: 'var(--font-mono)', fontSize: '11px', color: 'var(--text-tertiary)' }}>{tpl.productRef ?? '—'}</td>
                       <td style={{ textAlign: 'right' }}>
                         <div style={{ display: 'flex', gap: '3px', justifyContent: 'flex-end' }}>
-                          <button className="btn btn-secondary btn-sm" style={{ padding: '4px' }} title={canEdit ? t('Upravit', 'Edit') : t('Zobrazit', 'View')} onClick={() => openEditModal(tpl)}>
+                          <button type="button" className="btn btn-secondary btn-sm" style={{ padding: '4px' }} title={canEdit ? t('Upravit', 'Edit') : t('Zobrazit', 'View')} aria-label={canEdit ? t('Upravit šablonu', 'Edit template') : t('Zobrazit šablonu', 'View template')} onClick={() => openEditModal(tpl)}>
                             {canEdit ? <Edit size={13} /> : <Eye size={13} />}
                           </button>
                           {canEdit && (tpl.status ?? 'DRAFT') === 'DRAFT' && (
-                            <button className="btn btn-secondary btn-sm" style={{ padding: '4px', color: 'var(--success-text)' }} title={t('Publikovat', 'Publish')} onClick={() => setPendingAction({ id: tpl.id, kind: 'publish' })}>
+                            <button type="button" className="btn btn-secondary btn-sm" style={{ padding: '4px', color: 'var(--success-text)' }} title={t('Publikovat', 'Publish')} aria-label={t('Publikovat šablonu', 'Publish template')} onClick={() => setPendingAction({ id: tpl.id, kind: 'publish' })}>
                               <Send size={13} />
                             </button>
                           )}
                           {canEdit && tpl.status === 'PUBLISHED' && (
-                            <button className="btn btn-secondary btn-sm" style={{ padding: '4px', color: 'var(--warning-text)' }} title={t('Vyřadit', 'Retire')} onClick={() => setPendingAction({ id: tpl.id, kind: 'retire' })}>
+                            <button type="button" className="btn btn-secondary btn-sm" style={{ padding: '4px', color: 'var(--warning-text)' }} title={t('Vyřadit', 'Retire')} aria-label={t('Vyřadit šablonu', 'Retire template')} onClick={() => setPendingAction({ id: tpl.id, kind: 'retire' })}>
                               <Archive size={13} />
                             </button>
                           )}

--- a/openbank-admin-ui/src/test/document-templates-accessibility.guard.test.ts
+++ b/openbank-admin-ui/src/test/document-templates-accessibility.guard.test.ts
@@ -38,4 +38,11 @@ describe('document template authoring accessibility', () => {
     expect(page).toContain('id="template-status-filter"')
     expect(page).toContain('id="document-id"')
   })
+
+  it('names every icon-only row action and keeps it a non-submit button', () => {
+    expect(page).toContain("aria-label={canEdit ? t('Upravit šablonu', 'Edit template') : t('Zobrazit šablonu', 'View template')}")
+    expect(page).toContain("aria-label={t('Publikovat šablonu', 'Publish template')}")
+    expect(page).toContain("aria-label={t('Vyřadit šablonu', 'Retire template')}")
+    expect(page).toContain("<button type=\"button\" className=\"btn btn-secondary btn-sm\"")
+  })
 })


### PR DESCRIPTION
## Summary
- give icon-only Document Templates row actions localized accessible names
- mark row actions as non-submit buttons
- extend the accessibility guard for action naming and type

## Verification
- npm run type-check
- git diff --check
- focused Vitest blocked by environment missing @rolldown/binding-darwin-x64

Refs #4841