### PR TITLE
fix(analytics-sink): write quarantined messages to dead_letter_events

### DIFF
--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/port/out/DeadLetterSink.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/port/out/DeadLetterSink.kt
@@ -21,9 +21,15 @@ data class DeadLetterRecord(val contentHash: String, val rawPayload: String, val
  * Outbound port for quarantining un-projectable messages (ADR-0022).
  *
  * Replaces the old "log and swallow" behaviour: a dropped event is an invisible gap in the bronze
- * layer, which undermines the "complete, replayable log of record" guarantee. The default binding
- * [com.openbank.analytics.infrastructure.sink.LoggingDeadLetterSink] needs no infra; a ClickHouse
- * `dead_letter_events`-backed adapter lands with the warehouse adapter.
+ * layer, which undermines the "complete, replayable log of record" guarantee.
+ *
+ * Two bindings. [com.openbank.analytics.infrastructure.sink.ClickHouseDeadLetterSink] is the durable
+ * one — it writes the `dead_letter_events` row this KDoc describes — and is selected at build time by
+ * `openbank.analytics.sink.type=clickhouse`, alongside the durable warehouse sink. Otherwise the
+ * zero-infrastructure [com.openbank.analytics.infrastructure.sink.LoggingDeadLetterSink] applies, and
+ * "quarantined" then means **logged**: recoverable for as long as log retention holds, not from the
+ * table. Read a `quarantine()` that returns normally as proof of nothing — the two are
+ * indistinguishable at the call site (#5761).
  */
 interface DeadLetterSink {
     suspend fun quarantine(record: DeadLetterRecord)

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/sink/ClickHouseDeadLetterSink.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/sink/ClickHouseDeadLetterSink.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.analytics.infrastructure.sink
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.analytics.application.port.out.DeadLetterRecord
+import com.openbank.analytics.application.port.out.DeadLetterSink
+import com.openbank.analytics.infrastructure.clickhouse.ClickHouseClient
+import io.quarkus.arc.properties.IfBuildProperty
+import jakarta.annotation.Priority
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Alternative
+import jakarta.inject.Inject
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+/**
+ * CDI priority of the durable ClickHouse bindings over their `@Default` logging fallbacks — the same
+ * value [ClickHouseAnalyticsSink] and the WORM mirror use. Declared as a constant (not an inline
+ * literal) so detekt's `MagicNumber` needs no baseline entry; it sits ABOVE the annotated class on
+ * purpose, since a top-level declaration placed *between* an annotation and its class silently steals
+ * the annotation (see the fleet CLAUDE.md `@Path` footgun).
+ */
+private const val CLICKHOUSE_ALTERNATIVE_PRIORITY = 100
+
+/**
+ * Durable [DeadLetterSink] that quarantines an un-projectable message into the ClickHouse
+ * `dead_letter_events` table (ADR-0022).
+ *
+ * This is the adapter the port's KDoc, ADR-0022, both service diagrams, both language overview docs
+ * and the `dead_lettered` Grafana panel have always assumed exists. Until it did, `quarantine()`
+ * resolved to [LoggingDeadLetterSink] and "quarantined" meant *logged*: the row an operator would go
+ * looking for was never written, the documented "replay `raw_payload` through the normal mapping
+ * path" recovery had no source to replay from, and the panel read a **structural** zero — a value it
+ * could not have exceeded for any dead-letter rate, which reads as evidence of health (#5761).
+ *
+ * Note the shape that let that ship: [LoggingDeadLetterSink.quarantine] returns normally, and a
+ * normal return is indistinguishable from a successful durable write at every call site. Nothing in
+ * the consumer, the metrics or the logs could have disagreed.
+ *
+ * Same binding idiom as [ClickHouseAnalyticsSink] and
+ * [com.openbank.analytics.infrastructure.worm.ClickHouseWormArchive]: an `@Alternative`
+ * `@Priority(CLICKHOUSE_ALTERNATIVE_PRIORITY)` over the `@Default` logging fallback, gated at **build time** by
+ * `openbank.analytics.sink.type=clickhouse`, so the zero-infrastructure default still boots and
+ * tests without a ClickHouse server.
+ *
+ * Idempotency is delegated to the table engine exactly as [DeadLetterRecord] promises:
+ * `ReplacingMergeTree(failed_at)` ordered by `content_hash` collapses a re-delivered or replayed
+ * poison message to one row at merge / `FINAL`, so at-least-once delivery cannot inflate the DLQ.
+ *
+ * [DeadLetterRecord.rawPayload] is written **whole** and unmasked — it is by definition a message the
+ * masking projection could not parse, and a truncated payload is not replayable. The table's 1-year
+ * TTL (`V1__analytics_bronze_silver.sql`) bounds that exposure; it is operational quarantine, not the
+ * log of record.
+ */
+@ApplicationScoped
+@Alternative
+@Priority(CLICKHOUSE_ALTERNATIVE_PRIORITY)
+@IfBuildProperty(name = "openbank.analytics.sink.type", stringValue = "clickhouse")
+open class ClickHouseDeadLetterSink : DeadLetterSink {
+
+    @Inject
+    lateinit var clickhouse: ClickHouseClient
+
+    @Inject
+    lateinit var mapper: ObjectMapper
+
+    override suspend fun quarantine(record: DeadLetterRecord) {
+        clickhouse.insert(TABLE, rowJson(record))
+    }
+
+    /** Serialises a record into a `dead_letter_events` JSONEachRow object. Pure / unit-testable. */
+    internal fun rowJson(record: DeadLetterRecord): String {
+        val row = linkedMapOf<String, Any?>(
+            "content_hash" to record.contentHash,
+            "raw_payload" to record.rawPayload,
+            "error" to record.error,
+            "failed_at" to DT.format(record.failedAt),
+        )
+        return mapper.writeValueAsString(row)
+    }
+
+    private companion object {
+        const val TABLE = "dead_letter_events"
+
+        // ClickHouse DateTime64(3,'UTC') literal format: 'yyyy-MM-dd HH:mm:ss.SSS'.
+        val DT: DateTimeFormatter =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneOffset.UTC)
+    }
+}

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/sink/LoggingDeadLetterSink.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/sink/LoggingDeadLetterSink.kt
@@ -14,8 +14,14 @@ import org.jboss.logging.Logger
  * Default [DeadLetterSink] that emits the quarantined message at WARN with its content hash.
  *
  * WARN (not INFO) so it trips alerting — a non-zero DLQ rate means a producer is emitting malformed
- * events and bronze is losing rows. The full payload is logged (truncated) so the message is
- * recoverable from the log pipeline even before the ClickHouse `dead_letter_events` adapter exists.
+ * events and bronze is losing rows. The payload is logged truncated, so a message quarantined through
+ * this binding is recoverable only from the log pipeline, only for as long as log retention holds, and
+ * only up to 500 characters — it is NOT the durable, replayable `dead_letter_events` row that
+ * ADR-0022, the diagrams, the overview docs and the `dead_lettered` Grafana panel describe. That row
+ * is written by [ClickHouseDeadLetterSink], which this fallback yields to when
+ * `openbank.analytics.sink.type=clickhouse`. Any deployment relying on the documented "replay
+ * `raw_payload`" recovery, or reading that panel as a dead-letter rate, must select that binding —
+ * under this one the panel is a structural zero (#5761).
  */
 @ApplicationScoped
 @Default

--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/infrastructure/clickhouse/ClickHouseAdaptersTest.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/infrastructure/clickhouse/ClickHouseAdaptersTest.kt
@@ -5,10 +5,12 @@
 package com.openbank.analytics.infrastructure.clickhouse
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.analytics.application.port.out.DeadLetterRecord
 import com.openbank.analytics.application.port.out.IntegrityAnchor
 import com.openbank.analytics.application.port.out.ProposalDecisionPhase
 import com.openbank.analytics.infrastructure.proposal.ClickHouseProposalStore
 import com.openbank.analytics.infrastructure.reconcile.ClickHouseWarehouseStateReader
+import com.openbank.analytics.infrastructure.sink.ClickHouseDeadLetterSink
 import com.openbank.analytics.infrastructure.worm.ClickHouseWormArchive
 import com.openbank.libs.analytics.AggregateKey
 import com.openbank.libs.analytics.BackfillRequest
@@ -180,6 +182,53 @@ class ClickHouseAdaptersTest {
         }
 
         assertThat(worm.latest()).isNull()
+    }
+
+    // ------------------------------------------------------------------------ dead-letter quarantine
+
+    @Test
+    fun `quarantine inserts the raw payload into dead_letter_events`() = runBlocking<Unit> {
+        val client = FakeClickHouseClient()
+        val dlq = ClickHouseDeadLetterSink().apply {
+            clickhouse = client
+            mapper = this@ClickHouseAdaptersTest.mapper
+        }
+
+        dlq.quarantine(
+            DeadLetterRecord(
+                contentHash = "sha256:abc",
+                rawPayload = """{"broken":""",
+                error = "JsonParseException: unexpected end of input",
+                failedAt = Instant.parse("2026-05-01T10:00:00Z"),
+            ),
+        )
+
+        assertThat(client.lastInsertTable).isEqualTo("dead_letter_events")
+        val node = mapper.readTree(client.lastInsertBody!!)
+        assertThat(node.get("content_hash").asText()).isEqualTo("sha256:abc")
+        assertThat(node.get("raw_payload").asText()).isEqualTo("""{"broken":""")
+        assertThat(node.get("error").asText()).contains("JsonParseException")
+        assertThat(node.get("failed_at").asText()).isEqualTo("2026-05-01 10:00:00.000")
+    }
+
+    /**
+     * The payload must be written WHOLE. [com.openbank.analytics.infrastructure.sink.LoggingDeadLetterSink]
+     * truncates at 500 chars, which is fine for a log line and fatal for the documented recovery —
+     * an operator replays `raw_payload` through the mapping path, and a truncated payload does not
+     * parse. This is the assertion that distinguishes the durable binding from the logging one.
+     */
+    @Test
+    fun `quarantine does not truncate a payload longer than the log fallback would keep`() = runBlocking<Unit> {
+        val client = FakeClickHouseClient()
+        val dlq = ClickHouseDeadLetterSink().apply {
+            clickhouse = client
+            mapper = this@ClickHouseAdaptersTest.mapper
+        }
+        val long = "x".repeat(2_000)
+
+        dlq.quarantine(DeadLetterRecord("h", long, "boom", Instant.parse("2026-05-01T10:00:00Z")))
+
+        assertThat(mapper.readTree(client.lastInsertBody!!).get("raw_payload").asText()).isEqualTo(long)
     }
 
     // ------------------------------------------------------------------ durable ProposalStore (F3)

--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/infrastructure/sink/ClickHouseAnalyticsSinkIT.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/infrastructure/sink/ClickHouseAnalyticsSinkIT.kt
@@ -5,6 +5,7 @@
 package com.openbank.analytics.infrastructure.sink
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.analytics.application.port.out.DeadLetterRecord
 import com.openbank.analytics.infrastructure.clickhouse.ClickHouseClient
 import com.openbank.analytics.infrastructure.support.KGenericContainer
 import com.openbank.libs.analytics.AnalyticsEnvelope
@@ -24,7 +25,8 @@ import java.util.Optional
 import java.util.UUID
 
 /**
- * End-to-end verification of [ClickHouseAnalyticsSink] (ADR-0022 / ADR-0023 F1) against a real
+ * End-to-end verification of the ClickHouse-native write adapters — [ClickHouseAnalyticsSink]
+ * (ADR-0022 / ADR-0023 F1) and [ClickHouseDeadLetterSink] (ADR-0022 quarantine) — against a real
  * ClickHouse server. Unlike the unit test (which stubs the [ClickHouseAnalyticsSink.send] seam), this
  * exercises the **actual** HTTP insert path: the JDK HttpClient request, the JSONEachRow encoding, the
  * `X-ClickHouse-User/Key` auth headers, and the bronze schema from the real production DDL — all of
@@ -185,6 +187,67 @@ class ClickHouseAnalyticsSinkIT {
                 "AND table = 'gold_campaign_engagement' ORDER BY name FORMAT TabSeparated",
         )
         assertThat(columns).doesNotContain("party_id").doesNotContain("interaction_ref")
+    }
+
+    // ---------------------------------------------------------------- dead-letter quarantine (#5761)
+
+    private fun dlq() = ClickHouseDeadLetterSink().apply {
+        clickhouse = reader
+        mapper = this@ClickHouseAnalyticsSinkIT.mapper
+    }
+
+    /**
+     * The assertion #5761 was missing: a quarantined record must be **readable back out of the
+     * table**. The unit test can only prove the emitted JSONEachRow body is well shaped; only a real
+     * server proves the column contract matches the shipped DDL and that the row is actually there.
+     * Note what could not have caught this before — `LoggingDeadLetterSink.quarantine()` also returns
+     * normally, so nothing short of reading the table distinguishes a durable write from a log line.
+     */
+    @Test
+    fun `quarantine writes a row that is readable back from dead_letter_events`() = runBlocking<Unit> {
+        val hash = "sha256:${UUID.randomUUID()}"
+        val payload = """{"eventType":"account.opened","aggregateVersion":"""
+
+        dlq().quarantine(
+            DeadLetterRecord(
+                contentHash = hash,
+                rawPayload = payload,
+                error = "JsonParseException: unexpected end of input",
+                failedAt = Instant.parse("2026-05-30T12:00:00.000Z"),
+            ),
+        )
+
+        val row = reader.query(
+            "SELECT raw_payload, error, failed_at FROM $DB.dead_letter_events " +
+                "WHERE content_hash = '$hash' FORMAT TabSeparated",
+        ).trim()
+
+        val cols = row.split("\t")
+        // ClickHouse TabSeparated escapes the payload's quotes-free control chars only; the payload
+        // itself round-trips verbatim, which is what makes the documented replay possible.
+        assertThat(cols[0]).isEqualTo(payload)
+        assertThat(cols[1]).contains("JsonParseException")
+        assertThat(cols[2]).isEqualTo("2026-05-30 12:00:00.000")
+    }
+
+    /**
+     * [DeadLetterRecord]'s KDoc promises the DLQ is idempotent on the content hash so an
+     * at-least-once re-delivery of the same poison message does not inflate the queue — which the
+     * readiness probe (`ANALYTICS_MAX_DEAD_LETTERS`) and the Grafana panel both count. That promise
+     * is the table engine's, so only a real server can verify it.
+     */
+    @Test
+    fun `re-delivered poison message collapses to one dead-letter row at FINAL`() = runBlocking<Unit> {
+        val hash = "sha256:${UUID.randomUUID()}"
+        val record = DeadLetterRecord(hash, "{oops", "boom", Instant.parse("2026-05-30T12:00:00.000Z"))
+
+        dlq().quarantine(record)
+        dlq().quarantine(record)
+
+        val count = reader.query(
+            "SELECT count() FROM $DB.dead_letter_events FINAL WHERE content_hash = '$hash' FORMAT TabSeparated",
+        ).trim()
+        assertThat(count).isEqualTo("1")
     }
 
     private fun campaignEvent(eventType: String, payload: Map<String, Any>): AnalyticsEnvelope = AnalyticsEnvelope(


### PR DESCRIPTION
Closes #5761

## The choice: implement, not delete

The issue offers two honest endings. I implemented, and the evidence is that the store was never aspirational — every layer of this service already treats it as real:

- The port's own KDoc said the ClickHouse adapter *"lands with the warehouse adapter"*. The warehouse adapter (`ClickHouseAnalyticsSink`) landed. This one did not — so the promise is overdue, not hypothetical.
- The service has a fully built ClickHouse adapter layer to hang it on: `ClickHouseClient`, `ClickHouseWormArchive`, `ClickHouseProposalStore`, `ClickHouseWarehouseStateReader`. The DLQ was the one port with a reader and no writer.
- `05-operations.{en,cs}.md` documents a runbook that has no source: *"inspect `dead_letter_events.error` … once the producer is fixed, an operator replays `raw_payload` through the normal mapping path."* That is a recovery procedure, and it needs the row.
- `06-compliance.{en,cs}.md` cites dead-letter quarantine as the completeness control for **BCBS 239** and for **DORA Art. 16/17** incident visibility. Deleting the table means deleting a claimed regulatory control, which is a much larger decision than this issue.
- The deployed image is already built with `ANALYTICS_SINK_TYPE=clickhouse` (`gitops/components/analytics/analytics-sink.yaml`), so the durable binding activates on the next deploy with no config change.

## What changed

`ClickHouseDeadLetterSink` — the same binding idiom as the two adapters beside it: `@Alternative @Priority` over the `@Default` logging fallback, gated at **build time** by `openbank.analytics.sink.type=clickhouse`, so the zero-infrastructure default still boots and tests without a server. Idempotency is delegated to `ReplacingMergeTree(failed_at) ORDER BY content_hash`, exactly as `DeadLetterRecord`'s KDoc promises.

The payload is written **whole**. `LoggingDeadLetterSink` truncates at 500 characters — fine for a log line, fatal for the documented replay, since a truncated payload does not parse. There is a test for that specific difference.

Both KDocs that described the adapter as pending are corrected, and they now name the shape that let this ship: `LoggingDeadLetterSink.quarantine()` returns normally, and a normal return is indistinguishable from a durable write at every call site. Nothing in the consumer, the metrics or the logs could have disagreed.

## Falsification

Four new tests: two unit cases against a `FakeClickHouseClient` (no server, offline build unaffected), and two cases in the existing testcontainers IT that read the row **back out of a real ClickHouse** started from the shipped `V1__analytics_bronze_silver.sql` — one asserting the row is there and verbatim, one asserting a re-delivered poison message collapses to a single row under `FINAL`.

Then falsified, because a test that cannot detect the absence of what it tests is decoration. With the insert removed so `quarantine()` returns normally and writes nothing — precisely the `LoggingDeadLetterSink` shape that caused this bug — all four go red:

```
ClickHouseAdaptersTest > quarantine inserts the raw payload into dead_letter_events() FAILED
ClickHouseAdaptersTest > quarantine does not truncate a payload longer than the log fallback would keep() FAILED
ClickHouseAnalyticsSinkIT > quarantine writes a row that is readable back from dead_letter_events() FAILED
ClickHouseAnalyticsSinkIT > re-delivered poison message collapses to one dead-letter row at FINAL() FAILED
```

Restored: **92 tests / 0 skipped / 0 failures**. Skipped is reported deliberately — a Quarkus boot failure reports as SKIPPED, not FAILED.

## Verification

`:openbank-analytics-sink:ktlintCheck`, `detekt` and `test` each appear as executed tasks in the output, not merely absent from a failure list. The IT run used `-PwithDocker`, which is what un-excludes `@Tag("integration")`. Gradle was run serially throughout.

`@Priority` uses a named constant rather than an inline `100`, so detekt's `MagicNumber` needs no new baseline entry. It is declared **above** the annotations, not between them and the class — a top-level declaration in that position silently steals the annotation.

## No manual DDL follow-up

Nothing here changes ClickHouse DDL. `dead_letter_events` is already in `V1__analytics_bronze_silver.sql` and has been in the gitops ClickHouse init ConfigMap since that file was first committed (#1974), so it predates any running instance's first boot. The init ConfigMap's first-boot-only behaviour is therefore not a concern for this change — but it is exactly why no DDL was added here.

I did not touch AWS, the cluster, the live ClickHouse, or live Grafana.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
