### PR TITLE
docs(infra): cite the ADR that actually decided this (#5785)

### DIFF
--- a/openbank-infra/gitops/apps/aml.yaml
+++ b/openbank-infra/gitops/apps/aml.yaml
@@ -1,4 +1,4 @@
-# aml-service: AML screening case lifecycle + onboarding auto-screen (ADR-0073). Namespace: aml.
+# aml-service: AML screening case lifecycle + onboarding auto-screen (ADR-0267 §2). Namespace: aml.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -56,7 +56,7 @@ spec:
             - name: management
               containerPort: 8085
           env:
-            # AML/sanctions screening gate for account opening (ADR-0073). The
+            # AML/sanctions screening gate for account opening (ADR-0032 §C). The
             # service lives in the `sanctions` namespace on :8123; without this the
             # app falls back to a non-resolving default and account opening fails
             # closed (AccountScreeningUnavailableException) — blocking onboarding.

--- a/openbank-infra/gitops/components/accounts/kafka-account-mtls.yaml
+++ b/openbank-infra/gitops/components/accounts/kafka-account-mtls.yaml
@@ -4,7 +4,7 @@
 #   Produces: openbank.accounts.account.created (two channels: account-events-out + account-outbox-out)
 #             openbank.notification.requests (notification-requests-out)
 #             dead-letter-topic-party-events-in (SmallRye DLQ for party-events-in, failure-strategy)
-#   Consumes: openbank.party.events (group: openbank-account-service, ADR-0073 party lifecycle)
+#   Consumes: openbank.party.events (group: openbank-account-service, ADR-0267 §1 party lifecycle)
 ---
 apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -1,6 +1,6 @@
 # aml-service: AML screening case lifecycle. Publishes openbank.aml.events via a
 # transactional outbox (consumed by party-service for the KYC+AML activation gate,
-# ADR-0073) and consumes openbank.party.events to auto-open onboarding screenings.
+# ADR-0267 §2) and consumes openbank.party.events to auto-open onboarding screenings.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -105,8 +105,10 @@ spec:
             # createCase. Point at the in-namespace redis (redis.yaml).
             - name: QUARKUS_REDIS_HOSTS
               value: redis://redis.aml.svc:6379
-            # Sandbox straight-through AML (ADR-0073): auto-clear onboarding screenings so
-            # onboarding activates without an analyst. MUST be false in production.
+            # Sandbox straight-through AML: auto-clear onboarding screenings so onboarding
+            # activates without an analyst. MUST be false in production. No ADR decides this
+            # flag — ADR-0116 §4 decides only the KYC equivalent (openbank.kyc.auto-approve);
+            # the AML side is recorded in aml-service's own docs/ only (#5785).
             - name: OPENBANK_AML_AUTO_CLEAR
               value: "true"
             # ADR-0034 Phase 5 / issue #1797: aml-service shipped @Authorize with the app default

--- a/openbank-infra/gitops/components/aml/kafka-aml-mtls.yaml
+++ b/openbank-infra/gitops/components/aml/kafka-aml-mtls.yaml
@@ -1,7 +1,7 @@
 # Strimzi mTLS identity + ACLs for aml-service (ADR-0137 #2665 Tier 2c).
 #
 # aml-service publishes openbank.aml.events (outbox egress, ADR-0050) and
-# consumes openbank.party.events to auto-open onboarding screenings (ADR-0073).
+# consumes openbank.party.events to auto-open onboarding screenings (ADR-0267 §2).
 #
 # Identity model (ADR-0137): one KafkaUser = one client cert = one mTLS
 # principal for ALL Kafka traffic from this service. The KafkaUser ACLs list
@@ -36,7 +36,7 @@ spec:
           patternType: literal
         operations: [Write, Describe]
         host: "*"
-      # Onboarding trigger: consume PARTY_CREATED to auto-open screenings (ADR-0073)
+      # Onboarding trigger: consume PARTY_CREATED to auto-open screenings (ADR-0267 §2)
       - resource:
           type: topic
           name: openbank.party.events

--- a/openbank-infra/gitops/components/aml/kafka-topics.yaml
+++ b/openbank-infra/gitops/components/aml/kafka-topics.yaml
@@ -1,5 +1,5 @@
 # AML case lifecycle events — published by aml-service (outbox), consumed by party-service
-# (KYC+AML activation gate, ADR-0073) and onboarding-service (cockpit funnel).
+# (KYC+AML activation gate, ADR-0267 §2) and onboarding-service (cockpit funnel).
 apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:

--- a/openbank-infra/gitops/components/aml/namespace.yaml
+++ b/openbank-infra/gitops/components/aml/namespace.yaml
@@ -1,6 +1,6 @@
 # aml namespace (ADR-0037: domain = namespace). App plane. Holds aml-service plus its
 # single-owner CNPG Postgres. Publishes AML case lifecycle to openbank.aml.events
-# (consumed by party-service for the KYC+AML activation gate, ADR-0073).
+# (consumed by party-service for the KYC+AML activation gate, ADR-0267 §2).
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/openbank-infra/gitops/components/balances/kafka-balance-mtls.yaml
+++ b/openbank-infra/gitops/components/balances/kafka-balance-mtls.yaml
@@ -3,7 +3,7 @@
 # balance-service is both a producer and a consumer:
 #   Produces: openbank.balance.events (two channels: balance-events-out + balance-outbox-out)
 #   Consumes: openbank.ledger.journal.posted (group: openbank-balance-service, ADR-0039 Phase D)
-#             openbank.accounts.account.created (group: openbank-balance-service, ADR-0073)
+#             openbank.accounts.account.created (group: openbank-balance-service, ADR-0267 §3)
 #
 # ACL model (ADR-0137): one KafkaUser = one mTLS identity for ALL of this service's Kafka
 # traffic. The global gate allow.everyone.if.no.acl.found=true remains until all ~33 clients

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -120,7 +120,7 @@ spec:
             # (never a silent PASSED), but every new case would need an operator's attention.
             - name: SANCTIONS_SERVICE_URL
               value: http://sanctions-service.sanctions.svc:8123
-            # Sandbox straight-through KYC (ADR-0073): auto-approve cases opened from
+            # Sandbox straight-through KYC (ADR-0116 §4): auto-approve cases opened from
             # PARTY_CREATED so onboarding activates without an operator. MUST be false in prod.
             - name: OPENBANK_KYC_AUTO_APPROVE
               value: "true"

--- a/openbank-infra/gitops/components/party/kafka-party-mtls.yaml
+++ b/openbank-infra/gitops/components/party/kafka-party-mtls.yaml
@@ -6,8 +6,8 @@
 #
 # party-service ACL surface:
 #   Write + Describe: openbank.party.events    (own domain event output + outbox relay)
-#   Read  + Describe: openbank.kyc.events      (KYC case-lifecycle gate, ADR-0073)
-#   Read  + Describe: openbank.aml.events      (AML case-lifecycle gate, ADR-0073)
+#   Read  + Describe: openbank.kyc.events      (KYC case-lifecycle gate, ADR-0267 §2)
+#   Read  + Describe: openbank.aml.events      (AML case-lifecycle gate, ADR-0267 §2)
 #   Read  + Describe: openbank.consent.events  (marketing-consent projection, ADR-0205 D4)
 #   Read:             group openbank-party-service
 #


### PR DESCRIPTION
## What

Ten sites in `openbank-infra` cited **ADR-0073** (*"Hardware-backed credential storage for the
customer app"* — Android Keystore / iOS Keychain) for onboarding and account lifecycle. This is
the last tree in the #5785 sweep. **Three different ADRs**, decided per site — not a
find-and-replace.

| site | old | new | why |
|---|---|---|---|
| `components/kyc/kyc-service.yaml` (`OPENBANK_KYC_AUTO_APPROVE`) | ADR-0073 | **ADR-0116 §4** | ADR-0116 §4 *is* sandbox straight-through KYC: names the property, the `false` default, auto-approve on a `PARTY_CREATED` case, "MUST remain false in production" |
| `components/accounts/account-service.yaml` (`SANCTIONS_SERVICE_URL`) | ADR-0073 | **ADR-0032 §C** | the fail-closed screening gate for account opening; account-service's own `AccountScreeningPort.kt` already cites ADR-0032 §C for the same behaviour |
| `components/accounts/kafka-account-mtls.yaml` (consumes `openbank.party.events`) | ADR-0073 | **ADR-0266 §1** | `PARTY_CREATED` opens inert accounts |
| `components/balances/kafka-balance-mtls.yaml` (consumes `account.created`) | ADR-0073 | **ADR-0266 §3** | event-driven balance init |
| `components/party/kafka-party-mtls.yaml` (kyc.events + aml.events reads, 2 sites) | ADR-0073 | **ADR-0266 §2** | the KYC+AML two-key activation gate |
| `components/aml/kafka-topics.yaml` | ADR-0073 | **ADR-0266 §2** | same gate |
| `components/aml/namespace.yaml` | ADR-0073 | **ADR-0266 §2** | same gate |
| `components/aml/kafka-aml-mtls.yaml` (header + ACL comment, 2 sites) | ADR-0073 | **ADR-0266 §2** | auto-open onboarding screenings from `PARTY_CREATED` |
| `components/aml/aml-service.yaml` (header) | ADR-0073 | **ADR-0266 §2** | same |
| `apps/aml.yaml` | ADR-0073 | **ADR-0266 §2** | same |

### One site has no ADR behind it, and this PR says so rather than picking a number

`components/aml/aml-service.yaml`'s `OPENBANK_AML_AUTO_CLEAR` is **decided by no ADR**. ADR-0116 §4
decides only the KYC equivalent (`openbank.kyc.auto-approve`); ADR-0266 decides the activation gate
but not this flag. The comment now states the gap and points at the KYC sibling instead of citing a
plausible-looking number. Same treatment as in #5829 (aml tree). It is a flag that bypasses
four-eyes on a compliance control, so it is worth a decision record of its own.

### Scope

Comment-only, across gitops manifests. No `.rego`, no `rules.yaml` read-set key, no `agents.yaml` —
so no OPA bundle or `policy-checksum` restamp is involved. No image, env value, ACL, replica or
resource changes: `git diff -w` on these files is comments only.

`bash .github/scripts/check-adr-registry.sh` → OK (258 ADRs).

### Stacking

`origin/docs/account-adr-0073-miscitation` (#5784, which writes ADR-0266) is merged into this branch
so the registry gate resolves the citation — **it fails otherwise**, which is how the gate caught
the first attempt. Those files drop out of the diff once #5784 lands.

Every fixable site outside `openbank-account-service` is now covered by a PR:
#5826 balance · #5827 kyc · #5829 aml · #5830 onboarding · #5831 customer-edge · this one.

**Deliberately left alone:**
- `openbank-party-service/.../V8__party_aml_status.sql` — applied Flyway migration; Flyway
  checksums comments, so editing it is a startup failure. Keeps the wrong number permanently.
- `CHANGELOG.md` "ADR-0073 phase 1/2/3" entries — release-please-derived, immutable.
- `openbank-admin-ui/app-status.json` — **correct as-is**; that entry is the credential-storage
  feature, genuinely ADR-0073.
- `openbank-libs/governance/agents.yaml` — **correct as-is**; both hits are real credential/SCA
  dynamic-linking references.

Closes #5785
