### PR TITLE
feat(product-catalog): govern downstream product terms

### DIFF
--- a/docs/threat-models/openbank-account-service.md
+++ b/docs/threat-models/openbank-account-service.md
@@ -23,14 +23,14 @@ that is balance-service).
                                                                 |
                                                                 +--> [sanctions-service] (OIDC M2M, sync, ADR-0032)
                                                                 |
-                                                                +--> [product-catalog] (unauthenticated read, sync, fail-open, ADR-0158)
+                                                                +--> [product-catalog] (OIDC M2M read, sync, fail-open, ADR-0158)
 [Kafka party events] --in--> [account-service PartyEventConsumer] --activate--> [account-service]
                                                                 |
                                                                 +--M2M client_credentials (ROLE_OPERATOR)--> [transaction-service POST /api/v1/transactions]   (welcome bonus, sandbox-only)
 ```
 
 - **External entities:** operators/admins (human, OIDC via Keycloak), downstream consumers of account events, party-service (event source).
-- **Trust boundaries:** UI↔service (mTLS + OIDC + OPA authz, ADR-0034); service↔Postgres; service↔Kafka (outbox + party-events-in); **service↔transaction-service (outbound M2M, new — welcome-bonus grant)**; **account-service↔sanctions-service** (new, OIDC M2M, ADR-0032 §C); **account-service↔product-catalog** (new, unauthenticated read, ADR-0158 — fail-**open**, a deliberately different posture from the sanctions gate: an unreachable product catalogue is reference-data unavailability, not a compliance risk, and must never block account opening).
+- **Trust boundaries:** UI↔service (mTLS + OIDC + OPA authz, ADR-0034); service↔Postgres; service↔Kafka (outbox + party-events-in); **service↔transaction-service (outbound M2M, new — welcome-bonus grant)**; **account-service↔sanctions-service** (new, OIDC M2M, ADR-0032 §C); **account-service↔product-catalog** (OIDC M2M read, ADR-0158 — fail-**open**, a deliberately different posture from the sanctions gate: an unreachable product catalogue is reference-data unavailability, not a compliance risk, and must never block account opening).
 - **Assets:** account identity, IBAN, freeze/closure state, ownership linkage, **the oidc-client M2M secret** (grants ROLE_OPERATOR on the money path).
 
 ## 3. Authn/Authz
@@ -46,6 +46,7 @@ that is balance-service).
 |---|---|---|
 | **S**poofing | Caller impersonates operator | OIDC bearer + mTLS; no anonymous mutation |
 | **T**ampering | Forced freeze/close, IBAN reassignment | RBAC on all mutations; state-machine guards; DB constraints; audit trail |
+| **T**ampering | Open an account in a currency incompatible with its selected product | Confirmed catalog product responses are checked server-side for product identity and currency. A missing product rejects the request; an unavailable catalog stays explicitly fail-open as reference-data unavailability, with skipped validation logged. |
 | **R**epudiation | Operator denies freezing an account | AuditEvent per lifecycle transition (immutable, ADR audit) |
 | **I**nfo disclosure | IBAN / account enumeration via `/iban/{iban}` | AuthZ on lookup; rate limiting at gateway; no PII in IBAN response beyond need |
 | **I**nfo disclosure / **IDOR** | Customer reads another party's account/balance via a guessed id (reads are gated by role, not ownership; the edge calls with a ROLE_OPERATOR M2M token) | Primary control is at the customer-edge (resolves ownership before proxying, finding A1). **Defense-in-depth here:** when a call carries `X-Customer-Party-Id` the read must belong to that party, else 404 (no existence oracle) — catches an edge bug/new route that forwards the header but skips its own check. Operator/service reads (no header) unaffected. |
@@ -93,6 +94,14 @@ not change any existing request's outcome until explicitly flipped.
   it is a strict improvement over the prior state of no guard at all.
 
 ## 6. Change log
+
+- **2026-08-20** — Product-catalog product/currency enforcement (#668). This existing reference-data
+  edge now authenticates with the `openbank-services` OIDC client and validates a confirmed product's
+  currency before account creation. It deliberately preserves ADR-0158's fail-open posture only for
+  network/5xx unavailability: a definite 404 or incompatible currency cannot create an account.
+  Product-catalog cannot mutate accounts, and account-service never accepts a catalog currency from the
+  caller. Tests cover compatible, missing and mismatched currency responses. Rollback: revert the
+  validation while retaining the OIDC client filter required by catalog reads.
 
 - **2026-08-17** — **New inbound trust edge: the `lending` namespace.** #3931 added `lending` as
   an allowed ingress peer in this component's `network-policies.yaml`, so `lending-service` can

--- a/docs/threat-models/openbank-interest-service.md
+++ b/docs/threat-models/openbank-interest-service.md
@@ -23,6 +23,7 @@ money-path service, not adjacent.
 [Scheduler / Admin-UI] --HTTPS/internal--> [openbank-interest-service]
                                                 |
                      account lookup        ---|---> [account-service] (AccountDirectoryAdapter)
+                     published rate snapshot ---|---> [product-catalog] (immutable revision lookup)
                      capitalization journal ---|---> [ledger-service] (RestLedgerPostingAdapter, CapitalizationJournalFactory)
                      debit remittance       ---|---> [transaction-service] (TransactionServiceClient)
                      settlement ack         <---|--- [Kafka: withholding-remittance-settlement]
@@ -30,7 +31,7 @@ money-path service, not adjacent.
 ```
 
 - **External entities:** scheduler (internal trigger, no external caller), admin-UI (ROLE_OPERATOR/ADMIN for read/ops endpoints).
-- **Trust boundaries:** service → ledger-service (mTLS + OIDC, fail-closed via `LedgerCallGuard`); service → transaction-service (mTLS + OIDC); service → Kafka (mTLS, consumer/producer ACLs).
+- **Trust boundaries:** service → ledger-service (mTLS + OIDC, fail-closed via `LedgerCallGuard`); service → transaction-service (mTLS + OIDC); service → product-catalog (OIDC, immutable published-revision lookup only); service → Kafka (mTLS, consumer/producer ACLs).
 - **Assets:** accrued/capitalized interest amounts, withholding tax rate and remittance amounts, account balances (indirectly, via the ledger postings this service issues).
 
 ## 3. Authn/Authz
@@ -49,14 +50,19 @@ money-path service, not adjacent.
 | **I**nfo disclosure | Expose per-account interest/withholding amounts via error bodies or metrics | Error bodies carry codes only; metrics are low-cardinality (no account-id/amount labels, ADR-0077/0079) |
 | **D**oS | Flood the manual capitalization/remittance trigger, or replay settlement events | `@RolesAllowed` gate on manual triggers; idempotency key on both the ledger posting and the transaction-service debit guards duplicate runs |
 | **E**oP | Use the withholding remittance path to move funds unrelated to actual accrued tax | Remittance amount computed solely from `WithholdingRemittancePolicy` against the service's own accrual ledger, not from caller-supplied input; downstream `transaction-service` is the authoritative amount boundary |
+| **T**ampering | A catalog change makes historical or future accruals use an unintended rate | Consume only a maker-checker-published immutable revision; persist its content hash, effective interval and source revision locally; never resolve the latest catalog document during accrual; reject unsupported tiered profiles until their calculation is explicitly implemented |
 
 ## 5. Residual risks / assumptions
 
 - **Withholding-tax remittance to the tax authority is not yet wired to an external filing system** (#999 tracks actual remittance-to-authority; today the debit lands in an internal remittance-holding account). The money-path risk this threat model covers is the *internal* debit/capitalization flow, which is live.
-- **Interest rate configuration** is operator-managed and out of scope for this document (covered by the product-catalog/pricing threat surface).
+- Catalog-projected rate snapshots are an additional inbound reference-data boundary. A missing, malformed, stale or unsupported snapshot must prevent accrual for its affected product/currency; it must never fall back to a different current rate.
 - **Settlement ack consumer** (`WithholdingRemittanceSettlementConsumer`) trusts the Kafka topic's mTLS/ACL boundary as its authentication; no additional payload-level signature.
 
 ## 6. Change log
+
+- **2026-08-20** — Added catalog fixed-rate snapshot boundary. Only immutable maker-checker-published
+  revisions with a content hash and UTC-day-aligned effective interval can materialize a local rate.
+  Unsupported or malformed profiles are durably rejected; catalog outages do not advance the cursor.
 
 - **2026-08-03** — Missing required query/header parameter answered 500, not 400 (#3104). A required `@QueryParam`/`@HeaderParam` declared with a non-nullable Kotlin type was fed `null` by JAX-RS when the caller omitted it, and answered **500** rather than 400 (#3104). Kotlin's null-safety is compile-time only, so the declared type only decided where the failure landed: a non-suspend handler threw `Intrinsics.checkNotNullParameter` at the method boundary, and a **suspend** handler got no intrinsic at all, so the null flowed into the body. `productId` on capitalize and effectiveRate — #3104's own reproduction case. Both handlers are non-suspend, so `POST /api/v1/interest/capitalize/{accountId}` without `?productId=` threw at the method boundary and rendered 500 before any authorization-independent work ran. No fund movement is reachable without the parameter in either the old or the new behaviour — the change is purely which status the rejected request carries, and 5xx here also burnt this service's SLO error budget. No new caller or boundary. Rollback: revert.
 - **2026-08-03** — Prohibit service-account principals from interest writes (#3679 follow-up). The

--- a/docs/threat-models/openbank-lending-service.md
+++ b/docs/threat-models/openbank-lending-service.md
@@ -51,6 +51,11 @@
    active loans, 6.6M CZK principal, none of it reaching an account). Client-credentials
    (`ROLE_OPERATOR`, accepted by `transaction.create`). Build-time gated by
    `LENDING_BORROWER_CREDIT_BACKEND=rest` (§3), same pattern as item 2's `LENDING_LEDGER_BACKEND`.
+9. **Service → product-catalog (synchronous REST, new — #668).** `ProductCatalogLoanClient` reads one
+   exact `/api/v2/products/{offeringId}` published revision over OIDC client credentials. It never
+   writes catalog state. The adapter accepts only the banking loan schema, a matching offering id,
+   canonical decimal amounts/rates, and a 64-hex content hash; malformed, unavailable, draft or
+   mismatched data fails the application request closed rather than falling back to caller pricing.
 
 ## 3. Controls in place (this slice)
 
@@ -71,6 +76,12 @@
   an APPROVED application. Illegal transitions return 409, not a silent mutation.
 - **Offline-buildable defaults.** No-op `@Default` ports mean the service boots with zero external
   dependency; real integrations are explicit build-time opt-ins.
+- **Catalog-originated loan terms (#668, new).** When an application specifies a catalog offering,
+  `LendingService` resolves the published immutable revision and derives rate, tenor, currency and
+  amortization constraints from it. It persists offering id, revision id, schema version and content
+  hash on the application; subsequent catalog edits cannot reprice the already-originated decision.
+  A catalog response that is unavailable, malformed, non-published or outside supported limits fails
+  closed before application persistence.
 - **Secrets.** No hardcoded credentials; config values are env-var placeholders.
 - **Provisioning cycle integrity (ADR-0028 Phase 3, new this slice).** The scheduled IFRS 9 provisioning
   pass (`ProvisioningCycleScheduler` → `LendingService.runProvisioningCycle`) is a system-actor process,
@@ -339,6 +350,15 @@ against `lending.intake.caller-principal`, which refuses every call when unset.
   becomes load-bearing if that blanket operator grant is narrowed.
 
 ## 10. Change log
+
+- **2026-08-20** — Catalog-governed loan origination (#668). Adds the product-catalog OIDC read edge
+  described in §2 item 9. The caller may select an offering, never a revision or a rate: the service
+  validates the exact published banking-loan revision, persists its immutable identity/hash, and
+  rejects currency, tenor, amortization or principal-range mismatches before creating an application.
+  This closes price/configuration tampering at the money-path intake boundary; a catalog outage is a
+  fail-closed validation error, never a fallback to request-supplied economics. Consumer and provider
+  Pact coverage replay the full response seam. Rollback: leave `catalogOfferingId` absent and legacy
+  applications preserve their existing server-side rate flow.
 
 - **2026-08-17** — Disbursement customer-credit leg (#3931). **New trust boundaries added to §2
   (items 7-8).** The loan book's ledger journal only ever posted to internal GL accounts (Loans

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/application/port/out/ProductCatalogPort.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/application/port/out/ProductCatalogPort.kt
@@ -7,7 +7,13 @@ package com.openbank.account.application.port.out
 import java.util.UUID
 
 /** The minimal projection of a product-catalog `Product` needed to validate account opening (issue #668). */
-data class CatalogProduct(val id: UUID, val code: String, val status: String)
+data class CatalogProduct(
+    val id: UUID,
+    val code: String,
+    val status: String,
+    /** ISO-4217 product currency from the v1 compatibility projection. */
+    val currency: String,
+)
 
 /**
  * The outcome of resolving a product by its canonical id from `openbank-product-catalog`

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AccountService.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AccountService.kt
@@ -97,13 +97,20 @@ class AccountService(
         when (val lookup = productCatalog.findById(command.productId)) {
             is ProductLookupResult.NotFound ->
                 throw ProductNotEligibleException(command.productId, "product does not exist")
-            is ProductLookupResult.Found ->
+            is ProductLookupResult.Found -> {
                 if (lookup.product.status != "ACTIVE") {
                     throw ProductNotEligibleException(
                         command.productId,
                         "product status is ${lookup.product.status}, not ACTIVE",
                     )
                 }
+                if (lookup.product.currency != command.currency.code) {
+                    throw ProductNotEligibleException(
+                        command.productId,
+                        "product currency is ${lookup.product.currency}, not ${command.currency.code}",
+                    )
+                }
+            }
             ProductLookupResult.Unavailable -> Unit
         }
 

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/client/ProductCatalogAdapter.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/client/ProductCatalogAdapter.kt
@@ -37,7 +37,9 @@ class ProductCatalogAdapter : ProductCatalogPort {
     @Suppress("TooGenericExceptionCaught")
     override suspend fun findById(productId: UUID): ProductLookupResult = try {
         val response = client.getById(productId.toString()).awaitSuspending()
-        ProductLookupResult.Found(CatalogProduct(UUID.fromString(response.id), response.code, response.status))
+        ProductLookupResult.Found(
+            CatalogProduct(UUID.fromString(response.id), response.code, response.status, response.currency),
+        )
     } catch (e: WebApplicationException) {
         val status = e.response?.status ?: 0
         if (status == Response.Status.NOT_FOUND.statusCode) {

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/client/ProductCatalogClient.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/client/ProductCatalogClient.kt
@@ -34,4 +34,4 @@ interface ProductCatalogClient {
 
 /** The subset of product-catalog's `Product` this service actually consumes (issue #668). */
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class ProductCatalogResponse(val id: String, val code: String, val status: String)
+data class ProductCatalogResponse(val id: String, val code: String, val status: String, val currency: String)

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceTest.kt
@@ -352,7 +352,7 @@ class AccountServiceTest {
         coEvery { accountRepository.findByIdempotencyKey(any()) } returns null
         coEvery { sanctionsScreening.screen(any(), any()) } returns SanctionsScreenResult("CLEAR", 0.0, null)
         coEvery { productCatalog.findById(command.productId) } returns
-            ProductLookupResult.Found(CatalogProduct(command.productId, "SAVINGS_STANDARD", "DRAFT"))
+            ProductLookupResult.Found(CatalogProduct(command.productId, "SAVINGS_STANDARD", "DRAFT", "CZK"))
 
         assertThatThrownBy { runBlocking { service.openAccount(command) } }
             .isInstanceOf(ProductNotEligibleException::class.java)
@@ -368,7 +368,7 @@ class AccountServiceTest {
         coEvery { accountRepository.findByIdempotencyKey(any()) } returns null
         coEvery { sanctionsScreening.screen(any(), any()) } returns SanctionsScreenResult("CLEAR", 0.0, null)
         coEvery { productCatalog.findById(command.productId) } returns
-            ProductLookupResult.Found(CatalogProduct(command.productId, "SAVINGS_STANDARD", "ACTIVE"))
+            ProductLookupResult.Found(CatalogProduct(command.productId, "SAVINGS_STANDARD", "ACTIVE", "CZK"))
         every { ibanGenerator.generate(command.currency) } returns iban
         coEvery { accountRepository.existsByIban(iban) } returns false
         coEvery { accountRepository.saveNewAccount(any(), any(), any()) } answers { firstArg() }
@@ -377,6 +377,21 @@ class AccountServiceTest {
         val result = service.openAccount(command)
 
         assertThat(result.status).isEqualTo(AccountStatus.ACTIVE)
+    }
+
+    @Test
+    fun `openAccount refuses a confirmed product currency mismatch`() {
+        val command = openAccountCommand()
+        coEvery { accountRepository.findByIdempotencyKey(any()) } returns null
+        coEvery { sanctionsScreening.screen(any(), any()) } returns SanctionsScreenResult("CLEAR", 0.0, null)
+        coEvery { productCatalog.findById(command.productId) } returns
+            ProductLookupResult.Found(CatalogProduct(command.productId, "SAVINGS_STANDARD", "ACTIVE", "EUR"))
+
+        assertThatThrownBy { runBlocking { service.openAccount(command) } }
+            .isInstanceOf(ProductNotEligibleException::class.java)
+            .hasMessageContaining("EUR, not CZK")
+
+        coVerify(exactly = 0) { accountRepository.saveNewAccount(any(), any(), any()) }
     }
 
     @Test

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/contract/ProductCatalogLookupPactConsumerTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/contract/ProductCatalogLookupPactConsumerTest.kt
@@ -74,6 +74,7 @@ class ProductCatalogLookupPactConsumerTest {
                 o.stringValue("id", CURRENT_PERSONAL_PRODUCT_ID)
                 o.stringType("code", "CURRENT_PERSONAL")
                 o.stringType("status", "ACTIVE")
+                o.stringType("currency", "EUR")
             }.build(),
         )
         .toPact()
@@ -108,6 +109,7 @@ class ProductCatalogLookupPactConsumerTest {
         assertThat(product.id).isEqualTo(CURRENT_PERSONAL_PRODUCT_ID)
         assertThat(product.code).isEqualTo("CURRENT_PERSONAL")
         assertThat(product.status).isNotBlank()
+        assertThat(product.currency).isEqualTo("EUR")
     }
 
     @Test

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/client/ProductCatalogHostHeaderIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/client/ProductCatalogHostHeaderIT.kt
@@ -74,8 +74,9 @@ class ProductCatalogHostHeaderIT {
             http.createContext("/api/v1/products") { ex ->
                 hosts += ex.requestHeaders.getFirst("Host") ?: ""
                 val requestedId = ex.requestURI.path.substringAfterLast('/')
+                val currency = if (requestedId == EUR_PRODUCT_ID) "EUR" else "CZK"
                 val body =
-                    """{"id":"$requestedId","code":"BEZNY_UCET","status":"ACTIVE","currency":"CZK"}""".toByteArray()
+                    """{"id":"$requestedId","code":"BEZNY_UCET","status":"ACTIVE","currency":"$currency"}""".toByteArray()
                 ex.responseHeaders.add("Content-Type", "application/json")
                 ex.sendResponseHeaders(200, body.size.toLong())
                 ex.responseBody.use { it.write(body) }
@@ -101,5 +102,6 @@ class ProductCatalogHostHeaderIT {
         private const val EXPECTED_HOST = "product-catalog.accounts.svc"
         private const val STUB_PORT = 18106
         private const val PRODUCT_ID = "11111111-1111-1111-1111-111111111111"
+        private const val EUR_PRODUCT_ID = "00000000-2222-0000-0000-000000000002"
     }
 }

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/client/ProductCatalogHostHeaderIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/client/ProductCatalogHostHeaderIT.kt
@@ -75,7 +75,7 @@ class ProductCatalogHostHeaderIT {
                 hosts += ex.requestHeaders.getFirst("Host") ?: ""
                 val requestedId = ex.requestURI.path.substringAfterLast('/')
                 val body =
-                    """{"id":"$requestedId","code":"BEZNY_UCET","status":"ACTIVE"}""".toByteArray()
+                    """{"id":"$requestedId","code":"BEZNY_UCET","status":"ACTIVE","currency":"CZK"}""".toByteArray()
                 ex.responseHeaders.add("Content-Type", "application/json")
                 ex.sendResponseHeaders(200, body.size.toLong())
                 ex.responseBody.use { it.write(body) }

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/client/ProductCatalogHostHeaderIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/client/ProductCatalogHostHeaderIT.kt
@@ -76,7 +76,8 @@ class ProductCatalogHostHeaderIT {
                 val requestedId = ex.requestURI.path.substringAfterLast('/')
                 val currency = if (requestedId == EUR_PRODUCT_ID) "EUR" else "CZK"
                 val body =
-                    """{"id":"$requestedId","code":"BEZNY_UCET","status":"ACTIVE","currency":"$currency"}""".toByteArray()
+                    """{"id":"$requestedId","code":"BEZNY_UCET","status":"ACTIVE","currency":"$currency"}"""
+                        .toByteArray()
                 ex.responseHeaders.add("Content-Type", "application/json")
                 ex.sendResponseHeaders(200, body.size.toLong())
                 ex.responseBody.use { it.write(body) }

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/integration/AccountApiIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/integration/AccountApiIT.kt
@@ -29,6 +29,7 @@ class AccountApiIT {
     companion object {
         private val partyId = UUID.fromString("00000000-1111-0000-0000-000000000001")
         private val productId = UUID.fromString("00000000-2222-0000-0000-000000000001")
+        private val eurProductId = UUID.fromString("00000000-2222-0000-0000-000000000002")
         private var createdAccountId: String? = null
 
         init {
@@ -90,7 +91,7 @@ class AccountApiIT {
         val payload = """
             {
               "partyId": "$partyId",
-              "productId": "$productId",
+              "productId": "$eurProductId",
               "accountType": "SAVINGS",
               "currencyCode": "EUR",
               "legalName": "Test Customer"

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/catalog/CatalogInterestProfile.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/catalog/CatalogInterestProfile.kt
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.interest.infrastructure.catalog
+
+import com.openbank.interest.domain.model.DayCount
+import com.openbank.interest.infrastructure.client.CatalogOfferingClientResponse
+import com.openbank.interest.infrastructure.client.CatalogRevisionClientResponse
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+internal data class CatalogInterestProfile(
+    val revisionId: UUID,
+    val offeringId: UUID,
+    val specificationId: UUID,
+    val schemaId: String,
+    val schemaVersion: Int,
+    val contentHash: String,
+    val currency: String,
+    val annualRate: BigDecimal,
+    val dayCount: DayCount,
+    val effectiveFrom: LocalDate,
+    val effectiveTo: LocalDate?,
+)
+
+/** A rejected catalog profile is an auditable outcome, never a best-effort rate conversion. */
+internal class CatalogInterestProfileRejected(message: String) : IllegalArgumentException(message)
+
+/**
+ * Maps only the fixed-rate subset the daily accrual engine can prove today.
+ *
+ * Tiered profiles are deliberately rejected: their catalog schema does not state whether tiers are
+ * marginal or whole-balance, so treating a tier as one fixed rate would produce incorrect money.
+ */
+internal object CatalogInterestProfileParser {
+    private const val DEPOSIT_SCHEMA = "org.openbank.banking.deposit"
+    private const val FIXED = "FIXED"
+
+    fun parse(
+        revision: CatalogRevisionClientResponse,
+        offering: CatalogOfferingClientResponse,
+    ): CatalogInterestProfile {
+        require(revision.state == "PUBLISHED") { "revision is not published" }
+        require(revision.offeringId == offering.id) { "revision/offering identity mismatch" }
+        require(revision.schemaRef.id == DEPOSIT_SCHEMA) { "unsupported catalog schema ${revision.schemaRef.id}" }
+        val hash = requireNotNull(revision.contentHash) { "published revision has no content hash" }
+        val attributes = revision.content.attributes
+        val currency = attributes.requiredText("currency", "currency").also {
+            require(it.matches(Regex("[A-Z]{3}"))) { "currency must be ISO-4217" }
+        }
+        val interest = attributes.requiredObject("interest")
+        require(interest.requiredText("rateType", "interest.rateType") == FIXED) {
+            "unsupported interest.rateType; only FIXED is executable"
+        }
+        val annualRate = interest.requiredDecimal("annualRate", "interest.annualRate")
+        require(annualRate >= BigDecimal.ZERO) { "interest.annualRate must be non-negative" }
+        val dayCount = try {
+            DayCount.valueOf(interest.requiredText("dayCount", "interest.dayCount"))
+        } catch (_: IllegalArgumentException) {
+            throw CatalogInterestProfileRejected("unsupported interest.dayCount")
+        }
+        val from = requireMidnight(revision.effectiveFrom, "effectiveFrom")
+        val to = revision.effectiveTo?.let { requireMidnight(it, "effectiveTo").minusDays(1) }
+        require(to == null || to >= from) { "effective interval contains no accrual date" }
+        return CatalogInterestProfile(
+            revisionId = revision.id,
+            offeringId = offering.id,
+            specificationId = offering.specificationId,
+            schemaId = revision.schemaRef.id,
+            schemaVersion = revision.schemaRef.version,
+            contentHash = hash,
+            currency = currency,
+            annualRate = annualRate,
+            dayCount = dayCount,
+            effectiveFrom = from,
+            effectiveTo = to,
+        )
+    }
+
+    private fun requireMidnight(value: OffsetDateTime?, name: String): LocalDate {
+        requireNotNull(value) { "$name is required for a daily interest profile" }
+        val utc = value.withOffsetSameInstant(ZoneOffset.UTC)
+        require(utc.toLocalTime().toSecondOfDay() == 0 && utc.nano == 0) {
+            "$name must be aligned to midnight UTC for daily accrual"
+        }
+        return utc.toLocalDate()
+    }
+
+    private fun com.fasterxml.jackson.databind.JsonNode.requiredObject(name: String) = get(name).also {
+        require(it != null && it.isObject) { "$name must be an object" }
+    }!!
+
+    private fun com.fasterxml.jackson.databind.JsonNode.requiredText(name: String, path: String): String =
+        get(name)?.asText()
+            ?.takeIf { it.isNotBlank() }
+            ?: throw CatalogInterestProfileRejected("$path is required")
+
+    private fun com.fasterxml.jackson.databind.JsonNode.requiredDecimal(name: String, path: String): BigDecimal {
+        val text = requiredText(name, path)
+        require(text.matches(Regex("(0|[1-9][0-9]*)(\\.[0-9]+)?"))) { "$path must be a canonical decimal" }
+        return text.toBigDecimal()
+    }
+}

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/catalog/CatalogInterestProfileSynchronizer.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/catalog/CatalogInterestProfileSynchronizer.kt
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.interest.infrastructure.catalog
+
+import com.openbank.interest.domain.model.InterestRateConfig
+import com.openbank.interest.domain.model.InterestRateType
+import com.openbank.interest.infrastructure.client.CatalogEventClientResponse
+import com.openbank.interest.infrastructure.client.ProductCatalogClient
+import com.openbank.interest.infrastructure.persistence.entity.CatalogInterestEventReceiptEntity
+import com.openbank.interest.infrastructure.persistence.entity.CatalogInterestRateSnapshotEntity
+import com.openbank.interest.infrastructure.persistence.entity.CatalogInterestSyncStateEntity
+import com.openbank.interest.infrastructure.persistence.entity.InterestRateConfigEntity
+import com.openbank.interest.infrastructure.persistence.mapper.InterestMapper
+import io.quarkus.hibernate.reactive.panache.common.WithSession
+import io.smallrye.mutiny.Uni
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.hibernate.reactive.mutiny.Mutiny
+import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+internal enum class CatalogInterestSyncOutcome { IDLE, APPLIED, SKIPPED, REJECTED, FAILED }
+
+/**
+ * One-event-at-a-time durable consumer for catalog revisions.
+ *
+ * Catalog's cursor points after a page, not each element inside it.  Reading with `limit=1` is
+ * intentional: the rate write, receipt and cursor acknowledgement can then commit in one local
+ * transaction. A crash retries the same immutable event; it can never skip the remainder of a
+ * fetched page.
+ */
+@ApplicationScoped
+internal class CatalogInterestProfileSynchronizer @Inject constructor(
+    @RestClient private val catalog: ProductCatalogClient,
+    private val repository: CatalogInterestSyncRepository,
+) {
+    private val log = Logger.getLogger(CatalogInterestProfileSynchronizer::class.java)
+
+    fun synchronizeOne(): Uni<CatalogInterestSyncOutcome> = repository.cursor().flatMap { cursor ->
+        catalog.events(cursor, 1)
+    }.flatMap { page ->
+        if (page.items.isEmpty()) {
+            Uni.createFrom().item(CatalogInterestSyncOutcome.IDLE)
+        } else {
+            require(page.items.size == 1) { "catalog event page must contain one item" }
+            val nextCursor = requireNotNull(page.nextCursor) { "catalog event page has item without nextCursor" }
+            resolve(page.items.single()).flatMap { resolution -> repository.record(resolution, nextCursor) }
+        }
+    }
+
+    private fun resolve(event: CatalogEventClientResponse): Uni<CatalogInterestEventResolution> {
+        if (event.eventType != REVISION_PUBLISHED) {
+            return Uni.createFrom().item(
+                CatalogInterestEventResolution.skipped(event, "event is not a published revision"),
+            )
+        }
+        return catalog.revision(event.aggregateId).flatMap { revision ->
+            catalog.offering(revision.offeringId).map { offering ->
+                try {
+                    CatalogInterestEventResolution.applied(
+                        event,
+                        CatalogInterestProfileParser.parse(revision, offering),
+                    )
+                } catch (e: IllegalArgumentException) {
+                    CatalogInterestEventResolution.rejected(event, e.message ?: "catalog profile is not executable")
+                }
+            }
+        }.onFailure(CatalogInterestProfileRejected::class.java).recoverWithItem { e ->
+            // Parser rejections are durable operational outcomes; transport/authorization failures
+            // deliberately remain failures so the cursor is not advanced and the event retries.
+            log.warnf("catalog revision %s rejected: %s", event.aggregateId, e.message)
+            CatalogInterestEventResolution.rejected(event, e.message ?: "catalog profile is not executable")
+        }
+    }
+
+    private companion object {
+        const val REVISION_PUBLISHED = "com.openbank.catalog.revision_published"
+    }
+}
+
+internal data class CatalogInterestEventResolution(
+    val event: CatalogEventClientResponse,
+    val profile: CatalogInterestProfile?,
+    val outcome: CatalogInterestSyncOutcome,
+    val reason: String?,
+) {
+    companion object {
+        fun applied(event: CatalogEventClientResponse, profile: CatalogInterestProfile) =
+            CatalogInterestEventResolution(event, profile, CatalogInterestSyncOutcome.APPLIED, null)
+        fun skipped(event: CatalogEventClientResponse, reason: String) =
+            CatalogInterestEventResolution(event, null, CatalogInterestSyncOutcome.SKIPPED, reason)
+        fun rejected(event: CatalogEventClientResponse, reason: String) =
+            CatalogInterestEventResolution(event, null, CatalogInterestSyncOutcome.REJECTED, reason)
+    }
+}
+
+/** Owns the local all-or-nothing acknowledgement boundary. */
+@ApplicationScoped
+@Suppress("TooManyFunctions") // Transactional substeps intentionally stay co-located with the cursor acknowledgement.
+internal class CatalogInterestSyncRepository @Inject constructor(
+    private val sessions: Mutiny.SessionFactory,
+    private val mapper: InterestMapper,
+    private val clock: Clock,
+) {
+    @WithSession
+    fun cursor(): Uni<String?> = sessions.withSession { session ->
+        session.find(CatalogInterestSyncStateEntity::class.java, CONSUMER).map { it?.cursor }
+    }
+
+    fun record(resolution: CatalogInterestEventResolution, nextCursor: String): Uni<CatalogInterestSyncOutcome> =
+        sessions.withTransaction { session ->
+            val now = OffsetDateTime.now(clock)
+            session.find(CatalogInterestEventReceiptEntity::class.java, resolution.event.id).flatMap { receipt ->
+                if (receipt != null) {
+                    acknowledge(session, nextCursor, now).replaceWith(receipt.outcome.toSyncOutcome())
+                } else {
+                    persistResolution(session, resolution, now).flatMap { outcome ->
+                        acknowledge(session, nextCursor, now).replaceWith(outcome)
+                    }
+                }
+            }
+        }
+
+    private fun persistResolution(
+        session: Mutiny.Session,
+        resolution: CatalogInterestEventResolution,
+        now: OffsetDateTime,
+    ): Uni<CatalogInterestSyncOutcome> {
+        val profile = resolution.profile
+        if (profile == null) return persistReceipt(session, resolution, now, resolution.outcome)
+        return session.find(CatalogInterestRateSnapshotEntity::class.java, profile.revisionId).flatMap { existing ->
+            if (existing != null) {
+                persistReceipt(session, resolution, now, existing.outcome.toSyncOutcome())
+            } else {
+                applyProfile(session, resolution, profile, now)
+            }
+        }
+    }
+
+    private fun applyProfile(
+        session: Mutiny.Session,
+        resolution: CatalogInterestEventResolution,
+        profile: CatalogInterestProfile,
+        now: OffsetDateTime,
+    ): Uni<CatalogInterestSyncOutcome> = findOverlappingConfigs(session, profile).flatMap { configs ->
+        catalogConfigIds(session, profile).flatMap { ids ->
+            applyProfileAgainstExisting(session, resolution, profile, now, configs, ids.toSet())
+        }
+    }
+
+    private fun catalogConfigIds(session: Mutiny.Session, profile: CatalogInterestProfile): Uni<List<UUID>> =
+        session.createQuery(
+            "SELECT s.configId FROM CatalogInterestRateSnapshotEntity s WHERE s.specificationId = :spec AND s.currency = :currency AND s.outcome = 'APPLIED'",
+            UUID::class.java,
+        ).setParameter("spec", profile.specificationId).setParameter("currency", profile.currency).resultList
+
+    private fun applyProfileAgainstExisting(
+        session: Mutiny.Session,
+        resolution: CatalogInterestEventResolution,
+        profile: CatalogInterestProfile,
+        now: OffsetDateTime,
+        configs: List<InterestRateConfigEntity>,
+        catalogIds: Set<UUID>,
+    ): Uni<CatalogInterestSyncOutcome> {
+        val rejection = when {
+            configs.any { it.id !in catalogIds } -> "overlaps an operator-managed rate configuration"
+            configs.any { it.effectiveFrom >= profile.effectiveFrom } ->
+                "overlaps a catalog rate at the same or later effective date"
+            else -> null
+        }
+        if (rejection != null) return persistRejectedProfile(session, resolution, profile, now, rejection)
+        configs.forEach { config ->
+            config.effectiveTo = profile.effectiveFrom.minusDays(1)
+            config.updatedAt = now
+        }
+        return persistAppliedProfile(session, resolution, profile, now)
+    }
+
+    private fun persistAppliedProfile(
+        session: Mutiny.Session,
+        resolution: CatalogInterestEventResolution,
+        profile: CatalogInterestProfile,
+        now: OffsetDateTime,
+    ): Uni<CatalogInterestSyncOutcome> {
+        val config = mapper.toEntity(
+            InterestRateConfig(
+                productId = profile.specificationId.toString(),
+                currency = profile.currency,
+                rateType = InterestRateType.FIXED,
+                annualRate = profile.annualRate,
+                dayCount = profile.dayCount,
+                effectiveFrom = profile.effectiveFrom,
+                effectiveTo = profile.effectiveTo,
+                createdAt = now,
+                updatedAt = now,
+            ),
+        )
+        return session.persist(config).flatMap {
+            val snapshot = CatalogInterestRateSnapshotEntity().also {
+                it.revisionId = profile.revisionId
+                it.offeringId = profile.offeringId
+                it.specificationId = profile.specificationId
+                it.configId = config.id
+                it.schemaId = profile.schemaId
+                it.schemaVersion = profile.schemaVersion
+                it.contentHash = profile.contentHash
+                it.currency = profile.currency
+                it.annualRate = profile.annualRate
+                it.dayCount = profile.dayCount.name
+                it.effectiveFrom = profile.effectiveFrom
+                it.effectiveTo = profile.effectiveTo
+                it.outcome = "APPLIED"
+                it.createdAt = now
+            }
+            session.persist(snapshot).flatMap {
+                persistReceipt(session, resolution, now, CatalogInterestSyncOutcome.APPLIED)
+            }
+        }
+    }
+
+    private fun findOverlappingConfigs(
+        session: Mutiny.Session,
+        profile: CatalogInterestProfile,
+    ): Uni<List<InterestRateConfigEntity>> = session.createQuery(
+        "FROM InterestRateConfigEntity WHERE productId = :product AND accountId IS NULL AND currency = :currency " +
+            "AND active = true AND effectiveFrom <= :end AND (effectiveTo IS NULL OR effectiveTo >= :start)",
+        InterestRateConfigEntity::class.java,
+    ).setParameter("product", profile.specificationId.toString())
+        .setParameter("currency", profile.currency)
+        .setParameter("start", profile.effectiveFrom)
+        .setParameter("end", profile.effectiveTo ?: LocalDate.MAX)
+        .resultList
+
+    private fun persistRejectedProfile(
+        session: Mutiny.Session,
+        resolution: CatalogInterestEventResolution,
+        profile: CatalogInterestProfile,
+        now: OffsetDateTime,
+        reason: String,
+    ): Uni<CatalogInterestSyncOutcome> {
+        val snapshot = CatalogInterestRateSnapshotEntity().also {
+            it.revisionId = profile.revisionId
+            it.offeringId = profile.offeringId
+            it.specificationId = profile.specificationId
+            it.schemaId = profile.schemaId
+            it.schemaVersion = profile.schemaVersion
+            it.contentHash = profile.contentHash
+            it.outcome = "REJECTED"
+            it.reason = reason
+            it.createdAt = now
+        }
+        return session.persist(snapshot).flatMap {
+            persistReceipt(session, resolution.copy(reason = reason), now, CatalogInterestSyncOutcome.REJECTED)
+        }
+    }
+
+    private fun persistReceipt(
+        session: Mutiny.Session,
+        resolution: CatalogInterestEventResolution,
+        now: OffsetDateTime,
+        outcome: CatalogInterestSyncOutcome,
+    ): Uni<CatalogInterestSyncOutcome> {
+        val receipt = CatalogInterestEventReceiptEntity().also {
+            it.eventId = resolution.event.id
+            it.eventType = resolution.event.eventType
+            it.outcome = outcome.name
+            it.reason = resolution.reason?.take(MAX_REASON_LENGTH)
+            it.processedAt = now
+        }
+        return session.persist(receipt).replaceWith(outcome)
+    }
+
+    private fun acknowledge(session: Mutiny.Session, cursor: String, now: OffsetDateTime): Uni<Void> =
+        session.find(CatalogInterestSyncStateEntity::class.java, CONSUMER).flatMap { state ->
+            val mutable = state ?: CatalogInterestSyncStateEntity().also { it.consumer = CONSUMER }
+            mutable.cursor = cursor
+            mutable.updatedAt = now
+            if (state == null) session.persist(mutable) else Uni.createFrom().voidItem()
+        }
+
+    private fun String.toSyncOutcome(): CatalogInterestSyncOutcome = when (this) {
+        "APPLIED" -> CatalogInterestSyncOutcome.APPLIED
+        "REJECTED" -> CatalogInterestSyncOutcome.REJECTED
+        else -> CatalogInterestSyncOutcome.SKIPPED
+    }
+
+    private companion object {
+        const val CONSUMER = "interest-rate-snapshots"
+        const val MAX_REASON_LENGTH = 512
+    }
+}

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/ProductCatalogClient.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/ProductCatalogClient.kt
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.interest.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.databind.JsonNode
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.DefaultValue
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Read-only v2 catalog boundary for the interest rate snapshotter.
+ *
+ * The change stream only contains durable identifiers. Every published revision is consequently
+ * re-read by its immutable id and its offering is re-read to obtain the canonical specification id
+ * that account-service puts on accounts. No interest accrual ever calls this client directly.
+ */
+@RegisterRestClient(configKey = "product-catalog")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/api/v2")
+interface ProductCatalogClient {
+    @GET
+    @Path("/events")
+    fun events(
+        @QueryParam("after") after: String?,
+        @QueryParam("limit") @DefaultValue("1") limit: Int,
+    ): Uni<CatalogEventPageClientResponse>
+
+    @GET
+    @Path("/revisions/{id}")
+    fun revision(@PathParam("id") id: UUID): Uni<CatalogRevisionClientResponse>
+
+    @GET
+    @Path("/offerings/{id}")
+    fun offering(@PathParam("id") id: UUID): Uni<CatalogOfferingClientResponse>
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CatalogEventPageClientResponse(
+    val items: List<CatalogEventClientResponse> = emptyList(),
+    val nextCursor: String? = null,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CatalogEventClientResponse(
+    val id: UUID,
+    val aggregateType: String,
+    val aggregateId: UUID,
+    val eventType: String,
+    val occurredAt: OffsetDateTime,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CatalogRevisionClientResponse(
+    val id: UUID,
+    val offeringId: UUID,
+    val schemaRef: CatalogSchemaRefClientResponse,
+    val state: String,
+    val content: CatalogRevisionContentClientResponse,
+    val effectiveFrom: OffsetDateTime?,
+    val effectiveTo: OffsetDateTime?,
+    val contentHash: String?,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CatalogSchemaRefClientResponse(val id: String, val version: Int)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CatalogRevisionContentClientResponse(val attributes: JsonNode)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CatalogOfferingClientResponse(val id: UUID, val specificationId: UUID)

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/entity/InterestEntities.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/entity/InterestEntities.kt
@@ -24,6 +24,90 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 @Entity
+@Table(name = "catalog_interest_sync_state")
+class CatalogInterestSyncStateEntity : PanacheEntityBase() {
+    @Id
+    @Column(name = "consumer", length = 64)
+    var consumer: String = ""
+
+    @Column(name = "cursor")
+    var cursor: String? = null
+
+    @Column(name = "updated_at")
+    var updatedAt: OffsetDateTime = OffsetDateTime.MIN
+}
+
+@Entity
+@Table(name = "catalog_interest_event_receipts")
+class CatalogInterestEventReceiptEntity : PanacheEntityBase() {
+    @Id
+    @Column(name = "event_id", columnDefinition = "uuid")
+    var eventId: UUID = Ids.newId()
+
+    @Column(name = "event_type", length = 128)
+    var eventType: String = ""
+
+    @Column(name = "outcome", length = 32)
+    var outcome: String = ""
+
+    @Column(name = "reason", length = 512)
+    var reason: String? = null
+
+    @Column(name = "processed_at")
+    var processedAt: OffsetDateTime = OffsetDateTime.MIN
+}
+
+@Entity
+@Table(name = "catalog_interest_rate_snapshots")
+class CatalogInterestRateSnapshotEntity : PanacheEntityBase() {
+    @Id
+    @Column(name = "revision_id", columnDefinition = "uuid")
+    var revisionId: UUID = Ids.newId()
+
+    @Column(name = "offering_id", columnDefinition = "uuid")
+    var offeringId: UUID = Ids.newId()
+
+    @Column(name = "specification_id", columnDefinition = "uuid")
+    var specificationId: UUID = Ids.newId()
+
+    @Column(name = "config_id", columnDefinition = "uuid")
+    var configId: UUID? = null
+
+    @Column(name = "schema_id", length = 128)
+    var schemaId: String = ""
+
+    @Column(name = "schema_version")
+    var schemaVersion: Int = 0
+
+    @Column(name = "content_hash", length = 64)
+    var contentHash: String = ""
+
+    @Column(name = "currency", length = 3)
+    var currency: String? = null
+
+    @Column(name = "annual_rate", precision = 20, scale = 18)
+    var annualRate: BigDecimal? = null
+
+    @Column(name = "day_count", length = 16)
+    var dayCount: String? = null
+
+    @Column(name = "effective_from")
+    var effectiveFrom: LocalDate? = null
+
+    @Column(name = "effective_to")
+    var effectiveTo: LocalDate? = null
+
+    @Column(name = "outcome", length = 32)
+    var outcome: String = ""
+
+    @Column(name = "reason", length = 512)
+    var reason: String? = null
+
+    @Column(name = "created_at")
+    var createdAt: OffsetDateTime = OffsetDateTime.MIN
+}
+
+@Entity
 @Table(name = "interest_rate_configs")
 class InterestRateConfigEntity : PanacheEntityBase() {
     @Id
@@ -44,7 +128,9 @@ class InterestRateConfigEntity : PanacheEntityBase() {
     @Enumerated(EnumType.STRING)
     var rateType: InterestRateType = InterestRateType.FIXED
 
-    @Column(name = "annual_rate", precision = 10, scale = 6)
+    // Catalog v2 carries exact decimal strings with up to 18 fractional digits. Keep that
+    // precision through the reference-data boundary; binary/scale truncation changes money.
+    @Column(name = "annual_rate", precision = 20, scale = 18)
     var annualRate: BigDecimal = BigDecimal.ZERO
 
     @Column(name = "min_balance", precision = 20, scale = 4)

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/scheduler/CatalogInterestSnapshotScheduler.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/scheduler/CatalogInterestSnapshotScheduler.kt
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.interest.infrastructure.scheduler
+
+import com.openbank.interest.infrastructure.catalog.CatalogInterestProfileSynchronizer
+import com.openbank.interest.infrastructure.catalog.CatalogInterestSyncOutcome
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
+import io.quarkus.runtime.StartupEvent
+import io.quarkus.scheduler.Scheduled
+import io.smallrye.config.ConfigMapping
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
+import org.jboss.logging.Logger
+import java.time.Duration
+
+/** Polls one durable catalog event per run; see [CatalogInterestProfileSynchronizer]. */
+@ApplicationScoped
+internal class CatalogInterestSnapshotScheduler(
+    private val synchronizer: CatalogInterestProfileSynchronizer,
+    private val config: CatalogInterestSnapshotConfig,
+    private val domainMetrics: DomainMetrics,
+) {
+    private val log = Logger.getLogger(CatalogInterestSnapshotScheduler::class.java)
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    fun onStart(@Observes @Suppress("UNUSED_PARAMETER") event: StartupEvent) {
+        if (config.enabled()) liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW, EXPECTED_INTERVAL)
+    }
+
+    @Scheduled(
+        every = "{interest.catalog-sync.interval}",
+        delayed = "{interest.catalog-sync.initial-delay}",
+        identity = "interest-catalog-rate-snapshot-sync",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+    )
+    suspend fun synchronize() {
+        if (!config.enabled()) return
+        val outcome = synchronizer.synchronizeOne()
+            .onFailure().invoke { e ->
+                // The cursor intentionally stays put on transport/auth failures. A subsequent tick retries
+                // the same event, rather than allowing a temporary catalog outage to change money inputs.
+                log.error("catalog interest snapshot sync failed; cursor was not advanced", e)
+            }
+            .onFailure().recoverWithItem(CatalogInterestSyncOutcome.FAILED)
+            .awaitSuspending()
+        if (outcome != CatalogInterestSyncOutcome.FAILED) {
+            liveness?.recordSuccess()
+            if (outcome ==
+                CatalogInterestSyncOutcome.REJECTED
+            ) {
+                log.warn("catalog interest event rejected; see durable receipt")
+            }
+        }
+    }
+
+    private companion object {
+        const val WORKFLOW = "interest-catalog-rate-snapshot-sync"
+        val EXPECTED_INTERVAL: Duration = Duration.ofMinutes(1)
+    }
+}
+
+@ConfigMapping(prefix = "interest.catalog-sync")
+interface CatalogInterestSnapshotConfig {
+    fun enabled(): Boolean
+
+    // These values are also referenced by @Scheduled. Keeping them in the mapping makes SmallRye
+    // validate the whole configuration subtree instead of treating scheduler-only keys as unknown.
+    fun interval(): Duration
+
+    fun initialDelay(): Duration
+}

--- a/openbank-interest-service/src/main/resources/application.yaml
+++ b/openbank-interest-service/src/main/resources/application.yaml
@@ -75,6 +75,12 @@ quarkus:
     account-service:
       url: ${ACCOUNT_SERVICE_URL:http://localhost:8100}
       scope: jakarta.inject.Singleton
+    # Immutable catalog revision and durable event cursor used only by the reference-data
+    # snapshotter. Accrual reads its own PostgreSQL snapshot/config rows and never resolves the
+    # mutable "latest" catalog representation on the money path.
+    product-catalog:
+      url: ${PRODUCT_CATALOG_URL:http://localhost:8104}
+      scope: jakarta.inject.Singleton
   redis:
     hosts: redis://localhost:6379
   shutdown:
@@ -150,6 +156,13 @@ authz:
 # differs from its GL account's (the V14 cash-clearing bug); withholding-tax payable is CZK-only
 # because ADR-0033 §E withholds only CZK interest.
 interest:
+  catalog-sync:
+    # Expand safely: disabled until an environment gives the openbank-services principal catalog
+    # read access and opts into the migration. Enabling later is idempotent because receipts and the
+    # cursor commit with each snapshot.
+    enabled: ${INTEREST_CATALOG_SYNC_ENABLED:false}
+    interval: ${INTEREST_CATALOG_SYNC_INTERVAL:30s}
+    initial-delay: ${INTEREST_CATALOG_SYNC_INITIAL_DELAY:15s}
   ledger:
     system-actor-id: ${INTEREST_LEDGER_SYSTEM_ACTOR_ID:00000000-0000-0000-0000-0000000000cc}
     gl:

--- a/openbank-interest-service/src/main/resources/db/migration/V14__catalog_interest_rate_snapshots.sql
+++ b/openbank-interest-service/src/main/resources/db/migration/V14__catalog_interest_rate_snapshots.sql
@@ -1,0 +1,64 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+--
+-- Published catalog revisions are external reference data for a money-path service.  Keep the
+-- consumed immutable content hash and the event acknowledgement local, so an accrual can resolve
+-- a durable effective-dated rate without calling the catalog at calculation time.  The change is
+-- purely additive: older binaries neither read nor write these tables and continue using their
+-- existing operator-managed rate configurations during a rolling rollback.
+
+-- V1 stored an annual rate at scale six. Catalog v2 declares exact values through scale eighteen;
+-- widening is backward-compatible and preserves every existing value exactly.
+ALTER TABLE interest_rate_configs
+    ALTER COLUMN annual_rate TYPE NUMERIC(20,18);
+
+CREATE TABLE catalog_interest_sync_state (
+    consumer    VARCHAR(64) PRIMARY KEY,
+    cursor      TEXT,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE catalog_interest_event_receipts (
+    event_id      UUID PRIMARY KEY,
+    event_type    VARCHAR(128) NOT NULL,
+    outcome       VARCHAR(32) NOT NULL CHECK (outcome IN ('APPLIED', 'SKIPPED', 'REJECTED')),
+    reason        VARCHAR(512),
+    processed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE catalog_interest_rate_snapshots (
+    revision_id       UUID PRIMARY KEY,
+    offering_id       UUID NOT NULL,
+    specification_id  UUID NOT NULL,
+    config_id         UUID REFERENCES interest_rate_configs(id),
+    schema_id         VARCHAR(128) NOT NULL,
+    schema_version    INTEGER NOT NULL,
+    content_hash      CHAR(64) NOT NULL,
+    currency          CHAR(3),
+    annual_rate       NUMERIC(20,18),
+    day_count         VARCHAR(16),
+    effective_from    DATE,
+    effective_to      DATE,
+    outcome           VARCHAR(32) NOT NULL CHECK (outcome IN ('APPLIED', 'REJECTED')),
+    reason            VARCHAR(512),
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (
+        (outcome = 'APPLIED' AND config_id IS NOT NULL AND currency IS NOT NULL AND annual_rate IS NOT NULL
+            AND day_count IS NOT NULL AND effective_from IS NOT NULL)
+        OR
+        (outcome = 'REJECTED' AND config_id IS NULL)
+    ),
+    CHECK (effective_to IS NULL OR effective_to >= effective_from)
+);
+
+CREATE INDEX idx_catalog_interest_snapshots_specification
+    ON catalog_interest_rate_snapshots(specification_id, currency, effective_from DESC);
+
+-- Rollback:
+--   ALTER TABLE interest_rate_configs ALTER COLUMN annual_rate TYPE NUMERIC(10,6);
+--   DROP TABLE catalog_interest_rate_snapshots;
+--   DROP TABLE catalog_interest_event_receipts;
+--   DROP TABLE catalog_interest_sync_state;
+-- The annual-rate narrowing is safe only if no scale > 6 value has been imported. The additive
+-- tables themselves do not affect pre-V14 readers/writers, which remain readable/writable during
+-- an expand rollout. Retain the data in production rather than executing this rollback.

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/contract/ProductCatalogInterestSnapshotPactConsumerTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/contract/ProductCatalogInterestSnapshotPactConsumerTest.kt
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.interest.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.openbank.interest.infrastructure.client.CatalogEventPageClientResponse
+import com.openbank.interest.infrastructure.client.CatalogOfferingClientResponse
+import com.openbank.interest.infrastructure.client.CatalogRevisionClientResponse
+import com.openbank.interest.infrastructure.client.ProductCatalogClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import jakarta.ws.rs.Path as JaxrsPath
+
+/**
+ * Contract for the immutable catalog chain that feeds the interest-rate snapshotter.
+ *
+ * Literal paths are intentionally different from the reflected production-client request paths:
+ * provider replay catches server drift and the local assertion catches a client annotation drift.
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-product-catalog", pactVersion = PactSpecVersion.V3)
+class ProductCatalogInterestSnapshotPactConsumerTest {
+    private val mapper = ObjectMapper().findAndRegisterModules().registerKotlinModule()
+
+    @Pact(consumer = "openbank-interest-service", provider = "openbank-product-catalog")
+    fun publishedEventPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given(STATE)
+        .uponReceiving("GET one published catalog revision event for interest synchronization")
+        .path(EVENTS_PATH)
+        .query("limit=1")
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith().status(200).headers(mapOf("Content-Type" to "application/json"))
+        .body(EVENT_PAGE)
+        .toPact()
+
+    @Pact(consumer = "openbank-interest-service", provider = "openbank-product-catalog")
+    fun immutableRevisionPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given(STATE)
+        .uponReceiving("GET the immutable published fixed-rate catalog revision")
+        .path("/api/v2/revisions/$REVISION_ID")
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith().status(200).headers(mapOf("Content-Type" to "application/json"))
+        .body(REVISION)
+        .toPact()
+
+    @Pact(consumer = "openbank-interest-service", provider = "openbank-product-catalog")
+    fun offeringPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given(STATE)
+        .uponReceiving("GET the offering owning the published fixed-rate revision")
+        .path("/api/v2/offerings/$OFFERING_ID")
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith().status(200).headers(mapOf("Content-Type" to "application/json"))
+        .body(OFFERING)
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "publishedEventPact")
+    fun `events response deserializes through the production client DTO`(server: MockServer) {
+        assertPaths()
+        val page = get(server, eventsPath()).let { mapper.readValue(it, CatalogEventPageClientResponse::class.java) }
+        assertThat(page.items.single().aggregateId.toString()).isEqualTo(REVISION_ID)
+        assertThat(page.nextCursor).isNotBlank()
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "immutableRevisionPact")
+    fun `immutable revision retains exact decimal text`(server: MockServer) {
+        assertPaths()
+        val revision = get(server, revisionPath()).let {
+            mapper.readValue(it, CatalogRevisionClientResponse::class.java)
+        }
+        assertThat(revision.state).isEqualTo("PUBLISHED")
+        assertThat(revision.content.attributes.at("/interest/annualRate").asText())
+            .isEqualTo("0.012345678901234567")
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "offeringPact")
+    fun `offering response exposes canonical specification identity`(server: MockServer) {
+        assertPaths()
+        val offering = get(server, offeringPath()).let {
+            mapper.readValue(it, CatalogOfferingClientResponse::class.java)
+        }
+        assertThat(offering.specificationId.toString()).isEqualTo(SPECIFICATION_ID)
+    }
+
+    private fun get(server: MockServer, path: String): String = HttpClient.newHttpClient().send(
+        HttpRequest.newBuilder(URI.create(server.getUrl() + path))
+            .header("Accept", "application/json")
+            .GET()
+            .build(),
+        HttpResponse.BodyHandlers.ofString(),
+    ).body()
+
+    private fun assertPaths() {
+        assertThat(eventsPath()).isEqualTo(EVENTS_PATH + "?limit=1")
+        assertThat(revisionPath()).isEqualTo("/api/v2/revisions/$REVISION_ID")
+        assertThat(offeringPath()).isEqualTo("/api/v2/offerings/$OFFERING_ID")
+    }
+
+    private companion object {
+        const val STATE = "a published fixed-rate deposit revision exists for interest synchronization"
+        const val SPECIFICATION_ID = "10000000-0000-0000-0000-000000000010"
+        const val OFFERING_ID = "20000000-0000-0000-0000-000000000010"
+        const val REVISION_ID = "30000000-0000-0000-0000-000000000010"
+        const val EVENT_ID = "40000000-0000-0000-0000-000000000010"
+        const val EVENTS_PATH = "/api/v2/events"
+        const val EVENT_PAGE =
+            """{"items":[{"id":"$EVENT_ID","aggregateType":"catalog.revision","aggregateId":"$REVISION_ID","eventType":"com.openbank.catalog.revision_published","schemaVersion":1,"occurredAt":"2027-01-01T00:00:00Z","headers":{},"payload":{}}],"nextCursor":"MQ"}"""
+        const val REVISION =
+            """{"id":"$REVISION_ID","offeringId":"$OFFERING_ID","number":1,"schemaRef":{"id":"org.openbank.banking.deposit","version":2},"state":"PUBLISHED","content":{"name":{"en":"Interest pact deposit"},"attributes":{"currency":"EUR","productType":"SAVINGS","interest":{"rateType":"FIXED","dayCount":"ACT_365","payoutFrequency":"MONTHLY","annualRate":"0.012345678901234567"}},"prices":[],"eligibility":[],"relationships":[],"documentCodes":[]},"effectiveFrom":"2027-01-01T00:00:00Z","effectiveTo":null,"makerId":"pact-interest-author","checkerId":"pact-interest-checker","reason":"published fixed-rate fixture","contentHash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","createdAt":"2027-01-01T00:00:00Z","updatedAt":"2027-01-01T00:00:00Z","revision":0}"""
+        const val OFFERING =
+            """{"id":"$OFFERING_ID","specificationId":"$SPECIFICATION_ID","code":"PACT_INTEREST_OFFERING","market":{"brands":[],"countries":[],"channels":[],"segments":[],"locales":[]},"revision":0}"""
+
+        private fun eventsPath(): String {
+            val method = ProductCatalogClient::class.java.getMethod("events", String::class.java, Int::class.java)
+            return ProductCatalogClient::class.java.getAnnotation(JaxrsPath::class.java).value +
+                method.getAnnotation(JaxrsPath::class.java).value + "?limit=1"
+        }
+
+        private fun revisionPath(): String {
+            val method = ProductCatalogClient::class.java.getMethod(
+                "revision",
+                java.util.UUID::class.java,
+            )
+            return (
+                ProductCatalogClient::class.java.getAnnotation(JaxrsPath::class.java).value +
+                    method.getAnnotation(JaxrsPath::class.java).value
+                ).replace("{id}", REVISION_ID)
+        }
+
+        private fun offeringPath(): String {
+            val method = ProductCatalogClient::class.java.getMethod(
+                "offering",
+                java.util.UUID::class.java,
+            )
+            return (
+                ProductCatalogClient::class.java.getAnnotation(JaxrsPath::class.java).value +
+                    method.getAnnotation(JaxrsPath::class.java).value
+                ).replace("{id}", OFFERING_ID)
+        }
+    }
+}

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/catalog/CatalogInterestProfileParserTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/catalog/CatalogInterestProfileParserTest.kt
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.interest.infrastructure.catalog
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.interest.domain.model.DayCount
+import com.openbank.interest.infrastructure.client.CatalogOfferingClientResponse
+import com.openbank.interest.infrastructure.client.CatalogRevisionClientResponse
+import com.openbank.interest.infrastructure.client.CatalogRevisionContentClientResponse
+import com.openbank.interest.infrastructure.client.CatalogSchemaRefClientResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class CatalogInterestProfileParserTest {
+    private val revisionId = UUID.fromString("11000000-0000-0000-0000-000000000001")
+    private val offeringId = UUID.fromString("11000000-0000-0000-0000-000000000002")
+    private val specificationId = UUID.fromString("11000000-0000-0000-0000-000000000003")
+
+    @Test
+    fun `maps a fixed midnight-aligned deposit revision without binary conversion`() {
+        val profile = CatalogInterestProfileParser.parse(
+            revision(
+                """{"currency":"CZK","interest":{"rateType":"FIXED","annualRate":"0.123456789012345678","dayCount":"ACT_365"}}""",
+            ),
+            offering(),
+        )
+
+        assertThat(profile.specificationId).isEqualTo(specificationId)
+        assertThat(profile.currency).isEqualTo("CZK")
+        assertThat(profile.annualRate).isEqualByComparingTo(BigDecimal("0.123456789012345678"))
+        assertThat(profile.dayCount).isEqualTo(DayCount.ACT_365)
+        assertThat(profile.effectiveFrom).hasToString("2026-08-20")
+        assertThat(profile.effectiveTo).hasToString("2026-08-31")
+    }
+
+    @Test
+    fun `rejects tiered interest rather than inventing its calculation semantics`() {
+        assertThatThrownBy {
+            CatalogInterestProfileParser.parse(
+                revision(
+                    """{"currency":"CZK","interest":{"rateType":"TIERED","tiers":[{"fromBalance":"0","annualRate":"0.01"}],"dayCount":"ACT_365"}}""",
+                ),
+                offering(),
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("only FIXED is executable")
+    }
+
+    @Test
+    fun `rejects a partial-day catalog interval before it can affect a daily accrual`() {
+        assertThatThrownBy {
+            CatalogInterestProfileParser.parse(
+                revision(
+                    """{"currency":"CZK","interest":{"rateType":"FIXED","annualRate":"0.01","dayCount":"ACT_365"}}""",
+                    effectiveFrom = OffsetDateTime.parse("2026-08-20T12:00:00Z"),
+                ),
+                offering(),
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("midnight UTC")
+    }
+
+    private fun offering() = CatalogOfferingClientResponse(offeringId, specificationId)
+
+    private fun revision(
+        attributes: String,
+        effectiveFrom: OffsetDateTime = OffsetDateTime.parse("2026-08-20T00:00:00Z"),
+    ) = CatalogRevisionClientResponse(
+        id = revisionId,
+        offeringId = offeringId,
+        schemaRef = CatalogSchemaRefClientResponse("org.openbank.banking.deposit", 2),
+        state = "PUBLISHED",
+        content = CatalogRevisionContentClientResponse(jacksonObjectMapper().readTree(attributes)),
+        effectiveFrom = effectiveFrom,
+        effectiveTo = OffsetDateTime.parse("2026-09-01T00:00:00Z"),
+        contentHash = "a".repeat(64),
+    )
+}

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/catalog/CatalogInterestSyncRepositoryIT.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/catalog/CatalogInterestSyncRepositoryIT.kt
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.interest.infrastructure.catalog
+
+import com.openbank.interest.domain.model.DayCount
+import com.openbank.interest.infrastructure.client.CatalogEventClientResponse
+import com.openbank.interest.infrastructure.persistence.entity.CatalogInterestEventReceiptEntity
+import com.openbank.interest.infrastructure.persistence.entity.CatalogInterestRateSnapshotEntity
+import com.openbank.interest.infrastructure.persistence.entity.CatalogInterestSyncStateEntity
+import com.openbank.interest.infrastructure.persistence.entity.InterestRateConfigEntity
+import com.openbank.interest.it.PostgresRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.Uni
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.hibernate.reactive.mutiny.Mutiny
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/** Proves the local acknowledgement boundary with the real PostgreSQL schema. */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedisTestResource::class)
+internal class CatalogInterestSyncRepositoryIT {
+    @Inject
+    lateinit var repository: CatalogInterestSyncRepository
+
+    @Inject
+    lateinit var sessions: Mutiny.SessionFactory
+
+    @Test
+    fun `published fixed rate is exact, durable and idempotent`() {
+        val eventId = UUID.randomUUID()
+        val revisionId = UUID.randomUUID()
+        val profile = CatalogInterestProfile(
+            revisionId = revisionId,
+            offeringId = UUID.randomUUID(),
+            specificationId = UUID.randomUUID(),
+            schemaId = "org.openbank.banking.deposit",
+            schemaVersion = 2,
+            contentHash = "a".repeat(64),
+            currency = "EUR",
+            annualRate = BigDecimal("0.012345678901234567"),
+            dayCount = DayCount.ACT_365,
+            effectiveFrom = LocalDate.of(2027, 1, 1),
+            effectiveTo = null,
+        )
+        val resolution = CatalogInterestEventResolution.applied(event(eventId, revisionId), profile)
+
+        assertThat(onEventLoop { repository.record(resolution, "cursor-1") })
+            .isEqualTo(CatalogInterestSyncOutcome.APPLIED)
+        assertThat(onEventLoop { repository.record(resolution, "cursor-2") })
+            .isEqualTo(CatalogInterestSyncOutcome.APPLIED)
+
+        val persisted = onEventLoop {
+            sessions.withSession { session ->
+                // Hibernate Reactive sessions do not permit concurrent queries. The production write
+                // transaction is sequential too; this readback deliberately follows that contract.
+                session.find(CatalogInterestRateSnapshotEntity::class.java, revisionId).flatMap { snapshot ->
+                    session.find(CatalogInterestEventReceiptEntity::class.java, eventId).flatMap { receipt ->
+                        session.find(
+                            CatalogInterestSyncStateEntity::class.java,
+                            "interest-rate-snapshots",
+                        ).flatMap { cursor ->
+                            session.find(InterestRateConfigEntity::class.java, snapshot.configId).map { config ->
+                                PersistedState(snapshot, receipt, cursor, config)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        assertThat(persisted.snapshot.outcome).isEqualTo("APPLIED")
+        assertThat(persisted.snapshot.annualRate).isEqualByComparingTo("0.012345678901234567")
+        assertThat(persisted.config.productId).isEqualTo(profile.specificationId.toString())
+        assertThat(persisted.config.annualRate).isEqualByComparingTo("0.012345678901234567")
+        assertThat(persisted.receipt.outcome).isEqualTo("APPLIED")
+        assertThat(persisted.cursor.cursor).isEqualTo("cursor-2")
+        assertThat(countSnapshots(revisionId)).isEqualTo(1)
+        assertThat(countConfigs(profile.specificationId)).isEqualTo(1)
+    }
+
+    private fun event(eventId: UUID, revisionId: UUID) = CatalogEventClientResponse(
+        id = eventId,
+        aggregateType = "catalog.revision",
+        eventType = "com.openbank.catalog.revision_published",
+        aggregateId = revisionId,
+        occurredAt = OffsetDateTime.now(ZoneOffset.UTC),
+    )
+
+    private fun countSnapshots(revisionId: UUID): Long = onEventLoop {
+        sessions.withSession { session ->
+            session.createQuery(
+                "SELECT COUNT(s) FROM CatalogInterestRateSnapshotEntity s WHERE s.revisionId = :revision",
+                Long::class.javaObjectType,
+            ).setParameter("revision", revisionId).singleResult.map { it.toLong() }
+        }
+    }
+
+    private fun countConfigs(specificationId: UUID): Long = onEventLoop {
+        sessions.withSession { session ->
+            session.createQuery(
+                "SELECT COUNT(c) FROM InterestRateConfigEntity c WHERE c.productId = :product",
+                Long::class.javaObjectType,
+            ).setParameter("product", specificationId.toString()).singleResult.map { it.toLong() }
+        }
+    }
+
+    private fun <T> onEventLoop(work: () -> Uni<T>): T = VertxContextSupport.subscribeAndAwait(work)
+
+    private data class PersistedState(
+        val snapshot: CatalogInterestRateSnapshotEntity,
+        val receipt: CatalogInterestEventReceiptEntity,
+        val cursor: CatalogInterestSyncStateEntity,
+        val config: InterestRateConfigEntity,
+    )
+}

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/CatalogLoanProfilePort.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/CatalogLoanProfilePort.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.lending.application.port.out
+
+import com.openbank.lending.domain.model.CatalogLoanSnapshot
+import com.openbank.libs.lending.AmortizationMethod
+import io.smallrye.mutiny.Uni
+import java.math.BigDecimal
+import java.util.UUID
+
+/** Published product terms accepted by lending at origination. */
+data class CatalogLoanProfile(
+    val snapshot: CatalogLoanSnapshot,
+    val currency: String,
+    val tenorMonths: Int,
+    val method: AmortizationMethod,
+    val nominalAnnualRate: BigDecimal,
+    val minPrincipal: BigDecimal?,
+    val maxPrincipal: BigDecimal?,
+)
+
+/**
+ * Reads a published immutable loan offering from product-catalog. A catalog-selected loan fails
+ * closed if its exact revision cannot be resolved or does not satisfy the lending profile.
+ */
+interface CatalogLoanProfilePort {
+    fun resolvePublished(offeringId: UUID): Uni<CatalogLoanProfile>
+}

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
@@ -13,6 +13,8 @@ import com.openbank.lending.application.port.`in`.RescheduleLoanUseCase
 import com.openbank.lending.application.port.`in`.RunProvisioningCycleUseCase
 import com.openbank.lending.application.port.`in`.ServicingUseCase
 import com.openbank.lending.application.port.`in`.WriteOffLoanUseCase
+import com.openbank.lending.application.port.out.CatalogLoanProfile
+import com.openbank.lending.application.port.out.CatalogLoanProfilePort
 import com.openbank.lending.application.port.out.CollateralRepository
 import com.openbank.lending.application.port.out.CollateralValuationPort
 import com.openbank.lending.application.port.out.InstallmentRepository
@@ -62,6 +64,7 @@ import com.openbank.libs.lending.origination.OriginationTransitionResult
 import io.smallrye.mutiny.Multi
 import io.smallrye.mutiny.Uni
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
 import java.math.BigDecimal
 import java.time.Clock
 import java.time.LocalDate
@@ -83,7 +86,7 @@ import java.util.UUID
 // three-line economic change in a file move. The same call CustomerEdgeResource made. Splitting the
 // servicing/provisioning loops out is a real follow-up, not a drive-by.
 @Suppress("LongParameterList", "TooManyFunctions", "LargeClass")
-class LendingService(
+class LendingService @Inject constructor(
     private val applications: LoanApplicationRepository,
     private val loans: LoanRepository,
     private val installments: InstallmentRepository,
@@ -100,6 +103,7 @@ class LendingService(
     private val decisionEngine: OriginationDecisionService,
     private val borrowerAccounts: com.openbank.lending.application.port.out.BorrowerAccountLookupPort,
     private val borrowerCredit: com.openbank.lending.application.port.out.BorrowerCreditPort,
+    private val catalogLoanProfiles: CatalogLoanProfilePort = UnusedCatalogLoanProfilePort,
 ) : ApplyForLoanUseCase,
     DisburseLoanUseCase,
     ServicingUseCase,
@@ -238,7 +242,38 @@ class LendingService(
 
     // --- Origination --------------------------------------------------------------------------------
 
-    override fun apply(request: LoanApplicationRequest, proposedBy: String): Uni<LoanApplication> {
+    override fun apply(request: LoanApplicationRequest, proposedBy: String): Uni<LoanApplication> =
+        request.catalogOfferingId?.let { offeringId ->
+            catalogLoanProfiles.resolvePublished(offeringId).flatMap { profile ->
+                applyCatalogProfile(request, proposedBy, profile)
+            }
+        } ?: applyLegacy(request, proposedBy, null)
+
+    private fun applyCatalogProfile(
+        request: LoanApplicationRequest,
+        proposedBy: String,
+        profile: CatalogLoanProfile,
+    ): Uni<LoanApplication> {
+        require(request.requestedAmount.currency.code == profile.currency) {
+            "Requested currency does not match catalog"
+        }
+        require(request.termPeriods == profile.tenorMonths) { "Requested term does not match catalog" }
+        require(request.periodsPerYear == MONTHS_PER_YEAR) { "Catalog loans require monthly periods" }
+        require(request.method == profile.method) { "Requested amortization method does not match catalog" }
+        require(profile.minPrincipal == null || request.requestedAmount.amount >= profile.minPrincipal) {
+            "Requested amount is below the catalog minimum"
+        }
+        require(profile.maxPrincipal == null || request.requestedAmount.amount <= profile.maxPrincipal) {
+            "Requested amount exceeds the catalog maximum"
+        }
+        return applyLegacy(request.copy(nominalAnnualRate = profile.nominalAnnualRate), proposedBy, profile.snapshot)
+    }
+
+    private fun applyLegacy(
+        request: LoanApplicationRequest,
+        proposedBy: String,
+        catalogSnapshot: com.openbank.lending.domain.model.CatalogLoanSnapshot?,
+    ): Uni<LoanApplication> {
         complianceGuard.checkOriginationAllowed(request.jurisdiction, request.productType)
         require(request.requestedAmount.isPositive()) { "Requested amount must be positive" }
         require(request.termPeriods > 0) { "Term must be at least one period" }
@@ -266,6 +301,7 @@ class LendingService(
             ageYears = request.ageYears,
             residency = request.residency,
             employmentTenureMonths = request.employmentTenureMonths,
+            catalogSnapshot = catalogSnapshot,
         )
         return applications.save(application).call { saved ->
             val state = if (originationConfig.autoApprove) straightThrough(saved).status else saved.status
@@ -284,6 +320,11 @@ class LendingService(
                 ),
             )
         }
+    }
+
+    private data object UnusedCatalogLoanProfilePort : CatalogLoanProfilePort {
+        override fun resolvePublished(offeringId: UUID): Uni<CatalogLoanProfile> =
+            Uni.createFrom().failure(IllegalStateException("catalog loan profiles are not configured"))
     }
 
     /**
@@ -1304,5 +1345,6 @@ class LendingService(
 
     private companion object {
         const val MAX_LIST_LIMIT = 100
+        const val MONTHS_PER_YEAR = 12
     }
 }

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/LendingModels.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/LendingModels.kt
@@ -19,6 +19,14 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
+/** Immutable catalog evidence used to price and constrain an originated loan. */
+data class CatalogLoanSnapshot(
+    val offeringId: UUID,
+    val revisionId: UUID,
+    val contentHash: String,
+    val schemaVersion: Int,
+)
+
 /** Servicing and termination lifecycle of a booked loan (ADR-0028, ADR-0215 D1). */
 enum class LoanStatus {
     ACTIVE,
@@ -133,6 +141,7 @@ data class LoanApplication(
     val policyVersions: String? = null,
     val decisionInputHash: String? = null,
     val decidedEngineAt: OffsetDateTime? = null,
+    val catalogSnapshot: CatalogLoanSnapshot? = null,
 )
 
 /** A live loan booked from an approved, disbursed application. */
@@ -225,6 +234,7 @@ data class LoanApplicationRequest(
     val ageYears: Int? = null,
     val residency: String? = null,
     val employmentTenureMonths: Int? = null,
+    val catalogOfferingId: UUID? = null,
 )
 
 /**

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/ProductCatalogLoanProfileAdapter.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/ProductCatalogLoanProfileAdapter.kt
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.lending.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.databind.JsonNode
+import com.openbank.lending.application.port.out.CatalogLoanProfile
+import com.openbank.lending.application.port.out.CatalogLoanProfilePort
+import com.openbank.lending.domain.model.CatalogLoanSnapshot
+import com.openbank.libs.lending.AmortizationMethod
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import java.math.BigDecimal
+import java.util.UUID
+
+@RegisterRestClient(configKey = "product-catalog")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/api/v2")
+interface ProductCatalogLoanClient {
+    @GET
+    @Path("/products/{offeringId}")
+    fun published(@PathParam("offeringId") offeringId: UUID): Uni<CatalogLoanRevisionResponse>
+}
+
+@ApplicationScoped
+class RestCatalogLoanProfilePort(@RestClient private val catalog: ProductCatalogLoanClient) : CatalogLoanProfilePort {
+    override fun resolvePublished(offeringId: UUID): Uni<CatalogLoanProfile> =
+        catalog.published(offeringId).map { revision -> revision.toProfile(offeringId) }
+}
+
+internal fun CatalogLoanRevisionResponse.toProfile(expectedOfferingId: UUID): CatalogLoanProfile {
+    require(offeringId == expectedOfferingId) { "catalog returned a revision for a different offering" }
+    require(state == "PUBLISHED") { "catalog offering is not published" }
+    require(schemaRef.id == LOAN_SCHEMA_ID) { "catalog offering is not a loan product" }
+    val hash = requireNotNull(contentHash) { "published catalog revision has no content hash" }
+    require(HASH.matches(hash)) { "catalog revision has an invalid content hash" }
+    val attributes = content.attributes
+    val currency = attributes.requiredText("currency")
+    require(CURRENCY.matches(currency)) { "catalog currency is not ISO-4217" }
+    val tenor = attributes.requiredInt("tenorMonths")
+    require(tenor in MIN_TENOR_MONTHS..MAX_TENOR_MONTHS) { "catalog tenor is outside the supported range" }
+    val method = runCatching { AmortizationMethod.valueOf(attributes.requiredText("amortizationMethod")) }
+        .getOrElse { throw IllegalArgumentException("catalog amortization method is unsupported") }
+    val rate = attributes.requiredDecimal("nominalAnnualRate")
+    require(rate.signum() >= 0) { "catalog nominal rate cannot be negative" }
+    val minimum = attributes.optionalDecimal("minPrincipalAmount")
+    val maximum = attributes.optionalDecimal("maxPrincipalAmount")
+    require(minimum == null || maximum == null || minimum <= maximum) { "catalog principal range is inverted" }
+    return CatalogLoanProfile(
+        snapshot = CatalogLoanSnapshot(expectedOfferingId, id, hash, schemaRef.version),
+        currency = currency,
+        tenorMonths = tenor,
+        method = method,
+        nominalAnnualRate = rate,
+        minPrincipal = minimum,
+        maxPrincipal = maximum,
+    )
+}
+
+private fun JsonNode.requiredText(field: String): String =
+    path(field).takeIf { it.isTextual && it.asText().isNotBlank() }?.asText()
+        ?: throw IllegalArgumentException("catalog attribute '$field' is required")
+
+private fun JsonNode.requiredInt(field: String): Int = requireNotNull(
+    path(field).takeIf { it.isInt }?.intValue(),
+) { "catalog attribute '$field' must be an integer" }
+
+private fun JsonNode.optionalDecimal(field: String): BigDecimal? =
+    path(field).takeIf { it.isTextual }?.asText()?.let { value ->
+        require(DECIMAL.matches(value)) { "catalog attribute '$field' is not a canonical decimal" }
+        value.toBigDecimal()
+    }
+
+private fun JsonNode.requiredDecimal(field: String): BigDecimal =
+    requireNotNull(optionalDecimal(field)) { "catalog attribute '$field' is required" }
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CatalogLoanRevisionResponse(
+    val id: UUID,
+    val offeringId: UUID,
+    val schemaRef: CatalogLoanSchemaRefResponse,
+    val state: String,
+    val content: CatalogLoanRevisionContentResponse,
+    val contentHash: String?,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CatalogLoanSchemaRefResponse(val id: String, val version: Int)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CatalogLoanRevisionContentResponse(val attributes: JsonNode)
+
+private const val LOAN_SCHEMA_ID = "org.openbank.banking.loan"
+private const val MIN_TENOR_MONTHS = 1
+private const val MAX_TENOR_MONTHS = 480
+private val CURRENCY = Regex("^[A-Z]{3}$")
+private val DECIMAL = Regex("^(0|[1-9][0-9]*)(\\.[0-9]+)?$")
+private val HASH = Regex("^[0-9a-f]{64}$")

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/entity/LendingEntities.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/entity/LendingEntities.kt
@@ -113,6 +113,18 @@ class LoanApplicationEntity : PanacheEntityBase() {
     @Column(name = "decided_engine_at")
     var decidedEngineAt: OffsetDateTime? = null
 
+    @Column(name = "catalog_offering_id", columnDefinition = "uuid")
+    var catalogOfferingId: UUID? = null
+
+    @Column(name = "catalog_revision_id", columnDefinition = "uuid")
+    var catalogRevisionId: UUID? = null
+
+    @Column(name = "catalog_content_hash", length = 64)
+    var catalogContentHash: String? = null
+
+    @Column(name = "catalog_schema_version")
+    var catalogSchemaVersion: Int? = null
+
     @Column(name = "proposed_by")
     var proposedBy: String = ""
 

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/mapper/LendingMapper.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/mapper/LendingMapper.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.lending.infrastructure.persistence.mapper
 
+import com.openbank.lending.domain.model.CatalogLoanSnapshot
 import com.openbank.lending.domain.model.Collateral
 import com.openbank.lending.domain.model.Loan
 import com.openbank.lending.domain.model.LoanApplication
@@ -54,6 +55,10 @@ class LendingMapper {
         it.policyVersions = a.policyVersions
         it.decisionInputHash = a.decisionInputHash
         it.decidedEngineAt = a.decidedEngineAt
+        it.catalogOfferingId = a.catalogSnapshot?.offeringId
+        it.catalogRevisionId = a.catalogSnapshot?.revisionId
+        it.catalogContentHash = a.catalogSnapshot?.contentHash
+        it.catalogSchemaVersion = a.catalogSnapshot?.schemaVersion
     }
 
     fun toDomain(e: LoanApplicationEntity) = LoanApplication(
@@ -71,6 +76,7 @@ class LendingMapper {
         decisionReasons = e.decisionReasons, decisionMatchedRules = e.decisionMatchedRules,
         policyVersions = e.policyVersions, decisionInputHash = e.decisionInputHash,
         decidedEngineAt = e.decidedEngineAt,
+        catalogSnapshot = e.toCatalogSnapshot(),
     )
 
     fun toEntity(l: Loan) = LoanEntity().also {
@@ -185,4 +191,12 @@ class LendingMapper {
         expectedCreditLoss = Money.of(e.expectedCreditLoss, e.currency),
         createdAt = e.createdAt,
     )
+}
+
+private fun LoanApplicationEntity.toCatalogSnapshot(): CatalogLoanSnapshot? {
+    val offeringId = catalogOfferingId ?: return null
+    val revisionId = catalogRevisionId ?: return null
+    val contentHash = catalogContentHash ?: return null
+    val schemaVersion = catalogSchemaVersion ?: return null
+    return CatalogLoanSnapshot(offeringId, revisionId, contentHash, schemaVersion)
 }

--- a/openbank-lending-service/src/main/resources/application.yaml
+++ b/openbank-lending-service/src/main/resources/application.yaml
@@ -72,6 +72,10 @@ quarkus:
       url: ${ACCOUNT_SERVICE_URL:http://account-service.accounts.svc:8100}
       connect-timeout: 2000
       read-timeout: 3000
+    product-catalog:
+      url: ${PRODUCT_CATALOG_URL:http://localhost:8104}
+      connect-timeout: 2000
+      read-timeout: 3000
   redis:
     hosts: redis://localhost:6379
   shutdown:

--- a/openbank-lending-service/src/main/resources/db/migration/V12__catalog_loan_snapshot.sql
+++ b/openbank-lending-service/src/main/resources/db/migration/V12__catalog_loan_snapshot.sql
@@ -1,0 +1,13 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Catalog loan terms are evidence for an application: a later product change must not reprice it.
+-- Rollback: earlier binaries ignore these nullable additive columns.
+
+ALTER TABLE loan_application
+    ADD COLUMN catalog_offering_id UUID,
+    ADD COLUMN catalog_revision_id UUID,
+    ADD COLUMN catalog_content_hash VARCHAR(64),
+    ADD COLUMN catalog_schema_version INTEGER;
+
+CREATE INDEX idx_loan_application_catalog_revision
+    ON loan_application(catalog_revision_id)
+    WHERE catalog_revision_id IS NOT NULL;

--- a/openbank-lending-service/src/main/resources/openapi.yaml
+++ b/openbank-lending-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Lending Service API
-  version: 1.12.0
+  version: 1.13.0
   description: >-
     Loan origination, servicing, collateral and IFRS 9 provisioning (ADR-0028). The loan book posts
     cash events to ledger-service and never owns balances. Credit decisions and collateral
@@ -802,6 +802,13 @@ components:
         ageYears: { type: integer, nullable: true, description: Applicant age in years (majority floor) }
         residency: { type: string, nullable: true, description: Residency country code (e.g. CZ) }
         employmentTenureMonths: { type: integer, nullable: true }
+        catalogOfferingId:
+          type: string
+          format: uuid
+          nullable: true
+          description: >-
+            Optional published catalog offering. When supplied, its immutable revision sets the
+            rate, currency, tenor and amortization constraints and is retained with the application.
     DecisionRequest:
       type: object
       required: [approve]

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
@@ -6,6 +6,8 @@ package com.openbank.lending.application.usecase
 
 import com.openbank.lending.application.port.out.BorrowerAccountLookupPort
 import com.openbank.lending.application.port.out.BorrowerCreditPort
+import com.openbank.lending.application.port.out.CatalogLoanProfile
+import com.openbank.lending.application.port.out.CatalogLoanProfilePort
 import com.openbank.lending.application.port.out.CollateralRepository
 import com.openbank.lending.application.port.out.CollateralValuationPort
 import com.openbank.lending.application.port.out.InstallmentRepository
@@ -19,6 +21,7 @@ import com.openbank.lending.application.port.out.PostingKind
 import com.openbank.lending.application.port.out.ProvisioningRepository
 import com.openbank.lending.application.port.out.RiskParameterSource
 import com.openbank.lending.application.port.out.StarterCreditPolicy
+import com.openbank.lending.domain.model.CatalogLoanSnapshot
 import com.openbank.lending.domain.model.Collateral
 import com.openbank.lending.domain.model.CollateralDecisionRequest
 import com.openbank.lending.domain.model.CollateralRequest
@@ -82,6 +85,7 @@ class LendingServiceTest {
     private val provisioning = mockk<ProvisioningRepository>()
     private val borrowerAccounts = mockk<BorrowerAccountLookupPort>()
     private val borrowerCredit = mockk<BorrowerCreditPort>()
+    private val catalogLoanProfiles = mockk<CatalogLoanProfilePort>()
 
     private val service = LendingService(
         applications,
@@ -105,6 +109,7 @@ class LendingServiceTest {
         ),
         borrowerAccounts,
         borrowerCredit,
+        catalogLoanProfiles,
     )
 
     private val partyId = UUID.fromString("11111111-1111-1111-1111-111111111111")
@@ -328,6 +333,28 @@ class LendingServiceTest {
         assertThat(result.proposedBy).isEqualTo("alice")
         assertThat(result.decidedBy).isNull()
         verify(exactly = 1) { applications.save(any()) }
+    }
+
+    @Test
+    fun `catalog offering overrides client price and persists immutable snapshot`() {
+        val slot: CapturingSlot<LoanApplication> = slot()
+        val offeringId = UUID.fromString("10000000-0000-0000-0000-000000000012")
+        val snapshot = CatalogLoanSnapshot(
+            offeringId,
+            UUID.fromString("20000000-0000-0000-0000-000000000012"),
+            "b".repeat(64),
+            2,
+        )
+        every { catalogLoanProfiles.resolvePublished(offeringId) } returns Uni.createFrom().item(
+            CatalogLoanProfile(snapshot, "EUR", 12, AmortizationMethod.ANNUITY, BigDecimal("0.0699"), null, null),
+        )
+        every { applications.save(capture(slot)) } answers { Uni.createFrom().item(slot.captured) }
+
+        val result = service.apply(sampleRequest().copy(catalogOfferingId = offeringId), "alice").await().indefinitely()
+
+        assertThat(result.nominalAnnualRate).isEqualByComparingTo("0.0699")
+        assertThat(result.catalogSnapshot).isEqualTo(snapshot)
+        verify(exactly = 1) { catalogLoanProfiles.resolvePublished(offeringId) }
     }
 
     @Test

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/contract/ProductCatalogLoanProfilePactConsumerTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/contract/ProductCatalogLoanProfilePactConsumerTest.kt
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.lending.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.openbank.lending.infrastructure.client.CatalogLoanRevisionResponse
+import com.openbank.lending.infrastructure.client.ProductCatalogLoanClient
+import com.openbank.lending.infrastructure.client.toProfile
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import jakarta.ws.rs.Path as JaxrsPath
+
+/** Provider-replayed contract for catalog-priced loan origination. */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-product-catalog", pactVersion = PactSpecVersion.V3)
+class ProductCatalogLoanProfilePactConsumerTest {
+    private val mapper = ObjectMapper().findAndRegisterModules().registerKotlinModule()
+
+    @Pact(consumer = "openbank-lending-service", provider = "openbank-product-catalog")
+    fun publishedLoanPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given(STATE)
+        .uponReceiving("GET the published priced loan offering for origination")
+        .path(LITERAL_PATH)
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith().status(200).headers(mapOf("Content-Type" to "application/json"))
+        .body(REVISION)
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "publishedLoanPact")
+    fun `published loan terms deserialize with an exact price`(server: MockServer) {
+        assertThat(productionPath()).isEqualTo(LITERAL_PATH)
+        val response = HttpClient.newHttpClient().send(
+            HttpRequest.newBuilder(URI.create(server.getUrl() + productionPath()))
+                .header("Accept", "application/json")
+                .GET()
+                .build(),
+            HttpResponse.BodyHandlers.ofString(),
+        )
+        val revision = mapper.readValue(response.body(), CatalogLoanRevisionResponse::class.java)
+
+        assertThat(revision.toProfile(java.util.UUID.fromString(OFFERING_ID)).nominalAnnualRate)
+            .isEqualByComparingTo("0.0699")
+    }
+
+    private companion object {
+        const val STATE = "a published priced loan revision exists for lending originations"
+        const val OFFERING_ID = "20000000-0000-0000-0000-000000000011"
+        const val LITERAL_PATH = "/api/v2/products/$OFFERING_ID"
+        const val REVISION =
+            """{"id":"30000000-0000-0000-0000-000000000011","offeringId":"$OFFERING_ID","number":1,"schemaRef":{"id":"org.openbank.banking.loan","version":2},"state":"PUBLISHED","content":{"name":{"en":"Lending pact loan"},"attributes":{"productType":"INSTALLMENT_LOAN","currency":"EUR","tenorMonths":12,"amortizationMethod":"ANNUITY","nominalAnnualRate":"0.0699","accrualBasis":"ACT_365","allocationOrder":["INTEREST","PRINCIPAL"],"minPrincipalAmount":"1000","maxPrincipalAmount":"50000"},"prices":[],"eligibility":[],"relationships":[],"documentCodes":[]},"effectiveFrom":"2026-01-01T00:00:00Z","effectiveTo":null,"makerId":"pact-loan-author","checkerId":"pact-loan-checker","reason":"published priced loan fixture","contentHash":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z","revision":0}"""
+
+        private fun productionPath(): String {
+            val method = ProductCatalogLoanClient::class.java.getMethod("published", java.util.UUID::class.java)
+            return (
+                ProductCatalogLoanClient::class.java.getAnnotation(JaxrsPath::class.java).value +
+                    method.getAnnotation(JaxrsPath::class.java).value
+                ).replace("{offeringId}", OFFERING_ID)
+        }
+    }
+}

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/client/CatalogLoanProfileAdapterTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/client/CatalogLoanProfileAdapterTest.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.lending.infrastructure.client
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.libs.lending.AmortizationMethod
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class CatalogLoanProfileAdapterTest {
+    private val offeringId = UUID.fromString("10000000-0000-0000-0000-000000000011")
+
+    @Test
+    fun `published loan revision yields exact catalog terms`() {
+        val profile = revision().toProfile(offeringId)
+
+        assertThat(profile.currency).isEqualTo("EUR")
+        assertThat(profile.nominalAnnualRate).isEqualByComparingTo("0.0699")
+        assertThat(profile.method).isEqualTo(AmortizationMethod.ANNUITY)
+        assertThat(profile.minPrincipal).isEqualByComparingTo("1000")
+        assertThat(profile.maxPrincipal).isEqualByComparingTo("50000")
+        assertThat(profile.snapshot.revisionId).isEqualTo(UUID.fromString("20000000-0000-0000-0000-000000000011"))
+    }
+
+    @Test
+    fun `client supplied numeric encoding is rejected before it reaches money math`() {
+        val malformed = revision(rate = "1e3")
+
+        assertThatThrownBy { malformed.toProfile(offeringId) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("canonical decimal")
+    }
+
+    private fun revision(rate: String = "0.0699"): CatalogLoanRevisionResponse {
+        val attributes = jacksonObjectMapper().readTree(
+            """{"currency":"EUR","tenorMonths":60,"amortizationMethod":"ANNUITY","nominalAnnualRate":"$rate","minPrincipalAmount":"1000","maxPrincipalAmount":"50000"}""",
+        )
+        return CatalogLoanRevisionResponse(
+            id = UUID.fromString("20000000-0000-0000-0000-000000000011"),
+            offeringId = offeringId,
+            schemaRef = CatalogLoanSchemaRefResponse("org.openbank.banking.loan", 2),
+            state = "PUBLISHED",
+            content = CatalogLoanRevisionContentResponse(attributes),
+            contentHash = "a".repeat(64),
+        )
+    }
+}

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/persistence/mapper/LendingMapperTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/persistence/mapper/LendingMapperTest.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.lending.infrastructure.persistence.mapper
 
+import com.openbank.lending.domain.model.CatalogLoanSnapshot
 import com.openbank.lending.domain.model.Collateral
 import com.openbank.lending.domain.model.CollateralStatus
 import com.openbank.lending.domain.model.CollateralType
@@ -57,6 +58,12 @@ class LendingMapperTest {
             decisionReason = "affordability",
             createdAt = createdAt,
             decidedAt = createdAt.plusDays(1),
+            catalogSnapshot = CatalogLoanSnapshot(
+                UUID.fromString("10000000-0000-0000-0000-000000000013"),
+                UUID.fromString("20000000-0000-0000-0000-000000000013"),
+                "c".repeat(64),
+                2,
+            ),
         )
 
         val entity = mapper.toEntity(application)

--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/catalog/CatalogPackSeeder.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/catalog/CatalogPackSeeder.kt
@@ -161,6 +161,7 @@ class CatalogPackSeeder(
                 "/catalog-packs/banking/legacy-product-v1.schema.json",
             ),
             PackSchema("banking", "org.openbank.banking.loan", 1, "/catalog-packs/banking/loan-v1.schema.json"),
+            PackSchema("banking", "org.openbank.banking.loan", 2, "/catalog-packs/banking/loan-v2.schema.json"),
             PackSchema(
                 "insurance",
                 "org.openbank.insurance.term-life",

--- a/openbank-product-catalog/src/main/resources/catalog-packs/banking/loan-v2.schema.json
+++ b/openbank-product-catalog/src/main/resources/catalog-packs/banking/loan-v2.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:catalog-schema:org.openbank.banking.loan:2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["productType", "currency", "tenorMonths", "amortizationMethod", "nominalAnnualRate", "accrualBasis", "allocationOrder"],
+  "properties": {
+    "productType": { "type": "string", "enum": ["INSTALLMENT_LOAN", "MORTGAGE", "AUTO_LOAN", "STUDENT_LOAN", "CREDIT_LINE"] },
+    "currency": { "type": "string", "pattern": "^[A-Z]{3}$" },
+    "tenorMonths": { "type": "integer", "minimum": 1, "maximum": 480 },
+    "amortizationMethod": { "type": "string", "enum": ["ANNUITY", "EQUAL_PRINCIPAL", "BULLET"] },
+    "nominalAnnualRate": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)(\\.[0-9]+)?$",
+      "description": "Canonical non-negative decimal annual rate. Lending snapshots this exact value at application time."
+    },
+    "accrualBasis": { "type": "string", "enum": ["ACT_360", "ACT_365", "ACT_ACT", "THIRTY_360"] },
+    "allocationOrder": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 4,
+      "uniqueItems": true,
+      "items": { "type": "string", "enum": ["FEES", "PENALTY", "INTEREST", "PRINCIPAL"] }
+    },
+    "minPrincipalAmount": { "type": "string", "pattern": "^(0|[1-9][0-9]*)(\\.[0-9]+)?$" },
+    "maxPrincipalAmount": { "type": "string", "pattern": "^[1-9][0-9]*(\\.[0-9]+)?$" },
+    "gracePeriodDays": { "type": "integer", "minimum": 0, "maximum": 365 },
+    "collateralRequired": { "type": "boolean" },
+    "earlyRepaymentPenaltyPct": { "type": "string", "pattern": "^(0|[1-9][0-9]*)(\\.[0-9]+)?$" },
+    "fees": {
+      "type": "array",
+      "maxItems": 16,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["code", "name", "amountKind", "waivable"],
+        "properties": {
+          "code": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]{1,63}$" },
+          "name": { "type": "string", "minLength": 1, "maxLength": 128 },
+          "amountKind": { "type": "string", "enum": ["FIXED", "PERCENT_OF_PRINCIPAL"] },
+          "waivable": { "type": "boolean" },
+          "waiveCondition": { "type": "string", "maxLength": 256 }
+        }
+      }
+    }
+  }
+}

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/contract/CatalogPactProviderFixtures.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/contract/CatalogPactProviderFixtures.kt
@@ -36,6 +36,89 @@ class CatalogPactProviderFixtures(private val dataSource: DataSource) {
         insertDraft(connection, PUBLISH_REVISION_ID, PUBLISH_OFFERING_ID, "pact-independent-author")
     }
 
+    /** Immutable fixed-rate banking revision consumed by interest-service's catalog adapter Pact. */
+    fun publishedFixedRateDepositRevisionExists() = dataSource.connection.use { connection ->
+        // The cursor endpoint is globally ordered. Isolate this state so `limit=1` proves the
+        // event the interest consumer will actually acknowledge, not a pack-install side event.
+        connection.createStatement().use { it.executeUpdate("DELETE FROM catalog_outbox") }
+        connection.createStatement().use {
+            it.execute("SELECT setval('catalog_outbox_cursor_position_seq', 1, false)")
+        }
+        insertSpecification(connection, INTEREST_SPECIFICATION_ID, "PACT_INTEREST_DEPOSIT")
+        insertOffering(connection, INTEREST_OFFERING_ID, INTEREST_SPECIFICATION_ID, "PACT_INTEREST_OFFERING")
+        connection.prepareStatement(
+            "INSERT INTO catalog_revisions " +
+                "(id, offering_id, revision_no, schema_id, schema_version, state, content, effective_from, " +
+                "maker_id, checker_id, reason, content_hash, created_at, updated_at, lock_version) " +
+                "VALUES (?, ?, 1, ?, 2, 'PUBLISHED', CAST(? AS jsonb), ?, ?, ?, ?, ?, ?, ?, 0) " +
+                "ON CONFLICT (id) DO NOTHING",
+        ).use { statement ->
+            val now = FIXTURE_TIME
+            statement.setObject(1, INTEREST_REVISION_ID)
+            statement.setObject(2, INTEREST_OFFERING_ID)
+            statement.setString(3, DEPOSIT_SCHEMA_ID)
+            statement.setString(4, INTEREST_REVISION_CONTENT)
+            statement.setObject(5, OffsetDateTime.parse("2027-01-01T00:00:00Z"))
+            statement.setString(6, "pact-interest-author")
+            statement.setString(7, "pact-interest-checker")
+            statement.setString(8, "published fixed-rate fixture")
+            statement.setString(9, "a".repeat(64))
+            statement.setObject(10, now)
+            statement.setObject(11, now)
+            statement.executeUpdate()
+        }
+        connection.prepareStatement(
+            "INSERT INTO catalog_outbox " +
+                "(id, aggregate_type, aggregate_id, event_type, schema_version, occurred_at, " +
+                "headers, payload, created_at) " +
+                "VALUES (?, 'catalog.revision', ?, 'com.openbank.catalog.revision_published', 1, ?, " +
+                "'{}'::jsonb, '{}'::jsonb, ?) ON CONFLICT (id) DO NOTHING",
+        ).use { statement ->
+            val now = FIXTURE_TIME
+            statement.setObject(1, INTEREST_EVENT_ID)
+            statement.setObject(2, INTEREST_REVISION_ID)
+            statement.setObject(3, now)
+            statement.setObject(4, now)
+            statement.executeUpdate()
+        }
+    }
+
+    /** Published loan revision consumed by lending before an application is persisted. */
+    fun publishedPricedLoanRevisionExists() = dataSource.connection.use { connection ->
+        connection.prepareStatement(
+            "INSERT INTO catalog_specifications " +
+                "(id, code, schema_id, schema_version, created_at, lock_version) VALUES (?, ?, ?, 2, ?, 0) " +
+                "ON CONFLICT (id) DO NOTHING",
+        ).use { statement ->
+            statement.setObject(1, LOAN_SPECIFICATION_ID)
+            statement.setString(2, "PACT_PRICED_LOAN")
+            statement.setString(3, LOAN_SCHEMA_ID)
+            statement.setObject(4, LOAN_FIXTURE_TIME)
+            statement.executeUpdate()
+        }
+        insertOffering(connection, LOAN_OFFERING_ID, LOAN_SPECIFICATION_ID, "PACT_PRICED_LOAN_OFFERING")
+        connection.prepareStatement(
+            "INSERT INTO catalog_revisions " +
+                "(id, offering_id, revision_no, schema_id, schema_version, state, content, effective_from, " +
+                "maker_id, checker_id, reason, content_hash, created_at, updated_at, lock_version) " +
+                "VALUES (?, ?, 1, ?, 2, 'PUBLISHED', CAST(? AS jsonb), ?, ?, ?, ?, ?, ?, ?, 0) " +
+                "ON CONFLICT (id) DO NOTHING",
+        ).use { statement ->
+            statement.setObject(1, LOAN_REVISION_ID)
+            statement.setObject(2, LOAN_OFFERING_ID)
+            statement.setString(3, LOAN_SCHEMA_ID)
+            statement.setString(4, LOAN_REVISION_CONTENT)
+            statement.setObject(5, LOAN_FIXTURE_TIME)
+            statement.setString(6, "pact-loan-author")
+            statement.setString(7, "pact-loan-checker")
+            statement.setString(8, "published priced loan fixture")
+            statement.setString(9, "b".repeat(64))
+            statement.setObject(10, LOAN_FIXTURE_TIME)
+            statement.setObject(11, LOAN_FIXTURE_TIME)
+            statement.executeUpdate()
+        }
+    }
+
     private fun insertSpecification(connection: Connection, id: UUID, code: String) {
         connection.prepareStatement(
             "INSERT INTO catalog_specifications " +
@@ -83,6 +166,7 @@ class CatalogPactProviderFixtures(private val dataSource: DataSource) {
 
     private companion object {
         const val SCHEMA_ID = "org.openbank.insurance.term-life"
+        const val DEPOSIT_SCHEMA_ID = "org.openbank.banking.deposit"
         val OFFERING_SPECIFICATION_ID: UUID = UUID.fromString("10000000-0000-0000-0000-000000000001")
         val DRAFT_SPECIFICATION_ID: UUID = UUID.fromString("10000000-0000-0000-0000-000000000002")
         val UPDATE_SPECIFICATION_ID: UUID = UUID.fromString("10000000-0000-0000-0000-000000000003")
@@ -92,7 +176,21 @@ class CatalogPactProviderFixtures(private val dataSource: DataSource) {
         val PUBLISH_OFFERING_ID: UUID = UUID.fromString("20000000-0000-0000-0000-000000000003")
         val UPDATE_REVISION_ID: UUID = UUID.fromString("30000000-0000-0000-0000-000000000001")
         val PUBLISH_REVISION_ID: UUID = UUID.fromString("30000000-0000-0000-0000-000000000002")
+        val INTEREST_SPECIFICATION_ID: UUID = UUID.fromString("10000000-0000-0000-0000-000000000010")
+        val INTEREST_OFFERING_ID: UUID = UUID.fromString("20000000-0000-0000-0000-000000000010")
+        val INTEREST_REVISION_ID: UUID = UUID.fromString("30000000-0000-0000-0000-000000000010")
+        val INTEREST_EVENT_ID: UUID = UUID.fromString("40000000-0000-0000-0000-000000000010")
+        val LOAN_SPECIFICATION_ID: UUID = UUID.fromString("10000000-0000-0000-0000-000000000011")
+        val LOAN_OFFERING_ID: UUID = UUID.fromString("20000000-0000-0000-0000-000000000011")
+        val LOAN_REVISION_ID: UUID = UUID.fromString("30000000-0000-0000-0000-000000000011")
+        val FIXTURE_TIME: OffsetDateTime = OffsetDateTime.parse("2027-01-01T00:00:00Z")
+        val LOAN_FIXTURE_TIME: OffsetDateTime = OffsetDateTime.parse("2026-01-01T00:00:00Z")
         const val REVISION_CONTENT =
             """{"name":{"en":"Term life"},"attributes":{"coverage":{"amount":"100000","currency":"EUR"},"termYears":20,"premiumModel":"CALCULATED"},"prices":[],"eligibility":[],"relationships":[],"documentCodes":[]}"""
+        const val INTEREST_REVISION_CONTENT =
+            """{"name":{"en":"Interest pact deposit"},"attributes":{"currency":"EUR","productType":"SAVINGS","interest":{"rateType":"FIXED","dayCount":"ACT_365","payoutFrequency":"MONTHLY","annualRate":"0.012345678901234567"}},"prices":[],"eligibility":[],"relationships":[],"documentCodes":[]}"""
+        const val LOAN_SCHEMA_ID = "org.openbank.banking.loan"
+        const val LOAN_REVISION_CONTENT =
+            """{"name":{"en":"Lending pact loan"},"attributes":{"productType":"INSTALLMENT_LOAN","currency":"EUR","tenorMonths":12,"amortizationMethod":"ANNUITY","nominalAnnualRate":"0.0699","accrualBasis":"ACT_365","allocationOrder":["INTEREST","PRINCIPAL"],"minPrincipalAmount":"1000","maxPrincipalAmount":"50000"},"prices":[],"eligibility":[],"relationships":[],"documentCodes":[]}"""
     }
 }

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/contract/ProductCatalogPactBrokerProviderVerificationTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/contract/ProductCatalogPactBrokerProviderVerificationTest.kt
@@ -115,4 +115,10 @@ class ProductCatalogPactBrokerProviderVerificationTest {
 
     @State("Product Studio independently checkable draft exists")
     fun productStudioCheckableDraftExists() = catalogFixtures.independentlyCheckableDraftExists()
+
+    @State("a published fixed-rate deposit revision exists for interest synchronization")
+    fun publishedFixedRateDepositRevisionExists() = catalogFixtures.publishedFixedRateDepositRevisionExists()
+
+    @State("a published priced loan revision exists for lending originations")
+    fun publishedPricedLoanRevisionExists() = catalogFixtures.publishedPricedLoanRevisionExists()
 }

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/contract/ProductCatalogPactProviderVerificationTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/contract/ProductCatalogPactProviderVerificationTest.kt
@@ -138,4 +138,10 @@ class ProductCatalogPactProviderVerificationTest {
 
     @State("Product Studio independently checkable draft exists")
     fun productStudioCheckableDraftExists() = catalogFixtures.independentlyCheckableDraftExists()
+
+    @State("a published fixed-rate deposit revision exists for interest synchronization")
+    fun publishedFixedRateDepositRevisionExists() = catalogFixtures.publishedFixedRateDepositRevisionExists()
+
+    @State("a published priced loan revision exists for lending originations")
+    fun publishedPricedLoanRevisionExists() = catalogFixtures.publishedPricedLoanRevisionExists()
 }

--- a/pacts/openbank-account-service-openbank-product-catalog.json
+++ b/pacts/openbank-account-service-openbank-product-catalog.json
@@ -20,6 +20,7 @@
       "response": {
         "body": {
           "code": "CURRENT_PERSONAL",
+          "currency": "EUR",
           "id": "3f20a53e-5ea4-307a-8a0f-9605728381ba",
           "status": "ACTIVE"
         },
@@ -29,6 +30,14 @@
         "matchingRules": {
           "body": {
             "$.code": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.currency": {
               "combine": "AND",
               "matchers": [
                 {

--- a/pacts/openbank-interest-service-openbank-product-catalog.json
+++ b/pacts/openbank-interest-service-openbank-product-catalog.json
@@ -1,0 +1,174 @@
+{
+  "consumer": {
+    "name": "openbank-interest-service"
+  },
+  "interactions": [
+    {
+      "description": "GET one published catalog revision event for interest synchronization",
+      "providerStates": [
+        {
+          "name": "a published fixed-rate deposit revision exists for interest synchronization"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v2/events",
+        "query": {
+          "limit": [
+            "1"
+          ]
+        }
+      },
+      "response": {
+        "body": {
+          "items": [
+            {
+              "aggregateId": "30000000-0000-0000-0000-000000000010",
+              "aggregateType": "catalog.revision",
+              "eventType": "com.openbank.catalog.revision_published",
+              "headers": {
+
+              },
+              "id": "40000000-0000-0000-0000-000000000010",
+              "occurredAt": "2027-01-01T00:00:00Z",
+              "payload": {
+
+              },
+              "schemaVersion": 1
+            }
+          ],
+          "nextCursor": "MQ"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "GET the immutable published fixed-rate catalog revision",
+      "providerStates": [
+        {
+          "name": "a published fixed-rate deposit revision exists for interest synchronization"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v2/revisions/30000000-0000-0000-0000-000000000010"
+      },
+      "response": {
+        "body": {
+          "checkerId": "pact-interest-checker",
+          "content": {
+            "attributes": {
+              "currency": "EUR",
+              "interest": {
+                "annualRate": "0.012345678901234567",
+                "dayCount": "ACT_365",
+                "payoutFrequency": "MONTHLY",
+                "rateType": "FIXED"
+              },
+              "productType": "SAVINGS"
+            },
+            "documentCodes": [
+
+            ],
+            "eligibility": [
+
+            ],
+            "name": {
+              "en": "Interest pact deposit"
+            },
+            "prices": [
+
+            ],
+            "relationships": [
+
+            ]
+          },
+          "contentHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "createdAt": "2027-01-01T00:00:00Z",
+          "effectiveFrom": "2027-01-01T00:00:00Z",
+          "effectiveTo": null,
+          "id": "30000000-0000-0000-0000-000000000010",
+          "makerId": "pact-interest-author",
+          "number": 1,
+          "offeringId": "20000000-0000-0000-0000-000000000010",
+          "reason": "published fixed-rate fixture",
+          "revision": 0,
+          "schemaRef": {
+            "id": "org.openbank.banking.deposit",
+            "version": 2
+          },
+          "state": "PUBLISHED",
+          "updatedAt": "2027-01-01T00:00:00Z"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "GET the offering owning the published fixed-rate revision",
+      "providerStates": [
+        {
+          "name": "a published fixed-rate deposit revision exists for interest synchronization"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v2/offerings/20000000-0000-0000-0000-000000000010"
+      },
+      "response": {
+        "body": {
+          "code": "PACT_INTEREST_OFFERING",
+          "id": "20000000-0000-0000-0000-000000000010",
+          "market": {
+            "brands": [
+
+            ],
+            "channels": [
+
+            ],
+            "countries": [
+
+            ],
+            "locales": [
+
+            ],
+            "segments": [
+
+            ]
+          },
+          "revision": 0,
+          "specificationId": "10000000-0000-0000-0000-000000000010"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-product-catalog"
+  }
+}

--- a/pacts/openbank-lending-service-openbank-product-catalog.json
+++ b/pacts/openbank-lending-service-openbank-product-catalog.json
@@ -1,0 +1,89 @@
+{
+  "consumer": {
+    "name": "openbank-lending-service"
+  },
+  "interactions": [
+    {
+      "description": "GET the published priced loan offering for origination",
+      "providerStates": [
+        {
+          "name": "a published priced loan revision exists for lending originations"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v2/products/20000000-0000-0000-0000-000000000011"
+      },
+      "response": {
+        "body": {
+          "checkerId": "pact-loan-checker",
+          "content": {
+            "attributes": {
+              "accrualBasis": "ACT_365",
+              "allocationOrder": [
+                "INTEREST",
+                "PRINCIPAL"
+              ],
+              "amortizationMethod": "ANNUITY",
+              "currency": "EUR",
+              "maxPrincipalAmount": "50000",
+              "minPrincipalAmount": "1000",
+              "nominalAnnualRate": "0.0699",
+              "productType": "INSTALLMENT_LOAN",
+              "tenorMonths": 12
+            },
+            "documentCodes": [
+
+            ],
+            "eligibility": [
+
+            ],
+            "name": {
+              "en": "Lending pact loan"
+            },
+            "prices": [
+
+            ],
+            "relationships": [
+
+            ]
+          },
+          "contentHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "effectiveFrom": "2026-01-01T00:00:00Z",
+          "effectiveTo": null,
+          "id": "30000000-0000-0000-0000-000000000011",
+          "makerId": "pact-loan-author",
+          "number": 1,
+          "offeringId": "20000000-0000-0000-0000-000000000011",
+          "reason": "published priced loan fixture",
+          "revision": 0,
+          "schemaRef": {
+            "id": "org.openbank.banking.loan",
+            "version": 2
+          },
+          "state": "PUBLISHED",
+          "updatedAt": "2026-01-01T00:00:00Z"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-product-catalog"
+  }
+}


### PR DESCRIPTION
## Summary
- synchronize immutable published catalog rate snapshots into interest accruals
- enforce catalog product currency during account opening
- add a versioned banking loan schema and originate loans from a published catalog snapshot
- retain catalog revision/hash with the loan application and replay new consumer/provider Pacts

## Verification
- product-catalog, interest, account, billing and lending tests completed with no XML failures/errors after isolated account Pact replay
- account Pact provider replay: 4/0/0
- product-catalog Pact provider replay: 15/0/0
- lending catalog consumer Pact: 1/0/0
- ktlint, detekt and Quarkus fast-jar builds passed for all five services
- API contract gate: additive lending API 1.12.0 to 1.13.0

Refs #668