### PR TITLE
fix(ci): a dead-letter topic is WRITTEN, so the ACL gate must ask for Write

### DIFF
--- a/.github/scripts/check-kafka-acl-coverage.py
+++ b/.github/scripts/check-kafka-acl-coverage.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import argparse
 import pathlib
+import tempfile
 import sys
 
 import yaml
@@ -107,7 +108,18 @@ def required(app_yaml: pathlib.Path) -> set[tuple[str, str]]:
     for path, value in flat:
         if not path or path[-1] not in ("topic", "topics") or not isinstance(value, str):
             continue
-        if "incoming" in path:
+        # A dead-letter topic is WRITTEN by the connector, even though its config sits under an
+        # `incoming` channel. Direction-by-channel-key gets this exactly backwards: SmallRye parks
+        # the failed record by PRODUCING to the DLQ; nothing consumes it (by design — the
+        # party-events DLQ alert says so in as many words). The working example on main is
+        # account-service, whose KafkaUser grants `dead-letter-topic-party-events-in`
+        # `[Write, Describe]` with the comment "Without Write here, the DLQ send itself fails and
+        # the consumer [retries]". Classifying it Read would let a PR satisfy this gate with an ACL
+        # the broker still denies — a green check over a DLQ that cannot be written, which is worse
+        # than no DLQ at all: the rethrow it exists to serve then stops the channel (#5745).
+        if "dead-letter-queue" in path:
+            operation = "Write"
+        elif "incoming" in path:
             operation = "Read"
         elif "outgoing" in path:
             operation = "Write"
@@ -180,7 +192,42 @@ def selftest() -> int:
     if not kafka_users():
         print("selftest FAIL: no KafkaUser CRs found — the scan itself is broken.")
         return 1
-    print(f"selftest OK: {len(cases)} cases, both directions (flags the near-miss, spares the prefix match).")
+
+    # DIRECTION. A dead-letter topic is produced to, so it must come out as Write even though its
+    # config nests under an `incoming` channel. Asserted on a real config shape rather than on the
+    # regex, because the bug this guards against was invisible in the pattern and only showed up in
+    # what the extraction RETURNED: classifying it Read makes the gate satisfiable by an ACL the
+    # broker denies.
+    with tempfile.TemporaryDirectory() as td:
+        sample = pathlib.Path(td) / "application.yaml"
+        sample.write_text(
+            "mp:\n"
+            "  messaging:\n"
+            "    incoming:\n"
+            "      party-events-in:\n"
+            "        topic: openbank.party.events\n"
+            "        failure-strategy: dead-letter-queue\n"
+            "        dead-letter-queue:\n"
+            "          topic: openbank.dlq.acct.party-events-in\n"
+            "    outgoing:\n"
+            "      account-events-out:\n"
+            "        topic: openbank.accounts.account.created\n",
+            encoding="utf-8",
+        )
+        got = required(sample)
+    want = {
+        ("openbank.party.events", "Read"),
+        ("openbank.dlq.acct.party-events-in", "Write"),
+        ("openbank.accounts.account.created", "Write"),
+    }
+    if got != want:
+        print(f"selftest FAIL: direction inference wrong.\n  want {sorted(want)}\n  got  {sorted(got)}")
+        return 1
+
+    print(
+        f"selftest OK: {len(cases)} coverage cases both directions, plus DLQ direction "
+        "(a dead-letter topic under an incoming channel resolves to Write, not Read)."
+    )
     return 0
 
 


### PR DESCRIPTION
## Summary

`check-kafka-acl-coverage` infers the required operation from the channel key — `incoming` ⇒ `Read`,
`outgoing` ⇒ `Write` — and collects any `topic` key beneath it. A SmallRye dead-letter topic is
configured as `dead-letter-queue.topic` **nested under the incoming channel**, so it came out as
`Read`. It is **produced to**: the connector parks a failed record by PRODUCING to that topic, and
nothing consumes it by design.

## Why this is more than a wrong label

The broker runs `allow.everyone.if.no.acl.found=false`. So a PR could satisfy this gate by granting
`Read` and still have every DLQ send denied at runtime — **a green check over a dead-letter queue
that cannot be written**. That is worse than having no DLQ: the rethrow it exists to serve then
*stops the channel* instead of parking the record.

## Ground truth, already on `main`

`accounts/kafka-account-mtls.yaml` grants `dead-letter-topic-party-events-in` `[Write, Describe]`,
with the comment: *"Without Write here, the DLQ send itself fails and the consumer [retries]"*.

## How it was found, and the evidence

Diagnosing why **#5751** is red on `gates (data)`. That PR adds an explicit DLQ topic to every
incoming channel fleet-wide, which is the first change that makes this reachable at scale — every
one of its ~40 new topics is reported as a missing **Read** ACL.

Ran the gate's own `required()` against that branch:

```
openbank-balance-service:
   openbank.dlq.balance.balance-init-in    -> gate requires Read
   openbank.dlq.balance.ledger-events-in   -> gate requires Read
openbank-aml-service:
   openbank.dlq.aml.party-events-in        -> gate requires Read
```

Executed, not reasoned about.

## Falsifiability

The self-test now asserts the direction on a **real config shape** (incoming + nested
`dead-letter-queue` + outgoing) rather than on the regex — the bug was invisible in the pattern and
only showed up in what the extraction *returned*. Falsified both ways:

- fix removed → `selftest FAIL: direction inference wrong` naming `Read` where `Write` was wanted;
- restored → passes.

`--enforce` on `main` with the fix: **107 (topic, operation) pairs across 42 KafkaUsers, 0 gaps.**

## Scope
One file, `.github/scripts/`. No service code, no gitops, no `rules.yaml`.

Refs #5745, #2598
