### PR TITLE
feat(agent): offer two paid models in the assistant picker, off the free tier

### DIFF
--- a/openbank-admin-ui/src/components/agent/AgentDock.tsx
+++ b/openbank-admin-ui/src/components/agent/AgentDock.tsx
@@ -14,6 +14,31 @@ interface ToolCall { tool: string; allowed: boolean; resultPreview: string }
 interface Msg { role: 'user' | 'assistant'; content: string; toolCalls?: ToolCall[]; isProposal?: boolean }
 interface ModelInfo { id: string; provider: string; sensitivity: string }
 
+/**
+ * Human label for a model id. The VALUE stays the raw id — that is what agent-service resolves and
+ * what every audit event records, so the option value must never diverge from it. Only the visible
+ * text is friendlier.
+ *
+ * An unknown id falls through to its own last path segment rather than to a generic "model":
+ * whoever adds a route to litellm-config should get something readable in the picker without having
+ * to remember to edit this file, and a stale mapping must never hide which model is actually
+ * selected.
+ */
+const MODEL_LABELS: Record<string, string> = {
+  'mock-echo': 'mock (offline)',
+  'llama-3.3-70b-versatile': 'Llama 3.3 70B · free tier',
+  'openai/gpt-oss-120b': 'GPT-OSS 120B · fast',
+  'deepseek-ai/DeepSeek-V4-Pro': 'DeepSeek V4 Pro · strongest',
+}
+
+export function modelLabel(id: string): string {
+  // `??` is not enough on its own: 'vendor/'.split('/').pop() is an EMPTY STRING, not undefined,
+  // so it would pass through and render a blank option the operator cannot identify. The final
+  // literal covers the same shape for an empty id — agent-service should never send one, and if it
+  // ever does the picker must still show a row you can see and report, not an invisible one.
+  return MODEL_LABELS[id] || id.split('/').filter(Boolean).pop() || id || '(unnamed model)'
+}
+
 export function AgentDock() {
   const pathname = usePathname()
   const { t } = useLanguage()
@@ -109,7 +134,7 @@ export function AgentDock() {
                 aria-label={t('Model asistenta', 'Assistant model')}
                 style={{ fontSize: 11, padding: '3px 6px', borderRadius: 6, border: '1px solid var(--border)', background: 'var(--surface-2)', color: 'var(--text-secondary)' }}
               >
-                {models.map(m => <option key={m.id} value={m.id}>{m.id}</option>)}
+                {models.map(m => <option key={m.id} value={m.id} title={m.id}>{modelLabel(m.id)}</option>)}
               </select>
             )}
           </div>

--- a/openbank-admin-ui/src/test/agent-model-label.test.ts
+++ b/openbank-admin-ui/src/test/agent-model-label.test.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { describe, expect, it } from 'vitest'
+import { modelLabel } from '@/components/agent/AgentDock'
+
+/**
+ * The picker's labels are cosmetic; what must not break is the relationship between them and the
+ * id underneath. A label mapping that silently swallows an unknown model would show the operator a
+ * name that is not what agent-service will run, and every audit event records the id, not the label.
+ */
+describe('modelLabel', () => {
+  it('labels the registered models', () => {
+    expect(modelLabel('openai/gpt-oss-120b')).toContain('GPT-OSS 120B')
+    expect(modelLabel('deepseek-ai/DeepSeek-V4-Pro')).toContain('DeepSeek V4 Pro')
+    expect(modelLabel('llama-3.3-70b-versatile')).toContain('free tier')
+  })
+
+  it('falls back to the id itself for a model added to the gateway but not to this map', () => {
+    // The point: a new route must be usable the moment it is registered, without an admin-ui
+    // change, and must never be displayed as something else.
+    expect(modelLabel('zai-org/GLM-5.2')).toBe('GLM-5.2')
+    expect(modelLabel('some-model')).toBe('some-model')
+  })
+
+  it('never returns an empty label', () => {
+    // A trailing slash would make `split('/').pop()` an empty string, which renders as a blank
+    // option the operator cannot identify.
+    expect(modelLabel('vendor/')).not.toBe('')
+    expect(modelLabel('')).not.toBe('')
+  })
+})

--- a/openbank-agent-service/src/main/resources/application.yaml
+++ b/openbank-agent-service/src/main/resources/application.yaml
@@ -200,6 +200,27 @@ model-gateway:
       provider: openai-compat
       endpoint: ${AGENT_MODEL_ENDPOINT:https://api.groq.com/openai/v1}
       sensitivity: hosted
+    # Paid alternatives to the free Groq tier above, served through the SAME gateway endpoint and
+    # the same virtual key — a model entry here plus a route in litellm-config, no code change.
+    #
+    # WHY THESE TWO AND NOT WHATEVER IS TOP OF A LEADERBOARD: they were measured against a real
+    # Czech admin prompt through the gateway before being registered. gpt-oss-120b answered in
+    # 2.9s, DeepSeek-V4-Pro in 9.6s, both cleanly. Three others that look equally reasonable on
+    # paper were rejected by the same probe — Kimi-K3 leaked its chain of thought into the reply,
+    # GLM-5.2 returned empty content, Llama-4-Maverick answered HTTP 429 "Model busy". A config
+    # review cannot see any of that.
+    #
+    # Both stay `sensitivity: hosted`: they are off-cluster US providers, so the ADR-0031 D6
+    # sensitive-context routing must not choose them. That tier still needs a self-hosted model,
+    # which is the `vLLM` line ADR-0265 left as planned.
+    - id: openai/gpt-oss-120b
+      provider: openai-compat
+      endpoint: ${AGENT_MODEL_ENDPOINT:https://api.groq.com/openai/v1}
+      sensitivity: hosted
+    - id: deepseek-ai/DeepSeek-V4-Pro
+      provider: openai-compat
+      endpoint: ${AGENT_MODEL_ENDPOINT:https://api.groq.com/openai/v1}
+      sensitivity: hosted
     # The SAME openai-compat adapter serves any OpenAI-shaped backend — just change endpoint+key:
     # - id: qwen2.5                       # self-hosted Ollama for the SELF_HOSTED (sensitive) tier
     #   provider: openai-compat

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -96,8 +96,15 @@ spec:
             # model id to `groq/llama-3.3-70b-versatile`, so the model name is unchanged and this is
             # an endpoint + key change only. The provider key now lives solely in the ai-platform
             # gateway pod, which is the one workload permitted to leave the cluster.
+            # Default flipped off the free Groq tier. That tier enforces 12k tokens/min, and a
+            # tool round is 2+ completions each carrying the prompt, the tool schemas and the
+            # (capped) results — so a burst of clicks trips it and the assistant answers "I'm being
+            # rate-limited", which reads to an operator as the feature being broken. gpt-oss-120b
+            # is paid, measured at 2.9s on a real Czech admin prompt (vs 9.6s for DeepSeek-V4-Pro)
+            # and ~35x cheaper per output token than that stronger sibling. Both are in the picker;
+            # this only decides what a fresh session starts with.
             - name: AGENT_DEFAULT_MODEL
-              value: llama-3.3-70b-versatile
+              value: openai/gpt-oss-120b
             - name: AGENT_MODEL_ENDPOINT
               value: http://litellm.ai-platform.svc:4000/v1
             # LiteLLM virtual key (OpenBao litellm/KEY_AGENT_SERVICE via ESO), not a provider key.

--- a/openbank-infra/gitops/components/ai-platform/litellm-config.yaml
+++ b/openbank-infra/gitops/components/ai-platform/litellm-config.yaml
@@ -124,6 +124,46 @@ data:
           # price declared", which is the state that made every DeepSeek call cost $0 and quietly
           # voided three nested budgets. The gate rejects a zero for that reason, and it is right to.
           output_cost_per_token: 0.00000001
+      # ── Paid chat models for the admin-UI assistant ──────────────────────────────────────
+      #
+      # The picker in AgentDock has always existed; it only ever had one real model — Groq's free
+      # llama-3.3-70b-versatile, whose 12k tokens/min tier is what makes the assistant answer
+      # "I'm being rate-limited" under a burst of clicks. These two are paid, on a provider this
+      # gateway already holds a key for, and both were MEASURED against a real Czech prompt from
+      # inside this pod before being added — the same probe that caught Groq decommissioning
+      # Llama Guard:
+      #
+      #   openai/gpt-oss-120b          2.9s, clean Czech   <- fastest, ~35x cheaper per output token
+      #   deepseek-ai/DeepSeek-V4-Pro  9.6s, clean Czech   <- strongest
+      #   moonshotai/Kimi-K3          14.8s, LEAKED its chain of thought into the reply -> rejected
+      #   zai-org/GLM-5.2              8.0s, empty content within 120 tokens            -> rejected
+      #   meta-llama/Llama-4-Maverick  HTTP 429 "Model busy, retry later"                -> rejected
+      #
+      # The three rejections are the reason to measure rather than pick from a leaderboard: all are
+      # current, well-regarded models that would have read fine in a config review and produced a
+      # visibly broken assistant.
+      - model_name: openai/gpt-oss-120b
+        litellm_params:
+          model: deepinfra/openai/gpt-oss-120b
+          api_key: os.environ/DEEPINFRA_API_KEY
+          max_budget: 5
+          budget_duration: 1d
+          # DeepInfra rate card, read from api.deepinfra.com/models/<id>: cents_per_input_token
+          # 3.7e-06, cents_per_output_token 1.7e-05 — converted from cents to USD per token.
+          input_cost_per_token: 0.000000037
+          output_cost_per_token: 0.00000017
+      - model_name: deepseek-ai/DeepSeek-V4-Pro
+        litellm_params:
+          model: deepinfra/deepseek-ai/DeepSeek-V4-Pro
+          api_key: os.environ/DEEPINFRA_API_KEY
+          # Lower ceiling than the cheap route above, deliberately: this one costs ~15x more per
+          # output token, so an equal budget would buy a very unequal number of runs before the
+          # cap bites.
+          max_budget: 3
+          budget_duration: 1d
+          # cents_per_input_token 0.00013, cents_per_output_token 0.00026.
+          input_cost_per_token: 0.0000013
+          output_cost_per_token: 0.0000026
     general_settings:
       # Virtual keys and every budget below persist here. Injected from the CNPG litellm-db-app
       # secret (components/ai-platform/postgres.yaml) — see the DATABASE_URL note in litellm.yaml

--- a/openbank-infra/gitops/components/ai-platform/litellm.yaml
+++ b/openbank-infra/gitops/components/ai-platform/litellm.yaml
@@ -35,7 +35,7 @@ spec:
         # would leave agent-service's repointed call failing "model not found" with a green,
         # in-sync ArgoCD — the same silent-degradation shape as an `optional: true` secret ref.
         # BUMP THIS whenever litellm-config.yaml changes; that is what rolls the pod.
-        openbank.tech/litellm-config-revision: "10"
+        openbank.tech/litellm-config-revision: "11"
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
The picker in `AgentDock` has existed since the assistant shipped — it only ever had **one real
model**, Groq's free `llama-3.3-70b-versatile`. That tier enforces 12k tokens/min, and a tool round
is 2+ completions each carrying the prompt, tool schemas and capped results, so a burst of clicks
trips it and the assistant answers *"I'm being rate-limited"* — which reads to an operator as the
feature being broken.

## What is added

| model | measured | role |
|---|---|---|
| `openai/gpt-oss-120b` | **2.9s**, clean Czech | new default, ~15x cheaper per output token |
| `deepseek-ai/DeepSeek-V4-Pro` | **9.6s**, clean Czech | strongest |

## Chosen by measurement, not reputation

Every candidate was driven through a real Czech admin prompt from inside the gateway pod first.
Three current, well-regarded models failed in ways **no config review would catch**:

| rejected | why |
|---|---|
| `moonshotai/Kimi-K3` | leaked its chain of thought into the reply ("The user is asking in Czech…") |
| `zai-org/GLM-5.2` | returned **empty content** within 120 tokens |
| `meta-llama/Llama-4-Maverick` | HTTP 429 `Model busy, retry later` |

Same probe that caught Groq decommissioning Llama Guard in #5746.

## Details worth a look

- Prices read from DeepInfra's rate-card endpoint, not guessed. Each route has its **own** daily
  ceiling, DeepSeek's deliberately lower — an equal budget would buy a very unequal number of runs.
- Both stay `sensitivity: hosted`. They are off-cluster US providers, so ADR-0031 D6
  sensitive-context routing must not choose them; that tier still needs the self-hosted model
  ADR-0265 left as planned.
- Labels are cosmetic only: the option **value** stays the raw id, because agent-service resolves
  that id and every audit event records it. An unmapped id falls back to its own last path segment,
  so a new gateway route is usable without an admin-ui change.
- A test on that fallback **caught a real bug**: `'vendor/'.split('/').pop()` is an empty string,
  not `undefined`, so `??` let it through and the picker would have rendered a blank option.

Stacked on #5670 (base `feat/ai-stack-guardrails`) because it edits the same gateway config.

## Linked issues

Refs #5671
