### PR TITLE
fix(observability): tune Falco ruleset and alert on Critical detections

### DIFF
--- a/openbank-infra/gitops/apps/falco.yaml
+++ b/openbank-infra/gitops/apps/falco.yaml
@@ -64,10 +64,179 @@ spec:
           json_output: true
           json_include_output_property: true
           log_syslog: false
-          # Stock rules only (falco_rules.yaml from the falcoctl artifact
-          # follow); tuning exceptions land here as values once the first
-          # week of sandbox noise is triaged.
+          # Stock rules (falco_rules.yaml from the falcoctl artifact), plus the
+          # tuning exceptions in `customRules` below. `notice` stays the floor:
+          # the two highest-volume stock rules here are NOTICE, and the SOC
+          # dashboard + Loki retention are the consumers that want them.
           priority: notice
+
+        # ==========================================================================
+        # TUNING (issue #5734). The triage this file promised for "the first week of
+        # sandbox noise" — 15 months late, and it had to happen BEFORE any alert was
+        # added, because an alert over an untuned ruleset is muted within a day.
+        #
+        # BASELINE, measured over 24h of sandbox Loki on 2026-08-19, with each rule's
+        # STOCK PRIORITY (falcosecurity/rules falco_rules.yaml, Falco 0.44.1) — the
+        # priority is the load-bearing column, because it decides which of these an
+        # alert can ever see:
+        #
+        #   29465  Contact K8S API Server From Container   NOTICE
+        #    3150  Run shell untrusted                     NOTICE
+        #     450  Drop and execute new binary in container CRITICAL
+        #       5  Falco internal: syscall event drop      CRITICAL (Falco-internal)
+        #
+        # So the ~33k/day headline and the alertable volume are NOT the same number:
+        # a `priority=~Critical|Emergency` alert sees 455/day, not 33k. Tuning the two
+        # NOTICE rules buys log volume and dashboard signal; tuning `Drop and execute`
+        # is what makes an alert survivable. Both are done here, for different reasons.
+        #
+        # HOW THESE ARE WRITTEN. Every stock rule above ships a purpose-built tuning
+        # hook — a `user_known_*` macro defaulting to `never_true`, or an empty list.
+        # Overriding the hook is the sanctioned mechanism and leaves the rule itself
+        # untouched, so a chart bump cannot silently drop the exception (it would drop
+        # the whole file, loudly). `/etc/falco/rules.d` loads AFTER falco_rules.yaml
+        # (chart values `falco.rules_files`), so these overrides win.
+        #
+        # NOT DONE, DELIBERATELY: `Run shell untrusted` (3150/day) is left NOISY. Its
+        # condition requires a `protected_shell_spawner` ancestor (an http/db/nosql/
+        # mail server binary, or a JVM running kafka/tomcat/elasticsearch/...), and
+        # NOTHING in this repo identifies which of those is spawning a shell every
+        # ~30s. Every CronJob and sidecar this repo does declare has a plain
+        # entrypoint parent and so cannot be the source. An exception written from a
+        # guess would silence the rule that catches general RCE, which is the same
+        # write-only control with extra steps. It needs one Loki query against the
+        # live events (see the PR body for #5734) and then a tuning it can justify.
+        # It is NOTICE, so leaving it noisy costs log volume and nothing else — no
+        # alert below can see it.
+        # ==========================================================================
+        customRules:
+          openbank-tuning.yaml: |-
+            # ---------------------------------------------------------------
+            # Contact K8S API Server From Container  (29465/day, NOTICE)
+            #
+            # WHAT IT ACTUALLY DETECTS: any container connecting to
+            # kubernetes.default.svc. Stock excludes only ns kube-system and a
+            # fixed list of third-party operator images (`k8s_containers`) —
+            # none of which this estate runs. So every controller we DO run
+            # trips it continuously, which is the whole 29k.
+            #
+            # WHAT IS PRESERVED: the coverage that has value here is the ~60
+            # openbank APP namespaces (accounts, payments, ledger, sanctions,
+            # fraud, ...), where a connection to the API server is anomalous by
+            # construction — no openbank service carries a Kubernetes client
+            # dependency (no fabric8, no client-go) and no openbank
+            # ServiceAccount except admin-ui has any Role or ClusterRole bound.
+            # Not one of those namespaces is excepted below.
+            #
+            # (1) Pure platform/controller namespaces. Whole-namespace scope is
+            # honest here: these hold no business data path, every pod in them
+            # talks to the API server as its JOB, and the other ~90 stock rules
+            # — shell spawn, sensitive mount, drop-and-execute — still cover
+            # them. kube-system is already excluded upstream.
+            - macro: openbank_controller_namespaces
+              condition: >
+                (k8s.ns.name in (argocd, argo-rollouts, arc-runners, arc-systems,
+                                 cert-manager, cnpg-system, external-dns,
+                                 external-secrets, falco, ingress-nginx, keda,
+                                 kyverno, observability, vault, vpa))
+
+            # (2) The kubectl CronJobs, by IMAGE rather than by namespace —
+            # they run in `admin-ui`, `iam` and `finops-scaledown`, which are
+            # NOT namespaces to hand a blanket exception to. Every one of them
+            # is a `docker.io/alpine/k8s` pod whose entire purpose is to call
+            # the API server: finops scale-down/up, cost-collector,
+            # tier-classifier, sbom-drift-scanner, infra-vuln-scanner,
+            # keycloak-realm-drift.
+            - macro: openbank_kubectl_cronjob_image
+              condition: (container.image.repository endswith "alpine/k8s")
+
+            # (3) The admin-ui BFF, by IMAGE for the same reason — ns admin-ui
+            # also hosts the CronJobs above and would be a bad blanket. It is
+            # the one openbank service that genuinely calls the API server
+            # (src/lib/discovery.ts), its ClusterRole is read-only
+            # (get/list/watch on deployments/rollouts/services/endpoints) and
+            # is bound per-namespace, never cluster-wide.
+            # RESIDUAL, stated: code execution INSIDE the admin-ui container
+            # would no longer trip THIS rule. It still trips the shell-spawn,
+            # drop-and-execute and sensitive-file rules, and the RBAC above
+            # caps what the token can do. Scoping by image keeps every other
+            # container in ns admin-ui covered.
+            - macro: openbank_admin_ui_bff
+              condition: (container.image.repository endswith "openbank-admin-ui")
+
+            # (4) Strimzi's cluster operator — ns `messaging` also holds the
+            # Kafka brokers and Apicurio, which have no business calling the
+            # API server, so this is pod-scoped rather than namespace-scoped.
+            - macro: openbank_strimzi_operator
+              condition: >
+                (k8s.ns.name = "messaging"
+                 and k8s.pod.name startswith "strimzi-cluster-operator")
+
+            - macro: user_known_contact_k8s_api_server_activities
+              condition: >
+                (openbank_controller_namespaces
+                 or openbank_kubectl_cronjob_image
+                 or openbank_admin_ui_bff
+                 or openbank_strimzi_operator)
+              override:
+                condition: replace
+
+            # ---------------------------------------------------------------
+            # Drop and execute new binary in container  (450/day, CRITICAL)
+            #
+            # This is the rule that gates the alert, and the ONLY one of the
+            # four whose priority an alert on Critical can see. It fires on
+            # `proc.is_exe_upper_layer=true` — an executable that was written
+            # into the container's writable overlay layer AFTER image build and
+            # then exec'd. That is real malware behaviour, so the exception has
+            # to be tight enough that a genuine drop-and-execute anywhere else
+            # still fires.
+            #
+            # WHERE THE 450 COMES FROM. Candidates were enumerated from the
+            # repo and all but one are eliminated by the rule's own condition:
+            #   - JNI/native extraction (ONNX in fraud-service, netty epoll
+            #     fleet-wide, lz4) `dlopen`s a .so; the rule needs
+            #     `spawned_process`, so it cannot match.
+            #   - the pyroscope initContainer copies a JAR (run by the JVM from
+            #     the image), and litellm's initContainer stages prisma into an
+            #     emptyDir — an emptyDir is a separate mount, not the overlay
+            #     UPPER layer, so `is_exe_upper_layer` is false.
+            #   - ARC runners and their dind sidecar, the obvious suspects, are
+            #     NOT OBSERVABLE: Falco tolerates only workload=observability,
+            #     while the runner pool carries openbank.io/runner=true:NoSchedule
+            #     (arc-runners.tf), so no Falco pod runs on a runner node. The
+            #     header comment above says this and it checks out.
+            # What survives is `arc-stuck-runner-reaper` — a CronJob in ns
+            # arc-runners that is deliberately scheduled on the DEFAULT nodes
+            # (arc-runner-reaper.tf: "so the guard never itself provokes a
+            # runner-pool scale-up"), i.e. squarely in Falco's view. Its script
+            # opens with `apk add --no-cache jq curl` and then runs them:
+            # binaries installed into the writable layer of a running container
+            # and executed. That is the textbook shape of this rule.
+            # Arithmetic, which is why this is an identification and not a
+            # hypothesis: schedule */10 = 144 runs/day, each exec'ing at least
+            # curl (twice), jq and apk from the upper layer -> ~430/day against
+            # a measured 450/day.
+            #
+            # SCOPE: namespace AND pod-name prefix AND the three process names.
+            # Another pod in arc-runners still fires; a different binary
+            # dropped into the reaper pod itself still fires.
+            #
+            # THE PROPER FIX IS NOT THIS. `apk add` at runtime is the defect;
+            # baking jq+curl into the reaper image removes the detection at
+            # source and makes this macro dead. That is a Terraform change to
+            # local.arc_reaper_image and is out of scope for a gitops PR —
+            # tracked in the #5734 PR body. Delete this macro when it lands.
+            - macro: openbank_arc_reaper_apk_bootstrap
+              condition: >
+                (k8s.ns.name = "arc-runners"
+                 and k8s.pod.name startswith "arc-stuck-runner-reaper"
+                 and proc.name in (apk, jq, curl))
+
+            - macro: known_drop_and_execute_activities
+              condition: (openbank_arc_reaper_apk_bootstrap)
+              override:
+                condition: replace
 
         falcosidekick:
           enabled: false

--- a/openbank-infra/gitops/components/observability/loki-rules-falco-runtime.yaml
+++ b/openbank-infra/gitops/components/observability/loki-rules-falco-runtime.yaml
@@ -1,0 +1,179 @@
+# Runtime-security alerting on Falco detections (issue #5734).
+#
+# THE GAP THIS CLOSES. Falco has been deployed, healthy (14/14 DaemonSet pods) and actively
+# detecting since ADR-0081, and NOTHING alerted on any of it: zero PrometheusRule CRs referenced
+# Falco, and the cluster has zero Grafana-managed alert rules of any kind. apps/falco.yaml's own
+# design note said alerting "rides the existing Loki datasource" — the delivery half was built
+# (json stdout -> Alloy -> Loki, and the openbank-soc panels read it, #5052), the alerting half
+# never was. A control that detects and cannot tell anyone is write-only.
+#
+# WHY THIS FILE AND NOT A GRAFANA-MANAGED RULE. The issue suggested Grafana unified alerting.
+# This repo has no mechanism for that — no Grafana alert rule is expressible as a manifest here,
+# and building one would mean either provisioning CRs the Grafana chart is not configured for or
+# pushing rules through an API, which makes them a mutable runtime object rather than a reviewed
+# artifact. The Loki RULER is the mechanism that already exists and already does exactly this job:
+# a ConfigMap labelled loki_rule=1, picked up by the chart's k8s-sidecar into the ruler's local
+# rules directory (apps/loki.yaml `ruler` + `sidecar.rules`), evaluated against Loki and delivered
+# to the SAME Alertmanager as every PrometheusRule (`alertmanager_url` is configured and pointed at
+# kube-prometheus-stack-alertmanager). loki-rules-silent-failures.yaml and
+# loki-rules-endpoint-availability.yaml are the precedents. So: no new mechanism, no new plumbing,
+# no new webhook surface — which is what falco.yaml asked for in the first place.
+# The file is NEW rather than a document appended to an existing one on purpose: this repo has a
+# documented history of git calling a merge clean while keeping only ONE of two neighbouring
+# additions to a shared file (#3450/#3460), and a separate file cannot lose that way.
+#
+# WHY THE TUNING HAD TO COME FIRST, AND WHAT THE PRIORITIES ACTUALLY ARE. Measured 24h baseline
+# with each rule's STOCK priority:
+#
+#   29465  Contact K8S API Server From Container   NOTICE
+#    3150  Run shell untrusted                     NOTICE
+#     450  Drop and execute new binary in container CRITICAL
+#       5  Falco internal: syscall event drop      CRITICAL (Falco-internal, not a detection)
+#
+# The "33k/day" headline is NOT the alertable volume: a Critical-or-above filter sees 455/day, and
+# the two NOTICE rules are invisible to it. Untuned, that is ~19 pages an hour, forever — the
+# WorkflowLivenessStale shape this estate has already paid for, where noise on the control that
+# exists to make a dead control visible is the one thing that hides a dead control. The tuning in
+# apps/falco.yaml attributes the 450 to one CronJob's `apk add jq curl` and excepts exactly that;
+# the two NOTICE rules cannot reach these alerts at all.
+#
+# WHY NONE OF THESE PAGE YET, AND WHAT WOULD CHANGE THAT. All three are `warning` -> the
+# slack-alerts receiver, which is the only leg that reaches a human outside the perimeter
+# (kube-prometheus-stack.yaml routing; GoAlert and ntfy have no Ingress). That is a real alert
+# reaching a real human, and it is deliberately NOT `critical`, because the post-tuning volume has
+# not been MEASURED — only predicted from the repo. This estate's documented root cause is alert
+# fatigue, and both sibling files here made the same call for the same reason
+# (loki-rules-silent-failures.yaml: "a new rule that pages is a regression even when it is
+# correct"). PROMOTION CRITERION, so this does not sit at `warning` by inertia: when
+# FalcoCriticalRuntimeDetection has fired on fewer than 1 day in 7, flip its severity to `critical`
+# and it pages via GoAlert + Slack. Until that is done, and until a known-positive has been shown
+# to reach a human end-to-end, the runtime-security control is NOT complete — see #5734 step 3.
+#
+# Loki retention is 7d (ADR-0088 D3), so every window below stays well inside it.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-rules-falco-runtime
+  namespace: observability
+  labels:
+    loki_rule: "1"
+    app.kubernetes.io/part-of: observability
+data:
+  falco-runtime.yaml: |
+    groups:
+      - name: openbank.logs.falco-runtime
+        interval: 1m
+        rules:
+          # THE detection alert. Critical-or-above, which after the tuning means
+          # `Drop and execute new binary in container` (an executable written into the
+          # container's writable layer after image build, then run — MITRE persistence,
+          # PCI_DSS_11.5.1) plus anything else Falco rates Critical/Alert/Emergency.
+          #
+          # Deliberately NOT scoped to a rule name: the whole point is to catch the stock
+          # rule nobody predicted. A hand-kept list of rules to watch is a coverage set
+          # maintained separately from the thing it covers, which is how a gate ends up
+          # green about work it never did.
+          #
+          # `rule != "Falco internal: syscall event drop"` because that one is Falco
+          # reporting on ITSELF at Critical — agent health, not a detection, with a
+          # different responder and a different fix. It gets its own alert below.
+          #
+          # No `for:`. A drop-and-execute is a point event, not a condition that persists;
+          # `for` on a bursty log signal delays delivery and can drop it entirely if the
+          # burst does not span two evaluations.
+          - alert: FalcoCriticalRuntimeDetection
+            expr: |
+              sum by (rule) (
+                count_over_time(
+                  {namespace="falco"}
+                    | json
+                    | __error__=""
+                    | priority=~"Emergency|Alert|Critical"
+                    | rule!="Falco internal: syscall event drop"
+                  [10m]
+                )
+              ) > 0
+            labels:
+              severity: warning
+              team: platform
+            annotations:
+              summary: "Falco: {{ $labels.rule }} fired {{ $value | printf \"%.0f\" }}x in 10m"
+              description: >-
+                Falco raised a Critical-or-above runtime detection. This is the syscall-layer
+                control that watches a container AFTER admission — Kyverno and PSS cannot see any
+                of it. Read the full event, which names the namespace, pod, image, process,
+                command line and parent, in Loki:
+                {namespace="falco"} | json | rule="{{ $labels.rule }}"
+                — or the "Falco events by rule" panel on the openbank-soc dashboard. If the
+                detection is legitimate estate behaviour, tune it as a narrowly-scoped exception in
+                the `customRules` block of gitops/apps/falco.yaml (every stock rule ships a
+                user_known_* hook for exactly this); do NOT silence the rule, and do not widen this
+                alert. Known-legitimate today: the arc-stuck-runner-reaper CronJob's
+                `apk add jq curl`, already excepted there.
+
+          # Falco reporting that IT dropped syscall events: for that window the agent was
+          # partially blind, so the absence of a detection proves nothing. Rate-limited by
+          # Falco itself to one message per 30s (chart default syscall_event_drops:
+          # threshold .1, rate .03333), so 5/day is a genuinely small number of windows and
+          # not a suppressed flood. Separate from the alert above because the responder
+          # action is resource limits / driver, not incident response.
+          - alert: FalcoSyscallEventDrops
+            expr: |
+              sum by (hostname) (
+                count_over_time(
+                  {namespace="falco"}
+                    | json
+                    | __error__=""
+                    | rule="Falco internal: syscall event drop"
+                  [1h]
+                )
+              ) > 0
+            for: 5m
+            labels:
+              severity: warning
+              team: platform
+            annotations:
+              summary: "Falco dropped syscall events on {{ $labels.hostname }}"
+              description: >-
+                Falco's ring buffer overflowed on this node, so it did not see every syscall in
+                that window — a gap in the runtime-security control that no detection alert can
+                reveal, because the evidence is what went missing. Usually the CPU limit
+                (gitops/apps/falco.yaml sets 500m) under an event storm, or a busy node. Check
+                whether it correlates with a workload burst before raising the limit.
+
+          # DEAD-MAN'S SWITCH — the alert for "Falco stopped talking at all", which is the
+          # failure the two alerts above are structurally unable to report.
+          #
+          # This is written as absent_over_time and NOT as `count_over_time(...) == 0`, and
+          # the difference is the whole rule. An `== 0` comparison needs a SERIES to compare;
+          # when the stream is absent the selector matches nothing, the aggregation produces
+          # no series, and the comparison matches nothing — silent in exactly the case it
+          # exists for. This repo has already measured that trap on
+          # kube_endpointslice_endpoints (loki-rules-endpoint-availability.yaml: the obvious
+          # `sum by (...) == 0` returned zero results live, during the outage it described).
+          # absent_over_time returns 1 precisely WHEN there is nothing, which is the inversion
+          # that makes it work.
+          #
+          # t=0 behaviour, re-derived rather than assumed: the query reads Loki's stored data,
+          # not ruler memory, so a ruler or Falco pod RESTART does not fire it — the previous
+          # 30m of logs are still in Loki. Falco emits continuously (the untuned NOTICE rules
+          # alone are thousands a day, and `Run shell untrusted` is deliberately left noisy),
+          # so an empty 30m window means the agent, Alloy, or Loki ingestion is broken. A
+          # genuinely fresh Loki with no data at all WOULD fire, correctly. `for: 15m` damps
+          # a brief ingestion hiccup.
+          - alert: FalcoAgentSilent
+            expr: |
+              absent_over_time({namespace="falco"} [30m])
+            for: 15m
+            labels:
+              severity: warning
+              team: platform
+            annotations:
+              summary: "Falco has logged nothing for 30m — the runtime-security control is dark"
+              description: >-
+                No log line at all from namespace `falco` in 30 minutes. Falco is a DaemonSet that
+                normally emits continuously, so this means the agent, the Alloy tail, or Loki
+                ingestion has stopped — and while it is true, every Falco alert here is silent and
+                the estate has no runtime detection. Not the same failure as
+                FalcoSyscallEventDrops, which is a partial gap the agent itself reports. Check:
+                kubectl -n falco get ds,pods — then the Alloy DaemonSet and Loki ingester.


### PR DESCRIPTION
## What

Closes the alerting half of the Falco control, in the order #5734 states: **tune first, then alert.**

Falco has been detecting ~33k events/day with nothing alerting on any of them. This PR tunes the ruleset from repo evidence, then adds Loki-ruler alerts on what survives.

`Refs #5734` — **not `Closes`**, because step 3 (trigger a known-positive and confirm a human is paged) needs cluster access this PR did not have. See *Still owed* below.

## The number that reframes the issue

The 24h baseline, annotated with each rule's **stock priority** (falcosecurity/rules, Falco 0.44.1) — the column the issue did not have:

| count/day | rule | stock priority |
|---|---|---|
| 29465 | Contact K8S API Server From Container | NOTICE |
| 3150 | Run shell untrusted | NOTICE |
| 450 | Drop and execute new binary in container | **CRITICAL** |
| 5 | Falco internal: syscall event drop | **CRITICAL** (Falco-internal) |

So the "33k/day" headline and the **alertable** volume are not the same number: a `priority=~"Critical|Emergency"` alert sees **455/day, not 33k**, and the two NOTICE rules are invisible to it. That does not weaken the issue's ordering argument — 455/day is still ~19 pages an hour forever — but it does redirect it: tuning `Drop and execute` is what makes an alert survivable, and tuning the K8s-API rule buys log volume and dashboard signal.

## Tuning — and the evidence for each exception

Written against each stock rule's own `user_known_*` hook (a macro defaulting to `never_true`, or an empty list). That is the sanctioned mechanism, leaves the rule body untouched, and means a chart bump cannot silently drop an exception — it would drop the whole file, loudly. `/etc/falco/rules.d` loads after `falco_rules.yaml`, so the overrides win.

### Contact K8S API Server From Container — 29465/day

Stock excludes only `kube-system` plus a fixed list of third-party operator images (`k8s_containers`), **none of which this estate runs**. So every controller we do run trips it continuously.

| exception | scope | evidence |
|---|---|---|
| 15 platform/controller namespaces: `argocd argo-rollouts arc-runners arc-systems cert-manager cnpg-system external-dns external-secrets falco ingress-nginx keda kyverno observability vault vpa` | namespace | ArgoCD Applications' destinations plus the Terraform-installed operators (cert-manager, Karpenter, CNPG, KEDA, ARC). Also matches the repo's own authoritative infra-namespace list in `openbank-infra/scripts/netpol-coverage.py:42-48`. |
| the kubectl CronJobs | **image** (`endswith "alpine/k8s"`) | finops scale-down/up, cost-collector, tier-classifier, sbom-drift-scanner, infra-vuln-scanner, keycloak-realm-drift. They run in `admin-ui`, `iam`, `finops-scaledown` — namespaces that must **not** get a blanket. |
| the admin-ui BFF | **image** (`endswith "openbank-admin-ui"`) | the one openbank service that genuinely calls the API server (`src/lib/discovery.ts`). Its ClusterRole is read-only and bound per-namespace, never cluster-wide. |
| Strimzi cluster operator | namespace **+ pod prefix** | ns `messaging` also holds the Kafka brokers and Apicurio, which have no business calling the API server. |

**What is preserved, which is the point:** all ~60 openbank app namespaces. No openbank service carries a Kubernetes client dependency (no fabric8, no client-go anywhere in app code) and no openbank ServiceAccount except `admin-ui` has any Role or ClusterRole bound — so a connection to the API server from `payments` or `ledger` is anomalous by construction, and still fires.

**Residual, stated rather than buried:** code execution inside the admin-ui container no longer trips *this* rule. It still trips shell-spawn, drop-and-execute and sensitive-file rules, and the RBAC caps what the token can do. Scoping by image (not namespace) keeps every other container in `admin-ui` covered.

### Drop and execute new binary in container — 450/day, CRITICAL

The rule that gates the alert. It needs `proc.is_exe_upper_layer=true` — an executable written into the container's writable overlay after image build, then exec'd.

Candidates enumerated from the repo, and all but one eliminated **by the rule's own condition**:

- JNI/native extraction (ONNX in fraud-service, netty epoll fleet-wide, lz4) `dlopen`s a `.so`; the rule requires `spawned_process`, so it cannot match.
- The pyroscope initContainer copies a **JAR** (run by the JVM from the image); litellm's initContainer stages prisma into an **emptyDir** — a separate mount, not the overlay upper layer.
- ARC runners and their dind sidecar — the obvious suspects — are **not observable**. Falco tolerates only `workload=observability`, the runner pool carries `openbank.io/runner=true:NoSchedule`. The header comment in `falco.yaml` claims this and it checks out.

What survives is **`arc-stuck-runner-reaper`**: a CronJob in ns `arc-runners` deliberately scheduled on the **default** nodes ("so the guard never itself provokes a runner-pool scale-up"), i.e. squarely in Falco's view. Its script opens with `apk add --no-cache jq curl` and then runs them.

Arithmetic, which is why this is an identification rather than a hypothesis: schedule `*/10` = 144 runs/day, each exec'ing at least `curl` (twice), `jq` and `apk` from the upper layer → **~430/day against a measured 450/day.**

Excepted by namespace **and** pod-name prefix **and** process name (`apk, jq, curl`). Another pod in `arc-runners` still fires; a different binary dropped into the reaper pod itself still fires.

**The proper fix is not this exception.** `apk add` at runtime is the defect; baking jq+curl into `local.arc_reaper_image` removes the detection at source and makes the macro dead. That is a Terraform change and out of scope for a gitops PR — worth its own issue, and the macro says to delete it when that lands.

### Run shell untrusted — 3150/day — deliberately left NOISY

The rule's condition requires a `protected_shell_spawner` ancestor (an http/db/nosql/mail server binary, or a JVM running kafka/tomcat/elasticsearch/…). **Nothing in this repo identifies which of those is spawning a shell every ~30s** — every CronJob and sidecar the repo declares has a plain entrypoint parent and so cannot be the source.

An exception written from a guess would silence the rule that catches general RCE: the same write-only control with extra steps. A smaller honest tuning beats a large speculative one. It is NOTICE, so leaving it noisy costs log volume and nothing else — no alert here can see it.

The one query that would unblock it, against live Loki:

```
{namespace="falco"} | json | rule="Run shell untrusted"
```

and read `output_fields` for `proc.pname` / `proc.pexe` / `proc.pcmdline` / `k8s.ns.name`.

## Alerting — mechanism, and why not Grafana

The issue suggested a Grafana-managed rule. **This repo has no mechanism for one** — no Grafana alert rule is expressible as a manifest here, and building one would mean either provisioning CRs the Grafana chart is not configured for, or pushing rules through an API, which makes them mutable runtime objects rather than reviewed artifacts (`apps/loki.yaml` rejects exactly that for the ruler's S3 storage).

The smallest correct mechanism **already exists**: the **Loki ruler**. A ConfigMap labelled `loki_rule=1`, picked up by the chart's k8s-sidecar into the ruler's local rules directory, evaluated against Loki, delivered to the **same Alertmanager** as every PrometheusRule. `loki-rules-silent-failures.yaml` and `loki-rules-endpoint-availability.yaml` are the precedents. No new plumbing, no new webhook surface — what `falco.yaml` asked for.

`components/observability` is synced by a `directory: recurse: true` ArgoCD Application, so a new file needs no registration edit.

Three alerts:

1. **`FalcoCriticalRuntimeDetection`** — `priority=~"Emergency|Alert|Critical"`, excluding the Falco-internal drop rule. Deliberately **not** scoped to a rule name: the point is to catch the stock rule nobody predicted, and a hand-kept list of rules to watch is a coverage set maintained separately from what it covers. No `for:` — a drop-and-execute is a point event, and `for` on a bursty log signal delays or drops delivery.
2. **`FalcoSyscallEventDrops`** — Falco reporting that *it* went partially blind. Separate alert because the responder action is resource limits, not incident response.
3. **`FalcoAgentSilent`** — dead-man's switch, the failure the other two structurally cannot report.

### The two traps, addressed explicitly

- **Absent vector.** `FalcoAgentSilent` is `absent_over_time({namespace="falco"} [30m])`, **not** `count_over_time(...) == 0`. An `== 0` comparison needs a series to compare; when the stream is absent the selector matches nothing, the aggregation produces no series, and the comparison matches nothing — silent in exactly the case it exists for. This repo already measured that trap on `kube_endpointslice_endpoints`. `absent_over_time` returns 1 precisely when there is nothing.
- **t=0.** Re-derived rather than assumed: the query reads **Loki's stored data, not ruler memory**, so a ruler or Falco pod restart does **not** fire it — the previous 30m of logs are still in Loki. A genuinely fresh Loki with no data would fire, correctly. `for: 15m` damps an ingestion hiccup.

### Why none of these page yet

All three are `severity: warning` → the `slack-alerts` receiver, which per `kube-prometheus-stack.yaml` is the only leg reaching a human outside the perimeter (GoAlert and ntfy have no Ingress). That is a real alert reaching a real human.

They are deliberately **not** `critical`, because the post-tuning volume is **predicted from the repo, not measured**. This estate's documented root cause is alert fatigue, and both sibling rule files made the same call for the same reason — `loki-rules-silent-failures.yaml`: *"a new rule that pages is a regression even when it is correct."*

So the file carries a stated promotion criterion rather than sitting at `warning` by inertia: **when `FalcoCriticalRuntimeDetection` has fired on fewer than 1 day in 7, flip its severity to `critical`** and it pages via GoAlert + Slack.

## Still owed — this merge does NOT complete the control

1. **Step 3 of #5734, verify by effect.** Trigger a known-positive against the live cluster and confirm it reaches a human. Needs cluster access this PR did not have.
2. **Confirm the tuning actually removed the volume.** Every exception here is derived from repo evidence, not from live event fields — the `arc-stuck-runner-reaper` attribution is arithmetic (~430 predicted vs 450 measured), which is strong but is not the same as reading `k8s.pod.name` off the events. Re-measure the 24h baseline after this syncs.
3. **Promote to `critical`** once (1) and (2) hold, per the criterion in the file.
4. **`Run shell untrusted`** — run the query above and tune it from the real parent processes.
5. **Fix `arc_reaper_image`** to include jq+curl so the drop-and-execute exception becomes unnecessary.

Until (1) and (3), Falco is no longer write-only, but it still does not page.

## Verification done locally

- **`check-loki-rules`** — a real `grafana/loki:3.6.7` **ruler accepted** the new group (3/3 groups loaded), which is the only thing that can judge LogQL. Confirms `absent_over_time` over a log range and the `rule!=` label filter are valid.
- **Falsified on this file specifically** (a guard is proven by what it prevents): breaking the `absent_over_time` selector made the gate fail naming `FalcoAgentSilent` — `parse error at line 0, col 37: syntax error: unexpected RANGE`. Green here is meaningful, not vacuous.
- **`check-gitops-duplicate-resources`** OK — 673 manifests. The alerting rules are a **new file**, not a document appended to a shared one, precisely because this repo has a documented history (#3450/#3460) of git calling such a merge clean while keeping only one of two neighbouring additions.
- **`check-gitops-secret-refs`** OK — 566 declared, 430 references.
- **`check-critical-alert-egress`** OK — unchanged by this PR (it reads only `kube-prometheus-stack.yaml`).
- **`run-gates.py --all`** — **151/156 pass**. All 5 failures are the identical environmental cause, `PR_DIFF_BASE is empty but this gate requires it — refusing to run vacuously` (0.0s each: release-scope-mismatch, api-contract, db-migration, schema-compat, threat-model). CI supplies that variable.
- Both YAML levels parse, including the embedded Falco rules file and the embedded Loki rule group.

## Release scope

`fix(observability)` touching only `openbank-infra/gitops/**`, which is not a released component — no `version.txt`, no bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
