### PR TITLE
fix(admin-ui): make AgentDock controls accessible

### DIFF
--- a/openbank-admin-ui/src/components/agent/AgentDock.tsx
+++ b/openbank-admin-ui/src/components/agent/AgentDock.tsx
@@ -72,7 +72,10 @@ export function AgentDock() {
     <>
       {/* Floating bot button — present on every page via root layout */}
       <button
-        aria-label={t('OpenBank asistent', 'OpenBank assistant')}
+        type="button"
+        aria-label={open ? t('Zavřít asistenta', 'Close assistant') : t('Otevřít asistenta', 'Open assistant')}
+        aria-expanded={open}
+        aria-controls={open ? 'agent-dock-panel' : undefined}
         onClick={() => setOpen(o => !o)}
         style={{
           position: 'fixed', bottom: 24, right: 24, zIndex: 1000,
@@ -82,11 +85,14 @@ export function AgentDock() {
           boxShadow: '0 6px 20px rgba(0,0,0,0.18)',
         }}
       >
-        {open ? <X size={22} /> : <Bot size={22} />}
+        {open ? <X size={22} aria-hidden="true" /> : <Bot size={22} aria-hidden="true" />}
       </button>
 
       {open && (
         <div
+          id="agent-dock-panel"
+          role="region"
+          aria-label={t('Panel asistenta OpenBank', 'OpenBank assistant panel')}
           style={{
             position: 'fixed', bottom: 88, right: 24, zIndex: 1000,
             width: 400, maxWidth: 'calc(100vw - 48px)', height: 540, maxHeight: 'calc(100vh - 120px)',
@@ -97,7 +103,7 @@ export function AgentDock() {
         >
           {/* Header */}
           <div style={{ padding: '12px 14px', borderBottom: '1px solid var(--border)', display: 'flex', alignItems: 'center', gap: 8 }}>
-            <Bot size={16} style={{ color: 'var(--accent)' }} />
+            <Bot size={16} aria-hidden="true" style={{ color: 'var(--accent)' }} />
             <div style={{ flex: 1 }}>
               <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)' }}>{t('OpenBank asistent', 'OpenBank Assistant')}</div>
               <div style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>{t('jen pro čtení · řízeno politikou · auditováno', 'read-only · policy-gated · audited')}</div>
@@ -155,11 +161,11 @@ export function AgentDock() {
                   <div style={{ marginTop: 5, display: 'flex', flexDirection: 'column', gap: 3 }}>
                     {m.toolCalls.map((tc, j) => (
                       <div key={j} style={{ fontSize: 11, color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: 5 }}>
-                        <Wrench size={11} />
+                        <Wrench size={11} aria-hidden="true" />
                         <span style={{ fontFamily: 'JetBrains Mono, monospace' }}>{tc.tool}</span>
                         {tc.allowed
-                          ? <ShieldCheck size={11} style={{ color: 'var(--success)' }} />
-                          : <ShieldAlert size={11} style={{ color: 'var(--danger)' }} />}
+                          ? <ShieldCheck size={11} aria-hidden="true" style={{ color: 'var(--success)' }} />
+                          : <ShieldAlert size={11} aria-hidden="true" style={{ color: 'var(--danger)' }} />}
                       </div>
                     ))}
                   </div>
@@ -168,7 +174,7 @@ export function AgentDock() {
             ))}
             {busy && (
               <div style={{ alignSelf: 'flex-start', display: 'flex', alignItems: 'center', gap: 6, color: 'var(--text-tertiary)', fontSize: 12 }}>
-                <Loader2 size={13} className="animate-spin" /> {t('přemýšlím…', 'thinking…')}
+                <Loader2 size={13} aria-hidden="true" className="animate-spin" /> {t('přemýšlím…', 'thinking…')}
               </div>
             )}
           </div>
@@ -176,6 +182,8 @@ export function AgentDock() {
           {/* Input */}
           <div style={{ padding: 10, borderTop: '1px solid var(--border)', display: 'flex', gap: 8 }}>
             <input
+              id="agent-dock-input"
+              aria-label={t('Zpráva pro asistenta', 'Message for assistant')}
               value={input}
               onChange={e => setInput(e.target.value)}
               onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send() } }}
@@ -184,6 +192,8 @@ export function AgentDock() {
               style={{ flex: 1, fontSize: 12.5, padding: '8px 10px', borderRadius: 8, border: '1px solid var(--border)', background: 'var(--surface-2)', color: 'var(--text-primary)' }}
             />
             <button
+              type="button"
+              aria-label={t('Odeslat zprávu', 'Send message')}
               onClick={send}
               disabled={busy || !input.trim()}
               style={{
@@ -192,7 +202,7 @@ export function AgentDock() {
                 opacity: busy || !input.trim() ? 0.5 : 1,
               }}
             >
-              <Send size={15} />
+              <Send size={15} aria-hidden="true" />
             </button>
           </div>
         </div>

--- a/openbank-admin-ui/src/test/agent-dock-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/agent-dock-a11y.guard.test.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('AgentDock accessibility contract', () => {
+  const source = fs.readFileSync(path.join(process.cwd(), 'src/components/agent/AgentDock.tsx'), 'utf8')
+
+  it('exposes stateful, named controls and a stable panel target', () => {
+    expect(source).toContain('aria-expanded={open}')
+    expect(source).toContain("aria-controls={open ? 'agent-dock-panel' : undefined}")
+    expect(source).toContain('id="agent-dock-panel"')
+    expect(source).toContain('role="region"')
+    expect(source).toContain("aria-label={t('Zpráva pro asistenta', 'Message for assistant')}")
+    expect(source).toContain("aria-label={t('Odeslat zprávu', 'Send message')}")
+    expect(source).toContain('type="button"')
+    expect(source).toContain('aria-hidden="true"')
+  })
+})


### PR DESCRIPTION
## Summary
- expose AgentDock open/close state and a stable panel region
- label the assistant input and send action
- hide decorative icons and add a focused accessibility guard

Preserves existing /api/agent/chat GET/POST, model selection, policy and audit behavior.

Closes #5823