### PR TITLE
fix(admin-ui): improve ProcessView accessibility

### DIFF
--- a/openbank-admin-ui/src/components/docs/ProcessView.tsx
+++ b/openbank-admin-ui/src/components/docs/ProcessView.tsx
@@ -17,6 +17,7 @@ import type { ElementType } from 'react'
 import { ShieldCheck, Info, CheckCircle2, CircleDashed, Circle, X } from 'lucide-react'
 import { Mermaid } from '@/components/docs/Mermaid'
 import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { overallScore, type Process, type Status, type TechNode } from '@/lib/docs/process/schema'
 
 type Mode = 'reality' | 'target'
@@ -33,7 +34,7 @@ const ICON_MAP: Record<string, ElementType> = { ShieldCheck }
 
 function StatusDot({ status }: { status: Status }) {
   const m = STATUS_META[status]
-  return <m.Icon size={13} style={{ color: m.color, flexShrink: 0 }} />
+  return <m.Icon size={13} aria-hidden="true" style={{ color: m.color, flexShrink: 0 }} />
 }
 
 function StatusChip({ status }: { status: Status }) {
@@ -49,6 +50,7 @@ function StatusChip({ status }: { status: Status }) {
 }
 
 export function ProcessView({ proc }: { proc: Process }) {
+  const { t } = useLanguage()
   const [mode, setMode] = useState<Mode>('reality')
   const [lens, setLens] = useState<Lens>('story')
   const [selected, setSelected] = useState<TechNode | null>(null)
@@ -73,9 +75,9 @@ export function ProcessView({ proc }: { proc: Process }) {
 
       {/* Honesty banner + reality/target toggle */}
       <div className="card" style={{ padding: '12px 16px', marginBottom: '16px', display: 'flex', alignItems: 'center', gap: '16px', flexWrap: 'wrap' }}>
-        <div style={{ display: 'inline-flex', borderRadius: '8px', border: '1px solid var(--border)', overflow: 'hidden' }}>
+        <div role="group" aria-label={t('Režim zobrazení procesu', 'Process view mode')} style={{ display: 'inline-flex', borderRadius: '8px', border: '1px solid var(--border)', overflow: 'hidden' }}>
           {(['reality', 'target'] as Mode[]).map(m => (
-            <button key={m} onClick={() => setMode(m)} style={{
+            <button key={m} type="button" aria-pressed={mode === m} onClick={() => setMode(m)} style={{
               padding: '6px 14px', fontSize: '13px', fontWeight: 600, border: 'none', cursor: 'pointer',
               fontFamily: 'inherit',
               background: mode === m ? 'var(--accent)' : 'var(--surface)',
@@ -90,15 +92,15 @@ export function ProcessView({ proc }: { proc: Process }) {
           </div>
         ))}
         <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginLeft: 'auto', fontSize: '11px', color: 'var(--text-secondary)' }}>
-          <Info size={13} />
+          <Info size={13} aria-hidden="true" />
           Skóre = produkční compliance cíl. Dev sandbox je záměrně mimo scope pro některé prod controls (TLS, secrets — řeší infra vrstva).
         </div>
       </div>
 
       {/* Lens tabs */}
-      <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginBottom: '16px' }}>
+      <div role="group" aria-label={t('Čočka zobrazení procesu', 'Process view lens')} style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginBottom: '16px' }}>
         {([['story', '① Příběh'], ['token', '② Tokeny'], ['tech', '③ Technologie']] as [Lens, string][]).map(([id, label]) => (
-          <button key={id} onClick={() => setLens(id)} style={{
+          <button key={id} type="button" aria-pressed={lens === id} onClick={() => setLens(id)} style={{
             padding: '8px 16px', fontSize: '13px', fontWeight: 600, borderRadius: '8px',
             border: `1px solid ${lens === id ? 'var(--accent)' : 'var(--border)'}`,
             background: lens === id ? 'var(--accent)' : 'var(--surface)',
@@ -153,7 +155,7 @@ export function ProcessView({ proc }: { proc: Process }) {
                       const m = STATUS_META[n.status]
                       const active = selected?.id === n.id
                       return (
-                        <button key={n.id} onClick={() => setSelected(active ? null : n)} title={n.desc} style={{
+                        <button key={n.id} type="button" aria-label={n.name} aria-pressed={active} onClick={() => setSelected(active ? null : n)} title={n.desc} style={{
                           display: 'flex', alignItems: 'center', gap: '6px', padding: '6px 10px', borderRadius: '8px',
                           cursor: 'pointer', background: m.bg, border: `1px solid ${active ? m.color : m.border}`,
                           boxShadow: active ? `0 0 0 2px ${m.color}55` : 'none',
@@ -170,7 +172,7 @@ export function ProcessView({ proc }: { proc: Process }) {
                 <div className="card" style={{ padding: '14px 16px', borderLeft: `3px solid ${STATUS_META[selected.status].color}` }}>
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '6px' }}>
                     <span style={{ fontSize: '14px', fontWeight: 700, color: 'var(--text-primary)' }}>{selected.name}</span>
-                    <button onClick={() => setSelected(null)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)', padding: 0 }}><X size={15} /></button>
+                    <button type="button" aria-label={t('Zavřít technologické detaily', 'Close technology details')} onClick={() => setSelected(null)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)', padding: 0 }}><X size={15} aria-hidden="true" /></button>
                   </div>
                   <div style={{ marginBottom: '8px' }}><StatusChip status={selected.status} /></div>
                   <p style={{ fontSize: '13px', color: 'var(--text-secondary)', lineHeight: 1.6, margin: 0 }}>{selected.desc}</p>

--- a/openbank-admin-ui/src/test/process-view-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/process-view-a11y.guard.test.ts
@@ -1,0 +1,19 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('ProcessView accessibility contract', () => {
+  const source = fs.readFileSync(path.join(process.cwd(), 'src/components/docs/ProcessView.tsx'), 'utf8')
+
+  it('names stateful controls and hides decorative icons', () => {
+    expect(source).toContain("aria-label={t('Režim zobrazení procesu', 'Process view mode')}")
+    expect(source).toContain("aria-label={t('Čočka zobrazení procesu', 'Process view lens')}")
+    expect(source).toContain('aria-pressed={mode === m}')
+    expect(source).toContain('aria-pressed={lens === id}')
+    expect(source).toContain('aria-pressed={active}')
+    expect(source).toContain('aria-label={n.name}')
+    expect(source).toContain("aria-label={t('Zavřít technologické detaily', 'Close technology details')}")
+    expect(source).toContain('type="button"')
+    expect(source).toContain('aria-hidden="true"')
+  })
+})


### PR DESCRIPTION
## Summary
- expose mode and lens state to assistive technology
- name technology node and close controls
- mark decorative status icons and enforce button types

Preserves ProcessView state, manifest rendering, and all existing documentation behavior.

Refs #5823