### PR TITLE
feat(delegation): emit audit events for spend reserve, confirm and release

### DIFF
--- a/openbank-contracts/openbank-delegation-service/asyncapi.yaml
+++ b/openbank-contracts/openbank-delegation-service/asyncapi.yaml
@@ -78,6 +78,12 @@ channels:
         $ref: '#/components/messages/DelegationRenounced'
       DelegationExpired:
         $ref: '#/components/messages/DelegationExpired'
+      SpendReserved:
+        $ref: '#/components/messages/SpendReserved'
+      SpendConfirmed:
+        $ref: '#/components/messages/SpendConfirmed'
+      SpendReleased:
+        $ref: '#/components/messages/SpendReleased'
 
 operations:
   publishDelegationEvents:
@@ -96,6 +102,13 @@ operations:
       read model so that enforcing a delegation never requires a synchronous call to
       delegation-service. When either merges, add it here; a consumer absent from this list is a
       consumer nobody has agreed to keep compatible.
+
+      **`openbank-audit-service` subscribes as of #5728** (ADR-0249 D4). It was not subscribed to
+      this topic before, so no delegation event of any kind reached the audit trail — which is why
+      adding the spend-reservation events below without the subscription would have been an outbox
+      row nobody reads. It consumes every message on this channel generically (no per-type logic),
+      so a new event type does not break it; what it needs is `sourceService`, which the three
+      Spend* messages carry and the eight lifecycle messages do not yet.
     messages:
       - $ref: '#/channels/delegationEvents/messages/DelegationOffered'
       - $ref: '#/channels/delegationEvents/messages/DelegationActivated'
@@ -105,6 +118,9 @@ operations:
       - $ref: '#/channels/delegationEvents/messages/DelegationReinstated'
       - $ref: '#/channels/delegationEvents/messages/DelegationRenounced'
       - $ref: '#/channels/delegationEvents/messages/DelegationExpired'
+      - $ref: '#/channels/delegationEvents/messages/SpendReserved'
+      - $ref: '#/channels/delegationEvents/messages/SpendConfirmed'
+      - $ref: '#/channels/delegationEvents/messages/SpendReleased'
 
 components:
   messageTraits:
@@ -247,6 +263,28 @@ components:
                 `{"code":"CZK"}` while every consumer reads this as text. Matches the fleet's
                 event convention (AccountEvents, LedgerEvents).
 
+    # ADR-0249 D3/D4 — one unit of delegated spend. `aggregateId` is still the GRANT, not the
+    # reservation: the partition key is `aggregateId`, and keying on the reservation would let a
+    # consumer see spend against an authority whose revocation it has not applied yet.
+    reservation:
+      type: object
+      required: [reservationId, amount]
+      properties:
+        reservationId:
+          type: string
+          format: uuid
+          description: The unit of spend. Unique; NOT the partition key.
+        amount:
+          type: object
+          required: [amount, currency]
+          properties:
+            amount: { type: string, format: decimal }
+            currency:
+              type: string
+              minLength: 3
+              maxLength: 3
+              description: ISO 4217, flat — same `EventMoney` shape as `perTransactionLimit`.
+
   messages:
     DelegationOffered:
       name: DelegationOffered
@@ -385,3 +423,80 @@ components:
           - $ref: '#/components/schemas/envelope'
           - $ref: '#/components/schemas/parties'
           - $ref: '#/components/schemas/resource'
+
+    SpendReserved:
+      name: SpendReserved
+      title: Headroom was taken under the grant's cumulative ceilings
+      summary: |
+        Emitted by `SpendReservationService.reserve` and written to `delegation_outbox` in the SAME
+        transaction as the reservation row, so a committed reservation always has its event.
+
+        Emitted only for a NEWLY created reservation. An idempotent replay returns the reservation
+        an earlier call created and emits nothing — it created no state, so a second event would
+        claim a second spend. A refusal creates nothing and emits nothing either; a refused reserve
+        is visible as the absence of this event, not as an event of its own.
+
+        `idempotencyKey` is the caller's opaque key for the payment this reservation backs — the
+        only link from the audit trail to the money movement that consumed the headroom.
+      contentType: application/json
+      traits:
+        - $ref: '#/components/messageTraits/outboxHeaders'
+      payload:
+        allOf:
+          - $ref: '#/components/schemas/envelope'
+          - $ref: '#/components/schemas/parties'
+          - $ref: '#/components/schemas/reservation'
+          - type: object
+            required: [idempotencyKey]
+            properties:
+              idempotencyKey:
+                type: string
+
+    SpendConfirmed:
+      name: SpendConfirmed
+      title: The money moved — the headroom stays consumed
+      summary: |
+        Terminal for the reservation. Emitted only when the compare-and-set in
+        `SpendReservationRepository.settle` actually won: the losing side of a confirm/release race
+        changed nothing, and a re-confirm of an already-CONFIRMED reservation is a no-op replay, so
+        neither emits. One reservation therefore yields at most one settlement event.
+      contentType: application/json
+      traits:
+        - $ref: '#/components/messageTraits/outboxHeaders'
+      payload:
+        allOf:
+          - $ref: '#/components/schemas/envelope'
+          - $ref: '#/components/schemas/parties'
+          - $ref: '#/components/schemas/reservation'
+          - type: object
+            required: [settledAt]
+            properties:
+              settledAt:
+                type: string
+                format: date-time
+                description: >-
+                  When the reservation left RESERVED. Distinct from `occurredAt` only in intent:
+                  both are this call's clock reading, and neither has a default — an `occurredAt`
+                  that defaults is the Instant.EPOCH shape (#3874/#3883) that reads as 1970.
+
+    SpendReleased:
+      name: SpendReleased
+      title: The payment did not happen — the headroom comes back
+      summary: |
+        Terminal for the reservation, and the only settlement that RESTORES headroom. Same
+        emit-once-on-a-won-CAS rule as `SpendConfirmed`. A release is refused outright once the
+        reservation is CONFIRMED, so this event can never re-open a ceiling already spent through.
+      contentType: application/json
+      traits:
+        - $ref: '#/components/messageTraits/outboxHeaders'
+      payload:
+        allOf:
+          - $ref: '#/components/schemas/envelope'
+          - $ref: '#/components/schemas/parties'
+          - $ref: '#/components/schemas/reservation'
+          - type: object
+            required: [settledAt]
+            properties:
+              settledAt:
+                type: string
+                format: date-time

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/port/out/SpendReservationPorts.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/port/out/SpendReservationPorts.kt
@@ -9,6 +9,7 @@ import com.openbank.delegation.domain.model.SpendDecision
 import com.openbank.delegation.domain.model.SpendReservation
 import com.openbank.delegation.domain.model.SpendReservationState
 import com.openbank.delegation.domain.model.SpendWindow
+import com.openbank.libs.domain.event.DomainEvent
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -36,10 +37,17 @@ interface SpendReservationRepository {
      * [decide] is invoked with the totals of every RESERVED and CONFIRMED reservation on this grant
      * inside [window], denominated in [candidate]'s currency. It is called at most once, and only
      * after the concurrency guarantee is in place.
+     *
+     * [auditEvent] is written to the outbox INSIDE the same transaction as the insert, so a
+     * committed reservation always has its audit event and a rolled-back one never does
+     * (ADR-0249 D4, issue #5728). It is built from the reservation that was actually created, and
+     * is invoked ONLY on [ReserveOutcome.Created] — a replay created no state and so is not a
+     * second reservation to audit, and a refusal created none at all.
      */
     suspend fun reserve(
         candidate: SpendReservation,
         window: SpendWindow,
+        auditEvent: (SpendReservation) -> DomainEvent,
         decide: (CountedSpend) -> SpendDecision,
     ): ReserveOutcome
 
@@ -49,11 +57,16 @@ interface SpendReservationRepository {
      * Move a reservation out of RESERVED under a compare-and-set on its current state, so a
      * confirm and a release racing on the same reservation cannot both land. Returns null when the
      * row was not in RESERVED — the caller decides whether that is a replay or a conflict.
+     *
+     * [auditEvent] is written to the outbox in the same transaction as the state change, and only
+     * when the compare-and-set actually won: the losing side of a confirm/release race changed
+     * nothing, so auditing it would record a settlement that never happened.
      */
     suspend fun settle(
         grantId: UUID,
         reservationId: UUID,
         target: SpendReservationState,
         settledAt: OffsetDateTime,
+        auditEvent: (SpendReservation) -> DomainEvent,
     ): SpendReservation?
 }

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/usecase/SpendReservationService.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/usecase/SpendReservationService.kt
@@ -11,12 +11,17 @@ import com.openbank.delegation.application.port.`in`.ReserveSpendUseCase
 import com.openbank.delegation.application.port.out.DelegationRepository
 import com.openbank.delegation.application.port.out.ReserveOutcome
 import com.openbank.delegation.application.port.out.SpendReservationRepository
+import com.openbank.delegation.domain.event.EventMoney
+import com.openbank.delegation.domain.event.SpendConfirmed
+import com.openbank.delegation.domain.event.SpendReleased
+import com.openbank.delegation.domain.event.SpendReserved
 import com.openbank.delegation.domain.model.DelegationGrant
 import com.openbank.delegation.domain.model.SpendCeilings
 import com.openbank.delegation.domain.model.SpendDecision
 import com.openbank.delegation.domain.model.SpendReservation
 import com.openbank.delegation.domain.model.SpendReservationState
 import com.openbank.delegation.domain.model.SpendWindows
+import com.openbank.libs.domain.event.DomainEvent
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import java.time.Clock
@@ -64,6 +69,20 @@ class SpendReservationService(
         val outcome = reservationRepository.reserve(
             candidate = candidate,
             window = SpendWindows.windowAt(now),
+            // ADR-0249 D4 (#5728). `now` is this call's real clock reading, not a default: an
+            // `occurredAt` that defaults is the Instant.EPOCH shape (#3874/#3883) that every
+            // isNotNull() assertion in the fleet agreed with while the trail claimed 1970.
+            auditEvent = { reservation ->
+                SpendReserved(
+                    aggregateId = grant.id,
+                    reservationId = reservation.id,
+                    grantorPartyId = grant.grantorPartyId,
+                    granteePartyId = grant.granteePartyId,
+                    amount = EventMoney(reservation.amount.amount, reservation.amount.currency.code),
+                    idempotencyKey = reservation.idempotencyKey,
+                    occurredAt = now.toInstant(),
+                )
+            },
         ) { counted -> SpendCeilings.evaluate(grant, command.amount, counted, now) }
 
         return when (outcome) {
@@ -97,8 +116,11 @@ class SpendReservationService(
         callerPartyId: CallerPartyId,
         target: SpendReservationState,
     ): SpendReservation {
-        loadForGrantee(delegationId, callerPartyId)
-        val settled = reservationRepository.settle(delegationId, reservationId, target, OffsetDateTime.now(clock))
+        val grant = loadForGrantee(delegationId, callerPartyId)
+        val now = OffsetDateTime.now(clock)
+        val settled = reservationRepository.settle(delegationId, reservationId, target, now) { reservation ->
+            settlementEvent(grant, reservation, target, now)
+        }
         if (settled != null) return settled
 
         val current = reservationRepository.findById(delegationId, reservationId)
@@ -107,6 +129,50 @@ class SpendReservationService(
         throw SpendReservationStateException(
             "reservation $reservationId is ${current.state} and cannot become $target",
         )
+    }
+
+    /**
+     * ADR-0249 D4 — the confirmation and the release halves of "every grant, reservation,
+     * confirmation and revocation is an audit event" (#5728).
+     *
+     * Built here rather than in the repository because the grantor/grantee pair belongs to the
+     * grant, which the use case has already loaded and authorised against; the repository sees
+     * only the reservation row.
+     */
+    private fun settlementEvent(
+        grant: DelegationGrant,
+        reservation: SpendReservation,
+        target: SpendReservationState,
+        now: OffsetDateTime,
+    ): DomainEvent {
+        val amount = EventMoney(reservation.amount.amount, reservation.amount.currency.code)
+        val settledAt = reservation.settledAt ?: now
+        return when (target) {
+            SpendReservationState.CONFIRMED -> SpendConfirmed(
+                aggregateId = grant.id,
+                reservationId = reservation.id,
+                grantorPartyId = grant.grantorPartyId,
+                granteePartyId = grant.granteePartyId,
+                amount = amount,
+                settledAt = settledAt,
+                occurredAt = now.toInstant(),
+            )
+
+            SpendReservationState.RELEASED -> SpendReleased(
+                aggregateId = grant.id,
+                reservationId = reservation.id,
+                grantorPartyId = grant.grantorPartyId,
+                granteePartyId = grant.granteePartyId,
+                amount = amount,
+                settledAt = settledAt,
+                occurredAt = now.toInstant(),
+            )
+
+            // `settle` is only ever reached from confirm() or release(); RESERVED is not a target
+            // the compare-and-set accepts, so this branch is unreachable rather than a state to
+            // audit. Failing loudly beats inventing an event type for it.
+            SpendReservationState.RESERVED -> error("RESERVED is not a settlement target")
+        }
     }
 
     /**

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/domain/event/DelegationEvents.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/domain/event/DelegationEvents.kt
@@ -151,3 +151,89 @@ data class DelegationExpired(
     override val eventType = "DelegationExpired"
     override val version = 1L
 }
+
+/*
+ * ADR-0249 D4 — the reservation half of "every grant, reservation, confirmation and revocation is
+ * an audit event" (issue #5728).
+ *
+ * Until these existed, the D3 reserve/confirm/release path moved real money on a delegated
+ * authority and wrote nothing to the outbox at all, while this ADR was the compliance-facing
+ * record claiming it did. Card issuance/revocation was the only audited half.
+ *
+ * **Why `aggregateId` is the GRANT and not the reservation.** `OutboxKafkaHeaders.partitionKey`
+ * returns `aggregateId`, so keying on the grant puts a reserve and a revoke of the same grant on
+ * one partition, in order. Keying on the reservation would let a consumer see spend against an
+ * authority whose revocation it has not applied yet. The reservation keeps its own id in
+ * [SpendReserved.reservationId] and friends, which is what identifies the unit of spend.
+ *
+ * **Why PascalCase and not SCREAMING_SNAKE_CASE.** These share one topic
+ * (`openbank.delegation.events`) with the eight lifecycle events above, whose `eventType` is
+ * PascalCase and whose only in-tree consumers (`CardDelegationEventConsumer`, the account-service
+ * twin) match those strings literally. The SCREAMING_SNAKE spelling belongs to a different
+ * producer and a different topic — `EdgeAuditPublisher`'s `openbank.customer.audit`, where
+ * `CUSTOMER_DELEGATED_CARD_ISSUED` lives. Putting a second idiom into this stream would make the
+ * topic's own convention unstateable.
+ */
+
+/**
+ * Producing service, read by `AuditConsumer.resolveSourceService` as the strongest
+ * (EVENT-sourced) attribution — issues #3994/#5256, where producers omitting it landed every
+ * audit row as `"unknown"` with no error, because the consumer falls back to `?: "unknown"`.
+ *
+ * These are serialised data classes, so the wire key is this Kotlin property name and a grep for
+ * a quoted `"sourceService"` finds nothing here; `SpendReservationEventsTest` asserts it off real
+ * serialised JSON rather than off the property.
+ */
+internal const val DELEGATION_SOURCE_SERVICE = "delegation-service"
+
+/** Headroom was taken under the grant's ceilings — before the money moves. */
+data class SpendReserved(
+    override val aggregateId: UUID,
+    val reservationId: UUID,
+    val grantorPartyId: UUID,
+    val granteePartyId: UUID,
+    val amount: EventMoney,
+    /**
+     * The caller's key for the spend this reservation backs — the only link from the audit trail
+     * to the payment that consumed the headroom. Opaque and caller-chosen; never a PII field.
+     */
+    val idempotencyKey: String,
+    override val occurredAt: Instant,
+) : DomainEvent(occurredAt) {
+    override val aggregateType = "DelegationGrant"
+    override val eventType = "SpendReserved"
+    override val version = 1L
+    val sourceService: String = DELEGATION_SOURCE_SERVICE
+}
+
+/** The money moved: the headroom stays consumed. Terminal for this reservation. */
+data class SpendConfirmed(
+    override val aggregateId: UUID,
+    val reservationId: UUID,
+    val grantorPartyId: UUID,
+    val granteePartyId: UUID,
+    val amount: EventMoney,
+    val settledAt: OffsetDateTime,
+    override val occurredAt: Instant,
+) : DomainEvent(occurredAt) {
+    override val aggregateType = "DelegationGrant"
+    override val eventType = "SpendConfirmed"
+    override val version = 1L
+    val sourceService: String = DELEGATION_SOURCE_SERVICE
+}
+
+/** The payment did not happen: the headroom comes back. Terminal for this reservation. */
+data class SpendReleased(
+    override val aggregateId: UUID,
+    val reservationId: UUID,
+    val grantorPartyId: UUID,
+    val granteePartyId: UUID,
+    val amount: EventMoney,
+    val settledAt: OffsetDateTime,
+    override val occurredAt: Instant,
+) : DomainEvent(occurredAt) {
+    override val aggregateType = "DelegationGrant"
+    override val eventType = "SpendReleased"
+    override val version = 1L
+    val sourceService: String = DELEGATION_SOURCE_SERVICE
+}

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/persistence/repository/SpendReservationRepositoryImpl.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/persistence/repository/SpendReservationRepositoryImpl.kt
@@ -4,6 +4,8 @@
 
 package com.openbank.delegation.infrastructure.persistence.repository
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.delegation.application.port.out.DelegationOutboxRepository
 import com.openbank.delegation.application.port.out.ReserveOutcome
 import com.openbank.delegation.application.port.out.SpendReservationRepository
 import com.openbank.delegation.domain.model.CountedSpend
@@ -12,6 +14,8 @@ import com.openbank.delegation.domain.model.SpendReservation
 import com.openbank.delegation.domain.model.SpendReservationState
 import com.openbank.delegation.domain.model.SpendWindow
 import com.openbank.delegation.infrastructure.persistence.entity.SpendReservationEntity
+import com.openbank.libs.domain.event.DomainEvent
+import com.openbank.libs.persistence.outbox.OutboxMessage
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.PanacheRepository
 import io.smallrye.mutiny.Uni
@@ -43,18 +47,27 @@ import java.util.UUID
  * (same serialisation, but keyed on a number with no referential integrity, so a lock could be
  * taken on a grant that does not exist).
  *
+ * ADR-0249 D4 (issue #5728) adds the third: the audit event for a reserve or a settle is written
+ * to `delegation_outbox` INSIDE these same transactions, by the same rule the grant lifecycle
+ * already follows in `DelegationRepositoryImpl`. A separate publish after the commit would be a
+ * second failure point on a money path — the reservation would be real and the audit trail would
+ * not, which is the exact overclaim ADR-0249's Consequences section made about this path.
+ *
  * Idempotency is the second, independent guarantee: `uq_delegation_spend_idempotency` makes a
  * repeated key a database fact rather than a read-then-write, so even a retry that somehow escapes
  * the lock cannot double-count — it violates the constraint instead.
  */
 @ApplicationScoped
-class SpendReservationRepositoryImpl :
-    SpendReservationRepository,
+class SpendReservationRepositoryImpl(
+    private val outboxRepository: DelegationOutboxRepository,
+    private val objectMapper: ObjectMapper,
+) : SpendReservationRepository,
     PanacheRepository<SpendReservationEntity> {
 
     override suspend fun reserve(
         candidate: SpendReservation,
         window: SpendWindow,
+        auditEvent: (SpendReservation) -> DomainEvent,
         decide: (CountedSpend) -> SpendDecision,
     ): ReserveOutcome = Panache.withTransaction {
         Panache.getSession().flatMap { session ->
@@ -63,7 +76,7 @@ class SpendReservationRepositoryImpl :
                     if (existing != null) {
                         Uni.createFrom().item(ReserveOutcome.Replayed(existing.toDomain()) as ReserveOutcome)
                     } else {
-                        countAndInsert(session, candidate, window, decide)
+                        countAndInsert(session, candidate, window, auditEvent, decide)
                     }
                 }
             }
@@ -88,6 +101,7 @@ class SpendReservationRepositoryImpl :
         reservationId: UUID,
         target: SpendReservationState,
         settledAt: OffsetDateTime,
+        auditEvent: (SpendReservation) -> DomainEvent,
     ): SpendReservation? = Panache.withTransaction {
         find("id = ?1 and grantId = ?2", reservationId, grantId).firstResult<SpendReservationEntity>()
             .flatMap { before ->
@@ -101,8 +115,14 @@ class SpendReservationRepositoryImpl :
                         reservationId,
                         grantId,
                         SpendReservationState.RESERVED,
-                    ).map { count ->
-                        if (count > 0L) before.toDomain().copy(state = target, settledAt = settledAt) else null
+                    ).flatMap { count ->
+                        if (count > 0L) {
+                            val settled = before.toDomain().copy(state = target, settledAt = settledAt)
+                            outboxRepository.persistInTransaction(outboxMessage(auditEvent(settled)))
+                                .replaceWith(settled)
+                        } else {
+                            Uni.createFrom().nullItem()
+                        }
                     }
                 }
             }
@@ -121,15 +141,25 @@ class SpendReservationRepositoryImpl :
         session: Mutiny.Session,
         candidate: SpendReservation,
         window: SpendWindow,
+        auditEvent: (SpendReservation) -> DomainEvent,
         decide: (CountedSpend) -> SpendDecision,
     ): Uni<ReserveOutcome> = countedSpend(session, candidate, window).flatMap { counted ->
         when (val decision = decide(counted)) {
             is SpendDecision.Refused -> Uni.createFrom().item(ReserveOutcome.Refused(decision) as ReserveOutcome)
 
             SpendDecision.Allowed -> session.persist(SpendReservationEntity.fromDomain(candidate))
+                .flatMap { outboxRepository.persistInTransaction(outboxMessage(auditEvent(candidate))) }
                 .replaceWith(ReserveOutcome.Created(candidate) as ReserveOutcome)
         }
     }
+
+    /** Same shape as `DelegationRepositoryImpl.outboxMessage` — one outbox, one envelope. */
+    private fun outboxMessage(event: DomainEvent): OutboxMessage = OutboxMessage(
+        aggregateId = event.aggregateId,
+        eventType = event.eventType,
+        payload = objectMapper.writeValueAsString(event),
+        createdAt = event.occurredAt,
+    )
 
     /**
      * RESERVED and CONFIRMED count, RELEASED does not, and only rows in the SAME currency as the

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/application/usecase/SpendReservationServiceTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/application/usecase/SpendReservationServiceTest.kt
@@ -9,6 +9,9 @@ import com.openbank.delegation.application.port.`in`.ReserveSpendResult
 import com.openbank.delegation.application.port.out.DelegationRepository
 import com.openbank.delegation.application.port.out.ReserveOutcome
 import com.openbank.delegation.application.port.out.SpendReservationRepository
+import com.openbank.delegation.domain.event.SpendConfirmed
+import com.openbank.delegation.domain.event.SpendReleased
+import com.openbank.delegation.domain.event.SpendReserved
 import com.openbank.delegation.domain.model.CountedSpend
 import com.openbank.delegation.domain.model.DelegationCapability
 import com.openbank.delegation.domain.model.DelegationGrant
@@ -19,6 +22,7 @@ import com.openbank.delegation.domain.model.SpendRefusalReason
 import com.openbank.delegation.domain.model.SpendReservation
 import com.openbank.delegation.domain.model.SpendReservationState
 import com.openbank.delegation.domain.model.SpendWindow
+import com.openbank.libs.domain.event.DomainEvent
 import com.openbank.libs.domain.money.Money
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -216,14 +220,118 @@ class SpendReservationServiceTest {
      * Counts for real instead of returning canned answers, so the "reserved counts / confirmed
      * counts / released does not" rule is exercised by every test above rather than restated.
      */
+    // --- ADR-0249 D4 audit events (issue #5728) ---
+    //
+    // The ADR's Consequences section claims "every grant, reservation, confirmation and revocation
+    // is an audit event". Before #5728 this path emitted NOTHING, and the claim was checked by
+    // nobody. These assert the CONTENT — event type, both party ids, the reservation id, the
+    // amount, `sourceService` and a real clock reading — not merely that something was emitted:
+    // "the publisher was called" cannot tell a correct event from an empty one.
+
+    @Test
+    fun `a created reservation emits SpendReserved naming both parties, the reservation and the amount`() {
+        val result = reserve("1500.00", key = "payment-7")
+
+        val event = reservations.events.single()
+        assertThat(event).isInstanceOf(SpendReserved::class.java)
+        val reserved = event as SpendReserved
+        assertThat(reserved.eventType).isEqualTo("SpendReserved")
+        assertThat(reserved.aggregateType).isEqualTo("DelegationGrant")
+        // The GRANT is the aggregate/partition key; the reservation is a field. Keying on the
+        // reservation would let a consumer see spend against an authority whose revocation it has
+        // not applied yet.
+        assertThat(reserved.aggregateId).isEqualTo(currentGrant.id)
+        assertThat(reserved.reservationId).isEqualTo(result.reservation.id)
+        assertThat(reserved.grantorPartyId).isEqualTo(grantor)
+        assertThat(reserved.granteePartyId).isEqualTo(grantee)
+        assertThat(reserved.amount.amount).isEqualByComparingTo(BigDecimal("1500.00"))
+        assertThat(reserved.amount.currency).isEqualTo("CZK")
+        assertThat(reserved.idempotencyKey).isEqualTo("payment-7")
+        assertThat(reserved.sourceService).isEqualTo("delegation-service")
+    }
+
+    @Test
+    fun `confirm emits SpendConfirmed and release emits SpendReleased, each once`() {
+        val toConfirm = reserve("100.00")
+        val toRelease = reserve("200.00")
+        runBlocking { service.confirm(currentGrant.id, toConfirm.reservation.id, grantee) }
+        runBlocking { service.release(currentGrant.id, toRelease.reservation.id, grantee) }
+
+        val confirmed = reservations.events.filterIsInstance<SpendConfirmed>().single()
+        assertThat(confirmed.eventType).isEqualTo("SpendConfirmed")
+        assertThat(confirmed.aggregateId).isEqualTo(currentGrant.id)
+        assertThat(confirmed.reservationId).isEqualTo(toConfirm.reservation.id)
+        assertThat(confirmed.grantorPartyId).isEqualTo(grantor)
+        assertThat(confirmed.granteePartyId).isEqualTo(grantee)
+        assertThat(confirmed.amount.amount).isEqualByComparingTo(BigDecimal("100.00"))
+        assertThat(confirmed.settledAt).isEqualTo(now)
+        assertThat(confirmed.sourceService).isEqualTo("delegation-service")
+
+        val released = reservations.events.filterIsInstance<SpendReleased>().single()
+        assertThat(released.eventType).isEqualTo("SpendReleased")
+        assertThat(released.reservationId).isEqualTo(toRelease.reservation.id)
+        assertThat(released.amount.amount).isEqualByComparingTo(BigDecimal("200.00"))
+        assertThat(released.settledAt).isEqualTo(now)
+        assertThat(released.sourceService).isEqualTo("delegation-service")
+    }
+
+    @Test
+    fun `a replay and a refusal emit no event`() {
+        reserve("3000.00", key = "payment-42")
+        reserve("3000.00", key = "payment-42")
+        assertThatThrownBy { reserve("2500.00") }
+            .isInstanceOf(SpendReservationRefusedException::class.java)
+
+        // One reservation exists, so exactly one SpendReserved may. A replay created no state and
+        // a refusal created none at all; an event for either would claim a spend that never
+        // happened.
+        assertThat(reservations.events.filterIsInstance<SpendReserved>()).hasSize(1)
+    }
+
+    @Test
+    fun `a no-op re-confirm emits no second event`() {
+        val first = reserve("100.00")
+        runBlocking { service.confirm(currentGrant.id, first.reservation.id, grantee) }
+        runBlocking { service.confirm(currentGrant.id, first.reservation.id, grantee) }
+
+        assertThat(reservations.events.filterIsInstance<SpendConfirmed>()).hasSize(1)
+    }
+
+    @Test
+    fun `occurredAt is a real clock reading, not a default`() {
+        // Deliberately NOT the fixed clock the other tests use, and deliberately NOT isNotNull():
+        // `Instant.EPOCH` defaults passed every isNotNull() assertion in this fleet while the
+        // whole trail claimed 1970-01-01 (#3874/#3883). Only recency can tell them apart.
+        val realClockService = SpendReservationService(delegationRepository, reservations, Clock.systemUTC())
+        val before = Instant.now()
+        runBlocking {
+            realClockService.reserve(
+                ReserveSpendCommand(
+                    callerPartyId = grantee,
+                    delegationId = currentGrant.id,
+                    amount = czk("10.00"),
+                    idempotencyKey = "wall-clock",
+                ),
+            )
+        }
+        val after = Instant.now()
+
+        val reserved = reservations.events.filterIsInstance<SpendReserved>().single()
+        assertThat(reserved.occurredAt).isBetween(before, after)
+    }
+
     private class InMemorySpendReservationRepository : SpendReservationRepository {
         private val rows = ConcurrentHashMap<UUID, SpendReservation>()
 
         fun all(): List<SpendReservation> = rows.values.toList()
 
+        /** Every audit event the service handed us, in order — see [emitted]. */
+        val events = mutableListOf<DomainEvent>()
+
         override suspend fun reserve(
             candidate: SpendReservation,
             window: SpendWindow,
+            auditEvent: (SpendReservation) -> DomainEvent,
             decide: (CountedSpend) -> SpendDecision,
         ): ReserveOutcome {
             rows.values.firstOrNull {
@@ -246,6 +354,10 @@ class SpendReservationServiceTest {
                 is SpendDecision.Refused -> ReserveOutcome.Refused(decision)
                 SpendDecision.Allowed -> {
                     rows[candidate.id] = candidate
+                    // The real repository writes the outbox row inside the insert's transaction
+                    // and ONLY for a Created outcome; the fake mirrors that rule so a test can
+                    // tell an emitted event from an unemitted one.
+                    events += auditEvent(candidate)
                     ReserveOutcome.Created(candidate)
                 }
             }
@@ -259,6 +371,7 @@ class SpendReservationServiceTest {
             reservationId: UUID,
             target: SpendReservationState,
             settledAt: OffsetDateTime,
+            auditEvent: (SpendReservation) -> DomainEvent,
         ): SpendReservation? {
             val existing = findById(grantId, reservationId) ?: return null
             if (existing.state != SpendReservationState.RESERVED) return null
@@ -268,6 +381,7 @@ class SpendReservationServiceTest {
                 SpendReservationState.RESERVED -> return null
             }
             rows[reservationId] = settled
+            events += auditEvent(settled)
             return settled
         }
     }

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/domain/event/SpendReservationEventsTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/domain/event/SpendReservationEventsTest.kt
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.delegation.domain.event
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * ADR-0249 D4 (issue #5728) — what these events actually put ON THE WIRE.
+ *
+ * Asserted off serialised JSON, not off the Kotlin properties. These are serialised data classes,
+ * so `sourceService` exists on the wire only as a property name: a grep for a quoted
+ * `"sourceService"` in this service returns nothing, and a test reading `event.sourceService`
+ * would pass even if Jackson never emitted the field (the card-issuance twin,
+ * `CardEventsTest`, makes the same point for the same reason).
+ *
+ * `sourceService` is what `AuditConsumer.resolveSourceService` reads as the strongest
+ * (EVENT-sourced) attribution. Omitting it is silent: the consumer falls back to `?: "unknown"`
+ * with no error, which is how the fleet reached 76% unattributed rows (#3994/#5256).
+ */
+class SpendReservationEventsTest {
+
+    // WRITE_DATES_AS_TIMESTAMPS disabled to match the CDI ObjectMapper the outbox actually
+    // serialises with (Quarkus disables it by default). A bare ObjectMapper would render
+    // `occurredAt` as an epoch decimal here and as ISO-8601 in production — the test would then
+    // be describing a wire format nothing emits.
+    private val mapper = ObjectMapper()
+        .registerModule(JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
+    private val grant: UUID = UUID.randomUUID()
+    private val reservation: UUID = UUID.randomUUID()
+    private val grantor: UUID = UUID.randomUUID()
+    private val grantee: UUID = UUID.randomUUID()
+    private val at: Instant = Instant.parse("2026-08-20T09:15:00Z")
+    private val settled: OffsetDateTime = OffsetDateTime.ofInstant(at, ZoneOffset.UTC)
+    private val money = EventMoney(BigDecimal("1250.00"), "CZK")
+
+    @Test
+    fun `SpendReserved carries sourceService, the grant as aggregate and the reservation as a field`() {
+        val node = mapper.readTree(
+            mapper.writeValueAsString(
+                SpendReserved(grant, reservation, grantor, grantee, money, "payment-7", at),
+            ),
+        )
+
+        assertThat(node.get("sourceService").asText()).isEqualTo("delegation-service")
+        assertThat(node.get("eventType").asText()).isEqualTo("SpendReserved")
+        assertThat(node.get("aggregateType").asText()).isEqualTo("DelegationGrant")
+        assertThat(node.get("aggregateId").asText()).isEqualTo(grant.toString())
+        assertThat(node.get("reservationId").asText()).isEqualTo(reservation.toString())
+        assertThat(node.get("grantorPartyId").asText()).isEqualTo(grantor.toString())
+        assertThat(node.get("granteePartyId").asText()).isEqualTo(grantee.toString())
+        assertThat(node.get("idempotencyKey").asText()).isEqualTo("payment-7")
+        // Flat `currency: String`, not the domain CurrencyCode — Jackson renders that as
+        // {"code":"CZK"} while every consumer of this topic reads the field as text.
+        assertThat(node.get("amount").get("currency").asText()).isEqualTo("CZK")
+        assertThat(node.get("amount").get("amount").decimalValue()).isEqualByComparingTo(BigDecimal("1250.00"))
+    }
+
+    @Test
+    fun `SpendConfirmed carries sourceService on the wire`() {
+        val node = mapper.readTree(
+            mapper.writeValueAsString(
+                SpendConfirmed(grant, reservation, grantor, grantee, money, settled, at),
+            ),
+        )
+
+        assertThat(node.get("sourceService").asText()).isEqualTo("delegation-service")
+        assertThat(node.get("eventType").asText()).isEqualTo("SpendConfirmed")
+        assertThat(node.get("reservationId").asText()).isEqualTo(reservation.toString())
+        assertThat(node.hasNonNull("settledAt")).isTrue()
+    }
+
+    @Test
+    fun `SpendReleased carries sourceService on the wire`() {
+        val node = mapper.readTree(
+            mapper.writeValueAsString(
+                SpendReleased(grant, reservation, grantor, grantee, money, settled, at),
+            ),
+        )
+
+        assertThat(node.get("sourceService").asText()).isEqualTo("delegation-service")
+        assertThat(node.get("eventType").asText()).isEqualTo("SpendReleased")
+        assertThat(node.get("reservationId").asText()).isEqualTo(reservation.toString())
+    }
+
+    @Test
+    fun `occurredAt has no default — a caller must pass a clock reading`() {
+        // The Instant.EPOCH shape (#3874/#3883): a defaulted business time is a value every
+        // isNotNull() assertion agrees with and no reader can distinguish from a real one. There
+        // is no no-arg construction to test here BECAUSE the parameter is required, which is the
+        // property under test; this asserts the value that is passed survives serialisation.
+        val node = mapper.readTree(
+            mapper.writeValueAsString(
+                SpendReserved(grant, reservation, grantor, grantee, money, "k", at),
+            ),
+        )
+
+        assertThat(Instant.parse(node.get("occurredAt").asText())).isEqualTo(at)
+        assertThat(Instant.parse(node.get("occurredAt").asText())).isAfter(Instant.EPOCH)
+    }
+}

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/integration/SpendReservationOutboxWriteIT.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/integration/SpendReservationOutboxWriteIT.kt
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.delegation.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.delegation.it.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.config.ConfigProvider
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.sql.Connection
+import java.sql.DriverManager
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * ADR-0249 D4 (issue #5728) — the spend-reservation audit trail, proved by the only means that can.
+ *
+ * **Why an IT and not a unit test.** The guarantee is that the reservation row and its outbox row
+ * commit TOGETHER. A mocked repository cannot show that: it can only show that the use case handed
+ * an event to something. So this drives the real REST endpoint (the only way to get a Vert.x
+ * context for the reactive repository) and reads both tables with plain JDBC — the fleet pattern
+ * from `LendingOutboxWriteIT` and `ConsentRevocationOutboxIT`.
+ *
+ * **What it asserts is CONTENT, not presence.** An outbox row exists is a weak claim; the row must
+ * name the right event type, the right grant and reservation, both parties, the amount, a real
+ * `occurredAt`, and `sourceService` — which `AuditConsumer` falls back to `"unknown"` for, with no
+ * error, when a producer omits it (#3994/#5256).
+ */
+@QuarkusTest
+@QuarkusTestResource(SpendReservationOutboxWriteIT.InMemoryKafkaResource::class)
+@QuarkusTestResource(PostgresTestResource::class)
+class SpendReservationOutboxWriteIT {
+
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> =
+            InMemoryConnector.switchOutgoingChannelsToInMemory("delegation-events-out")
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    private val mapper = ObjectMapper()
+    private val grantor: UUID = UUID.randomUUID()
+    private val grantee: UUID = UUID.randomUUID()
+
+    private fun jdbc(): Connection {
+        val url = ConfigProvider.getConfig().getValue("quarkus.datasource.jdbc.url", String::class.java)
+        return DriverManager.getConnection(url, "openbank", "openbank_secret")
+    }
+
+    private fun seedGrant(): UUID {
+        val id = UUID.randomUUID()
+        jdbc().use { c ->
+            c.prepareStatement(
+                """
+                insert into delegation_grants
+                    (id, grantor_party_id, grantee_party_id, resource_type, resource_id, approval_policy,
+                     daily_limit_amount, daily_limit_currency, valid_from, valid_to, status, created_at, updated_at)
+                values (?, ?, ?, 'ACCOUNT', ?, 'SOLO', 5000.00, 'CZK',
+                        now() - interval '1 day', now() + interval '30 days', 'ACTIVE', now(), now())
+                """.trimIndent(),
+            ).use { ps ->
+                ps.setObject(1, id)
+                ps.setObject(2, grantor)
+                ps.setObject(3, grantee)
+                ps.setObject(4, UUID.randomUUID())
+                ps.executeUpdate()
+            }
+            c.prepareStatement(
+                "insert into delegation_capabilities (grant_id, capability) values (?, 'ACCOUNT_INITIATE_PAYMENT')",
+            ).use { ps ->
+                ps.setObject(1, id)
+                ps.executeUpdate()
+            }
+        }
+        return id
+    }
+
+    /** Outbox payloads for one grant, newest last. Read with plain JDBC — no ORM in the assertion. */
+    private fun outboxPayloads(grantId: UUID, eventType: String): List<String> = jdbc().use { c ->
+        c.prepareStatement(
+            "select payload from delegation_outbox where aggregate_id = ? and event_type = ? order by id",
+        ).use { ps ->
+            ps.setObject(1, grantId)
+            ps.setString(2, eventType)
+            ps.executeQuery().use { rs ->
+                buildList { while (rs.next()) add(rs.getString(1)) }
+            }
+        }
+    }
+
+    private fun reserve(grantId: UUID, amount: String, key: String): String = RestAssured.given()
+        .contentType(ContentType.JSON)
+        .header(CUSTOMER_PARTY_HEADER, grantee.toString())
+        .body("""{"amount": $amount, "currency": "CZK", "idempotencyKey": "$key"}""")
+        .post("/api/v1/delegations/$grantId/reservations")
+        .then().statusCode(HTTP_CREATED)
+        .extract().path("reservationId")
+
+    private fun settle(grantId: UUID, reservationId: String, verb: String) {
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .header(CUSTOMER_PARTY_HEADER, grantee.toString())
+            .post("/api/v1/delegations/$grantId/reservations/$reservationId/$verb")
+            .then().statusCode(HTTP_OK)
+    }
+
+    @Test
+    @TestSecurity(user = "svc", roles = ["ROLE_API"])
+    fun `a reserve commits its audit event in the same transaction as the reservation row`() {
+        val before = Instant.now()
+        val grantId = seedGrant()
+
+        val reservationId = reserve(grantId, "1250.00", "payment-7")
+
+        val payloads = outboxPayloads(grantId, "SpendReserved")
+        assertThat(payloads).hasSize(1)
+        val node = mapper.readTree(payloads.single())
+        assertThat(node.get("eventType").asText()).isEqualTo("SpendReserved")
+        assertThat(node.get("aggregateType").asText()).isEqualTo("DelegationGrant")
+        assertThat(node.get("aggregateId").asText()).isEqualTo(grantId.toString())
+        assertThat(node.get("reservationId").asText()).isEqualTo(reservationId)
+        assertThat(node.get("grantorPartyId").asText()).isEqualTo(grantor.toString())
+        assertThat(node.get("granteePartyId").asText()).isEqualTo(grantee.toString())
+        assertThat(node.get("idempotencyKey").asText()).isEqualTo("payment-7")
+        assertThat(node.get("amount").get("amount").decimalValue()).isEqualByComparingTo(BigDecimal("1250.00"))
+        assertThat(node.get("amount").get("currency").asText()).isEqualTo("CZK")
+        // The attribution field AuditConsumer falls back to "unknown" for, silently (#3994/#5256).
+        assertThat(node.get("sourceService").asText()).isEqualTo("delegation-service")
+        // Recency, never isNotNull(): Instant.EPOCH passes isNotNull() and reads as 1970
+        // (#3874/#3883). Only a bounded window can tell a real clock reading from a default.
+        assertThat(Instant.parse(node.get("occurredAt").asText())).isBetween(before, Instant.now())
+    }
+
+    @Test
+    @TestSecurity(user = "svc", roles = ["ROLE_API"])
+    fun `confirm and release each commit their own audit event`() {
+        val before = Instant.now()
+        val grantId = seedGrant()
+        val toConfirm = reserve(grantId, "100.00", "to-confirm")
+        val toRelease = reserve(grantId, "200.00", "to-release")
+
+        settle(grantId, toConfirm, "confirm")
+        settle(grantId, toRelease, "release")
+
+        val confirmed = mapper.readTree(outboxPayloads(grantId, "SpendConfirmed").single())
+        assertThat(confirmed.get("reservationId").asText()).isEqualTo(toConfirm)
+        assertThat(confirmed.get("grantorPartyId").asText()).isEqualTo(grantor.toString())
+        assertThat(confirmed.get("granteePartyId").asText()).isEqualTo(grantee.toString())
+        assertThat(confirmed.get("amount").get("amount").decimalValue()).isEqualByComparingTo(BigDecimal("100.00"))
+        assertThat(confirmed.get("sourceService").asText()).isEqualTo("delegation-service")
+        assertThat(Instant.parse(confirmed.get("occurredAt").asText())).isBetween(before, Instant.now())
+        assertThat(confirmed.hasNonNull("settledAt")).isTrue()
+
+        val released = mapper.readTree(outboxPayloads(grantId, "SpendReleased").single())
+        assertThat(released.get("reservationId").asText()).isEqualTo(toRelease)
+        assertThat(released.get("amount").get("amount").decimalValue()).isEqualByComparingTo(BigDecimal("200.00"))
+        assertThat(released.get("sourceService").asText()).isEqualTo("delegation-service")
+    }
+
+    @Test
+    @TestSecurity(user = "svc", roles = ["ROLE_API"])
+    fun `a replayed reserve and a no-op re-confirm write no second outbox row`() {
+        val grantId = seedGrant()
+        val reservationId = reserve(grantId, "100.00", "same-key")
+        reserve(grantId, "100.00", "same-key")
+
+        settle(grantId, reservationId, "confirm")
+        settle(grantId, reservationId, "confirm")
+
+        // One reservation and one settlement happened, so one event of each may exist. A second
+        // would claim a spend that never took headroom.
+        assertThat(outboxPayloads(grantId, "SpendReserved")).hasSize(1)
+        assertThat(outboxPayloads(grantId, "SpendConfirmed")).hasSize(1)
+    }
+
+    @Test
+    @TestSecurity(user = "svc", roles = ["ROLE_API"])
+    fun `a refused reserve leaves neither a reservation row nor an outbox row`() {
+        val grantId = seedGrant()
+        reserve(grantId, "4000.00", "first")
+
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .header(CUSTOMER_PARTY_HEADER, grantee.toString())
+            .body("""{"amount": 2000.00, "currency": "CZK", "idempotencyKey": "refused"}""")
+            .post("/api/v1/delegations/$grantId/reservations")
+            .then().statusCode(HTTP_CONFLICT)
+
+        // Atomicity in the other direction: nothing committed, so nothing was audited. If the
+        // event were published outside the transaction, this row would exist.
+        assertThat(outboxPayloads(grantId, "SpendReserved")).hasSize(1)
+    }
+
+    private companion object {
+        const val CUSTOMER_PARTY_HEADER = "X-Customer-Party-Id"
+        const val HTTP_OK = 200
+        const val HTTP_CREATED = 201
+        const val HTTP_CONFLICT = 409
+    }
+}


### PR DESCRIPTION
## What ADR-0249 D4 claims, and what was true

> Every grant, reservation, confirmation and revocation is an audit event.

Card issuance/revocation was the only half built. The D3 reserve/confirm/release path —
which moves real money on a delegated authority — emitted **nothing at all**, while ADR-0249
is the compliance-facing record claiming full coverage. Found by the audit in #5727.

This PR builds the **audit-events half**. The grantor-notification half of D4 stays unbuilt
(it needs a design call — see below), hence `Refs #5728`, not `Closes`.

## What is emitted

Three new events in `openbank-delegation-service/src/main/.../domain/event/DelegationEvents.kt`:
`SpendReserved`, `SpendConfirmed`, `SpendReleased`. Each is written to `delegation_outbox`
**inside the same transaction** as the reservation insert / the settle compare-and-set, by the
rule `DelegationRepositoryImpl` already follows for the grant lifecycle. A publish after the
commit would be a second failure point on a money path: the reservation real, the audit trail
absent.

Design calls, each documented in place:

- **`aggregateId` is the GRANT, not the reservation.** `OutboxKafkaHeaders.partitionKey` returns
  `aggregateId`, so keying on the grant keeps a reserve and a revoke of one grant ordered on one
  partition. Keying on the reservation would let a consumer see spend against an authority whose
  revocation it has not applied yet. The reservation keeps its own id as a field.
- **PascalCase `eventType`, not SCREAMING_SNAKE_CASE.** These share `openbank.delegation.events`
  with the eight lifecycle events, whose `eventType` is PascalCase and whose in-tree consumers
  (`CardDelegationEventConsumer` and its account-service twin) match those strings literally.
  `CUSTOMER_DELEGATED_CARD_ISSUED` belongs to a different producer and a different topic
  (`EdgeAuditPublisher` / `openbank.customer.audit`). A second idiom in one stream would make the
  topic's convention unstateable.
- **`sourceService = "delegation-service"` on all three** — the field `AuditConsumer` falls back
  to `?: "unknown"` for, silently, with no error (#3994/#5256).
- **`occurredAt` is this call's clock reading, never a default** — the `Instant.EPOCH` shape
  (#3874/#3883).
- **Emitted only where state changed**: not on an idempotent replay, not on a refusal, not on the
  losing side of a confirm/release race. One reservation yields at most one settlement event.

The AsyncAPI contract is updated in the same change; `check-event-contract-code-agreement.py`
fails otherwise, and did until it was.

## The half that made the emission real

audit-service was **not subscribed to `openbank.delegation.events` at all** — absent from both
`application.yaml`'s topics list and `TopicAttribution`. So no delegation event of any kind has
ever reached the audit trail, including the eight existing grant lifecycle events. Emitting the
new events without fixing that would have been an outbox row nobody reads.

Three parts, two of which are silent on their own: the topics list, the `TopicAttribution` row
(so the eight older events resolve TOPIC-sourced rather than `"unknown"`), and the KafkaUser
**Read ACL** — without which the subscription is ACL-denied at runtime with nothing in this repo
disagreeing. Same shape as #5338, where the identical gap meant SCA device enrollment was never
audited.

## Verified by effect

`SpendReservationOutboxWriteIT` (new) drives the **real REST endpoint** (RestAssured +
`@TestSecurity`) against a real Postgres and reads `delegation_outbox` with **plain JDBC** — the
`LendingOutboxWriteIT` / `ConsentRevocationOutboxIT` pattern, because a mocked repository cannot
prove atomicity. It asserts CONTENT, not that a publisher was called: event type, aggregate type,
both party ids, the reservation id, the amount and currency, `sourceService`, and `occurredAt`
by **recency** (`isBetween(before, now)`) — never `isNotNull()`, which passes against 1970.

**Falsification — each protection removed, and the tests confirmed red:**

| removed | tests that went red |
|---|---|
| the reserve emission | 3 (`SpendReservationOutboxWriteIT`) |
| the settle emission | 2 (`SpendReservationOutboxWriteIT`) |
| correct `sourceService` (set to `"unknown"`) | 7 across all three new/extended suites |
| real `occurredAt` (set to `Instant.EPOCH`) | 3, including the recency test |
| the audit-service topic subscription | `TopicAttributionCoverageTest` |

`openbank.outbox.dispatch-enabled` is already `true` in this service's `application.yaml`, so the
rows dispatch rather than sitting at `attempt_count = 0`.

## Verification

- `:openbank-delegation-service:` `ktlintCheck` + `detekt` green; `test` **127 tests, 0 failures,
  1 skipped** — the skip is `DelegationEventPactBrokerProviderVerificationTest`, broker-gated by
  `@EnabledIfSystemProperty(pactbroker.url)` and pre-existing.
- `:openbank-audit-service:` `ktlintCheck` + `detekt` + `test` green.
- `run-gates.py --all` with `PR_DIFF_BASE=origin/main`: **153 PASS**. The 3 residual are
  environmental/pre-existing and untouched by this change — `api-contract` needs `sudo` to install
  `oasdiff` locally (and no `openapi.yaml` changed here), `release-scope-mismatch` needs `PR_TITLE`,
  `loki-rule-load-test` is unfalsified on `main`.

## Money path

`openbank-delegation-service` **is** in `rules.yaml: money_path_services` — so this needs 2
approvals per ADR-0030. Its threat model exists (`docs/threat-models/openbank-delegation-service.md`).
The enforced threat-model-diff gate was run rather than guessed:

```
python3 openbank-infra/scripts/check-threat-model-diff.py --base origin/main --enforce
threat-model-diff gate: no money-path trust-boundary change without a threat-model update.  (exit 0)
```

It does not classify this as a trust-boundary move, which reads right: no new ingress, no new
authority, no change to who may reserve. It only records what already happens.

## What the grantor-notification half still needs (NOT built here)

Deliberately out of scope — it is the part that needs a decision, not code:

1. **What "first use of a new authority" means.** First *reserve* under a grant? First *confirmed*
   spend? First use of each capability, or of the grant as a whole? A reserve that is later released
   moved no money — notifying on it teaches the grantor to ignore the alert.
2. **Dedup across repeat uses, and where the "already notified" state lives.** A per-grant flag on
   the aggregate is the obvious answer and is a schema change; deriving it from the event history
   is not available, since this topic has 7-day retention and is not compacted.
3. **Which template, and whether it is opt-out.** `notification-service` has no template for this,
   and no service in either delegation-service or card-issuance-service calls it today.
4. **Whether it reuses `DelegationNotificationConsumer`** (#5661/#5700) or needs its own trigger.
   First-use is a different signal from the lifecycle events that consumer handles
   (offered/accepted/revoked/expired) — it is derived from spend, not from a transition.

The events this PR adds are the natural trigger for whatever is decided: `SpendReserved` and
`SpendConfirmed` now exist on a topic, keyed by grant, and audit-service is subscribed to it.

Refs #5728
