### PR TITLE
feat(case-coordinator): isolate incident shadow pilot

### DIFF
--- a/openbank-admin-ui/src/app/iaops/cases/[caseId]/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/cases/[caseId]/page.tsx
@@ -164,6 +164,12 @@ export default function IaopsCaseThreadPage() {
                   detail: t('Koordinátor vytvořil proposal event. Stav doručení a lidského rozhodnutí tato stránka nesleduje.', 'The coordinator created a proposal event. This page does not track delivery or the human decision.'),
                   tone: 'var(--accent-text)', bg: 'var(--accent-bg)', border: 'var(--accent-border)',
                 }
+              : brief.stage === 'shadow_recorded'
+                ? {
+                    title: t('Shadow výsledek zaznamenán', 'Shadow result recorded'),
+                    detail: t('Jde pouze o pilotní důkaz. Výsledek nebyl odeslán do HITL fronty ani nepředstavuje lidské rozhodnutí.', 'This is pilot evidence only. It was not sent to the HITL queue and is not a human decision.'),
+                    tone: 'var(--info-text)', bg: 'var(--info-bg)', border: 'var(--border)',
+                  }
               : brief.stage === 'needs_convergence'
                 ? {
                     title: t('Neshoda zůstává viditelná', 'Dissent remains visible'),

--- a/openbank-admin-ui/src/app/iaops/cases/[caseId]/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/cases/[caseId]/page.tsx
@@ -16,7 +16,7 @@ import { caseStatusPresentation } from '@/lib/governance/caseStatusPresentation'
 import type { CaseStatus } from '@/lib/governance/caseStatusPresentation'
 import { PageHeader } from '@/components/ui/PageHeader'
 
-type EntryType = 'CASE_OPENED' | 'CONTRIBUTION' | 'PROPOSAL_EMITTED'
+type EntryType = 'CASE_OPENED' | 'CONTRIBUTION' | 'PROPOSAL_EMITTED' | 'SHADOW_RECORDED'
 
 interface ThreadEntry {
   type: EntryType
@@ -29,6 +29,7 @@ interface ThreadEntry {
   contested?: boolean
   proposalId?: string
   proposalType?: string
+  shadow?: boolean
 }
 
 interface CaseThread {
@@ -240,7 +241,8 @@ export default function IaopsCaseThreadPage() {
                   </div>
                 )
               }
-              if (entry.type === 'PROPOSAL_EMITTED') {
+              if (entry.type === 'PROPOSAL_EMITTED' || entry.type === 'SHADOW_RECORDED') {
+                const shadow = entry.type === 'SHADOW_RECORDED' || entry.shadow === true
                 return (
                   <div key={index} style={{
                     padding: '14px 18px', borderRadius: '12px',
@@ -249,7 +251,7 @@ export default function IaopsCaseThreadPage() {
                     <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
                       <Sparkles size={14} style={{ color: 'var(--accent-text)' }} />
                       <span style={{ fontSize: '12px', fontWeight: 700, color: 'var(--accent-text)' }}>
-                        {t('Návrh zaznamenán ve vlákně', 'Proposal recorded in the thread')}
+                        {shadow ? t('Shadow výsledek zaznamenán', 'Shadow result recorded') : t('Návrh zaznamenán ve vlákně', 'Proposal recorded in the thread')}
                       </span>
                       <span style={{ fontFamily: 'var(--font-mono)', fontSize: '11px', color: 'var(--text-secondary)' }}>{entry.proposalType ?? ''}</span>
                       <span style={{ marginLeft: 'auto', fontSize: '11px', color: 'var(--text-tertiary)' }}>{fmt(entry.atEpochMs)}</span>
@@ -257,9 +259,9 @@ export default function IaopsCaseThreadPage() {
                     {entry.summary && (
                       <p style={{ fontSize: '12px', color: 'var(--text-secondary)', margin: '8px 0 0', lineHeight: 1.5 }}>{entry.summary}</p>
                     )}
-                    <Link href="/approvals" style={{ display: 'inline-flex', alignItems: 'center', gap: '5px', marginTop: '10px', fontSize: '11px', fontWeight: 700, color: 'var(--accent-text)', textDecoration: 'none' }}>
+                    {!shadow && <Link href="/approvals" style={{ display: 'inline-flex', alignItems: 'center', gap: '5px', marginTop: '10px', fontSize: '11px', fontWeight: 700, color: 'var(--accent-text)', textDecoration: 'none' }}>
                       {t('Procházet HITL frontu', 'Browse the HITL queue')}
-                    </Link>
+                    </Link>}
                   </div>
                 )
               }

--- a/openbank-admin-ui/src/lib/governance/caseDecisionBrief.ts
+++ b/openbank-admin-ui/src/lib/governance/caseDecisionBrief.ts
@@ -2,7 +2,7 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 
 export type CaseStatus = 'OPEN' | 'CONVERGING' | 'CONTESTED' | 'SYNTHESIZED' | 'CLOSED'
-export type CaseEntryType = 'CASE_OPENED' | 'CONTRIBUTION' | 'PROPOSAL_EMITTED'
+export type CaseEntryType = 'CASE_OPENED' | 'CONTRIBUTION' | 'PROPOSAL_EMITTED' | 'SHADOW_RECORDED'
 
 export interface CaseThreadEntry {
   type: CaseEntryType

--- a/openbank-admin-ui/src/lib/governance/caseDecisionBrief.ts
+++ b/openbank-admin-ui/src/lib/governance/caseDecisionBrief.ts
@@ -17,7 +17,7 @@ export interface CaseThreadForBrief {
   entries: CaseThreadEntry[]
 }
 
-export type DecisionBriefStage = 'proposal_recorded' | 'needs_convergence' | 'gathering_evidence'
+export type DecisionBriefStage = 'proposal_recorded' | 'shadow_recorded' | 'needs_convergence' | 'gathering_evidence'
 
 export interface CaseDecisionBrief {
   stage: DecisionBriefStage
@@ -34,9 +34,16 @@ export function deriveCaseDecisionBrief(thread: CaseThreadForBrief): CaseDecisio
   const evidenceRefCount = new Set(activeContributions.flatMap(entry => entry.evidenceRefs ?? [])).size
   const contestedContributionCount = activeContributions.filter(entry => entry.contested).length
   const proposalEmitted = thread.entries.some(entry => entry.type === 'PROPOSAL_EMITTED')
+  const shadowRecorded = thread.entries.some(entry => entry.type === 'SHADOW_RECORDED')
 
   return {
-    stage: proposalEmitted ? 'proposal_recorded' : thread.status === 'CONTESTED' ? 'needs_convergence' : 'gathering_evidence',
+    stage: proposalEmitted
+      ? 'proposal_recorded'
+      : shadowRecorded
+        ? 'shadow_recorded'
+        : thread.status === 'CONTESTED'
+          ? 'needs_convergence'
+          : 'gathering_evidence',
     contributorCount,
     evidenceRefCount,
     contestedContributionCount,

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseOpenService.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseOpenService.kt
@@ -84,6 +84,9 @@ class CaseOpenService(
         if (!gate.canOpenCase(openedBy) || caseClass !in config.case().enabledClasses()) {
             return CaseOpenResult.Denied
         }
+        if (config.case().deliveryMode().name == "SHADOW" && caseClass != CaseClass.INCIDENT_RESPONSE) {
+            return CaseOpenResult.Denied
+        }
         val now = clock.millis()
         if (!consumeOpenQuota(callerPrincipal, now)) return CaseOpenResult.RateLimited
         if (countRunningCases() >= config.case().maxConcurrent()) {
@@ -101,6 +104,7 @@ class CaseOpenService(
             deadlineEpochMs = now + config.case().ttl().toMillis(),
             contestedRateThreshold = config.case().contestedRateThreshold(),
             maxContributions = config.case().maxContributions(),
+            deliveryMode = config.case().deliveryMode(),
         )
         val options = WorkflowOptions.newBuilder()
             .setWorkflowId(workflowId)

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseThreadProjection.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseThreadProjection.kt
@@ -57,10 +57,15 @@ object CaseThreadProjection {
             proposals.forEach { p ->
                 add(
                     ThreadEntry(
-                        type = ThreadEntryType.PROPOSAL_EMITTED,
+                        type = if (p.status == "SHADOW") {
+                            ThreadEntryType.SHADOW_RECORDED
+                        } else {
+                            ThreadEntryType.PROPOSAL_EMITTED
+                        },
                         atEpochMs = p.emittedAtEpochMs,
                         proposalId = p.proposalId,
                         proposalType = p.proposalType,
+                        shadow = p.status == "SHADOW",
                     ),
                 )
             }

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/ShadowPilotPreflight.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/ShadowPilotPreflight.kt
@@ -37,7 +37,10 @@ class ShadowPilotPreflight(
     }
 
     private fun verifyNoLegacyOpenCases() {
-        if (alreadyCompleted()) return
+        val rolloutId = config.case().shadowRolloutId().filter { it.isNotBlank() }.orElseThrow {
+            IllegalStateException("Shadow pilot requires a distinct shadowRolloutId")
+        }
+        if (alreadyCompleted(rolloutId)) return
         check(temporalConfig.enabled()) {
             "Shadow pilot requires Temporal to be enabled for its legacy-workflow preflight"
         }
@@ -52,14 +55,16 @@ class ShadowPilotPreflight(
             "Shadow pilot cannot start while $openRuns legacy case workflow run(s) are open"
         }
         dataSource.connection.use { connection ->
-            connection.prepareStatement("INSERT INTO case_shadow_pilot_preflight (id) VALUES (TRUE) ON CONFLICT DO NOTHING").use {
+            connection.prepareStatement("INSERT INTO case_shadow_pilot_preflight (rollout_id) VALUES (?) ON CONFLICT DO NOTHING").use {
+                it.setString(1, rolloutId)
                 it.executeUpdate()
             }
         }
     }
 
-    private fun alreadyCompleted(): Boolean = dataSource.connection.use { connection ->
-        connection.prepareStatement("SELECT EXISTS (SELECT 1 FROM case_shadow_pilot_preflight WHERE id = TRUE)").use { statement ->
+    private fun alreadyCompleted(rolloutId: String): Boolean = dataSource.connection.use { connection ->
+        connection.prepareStatement("SELECT EXISTS (SELECT 1 FROM case_shadow_pilot_preflight WHERE rollout_id = ?)").use { statement ->
+            statement.setString(1, rolloutId)
             statement.executeQuery().use { result -> result.next() && result.getBoolean(1) }
         }
     }

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/ShadowPilotPreflight.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/ShadowPilotPreflight.kt
@@ -13,6 +13,7 @@ import io.temporal.api.filter.v1.WorkflowTypeFilter
 import io.temporal.api.workflowservice.v1.ListOpenWorkflowExecutionsRequest
 import io.temporal.client.WorkflowClient
 import jakarta.enterprise.context.ApplicationScoped
+import javax.sql.DataSource
 
 /**
  * Refuses a shadow-pilot rollout while a legacy case workflow remains open.
@@ -28,6 +29,7 @@ class ShadowPilotPreflight(
     private val workflowClient: WorkflowClient,
     private val temporalConfig: TemporalConfig,
     private val config: CaseCoordinatorConfig,
+    private val dataSource: DataSource,
 ) {
 
     init {
@@ -35,6 +37,7 @@ class ShadowPilotPreflight(
     }
 
     private fun verifyNoLegacyOpenCases() {
+        if (alreadyCompleted()) return
         check(temporalConfig.enabled()) {
             "Shadow pilot requires Temporal to be enabled for its legacy-workflow preflight"
         }
@@ -47,6 +50,17 @@ class ShadowPilotPreflight(
             .executionsCount
         check(openRuns == 0) {
             "Shadow pilot cannot start while $openRuns legacy case workflow run(s) are open"
+        }
+        dataSource.connection.use { connection ->
+            connection.prepareStatement("INSERT INTO case_shadow_pilot_preflight (id) VALUES (TRUE) ON CONFLICT DO NOTHING").use {
+                it.executeUpdate()
+            }
+        }
+    }
+
+    private fun alreadyCompleted(): Boolean = dataSource.connection.use { connection ->
+        connection.prepareStatement("SELECT EXISTS (SELECT 1 FROM case_shadow_pilot_preflight WHERE id = TRUE)").use { statement ->
+            statement.executeQuery().use { result -> result.next() && result.getBoolean(1) }
         }
     }
 

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/ShadowPilotPreflight.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/ShadowPilotPreflight.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.application
+
+import com.openbank.casecoordinator.domain.model.CaseDeliveryMode
+import com.openbank.casecoordinator.infrastructure.config.CaseCoordinatorConfig
+import com.openbank.libs.temporal.TemporalConfig
+import io.quarkus.runtime.Startup
+import io.temporal.api.filter.v1.WorkflowTypeFilter
+import io.temporal.api.workflowservice.v1.ListOpenWorkflowExecutionsRequest
+import io.temporal.client.WorkflowClient
+import jakarta.enterprise.context.ApplicationScoped
+
+/**
+ * Refuses a shadow-pilot rollout while a legacy case workflow remains open.
+ *
+ * A run started before [CaseDeliveryMode] was introduced deserializes without a delivery mode and
+ * deliberately defaults to HITL for replay compatibility. Allowing it to finish after the GitOps
+ * switch would therefore still publish a human-actionable proposal. The visibility query is a
+ * rollout precondition, not a runtime estimate: unavailable Temporal visibility fails startup.
+ */
+@Startup
+@ApplicationScoped
+class ShadowPilotPreflight(
+    private val workflowClient: WorkflowClient,
+    private val temporalConfig: TemporalConfig,
+    private val config: CaseCoordinatorConfig,
+) {
+
+    init {
+        if (config.case().deliveryMode() == CaseDeliveryMode.SHADOW) verifyNoLegacyOpenCases()
+    }
+
+    private fun verifyNoLegacyOpenCases() {
+        check(temporalConfig.enabled()) {
+            "Shadow pilot requires Temporal to be enabled for its legacy-workflow preflight"
+        }
+        val request = ListOpenWorkflowExecutionsRequest.newBuilder()
+            .setNamespace(workflowClient.options.namespace)
+            .setTypeFilter(WorkflowTypeFilter.newBuilder().setName(WORKFLOW_TYPE).build())
+            .build()
+        val openRuns = workflowClient.workflowServiceStubs.blockingStub()
+            .listOpenWorkflowExecutions(request)
+            .executionsCount
+        check(openRuns == 0) {
+            "Shadow pilot cannot start while $openRuns legacy case workflow run(s) are open"
+        }
+    }
+
+    private companion object {
+        const val WORKFLOW_TYPE = "CaseWorkflow"
+    }
+}

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflow.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflow.kt
@@ -56,7 +56,7 @@ interface CaseSynthesisActivity {
 /** Emits the single HITL proposal into the case outbox (D7). */
 @ActivityInterface
 interface CaseProposalActivity {
-    fun emitProposal(caseId: String, proposalType: String, summary: String, contested: Boolean): String
+    fun emitProposal(caseId: String, proposalType: String, summary: String, contested: Boolean, shadow: Boolean): String
 }
 
 /** Persists case lifecycle + contribution rows to the V1 schema. */

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflow.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflow.kt
@@ -56,7 +56,20 @@ interface CaseSynthesisActivity {
 /** Emits the single HITL proposal into the case outbox (D7). */
 @ActivityInterface
 interface CaseProposalActivity {
-    fun emitProposal(caseId: String, proposalType: String, summary: String, contested: Boolean, shadow: Boolean): String
+    /** Legacy activity name and payload; never change while old workflows can replay. */
+    fun emitProposal(caseId: String, proposalType: String, summary: String, contested: Boolean): String
+}
+
+/** New activity type keeps shadow delivery out of legacy Temporal histories. */
+@ActivityInterface
+interface CaseProposalDeliveryActivity {
+    fun emitProposalWithDelivery(
+        caseId: String,
+        proposalType: String,
+        summary: String,
+        contested: Boolean,
+        shadow: Boolean,
+    ): String
 }
 
 /** Persists case lifecycle + contribution rows to the V1 schema. */

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflowImpl.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflowImpl.kt
@@ -143,7 +143,13 @@ class CaseWorkflowImpl : CaseWorkflow {
         contested: Boolean,
     ): CaseOutcome {
         persistence.recordContributions(start.caseId, contributions)
-        val proposalId = proposals.emitProposal(start.caseId, eventType, summary, contested)
+        val proposalId = proposals.emitProposal(
+            start.caseId,
+            eventType,
+            summary,
+            contested,
+            start.deliveryMode.name == "SHADOW",
+        )
         persistence.recordCaseClosed(start.caseId, status.name, Workflow.currentTimeMillis())
         return CaseOutcome(
             caseId = start.caseId,

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflowImpl.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflowImpl.kt
@@ -43,6 +43,7 @@ class CaseWorkflowImpl : CaseWorkflow {
 
     private val synthesis = Workflow.newActivityStub(CaseSynthesisActivity::class.java, longOptions)
     private val proposals = Workflow.newActivityStub(CaseProposalActivity::class.java, shortOptions)
+    private val deliveryProposals = Workflow.newActivityStub(CaseProposalDeliveryActivity::class.java, shortOptions)
     private val persistence = Workflow.newActivityStub(CasePersistenceActivity::class.java, shortOptions)
 
     private var status = CaseStatus.OPEN
@@ -143,13 +144,19 @@ class CaseWorkflowImpl : CaseWorkflow {
         contested: Boolean,
     ): CaseOutcome {
         persistence.recordContributions(start.caseId, contributions)
-        val proposalId = proposals.emitProposal(
-            start.caseId,
-            eventType,
-            summary,
-            contested,
-            start.deliveryMode.name == "SHADOW",
-        )
+        val proposalId = if (Workflow.getVersion(DELIVERY_MODE_CHANGE_ID, Workflow.DEFAULT_VERSION, 1) ==
+            Workflow.DEFAULT_VERSION
+        ) {
+            proposals.emitProposal(start.caseId, eventType, summary, contested)
+        } else {
+            deliveryProposals.emitProposalWithDelivery(
+                start.caseId,
+                eventType,
+                summary,
+                contested,
+                start.deliveryMode.name == "SHADOW",
+            )
+        }
         persistence.recordCaseClosed(start.caseId, status.name, Workflow.currentTimeMillis())
         return CaseOutcome(
             caseId = start.caseId,
@@ -168,5 +175,9 @@ class CaseWorkflowImpl : CaseWorkflow {
     } else {
         "TIMEOUT: case reached its deadline with ${contributions.size} contributions, " +
             "${participants.size} participants, no synthesis requested"
+    }
+
+    private companion object {
+        const val DELIVERY_MODE_CHANGE_ID = "case-proposal-delivery-mode-v1"
     }
 }

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/domain/model/CaseModels.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/domain/model/CaseModels.kt
@@ -29,6 +29,9 @@ enum class CaseStatus {
     CLOSED,
 }
 
+/** Delivery is explicit in the workflow input so replay cannot depend on mutable deployment config. */
+enum class CaseDeliveryMode { HITL, SHADOW }
+
 /** Start parameters for a case workflow run. */
 data class CaseStart(
     val caseId: String,
@@ -39,6 +42,7 @@ data class CaseStart(
     val deadlineEpochMs: Long,
     val contestedRateThreshold: Double,
     val maxContributions: Int,
+    val deliveryMode: CaseDeliveryMode = CaseDeliveryMode.HITL,
 )
 
 data class JoinSignal(val agentId: String, val role: String)

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/domain/model/CaseThread.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/domain/model/CaseThread.kt
@@ -34,12 +34,18 @@ data class ContributionRow(
 )
 
 /** Raw terminal proposal row projected from `case_outbox` (ADR-0244 D7). */
-data class ProposalEventRow(val proposalId: String, val proposalType: String, val emittedAtEpochMs: Long)
+data class ProposalEventRow(
+    val proposalId: String,
+    val proposalType: String,
+    val status: String,
+    val emittedAtEpochMs: Long,
+)
 
 enum class ThreadEntryType {
     CASE_OPENED,
     CONTRIBUTION,
     PROPOSAL_EMITTED,
+    SHADOW_RECORDED,
 }
 
 /** One thread entry in the ADR-0246 timeline, oldest first. */
@@ -54,6 +60,7 @@ data class ThreadEntry(
     val contested: Boolean = false,
     val proposalId: String? = null,
     val proposalType: String? = null,
+    val shadow: Boolean = false,
 )
 
 /** Case list item — `GET /api/v1/case-coordinator/cases`. */

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/config/CaseCoordinatorConfig.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/config/CaseCoordinatorConfig.kt
@@ -84,5 +84,7 @@ interface CaseCoordinatorConfig {
         /** Shadow mode is valid only for the bounded non-money-path incident-response pilot. */
         @WithDefault("HITL")
         fun deliveryMode(): CaseDeliveryMode
+
+        fun shadowRolloutId(): java.util.Optional<String>
     }
 }

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/config/CaseCoordinatorConfig.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/config/CaseCoordinatorConfig.kt
@@ -6,6 +6,7 @@
 package com.openbank.casecoordinator.infrastructure.config
 
 import com.openbank.casecoordinator.domain.model.CaseClass
+import com.openbank.casecoordinator.domain.model.CaseDeliveryMode
 import io.smallrye.config.ConfigMapping
 import io.smallrye.config.WithDefault
 import jakarta.enterprise.context.ApplicationScoped
@@ -79,5 +80,9 @@ interface CaseCoordinatorConfig {
 
         @WithDefault("40")
         fun maxContributions(): Int
+
+        /** Shadow mode is valid only for the bounded non-money-path incident-response pilot. */
+        @WithDefault("HITL")
+        fun deliveryMode(): CaseDeliveryMode
     }
 }

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/persistence/CaseThreadReadRepository.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/persistence/CaseThreadReadRepository.kt
@@ -58,7 +58,7 @@ class CaseThreadReadRepository(private val dataSource: DataSource, private val o
 
     fun listProposalEvents(workflowId: String): List<ProposalEventRow> = query(
         """
-        SELECT o.event_id, o.event_type, o.created_at
+        SELECT o.event_id, o.event_type, o.status, o.created_at
         FROM case_outbox o
         JOIN case_workflow w ON w.id = o.aggregate_id
         WHERE w.workflow_id = ?
@@ -69,6 +69,7 @@ class CaseThreadReadRepository(private val dataSource: DataSource, private val o
             ProposalEventRow(
                 proposalId = rs.getObject("event_id", UUID::class.java).toString(),
                 proposalType = rs.getString("event_type"),
+                status = rs.getString("status"),
                 emittedAtEpochMs = rs.getTimestamp("created_at").toInstant().toEpochMilli(),
             )
         },

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/workflow/CaseActivitiesImpl.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/workflow/CaseActivitiesImpl.kt
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.casecoordinator.application.port.out.CaseCoordinatorLlmPort
 import com.openbank.casecoordinator.application.workflow.CasePersistenceActivity
 import com.openbank.casecoordinator.application.workflow.CaseProposalActivity
+import com.openbank.casecoordinator.application.workflow.CaseProposalDeliveryActivity
 import com.openbank.casecoordinator.application.workflow.CaseSynthesisActivity
 import com.openbank.casecoordinator.domain.model.CaseStart
 import com.openbank.casecoordinator.domain.model.Contribution
@@ -37,6 +38,7 @@ class CaseActivitiesImpl(
     private val objectMapper: ObjectMapper,
 ) : CaseSynthesisActivity,
     CaseProposalActivity,
+    CaseProposalDeliveryActivity,
     CasePersistenceActivity {
 
     override fun synthesize(caseId: String, caseClass: String, contributions: List<Contribution>): String? {
@@ -56,7 +58,10 @@ class CaseActivitiesImpl(
         return runBlocking { llm.synthesizeConvergence(context) }
     }
 
-    override fun emitProposal(
+    override fun emitProposal(caseId: String, proposalType: String, summary: String, contested: Boolean): String =
+        emitProposalWithDelivery(caseId, proposalType, summary, contested, shadow = false)
+
+    override fun emitProposalWithDelivery(
         caseId: String,
         proposalType: String,
         summary: String,

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/workflow/CaseActivitiesImpl.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/workflow/CaseActivitiesImpl.kt
@@ -56,7 +56,13 @@ class CaseActivitiesImpl(
         return runBlocking { llm.synthesizeConvergence(context) }
     }
 
-    override fun emitProposal(caseId: String, proposalType: String, summary: String, contested: Boolean): String {
+    override fun emitProposal(
+        caseId: String,
+        proposalType: String,
+        summary: String,
+        contested: Boolean,
+        shadow: Boolean,
+    ): String {
         val eventId = UUID.randomUUID()
         val now = Instant.now(clock)
         val payload = objectMapper.writeValueAsString(
@@ -65,6 +71,7 @@ class CaseActivitiesImpl(
                 "proposalType" to proposalType,
                 "summary" to summary,
                 "contested" to contested,
+                "deliveryMode" to if (shadow) "SHADOW" else "HITL",
                 "occurredAt" to now.toString(),
             ),
         )
@@ -80,7 +87,9 @@ class CaseActivitiesImpl(
                 ps.setObject(P2, caseUuid(caseId))
                 ps.setString(P3, proposalType)
                 ps.setString(P4, payload)
-                ps.setString(P5, OutboxStatus.PENDING.name)
+                // SHADOW is intentionally not a processable outbox state, so no dispatcher can
+                // publish it to proposal-events or expose it to the human approval channel.
+                ps.setString(P5, if (shadow) SHADOW_STATUS else OutboxStatus.PENDING.name)
                 ps.setTimestamp(P6, Timestamp.from(now))
                 ps.setTimestamp(P7, Timestamp.from(now))
                 ps.executeUpdate()
@@ -165,6 +174,7 @@ class CaseActivitiesImpl(
     private companion object {
         /** incident-response budget from agents.yaml case_classes; token accounting lands with evals. */
         const val TOKENS_PER_CASE = 200_000
+        const val SHADOW_STATUS = "SHADOW"
 
         const val P1 = 1
         const val P2 = 2

--- a/openbank-case-coordinator-agent/src/main/resources/application.yaml
+++ b/openbank-case-coordinator-agent/src/main/resources/application.yaml
@@ -114,6 +114,8 @@ openbank:
     # key degrades the synthesis call instead of CrashLooping the pod.
     model-endpoint: ${CASE_COORDINATOR_MODEL_ENDPOINT:https://api.deepinfra.com/v1/openai}
     model-id: ${CASE_COORDINATOR_MODEL_ID:deepseek-ai/DeepSeek-V3.2}
+    case:
+      delivery-mode: ${CASE_COORDINATOR_CASE_DELIVERY_MODE:HITL}
 
 mp:
   messaging:

--- a/openbank-case-coordinator-agent/src/main/resources/application.yaml
+++ b/openbank-case-coordinator-agent/src/main/resources/application.yaml
@@ -116,6 +116,7 @@ openbank:
     model-id: ${CASE_COORDINATOR_MODEL_ID:deepseek-ai/DeepSeek-V3.2}
     case:
       delivery-mode: ${CASE_COORDINATOR_CASE_DELIVERY_MODE:HITL}
+      shadow-rollout-id: ${CASE_COORDINATOR_CASE_SHADOW_ROLLOUT_ID:}
 
 mp:
   messaging:

--- a/openbank-case-coordinator-agent/src/main/resources/db/migration/V4__shadow_pilot_preflight.sql
+++ b/openbank-case-coordinator-agent/src/main/resources/db/migration/V4__shadow_pilot_preflight.sql
@@ -1,4 +1,4 @@
 CREATE TABLE case_shadow_pilot_preflight (
-    id BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (id),
+    rollout_id VARCHAR(128) PRIMARY KEY,
     completed_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/openbank-case-coordinator-agent/src/main/resources/db/migration/V4__shadow_pilot_preflight.sql
+++ b/openbank-case-coordinator-agent/src/main/resources/db/migration/V4__shadow_pilot_preflight.sql
@@ -1,0 +1,4 @@
+CREATE TABLE case_shadow_pilot_preflight (
+    id BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (id),
+    completed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/openbank-case-coordinator-agent/src/main/resources/openapi.yaml
+++ b/openbank-case-coordinator-agent/src/main/resources/openapi.yaml
@@ -318,7 +318,7 @@ components:
       properties:
         type:
           type: string
-          enum: [CASE_OPENED, CONTRIBUTION, PROPOSAL_EMITTED]
+          enum: [CASE_OPENED, CONTRIBUTION, PROPOSAL_EMITTED, SHADOW_RECORDED]
         atEpochMs:
           type: integer
           format: int64
@@ -341,6 +341,9 @@ components:
           type: string
         proposalType:
           type: string
+        shadow:
+          type: boolean
+          description: True when this terminal result is recorded for the bounded shadow pilot and was not delivered to HITL.
 
     CaseThread:
       type: object

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseOpenServiceTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseOpenServiceTest.kt
@@ -6,6 +6,7 @@
 package com.openbank.casecoordinator.application
 
 import com.openbank.casecoordinator.domain.model.CaseClass
+import com.openbank.casecoordinator.domain.model.CaseDeliveryMode
 import com.openbank.casecoordinator.infrastructure.config.CaseCoordinatorConfig
 import com.openbank.libs.temporal.TemporalConfig
 import io.mockk.every
@@ -16,6 +17,7 @@ import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc
 import io.temporal.client.WorkflowClient
 import io.temporal.client.WorkflowClientOptions
 import io.temporal.client.WorkflowExecutionAlreadyStarted
+import io.temporal.client.WorkflowOptions
 import io.temporal.client.WorkflowStub
 import io.temporal.serviceclient.WorkflowServiceStubs
 import org.assertj.core.api.Assertions.assertThat
@@ -64,6 +66,7 @@ class CaseOpenServiceTest {
         every { caseGroup.ttl() } returns java.time.Duration.ofMinutes(20)
         every { caseGroup.contestedRateThreshold() } returns 0.35
         every { caseGroup.maxContributions() } returns 40
+        every { caseGroup.deliveryMode() } returns CaseDeliveryMode.HITL
         every { workflowClient.options } returns WorkflowClientOptions.newBuilder().setNamespace("openbank").build()
         every { workflowClient.newUntypedWorkflowStub("CaseWorkflow", any()) } returns untyped
         every { untyped.start(any()) } returns WorkflowExecution.getDefaultInstance()
@@ -101,6 +104,19 @@ class CaseOpenServiceTest {
         assertThat(
             service.open(PRINCIPAL, COORDINATOR, CaseClass.FRAUD_INVESTIGATION, "case-7", "hitl-fraud-queue"),
         ).isEqualTo(CaseOpenResult.Denied)
+    }
+
+    @Test
+    fun `shadow mode denies money-path case classes before a workflow can start`() {
+        every { caseGroup.deliveryMode() } returns CaseDeliveryMode.SHADOW
+        every { caseGroup.enabledClasses() } returns setOf(CaseClass.INCIDENT_RESPONSE, CaseClass.FRAUD_INVESTIGATION)
+
+        assertThat(
+            service.open(PRINCIPAL, COORDINATOR, CaseClass.FRAUD_INVESTIGATION, "case-7", "hitl-fraud-queue"),
+        ).isEqualTo(CaseOpenResult.Denied)
+        io.mockk.verify(exactly = 0) {
+            workflowClient.newUntypedWorkflowStub(any<String>(), any<WorkflowOptions>())
+        }
     }
 
     @Test

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseThreadProjectionTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseThreadProjectionTest.kt
@@ -57,6 +57,7 @@ class CaseThreadProjectionTest {
         val proposal = ProposalEventRow(
             proposalId = "prop-1",
             proposalType = "case-synthesis",
+            status = "SENT",
             emittedAtEpochMs = T0 + 2 * LATER_MS,
         )
 
@@ -68,6 +69,22 @@ class CaseThreadProjectionTest {
             ThreadEntryType.PROPOSAL_EMITTED,
         )
         assertThat(thread.entries[2].proposalId).isEqualTo("prop-1")
+    }
+
+    @Test
+    fun `a shadow terminal result is not projected as a HITL proposal`() {
+        val shadow = ProposalEventRow(
+            proposalId = "shadow-1",
+            proposalType = "case-synthesis",
+            status = "SHADOW",
+            emittedAtEpochMs = T0 + LATER_MS,
+        )
+
+        val thread = CaseThreadProjection.project(caseRow, emptyList(), listOf(shadow))
+
+        val entry = thread.entries.single { it.type == ThreadEntryType.SHADOW_RECORDED }
+        assertThat(entry.shadow).isTrue()
+        assertThat(thread.entries.map { it.type }).doesNotContain(ThreadEntryType.PROPOSAL_EMITTED)
     }
 
     @Test

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/ShadowPilotPreflightTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/ShadowPilotPreflightTest.kt
@@ -16,6 +16,10 @@ import io.temporal.client.WorkflowClientOptions
 import io.temporal.serviceclient.WorkflowServiceStubs
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.junit.jupiter.api.Test
+import java.sql.Connection
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.util.Optional
 import javax.sql.DataSource
 
 class ShadowPilotPreflightTest {
@@ -30,6 +34,16 @@ class ShadowPilotPreflightTest {
     fun `shadow startup refuses an existing legacy case workflow`() {
         every { config.case() } returns caseGroup
         every { caseGroup.deliveryMode() } returns CaseDeliveryMode.SHADOW
+        every { caseGroup.shadowRolloutId() } returns Optional.of("shadow-test")
+        val connection = mockk<Connection>()
+        val statement = mockk<PreparedStatement>()
+        val result = mockk<ResultSet>()
+        every { dataSource.connection } returns connection
+        every { connection.prepareStatement(any()) } returns statement
+        every { statement.setString(any(), any()) } returns Unit
+        every { statement.executeQuery() } returns result
+        every { result.next() } returns true
+        every { result.getBoolean(1) } returns false
         every { temporal.enabled() } returns true
         every { client.options } returns WorkflowClientOptions.newBuilder().setNamespace("openbank").build()
         val stubs = mockk<WorkflowServiceStubs>()

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/ShadowPilotPreflightTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/ShadowPilotPreflightTest.kt
@@ -35,9 +35,9 @@ class ShadowPilotPreflightTest {
         every { config.case() } returns caseGroup
         every { caseGroup.deliveryMode() } returns CaseDeliveryMode.SHADOW
         every { caseGroup.shadowRolloutId() } returns Optional.of("shadow-test")
-        val connection = mockk<Connection>()
-        val statement = mockk<PreparedStatement>()
-        val result = mockk<ResultSet>()
+        val connection = mockk<Connection>(relaxed = true)
+        val statement = mockk<PreparedStatement>(relaxed = true)
+        val result = mockk<ResultSet>(relaxed = true)
         every { dataSource.connection } returns connection
         every { connection.prepareStatement(any()) } returns statement
         every { statement.setString(any(), any()) } returns Unit

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/ShadowPilotPreflightTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/ShadowPilotPreflightTest.kt
@@ -16,6 +16,7 @@ import io.temporal.client.WorkflowClientOptions
 import io.temporal.serviceclient.WorkflowServiceStubs
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.junit.jupiter.api.Test
+import javax.sql.DataSource
 
 class ShadowPilotPreflightTest {
 
@@ -23,6 +24,7 @@ class ShadowPilotPreflightTest {
     private val temporal = mockk<TemporalConfig>()
     private val config = mockk<CaseCoordinatorConfig>()
     private val caseGroup = mockk<CaseCoordinatorConfig.CaseGroup>()
+    private val dataSource = mockk<DataSource>()
 
     @Test
     fun `shadow startup refuses an existing legacy case workflow`() {
@@ -38,7 +40,7 @@ class ShadowPilotPreflightTest {
             .addExecutions(io.temporal.api.workflow.v1.WorkflowExecutionInfo.getDefaultInstance())
             .build()
 
-        assertThatIllegalStateException().isThrownBy { ShadowPilotPreflight(client, temporal, config) }
+        assertThatIllegalStateException().isThrownBy { ShadowPilotPreflight(client, temporal, config, dataSource) }
             .withMessageContaining("legacy case workflow")
     }
 }

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/ShadowPilotPreflightTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/ShadowPilotPreflightTest.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.application
+
+import com.openbank.casecoordinator.domain.model.CaseDeliveryMode
+import com.openbank.casecoordinator.infrastructure.config.CaseCoordinatorConfig
+import com.openbank.libs.temporal.TemporalConfig
+import io.mockk.every
+import io.mockk.mockk
+import io.temporal.api.workflowservice.v1.ListOpenWorkflowExecutionsResponse
+import io.temporal.client.WorkflowClient
+import io.temporal.client.WorkflowClientOptions
+import io.temporal.serviceclient.WorkflowServiceStubs
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
+import org.junit.jupiter.api.Test
+
+class ShadowPilotPreflightTest {
+
+    private val client = mockk<WorkflowClient>()
+    private val temporal = mockk<TemporalConfig>()
+    private val config = mockk<CaseCoordinatorConfig>()
+    private val caseGroup = mockk<CaseCoordinatorConfig.CaseGroup>()
+
+    @Test
+    fun `shadow startup refuses an existing legacy case workflow`() {
+        every { config.case() } returns caseGroup
+        every { caseGroup.deliveryMode() } returns CaseDeliveryMode.SHADOW
+        every { temporal.enabled() } returns true
+        every { client.options } returns WorkflowClientOptions.newBuilder().setNamespace("openbank").build()
+        val stubs = mockk<WorkflowServiceStubs>()
+        val blocking = mockk<io.temporal.api.workflowservice.v1.WorkflowServiceGrpc.WorkflowServiceBlockingStub>()
+        every { client.workflowServiceStubs } returns stubs
+        every { stubs.blockingStub() } returns blocking
+        every { blocking.listOpenWorkflowExecutions(any()) } returns ListOpenWorkflowExecutionsResponse.newBuilder()
+            .addExecutions(io.temporal.api.workflow.v1.WorkflowExecutionInfo.getDefaultInstance())
+            .build()
+
+        assertThatIllegalStateException().isThrownBy { ShadowPilotPreflight(client, temporal, config) }
+            .withMessageContaining("legacy case workflow")
+    }
+}

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflowTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflowTest.kt
@@ -49,6 +49,7 @@ class CaseWorkflowTest {
     private lateinit var worker: Worker
     private lateinit var synthesis: CaseSynthesisActivity
     private lateinit var proposals: CaseProposalActivity
+    private lateinit var deliveryProposals: CaseProposalDeliveryActivity
     private lateinit var persistence: CasePersistenceActivity
 
     companion object {
@@ -78,10 +79,11 @@ class CaseWorkflowTest {
         worker.registerWorkflowImplementationTypes(CaseWorkflowImpl::class.java)
         synthesis = mockk(relaxed = true)
         proposals = mockk(relaxed = true)
+        deliveryProposals = mockk(relaxed = true)
         persistence = mockk(relaxed = true)
         every { synthesis.synthesize(any(), any(), any()) } returns "CONVERGED: restart the ingest consumer"
-        every { proposals.emitProposal(any(), any(), any(), any(), any()) } returns "proposal-1"
-        worker.registerActivitiesImplementations(synthesis, proposals, persistence)
+        every { deliveryProposals.emitProposalWithDelivery(any(), any(), any(), any(), any()) } returns "proposal-1"
+        worker.registerActivitiesImplementations(synthesis, proposals, deliveryProposals, persistence)
         env.start()
     }
 
@@ -126,7 +128,13 @@ class CaseWorkflowTest {
         assertThat(outcome.proposalId).isEqualTo("proposal-1")
         verify(exactly = 1) { synthesis.synthesize("case-incident-response-ingest-1", "INCIDENT_RESPONSE", any()) }
         verify(exactly = 1) {
-            proposals.emitProposal("case-incident-response-ingest-1", "case-synthesis", any(), false, false)
+            deliveryProposals.emitProposalWithDelivery(
+                "case-incident-response-ingest-1",
+                "case-synthesis",
+                any(),
+                false,
+                false,
+            )
         }
     }
 
@@ -138,7 +146,7 @@ class CaseWorkflowTest {
         result(stub)
 
         verify(exactly = 1) {
-            proposals.emitProposal(any(), "case-synthesis", any(), false, true)
+            deliveryProposals.emitProposalWithDelivery(any(), "case-synthesis", any(), false, true)
         }
     }
 
@@ -164,7 +172,7 @@ class CaseWorkflowTest {
                 },
             )
         }
-        verify(exactly = 1) { proposals.emitProposal(any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { deliveryProposals.emitProposalWithDelivery(any(), any(), any(), any(), any()) }
         // Both contributions — superseded draft included — are recorded history for the thread view.
         verify(exactly = 1) {
             persistence.recordContributions(any(), match { it.size == 2 })
@@ -180,7 +188,7 @@ class CaseWorkflowTest {
 
         assertThat(outcome.status).isEqualTo(CaseStatus.CONTESTED)
         verify(exactly = 0) { synthesis.synthesize(any(), any(), any()) }
-        verify(exactly = 1) { proposals.emitProposal(any(), "case-contested", any(), true, false) }
+        verify(exactly = 1) { deliveryProposals.emitProposalWithDelivery(any(), "case-contested", any(), true, false) }
     }
 
     @Test
@@ -191,7 +199,7 @@ class CaseWorkflowTest {
 
         assertThat(outcome.status).isEqualTo(CaseStatus.CLOSED)
         verify(exactly = 0) { synthesis.synthesize(any(), any(), any()) }
-        verify(exactly = 1) { proposals.emitProposal(any(), "case-timeout", any(), false, false) }
+        verify(exactly = 1) { deliveryProposals.emitProposalWithDelivery(any(), "case-timeout", any(), false, false) }
     }
 
     @Test
@@ -207,7 +215,7 @@ class CaseWorkflowTest {
 
         assertThat(outcome.status).isEqualTo(CaseStatus.SYNTHESIZED)
         assertThat(outcome.contributionCount).isEqualTo(10)
-        verify(exactly = 1) { proposals.emitProposal(any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { deliveryProposals.emitProposalWithDelivery(any(), any(), any(), any(), any()) }
         verify(exactly = 1) { persistence.recordCaseClosed(any(), "SYNTHESIZED", any()) }
     }
 }

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflowTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflowTest.kt
@@ -7,6 +7,7 @@ package com.openbank.casecoordinator.application.workflow
 
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.openbank.casecoordinator.domain.model.CaseClass
+import com.openbank.casecoordinator.domain.model.CaseDeliveryMode
 import com.openbank.casecoordinator.domain.model.CaseOutcome
 import com.openbank.casecoordinator.domain.model.CaseStart
 import com.openbank.casecoordinator.domain.model.CaseStatus
@@ -79,7 +80,7 @@ class CaseWorkflowTest {
         proposals = mockk(relaxed = true)
         persistence = mockk(relaxed = true)
         every { synthesis.synthesize(any(), any(), any()) } returns "CONVERGED: restart the ingest consumer"
-        every { proposals.emitProposal(any(), any(), any(), any()) } returns "proposal-1"
+        every { proposals.emitProposal(any(), any(), any(), any(), any()) } returns "proposal-1"
         worker.registerActivitiesImplementations(synthesis, proposals, persistence)
         env.start()
     }
@@ -87,7 +88,7 @@ class CaseWorkflowTest {
     @AfterEach
     fun tearDown() = env.close()
 
-    private fun start(deadlineMs: Long = TTL_MS): CaseWorkflow {
+    private fun start(deadlineMs: Long = TTL_MS, deliveryMode: CaseDeliveryMode = CaseDeliveryMode.HITL): CaseWorkflow {
         val start = CaseStart(
             caseId = "case-incident-response-ingest-1",
             caseClass = CaseClass.INCIDENT_RESPONSE,
@@ -97,6 +98,7 @@ class CaseWorkflowTest {
             deadlineEpochMs = System.currentTimeMillis() + deadlineMs,
             contestedRateThreshold = THRESHOLD,
             maxContributions = 40,
+            deliveryMode = deliveryMode,
         )
         val stub = env.workflowClient.newWorkflowStub(
             CaseWorkflow::class.java,
@@ -124,7 +126,19 @@ class CaseWorkflowTest {
         assertThat(outcome.proposalId).isEqualTo("proposal-1")
         verify(exactly = 1) { synthesis.synthesize("case-incident-response-ingest-1", "INCIDENT_RESPONSE", any()) }
         verify(exactly = 1) {
-            proposals.emitProposal("case-incident-response-ingest-1", "case-synthesis", any(), false)
+            proposals.emitProposal("case-incident-response-ingest-1", "case-synthesis", any(), false, false)
+        }
+    }
+
+    @Test
+    fun `shadow case never requests HITL publication`() {
+        val stub = start(deliveryMode = CaseDeliveryMode.SHADOW)
+        stub.requestSynthesis(SynthesisRequest("case-coordinator"))
+
+        result(stub)
+
+        verify(exactly = 1) {
+            proposals.emitProposal(any(), "case-synthesis", any(), false, true)
         }
     }
 
@@ -150,7 +164,7 @@ class CaseWorkflowTest {
                 },
             )
         }
-        verify(exactly = 1) { proposals.emitProposal(any(), any(), any(), any()) }
+        verify(exactly = 1) { proposals.emitProposal(any(), any(), any(), any(), any()) }
         // Both contributions — superseded draft included — are recorded history for the thread view.
         verify(exactly = 1) {
             persistence.recordContributions(any(), match { it.size == 2 })
@@ -166,7 +180,7 @@ class CaseWorkflowTest {
 
         assertThat(outcome.status).isEqualTo(CaseStatus.CONTESTED)
         verify(exactly = 0) { synthesis.synthesize(any(), any(), any()) }
-        verify(exactly = 1) { proposals.emitProposal(any(), "case-contested", any(), true) }
+        verify(exactly = 1) { proposals.emitProposal(any(), "case-contested", any(), true, false) }
     }
 
     @Test
@@ -177,7 +191,7 @@ class CaseWorkflowTest {
 
         assertThat(outcome.status).isEqualTo(CaseStatus.CLOSED)
         verify(exactly = 0) { synthesis.synthesize(any(), any(), any()) }
-        verify(exactly = 1) { proposals.emitProposal(any(), "case-timeout", any(), false) }
+        verify(exactly = 1) { proposals.emitProposal(any(), "case-timeout", any(), false, false) }
     }
 
     @Test
@@ -193,7 +207,7 @@ class CaseWorkflowTest {
 
         assertThat(outcome.status).isEqualTo(CaseStatus.SYNTHESIZED)
         assertThat(outcome.contributionCount).isEqualTo(10)
-        verify(exactly = 1) { proposals.emitProposal(any(), any(), any(), any()) }
+        verify(exactly = 1) { proposals.emitProposal(any(), any(), any(), any(), any()) }
         verify(exactly = 1) { persistence.recordCaseClosed(any(), "SYNTHESIZED", any()) }
     }
 }

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/infrastructure/workflow/CaseShadowOutboxIT.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/infrastructure/workflow/CaseShadowOutboxIT.kt
@@ -6,9 +6,14 @@
 package com.openbank.casecoordinator.infrastructure.workflow
 
 import com.openbank.casecoordinator.PostgresTestResource
+import com.openbank.casecoordinator.infrastructure.persistence.CaseOutboxRepositoryImpl
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.uni
 import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -28,6 +33,12 @@ class CaseShadowOutboxIT {
 
     @Inject
     lateinit var dataSource: DataSource
+
+    @Inject
+    lateinit var repository: CaseOutboxRepositoryImpl
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
 
     @AfterEach
     fun cleanUp() {
@@ -49,21 +60,14 @@ class CaseShadowOutboxIT {
 
         activities.emitProposalWithDelivery(WORKFLOW_ID, "case-synthesis", "shadow only", false, shadow = true)
 
+        assertThat(onEventLoop { repository.listProcessable(10) }).isEmpty()
+
         dataSource.connection.use { conn ->
             conn.prepareStatement("SELECT status FROM case_outbox WHERE aggregate_id = ?").use { ps ->
                 ps.setObject(1, CASE_UUID)
                 ps.executeQuery().use { rs ->
                     assertThat(rs.next()).isTrue()
                     assertThat(rs.getString("status")).isEqualTo("SHADOW")
-                }
-            }
-            conn.prepareStatement(
-                "SELECT count(*) FROM case_outbox WHERE aggregate_id = ? AND status IN ('PENDING', 'FAILED')",
-            ).use { ps ->
-                ps.setObject(1, CASE_UUID)
-                ps.executeQuery().use { rs ->
-                    assertThat(rs.next()).isTrue()
-                    assertThat(rs.getInt(1)).isZero()
                 }
             }
         }

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/infrastructure/workflow/CaseShadowOutboxIT.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/infrastructure/workflow/CaseShadowOutboxIT.kt
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.infrastructure.workflow
+
+import com.openbank.casecoordinator.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.UUID
+import javax.sql.DataSource
+
+/** Real-DB proof that a shadow result cannot enter the dispatcher selection set. */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class CaseShadowOutboxIT {
+
+    @Inject
+    lateinit var activities: CaseActivitiesImpl
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    @AfterEach
+    fun cleanUp() {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement("DELETE FROM case_outbox WHERE aggregate_id = ?").use {
+                it.setObject(1, CASE_UUID)
+                it.executeUpdate()
+            }
+            conn.prepareStatement("DELETE FROM case_workflow WHERE id = ?").use {
+                it.setObject(1, CASE_UUID)
+                it.executeUpdate()
+            }
+        }
+    }
+
+    @Test
+    fun `shadow proposal is recorded but is not processable by the outbox dispatcher`() {
+        seedCase()
+
+        activities.emitProposalWithDelivery(WORKFLOW_ID, "case-synthesis", "shadow only", false, shadow = true)
+
+        dataSource.connection.use { conn ->
+            conn.prepareStatement("SELECT status FROM case_outbox WHERE aggregate_id = ?").use { ps ->
+                ps.setObject(1, CASE_UUID)
+                ps.executeQuery().use { rs ->
+                    assertThat(rs.next()).isTrue()
+                    assertThat(rs.getString("status")).isEqualTo("SHADOW")
+                }
+            }
+            conn.prepareStatement(
+                "SELECT count(*) FROM case_outbox WHERE aggregate_id = ? AND status IN ('PENDING', 'FAILED')",
+            ).use { ps ->
+                ps.setObject(1, CASE_UUID)
+                ps.executeQuery().use { rs ->
+                    assertThat(rs.next()).isTrue()
+                    assertThat(rs.getInt(1)).isZero()
+                }
+            }
+        }
+    }
+
+    private fun seedCase() {
+        val now = Timestamp.from(Instant.parse("2026-08-20T09:00:00Z"))
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                """
+                INSERT INTO case_workflow
+                    (id, workflow_id, case_class, disposition_target, opened_at, deadline_at,
+                     status, budget_tokens, budget_contributions, contested_rate)
+                VALUES (?, ?, 'INCIDENT_RESPONSE', 'alert-7', ?, ?, 'OPEN', 200000, 40, 0.0)
+                """.trimIndent(),
+            ).use { ps ->
+                ps.setObject(1, CASE_UUID)
+                ps.setString(2, WORKFLOW_ID)
+                ps.setTimestamp(3, now)
+                ps.setTimestamp(4, now)
+                ps.executeUpdate()
+            }
+        }
+    }
+
+    private companion object {
+        const val WORKFLOW_ID = "case-incident-response-shadow-it"
+        val CASE_UUID: UUID = UUID.nameUUIDFromBytes(WORKFLOW_ID.toByteArray(StandardCharsets.UTF_8))
+    }
+}

--- a/openbank-infra/gitops/components/case-coordinator/case-coordinator-service.yaml
+++ b/openbank-infra/gitops/components/case-coordinator/case-coordinator-service.yaml
@@ -124,6 +124,9 @@ spec:
             # them to proposal-events/HITL. Any other class is rejected by CaseOpenService.
             - name: CASE_COORDINATOR_CASE_DELIVERY_MODE
               value: SHADOW
+            # Rotate this ID for each distinct shadow rollout; startup then rechecks legacy runs.
+            - name: CASE_COORDINATOR_CASE_SHADOW_ROLLOUT_ID
+              value: incident-triage-shadow-2026-08-20
             # LiteLLM virtual key (ESO case-coordinator-litellm; reuses KEY_AGENT_SERVICE
             # until a per-service virtual key is provisioned in Vault — a Vault admin action).
             - name: CASE_COORDINATOR_MODEL_API_KEY

--- a/openbank-infra/gitops/components/case-coordinator/case-coordinator-service.yaml
+++ b/openbank-infra/gitops/components/case-coordinator/case-coordinator-service.yaml
@@ -120,6 +120,10 @@ spec:
             # which the NetworkPolicy egress denies.
             - name: CASE_COORDINATOR_MODEL_ENDPOINT
               value: http://litellm.ai-platform.svc:4000/v1
+            # Seven-day incident-response pilot: persist results for measurement but never relay
+            # them to proposal-events/HITL. Any other class is rejected by CaseOpenService.
+            - name: CASE_COORDINATOR_CASE_DELIVERY_MODE
+              value: SHADOW
             # LiteLLM virtual key (ESO case-coordinator-litellm; reuses KEY_AGENT_SERVICE
             # until a per-service virtual key is provisioned in Vault — a Vault admin action).
             - name: CASE_COORDINATOR_MODEL_API_KEY


### PR DESCRIPTION
## What

Safely isolates the ADR-0244 incident-response shadow pilot from the human approval channel.

- Carries an explicit delivery mode in the Temporal workflow input.
- Allows SHADOW only for INCIDENT_RESPONSE.
- Writes shadow terminal results with a non-processable outbox status, so the existing dispatcher cannot relay them to proposal-events.
- Configures the sandbox workload for SHADOW while retaining HITL as the default.

## Evidence

- Targeted workflow test covers propagation of SHADOW.
- Local ktlint, detekt, Quarkus build, and the targeted test were run.

No pilot outcome, deployment, or phase promotion is claimed by this PR. It only establishes the safe runtime boundary required before the seven-day / approximately fifty-case pilot in #5839.

Refs #5839