### PR TITLE
fix(admin-ui): expose payment payload disclosure

### DIFF
--- a/openbank-admin-ui/src/app/payments/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/payments/[id]/page.tsx
@@ -147,15 +147,17 @@ function PaymentDetailContent() {
             ]} />
           </div>
           <div className="card" style={{ gridColumn: '1 / -1' }}>
-            <button onClick={() => setShowRaw(s => !s)}
+            <button type="button" aria-expanded={showRaw} aria-controls={showRaw ? 'payment-raw-payload' : undefined} aria-label={showRaw ? t('Skrýt surová data platby', 'Hide raw payment payload') : t('Zobrazit surová data platby', 'Show raw payment payload')} onClick={() => setShowRaw(s => !s)}
               style={{ width: '100%', display: 'flex', alignItems: 'center', gap: '6px', padding: '12px 18px', background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)', fontSize: '13px', fontWeight: 600 }}>
-              {showRaw ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+              {showRaw ? <ChevronDown size={14} aria-hidden="true" /> : <ChevronRight size={14} aria-hidden="true" />}
               {t('Surová data (JSON)', 'Raw payload (JSON)')}
             </button>
             {showRaw && (
-              <pre style={{ margin: 0, padding: '0 18px 18px', fontSize: '11px', fontFamily: 'var(--font-mono)', color: 'var(--text-secondary)', overflowX: 'auto' }}>
-                {JSON.stringify(payment, null, 2)}
-              </pre>
+              <div id="payment-raw-payload" role="region" aria-label={t('Surová data platby', 'Raw payment payload')}>
+                <pre style={{ margin: 0, padding: '0 18px 18px', fontSize: '11px', fontFamily: 'var(--font-mono)', color: 'var(--text-secondary)', overflowX: 'auto' }}>
+                  {JSON.stringify(payment, null, 2)}
+                </pre>
+              </div>
             )}
           </div>
         </div>

--- a/openbank-admin-ui/src/test/payment-detail-disclosure-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/payment-detail-disclosure-a11y.guard.test.ts
@@ -1,0 +1,17 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('payment detail raw payload disclosure accessibility', () => {
+  const source = fs.readFileSync(path.join(process.cwd(), 'src/app/payments/[id]/page.tsx'), 'utf8')
+
+  it('exposes disclosure state and a labelled payload region', () => {
+    expect(source).toContain('aria-expanded={showRaw}')
+    expect(source).toContain("aria-controls={showRaw ? 'payment-raw-payload' : undefined}")
+    expect(source).toContain('id="payment-raw-payload"')
+    expect(source).toContain('role="region"')
+    expect(source).toContain("aria-label={showRaw ? t('Skrýt surová data platby', 'Hide raw payment payload') : t('Zobrazit surová data platby', 'Show raw payment payload')}")
+    expect(source).toContain('aria-hidden="true"')
+    expect(source).toContain('type="button"')
+  })
+})


### PR DESCRIPTION
## Summary
- expose raw payment payload disclosure state
- provide a labelled, stable payload region
- hide disclosure icons and enforce button type

Preserves payment fetch/BFF, RBAC, JSON rendering and mutation behavior.

Refs #5823