### PR TITLE
fix(admin-ui): expose party detail tab state

### DIFF
--- a/openbank-admin-ui/src/app/parties/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/parties/[id]/page.tsx
@@ -132,10 +132,12 @@ function PartyDetailPage() {
 
       {/* Loop var is `item`, never `t` — a callback param named `t` shadows the translation
           function (see openbank-admin-ui/CLAUDE.md rule #4; sanctions/page.tsx does this). */}
-      <div style={{ display: 'flex', gap: '2px', marginBottom: '16px', flexWrap: 'wrap' }}>
+      <div role="group" aria-label={t('Sekce detailu subjektu', 'Party detail sections')} style={{ display: 'flex', gap: '2px', marginBottom: '16px', flexWrap: 'wrap' }}>
         {tabs.map(item => (
           <button
             key={item.id}
+            type="button"
+            aria-pressed={tab === item.id}
             onClick={() => setTab(item.id)}
             style={{
               display: 'flex', alignItems: 'center', gap: '4px', padding: '5px 10px', fontSize: '11px',
@@ -144,7 +146,7 @@ function PartyDetailPage() {
               color: tab === item.id ? '#fff' : 'var(--text-secondary)', transition: 'all 0.1s',
             }}
           >
-            {item.icon}{item.label}
+            <span aria-hidden="true">{item.icon}</span>{item.label}
           </button>
         ))}
       </div>

--- a/openbank-admin-ui/src/test/party-detail-tabs-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/party-detail-tabs-a11y.guard.test.ts
@@ -1,0 +1,14 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('party detail tab accessibility', () => {
+  const source = fs.readFileSync(path.join(process.cwd(), 'src/app/parties/[id]/page.tsx'), 'utf8')
+
+  it('exposes the active PII detail section and hides tab icons', () => {
+    expect(source).toContain("aria-label={t('Sekce detailu subjektu', 'Party detail sections')}")
+    expect(source).toContain('aria-pressed={tab === item.id}')
+    expect(source).toContain('type="button"')
+    expect(source).toContain('aria-hidden="true"')
+  })
+})


### PR DESCRIPTION
## Summary
- expose the active Party detail section
- hide decorative tab icons and enforce button types

Preserves party fetch, deep links, messaging/four-eyes workflows, PII rendering and RBAC.

Refs #5823