### PR TITLE
fix(admin-ui): expose onboarding stage filter state

### DIFF
--- a/openbank-admin-ui/src/app/onboarding/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/page.tsx
@@ -185,7 +185,7 @@ export default function OnboardingPage() {
           <DataUnavailable kind={countsUnavail.kind} service={t('Onboarding-service', 'Onboarding-service')} feature={t('Funnel počty', 'Funnel counts')} lang={language} dense />
         </div>
       ) : (
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: '10px', marginBottom: '20px' }}>
+        <div role="group" aria-label={t('Filtr fází onboardingu', 'Onboarding stage filters')} style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: '10px', marginBottom: '20px' }}>
           {STAGES.map(s => {
             const count = counts[s] ?? 0
             const isActive = stage === s
@@ -193,6 +193,8 @@ export default function OnboardingPage() {
             return (
               <button
                 key={s}
+                type="button"
+                aria-pressed={isActive}
                 onClick={() => handleStageFilter(isActive ? '' : s)}
                 style={{
                   background: isActive ? `${color}18` : 'var(--surface)',

--- a/openbank-admin-ui/src/test/onboarding-stage-filters-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/onboarding-stage-filters-a11y.guard.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const read = () => fs.readFileSync(path.join(process.cwd(), 'src/app/onboarding/page.tsx'), 'utf8')
+
+describe('onboarding stage filter accessibility', () => {
+  it('exposes a labelled group of stateful filter buttons', () => {
+    const source = read()
+    expect(source).toContain('role="group" aria-label={t(\'Filtr fází onboardingu\', \'Onboarding stage filters\')}')
+    expect(source).toContain('type="button"')
+    expect(source).toContain('aria-pressed={isActive}')
+    expect(source).toContain('handleStageFilter(isActive ? \'\' : s)')
+  })
+})


### PR DESCRIPTION
## Summary
- expose onboarding KPI stage filters as a labelled stateful group
- add explicit button types and aria-pressed state
- add a focused accessibility source guard

Preserves onboarding fetch, pagination, actions and RBAC.\n\nRefs #5146