### PR TITLE
fix(sepa-payment): add sourceService to the Temporal-path event payloads

### DIFF
--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditAttributionTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditAttributionTest.kt
@@ -196,6 +196,26 @@ class AuditAttributionTest {
     }
 
     @Test
+    fun `sepa-payment's Temporal-path payload is attributed to the producer too`(): Unit = runBlocking {
+        // The sweep above fixed only the non-Temporal path (SepaPaymentEvents.kt, a serialised data
+        // class). SepaPaymentActivitiesImpl builds five payloads BY HAND onto the same topic, and
+        // they carried no `sourceService` at all — so a grep for the quoted key found the fixed
+        // half and a reader of the data class found the other, and neither probe could see the gap.
+        // This is the exact wire shape that publisher now emits (see the producer-side assertion in
+        // SepaPaymentActivitiesImplTest, which reads it off the real built payload).
+        val entry = capturingSave()
+
+        consumer.consume(
+            """{"paymentId":"${UUID.randomUUID()}","status":"PROCESSING",""" +
+                """"occurredAt":"2026-03-01T12:34:56Z","sourceService":"sepa-payment"}""",
+            EventAddress(topic = "openbank.sepa.payment.events"),
+        )
+
+        assertThat(entry.captured.sourceService).isEqualTo("sepa-payment")
+        assertThat(entry.captured.sourceServiceSource).isEqualTo(AttributionSource.EVENT)
+    }
+
+    @Test
     fun `dispute-service's own sourceService wins, no longer falling to the topic table`(): Unit = runBlocking {
         // Issue #3994/#5256's dispute-service fix: DisputeService's hand-built outbox payloads
         // (dispute.opened / dispute.resolved / dispute.remediation_requested) and

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/workflow/SepaPaymentActivitiesImpl.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/workflow/SepaPaymentActivitiesImpl.kt
@@ -123,6 +123,15 @@ open class SepaPaymentActivitiesImpl(
         decision
     }
 
+    // Issue #3994/#5256: every payload below also carries `sourceService`, so AuditConsumer
+    // attributes the row from the producer's own claim (AttributionSource.EVENT) rather than
+    // falling through to its topic-derived table — a silent, successful default visible only by
+    // grouping `audit_entries` on a live database. The fleet sweep patched only the non-Temporal
+    // path (SepaPaymentEvents.kt, a serialised data class); these five hand-built payload strings
+    // are the SAME topic (`openbank.sepa.payment.events`, via `events-out`) and were missed
+    // because a grep for the quoted key cannot see a data class and a reader of the data class
+    // cannot see these strings.
+    //
     // #3914: every payload below carries `occurredAt` = the transitioned aggregate's `updatedAt`,
     // which `SepaPayment.transitionTo` stamps with `Instant.now(clock)` AT the state change. That
     // is the business event time; `SepaPaymentOutboxMessage.createdAt` next to it is the outbox
@@ -139,7 +148,8 @@ open class SepaPaymentActivitiesImpl(
             outboxMessage = SepaPaymentOutboxMessage(
                 aggregateId = updated.id,
                 eventType = PAYMENT_STATUS_CHANGED_EVENT,
-                payload = """{"paymentId":"$paymentId","status":"VALIDATED","occurredAt":"${updated.updatedAt}"}""",
+                payload = """{"paymentId":"$paymentId","status":"VALIDATED",""" +
+                    """"occurredAt":"${updated.updatedAt}","sourceService":"$SOURCE_SERVICE"}""",
                 createdAt = Instant.now(clock),
             ),
         )
@@ -156,7 +166,7 @@ open class SepaPaymentActivitiesImpl(
                 aggregateId = updated.id,
                 eventType = PAYMENT_STATUS_CHANGED_EVENT,
                 payload = """{"paymentId":"$paymentId","status":"REJECTED","reason":"SANCTIONS_HIT",""" +
-                    """"occurredAt":"${updated.updatedAt}"}""",
+                    """"occurredAt":"${updated.updatedAt}","sourceService":"$SOURCE_SERVICE"}""",
                 createdAt = Instant.now(clock),
             ),
         )
@@ -222,7 +232,8 @@ open class SepaPaymentActivitiesImpl(
                 outboxMessage = SepaPaymentOutboxMessage(
                     aggregateId = rejected.id,
                     eventType = PAYMENT_STATUS_CHANGED_EVENT,
-                    payload = """{"paymentId":"$paymentId","status":"REJECTED","occurredAt":"${rejected.updatedAt}"}""",
+                    payload = """{"paymentId":"$paymentId","status":"REJECTED",""" +
+                        """"occurredAt":"${rejected.updatedAt}","sourceService":"$SOURCE_SERVICE"}""",
                     createdAt = Instant.now(clock),
                 ),
             )
@@ -241,7 +252,8 @@ open class SepaPaymentActivitiesImpl(
             outboxMessage = SepaPaymentOutboxMessage(
                 aggregateId = processing.id,
                 eventType = PAYMENT_STATUS_CHANGED_EVENT,
-                payload = """{"paymentId":"$paymentId","status":"PROCESSING","occurredAt":"${processing.updatedAt}"}""",
+                payload = """{"paymentId":"$paymentId","status":"PROCESSING",""" +
+                    """"occurredAt":"${processing.updatedAt}","sourceService":"$SOURCE_SERVICE"}""",
                 createdAt = Instant.now(clock),
             ),
         )
@@ -259,7 +271,7 @@ open class SepaPaymentActivitiesImpl(
                     aggregateId = completed.id,
                     eventType = PAYMENT_STATUS_CHANGED_EVENT,
                     payload = """{"paymentId":"$paymentId","status":"COMPLETED",""" +
-                        """"occurredAt":"${completed.updatedAt}"}""",
+                        """"occurredAt":"${completed.updatedAt}","sourceService":"$SOURCE_SERVICE"}""",
                     createdAt = Instant.now(clock),
                 ),
             )
@@ -324,3 +336,10 @@ open class SepaPaymentActivitiesImpl(
         CoroutineScope(Dispatchers.Unconfined).async { block() }.asUni()
     }
 }
+
+/**
+ * This service's audit attribution (issue #3994/#5256) — the module directory without the
+ * `openbank-` prefix, matching `SepaPaymentEvents.kt`'s non-Temporal payloads and the value
+ * audit-service's own topic table maps `openbank.sepa.payment.events` to.
+ */
+private const val SOURCE_SERVICE = "sepa-payment"

--- a/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/application/workflow/SepaPaymentActivitiesImplTest.kt
+++ b/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/application/workflow/SepaPaymentActivitiesImplTest.kt
@@ -386,7 +386,50 @@ class SepaPaymentActivitiesImplTest {
         }
     }
 
+    // --- #3994/#5256: audit attribution on the Temporal-path payloads -------------------------
+    //
+    // The fleet sweep added `sourceService` to this service's non-Temporal path (a serialised data
+    // class, SepaPaymentEvents.kt) and missed these five hand-built payload strings on the SAME
+    // topic. Asserting the key on the payload the PRODUCTION code actually builds is the point: a
+    // test that only asserts a field on a data class cannot see a hand-built string, and a grep for
+    // the quoted key cannot see a data class.
+
+    @Test
+    fun `every Temporal-path payload self-reports sepa-payment as its source service`() {
+        val outboxes = mutableListOf<SepaPaymentOutboxMessage>()
+        coEvery { paymentRepository.update(any(), capture(outboxes)) } answers { firstArg() }
+
+        val activities = fixedClockActivities()
+
+        coEvery { paymentRepository.findById(paymentId) } returns payment
+        activities.validatePayment(paymentId)
+        activities.rejectPayment(paymentId)
+
+        // Scheme accept -> PROCESSING + COMPLETED.
+        coEvery { paymentRepository.findById(paymentId) } returns payment.copy(status = SepaPaymentStatus.VALIDATED)
+        coEvery { schemeGatewayPort.submit(any()) } returns SchemeSubmissionOutcome(accepted = true, reasonCode = null)
+        activities.submitToScheme(paymentId)
+
+        // Scheme reject -> REJECTED.
+        coEvery { schemeGatewayPort.submit(any()) } returns
+            SchemeSubmissionOutcome(accepted = false, reasonCode = "AM04")
+        activities.submitToScheme(paymentId)
+
+        assertThat(outboxes).hasSize(EXPECTED_TEMPORAL_PAYLOADS)
+        assertThat(outboxes.map { objectMapper.readTree(it.payload).get("status").asText() })
+            .containsExactly("VALIDATED", "REJECTED", "PROCESSING", "COMPLETED", "REJECTED")
+        // Read the parsed JSON, not a substring: a `contains` would also pass on a key that is
+        // present but nested, or on a value that merely starts with the expected text.
+        assertThat(outboxes.map { objectMapper.readTree(it.payload).get("sourceService")?.asText() })
+            .containsOnly("sepa-payment")
+    }
+
     private val objectMapper = ObjectMapper()
+
+    private companion object {
+        /** validate + reject + (processing, completed) + scheme-reject. */
+        const val EXPECTED_TEMPORAL_PAYLOADS = 5
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds `sourceService` to the five **hand-built** event payloads in
`SepaPaymentActivitiesImpl` (the Temporal path): `VALIDATED`, `REJECTED`
(sanctions), `REJECTED` (scheme), `PROCESSING`, `COMPLETED`.

The #5256 fleet sweep fixed this service's **non-Temporal** path only
(`SepaPaymentEvents.kt`, a serialised data class). These five payload strings
reach the *same* `openbank.sepa.payment.events` topic through the same outbox and
the same `KafkaSepaPaymentEventPublisher`, and carried no `sourceService` at all —
so `AuditConsumer` fell through to its topic-derived table for every one of them,
recording `AttributionSource.TOPIC` rather than the producer's own claim.

`sepa-payment` is a money-path service (`rules.yaml: money_path_services`) — this
PR needs 2 approvals.

### Why the sweep missed it

Event payloads are built two ways in this repo, and each of the two obvious probes
is structurally blind to one of them:

- a grep for `"sourceService"` finds hand-built maps and **cannot** see a
  serialised data class (the key exists only as a Kotlin property name);
- reading the event data class finds the serialised path and **cannot** see
  hand-built payload strings.

This service has one of each, on one topic, so whichever probe was used returned a
clean-looking answer about the half it could see. The gap was found by enumerating
every outbox write site that reaches the audited topic, rather than by either grep.

## Verification — the wire payload, not the field

A test asserting a field on a data class does not prove the wire carries it, and
here there is no data class at all. Both halves are asserted:

- **Producer side** — `SepaPaymentActivitiesImplTest`: drives the real activity
  methods and reads `sourceService` off the payload the production code actually
  builds, for all five payloads, via parsed JSON (not a substring `contains`,
  which would also pass on a nested key or a prefix match).
- **Consumer side** — `AuditAttributionTest`: feeds that same wire shape through
  `AuditConsumer.consume` and asserts it resolves
  `sourceServiceSource == AttributionSource.EVENT`, not the fallback.

**Falsification:** deleting `sourceService` from the `PROCESSING` payload turns the
producer test red (`BUILD FAILED`, the new test named as the failure). Restored
before commit.

## Test plan

- [x] `./gradlew :openbank-sepa-payment:ktlintCheck :openbank-sepa-payment:detekt` — green (both `ktlintMainSourceSetCheck` and `ktlintTestSourceSetCheck` confirmed to have run, not merely absent from a short-circuited task list)
- [x] `./gradlew :openbank-sepa-payment:test --tests "...SepaPaymentActivitiesImplTest"` — green
- [x] `./gradlew :openbank-audit-service:ktlintCheck :openbank-audit-service:detekt :openbank-audit-service:test --tests "...AuditAttributionTest"` — 27 tests, 0 failures, **0 skipped**
- [x] Negative case: field removed ⇒ producer test fails

## Not changed here

`occurredAt` was already correct on all five payloads (#3914).

Refs #5256
