### PR TITLE
fix(flaky-test-hunter): enforce the bounded non-money GitHub write surface

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1555,6 +1555,33 @@ gates:
     run: |
       bash .github/scripts/check-agent-charter-registry.sh
 
+  # ADR-0031 D9 phase 3 (issue #5281): flaky-test-hunter is the only chartered agent with a real
+  # GitHub write path. The two properties that make that acceptable — the write is confined to one
+  # NON-money-path module's own test tree, and the agent opens a PR but never merges or approves —
+  # held only because a human read a Kotlin constant. Every existing unit test pins that a LEDGER
+  # path is refused, so re-pointing the writer at another service would keep them all green, and
+  # money_path_services is a list that GROWS (settlement, sanctions, sdd and interest were all
+  # added after the fact). This binds the constant to rules.yaml: money_path_services itself
+  # rather than to a second hand-kept copy, and rejects any merge/approve/review-request endpoint
+  # literal in the adapter.
+  #
+  # ENFORCED. Pure python + one file read, <1 s. Falsified by effect against the real adapter on
+  # 2026-08-20: a money-path prefix, an added `PUT /pulls/{n}/merge`, and a deleted bound each make
+  # it exit 1; removing either half of `evaluate` makes the self-test go red.
+  - id: agent-bounded-write-surface
+    min_subjects: 20   # the money_path_services entries the bound is checked against; 23 today
+                        # (2026-08-20). A gate that resolves an empty list would pass everything,
+                        # so the floor moves with the list rather than tracking it exactly.
+    name: "agent bounded GitHub write surface (ADR-0031 D9 phase 3, enforced)"
+    group: registry
+    mode: enforced
+    rationale: "flaky-test-hunter is the only agent with a real GitHub write path; its non-money-path confinement and its inability to merge or approve held only because a human read a Kotlin constant, and money_path_services grows over time."
+    review_after: "2027-02-20"
+    selftest: python3 .github/scripts/check-agent-bounded-write-surface.py --self-test
+    selftest_expect: pass
+    run: |
+      python3 .github/scripts/check-agent-bounded-write-surface.py
+
   - id: agent-model-parity
     name: "agent model-id parity, agents.yaml vs application.yaml (ADR-0031 D5, enforced)"
     group: registry

--- a/.github/scripts/check-agent-bounded-write-surface.py
+++ b/.github/scripts/check-agent-bounded-write-surface.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Detector: does the ADR-0031 D9 phase-3 development agent's GitHub writer still confine itself
+# to ONE non-money-path module's test tree, and still lack any merge/approve surface? (issue #5281)
+#
+# WHY THIS EXISTS
+#   flaky-test-hunter is the only chartered agent with a real GitHub write path. Two properties
+#   make that acceptable under ADR-0031 D9 phase 3, and today BOTH hold only because a human read
+#   a Kotlin constant:
+#
+#     1. The write is confined to `openbank-flaky-test-hunter/src/test/kotlin/` — the agent's own
+#        test sources, in a module that is NOT in rules.yaml: money_path_services. Phase 4 (money
+#        path) explicitly needs 2 approvals + a threat model; phase 3 must not reach it.
+#     2. The agent opens a PR and stops. It never merges, never approves, never requests review
+#        away from a human. That is the "agent proposes, human disposes" invariant.
+#
+#   Neither property is currently enforced by anything a change can trip over. The unit tests pin
+#   the CURRENT prefix (a ledger path is refused), so re-pointing the writer at, say,
+#   openbank-settlement-service would keep every test green — and money_path_services is a list
+#   that GROWS: settlement, sanctions, sdd and interest were all added to it after the fact, so a
+#   module that is safe today can become money-path tomorrow with no code change at all. Likewise
+#   nothing anywhere would go red if someone added `PUT /pulls/{n}/merge` to the adapter.
+#
+#   So the binding is asserted here, at build time, against rules.yaml itself rather than against
+#   a second hand-kept list — the failure mode CLAUDE.md calls out for gates whose scope is a
+#   hand-maintained copy of the thing they check.
+#
+# WHAT IT CHECKS (against the adapter source, not against prose)
+#   - the bounded prefix constant still exists and is a string literal;
+#   - it confines to a `src/test/` tree (a `src/main/` prefix would let the agent write shipped
+#     code, which is a different decision entirely);
+#   - its leading path segment names a module that is NOT in rules.yaml: money_path_services;
+#   - the adapter source contains no merge / approve / review-request GitHub endpoint literal.
+#
+#   It does NOT try to prove the agent "behaves"; a static file check cannot. It proves the two
+#   structural bounds the charter and ADR-0031 D9 phase 3 rest on are still the ones in the code.
+#
+# Run:
+#   python3 .github/scripts/check-agent-bounded-write-surface.py [--self-test]
+
+import argparse
+import pathlib
+import re
+import sys
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    print("::warning::PyYAML not available — skipping bounded write-surface check")
+    sys.exit(0)
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import gatelib  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+RULES_YAML = REPO / "openbank-libs" / "governance" / "rules.yaml"
+MAIN_SRC = REPO / "openbank-flaky-test-hunter" / "src" / "main" / "kotlin"
+ADAPTER = (
+    REPO
+    / "openbank-flaky-test-hunter"
+    / "src"
+    / "main"
+    / "kotlin"
+    / "com"
+    / "openbank"
+    / "flakytest"
+    / "infrastructure"
+    / "adapter"
+    / "GitHubProposalAdapter.kt"
+)
+
+PREFIX_CONST = re.compile(
+    r'\bOWN_TEST_SOURCE_PREFIX\s*(?::\s*String\s*)?=\s*"([^"]*)"'
+)
+
+# GitHub REST surfaces that would turn "propose" into "dispose". Matched as substrings of any
+# string literal in the adapter, so a path assembled from one of these constants is still caught.
+FORBIDDEN_ENDPOINTS = {
+    "/merge": "merges its own pull request",
+    "/reviews": "approves (or dismisses review on) its own pull request",
+    "/requested_reviewers": "assigns its own reviewers",
+    "/branches/main/protection": "edits branch protection",
+}
+
+STRING_LITERAL = re.compile(r'"((?:[^"\\]|\\.)*)"')
+
+# Any literal that looks like a module-scoped source-tree prefix. The bound must be asserted in
+# exactly ONE place (BoundedTestPath); a second copy elsewhere in the agent's main sources is the
+# hand-kept-duplicate shape where relaxing one half leaves the two disagreeing with nothing red.
+# LlmDiagnosisAdapter carried exactly such a copy until #5281.
+SOURCE_TREE_PREFIX = re.compile(r"^openbank-[a-z0-9-]+/src/(main|test)/kotlin/")
+
+
+def evaluate(source: str, money_path: set[str]) -> list[str]:
+    """Return a list of findings. Empty list == the bounded write surface still holds."""
+    findings: list[str] = []
+
+    match = PREFIX_CONST.search(source)
+    if not match:
+        findings.append(
+            "the adapter declares no OWN_TEST_SOURCE_PREFIX string literal — the bounded write "
+            "surface has been removed or renamed, so nothing confines the agent's writes"
+        )
+    else:
+        prefix = match.group(1)
+        segments = [s for s in prefix.split("/") if s]
+        module = segments[0] if segments else ""
+        if "src/test/" not in prefix:
+            findings.append(
+                f"OWN_TEST_SOURCE_PREFIX {prefix!r} does not confine to a src/test/ tree — "
+                "phase 3 permits test-only changes, not shipped code"
+            )
+        if not module:
+            findings.append(f"OWN_TEST_SOURCE_PREFIX {prefix!r} names no module")
+        elif module in money_path:
+            findings.append(
+                f"OWN_TEST_SOURCE_PREFIX {prefix!r} points at {module!r}, which rules.yaml lists "
+                "in money_path_services — ADR-0031 D9 phase 4 (money path) requires 2 approvals "
+                "and a threat model, and is not what this writer is chartered for"
+            )
+
+    for literal in STRING_LITERAL.findall(source):
+        for endpoint, what in FORBIDDEN_ENDPOINTS.items():
+            if endpoint in literal:
+                findings.append(
+                    f"the adapter references the GitHub endpoint {endpoint!r} (in {literal!r}): it "
+                    f"{what}. The agent proposes; a human disposes (ADR-0031 D9)."
+                )
+
+    return findings
+
+
+def relative(path: pathlib.Path) -> str:
+    try:
+        return str(path.relative_to(REPO))
+    except ValueError:
+        return path.name
+
+
+def duplicate_bounds(main_src: pathlib.Path) -> list[str]:
+    """Every module-scoped source-tree prefix literal outside the one canonical declaration."""
+    findings: list[str] = []
+    for kt in sorted(main_src.rglob("*.kt")):
+        text = kt.read_text()
+        canonical = kt.name == "GitHubProposalAdapter.kt"
+        for literal in STRING_LITERAL.findall(text):
+            if not SOURCE_TREE_PREFIX.match(literal):
+                continue
+            if canonical and PREFIX_CONST.search(text) and PREFIX_CONST.search(text).group(1) == literal:
+                continue
+            findings.append(
+                f"{relative(kt)} repeats the bounded-path prefix {literal!r} as its own "
+                "string literal — the bound must come from BoundedTestPath alone, or the two "
+                "copies can be widened independently with nothing going red"
+            )
+    return findings
+
+
+def money_path_services() -> set[str]:
+    doc = yaml.safe_load(RULES_YAML.read_text()) or {}
+    return set(doc.get("money_path_services") or [])
+
+
+def self_test() -> int:
+    """Falsify the comparison in BOTH directions against fixtures."""
+    fails: list[str] = []
+    money = {"openbank-ledger-service", "openbank-settlement-service"}
+
+    def case(label: str, source: str, want_findings: bool) -> None:
+        got = evaluate(source, money)
+        if bool(got) != want_findings:
+            fails.append(f"{label}: expected findings={want_findings}, got {got}")
+
+    clean = (
+        'private const val OWN_TEST_SOURCE_PREFIX = "openbank-flaky-test-hunter/src/test/kotlin/"\n'
+        'val r = send("POST", "/pulls", body)\n'
+    )
+    case("the chartered bounded prefix and no merge surface is clean", clean, False)
+
+    # THE DEFECT this gate exists for: re-pointing the writer at a money-path module. Every
+    # existing unit test stays green, because they only pin that a LEDGER path is refused.
+    case(
+        "a money-path module prefix is FLAGGED",
+        'private const val OWN_TEST_SOURCE_PREFIX = "openbank-settlement-service/src/test/kotlin/"\n',
+        True,
+    )
+    case(
+        "the ledger prefix is FLAGGED",
+        'private const val OWN_TEST_SOURCE_PREFIX = "openbank-ledger-service/src/test/kotlin/"\n',
+        True,
+    )
+    # Widening from test sources to shipped code.
+    case(
+        "a src/main prefix is FLAGGED",
+        'private const val OWN_TEST_SOURCE_PREFIX = "openbank-flaky-test-hunter/src/main/kotlin/"\n',
+        True,
+    )
+    # Deleting the bound must not read as "no violation found".
+    case("a removed prefix constant is FLAGGED", 'val r = send("POST", "/pulls", body)\n', True)
+    case("an empty source is FLAGGED", "", True)
+    # The proposes-not-disposes invariant, one case per forbidden endpoint.
+    for endpoint in FORBIDDEN_ENDPOINTS:
+        case(f"a {endpoint!r} call is FLAGGED", clean + f'send("PUT", "/pulls/1{endpoint}", null)\n', True)
+    # A non-money module that is merely different is NOT a finding — this gate binds to
+    # money_path_services, not to one hardcoded module name.
+    case(
+        "a different non-money module is clean",
+        'private const val OWN_TEST_SOURCE_PREFIX = "openbank-docs-truth-agent/src/test/kotlin/"\n',
+        False,
+    )
+
+    # A fixture-only self-test cannot notice that this script's subjects stopped existing.
+    if not ADAPTER.exists():
+        fails.append(f"the adapter this gate checks is missing: {ADAPTER}")
+    elif not MAIN_SRC.exists():
+        fails.append(f"the agent main sources are missing: {MAIN_SRC}")
+    else:
+        # Falsify duplicate_bounds against a fixture tree, both directions.
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            (root / "GitHubProposalAdapter.kt").write_text(
+                'private const val OWN_TEST_SOURCE_PREFIX = "openbank-flaky-test-hunter/src/test/kotlin/"\n'
+            )
+            if duplicate_bounds(root):
+                fails.append("duplicate_bounds flags the single canonical declaration")
+            (root / "Other.kt").write_text('val p = "openbank-flaky-test-hunter/src/test/kotlin/"\n')
+            if not duplicate_bounds(root):
+                fails.append("duplicate_bounds does NOT flag a second copy of the bound")
+    if not RULES_YAML.exists():
+        fails.append(f"rules.yaml not found at {RULES_YAML}")
+    elif not money_path_services():
+        fails.append("rules.yaml: money_path_services resolved empty — this gate would pass vacuously")
+
+    if fails:
+        for f in fails:
+            sys.stderr.write(f"::error::self-test: {f}\n")
+        sys.stderr.write(f"self-test FAILED ({len(fails)} case(s))\n")
+        return 1
+    print(
+        f"self-test ok: bounded write surface is falsifiable "
+        f"({8 + len(FORBIDDEN_ENDPOINTS)} cases + a live read of the adapter and rules.yaml)"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if not ADAPTER.exists():
+        print(f"::error::{ADAPTER} not found — this check must not pass vacuously.")
+        return 1
+    if not RULES_YAML.exists():
+        print(f"::error::{RULES_YAML} not found — this check must not pass vacuously.")
+        return 1
+
+    money = money_path_services()
+    if not money:
+        print("::error::rules.yaml: money_path_services is empty — refusing to pass vacuously.")
+        return 1
+
+    gatelib.subjects(len(money), "money_path_services entries the bound is checked against")
+
+    findings = evaluate(ADAPTER.read_text(), money) + duplicate_bounds(MAIN_SRC)
+    if not findings:
+        print(
+            "agent bounded write surface: flaky-test-hunter's GitHub writer is still confined to "
+            f"its own src/test tree, outside all {len(money)} money_path_services, with no "
+            "merge/approve/review-request endpoint, declared in exactly one place."
+        )
+        return 0
+
+    for f in findings:
+        print(f"::error::check-agent-bounded-write-surface: {f}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/agents/flaky-test-hunter.md
+++ b/docs/agents/flaky-test-hunter.md
@@ -61,13 +61,21 @@ find nothing.
   parameterized/dynamic tests) is deliberately not flagged, to avoid false-flagging every
   parameterized suite in the fleet — a real but rarer drift shape (a source-level `@Test` that
   somehow inflates the reported count) is out of scope.
-- `LlmDiagnosisPort.proposeFixDiff` only branches non-null-eligible for `TEST_COUNT_DRIFT`, and even
-  that branch still returns `null` unconditionally in v1 — this agent never proposes a fix diff for
-  any check type yet, the same bootstrap-stub state every sibling agent shipped with, but a
-  deliberately more conservative default (see Mission) than most of them.
-- The `LlmDiagnosisPort` and `GitHubProposalPort` adapters are stubs pending the shared LiteLLM
-  gateway and GitHub App installation-token wiring, the same bootstrap state every sibling agent
-  shipped with.
+- `LlmDiagnosisPort.proposeFixDiff` returns a fix marker for exactly one shape:
+  `RUNBLOCKING_UNIT_MISSING` inside this agent's own `src/test/kotlin/` tree. It never returns a
+  model-generated diff — the model is kept out of the write decision entirely (ADR-0031 D9). Every
+  other finding, and every other check type, is ticket-only and human-triaged.
+- `GitHubProposalAdapter` is a real, token-backed writer as of ADR-0031 D9 phase 3 (#5281), not a
+  stub. It fails closed on an absent or blank token (no network call at all), refuses any path
+  outside `BoundedTestPath` and any fix marker it does not recognise, and never merges, approves or
+  requests review — a human disposes of the PR through the ordinary protected-branch policy. Both
+  bounds are enforced at build time by `.github/scripts/check-agent-bounded-write-surface.py`
+  (gate `agent-bounded-write-surface`), which binds the writer's target module to
+  `rules.yaml: money_path_services` rather than to a second hand-kept list.
+- Sibling agents (`docs-truth-agent`, `authz-policy-auditor`) still carry the original bootstrap
+  `GitHubProposalAdapter` stub, which returns a fabricated `pending-...` URL rather than refusing.
+  That is the opposite of the `UnwiredProposalPort` pattern the fleet has since settled on and is
+  tracked separately; nothing in this agent depends on it.
 - `repo-root` (`FLAKY_TEST_HUNTER_REPO_ROOT`) must point at a mounted, up-to-date checkout of `main`
   for the `TestScanPort` checks to be meaningful — the deployment-side checkout-mount wiring is
   tracked separately and not yet part of this PR's gitops manifest.

--- a/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/infrastructure/adapter/GitHubProposalAdapter.kt
+++ b/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/infrastructure/adapter/GitHubProposalAdapter.kt
@@ -173,39 +173,13 @@ class GitHubProposalAdapter(private val config: FlakyTestHunterConfig) : GitHubP
     }
 }
 
-@Suppress("UnusedPrivateProperty")
-/** Pure transformer used by the adapter after it has fetched the source from GitHub. */
-internal object ExplicitUnitReturnType {
-    private val expressionBodyRunBlocking = Regex("""^(\s*fun\s+[A-Za-z`][^=]*\))\s*=\s*runBlocking\s*\{""")
-
-    private val safeExpressionBodyRunBlocking = Regex("""^(\s*fun\s+[A-Za-z_][^=]*\))\s*=\s*runBlocking\s*\{""")
-
-    private val verifiedExpressionBodyRunBlocking =
-        Regex("^(\\\\s*fun\\\\s+[A-Za-z_][^=]*\\\\))\\\\s*=\\\\s*runBlocking\\\\s*\\\\{")
-
-    private val finalExpressionBodyRunBlocking = Regex("^(\\s*fun\\s+[A-Za-z_][^=]*\\))\\s*=\\s*runBlocking\\s*\\{")
-
-    /** Returns null unless precisely one safe replacement is possible. */
-    fun apply(source: String): String? {
-        val matches = source.lineSequence().filter { finalExpressionBodyRunBlocking.containsMatchIn(it) }.toList()
-        if (matches.size != 1) return null
-        return source.replaceFirst(finalExpressionBodyRunBlocking, "$1: Unit = runBlocking {")
-    }
-}
-
-/** The phase-3 transformer is deliberately independent from the legacy generic detector regex. */
-internal object BoundedUnitReturnType {
-    private val expressionBodyRunBlocking =
-        Regex("^(\\s*fun\\s+[A-Za-z_][^=]*\\))\\s*=\\s*runBlocking\\s*\\{")
-
-    fun apply(source: String): String? {
-        val matches = source.lineSequence().filter { expressionBodyRunBlocking.containsMatchIn(it) }.toList()
-        if (matches.size != 1) return null
-        return source.replaceFirst(expressionBodyRunBlocking, "$1: Unit = runBlocking {")
-    }
-}
-
-/** String-only implementation: exactly one ordinary Kotlin test function is accepted. */
+/**
+ * The one transformer the adapter uses. String-only and deliberately not regex-based: exactly one
+ * ordinary Kotlin test function is accepted, and anything ambiguous returns null so the caller
+ * falls back to the human ticket path. Falsified by [ExplicitUnitReturnTypeTest] in both
+ * directions — a repairable file is repaired, and multi-match / already-typed / string-literal
+ * lookalikes are all refused.
+ */
 internal object ManualBoundedUnitReturnType {
     private const val EXPRESSION_BODY_RUN_BLOCKING = " = runBlocking {"
 

--- a/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/infrastructure/adapter/LlmDiagnosisAdapter.kt
+++ b/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/infrastructure/adapter/LlmDiagnosisAdapter.kt
@@ -67,7 +67,11 @@ class LlmDiagnosisAdapter : LlmDiagnosisPort {
 
     override suspend fun proposeFixDiff(finding: FlakyTestFinding, diagnosis: String): String? = if (
         finding.checkType == com.openbank.flakytest.domain.model.FlakyTestCheckType.RUNBLOCKING_UNIT_MISSING &&
-        finding.filePath.startsWith("openbank-flaky-test-hunter/src/test/kotlin/")
+        // The bound is asserted in ONE place. This used to repeat the prefix as its own string
+        // literal, which is the hand-kept-copy shape a widening edit could silently desynchronise:
+        // relaxing it here while BoundedTestPath stayed strict (or the reverse) would leave the
+        // two halves of the same rule disagreeing, with nothing red.
+        BoundedTestPath.isSafe(finding.filePath)
     ) {
         ADD_EXPLICIT_UNIT_RETURN_TYPE
     } else {


### PR DESCRIPTION
## What this changes

`flaky-test-hunter` is the only chartered agent with a **real GitHub write path** (ADR-0031 D9
phase 3). Most of what #5281 asks for already landed on `main`: the token-backed, fail-closed
`GitHubProposalAdapter`, the one mechanically-verifiable change shape, the AI-attributed audit on
every disposition, and the contract/degraded-path tests. This PR closes the part that had **no
enforcement behind it**.

### 1. The two safety bounds were held only by a human reading a constant

Phase 3 rests on two properties:

1. the write is confined to one **non-money-path** module's own test tree;
2. the agent opens a PR and stops — it never merges, approves, or requests review.

Neither was enforced by anything a change could trip over:

- The unit tests pin only that a **ledger** path is refused. Re-pointing the writer at, say,
  `openbank-settlement-service` would keep every test green.
- `money_path_services` is a list that **grows** — settlement, sanctions, sdd and interest were all
  added to it after the fact. A module that is safe today can become money-path tomorrow with no
  code change at all, and nothing would notice.
- Nothing anywhere would go red if someone added `PUT /pulls/{n}/merge` to the adapter.

New gate `agent-bounded-write-surface`
(`.github/scripts/check-agent-bounded-write-surface.py`, `mode: enforced`, group `registry`) binds
the writer's target to `rules.yaml: money_path_services` **itself** rather than to a second
hand-kept list — the failure shape `CLAUDE.md` calls out for gates whose scope is a maintained copy
of the thing they check.

### 2. The bound was declared twice

`LlmDiagnosisAdapter.proposeFixDiff` repeated the prefix as its own string literal instead of
calling `BoundedTestPath`. Two copies of one rule can be widened independently with nothing going
red — and the copy was the weaker one: a plain `startsWith` with no traversal, no leading-slash and
no percent-encoding checks. It now calls `BoundedTestPath.isSafe`, and the gate refuses any
re-introduced duplicate.

### 3. Dead transformer debris

`GitHubProposalAdapter.kt` carried two entirely unused transformer objects
(`ExplicitUnitReturnType` with three dead regex properties, one of them a mangled escaped literal,
plus `BoundedUnitReturnType`) behind a `@Suppress("UnusedPrivateProperty")`. Nothing referenced
them and nothing tested them; a future reader switching to one would have silently traded away the
string-based transformer's refusal properties. Removed.

### 4. The agent doc claimed a stub

`docs/agents/flaky-test-hunter.md` still described `GitHubProposalPort` as "a stub pending GitHub
App installation-token wiring" and `proposeFixDiff` as returning `null` unconditionally. Both were
false. Corrected, and it now names the gate that enforces the bounds.

## Guard falsification (verify by effect, both directions)

Against the **real** adapter file, not a fixture:

| Mutation | Gate |
|---|---|
| prefix re-pointed at `openbank-ledger-service` | **exit 1** — names the money-path violation |
| `PUT /pulls/1/merge` added to the adapter | **exit 1** — "the agent proposes; a human disposes" |
| `OWN_TEST_SOURCE_PREFIX` deleted | **exit 1** — absence does not read as compliance |
| duplicate prefix literal restored in `LlmDiagnosisAdapter` | **exit 1** |
| unmodified `origin/main` state | **exit 0** |

And the self-test is itself falsifiable — removing the money-path comparison from `evaluate()`
turns 2 self-test cases red; removing the endpoint scan turns 4 red. It also refuses to pass
vacuously: an empty `money_path_services`, a missing `rules.yaml`, or a missing adapter each fail
rather than report clean.

12 self-test cases + a live read of both the adapter and `rules.yaml`.

## Charter

**No charter change is required, and none was made.** `agents.yaml` grants
`tier: write_proposal, resources: [github-pr]` with an explicit `deny: tier: write, resources: ["*"]`
— exactly the capability this writer uses. Since `agents.yaml` is untouched, none of its three
derived tails (`docs/compliance/eu-ai-act.md`, the OPA bundle ConfigMaps + `policy-checksum`
annotations, `ai-governance-snapshot.json`) needed regenerating.

## Not in scope, deliberately

- **No promotion of the published rollout status.** The remaining phase-3 evidence — a real
  agent-generated PR URL, its policy-decision/AI-attributed audit records, and a protected-branch
  human merge by a different principal — is runtime evidence this PR cannot manufacture. `Refs`,
  not `Closes`.
- **Money-path is untouched**, and now structurally so rather than by convention.
- Sibling agents `docs-truth-agent` and `authz-policy-auditor` still carry the original bootstrap
  `GitHubProposalAdapter` stub that returns a **fabricated** `pending-...` URL rather than refusing
  — the opposite of the `UnwiredProposalPort` pattern the fleet settled on (#3613/#3826). Noted in
  the agent doc; worth its own issue, not widened into here.

Refs ADR-0031 D9 and #5281.
