### PR TITLE
fix(admin-ui): expose cards filter state

### DIFF
--- a/openbank-admin-ui/src/app/cards/page.tsx
+++ b/openbank-admin-ui/src/app/cards/page.tsx
@@ -161,14 +161,14 @@ export default function CardsPage() {
             </div>
             <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap', alignItems: 'center' }}>
               <div role="group" aria-label={t('Filtr podle stavu', 'Filter by status')} style={{ display: 'flex', gap: '5px', flexWrap: 'wrap' }}>
-                <button style={chip(statusFilter === ALL)} onClick={() => { setStatusFilter(ALL); setVisible(PAGE_SIZE) }}>
+                <button type="button" aria-pressed={statusFilter === ALL} style={chip(statusFilter === ALL)} onClick={() => { setStatusFilter(ALL); setVisible(PAGE_SIZE) }}>
                   {t('Vše', 'All')} · {cards.length}
                 </button>
                 {CARD_STATUSES.filter(s => countBy(s) > 0).map(s => {
                   const c = cardStatusColor(s)
                   const active = statusFilter === s
                   return (
-                    <button key={s} onClick={() => { setStatusFilter(active ? ALL : s); setVisible(PAGE_SIZE) }}
+                    <button key={s} type="button" aria-pressed={active} onClick={() => { setStatusFilter(active ? ALL : s); setVisible(PAGE_SIZE) }}
                       style={{ ...chip(active), background: active ? c.bg : 'var(--surface-2)', color: active ? c.text : 'var(--text-secondary)', borderColor: active ? c.border : 'var(--border)' }}>
                       {s} · {countBy(s)}
                     </button>
@@ -179,7 +179,7 @@ export default function CardsPage() {
                 {CARD_TYPES.filter(ct => cards.some(c => c.cardType === ct)).map(ct => {
                   const active = typeFilter === ct
                   return (
-                    <button key={ct} style={chip(active)} onClick={() => { setTypeFilter(active ? ALL : ct); setVisible(PAGE_SIZE) }}>
+                    <button key={ct} type="button" aria-pressed={active} style={chip(active)} onClick={() => { setTypeFilter(active ? ALL : ct); setVisible(PAGE_SIZE) }}>
                       {ct}
                     </button>
                   )

--- a/openbank-admin-ui/src/test/cards-filter-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/cards-filter-a11y.guard.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const read = () => fs.readFileSync(path.join(process.cwd(), 'src/app/cards/page.tsx'), 'utf8')
+
+describe('cards filter accessibility', () => {
+  it('exposes state and safe button semantics for status and type filters', () => {
+    const source = read()
+    expect(source).toContain('aria-label={t(\'Filtr podle stavu\', \'Filter by status\')}')
+    expect(source).toContain('aria-label={t(\'Filtr podle typu\', \'Filter by type\')}')
+    expect(source).toContain('type="button" aria-pressed={statusFilter === ALL}')
+    expect(source).toContain('type="button" aria-pressed={active}')
+    expect(source).toContain('setStatusFilter(active ? ALL : s)')
+    expect(source).toContain('setTypeFilter(active ? ALL : ct)')
+  })
+})


### PR DESCRIPTION
## Summary
- expose cards status/type filter state via aria-pressed
- make filter buttons explicit non-submit buttons
- add focused accessibility source guard

Preserves card fetch/filter/pagination, lifecycle transitions, PCI masking and RBAC.\n\nRefs #5146