### PR TITLE
feat(kyc): adverse-media port with an explicit not-configured state

### DIFF
--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/application/port/out/AdverseMediaScreeningPort.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/application/port/out/AdverseMediaScreeningPort.kt
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyc.application.port.out
+
+import com.openbank.kyc.domain.model.CheckStatus
+
+/**
+ * Outcome of an adverse-media screen. Deliberately **four-valued**: "we could not screen" is never
+ * the same value as "we screened and found nothing".
+ *
+ * This repo has paid for the opposite shape twice — a disabled push adapter whose
+ * `skipped()` result carried `success = true` counted every undelivered push as delivered
+ * (ADR-0252 phase 0, #4348), and a dead-letter sink whose `quarantine()` was a single log line
+ * made "quarantined" mean "logged". An adverse-media check that cannot reach a source must not be
+ * representable as a clean result, so [NO_HIT] is a distinct enum member that only a reachable,
+ * configured source can produce.
+ */
+enum class AdverseMediaOutcome {
+    /** The source was reached and returned at least one candidate article/record for the subject. */
+    HIT,
+
+    /**
+     * The source was reached and returned nothing. **Only** a configured, reachable source may
+     * yield this — it is the sole outcome that maps to [CheckStatus.PASSED].
+     */
+    NO_HIT,
+
+    /** A source is configured but could not be reached (transport fault, timeout, open circuit). */
+    SOURCE_UNAVAILABLE,
+
+    /**
+     * No adverse-media source is configured on this platform at all. This is the state OpenBank is
+     * in today: ADR-0256 D5 defers adverse media because no change-detectable, EU-residency-compatible,
+     * licensed source has been selected (issue #4459). It is a *permanent* unresolved state, not a
+     * transient one, and is reported as such rather than as an absence of findings.
+     */
+    SOURCE_NOT_CONFIGURED,
+    ;
+
+    /**
+     * Fail-closed mapping onto the KYC check lifecycle. Exhaustive by construction: a new outcome
+     * member will not compile until it declares which side of the line it falls on, and every side
+     * except [NO_HIT] is [CheckStatus.MANUAL_REVIEW] — an unresolved check a human must dispose of,
+     * never a [CheckStatus.PASSED] the platform did not earn.
+     *
+     * Note the deliberate asymmetry with a hit: [HIT] is also MANUAL_REVIEW, not FAILED, because
+     * ADR-0116's four-eyes gate owns the disposition — a trigger may never decide anything about a
+     * customer (ADR-0256 D2).
+     */
+    fun toCheckStatus(): CheckStatus = when (this) {
+        NO_HIT -> CheckStatus.PASSED
+        HIT, SOURCE_UNAVAILABLE, SOURCE_NOT_CONFIGURED -> CheckStatus.MANUAL_REVIEW
+    }
+
+    /** True when this outcome represents an actual observation of the source's contents. */
+    val isResolved: Boolean get() = this == HIT || this == NO_HIT
+}
+
+/**
+ * Result of one adverse-media screen. [sourceId] is null exactly when [outcome] is
+ * [AdverseMediaOutcome.SOURCE_NOT_CONFIGURED] — the provenance of a screening result is part of
+ * the result, so a case's check can record *which* source (and therefore which coverage) backed it.
+ */
+data class AdverseMediaScreeningResult(
+    val outcome: AdverseMediaOutcome,
+    val sourceId: String?,
+    val matchedHeadline: String? = null,
+) {
+    init {
+        require((sourceId == null) == (outcome == AdverseMediaOutcome.SOURCE_NOT_CONFIGURED)) {
+            "sourceId must be null iff outcome is SOURCE_NOT_CONFIGURED (was outcome=$outcome, sourceId=$sourceId)"
+        }
+    }
+}
+
+/**
+ * Outbound port for adverse-media screening of a party name.
+ *
+ * **There is no production implementation backed by a real source today.** ADR-0256 D5 keeps
+ * adverse media out of the perpetual-KYC trigger catalogue precisely because a stub would make
+ * `CheckType.ADVERSE_MEDIA` decorative; this port exists so that when a source is selected
+ * (#4459) it lands behind a contract that cannot express "clean" without having read something,
+ * and so that the platform's *lack* of coverage is observable today rather than implicit.
+ */
+interface AdverseMediaScreeningPort {
+
+    /**
+     * Stable identifier of the backing source, or **null when no source is configured**. The
+     * readiness gauge is derived from this rather than from a separate config key, so the reported
+     * coverage cannot drift from the adapter actually wired in.
+     */
+    val sourceId: String?
+
+    suspend fun screen(name: String, idempotencyKey: String): AdverseMediaScreeningResult
+}

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/client/UnconfiguredAdverseMediaSource.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/client/UnconfiguredAdverseMediaSource.kt
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyc.infrastructure.client
+
+import com.openbank.kyc.application.port.out.AdverseMediaOutcome
+import com.openbank.kyc.application.port.out.AdverseMediaScreeningPort
+import com.openbank.kyc.application.port.out.AdverseMediaScreeningResult
+import jakarta.enterprise.context.ApplicationScoped
+
+/**
+ * The only [AdverseMediaScreeningPort] implementation on the platform today: it reports that no
+ * adverse-media source is configured, and it can return nothing else.
+ *
+ * This is **not** a stub that answers "no adverse media found". That distinction is the entire
+ * point of the class: OpenBank has no licensed, EU-residency-compatible, change-detectable
+ * adverse-media feed (ADR-0256 D5, issue #4459), and a screening path that quietly returns a clean
+ * result for a source it never reached is worse than having no path at all — it manufactures
+ * evidence of a control that does not exist.
+ *
+ * When a real source lands, it replaces this bean (an `@Alternative`/`@Priority` or a
+ * build-profile selection) and returns a non-null `sourceId`; nothing else in the port contract
+ * changes.
+ */
+@ApplicationScoped
+class UnconfiguredAdverseMediaSource : AdverseMediaScreeningPort {
+
+    /** Null by construction — see [AdverseMediaScreeningPort.sourceId]. */
+    override val sourceId: String? = null
+
+    override suspend fun screen(name: String, idempotencyKey: String): AdverseMediaScreeningResult =
+        AdverseMediaScreeningResult(outcome = AdverseMediaOutcome.SOURCE_NOT_CONFIGURED, sourceId = null)
+}

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/observability/AdverseMediaSourceReadiness.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/observability/AdverseMediaSourceReadiness.kt
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyc.infrastructure.observability
+
+import com.openbank.kyc.application.port.out.AdverseMediaScreeningPort
+import io.micrometer.core.instrument.MeterRegistry
+import io.quarkus.runtime.Startup
+import jakarta.annotation.PostConstruct
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+import org.jboss.logging.Logger
+
+/**
+ * Publishes whether this platform has an adverse-media source at all, as
+ * `openbank_kyc_adverse_media_source_configured` (1 = a source is wired, 0 = none).
+ *
+ * Today the value is **0**, and that is the deliverable: ADR-0256 D5's "no adverse-media source
+ * exists" stops being a sentence in a decision record and becomes a number an operator or auditor
+ * can query. The gauge is derived from [AdverseMediaScreeningPort.sourceId] rather than from a
+ * config flag, so it cannot claim coverage the wired adapter does not have.
+ *
+ * `@Startup` is load-bearing. `@ApplicationScoped` is lazy: Quarkus creates the bean on first
+ * use through a client proxy, so a boot-time warning in `init {}` or `@PostConstruct` on a bean
+ * nothing calls never reaches a pod log. This repo shipped a PAdES adapter warning that its seals
+ * were "worthless as evidence" and that line never once appeared in production (#1299). Without
+ * `@Startup` the gauge below would likewise never be registered, and an absent series reads to
+ * every dashboard exactly like a healthy one that has not scraped yet.
+ */
+@Startup
+@ApplicationScoped
+class AdverseMediaSourceReadiness {
+
+    @Inject
+    lateinit var port: AdverseMediaScreeningPort
+
+    @Inject
+    lateinit var registryInstance: Instance<MeterRegistry>
+
+    private val log = Logger.getLogger(AdverseMediaSourceReadiness::class.java)
+
+    /** 1 when a real adverse-media source backs the port, 0 when none is configured. */
+    fun configured(): Int = if (port.sourceId != null) 1 else 0
+
+    @PostConstruct
+    fun register() {
+        if (configured() == 0) {
+            log.warn(
+                "No adverse-media source is configured (ADR-0256 D5, issue #4459): KYC cases carry NO " +
+                    "adverse-media coverage. openbank_kyc_adverse_media_source_configured=0. Any " +
+                    "adverse-media check on a case will resolve to MANUAL_REVIEW, never PASSED.",
+            )
+        } else {
+            log.infof("Adverse-media source configured: %s", port.sourceId)
+        }
+        if (registryInstance.isResolvable) {
+            registryInstance.get().gauge(
+                "openbank_kyc_adverse_media_source_configured",
+                this,
+            ) { it.configured().toDouble() }
+        }
+    }
+}

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/application/port/out/AdverseMediaScreeningPortTest.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/application/port/out/AdverseMediaScreeningPortTest.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyc.application.port.out
+
+import com.openbank.kyc.domain.model.CheckStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * The fail-closed contract, tested in **both directions**: a resolved clean screen is the only
+ * thing that may PASS, and every unresolved outcome — including the one this platform is
+ * permanently in today — must not be representable as clean.
+ */
+class AdverseMediaScreeningPortTest {
+
+    @Test
+    fun `only a reached, empty source passes the check`() {
+        assertThat(AdverseMediaOutcome.NO_HIT.toCheckStatus()).isEqualTo(CheckStatus.PASSED)
+    }
+
+    @Test
+    fun `a hit is manual review, never an automated failure`() {
+        // ADR-0116 four-eyes / ADR-0256 D2: a trigger opens a case, it never decides one.
+        assertThat(AdverseMediaOutcome.HIT.toCheckStatus()).isEqualTo(CheckStatus.MANUAL_REVIEW)
+    }
+
+    @Test
+    fun `an unreachable source is unresolved, not clean`() {
+        assertThat(AdverseMediaOutcome.SOURCE_UNAVAILABLE.toCheckStatus()).isEqualTo(CheckStatus.MANUAL_REVIEW)
+        assertThat(AdverseMediaOutcome.SOURCE_UNAVAILABLE.isResolved).isFalse()
+    }
+
+    @Test
+    fun `an unconfigured source is unresolved, not clean`() {
+        assertThat(AdverseMediaOutcome.SOURCE_NOT_CONFIGURED.toCheckStatus()).isEqualTo(CheckStatus.MANUAL_REVIEW)
+        assertThat(AdverseMediaOutcome.SOURCE_NOT_CONFIGURED.isResolved).isFalse()
+    }
+
+    /**
+     * The invariant stated as a set, so that adding a future outcome member without deciding its
+     * side of the line is caught here rather than by whatever first records a PASSED check.
+     */
+    @Test
+    fun `NO_HIT is the only outcome in the whole enum that can pass`() {
+        val passing = AdverseMediaOutcome.entries.filter { it.toCheckStatus() == CheckStatus.PASSED }
+        assertThat(passing).containsExactly(AdverseMediaOutcome.NO_HIT)
+    }
+
+    @Test
+    fun `a clean-looking result cannot be constructed without naming its source`() {
+        assertThatThrownBy { AdverseMediaScreeningResult(AdverseMediaOutcome.NO_HIT, sourceId = null) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy { AdverseMediaScreeningResult(AdverseMediaOutcome.HIT, sourceId = null) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `an unconfigured result cannot claim a source`() {
+        assertThatThrownBy {
+            AdverseMediaScreeningResult(AdverseMediaOutcome.SOURCE_NOT_CONFIGURED, sourceId = "some-vendor")
+        }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `a resolved result records the source that produced it`() {
+        val r = AdverseMediaScreeningResult(AdverseMediaOutcome.HIT, sourceId = "vendor-x", matchedHeadline = "h")
+        assertThat(r.sourceId).isEqualTo("vendor-x")
+        assertThat(r.outcome.isResolved).isTrue()
+    }
+}

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/infrastructure/client/UnconfiguredAdverseMediaSourceTest.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/infrastructure/client/UnconfiguredAdverseMediaSourceTest.kt
@@ -22,7 +22,7 @@ class UnconfiguredAdverseMediaSourceTest {
 
     @Test
     fun `screening a party without a configured source is SOURCE_NOT_CONFIGURED, not NO_HIT`(): Unit = runBlocking {
-        val result = source.screen("Andrej Babiš", "kyc-adverse-media-1")
+        val result = source.screen("Adverse Subject Zero", "kyc-adverse-media-1")
 
         assertThat(result.outcome).isEqualTo(AdverseMediaOutcome.SOURCE_NOT_CONFIGURED)
         assertThat(result.outcome).isNotEqualTo(AdverseMediaOutcome.NO_HIT)
@@ -33,8 +33,10 @@ class UnconfiguredAdverseMediaSourceTest {
     @Test
     fun `the unconfigured outcome never resolves a check to PASSED`(): Unit = runBlocking {
         // Every name, adversely-reported or not, lands in the same unresolved state — the honest
-        // answer when nothing was read.
-        listOf("Andrej Babiš", "Jan Novák", "").forEach { name ->
+        // answer when nothing was read. Subjects are fictional by construction: this is a PUBLIC
+        // repository and adverse-media screening is negative-news search, so a real person's name
+        // must never appear as a test subject here.
+        listOf("Adverse Subject Zero", "Jan Novák", "").forEach { name ->
             assertThat(source.screen(name, "k").outcome.toCheckStatus()).isEqualTo(CheckStatus.MANUAL_REVIEW)
         }
     }

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/infrastructure/client/UnconfiguredAdverseMediaSourceTest.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/infrastructure/client/UnconfiguredAdverseMediaSourceTest.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyc.infrastructure.client
+
+import com.openbank.kyc.application.port.out.AdverseMediaOutcome
+import com.openbank.kyc.domain.model.CheckStatus
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/** The default adapter must report absence of a source — never an absence of findings. */
+class UnconfiguredAdverseMediaSourceTest {
+
+    private val source = UnconfiguredAdverseMediaSource()
+
+    @Test
+    fun `reports no source id`() {
+        assertThat(source.sourceId).isNull()
+    }
+
+    @Test
+    fun `screening a party without a configured source is SOURCE_NOT_CONFIGURED, not NO_HIT`(): Unit = runBlocking {
+        val result = source.screen("Andrej Babiš", "kyc-adverse-media-1")
+
+        assertThat(result.outcome).isEqualTo(AdverseMediaOutcome.SOURCE_NOT_CONFIGURED)
+        assertThat(result.outcome).isNotEqualTo(AdverseMediaOutcome.NO_HIT)
+        assertThat(result.outcome.isResolved).isFalse()
+        assertThat(result.sourceId).isNull()
+    }
+
+    @Test
+    fun `the unconfigured outcome never resolves a check to PASSED`(): Unit = runBlocking {
+        // Every name, adversely-reported or not, lands in the same unresolved state — the honest
+        // answer when nothing was read.
+        listOf("Andrej Babiš", "Jan Novák", "").forEach { name ->
+            assertThat(source.screen(name, "k").outcome.toCheckStatus()).isEqualTo(CheckStatus.MANUAL_REVIEW)
+        }
+    }
+}

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/infrastructure/observability/AdverseMediaSourceReadinessTest.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/infrastructure/observability/AdverseMediaSourceReadinessTest.kt
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyc.infrastructure.observability
+
+import com.openbank.kyc.application.port.out.AdverseMediaOutcome
+import com.openbank.kyc.application.port.out.AdverseMediaScreeningPort
+import com.openbank.kyc.application.port.out.AdverseMediaScreeningResult
+import com.openbank.kyc.infrastructure.client.UnconfiguredAdverseMediaSource
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.enterprise.inject.Instance
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AdverseMediaSourceReadinessTest {
+
+    private fun readiness(port: AdverseMediaScreeningPort, registry: MeterRegistry?): AdverseMediaSourceReadiness {
+        val instance: Instance<MeterRegistry> = mockk(relaxed = true)
+        every { instance.isResolvable } returns (registry != null)
+        if (registry != null) every { instance.get() } returns registry
+        return AdverseMediaSourceReadiness().also {
+            it.port = port
+            it.registryInstance = instance
+        }
+    }
+
+    private fun configuredPort(): AdverseMediaScreeningPort = object : AdverseMediaScreeningPort {
+        override val sourceId: String = "some-real-feed"
+        override suspend fun screen(name: String, idempotencyKey: String) =
+            AdverseMediaScreeningResult(AdverseMediaOutcome.NO_HIT, sourceId)
+    }
+
+    @Test
+    fun `gauge reads 0 on the platform as shipped — no adverse-media source exists`() {
+        val registry = SimpleMeterRegistry()
+        readiness(UnconfiguredAdverseMediaSource(), registry).register()
+
+        val gauge = registry.find("openbank_kyc_adverse_media_source_configured").gauge()
+        assertThat(gauge).isNotNull()
+        assertThat(gauge!!.value()).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `gauge reads 1 once a source backs the port`() {
+        val registry = SimpleMeterRegistry()
+        readiness(configuredPort(), registry).register()
+
+        assertThat(registry.find("openbank_kyc_adverse_media_source_configured").gauge()!!.value()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `registration is safe when no meter registry is resolvable`() {
+        readiness(UnconfiguredAdverseMediaSource(), null).register()
+    }
+}


### PR DESCRIPTION
## What this is

ADR-0256 **D5** decided that adverse media is **out of scope**: `CheckType.ADVERSE_MEDIA` exists in
the KYC domain model, no adverse-media source exists on the platform, and the ADR explicitly does
not create one — *"a stubbed feed would make a catalogue member decorative"*. Issue #4459 asks for
the thing the ADR deferred: select and land a **real** source (vendor feed or in-repo ingestion),
change-detectable, EU-residency-compatible (ADR-0175), and licensed.

No such source is obtainable from this repo. Every candidate needs either a commercial contract
(World-Check / ComplyAdvantage / Refinitiv) or a licensing + residency decision on a public dataset
(GDELT-class). That is a procurement and legal question, not a coding one. So this PR does **not**
close #4459 and does not add the `ADVERSE_MEDIA_CHANGED` trigger to the ADR-0256 catalogue.

What it lands instead is the half that is honest without a source: **the port, the fail-closed
outcome model, and an observable statement that the platform has no coverage.**

## Why not a stub

A stub adapter returning "no adverse media found" would be the exact defect this repo has already
paid for twice:

- `PushResult.skipped()` carried `success = true`, so every push in an environment with no APNs
  credentials was counted as delivered and committed `SENT` (ADR-0252 phase 0, #4348).
- `LoggingDeadLetterSink.quarantine()` was one `log.warnf`, so "quarantined" meant "logged".

An adverse-media screen that cannot reach a source must not be representable as a clean result.

## What is in the diff

`openbank-kyc-service`, four files (3 main + 3 test):

- **`AdverseMediaScreeningPort`** — a **four-valued** `AdverseMediaOutcome`
  (`HIT` / `NO_HIT` / `SOURCE_UNAVAILABLE` / `SOURCE_NOT_CONFIGURED`). "Could not screen" is never
  the same value as "screened and found nothing"; there is no shared boolean. `toCheckStatus()` is
  an exhaustive `when` in which **`NO_HIT` is the only member that maps to `PASSED`** — `HIT` maps
  to `MANUAL_REVIEW` too, because ADR-0116's four-eyes gate owns the disposition and a trigger may
  never decide anything about a customer (ADR-0256 D2). `AdverseMediaScreeningResult` carries an
  `init` invariant: `sourceId` is null **iff** the outcome is `SOURCE_NOT_CONFIGURED`, so a clean
  result cannot be constructed without naming the source that produced it.
- **`UnconfiguredAdverseMediaSource`** — the only implementation today. It reports the *absence of a
  source*, and it can return nothing else.
- **`AdverseMediaSourceReadiness`** — `@Startup @ApplicationScoped`, publishes
  `openbank_kyc_adverse_media_source_configured` (today: **0**) and logs a boot-time warning naming
  the gap. `@Startup` is load-bearing: `@ApplicationScoped` is lazy, so a warning or a gauge
  registration on a bean nothing calls never reaches a pod log — this repo shipped a PAdES adapter
  warning its seals were "worthless as evidence" and that line never once appeared (#1299). The
  gauge is derived from `AdverseMediaScreeningPort.sourceId`, not from a config key, so it cannot
  claim coverage the wired adapter does not have.

**Deliberately not wired into `KycService.createCase`.** No `ADVERSE_MEDIA` check is created on any
case today, and adding one now would put a permanently-`MANUAL_REVIEW` check on every KYC case —
operator load for zero coverage, which is the decorative outcome D5 exists to prevent. Wiring lands
with the source.

## Evidence

Verified by effect in both directions, then falsified by breaking the implementation:

| Break | Test that went red |
|---|---|
| `UnconfiguredAdverseMediaSource.screen` returns `NO_HIT` (the stub this PR argues against) | `UnconfiguredAdverseMediaSourceTest` (2 tests) |
| `toCheckStatus()` maps `SOURCE_NOT_CONFIGURED -> PASSED` | `AdverseMediaScreeningPortTest` (2 tests) |
| gauge registration removed from `@PostConstruct` | `AdverseMediaSourceReadinessTest` (2 tests) |

Each break was applied, the suite re-run to confirm the corresponding test fails, and the break
reverted. The positive direction is covered too: a configured port produces gauge `1`, and a `HIT`
result records its source.

Local gate on `openbank-kyc-service`: `ktlintCheck` PASS, `detekt` PASS, `test` **98 tests, 0
failures, 1 skipped** (the pre-existing broker-gated `KycEventPactBrokerProviderVerificationTest`,
unchanged), `quarkusBuild` BUILD SUCCESSFUL — the last one is what proves the `@Startup` bean's
injection point resolves, since CDI failures surface only there.

## Scope notes

- `openbank-kyc-service` is **not** in `rules.yaml: money_path_services`, so the two-approval and
  threat-model gates do not apply.
- No API change (no endpoint added), no DB change, no event-contract change, no `agents.yaml` or
  `rules.yaml` change, so none of the derived-artifact regenerations are triggered.
- Unrelated observation, not fixed here: `openbank-kyc-service/src/main/resources/openapi.yaml`
  advertises a check-type enum (`IDENTITY, SANCTIONS, PEP, ADVERSE_MEDIA, SOURCE_OF_FUNDS`) that
  does not match the domain `CheckType` (`IDENTITY, ADDRESS, PEP_SCREENING, SANCTIONS_SCREENING,
  ADVERSE_MEDIA`). Worth its own issue.

Refs #4459
Refs ADR-0256 D5
