### PR TITLE
fix(lending): add sourceService to loan.withdrawn and loan.accelerated

### DIFF
--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditAttributionTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditAttributionTest.kt
@@ -506,6 +506,26 @@ class AuditAttributionTest {
     }
 
     @Test
+    fun `lending-service's shared-helper event types are attributed to the producer too`(): Unit = runBlocking {
+        // #5399 swept this module's nine per-event payload builders and missed loan.withdrawn and
+        // loan.accelerated — the only two types built by a shared, parameterised helper
+        // (TerminationService.emitDomainEvent), so a reader following the per-event builders never
+        // reached them. This is that helper's wire shape (see TerminationServiceTest, which reads
+        // the key off the payload the production code actually emits).
+        val entry = capturingSave()
+
+        consumer.consume(
+            """{"eventType":"loan.withdrawn","loanId":"${UUID.randomUUID()}",""" +
+                """"partyId":"${UUID.randomUUID()}","occurredAt":"2026-08-09T12:00:00Z",""" +
+                """"sourceService":"lending"}""",
+            EventAddress(topic = "openbank.lending.events"),
+        )
+
+        assertThat(entry.captured.sourceService).isEqualTo("lending")
+        assertThat(entry.captured.sourceServiceSource).isEqualTo(AttributionSource.EVENT)
+    }
+
+    @Test
     fun `the producer's own claim wins over the topic, and is marked as the producer's`(): Unit = runBlocking {
         // Body-first ordering: this change can only turn a sentinel into a value. It must never
         // re-attribute a row that is already attributed, or customer-edge's 421 correct rows move.

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/TerminationService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/TerminationService.kt
@@ -357,11 +357,29 @@ class TerminationService(
         return LendingOutboxMessage(aggregateId = id, eventType = "credit.loan.transition", payload = payload)
     }
 
+    /**
+     * `loan.withdrawn` and `loan.accelerated`, the two event types this helper is parameterised
+     * over. Both land on `openbank.lending.events`, which audit-service consumes.
+     *
+     * Issue #3994/#5256: the payload carries `sourceService` so `AuditConsumer` attributes the row
+     * from the producer's own claim ([AttributionSource.EVENT]) rather than falling through to its
+     * topic-derived table — a silent, successful default that is only visible by grouping
+     * `audit_entries` on a live database. PR #5399 swept this module's other nine event types and
+     * missed these two, because they are the only ones built by a shared, parameterised helper
+     * rather than by a per-event payload builder.
+     *
+     * The value is `"lending"`, not `"lending-service"`: every other event type in this module
+     * already self-reports `"lending"`, and one producer reporting two different names for itself
+     * splits its own attribution. `eventType` is the caller's [type] verbatim — this module's
+     * discriminators are dotted lowercase (`loan.withdrawn`), matching the `ce-type` header the
+     * outbox already publishes, so it deliberately does NOT take the fleet's SCREAMING_SNAKE form.
+     */
     private fun emitDomainEvent(loan: Loan, type: String): Uni<Unit> = events.emit(
         LendingOutboxMessage(
             aggregateId = loan.id.value,
             eventType = type,
-            payload = """{"loanId":"${loan.id.value}","partyId":"${loan.partyId}","occurredAt":"${clock.instant()}"}""",
+            payload = """{"eventType":"$type","loanId":"${loan.id.value}","partyId":"${loan.partyId}",""" +
+                """"occurredAt":"${clock.instant()}","sourceService":"lending"}""",
         ),
     )
 

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/TerminationServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/TerminationServiceTest.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.lending.application.usecase
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.lending.application.port.out.CollateralRepository
 import com.openbank.lending.application.port.out.InstallmentRepository
 import com.openbank.lending.application.port.out.LedgerPosting
@@ -258,6 +259,52 @@ class TerminationServiceTest {
 
         assertThatThrownBy { service.accelerate(loan.id, "risk-1").await().indefinitely() }
             .hasMessageContaining("notice period")
+    }
+
+    // --- #3994/#5256: audit attribution on the two shared-helper event types -------------------
+    //
+    // `loan.withdrawn` and `loan.accelerated` are the only event types in this module built by a
+    // shared, parameterised helper (TerminationService.emitDomainEvent) rather than by a per-event
+    // payload builder, which is why the #5399 sweep patched their nine siblings and missed them.
+    // Both reach `openbank.lending.events`, which audit-service consumes: without `sourceService`
+    // AuditConsumer falls through to its topic table and records the row as TOPIC-attributed rather
+    // than as the producer's own claim — a silent, successful default.
+    //
+    // The assertion reads the emitted payload the PRODUCTION code builds, parsed as JSON, so it
+    // cannot pass on a key that is merely present as a substring somewhere else in the string.
+
+    @Test
+    fun `loan-withdrawn self-reports lending as its source service`() {
+        val loan = loan(LoanStatus.ACTIVE)
+        stubPack()
+        every { loans.findById(loan.id) } returns Uni.createFrom().item(loan)
+        every { installments.findByLoan(loan.id) } returns Uni.createFrom().item(emptyList())
+        val emitted = mutableListOf<LendingOutboxMessage>()
+        every { events.emit(capture(emitted)) } returns Uni.createFrom().item(Unit)
+
+        service.withdraw(loan.id, "customer-1").await().indefinitely()
+
+        val withdrawn = emitted.single { it.eventType == "loan.withdrawn" }
+        val payload = ObjectMapper().readTree(withdrawn.payload)
+        assertThat(payload.get("sourceService")?.asText()).isEqualTo("lending")
+        assertThat(payload.get("eventType")?.asText()).isEqualTo("loan.withdrawn")
+    }
+
+    @Test
+    fun `loan-accelerated self-reports lending as its source service`() {
+        val loan = loan(LoanStatus.TERMINATION_NOTICED).copy(noticeEndsOn = LocalDate.parse("2026-01-01"))
+        stubPack()
+        every { loans.findById(loan.id) } returns Uni.createFrom().item(loan)
+        every { installments.findByLoan(loan.id) } returns Uni.createFrom().item(emptyList())
+        val emitted = mutableListOf<LendingOutboxMessage>()
+        every { events.emit(capture(emitted)) } returns Uni.createFrom().item(Unit)
+
+        service.accelerate(loan.id, "risk-1").await().indefinitely()
+
+        val accelerated = emitted.single { it.eventType == "loan.accelerated" }
+        val payload = ObjectMapper().readTree(accelerated.payload)
+        assertThat(payload.get("sourceService")?.asText()).isEqualTo("lending")
+        assertThat(payload.get("eventType")?.asText()).isEqualTo("loan.accelerated")
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds `sourceService` (and a body-level `eventType`) to `loan.withdrawn` and
`loan.accelerated` — the two event types PR #5399 missed when it swept this
module for #5256.

#5399 patched nine per-event payload builders. These two are the only event types
in the module produced by a **shared, parameterised helper**
(`TerminationService.emitDomainEvent(loan, type)`), so enumerating the per-event
builders — the obvious way to work through this module — never reaches them, and
makes the module's event-type count read as 9 when it is 11. The helper sits
directly below `loanEvidence` in the same file, which #5399 *did* fix.

Both types land on `openbank.lending.events`, which audit-service consumes, so
`AuditConsumer` attributed both from its topic table rather than the producer's
own claim: no error, no metric, no log line — visible only by grouping
`audit_entries` on a live database.

lending-service is a money-path service (`rules.yaml: money_path_services`) —
this PR needs 2 approvals.

## Naming — two deliberate departures from the fleet default

**`eventType` stays dotted lowercase.** The issue names SCREAMING_SNAKE as the
convention, but this module's discriminators are `loan.withdrawn`-style, that is
what the outbox already publishes in the `ce-type` header, and that is what its
consumers match on. Forcing the convention here would break a working contract, so
the body value is the caller's `type` verbatim — the convention is the default,
not an override of a live contract.

**`sourceService` is `"lending"`, not `"lending-service"`.** Every other event type
in this module already self-reports `"lending"`, so this keeps the producer
self-consistent. Note this differs from what audit-service's `TopicAttribution`
derives for the topic (`lending-service`), which #5399 flagged and left. That
inconsistency is real but is **not** made worse by this PR — it is
pre-existing across nine event types, and having these two disagree with the other
nine would be strictly worse. Worth a follow-up decision on which spelling wins
fleet-wide; deliberately not resolved here, since converging would rename nine
already-shipped event types and split historical rows a second time.

## Verification — the wire payload, not the field

- **Producer side** — `TerminationServiceTest`: drives the real `withdraw` and
  `accelerate` paths, captures the emitted `LendingOutboxMessage`, and reads
  `sourceService`/`eventType` off the payload as **parsed JSON** (not a substring
  match, which could pass on an unrelated occurrence in the string).
- **Consumer side** — `AuditAttributionTest`: feeds that same wire shape through
  `AuditConsumer.consume` and asserts
  `sourceServiceSource == AttributionSource.EVENT`.

**Falsification:** removing `sourceService` from the helper turns **both** producer
tests red. Restored before commit.

## Test plan

- [x] `./gradlew :openbank-lending-service:ktlintCheck :openbank-lending-service:detekt` — green (`ktlintMainSourceSetCheck` and `ktlintTestSourceSetCheck` both confirmed to have executed)
- [x] `./gradlew :openbank-lending-service:test --tests "...TerminationServiceTest"` — 12 tests, 0 failures, **0 skipped**
- [x] `./gradlew :openbank-audit-service:ktlintCheck :openbank-audit-service:detekt :openbank-audit-service:test --tests "...AuditAttributionTest"` — 27 tests, 0 failures, **0 skipped**
- [x] Negative case: field removed ⇒ both producer tests fail

## Not changed here

`occurredAt` was already present on both payloads.

Refs #5256
