### PR TITLE
fix(admin-ui): resolve the repo-fixable prod-readiness NO-GO causes (contract tests, undeployed component)

### DIFF
--- a/docs/runbooks/svc-tax-reporting.md
+++ b/docs/runbooks/svc-tax-reporting.md
@@ -8,6 +8,19 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 > Operational runbook for the `tax-reporting` service. Data domain **platform**,
 > classification **confidential**, datastore **PostgreSQL**.
 
+## Deployment status — NOT DEPLOYED
+
+**This service has no workload anywhere in `openbank-infra/gitops/`** — no Deployment,
+no Rollout, and therefore no namespace, no CNPG cluster, no NetworkPolicy and no
+PodMonitor coverage. It is a released component (it has a `version.txt`) that has never
+run, so **every `kubectl` command below names a namespace that does not exist** and every
+procedure here is a plan rather than a rehearsed one.
+
+The production-readiness matrix reports it as **NOT-DEPLOYED** rather than NO-GO for the
+same reason: the cells it fails are consequences of the absent workload, not controls
+someone skipped, and none of them can be closed by a repo change. Whether this service
+should be deployed is an owner decision — see the service's own `CLAUDE.md`.
+
 ## Service identity
 
 | Field | Value |

--- a/openbank-admin-ui/scripts/collect-prod-readiness.mjs
+++ b/openbank-admin-ui/scripts/collect-prod-readiness.mjs
@@ -429,11 +429,27 @@ function scoreC4Data(short) {
   }
 }
 
+/**
+ * True when the service has NO workload in gitops at all — not a Deployment, not a Rollout.
+ * Distinct from 'deployed but unscraped' and from 'stateless': a released component with no
+ * workload cannot own a CNPG cluster or a scraped namespace, so those cells report absences it
+ * could not have avoided. openbank-tax-reporting-service is the one such service today and it is
+ * deliberate (#5760). Naming the state is honesty, not leniency — see computeGate.
+ */
+function isUndeployed(short) {
+  return serviceNamespace(short) === null
+}
+
 function scoreC5Backup(short) {
   if (isStateless(declaredDatastore(short))) {
     // No datastore, nothing to back up. finrep scored 0 ('no CNPG cluster') for the absence of a
     // cluster it must not have — an unachievable 0 that read like a missing backup.
     return { score: 2, evidence: 'n/a — declares no datastore (stateless), nothing to back up' }
+  }
+  if (isUndeployed(short)) {
+    // Still 0 — only the evidence changes. 'no CNPG cluster' reads as a backup someone forgot to
+    // configure; the cluster is absent because the whole workload is (#5760).
+    return { score: 0, evidence: 'no CNPG cluster — service has no gitops workload at all' }
   }
   const clusters = gitopsFilesWithKind(short, 'Cluster')
   const cnpg = clusters.filter(f => f.includes('postgres') || readText(f).toLowerCase().includes('cnpg'))
@@ -555,7 +571,11 @@ function computeGate(short, scores) {
   const critical = new Set(['C1', 'C5', 'C7'])
   for (const { code } of DIMENSIONS) {
     const need = mp && critical.has(code) ? 3 : 2
-    if ((scores[code] ?? 0) < need) return 'NO-GO'
+    // NOT-DEPLOYED is only ever reached in place of NO-GO, never in place of GO: the GO branch
+    // below is the fall-through, and a service with no namespace scores C8 <= 1 anyway. So no
+    // score reachable in this state is treated more leniently than before — 'not production
+    // ready' and 'not in production' simply stop rendering as the same fact (#5760, #5706).
+    if ((scores[code] ?? 0) < need) return isUndeployed(short) ? 'NOT-DEPLOYED' : 'NO-GO'
   }
   return 'GO'
 }
@@ -637,5 +657,5 @@ const payload = {
 
 writeFileSync(OUT, JSON.stringify(payload, null, 2))
 console.log(
-  `[collect-prod-readiness] ${results.length} services scored, ${go} GO / ${results.length - go} NO-GO → ${OUT}`,
+  `[collect-prod-readiness] ${results.length} services scored, ${go} GO / ${results.filter(r => r.gate === 'NO-GO').length} NO-GO / ${results.filter(r => r.gate === 'NOT-DEPLOYED').length} NOT-DEPLOYED → ${OUT}`,
 )

--- a/openbank-admin-ui/src/app/api/prod-readiness/route.ts
+++ b/openbank-admin-ui/src/app/api/prod-readiness/route.ts
@@ -23,7 +23,7 @@ interface ReadinessService {
   money_path: boolean
   scores: Record<string, number>
   evidence: Record<string, string>
-  gate: 'GO' | 'NO-GO'
+  gate: 'GO' | 'NO-GO' | 'NOT-DEPLOYED'
 }
 
 interface ReadinessReport {

--- a/openbank-admin-ui/src/app/system/readiness/page.tsx
+++ b/openbank-admin-ui/src/app/system/readiness/page.tsx
@@ -6,7 +6,7 @@
 
 import { useState, useEffect } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
-import { ClipboardCheck, RefreshCw, Star, CheckCircle2, XCircle } from 'lucide-react'
+import { ClipboardCheck, RefreshCw, Star, CheckCircle2, XCircle, CircleSlash } from 'lucide-react'
 import { PageHeader, StatCard, StatusBadge, SWATCH_CLASS, type Tone } from '@/components/ui'
 
 interface ReadinessService {
@@ -14,7 +14,7 @@ interface ReadinessService {
   money_path: boolean
   scores: Record<string, number>
   evidence: Record<string, string>
-  gate: 'GO' | 'NO-GO'
+  gate: 'GO' | 'NO-GO' | 'NOT-DEPLOYED'
 }
 interface ReadinessReport {
   generated_for: string
@@ -54,7 +54,11 @@ export default function ReadinessPage() {
   const services = data?.services ?? []
   const dims = data?.dimensions ?? []
   const go = services.filter(s => s.gate === 'GO').length
-  const nogo = services.length - go
+  // Counted, not derived as `length - go`: NOT-DEPLOYED is a third verdict (#5760), and folding it
+  // into NO-GO is exactly the conflation the collectors stopped making — "not production ready"
+  // and "not in production" are different facts and need different work from different people.
+  const nogo = services.filter(s => s.gate === 'NO-GO').length
+  const undeployed = services.filter(s => s.gate === 'NOT-DEPLOYED').length
   const mp = services.filter(s => s.money_path)
 
   return (
@@ -88,6 +92,14 @@ export default function ReadinessPage() {
         <StatCard label={t('Služeb', 'Services')} value={services.length} />
         <StatCard label="GO" value={go} tone="success" icon={<CheckCircle2 size={16} />} />
         <StatCard label="NO-GO" value={nogo} tone="danger" icon={<XCircle size={16} />} />
+        {undeployed > 0 && (
+          <StatCard
+            label={t('Nenasazeno', 'Not deployed')}
+            value={undeployed}
+            tone="neutral"
+            icon={<CircleSlash size={16} />}
+          />
+        )}
         <StatCard
           label={t('Money-path', 'Money-path')}
           value={`${mp.filter(s => s.gate === 'GO').length}/${mp.length}`}

--- a/openbank-admin-ui/src/components/ui/tone.ts
+++ b/openbank-admin-ui/src/components/ui/tone.ts
@@ -146,6 +146,10 @@ const TONE_BY_STATUS: Record<string, Tone> = {
   GO: 'success',
   'NO-GO': 'danger',
   NOGO: 'danger',
+  // A released component with no gitops workload at all (#5760). Neutral on purpose: it is not a
+  // failed control (danger) and emphatically not a pass (success) — there is nothing running to
+  // judge. Reached only in place of NO-GO; see the collectors' computeGate.
+  'NOT-DEPLOYED': 'neutral',
 }
 
 /**

--- a/openbank-infra/scripts/generate-service-runbooks.py
+++ b/openbank-infra/scripts/generate-service-runbooks.py
@@ -83,8 +83,43 @@ def service_namespace(short: str) -> str:
     and the PodMonitor coverage gate — three tools were each growing their own copy of this
     question, and two of them had already answered it wrong in two different ways (#2255). Only
     the display fallback is local: a service with no workload still needs *something* to render.
+
+    That fallback is a LIE for the one service it applies to, which is why
+    [deployment_status] exists: with no workload anywhere in gitops the runbook silently
+    interpolated the short name and told the on-call engineer to run `kubectl -n tax-reporting`
+    against a namespace that has never existed — the exact defect this function's second
+    paragraph records as fixed, surviving in the one case the fix could not resolve. The
+    fallback stays (the commands need to render as something) and the banner now says the
+    commands do not apply.
     """
     return gitops_facts.service_namespace(short, GITOPS) or short
+
+
+def deployment_status(short: str) -> str:
+    """A banner for a service with NO workload in gitops — Deployment, Rollout or nothing.
+
+    Derived, never declared: the same `gitops_facts.service_namespace` question the
+    prod-readiness collector asks for its NOT-DEPLOYED verdict (#5706, #5760), so the runbook
+    and the matrix cannot disagree about whether a service runs. Empty for every deployed
+    service, so this changes no committed runbook but the undeployed one.
+    """
+    if gitops_facts.service_namespace(short, GITOPS) is not None:
+        return ""
+    return (
+        "## Deployment status — NOT DEPLOYED\n"
+        "\n"
+        "**This service has no workload anywhere in `openbank-infra/gitops/`** — no Deployment,\n"
+        "no Rollout, and therefore no namespace, no CNPG cluster, no NetworkPolicy and no\n"
+        "PodMonitor coverage. It is a released component (it has a `version.txt`) that has never\n"
+        "run, so **every `kubectl` command below names a namespace that does not exist** and every\n"
+        "procedure here is a plan rather than a rehearsed one.\n"
+        "\n"
+        "The production-readiness matrix reports it as **NOT-DEPLOYED** rather than NO-GO for the\n"
+        "same reason: the cells it fails are consequences of the absent workload, not controls\n"
+        "someone skipped, and none of them can be closed by a repo change. Whether this service\n"
+        "should be deployed is an owner decision — see the service's own `CLAUDE.md`.\n"
+        "\n"
+    )
 
 
 def is_stateless(datastore: str) -> bool:
@@ -189,7 +224,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 > Operational runbook for the `{short}` service. Data domain **{domain}**,
 > classification **{classification}**, datastore **{datastore}**.
 
-## Service identity
+{deployment_status}## Service identity
 
 | Field | Value |
 |---|---|
@@ -336,6 +371,7 @@ def render(short: str) -> str:
         short=short,
         module=gitops_facts.module_dir(short, REPO).name,
         ns=service_namespace(short),
+        deployment_status=deployment_status(short),
         failure_modes=failure_modes,
         domain=f.get("dataDomain", "—"),
         datastore=datastore,
@@ -435,6 +471,24 @@ def self_test() -> int:
     case("owns_no_db=True changes the answer for a service WITH a datastore",
          dr_for("Redis", has_backup=False, owns_no_db=True)
          != dr_for("Redis", has_backup=False, owns_no_db=False))
+
+    # --- the NOT-DEPLOYED banner (#5706, #5760) ---------------------------------------------
+    # Falsified against a real repo fact rather than a fixture, because the whole point is that
+    # the banner and the readiness matrix answer the SAME question from the SAME resolver: if
+    # gitops_facts ever starts resolving a namespace for an undeployed service, both this and
+    # the collector's NOT-DEPLOYED verdict go wrong together and this case is what says so.
+    undeployed = [x for x in all_services() if gitops_facts.service_namespace(x, GITOPS) is None]
+    deployed = [x for x in all_services() if gitops_facts.service_namespace(x, GITOPS) is not None]
+    case("a deployed service gets no deployment banner",
+         all(deployment_status(x) == "" for x in deployed[:5]))
+    if undeployed:
+        t = deployment_status(undeployed[0])
+        case("an undeployed service is told its kubectl commands name a namespace that does not exist",
+             says(t, "NOT DEPLOYED", "namespace that does not exist"))
+        case("...and the banner reaches the rendered runbook",
+             "NOT DEPLOYED" in render(undeployed[0]))
+    # No `else` that passes: an empty undeployed set is the expected steady state (every released
+    # component deployed), and the two cases above are then vacuous rather than wrong.
 
     # --- the ownsNoDatabase assertion itself ------------------------------------------------
     case("an explicit ownsNoDatabase: true is honoured",

--- a/openbank-infra/scripts/prod-readiness-collector.py
+++ b/openbank-infra/scripts/prod-readiness-collector.py
@@ -323,11 +323,32 @@ def score_c4_data(short: str, att, today) -> tuple[int, str]:
     return s, f"{len(migs)} migrations, rollback_note={'y' if rollback else 'n'}"
 
 
+def is_undeployed(short: str) -> bool:
+    """True when the service has NO workload in gitops at all — not a Deployment, not a Rollout.
+
+    Distinct from "deployed but unscraped" and from "stateless". A released component with no
+    workload cannot own a CNPG cluster, a PodMonitor namespace or a NetworkPolicy, so the cells
+    that read those all report absences the service could not have avoided while it stays
+    undeployed. openbank-tax-reporting-service is the one such service today and it is
+    deliberate — `openbank-infra/aws/envs/sandbox-platform/ecr-service-repositories.tf` names it
+    as "a released component with no gitops workload, no auto-deploy entry and — correctly — no
+    repository" (#5760). Naming that state is the honest representation; it is NOT a pass, see
+    [ServiceReadiness.compute_gate].
+    """
+    return service_namespace(short, GITOPS) is None
+
+
 def score_c5_backup(short: str, att, today) -> tuple[int, str]:
     if is_stateless(declared_datastore(short, REPO)):
         # No datastore, nothing to back up. finrep scored 0 ("no CNPG cluster") for the absence
         # of a cluster it must not have — an unachievable 0 that read like a missing backup.
         return 2, "n/a — declares no datastore (stateless), nothing to back up"
+    if is_undeployed(short):
+        # Still 0 — a stateful service with no backup is not ready, and an undeployed one is not
+        # ready either. Only the EVIDENCE changes: "no CNPG cluster" reads as a backup someone
+        # forgot to configure and sends the reader to the gitops backup docs, when the cluster is
+        # absent because the entire workload is (#5760). The gate says which of the two it is.
+        return 0, "no CNPG cluster — service has no gitops workload at all"
     clusters = gitops_files_for(short, "Cluster")
     cnpg = [f for f in clusters if "postgres" in f.name or "cnpg" in read(f).lower()]
     if not cnpg:
@@ -469,7 +490,23 @@ class ServiceReadiness:
             need = 3 if (self.money_path and code in critical) else 2
             if s < need:
                 ok = False
-        self.gate = "GO" if ok else "NO-GO"
+        # A released component with no workload anywhere in gitops gets its own verdict. It is
+        # NOT a pass and can never become one from here: NOT-DEPLOYED is only ever reached in
+        # place of NO-GO — a service that clears every dimension while undeployed is impossible
+        # (C8 scores at most 1 without a namespace), and the `ok` branch is checked first anyway,
+        # so no score this state can produce is treated more leniently than before.
+        #
+        # What it buys: "not production-ready" and "not in production" are different facts and
+        # used to render identically. tax-reporting sat in the NO-GO column next to 25 services
+        # that ARE deployed and failing a control, so its actual blocker — an undecided
+        # deployment (#5760, #5706) — was invisible in every headline the matrix produced, and
+        # three of its cells read as missing controls rather than as consequences.
+        if ok:
+            self.gate = "GO"
+        elif is_undeployed(self.service):
+            self.gate = "NOT-DEPLOYED"
+        else:
+            self.gate = "NO-GO"
 
 
 def collect(short: str, att, today: str) -> ServiceReadiness:

--- a/openbank-infra/scripts/prod_readiness_collector_test.py
+++ b/openbank-infra/scripts/prod_readiness_collector_test.py
@@ -165,6 +165,9 @@ class CollectorScorerTest(unittest.TestCase):
     def test_a_money_path_service_needs_three_on_the_critical_cells(self):
         """The stricter gate is what the six leniently-scored services were missing."""
         self.write_rules(("openbank-widget-service",))
+        # DEPLOYED on purpose: an undeployed service takes the NOT-DEPLOYED verdict instead of
+        # NO-GO, so without this the test would assert the wrong branch (#5706).
+        self.deploy()
         r = self.mod.ServiceReadiness(service="widget", money_path=True)
         r.scores = {c: 2 for c, _ in self.mod.DIMENSIONS}
         r.compute_gate()
@@ -175,10 +178,51 @@ class CollectorScorerTest(unittest.TestCase):
         self.assertEqual(r.gate, "GO")
 
     def test_a_non_money_path_service_clears_at_all_twos(self):
+        self.deploy()
         r = self.mod.ServiceReadiness(service="widget", money_path=False)
         r.scores = {c: 2 for c, _ in self.mod.DIMENSIONS}
         r.compute_gate()
         self.assertEqual(r.gate, "GO")
+
+    # -- the third verdict: a released component with no workload (#5706, #5760) -----------
+    def test_a_service_with_no_gitops_workload_is_reported_as_not_deployed(self):
+        """tax-reporting sat in the NO-GO column beside 25 services that ARE deployed and failing
+        a control, so its actual blocker — an undecided deployment — was invisible."""
+        self.write_rules(("openbank-ledger-service",))
+        r = self.mod.ServiceReadiness(service="widget", money_path=False)
+        r.scores = {c: 2 for c, _ in self.mod.DIMENSIONS}
+        r.scores["C5"] = 0
+        r.compute_gate()
+        self.assertEqual(r.gate, "NOT-DEPLOYED")
+
+    def test_not_deployed_never_replaces_a_GO(self):
+        """The falsification that matters: the new verdict must be reachable ONLY where the old
+        code said NO-GO. A scorer that can no longer say NO-GO is worse than one that says it
+        wrongly, so this asserts the same scores still fail for a DEPLOYED service and that a
+        passing scorecard is unaffected by deployment state."""
+        self.write_rules(("openbank-ledger-service",))
+        failing = {c: 2 for c, _ in self.mod.DIMENSIONS} | {"C5": 0}
+        undeployed = self.mod.ServiceReadiness(service="widget", money_path=False)
+        undeployed.scores = dict(failing)
+        undeployed.compute_gate()
+        self.deploy()
+        deployed = self.mod.ServiceReadiness(service="widget", money_path=False)
+        deployed.scores = dict(failing)
+        deployed.compute_gate()
+        self.assertEqual((undeployed.gate, deployed.gate), ("NOT-DEPLOYED", "NO-GO"))
+        # And an all-clear scorecard is GO either way — the branch is only ever the failure one.
+        passing = self.mod.ServiceReadiness(service="widget", money_path=False)
+        passing.scores = {c: 2 for c, _ in self.mod.DIMENSIONS}
+        passing.compute_gate()
+        self.assertEqual(passing.gate, "GO")
+
+    def test_c5_evidence_names_the_missing_workload_not_a_missing_backup(self):
+        """`no CNPG cluster` sent the reader to the backup docs for a service whose whole workload
+        is absent. The SCORE stays 0 — this is about what the 0 says, not about passing."""
+        self.governance(datastore="PostgreSQL", schema="widget")
+        score, evidence = self.mod.score_c5_backup("widget", {}, "2026-08-20")
+        self.assertEqual(score, 0, "an undeployed stateful service must not score above Absent")
+        self.assertIn("no gitops workload", evidence)
 
     def test_threat_model_is_looked_up_under_the_resolved_module_name(self):
         """C7 read docs/threat-models/openbank-sepa-payment-service.md — a file that cannot exist."""

--- a/openbank-tax-reporting-service/CLAUDE.md
+++ b/openbank-tax-reporting-service/CLAUDE.md
@@ -1,0 +1,45 @@
+# openbank-tax-reporting-service — agent notes
+
+## This service is NOT DEPLOYED, and that is deliberate
+
+`grep -rn "tax-reporting" openbank-infra/gitops/` returns **zero hits**. There is no Deployment,
+no Rollout, no KafkaUser, no auto-deploy entry and no ECR repository. This is known and recorded
+outside this file too — `openbank-infra/aws/envs/sandbox-platform/ecr-service-repositories.tf`
+explains why the ECR list is not derived from release-please's package list and names this module
+as "a released component with no gitops workload, no auto-deploy entry and — correctly — no
+repository".
+
+It is nevertheless a **released component**: it has a `version.txt`, is registered in
+`release-please-config.json` + `.release-please-manifest.json`, and accrues version bumps and
+changelog entries for a workload nobody runs.
+
+### What follows from that, so nobody re-derives it a fourth time
+
+- **Nothing here has ever executed in an environment.** The §38d withholding consumer, the ports,
+  the schema and the migrations are real code with no runtime. `db/migration` has never been
+  applied anywhere, so — unusually for this repo — the Flyway "never edit an applied migration"
+  rule does not bind yet.
+- **The production-readiness matrix reports this service as `NOT-DEPLOYED`, not NO-GO** (#5706).
+  Its C5 ("no CNPG cluster"), C7 (no NetworkPolicy) and C8 ("not deployed") are consequences of
+  the absent workload rather than controls anyone skipped, and **none of them can be closed by a
+  repo change**. Do not try to raise them.
+- **C3 has no contract test and cannot honestly get one.** Nothing in the repo consumes this
+  service's HTTP API and it ships no outbound rest-client, so there is no consumer whose
+  expectations a pact could encode. Authoring one against an invented consumer would be a scoring
+  artifact of exactly the kind the C3 probe was repaired to reject.
+- **The absent KafkaUser is a consequence, not an independent gap** — that framing was corrected
+  in #5760. `check-incoming-dlq-wiring.py` carries a baseline entry for
+  `openbank.dlq.tax-reporting.withholding-remitted-in` for the same reason (#5751), and it comes
+  off the day this deploys.
+- **`docs/runbooks/svc-tax-reporting.md` is generated and carries a NOT DEPLOYED banner.** Every
+  `kubectl` line in it names a namespace that does not exist. Never hand-edit it (ADR-0029 rule
+  #6); the banner comes from `generate-service-runbooks.py` and disappears on its own once a
+  workload exists.
+
+### The open decision (#5760) — an owner's, not an agent's
+
+Whether this service should be deployed at all. If yes, it needs the full gitops set: workload,
+KafkaUser with Read on its source topic and Write on its DLQ, auto-deploy entry, ECR repository —
+and the DLQ baseline entry comes off. If no, it should be said out loud here and the release
+registration reconsidered, because a component that releases forever and runs never is a standing
+source of exactly this confusion.


### PR DESCRIPTION
## What

The three remaining repo-fixable NO-GO causes from #5706, taken one at a time. One was already
fixed on `main`, one is genuinely repo-fixable and is fixed here, and one is repo-fixable only in
what the matrix *says* — the thing it reports is an owner decision, not a code change.

`Refs #5706` rather than `Closes`: cause 1 leaves a decision open (#5760) and tax-reporting's own
C2/C3/C5/C7/C8 cells stay where they are.

## Cause 3 — mcp-service C4 rollback note: already done, nothing to do here

`#5832` landed `openbank-mcp-service/src/main/resources/docs/04-data.md` and mcp now scores
`C4=2 [2 migrations, rollback_note=y]` with an overall **GO**, measured on the collector as of
`origin/main`. The issue's framing ("mcp-service ships no docs pack at all") is stale. The
locale-less filename is deliberate and supported — `ClasspathMarkdownLoader` documents
`docs/04-data.md` as the language-agnostic form served for any language — so this is not the
"landed but unreachable" shape it superficially resembles.

## Cause 2 — missing contract tests: repo-fixable for two of three

`campaign` and `engagement` both consume exactly one route,
`GET /api/v1/consents/party/{partyId}/grantee/{granteeId}/active?scope=…` (ADR-0198 D4), and read
exactly one field off it. Both now ship a consumer pact with **both** branches (an ACTIVE
per-channel consent; a party with no consent, which is a 200 with `granted: false`, not a 404),
and the provider half is wired in the same change — three states on consent-service's existing
always-running `@PactFolder` class.

The provider replay earned its keep on the first run: it answered **400 "Consent validity exceeds
maximum allowed 365 days"** against a seeded window of 366 days, a rule the consumer mock has no
way to know about. That is the asymmetry the repo's Pact discipline is built around, reproduced.

`granted` is pinned by value rather than `booleanType`; expected paths are literals retyped from
`ConsentResource`, with only the outgoing request reflected off the client's `@Path`.

**tax-reporting is deliberately not given one.** Nothing in the repo consumes its HTTP API and it
ships no outbound rest-client, so there is no consumer whose expectations a pact could encode.
Authoring one against an invented consumer would be a scoring artifact of exactly the kind the C3
probe was repaired to reject. Its C3 stays 1.

## Cause 1 — tax-reporting: the honest fix is representation, not deployment

Per #5760 the service has **no gitops workload at all**, and that is deliberate and already
documented in `ecr-service-repositories.tf`. So its C5 ("no CNPG cluster"), C7 (no NetworkPolicy)
and C8 ("not deployed") are consequences of the absent workload rather than controls anyone
skipped, and none of them can be closed by a repo change. Deploying is the owner's call.

What the matrix could not do is say so. Both collectors now emit a third verdict, **NOT-DEPLOYED**,
and C5's evidence names the missing workload instead of a missing backup.

**This is not a loosening.** NOT-DEPLOYED is reachable only where the old code said NO-GO: the GO
branch is evaluated first, and a service with no namespace scores C8 <= 1 anyway. C5 still scores
0. `test_not_deployed_never_replaces_a_GO` asserts exactly that — same failing scorecard, deployed
fixture, still NO-GO; all-clear scorecard, still GO — and the two pre-existing gate tests now have
to deploy their fixture, which is how a hidden branch change would have surfaced.

The undeployed state is also recorded in `docs/runbooks/svc-tax-reporting.md`, so the next person
to find a §38d statutory consumer with no runtime does not re-derive it (the third independent
derivation, after #5751's baseline comment and #5760).

## Evidence — before / after, same collector

| service | before | after |
|---|---|---|
| campaign | `C3=1 [openapi=y, NO contract test in src/test]` | `C3=2 [openapi=y, 1 pact test(s)]` (still NO-GO on C8: no domain metrics) |
| engagement | `C3=1`, gate NO-GO | `C3=2`, gate **GO** |
| tax-reporting | `C5=0 [no CNPG cluster]`, gate NO-GO | `C5=0 [no CNPG cluster — service has no gitops workload at all]`, gate **NOT-DEPLOYED** |
| mcp | `C4=2`, gate GO (already, via #5832) | unchanged |

Verification run locally, serially:

- `check-readiness-collectors-agree.py` — `SUBJECTS=44`, identical scores/evidence/gates; and
  `--self-test` still produces 101 divergences, so the gate can still fail.
- `prod_readiness_collector_test.py` — 32 tests, OK (28 before).
- consumer pacts: 4/4 green, both pact files generated.
- `ConsentPactProviderVerificationTest` — **6 interactions, 0 failures, 0 skipped** (read from the
  JUnit XML; pact-jvm's "Not all of the 2 were verified" console line is the known artifact).
- `check-pact-provider-replay.py` — OK, `KNOWN_UNCOVERED` still empty.
- `derive-pact-drift-scope.sh` — exit 0, both new modules in scope.
- `ktlintCheck` + `detekt` for campaign/engagement/consent — all six tasks executed, green.
- admin-ui `npm test` — 203 files / 1538 tests passed.

## Noted in passing, not fixed here

`score_c4_data` globs `<module>/**/db/migration/V*.sql`, which includes `build/`, so a locally
built module double-counts its migrations in the evidence string (campaign read "16" on a clean
tree and "32" after a build). Evidence text only — no score or gate depends on the count, and both
collectors do it identically so the agreement gate is unaffected.

Refs #5706, #5760

## Follow-up in this PR (from CI)

`gates (gitops)` failed the `service-runbook-drift` gate on the first push: I had hand-edited
`docs/runbooks/svc-tax-reporting.md`, which is generated (ADR-0029 rule #6). Fixed in `c95ad73`,
and the fix surfaced a defect underneath rather than just moving text.

`generate-service-runbooks.py`'s `service_namespace()` falls back to the service SHORT NAME when
no workload resolves, so tax-reporting's runbook instructed the on-call engineer to run
`kubectl -n tax-reporting` against a namespace that has never existed — the exact defect that
function's docstring records as fixed for a third of the fleet, surviving in the one case the fix
could not resolve, because there the right answer is not a different namespace but "no namespace
at all".

The banner is now derived from the same `gitops_facts.service_namespace` call the collector uses
for NOT-DEPLOYED, so the runbook and the matrix cannot disagree about whether a service runs. It
renders empty for every deployed service — regenerating all 44 runbooks changes exactly one file.
Two self-test cases added (17, was 15). The service-specific record moved to
`openbank-tax-reporting-service/CLAUDE.md`.

Measured both directions: the drift gate FAILS on a staged hand-edit and PASSES on the
regenerated tree.
