### PR TITLE
fix(statement-service): add sourceService and occurredAt to the restated event

### DIFF
--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditAttributionTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditAttributionTest.kt
@@ -7,6 +7,7 @@ package com.openbank.audit.application
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.openbank.audit.domain.model.AttributionSource
 import com.openbank.audit.domain.model.AuditEntry
+import com.openbank.audit.domain.model.OccurredAtSource
 import com.openbank.audit.infrastructure.persistence.AuditRepository
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.coEvery
@@ -397,6 +398,28 @@ class AuditAttributionTest {
 
         assertThat(entry.captured.sourceService).isEqualTo("statement-service")
         assertThat(entry.captured.sourceServiceSource).isEqualTo(AttributionSource.EVENT)
+    }
+
+    @Test
+    fun `statement-service's restated event is attributed to the producer too`(): Unit = runBlocking {
+        // The sweep patched period.closed.v1 and period.close_failed.v1 and missed the third type,
+        // account.statement.period.restated.v1, which lives in its own service class
+        // (StatementRestatementService) rather than in StatementService/CloseOrchestrator. It also
+        // carried no `occurredAt`, so the row was stamped with the consumer's INGEST time and that
+        // was recorded as the business time — asserted here as OccurredAtSource.EVENT.
+        val entry = capturingSave()
+
+        consumer.consume(
+            """{"eventType":"account.statement.period.restated.v1",""" +
+                """"accountId":"${UUID.randomUUID()}","occurredAt":"2026-02-01T02:30:00Z",""" +
+                """"sourceService":"statement-service"}""",
+            EventAddress(topic = "openbank.statement.event"),
+        )
+
+        assertThat(entry.captured.sourceService).isEqualTo("statement-service")
+        assertThat(entry.captured.sourceServiceSource).isEqualTo(AttributionSource.EVENT)
+        assertThat(entry.captured.occurredAt).isEqualTo(Instant.parse("2026-02-01T02:30:00Z"))
+        assertThat(entry.captured.occurredAtSource).isEqualTo(OccurredAtSource.EVENT)
     }
 
     @Test

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/StatementRestatementService.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/StatementRestatementService.kt
@@ -162,6 +162,13 @@ class StatementRestatementService(
      * Consumers of `period.closed` keep their contract unchanged; a consumer that must react to a
      * correction opts in explicitly (a silently-widened `period.closed` would have downstream
      * systems treat a restatement as a first close).
+     *
+     * Issue #3994/#5256: `sourceService` lets `AuditConsumer` attribute the row from the producer's
+     * own claim ([AttributionSource.EVENT]) instead of its topic-derived fallback, and `occurredAt`
+     * (the fleet's canonical event-time key, mirrored from `closedAt` exactly as the two sibling
+     * `period.closed`/`close_failed` payloads do) stops the audit row being stamped with ingest
+     * time. Both siblings were patched by the fleet sweep; this third event type was missed because
+     * it lives in its own service class rather than in `StatementService`/`CloseOrchestrator`.
      */
     private fun periodRestatedEvent(
         account: PocketAccountInfo,
@@ -183,7 +190,9 @@ class StatementRestatementService(
             "supersededClosingBalance":${superseded.closingBalance.toPlainString()},
             "entryCount":${period.entryCount},
             "supersededEntryCount":${superseded.entryCount},
-            "closedAt":"${period.closedAt}"}
+            "closedAt":"${period.closedAt}",
+            "occurredAt":"${period.closedAt}",
+            "sourceService":"statement-service"}
         """.trimIndent().replace("\n", "")
         return StatementOutboxMessage(
             eventId = Ids.newId(),

--- a/openbank-statement-service/src/test/kotlin/com/openbank/statement/application/usecase/StatementRestatementAuditPayloadTest.kt
+++ b/openbank-statement-service/src/test/kotlin/com/openbank/statement/application/usecase/StatementRestatementAuditPayloadTest.kt
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.statement.application.usecase
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.libs.persistence.outbox.OutboxMessage
+import com.openbank.statement.Fixtures
+import com.openbank.statement.application.port.out.AccountInfoPort
+import com.openbank.statement.application.port.out.BalancePort
+import com.openbank.statement.application.port.out.BookedEntryPort
+import com.openbank.statement.application.port.out.PocketAccountInfo
+import com.openbank.statement.application.port.out.StatementPeriodRepository
+import com.openbank.statement.domain.model.BalanceAnchor
+import com.openbank.statement.domain.model.PeriodCloseStatus
+import com.openbank.statement.domain.model.StatementPeriod
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.smallrye.mutiny.Uni
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Issue #3994/#5256: `account.statement.period.restated.v1` must carry `sourceService` and
+ * `occurredAt` on the wire.
+ *
+ * Its two sibling event types (`period.closed.v1` in [StatementService], `period.close_failed.v1`
+ * in `CloseOrchestrator`) were both patched by the fleet sweep; this third type was missed because
+ * it lives in its own service class. Without `sourceService`, `AuditConsumer` attributes the row
+ * from its topic table rather than the producer's own claim; without `occurredAt` it stamps the row
+ * with the CONSUMER's ingest time and calls that the business time.
+ *
+ * The assertion reads the payload the PRODUCTION builder emits, parsed as JSON — not a substring
+ * match on the template, and not a field on a data class (there is no data class here: the payload
+ * is a hand-built string, which is precisely the shape a grep for the quoted key finds and a reader
+ * of the event classes does not).
+ */
+class StatementRestatementAuditPayloadTest {
+
+    private val accountId: UUID = Fixtures.ACCOUNT_ID
+    private val currency = "CZK"
+    private val from: LocalDate = LocalDate.parse("2026-01-01")
+    private val to: LocalDate = LocalDate.parse("2026-01-31")
+    private val closedAt: Instant = Instant.parse("2026-02-01T02:30:00Z")
+
+    private val accountInfo: AccountInfoPort = mockk()
+    private val bookedEntries: BookedEntryPort = mockk()
+    private val balance: BalancePort = mockk()
+    private val periods: StatementPeriodRepository = mockk()
+
+    private fun standing() = StatementPeriod(
+        id = UUID.randomUUID(),
+        accountId = accountId,
+        pocketCurrency = currency,
+        periodFrom = from,
+        periodTo = to,
+        legalSequenceNumber = 1,
+        electronicSequenceNumber = 1,
+        openingBalance = BigDecimal("1000.00"),
+        // Deliberately different from what the recomputation below yields, so the service takes the
+        // supersede branch rather than its "nothing to correct" no-op.
+        closingBalance = BigDecimal("1200.00"),
+        entryCount = 2,
+        closedAt = closedAt,
+        status = PeriodCloseStatus.CLOSED,
+    )
+
+    @Test
+    fun `the restated event carries sourceService and occurredAt on the wire`() {
+        val entries = listOf(Fixtures.entry(ref = "TX-1", amount = "100.00"))
+        val emitted = slot<OutboxMessage>()
+
+        every { accountInfo.pocketAccount(accountId) } returns Uni.createFrom().item(
+            PocketAccountInfo(accountId, "CZ6508000000192000145399", "Jan Novak", listOf(currency)),
+        )
+        every { periods.findByPeriod(accountId, currency, from, to) } returns Uni.createFrom().item(standing())
+        every { bookedEntries.bookedEntries(accountId, currency, from, to) } returns Uni.createFrom().item(entries)
+        every { periods.priorClosing(accountId, currency, from) } returns Uni.createFrom().item(BigDecimal("1000.00"))
+        every { balance.closingBalance(accountId, currency, to) } returns Uni.createFrom().item(
+            BalanceAnchor(BigDecimal("1100.00"), currency, to),
+        )
+        every { periods.nextLegalSequence(accountId, currency) } returns Uni.createFrom().item(2L)
+        every { periods.supersedeAndReplace(any(), any(), capture(emitted)) } answers {
+            Uni.createFrom().item(secondArg<StatementPeriod>())
+        }
+
+        val service = StatementRestatementService(accountInfo, bookedEntries, balance, periods)
+        service.clock = { closedAt }
+        service.restatePocketPeriod(accountId, currency, from, to).await().indefinitely()
+
+        val payload = ObjectMapper().readTree(emitted.captured.payload)
+        assertThat(payload.get("eventType")?.asText()).isEqualTo("account.statement.period.restated.v1")
+        assertThat(payload.get("sourceService")?.asText()).isEqualTo("statement-service")
+        // An EXACT instant against the stubbed clock seam, never isNotNull(): a non-null assertion
+        // passes against Instant.EPOCH, and asText() yields the four-character text "null" for a
+        // JSON null.
+        assertThat(Instant.parse(payload.get("occurredAt").asText())).isEqualTo(closedAt)
+    }
+}


### PR DESCRIPTION
## Summary

`account.statement.period.restated.v1` is the one event type of this service's
three that the #5256 sweep missed, and it was missing **both** attribution fields.

Its two siblings (`period.closed.v1` in `StatementService`,
`period.close_failed.v1` in `CloseOrchestrator`) were patched by the sweep. This
third type lives in its own class, `StatementRestatementService`, so a sweep
working through the other two files never reaches it.

| | before | after |
|---|---|---|
| `sourceService` | absent → `AuditConsumer` falls to its topic table (`AttributionSource.TOPIC`) | `"statement-service"` → `AttributionSource.EVENT` |
| `occurredAt` | **absent entirely** → row stamped with the consumer's INGEST time | `closedAt` → `OccurredAtSource.EVENT` |

## The `occurredAt` half — deliberate, and beyond the issue's stated scope

Calling this out explicitly rather than folding it in silently. `AuditConsumer.eventTime()`
reads only `occurredAt`; the payload had `closedAt` and nothing else, so **every**
restatement row recorded the consumer's ingest time as the business time and
incremented `openbank.audit.event.time.missing`. Under consumer lag or a replay
that is arbitrarily wrong — and a restatement is a correction to an already-issued
legal statement page (ADR-0035 §D), the one event in this service where "when did
this happen" is evidentiary.

The value mirrors `closedAt`, exactly as the sibling `period.closed.v1` payload
does, so a correction can never report its time differently from the close it
replaces. It is a one-token addition to the same payload string I was already
editing, so splitting it into its own PR would have meant touching the same line
twice for no reviewer benefit.

## Verification — the wire payload, not the field

There is no data class here: the payload is a hand-built string, so a test
asserting a property on an event class could not see it at all.

- **Producer side** — new `StatementRestatementAuditPayloadTest`: drives the real
  `restatePocketPeriod` path with mocked ports, captures the emitted
  `OutboxMessage`, and reads both keys off the payload **the production builder
  emits**, as parsed JSON. `occurredAt` is asserted as an **exact instant** against
  the stubbed clock seam — never `isNotNull()`, which would pass against
  `Instant.EPOCH`, and never `isNotEmpty()` on the string, which would pass against
  the four-character text `"null"` that `asText()` yields for a JSON null.
- **Consumer side** — `AuditAttributionTest`: feeds that shape through
  `AuditConsumer.consume` and asserts both
  `sourceServiceSource == AttributionSource.EVENT` and
  `occurredAtSource == OccurredAtSource.EVENT`.

**Falsification:** removing both fields turns the producer test red. Restored
before commit.

## Test plan

- [x] `./gradlew :openbank-statement-service:ktlintCheck :openbank-statement-service:detekt` — green (`ktlintMainSourceSetCheck` and `ktlintTestSourceSetCheck` both confirmed to have executed)
- [x] `./gradlew :openbank-statement-service:test --tests "...StatementRestatementAuditPayloadTest"` — 1 test, 0 failures, **0 skipped**
- [x] `./gradlew :openbank-audit-service:ktlintCheck :openbank-audit-service:detekt` — green; `ktlintTestSourceSetCheck` re-run with `--rerun-tasks` rather than trusting an `UP-TO-DATE` on a file I had just edited
- [x] `./gradlew :openbank-audit-service:test --tests "...AuditAttributionTest"` — 27 tests, 0 failures, **0 skipped**
- [x] Negative case: both fields removed ⇒ producer test fails

Refs #5256
