### PR TITLE
test(copilot): add the copilot proposal-quality eval pack, with an UNAVAILABLE outcome

### DIFF
--- a/.github/scripts/check-gradle-cache-writers.py
+++ b/.github/scripts/check-gradle-cache-writers.py
@@ -94,6 +94,12 @@ DECLARED: dict[str, tuple[str, str]] = {
         "Restores fleet-lint's home and re-downloads only the runtime-only artifacts "
         "`assemble` needs beyond it.",
     ),
+    "evals-copilot-proposal.yml::copilot-proposal-pack": (
+        "read-only",
+        "Scoped to one service's eval test classes (pure-JVM, no infra); resolves a small subset "
+        "of what fleet-lint already restores fleet-wide. Same reasoning as its sibling "
+        "evals-fraud-review.yml below.",
+    ),
     "evals-fraud-review.yml::fraud-review-pack": (
         "read-only",
         "Scoped to one service's test classes; resolves a small subset of what fleet-lint "

--- a/.github/workflows/evals-copilot-proposal.yml
+++ b/.github/workflows/evals-copilot-proposal.yml
@@ -1,0 +1,92 @@
+# -----------------------------------------------------------------------------
+# Copilot proposal-quality eval-pack gate (issue #4463; ADR-0148 evals gate; ADR-0235 archived-per-run).
+#
+# The second of the two scenario packs #4463 asked for — the one evals/README.md deferred when the
+# fraud pack shipped (PR #5105). Like that pack, it asserts on DETERMINISTIC production code
+# (PaymentProposalTool, CardFreezeProposalTool, CopilotPolicyGate), never on model output, so there
+# is nothing to record or replay and the LLM egress path being down does not affect it. See
+# evals/README.md for the split between this mechanism and openbank-libs/governance/evals/ (the
+# ADR-0148 LLM prompt/model replay gate).
+#
+# What this pack adds structurally over the fraud one: a third outcome. The two properties #4463
+# named that this service cannot assert today — SCA proposal-token binding and PSD2 consent scope —
+# are reported as UNAVAILABLE, never as a pass and never as a zero, and a guard test fails the build
+# if either gap closes without the scenario being promoted.
+#
+# Additive to services-ci.yml, which already runs the whole openbank-copilot-service suite on any
+# change under that module. What this workflow adds: archiving the eval pack's JSON report as a
+# build artifact, and a visible status check independent of the full per-module build.
+# -----------------------------------------------------------------------------
+name: Evals - copilot proposal quality
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "openbank-copilot-service/src/main/kotlin/com/openbank/copilot/domain/**"
+      - "openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/CopilotPolicyGate.kt"
+      - "openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/tool/**"
+      - "openbank-copilot-service/src/test/kotlin/com/openbank/copilot/evals/**"
+      - "openbank-copilot-service/src/test/resources/evals/**"
+      - "evals/**"
+      - ".github/workflows/evals-copilot-proposal.yml"
+  pull_request:
+    paths:
+      - "openbank-copilot-service/src/main/kotlin/com/openbank/copilot/domain/**"
+      - "openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/CopilotPolicyGate.kt"
+      - "openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/tool/**"
+      - "openbank-copilot-service/src/test/kotlin/com/openbank/copilot/evals/**"
+      - "openbank-copilot-service/src/test/resources/evals/**"
+      - "evals/**"
+      - ".github/workflows/evals-copilot-proposal.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: evals-copilot-proposal-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
+jobs:
+  copilot-proposal-pack:
+    name: copilot-proposal-quality eval pack
+    runs-on: ubuntu-latest # public repo: hosted runners free + unlimited (FinOps: hosted-first)
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: |
+            21
+            25
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          # NEVER write the Actions cache from this job -- restore only (#3299). Same budget
+          # reasoning evals-fraud-review.yml documents: the Gradle cache-writer budget is fixed at
+          # 5 main-push jobs and `fleet-lint` is the designated Linux-X64 writer.
+          cache-read-only: true
+
+      # Pure-JVM application/domain code with zero infra dependency (no DB/Kafka/Redis) — `--tests`
+      # scopes the run to exactly the eval classes so a failure names the regression gate itself,
+      # not an unrelated copilot-service test.
+      - name: Run the copilot-proposal-quality eval pack
+        run: |
+          ./gradlew :openbank-copilot-service:test \
+            --tests "com.openbank.copilot.evals.*" \
+            --console=plain
+
+      - name: Archive the eval report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: copilot-proposal-eval-report-${{ github.run_id }}-${{ github.run_attempt }}
+          path: openbank-copilot-service/build/eval-reports/copilot-proposal-quality.json
+          retention-days: 90
+          if-no-files-found: error

--- a/.github/workflows/main-red-watch.yml
+++ b/.github/workflows/main-red-watch.yml
@@ -67,6 +67,7 @@ on:
       - "AI governance snapshot"
       - "API contract post-merge guard"
       - "EU AI Act registry"
+      - "Evals - copilot proposal quality"
       - "Evals - fraud review"
       - "Fleet lint"
       - "Label sync"

--- a/evals/README.md
+++ b/evals/README.md
@@ -19,7 +19,7 @@ a prompt hash does.
 
 ## Scenario packs
 
-### 1. Fraud review — shipped in this PR
+### 1. Fraud review — shipped (PR #5105)
 
 Location: `openbank-fraud-service/src/test/kotlin/com/openbank/fraud/evals/`.
 
@@ -44,38 +44,60 @@ this eval pack; archives the JSON report as a build artifact on every run.
 **Data.** Every account/counterparty id is a deterministic name-based UUID derived from a fixed
 seed string (ADR-0175 §5 class 3 — synthetic/non-personal). No production data of any kind.
 
-### 2. Copilot proposal quality — deferred, not shipped in this PR
+### 2. Copilot proposal quality — shipped
 
-Issue #4463 also asked for a pack asserting that `propose.payment`/`propose.card_freeze`
-proposals "carry correct SCA binding and never exceed consent scope." Scoping this out for a
-follow-up rather than shipping a shallow version, for two concrete reasons found while surveying
-`openbank-copilot-service`:
+Location: `openbank-copilot-service/src/test/kotlin/com/openbank/copilot/evals/`.
 
-1. **"Consent scope" checking does not exist in the code path the issue names.** PSD2
-   consent-scope enforcement lives in `openbank-mcp-service`
-   (`ProposedOnly.kt`/`ProposePaymentArgs.kt`), which is a *different, currently-unwired* tool
-   implementation from `openbank-copilot-service`'s `PaymentProposalTool`/`CardFreezeProposalTool`
-   (see `docs/adr/0195-mcp-server-caller-authentication-and-psd2-consent-binding.md` and issue
-   #2414). A "consent-scope" eval scenario against `openbank-copilot-service` today would be
-   asserting on a check that literally does not run there — an eval suite that always trivially
-   passes because the property under test is absent is worse than no suite (same failure mode
-   ADR-0148's own "Negative" section warns about: "a shallow eval suite would satisfy the gate's
-   letter without its purpose").
-2. **"SCA binding" is not a single field to assert on.** It spans three separate classes
-   (`PaymentProposalTool`/`CardFreezeProposalTool` build the `ActionProposal`; `ProposalToken`
-   assembly happens inside `CopilotChatService`; binding is enforced as an identity check in
-   `ActionConfirmResource`) — a real scenario pack needs to drive that whole path, which is a
-   materially bigger integration surface than the fraud pack's single pure function.
+Issue #4463 asked for scenarios proving `propose.payment` / `propose.card_freeze` proposals "carry
+correct SCA binding and never exceed consent scope". **Two of those three properties are not
+assertable in this service today**, and the pack says so with a distinct outcome rather than
+scoring them:
 
-**What doing this properly needs**, tracked as this issue's follow-up rather than invented here:
-either wire `openbank-copilot-service`'s proposal tools to the same consent-scope check
-`openbank-mcp-service` already has (closing #2414 first — an eval against a gap that's about to
-close is more useful than one against a gap that stays open), or explicitly scope the pack to what
-*does* exist today (`CopilotPolicyGate.authorize` capability/OPA checks, `ProposalToken`
-expiry/customer-id binding) and document the consent-scope gap as a known limitation rather than
-silently asserting nothing. Either way this is deterministic application-layer logic, not model
-output — the same "assert on the business logic around the AI, not on live model text" principle
-the fraud pack already applies, per ADR-0148/ADR-0235's record/replay rationale.
+| property | outcome class | why |
+|---|---|---|
+| proposal construction is validated, propose-only, bounded | **runnable** — 8 scenarios | `PaymentProposalTool` / `CardFreezeProposalTool` are pure functions over a `JsonNode` |
+| capability gating is deny-by-default | **runnable** — 3 scenarios | `CopilotPolicyGate.authorize` is application-layer code with injectable ports |
+| SCA binding (proposal token → confirm) | **`UNAVAILABLE`** | nothing under `openbank-copilot-service/src/main` ever constructs a `ProposalToken`. `ActionConfirmResource` reads the token store; no production code writes to it, so `/api/v1/copilot/actions/{id}/confirm` can only ever answer `404 PROPOSAL_NOT_FOUND` and there is no binding to assert on |
+| PSD2 consent scope not exceeded | **`UNAVAILABLE`** | consent-scope enforcement lives in `openbank-mcp-service`'s tool implementation (ADR-0195), a different and currently-unwired path — issue #2414 |
+
+**`UNAVAILABLE` is a first-class outcome with its own value.** It is never folded into a pass (which
+would claim a measurement nobody made) and never into a failure or a zero (which would report an
+agent-quality regression for a wiring gap). The pass rate is computed over `passed + failed` only;
+the unavailable count rides beside it in the archived report. When *nothing* is assertable the rate
+is `null` and `regressed` is `true` — a pack that measured nothing must never read as a clean pass.
+This repo has shipped the collapsed version of that distinction before: a disabled push adapter
+whose skip returned `success = true`, and a pentest attestation minted by a job that fuzzed nothing.
+
+Files:
+
+- `CopilotProposalScenarios.kt` — the pack: declarative ground truth (expected proposal fields,
+  expected rejection, expected policy verdict) over fixed synthetic UUIDs (ADR-0175 §5 class 3).
+- `CopilotProposalEvalRunner.kt` — calls the real production classes and returns the three-valued
+  `ScenarioOutcome`.
+- `CopilotProposalEvalSuiteTest.kt` — one `DynamicTest` per scenario (per-scenario pass/fail in the
+  JUnit XML; an `UNAVAILABLE` scenario is `abort`ed so it appears as a **third status — skipped —
+  with its reason**), plus the regression gate that archives
+  `build/eval-reports/copilot-proposal-quality.json` and fails below
+  `src/test/resources/evals/copilot-proposal-baseline.json`.
+- `CopilotProposalEvalHarnessSelfTest.kt` — proves the gate can go red *and* that the third outcome
+  cannot collapse: known-bad ground truth must FAIL, an unavailable scenario must not become a pass,
+  and adding unavailable scenarios must not move the pass rate.
+- `ProposalPathAvailabilityTest.kt` — **stops an `UNAVAILABLE` declaration outliving its gap.** Each
+  unavailability rests on a checkable fact about the source tree, re-proven every run; the moment a
+  `ProposalToken` is constructed in `src/main`, or a consent scope is referenced there, the build
+  goes red telling you to promote the scenario. Same bidirectional rule as
+  `openbank-libs/governance/evals/recordings/backlog.yaml`: an undeclared gap and a stale
+  declaration are both errors.
+
+CI: `.github/workflows/evals-copilot-proposal.yml`, path-scoped to the proposal tools, the policy
+gate, the copilot domain and this eval pack; archives the JSON report on every run.
+
+**Why this pack needs no live model.** The LLM egress path is not a dependency of a single scenario
+here — every one calls deterministic production code. That matters right now: the platform's
+`openbank_llm_requests_total` has only ever recorded `http_error` outcomes (issue #5736), so a
+benchmark that drove the real agents would today score zero for reasons that have nothing to do with
+agent quality. The ADR-0148 record/replay gate reaches the model half by replaying *recorded*
+output, which is why it is a different mechanism in a different tree — see the table at the top.
 
 ## References
 

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/evals/CopilotProposalEvalHarnessSelfTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/evals/CopilotProposalEvalHarnessSelfTest.kt
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.copilot.evals
+
+import com.openbank.copilot.domain.ActionKind
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Proves [CopilotProposalEvalRunner] can actually report a FAILURE, and that its third outcome
+ * cannot collapse into either of the other two — not merely that the harness runs.
+ *
+ * `openbank-libs/governance/evals/README.md` states the principle for the sibling LLM gate: "a
+ * runner that has quietly lost the ability to fail takes the build down with it rather than
+ * reporting green". A pack with an UNAVAILABLE outcome needs the same proof twice over, because
+ * there are now two ways for it to become theatre:
+ *
+ *  - the comparison stops detecting a wrong result (`known-bad ground truth reported as PASS`), and
+ *  - the unavailable outcome silently becomes a pass, or silently becomes a zero that tanks the rate.
+ *
+ * Every fixture here is built ad hoc and asserted through the runner directly — never added to
+ * [COPILOT_PROPOSAL_SCENARIOS], which would make the real pack permanently red for the wrong reason.
+ */
+class CopilotProposalEvalHarnessSelfTest {
+
+    private val knownGood = COPILOT_PROPOSAL_SCENARIOS.single { it.id == "payment-fields-are-validated-not-narrated" }
+
+    @Test
+    fun `control - the known-good fixture passes`() {
+        assertThat(CopilotProposalEvalRunner.evaluate(knownGood).outcome)
+            .withFailMessage("control fixture failed — the comparison logic itself is broken")
+            .isEqualTo(ScenarioOutcome.PASS)
+    }
+
+    @Test
+    fun `runner reports FAIL for a deliberately wrong expected amount`() {
+        val knownBad = knownGood.copy(
+            id = "self-test-wrong-amount",
+            expected = ExpectedOutcome.Proposal(
+                kind = ActionKind.PAYMENT,
+                fields = (knownGood.expected as ExpectedOutcome.Proposal).fields + ("amount" to "999999.00"),
+            ),
+        )
+        assertThat(CopilotProposalEvalRunner.evaluate(knownBad).outcome)
+            .withFailMessage(
+                "harness self-test FAILED: a proposal whose amount is off by six orders of magnitude " +
+                    "was reported as PASS — the pack is assurance theatre",
+            )
+            .isEqualTo(ScenarioOutcome.FAIL)
+    }
+
+    @Test
+    fun `runner reports FAIL when a rejection is expected but a proposal is produced`() {
+        val knownBad = knownGood.copy(
+            id = "self-test-expected-rejection",
+            expected = ExpectedOutcome.Rejected(errorContains = "IBAN"),
+        )
+        assertThat(CopilotProposalEvalRunner.evaluate(knownBad).outcome)
+            .withFailMessage("harness self-test FAILED: a produced proposal satisfied an expected rejection")
+            .isEqualTo(ScenarioOutcome.FAIL)
+    }
+
+    @Test
+    fun `runner reports FAIL when the gate's verdict is the opposite of ground truth`() {
+        val allowScenario = COPILOT_PROPOSAL_SCENARIOS.single { it.id == "gate-allows-declared-action-capability" }
+        val knownBad = allowScenario.copy(
+            id = "self-test-inverted-gate-verdict",
+            expected = ExpectedOutcome.Decision(allow = false),
+        )
+        assertThat(CopilotProposalEvalRunner.evaluate(knownBad).outcome)
+            .withFailMessage("harness self-test FAILED: an allowed capability satisfied an expected deny")
+            .isEqualTo(ScenarioOutcome.FAIL)
+    }
+
+    // --- the UNAVAILABLE outcome must be its own value ------------------------------------------
+
+    @Test
+    fun `an unavailable scenario is neither a pass nor a failure`() {
+        val unavailable = COPILOT_PROPOSAL_SCENARIOS.first { it.subject is ProposalSubject.NotWiredYet }
+        val result = CopilotProposalEvalRunner.evaluate(unavailable)
+
+        assertThat(result.outcome)
+            .withFailMessage(
+                "an unwired requirement was scored as %s. Folding 'could not run' into a real result " +
+                    "is how a disabled adapter reports as a working one — the exact defect this pack's " +
+                    "third outcome exists to prevent.",
+                result.outcome,
+            )
+            .isEqualTo(ScenarioOutcome.UNAVAILABLE)
+        assertThat(result.trackedBy).isNotBlank()
+    }
+
+    @Test
+    fun `unavailable scenarios are excluded from the pass rate, not counted as zero`() {
+        val oneGood = listOf(knownGood)
+        val unavailable = COPILOT_PROPOSAL_SCENARIOS.filter { it.subject is ProposalSubject.NotWiredYet }
+
+        val alone = CopilotProposalEvalRunner.run(oneGood, minPassRate = 1.0)
+        val withUnavailable = CopilotProposalEvalRunner.run(oneGood + unavailable, minPassRate = 1.0)
+
+        assertThat(withUnavailable.passRate)
+            .withFailMessage(
+                "adding %d unavailable scenario(s) moved the pass rate from %s to %s — they are being " +
+                    "scored as failures, so the pack would report an agent-quality regression for a " +
+                    "wiring gap it cannot measure",
+                unavailable.size,
+                alone.passRate,
+                withUnavailable.passRate,
+            )
+            .isEqualTo(alone.passRate)
+        assertThat(withUnavailable.unavailable).isEqualTo(unavailable.size)
+        assertThat(withUnavailable.regressed).isFalse()
+    }
+
+    @Test
+    fun `a pack with nothing assertable has a null rate and REGRESSES - it never reads as a clean pass`() {
+        val onlyUnavailable = COPILOT_PROPOSAL_SCENARIOS.filter { it.subject is ProposalSubject.NotWiredYet }
+        val report = CopilotProposalEvalRunner.run(onlyUnavailable, minPassRate = 1.0)
+
+        assertThat(report.passRate)
+            .withFailMessage("a pack that measured nothing reported a numeric score of %s", report.passRate)
+            .isNull()
+        assertThat(report.regressed)
+            .withFailMessage(
+                "a pack where every scenario was unavailable reported regressed=false — it would clear " +
+                    "its gate having measured nothing at all",
+            )
+            .isTrue()
+    }
+}

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/evals/CopilotProposalEvalRunner.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/evals/CopilotProposalEvalRunner.kt
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.copilot.evals
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.openbank.copilot.application.CopilotPolicyGate
+import com.openbank.copilot.application.port.out.ProposalResult
+import com.openbank.copilot.application.port.out.ToolPolicyDecision
+import com.openbank.copilot.application.port.out.ToolPolicyPort
+import com.openbank.copilot.infrastructure.tool.CardFreezeProposalTool
+import com.openbank.copilot.infrastructure.tool.PaymentProposalTool
+import com.openbank.libs.audit.AuditEvent
+import com.openbank.libs.audit.AuditEventPublisher
+import kotlinx.coroutines.runBlocking
+import java.time.Clock
+import java.time.Instant
+
+/**
+ * Three-valued, on purpose.
+ *
+ * `UNAVAILABLE` is a **first-class outcome with its own value** — it is never folded into [PASS]
+ * (which would report quality nobody measured) and never into [FAIL] or a zero score (which would
+ * report a quality regression for a wiring gap). The pass rate in [SuiteReport] is computed over
+ * `PASS + FAIL` only; the UNAVAILABLE count is carried beside it, not inside it.
+ *
+ * This repo has shipped the collapsed version of this distinction more than once — a disabled push
+ * adapter whose skip returned `success = true`, and a `quarantine()` that was one `log.warnf` — and
+ * both read as working for as long as nobody looked. See `evals/README.md`.
+ */
+enum class ScenarioOutcome { PASS, FAIL, UNAVAILABLE }
+
+/** Outcome of one [CopilotProposalScenario] against the real production classes. */
+data class ProposalScenarioResult(
+    val id: String,
+    val description: String,
+    val requirement: String,
+    val outcome: ScenarioOutcome,
+    /** Ground truth, rendered for the archived report. */
+    val expected: String,
+    /** What the production code actually produced, or the unavailability reason. */
+    val actual: String,
+    /** Populated only for [ScenarioOutcome.UNAVAILABLE] — the issue that closes the gap. */
+    val trackedBy: String? = null,
+)
+
+/** The archived-per-run report (ADR-0235 "results archived per-run"). */
+data class ProposalSuiteReport(
+    val suite: String,
+    val version: String,
+    val runAt: String,
+    val total: Int,
+    val passed: Int,
+    val failed: Int,
+    /** Scenarios that could not run at all. Reported, never scored. */
+    val unavailable: Int,
+    /** `passed / (passed + failed)`, and `null` when nothing was assertable — never a silent 0.0. */
+    val passRate: Double?,
+    val minPassRate: Double,
+    val regressed: Boolean,
+    val results: List<ProposalScenarioResult>,
+)
+
+/**
+ * A [ToolPolicyPort] that always allows. The gate under test has two layers; this pack asserts the
+ * **application whitelist** (layer 1), so layer 2 is held constant at "allow" — a denying stub would
+ * make every gate scenario pass for the wrong reason and prove nothing about the whitelist.
+ */
+private object AlwaysAllowPolicy : ToolPolicyPort {
+    override fun authorize(toolName: String, customerId: String, amount: String?) = ToolPolicyDecision.ALLOWED
+}
+
+private object DiscardingAuditPublisher : AuditEventPublisher {
+    override suspend fun publish(event: AuditEvent) = Unit
+}
+
+/**
+ * The runner for the copilot proposal-quality pack. Calls the **real** production classes
+ * ([PaymentProposalTool], [CardFreezeProposalTool], [CopilotPolicyGate]) — there is no model call
+ * anywhere in this pack, so there is nothing to record or replay, and the LLM egress path being
+ * down does not affect a single scenario here. See `evals/README.md` for why that split exists.
+ */
+object CopilotProposalEvalRunner {
+    const val SUITE = "copilot-proposal-quality"
+    const val VERSION = "v1"
+
+    private val mapper = ObjectMapper().registerKotlinModule()
+    private val paymentTool = PaymentProposalTool()
+    private val cardFreezeTool = CardFreezeProposalTool()
+    private val gate = CopilotPolicyGate(DiscardingAuditPublisher, AlwaysAllowPolicy, opaEnforce = true)
+
+    /** Pure apart from the production call it makes. The one comparison the whole gate rests on. */
+    fun evaluate(scenario: CopilotProposalScenario): ProposalScenarioResult {
+        val subject = scenario.subject
+        if (subject is ProposalSubject.NotWiredYet) {
+            return ProposalScenarioResult(
+                id = scenario.id,
+                description = scenario.description,
+                requirement = scenario.requirement,
+                outcome = ScenarioOutcome.UNAVAILABLE,
+                expected = "not assertable in this service today",
+                actual = subject.reason,
+                trackedBy = subject.trackedBy,
+            )
+        }
+
+        val (actual, matched) = when (subject) {
+            is ProposalSubject.ProposePayment -> compareProposal(
+                paymentTool.propose(mapper.readTree(subject.argsJson)),
+                scenario.expected,
+            )
+            is ProposalSubject.ProposeCardFreeze -> compareProposal(
+                cardFreezeTool.propose(mapper.readTree(subject.argsJson)),
+                scenario.expected,
+            )
+            is ProposalSubject.AuthorizeCapability -> {
+                val decision = runBlocking { gate.authorize("synthetic-customer", subject.tool, subject.capability) }
+                val rendered = "allow=${decision.allow} reason=${decision.reason}"
+                val want = scenario.expected
+                rendered to (want is ExpectedOutcome.Decision && want.allow == decision.allow)
+            }
+            is ProposalSubject.NotWiredYet -> error("unreachable — handled above")
+        }
+
+        return ProposalScenarioResult(
+            id = scenario.id,
+            description = scenario.description,
+            requirement = scenario.requirement,
+            outcome = if (matched) ScenarioOutcome.PASS else ScenarioOutcome.FAIL,
+            expected = render(scenario.expected),
+            actual = actual,
+        )
+    }
+
+    /** Returns (rendered actual, matched). Field comparison is EXACT — an extra field is a mismatch. */
+    private fun compareProposal(result: ProposalResult, expected: ExpectedOutcome): Pair<String, Boolean> {
+        val proposal = result.proposal
+        val rendered = when {
+            proposal != null -> "proposal(kind=${proposal.kind}, fields=${proposal.fields})"
+            else -> "rejected(${result.error})"
+        }
+        val matched = when (expected) {
+            is ExpectedOutcome.Proposal ->
+                proposal != null && proposal.kind == expected.kind && proposal.fields == expected.fields
+            is ExpectedOutcome.Rejected ->
+                proposal == null && (result.error?.contains(expected.errorContains, ignoreCase = true) == true)
+            else -> false
+        }
+        return rendered to matched
+    }
+
+    private fun render(expected: ExpectedOutcome): String = when (expected) {
+        is ExpectedOutcome.Proposal -> "proposal(kind=${expected.kind}, fields=${expected.fields})"
+        is ExpectedOutcome.Rejected -> "rejected(error containing '${expected.errorContains}')"
+        is ExpectedOutcome.Decision -> "allow=${expected.allow}"
+        ExpectedOutcome.NotAssertable -> "not assertable"
+    }
+
+    fun run(
+        scenarios: List<CopilotProposalScenario> = COPILOT_PROPOSAL_SCENARIOS,
+        minPassRate: Double,
+        clock: Clock = Clock.systemUTC(),
+    ): ProposalSuiteReport {
+        val results = scenarios.map { evaluate(it) }
+        val passed = results.count { it.outcome == ScenarioOutcome.PASS }
+        val failed = results.count { it.outcome == ScenarioOutcome.FAIL }
+        val unavailable = results.count { it.outcome == ScenarioOutcome.UNAVAILABLE }
+        val scored = passed + failed
+        // null, not 0.0: "nothing could be measured" and "everything measured failed" are different
+        // facts, and a benchmark that renders the first as the second reports a score it cannot earn.
+        val rate = if (scored == 0) null else passed.toDouble() / scored
+        return ProposalSuiteReport(
+            suite = SUITE,
+            version = VERSION,
+            runAt = Instant.now(clock).toString(),
+            total = results.size,
+            passed = passed,
+            failed = failed,
+            unavailable = unavailable,
+            passRate = rate,
+            minPassRate = minPassRate,
+            // An unmeasurable suite is NOT a passing suite: no rate means the gate cannot clear.
+            regressed = rate == null || rate < minPassRate,
+            results = results,
+        )
+    }
+}
+
+private val proposalReportMapper: ObjectMapper = ObjectMapper()
+    .registerKotlinModule()
+    .registerModule(JavaTimeModule())
+    .apply { enable(SerializationFeature.INDENT_OUTPUT) }
+
+fun ProposalSuiteReport.toJson(): String = proposalReportMapper.writeValueAsString(this)

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/evals/CopilotProposalEvalSuiteTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/evals/CopilotProposalEvalSuiteTest.kt
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.copilot.evals
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assumptions.abort
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
+import java.io.File
+
+/** Regression floor read from `src/test/resources/evals/copilot-proposal-baseline.json`. */
+private data class ProposalBaseline(val suite: String, val version: String, val minPassRate: Double)
+
+private val proposalBaselineMapper = ObjectMapper().registerKotlinModule()
+
+/**
+ * The **copilot proposal-quality** eval pack — issue #4463's second scenario pack, deferred when the
+ * fraud pack shipped (PR #5105) and scoped here to what is honestly assertable. Mirrors
+ * `FraudReviewEvalSuiteTest` in openbank-fraud-service, with one structural addition: a third
+ * outcome.
+ *
+ * 1. The `copilot proposal scenarios` [TestFactory] gives **per-scenario pass/fail** in CI's JUnit
+ *    XML. A [ScenarioOutcome.UNAVAILABLE] scenario is `abort`ed, so JUnit reports it as **skipped**
+ *    with its reason — a third status in the XML, distinct from both green and red. It is not
+ *    asserted green (which would claim a measurement nobody made) and not asserted red (which would
+ *    report an agent-quality regression for a wiring gap).
+ * 2. The regression gate archives a JSON report to `build/eval-reports/` (ADR-0235 "results archived
+ *    per-run") and fails below the declared floor — the ADR-0020 ratchet. The floor is applied to
+ *    `passed / (passed + failed)`; unavailable scenarios are counted and reported, never scored.
+ *
+ * See [CopilotProposalEvalHarnessSelfTest] for the falsification proof, and
+ * [ProposalPathAvailabilityTest] for the guard that stops an UNAVAILABLE declaration outliving the
+ * gap it describes.
+ */
+class CopilotProposalEvalSuiteTest {
+
+    @TestFactory
+    fun `copilot proposal scenarios`(): List<DynamicTest> = COPILOT_PROPOSAL_SCENARIOS.map { scenario ->
+        DynamicTest.dynamicTest("${scenario.id}: ${scenario.description}") {
+            val result = CopilotProposalEvalRunner.evaluate(scenario)
+
+            if (result.outcome == ScenarioOutcome.UNAVAILABLE) {
+                abort<Unit>(
+                    "UNAVAILABLE (not a pass, not a failure) — ${scenario.id}: ${result.actual}. " +
+                        "Requirement: ${scenario.requirement}. Tracked by ${result.trackedBy}.",
+                )
+            }
+
+            assertThat(result.outcome)
+                .withFailMessage(
+                    "scenario '%s' FAILED (%s)%n  expected: %s%n  actual:   %s",
+                    scenario.id,
+                    scenario.requirement,
+                    result.expected,
+                    result.actual,
+                )
+                .isEqualTo(ScenarioOutcome.PASS)
+        }
+    }
+
+    @Test
+    fun `regression gate archives the run and fails below the declared baseline`() {
+        val baseline = readBaseline()
+        val report = CopilotProposalEvalRunner.run(minPassRate = baseline.minPassRate)
+
+        val outDir = File("build/eval-reports")
+        outDir.mkdirs()
+        File(outDir, "copilot-proposal-quality.json").writeText(report.toJson())
+
+        // A null rate means nothing was assertable at all. That is a broken pack, not a passing one,
+        // and it must not read as 0.0 either — hence the explicit branch.
+        assertThat(report.passRate)
+            .withFailMessage(
+                "copilot-proposal-quality has NO assertable scenarios (%d/%d unavailable) — the pack " +
+                    "measures nothing and cannot clear its floor. See build/eval-reports/.",
+                report.unavailable,
+                report.total,
+            )
+            .isNotNull()
+
+        assertThat(report.passRate!!)
+            .withFailMessage(
+                "copilot-proposal-quality eval pack regressed: pass rate %.4f is below the declared " +
+                    "floor %.4f (%d passed, %d failed, %d unavailable of %d) — see " +
+                    "build/eval-reports/copilot-proposal-quality.json",
+                report.passRate,
+                baseline.minPassRate,
+                report.passed,
+                report.failed,
+                report.unavailable,
+                report.total,
+            )
+            .isGreaterThanOrEqualTo(baseline.minPassRate)
+    }
+
+    private fun readBaseline(): ProposalBaseline {
+        val stream = javaClass.getResourceAsStream("/evals/copilot-proposal-baseline.json")
+            ?: error("missing src/test/resources/evals/copilot-proposal-baseline.json")
+        return stream.use { proposalBaselineMapper.readValue(it, ProposalBaseline::class.java) }
+    }
+}

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/evals/CopilotProposalScenarios.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/evals/CopilotProposalScenarios.kt
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.copilot.evals
+
+import com.openbank.copilot.domain.ActionKind
+
+/**
+ * The **copilot proposal-quality** scenario pack — issue #4463's second pack, the one
+ * [`evals/README.md`](../../../../../../../../../evals/README.md) deliberately deferred when the
+ * fraud pack shipped (PR #5105).
+ *
+ * ## What this pack asserts on, and what it deliberately does not
+ *
+ * Issue #4463 asked for scenarios proving `propose.payment` / `propose.card_freeze` proposals
+ * "carry correct SCA binding and never exceed consent scope". Two of those three properties are
+ * **not assertable in this service today**, and this pack says so with a distinct outcome
+ * ([ScenarioOutcome.UNAVAILABLE]) rather than pretending otherwise:
+ *
+ * | property | state | why |
+ * |---|---|---|
+ * | proposal construction is validated, propose-only, and bounded | **RUNNABLE** | `PaymentProposalTool` / `CardFreezeProposalTool` are pure functions over a `JsonNode` |
+ * | capability gating is deny-by-default | **RUNNABLE** | `CopilotPolicyGate.authorize` is application-layer code with injectable ports |
+ * | SCA binding (proposal token → confirm) | **UNAVAILABLE** | nothing in `src/main` ever constructs a `ProposalToken`, so `ActionConfirmResource` can only ever answer 404 — see [ProposalPathAvailabilityTest] |
+ * | PSD2 consent scope not exceeded | **UNAVAILABLE** | the consent-scope check lives in `openbank-mcp-service`, a different and currently-unwired tool implementation (ADR-0195, issue #2414) |
+ *
+ * An UNAVAILABLE scenario is **never** counted as a pass and **never** dragged into the pass rate
+ * as a zero — it is its own value, reported and archived separately. That distinction is the whole
+ * point: a benchmark that scored these two as failures would report an agent-quality regression for
+ * a wiring gap, and one that scored them as passes would be assurance theatre. Both are shapes this
+ * repo has already paid for (a disabled adapter returning `success = true`; a pentest attestation
+ * minted by a job that fuzzed nothing).
+ *
+ * And an UNAVAILABLE declaration cannot quietly become permanent: [ProposalPathAvailabilityTest]
+ * fails the build the moment the precondition stops holding, which forces the scenario to be
+ * promoted to a real one. Same bidirectional rule as `recordings/backlog.yaml` in the sibling
+ * ADR-0148 LLM evals gate — an undeclared gap and a stale declaration are both errors.
+ *
+ * ## Data
+ *
+ * Every account/card id below is a fixed literal UUID with no counterpart in any real system
+ * (ADR-0175 §5 class 3 — synthetic/non-personal). No production data of any kind.
+ */
+
+/** The subject under test for one scenario — what the runner actually calls. */
+sealed interface ProposalSubject {
+    /** Call `PaymentProposalTool.propose(args)`. */
+    data class ProposePayment(val argsJson: String) : ProposalSubject
+
+    /** Call `CardFreezeProposalTool.propose(args)`. */
+    data class ProposeCardFreeze(val argsJson: String) : ProposalSubject
+
+    /** Call `CopilotPolicyGate.authorize(customerId, tool, capability)`. */
+    data class AuthorizeCapability(val tool: String, val capability: String?) : ProposalSubject
+
+    /**
+     * The property is real and required, but no code path in this service exercises it yet.
+     * [reason] must be a *checkable* fact, not an intention — [ProposalPathAvailabilityTest]
+     * re-proves each one on every run.
+     */
+    data class NotWiredYet(val reason: String, val trackedBy: String) : ProposalSubject
+}
+
+/** Declared ground truth for one scenario. */
+sealed interface ExpectedOutcome {
+    /** A validated proposal of [kind] whose `fields` are exactly [fields] — no more, no less. */
+    data class Proposal(val kind: ActionKind, val fields: Map<String, String>) : ExpectedOutcome
+
+    /** No proposal at all; a customer-facing error containing [errorContains]. */
+    data class Rejected(val errorContains: String) : ExpectedOutcome
+
+    /** A policy decision whose `allow` is [allow]. */
+    data class Decision(val allow: Boolean) : ExpectedOutcome
+
+    /** Nothing to compare — the subject is [ProposalSubject.NotWiredYet]. */
+    data object NotAssertable : ExpectedOutcome
+}
+
+data class CopilotProposalScenario(
+    val id: String,
+    val description: String,
+    /** The ADR/decision this scenario exists to protect — so a failure names what broke, not just that something did. */
+    val requirement: String,
+    val subject: ProposalSubject,
+    val expected: ExpectedOutcome,
+)
+
+// Fixed synthetic identifiers (ADR-0175 §5 class 3). Not derived from, and not resolvable to, anything real.
+private const val ACCOUNT = "3f2a1c40-0000-4000-8000-00000000a001"
+private const val CARD = "3f2a1c40-0000-4000-8000-00000000c001"
+private const val PAYEE = "CZ6508000000192000145399"
+
+val COPILOT_PROPOSAL_SCENARIOS: List<CopilotProposalScenario> = listOf(
+
+    // --- propose_payment: the money-path proposal itself ------------------------------------
+    CopilotProposalScenario(
+        id = "payment-fields-are-validated-not-narrated",
+        description = "A well-formed payment request yields a PAYMENT proposal whose fields are the " +
+            "validated parameters — authoritative, not the model's prose.",
+        requirement = "ADR-0089 D2 — the app renders `fields`, never the model's sentence.",
+        subject = ProposalSubject.ProposePayment(
+            """{"fromAccountId":"$ACCOUNT","payeeIban":"${PAYEE.lowercase()}","amount":"1500.00"}""",
+        ),
+        expected = ExpectedOutcome.Proposal(
+            kind = ActionKind.PAYMENT,
+            // IBAN normalised to upper case, amount to plain string, currency defaulted.
+            fields = mapOf(
+                "fromAccountId" to ACCOUNT,
+                "payeeIban" to PAYEE,
+                "amount" to "1500.00",
+                "currency" to "CZK",
+            ),
+        ),
+    ),
+    CopilotProposalScenario(
+        id = "payment-amount-normalised-from-czech-decimal-comma",
+        description = "`1500,50` is the Czech decimal form a customer types; it must reach the action " +
+            "card as 1500.50, not be silently rejected or truncated to 1500.",
+        requirement = "ADR-0089 D2 — the confirmed amount is the one the customer meant.",
+        subject = ProposalSubject.ProposePayment(
+            """{"fromAccountId":"$ACCOUNT","payeeIban":"$PAYEE","amount":"1500,50","currency":"czk"}""",
+        ),
+        expected = ExpectedOutcome.Proposal(
+            kind = ActionKind.PAYMENT,
+            fields = mapOf(
+                "fromAccountId" to ACCOUNT,
+                "payeeIban" to PAYEE,
+                "amount" to "1500.50",
+                "currency" to "CZK",
+            ),
+        ),
+    ),
+    CopilotProposalScenario(
+        id = "payment-rejects-malformed-iban",
+        description = "A payee IBAN the model invented or an injected string reshaped must not become " +
+            "an action card the customer is invited to confirm.",
+        requirement = "ADR-0089 D2 — validation happens before the customer ever sees a payee.",
+        subject = ProposalSubject.ProposePayment(
+            """{"fromAccountId":"$ACCOUNT","payeeIban":"NOT-AN-IBAN","amount":"10.00"}""",
+        ),
+        expected = ExpectedOutcome.Rejected(errorContains = "IBAN"),
+    ),
+    CopilotProposalScenario(
+        id = "payment-rejects-non-uuid-source-account",
+        description = "The source account must be one of the customer's own account UUIDs; a free-text " +
+            "account reference is a rejection, never a proposal with an unresolvable source.",
+        requirement = "ADR-0089 D2 — a proposal with no valid source account cannot be confirmed downstream.",
+        subject = ProposalSubject.ProposePayment(
+            """{"fromAccountId":"my current account","payeeIban":"$PAYEE","amount":"10.00"}""",
+        ),
+        expected = ExpectedOutcome.Rejected(errorContains = "účtu"),
+    ),
+    CopilotProposalScenario(
+        id = "payment-rejects-non-positive-amount",
+        description = "A zero or negative amount is not a payment. Rejecting it here keeps a nonsensical " +
+            "card out of the SCA flow rather than relying on a downstream service to catch it.",
+        requirement = "ADR-0089 D2 — propose-only still means propose something valid.",
+        subject = ProposalSubject.ProposePayment(
+            """{"fromAccountId":"$ACCOUNT","payeeIban":"$PAYEE","amount":"-250.00"}""",
+        ),
+        expected = ExpectedOutcome.Rejected(errorContains = "kladná"),
+    ),
+    CopilotProposalScenario(
+        id = "payment-bounds-adversarial-note",
+        description = "The payee note is attacker-influenceable free text rendered on the action card the " +
+            "customer reads. It must be bounded, so an over-long or hostile note cannot bloat or " +
+            "restructure the card around the amount and payee.",
+        requirement = "ADR-0089 D2 (#998 nit 1) — the action card is not a model-controlled surface.",
+        subject = ProposalSubject.ProposePayment(
+            """{"fromAccountId":"$ACCOUNT","payeeIban":"$PAYEE","amount":"10.00","note":"${"N".repeat(500)}"}""",
+        ),
+        expected = ExpectedOutcome.Proposal(
+            kind = ActionKind.PAYMENT,
+            fields = mapOf(
+                "fromAccountId" to ACCOUNT,
+                "payeeIban" to PAYEE,
+                "amount" to "10.00",
+                "currency" to "CZK",
+                "note" to "N".repeat(140),
+            ),
+        ),
+    ),
+
+    // --- propose_card_freeze -----------------------------------------------------------------
+    CopilotProposalScenario(
+        id = "card-freeze-proposes-only-a-validated-card",
+        description = "A card freeze is precautionary but still a state change, so it takes the same " +
+            "propose-only path: a validated card id and nothing else.",
+        requirement = "ADR-0089 D2 — every state change is a proposal, low-risk or not.",
+        subject = ProposalSubject.ProposeCardFreeze("""{"cardId":"$CARD","reason":"ztracená karta"}"""),
+        expected = ExpectedOutcome.Proposal(
+            kind = ActionKind.CARD_FREEZE,
+            fields = mapOf("cardId" to CARD, "reason" to "ztracená karta"),
+        ),
+    ),
+    CopilotProposalScenario(
+        id = "card-freeze-rejects-non-uuid-card",
+        description = "A card reference the model paraphrased ('the blue one') is a rejection, not a " +
+            "freeze proposal against an unresolvable id.",
+        requirement = "ADR-0089 D2 — validate before proposing.",
+        subject = ProposalSubject.ProposeCardFreeze("""{"cardId":"the blue one"}"""),
+        expected = ExpectedOutcome.Rejected(errorContains = "karty"),
+    ),
+
+    // --- capability gate: deny-by-default -----------------------------------------------------
+    CopilotProposalScenario(
+        id = "gate-allows-declared-action-capability",
+        description = "`payment.propose` is on the closed ACTION whitelist, so the gate allows it — " +
+            "the control on a proposal is HITL + SCA downstream, not a blanket refusal here.",
+        requirement = "ADR-0089 D3 — a closed whitelist that allows nothing is not a gate, it is an outage.",
+        subject = ProposalSubject.AuthorizeCapability("propose_payment", "payment.propose"),
+        expected = ExpectedOutcome.Decision(allow = true),
+    ),
+    CopilotProposalScenario(
+        id = "gate-denies-capability-outside-the-closed-whitelist",
+        description = "A capability that is not on either whitelist is denied. This is the differential " +
+            "control for the scenario above: without it, an always-allow gate would also pass.",
+        requirement = "ADR-0089 D3 / ADR-0034 D1 — deny-by-default.",
+        subject = ProposalSubject.AuthorizeCapability("propose_wire_transfer", "payment.execute"),
+        expected = ExpectedOutcome.Decision(allow = false),
+    ),
+    CopilotProposalScenario(
+        id = "gate-denies-tool-declaring-no-capability",
+        description = "A tool that declares no capability at all is denied, not defaulted into the read " +
+            "set — the absent case is the one a deny-by-default gate most often gets wrong.",
+        requirement = "ADR-0089 D3 — absent is not permissive.",
+        subject = ProposalSubject.AuthorizeCapability("propose_payment", null),
+        expected = ExpectedOutcome.Decision(allow = false),
+    ),
+
+    // --- declared UNAVAILABLE: real requirements with no code path to assert on ---------------
+    CopilotProposalScenario(
+        id = "sca-binding-proposal-token-is-issued-and-owner-bound",
+        description = "Issue #4463 asks that a proposal 'carries correct SCA binding'. The binding half " +
+            "of ADR-0089 D2 Track A (a ProposalToken issued with the proposal, owner-bound, TTL-bound, " +
+            "one-time) has no producer: `ActionConfirmResource` reads the token store, and no code in " +
+            "src/main ever writes to it.",
+        requirement = "ADR-0089 D2 Track A — proposal token binds the confirm to one customer and one action.",
+        subject = ProposalSubject.NotWiredYet(
+            reason = "no src/main code constructs a ProposalToken, so /api/v1/copilot/actions/{id}/confirm " +
+                "can only ever answer 404 PROPOSAL_NOT_FOUND — there is no binding to assert on",
+            trackedBy = "#4463",
+        ),
+        expected = ExpectedOutcome.NotAssertable,
+    ),
+    CopilotProposalScenario(
+        id = "proposal-never-exceeds-psd2-consent-scope",
+        description = "Issue #4463 asks that a proposal 'never exceeds consent scope'. PSD2 consent-scope " +
+            "enforcement lives in openbank-mcp-service's tool implementation, which is a different and " +
+            "currently-unwired path from this service's proposal tools. Asserting it here would be a " +
+            "scenario that passes because the property under test is absent.",
+        requirement = "ADR-0195 — MCP caller authentication and PSD2 consent binding.",
+        subject = ProposalSubject.NotWiredYet(
+            reason = "consent-scope checking is not reachable from openbank-copilot-service's proposal " +
+                "tools; it exists only in the unwired openbank-mcp-service implementation",
+            trackedBy = "#2414",
+        ),
+        expected = ExpectedOutcome.NotAssertable,
+    ),
+)

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/evals/ProposalPathAvailabilityTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/evals/ProposalPathAvailabilityTest.kt
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.copilot.evals
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Stops an [ScenarioOutcome.UNAVAILABLE] declaration outliving the gap it describes.
+ *
+ * The two unavailable scenarios in [COPILOT_PROPOSAL_SCENARIOS] each rest on a **checkable fact**
+ * about this service's source tree, not on an intention. This class re-proves that fact on every
+ * run and goes RED when it stops holding — which is the signal to promote the scenario from
+ * "declared unavailable" to a real assertion.
+ *
+ * The failure mode this exists to prevent is the one `evals/README.md` and
+ * `openbank-libs/governance/evals/recordings/backlog.yaml` both name: an exclusion list that reads
+ * as passing when it grows, and never as unchecked. There the rule is bidirectional (an undeclared
+ * gap and a stale declaration are both errors); here the undeclared direction is covered by the
+ * scenarios themselves and the stale direction is covered below.
+ */
+class ProposalPathAvailabilityTest {
+
+    private val mainSources: List<File> =
+        File("src/main/kotlin").walkTopDown().filter { it.isFile && it.extension == "kt" }.toList()
+
+    @Test
+    fun `the pack can actually see this service's sources`() {
+        // Control: without this, every assertion below would pass vacuously if the working directory
+        // or the layout ever moved — a probe that reports clean because it read nothing.
+        assertThat(mainSources)
+            .withFailMessage("found no .kt files under src/main/kotlin — this guard is reading nothing")
+            .isNotEmpty()
+        assertThat(mainSources.map { it.name })
+            .contains("ProposalToken.kt", "ActionConfirmResource.kt", "PaymentProposalTool.kt")
+    }
+
+    @Test
+    fun `SCA-binding stays unavailable only while no production code issues a ProposalToken`() {
+        val issuers = mainSources.filter { it.readText().contains("ProposalToken(") }
+
+        assertThat(issuers)
+            .withFailMessage(
+                "PROMOTE THE SCENARIO: %s now constructs a ProposalToken, so the ADR-0089 D2 Track A " +
+                    "SCA binding finally has a producer and " +
+                    "'sca-binding-proposal-token-is-issued-and-owner-bound' must stop being declared " +
+                    "UNAVAILABLE in CopilotProposalScenarios.kt — assert the binding (owner, TTL, " +
+                    "one-time use) for real. Leaving the declaration in place would be exactly the " +
+                    "stale-exclusion defect this guard exists to catch.",
+                issuers.map { it.name },
+            )
+            // Only the declaration file itself may name the type.
+            .allMatch { it.name == "ProposalToken.kt" }
+
+        // And the declared scenario must still be present and still unavailable — the guard is
+        // worthless if someone deletes the scenario instead of promoting it.
+        val declared = COPILOT_PROPOSAL_SCENARIOS.single {
+            it.id ==
+                "sca-binding-proposal-token-is-issued-and-owner-bound"
+        }
+        assertThat(declared.subject).isInstanceOf(ProposalSubject.NotWiredYet::class.java)
+    }
+
+    @Test
+    fun `consent-scope stays unavailable only while this service has no consent-scope check`() {
+        val consentAware = mainSources.filter {
+            val text = it.readText()
+            text.contains("consentScope", ignoreCase = true) || text.contains("consent_scope", ignoreCase = true)
+        }
+
+        assertThat(consentAware)
+            .withFailMessage(
+                "PROMOTE THE SCENARIO: %s now references a consent scope, so " +
+                    "'proposal-never-exceeds-psd2-consent-scope' must stop being declared UNAVAILABLE " +
+                    "and assert the ADR-0195 check for real (issue #2414).",
+                consentAware.map { it.name },
+            )
+            .isEmpty()
+
+        val declared = COPILOT_PROPOSAL_SCENARIOS.single { it.id == "proposal-never-exceeds-psd2-consent-scope" }
+        assertThat(declared.subject).isInstanceOf(ProposalSubject.NotWiredYet::class.java)
+    }
+}

--- a/openbank-copilot-service/src/test/resources/evals/copilot-proposal-baseline.json
+++ b/openbank-copilot-service/src/test/resources/evals/copilot-proposal-baseline.json
@@ -1,0 +1,5 @@
+{
+  "suite": "copilot-proposal-quality",
+  "version": "v1",
+  "minPassRate": 1.0
+}


### PR DESCRIPTION
## What

Issue #4463's **second scenario pack** — the copilot proposal-quality one that
[`evals/README.md`](../blob/main/evals/README.md) deliberately deferred when the fraud pack shipped
in #5105.

## The framing question first: can the agents execute at all?

No — and it does not matter for this pack, which is why this is the piece that was worth building.

Every LLM call the platform has made has failed: `openbank_llm_requests_total` carries exactly one
outcome value, `http_error` (issue #5736, PR #5877), and no `success` has ever existed. A benchmark
that drove the real agents would today score zero for reasons that have nothing to do with agent
quality.

That is also, precisely, what ADR-0148 and ADR-0235 already decided against. Both explicitly
**reject a live-model step in CI** ("CI has no model credentials and a live model is not
deterministic") and both build the model half on the offline record/replay runner
`.github/scripts/run-evals.py`. So the model-facing half of #4463's ask is not missing — it shipped,
and it reaches model behaviour by replaying *recorded* output rather than by calling anything.

What #4463 added on top was two **scenario packs**. Both are deterministic business logic around the
AI, not model output. Pack 1 (fraud review) shipped in #5105. This is pack 2.

**No model call appears anywhere in this pack.** Every scenario calls real production classes. The
dead LLM path does not affect a single one.

## What is measurable, and what honestly is not

#4463 asked for scenarios proving `propose.payment` / `propose.card_freeze` proposals "carry correct
SCA binding and never exceed consent scope". Two of those three properties **are not assertable in
this service today**, and this pack says so with a distinct outcome instead of scoring them:

| property | outcome | why |
|---|---|---|
| proposal construction is validated, propose-only, bounded | **runnable** (8 scenarios) | `PaymentProposalTool` / `CardFreezeProposalTool` are pure functions over a `JsonNode` |
| capability gating is deny-by-default | **runnable** (3 scenarios) | `CopilotPolicyGate.authorize` has injectable ports |
| SCA binding (proposal token to confirm) | **`UNAVAILABLE`** | nothing under `openbank-copilot-service/src/main` ever constructs a `ProposalToken` |
| PSD2 consent scope not exceeded | **`UNAVAILABLE`** | the check lives in the unwired `openbank-mcp-service` implementation (ADR-0195, #2414) |

### The SCA-binding finding is worth reading on its own

`ActionConfirmResource` reads the proposal-token store. **No production code writes to it.**
`ProposalToken(` is constructed in exactly one place in this repo — a test. So
`POST /api/v1/copilot/actions/{tokenId}/confirm` can only ever answer `404 PROPOSAL_NOT_FOUND` on a
running pod, and ADR-0089 D2 Track A's SCA binding has no producer. Nothing about it looks broken:
the endpoint exists, the store exists, both Redis and in-memory adapters exist, and
`ActionConfirmResourceTest` is green because it seeds the store itself. This PR does not fix that —
it declares it, tracks it, and makes it impossible to forget.

## `UNAVAILABLE` is a first-class value

It is never folded into a pass (which would claim a measurement nobody made) and never into a
failure or a zero (which would report an agent-quality regression for a wiring gap):

- the pass rate is computed over `passed + failed` only; the unavailable count rides beside it;
- when *nothing* is assertable the rate is `null` and `regressed` is `true`, so a pack that measured
  nothing can never read as a clean pass;
- in the JUnit XML an unavailable scenario is `abort`ed, appearing as a **third status — skipped,
  with its reason** — next to green and red.

This repo has shipped the collapsed version of that distinction before: a disabled push adapter
whose skip returned `success = true`, a `quarantine()` that was one `log.warnf`, and a pentest
attestation minted by a job that fuzzed nothing.

## And the declaration cannot outlive the gap

`ProposalPathAvailabilityTest` re-proves each unavailability against the source tree on every run.
The moment a `ProposalToken` is constructed under `src/main`, or a consent scope is referenced
there, the build goes **red** telling you to promote the scenario to a real assertion. It also
asserts the scenarios are still present and still unavailable, so deleting one instead of promoting
it fails too — and carries a control test proving it is actually reading files rather than passing
vacuously. Same bidirectional rule as `recordings/backlog.yaml` in the sibling ADR-0148 gate: an
undeclared gap and a stale declaration are both errors.

## Verification — falsified, not merely run

Local: `ktlintCheck` + `detekt` green, then the full `:openbank-copilot-service:test` — **165 tests,
0 failures, 0 errors, 2 skipped**, and the 2 skipped are exactly the two `UNAVAILABLE` scenarios.

Then the scorer was broken three ways and confirmed red each time:

| break | result |
|---|---|
| comparison always returns "matched" | 2 self-tests **FAILED** |
| `UNAVAILABLE` mapped to `PASS` | 3 self-tests **FAILED**, and the 2 skips vanished |
| append `ProposalToken(` to a `src/main` file | both availability guards **FAILED** |

`run-gates.py --all`: 156 gates, and the two failures this branch introduced are both fixed here —
`main-red-watch-declaration` (the new workflow is now in `main-red-watch.yml`'s watch list) and
`gradle-cache-writer-budget` (declared `read-only`, mirroring `evals-fraud-review.yml`). The
remaining 5 FAIL + 1 UNFALSIFIED were confirmed **identical on clean `origin/main`** in a separate
worktree — they require a `PR_DIFF_BASE` or a live Loki and are environmental, not from this branch.

## Not in scope

No `src/main` change, so no release-axis version bump (everything is `src/test`, which is in
admin-ui-style `exclude-paths` for the release trigger, plus CI/docs). Neither `UNAVAILABLE` gap is
*closed* here — closing them is wiring work in `openbank-copilot-service` and `#2414`, and inventing
an assertion against a check that does not run is the shallow-suite failure ADR-0148's own
"Negative" section warns about.

Refs #4463
