### PR TITLE
test(audit): prove sca-service's DEVICE_ENROLLED attribution on the wire

### DIFF
--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditAttributionTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditAttributionTest.kt
@@ -7,6 +7,7 @@ package com.openbank.audit.application
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.openbank.audit.domain.model.AttributionSource
 import com.openbank.audit.domain.model.AuditEntry
+import com.openbank.audit.domain.model.OccurredAtSource
 import com.openbank.audit.infrastructure.persistence.AuditRepository
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.coEvery
@@ -456,6 +457,31 @@ class AuditAttributionTest {
         assertThat(entry.captured.eventType).isEqualTo("ICT_INCIDENT_REPORTED")
         assertThat(entry.captured.sourceService).isEqualTo("security-scanner")
         assertThat(entry.captured.sourceServiceSource).isEqualTo(AttributionSource.EVENT)
+    }
+
+    @Test
+    fun `sca-service's own sourceService wins, no longer falling to the topic table`(): Unit = runBlocking {
+        // Issue #3994/#5256: sca-service's DEVICE_ENROLLED payload (ScaService.kt, a hand-built map
+        // serialised onto the outbox) carries "sourceService" — but it was the ONE producer of the
+        // 21 audited topics with no wire-payload test, so nothing held the claim. The topic is live:
+        // #5369 added openbank.sca.events to this service's consumed-topics list, closing #5338,
+        // where SCA device enrollment had never been audited at all. sca-service is money-path.
+        //
+        // This test is what the sweep's own closure criterion asks for and is the last of the 21
+        // producers to get it. The payload shape below is ScaService.kt's verbatim.
+        val entry = capturingSave()
+
+        consumer.consume(
+            """{"eventType":"DEVICE_ENROLLED","deviceId":"${UUID.randomUUID()}",""" +
+                """"partyId":"${UUID.randomUUID()}","credentialId":"cred-1","algorithm":"ES256",""" +
+                """"occurredAt":"2026-08-09T11:00:00Z","sourceService":"sca-service"}""",
+            EventAddress(topic = "openbank.sca.events"),
+        )
+
+        assertThat(entry.captured.sourceService).isEqualTo("sca-service")
+        assertThat(entry.captured.sourceServiceSource).isEqualTo(AttributionSource.EVENT)
+        assertThat(entry.captured.occurredAt).isEqualTo(Instant.parse("2026-08-09T11:00:00Z"))
+        assertThat(entry.captured.occurredAtSource).isEqualTo(OccurredAtSource.EVENT)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds the missing wire-payload attribution test for **sca-service** — the one
producer of the 21 topics `AuditConsumer` subscribes to that had none.

**No production code changes.** `ScaService.kt`'s hand-built `DEVICE_ENROLLED`
outbox payload is already correct: it carries `eventType`, `occurredAt` and
`sourceService = "sca-service"`. This is a missing *proof*, not a missing fix.

That distinction is the reason to file it. #5256's closure criterion is a test
showing `AuditConsumer` resolves `AttributionSource.EVENT` rather than its topic
fallback. Nineteen producers got such a test; for this one the claim rested only on
reading the source, so nothing would have caught a regression. The topic is live —
#5369 subscribed audit-service to `openbank.sca.events`, closing #5338, where SCA
device enrollment had never been audited at all — and sca-service is money-path.

The test also asserts `OccurredAtSource.EVENT`, since this payload is one of the
producers that does supply a business event time.

**Falsification:** dropping `sourceService` from the wire payload turns the test
red. Restored before commit.

## Test plan

- [x] `./gradlew :openbank-audit-service:ktlintCheck :openbank-audit-service:detekt` — green
- [x] `./gradlew :openbank-audit-service:ktlintTestSourceSetCheck :openbank-audit-service:test --tests "...AuditAttributionTest" --rerun-tasks` — 27 tests, 0 failures, **0 skipped** (forced rather than trusting an `UP-TO-DATE`)
- [x] Negative case: key removed ⇒ test fails

## Follow-up noted, not changed here

`ScaService.kt:456-461` carries a now-stale comment asserting `sourceService` "has
no consumer today" and that audit-service "does not currently subscribe to
`openbank.sca.events` at all". Both stopped being true when #5369 merged. Left
alone to keep this PR test-only rather than mixing a second released component
into it.

Refs #5256
