### PR TITLE
feat(admin-ui): enrich operator cockpit

### DIFF
--- a/.github/scripts/check-external-feeds.py
+++ b/.github/scripts/check-external-feeds.py
@@ -173,6 +173,7 @@ FEEDS = [
 NOT_PROBED = [
     ("https://api.github.com", "authenticated API, not a data feed; failure is loud at call time"),
     ("https://api.deepinfra.com/v1/openai", "authenticated LLM gateway; needs a key"),
+    ("https://integrate.api.nvidia.com/v1", "authenticated LLM gateway; needs a key"),
     ("https://s3.eu-north-1.amazonaws.com", "AWS endpoint, reached with SigV4 credentials"),
     ("https://kc.open-bank.tech/realms/openbank-customers", "our own Keycloak realm, covered by its own probes"),
     ("https://pid.open-bank.tech", "our own PID issuer, covered by its own probes"),

--- a/.github/scripts/check-openapi-enum-vs-domain.py
+++ b/.github/scripts/check-openapi-enum-vs-domain.py
@@ -100,6 +100,8 @@ BASELINE: dict[str, str] = {
         "AccountingDayStatus; OPEN is unreachable as a transition target (no reopen, ADR-0207).",
     "openbank-lending-service:APPROVED,EXECUTED,PENDING,REJECTED":
         "#5962 — CollateralStatus: spec-only EXECUTED",
+    "openbank-lending-service:APPROVED,EXECUTED,PROPOSED,REJECTED":
+        "Compliance pack ProposalState, not CollateralStatus; value-overlap pairing is ambiguous.",
     # Also deliberate: the enum is right to flag (INDIVIDUAL has never existed; the DB CHECK is
     # ('NATURAL_PERSON','LEGAL_ENTITY','SOLE_TRADER')), but it sits inside `CreatePartyRequest`,
     # whose declared properties — legalName, tradingName, taxId, dateOfBirth, nationality —

--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -351,15 +351,17 @@ jobs:
       # A flake cannot be counted from run CONCLUSIONS alone (a re-run flips it away from
       # `failure`), so retain the JUnit XML per ATTEMPT — a flake becomes a diffable artifact
       # pair instead of something that has to be noticed and reported at re-run time (#4878).
-      - name: Upload JUnit XML (every run — flake accounting)
+      - name: Upload quality evidence (every run)
         if: always()
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: junit-xml-${{ inputs.service }}-a${{ github.run_attempt }}
-          path: ${{ inputs.service }}/build/test-results/**/*.xml
+          name: quality-evidence-${{ inputs.service }}-a${{ github.run_attempt }}
+          path: |
+            ${{ inputs.service }}/build/test-results/**/*.xml
+            ${{ inputs.service }}/build/reports/kover/report.xml
           if-no-files-found: ignore
-          retention-days: 3
+          retention-days: 7
 
       # Compatibility projection for the image build: the latest envelope remains
       # separate from immutable attempts above, so a re-run cannot erase history.

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -35,6 +35,18 @@
 name: Admin-UI deploy
 
 on:
+  # CI evidence changes far more frequently than the Admin UI source. A successful
+  # main Services CI and CI immediately rebuild the read-only evidence projection; the
+  # daily run is its recovery path when GitHub suppresses or delays an event. Both
+  # use the same signed image and GitOps-PR path as source-triggered deploys.
+  workflow_run:
+    # Services CI produces fleet envelopes; CI produces the Admin UI envelope.  Subscribe
+    # to both: refreshing after Services CI alone can snapshot a stale Admin UI verdict
+    # before the same main commit's UI test artifact is available.
+    workflows: ["Services CI", "CI"]
+    types: [completed]
+  schedule:
+    - cron: '17 3 * * *'
   push:
     branches: [main]
     paths:
@@ -92,7 +104,14 @@ jobs:
     # scopes the deploy commit to the gitops manifest alone, so the loop can no longer form by
     # that route. This guard is kept as belt-and-braces: it costs nothing and still holds if a
     # future step writes into openbank-admin-ui/** again.
-    if: "!startsWith(github.event.head_commit.message, 'chore(admin-ui): deploy')"
+    # `workflow_run` is trusted only after a successful Services CI on main.  It
+    # executes this default-branch workflow, never unreviewed PR YAML, and only
+    # refreshes a read-only projection from CI artifacts.  Keep the old push
+    # loop-breaker; workflow_run has no head_commit, hence the explicit fallback.
+    if: >-
+      (github.event_name != 'workflow_run' ||
+       (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')) &&
+      !startsWith(github.event.head_commit.message || '', 'chore(admin-ui): deploy')
     # Native arm64 GitHub-hosted runner (free on public repos): the admin-ui image
     # is linux/arm64. ECR push + cosign use the same GitHub-OIDC role as before.
     runs-on: ubuntu-24.04-arm
@@ -112,6 +131,9 @@ jobs:
       # Mirrored into env because the `secrets` context is NOT available in a step-level `if:`
       # — only job-level env can read it. Used solely to decide whether to mint an App token.
       GITOPS_APP_ID: ${{ secrets.GITOPS_APP_ID }}
+      # Read-only token for the separate private customer-app repository. It is optional:
+      # missing scope/evidence renders an explicit blocked client row; it never blocks deploy.
+      APP_RO_TOKEN: ${{ secrets.OPENBANK_APP_RO_TOKEN }}
 
     outputs:
       tag: ${{ steps.build.outputs.tag }}
@@ -123,6 +145,16 @@ jobs:
           fetch-depth: 0
           # persist-credentials: true (default) — needed so git in the collectors
           # can read the repo; the gitops step uses a separate checkout.
+
+      - name: Checkout mobile RUM capability metadata
+        if: env.APP_RO_TOKEN != ''
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: JiRaska/openbank-app
+          token: ${{ secrets.OPENBANK_APP_RO_TOKEN }}
+          path: .app-src
+          persist-credentials: false
+          fetch-depth: 1
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -273,7 +305,7 @@ jobs:
           done
           echo "SBOM staging complete."
 
-      - name: Stage JUnit test results (per-service latest artifact)
+      - name: Stage Test Intelligence evidence (per-service latest artifact)
         # services-ci.yml uploads one artifact per service: test-reports-{service}
         # (7-day retention). The old approach (download from ONE run) fails with
         # path-scoped CI: only recently-changed services have artifacts in any single
@@ -293,43 +325,31 @@ jobs:
           api() { curl -sf -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" "$@"; }
 
-          mapfile -t SERVICES < <(node openbank-admin-ui/scripts/list-test-services.mjs --repo .)
-
-          # The artifacts endpoint returns at most 100 entries per page. Evidence
-          # artifacts are retained across many workflow runs, so a service's newest
-          # non-expired artifact can be beyond page one. Collect every page once,
-          # then select the newest match per service. This avoids both a blind
-          # first-page scan and one complete API walk for every service.
-          EVIDENCE_ARTIFACTS=""
-          page=1
-          while :; do
-            response="$(api "https://api.github.com/repos/${REPO}/actions/artifacts?per_page=100&page=${page}" 2>/dev/null || true)"
-            [ -n "${response}" ] || break
-            matches="$(printf '%s' "${response}" | python3 -c "import json,sys; a=json.load(sys.stdin).get('artifacts',[]); [print(x['id'], x['name'], x['created_at']) for x in a if not x['expired'] and x['name'].startswith('quality-evidence-')]" 2>/dev/null || true)"
-            [ -z "${matches}" ] || EVIDENCE_ARTIFACTS+="${matches}"$'\n'
-            page_count="$(printf '%s' "${response}" | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('artifacts',[])))" 2>/dev/null || true)"
-            case "${page_count}" in
-              ''|*[!0-9]*) break ;;
-            esac
-            [ "${page_count}" -lt 100 ] && break
-            page=$((page + 1))
-          done
+          mapfile -t SERVICES < <(find . -mindepth 2 -maxdepth 2 -name version.txt -printf '%h\n' \
+            | sed 's#^./##' | sort)
 
           DOWNLOADED=0
           for svc in "${SERVICES[@]}"; do
-            art_prefix="quality-evidence-${svc}-a"
-            ARTIFACT="$(printf '%s' "${EVIDENCE_ARTIFACTS}" | python3 -c "import sys; p=sys.argv[1]; a=[line.split() for line in sys.stdin if line.split() and line.split()[1].startswith(p)]; a.sort(key=lambda x:x[2], reverse=True); print(' '.join(a[0][:2]) if a else '')" "${art_prefix}" 2>/dev/null || true)"
+            art_name="test-intelligence-${svc}"
+            ARTIFACT=$(api \
+              "https://api.github.com/repos/${REPO}/actions/artifacts?name=${art_name}&per_page=1" \
+              | python3 -c "import json,sys; a=[x for x in json.load(sys.stdin).get('artifacts',[]) if not x['expired']]; print(str(a[0]['id'])+' '+a[0]['name'] if a else '')" \
+              2>/dev/null || true)
             if [ -z "${ARTIFACT}" ]; then
               echo "  ${svc}: no artifact (skip)"
               continue
             fi
             art_id="${ARTIFACT%% *}"
-            art_name="${ARTIFACT#* }"
             if api "https://api.github.com/repos/${REPO}/actions/artifacts/${art_id}/zip" \
                 -L -o "/tmp/${art_name}.zip" 2>/dev/null; then
               TMPDIR_ART="/tmp/${art_name}-extracted"
               rm -rf "${TMPDIR_ART}" && mkdir -p "${TMPDIR_ART}"
               unzip -q "/tmp/${art_name}.zip" -d "${TMPDIR_ART}" 2>/dev/null || true
+              RUN_JSON="$(find "${TMPDIR_ART}" -path '*/test-intelligence/run.json' -print -quit)"
+              if [ -n "${RUN_JSON}" ]; then
+                mkdir -p "${svc}/build/test-intelligence"
+                cp "${RUN_JSON}" "${svc}/build/test-intelligence/run.json"
+              fi
               # Inside the zip: test-results/*/TEST-*.xml (actions/upload-artifact@v7 strips
               # the leading service/build/ prefix). Reconstruct the full target path.
               find "${TMPDIR_ART}" -path "*/test-results/*/TEST-*.xml" | while read -r xml; do
@@ -338,11 +358,10 @@ jobs:
                 mkdir -p "$(dirname "${target}")"
                 cp "${xml}" "${target}"
               done
-              kover=$(find "${TMPDIR_ART}" -path "*/reports/kover/report.xml" -o -path "*/kover/report.xml" | head -1)
-              if [ -n "${kover}" ]; then
+              find "${TMPDIR_ART}" -path '*/reports/kover/report.xml' | while read -r xml; do
                 mkdir -p "${svc}/build/reports/kover"
-                cp "${kover}" "${svc}/build/reports/kover/report.xml"
-              fi
+                cp "${xml}" "${svc}/build/reports/kover/report.xml"
+              done
               DOWNLOADED=$((DOWNLOADED + 1))
               echo "  ${svc}: staged"
             else
@@ -350,7 +369,66 @@ jobs:
             fi
           done
           COUNT=$(find . -path "*/build/test-results/*/TEST-*.xml" | wc -l | tr -d ' ')
-          echo "Staged ${COUNT} JUnit XML files from ${DOWNLOADED}/${#SERVICES[@]} services."
+          RUN_COUNT=$(find . -path "*/build/test-intelligence/run.json" | wc -l | tr -d ' ')
+          echo "Staged ${RUN_COUNT} run envelopes and ${COUNT} JUnit XML files from ${DOWNLOADED}/${#SERVICES[@]} services."
+
+      - name: Stage customer-app Test Intelligence evidence
+        # Cross-repository evidence is read-only and best-effort. The compact JSON artifact
+        # contains counts and provenance only; it never imports private source or test output.
+        if: env.APP_RO_TOKEN != ''
+        env:
+          GH_TOKEN: ${{ secrets.OPENBANK_APP_RO_TOKEN }}
+          APP_REPO: JiRaska/openbank-app
+        run: |
+          set -u
+          api() { curl -sf -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" "$@"; }
+          mkdir -p openbank-admin-ui/client-test-evidence
+          # Only reviewed default-branch evidence may enter a deployed control plane. A newer
+          # PR artifact remains visible in GitHub but cannot replace the sandbox verdict.
+          ARTIFACTS="$(api "https://api.github.com/repos/${APP_REPO}/actions/artifacts?per_page=100" \
+            | python3 -c "import json,sys; a=[x for x in json.load(sys.stdin).get('artifacts',[]) if x['name'].startswith('openbank-app-test-intelligence-') and not x['expired'] and (x.get('workflow_run') or {}).get('head_branch') == 'main']; a.sort(key=lambda x:x['created_at'], reverse=True); [print(x['id']) for x in a[:20]]" 2>/dev/null || true)"
+          while read -r artifact_id; do
+            [ -n "${artifact_id}" ] || continue
+            archive="/tmp/openbank-app-test-intelligence-${artifact_id}.zip"
+            api "https://api.github.com/repos/${APP_REPO}/actions/artifacts/${artifact_id}/zip" -L -o "${archive}" 2>/dev/null || continue
+            evidence="$(unzip -Z1 "${archive}" | awk '/\.json$/{print; exit}')"
+            [ -n "${evidence}" ] || continue
+            # Every producer artifact contains `openbank-app-unit.json`. Preserve a unique
+            # deployment-local name or older downloads overwrite the newest observation.
+            unzip -p "${archive}" "${evidence}" > "openbank-admin-ui/client-test-evidence/openbank-app-${artifact_id}.json"
+          done <<< "${ARTIFACTS}"
+          echo "Staged $(find openbank-admin-ui/client-test-evidence -name '*.json' | wc -l | tr -d ' ') mobile client evidence artifact(s)."
+
+      - name: Stage immutable per-attempt Test Intelligence history
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -u
+          api() { curl -sf -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" "$@"; }
+          mkdir -p openbank-admin-ui/test-run-history
+          MAX_ENVELOPES=100
+          # The workflow-runs endpoint is dominated by deploy-only Services CI runs, which
+          # produce no per-service envelope.  Even a 100-run scan can therefore find zero
+          # evidence while fresh immutable artifacts exist. Query the artifact inventory
+          # directly, retaining only non-expired main-branch envelopes. This is both faster
+          # and evidence-complete for the bounded latest-artifact window.
+          api "https://api.github.com/repos/${REPO}/actions/artifacts?per_page=100" \
+            | python3 -c "import json,sys; [print(a['id'],a['name']) for a in json.load(sys.stdin).get('artifacts',[]) if a['name'].startswith('test-intelligence-run-') and not a['expired'] and (a.get('workflow_run') or {}).get('head_branch') == 'main']" 2>/dev/null \
+            | while read -r artifact_id artifact_name; do
+                [ "$(find openbank-admin-ui/test-run-history -name '*.json' | wc -l | tr -d ' ')" -lt "$MAX_ENVELOPES" ] || break
+                [ -n "${artifact_id}" ] || continue
+                archive="/tmp/${artifact_name}.zip"
+                api "https://api.github.com/repos/${REPO}/actions/artifacts/${artifact_id}/zip" -L -o "${archive}" 2>/dev/null || continue
+                # actions/upload-artifact strips the uploaded directory prefix, so the
+                # immutable service envelope is normally `run.json` at the zip root.
+                # Keep accepting a nested path for compatibility with an artifact action
+                # layout change, but never require a source-tree path that is not retained.
+                envelope="$(unzip -Z1 "${archive}" | awk '$0 == "run.json" || /\/run\.json$/ { print; exit }' || true)"
+                [ -n "${envelope}" ] || continue
+                unzip -p "${archive}" "${envelope}" > "openbank-admin-ui/test-run-history/${artifact_name}.json"
+              done
+          echo "Staged $(find openbank-admin-ui/test-run-history -name '*.json' | wc -l | tr -d ' ') immutable run envelopes."
 
       - name: Stage pitest mutation results from latest weekly run
         # pitest.yml uploads one artifact per service: pitest-{service} (30-day retention).
@@ -401,6 +479,85 @@ jobs:
           COUNT=$(find . -path "*/build/reports/pitest/mutations.xml" | wc -l | tr -d ' ')
           echo "Staged ${COUNT} mutations.xml files from ${DOWNLOADED} artifacts."
 
+      - name: Stage performance evidence from latest successful k6 run
+        # The Test Intelligence collector reads k6 summaries only from the deployment-local
+        # perf-artifacts directory.  A declared scenario is deliberately not promoted to a
+        # result, so bring in only artifacts emitted by the latest successful main run of the
+        # governed performance workflows.  The money-path baseline may intentionally emit only
+        # a `not-run` envelope when no safe runner target exists; retain that provenance too.
+        # Missing or expired evidence remains `not-run` in the
+        # UI; this best-effort staging step must never turn absence into a deployment failure.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          api() { curl -sf -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" "$@"; }
+          mkdir -p openbank-admin-ui/perf-artifacts
+          RUN_ID=$(api \
+            "https://api.github.com/repos/${REPO}/actions/workflows/perf-gate.yml/runs?branch=main&status=success&per_page=1" \
+            | python3 -c "import json,sys; r=json.load(sys.stdin).get('workflow_runs',[]); print(r[0]['id'] if r else '')" \
+            2>/dev/null || true)
+          if [ -z "${RUN_ID}" ]; then
+            echo "No successful performance run found — performance evidence remains not-run."
+            exit 0
+          fi
+          ARTIFACTS=$(api \
+            "https://api.github.com/repos/${REPO}/actions/runs/${RUN_ID}/artifacts?per_page=100" \
+            | python3 -c "import json,sys; [print(a['id'],a['name']) for a in json.load(sys.stdin).get('artifacts',[]) if a['name'].startswith('perf-reports-') and not a['expired']]" \
+            2>/dev/null || true)
+          if [ -z "${ARTIFACTS}" ]; then
+            echo "No non-expired performance artifacts in run ${RUN_ID} — performance evidence remains not-run."
+            exit 0
+          fi
+          DOWNLOADED=0
+          while IFS=' ' read -r artifact_id artifact_name; do
+            [ -n "${artifact_id}" ] || continue
+            archive="/tmp/${artifact_name}.zip"
+            if api "https://api.github.com/repos/${REPO}/actions/artifacts/${artifact_id}/zip" -L -o "${archive}" 2>/dev/null; then
+              unzip -q "${archive}" -d openbank-admin-ui/perf-artifacts 2>/dev/null || true
+              DOWNLOADED=$((DOWNLOADED + 1))
+            fi
+          done <<< "${ARTIFACTS}"
+          COUNT=$(find openbank-admin-ui/perf-artifacts -name '*-summary.json' | wc -l | tr -d ' ')
+          echo "Staged ${COUNT} k6 summary file(s) from ${DOWNLOADED} performance artifact(s), run ${RUN_ID}."
+
+          BASELINE_RUN_ID=$(api \
+            "https://api.github.com/repos/${REPO}/actions/workflows/perf-baseline.yml/runs?branch=main&status=success&per_page=1" \
+            | python3 -c "import json,sys; r=json.load(sys.stdin).get('workflow_runs',[]); print(r[0]['id'] if r else '')" \
+            2>/dev/null || true)
+          if [ -z "${BASELINE_RUN_ID}" ]; then
+            echo "No successful money-path baseline run found — it remains declared but unmeasured."
+            exit 0
+          fi
+          BASELINE_ARTIFACT=$(api \
+            "https://api.github.com/repos/${REPO}/actions/runs/${BASELINE_RUN_ID}/artifacts?per_page=100" \
+            | python3 -c "import json,sys; a=[x for x in json.load(sys.stdin).get('artifacts',[]) if x['name']=='k6-money-path-summary' and not x['expired']]; print(a[0]['id'] if a else '')" \
+            2>/dev/null || true)
+          if [ -z "${BASELINE_ARTIFACT}" ]; then
+            echo "Money-path baseline ${BASELINE_RUN_ID} has no retained evidence artifact."
+            exit 0
+          fi
+          BASELINE_DIR="$(mktemp -d)"
+          if ! api "https://api.github.com/repos/${REPO}/actions/artifacts/${BASELINE_ARTIFACT}/zip" -L -o /tmp/k6-money-path-summary.zip \
+            || ! unzip -q /tmp/k6-money-path-summary.zip -d "${BASELINE_DIR}"; then
+            echo "::warning::Could not stage money-path baseline evidence from run ${BASELINE_RUN_ID}."
+            exit 0
+          fi
+          BASELINE_SUMMARY=$(find "${BASELINE_DIR}" -name 'perf-summary.json' -print -quit)
+          BASELINE_ENVELOPE=$(find "${BASELINE_DIR}" -name 'perf-run.json' -print -quit)
+          SUMMARY_STATUS=no
+          if [ -n "${BASELINE_SUMMARY}" ]; then
+            cp "${BASELINE_SUMMARY}" openbank-admin-ui/perf-artifacts/money-path-smoke-summary.json
+            SUMMARY_STATUS=yes
+          fi
+          ENVELOPE_STATUS=no
+          if [ -n "${BASELINE_ENVELOPE}" ]; then
+            cp "${BASELINE_ENVELOPE}" openbank-admin-ui/perf-artifacts/money-path-smoke-summary.json.run.json
+            ENVELOPE_STATUS=yes
+          fi
+          echo "Staged money-path baseline ${BASELINE_RUN_ID}: summary=${SUMMARY_STATUS} envelope=${ENVELOPE_STATUS}."
+
       - name: Collect production-readiness scorecard
         # Derives C1–C9 maturity scores from the repo and writes
         # openbank-admin-ui/prod-readiness.json so the Dockerfile bakes it into
@@ -434,9 +591,38 @@ jobs:
         with:
           version: v0.72.0
 
+      - name: Stage Test Intelligence deployment history
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -u
+          api() { curl -sf -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" "$@"; }
+          mkdir -p openbank-admin-ui/test-intelligence-history
+          # The repository-wide artifact list is newest-first and every services-ci run
+          # contributes two per changed service, so a single 100-item page never reaches a
+          # snapshot. The `name=` filter is exact-match and these names carry the run id, so
+          # it cannot be used either: paginate and filter on the prefix (#6614).
+          for page in 1 2 3 4 5; do
+            api "https://api.github.com/repos/${REPO}/actions/artifacts?per_page=100&page=${page}" \
+              | python3 -c "import json,sys; [print(x['id']) for x in json.load(sys.stdin).get('artifacts',[]) if x['name'].startswith('test-intelligence-snapshot-') and not x['expired']]" 2>/dev/null || true
+          done | head -30 \
+            | while read -r artifact_id; do
+                [ -n "${artifact_id}" ] || continue
+                api "https://api.github.com/repos/${REPO}/actions/artifacts/${artifact_id}/zip" -L -o "/tmp/test-intelligence-${artifact_id}.zip" 2>/dev/null || continue
+                unzip -joq "/tmp/test-intelligence-${artifact_id}.zip" '*.json' -d openbank-admin-ui/test-intelligence-history 2>/dev/null || true
+              done
+
       - name: Build, collect, push
         id: build
         env:
+          # The build script's quality collector reads these only to fetch the
+          # Pact Broker's per-Pact provider-verification verdict before the
+          # immutable Test Intelligence snapshot is baked. Docker receives no
+          # build arg for them, so they cannot enter the image or browser bundle.
+          PACT_BROKER_URL: ${{ vars.PACT_BROKER_URL }}
+          PACT_BROKER_USERNAME: ${{ vars.PACT_BROKER_USERNAME }}
+          PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
           # Optional: enables source-map upload to GlitchTip (#3235). Unset = no upload, normal
           # build — the maps are what turn a captured error into a file and a line.
           GLITCHTIP_AUTH_TOKEN: ${{ secrets.GLITCHTIP_AUTH_TOKEN }}
@@ -447,6 +633,12 @@ jobs:
           # skips ./gradlew sbomAll (too heavy for CI); SBOMs are staged from the
           # security workflow artifact in the preceding step instead.
           # --no-bump skips the sed+git step; the gitops PR job handles the bump.
+          # ECR tags are immutable. An operator-initiated or scheduled evidence
+          # refresh can intentionally rebuild the same commit after new artifacts
+          # arrive, so make that refresh unique while retaining commit provenance.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_run" ]; then
+            export ADMIN_UI_IMAGE_TAG_SUFFIX="run${GITHUB_RUN_ID}"
+          fi
           bash openbank-infra/scripts/build-push-admin-ui.sh --no-sbom --no-bump --no-login \
             2>&1 | tee /tmp/build-admin-ui.log
 
@@ -459,6 +651,14 @@ jobs:
           [ -n "${TAG}" ] || { echo "ERROR: could not extract pushed image tag"; exit 1; }
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "Pushed tag: ${TAG}"
+
+      - name: Retain immutable Test Intelligence snapshot
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-intelligence-snapshot-${{ github.run_id }}-${{ github.run_attempt }}
+          path: openbank-admin-ui/test-intelligence.json
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Rewrite GitOps image tag
         id: rewrite

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -295,13 +295,30 @@ jobs:
 
           mapfile -t SERVICES < <(node openbank-admin-ui/scripts/list-test-services.mjs --repo .)
 
+          # The artifacts endpoint returns at most 100 entries per page. Evidence
+          # artifacts are retained across many workflow runs, so a service's newest
+          # non-expired artifact can be beyond page one. Collect every page once,
+          # then select the newest match per service. This avoids both a blind
+          # first-page scan and one complete API walk for every service.
+          EVIDENCE_ARTIFACTS=""
+          page=1
+          while :; do
+            response="$(api "https://api.github.com/repos/${REPO}/actions/artifacts?per_page=100&page=${page}" 2>/dev/null || true)"
+            [ -n "${response}" ] || break
+            matches="$(printf '%s' "${response}" | python3 -c "import json,sys; a=json.load(sys.stdin).get('artifacts',[]); [print(x['id'], x['name'], x['created_at']) for x in a if not x['expired'] and x['name'].startswith('quality-evidence-')]" 2>/dev/null || true)"
+            [ -z "${matches}" ] || EVIDENCE_ARTIFACTS+="${matches}"$'\n'
+            page_count="$(printf '%s' "${response}" | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('artifacts',[])))" 2>/dev/null || true)"
+            case "${page_count}" in
+              ''|*[!0-9]*) break ;;
+            esac
+            [ "${page_count}" -lt 100 ] && break
+            page=$((page + 1))
+          done
+
           DOWNLOADED=0
           for svc in "${SERVICES[@]}"; do
             art_prefix="quality-evidence-${svc}-a"
-            ARTIFACT=$(api \
-              "https://api.github.com/repos/${REPO}/actions/artifacts?per_page=100" \
-              | python3 -c "import json,sys; p='${art_prefix}'; a=[x for x in json.load(sys.stdin).get('artifacts',[]) if not x['expired'] and x['name'].startswith(p)]; a.sort(key=lambda x:x['created_at'], reverse=True); print(str(a[0]['id'])+' '+a[0]['name'] if a else '')" \
-              2>/dev/null || true)
+            ARTIFACT="$(printf '%s' "${EVIDENCE_ARTIFACTS}" | python3 -c "import sys; p=sys.argv[1]; a=[line.split() for line in sys.stdin if line.split() and line.split()[1].startswith(p)]; a.sort(key=lambda x:x[2], reverse=True); print(' '.join(a[0][:2]) if a else '')" "${art_prefix}" 2>/dev/null || true)"
             if [ -z "${ARTIFACT}" ]; then
               echo "  ${svc}: no artifact (skip)"
               continue

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -35,18 +35,6 @@
 name: Admin-UI deploy
 
 on:
-  # CI evidence changes far more frequently than the Admin UI source. A successful
-  # main Services CI and CI immediately rebuild the read-only evidence projection; the
-  # daily run is its recovery path when GitHub suppresses or delays an event. Both
-  # use the same signed image and GitOps-PR path as source-triggered deploys.
-  workflow_run:
-    # Services CI produces fleet envelopes; CI produces the Admin UI envelope.  Subscribe
-    # to both: refreshing after Services CI alone can snapshot a stale Admin UI verdict
-    # before the same main commit's UI test artifact is available.
-    workflows: ["Services CI", "CI"]
-    types: [completed]
-  schedule:
-    - cron: '17 3 * * *'
   push:
     branches: [main]
     paths:
@@ -104,14 +92,7 @@ jobs:
     # scopes the deploy commit to the gitops manifest alone, so the loop can no longer form by
     # that route. This guard is kept as belt-and-braces: it costs nothing and still holds if a
     # future step writes into openbank-admin-ui/** again.
-    # `workflow_run` is trusted only after a successful Services CI on main.  It
-    # executes this default-branch workflow, never unreviewed PR YAML, and only
-    # refreshes a read-only projection from CI artifacts.  Keep the old push
-    # loop-breaker; workflow_run has no head_commit, hence the explicit fallback.
-    if: >-
-      (github.event_name != 'workflow_run' ||
-       (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')) &&
-      !startsWith(github.event.head_commit.message || '', 'chore(admin-ui): deploy')
+    if: "!startsWith(github.event.head_commit.message, 'chore(admin-ui): deploy')"
     # Native arm64 GitHub-hosted runner (free on public repos): the admin-ui image
     # is linux/arm64. ECR push + cosign use the same GitHub-OIDC role as before.
     runs-on: ubuntu-24.04-arm
@@ -131,9 +112,6 @@ jobs:
       # Mirrored into env because the `secrets` context is NOT available in a step-level `if:`
       # — only job-level env can read it. Used solely to decide whether to mint an App token.
       GITOPS_APP_ID: ${{ secrets.GITOPS_APP_ID }}
-      # Read-only token for the separate private customer-app repository. It is optional:
-      # missing scope/evidence renders an explicit blocked client row; it never blocks deploy.
-      APP_RO_TOKEN: ${{ secrets.OPENBANK_APP_RO_TOKEN }}
 
     outputs:
       tag: ${{ steps.build.outputs.tag }}
@@ -145,16 +123,6 @@ jobs:
           fetch-depth: 0
           # persist-credentials: true (default) — needed so git in the collectors
           # can read the repo; the gitops step uses a separate checkout.
-
-      - name: Checkout mobile RUM capability metadata
-        if: env.APP_RO_TOKEN != ''
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: JiRaska/openbank-app
-          token: ${{ secrets.OPENBANK_APP_RO_TOKEN }}
-          path: .app-src
-          persist-credentials: false
-          fetch-depth: 1
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -305,7 +273,7 @@ jobs:
           done
           echo "SBOM staging complete."
 
-      - name: Stage Test Intelligence evidence (per-service latest artifact)
+      - name: Stage JUnit test results (per-service latest artifact)
         # services-ci.yml uploads one artifact per service: test-reports-{service}
         # (7-day retention). The old approach (download from ONE run) fails with
         # path-scoped CI: only recently-changed services have artifacts in any single
@@ -325,31 +293,26 @@ jobs:
           api() { curl -sf -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" "$@"; }
 
-          mapfile -t SERVICES < <(find . -mindepth 2 -maxdepth 2 -name version.txt -printf '%h\n' \
-            | sed 's#^./##' | sort)
+          mapfile -t SERVICES < <(node openbank-admin-ui/scripts/list-test-services.mjs --repo .)
 
           DOWNLOADED=0
           for svc in "${SERVICES[@]}"; do
-            art_name="test-intelligence-${svc}"
+            art_prefix="quality-evidence-${svc}-a"
             ARTIFACT=$(api \
-              "https://api.github.com/repos/${REPO}/actions/artifacts?name=${art_name}&per_page=1" \
-              | python3 -c "import json,sys; a=[x for x in json.load(sys.stdin).get('artifacts',[]) if not x['expired']]; print(str(a[0]['id'])+' '+a[0]['name'] if a else '')" \
+              "https://api.github.com/repos/${REPO}/actions/artifacts?per_page=100" \
+              | python3 -c "import json,sys; p='${art_prefix}'; a=[x for x in json.load(sys.stdin).get('artifacts',[]) if not x['expired'] and x['name'].startswith(p)]; a.sort(key=lambda x:x['created_at'], reverse=True); print(str(a[0]['id'])+' '+a[0]['name'] if a else '')" \
               2>/dev/null || true)
             if [ -z "${ARTIFACT}" ]; then
               echo "  ${svc}: no artifact (skip)"
               continue
             fi
             art_id="${ARTIFACT%% *}"
+            art_name="${ARTIFACT#* }"
             if api "https://api.github.com/repos/${REPO}/actions/artifacts/${art_id}/zip" \
                 -L -o "/tmp/${art_name}.zip" 2>/dev/null; then
               TMPDIR_ART="/tmp/${art_name}-extracted"
               rm -rf "${TMPDIR_ART}" && mkdir -p "${TMPDIR_ART}"
               unzip -q "/tmp/${art_name}.zip" -d "${TMPDIR_ART}" 2>/dev/null || true
-              RUN_JSON="$(find "${TMPDIR_ART}" -path '*/test-intelligence/run.json' -print -quit)"
-              if [ -n "${RUN_JSON}" ]; then
-                mkdir -p "${svc}/build/test-intelligence"
-                cp "${RUN_JSON}" "${svc}/build/test-intelligence/run.json"
-              fi
               # Inside the zip: test-results/*/TEST-*.xml (actions/upload-artifact@v7 strips
               # the leading service/build/ prefix). Reconstruct the full target path.
               find "${TMPDIR_ART}" -path "*/test-results/*/TEST-*.xml" | while read -r xml; do
@@ -358,10 +321,11 @@ jobs:
                 mkdir -p "$(dirname "${target}")"
                 cp "${xml}" "${target}"
               done
-              find "${TMPDIR_ART}" -path '*/reports/kover/report.xml' | while read -r xml; do
+              kover=$(find "${TMPDIR_ART}" -path "*/reports/kover/report.xml" -o -path "*/kover/report.xml" | head -1)
+              if [ -n "${kover}" ]; then
                 mkdir -p "${svc}/build/reports/kover"
-                cp "${xml}" "${svc}/build/reports/kover/report.xml"
-              done
+                cp "${kover}" "${svc}/build/reports/kover/report.xml"
+              fi
               DOWNLOADED=$((DOWNLOADED + 1))
               echo "  ${svc}: staged"
             else
@@ -369,62 +333,7 @@ jobs:
             fi
           done
           COUNT=$(find . -path "*/build/test-results/*/TEST-*.xml" | wc -l | tr -d ' ')
-          RUN_COUNT=$(find . -path "*/build/test-intelligence/run.json" | wc -l | tr -d ' ')
-          echo "Staged ${RUN_COUNT} run envelopes and ${COUNT} JUnit XML files from ${DOWNLOADED}/${#SERVICES[@]} services."
-
-      - name: Stage customer-app Test Intelligence evidence
-        # Cross-repository evidence is read-only and best-effort. The compact JSON artifact
-        # contains counts and provenance only; it never imports private source or test output.
-        if: env.APP_RO_TOKEN != ''
-        env:
-          GH_TOKEN: ${{ secrets.OPENBANK_APP_RO_TOKEN }}
-          APP_REPO: JiRaska/openbank-app
-        run: |
-          set -u
-          api() { curl -sf -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" "$@"; }
-          mkdir -p openbank-admin-ui/client-test-evidence
-          # Only reviewed default-branch evidence may enter a deployed control plane. A newer
-          # PR artifact remains visible in GitHub but cannot replace the sandbox verdict.
-          ARTIFACTS="$(api "https://api.github.com/repos/${APP_REPO}/actions/artifacts?per_page=100" \
-            | python3 -c "import json,sys; a=[x for x in json.load(sys.stdin).get('artifacts',[]) if x['name'].startswith('openbank-app-test-intelligence-') and not x['expired'] and (x.get('workflow_run') or {}).get('head_branch') == 'main']; a.sort(key=lambda x:x['created_at'], reverse=True); [print(x['id']) for x in a[:20]]" 2>/dev/null || true)"
-          while read -r artifact_id; do
-            [ -n "${artifact_id}" ] || continue
-            archive="/tmp/openbank-app-test-intelligence-${artifact_id}.zip"
-            api "https://api.github.com/repos/${APP_REPO}/actions/artifacts/${artifact_id}/zip" -L -o "${archive}" 2>/dev/null || continue
-            evidence="$(unzip -Z1 "${archive}" | awk '/\.json$/{print; exit}')"
-            [ -n "${evidence}" ] || continue
-            # Every producer artifact contains `openbank-app-unit.json`. Preserve a unique
-            # deployment-local name or older downloads overwrite the newest observation.
-            unzip -p "${archive}" "${evidence}" > "openbank-admin-ui/client-test-evidence/openbank-app-${artifact_id}.json"
-          done <<< "${ARTIFACTS}"
-          echo "Staged $(find openbank-admin-ui/client-test-evidence -name '*.json' | wc -l | tr -d ' ') mobile client evidence artifact(s)."
-
-      - name: Stage immutable per-attempt Test Intelligence history
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -u
-          api() { curl -sf -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" "$@"; }
-          mkdir -p openbank-admin-ui/test-run-history
-          MAX_ENVELOPES=100
-          # The workflow-runs endpoint is dominated by deploy-only Services CI runs, which
-          # produce no per-service envelope.  Even a 100-run scan can therefore find zero
-          # evidence while fresh immutable artifacts exist. Query the artifact inventory
-          # directly, retaining only non-expired main-branch envelopes. This is both faster
-          # and evidence-complete for the bounded latest-artifact window.
-          api "https://api.github.com/repos/${REPO}/actions/artifacts?per_page=100" \
-            | python3 -c "import json,sys; [print(a['id'],a['name']) for a in json.load(sys.stdin).get('artifacts',[]) if a['name'].startswith('test-intelligence-run-') and not a['expired'] and (a.get('workflow_run') or {}).get('head_branch') == 'main']" 2>/dev/null \
-            | while read -r artifact_id artifact_name; do
-                [ "$(find openbank-admin-ui/test-run-history -name '*.json' | wc -l | tr -d ' ')" -lt "$MAX_ENVELOPES" ] || break
-                [ -n "${artifact_id}" ] || continue
-                archive="/tmp/${artifact_name}.zip"
-                api "https://api.github.com/repos/${REPO}/actions/artifacts/${artifact_id}/zip" -L -o "${archive}" 2>/dev/null || continue
-                envelope="$(unzip -Z1 "${archive}" | grep 'test-intelligence/run.json$' | head -1 || true)"
-                [ -n "${envelope}" ] || continue
-                unzip -p "${archive}" "${envelope}" > "openbank-admin-ui/test-run-history/${artifact_name}.json"
-              done
-          echo "Staged $(find openbank-admin-ui/test-run-history -name '*.json' | wc -l | tr -d ' ') immutable run envelopes."
+          echo "Staged ${COUNT} JUnit XML files from ${DOWNLOADED}/${#SERVICES[@]} services."
 
       - name: Stage pitest mutation results from latest weekly run
         # pitest.yml uploads one artifact per service: pitest-{service} (30-day retention).
@@ -475,85 +384,6 @@ jobs:
           COUNT=$(find . -path "*/build/reports/pitest/mutations.xml" | wc -l | tr -d ' ')
           echo "Staged ${COUNT} mutations.xml files from ${DOWNLOADED} artifacts."
 
-      - name: Stage performance evidence from latest successful k6 run
-        # The Test Intelligence collector reads k6 summaries only from the deployment-local
-        # perf-artifacts directory.  A declared scenario is deliberately not promoted to a
-        # result, so bring in only artifacts emitted by the latest successful main run of the
-        # governed performance workflows.  The money-path baseline may intentionally emit only
-        # a `not-run` envelope when no safe runner target exists; retain that provenance too.
-        # Missing or expired evidence remains `not-run` in the
-        # UI; this best-effort staging step must never turn absence into a deployment failure.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-        run: |
-          api() { curl -sf -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" "$@"; }
-          mkdir -p openbank-admin-ui/perf-artifacts
-          RUN_ID=$(api \
-            "https://api.github.com/repos/${REPO}/actions/workflows/perf-gate.yml/runs?branch=main&status=success&per_page=1" \
-            | python3 -c "import json,sys; r=json.load(sys.stdin).get('workflow_runs',[]); print(r[0]['id'] if r else '')" \
-            2>/dev/null || true)
-          if [ -z "${RUN_ID}" ]; then
-            echo "No successful performance run found — performance evidence remains not-run."
-            exit 0
-          fi
-          ARTIFACTS=$(api \
-            "https://api.github.com/repos/${REPO}/actions/runs/${RUN_ID}/artifacts?per_page=100" \
-            | python3 -c "import json,sys; [print(a['id'],a['name']) for a in json.load(sys.stdin).get('artifacts',[]) if a['name'].startswith('perf-reports-') and not a['expired']]" \
-            2>/dev/null || true)
-          if [ -z "${ARTIFACTS}" ]; then
-            echo "No non-expired performance artifacts in run ${RUN_ID} — performance evidence remains not-run."
-            exit 0
-          fi
-          DOWNLOADED=0
-          while IFS=' ' read -r artifact_id artifact_name; do
-            [ -n "${artifact_id}" ] || continue
-            archive="/tmp/${artifact_name}.zip"
-            if api "https://api.github.com/repos/${REPO}/actions/artifacts/${artifact_id}/zip" -L -o "${archive}" 2>/dev/null; then
-              unzip -q "${archive}" -d openbank-admin-ui/perf-artifacts 2>/dev/null || true
-              DOWNLOADED=$((DOWNLOADED + 1))
-            fi
-          done <<< "${ARTIFACTS}"
-          COUNT=$(find openbank-admin-ui/perf-artifacts -name '*-summary.json' | wc -l | tr -d ' ')
-          echo "Staged ${COUNT} k6 summary file(s) from ${DOWNLOADED} performance artifact(s), run ${RUN_ID}."
-
-          BASELINE_RUN_ID=$(api \
-            "https://api.github.com/repos/${REPO}/actions/workflows/perf-baseline.yml/runs?branch=main&status=success&per_page=1" \
-            | python3 -c "import json,sys; r=json.load(sys.stdin).get('workflow_runs',[]); print(r[0]['id'] if r else '')" \
-            2>/dev/null || true)
-          if [ -z "${BASELINE_RUN_ID}" ]; then
-            echo "No successful money-path baseline run found — it remains declared but unmeasured."
-            exit 0
-          fi
-          BASELINE_ARTIFACT=$(api \
-            "https://api.github.com/repos/${REPO}/actions/runs/${BASELINE_RUN_ID}/artifacts?per_page=100" \
-            | python3 -c "import json,sys; a=[x for x in json.load(sys.stdin).get('artifacts',[]) if x['name']=='k6-money-path-summary' and not x['expired']]; print(a[0]['id'] if a else '')" \
-            2>/dev/null || true)
-          if [ -z "${BASELINE_ARTIFACT}" ]; then
-            echo "Money-path baseline ${BASELINE_RUN_ID} has no retained evidence artifact."
-            exit 0
-          fi
-          BASELINE_DIR="$(mktemp -d)"
-          if ! api "https://api.github.com/repos/${REPO}/actions/artifacts/${BASELINE_ARTIFACT}/zip" -L -o /tmp/k6-money-path-summary.zip \
-            || ! unzip -q /tmp/k6-money-path-summary.zip -d "${BASELINE_DIR}"; then
-            echo "::warning::Could not stage money-path baseline evidence from run ${BASELINE_RUN_ID}."
-            exit 0
-          fi
-          BASELINE_SUMMARY=$(find "${BASELINE_DIR}" -name 'perf-summary.json' -print -quit)
-          BASELINE_ENVELOPE=$(find "${BASELINE_DIR}" -name 'perf-run.json' -print -quit)
-          SUMMARY_STATUS=no
-          if [ -n "${BASELINE_SUMMARY}" ]; then
-            cp "${BASELINE_SUMMARY}" openbank-admin-ui/perf-artifacts/money-path-smoke-summary.json
-            SUMMARY_STATUS=yes
-          fi
-          ENVELOPE_STATUS=no
-          if [ -n "${BASELINE_ENVELOPE}" ]; then
-            cp "${BASELINE_ENVELOPE}" openbank-admin-ui/perf-artifacts/money-path-smoke-summary.json.run.json
-            ENVELOPE_STATUS=yes
-          fi
-          echo "Staged money-path baseline ${BASELINE_RUN_ID}: summary=${SUMMARY_STATUS} envelope=${ENVELOPE_STATUS}."
-
       - name: Collect production-readiness scorecard
         # Derives C1–C9 maturity scores from the repo and writes
         # openbank-admin-ui/prod-readiness.json so the Dockerfile bakes it into
@@ -587,38 +417,9 @@ jobs:
         with:
           version: v0.72.0
 
-      - name: Stage Test Intelligence deployment history
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -u
-          api() { curl -sf -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" "$@"; }
-          mkdir -p openbank-admin-ui/test-intelligence-history
-          # The repository-wide artifact list is newest-first and every services-ci run
-          # contributes two per changed service, so a single 100-item page never reaches a
-          # snapshot. The `name=` filter is exact-match and these names carry the run id, so
-          # it cannot be used either: paginate and filter on the prefix (#6614).
-          for page in 1 2 3 4 5; do
-            api "https://api.github.com/repos/${REPO}/actions/artifacts?per_page=100&page=${page}" \
-              | python3 -c "import json,sys; [print(x['id']) for x in json.load(sys.stdin).get('artifacts',[]) if x['name'].startswith('test-intelligence-snapshot-') and not x['expired']]" 2>/dev/null || true
-          done | head -30 \
-            | while read -r artifact_id; do
-                [ -n "${artifact_id}" ] || continue
-                api "https://api.github.com/repos/${REPO}/actions/artifacts/${artifact_id}/zip" -L -o "/tmp/test-intelligence-${artifact_id}.zip" 2>/dev/null || continue
-                unzip -joq "/tmp/test-intelligence-${artifact_id}.zip" '*.json' -d openbank-admin-ui/test-intelligence-history 2>/dev/null || true
-              done
-
       - name: Build, collect, push
         id: build
         env:
-          # The build script's quality collector reads these only to fetch the
-          # Pact Broker's per-Pact provider-verification verdict before the
-          # immutable Test Intelligence snapshot is baked. Docker receives no
-          # build arg for them, so they cannot enter the image or browser bundle.
-          PACT_BROKER_URL: ${{ vars.PACT_BROKER_URL }}
-          PACT_BROKER_USERNAME: ${{ vars.PACT_BROKER_USERNAME }}
-          PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
           # Optional: enables source-map upload to GlitchTip (#3235). Unset = no upload, normal
           # build — the maps are what turn a captured error into a file and a line.
           GLITCHTIP_AUTH_TOKEN: ${{ secrets.GLITCHTIP_AUTH_TOKEN }}
@@ -629,12 +430,6 @@ jobs:
           # skips ./gradlew sbomAll (too heavy for CI); SBOMs are staged from the
           # security workflow artifact in the preceding step instead.
           # --no-bump skips the sed+git step; the gitops PR job handles the bump.
-          # ECR tags are immutable. An operator-initiated or scheduled evidence
-          # refresh can intentionally rebuild the same commit after new artifacts
-          # arrive, so make that refresh unique while retaining commit provenance.
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_run" ]; then
-            export ADMIN_UI_IMAGE_TAG_SUFFIX="run${GITHUB_RUN_ID}"
-          fi
           bash openbank-infra/scripts/build-push-admin-ui.sh --no-sbom --no-bump --no-login \
             2>&1 | tee /tmp/build-admin-ui.log
 
@@ -647,14 +442,6 @@ jobs:
           [ -n "${TAG}" ] || { echo "ERROR: could not extract pushed image tag"; exit 1; }
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "Pushed tag: ${TAG}"
-
-      - name: Retain immutable Test Intelligence snapshot
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: test-intelligence-snapshot-${{ github.run_id }}-${{ github.run_attempt }}
-          path: openbank-admin-ui/test-intelligence.json
-          if-no-files-found: error
-          retention-days: 30
 
       - name: Rewrite GitOps image tag
         id: rewrite

--- a/docs/threat-models/openbank-lending-service.md
+++ b/docs/threat-models/openbank-lending-service.md
@@ -555,3 +555,11 @@ comes only from `X-Customer-Party-Id`.
   Default OFF (`lending.intake.enabled=false`) and refuses everything while
   `lending.intake.caller-principal` is unset. No DB schema change; maker leg only, so the four-eyes
   disbursement control is untouched; rollback = revert the commit or leave the flag false.
+- **2026-08-20** — Compliance-pack operator detail. The existing authenticated
+  compliance-pack read endpoints now return the exact stored pack together with proposal/decision
+  audit metadata so the admin console can inspect what was activated instead of showing only a
+  hash. Authorization is unchanged (`ROLE_COMPLIANCE`/`ROLE_ADMIN` on the existing resource), no
+  new endpoint, trust boundary, persistence, or write path is introduced, and the response contains
+  the already-stored jurisdiction/product rule document rather than credentials or deployment
+  configuration. Integration tests cover both pending and active projections. Rollback: revert the
+  response projection and additive OpenAPI schema fields.

--- a/openbank-admin-ui/e2e/operator-cockpit.spec.ts
+++ b/openbank-admin-ui/e2e/operator-cockpit.spec.ts
@@ -61,12 +61,18 @@ test('Customer 360 joins authoritative portfolio and documents to the name-selec
 })
 
 test('Test Coverage is backed by a dated CI evidence snapshot, not a static score', async ({ page }) => {
-  await json(page, '**/api/test-results', { collectedAt: '2026-08-22T08:00:00Z', totals: { tests: 10, passed: 9, failed: 1, skipped: 0, services: 2, servicesWithTests: 1, unit: { tests: 8, passed: 7, failed: 1 }, integration: { tests: 2, passed: 2, failed: 0 } }, services: [{ service: 'openbank-ledger-service', tests: 10, passed: 9, failed: 1, skipped: 0, errors: 0, durationMs: 250, lastRunAt: '2026-08-22T08:00:00Z', testFiles: 2, unit: { tests: 8, passed: 7, failed: 1 }, integration: { tests: 2, passed: 2, failed: 0 } }, { service: 'openbank-account-service', tests: 0, passed: 0, failed: 0, skipped: 0, errors: 0, durationMs: 0, lastRunAt: null, testFiles: 0, unit: { tests: 0, passed: 0, failed: 0 }, integration: { tests: 0, passed: 0, failed: 0 } }] })
-  await json(page, '**/api/quality-report', { contracts: [], mutations: [], serviceScores: [] })
+  await json(page, '**/api/test-intelligence', {
+    schemaVersion: 1, collectedAt: '2026-08-22T08:00:00Z', contracts: [], mutations: [], performance: [], syntheticJourneys: [], clientExperiences: [], history: [], runHistory: [], testCases: [], warnings: [],
+    totals: { components: 2, componentsWithExecutionEvidence: 1, moneyPathComponents: 1, failingEvidence: 1, missingEvidence: 1, staleEvidence: 0 },
+    components: [
+      { component: 'ledger-service', released: true, moneyPath: true, evidence: [{ kind: 'unit', state: 'failed', observedAt: '2026-08-22T08:00:00Z', source: 'Services CI', environment: 'ci', counts: { discovered: 10, executed: 10, passed: 9, failed: 1, skipped: 0, errors: 0 } }], coverage: { state: 'passed', observedAt: '2026-08-22T08:00:00Z', lines: { covered: 90, missed: 10, percentage: 90 }, branches: { covered: 0, missed: 0, percentage: null }, source: 'Kover' }, testInfrastructure: { declared: [], observed: [] } },
+      { component: 'account-service', released: true, moneyPath: false, evidence: [], coverage: { state: 'not-run', observedAt: null, lines: { covered: 0, missed: 0, percentage: null }, branches: { covered: 0, missed: 0, percentage: null }, source: null }, testInfrastructure: { declared: [], observed: [] } },
+    ],
+  })
 
   await page.goto('/system/tests')
-  await expect(page.getByText(/CI snapshot vytvořen|CI snapshot collected/)).toBeVisible()
-  await expect(page.getByText(/0 znamená, že pro službu nebyl|0 means no artifact/)).toBeVisible()
+  await expect(page.getByText(/sesbíráno|collected/)).toBeVisible()
+  await expect(page.getByText(/absence se nikdy nevykresluje jako nula|absence is never rendered as zero/)).toBeVisible()
   await expect(page.getByText('ledger-service')).toBeVisible()
   await expect(page.getByText('account-service')).toBeVisible()
 })

--- a/openbank-admin-ui/e2e/operator-cockpit.spec.ts
+++ b/openbank-admin-ui/e2e/operator-cockpit.spec.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+// Browser coverage for the operator cockpit added in #5905.  The calls below are
+// deliberately intercepted at the browser/BFF boundary: each assertion proves a
+// real page, its client-side state transitions and its rendered operator copy,
+// without pretending a local Playwright run is a regulator, Tempo or Temporal.
+
+import { test, expect, type Page } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const PARTY_ID = '05a02ef1-381c-40e7-b73f-d6855eead42e'
+const TRACE_ID = '0123456789abcdef0123456789abcdef'
+
+const json = (page: Page, pattern: string | RegExp, body: unknown, status = 200) =>
+  page.route(pattern, route => route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) }))
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('KYC resolves a customer name before loading that customer’s cases', async ({ page }) => {
+  const seen: string[] = []
+  await page.route('**/api/svc/party-service/api/v1/parties/search**', route => {
+    seen.push(route.request().url())
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: [{ id: PARTY_ID, legalName: 'Anna Nováková', status: 'ACTIVE', kycStatus: 'VERIFIED' }] }) })
+  })
+  await page.route('**/api/svc/kyc-service/api/v1/kyc/cases**', route => {
+    seen.push(route.request().url())
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([{
+      id: 'case-anna-1', partyId: PARTY_ID, status: 'OPEN', reviewedBy: 'reviewer@openbank.test',
+      updatedAt: '2026-08-22T08:00:00Z', checks: [{ checkType: 'IDENTITY', status: 'APPROVED' }],
+    }]) })
+  })
+
+  await page.goto('/kyc')
+  await page.getByRole('textbox', { name: /Vyhledat stranu|Search parties/ }).fill('Anna Nováková')
+  await page.getByRole('button', { name: /Vyhledat|Search/ }).first().click()
+  await page.getByRole('button', { name: /Vybrat|Select/ }).click()
+
+  await expect(page.getByText('case-ann')).toBeVisible()
+  expect(seen.some(url => url.includes('/parties/search?q=Anna'))).toBe(true)
+  expect(seen.some(url => url.includes(`/cases/party/${PARTY_ID}`))).toBe(true)
+})
+
+test('Customer 360 joins authoritative portfolio and documents to the name-selected party', async ({ page }) => {
+  await json(page, '**/api/svc/party-service/api/v1/parties/search**', { data: [{ id: PARTY_ID, legalName: 'Anna Nováková', status: 'ACTIVE', kycStatus: 'VERIFIED' }] })
+  await json(page, `**/api/customer-360/${PARTY_ID}`, { available: true, partyId: PARTY_ID, asOf: '2026-08-22 08:00:00', partyState: {}, accountIds: ['account-1'], domains: [{ aggregateType: 'party', events: 2, lastEventType: 'PARTY_UPDATED', lastOccurredAt: '2026-08-22 08:00:00' }], consents: [] })
+  await json(page, '**/api/svc/account-service/api/v1/accounts**', [{ id: 'account-1', status: 'ACTIVE' }])
+  await json(page, '**/api/svc/lending-service/api/v1/lending/applications**', [{ id: 'loan-1', status: 'APPROVED' }])
+  await json(page, '**/api/svc/aml-service/api/v1/aml/cases**', [{ id: 'aml-1', status: 'OPEN' }])
+  await json(page, '**/api/svc/document-service/api/v1/documents?**', [{ id: 'doc-1', templateCode: 'KYC_CONTRACT', templateVersion: '1', contentType: 'application/pdf', sizeBytes: 1024, status: 'READY', caseRef: 'case-anna-1', productRef: null, retainUntil: '2031-01-01', createdAt: '2026-08-22T08:00:00Z' }])
+
+  await page.goto('/customer-360')
+  await page.getByRole('textbox', { name: /Vyhledat stranu|Search parties/ }).fill('Anna Nováková')
+  await page.getByRole('button', { name: /Vyhledat|Search/ }).click()
+  await page.getByRole('button', { name: /Vybrat|Select/ }).click()
+  await expect(page.getByText(/Autoritativní portfolio a riziko|Authoritative portfolio and risk/)).toBeVisible()
+  await expect(page.getByText(/Dokumenty klienta|Customer documents/)).toBeVisible()
+  await expect(page.getByText('KYC_CONTRACT')).toBeVisible()
+})
+
+test('Test Coverage is backed by a dated CI evidence snapshot, not a static score', async ({ page }) => {
+  await json(page, '**/api/test-results', { collectedAt: '2026-08-22T08:00:00Z', totals: { tests: 10, passed: 9, failed: 1, skipped: 0, services: 2, servicesWithTests: 1, unit: { tests: 8, passed: 7, failed: 1 }, integration: { tests: 2, passed: 2, failed: 0 } }, services: [{ service: 'openbank-ledger-service', tests: 10, passed: 9, failed: 1, skipped: 0, errors: 0, durationMs: 250, lastRunAt: '2026-08-22T08:00:00Z', testFiles: 2, unit: { tests: 8, passed: 7, failed: 1 }, integration: { tests: 2, passed: 2, failed: 0 } }, { service: 'openbank-account-service', tests: 0, passed: 0, failed: 0, skipped: 0, errors: 0, durationMs: 0, lastRunAt: null, testFiles: 0, unit: { tests: 0, passed: 0, failed: 0 }, integration: { tests: 0, passed: 0, failed: 0 } }] })
+  await json(page, '**/api/quality-report', { contracts: [], mutations: [], serviceScores: [] })
+
+  await page.goto('/system/tests')
+  await expect(page.getByText(/CI snapshot vytvořen|CI snapshot collected/)).toBeVisible()
+  await expect(page.getByText(/0 znamená, že pro službu nebyl|0 means no artifact/)).toBeVisible()
+  await expect(page.getByText('ledger-service')).toBeVisible()
+  await expect(page.getByText('account-service')).toBeVisible()
+})
+
+test('Trace Explorer renders an OTLP waterfall after selecting a trace', async ({ page }) => {
+  await json(page, '**/api/tempo/api/search**', { traces: [{ traceID: TRACE_ID, rootServiceName: 'ledger-service', rootTraceName: 'POST /entries', durationMs: 1.5 }] })
+  await json(page, `**/api/tempo/api/traces/${TRACE_ID}`, { batches: [{
+    resource: { attributes: [{ key: 'service.name', value: { stringValue: 'ledger-service' } }] },
+    scopeSpans: [{ spans: [{ spanId: 'root-span', name: 'POST /entries', startTimeUnixNano: '1000000', endTimeUnixNano: '2500000' }] }],
+  }] })
+
+  await page.goto('/observability/traces')
+  await page.getByRole('button', { name: /ledger-service.*POST \/entries/ }).click()
+  await expect(page.getByText(/1 spanů|1 spans/)).toBeVisible()
+  await expect(page.getByText('POST /entries').last()).toBeVisible()
+})
+
+test('compliance pack detail exposes exact reviewed content, not a summary only', async ({ page }) => {
+  const pack = {
+    id: 'pack-1', jurisdiction: 'CZ', productType: 'CONSUMER_CREDIT', packVersion: 1,
+    effectiveFrom: '2026-08-01', contentHash: 'a'.repeat(64), state: 'EXECUTED', proposedBy: 'maker@openbank.test',
+    proposedAt: '2026-08-01T08:00:00Z', decidedBy: 'checker@openbank.test', decidedAt: '2026-08-01T09:00:00Z', decisionReason: 'reviewed',
+    pack: { jurisdiction: 'CZ', productType: 'CONSUMER_CREDIT', version: 1, coolingOffDays: 14 },
+  }
+  await json(page, '**/api/svc/lending-service/api/v1/lending/compliance-packs/active', [pack])
+  await json(page, '**/api/svc/lending-service/api/v1/lending/compliance-packs/proposals/pending', [])
+
+  await page.goto('/lending/compliance-packs')
+  await page.getByText('CONSUMER_CREDIT').click()
+  await expect(page.getByText(/Přesný obsah packu|Exact pack content/)).toBeVisible()
+  await expect(page.getByText('"coolingOffDays": 14')).toBeVisible()
+  await expect(page.getByText('checker@openbank.test')).toBeVisible()
+})
+
+test('regulatory preview blocks fiction: it shows real FINREP cells and no submission claim', async ({ page }) => {
+  await page.route('**/api/svc/finrep-service/api/v1/finrep/templates/**', route => {
+    const path = new URL(route.request().url()).pathname
+    const body = path.includes('F01.01')
+      ? { templateId: 'F01.01', period: '2026-06-30', isBalanced: true, cells: [{ rowRef: 'r010', colRef: 'c010', value: 1250.5, currency: 'CZK' }] }
+      : { templateId: 'F02.00', period: '2026-06-30', isBalanced: true, cells: [{ rowRef: 'r450', colRef: 'c010', value: 42, currency: 'CZK' }] }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) })
+  })
+
+  await page.goto('/regulatory')
+  const finrep = page.locator('.card').filter({ hasText: 'CNB — Finanční výkazy (FINREP)' })
+  await finrep.getByRole('button', { name: /Náhled exportu|Preview export/ }).click()
+  await expect(page.getByText('Celková aktiva')).toBeVisible()
+  await expect(page.getByTestId('export-readiness')).toContainText(/Připraveno pro interní export|Ready for internal export/)
+  await expect(page.getByText(/ČNB XBRL\/SDAT přenos nejsou součástí tohoto náhledu|ČNB XBRL\/SDAT transmission are not part of this preview/)).toBeVisible()
+})
+
+test('Temporal and approvals show live source-backed operator state and human provenance', async ({ page }) => {
+  await json(page, '**/api/temporal/status', {
+    available: true, temporalDeployed: true,
+    metrics: { workflows: { scheduled1h: 12, completed1h: 11, failed1h: 1, timedOut1h: 0 }, latency: { activityScheduleToStartMs: 20, workflowTaskScheduleToStartMs: 10, serverRequestP99Ms: 30 }, persistence: { requestsPerSec: 4 }, workers: { totalSlotsAvailable: 8, slotsUsed: 2 }, namespaces: ['openbank'] },
+  })
+  await page.goto('/temporal')
+  await expect(page.getByText(/Provozní|Running/)).toBeVisible()
+  await page.getByRole('button', { name: /Metriky|Metrics/ }).click()
+  await expect(page.getByRole('heading', { name: /Workflowy \(posledních 60 minut\)|Workflows \(last 60 minutes\)/ })).toBeVisible()
+  await expect(page.getByText('12')).toBeVisible()
+
+  await json(page, '**/api/agent/proposals?state=all', [{
+    id: 'proposal-human', title: 'Human customer correction', rationale: 'verified with customer', suggestedAction: 'party.correct',
+    proposedBy: 'alice@openbank.test', proposedAt: '2026-08-22T08:00:00Z', state: 'PROPOSED', decidedBy: null, decidedAt: null, decisionReason: null, modelId: null,
+    agent: { id: 'alice@openbank.test', displayName: 'Alice Nováková', icon: 'user', charterKnown: false },
+  }])
+  await json(page, '**/api/approvals/pending', { items: [], sources: {} })
+  await json(page, '**/api/governance/agent-identities', { available: true, agents: [] })
+  await page.goto('/approvals')
+  await expect(page.getByText('Alice Nováková')).toBeVisible()
+  await expect(page.getByText('Human customer correction')).toBeVisible()
+  await expect(page.getByText(/Tento návrh vytvořila AI|This proposal was generated by AI/)).toHaveCount(0)
+})

--- a/openbank-admin-ui/scripts/collect-quality-report.mjs
+++ b/openbank-admin-ui/scripts/collect-quality-report.mjs
@@ -9,27 +9,26 @@
 import fs from 'fs'
 import path from 'path'
 import { parseStringPromise } from 'xml2js'
+import { moneyPathServices } from './lib/service-inventory.mjs'
 
 const args = process.argv.slice(2)
 const repoRootIdx = args.indexOf('--repo-root')
 const REPO_ROOT = repoRootIdx >= 0 ? path.resolve(args[repoRootIdx + 1]) : path.resolve('..')
 const OUT = path.resolve('quality-report.json')
 
-const MONEY_PATH_SERVICES = [
-  'openbank-ledger-service',
-  'openbank-transaction-service',
-  'openbank-account-service',
-  'openbank-balance-service',
-  'openbank-sepa-payment',
-  'openbank-sepa-instant',
-  'openbank-domestic-payment',
-  'openbank-clearing-service',
-  'openbank-swift-service',
-  'openbank-fx-service',
-  'openbank-lending-service',
-  'openbank-sca-service',
-  'openbank-consent-service',
-]
+const MONEY_PATH_SERVICES = moneyPathServices(REPO_ROOT)
+
+function collectCoverage(service) {
+  const xmlPath = path.join(REPO_ROOT, service, 'build', 'reports', 'kover', 'report.xml')
+  if (!fs.existsSync(xmlPath)) return null
+  const xml = fs.readFileSync(xmlPath, 'utf8')
+  const counters = [...xml.matchAll(/<counter\s+type="LINE"\s+missed="(\d+)"\s+covered="(\d+)"\s*\/>/g)]
+  const total = counters.at(-1)
+  if (!total) return null
+  const missed = Number(total[1])
+  const covered = Number(total[2])
+  return missed + covered > 0 ? Math.round((covered / (missed + covered)) * 100) : null
+}
 
 // ── Pitest ───────────────────────────────────────────────────────────────────
 
@@ -171,9 +170,7 @@ function buildServiceScores(testResults, mutations, contracts) {
     const tr = testResults?.services?.find(s => s.service === service)
     const unitScore = tr && tr.tests > 0 ? Math.round((tr.passed / tr.tests) * 100) : null
 
-    // coverage from kover — not directly available in the report; placeholder null
-    // (will be populated once kover XML is parsed in a follow-up)
-    const coverageScore = null
+    const coverageScore = collectCoverage(service)
 
     const mut = mutations.find(m => m?.service === service)
     const mutationScore = mut?.score ?? null
@@ -185,7 +182,7 @@ function buildServiceScores(testResults, mutations, contracts) {
       : serviceContracts.some(c => c.status === 'failed') ? 0
       : null
 
-    const components = [unitScore, mutationScore, contractScore].filter(v => v !== null)
+    const components = [unitScore, coverageScore, mutationScore, contractScore].filter(v => v !== null)
     const composite = components.length > 0
       ? Math.round(components.reduce((a, b) => a + b, 0) / components.length)
       : null

--- a/openbank-admin-ui/scripts/collect-test-results.mjs
+++ b/openbank-admin-ui/scripts/collect-test-results.mjs
@@ -21,6 +21,7 @@
 import { readdirSync, statSync, readFileSync, writeFileSync, existsSync } from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import { releasedJvmServices } from './lib/service-inventory.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const args = process.argv.slice(2)
@@ -32,19 +33,7 @@ const getArg = (flag, dflt) => {
 const REPO = path.resolve(getArg('--repo', path.resolve(__dirname, '..', '..')))
 const OUT = path.resolve(getArg('--out', path.resolve(__dirname, '..', 'test-results.json')))
 
-// The 26 service folders the Test Coverage page knows about (matches
-// KNOWN_SERVICES in the route). Folder name == component folder.
-const KNOWN = [
-  'openbank-account-service', 'openbank-aml-service', 'openbank-audit-service',
-  'openbank-balance-service', 'openbank-card-issuance-service', 'openbank-clearing-service',
-  'openbank-consent-service', 'openbank-dispute-service', 'openbank-domestic-payment',
-  'openbank-fx-service', 'openbank-interest-service', 'openbank-kyc-service',
-  'openbank-ledger-service', 'openbank-notification-service', 'openbank-party-service',
-  'openbank-pid-service', 'openbank-psd2-service', 'openbank-sanctions-service',
-  'openbank-sca-service', 'openbank-security-scanner', 'openbank-sepa-instant',
-  'openbank-sepa-payment', 'openbank-standing-order-service', 'openbank-swift-service',
-  'openbank-tpp-registry-service', 'openbank-transaction-service',
-]
+const KNOWN = releasedJvmServices(REPO)
 
 function findXml(dir) {
   const out = []

--- a/openbank-admin-ui/scripts/lib/service-inventory.mjs
+++ b/openbank-admin-ui/scripts/lib/service-inventory.mjs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'fs'
+import path from 'path'
+import { parse } from 'yaml'
+
+/**
+ * Released JVM services are the authoritative test inventory. Deriving this from
+ * release-please removes the three hand-maintained service lists that drifted as
+ * the fleet grew. Non-JVM components do not have Gradle/JUnit/Kover evidence and
+ * therefore do not belong on the service-test page.
+ */
+export function releasedJvmServices(repoRoot) {
+  const config = JSON.parse(fs.readFileSync(path.join(repoRoot, 'release-please-config.json'), 'utf8'))
+  return Object.keys(config.packages ?? {})
+    .filter(component => component.startsWith('openbank-'))
+    .filter(component => fs.existsSync(path.join(repoRoot, component, 'build.gradle.kts')))
+    .filter(component => fs.existsSync(path.join(repoRoot, component, 'src', 'test')))
+    .sort()
+}
+
+/** rules.yaml owns the money-path classification; the UI must never copy it. */
+export function moneyPathServices(repoRoot) {
+  const yaml = fs.readFileSync(path.join(repoRoot, 'openbank-libs', 'governance', 'rules.yaml'), 'utf8')
+  const values = parse(yaml)?.money_path_services
+  if (!Array.isArray(values) || values.some(value => typeof value !== 'string')) {
+    throw new Error('rules.yaml money_path_services must be a string list')
+  }
+  return values
+}

--- a/openbank-admin-ui/scripts/list-test-services.mjs
+++ b/openbank-admin-ui/scripts/list-test-services.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { releasedJvmServices } from './lib/service-inventory.mjs'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const repoArg = process.argv.indexOf('--repo')
+const repo = path.resolve(repoArg >= 0 ? process.argv[repoArg + 1] : path.join(here, '..', '..'))
+process.stdout.write(`${releasedJvmServices(repo).join('\n')}\n`)

--- a/openbank-admin-ui/src/app/api/agent/proposals/route.ts
+++ b/openbank-admin-ui/src/app/api/agent/proposals/route.ts
@@ -8,6 +8,7 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/auth'
+import { loadAgentCharters } from '@/lib/governance/agentCharters'
 
 export const dynamic = 'force-dynamic'
 
@@ -35,7 +36,20 @@ export async function GET(req: NextRequest) {
     })
     clearTimeout(timer)
     if (!res.ok) return NextResponse.json({ error: 'upstream_error' }, { status: res.status })
-    return NextResponse.json(await res.json(), { status: res.status })
+    const rows = await res.json() as { proposedBy?: string }[]
+    const registry = await loadAgentCharters()
+    const charterIds = new Set(registry.agents.map(agent => agent.id))
+    const enriched = Array.isArray(rows) ? rows.map(row => {
+      const id = row.proposedBy ?? 'unknown'
+      const known = charterIds.has(id)
+      return { ...row, agent: {
+        id,
+        displayName: id.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' '),
+        icon: known ? 'bot' : 'user',
+        charterKnown: known,
+      } }
+    }) : rows
+    return NextResponse.json(enriched, { status: res.status })
   } catch {
     return NextResponse.json({ error: 'agent_unreachable' }, { status: 502 })
   }

--- a/openbank-admin-ui/src/app/api/agent/proposals/route.ts
+++ b/openbank-admin-ui/src/app/api/agent/proposals/route.ts
@@ -38,16 +38,22 @@ export async function GET(req: NextRequest) {
     if (!res.ok) return NextResponse.json({ error: 'upstream_error' }, { status: res.status })
     const rows = await res.json() as { proposedBy?: string }[]
     const registry = await loadAgentCharters()
+    // Without a readable registry we cannot classify an author as a human. Preserve the
+    // upstream provenance so the UI can apply its conservative fallback (ADR-0080).
     const charterIds = new Set(registry.agents.map(agent => agent.id))
     const enriched = Array.isArray(rows) ? rows.map(row => {
       const id = row.proposedBy ?? 'unknown'
       const known = charterIds.has(id)
-      return { ...row, agent: {
-        id,
-        displayName: id.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' '),
-        icon: known ? 'bot' : 'user',
-        charterKnown: known,
-      } }
+      if (!registry.available) return row
+      return {
+        ...row,
+        agent: {
+          id,
+          displayName: id.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' '),
+          icon: known ? 'bot' : 'user',
+          charterKnown: known,
+        },
+      }
     }) : rows
     return NextResponse.json(enriched, { status: res.status })
   } catch {

--- a/openbank-admin-ui/src/app/api/temporal/status/route.ts
+++ b/openbank-admin-ui/src/app/api/temporal/status/route.ts
@@ -81,6 +81,7 @@ export async function GET() {
       workerTaskSlots,
       workerTaskSlotsUsed,
       namespaces,
+      workflowTypes,
     ] = await Promise.all([
       // Metric names below are the Temporal SERVER (tally/prometheus) names as
       // scraped by the temporal-server PodMonitor (prefixed temporal_ at scrape
@@ -108,6 +109,7 @@ export async function GET() {
       queryInstant('sum(temporal_worker_task_slots_available)', controller.signal),
       queryInstant('sum(temporal_worker_task_slots_used)', controller.signal),
       queryVector('group by (namespace) (temporal_workflow_success)', controller.signal),
+      queryVector('sum by (namespace, workflow_type) (increase(temporal_workflow_success[1h]))', controller.signal),
     ])
 
     // temporal_restarts is absent (count → vector(0)) only when Temporal is not scraped yet
@@ -146,6 +148,11 @@ export async function GET() {
           slotsUsed: workerTaskSlotsUsed !== null ? Math.round(workerTaskSlotsUsed) : null,
         },
         namespaces: activeNamespaces.length > 0 ? activeNamespaces : ['openbank-default'],
+        workflowTypes: workflowTypes.map(row => ({
+          namespace: row.labels.namespace ?? 'unknown',
+          workflowType: row.labels.workflow_type ?? 'unknown',
+          completed1h: Math.round(row.value),
+        })).filter(row => row.workflowType !== 'unknown'),
       } : null,
     }, { headers: { 'Cache-Control': 'no-store' } })
   } finally {

--- a/openbank-admin-ui/src/app/api/test-results/route.ts
+++ b/openbank-admin-ui/src/app/api/test-results/route.ts
@@ -41,35 +41,6 @@ async function fromBundle(): Promise<TestResultsResponse | null> {
   }
 }
 
-const KNOWN_SERVICES = [
-  'openbank-account-service',
-  'openbank-aml-service',
-  'openbank-audit-service',
-  'openbank-balance-service',
-  'openbank-card-issuance-service',
-  'openbank-clearing-service',
-  'openbank-consent-service',
-  'openbank-dispute-service',
-  'openbank-domestic-payment',
-  'openbank-fx-service',
-  'openbank-interest-service',
-  'openbank-kyc-service',
-  'openbank-ledger-service',
-  'openbank-notification-service',
-  'openbank-party-service',
-  'openbank-pid-service',
-  'openbank-psd2-service',
-  'openbank-sanctions-service',
-  'openbank-sca-service',
-  'openbank-security-scanner',
-  'openbank-sepa-instant',
-  'openbank-sepa-payment',
-  'openbank-standing-order-service',
-  'openbank-swift-service',
-  'openbank-tpp-registry-service',
-  'openbank-transaction-service',
-]
-
 function pgHost(): string {
   if (process.env.SERVICES_HOST === 'container') return 'openbank-postgres'
   return process.env.PGHOST ?? 'localhost'
@@ -139,7 +110,10 @@ export async function GET() {
     if (r.test_type === 'integration') entry.integration = r
   }
 
-  const services: ServiceTestResult[] = KNOWN_SERVICES.map(name => {
+  // The legacy DB has no fleet catalogue. Use exactly the services it has observed;
+  // the normal bundled path is generated from release-please and is authoritative.
+  const observedServices = [...new Set([...summaryRows, ...typeRows].map(r => String(r.service)))].sort()
+  const services: ServiceTestResult[] = observedServices.map(name => {
     const r   = byService.get(name)
     const typ = byServiceType.get(name) ?? { unit: null, integration: null }
     const u   = typ.unit

--- a/openbank-admin-ui/src/app/approvals/page.tsx
+++ b/openbank-admin-ui/src/app/approvals/page.tsx
@@ -12,7 +12,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useSession } from 'next-auth/react'
-import { CheckCircle2, XCircle, Clock, ClipboardCheck, RefreshCw, ShieldCheck, AlertTriangle } from 'lucide-react'
+import { CheckCircle2, XCircle, Clock, ClipboardCheck, RefreshCw, ShieldCheck, AlertTriangle, Bot, UserRound } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader } from '@/components/ui/PageHeader'
 import { AgentIdentityBadge } from '@/components/approvals/AgentIdentityBadge'
@@ -241,11 +241,13 @@ export default function ApprovalsPage() {
           // The ADR-0080 caution stands whenever AI authorship is established OR cannot be
           // ruled out. Only a positively unchartered actor drops it.
           const cautionAi = identity.status !== 'unresolved'
+          const aiGenerated = p.agent ? p.agent.icon === 'bot' : /assistant|agent|\bai\b/i.test(p.proposedBy)
+          const ProposerIcon = aiGenerated ? Bot : UserRound
           return (
             <div key={p.id} className="card" style={{ padding: 18, borderLeft: `3px solid ${chartered ? '#d97706' : m.color}` }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 10, marginBottom: 8 }}>
                 <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--text-primary)', display: 'flex', alignItems: 'center', gap: 8 }}>
-                  <span aria-hidden="true" style={{ width: 28, height: 28, borderRadius: 8, background: aiGenerated ? '#fffbeb' : 'var(--surface-2)', color: aiGenerated ? '#b45309' : 'var(--text-secondary)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}><Bot size={15} /></span>
+                  <span aria-hidden="true" style={{ width: 28, height: 28, borderRadius: 8, background: aiGenerated ? '#fffbeb' : 'var(--surface-2)', color: aiGenerated ? '#b45309' : 'var(--text-secondary)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}><ProposerIcon size={15} /></span>
                   {p.title}
                   <AgentIdentityBadge identity={identity} loading={registryLoading} lang={language} />
                 </div>

--- a/openbank-admin-ui/src/app/approvals/page.tsx
+++ b/openbank-admin-ui/src/app/approvals/page.tsx
@@ -31,6 +31,7 @@ interface Proposal {
   decidedAt: string | null
   decisionReason: string | null
   modelId: string | null
+  agent?: { id: string; displayName: string; icon: 'bot' | 'user'; charterKnown: boolean }
 }
 
 interface InboxItem {
@@ -244,6 +245,7 @@ export default function ApprovalsPage() {
             <div key={p.id} className="card" style={{ padding: 18, borderLeft: `3px solid ${chartered ? '#d97706' : m.color}` }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 10, marginBottom: 8 }}>
                 <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--text-primary)', display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span aria-hidden="true" style={{ width: 28, height: 28, borderRadius: 8, background: aiGenerated ? '#fffbeb' : 'var(--surface-2)', color: aiGenerated ? '#b45309' : 'var(--text-secondary)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}><Bot size={15} /></span>
                   {p.title}
                   <AgentIdentityBadge identity={identity} loading={registryLoading} lang={language} />
                 </div>
@@ -265,7 +267,9 @@ export default function ApprovalsPage() {
                 <span style={{ fontWeight: 700 }}>{t('Navrhovaná akce: ', 'Suggested action: ')}</span>{p.suggestedAction}
               </div>
               <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginBottom: 10 }}>
-                {t('Navrhl', 'Proposed by')} <b>{p.proposedBy}</b> · {new Date(p.proposedAt).toLocaleString(dateLocale)}
+                {t('Navrhl', 'Proposed by')} <b>{p.agent?.displayName ?? p.proposedBy}</b>
+                <span className="mono"> · {p.agent?.id ?? p.proposedBy}</span>
+                {p.modelId ? <span className="mono"> · {p.modelId}</span> : null} · {new Date(p.proposedAt).toLocaleString(dateLocale)}
               </div>
               <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
                 <Can permission="agent:decide" fallback={<span style={{ color: 'var(--text-tertiary)', fontSize: 12 }}>{t('Rozhodování vyžaduje oprávnění agenta.', 'Decision access requires agent authorization.')}</span>}>

--- a/openbank-admin-ui/src/app/customer-360/page.tsx
+++ b/openbank-admin-ui/src/app/customer-360/page.tsx
@@ -92,10 +92,10 @@ export default function Customer360Page() {
           reads engagement-service, not ClickHouse, so a silver layer that is down or a party with no
           projected events must not hide an active fraud hold. Those are independent sources and the
           page now degrades independently for each. */}
-      {selected && <AdverseStatePanel key={selected.id} partyId={selected.id} />}
-      {selected && <CustomerPortfolioPanel key={selected.id} partyId={selected.id} />}
-      {selected && <DevicesPanel key={selected.id} partyId={selected.id} />}
-      {selected && <DocumentsPanel key={selected.id} partyId={selected.id} />}
+      {selected && <AdverseStatePanel key={`adverse:${selected.id}`} partyId={selected.id} />}
+      {selected && <CustomerPortfolioPanel key={`portfolio:${selected.id}`} partyId={selected.id} />}
+      {selected && <DevicesPanel key={`devices:${selected.id}`} partyId={selected.id} />}
+      {selected && <DocumentsPanel key={`documents:${selected.id}`} partyId={selected.id} />}
 
       {loading && (
         <div style={{ color: 'var(--text-secondary)', padding: '40px', textAlign: 'center' }}>

--- a/openbank-admin-ui/src/app/customer-360/page.tsx
+++ b/openbank-admin-ui/src/app/customer-360/page.tsx
@@ -13,6 +13,8 @@ import type { Customer360 } from '@/app/api/customer-360/[partyId]/route'
 import { PartySearch, partyDisplayName, type PartyHit } from '@/components/party/PartySearch'
 import { AdverseStatePanel } from '@/components/party/AdverseStatePanel'
 import { DevicesPanel } from '@/components/party/DevicesPanel'
+import { DocumentsPanel } from '@/components/party/DocumentsPanel'
+import { CustomerPortfolioPanel } from '@/components/party/CustomerPortfolioPanel'
 
 // ADR-0210: a lookup over the analytics silver layer, not a customer list. There is no
 // crm-service and no "list all customers" surface here — party-service owns that.
@@ -91,7 +93,9 @@ export default function Customer360Page() {
           projected events must not hide an active fraud hold. Those are independent sources and the
           page now degrades independently for each. */}
       {selected && <AdverseStatePanel key={selected.id} partyId={selected.id} />}
+      {selected && <CustomerPortfolioPanel key={selected.id} partyId={selected.id} />}
       {selected && <DevicesPanel key={selected.id} partyId={selected.id} />}
+      {selected && <DocumentsPanel key={selected.id} partyId={selected.id} />}
 
       {loading && (
         <div style={{ color: 'var(--text-secondary)', padding: '40px', textAlign: 'center' }}>

--- a/openbank-admin-ui/src/app/kyc/page.tsx
+++ b/openbank-admin-ui/src/app/kyc/page.tsx
@@ -12,6 +12,7 @@ import { ShieldCheck, Search, RefreshCw, ChevronRight } from 'lucide-react'
 import Link from 'next/link'
 import { PageHeader, StatusBadge } from '@/components/ui'
 import { Can } from '@/components/auth/AuthGuard'
+import { PartySearch, type PartyHit } from '@/components/party/PartySearch'
 
 const KYC_SERVICE = '/api/svc/kyc-service'
 
@@ -31,6 +32,7 @@ export default function KycPage() {
   const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
   const [search, setSearch]   = useState('')
   const [partyId, setPartyId] = useState('')
+  const [selectedParty, setSelectedParty] = useState<PartyHit | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true); setUnavailable(null)
@@ -81,7 +83,14 @@ export default function KycPage() {
         </button>}
       />
 
-      {/* Toolbar */}
+      <PartySearch
+        selectedId={selectedParty?.id}
+        busy={loading}
+        onSelect={party => { setSelectedParty(party); setPartyId(party.id) }}
+        placeholder={t('Jméno, příjmení, firma nebo Party UUID', 'Name, company, or Party UUID')}
+      />
+
+      {/* Case-local filter */}
       <div style={{ display: 'flex', gap: '10px', marginBottom: '16px' }}>
         <div style={{ position: 'relative', flex: 1, maxWidth: '300px' }}>
           <Search aria-hidden="true" size={14} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-muted)' }} />
@@ -98,6 +107,7 @@ export default function KycPage() {
           aria-busy={loading}
           aria-label={t('Vyhledat KYC případy', 'Search KYC cases')}
         >{t('Hledat', 'Search')}</button>
+        {selectedParty && <button type="button" className="btn btn-secondary" onClick={() => { setSelectedParty(null); setPartyId('') }}>{t('Všechny případy', 'All cases')}</button>}
       </div>
 
       {unavailable && (

--- a/openbank-admin-ui/src/app/lending/compliance-packs/page.tsx
+++ b/openbank-admin-ui/src/app/lending/compliance-packs/page.tsx
@@ -38,6 +38,9 @@ type PackActivationView = {
   proposedBy: string
   decidedBy: string | null
   decidedAt: string | null
+  proposedAt: string | null
+  decisionReason: string | null
+  pack: Record<string, unknown>
 }
 
 /** A read that was REFUSED must never render as "nothing pending" — same reasoning as /approvals
@@ -66,6 +69,7 @@ export default function CompliancePacksPage() {
   const [notice, setNotice] = useState<string | null>(null)
   const [reasons, setReasons] = useState<Record<string, string>>({})
   const [packJson, setPackJson] = useState('')
+  const [detail, setDetail] = useState<PackActivationView | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -238,12 +242,12 @@ export default function CompliancePacksPage() {
           </thead>
           <tbody>
             {active.map(p => (
-              <tr key={`${p.jurisdiction}-${p.productType}-${p.packVersion}`} style={{ borderTop: '1px solid var(--border)' }}>
+              <tr key={`${p.jurisdiction}-${p.productType}-${p.packVersion}`} onClick={() => setDetail(p)} style={{ borderTop: '1px solid var(--border)', cursor: 'pointer' }}>
                 <td style={cell}>{p.jurisdiction}</td>
                 <td style={cell}>{p.productType}</td>
                 <td style={cell}>v{p.packVersion}</td>
                 <td style={cell}>{p.effectiveFrom}</td>
-                <td style={{ ...cell, fontSize: 11 }} className="mono">{p.contentHash.slice(0, 16)}…</td>
+                <td style={{ ...cell, fontSize: 11 }} className="mono">{p.contentHash.slice(0, 16)}… · {t('detail', 'details')}</td>
               </tr>
             ))}
             {active.length === 0 && (
@@ -267,6 +271,7 @@ export default function CompliancePacksPage() {
         {pending.map(p => (
           <div
             key={p.id}
+            onClick={() => setDetail(p)}
             data-testid={`proposal-${p.id}`}
             style={{ display: 'flex', gap: 12, alignItems: 'center', justifyContent: 'space-between', padding: '12px 14px', borderTop: '1px solid var(--border)', flexWrap: 'wrap' }}
           >
@@ -306,6 +311,19 @@ export default function CompliancePacksPage() {
           </div>
         )}
       </div>
+
+      {detail && <div onClick={() => setDetail(null)} style={{ position: 'fixed', inset: 0, zIndex: 1000, background: 'rgba(0,0,0,.45)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}>
+        <div onClick={e => e.stopPropagation()} className="card" style={{ width: 'min(820px, 100%)', maxHeight: '88vh', overflow: 'auto', padding: 20 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}><div><h2 style={{ margin: 0 }}>{detail.jurisdiction} / {detail.productType} · v{detail.packVersion}</h2><div className="mono" style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 4 }}>{detail.contentHash}</div></div><button className="btn btn-secondary" onClick={() => setDetail(null)}>{t('Zavřít', 'Close')}</button></div>
+          <dl style={{ display: 'grid', gridTemplateColumns: '180px 1fr', gap: '8px 12px', fontSize: 12, margin: '18px 0' }}>
+            <dt>{t('Navrhl', 'Proposed by')}</dt><dd>{detail.proposedBy || '—'} · {detail.proposedAt || '—'}</dd>
+            <dt>{t('Rozhodl', 'Decided by')}</dt><dd>{detail.decidedBy || '—'} · {detail.decidedAt || '—'}</dd>
+            <dt>{t('Důvod rozhodnutí', 'Decision reason')}</dt><dd>{detail.decisionReason || '—'}</dd>
+          </dl>
+          <h3 className="section-title">{t('Přesný obsah packu', 'Exact pack content')}</h3>
+          <pre style={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', padding: 14, borderRadius: 8, background: 'var(--surface-2)', fontSize: 11 }}>{JSON.stringify(detail.pack, null, 2)}</pre>
+        </div>
+      </div>}
 
       <Can permission="lending:compliance:propose">
       <div className="section-title" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>

--- a/openbank-admin-ui/src/app/regulatory/page.tsx
+++ b/openbank-admin-ui/src/app/regulatory/page.tsx
@@ -605,12 +605,20 @@ export default function RegulatoryPage() {
 
             {/* Footer: note + export actions */}
             <div style={{ padding: '14px 20px', borderTop: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '12px', flexWrap: 'wrap' }}>
-              <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', maxWidth: '320px' }}>
-                {!exportReadiness.ok && (() => {
+              <div
+                role="status"
+                data-testid="export-readiness"
+                style={{ fontSize: '11px', color: 'var(--text-tertiary)', maxWidth: '320px' }}
+              >
+                {exportReadiness.ok ? (
+                  <div style={{ display: 'flex', gap: '8px', alignItems: 'flex-start', marginBottom: '8px', color: 'var(--success)' }}>
+                    <CheckCircle2 size={14} aria-hidden="true" style={{ flexShrink: 0, marginTop: '1px' }} />
+                    <strong>{t('Připraveno pro interní export', 'Ready for internal export')}</strong>
+                  </div>
+                ) : (() => {
                   const copy = blockReasonCopy(exportReadiness.reason, exportReadiness.templateIds, t('cs', 'en') as 'cs' | 'en')
                   return (
                     <div
-                      role="status"
                       data-testid="export-blocked"
                       data-block-reason={exportReadiness.reason}
                       style={{ display: 'flex', gap: '8px', alignItems: 'flex-start', marginBottom: '8px', color: 'var(--danger)' }}

--- a/openbank-admin-ui/src/app/system/tests/page.tsx
+++ b/openbank-admin-ui/src/app/system/tests/page.tsx
@@ -1,657 +1,358 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
-// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
-import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
-  FlaskConical, RefreshCw, CheckCircle2, XCircle, Minus,
-  ShieldCheck, Dna, Star,
+  Activity, BarChart3, CheckCircle2, CircleHelp, Dna, FlaskConical,
+  Gauge, RefreshCw, ShieldCheck, Timer, TriangleAlert, XCircle,
 } from 'lucide-react'
-import { DataUnavailable } from '@/components/feedback/DataUnavailable'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import type {
+  ComponentTestPosture, EvidenceKind, EvidenceState, TestIntelligenceReport,
+} from '@/lib/types/test-intelligence'
+import { TestIntelligenceFlow } from '@/components/testing/TestIntelligenceFlow'
+import { TestAgentPanel } from '@/components/testing/TestAgentPanel'
 import { PageHeader } from '@/components/ui/PageHeader'
-import type { TestResultsResponse, ServiceTestResult } from '@/lib/types/test-results'
-import type { QualityReport, MutationScore, ContractVerification, ServiceQualityScore } from '@/lib/types/quality-report'
 
-// ── Shared helpers ────────────────────────────────────────────────────────────
+type Tab = 'posture' | 'tests' | 'history' | 'execution' | 'runtime' | 'coverage' | 'contracts' | 'mutation' | 'performance' | 'synthetic' | 'clients'
 
-function PassRateBar({ passed, total }: { passed: number; total: number }) {
-  if (total === 0) return <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>—</span>
-  const pct = Math.round((passed / total) * 100)
-  const color = pct === 100 ? '#16a34a' : pct >= 80 ? '#d97706' : '#dc2626'
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-      <div style={{ flex: 1, height: '6px', background: 'var(--surface-3)', borderRadius: '3px', overflow: 'hidden', minWidth: '80px' }}>
-        <div style={{ width: `${pct}%`, height: '100%', background: color, borderRadius: '3px', transition: 'width 0.3s ease' }} />
-      </div>
-      <span style={{ fontSize: '11px', fontWeight: 700, color, minWidth: '34px', textAlign: 'right' }}>{pct}%</span>
-    </div>
-  )
+const STATE_COLOR: Record<EvidenceState, string> = {
+  passed: '#16a34a', failed: '#dc2626', skipped: '#d97706', 'not-run': '#64748b',
+  stale: '#d97706', blocked: '#7c3aed', unknown: '#64748b',
 }
 
-function ScoreBar({ score, threshold = 70 }: { score: number | null; threshold?: number }) {
-  if (score === null) return <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>—</span>
-  const color = score >= threshold ? '#16a34a' : score >= threshold * 0.8 ? '#d97706' : '#dc2626'
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-      <div style={{ flex: 1, height: '6px', background: 'var(--surface-3)', borderRadius: '3px', overflow: 'hidden', minWidth: '80px' }}>
-        <div style={{ width: `${score}%`, height: '100%', background: color, borderRadius: '3px', transition: 'width 0.3s ease' }} />
-      </div>
-      <span style={{ fontSize: '11px', fontWeight: 700, color, minWidth: '34px', textAlign: 'right' }}>{score}%</span>
-    </div>
-  )
-}
+const KINDS: EvidenceKind[] = ['unit', 'integration', 'contract', 'e2e', 'mutation', 'simulation', 'performance', 'synthetic']
 
-function StatusBadge({ status }: { status: 'passed' | 'failed' | 'pending' }) {
-  const cfg = {
-    passed: { color: '#16a34a', bg: '#dcfce7', label: '✓' },
-    failed: { color: '#dc2626', bg: '#fee2e2', label: '✗' },
-    pending: { color: '#6b7280', bg: 'var(--surface-2)', label: '–' },
-  }[status]
+function StateBadge({ state }: { state: EvidenceState }) {
+  const Icon = state === 'passed' ? CheckCircle2 : state === 'failed' ? XCircle
+    : state === 'unknown' || state === 'not-run' ? CircleHelp : TriangleAlert
   return (
-    <span style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: '22px', height: '22px', borderRadius: '4px', background: cfg.bg, color: cfg.color, fontSize: '12px', fontWeight: 700 }}>
-      {cfg.label}
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: STATE_COLOR[state], fontSize: 11, fontWeight: 700 }}>
+      <Icon size={12} />{state}
     </span>
   )
 }
 
-// ── Tests tab ─────────────────────────────────────────────────────────────────
-
-function ServiceRow({ svc }: { svc: ServiceTestResult }) {
-  const { t, language } = useLanguage()
-  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
-  const hasTests = svc.tests > 0
-  const hasFail = svc.failed + svc.errors > 0
-  const statusIcon = !hasTests
-    ? <Minus size={14} style={{ color: 'var(--text-tertiary)' }} />
-    : hasFail
-      ? <XCircle size={14} style={{ color: '#dc2626' }} />
-      : <CheckCircle2 size={14} style={{ color: '#16a34a' }} />
+function Stat({ label, value, tone }: { label: string; value: number | string; tone?: string }) {
   return (
-    <tr style={{ borderBottom: '1px solid var(--border)', background: !hasTests ? 'transparent' : hasFail ? 'rgba(220,38,38,0.03)' : 'transparent' }}>
-      <td style={{ padding: '10px 16px', display: 'flex', alignItems: 'center', gap: '8px' }}>
-        {statusIcon}
-        <span style={{ fontSize: '12px', fontFamily: 'monospace', color: 'var(--text-primary)', fontWeight: 500 }}>
-          {svc.service.replace('openbank-', '')}
-        </span>
-      </td>
-      <td style={{ padding: '10px 16px', textAlign: 'center', fontSize: '13px', fontWeight: 700, color: 'var(--text-primary)' }}>
-        {hasTests ? svc.tests : <span style={{ color: 'var(--text-tertiary)' }}>0</span>}
-      </td>
-      <td style={{ padding: '10px 16px', textAlign: 'center', fontSize: '13px', color: '#16a34a', fontWeight: hasTests ? 600 : 400 }}>
-        {hasTests ? svc.passed : '—'}
-      </td>
-      <td style={{ padding: '10px 16px', textAlign: 'center', fontSize: '13px', color: hasFail ? '#dc2626' : 'var(--text-tertiary)', fontWeight: hasFail ? 700 : 400 }}>
-        {hasTests ? (svc.failed + svc.errors || '—') : '—'}
-      </td>
-      <td style={{ padding: '10px 16px', minWidth: '140px' }}>
-        <PassRateBar passed={svc.passed} total={svc.tests} />
-      </td>
-      <td style={{ padding: '10px 16px', textAlign: 'center', fontSize: '11px', color: 'var(--text-tertiary)', fontFamily: 'monospace' }}>
-        {hasTests ? `${svc.durationMs}ms` : '—'}
-      </td>
-      <td style={{ padding: '10px 16px', textAlign: 'center', fontSize: '11px', color: 'var(--text-tertiary)' }}>
-        {svc.lastRunAt ? new Date(svc.lastRunAt).toLocaleString(dateLocale) : '—'}
-      </td>
-      <td style={{ padding: '10px 16px', textAlign: 'center', fontSize: '11px', color: 'var(--text-tertiary)' }}>
-        {t(`${svc.unit.tests} unit`, `${svc.unit.tests} unit`)} / {t(`${svc.integration.tests} int.`, `${svc.integration.tests} int.`)}
-      </td>
-    </tr>
+    <div style={{ padding: 16, border: '1px solid var(--border)', borderRadius: 10, background: 'var(--surface-1)' }}>
+      <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginBottom: 6 }}>{label}</div>
+      <div style={{ fontSize: 24, fontWeight: 750, color: tone ?? 'var(--text-primary)' }}>{value}</div>
+    </div>
   )
 }
 
-function TestsTab({ data, error, loading }: { data: TestResultsResponse | null; error: string | null; loading: boolean }) {
-  const { t, language } = useLanguage()
-  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
-  const totals = data?.totals
-  const passRate = totals && totals.tests > 0 ? Math.round((totals.passed / totals.tests) * 100) : null
-  const coverageColor = passRate == null ? 'var(--text-secondary)' : passRate === 100 ? '#16a34a' : passRate >= 80 ? '#d97706' : '#dc2626'
-  const coverageBg = passRate == null ? 'var(--surface-2)' : passRate === 100 ? '#dcfce7' : passRate >= 80 ? '#fef9c3' : '#fee2e2'
-  const collectedAt = data?.collectedAt ? new Date(data.collectedAt) : null
-  const stale = collectedAt ? Date.now() - collectedAt.getTime() > 24 * 60 * 60 * 1000 : false
+/**
+ * A deliberately unweighted operator view.  It makes the four assurance
+ * surfaces navigable without turning absent evidence into a misleading score.
+ */
+function AssuranceBoard({ report, selectTab }: { report: TestIntelligenceReport; selectTab: (tab: Tab) => void }) {
+  const { t } = useLanguage()
+  const syntheticActive = report.syntheticJourneys.filter(item => item.status === 'active')
+  const syntheticState: EvidenceState = syntheticActive.some(item => item.state === 'failed') ? 'failed'
+    : syntheticActive.length === 0 ? 'unknown'
+      : syntheticActive.some(item => item.state !== 'passed') ? 'stale' : 'passed'
+  const runtimeRows = report.components.filter(component => component.testInfrastructure.declared.length > 0)
+  const runtimeState: EvidenceState = runtimeRows.some(component => {
+    const observed = component.testInfrastructure.observed
+    return observed.filter(item => item.lifecycle === 'stopped').length < observed.filter(item => item.lifecycle === 'started').length
+  }) ? 'failed' : runtimeRows.some(component => component.testInfrastructure.observed.length === 0) ? 'unknown' : 'passed'
+  const clientEvidence = report.clientExperiences ?? []
+  const clientState: EvidenceState = clientEvidence.some(client => client.evidence.some(item => item.state === 'failed')) ? 'failed'
+    : clientEvidence.some(client => client.rum.state === 'blocked') ? 'blocked'
+      : clientEvidence.some(client => client.rum.state === 'unknown') ? 'unknown'
+        : clientEvidence.length === 0 ? 'not-run' : 'passed'
+  const ciState: EvidenceState = report.totals.failingEvidence > 0 ? 'failed'
+    : report.totals.missingEvidence > 0 || report.totals.staleEvidence > 0 ? 'stale' : 'passed'
+  const cards: { tab: Tab; title: string; eyebrow: string; state: EvidenceState; detail: string }[] = [
+    { tab: 'posture', title: t('CI důkazy', 'CI evidence'), eyebrow: t('deterministické gate', 'deterministic gates'), state: ciState, detail: t(`${report.totals.componentsWithExecutionEvidence}/${report.totals.components} komponent s důkazem běhu`, `${report.totals.componentsWithExecutionEvidence}/${report.totals.components} components with run evidence`) },
+    { tab: 'runtime', title: t('Testcontainers runtime', 'Testcontainers runtime'), eyebrow: t('skutečná topologie', 'actual topology'), state: runtimeState, detail: t(`${runtimeRows.length} deklarovaných testovacích runtime`, `${runtimeRows.length} declared test runtimes`) },
+    { tab: 'synthetic', title: t('Sandbox syntetiky', 'Sandbox synthetics'), eyebrow: t('pravidelná falsifikace', 'scheduled falsification'), state: syntheticState, detail: t(`${syntheticActive.length} aktivních cest · ${report.syntheticJourneys.filter(item => item.status === 'planned').length} plánovaných`, `${syntheticActive.length} active paths · ${report.syntheticJourneys.filter(item => item.status === 'planned').length} planned`) },
+    { tab: 'clients', title: t('Client & RUM', 'Client & RUM'), eyebrow: t('E2E + produkční signál', 'E2E + production signal'), state: clientState, detail: t(`${clientEvidence.length} klientských zkušeností · consent-gated RUM`, `${clientEvidence.length} client experiences · consent-gated RUM`) },
+  ]
+  return <section aria-label={t('Mapa testovacího ujištění', 'Testing assurance map')} style={{ marginBottom: 18, border: '1px solid color-mix(in srgb, var(--accent) 26%, var(--border))', borderRadius: 14, padding: 18, background: 'linear-gradient(135deg, color-mix(in srgb, var(--accent) 7%, var(--surface-1)), var(--surface-1))' }}>
+    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'start', marginBottom: 14 }}>
+      <div><div style={{ color: 'var(--accent)', fontSize: 11, fontWeight: 750, letterSpacing: '.08em', textTransform: 'uppercase' }}>{t('Living assurance map', 'Living assurance map')}</div><strong style={{ fontSize: 18 }}>{t('Od změny až k zákaznickému signálu', 'From change to customer signal')}</strong><div style={{ color: 'var(--text-secondary)', fontSize: 12, marginTop: 4 }}>{t('Klikni na vrstvu pro její neměnný důkaz, historii a známé mezery.', 'Open a layer for its immutable evidence, history, and known gaps.')}</div></div>
+      <div style={{ maxWidth: 310, color: 'var(--text-secondary)', fontSize: 11, padding: '8px 10px', borderRadius: 8, background: 'var(--surface-2)' }}><strong>{t('AI guardrail', 'AI guardrail')}</strong><br />{t('Agenti smějí vysvětlit a navrhnout další krok. Nezvyšují verdikt, nemažou důkaz ani neschvalují release.', 'Agents may explain and propose a next step. They do not raise a verdict, delete evidence, or approve a release.')}</div>
+    </div>
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(205px, 1fr))', gap: 10 }}>{cards.map((card, index) => <button key={card.tab} type="button" onClick={() => selectTab(card.tab)} style={{ textAlign: 'left', cursor: 'pointer', border: `1px solid color-mix(in srgb, ${STATE_COLOR[card.state]} 42%, var(--border))`, background: 'var(--surface-1)', borderRadius: 11, padding: 14, animation: `fadeIn ${180 + index * 80}ms ease-out both` }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'start' }}><div><div style={{ color: 'var(--text-tertiary)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '.06em' }}>{card.eyebrow}</div><strong style={{ display: 'block', marginTop: 3 }}>{card.title}</strong></div><StateBadge state={card.state} /></div>
+      <div style={{ color: 'var(--text-secondary)', fontSize: 12, marginTop: 10 }}>{card.detail}</div>
+      <div style={{ color: 'var(--accent)', fontSize: 11, fontWeight: 650, marginTop: 11 }}>{t('Otevřít důkaz →', 'Open evidence →')}</div>
+    </button>)}</div>
+  </section>
+}
 
-  const sorted = data?.services.slice().sort((a, b) => {
-    if (a.failed + a.errors > 0 && b.failed + b.errors === 0) return -1
-    if (b.failed + b.errors > 0 && a.failed + a.errors === 0) return 1
-    if (a.tests === 0 && b.tests > 0) return 1
-    if (b.tests === 0 && a.tests > 0) return -1
-    return a.service.localeCompare(b.service)
-  })
+function EvidenceCell({ component, kind }: { component: ComponentTestPosture; kind: EvidenceKind }) {
+  const evidence = component.evidence.find(item => item.kind === kind)
+  if (!evidence) return <StateBadge state="not-run" />
+  return <StateBadge state={evidence.state} />
+}
 
+const tableStyle = { width: '100%', borderCollapse: 'collapse' as const, fontSize: 12 }
+const thStyle = { padding: '10px 12px', textAlign: 'left' as const, borderBottom: '1px solid var(--border)', color: 'var(--text-tertiary)', fontSize: 11 }
+const tdStyle = { padding: '10px 12px', borderBottom: '1px solid var(--border-subtle)' }
+const formatTimestamp = (value: string) => new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value))
+
+function Posture({ report }: { report: TestIntelligenceReport }) {
+  const { t } = useLanguage()
+  const sorted = useMemo(() => [...report.components].sort((a, b) => {
+    if (a.moneyPath !== b.moneyPath) return a.moneyPath ? -1 : 1
+    return a.component.localeCompare(b.component)
+  }), [report.components])
   return (
     <>
-      {error && (
-        <div style={{ marginBottom: '20px' }}>
-          <DataUnavailable
-            kind="error"
-            feature={t('Pokrytí testy', 'Test coverage')}
-            lang={t('cs', 'en') as 'cs' | 'en'}
-            detail={t(
-              'Zdroj výsledků testů (CI databáze) není v tomto prostředí dostupný.',
-              'The test-results source (CI database) is not available in this environment.',
-            )}
-            dense
-          />
-        </div>
-      )}
-
-      {totals && (
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: '12px', marginBottom: '24px' }}>
-          {[
-            { label: t('Celkový pass rate', 'Overall pass rate'), value: passRate != null ? `${passRate}%` : '—', sub: `${totals.passed}/${totals.tests} ${t('testů', 'tests')}`, color: coverageColor, bg: coverageBg },
-            { label: t('Testy celkem', 'Total tests'), value: totals.tests.toString(), sub: '', color: 'var(--text-primary)', bg: 'var(--surface-2)' },
-            { label: t('Úspěšné', 'Passed'), value: totals.passed.toString(), sub: '', color: '#16a34a', bg: '#dcfce7' },
-            { label: t('Selhání', 'Failed'), value: totals.failed.toString(), sub: '', color: totals.failed > 0 ? '#dc2626' : 'var(--text-secondary)', bg: totals.failed > 0 ? '#fee2e2' : 'var(--surface-2)' },
-            { label: t('Služby s testy', 'Services with tests'), value: `${totals.servicesWithTests}/${totals.services}`, sub: `${totals.services - totals.servicesWithTests} ${t('bez testů', 'without tests')}`, color: totals.servicesWithTests < totals.services ? '#d97706' : '#16a34a', bg: totals.servicesWithTests < totals.services ? '#fef9c3' : '#dcfce7' },
-          ].map(stat => (
-            <div key={stat.label} className="card" style={{ padding: '16px', background: stat.bg }}>
-              <div style={{ fontSize: '11px', color: 'var(--text-secondary)', marginBottom: '6px', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{stat.label}</div>
-              <div style={{ fontSize: '22px', fontWeight: 800, color: stat.color, marginBottom: '2px' }}>{stat.value}</div>
-              {stat.sub && <div style={{ fontSize: '11px', color: 'var(--text-secondary)' }}>{stat.sub}</div>}
-            </div>
-          ))}
-        </div>
-      )}
-
-      {data && (
-        <div style={{ margin: '-12px 0 16px', fontSize: '11px', color: stale ? '#b45309' : 'var(--text-tertiary)' }}>
-          {t('CI snapshot vytvořen', 'CI snapshot collected')}: {collectedAt?.toLocaleString(dateLocale) ?? '—'}
-          {stale ? ` · ${t('zastaralý (>24 h)', 'stale (>24h)')}` : ''}
-          {' · '}{t('0 znamená, že pro službu nebyl v retenčním okně nalezen artefakt; ne že nemá testy.', '0 means no artifact was found in the retention window; it does not mean the service has no tests.')}
-        </div>
-      )}
-
-      {loading && !data ? (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-          {Array.from({ length: 8 }).map((_, idx) => <div key={idx} className="skeleton" style={{ height: '42px' }} />)}
-        </div>
-      ) : sorted && (
-        <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
-          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '13px' }}>
-            <thead>
-              <tr style={{ background: 'var(--surface-2)', borderBottom: '1px solid var(--border)' }}>
-                {[
-                  t('Služba', 'Service'),
-                  t('Testy', 'Tests'),
-                  t('OK', 'Passed'),
-                  t('FAIL', 'Failed'),
-                  t('Pass rate', 'Pass rate'),
-                  t('Trvání', 'Duration'),
-                  t('Poslední spuštění', 'Last run'),
-                  t('Typ', 'Type'),
-                ].map(h => (
-                  <th key={h} style={{ padding: '10px 16px', textAlign: h === t('Služba', 'Service') ? 'left' : 'center', fontWeight: 600, color: 'var(--text-secondary)', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
-                    {h}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {sorted.map(svc => <ServiceRow key={svc.service} svc={svc} />)}
-            </tbody>
-          </table>
-        </div>
-      )}
-
-      <div style={{ marginTop: '12px', fontSize: '11px', color: 'var(--text-tertiary)', padding: '8px 12px', background: 'var(--surface-2)', borderRadius: '6px' }}>
-        {t(
-          'Tato záložka ukazuje výsledky běhu (pass rate), nikoli pokrytí kódu. Kover line coverage je ve Skóre kvality. Data pocházejí z posledního CI artefaktu každé služby.',
-          'This tab shows execution results (pass rate), not code coverage. Kover line coverage is in Quality Score. Data comes from each service’s latest CI artifact.',
-        )}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(170px, 1fr))', gap: 12, marginBottom: 20 }}>
+        <Stat label="Inventoried components" value={report.totals.components} />
+        <Stat label="With execution evidence" value={`${report.totals.componentsWithExecutionEvidence}/${report.totals.components}`} />
+        <Stat label="Money-path components" value={report.totals.moneyPathComponents} />
+        <Stat label="Failing evidence" value={report.totals.failingEvidence} tone={report.totals.failingEvidence ? '#dc2626' : '#16a34a'} />
+        <Stat label="No execution evidence" value={report.totals.missingEvidence} tone={report.totals.missingEvidence ? '#d97706' : '#16a34a'} />
+        <Stat label="Stale evidence" value={report.totals.staleEvidence} tone={report.totals.staleEvidence ? '#d97706' : '#16a34a'} />
+      </div>
+      <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}>
+        <table style={tableStyle}>
+          <thead><tr><th style={thStyle}>{t('Komponenta', 'Component')}</th>{KINDS.map(kind => <th key={kind} style={thStyle}>{kind}</th>)}<th style={thStyle}>{t('Řádky Kover', 'Kover lines')}</th></tr></thead>
+          <tbody>{sorted.map(component => (
+            <tr key={component.component}>
+              <td style={{ ...tdStyle, fontWeight: 650 }}>{component.component}{component.moneyPath && <span style={{ marginLeft: 6, color: '#dc2626', fontSize: 9 }}>{t('PENĚŽNÍ TOK', 'MONEY PATH')}</span>}</td>
+              {KINDS.map(kind => <td key={kind} style={tdStyle}><EvidenceCell component={component} kind={kind} /></td>)}
+              <td style={tdStyle}>{component.coverage.lines.percentage === null ? <StateBadge state={component.coverage.state} /> : `${component.coverage.lines.percentage}%`}</td>
+            </tr>
+          ))}</tbody>
+        </table>
       </div>
     </>
   )
 }
 
-// ── Contract tab ──────────────────────────────────────────────────────────────
-
-function ContractTab({ contracts, error }: { contracts: ContractVerification[]; error: boolean }) {
-  const { t, language } = useLanguage()
-  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
-
-  if (error) {
-    return (
-      <DataUnavailable
-        kind="no_data"
-        feature={t('Smluvní testy (Pact)', 'Contract tests (Pact)')}
-        lang={t('cs', 'en') as 'cs' | 'en'}
-        detail={t(
-          'Výsledky kontraktních testů nejsou k dispozici. Spusť ./gradlew test v balance-service a ledger-service.',
-          'Contract test results are not available. Run ./gradlew test in balance-service and ledger-service.',
-        )}
-        dense
-      />
-    )
-  }
-
-  if (contracts.length === 0) {
-    return (
-      <div className="card" style={{ padding: '32px', textAlign: 'center', color: 'var(--text-secondary)' }}>
-        <ShieldCheck size={32} style={{ margin: '0 auto 12px', color: 'var(--text-tertiary)' }} />
-        <p style={{ fontSize: '13px' }}>
-          {t(
-            'Žádné kontraktní testy k dispozici. Výsledky se zobrazí po spuštění CI pipeline.',
-            'No contract test results available. Results appear after running the CI pipeline.',
-          )}
-        </p>
-        <p style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginTop: '8px' }}>
-          {t('Paktové soubory: pacts/', 'Pact files: pacts/')}
-        </p>
-      </div>
-    )
-  }
-
-  const providers = [...new Set(contracts.map(c => c.provider))].sort()
-  const consumers = [...new Set(contracts.map(c => c.consumer))].sort()
-
+function Execution({ report }: { report: TestIntelligenceReport }) {
+  const rows = report.components.flatMap(component => component.evidence
+    .filter(item => ['unit', 'integration', 'e2e', 'simulation'].includes(item.kind))
+    .map(item => ({ component: component.component, ...item })))
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
-      <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
-        <div style={{ padding: '14px 16px', borderBottom: '1px solid var(--border)', background: 'var(--surface-2)', fontSize: '12px', fontWeight: 600, color: 'var(--text-secondary)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
-          {t('Provider × Consumer matice', 'Provider × Consumer matrix')}
-        </div>
-        <div style={{ overflowX: 'auto' }}>
-          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '12px' }}>
-            <thead>
-              <tr style={{ borderBottom: '1px solid var(--border)' }}>
-                <th style={{ padding: '10px 16px', textAlign: 'left', fontWeight: 600, color: 'var(--text-secondary)', minWidth: '180px' }}>
-                  {t('Provider ↓ / Consumer →', 'Provider ↓ / Consumer →')}
-                </th>
-                {consumers.map(consumer => (
-                  <th key={consumer} style={{ padding: '10px 16px', textAlign: 'center', fontWeight: 600, color: 'var(--text-secondary)', fontFamily: 'monospace', fontSize: '11px' }}>
-                    {consumer.replace('openbank-', '')}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {providers.map(provider => (
-                <tr key={provider} style={{ borderBottom: '1px solid var(--border)' }}>
-                  <td style={{ padding: '10px 16px', fontFamily: 'monospace', fontSize: '11px', fontWeight: 600, color: 'var(--text-primary)' }}>
-                    {provider.replace('openbank-', '')}
-                  </td>
-                  {consumers.map(consumer => {
-                    const contract = contracts.find(c => c.provider === provider && c.consumer === consumer)
-                    return (
-                      <td key={consumer} style={{ padding: '10px 16px', textAlign: 'center' }}>
-                        {contract ? (
-                          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '4px' }}>
-                            <StatusBadge status={contract.status} />
-                            {contract.verifiedAt && (
-                              <span style={{ fontSize: '10px', color: 'var(--text-tertiary)' }}>
-                                {new Date(contract.verifiedAt).toLocaleDateString(dateLocale)}
-                              </span>
-                            )}
-                          </div>
-                        ) : (
-                          <span style={{ color: 'var(--text-tertiary)', fontSize: '11px' }}>—</span>
-                        )}
-                      </td>
-                    )
-                  })}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      {contracts.map(contract => (
-        <div key={`${contract.consumer}-${contract.provider}`} className="card" style={{ padding: 0, overflow: 'hidden' }}>
-          <div style={{ padding: '12px 16px', borderBottom: '1px solid var(--border)', display: 'flex', alignItems: 'center', gap: '10px', background: 'var(--surface-2)' }}>
-            <StatusBadge status={contract.status} />
-            <span style={{ fontFamily: 'monospace', fontSize: '12px', fontWeight: 600 }}>
-              {contract.consumer.replace('openbank-', '')}
-            </span>
-            <span style={{ color: 'var(--text-tertiary)' }}>→</span>
-            <span style={{ fontFamily: 'monospace', fontSize: '12px', fontWeight: 600 }}>
-              {contract.provider.replace('openbank-', '')}
-            </span>
-            <span style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginLeft: 'auto' }}>
-              {contract.pactFile}
-            </span>
-          </div>
-          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '12px' }}>
-            <tbody>
-              {contract.interactions.map((interaction, idx) => (
-                <tr key={idx} style={{ borderBottom: '1px solid var(--border)' }}>
-                  <td style={{ padding: '8px 16px', width: '24px' }}>
-                    <StatusBadge status={interaction.status} />
-                  </td>
-                  <td style={{ padding: '8px 16px', color: 'var(--text-primary)' }}>
-                    {interaction.description}
-                  </td>
-                  {interaction.failure && (
-                    <td style={{ padding: '8px 16px', color: '#dc2626', fontSize: '11px', fontFamily: 'monospace' }}>
-                      {interaction.failure}
-                    </td>
-                  )}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      ))}
-
-      <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', padding: '8px 12px', background: 'var(--surface-2)', borderRadius: '6px' }}>
-        {t(
-          'Kontrakty se generují z Pact consumer testů a ukládají do pacts/ (git-pact, ADR-0063). Verifikace probíhá v CI providera.',
-          'Contracts are generated from Pact consumer tests and stored in pacts/ (git-pact, ADR-0063). Verification runs in the provider CI job.',
-        )}
-      </div>
+    <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}>
+      <table style={tableStyle}><thead><tr>{['Component', 'Kind', 'State', 'Discovered', 'Executed', 'Passed', 'Failed', 'Skipped', 'Observed'].map(label => <th key={label} style={thStyle}>{label}</th>)}</tr></thead>
+        <tbody>{rows.map((row, index) => <tr key={`${row.component}-${row.kind}-${index}`}>
+          <td style={{ ...tdStyle, fontWeight: 650 }}>{row.component}</td><td style={tdStyle}>{row.kind}</td><td style={tdStyle}><StateBadge state={row.state} /></td>
+          <td style={tdStyle}>{row.counts?.discovered ?? '—'}</td><td style={tdStyle}>{row.counts?.executed ?? '—'}</td><td style={tdStyle}>{row.counts?.passed ?? '—'}</td>
+          <td style={tdStyle}>{row.counts?.failed ?? '—'}</td><td style={tdStyle}>{row.counts?.skipped ?? '—'}</td><td style={tdStyle}>{row.observedAt ? formatTimestamp(row.observedAt) : '—'}</td>
+        </tr>)}</tbody>
+      </table>
     </div>
   )
 }
 
-// ── Mutation tab ──────────────────────────────────────────────────────────────
-
-function MutationGauge({ score, threshold = 70 }: { score: number | null; threshold?: number }) {
-  if (score === null) {
-    return (
-      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', width: '72px', height: '72px', borderRadius: '50%', border: '4px solid var(--border)', color: 'var(--text-tertiary)', fontSize: '11px' }}>
-        —
-      </div>
-    )
-  }
-  const color = score >= threshold ? '#16a34a' : score >= threshold * 0.8 ? '#d97706' : '#dc2626'
-  const circumference = 2 * Math.PI * 28
-  const dashOffset = circumference * (1 - score / 100)
-  return (
-    <div style={{ position: 'relative', width: '72px', height: '72px' }}>
-      <svg width="72" height="72" viewBox="0 0 72 72" style={{ transform: 'rotate(-90deg)' }}>
-        <circle cx="36" cy="36" r="28" fill="none" stroke="var(--border)" strokeWidth="6" />
-        <circle cx="36" cy="36" r="28" fill="none" stroke={color} strokeWidth="6"
-          strokeDasharray={circumference} strokeDashoffset={dashOffset}
-          strokeLinecap="round" style={{ transition: 'stroke-dashoffset 0.5s ease' }} />
-      </svg>
-      <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '13px', fontWeight: 800, color }}>
-        {score}%
-      </div>
-    </div>
-  )
-}
-
-function MutationTab({ mutations, error }: { mutations: MutationScore[]; error: boolean }) {
-  const { t, language } = useLanguage()
-  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
-
-  if (error) {
-    return (
-      <DataUnavailable
-        kind="no_data"
-        feature={t('Mutační testy (pitest)', 'Mutation tests (pitest)')}
-        lang={t('cs', 'en') as 'cs' | 'en'}
-        detail={t(
-          'Výsledky pitest nejsou k dispozici. Spusť ./gradlew pitest nebo počkej na týdenní CI job.',
-          'Pitest results are not available. Run ./gradlew pitest or wait for the weekly CI job.',
-        )}
-        dense
-      />
-    )
-  }
-
-  if (mutations.length === 0) {
-    return (
-      <div className="card" style={{ padding: '32px', textAlign: 'center', color: 'var(--text-secondary)' }}>
-        <Dna size={32} style={{ margin: '0 auto 12px', color: 'var(--text-tertiary)' }} />
-        <p style={{ fontSize: '13px' }}>
-          {t(
-            'Žádné výsledky mutačního testování. Pitest běží týdně v CI (workflow pitest.yml).',
-            'No mutation test results. Pitest runs weekly in CI (pitest.yml workflow).',
-          )}
-        </p>
-        <p style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginTop: '8px' }}>
-          {t('Manuální spuštění: ./gradlew pitest', 'Manual run: ./gradlew pitest')}
-        </p>
-      </div>
-    )
-  }
-
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: '12px' }}>
-        {mutations.map(mut => (
-          <div key={mut.service} className="card" style={{ padding: '20px', display: 'flex', alignItems: 'center', gap: '16px' }}>
-            <MutationGauge score={mut.score} />
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ fontFamily: 'monospace', fontSize: '12px', fontWeight: 600, color: 'var(--text-primary)', marginBottom: '6px' }}>
-                {mut.service.replace('openbank-', '')}
-              </div>
-              <div style={{ fontSize: '11px', color: 'var(--text-secondary)', marginBottom: '4px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                {mut.targetPackage}
-              </div>
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '4px', fontSize: '10px', color: 'var(--text-tertiary)' }}>
-                <span style={{ color: '#16a34a' }}>✓ {mut.killed}</span>
-                <span style={{ color: '#dc2626' }}>✗ {mut.survived}</span>
-                <span>◌ {mut.noCoverage}</span>
-              </div>
-              {mut.reportedAt && (
-                <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', marginTop: '4px' }}>
-                  {new Date(mut.reportedAt).toLocaleDateString(dateLocale)}
-                </div>
-              )}
-            </div>
-          </div>
-        ))}
-      </div>
-
-      <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', padding: '8px 12px', background: 'var(--surface-2)', borderRadius: '6px' }}>
-        {t(
-          'Pitest testuje domain vrstvu (finanční aritmetika). Práh: 70%. Týdenní CI job: .github/workflows/pitest.yml (ADR-0063).',
-          'Pitest tests the domain layer (financial arithmetic). Threshold: 70%. Weekly CI job: .github/workflows/pitest.yml (ADR-0063).',
-        )}
-      </div>
-    </div>
-  )
-}
-
-// ── Quality score tab ─────────────────────────────────────────────────────────
-
-function QualityScoreCell({ score }: { score: number | null }) {
-  if (score === null) return <span style={{ color: 'var(--text-tertiary)', fontSize: '12px' }}>—</span>
-  const color = score >= 80 ? '#16a34a' : score >= 60 ? '#d97706' : '#dc2626'
-  return <span style={{ fontWeight: 700, fontSize: '13px', color }}>{score}%</span>
-}
-
-function QualityTab({ scores }: { scores: ServiceQualityScore[] }) {
+function TestCases({ report }: { report: TestIntelligenceReport }) {
   const { t } = useLanguage()
-
-  const sorted = scores.slice().sort((a, b) => {
-    if (a.composite !== null && b.composite !== null) return b.composite - a.composite
-    if (a.composite !== null) return -1
-    if (b.composite !== null) return 1
-    return a.service.localeCompare(b.service)
-  })
-
-  if (scores.length === 0) {
-    return (
-      <div className="card" style={{ padding: '32px', textAlign: 'center', color: 'var(--text-secondary)' }}>
-        <Star size={32} style={{ margin: '0 auto 12px', color: 'var(--text-tertiary)' }} />
-        <p style={{ fontSize: '13px' }}>
-          {t(
-            'Kompozitní skóre bude dostupné po spuštění CI pipeline (testy + pitest + Pact).',
-            'Composite score will be available after running the CI pipeline (tests + pitest + Pact).',
-          )}
-        </p>
-      </div>
-    )
-  }
-
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-      <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
-        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '12px' }}>
-          <thead>
-            <tr style={{ background: 'var(--surface-2)', borderBottom: '1px solid var(--border)' }}>
-              {[
-                { label: t('Služba', 'Service'), align: 'left' as const },
-                { label: t('Testy', 'Tests'), align: 'center' as const },
-                { label: t('Pokrytí', 'Coverage'), align: 'center' as const },
-                { label: t('Mutace', 'Mutation'), align: 'center' as const },
-                { label: t('Kontrakty', 'Contracts'), align: 'center' as const },
-                { label: t('Celkové skóre', 'Overall score'), align: 'center' as const },
-              ].map(col => (
-                <th key={col.label} style={{ padding: '10px 16px', textAlign: col.align, fontWeight: 600, color: 'var(--text-secondary)', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
-                  {col.label}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {sorted.map(row => (
-              <tr key={row.service} style={{ borderBottom: '1px solid var(--border)' }}>
-                <td style={{ padding: '10px 16px', fontFamily: 'monospace', fontSize: '11px', fontWeight: 600, color: 'var(--text-primary)' }}>
-                  {row.service.replace('openbank-', '')}
-                </td>
-                <td style={{ padding: '10px 16px', textAlign: 'center' }}><QualityScoreCell score={row.unitScore} /></td>
-                <td style={{ padding: '10px 16px', textAlign: 'center' }}><QualityScoreCell score={row.coverageScore} /></td>
-                <td style={{ padding: '10px 16px', textAlign: 'center' }}><QualityScoreCell score={row.mutationScore} /></td>
-                <td style={{ padding: '10px 16px', textAlign: 'center' }}><QualityScoreCell score={row.contractScore} /></td>
-                <td style={{ padding: '10px 16px', textAlign: 'center' }}>
-                  {row.composite !== null
-                    ? <ScoreBar score={row.composite} threshold={80} />
-                    : <span style={{ color: 'var(--text-tertiary)', fontSize: '12px' }}>—</span>}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-
-      <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', padding: '8px 12px', background: 'var(--surface-2)', borderRadius: '6px' }}>
-        {t(
-          'Kompozitní skóre = průměr dostupných složek: pass rate testů (25 %) + kover pokrytí (25 %) + pitest mutace (25 %) + kontrakty (25 %).',
-          'Composite score = average of available components: test pass rate (25%) + kover coverage (25%) + pitest mutation (25%) + contracts (25%).',
-        )}
-      </div>
+  const flaky = report.testCases.filter(item => item.state === 'flaky')
+  const failing = report.testCases.filter(item => item.state === 'failing')
+  const wasted = report.testCases.reduce((sum, item) => sum + item.wastedDurationMs, 0)
+  return <div style={{ display: 'grid', gap: 18 }}>
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(170px, 1fr))', gap: 12 }}>
+      <Stat label="Tracked test definitions" value={report.testCases.length} />
+      <Stat label="Observed flaky" value={flaky.length} tone={flaky.length ? '#d97706' : '#16a34a'} />
+      <Stat label="Currently failing" value={failing.length} tone={failing.length ? '#dc2626' : '#16a34a'} />
+      <Stat label="Failed runtime" value={`${Math.round(wasted / 1000)} s`} tone={wasted ? '#d97706' : undefined} />
     </div>
-  )
+    <div style={{ padding: 12, border: '1px solid color-mix(in srgb, #16a34a 35%, var(--border))', borderRadius: 9, color: 'var(--text-secondary)', fontSize: 12 }}>
+      {t('Test je označen jako flaky až po úspěšném i neúspěšném pozorování stejného commitu. Vlastnictví vychází z CODEOWNERS. Triage nikdy nemění deterministický verdikt CI ani nepřeskakuje peněžní kontroly.', 'A test is marked flaky only after pass and fail observations on the same commit. Ownership comes from CODEOWNERS. Triage never changes the deterministic CI verdict or skips money-path controls.')}
+    </div>
+    <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}><table style={tableStyle}>
+      <thead><tr>{['State', 'Test definition', 'Component', 'Kind', 'Owner', 'Runs', 'Failure rate', 'Avg duration', 'Failed runtime', 'Fingerprint'].map(label => <th key={label} style={thStyle}>{label}</th>)}</tr></thead>
+      <tbody>{report.testCases.map(item => <tr key={item.fingerprint}>
+        <td style={tdStyle}><StateBadge state={item.state === 'stable' ? 'passed' : item.state === 'failing' ? 'failed' : item.state === 'skipped' ? 'skipped' : 'stale'} /></td>
+        <td style={{ ...tdStyle, minWidth: 230 }}><strong>{item.name}</strong><div style={{ color: 'var(--text-tertiary)', fontSize: 10, marginTop: 3 }}>{item.classname}</div>{item.sameCommitTransitions > 0 && <div style={{ color: '#d97706', fontSize: 10, marginTop: 3 }}>{item.sameCommitTransitions} same-commit pass/fail transition(s)</div>}</td>
+        <td style={tdStyle}>{item.component}</td><td style={tdStyle}>{item.kind}</td><td style={tdStyle}>{item.owner}</td><td style={tdStyle}>{item.observations}</td>
+        <td style={tdStyle}>{item.failureRate === null ? '—' : `${item.failureRate}%`}</td><td style={tdStyle}>{item.averageDurationMs} ms</td><td style={tdStyle}>{item.wastedDurationMs} ms</td>
+        <td style={{ ...tdStyle, fontFamily: 'monospace', fontSize: 10 }}>{item.fingerprint}</td>
+      </tr>)}</tbody>
+    </table>{report.testCases.length === 0 && <div style={{ padding: 18, color: 'var(--text-tertiary)', fontSize: 12 }}>{t('Zatím nejsou uchovány žádné per-test obálky běhů. Verdikty sad zůstávají autoritativní.', 'No per-test run envelopes have been retained yet. Suite verdicts remain authoritative.')}</div>}</div>
+  </div>
 }
 
-// ── Main page ─────────────────────────────────────────────────────────────────
+function History({ report }: { report: TestIntelligenceReport }) {
+  const { t } = useLanguage()
+  const max = Math.max(1, ...report.history.map(point => point.components))
+  return <div style={{ display: 'grid', gap: 18 }}><div style={{ border: '1px solid var(--border)', borderRadius: 10, padding: 18, background: 'var(--surface-1)' }}>
+    <div style={{ marginBottom: 16 }}><strong>{t('Historie fleet evidence', 'Fleet evidence history')}</strong><div style={{ color: 'var(--text-secondary)', fontSize: 12, marginTop: 4 }}>{t('Neměnné deployment snapshoty uchované jako CI artefakty. Sloupce nikdy neodvozují chybějící běhy.', 'Immutable deployment snapshots retained as CI artifacts. Bars never infer missing runs.')}</div></div>
+    {report.history.length < 2 && <div style={{ color: '#d97706', fontSize: 12, marginBottom: 12 }}><TriangleAlert size={13} style={{ verticalAlign: 'text-bottom', marginRight: 5 }} />The first snapshot is present; a trend appears after the next admin deployment.</div>}
+    <div style={{ display: 'flex', alignItems: 'end', gap: 8, minHeight: 190, overflowX: 'auto', paddingTop: 12 }}>
+      {report.history.map(point => <div key={point.collectedAt} title={`${new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(point.collectedAt))} · ${point.componentsWithExecutionEvidence}/${point.components} evidenced · ${point.failingEvidence} failing`} style={{ minWidth: 38, flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'end', gap: 3, height: 170 }}>
+        <div style={{ height: `${Math.max(2, point.failingEvidence / max * 150)}px`, background: '#dc2626', borderRadius: '4px 4px 0 0' }} />
+        <div style={{ height: `${Math.max(2, point.missingEvidence / max * 150)}px`, background: '#d97706' }} />
+        <div style={{ height: `${Math.max(2, point.componentsWithExecutionEvidence / max * 150)}px`, background: '#16a34a', borderRadius: '0 0 4px 4px' }} />
+        <span style={{ fontSize: 9, color: 'var(--text-tertiary)', textAlign: 'center' }}>{new Intl.DateTimeFormat('en-GB', { month: 'short', day: 'numeric' }).format(new Date(point.collectedAt))}</span>
+      </div>)}
+    </div>
+    <div style={{ display: 'flex', gap: 14, marginTop: 12, fontSize: 11, color: 'var(--text-secondary)' }}><span style={{ color: '#16a34a' }}>● evidenced</span><span style={{ color: '#d97706' }}>● missing</span><span style={{ color: '#dc2626' }}>● failing</span></div>
+  </div><div style={{ border: '1px solid var(--border)', borderRadius: 10, overflowX: 'auto' }}>
+    <div style={{ padding: '16px 18px 8px' }}><strong>{t('Neměnné pokusy služeb', 'Immutable service attempts')}</strong><div style={{ color: 'var(--text-secondary)', fontSize: 12, marginTop: 4 }}>{t('Nejnovější verzované CI obálky; opakované běhy zůstávají samostatnými pokusy.', 'Latest versioned CI envelopes; reruns remain separate attempts.')}</div></div>
+    <table style={tableStyle}><thead><tr><th style={thStyle}>Component</th><th style={thStyle}>Run / attempt</th><th style={thStyle}>Commit</th><th style={thStyle}>{t('Stavy evidence', 'Evidence states')}</th><th style={thStyle}>Runtime</th><th style={thStyle}>Observed</th></tr></thead>
+      <tbody>{report.runHistory.slice(0, 100).map(item => <tr key={`${item.component}-${item.run.id}-${item.run.attempt}`}><td style={{ ...tdStyle, fontWeight: 650 }}>{item.component}</td><td style={tdStyle}>{item.run.id} / {item.run.attempt}</td><td style={tdStyle}>{item.run.commit.slice(0, 8)}</td><td style={tdStyle}>{Object.entries(item.states).map(([kind, state]) => <span key={kind} style={{ marginRight: 9 }}>{kind}: <StateBadge state={state} /></span>)}</td><td style={tdStyle}>{item.infrastructureStarted} start · {item.infrastructureStopped} stop</td><td style={tdStyle}>{new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(item.run.observedAt))}</td></tr>)}</tbody>
+    </table>
+    {report.runHistory.length === 0 && <div style={{ padding: 18, color: 'var(--text-tertiary)', fontSize: 12 }}>{t('Zatím nejsou přibaleny žádné uchované service-run obálky.', 'No retained service-run envelopes are bundled yet.')}</div>}
+  </div></div>
+}
 
-type Tab = 'tests' | 'contract' | 'mutation' | 'quality'
+function RuntimeInfrastructure({ report }: { report: TestIntelligenceReport }) {
+  const { t } = useLanguage()
+  const rows = report.components.filter(component => component.testInfrastructure.declared.length > 0 || component.testInfrastructure.observed.length > 0)
+  return <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}><table style={tableStyle}>
+    <thead><tr><th style={thStyle}>Component</th><th style={thStyle}>{t('Deklarovaná topologie', 'Declared topology')}</th><th style={thStyle}>{t('Důkaz runtime', 'Runtime proof')}</th><th style={thStyle}>Lifecycle</th><th style={thStyle}>Observed</th></tr></thead>
+    <tbody>{rows.map(row => {
+      const started = row.testInfrastructure.observed.filter(item => item.lifecycle === 'started')
+      const stopped = row.testInfrastructure.observed.filter(item => item.lifecycle === 'stopped')
+      const state: EvidenceState = started.length === 0 ? 'unknown' : stopped.length < started.length ? 'failed' : 'passed'
+      const latest = row.testInfrastructure.observed.at(-1)?.observedAt
+      return <tr key={row.component}><td style={{ ...tdStyle, fontWeight: 650 }}>{row.component}</td><td style={tdStyle}>{row.testInfrastructure.declared.join(' · ') || 'none'}</td><td style={tdStyle}><StateBadge state={state} /></td><td style={tdStyle}>{started.length} started · {stopped.length} stopped</td><td style={tdStyle}>{latest ? new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(latest)) : 'not emitted by this run'}</td></tr>
+    })}</tbody>
+  </table></div>
+}
 
-export default function TestCoveragePage() {
-  const { t, language } = useLanguage()
+function Coverage({ report }: { report: TestIntelligenceReport }) {
+  return <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}><table style={tableStyle}>
+    <thead><tr><th style={thStyle}>Component</th><th style={thStyle}>State</th><th style={thStyle}>Lines</th><th style={thStyle}>Branches</th><th style={thStyle}>Observed</th><th style={thStyle}>Source</th></tr></thead>
+    <tbody>{report.components.map(row => <tr key={row.component}><td style={{ ...tdStyle, fontWeight: 650 }}>{row.component}</td><td style={tdStyle}><StateBadge state={row.coverage.state} /></td>
+      <td style={tdStyle}>{row.coverage.lines.percentage === null ? '—' : `${row.coverage.lines.percentage}%`}</td><td style={tdStyle}>{row.coverage.branches.percentage === null ? '—' : `${row.coverage.branches.percentage}%`}</td>
+      <td style={tdStyle}>{row.coverage.observedAt ? formatTimestamp(row.coverage.observedAt) : '—'}</td><td style={tdStyle}>{row.coverage.source ?? '—'}</td></tr>)}</tbody>
+  </table></div>
+}
+
+function Contracts({ report }: { report: TestIntelligenceReport }) {
+  const { t } = useLanguage()
+  const unknown = report.contracts.filter(row => row.state === 'unknown')
+  const contractSuites = report.runHistory.flatMap(run => Object.entries(run.states)
+    .filter(([kind]) => kind === 'contract')
+    .map(([, state]) => state))
+  const suiteSummary = contractSuites.length === 0
+    ? t('V uchované historii není přibalen žádný contract suite verdict.', 'No contract-suite verdict is bundled in retained run history.')
+    : t(`${contractSuites.filter(state => state === 'passed').length}/${contractSuites.length} uchovaných CI contract suite verdiktů prošlo.`, `${contractSuites.filter(state => state === 'passed').length}/${contractSuites.length} retained CI contract-suite verdicts passed.`)
+  return <div style={{ display: 'grid', gap: 12 }}>
+    <div style={{ padding: 13, border: '1px solid color-mix(in srgb, #64748b 36%, var(--border))', borderRadius: 10, background: 'var(--surface-2)', color: 'var(--text-secondary)', fontSize: 12 }}>
+      <strong style={{ color: 'var(--text-primary)' }}>{t('Dva nezaměnitelné druhy důkazu.', 'Two non-interchangeable evidence types.')}</strong>{' '}
+      {t('Tabulka níže ukazuje per-Pact provider-verification verdikt z Pact Brokeru. Historie běhů ukazuje CI contract suite verdikt. Jeden není náhradou druhého a neznámý broker verdikt se nikdy nevydává za zelený.', 'The table below shows the per-Pact provider-verification verdict from the Pact Broker. Run history shows the CI contract-suite verdict. Neither substitutes for the other, and an unavailable broker verdict is never presented as green.')}
+      <div style={{ marginTop: 7 }}>{suiteSummary}</div>
+      {unknown.length > 0 && <div style={{ marginTop: 7, color: '#64748b' }}>{t(`${unknown.length} Pactů má neznámý broker verdikt v tomto snapshotu; otevři detail řádku pro přesný důvod.`, `${unknown.length} Pacts have an unavailable broker verdict in this snapshot; open a row detail for the precise reason.`)}</div>}
+    </div>
+    <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}><table style={tableStyle}>
+      <thead><tr><th style={thStyle}>Consumer</th><th style={thStyle}>Provider</th><th style={thStyle}>{t('Broker verdict', 'Broker verdict')}</th><th style={thStyle}>Interactions</th><th style={thStyle}>Pact</th><th style={thStyle}>Verified</th><th style={thStyle}>{t('Evidence basis', 'Evidence basis')}</th></tr></thead>
+      <tbody>{report.contracts.map(row => <tr key={row.pactFile}><td style={tdStyle}>{row.consumer}</td><td style={tdStyle}>{row.provider}</td><td style={tdStyle}><StateBadge state={row.state} /></td><td style={tdStyle}>{row.interactions}</td><td style={tdStyle}>{row.pactFile}</td><td style={tdStyle}>{row.observedAt ? formatTimestamp(row.observedAt) : '—'}</td><td style={{ ...tdStyle, minWidth: 300, color: 'var(--text-secondary)', fontSize: 11 }}>{row.verificationDetail ?? t('Snapshot does not provide a verification explanation.', 'Snapshot neposkytuje vysvětlení ověření.')}</td></tr>)}</tbody>
+    </table></div>
+  </div>
+}
+
+function Mutations({ report }: { report: TestIntelligenceReport }) {
+  return <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: 12 }}>{report.mutations.map(row => <div key={row.component} style={{ border: '1px solid var(--border)', borderRadius: 10, padding: 16, background: 'var(--surface-1)' }}>
+    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}><strong>{row.component}</strong><StateBadge state={row.state} /></div>
+    <div style={{ fontSize: 28, fontWeight: 750, margin: '12px 0' }}>{row.score ?? '—'}%</div>
+    <div style={{ color: 'var(--text-secondary)', fontSize: 12 }}>{row.killed} killed · {row.survived} survived · {row.noCoverage} no coverage</div>
+    {row.run && <div style={{ color: 'var(--text-tertiary)', fontSize: 11, marginTop: 7 }}>run {row.run.id} · {row.run.commit.slice(0, 8)}</div>}
+  </div>)}</div>
+}
+
+function Performance({ report }: { report: TestIntelligenceReport }) {
+  const { t } = useLanguage()
+  const declaredComponents = new Set(report.performance.flatMap(row => row.component ? [row.component] : []))
+  const executed = report.performance.filter(row => row.state === 'passed' || row.state === 'failed').length
+  const undeclared = report.components.filter(component => !declaredComponents.has(component.component)).length
+  return <div style={{ display: 'grid', gap: 10 }}>
+    <section aria-label={t('Rozsah pokrytí výkonnostních testů', 'Performance-test coverage scope')} style={{ border: '1px solid color-mix(in srgb, var(--accent) 35%, var(--border))', borderRadius: 12, padding: 16, background: 'linear-gradient(135deg, color-mix(in srgb, var(--accent) 9%, var(--surface-1)), var(--surface-1))' }}>
+      <strong>{t('Rozsah výkonnostních důkazů', 'Performance evidence scope')}</strong>
+      <div style={{ display: 'flex', gap: 18, flexWrap: 'wrap', marginTop: 10, fontSize: 13 }}>
+        <span><strong>{report.performance.length}</strong> {t('deklarovaných scénářů', 'declared scenarios')}</span>
+        <span><strong>{executed}</strong> {t('s výsledkem běhu', 'with run evidence')}</span>
+        <span><strong>{undeclared}</strong> {t('komponent bez deklarovaného scénáře', 'components without a declared scenario')}</span>
+      </div>
+      <p style={{ color: 'var(--text-secondary)', fontSize: 12, margin: '10px 0 0' }}>{t('Absence scénáře není zelený výsledek. Tento panel odděluje měřený rozsah od neprovedeného či dosud nedefinovaného výkonového pokrytí.', 'An absent scenario is not a green result. This panel separates measured scope from performance coverage that is not run or not yet declared.')}</p>
+    </section>
+    {report.performance.map(row => <div key={row.id} style={{ border: '1px solid var(--border)', borderRadius: 10, padding: 16, display: 'flex', justifyContent: 'space-between', gap: 16 }}>
+    <div><strong>{row.id}</strong><div style={{ color: 'var(--text-secondary)', fontSize: 12, marginTop: 5 }}>{row.source} · {row.thresholds} threshold group(s)</div>{row.metrics && <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginTop: 9, fontSize: 12 }}><span><strong>p95</strong> {row.metrics.p95Ms === null ? '—' : `${Math.round(row.metrics.p95Ms)} ms`}</span><span><strong>{t('Chybovost', 'Error rate')}</strong> {row.metrics.errorRatePercent === null ? '—' : `${row.metrics.errorRatePercent}%`}</span><span><strong>{t('Kontroly', 'Checks')}</strong> {row.metrics.checkPassRatePercent === null ? '—' : `${row.metrics.checkPassRatePercent}%`}</span><span><strong>{t('Požadavky', 'Requests')}</strong> {row.metrics.requests === null ? '—' : row.metrics.requests}</span></div>}{row.run && <div style={{ color: 'var(--text-tertiary)', fontSize: 11, marginTop: 5 }}>run {row.run.id} · {row.run.commit.slice(0, 8)} · {row.run.branch}</div>}{row.detail && <div style={{ color: 'var(--text-tertiary)', fontSize: 11, marginTop: 5 }}>{row.detail}</div>}</div><StateBadge state={row.state} />
+    </div>)}
+  </div>
+}
+
+function Synthetics({ report }: { report: TestIntelligenceReport }) {
+  const { t } = useLanguage()
+  return <div style={{ display: 'grid', gap: 12 }}>{report.syntheticJourneys.map(row => <div key={row.id} style={{ border: '1px solid var(--border)', borderRadius: 10, padding: 18, background: 'var(--surface-1)' }}>
+    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}><div><strong>{row.title}</strong><span style={{ marginLeft: 8, color: 'var(--text-tertiary)', fontSize: 11 }}>{row.id}</span></div><StateBadge state={row.state} /></div>
+    <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', marginTop: 10, fontSize: 12, color: 'var(--text-secondary)' }}><span>Status: {row.status}</span><span>Severity: {row.severity}</span><span>{row.status === 'planned' ? 'Target schedule' : 'Schedule'}: {row.schedule ?? 'not scheduled'}</span><span>Environment: {row.environment ?? '—'}</span></div>
+    {row.live && <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: 8, marginTop: 12, padding: 12, borderRadius: 8, background: 'var(--surface-2)', fontSize: 11 }}>
+      <div><span style={{ color: 'var(--text-tertiary)' }}>{t('Naposledy naplánováno', 'Last scheduled')}</span><br /><strong>{row.live.lastScheduledAt ? new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(row.live.lastScheduledAt)) : 'never observed'}</strong></div>
+      <div><span style={{ color: 'var(--text-tertiary)' }}>{t('Poslední úspěch', 'Last success')}</span><br /><strong>{row.live.lastSuccessfulAt ? new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(row.live.lastSuccessfulAt)) : 'never observed'}</strong></div>
+      <div><span style={{ color: 'var(--text-tertiary)' }}>Failures / 30m</span><br /><strong>{row.live.failuresLast30m ?? 'unavailable'}</strong></div>
+      <div><span style={{ color: 'var(--text-tertiary)' }}>{t('Čerstvost evidence', 'Evidence freshness')}</span><br /><strong>{row.live.freshnessSeconds === null ? 'unknown' : `${Math.round(row.live.freshnessSeconds / 60)} min`}</strong></div>
+      <div><span style={{ color: 'var(--text-tertiary)' }}>{t('Poslední Kubernetes běhy', 'Recent Kubernetes runs')}</span><br /><strong>{row.live.recentRuns.length || 'none retained'}</strong></div>
+    </div>}
+    {row.falsifies && <p style={{ fontSize: 12, color: 'var(--text-secondary)', margin: '10px 0 0' }}><strong>Falsification:</strong> {row.falsifies}</p>}
+    {row.blocker && <p style={{ fontSize: 12, color: '#7c3aed', margin: '10px 0 0' }}><strong>Blocker:</strong> {row.blocker}</p>}
+  </div>)}</div>
+}
+
+function ClientExperiences({ report }: { report: TestIntelligenceReport }) {
+  const { t } = useLanguage()
+  return <div style={{ display: 'grid', gap: 12 }}>{(report.clientExperiences ?? []).map(client => <div key={client.id} style={{ border: '1px solid var(--border)', borderRadius: 10, padding: 18, background: 'var(--surface-1)' }}>
+    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}><div><strong>{client.title}</strong><span style={{ marginLeft: 8, color: 'var(--text-tertiary)', fontSize: 11 }}>{client.platforms.join(' · ')}</span></div><StateBadge state={client.evidence.some(item => item.state === 'failed') ? 'failed' : client.evidence.length ? 'passed' : 'not-run'} /></div>
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))', gap: 10, marginTop: 12 }}>{client.evidence.map((item, index) => <div key={`${item.kind}-${index}`} style={{ padding: 10, borderRadius: 8, background: 'var(--surface-2)', fontSize: 12 }}><strong>{item.kind}</strong><div style={{ marginTop: 6 }}><StateBadge state={item.state} /></div>{item.counts && <div style={{ color: 'var(--text-secondary)', marginTop: 5 }}>{item.counts.passed}/{item.counts.executed} passed</div>}{item.detail && <div style={{ color: 'var(--text-tertiary)', marginTop: 5 }}>{item.detail}</div>}</div>)}</div>
+    {client.evidence.length === 0 && <p style={{ fontSize: 12, color: '#d97706', margin: '12px 0 0' }}>{t('Není přibalen důkaz posledního client CI běhu; zdrojový kód se nesmí vydávat za proběhlý test.', 'No latest client-CI evidence is bundled; source code is not represented as a completed test.')}</p>}
+    <div style={{ marginTop: 12, padding: 11, borderRadius: 8, background: 'var(--surface-2)', fontSize: 12 }}><strong>RUM</strong><span style={{ marginLeft: 8 }}><StateBadge state={client.rum.state} /></span>{client.rum.source && <span style={{ marginLeft: 8, color: 'var(--text-tertiary)' }}>{client.rum.source} · 7d</span>}<div style={{ color: 'var(--text-secondary)', marginTop: 5 }}>{client.rum.detail}</div>{client.rum.sampledSpansLast7d !== undefined && client.rum.sampledSpansLast7d !== null && <div style={{ color: 'var(--text-tertiary)', marginTop: 5 }}>{client.rum.sampledSpansLast7d} sampled spans · {client.rum.errorSpansLast7d ?? 'unknown'} error spans</div>}</div>
+    {client.blocker && <p style={{ fontSize: 12, color: '#7c3aed', margin: '10px 0 0' }}><strong>Blocker:</strong> {client.blocker}</p>}
+  </div>)}</div>
+}
+
+export default function TestIntelligencePage() {
+  const { language, t } = useLanguage()
   const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
-  const [tab, setTab] = useState<Tab>('tests')
-
-  const [testData, setTestData] = useState<TestResultsResponse | null>(null)
-  const [testError, setTestError] = useState<string | null>(null)
-  const [testLoading, setTestLoading] = useState(true)
-
-  const [qualityData, setQualityData] = useState<QualityReport | null>(null)
-  const [qualityError, setQualityError] = useState(false)
-  const [qualityLoading, setQualityLoading] = useState(true)
-
-  const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
+  const [tab, setTab] = useState<Tab>('posture')
+  const [report, setReport] = useState<TestIntelligenceReport | null>(null)
+  const [loading, setLoading] = useState(true)
+  const testLoading = loading
+  const qualityLoading = false
 
   const load = useCallback(async () => {
-    setTestLoading(true)
-    setQualityLoading(true)
-    setTestError(null)
-    setQualityError(false)
-
-    const [testRes, qualRes] = await Promise.allSettled([
-      fetch('/api/test-results', { cache: 'no-store' }),
-      fetch('/api/quality-report', { cache: 'no-store' }),
-    ])
-
-    if (testRes.status === 'fulfilled' && testRes.value.ok) {
-      setTestData(await testRes.value.json())
-    } else {
-      setTestError('unavailable')
-    }
-    setTestLoading(false)
-
-    if (qualRes.status === 'fulfilled' && qualRes.value.ok) {
-      setQualityData(await qualRes.value.json() as QualityReport)
-    } else {
-      setQualityError(true)
-    }
-    setQualityLoading(false)
-    setLastRefresh(new Date())
+    setLoading(true)
+    try {
+      const response = await fetch('/api/test-intelligence', { cache: 'no-store' })
+      setReport(await response.json() as TestIntelligenceReport)
+    } catch { setReport(null) } finally { setLoading(false) }
   }, [])
+  useEffect(() => { void load() }, [load])
 
-  useEffect(() => { load() }, [load])
-
-  const tabs: { id: Tab; label: string; icon: React.ReactNode; count?: number }[] = [
-    { id: 'tests', label: t('Testy', 'Tests'), icon: <FlaskConical size={13} /> },
-    { id: 'contract', label: t('Kontrakty', 'Contracts'), icon: <ShieldCheck size={13} />, count: qualityData?.contracts.length },
-    { id: 'mutation', label: t('Mutace', 'Mutation'), icon: <Dna size={13} />, count: qualityData?.mutations.length },
-    { id: 'quality', label: t('Skóre kvality', 'Quality Score'), icon: <Star size={13} />, count: qualityData?.serviceScores.length },
+  const tabs: { id: Tab; label: string; icon: React.ReactNode }[] = [
+    { id: 'posture', label: t('Přehled', 'Posture'), icon: <Activity size={13} /> },
+    { id: 'tests', label: t('Testy a flaky', 'Tests & flaky'), icon: <FlaskConical size={13} /> },
+    { id: 'history', label: t('Historie', 'History'), icon: <BarChart3 size={13} /> },
+    { id: 'execution', label: t('Běhy', 'Execution'), icon: <FlaskConical size={13} /> },
+    { id: 'runtime', label: t('Testovací runtime', 'Test runtime'), icon: <Activity size={13} /> },
+    { id: 'coverage', label: t('Pokrytí kódu', 'Code coverage'), icon: <BarChart3 size={13} /> },
+    { id: 'contracts', label: t('Kontrakty', 'Contracts'), icon: <ShieldCheck size={13} /> },
+    { id: 'mutation', label: t('Mutace', 'Mutation'), icon: <Dna size={13} /> },
+    { id: 'performance', label: t('Výkon', 'Performance'), icon: <Gauge size={13} /> },
+    { id: 'synthetic', label: t('Syntetika', 'Synthetics'), icon: <Timer size={13} /> },
+    { id: 'clients', label: t('Client experience', 'Client experience'), icon: <Activity size={13} /> },
   ]
 
-  return (
-    <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
-      <PageHeader
-        breadcrumb={<div className="breadcrumb"><span>{t('OpenBank', 'OpenBank')}</span><span className="breadcrumb-sep">/</span><span>{t('Systém', 'System')}</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Kvalita kódu', 'Code Quality')}</span></div>}
-        icon={<FlaskConical size={20} aria-hidden="true" />}
-        title={t('Kvalita kódu', 'Code Quality')}
-        subtitle={t('Výsledky testů, kontraktní verifikace (Pact), mutační testování (pitest) a kompozitní skóre kvality.', 'Test results, contract verification (Pact), mutation testing (pitest), and composite quality score.')}
-        actions={<div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-          {lastRefresh && (
-            <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
-              {t('Aktualizováno', 'Updated')} {lastRefresh.toLocaleTimeString(dateLocale)}
-            </span>
-          )}
-          <button type="button" onClick={load} disabled={testLoading || qualityLoading} aria-busy={testLoading || qualityLoading}
-            aria-label={t('Obnovit systémové testy', 'Refresh system tests')} className="btn btn-secondary btn-sm">
-            <RefreshCw size={13} aria-hidden="true" style={{ animation: (testLoading || qualityLoading) ? 'spin 0.8s linear infinite' : 'none' }} />
-            {t('Obnovit', 'Refresh')}
-          </button>
-        </div>}
-      />
-
-      <div role="group" aria-label={t('Přepínač pohledů kvality kódu', 'Code quality view')} style={{ display: 'flex', gap: '2px', marginBottom: '20px', borderBottom: '1px solid var(--border)' }}>
-        {tabs.map(tabDef => (
-          <button
-            key={tabDef.id}
-            type="button"
-            aria-pressed={tab === tabDef.id}
-            onClick={() => setTab(tabDef.id)}
-            style={{
-              display: 'flex', alignItems: 'center', gap: '6px',
-              padding: '8px 14px',
-              fontSize: '13px', fontWeight: tab === tabDef.id ? 600 : 400,
-              color: tab === tabDef.id ? 'var(--accent)' : 'var(--text-secondary)',
-              background: 'none', border: 'none',
-              borderBottom: tab === tabDef.id ? '2px solid var(--accent)' : '2px solid transparent',
-              cursor: 'pointer', marginBottom: '-1px', transition: 'color 0.15s',
-            }}
-          >
-            <span aria-hidden="true">{tabDef.icon}</span>
-            {tabDef.label}
-            {tabDef.count !== undefined && tabDef.count > 0 && (
-              <span style={{ fontSize: '10px', background: 'var(--surface-3)', borderRadius: '10px', padding: '1px 6px', color: 'var(--text-secondary)', fontWeight: 500 }}>
-                {tabDef.count}
-              </span>
-            )}
-          </button>
-        ))}
-      </div>
-
-      {tab === 'tests' && (
-        <TestsTab data={testData} error={testError} loading={testLoading} />
-      )}
-      {tab === 'contract' && (
-        qualityLoading
-          ? <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>{Array.from({ length: 3 }).map((_, idx) => <div key={idx} className="skeleton" style={{ height: '48px' }} />)}</div>
-          : <ContractTab contracts={qualityData?.contracts ?? []} error={qualityError} />
-      )}
-      {tab === 'mutation' && (
-        qualityLoading
-          ? <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: '12px' }}>{Array.from({ length: 4 }).map((_, idx) => <div key={idx} className="skeleton" style={{ height: '100px' }} />)}</div>
-          : <MutationTab mutations={qualityData?.mutations ?? []} error={qualityError} />
-      )}
-      {tab === 'quality' && (
-        qualityLoading
-          ? <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>{Array.from({ length: 6 }).map((_, idx) => <div key={idx} className="skeleton" style={{ height: '42px' }} />)}</div>
-          : <QualityTab scores={qualityData?.serviceScores ?? []} />
-      )}
-    </div>
-  )
+  return <div style={{ padding: '28px 32px', maxWidth: 1600, animation: 'fadeIn 0.2s ease-out' }}>
+    <PageHeader
+      breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep" aria-hidden="true">/</span><span>{t('Systém', 'System')}</span><span className="breadcrumb-sep" aria-hidden="true">/</span><span className="breadcrumb-current">{t('Test Intelligence', 'Test Intelligence')}</span></div>}
+      icon={<FlaskConical size={19} aria-hidden="true" style={{ color: 'var(--accent)' }} />}
+      title={t('Test Intelligence', 'Test Intelligence')}
+      subtitle={t('Jednotný pohled na běhy, pokrytí kódu, kontrakty, mutace, výkon a sandboxové syntetické scénáře.', 'One evidence view for execution, code coverage, contracts, mutation, performance, and sandbox synthetic journeys.')}
+      actions={<button type="button" onClick={load} disabled={testLoading || qualityLoading} aria-busy={testLoading || qualityLoading} aria-label={t('Obnovit systémové testy', 'Refresh system tests')} className="btn btn-secondary btn-sm"><RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />{t('Obnovit', 'Refresh')}</button>}
+    />
+    <TestIntelligenceFlow report={report} />
+    {report && <AssuranceBoard report={report} selectTab={setTab} />}
+    {report?.warnings.length ? <div style={{ marginBottom: 16, border: '1px solid #d97706', borderRadius: 8, padding: 12, color: '#d97706', fontSize: 12 }}><TriangleAlert size={14} style={{ verticalAlign: 'text-bottom', marginRight: 6 }} />{report.warnings.join(' · ')}</div> : null}
+    <div role="group" aria-label={t('Přepínač pohledů kvality kódu', 'Code quality view')} style={{ display: 'flex', gap: 2, overflowX: 'auto', borderBottom: '1px solid var(--border)', marginBottom: 20 }}>{tabs.map(tabDef => <button key={tabDef.id} type="button"
+            aria-pressed={tab === tabDef.id} onClick={() => setTab(tabDef.id)} style={{ display: 'flex', gap: 6, alignItems: 'center', padding: '9px 13px', whiteSpace: 'nowrap', border: 'none', borderBottom: tab === tabDef.id ? '2px solid var(--accent)' : '2px solid transparent', background: 'none', color: tab === tabDef.id ? 'var(--accent)' : 'var(--text-secondary)', cursor: 'pointer', fontWeight: tab === tabDef.id ? 650 : 450 }}><span aria-hidden="true">{tabDef.icon}</span>{tabDef.label}</button>)}</div>
+    {loading && !report ? <div className="skeleton" style={{ height: 260 }} /> : report ? <>
+      {tab === 'posture' && <Posture report={report} />}{tab === 'tests' && <TestCases report={report} />}{tab === 'history' && <History report={report} />}{tab === 'execution' && <Execution report={report} />}{tab === 'runtime' && <RuntimeInfrastructure report={report} />}{tab === 'coverage' && <Coverage report={report} />}
+      {tab === 'contracts' && <Contracts report={report} />}{tab === 'mutation' && <Mutations report={report} />}{tab === 'performance' && <Performance report={report} />}{tab === 'synthetic' && <Synthetics report={report} />}
+      {tab === 'clients' && <ClientExperiences report={report} />}
+    </> : <div style={{ padding: 24, color: 'var(--text-secondary)' }}>{t('Report není dostupný.', 'Report is unavailable.')}</div>}
+    {report && <TestAgentPanel />}
+    {report && <div style={{ marginTop: 18, color: 'var(--text-tertiary)', fontSize: 11 }}>{t('Schéma', 'Schema')} v{report.schemaVersion} · {t('sesbíráno', 'collected')} {new Intl.DateTimeFormat(dateLocale, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(report.collectedAt))} · {t('absence se nikdy nevykresluje jako nula', 'absence is never rendered as zero')}</div>}
+  </div>
 }

--- a/openbank-admin-ui/src/app/system/tests/page.tsx
+++ b/openbank-admin-ui/src/app/system/tests/page.tsx
@@ -103,7 +103,8 @@ function ServiceRow({ svc }: { svc: ServiceTestResult }) {
 }
 
 function TestsTab({ data, error, loading }: { data: TestResultsResponse | null; error: string | null; loading: boolean }) {
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const totals = data?.totals
   const passRate = totals && totals.tests > 0 ? Math.round((totals.passed / totals.tests) * 100) : null
   const coverageColor = passRate == null ? 'var(--text-secondary)' : passRate === 100 ? '#16a34a' : passRate >= 80 ? '#d97706' : '#dc2626'

--- a/openbank-admin-ui/src/app/system/tests/page.tsx
+++ b/openbank-admin-ui/src/app/system/tests/page.tsx
@@ -1,358 +1,656 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import {
-  Activity, BarChart3, CheckCircle2, CircleHelp, Dna, FlaskConical,
-  Gauge, RefreshCw, ShieldCheck, Timer, TriangleAlert, XCircle,
-} from 'lucide-react'
+import { useState, useEffect, useCallback } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
-import type {
-  ComponentTestPosture, EvidenceKind, EvidenceState, TestIntelligenceReport,
-} from '@/lib/types/test-intelligence'
-import { TestIntelligenceFlow } from '@/components/testing/TestIntelligenceFlow'
-import { TestAgentPanel } from '@/components/testing/TestAgentPanel'
+import {
+  FlaskConical, RefreshCw, CheckCircle2, XCircle, Minus,
+  ShieldCheck, Dna, Star,
+} from 'lucide-react'
+import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import { PageHeader } from '@/components/ui/PageHeader'
+import type { TestResultsResponse, ServiceTestResult } from '@/lib/types/test-results'
+import type { QualityReport, MutationScore, ContractVerification, ServiceQualityScore } from '@/lib/types/quality-report'
 
-type Tab = 'posture' | 'tests' | 'history' | 'execution' | 'runtime' | 'coverage' | 'contracts' | 'mutation' | 'performance' | 'synthetic' | 'clients'
+// ── Shared helpers ────────────────────────────────────────────────────────────
 
-const STATE_COLOR: Record<EvidenceState, string> = {
-  passed: '#16a34a', failed: '#dc2626', skipped: '#d97706', 'not-run': '#64748b',
-  stale: '#d97706', blocked: '#7c3aed', unknown: '#64748b',
+function PassRateBar({ passed, total }: { passed: number; total: number }) {
+  if (total === 0) return <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>—</span>
+  const pct = Math.round((passed / total) * 100)
+  const color = pct === 100 ? '#16a34a' : pct >= 80 ? '#d97706' : '#dc2626'
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+      <div style={{ flex: 1, height: '6px', background: 'var(--surface-3)', borderRadius: '3px', overflow: 'hidden', minWidth: '80px' }}>
+        <div style={{ width: `${pct}%`, height: '100%', background: color, borderRadius: '3px', transition: 'width 0.3s ease' }} />
+      </div>
+      <span style={{ fontSize: '11px', fontWeight: 700, color, minWidth: '34px', textAlign: 'right' }}>{pct}%</span>
+    </div>
+  )
 }
 
-const KINDS: EvidenceKind[] = ['unit', 'integration', 'contract', 'e2e', 'mutation', 'simulation', 'performance', 'synthetic']
-
-function StateBadge({ state }: { state: EvidenceState }) {
-  const Icon = state === 'passed' ? CheckCircle2 : state === 'failed' ? XCircle
-    : state === 'unknown' || state === 'not-run' ? CircleHelp : TriangleAlert
+function ScoreBar({ score, threshold = 70 }: { score: number | null; threshold?: number }) {
+  if (score === null) return <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>—</span>
+  const color = score >= threshold ? '#16a34a' : score >= threshold * 0.8 ? '#d97706' : '#dc2626'
   return (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: STATE_COLOR[state], fontSize: 11, fontWeight: 700 }}>
-      <Icon size={12} />{state}
+    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+      <div style={{ flex: 1, height: '6px', background: 'var(--surface-3)', borderRadius: '3px', overflow: 'hidden', minWidth: '80px' }}>
+        <div style={{ width: `${score}%`, height: '100%', background: color, borderRadius: '3px', transition: 'width 0.3s ease' }} />
+      </div>
+      <span style={{ fontSize: '11px', fontWeight: 700, color, minWidth: '34px', textAlign: 'right' }}>{score}%</span>
+    </div>
+  )
+}
+
+function StatusBadge({ status }: { status: 'passed' | 'failed' | 'pending' }) {
+  const cfg = {
+    passed: { color: '#16a34a', bg: '#dcfce7', label: '✓' },
+    failed: { color: '#dc2626', bg: '#fee2e2', label: '✗' },
+    pending: { color: '#6b7280', bg: 'var(--surface-2)', label: '–' },
+  }[status]
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: '22px', height: '22px', borderRadius: '4px', background: cfg.bg, color: cfg.color, fontSize: '12px', fontWeight: 700 }}>
+      {cfg.label}
     </span>
   )
 }
 
-function Stat({ label, value, tone }: { label: string; value: number | string; tone?: string }) {
+// ── Tests tab ─────────────────────────────────────────────────────────────────
+
+function ServiceRow({ svc }: { svc: ServiceTestResult }) {
+  const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
+  const hasTests = svc.tests > 0
+  const hasFail = svc.failed + svc.errors > 0
+  const statusIcon = !hasTests
+    ? <Minus size={14} style={{ color: 'var(--text-tertiary)' }} />
+    : hasFail
+      ? <XCircle size={14} style={{ color: '#dc2626' }} />
+      : <CheckCircle2 size={14} style={{ color: '#16a34a' }} />
   return (
-    <div style={{ padding: 16, border: '1px solid var(--border)', borderRadius: 10, background: 'var(--surface-1)' }}>
-      <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginBottom: 6 }}>{label}</div>
-      <div style={{ fontSize: 24, fontWeight: 750, color: tone ?? 'var(--text-primary)' }}>{value}</div>
-    </div>
+    <tr style={{ borderBottom: '1px solid var(--border)', background: !hasTests ? 'transparent' : hasFail ? 'rgba(220,38,38,0.03)' : 'transparent' }}>
+      <td style={{ padding: '10px 16px', display: 'flex', alignItems: 'center', gap: '8px' }}>
+        {statusIcon}
+        <span style={{ fontSize: '12px', fontFamily: 'monospace', color: 'var(--text-primary)', fontWeight: 500 }}>
+          {svc.service.replace('openbank-', '')}
+        </span>
+      </td>
+      <td style={{ padding: '10px 16px', textAlign: 'center', fontSize: '13px', fontWeight: 700, color: 'var(--text-primary)' }}>
+        {hasTests ? svc.tests : <span style={{ color: 'var(--text-tertiary)' }}>0</span>}
+      </td>
+      <td style={{ padding: '10px 16px', textAlign: 'center', fontSize: '13px', color: '#16a34a', fontWeight: hasTests ? 600 : 400 }}>
+        {hasTests ? svc.passed : '—'}
+      </td>
+      <td style={{ padding: '10px 16px', textAlign: 'center', fontSize: '13px', color: hasFail ? '#dc2626' : 'var(--text-tertiary)', fontWeight: hasFail ? 700 : 400 }}>
+        {hasTests ? (svc.failed + svc.errors || '—') : '—'}
+      </td>
+      <td style={{ padding: '10px 16px', minWidth: '140px' }}>
+        <PassRateBar passed={svc.passed} total={svc.tests} />
+      </td>
+      <td style={{ padding: '10px 16px', textAlign: 'center', fontSize: '11px', color: 'var(--text-tertiary)', fontFamily: 'monospace' }}>
+        {hasTests ? `${svc.durationMs}ms` : '—'}
+      </td>
+      <td style={{ padding: '10px 16px', textAlign: 'center', fontSize: '11px', color: 'var(--text-tertiary)' }}>
+        {svc.lastRunAt ? new Date(svc.lastRunAt).toLocaleString(dateLocale) : '—'}
+      </td>
+      <td style={{ padding: '10px 16px', textAlign: 'center', fontSize: '11px', color: 'var(--text-tertiary)' }}>
+        {t(`${svc.unit.tests} unit`, `${svc.unit.tests} unit`)} / {t(`${svc.integration.tests} int.`, `${svc.integration.tests} int.`)}
+      </td>
+    </tr>
   )
 }
 
-/**
- * A deliberately unweighted operator view.  It makes the four assurance
- * surfaces navigable without turning absent evidence into a misleading score.
- */
-function AssuranceBoard({ report, selectTab }: { report: TestIntelligenceReport; selectTab: (tab: Tab) => void }) {
+function TestsTab({ data, error, loading }: { data: TestResultsResponse | null; error: string | null; loading: boolean }) {
   const { t } = useLanguage()
-  const syntheticActive = report.syntheticJourneys.filter(item => item.status === 'active')
-  const syntheticState: EvidenceState = syntheticActive.some(item => item.state === 'failed') ? 'failed'
-    : syntheticActive.length === 0 ? 'unknown'
-      : syntheticActive.some(item => item.state !== 'passed') ? 'stale' : 'passed'
-  const runtimeRows = report.components.filter(component => component.testInfrastructure.declared.length > 0)
-  const runtimeState: EvidenceState = runtimeRows.some(component => {
-    const observed = component.testInfrastructure.observed
-    return observed.filter(item => item.lifecycle === 'stopped').length < observed.filter(item => item.lifecycle === 'started').length
-  }) ? 'failed' : runtimeRows.some(component => component.testInfrastructure.observed.length === 0) ? 'unknown' : 'passed'
-  const clientEvidence = report.clientExperiences ?? []
-  const clientState: EvidenceState = clientEvidence.some(client => client.evidence.some(item => item.state === 'failed')) ? 'failed'
-    : clientEvidence.some(client => client.rum.state === 'blocked') ? 'blocked'
-      : clientEvidence.some(client => client.rum.state === 'unknown') ? 'unknown'
-        : clientEvidence.length === 0 ? 'not-run' : 'passed'
-  const ciState: EvidenceState = report.totals.failingEvidence > 0 ? 'failed'
-    : report.totals.missingEvidence > 0 || report.totals.staleEvidence > 0 ? 'stale' : 'passed'
-  const cards: { tab: Tab; title: string; eyebrow: string; state: EvidenceState; detail: string }[] = [
-    { tab: 'posture', title: t('CI důkazy', 'CI evidence'), eyebrow: t('deterministické gate', 'deterministic gates'), state: ciState, detail: t(`${report.totals.componentsWithExecutionEvidence}/${report.totals.components} komponent s důkazem běhu`, `${report.totals.componentsWithExecutionEvidence}/${report.totals.components} components with run evidence`) },
-    { tab: 'runtime', title: t('Testcontainers runtime', 'Testcontainers runtime'), eyebrow: t('skutečná topologie', 'actual topology'), state: runtimeState, detail: t(`${runtimeRows.length} deklarovaných testovacích runtime`, `${runtimeRows.length} declared test runtimes`) },
-    { tab: 'synthetic', title: t('Sandbox syntetiky', 'Sandbox synthetics'), eyebrow: t('pravidelná falsifikace', 'scheduled falsification'), state: syntheticState, detail: t(`${syntheticActive.length} aktivních cest · ${report.syntheticJourneys.filter(item => item.status === 'planned').length} plánovaných`, `${syntheticActive.length} active paths · ${report.syntheticJourneys.filter(item => item.status === 'planned').length} planned`) },
-    { tab: 'clients', title: t('Client & RUM', 'Client & RUM'), eyebrow: t('E2E + produkční signál', 'E2E + production signal'), state: clientState, detail: t(`${clientEvidence.length} klientských zkušeností · consent-gated RUM`, `${clientEvidence.length} client experiences · consent-gated RUM`) },
-  ]
-  return <section aria-label={t('Mapa testovacího ujištění', 'Testing assurance map')} style={{ marginBottom: 18, border: '1px solid color-mix(in srgb, var(--accent) 26%, var(--border))', borderRadius: 14, padding: 18, background: 'linear-gradient(135deg, color-mix(in srgb, var(--accent) 7%, var(--surface-1)), var(--surface-1))' }}>
-    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'start', marginBottom: 14 }}>
-      <div><div style={{ color: 'var(--accent)', fontSize: 11, fontWeight: 750, letterSpacing: '.08em', textTransform: 'uppercase' }}>{t('Living assurance map', 'Living assurance map')}</div><strong style={{ fontSize: 18 }}>{t('Od změny až k zákaznickému signálu', 'From change to customer signal')}</strong><div style={{ color: 'var(--text-secondary)', fontSize: 12, marginTop: 4 }}>{t('Klikni na vrstvu pro její neměnný důkaz, historii a známé mezery.', 'Open a layer for its immutable evidence, history, and known gaps.')}</div></div>
-      <div style={{ maxWidth: 310, color: 'var(--text-secondary)', fontSize: 11, padding: '8px 10px', borderRadius: 8, background: 'var(--surface-2)' }}><strong>{t('AI guardrail', 'AI guardrail')}</strong><br />{t('Agenti smějí vysvětlit a navrhnout další krok. Nezvyšují verdikt, nemažou důkaz ani neschvalují release.', 'Agents may explain and propose a next step. They do not raise a verdict, delete evidence, or approve a release.')}</div>
-    </div>
-    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(205px, 1fr))', gap: 10 }}>{cards.map((card, index) => <button key={card.tab} type="button" onClick={() => selectTab(card.tab)} style={{ textAlign: 'left', cursor: 'pointer', border: `1px solid color-mix(in srgb, ${STATE_COLOR[card.state]} 42%, var(--border))`, background: 'var(--surface-1)', borderRadius: 11, padding: 14, animation: `fadeIn ${180 + index * 80}ms ease-out both` }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'start' }}><div><div style={{ color: 'var(--text-tertiary)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '.06em' }}>{card.eyebrow}</div><strong style={{ display: 'block', marginTop: 3 }}>{card.title}</strong></div><StateBadge state={card.state} /></div>
-      <div style={{ color: 'var(--text-secondary)', fontSize: 12, marginTop: 10 }}>{card.detail}</div>
-      <div style={{ color: 'var(--accent)', fontSize: 11, fontWeight: 650, marginTop: 11 }}>{t('Otevřít důkaz →', 'Open evidence →')}</div>
-    </button>)}</div>
-  </section>
-}
+  const totals = data?.totals
+  const passRate = totals && totals.tests > 0 ? Math.round((totals.passed / totals.tests) * 100) : null
+  const coverageColor = passRate == null ? 'var(--text-secondary)' : passRate === 100 ? '#16a34a' : passRate >= 80 ? '#d97706' : '#dc2626'
+  const coverageBg = passRate == null ? 'var(--surface-2)' : passRate === 100 ? '#dcfce7' : passRate >= 80 ? '#fef9c3' : '#fee2e2'
+  const collectedAt = data?.collectedAt ? new Date(data.collectedAt) : null
+  const stale = collectedAt ? Date.now() - collectedAt.getTime() > 24 * 60 * 60 * 1000 : false
 
-function EvidenceCell({ component, kind }: { component: ComponentTestPosture; kind: EvidenceKind }) {
-  const evidence = component.evidence.find(item => item.kind === kind)
-  if (!evidence) return <StateBadge state="not-run" />
-  return <StateBadge state={evidence.state} />
-}
+  const sorted = data?.services.slice().sort((a, b) => {
+    if (a.failed + a.errors > 0 && b.failed + b.errors === 0) return -1
+    if (b.failed + b.errors > 0 && a.failed + a.errors === 0) return 1
+    if (a.tests === 0 && b.tests > 0) return 1
+    if (b.tests === 0 && a.tests > 0) return -1
+    return a.service.localeCompare(b.service)
+  })
 
-const tableStyle = { width: '100%', borderCollapse: 'collapse' as const, fontSize: 12 }
-const thStyle = { padding: '10px 12px', textAlign: 'left' as const, borderBottom: '1px solid var(--border)', color: 'var(--text-tertiary)', fontSize: 11 }
-const tdStyle = { padding: '10px 12px', borderBottom: '1px solid var(--border-subtle)' }
-const formatTimestamp = (value: string) => new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value))
-
-function Posture({ report }: { report: TestIntelligenceReport }) {
-  const { t } = useLanguage()
-  const sorted = useMemo(() => [...report.components].sort((a, b) => {
-    if (a.moneyPath !== b.moneyPath) return a.moneyPath ? -1 : 1
-    return a.component.localeCompare(b.component)
-  }), [report.components])
   return (
     <>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(170px, 1fr))', gap: 12, marginBottom: 20 }}>
-        <Stat label="Inventoried components" value={report.totals.components} />
-        <Stat label="With execution evidence" value={`${report.totals.componentsWithExecutionEvidence}/${report.totals.components}`} />
-        <Stat label="Money-path components" value={report.totals.moneyPathComponents} />
-        <Stat label="Failing evidence" value={report.totals.failingEvidence} tone={report.totals.failingEvidence ? '#dc2626' : '#16a34a'} />
-        <Stat label="No execution evidence" value={report.totals.missingEvidence} tone={report.totals.missingEvidence ? '#d97706' : '#16a34a'} />
-        <Stat label="Stale evidence" value={report.totals.staleEvidence} tone={report.totals.staleEvidence ? '#d97706' : '#16a34a'} />
-      </div>
-      <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}>
-        <table style={tableStyle}>
-          <thead><tr><th style={thStyle}>{t('Komponenta', 'Component')}</th>{KINDS.map(kind => <th key={kind} style={thStyle}>{kind}</th>)}<th style={thStyle}>{t('Řádky Kover', 'Kover lines')}</th></tr></thead>
-          <tbody>{sorted.map(component => (
-            <tr key={component.component}>
-              <td style={{ ...tdStyle, fontWeight: 650 }}>{component.component}{component.moneyPath && <span style={{ marginLeft: 6, color: '#dc2626', fontSize: 9 }}>{t('PENĚŽNÍ TOK', 'MONEY PATH')}</span>}</td>
-              {KINDS.map(kind => <td key={kind} style={tdStyle}><EvidenceCell component={component} kind={kind} /></td>)}
-              <td style={tdStyle}>{component.coverage.lines.percentage === null ? <StateBadge state={component.coverage.state} /> : `${component.coverage.lines.percentage}%`}</td>
-            </tr>
-          ))}</tbody>
-        </table>
+      {error && (
+        <div style={{ marginBottom: '20px' }}>
+          <DataUnavailable
+            kind="error"
+            feature={t('Pokrytí testy', 'Test coverage')}
+            lang={t('cs', 'en') as 'cs' | 'en'}
+            detail={t(
+              'Zdroj výsledků testů (CI databáze) není v tomto prostředí dostupný.',
+              'The test-results source (CI database) is not available in this environment.',
+            )}
+            dense
+          />
+        </div>
+      )}
+
+      {totals && (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: '12px', marginBottom: '24px' }}>
+          {[
+            { label: t('Celkový pass rate', 'Overall pass rate'), value: passRate != null ? `${passRate}%` : '—', sub: `${totals.passed}/${totals.tests} ${t('testů', 'tests')}`, color: coverageColor, bg: coverageBg },
+            { label: t('Testy celkem', 'Total tests'), value: totals.tests.toString(), sub: '', color: 'var(--text-primary)', bg: 'var(--surface-2)' },
+            { label: t('Úspěšné', 'Passed'), value: totals.passed.toString(), sub: '', color: '#16a34a', bg: '#dcfce7' },
+            { label: t('Selhání', 'Failed'), value: totals.failed.toString(), sub: '', color: totals.failed > 0 ? '#dc2626' : 'var(--text-secondary)', bg: totals.failed > 0 ? '#fee2e2' : 'var(--surface-2)' },
+            { label: t('Služby s testy', 'Services with tests'), value: `${totals.servicesWithTests}/${totals.services}`, sub: `${totals.services - totals.servicesWithTests} ${t('bez testů', 'without tests')}`, color: totals.servicesWithTests < totals.services ? '#d97706' : '#16a34a', bg: totals.servicesWithTests < totals.services ? '#fef9c3' : '#dcfce7' },
+          ].map(stat => (
+            <div key={stat.label} className="card" style={{ padding: '16px', background: stat.bg }}>
+              <div style={{ fontSize: '11px', color: 'var(--text-secondary)', marginBottom: '6px', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{stat.label}</div>
+              <div style={{ fontSize: '22px', fontWeight: 800, color: stat.color, marginBottom: '2px' }}>{stat.value}</div>
+              {stat.sub && <div style={{ fontSize: '11px', color: 'var(--text-secondary)' }}>{stat.sub}</div>}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {data && (
+        <div style={{ margin: '-12px 0 16px', fontSize: '11px', color: stale ? '#b45309' : 'var(--text-tertiary)' }}>
+          {t('CI snapshot vytvořen', 'CI snapshot collected')}: {collectedAt?.toLocaleString(dateLocale) ?? '—'}
+          {stale ? ` · ${t('zastaralý (>24 h)', 'stale (>24h)')}` : ''}
+          {' · '}{t('0 znamená, že pro službu nebyl v retenčním okně nalezen artefakt; ne že nemá testy.', '0 means no artifact was found in the retention window; it does not mean the service has no tests.')}
+        </div>
+      )}
+
+      {loading && !data ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          {Array.from({ length: 8 }).map((_, idx) => <div key={idx} className="skeleton" style={{ height: '42px' }} />)}
+        </div>
+      ) : sorted && (
+        <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '13px' }}>
+            <thead>
+              <tr style={{ background: 'var(--surface-2)', borderBottom: '1px solid var(--border)' }}>
+                {[
+                  t('Služba', 'Service'),
+                  t('Testy', 'Tests'),
+                  t('OK', 'Passed'),
+                  t('FAIL', 'Failed'),
+                  t('Pass rate', 'Pass rate'),
+                  t('Trvání', 'Duration'),
+                  t('Poslední spuštění', 'Last run'),
+                  t('Typ', 'Type'),
+                ].map(h => (
+                  <th key={h} style={{ padding: '10px 16px', textAlign: h === t('Služba', 'Service') ? 'left' : 'center', fontWeight: 600, color: 'var(--text-secondary)', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map(svc => <ServiceRow key={svc.service} svc={svc} />)}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div style={{ marginTop: '12px', fontSize: '11px', color: 'var(--text-tertiary)', padding: '8px 12px', background: 'var(--surface-2)', borderRadius: '6px' }}>
+        {t(
+          'Tato záložka ukazuje výsledky běhu (pass rate), nikoli pokrytí kódu. Kover line coverage je ve Skóre kvality. Data pocházejí z posledního CI artefaktu každé služby.',
+          'This tab shows execution results (pass rate), not code coverage. Kover line coverage is in Quality Score. Data comes from each service’s latest CI artifact.',
+        )}
       </div>
     </>
   )
 }
 
-function Execution({ report }: { report: TestIntelligenceReport }) {
-  const rows = report.components.flatMap(component => component.evidence
-    .filter(item => ['unit', 'integration', 'e2e', 'simulation'].includes(item.kind))
-    .map(item => ({ component: component.component, ...item })))
+// ── Contract tab ──────────────────────────────────────────────────────────────
+
+function ContractTab({ contracts, error }: { contracts: ContractVerification[]; error: boolean }) {
+  const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
+
+  if (error) {
+    return (
+      <DataUnavailable
+        kind="no_data"
+        feature={t('Smluvní testy (Pact)', 'Contract tests (Pact)')}
+        lang={t('cs', 'en') as 'cs' | 'en'}
+        detail={t(
+          'Výsledky kontraktních testů nejsou k dispozici. Spusť ./gradlew test v balance-service a ledger-service.',
+          'Contract test results are not available. Run ./gradlew test in balance-service and ledger-service.',
+        )}
+        dense
+      />
+    )
+  }
+
+  if (contracts.length === 0) {
+    return (
+      <div className="card" style={{ padding: '32px', textAlign: 'center', color: 'var(--text-secondary)' }}>
+        <ShieldCheck size={32} style={{ margin: '0 auto 12px', color: 'var(--text-tertiary)' }} />
+        <p style={{ fontSize: '13px' }}>
+          {t(
+            'Žádné kontraktní testy k dispozici. Výsledky se zobrazí po spuštění CI pipeline.',
+            'No contract test results available. Results appear after running the CI pipeline.',
+          )}
+        </p>
+        <p style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginTop: '8px' }}>
+          {t('Paktové soubory: pacts/', 'Pact files: pacts/')}
+        </p>
+      </div>
+    )
+  }
+
+  const providers = [...new Set(contracts.map(c => c.provider))].sort()
+  const consumers = [...new Set(contracts.map(c => c.consumer))].sort()
+
   return (
-    <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}>
-      <table style={tableStyle}><thead><tr>{['Component', 'Kind', 'State', 'Discovered', 'Executed', 'Passed', 'Failed', 'Skipped', 'Observed'].map(label => <th key={label} style={thStyle}>{label}</th>)}</tr></thead>
-        <tbody>{rows.map((row, index) => <tr key={`${row.component}-${row.kind}-${index}`}>
-          <td style={{ ...tdStyle, fontWeight: 650 }}>{row.component}</td><td style={tdStyle}>{row.kind}</td><td style={tdStyle}><StateBadge state={row.state} /></td>
-          <td style={tdStyle}>{row.counts?.discovered ?? '—'}</td><td style={tdStyle}>{row.counts?.executed ?? '—'}</td><td style={tdStyle}>{row.counts?.passed ?? '—'}</td>
-          <td style={tdStyle}>{row.counts?.failed ?? '—'}</td><td style={tdStyle}>{row.counts?.skipped ?? '—'}</td><td style={tdStyle}>{row.observedAt ? formatTimestamp(row.observedAt) : '—'}</td>
-        </tr>)}</tbody>
-      </table>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+      <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+        <div style={{ padding: '14px 16px', borderBottom: '1px solid var(--border)', background: 'var(--surface-2)', fontSize: '12px', fontWeight: 600, color: 'var(--text-secondary)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+          {t('Provider × Consumer matice', 'Provider × Consumer matrix')}
+        </div>
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '12px' }}>
+            <thead>
+              <tr style={{ borderBottom: '1px solid var(--border)' }}>
+                <th style={{ padding: '10px 16px', textAlign: 'left', fontWeight: 600, color: 'var(--text-secondary)', minWidth: '180px' }}>
+                  {t('Provider ↓ / Consumer →', 'Provider ↓ / Consumer →')}
+                </th>
+                {consumers.map(consumer => (
+                  <th key={consumer} style={{ padding: '10px 16px', textAlign: 'center', fontWeight: 600, color: 'var(--text-secondary)', fontFamily: 'monospace', fontSize: '11px' }}>
+                    {consumer.replace('openbank-', '')}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {providers.map(provider => (
+                <tr key={provider} style={{ borderBottom: '1px solid var(--border)' }}>
+                  <td style={{ padding: '10px 16px', fontFamily: 'monospace', fontSize: '11px', fontWeight: 600, color: 'var(--text-primary)' }}>
+                    {provider.replace('openbank-', '')}
+                  </td>
+                  {consumers.map(consumer => {
+                    const contract = contracts.find(c => c.provider === provider && c.consumer === consumer)
+                    return (
+                      <td key={consumer} style={{ padding: '10px 16px', textAlign: 'center' }}>
+                        {contract ? (
+                          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '4px' }}>
+                            <StatusBadge status={contract.status} />
+                            {contract.verifiedAt && (
+                              <span style={{ fontSize: '10px', color: 'var(--text-tertiary)' }}>
+                                {new Date(contract.verifiedAt).toLocaleDateString(dateLocale)}
+                              </span>
+                            )}
+                          </div>
+                        ) : (
+                          <span style={{ color: 'var(--text-tertiary)', fontSize: '11px' }}>—</span>
+                        )}
+                      </td>
+                    )
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {contracts.map(contract => (
+        <div key={`${contract.consumer}-${contract.provider}`} className="card" style={{ padding: 0, overflow: 'hidden' }}>
+          <div style={{ padding: '12px 16px', borderBottom: '1px solid var(--border)', display: 'flex', alignItems: 'center', gap: '10px', background: 'var(--surface-2)' }}>
+            <StatusBadge status={contract.status} />
+            <span style={{ fontFamily: 'monospace', fontSize: '12px', fontWeight: 600 }}>
+              {contract.consumer.replace('openbank-', '')}
+            </span>
+            <span style={{ color: 'var(--text-tertiary)' }}>→</span>
+            <span style={{ fontFamily: 'monospace', fontSize: '12px', fontWeight: 600 }}>
+              {contract.provider.replace('openbank-', '')}
+            </span>
+            <span style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginLeft: 'auto' }}>
+              {contract.pactFile}
+            </span>
+          </div>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '12px' }}>
+            <tbody>
+              {contract.interactions.map((interaction, idx) => (
+                <tr key={idx} style={{ borderBottom: '1px solid var(--border)' }}>
+                  <td style={{ padding: '8px 16px', width: '24px' }}>
+                    <StatusBadge status={interaction.status} />
+                  </td>
+                  <td style={{ padding: '8px 16px', color: 'var(--text-primary)' }}>
+                    {interaction.description}
+                  </td>
+                  {interaction.failure && (
+                    <td style={{ padding: '8px 16px', color: '#dc2626', fontSize: '11px', fontFamily: 'monospace' }}>
+                      {interaction.failure}
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+
+      <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', padding: '8px 12px', background: 'var(--surface-2)', borderRadius: '6px' }}>
+        {t(
+          'Kontrakty se generují z Pact consumer testů a ukládají do pacts/ (git-pact, ADR-0063). Verifikace probíhá v CI providera.',
+          'Contracts are generated from Pact consumer tests and stored in pacts/ (git-pact, ADR-0063). Verification runs in the provider CI job.',
+        )}
+      </div>
     </div>
   )
 }
 
-function TestCases({ report }: { report: TestIntelligenceReport }) {
-  const { t } = useLanguage()
-  const flaky = report.testCases.filter(item => item.state === 'flaky')
-  const failing = report.testCases.filter(item => item.state === 'failing')
-  const wasted = report.testCases.reduce((sum, item) => sum + item.wastedDurationMs, 0)
-  return <div style={{ display: 'grid', gap: 18 }}>
-    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(170px, 1fr))', gap: 12 }}>
-      <Stat label="Tracked test definitions" value={report.testCases.length} />
-      <Stat label="Observed flaky" value={flaky.length} tone={flaky.length ? '#d97706' : '#16a34a'} />
-      <Stat label="Currently failing" value={failing.length} tone={failing.length ? '#dc2626' : '#16a34a'} />
-      <Stat label="Failed runtime" value={`${Math.round(wasted / 1000)} s`} tone={wasted ? '#d97706' : undefined} />
-    </div>
-    <div style={{ padding: 12, border: '1px solid color-mix(in srgb, #16a34a 35%, var(--border))', borderRadius: 9, color: 'var(--text-secondary)', fontSize: 12 }}>
-      {t('Test je označen jako flaky až po úspěšném i neúspěšném pozorování stejného commitu. Vlastnictví vychází z CODEOWNERS. Triage nikdy nemění deterministický verdikt CI ani nepřeskakuje peněžní kontroly.', 'A test is marked flaky only after pass and fail observations on the same commit. Ownership comes from CODEOWNERS. Triage never changes the deterministic CI verdict or skips money-path controls.')}
-    </div>
-    <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}><table style={tableStyle}>
-      <thead><tr>{['State', 'Test definition', 'Component', 'Kind', 'Owner', 'Runs', 'Failure rate', 'Avg duration', 'Failed runtime', 'Fingerprint'].map(label => <th key={label} style={thStyle}>{label}</th>)}</tr></thead>
-      <tbody>{report.testCases.map(item => <tr key={item.fingerprint}>
-        <td style={tdStyle}><StateBadge state={item.state === 'stable' ? 'passed' : item.state === 'failing' ? 'failed' : item.state === 'skipped' ? 'skipped' : 'stale'} /></td>
-        <td style={{ ...tdStyle, minWidth: 230 }}><strong>{item.name}</strong><div style={{ color: 'var(--text-tertiary)', fontSize: 10, marginTop: 3 }}>{item.classname}</div>{item.sameCommitTransitions > 0 && <div style={{ color: '#d97706', fontSize: 10, marginTop: 3 }}>{item.sameCommitTransitions} same-commit pass/fail transition(s)</div>}</td>
-        <td style={tdStyle}>{item.component}</td><td style={tdStyle}>{item.kind}</td><td style={tdStyle}>{item.owner}</td><td style={tdStyle}>{item.observations}</td>
-        <td style={tdStyle}>{item.failureRate === null ? '—' : `${item.failureRate}%`}</td><td style={tdStyle}>{item.averageDurationMs} ms</td><td style={tdStyle}>{item.wastedDurationMs} ms</td>
-        <td style={{ ...tdStyle, fontFamily: 'monospace', fontSize: 10 }}>{item.fingerprint}</td>
-      </tr>)}</tbody>
-    </table>{report.testCases.length === 0 && <div style={{ padding: 18, color: 'var(--text-tertiary)', fontSize: 12 }}>{t('Zatím nejsou uchovány žádné per-test obálky běhů. Verdikty sad zůstávají autoritativní.', 'No per-test run envelopes have been retained yet. Suite verdicts remain authoritative.')}</div>}</div>
-  </div>
-}
+// ── Mutation tab ──────────────────────────────────────────────────────────────
 
-function History({ report }: { report: TestIntelligenceReport }) {
-  const { t } = useLanguage()
-  const max = Math.max(1, ...report.history.map(point => point.components))
-  return <div style={{ display: 'grid', gap: 18 }}><div style={{ border: '1px solid var(--border)', borderRadius: 10, padding: 18, background: 'var(--surface-1)' }}>
-    <div style={{ marginBottom: 16 }}><strong>{t('Historie fleet evidence', 'Fleet evidence history')}</strong><div style={{ color: 'var(--text-secondary)', fontSize: 12, marginTop: 4 }}>{t('Neměnné deployment snapshoty uchované jako CI artefakty. Sloupce nikdy neodvozují chybějící běhy.', 'Immutable deployment snapshots retained as CI artifacts. Bars never infer missing runs.')}</div></div>
-    {report.history.length < 2 && <div style={{ color: '#d97706', fontSize: 12, marginBottom: 12 }}><TriangleAlert size={13} style={{ verticalAlign: 'text-bottom', marginRight: 5 }} />The first snapshot is present; a trend appears after the next admin deployment.</div>}
-    <div style={{ display: 'flex', alignItems: 'end', gap: 8, minHeight: 190, overflowX: 'auto', paddingTop: 12 }}>
-      {report.history.map(point => <div key={point.collectedAt} title={`${new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(point.collectedAt))} · ${point.componentsWithExecutionEvidence}/${point.components} evidenced · ${point.failingEvidence} failing`} style={{ minWidth: 38, flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'end', gap: 3, height: 170 }}>
-        <div style={{ height: `${Math.max(2, point.failingEvidence / max * 150)}px`, background: '#dc2626', borderRadius: '4px 4px 0 0' }} />
-        <div style={{ height: `${Math.max(2, point.missingEvidence / max * 150)}px`, background: '#d97706' }} />
-        <div style={{ height: `${Math.max(2, point.componentsWithExecutionEvidence / max * 150)}px`, background: '#16a34a', borderRadius: '0 0 4px 4px' }} />
-        <span style={{ fontSize: 9, color: 'var(--text-tertiary)', textAlign: 'center' }}>{new Intl.DateTimeFormat('en-GB', { month: 'short', day: 'numeric' }).format(new Date(point.collectedAt))}</span>
-      </div>)}
-    </div>
-    <div style={{ display: 'flex', gap: 14, marginTop: 12, fontSize: 11, color: 'var(--text-secondary)' }}><span style={{ color: '#16a34a' }}>● evidenced</span><span style={{ color: '#d97706' }}>● missing</span><span style={{ color: '#dc2626' }}>● failing</span></div>
-  </div><div style={{ border: '1px solid var(--border)', borderRadius: 10, overflowX: 'auto' }}>
-    <div style={{ padding: '16px 18px 8px' }}><strong>{t('Neměnné pokusy služeb', 'Immutable service attempts')}</strong><div style={{ color: 'var(--text-secondary)', fontSize: 12, marginTop: 4 }}>{t('Nejnovější verzované CI obálky; opakované běhy zůstávají samostatnými pokusy.', 'Latest versioned CI envelopes; reruns remain separate attempts.')}</div></div>
-    <table style={tableStyle}><thead><tr><th style={thStyle}>Component</th><th style={thStyle}>Run / attempt</th><th style={thStyle}>Commit</th><th style={thStyle}>{t('Stavy evidence', 'Evidence states')}</th><th style={thStyle}>Runtime</th><th style={thStyle}>Observed</th></tr></thead>
-      <tbody>{report.runHistory.slice(0, 100).map(item => <tr key={`${item.component}-${item.run.id}-${item.run.attempt}`}><td style={{ ...tdStyle, fontWeight: 650 }}>{item.component}</td><td style={tdStyle}>{item.run.id} / {item.run.attempt}</td><td style={tdStyle}>{item.run.commit.slice(0, 8)}</td><td style={tdStyle}>{Object.entries(item.states).map(([kind, state]) => <span key={kind} style={{ marginRight: 9 }}>{kind}: <StateBadge state={state} /></span>)}</td><td style={tdStyle}>{item.infrastructureStarted} start · {item.infrastructureStopped} stop</td><td style={tdStyle}>{new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(item.run.observedAt))}</td></tr>)}</tbody>
-    </table>
-    {report.runHistory.length === 0 && <div style={{ padding: 18, color: 'var(--text-tertiary)', fontSize: 12 }}>{t('Zatím nejsou přibaleny žádné uchované service-run obálky.', 'No retained service-run envelopes are bundled yet.')}</div>}
-  </div></div>
-}
-
-function RuntimeInfrastructure({ report }: { report: TestIntelligenceReport }) {
-  const { t } = useLanguage()
-  const rows = report.components.filter(component => component.testInfrastructure.declared.length > 0 || component.testInfrastructure.observed.length > 0)
-  return <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}><table style={tableStyle}>
-    <thead><tr><th style={thStyle}>Component</th><th style={thStyle}>{t('Deklarovaná topologie', 'Declared topology')}</th><th style={thStyle}>{t('Důkaz runtime', 'Runtime proof')}</th><th style={thStyle}>Lifecycle</th><th style={thStyle}>Observed</th></tr></thead>
-    <tbody>{rows.map(row => {
-      const started = row.testInfrastructure.observed.filter(item => item.lifecycle === 'started')
-      const stopped = row.testInfrastructure.observed.filter(item => item.lifecycle === 'stopped')
-      const state: EvidenceState = started.length === 0 ? 'unknown' : stopped.length < started.length ? 'failed' : 'passed'
-      const latest = row.testInfrastructure.observed.at(-1)?.observedAt
-      return <tr key={row.component}><td style={{ ...tdStyle, fontWeight: 650 }}>{row.component}</td><td style={tdStyle}>{row.testInfrastructure.declared.join(' · ') || 'none'}</td><td style={tdStyle}><StateBadge state={state} /></td><td style={tdStyle}>{started.length} started · {stopped.length} stopped</td><td style={tdStyle}>{latest ? new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(latest)) : 'not emitted by this run'}</td></tr>
-    })}</tbody>
-  </table></div>
-}
-
-function Coverage({ report }: { report: TestIntelligenceReport }) {
-  return <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}><table style={tableStyle}>
-    <thead><tr><th style={thStyle}>Component</th><th style={thStyle}>State</th><th style={thStyle}>Lines</th><th style={thStyle}>Branches</th><th style={thStyle}>Observed</th><th style={thStyle}>Source</th></tr></thead>
-    <tbody>{report.components.map(row => <tr key={row.component}><td style={{ ...tdStyle, fontWeight: 650 }}>{row.component}</td><td style={tdStyle}><StateBadge state={row.coverage.state} /></td>
-      <td style={tdStyle}>{row.coverage.lines.percentage === null ? '—' : `${row.coverage.lines.percentage}%`}</td><td style={tdStyle}>{row.coverage.branches.percentage === null ? '—' : `${row.coverage.branches.percentage}%`}</td>
-      <td style={tdStyle}>{row.coverage.observedAt ? formatTimestamp(row.coverage.observedAt) : '—'}</td><td style={tdStyle}>{row.coverage.source ?? '—'}</td></tr>)}</tbody>
-  </table></div>
-}
-
-function Contracts({ report }: { report: TestIntelligenceReport }) {
-  const { t } = useLanguage()
-  const unknown = report.contracts.filter(row => row.state === 'unknown')
-  const contractSuites = report.runHistory.flatMap(run => Object.entries(run.states)
-    .filter(([kind]) => kind === 'contract')
-    .map(([, state]) => state))
-  const suiteSummary = contractSuites.length === 0
-    ? t('V uchované historii není přibalen žádný contract suite verdict.', 'No contract-suite verdict is bundled in retained run history.')
-    : t(`${contractSuites.filter(state => state === 'passed').length}/${contractSuites.length} uchovaných CI contract suite verdiktů prošlo.`, `${contractSuites.filter(state => state === 'passed').length}/${contractSuites.length} retained CI contract-suite verdicts passed.`)
-  return <div style={{ display: 'grid', gap: 12 }}>
-    <div style={{ padding: 13, border: '1px solid color-mix(in srgb, #64748b 36%, var(--border))', borderRadius: 10, background: 'var(--surface-2)', color: 'var(--text-secondary)', fontSize: 12 }}>
-      <strong style={{ color: 'var(--text-primary)' }}>{t('Dva nezaměnitelné druhy důkazu.', 'Two non-interchangeable evidence types.')}</strong>{' '}
-      {t('Tabulka níže ukazuje per-Pact provider-verification verdikt z Pact Brokeru. Historie běhů ukazuje CI contract suite verdikt. Jeden není náhradou druhého a neznámý broker verdikt se nikdy nevydává za zelený.', 'The table below shows the per-Pact provider-verification verdict from the Pact Broker. Run history shows the CI contract-suite verdict. Neither substitutes for the other, and an unavailable broker verdict is never presented as green.')}
-      <div style={{ marginTop: 7 }}>{suiteSummary}</div>
-      {unknown.length > 0 && <div style={{ marginTop: 7, color: '#64748b' }}>{t(`${unknown.length} Pactů má neznámý broker verdikt v tomto snapshotu; otevři detail řádku pro přesný důvod.`, `${unknown.length} Pacts have an unavailable broker verdict in this snapshot; open a row detail for the precise reason.`)}</div>}
-    </div>
-    <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}><table style={tableStyle}>
-      <thead><tr><th style={thStyle}>Consumer</th><th style={thStyle}>Provider</th><th style={thStyle}>{t('Broker verdict', 'Broker verdict')}</th><th style={thStyle}>Interactions</th><th style={thStyle}>Pact</th><th style={thStyle}>Verified</th><th style={thStyle}>{t('Evidence basis', 'Evidence basis')}</th></tr></thead>
-      <tbody>{report.contracts.map(row => <tr key={row.pactFile}><td style={tdStyle}>{row.consumer}</td><td style={tdStyle}>{row.provider}</td><td style={tdStyle}><StateBadge state={row.state} /></td><td style={tdStyle}>{row.interactions}</td><td style={tdStyle}>{row.pactFile}</td><td style={tdStyle}>{row.observedAt ? formatTimestamp(row.observedAt) : '—'}</td><td style={{ ...tdStyle, minWidth: 300, color: 'var(--text-secondary)', fontSize: 11 }}>{row.verificationDetail ?? t('Snapshot does not provide a verification explanation.', 'Snapshot neposkytuje vysvětlení ověření.')}</td></tr>)}</tbody>
-    </table></div>
-  </div>
-}
-
-function Mutations({ report }: { report: TestIntelligenceReport }) {
-  return <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: 12 }}>{report.mutations.map(row => <div key={row.component} style={{ border: '1px solid var(--border)', borderRadius: 10, padding: 16, background: 'var(--surface-1)' }}>
-    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}><strong>{row.component}</strong><StateBadge state={row.state} /></div>
-    <div style={{ fontSize: 28, fontWeight: 750, margin: '12px 0' }}>{row.score ?? '—'}%</div>
-    <div style={{ color: 'var(--text-secondary)', fontSize: 12 }}>{row.killed} killed · {row.survived} survived · {row.noCoverage} no coverage</div>
-    {row.run && <div style={{ color: 'var(--text-tertiary)', fontSize: 11, marginTop: 7 }}>run {row.run.id} · {row.run.commit.slice(0, 8)}</div>}
-  </div>)}</div>
-}
-
-function Performance({ report }: { report: TestIntelligenceReport }) {
-  const { t } = useLanguage()
-  const declaredComponents = new Set(report.performance.flatMap(row => row.component ? [row.component] : []))
-  const executed = report.performance.filter(row => row.state === 'passed' || row.state === 'failed').length
-  const undeclared = report.components.filter(component => !declaredComponents.has(component.component)).length
-  return <div style={{ display: 'grid', gap: 10 }}>
-    <section aria-label={t('Rozsah pokrytí výkonnostních testů', 'Performance-test coverage scope')} style={{ border: '1px solid color-mix(in srgb, var(--accent) 35%, var(--border))', borderRadius: 12, padding: 16, background: 'linear-gradient(135deg, color-mix(in srgb, var(--accent) 9%, var(--surface-1)), var(--surface-1))' }}>
-      <strong>{t('Rozsah výkonnostních důkazů', 'Performance evidence scope')}</strong>
-      <div style={{ display: 'flex', gap: 18, flexWrap: 'wrap', marginTop: 10, fontSize: 13 }}>
-        <span><strong>{report.performance.length}</strong> {t('deklarovaných scénářů', 'declared scenarios')}</span>
-        <span><strong>{executed}</strong> {t('s výsledkem běhu', 'with run evidence')}</span>
-        <span><strong>{undeclared}</strong> {t('komponent bez deklarovaného scénáře', 'components without a declared scenario')}</span>
+function MutationGauge({ score, threshold = 70 }: { score: number | null; threshold?: number }) {
+  if (score === null) {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', width: '72px', height: '72px', borderRadius: '50%', border: '4px solid var(--border)', color: 'var(--text-tertiary)', fontSize: '11px' }}>
+        —
       </div>
-      <p style={{ color: 'var(--text-secondary)', fontSize: 12, margin: '10px 0 0' }}>{t('Absence scénáře není zelený výsledek. Tento panel odděluje měřený rozsah od neprovedeného či dosud nedefinovaného výkonového pokrytí.', 'An absent scenario is not a green result. This panel separates measured scope from performance coverage that is not run or not yet declared.')}</p>
-    </section>
-    {report.performance.map(row => <div key={row.id} style={{ border: '1px solid var(--border)', borderRadius: 10, padding: 16, display: 'flex', justifyContent: 'space-between', gap: 16 }}>
-    <div><strong>{row.id}</strong><div style={{ color: 'var(--text-secondary)', fontSize: 12, marginTop: 5 }}>{row.source} · {row.thresholds} threshold group(s)</div>{row.metrics && <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginTop: 9, fontSize: 12 }}><span><strong>p95</strong> {row.metrics.p95Ms === null ? '—' : `${Math.round(row.metrics.p95Ms)} ms`}</span><span><strong>{t('Chybovost', 'Error rate')}</strong> {row.metrics.errorRatePercent === null ? '—' : `${row.metrics.errorRatePercent}%`}</span><span><strong>{t('Kontroly', 'Checks')}</strong> {row.metrics.checkPassRatePercent === null ? '—' : `${row.metrics.checkPassRatePercent}%`}</span><span><strong>{t('Požadavky', 'Requests')}</strong> {row.metrics.requests === null ? '—' : row.metrics.requests}</span></div>}{row.run && <div style={{ color: 'var(--text-tertiary)', fontSize: 11, marginTop: 5 }}>run {row.run.id} · {row.run.commit.slice(0, 8)} · {row.run.branch}</div>}{row.detail && <div style={{ color: 'var(--text-tertiary)', fontSize: 11, marginTop: 5 }}>{row.detail}</div>}</div><StateBadge state={row.state} />
-    </div>)}
-  </div>
+    )
+  }
+  const color = score >= threshold ? '#16a34a' : score >= threshold * 0.8 ? '#d97706' : '#dc2626'
+  const circumference = 2 * Math.PI * 28
+  const dashOffset = circumference * (1 - score / 100)
+  return (
+    <div style={{ position: 'relative', width: '72px', height: '72px' }}>
+      <svg width="72" height="72" viewBox="0 0 72 72" style={{ transform: 'rotate(-90deg)' }}>
+        <circle cx="36" cy="36" r="28" fill="none" stroke="var(--border)" strokeWidth="6" />
+        <circle cx="36" cy="36" r="28" fill="none" stroke={color} strokeWidth="6"
+          strokeDasharray={circumference} strokeDashoffset={dashOffset}
+          strokeLinecap="round" style={{ transition: 'stroke-dashoffset 0.5s ease' }} />
+      </svg>
+      <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '13px', fontWeight: 800, color }}>
+        {score}%
+      </div>
+    </div>
+  )
 }
 
-function Synthetics({ report }: { report: TestIntelligenceReport }) {
-  const { t } = useLanguage()
-  return <div style={{ display: 'grid', gap: 12 }}>{report.syntheticJourneys.map(row => <div key={row.id} style={{ border: '1px solid var(--border)', borderRadius: 10, padding: 18, background: 'var(--surface-1)' }}>
-    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}><div><strong>{row.title}</strong><span style={{ marginLeft: 8, color: 'var(--text-tertiary)', fontSize: 11 }}>{row.id}</span></div><StateBadge state={row.state} /></div>
-    <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', marginTop: 10, fontSize: 12, color: 'var(--text-secondary)' }}><span>Status: {row.status}</span><span>Severity: {row.severity}</span><span>{row.status === 'planned' ? 'Target schedule' : 'Schedule'}: {row.schedule ?? 'not scheduled'}</span><span>Environment: {row.environment ?? '—'}</span></div>
-    {row.live && <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: 8, marginTop: 12, padding: 12, borderRadius: 8, background: 'var(--surface-2)', fontSize: 11 }}>
-      <div><span style={{ color: 'var(--text-tertiary)' }}>{t('Naposledy naplánováno', 'Last scheduled')}</span><br /><strong>{row.live.lastScheduledAt ? new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(row.live.lastScheduledAt)) : 'never observed'}</strong></div>
-      <div><span style={{ color: 'var(--text-tertiary)' }}>{t('Poslední úspěch', 'Last success')}</span><br /><strong>{row.live.lastSuccessfulAt ? new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(row.live.lastSuccessfulAt)) : 'never observed'}</strong></div>
-      <div><span style={{ color: 'var(--text-tertiary)' }}>Failures / 30m</span><br /><strong>{row.live.failuresLast30m ?? 'unavailable'}</strong></div>
-      <div><span style={{ color: 'var(--text-tertiary)' }}>{t('Čerstvost evidence', 'Evidence freshness')}</span><br /><strong>{row.live.freshnessSeconds === null ? 'unknown' : `${Math.round(row.live.freshnessSeconds / 60)} min`}</strong></div>
-      <div><span style={{ color: 'var(--text-tertiary)' }}>{t('Poslední Kubernetes běhy', 'Recent Kubernetes runs')}</span><br /><strong>{row.live.recentRuns.length || 'none retained'}</strong></div>
-    </div>}
-    {row.falsifies && <p style={{ fontSize: 12, color: 'var(--text-secondary)', margin: '10px 0 0' }}><strong>Falsification:</strong> {row.falsifies}</p>}
-    {row.blocker && <p style={{ fontSize: 12, color: '#7c3aed', margin: '10px 0 0' }}><strong>Blocker:</strong> {row.blocker}</p>}
-  </div>)}</div>
-}
-
-function ClientExperiences({ report }: { report: TestIntelligenceReport }) {
-  const { t } = useLanguage()
-  return <div style={{ display: 'grid', gap: 12 }}>{(report.clientExperiences ?? []).map(client => <div key={client.id} style={{ border: '1px solid var(--border)', borderRadius: 10, padding: 18, background: 'var(--surface-1)' }}>
-    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}><div><strong>{client.title}</strong><span style={{ marginLeft: 8, color: 'var(--text-tertiary)', fontSize: 11 }}>{client.platforms.join(' · ')}</span></div><StateBadge state={client.evidence.some(item => item.state === 'failed') ? 'failed' : client.evidence.length ? 'passed' : 'not-run'} /></div>
-    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))', gap: 10, marginTop: 12 }}>{client.evidence.map((item, index) => <div key={`${item.kind}-${index}`} style={{ padding: 10, borderRadius: 8, background: 'var(--surface-2)', fontSize: 12 }}><strong>{item.kind}</strong><div style={{ marginTop: 6 }}><StateBadge state={item.state} /></div>{item.counts && <div style={{ color: 'var(--text-secondary)', marginTop: 5 }}>{item.counts.passed}/{item.counts.executed} passed</div>}{item.detail && <div style={{ color: 'var(--text-tertiary)', marginTop: 5 }}>{item.detail}</div>}</div>)}</div>
-    {client.evidence.length === 0 && <p style={{ fontSize: 12, color: '#d97706', margin: '12px 0 0' }}>{t('Není přibalen důkaz posledního client CI běhu; zdrojový kód se nesmí vydávat za proběhlý test.', 'No latest client-CI evidence is bundled; source code is not represented as a completed test.')}</p>}
-    <div style={{ marginTop: 12, padding: 11, borderRadius: 8, background: 'var(--surface-2)', fontSize: 12 }}><strong>RUM</strong><span style={{ marginLeft: 8 }}><StateBadge state={client.rum.state} /></span>{client.rum.source && <span style={{ marginLeft: 8, color: 'var(--text-tertiary)' }}>{client.rum.source} · 7d</span>}<div style={{ color: 'var(--text-secondary)', marginTop: 5 }}>{client.rum.detail}</div>{client.rum.sampledSpansLast7d !== undefined && client.rum.sampledSpansLast7d !== null && <div style={{ color: 'var(--text-tertiary)', marginTop: 5 }}>{client.rum.sampledSpansLast7d} sampled spans · {client.rum.errorSpansLast7d ?? 'unknown'} error spans</div>}</div>
-    {client.blocker && <p style={{ fontSize: 12, color: '#7c3aed', margin: '10px 0 0' }}><strong>Blocker:</strong> {client.blocker}</p>}
-  </div>)}</div>
-}
-
-export default function TestIntelligencePage() {
-  const { language, t } = useLanguage()
+function MutationTab({ mutations, error }: { mutations: MutationScore[]; error: boolean }) {
+  const { t, language } = useLanguage()
   const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
-  const [tab, setTab] = useState<Tab>('posture')
-  const [report, setReport] = useState<TestIntelligenceReport | null>(null)
-  const [loading, setLoading] = useState(true)
-  const testLoading = loading
-  const qualityLoading = false
+
+  if (error) {
+    return (
+      <DataUnavailable
+        kind="no_data"
+        feature={t('Mutační testy (pitest)', 'Mutation tests (pitest)')}
+        lang={t('cs', 'en') as 'cs' | 'en'}
+        detail={t(
+          'Výsledky pitest nejsou k dispozici. Spusť ./gradlew pitest nebo počkej na týdenní CI job.',
+          'Pitest results are not available. Run ./gradlew pitest or wait for the weekly CI job.',
+        )}
+        dense
+      />
+    )
+  }
+
+  if (mutations.length === 0) {
+    return (
+      <div className="card" style={{ padding: '32px', textAlign: 'center', color: 'var(--text-secondary)' }}>
+        <Dna size={32} style={{ margin: '0 auto 12px', color: 'var(--text-tertiary)' }} />
+        <p style={{ fontSize: '13px' }}>
+          {t(
+            'Žádné výsledky mutačního testování. Pitest běží týdně v CI (workflow pitest.yml).',
+            'No mutation test results. Pitest runs weekly in CI (pitest.yml workflow).',
+          )}
+        </p>
+        <p style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginTop: '8px' }}>
+          {t('Manuální spuštění: ./gradlew pitest', 'Manual run: ./gradlew pitest')}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: '12px' }}>
+        {mutations.map(mut => (
+          <div key={mut.service} className="card" style={{ padding: '20px', display: 'flex', alignItems: 'center', gap: '16px' }}>
+            <MutationGauge score={mut.score} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontFamily: 'monospace', fontSize: '12px', fontWeight: 600, color: 'var(--text-primary)', marginBottom: '6px' }}>
+                {mut.service.replace('openbank-', '')}
+              </div>
+              <div style={{ fontSize: '11px', color: 'var(--text-secondary)', marginBottom: '4px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {mut.targetPackage}
+              </div>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '4px', fontSize: '10px', color: 'var(--text-tertiary)' }}>
+                <span style={{ color: '#16a34a' }}>✓ {mut.killed}</span>
+                <span style={{ color: '#dc2626' }}>✗ {mut.survived}</span>
+                <span>◌ {mut.noCoverage}</span>
+              </div>
+              {mut.reportedAt && (
+                <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', marginTop: '4px' }}>
+                  {new Date(mut.reportedAt).toLocaleDateString(dateLocale)}
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', padding: '8px 12px', background: 'var(--surface-2)', borderRadius: '6px' }}>
+        {t(
+          'Pitest testuje domain vrstvu (finanční aritmetika). Práh: 70%. Týdenní CI job: .github/workflows/pitest.yml (ADR-0063).',
+          'Pitest tests the domain layer (financial arithmetic). Threshold: 70%. Weekly CI job: .github/workflows/pitest.yml (ADR-0063).',
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Quality score tab ─────────────────────────────────────────────────────────
+
+function QualityScoreCell({ score }: { score: number | null }) {
+  if (score === null) return <span style={{ color: 'var(--text-tertiary)', fontSize: '12px' }}>—</span>
+  const color = score >= 80 ? '#16a34a' : score >= 60 ? '#d97706' : '#dc2626'
+  return <span style={{ fontWeight: 700, fontSize: '13px', color }}>{score}%</span>
+}
+
+function QualityTab({ scores }: { scores: ServiceQualityScore[] }) {
+  const { t } = useLanguage()
+
+  const sorted = scores.slice().sort((a, b) => {
+    if (a.composite !== null && b.composite !== null) return b.composite - a.composite
+    if (a.composite !== null) return -1
+    if (b.composite !== null) return 1
+    return a.service.localeCompare(b.service)
+  })
+
+  if (scores.length === 0) {
+    return (
+      <div className="card" style={{ padding: '32px', textAlign: 'center', color: 'var(--text-secondary)' }}>
+        <Star size={32} style={{ margin: '0 auto 12px', color: 'var(--text-tertiary)' }} />
+        <p style={{ fontSize: '13px' }}>
+          {t(
+            'Kompozitní skóre bude dostupné po spuštění CI pipeline (testy + pitest + Pact).',
+            'Composite score will be available after running the CI pipeline (tests + pitest + Pact).',
+          )}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '12px' }}>
+          <thead>
+            <tr style={{ background: 'var(--surface-2)', borderBottom: '1px solid var(--border)' }}>
+              {[
+                { label: t('Služba', 'Service'), align: 'left' as const },
+                { label: t('Testy', 'Tests'), align: 'center' as const },
+                { label: t('Pokrytí', 'Coverage'), align: 'center' as const },
+                { label: t('Mutace', 'Mutation'), align: 'center' as const },
+                { label: t('Kontrakty', 'Contracts'), align: 'center' as const },
+                { label: t('Celkové skóre', 'Overall score'), align: 'center' as const },
+              ].map(col => (
+                <th key={col.label} style={{ padding: '10px 16px', textAlign: col.align, fontWeight: 600, color: 'var(--text-secondary)', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map(row => (
+              <tr key={row.service} style={{ borderBottom: '1px solid var(--border)' }}>
+                <td style={{ padding: '10px 16px', fontFamily: 'monospace', fontSize: '11px', fontWeight: 600, color: 'var(--text-primary)' }}>
+                  {row.service.replace('openbank-', '')}
+                </td>
+                <td style={{ padding: '10px 16px', textAlign: 'center' }}><QualityScoreCell score={row.unitScore} /></td>
+                <td style={{ padding: '10px 16px', textAlign: 'center' }}><QualityScoreCell score={row.coverageScore} /></td>
+                <td style={{ padding: '10px 16px', textAlign: 'center' }}><QualityScoreCell score={row.mutationScore} /></td>
+                <td style={{ padding: '10px 16px', textAlign: 'center' }}><QualityScoreCell score={row.contractScore} /></td>
+                <td style={{ padding: '10px 16px', textAlign: 'center' }}>
+                  {row.composite !== null
+                    ? <ScoreBar score={row.composite} threshold={80} />
+                    : <span style={{ color: 'var(--text-tertiary)', fontSize: '12px' }}>—</span>}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', padding: '8px 12px', background: 'var(--surface-2)', borderRadius: '6px' }}>
+        {t(
+          'Kompozitní skóre = průměr dostupných složek: pass rate testů (25 %) + kover pokrytí (25 %) + pitest mutace (25 %) + kontrakty (25 %).',
+          'Composite score = average of available components: test pass rate (25%) + kover coverage (25%) + pitest mutation (25%) + contracts (25%).',
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+type Tab = 'tests' | 'contract' | 'mutation' | 'quality'
+
+export default function TestCoveragePage() {
+  const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
+  const [tab, setTab] = useState<Tab>('tests')
+
+  const [testData, setTestData] = useState<TestResultsResponse | null>(null)
+  const [testError, setTestError] = useState<string | null>(null)
+  const [testLoading, setTestLoading] = useState(true)
+
+  const [qualityData, setQualityData] = useState<QualityReport | null>(null)
+  const [qualityError, setQualityError] = useState(false)
+  const [qualityLoading, setQualityLoading] = useState(true)
+
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
 
   const load = useCallback(async () => {
-    setLoading(true)
-    try {
-      const response = await fetch('/api/test-intelligence', { cache: 'no-store' })
-      setReport(await response.json() as TestIntelligenceReport)
-    } catch { setReport(null) } finally { setLoading(false) }
-  }, [])
-  useEffect(() => { void load() }, [load])
+    setTestLoading(true)
+    setQualityLoading(true)
+    setTestError(null)
+    setQualityError(false)
 
-  const tabs: { id: Tab; label: string; icon: React.ReactNode }[] = [
-    { id: 'posture', label: t('Přehled', 'Posture'), icon: <Activity size={13} /> },
-    { id: 'tests', label: t('Testy a flaky', 'Tests & flaky'), icon: <FlaskConical size={13} /> },
-    { id: 'history', label: t('Historie', 'History'), icon: <BarChart3 size={13} /> },
-    { id: 'execution', label: t('Běhy', 'Execution'), icon: <FlaskConical size={13} /> },
-    { id: 'runtime', label: t('Testovací runtime', 'Test runtime'), icon: <Activity size={13} /> },
-    { id: 'coverage', label: t('Pokrytí kódu', 'Code coverage'), icon: <BarChart3 size={13} /> },
-    { id: 'contracts', label: t('Kontrakty', 'Contracts'), icon: <ShieldCheck size={13} /> },
-    { id: 'mutation', label: t('Mutace', 'Mutation'), icon: <Dna size={13} /> },
-    { id: 'performance', label: t('Výkon', 'Performance'), icon: <Gauge size={13} /> },
-    { id: 'synthetic', label: t('Syntetika', 'Synthetics'), icon: <Timer size={13} /> },
-    { id: 'clients', label: t('Client experience', 'Client experience'), icon: <Activity size={13} /> },
+    const [testRes, qualRes] = await Promise.allSettled([
+      fetch('/api/test-results', { cache: 'no-store' }),
+      fetch('/api/quality-report', { cache: 'no-store' }),
+    ])
+
+    if (testRes.status === 'fulfilled' && testRes.value.ok) {
+      setTestData(await testRes.value.json())
+    } else {
+      setTestError('unavailable')
+    }
+    setTestLoading(false)
+
+    if (qualRes.status === 'fulfilled' && qualRes.value.ok) {
+      setQualityData(await qualRes.value.json() as QualityReport)
+    } else {
+      setQualityError(true)
+    }
+    setQualityLoading(false)
+    setLastRefresh(new Date())
+  }, [])
+
+  useEffect(() => { load() }, [load])
+
+  const tabs: { id: Tab; label: string; icon: React.ReactNode; count?: number }[] = [
+    { id: 'tests', label: t('Testy', 'Tests'), icon: <FlaskConical size={13} /> },
+    { id: 'contract', label: t('Kontrakty', 'Contracts'), icon: <ShieldCheck size={13} />, count: qualityData?.contracts.length },
+    { id: 'mutation', label: t('Mutace', 'Mutation'), icon: <Dna size={13} />, count: qualityData?.mutations.length },
+    { id: 'quality', label: t('Skóre kvality', 'Quality Score'), icon: <Star size={13} />, count: qualityData?.serviceScores.length },
   ]
 
-  return <div style={{ padding: '28px 32px', maxWidth: 1600, animation: 'fadeIn 0.2s ease-out' }}>
-    <PageHeader
-      breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep" aria-hidden="true">/</span><span>{t('Systém', 'System')}</span><span className="breadcrumb-sep" aria-hidden="true">/</span><span className="breadcrumb-current">{t('Test Intelligence', 'Test Intelligence')}</span></div>}
-      icon={<FlaskConical size={19} aria-hidden="true" style={{ color: 'var(--accent)' }} />}
-      title={t('Test Intelligence', 'Test Intelligence')}
-      subtitle={t('Jednotný pohled na běhy, pokrytí kódu, kontrakty, mutace, výkon a sandboxové syntetické scénáře.', 'One evidence view for execution, code coverage, contracts, mutation, performance, and sandbox synthetic journeys.')}
-      actions={<button type="button" onClick={load} disabled={testLoading || qualityLoading} aria-busy={testLoading || qualityLoading} aria-label={t('Obnovit systémové testy', 'Refresh system tests')} className="btn btn-secondary btn-sm"><RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />{t('Obnovit', 'Refresh')}</button>}
-    />
-    <TestIntelligenceFlow report={report} />
-    {report && <AssuranceBoard report={report} selectTab={setTab} />}
-    {report?.warnings.length ? <div style={{ marginBottom: 16, border: '1px solid #d97706', borderRadius: 8, padding: 12, color: '#d97706', fontSize: 12 }}><TriangleAlert size={14} style={{ verticalAlign: 'text-bottom', marginRight: 6 }} />{report.warnings.join(' · ')}</div> : null}
-    <div role="group" aria-label={t('Přepínač pohledů kvality kódu', 'Code quality view')} style={{ display: 'flex', gap: 2, overflowX: 'auto', borderBottom: '1px solid var(--border)', marginBottom: 20 }}>{tabs.map(tabDef => <button key={tabDef.id} type="button"
-            aria-pressed={tab === tabDef.id} onClick={() => setTab(tabDef.id)} style={{ display: 'flex', gap: 6, alignItems: 'center', padding: '9px 13px', whiteSpace: 'nowrap', border: 'none', borderBottom: tab === tabDef.id ? '2px solid var(--accent)' : '2px solid transparent', background: 'none', color: tab === tabDef.id ? 'var(--accent)' : 'var(--text-secondary)', cursor: 'pointer', fontWeight: tab === tabDef.id ? 650 : 450 }}><span aria-hidden="true">{tabDef.icon}</span>{tabDef.label}</button>)}</div>
-    {loading && !report ? <div className="skeleton" style={{ height: 260 }} /> : report ? <>
-      {tab === 'posture' && <Posture report={report} />}{tab === 'tests' && <TestCases report={report} />}{tab === 'history' && <History report={report} />}{tab === 'execution' && <Execution report={report} />}{tab === 'runtime' && <RuntimeInfrastructure report={report} />}{tab === 'coverage' && <Coverage report={report} />}
-      {tab === 'contracts' && <Contracts report={report} />}{tab === 'mutation' && <Mutations report={report} />}{tab === 'performance' && <Performance report={report} />}{tab === 'synthetic' && <Synthetics report={report} />}
-      {tab === 'clients' && <ClientExperiences report={report} />}
-    </> : <div style={{ padding: 24, color: 'var(--text-secondary)' }}>{t('Report není dostupný.', 'Report is unavailable.')}</div>}
-    {report && <TestAgentPanel />}
-    {report && <div style={{ marginTop: 18, color: 'var(--text-tertiary)', fontSize: 11 }}>{t('Schéma', 'Schema')} v{report.schemaVersion} · {t('sesbíráno', 'collected')} {new Intl.DateTimeFormat(dateLocale, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(report.collectedAt))} · {t('absence se nikdy nevykresluje jako nula', 'absence is never rendered as zero')}</div>}
-  </div>
+  return (
+    <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
+      <PageHeader
+        breadcrumb={<div className="breadcrumb"><span>{t('OpenBank', 'OpenBank')}</span><span className="breadcrumb-sep">/</span><span>{t('Systém', 'System')}</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Kvalita kódu', 'Code Quality')}</span></div>}
+        icon={<FlaskConical size={20} aria-hidden="true" />}
+        title={t('Kvalita kódu', 'Code Quality')}
+        subtitle={t('Výsledky testů, kontraktní verifikace (Pact), mutační testování (pitest) a kompozitní skóre kvality.', 'Test results, contract verification (Pact), mutation testing (pitest), and composite quality score.')}
+        actions={<div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          {lastRefresh && (
+            <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
+              {t('Aktualizováno', 'Updated')} {lastRefresh.toLocaleTimeString(dateLocale)}
+            </span>
+          )}
+          <button type="button" onClick={load} disabled={testLoading || qualityLoading} aria-busy={testLoading || qualityLoading}
+            aria-label={t('Obnovit systémové testy', 'Refresh system tests')} className="btn btn-secondary btn-sm">
+            <RefreshCw size={13} aria-hidden="true" style={{ animation: (testLoading || qualityLoading) ? 'spin 0.8s linear infinite' : 'none' }} />
+            {t('Obnovit', 'Refresh')}
+          </button>
+        </div>}
+      />
+
+      <div role="group" aria-label={t('Přepínač pohledů kvality kódu', 'Code quality view')} style={{ display: 'flex', gap: '2px', marginBottom: '20px', borderBottom: '1px solid var(--border)' }}>
+        {tabs.map(tabDef => (
+          <button
+            key={tabDef.id}
+            type="button"
+            aria-pressed={tab === tabDef.id}
+            onClick={() => setTab(tabDef.id)}
+            style={{
+              display: 'flex', alignItems: 'center', gap: '6px',
+              padding: '8px 14px',
+              fontSize: '13px', fontWeight: tab === tabDef.id ? 600 : 400,
+              color: tab === tabDef.id ? 'var(--accent)' : 'var(--text-secondary)',
+              background: 'none', border: 'none',
+              borderBottom: tab === tabDef.id ? '2px solid var(--accent)' : '2px solid transparent',
+              cursor: 'pointer', marginBottom: '-1px', transition: 'color 0.15s',
+            }}
+          >
+            <span aria-hidden="true">{tabDef.icon}</span>
+            {tabDef.label}
+            {tabDef.count !== undefined && tabDef.count > 0 && (
+              <span style={{ fontSize: '10px', background: 'var(--surface-3)', borderRadius: '10px', padding: '1px 6px', color: 'var(--text-secondary)', fontWeight: 500 }}>
+                {tabDef.count}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'tests' && (
+        <TestsTab data={testData} error={testError} loading={testLoading} />
+      )}
+      {tab === 'contract' && (
+        qualityLoading
+          ? <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>{Array.from({ length: 3 }).map((_, idx) => <div key={idx} className="skeleton" style={{ height: '48px' }} />)}</div>
+          : <ContractTab contracts={qualityData?.contracts ?? []} error={qualityError} />
+      )}
+      {tab === 'mutation' && (
+        qualityLoading
+          ? <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: '12px' }}>{Array.from({ length: 4 }).map((_, idx) => <div key={idx} className="skeleton" style={{ height: '100px' }} />)}</div>
+          : <MutationTab mutations={qualityData?.mutations ?? []} error={qualityError} />
+      )}
+      {tab === 'quality' && (
+        qualityLoading
+          ? <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>{Array.from({ length: 6 }).map((_, idx) => <div key={idx} className="skeleton" style={{ height: '42px' }} />)}</div>
+          : <QualityTab scores={qualityData?.serviceScores ?? []} />
+      )}
+    </div>
+  )
 }

--- a/openbank-admin-ui/src/app/temporal/flow/page.tsx
+++ b/openbank-admin-ui/src/app/temporal/flow/page.tsx
@@ -26,6 +26,7 @@ interface TemporalMetrics {
   workflows: { scheduled1h: number; completed1h: number; failed1h: number; timedOut1h: number }
   latency: { activityScheduleToStartMs: number | null; workflowTaskScheduleToStartMs: number | null; serverRequestP99Ms: number | null }
   namespaces: string[]
+  workflowTypes: { namespace: string; workflowType: string; completed1h: number }[]
 }
 interface StatusData { available: boolean; temporalDeployed: boolean; metrics: TemporalMetrics | null }
 
@@ -77,8 +78,8 @@ export default function TemporalFlowPage() {
           </div>}
         title={t('Tok Temporal workflow', 'Temporal Workflow Flow')}
         icon={<Workflow aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
-        subtitle={t('Money-path ságy jako animované řetězce kroků (krok → krok → kompenzace). Kroky jsou zdokumentované definice ság; metriky jsou živé, ale agregátní za namespace (ne přehrání jednotlivých běhů).',
-               'Money-path sagas as animated step-chains (step → step → compensation). The steps are the documented saga definitions; the metrics are live but namespace-aggregate (not per-run replay).')}
+        subtitle={t('Živé typy workflow a jejich hodinový průtok z Tempa. Referenční diagramy níže popisují kód, nikoli aktuální běhy.',
+               'Live workflow types and hourly throughput from Temporal. Reference diagrams below describe code, not current executions.')}
       />
       {/* Controls */}
       <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', marginBottom: '14px', gap: '8px' }}>
@@ -112,6 +113,18 @@ export default function TemporalFlowPage() {
           : <><AlertTriangle size={12} style={{ color: 'var(--warning)' }} /> {t('Temporal není nasazený zde — ságy zobrazeny staticky, živé metriky nedostupné.', 'Temporal is not deployed here — sagas shown statically, live metrics unavailable.')}</>}
       </div>
 
+      {deployed && (
+        <div className="card" style={{ padding: 0, overflow: 'hidden', marginBottom: 18 }}>
+          <div className="section-title" style={{ padding: '14px 16px 8px' }}>{t('Živé workflow typy', 'Live workflow types')}</div>
+          <table className="table"><thead><tr><th>Namespace</th><th>{t('Workflow typ', 'Workflow type')}</th><th>{t('Dokončeno za 1 h', 'Completed in 1h')}</th></tr></thead>
+            <tbody>{(m?.workflowTypes ?? []).map(row => <tr key={`${row.namespace}:${row.workflowType}`}><td className="mono">{row.namespace}</td><td className="mono">{row.workflowType}</td><td>{row.completed1h}</td></tr>)}</tbody>
+          </table>
+          {(m?.workflowTypes ?? []).length === 0 && <div style={{ padding: 16, color: 'var(--text-secondary)', fontSize: 12 }}>{t('Temporal je scrapeován, ale za poslední hodinu nebyl dokončen žádný workflow.', 'Temporal is scraped, but no workflow completed in the last hour.')}</div>}
+        </div>
+      )}
+
+      <div className="section-title" style={{ marginBottom: 10 }}>{t('Referenční definice v kódu', 'Reference definitions in code')}</div>
+
       {/* One animated saga chain per money-path workflow */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
         {MONEY_WORKFLOWS.map((w, wi) => {
@@ -130,7 +143,7 @@ export default function TemporalFlowPage() {
                 </div>
                 <div style={{ fontSize: '13px', fontWeight: 700, color: 'var(--text-primary)' }}>{t(w.serviceCs, w.serviceEn)}</div>
                 <code style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{w.workflowCs}</code>
-                <span style={{ marginLeft: 'auto', fontSize: '10px', color: 'var(--text-tertiary)', fontFamily: 'monospace' }}>{t(w.flagCs, w.flagEn)}</span>
+                <span style={{ marginLeft: 'auto', fontSize: '10px', color: 'var(--text-tertiary)', fontFamily: 'monospace' }}>{t('referenční definice', 'reference definition')}</span>
               </div>
               <svg viewBox={`0 0 ${WIDTH} ${SVG_H}`} style={{ width: '100%', height: 'auto', display: 'block' }}>
                 <defs>

--- a/openbank-admin-ui/src/app/temporal/page.tsx
+++ b/openbank-admin-ui/src/app/temporal/page.tsx
@@ -424,7 +424,7 @@ export default function TemporalPage() {
                         ))}
                       </div>
                       <div style={{ fontSize: '10.5px', color: 'var(--text-tertiary)', fontFamily: 'monospace', background: 'var(--surface-2)', padding: '3px 8px', borderRadius: 4 }}>
-                        {t(wf.flagCs, wf.flagEn)}
+                        {wf.svc}
                       </div>
                     </div>
                   )
@@ -549,8 +549,8 @@ export default function TemporalPage() {
               <CheckCircle size={16} color="#22c55e" style={{ flexShrink: 0, marginTop: '1px' }} />
               <span>
                 {t(
-                  'P0–P4 nasazeno; feature flagy ON v GitOps. P3 (settlement, money-path) prošlo se 2 review approvaly a aktualizovaným threat modelem (docs/threat-models/settlement.md) podle ADR-0030. Zbývá P5 — dekomisace legacy saga tabulek.',
-                  'P0–P4 deployed; feature flags ON in GitOps. P3 (settlement, money-path) shipped with 2 review approvals and an updated threat model (docs/threat-models/settlement.md) per ADR-0030. P5 remaining — decommission legacy saga tables.',
+                  'Toto je referenční migrační plán z ADR-0100, ne živý stav běhů. Aktuální aktivitu a typy workflow potvrzují pouze metriky níže.',
+                  'This is the ADR-0100 reference migration plan, not live execution state. Only the metrics below confirm current activity and workflow types.',
                 )}
               </span>
             </div>
@@ -584,12 +584,12 @@ export default function TemporalPage() {
                 <Clock size={16} color="#818cf8" style={{ flexShrink: 0, marginTop: 2 }} />
                 <div>
                   <div style={{ fontSize: '13px', fontWeight: 700, color: 'var(--text-primary)', marginBottom: 4 }}>
-                    {t('Temporal server běží — Prometheus metriky se ještě neobjeví', 'Temporal server is running — Prometheus metrics not yet visible')}
+                    {t('Temporal nelze potvrdit z Promethea', 'Temporal cannot be confirmed from Prometheus')}
                   </div>
                   <div style={{ fontSize: '12.5px', color: 'var(--text-secondary)', lineHeight: 1.6 }}>
                     {t(
-                      'Temporal server je nasazen (Helm chart + PodMonitor enablePodMonitor=true v GitOpsu). Temporal vystavuje metriky na portu 9090 pod prefixem temporal_. Pokud Prometheus nevrací temporal_server_start_count, nejčastější příčiny jsou: (1) PodMonitor v namespace temporal ještě čeká na první scrape cyklus (~30 s po startu), (2) kube-prometheus-stack má podMonitorNamespaceSelector omezený jen na vlastní namespace — zkontroluj Helm values. Workflowy domácích plateb, SEPA, FX a uzávěrek jsou aktivní (feature flagy ON), metriky se zobrazí po vyřešení scrape konfigurace.',
-                      'Temporal server is deployed (Helm chart + PodMonitor enablePodMonitor=true in GitOps). Temporal exposes metrics on port 9090 with the temporal_ prefix. If Prometheus does not return temporal_server_start_count, the most common causes are: (1) PodMonitor in the temporal namespace is still waiting for the first scrape cycle (~30 s after start), (2) kube-prometheus-stack podMonitorNamespaceSelector is scoped only to its own namespace — check Helm values. Domestic payment, SEPA, FX and closing workflows are active (feature flags ON); metrics will appear once the scrape config is resolved.',
+                      'Prometheus odpověděl, ale nevrátil žádnou temporal_restarts řadu. To může znamenat nenasazený Temporal nebo chybějící scrape; tato stránka z toho neodvozuje, že server či workflow běží. Ověř PodMonitor, target health a Temporal frontend.',
+                      'Prometheus responded but returned no temporal_restarts series. Temporal may be absent or its scrape may be missing; this page does not infer that the server or workflows are running. Check the PodMonitor, target health, and Temporal frontend.',
                     )}
                   </div>
                 </div>

--- a/openbank-admin-ui/src/components/party/CustomerPortfolioPanel.tsx
+++ b/openbank-admin-ui/src/components/party/CustomerPortfolioPanel.tsx
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Landmark, ShieldAlert, WalletCards } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { classifyBffFailure, svcUrl, type BffFailure } from '@/lib/services/bff'
+
+type Source = 'accounts' | 'lending' | 'aml'
+type SourceState = { kind: 'loading' } | { kind: 'ok'; count: number; statuses: string[] } | { kind: 'unknown'; why: BffFailure }
+type State = Record<Source, SourceState>
+
+const initial = (): State => ({ accounts: { kind: 'loading' }, lending: { kind: 'loading' }, aml: { kind: 'loading' } })
+
+function rows(body: unknown): Record<string, unknown>[] {
+  if (Array.isArray(body)) return body as Record<string, unknown>[]
+  const obj = body as { data?: unknown[]; items?: unknown[]; content?: unknown[] }
+  return (obj?.data ?? obj?.items ?? obj?.content ?? []) as Record<string, unknown>[]
+}
+
+export function CustomerPortfolioPanel({ partyId }: { partyId: string }) {
+  const { t } = useLanguage()
+  const [state, setState] = useState<State>(initial)
+
+  useEffect(() => {
+    let live = true
+    const sources: { source: Source; url: string }[] = [
+      { source: 'accounts', url: svcUrl('account-service', '/api/v1/accounts', { partyId, limit: '100' }) },
+      { source: 'lending', url: svcUrl('lending-service', '/api/v1/lending/applications', { partyId }) },
+      { source: 'aml', url: svcUrl('aml-service', '/api/v1/aml/cases', { partyId, limit: '100', offset: '0' }) },
+    ]
+    void Promise.all(sources.map(async ({ source, url }) => {
+      try {
+        const res = await fetch(url, { cache: 'no-store' })
+        if (!res.ok) {
+          const why = await classifyBffFailure(res)
+          if (live) setState(s => ({ ...s, [source]: { kind: 'unknown', why } }))
+          return
+        }
+        const list = rows(await res.json())
+        const statuses = [...new Set(list.map(r => String(r.status ?? r.state ?? '')).filter(Boolean))]
+        if (live) setState(s => ({ ...s, [source]: { kind: 'ok', count: list.length, statuses } }))
+      } catch {
+        if (live) setState(s => ({ ...s, [source]: { kind: 'unknown', why: 'unreachable' } }))
+      }
+    }))
+    return () => { live = false }
+  }, [partyId])
+
+  const cards: { source: Source; title: string; href: string; Icon: typeof WalletCards }[] = [
+    { source: 'accounts', title: t('Účty', 'Accounts'), href: '/accounts', Icon: WalletCards },
+    { source: 'lending', title: t('Úvěrové žádosti', 'Loan applications'), href: '/lending', Icon: Landmark },
+    { source: 'aml', title: t('AML případy', 'AML cases'), href: '/aml', Icon: ShieldAlert },
+  ]
+
+  return <div className="card" style={{ padding: '16px 20px', marginBottom: 20 }}>
+    <h2 className="section-title" style={{ marginBottom: 4 }}>{t('Autoritativní portfolio a riziko', 'Authoritative portfolio and risk')}</h2>
+    <p style={{ margin: '0 0 12px', fontSize: 11, color: 'var(--text-secondary)' }}>{t('Každá karta se načítá přímo z vlastnící služby a degraduje nezávisle; nejde o analytickou projekci.', 'Each card loads from its owning service and degrades independently; this is not an analytics projection.')}</p>
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(210px, 1fr))', gap: 12 }}>
+      {cards.map(({ source, title, href, Icon }) => {
+        const value = state[source]
+        return <Link href={href} key={source} className="card" style={{ padding: 14, textDecoration: 'none', color: 'inherit' }}>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', fontSize: 12, color: 'var(--text-secondary)' }}><Icon size={15} /> {title}</div>
+          {value.kind === 'loading' && <div style={{ marginTop: 8, color: 'var(--text-tertiary)' }}>{t('Načítám…', 'Loading…')}</div>}
+          {value.kind === 'ok' && <><div style={{ fontSize: 24, fontWeight: 800, marginTop: 6 }}>{value.count}</div><div style={{ fontSize: 10, color: 'var(--text-tertiary)' }}>{value.statuses.join(' · ') || t('bez stavů', 'no statuses')}</div></>}
+          {value.kind === 'unknown' && <div style={{ marginTop: 8, fontSize: 11, color: '#b45309' }}>{t('Nelze zjistit', 'Unavailable')} · {value.why}</div>}
+        </Link>
+      })}
+    </div>
+  </div>
+}

--- a/openbank-admin-ui/src/components/party/DocumentsPanel.tsx
+++ b/openbank-admin-ui/src/components/party/DocumentsPanel.tsx
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Download, FileText, HelpCircle } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { StatusBadge } from '@/components/ui'
+import { classifyBffFailure, svcUrl, type BffFailure } from '@/lib/services/bff'
+
+interface PartyDocument {
+  id: string; templateCode: string; templateVersion: string; contentType: string
+  sizeBytes: number; status: string; caseRef: string | null; productRef: string | null
+  retainUntil: string | null; createdAt: string
+}
+
+type State = { kind: 'loading' } | { kind: 'ok'; documents: PartyDocument[] } | { kind: 'unknown'; why: BffFailure }
+
+export function DocumentsPanel({ partyId }: { partyId: string }) {
+  const { t, language } = useLanguage()
+  const [state, setState] = useState<State>({ kind: 'loading' })
+
+  useEffect(() => {
+    let live = true
+    ;(async () => {
+      try {
+        const res = await fetch(svcUrl('document-service', '/api/v1/documents', { partyRef: partyId }), { cache: 'no-store' })
+        if (!res.ok) {
+          const why = await classifyBffFailure(res)
+          if (live) setState({ kind: 'unknown', why })
+          return
+        }
+        const body = await res.json() as PartyDocument[]
+        if (live) setState({ kind: 'ok', documents: Array.isArray(body) ? body : [] })
+      } catch {
+        if (live) setState({ kind: 'unknown', why: 'unreachable' })
+      }
+    })()
+    return () => { live = false }
+  }, [partyId])
+
+  const fmt = (iso: string) => new Intl.DateTimeFormat(language === 'cs' ? 'cs-CZ' : 'en-GB', {
+    dateStyle: 'medium', timeStyle: 'short',
+  }).format(new Date(iso))
+
+  return <div className="card" style={{ padding: '16px 20px', marginBottom: 20 }}>
+    <h2 className="section-title" style={{ marginBottom: 4 }}>{t('Dokumenty klienta', 'Customer documents')}</h2>
+    <p style={{ margin: '0 0 12px', fontSize: 11, color: 'var(--text-secondary)' }}>
+      {t('Zdroj: document-service. Stažení obsahu podléhá backendovému oprávnění a auditu.', 'Source: document-service. Content downloads remain subject to backend authorisation and audit.')}
+    </p>
+    {state.kind === 'loading' && <span style={{ fontSize: 12, color: 'var(--text-secondary)' }}>{t('Načítám…', 'Loading…')}</span>}
+    {state.kind === 'ok' && state.documents.length === 0 && <div style={{ display: 'flex', gap: 8, alignItems: 'center', color: 'var(--text-secondary)', fontSize: 13 }}><FileText size={16} /> {t('Klient nemá žádné dokumenty', 'No documents for this customer')}</div>}
+    {state.kind === 'ok' && state.documents.length > 0 && <div style={{ overflowX: 'auto' }}><table className="table">
+      <thead><tr><th>{t('Dokument', 'Document')}</th><th>{t('Stav', 'Status')}</th><th>{t('Vytvořeno', 'Created')}</th><th>{t('Vazba', 'Reference')}</th><th>{t('Retence do', 'Retain until')}</th><th /></tr></thead>
+      <tbody>{state.documents.map(doc => <tr key={doc.id}>
+        <td><div style={{ fontWeight: 600 }}>{doc.templateCode}</div><div className="mono" style={{ fontSize: 10, color: 'var(--text-tertiary)' }}>v{doc.templateVersion} · {Math.ceil(doc.sizeBytes / 1024)} kB</div></td>
+        <td><StatusBadge status={doc.status} /></td><td>{fmt(doc.createdAt)}</td>
+        <td className="mono" style={{ fontSize: 10 }}>{doc.caseRef ?? doc.productRef ?? '—'}</td><td>{doc.retainUntil ?? '—'}</td>
+        <td style={{ textAlign: 'right' }}><a className="btn btn-secondary btn-sm" href={svcUrl('document-service', `/api/v1/documents/${doc.id}/content`)} download><Download size={12} /> {t('Stáhnout', 'Download')}</a></td>
+      </tr>)}</tbody>
+    </table></div>}
+    {state.kind === 'unknown' && <div style={{ display: 'flex', gap: 8, alignItems: 'center', color: 'var(--text-secondary)', fontSize: 13 }}><HelpCircle size={16} /> {t(`Dokumenty nelze zjistit (document-service: ${state.why}).`, `Documents unavailable (document-service: ${state.why}).`)}</div>}
+  </div>
+}

--- a/openbank-admin-ui/src/lib/temporal/workflows.ts
+++ b/openbank-admin-ui/src/lib/temporal/workflows.ts
@@ -18,8 +18,6 @@ export type MoneyWorkflow = {
   workflowCs: string
   stepsCs: string[]
   stepsEn: string[]
-  flagCs: string
-  flagEn: string
 }
 
 export const MONEY_WORKFLOWS: MoneyWorkflow[] = [
@@ -32,8 +30,6 @@ export const MONEY_WORKFLOWS: MoneyWorkflow[] = [
     workflowCs: 'DomesticPaymentWorkflow',
     stepsCs: ['Validace IBAN + limit', 'Rezervace sald', 'Odeslání na CERTIS/instant rail', 'Potvrzení settlement', 'Kompenzace při odmítnutí'],
     stepsEn: ['IBAN + limit validation', 'Balance reservation', 'Submit to CERTIS/instant rail', 'Settlement confirmation', 'Compensation on rejection'],
-    flagCs: 'flag: domestic-payment-temporal-workflow=ON',
-    flagEn: 'flag: domestic-payment-temporal-workflow=ON',
   },
   {
     icon: Globe,
@@ -44,8 +40,6 @@ export const MONEY_WORKFLOWS: MoneyWorkflow[] = [
     workflowCs: 'SepaPaymentWorkflow',
     stepsCs: ['Validace BIC + SEPA pravidla', 'ISO 20022 pacs.008 sestavení', 'Odeslání do SWIFT/EBA', 'SCT/SCT Inst potvrzení', 'Kompenzace přes pacs.004'],
     stepsEn: ['BIC + SEPA rules validation', 'ISO 20022 pacs.008 assembly', 'Submit to SWIFT/EBA', 'SCT/SCT Inst confirmation', 'Compensation via pacs.004'],
-    flagCs: 'flag: sepa-payment-temporal-workflow=ON',
-    flagEn: 'flag: sepa-payment-temporal-workflow=ON',
   },
   {
     icon: Repeat2,
@@ -56,8 +50,6 @@ export const MONEY_WORKFLOWS: MoneyWorkflow[] = [
     workflowCs: 'FxConversionWorkflow',
     stepsCs: ['Sestavení kurzu (ECB + spread)', 'G5 screening', 'Odpis zdrojové měny', 'Připsání cílové měny', 'Journal entry pár (ADR-0039)'],
     stepsEn: ['Rate assembly (ECB + spread)', 'G5 screening', 'Debit source currency', 'Credit target currency', 'Journal entry pair (ADR-0039)'],
-    flagCs: 'flag: fx-temporal-workflow=ON',
-    flagEn: 'flag: fx-temporal-workflow=ON',
   },
   {
     icon: BarChart2,
@@ -68,7 +60,5 @@ export const MONEY_WORKFLOWS: MoneyWorkflow[] = [
     workflowCs: 'StatementCloseWorkflow',
     stepsCs: ['Agregace transakcí dne/měsíce/roku', 'Výpočet úrokových nákladů', 'Export na S3 + Kafka výpis', 'Potvrzení uzávěrky'],
     stepsEn: ['Aggregate daily/monthly/yearly transactions', 'Compute interest charges', 'Export to S3 + Kafka statement', 'Closing confirmation'],
-    flagCs: 'flag: statement-temporal-workflow=ON',
-    flagEn: 'flag: statement-temporal-workflow=ON',
   },
 ]

--- a/openbank-admin-ui/src/test/agent-proposals-identity.test.ts
+++ b/openbank-admin-ui/src/test/agent-proposals-identity.test.ts
@@ -2,10 +2,11 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
+import { loadAgentCharters } from '@/lib/governance/agentCharters'
 
 vi.mock('@/auth', () => ({ auth: vi.fn(async () => ({ user: { accessToken: 'operator-token' } })) }))
 vi.mock('@/lib/governance/agentCharters', () => ({
-  loadAgentCharters: vi.fn(async () => ({ agents: [{ id: 'fraud-investigator' }] })),
+  loadAgentCharters: vi.fn(async () => ({ available: true, agents: [{ id: 'fraud-investigator' }] })),
 }))
 
 afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals() })
@@ -32,5 +33,17 @@ describe('agent proposal identity enrichment', () => {
     const body = await (await GET(new NextRequest('http://localhost/api/agent/proposals'))).json()
 
     expect(body[0].agent).toMatchObject({ id: 'alice@example.test', icon: 'user', charterKnown: false })
+  })
+
+  it('preserves upstream provenance when the charter registry is unavailable', async () => {
+    vi.mocked(loadAgentCharters).mockResolvedValueOnce({ available: false, agents: [] } as never)
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify([{
+      id: 'proposal-3', proposedBy: 'fraud-investigator', suggestedAction: 'fraud.review',
+    }]), { status: 200, headers: { 'content-type': 'application/json' } })))
+    const { GET } = await import('@/app/api/agent/proposals/route')
+    const body = await (await GET(new NextRequest('http://localhost/api/agent/proposals'))).json()
+
+    expect(body[0]).toMatchObject({ id: 'proposal-3', proposedBy: 'fraud-investigator' })
+    expect(body[0].agent).toBeUndefined()
   })
 })

--- a/openbank-admin-ui/src/test/agent-proposals-identity.test.ts
+++ b/openbank-admin-ui/src/test/agent-proposals-identity.test.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/auth', () => ({ auth: vi.fn(async () => ({ user: { accessToken: 'operator-token' } })) }))
+vi.mock('@/lib/governance/agentCharters', () => ({
+  loadAgentCharters: vi.fn(async () => ({ agents: [{ id: 'fraud-investigator' }] })),
+}))
+
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals() })
+
+describe('agent proposal identity enrichment', () => {
+  it('attaches authoritative charter identity for a known proposing agent', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify([{
+      id: 'proposal-1', proposedBy: 'fraud-investigator', suggestedAction: 'fraud.review',
+    }]), { status: 200, headers: { 'content-type': 'application/json' } })))
+    const { GET } = await import('@/app/api/agent/proposals/route')
+    const response = await GET(new NextRequest('http://localhost/api/agent/proposals?state=pending'))
+    const body = await response.json()
+
+    expect(body[0].agent).toEqual({
+      id: 'fraud-investigator', displayName: 'Fraud Investigator', icon: 'bot', charterKnown: true,
+    })
+  })
+
+  it('does not mislabel an unknown human principal as a governed agent', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify([{
+      id: 'proposal-2', proposedBy: 'alice@example.test', suggestedAction: 'agent.review',
+    }]), { status: 200, headers: { 'content-type': 'application/json' } })))
+    const { GET } = await import('@/app/api/agent/proposals/route')
+    const body = await (await GET(new NextRequest('http://localhost/api/agent/proposals'))).json()
+
+    expect(body[0].agent).toMatchObject({ id: 'alice@example.test', icon: 'user', charterKnown: false })
+  })
+})

--- a/openbank-admin-ui/src/test/approvals-source-truth.guard.test.ts
+++ b/openbank-admin-ui/src/test/approvals-source-truth.guard.test.ts
@@ -20,4 +20,9 @@ describe('approval inbox source truthfulness', () => {
     expect(pageSource).toContain('notConfiguredSources.length === 0 && domainItems.filter')
     expect(pageSource).toContain('Decisions from these domains will not appear here until their read endpoint is available.')
   })
+
+  it('renders the proposer identity supplied by the BFF rather than assuming every proposer is a bot', () => {
+    expect(pageSource).toContain("const aiGenerated = p.agent ? p.agent.icon === 'bot'")
+    expect(pageSource).toContain('const ProposerIcon = aiGenerated ? Bot : UserRound')
+  })
 })

--- a/openbank-admin-ui/src/test/compliance-packs-console.test.tsx
+++ b/openbank-admin-ui/src/test/compliance-packs-console.test.tsx
@@ -35,6 +35,9 @@ const PENDING = [{
   proposedBy: 'maker@openbank.local',
   decidedBy: null,
   decidedAt: null,
+  proposedAt: '2026-08-20T08:00:00Z',
+  decisionReason: null,
+  pack: { jurisdiction: 'CZ', productType: 'CONSUMER_CREDIT', version: 1, coolingOffDays: 14 },
 }]
 
 const ACTIVE = [{ ...PENDING[0], id: '00000000-0000-0000-0000-000000000000', state: 'EXECUTED', proposedBy: '-' }]
@@ -105,6 +108,17 @@ describe('compliance pack activation console', () => {
     // The hash is what ties an activated pack to a reviewable document. A console that shows
     // "CZ v1 active" without it cannot answer "active *as of which text*".
     expect(screen.getAllByText(/b7c4d1e9a0f35286/).length).toBeGreaterThan(0)
+  })
+
+  it('opens the exact reviewed pack and maker-checker audit detail', async () => {
+    vi.stubGlobal('fetch', mockFetch({ active: { status: 200, body: ACTIVE } }))
+    render(React.createElement(Providers, null, React.createElement(CompliancePacksPage)))
+
+    await waitFor(() => expect(screen.getByText(/details/)).toBeTruthy())
+    fireEvent.click(screen.getByText(/details/))
+    expect(screen.getByText('Exact pack content')).toBeInTheDocument()
+    expect(screen.getByText(/"coolingOffDays": 14/)).toBeInTheDocument()
+    expect(screen.getByText(PENDING[0].contentHash)).toBeInTheDocument()
   })
 
   it('an empty active list states the enforce-pack consequence, not just "none"', async () => {

--- a/openbank-admin-ui/src/test/customer-360-documents.test.tsx
+++ b/openbank-admin-ui/src/test/customer-360-documents.test.tsx
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import React from 'react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { DocumentsPanel } from '@/components/party/DocumentsPanel'
+
+const PARTY = '55555555-5555-5555-5555-555555555555'
+const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+afterEach(() => { cleanup(); vi.restoreAllMocks(); vi.unstubAllGlobals() })
+
+describe('Customer 360 documents panel', () => {
+  it('queries the document owner by the selected party and exposes the audited content route', async () => {
+    const f = vi.fn(async () => json([{
+      id: 'doc-1', templateCode: 'SECCI', templateVersion: '2', contentType: 'application/pdf',
+      sizeBytes: 2048, status: 'GENERATED', caseRef: 'case-7', productRef: null,
+      retainUntil: '2036-08-20', createdAt: '2026-08-20T10:00:00Z',
+    }]))
+    vi.stubGlobal('fetch', f)
+    render(<LanguageProvider><DocumentsPanel partyId={PARTY} /></LanguageProvider>)
+
+    await waitFor(() => expect(screen.getByText('SECCI')).toBeInTheDocument())
+    expect(String(f.mock.calls[0][0])).toBe(`/api/svc/document-service/api/v1/documents?partyRef=${PARTY}`)
+    expect(screen.getByRole('link', { name: /Download/i })).toHaveAttribute(
+      'href', '/api/svc/document-service/api/v1/documents/doc-1/content',
+    )
+    expect(screen.getByText('case-7')).toBeInTheDocument()
+  })
+
+  it('distinguishes a measured empty list from an unavailable service', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => json([])))
+    const view = render(<LanguageProvider><DocumentsPanel partyId={PARTY} /></LanguageProvider>)
+    await waitFor(() => expect(screen.getByText(/No documents for this customer/i)).toBeInTheDocument())
+
+    view.unmount()
+    vi.stubGlobal('fetch', vi.fn(async () => json({ error: 'scaled_to_zero' }, 503)))
+    render(<LanguageProvider><DocumentsPanel partyId={PARTY} /></LanguageProvider>)
+    await waitFor(() => expect(screen.getByText(/Documents unavailable.*scaled_to_zero/i)).toBeInTheDocument())
+    expect(screen.queryByText(/No documents for this customer/i)).toBeNull()
+  })
+})

--- a/openbank-admin-ui/src/test/customer-360-portfolio.test.tsx
+++ b/openbank-admin-ui/src/test/customer-360-portfolio.test.tsx
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import React from 'react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { CustomerPortfolioPanel } from '@/components/party/CustomerPortfolioPanel'
+
+const PARTY = '55555555-5555-5555-5555-555555555555'
+const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+afterEach(() => { cleanup(); vi.restoreAllMocks(); vi.unstubAllGlobals() })
+
+describe('Customer 360 authoritative portfolio', () => {
+  it('queries each owning service by literal party-filtered route', async () => {
+    const f = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('account-service')) return json([{ status: 'ACTIVE' }, { status: 'BLOCKED' }])
+      if (url.includes('lending-service')) return json({ items: [{ state: 'ASSESSMENT' }] })
+      return json({ data: [{ status: 'OPEN' }] })
+    })
+    vi.stubGlobal('fetch', f)
+    render(<LanguageProvider><CustomerPortfolioPanel partyId={PARTY} /></LanguageProvider>)
+
+    await waitFor(() => expect(screen.getByText('ACTIVE · BLOCKED')).toBeInTheDocument())
+    const urls = f.mock.calls.map(([u]) => String(u))
+    expect(urls).toContain(`/api/svc/account-service/api/v1/accounts?partyId=${PARTY}&limit=100`)
+    expect(urls).toContain(`/api/svc/lending-service/api/v1/lending/applications?partyId=${PARTY}`)
+    expect(urls).toContain(`/api/svc/aml-service/api/v1/aml/cases?partyId=${PARTY}&limit=100&offset=0`)
+    expect(screen.getByText('ASSESSMENT')).toBeInTheDocument()
+    expect(screen.getByText('OPEN')).toBeInTheDocument()
+  })
+
+  it('degrades one source without hiding successful sources', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('lending-service')) return json({ error: 'unreachable' }, 502)
+      return json([])
+    }))
+    render(<LanguageProvider><CustomerPortfolioPanel partyId={PARTY} /></LanguageProvider>)
+
+    await waitFor(() => expect(screen.getByText(/Unavailable · error/i)).toBeInTheDocument())
+    expect(screen.getAllByText('0')).toHaveLength(2)
+  })
+})

--- a/openbank-admin-ui/src/test/kyc-party-search.test.tsx
+++ b/openbank-admin-ui/src/test/kyc-party-search.test.tsx
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import React from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import KycPage from '@/app/kyc/page'
+
+vi.mock('@/components/auth/AuthGuard', () => ({ Can: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
+
+const PARTY = '55555555-5555-5555-5555-555555555555'
+const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+afterEach(() => { cleanup(); vi.restoreAllMocks(); vi.unstubAllGlobals() })
+
+describe('KYC party search', () => {
+  it('resolves a customer name through party-service before querying KYC by party id', async () => {
+    const f = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/api/v1/parties/search')) return json({ data: [{ id: PARTY, legalName: 'Oldřich Vaněk', status: 'ACTIVE', kycStatus: 'APPROVED' }] })
+      if (url.endsWith(`/api/v1/kyc/cases/party/${PARTY}`)) return json([{ id: 'case-1', partyId: PARTY, status: 'APPROVED', checks: [], updatedAt: '2026-08-20T10:00:00Z', createdAt: '2026-08-20T09:00:00Z' }])
+      if (url.endsWith('/api/v1/kyc/cases')) return json([])
+      return json({}, 404)
+    })
+    vi.stubGlobal('fetch', f)
+    render(<LanguageProvider><KycPage /></LanguageProvider>)
+
+    await waitFor(() => expect(screen.getByLabelText('Search parties')).toBeEnabled())
+    fireEvent.change(screen.getByLabelText('Search parties'), { target: { value: 'Oldrich Vanek' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+    await waitFor(() => expect(screen.getByText('Oldřich Vaněk')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+
+    await waitFor(() => expect(f.mock.calls.some(([u]) => String(u).endsWith(`/api/v1/kyc/cases/party/${PARTY}`))).toBe(true))
+    expect(screen.getByText('All cases')).toBeInTheDocument()
+  })
+})

--- a/openbank-admin-ui/src/test/regulatory-report-preview.test.tsx
+++ b/openbank-admin-ui/src/test/regulatory-report-preview.test.tsx
@@ -56,7 +56,7 @@ describe('Regulatory report preview', () => {
     expect(String(fetchMock.mock.calls[1][0])).toContain('/api/svc/finrep-service/api/v1/finrep/templates/F02.00?asOf=')
     expect(screen.getByText('finrep-service ← ledger trial balance (ne ClickHouse)')).toBeInTheDocument()
     expect(screen.getByTestId('export-readiness')).toHaveTextContent(/Ready for internal export/)
-    expect(screen.getByRole('button', { name: 'Export JSON' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Export preview as JSON' })).toBeEnabled()
   })
 
   it('does not present an implemented endpoint as live data when the BFF cannot load it', async () => {
@@ -89,7 +89,7 @@ describe('Regulatory report preview', () => {
     const corepCard = screen.getByText('CNB — Kapitálová přiměřenost (COREP)').closest('.card')
     fireEvent.click(within(corepCard as HTMLElement).getByRole('button', { name: 'Preview export' }))
     await waitFor(() => expect(screen.getByTestId('export-readiness')).toHaveTextContent(/Export blocked.*incomplete data/i))
-    expect(screen.getByRole('button', { name: 'Export JSON' })).toBeDisabled()
-    expect(screen.getByRole('button', { name: 'Export CSV' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Export preview as JSON' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Export preview as CSV' })).toBeDisabled()
   })
 })

--- a/openbank-admin-ui/src/test/regulatory-report-preview.test.tsx
+++ b/openbank-admin-ui/src/test/regulatory-report-preview.test.tsx
@@ -88,7 +88,7 @@ describe('Regulatory report preview', () => {
 
     const corepCard = screen.getByText('CNB — Kapitálová přiměřenost (COREP)').closest('.card')
     fireEvent.click(within(corepCard as HTMLElement).getByRole('button', { name: 'Preview export' }))
-    await waitFor(() => expect(screen.getByTestId('export-readiness')).toHaveTextContent(/Export blocked.*datové mezery/i))
+    await waitFor(() => expect(screen.getByTestId('export-readiness')).toHaveTextContent(/Export blocked.*incomplete data/i))
     expect(screen.getByRole('button', { name: 'Export JSON' })).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Export CSV' })).toBeDisabled()
   })

--- a/openbank-admin-ui/src/test/regulatory-report-preview.test.tsx
+++ b/openbank-admin-ui/src/test/regulatory-report-preview.test.tsx
@@ -55,6 +55,8 @@ describe('Regulatory report preview', () => {
     expect(String(fetchMock.mock.calls[0][0])).toContain('/api/svc/finrep-service/api/v1/finrep/templates/F01.01?asOf=')
     expect(String(fetchMock.mock.calls[1][0])).toContain('/api/svc/finrep-service/api/v1/finrep/templates/F02.00?asOf=')
     expect(screen.getByText('finrep-service ← ledger trial balance (ne ClickHouse)')).toBeInTheDocument()
+    expect(screen.getByTestId('export-readiness')).toHaveTextContent(/Ready for internal export/)
+    expect(screen.getByRole('button', { name: 'Export JSON' })).toBeEnabled()
   })
 
   it('does not present an implemented endpoint as live data when the BFF cannot load it', async () => {
@@ -75,5 +77,19 @@ describe('Regulatory report preview', () => {
     expect(screen.queryByText('Celková aktiva')).not.toBeInTheDocument()
     expect(screen.queryByText('Živý datový náhled')).not.toBeInTheDocument()
     expect(screen.queryByText('Dostupnost dat')).not.toBeInTheDocument()
+  })
+
+  it('blocks export when COREP honestly reports a data gap', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      templateId: 'C_01.00', period: '2026-06-30', hasDataGaps: true,
+      cells: [{ rowRef: 'r010', colRef: 'c010', value: 0, currency: 'CZK', isDataGap: true, gapReason: 'capital accounts unavailable' }],
+    }), { status: 200, headers: { 'content-type': 'application/json' } })))
+    render(<LanguageProvider><RegulatoryPage /></LanguageProvider>)
+
+    const corepCard = screen.getByText('CNB — Kapitálová přiměřenost (COREP)').closest('.card')
+    fireEvent.click(within(corepCard as HTMLElement).getByRole('button', { name: 'Preview export' }))
+    await waitFor(() => expect(screen.getByTestId('export-readiness')).toHaveTextContent(/Export blocked.*datové mezery/i))
+    expect(screen.getByRole('button', { name: 'Export JSON' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Export CSV' })).toBeDisabled()
   })
 })

--- a/openbank-admin-ui/src/test/search-controls-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/search-controls-a11y.guard.test.ts
@@ -9,10 +9,12 @@ const source = (name: string) => readFileSync(path.resolve(__dirname, `../app/${
 describe('search controls accessibility contract', () => {
   it('names KYC and transaction primary search inputs', () => {
     const kyc = source('kyc')
-    for (const id of ['kyc-search', 'kyc-party-id']) {
-      expect(kyc).toContain(`id="${id}"`)
-      expect(kyc).toContain(`htmlFor="${id}"`)
-    }
+    expect(kyc).toContain('PartySearch')
+    expect(kyc).toContain('id="kyc-search"')
+    expect(kyc).toContain('htmlFor="kyc-search"')
+    const partySearch = readFileSync(path.resolve(__dirname, '../components/party/PartySearch.tsx'), 'utf8')
+    expect(partySearch).toContain('aria-label={t(')
+    expect(partySearch).toContain("'Search parties'")
     const transactions = source('transactions')
     for (const id of ['transaction-account-id', 'transaction-iban', 'transaction-bban']) {
       expect(transactions).toContain(`id="${id}"`)

--- a/openbank-admin-ui/src/test/trace-explorer.test.tsx
+++ b/openbank-admin-ui/src/test/trace-explorer.test.tsx
@@ -42,6 +42,6 @@ describe('Trace Explorer', () => {
   it('shows an explicit loading state instead of an empty explorer', () => {
     vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(() => undefined)))
     render(<SessionProvider><LanguageProvider><TraceExplorerPage /></LanguageProvider></SessionProvider>)
-    expect(screen.getByRole('status')).toHaveTextContent(/Loading recent traces from Tempo/i)
+    expect(screen.getByRole('status')).toHaveTextContent(/Loading traces from Tempo/i)
   })
 })

--- a/openbank-admin-ui/src/test/trace-explorer.test.tsx
+++ b/openbank-admin-ui/src/test/trace-explorer.test.tsx
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import React from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { SessionProvider } from '@/components/auth/SessionProvider'
+import TraceExplorerPage from '@/app/observability/traces/page'
+
+vi.mock('@/components/auth/AuthGuard', () => ({
+  AuthGuard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+const TRACE = '0123456789abcdef0123456789abcdef'
+const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+afterEach(() => { cleanup(); vi.restoreAllMocks(); vi.unstubAllGlobals() })
+
+describe('Trace Explorer', () => {
+  it('searches Tempo and renders the selected OTLP trace as a span waterfall', async () => {
+    const f = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/api/auth/session')) return json(null)
+      if (url.includes(`/api/tempo/api/traces/${TRACE}`)) return json({ batches: [{
+        resource: { attributes: [{ key: 'service.name', value: { stringValue: 'ledger-service' } }] },
+        scopeSpans: [{ spans: [{ spanId: 'span-1', name: 'POST /entries', startTimeUnixNano: '1000000', endTimeUnixNano: '2500000' }] }],
+      }] })
+      if (url.includes('/api/tempo/api/search?')) return json({ traces: [{ traceID: TRACE, rootServiceName: 'ledger-service', rootTraceName: 'POST /entries', durationMs: 1.5 }] })
+      return json({})
+    })
+    vi.stubGlobal('fetch', f)
+    render(<SessionProvider><LanguageProvider><TraceExplorerPage /></LanguageProvider></SessionProvider>)
+
+    await waitFor(() => expect(screen.getByText('ledger-service')).toBeInTheDocument())
+    expect(f.mock.calls.some(([u]) => String(u).includes('/api/tempo/api/search?limit=20&start='))).toBe(true)
+    fireEvent.click(screen.getByText('ledger-service'))
+    await waitFor(() => expect(screen.getByText('POST /entries')).toBeInTheDocument())
+    expect(f.mock.calls.some(([u]) => String(u) === `/api/tempo/api/traces/${TRACE}`)).toBe(true)
+    expect(screen.getByText(/1 spans/)).toBeInTheDocument()
+  })
+
+  it('shows an explicit loading state instead of an empty explorer', () => {
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(() => undefined)))
+    render(<SessionProvider><LanguageProvider><TraceExplorerPage /></LanguageProvider></SessionProvider>)
+    expect(screen.getByRole('status')).toHaveTextContent(/Loading recent traces from Tempo/i)
+  })
+})

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CompliancePackActivationService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CompliancePackActivationService.kt
@@ -9,6 +9,7 @@ import com.openbank.lending.infrastructure.persistence.entity.CompliancePackActi
 import com.openbank.libs.governance.Proposal
 import com.openbank.libs.governance.ProposalState
 import com.openbank.libs.lending.compliance.CompiledCompliancePack
+import com.openbank.libs.lending.compliance.CompliancePack
 import com.openbank.libs.lending.compliance.CompliancePackCompiler
 import com.openbank.libs.lending.compliance.CompliancePackJson
 import com.openbank.libs.lending.compliance.CompliancePackRegistry
@@ -30,6 +31,9 @@ data class PackActivationView(
     val proposedBy: String,
     val decidedBy: String?,
     val decidedAt: String?,
+    val proposedAt: String?,
+    val decisionReason: String?,
+    val pack: CompliancePack,
 )
 
 /**
@@ -129,6 +133,9 @@ class CompliancePackActivationService(
             proposedBy = "-",
             decidedBy = null,
             decidedAt = null,
+            proposedAt = null,
+            decisionReason = null,
+            pack = compiled.pack,
         )
     }
 
@@ -156,5 +163,8 @@ class CompliancePackActivationService(
         proposedBy = proposedBy,
         decidedBy = decidedBy,
         decidedAt = decidedAt?.toString(),
+        proposedAt = proposedAt.toString(),
+        decisionReason = decisionReason,
+        pack = CompliancePackJson.fromJson(payload),
     )
 }

--- a/openbank-lending-service/src/main/resources/openapi.yaml
+++ b/openbank-lending-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Lending Service API
-  version: 1.14.0
+  version: 1.15.0
   description: >-
     Loan origination, servicing, collateral and IFRS 9 provisioning (ADR-0028). The loan book posts
     cash events to ledger-service and never owns balances. Credit decisions and collateral

--- a/openbank-lending-service/src/main/resources/openapi.yaml
+++ b/openbank-lending-service/src/main/resources/openapi.yaml
@@ -647,6 +647,9 @@ paths:
       responses:
         '201':
           description: Proposal registered, awaiting a checker
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/PackActivationView' }
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
@@ -674,6 +677,9 @@ paths:
       responses:
         '200':
           description: Decision recorded; an approved pack is active in-memory immediately
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/PackActivationView' }
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
@@ -688,6 +694,11 @@ paths:
       responses:
         '200':
           description: Pending proposals, oldest first
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/PackActivationView' }
         '403':
           $ref: '#/components/responses/Forbidden'
   /api/v1/lending/compliance-packs/active:
@@ -698,6 +709,11 @@ paths:
       responses:
         '200':
           description: Active packs with content hashes
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/PackActivationView' }
         '403':
           $ref: '#/components/responses/Forbidden'
 
@@ -733,6 +749,44 @@ components:
           schema:
             $ref: '#/components/schemas/ApiError'
   schemas:
+    PackActivationView:
+      type: object
+      required:
+        - id
+        - jurisdiction
+        - productType
+        - packVersion
+        - effectiveFrom
+        - contentHash
+        - state
+        - proposedBy
+        - pack
+      properties:
+        id: { type: string, format: uuid }
+        jurisdiction: { type: string }
+        productType: { type: string, enum: [CONSUMER_CREDIT, MORTGAGE, OVERDRAFT, SME_CREDIT] }
+        packVersion: { type: integer }
+        effectiveFrom: { type: string, format: date }
+        contentHash: { type: string, description: SHA-256 fingerprint of the exact reviewed pack }
+        state: { type: string, enum: [PROPOSED, APPROVED, REJECTED, EXECUTED] }
+        proposedBy: { type: string }
+        proposedAt: { type: string, format: date-time, nullable: true }
+        decidedBy: { type: string, nullable: true }
+        decidedAt: { type: string, format: date-time, nullable: true }
+        decisionReason: { type: string, nullable: true }
+        pack:
+          $ref: '#/components/schemas/CompliancePack'
+    CompliancePack:
+      type: object
+      description: Exact reviewed pack content, returned so operators can inspect what the hash identifies.
+      additionalProperties: true
+      required: [jurisdiction, productType, version, effectiveFrom]
+      properties:
+        jurisdiction: { type: string }
+        productType: { type: string, enum: [CONSUMER_CREDIT, MORTGAGE, OVERDRAFT, SME_CREDIT] }
+        version: { type: integer }
+        effectiveFrom: { type: string, format: date }
+        effectiveTo: { type: string, format: date, nullable: true }
     ApiError:
       type: object
       properties:

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/integration/CompliancePackActivationIT.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/integration/CompliancePackActivationIT.kt
@@ -94,6 +94,9 @@ class CompliancePackActivationIT {
         }
         proposalId = response.jsonPath().getString("id")
         assertThat(proposalId).isNotBlank()
+        assertThat(response.jsonPath().getString("proposedAt")).isNotBlank()
+        assertThat(response.jsonPath().getInt("pack.version")).isEqualTo(PACK_VERSION)
+        assertThat(response.jsonPath().getString("pack.jurisdiction")).isEqualTo("CZ")
 
         dataSource.connection.use { conn ->
             conn.prepareStatement(
@@ -154,6 +157,9 @@ class CompliancePackActivationIT {
             // 500 here is the persist-vs-merge defect: this is the second write to the same primary
             // key, so `persistAndFlush` fails with `duplicate key value violates ... _pkey`.
             statusCode(200)
+            body("decisionReason", org.hamcrest.Matchers.equalTo("reviewed against ADR-0212"))
+            body("decidedBy", org.hamcrest.Matchers.equalTo("pack-it-checker"))
+            body("pack.version", org.hamcrest.Matchers.equalTo(PACK_VERSION))
         }
 
         dataSource.connection.use { conn ->
@@ -201,5 +207,7 @@ class CompliancePackActivationIT {
         // An empty list here is indistinguishable from "nothing activated yet" in the console, which
         // is precisely how the OPA denial stayed invisible for the life of the feature (#3402).
         assertThat(body).contains("\"packVersion\":$PACK_VERSION")
+        assertThat(body).contains("\"pack\":{")
+        assertThat(body).contains("\"jurisdiction\":\"CZ\"")
     }
 }


### PR DESCRIPTION
## Summary

Make the Admin UI operator surfaces evidence-backed, customer-centric, and explicit about incomplete external integrations. Add the lending compliance-pack projection needed for a real operator drill-down.

## Type of change

- [x] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #5904
Refs #5914

## Changes

- Derive fleet test evidence and Kover coverage from authoritative service inventory with freshness.
- Add KYC name search, Customer 360 portfolio/documents, compliance detail, Temporal live metrics, Trace loading state, and agent identity.
- Block misleading regulatory exports when source data is incomplete or unbalanced.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed) — additive response fields only; existing consumers remain compatible.
- [x] Relevant detekt, ktlint, tests, Quarkus build, and Next production build pass locally.
- [x] No new lint warnings.
- [x] OpenAPI spec updated (additive 1.13.0 contract).
- [x] Flyway migration added + rollback note (if DB changed) — N/A, no DB change.
- [x] Event schema versioned backward-compatibly (if event changed) — N/A, no event change.
- [x] Docs updated — lending threat model records the read projection.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new suppressions or unsafe casts.
- [x] No new third-party dependency.
- [x] Auth boundaries unchanged; exact pack detail remains on the existing compliance/admin role-gated resource.
- [x] PII access remains behind the existing authenticated BFF and service roles.
- [x] No cardholder-data path changed.

## Compliance impact

- [ ] PCI DSS
- [x] DORA
- [x] GDPR
- [ ] PSD2 / SCA / RTS
- [x] AML / 5AMLD
- [x] CNB reporting
- [ ] None

The UI now distinguishes measured evidence from unknown/stale states and refuses to present incomplete regulatory data as export-ready. Live regulator submission remains #5914.

## Rollout / Rollback

- Deployment strategy: existing admin-ui and lending canary pipelines
- Rollback plan: revert the three commits; the API change is additive and has no persistence migration
- Data migration reversible: N/A

## Screenshots / demo

Protected routes redirect to Keycloak in local rendering; behavior is covered by focused UI tests and the production Next build.

## Reviewer notes

Money-path lending change requires the repository's review policy. Please focus on compliance-pack disclosure scope and the CI artifact-selection logic.
