### PR TITLE
fix(agents): refuse instead of returning a fabricated proposal URL in docs-truth-agent and authz-policy-auditor

### DIFF
--- a/docs/agents/authz-policy-auditor.md
+++ b/docs/agents/authz-policy-auditor.md
@@ -73,10 +73,19 @@ vs. `tool_tiers` drift) proactively covering a related, not-yet-incident-causing
   per-service `*-opa-bundle.yaml` copies `gen-*-opa-bundle.sh` mechanically derives from them — a
   regression at the source is the primary defense; the generated copies are supposed to be
   mechanically regenerated, not independently authored.
-- The `LlmDiagnosisPort` and `GitHubProposalPort` adapters are stubs pending the shared LiteLLM
-  gateway and GitHub App installation-token wiring, the same bootstrap state every sibling agent
-  shipped with. `proposeFixDiff` returns `null` unconditionally BY DESIGN here (not just pending
-  integration) — this agent never proposes a fix diff for a security-policy defect.
+- The `LlmDiagnosisPort` adapter is a stub pending the shared LiteLLM gateway. `proposeFixDiff`
+  returns `null` unconditionally BY DESIGN here (not just pending integration) — this agent never
+  proposes a fix diff for a security-policy defect.
+- **`GitHubProposalPort` is unwired and REFUSES — no finding of this agent reaches GitHub today**
+  (#5897). Both methods return `null`, and `DiagnoseAndProposeActivityImpl` then leaves the finding
+  `DIAGNOSED` with a null `proposalUrl`: it is never counted in a run's `findingsProposed` and never
+  presented as awaiting a human. It previously returned a fabricated
+  `https://github.com/openbank/openbank/issues/pending-authz-policy-auditor-<id>` URL and moved the
+  finding to `PROPOSED` — which on this agent meant an authorization-policy defect nobody had filed
+  being reported as filed and awaiting the `two_person_review` its charter requires. `openProposalPr`
+  refuses **permanently** (ADR-0167: never a fix PR on an authorization policy); `openTicket`
+  refuses because no `github-token` config exists in this service. Follows
+  `openbank-mcp-service`'s `UnwiredProposalPort` (#3900).
 - `repo-root` (`AUTHZ_POLICY_AUDITOR_REPO_ROOT`) must point at a mounted, up-to-date checkout of
   `main` for the `PolicyScanPort` checks to be meaningful — the deployment-side checkout-mount
   wiring (a sidecar or init-container `git pull`) is tracked separately and not yet part of this

--- a/docs/agents/docs-truth-agent.md
+++ b/docs/agents/docs-truth-agent.md
@@ -77,11 +77,18 @@ closing a gap none of this repo's other control-plane agents cover.
   wrong-attribution case but is still a proximity-based text scan, not a structural YAML parse — a
   `rules.yaml` restructuring that moves `enforced:` more than `SEARCH_WINDOW` (15) lines from its
   `gate:` key would silently stop matching.
-- The `LlmDiagnosisPort` and `GitHubProposalPort` adapters are stubs pending the shared LiteLLM
-  gateway and GitHub App installation-token wiring, the same bootstrap state finops-agent/devops-
-  agent/control-liveness-sentinel/governance-auditor/release-steward shipped with. Until that
-  lands, a finding produces a tracking ticket with a placeholder summary rather than an
-  LLM-drafted root-cause note, and `proposeFixDiff` never yet returns a real diff.
+- The `LlmDiagnosisPort` adapter is a stub pending the shared LiteLLM gateway, so `proposeFixDiff`
+  never yet returns a real diff.
+- **`GitHubProposalPort` is unwired and REFUSES — no finding of this agent reaches GitHub today**
+  (#5897). Both methods return `null`, and `DiagnoseAndProposeActivityImpl` then leaves the finding
+  `DIAGNOSED` with a null `proposalUrl`: it is never counted in a run's `findingsProposed` and never
+  presented as awaiting a human. It previously returned a fabricated
+  `https://github.com/openbank/openbank/pulls/pending-docs-truth-agent-<id>` URL and moved the
+  finding to `PROPOSED` — a no-op sharing its shape with a real result, on a host that is not even
+  this repository. This follows `openbank-mcp-service`'s `UnwiredProposalPort` (#3900).
+  The charter already grants `tier: write_proposal` on `github-pr`, so wiring it needs no charter
+  change — but unlike `flaky-test-hunter` this service has no `github-token` config, so there is no
+  token path to fail closed on yet. `flaky-test-hunter`'s adapter is the template.
 - `repo-root` (`DOCS_TRUTH_AGENT_REPO_ROOT`) must point at a mounted, up-to-date checkout of `main`
   for the `RepoScanPort`/`GovernanceRulesPort` checks to be meaningful — the deployment-side
   checkout-mount wiring (a sidecar or init-container `git pull`) is tracked separately and not yet

--- a/openbank-authz-policy-auditor/src/main/kotlin/com/openbank/authzaudit/application/port/out/AuthzPolicyPorts.kt
+++ b/openbank-authz-policy-auditor/src/main/kotlin/com/openbank/authzaudit/application/port/out/AuthzPolicyPorts.kt
@@ -36,15 +36,24 @@ interface LlmDiagnosisPort {
     suspend fun proposeFixDiff(finding: AuthzPolicyFinding, diagnosis: String): String?
 }
 
+/**
+ * Both methods return the URL of a proposal that was actually created, or `null` when none was —
+ * an unwired write path, a missing token, or a refused finding. `null` is the ONLY way to say
+ * "nothing was created": there is deliberately no placeholder-URL return, because a well-formed
+ * string is indistinguishable from a delivered proposal to every consumer (#5897, and the
+ * `UnwiredProposalPort` precedent in `openbank-mcp-service`, #3900).
+ */
 interface GitHubProposalPort {
     /** Not called in v1 — see [LlmDiagnosisPort.proposeFixDiff]. Kept for interface parity with
-     * every sibling agent's [GitHubProposalPort] shape. */
-    suspend fun openProposalPr(finding: AuthzPolicyFinding, fixDiff: String): String
+     * every sibling agent's [GitHubProposalPort] shape. Always returns `null` for this agent:
+     * ADR-0167 forbids an auto-fix PR on an authorization policy outright. */
+    suspend fun openProposalPr(finding: AuthzPolicyFinding, fixDiff: String): String?
 
     /** The only disposition path in v1: every finding is a ticket a human triages (ADR-0167
      * Decision) — authorization-policy findings are security-adjacent, so this agent errs toward
-     * ticket-only rather than any auto-fix, even the fleet's usual "one narrow mechanical case." */
-    suspend fun openTicket(finding: AuthzPolicyFinding, diagnosis: String): String
+     * ticket-only rather than any auto-fix, even the fleet's usual "one narrow mechanical case."
+     * Returns `null` when no ticket was opened. */
+    suspend fun openTicket(finding: AuthzPolicyFinding, diagnosis: String): String?
 }
 
 interface FindingRepository {

--- a/openbank-authz-policy-auditor/src/main/kotlin/com/openbank/authzaudit/application/workflow/DiagnoseAndProposeActivityImpl.kt
+++ b/openbank-authz-policy-auditor/src/main/kotlin/com/openbank/authzaudit/application/workflow/DiagnoseAndProposeActivityImpl.kt
@@ -55,21 +55,31 @@ open class DiagnoseAndProposeActivityImpl(
         val rootCause = finding.rootCause
             ?: error("Cannot propose without a diagnosis for finding ${finding.id}")
         val fixDiff = llm.proposeFixDiff(finding, rootCause)
-        val proposed = if (fixDiff != null) {
-            val prUrl = githubProposal.openProposalPr(finding, fixDiff)
+        val prUrl = fixDiff?.let { githubProposal.openProposalPr(finding, it) }
+        val proposalUrl = prUrl ?: githubProposal.openTicket(finding, rootCause)
+        val proposed = if (proposalUrl != null) {
             finding.copy(
-                proposedFixDiff = fixDiff,
-                proposalUrl = prUrl,
+                proposedFixDiff = if (prUrl != null) fixDiff else finding.proposedFixDiff,
+                proposalUrl = proposalUrl,
                 status = FindingStatus.PROPOSED,
                 proposedAt = Instant.now(),
             )
         } else {
-            val ticketUrl = githubProposal.openTicket(finding, rootCause)
-            finding.copy(
-                proposalUrl = ticketUrl,
-                status = FindingStatus.PROPOSED,
-                proposedAt = Instant.now(),
+            // NOTHING was created, so the finding must NOT read as proposed. It stays DIAGNOSED
+            // with a null proposalUrl and a null proposedAt, which is what keeps it out of
+            // AuthzPolicyAuditorWorkflowImpl's `findingsProposed` count and out of the HITL queue
+            // as a delivered proposal. The predecessor of this branch returned a fabricated
+            // `pending-authz-policy-auditor-<id>` URL and moved the finding to PROPOSED — a no-op
+            // that shared its shape with a real result (#5897). On this agent that is the worse
+            // failure of the two: an unfiled authorization-policy finding reported as filed.
+            log.warnf(
+                "No proposal was created for finding %s (%s) on %s — leaving it DIAGNOSED; " +
+                    "nothing is awaiting a human.",
+                finding.id,
+                finding.checkType,
+                finding.component,
             )
+            finding.copy(status = FindingStatus.DIAGNOSED, proposalUrl = null, proposedAt = null)
         }
         findingRepository.update(proposed)
     }

--- a/openbank-authz-policy-auditor/src/main/kotlin/com/openbank/authzaudit/infrastructure/adapter/GitHubProposalAdapter.kt
+++ b/openbank-authz-policy-auditor/src/main/kotlin/com/openbank/authzaudit/infrastructure/adapter/GitHubProposalAdapter.kt
@@ -11,50 +11,57 @@ import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
 
 /**
- * GitHub App adapter for opening authz-policy-drift tracking tickets. `openProposalPr` stays wired
- * for interface parity with every sibling agent's `GitHubProposalPort` shape, but is never called
- * in v1 (ADR-0167 Decision: `LlmDiagnosisPort.proposeFixDiff` always returns null) — an
- * authorization-policy finding is security-adjacent, so this agent errs toward ticket-only rather
- * than any auto-fix, even the fleet's usual "one narrow mechanical case."
+ * The GitHub write path for this agent is NOT wired, so it refuses (#5897).
  *
- * Uses a GitHub App installation token. Full implementation tracked separately; this stub returns a
- * placeholder URL to keep the workflow structurally complete, matching the finops-agent/devops-
- * agent/control-liveness-sentinel/governance-auditor/release-steward/docs-truth-agent bootstrap
- * pattern.
+ * This replaces a bootstrap stub that returned
+ * `https://github.com/openbank/openbank/issues/pending-authz-policy-auditor-<id>`. That was two
+ * defects at once. The string was a **fabricated success**: the caller stored it as `proposalUrl`
+ * and moved the finding to [com.openbank.authzaudit.domain.model.FindingStatus.PROPOSED], so an
+ * authorization-policy defect that nobody had filed anywhere was reported as filed and awaiting
+ * human triage — on the one agent whose entire v1 disposition is "a human triages every finding"
+ * (ADR-0167), with `two_person_review: authz_policy_findings` in its charter. And the host was
+ * wrong — this repository is `JiRaska/open-bank-oss`, never `openbank/openbank` — so even read as
+ * a placeholder it pointed at nothing.
+ *
+ * The fleet settled this with `openbank-mcp-service`'s `UnwiredProposalPort` (#3900): an unwired
+ * port refuses rather than inventing an answer. This is that pattern, expressed as `null` rather
+ * than a throw because a Temporal activity must reach a terminal disposition rather than retry
+ * forever — the refusal is carried by the return TYPE, and
+ * [com.openbank.authzaudit.application.workflow.DiagnoseAndProposeActivityImpl] leaves the finding
+ * `DIAGNOSED` when it gets one.
+ *
+ * [openProposalPr] refuses **permanently**, not pending wiring: ADR-0167's Decision is that this
+ * agent never opens a fix PR, because a wrong auto-fix on a rego rule or a charter is a live
+ * security exposure. [openTicket] refuses because no token path exists — unlike
+ * `flaky-test-hunter`, this service has no `github-token` config to fail closed on. The charter
+ * (`agents.yaml: authz-policy-auditor`) does grant `tier: write_proposal` on `github-pr`, so
+ * wiring the ticket path later needs no charter change; `flaky-test-hunter`'s adapter is the
+ * template.
  */
 @ApplicationScoped
 class GitHubProposalAdapter : GitHubProposalPort {
 
     private val log = Logger.getLogger(GitHubProposalAdapter::class.java)
 
-    companion object {
-        private const val ID_PREFIX_LEN = 8
-    }
-
-    override suspend fun openProposalPr(finding: AuthzPolicyFinding, fixDiff: String): String {
-        log.infof(
-            "GitHub PR proposal requested for finding %s checkType=%s component=%s — stub (never called in v1)",
+    override suspend fun openProposalPr(finding: AuthzPolicyFinding, fixDiff: String): String? {
+        log.warnf(
+            "Refusing GitHub PR proposal for finding %s (checkType=%s component=%s): this agent never " +
+                "opens a fix PR on an authorization policy (ADR-0167). NOTHING was created.",
             finding.id,
             finding.checkType,
             finding.component,
         )
-        // TODO(ADR-0167): create branch + PR via GitHub App installation token, IF this agent's
-        // ticket-only v1 stance is ever deliberately re-evaluated for a narrower mechanical case.
-        return "https://github.com/openbank/openbank/pulls/pending-authz-policy-auditor-${finding.id.take(
-            ID_PREFIX_LEN,
-        )}"
+        return null
     }
 
-    override suspend fun openTicket(finding: AuthzPolicyFinding, diagnosis: String): String {
-        log.infof(
-            "GitHub tracking-ticket requested for finding %s checkType=%s component=%s — stub",
+    override suspend fun openTicket(finding: AuthzPolicyFinding, diagnosis: String): String? {
+        log.warnf(
+            "Refusing GitHub tracking ticket for finding %s (checkType=%s component=%s): no GitHub write " +
+                "path is wired, so NOTHING was created. Do not report this as a delivered proposal.",
             finding.id,
             finding.checkType,
             finding.component,
         )
-        // TODO(ADR-0167): open a tracking issue via GitHub App installation token
-        return "https://github.com/openbank/openbank/issues/pending-authz-policy-auditor-${finding.id.take(
-            ID_PREFIX_LEN,
-        )}"
+        return null
     }
 }

--- a/openbank-authz-policy-auditor/src/test/kotlin/com/openbank/authzaudit/application/workflow/RefusedProposalIsNotRecordedAsProposedTest.kt
+++ b/openbank-authz-policy-auditor/src/test/kotlin/com/openbank/authzaudit/application/workflow/RefusedProposalIsNotRecordedAsProposedTest.kt
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.authzaudit.application.workflow
+
+import com.openbank.authzaudit.application.port.out.FindingRepository
+import com.openbank.authzaudit.application.port.out.GitHubProposalPort
+import com.openbank.authzaudit.application.port.out.LlmDiagnosisPort
+import com.openbank.authzaudit.domain.model.AuthzPolicyCheckType
+import com.openbank.authzaudit.domain.model.AuthzPolicyFinding
+import com.openbank.authzaudit.domain.model.FindingSeverity
+import com.openbank.authzaudit.domain.model.FindingStatus
+import com.openbank.authzaudit.infrastructure.adapter.GitHubProposalAdapter
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+
+/**
+ * The unwired GitHub path must not be representable as a delivered proposal (#5897).
+ *
+ * Asserting "the adapter returns null" alone would be the weak test this repo keeps warning about:
+ * the predecessor stub also "returned a value", and the defect was entirely in what the CALLER did
+ * with it. So these tests drive the real [DiagnoseAndProposeActivityImpl] over the real
+ * [GitHubProposalAdapter] and assert on what is PERSISTED and on the number
+ * [AuthzPolicyAuditorWorkflowImpl] reports — the two places a fabricated URL was read as success. On this agent that mattered most: ADR-0167
+ * makes every finding a human-triage ticket, so a finding recorded as PROPOSED with nobody
+ * holding it is an unfiled authorization-policy defect reported as filed.
+ */
+class RefusedProposalIsNotRecordedAsProposedTest {
+
+    private class RecordingRepository : FindingRepository {
+        var updated: AuthzPolicyFinding? = null
+        override suspend fun save(finding: AuthzPolicyFinding): AuthzPolicyFinding = finding
+        override suspend fun findActive(): List<AuthzPolicyFinding> = emptyList()
+        override suspend fun findById(id: String): AuthzPolicyFinding? = null
+        override suspend fun update(finding: AuthzPolicyFinding): AuthzPolicyFinding {
+            updated = finding
+            return finding
+        }
+    }
+
+    private class FixedDiagnosis(private val fixDiff: String?) : LlmDiagnosisPort {
+        override suspend fun diagnose(finding: AuthzPolicyFinding, contextMetrics: Map<String, Double>): String =
+            "root cause"
+
+        override suspend fun proposeFixDiff(finding: AuthzPolicyFinding, diagnosis: String): String? = fixDiff
+    }
+
+    private class SyncActivity(
+        llm: LlmDiagnosisPort,
+        githubProposal: GitHubProposalPort,
+        findingRepository: FindingRepository,
+    ) : DiagnoseAndProposeActivityImpl(llm, githubProposal, findingRepository) {
+        // The production bridge needs a Vert.x context that a plain unit test has none of; the
+        // logic under test is the branch, not the bridge.
+        override fun <T> runOnVertxContext(block: suspend () -> T): T = runBlocking { block() }
+    }
+
+    private fun finding() = AuthzPolicyFinding(
+        id = "f-11111111-2222",
+        checkType = AuthzPolicyCheckType.UNREACHABLE_PRINCIPAL_TYPE_RULE,
+        severity = FindingSeverity.CRITICAL,
+        detectedAt = Instant.parse("2026-01-01T00:00:00Z"),
+        title = "rest.rego gates on a principal type the interceptor never emits",
+        component = "rest.rego",
+        filePath = "openbank-infra/gitops/components/policy/rest.rego",
+        rawMetricValue = BigDecimal.ONE,
+        threshold = BigDecimal.ZERO,
+        rootCause = "root cause",
+        status = FindingStatus.DIAGNOSED,
+        diagnosedAt = Instant.parse("2026-01-01T00:01:00Z"),
+    )
+
+    private fun proposeWith(fixDiff: String?): Pair<AuthzPolicyFinding, RecordingRepository> {
+        val repository = RecordingRepository()
+        val result = SyncActivity(FixedDiagnosis(fixDiff), GitHubProposalAdapter(), repository)
+            .propose(finding())
+        return result to repository
+    }
+
+    @Test
+    fun `a refused ticket leaves the finding DIAGNOSED with no proposal url`() {
+        val (result, repository) = proposeWith(fixDiff = null)
+
+        // What is persisted is what a human and the HITL queue read.
+        assertThat(repository.updated).isNotNull
+        assertThat(repository.updated!!.status).isEqualTo(FindingStatus.DIAGNOSED)
+        assertThat(repository.updated!!.proposalUrl).isNull()
+        assertThat(repository.updated!!.proposedAt).isNull()
+        assertThat(result.status).isNotEqualTo(FindingStatus.PROPOSED)
+    }
+
+    @Test
+    fun `a refused fix-diff PR also leaves the finding DIAGNOSED`() {
+        val (result, repository) = proposeWith(fixDiff = "--- a/rest.rego\n+++ b/rest.rego\n")
+
+        assertThat(repository.updated!!.status).isEqualTo(FindingStatus.DIAGNOSED)
+        assertThat(repository.updated!!.proposalUrl).isNull()
+        assertThat(result.proposedFixDiff).isNull()
+    }
+
+    /**
+     * The consumer assertion: [AuthzPolicyAuditorWorkflowImpl] reports `findingsProposed` as
+     * `count { it.status == PROPOSED }`. A refusal must contribute zero to that number — this is
+     * the exact count the fabricated `pending-authz-policy-auditor-<id>` URL used to inflate.
+     */
+    @Test
+    fun `a refused proposal contributes nothing to the reported findingsProposed count`() {
+        val (result, _) = proposeWith(fixDiff = null)
+
+        assertThat(listOf(result).count { it.status == FindingStatus.PROPOSED }).isZero()
+    }
+
+    /** No surviving string may point at a repository that does not exist. */
+    @Test
+    fun `no returned value names a repository host at all`(): Unit = runBlocking {
+        val adapter = GitHubProposalAdapter()
+        assertThat(adapter.openTicket(finding(), "root cause")).isNull()
+        assertThat(adapter.openProposalPr(finding(), "diff")).isNull()
+    }
+}

--- a/openbank-docs-truth-agent/src/main/kotlin/com/openbank/docstruth/application/port/out/DocsTruthPorts.kt
+++ b/openbank-docs-truth-agent/src/main/kotlin/com/openbank/docstruth/application/port/out/DocsTruthPorts.kt
@@ -45,14 +45,23 @@ interface LlmDiagnosisPort {
     suspend fun proposeFixDiff(finding: DocsTruthFinding, diagnosis: String): String?
 }
 
+/**
+ * Both methods return the URL of a proposal that was actually created, or `null` when none was —
+ * an unwired write path, a missing token, or a refused finding. `null` is the ONLY way to say
+ * "nothing was created": there is deliberately no placeholder-URL return, because a well-formed
+ * string is indistinguishable from a delivered proposal to every consumer (#5897, and the
+ * `UnwiredProposalPort` precedent in `openbank-mcp-service`, #3900).
+ */
 interface GitHubProposalPort {
     /** The one narrow mechanically-fixable case — flipping just the `Delivery-Status:` line when
      * the evidence is unambiguous. Not the primary proposal path: correcting an ADR's substantive
-     * content needs a human who reads both the ADR and the code, not a diff (ADR-0166 Decision). */
-    suspend fun openProposalPr(finding: DocsTruthFinding, fixDiff: String): String
+     * content needs a human who reads both the ADR and the code, not a diff (ADR-0166 Decision).
+     * Returns `null` when no PR was opened. */
+    suspend fun openProposalPr(finding: DocsTruthFinding, fixDiff: String): String?
 
-    /** The primary proposal path: an ADR-status-vs-code drift needing human triage. */
-    suspend fun openTicket(finding: DocsTruthFinding, diagnosis: String): String
+    /** The primary proposal path: an ADR-status-vs-code drift needing human triage. Returns `null`
+     * when no ticket was opened. */
+    suspend fun openTicket(finding: DocsTruthFinding, diagnosis: String): String?
 }
 
 interface FindingRepository {

--- a/openbank-docs-truth-agent/src/main/kotlin/com/openbank/docstruth/application/workflow/DiagnoseAndProposeActivityImpl.kt
+++ b/openbank-docs-truth-agent/src/main/kotlin/com/openbank/docstruth/application/workflow/DiagnoseAndProposeActivityImpl.kt
@@ -60,21 +60,30 @@ open class DiagnoseAndProposeActivityImpl(
         val rootCause = finding.rootCause
             ?: error("Cannot propose without a diagnosis for finding ${finding.id}")
         val fixDiff = llm.proposeFixDiff(finding, rootCause)
-        val proposed = if (fixDiff != null) {
-            val prUrl = githubProposal.openProposalPr(finding, fixDiff)
+        val prUrl = fixDiff?.let { githubProposal.openProposalPr(finding, it) }
+        val proposalUrl = prUrl ?: githubProposal.openTicket(finding, rootCause)
+        val proposed = if (proposalUrl != null) {
             finding.copy(
-                proposedFixDiff = fixDiff,
-                proposalUrl = prUrl,
+                proposedFixDiff = if (prUrl != null) fixDiff else finding.proposedFixDiff,
+                proposalUrl = proposalUrl,
                 status = FindingStatus.PROPOSED,
                 proposedAt = Instant.now(),
             )
         } else {
-            val ticketUrl = githubProposal.openTicket(finding, rootCause)
-            finding.copy(
-                proposalUrl = ticketUrl,
-                status = FindingStatus.PROPOSED,
-                proposedAt = Instant.now(),
+            // NOTHING was created, so the finding must NOT read as proposed. It stays DIAGNOSED
+            // with a null proposalUrl and a null proposedAt, which is what keeps it out of
+            // DocsTruthWorkflowImpl's `findingsProposed` count and out of the HITL queue as a
+            // delivered proposal. The predecessor of this branch returned a fabricated
+            // `pending-docs-truth-agent-<id>` URL and moved the finding to PROPOSED — a no-op that
+            // shared its shape with a real result (#5897).
+            log.warnf(
+                "No proposal was created for finding %s (%s) on %s — leaving it DIAGNOSED; " +
+                    "nothing is awaiting a human.",
+                finding.id,
+                finding.checkType,
+                finding.component,
             )
+            finding.copy(status = FindingStatus.DIAGNOSED, proposalUrl = null, proposedAt = null)
         }
         findingRepository.update(proposed)
     }

--- a/openbank-docs-truth-agent/src/main/kotlin/com/openbank/docstruth/infrastructure/adapter/GitHubProposalAdapter.kt
+++ b/openbank-docs-truth-agent/src/main/kotlin/com/openbank/docstruth/infrastructure/adapter/GitHubProposalAdapter.kt
@@ -11,42 +11,56 @@ import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
 
 /**
- * GitHub App adapter for opening ADR-status-drift tracking tickets and, for the rare mechanical
- * case (an unambiguous `Delivery-Status:` line flip), a scaffold pull request (HITL approval gate
- * either way).
+ * The GitHub write path for this agent is NOT wired, so it refuses (#5897).
  *
- * Uses a GitHub App installation token. Full implementation tracked separately; this stub returns
- * a placeholder URL to keep the workflow structurally complete, matching the finops-agent/devops-
- * agent/control-liveness-sentinel/governance-auditor/release-steward bootstrap pattern.
+ * This replaces a bootstrap stub that returned
+ * `https://github.com/openbank/openbank/pulls/pending-docs-truth-agent-<id>`. That was two defects
+ * at once. The string was a **fabricated success**: the caller stored it as `proposalUrl` and moved
+ * the finding to [com.openbank.docstruth.domain.model.FindingStatus.PROPOSED], so the workflow
+ * result counted a proposal, the HITL queue listed one, and a human reading the finding was told a
+ * ticket existed that nobody had opened. And the host was wrong — this repository is
+ * `JiRaska/open-bank-oss`, never `openbank/openbank` — so even read as a placeholder it pointed at
+ * nothing. Same family as `PushResult.skipped()` carrying `success = true` (ADR-0252 phase 0) and
+ * `LoggingDeadLetterSink` making "quarantined" mean `log.warnf` (#5761).
+ *
+ * The fleet settled this with `openbank-mcp-service`'s `UnwiredProposalPort` (#3900): an unwired
+ * port refuses rather than inventing an answer. This is that pattern, expressed as `null` rather
+ * than a throw because a Temporal activity must reach a terminal disposition rather than retry
+ * forever — the refusal is carried by the return TYPE, and
+ * [com.openbank.docstruth.application.workflow.DiagnoseAndProposeActivityImpl] leaves the finding
+ * `DIAGNOSED` when it gets one. A refused proposal is therefore not representable as a delivered
+ * one anywhere downstream.
+ *
+ * Wiring this is permitted by the charter (`agents.yaml: docs-truth-agent` grants
+ * `tier: write_proposal` on `github-pr`) but is deliberately NOT done here: unlike
+ * `flaky-test-hunter`, this service has no `github-token` config, so there is no token path to
+ * fail closed on — only one to build. `flaky-test-hunter`'s adapter is the template if and when
+ * that happens (ADR-0166).
  */
 @ApplicationScoped
 class GitHubProposalAdapter : GitHubProposalPort {
 
     private val log = Logger.getLogger(GitHubProposalAdapter::class.java)
 
-    companion object {
-        private const val ID_PREFIX_LEN = 8
-    }
-
-    override suspend fun openProposalPr(finding: DocsTruthFinding, fixDiff: String): String {
-        log.infof(
-            "GitHub PR proposal requested for finding %s checkType=%s component=%s — stub",
+    override suspend fun openProposalPr(finding: DocsTruthFinding, fixDiff: String): String? {
+        log.warnf(
+            "Refusing GitHub PR proposal for finding %s (checkType=%s component=%s): no GitHub write " +
+                "path is wired, so NOTHING was created. Do not report this as a delivered proposal.",
             finding.id,
             finding.checkType,
             finding.component,
         )
-        // TODO(ADR-0166): create branch + PR via GitHub App installation token
-        return "https://github.com/openbank/openbank/pulls/pending-docs-truth-agent-${finding.id.take(ID_PREFIX_LEN)}"
+        return null
     }
 
-    override suspend fun openTicket(finding: DocsTruthFinding, diagnosis: String): String {
-        log.infof(
-            "GitHub tracking-ticket requested for finding %s checkType=%s component=%s — stub",
+    override suspend fun openTicket(finding: DocsTruthFinding, diagnosis: String): String? {
+        log.warnf(
+            "Refusing GitHub tracking ticket for finding %s (checkType=%s component=%s): no GitHub write " +
+                "path is wired, so NOTHING was created. Do not report this as a delivered proposal.",
             finding.id,
             finding.checkType,
             finding.component,
         )
-        // TODO(ADR-0166): open a tracking issue via GitHub App installation token
-        return "https://github.com/openbank/openbank/issues/pending-docs-truth-agent-${finding.id.take(ID_PREFIX_LEN)}"
+        return null
     }
 }

--- a/openbank-docs-truth-agent/src/test/kotlin/com/openbank/docstruth/application/workflow/RefusedProposalIsNotRecordedAsProposedTest.kt
+++ b/openbank-docs-truth-agent/src/test/kotlin/com/openbank/docstruth/application/workflow/RefusedProposalIsNotRecordedAsProposedTest.kt
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.docstruth.application.workflow
+
+import com.openbank.docstruth.application.port.out.FindingRepository
+import com.openbank.docstruth.application.port.out.GitHubProposalPort
+import com.openbank.docstruth.application.port.out.LlmDiagnosisPort
+import com.openbank.docstruth.domain.model.DocsTruthCheckType
+import com.openbank.docstruth.domain.model.DocsTruthFinding
+import com.openbank.docstruth.domain.model.FindingSeverity
+import com.openbank.docstruth.domain.model.FindingStatus
+import com.openbank.docstruth.infrastructure.adapter.GitHubProposalAdapter
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+
+/**
+ * The unwired GitHub path must not be representable as a delivered proposal (#5897).
+ *
+ * Asserting "the adapter returns null" alone would be the weak test this repo keeps warning about:
+ * the predecessor stub also "returned a value", and the defect was entirely in what the CALLER did
+ * with it. So these tests drive the real [DiagnoseAndProposeActivityImpl] over the real
+ * [GitHubProposalAdapter] and assert on what is PERSISTED and on the number
+ * [DocsTruthWorkflowImpl] reports — the two places a fabricated URL was read as success.
+ */
+class RefusedProposalIsNotRecordedAsProposedTest {
+
+    private class RecordingRepository : FindingRepository {
+        var updated: DocsTruthFinding? = null
+        override suspend fun save(finding: DocsTruthFinding): DocsTruthFinding = finding
+        override suspend fun findActive(): List<DocsTruthFinding> = emptyList()
+        override suspend fun findById(id: String): DocsTruthFinding? = null
+        override suspend fun update(finding: DocsTruthFinding): DocsTruthFinding {
+            updated = finding
+            return finding
+        }
+    }
+
+    private class FixedDiagnosis(private val fixDiff: String?) : LlmDiagnosisPort {
+        override suspend fun diagnose(finding: DocsTruthFinding, contextMetrics: Map<String, Double>): String =
+            "root cause"
+
+        override suspend fun proposeFixDiff(finding: DocsTruthFinding, diagnosis: String): String? = fixDiff
+    }
+
+    private class SyncActivity(
+        llm: LlmDiagnosisPort,
+        githubProposal: GitHubProposalPort,
+        findingRepository: FindingRepository,
+    ) : DiagnoseAndProposeActivityImpl(llm, githubProposal, findingRepository) {
+        // The production bridge needs a Vert.x context that a plain unit test has none of; the
+        // logic under test is the branch, not the bridge.
+        override fun <T> runOnVertxContext(block: suspend () -> T): T = runBlocking { block() }
+    }
+
+    private fun finding() = DocsTruthFinding(
+        id = "f-11111111-2222",
+        checkType = DocsTruthCheckType.SHIPPED_ARTIFACT_MISSING,
+        severity = FindingSeverity.CRITICAL,
+        detectedAt = Instant.parse("2026-01-01T00:00:00Z"),
+        title = "ADR-0139 claims OnlineFeatureStore",
+        component = "ADR-0139",
+        adrPath = "docs/adr/0139-online-feature-store.md",
+        rawMetricValue = BigDecimal.ONE,
+        threshold = BigDecimal.ZERO,
+        rootCause = "root cause",
+        status = FindingStatus.DIAGNOSED,
+        diagnosedAt = Instant.parse("2026-01-01T00:01:00Z"),
+    )
+
+    private fun proposeWith(fixDiff: String?): Pair<DocsTruthFinding, RecordingRepository> {
+        val repository = RecordingRepository()
+        val result = SyncActivity(FixedDiagnosis(fixDiff), GitHubProposalAdapter(), repository)
+            .propose(finding())
+        return result to repository
+    }
+
+    @Test
+    fun `a refused ticket leaves the finding DIAGNOSED with no proposal url`() {
+        val (result, repository) = proposeWith(fixDiff = null)
+
+        // What is persisted is what a human and the HITL queue read.
+        assertThat(repository.updated).isNotNull
+        assertThat(repository.updated!!.status).isEqualTo(FindingStatus.DIAGNOSED)
+        assertThat(repository.updated!!.proposalUrl).isNull()
+        assertThat(repository.updated!!.proposedAt).isNull()
+        assertThat(result.status).isNotEqualTo(FindingStatus.PROPOSED)
+    }
+
+    @Test
+    fun `a refused fix-diff PR also leaves the finding DIAGNOSED`() {
+        val (result, repository) = proposeWith(fixDiff = "--- a/docs/adr/0139.md\n+++ b/docs/adr/0139.md\n")
+
+        assertThat(repository.updated!!.status).isEqualTo(FindingStatus.DIAGNOSED)
+        assertThat(repository.updated!!.proposalUrl).isNull()
+        assertThat(result.proposedFixDiff).isNull()
+    }
+
+    /**
+     * The consumer assertion: [DocsTruthWorkflowImpl] reports `findingsProposed` as
+     * `count { it.status == PROPOSED }`. A refusal must contribute zero to that number — this is
+     * the exact count the fabricated `pending-docs-truth-agent-<id>` URL used to inflate.
+     */
+    @Test
+    fun `a refused proposal contributes nothing to the reported findingsProposed count`() {
+        val (result, _) = proposeWith(fixDiff = null)
+
+        assertThat(listOf(result).count { it.status == FindingStatus.PROPOSED }).isZero()
+    }
+
+    /** No surviving string may point at a repository that does not exist. */
+    @Test
+    fun `no returned value names a repository host at all`(): Unit = runBlocking {
+        val adapter = GitHubProposalAdapter()
+        assertThat(adapter.openTicket(finding(), "root cause")).isNull()
+        assertThat(adapter.openProposalPr(finding(), "diff")).isNull()
+    }
+}


### PR DESCRIPTION
## What this changes

Both remaining bootstrap `GitHubProposalAdapter` stubs — `docs-truth-agent` and
`authz-policy-auditor` — returned a fabricated URL instead of refusing:

```
https://github.com/openbank/openbank/pulls/pending-docs-truth-agent-<id>
https://github.com/openbank/openbank/issues/pending-authz-policy-auditor-<id>
```

Two defects, as #5897 sets out. The value was a **no-op sharing its shape with a real result** —
and the host was a repository that does not exist (this one is `JiRaska/open-bank-oss`).

## Per adapter: refuse, not wire

**Both refuse.** Both charters *do* grant `tier: write_proposal` on `github-pr`, so wiring would
not have been a charter widening — but neither service has a `github-token` config, so there is no
token path to fail closed on, only one to build. `flaky-test-hunter` (PR #5890) is the one agent
that has one, and it stays the template if either is wired later. Refusing is the safer default and
matches `openbank-mcp-service`'s `UnwiredProposalPort` (#3900).

`authz-policy-auditor.openProposalPr` refuses **permanently**, not pending wiring: ADR-0167's
Decision is that this agent never opens a fix PR on an authorization policy.

**`agents.yaml` is untouched**, so none of its three derived tails (`docs/compliance/eu-ai-act.md`,
the OPA bundle ConfigMaps + `policy-checksum` annotations, `ai-governance-snapshot.json`) needed
regenerating.

## Proving the refusal cannot read as success

Asserting "the adapter returns an error" alone would be the weak test this repo keeps warning
about — the old stub also returned a value, and the whole defect lived in what the **caller** did
with it. `GitHubProposalPort` now returns `String?`; the load-bearing change is in
`DiagnoseAndProposeActivityImpl`, which on `null` leaves the finding **`DIAGNOSED`** with a null
`proposalUrl` and a null `proposedAt`, instead of moving it to `PROPOSED`.

So the tests drive the real activity over the real adapter and assert on the two places the
fabricated URL was read as success:

| Assertion | Consumer it protects |
|---|---|
| persisted finding is `DIAGNOSED`, `proposalUrl` null, `proposedAt` null | the row a human and the HITL queue read |
| `count { status == PROPOSED } == 0` | `findingsProposed` in the run report |
| neither adapter method returns any host string | #5897 defect 2 |

On `authz-policy-auditor` this is the sharper one: ADR-0167 makes every finding a human-triage
ticket and the charter requires `two_person_review`, so a finding recorded `PROPOSED` with nobody
holding it is an unfiled authorization-policy defect reported as filed.

## Falsification (verify by effect)

Restored the fabricated-URL branch in each adapter and re-ran:

| Module | Result |
|---|---|
| `openbank-docs-truth-agent` | **4 of 4 tests FAILED** |
| `openbank-authz-policy-auditor` | **4 of 4 tests FAILED** |

Restored, both green again. No remaining live string in either service names `openbank/openbank` —
the only surviving occurrences are the KDoc paragraphs describing the removed defect.

## Verification

Per module, serialized, `--rerun-tasks`, exit code read from a redirected log (not a pipeline):

| Module | ktlintCheck | detekt | test | quarkusBuild |
|---|---|---|---|---|
| `openbank-docs-truth-agent` | pass | pass | **61 tests, 0 failures, 0 errors, 0 skipped** | pass |
| `openbank-authz-policy-auditor` | pass | pass | **36 tests, 0 failures, 0 errors, 0 skipped** | pass |

`quarkusBuild` included because ktlint + unit tests do not validate CDI wiring, and both adapters
are `@ApplicationScoped` beans whose port signature changed.

Closes #5897. Refs #3900, PR #5890.
