### PR TITLE
fix(admin-ui): expose AML scan state

### DIFF
--- a/openbank-admin-ui/src/app/aml/page.tsx
+++ b/openbank-admin-ui/src/app/aml/page.tsx
@@ -76,8 +76,8 @@ export default function AmlPage() {
                 checking: t('Zjišťuji stav služby…', 'Checking service…'),
               }}
             />
-            <button onClick={triggerScan} disabled={scanning || !serviceReachable} className="btn btn-primary btn-sm" style={{ background: 'var(--accent)', color: 'white', border: 'none', padding: '6px 12px', borderRadius: '6px', fontSize: '13px', fontWeight: 600, cursor: scanning || !serviceReachable ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', gap: '6px', opacity: scanning || !serviceReachable ? 0.6 : 1 }}>
-              <Play size={13} style={{ animation: scanning ? 'pulse 1s infinite' : 'none' }} />
+            <button type="button" aria-label={t('Spustit AML kontrolu', 'Run AML scan')} aria-busy={scanning} onClick={triggerScan} disabled={scanning || !serviceReachable} className="btn btn-primary btn-sm" style={{ background: 'var(--accent)', color: 'white', border: 'none', padding: '6px 12px', borderRadius: '6px', fontSize: '13px', fontWeight: 600, cursor: scanning || !serviceReachable ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', gap: '6px', opacity: scanning || !serviceReachable ? 0.6 : 1 }}>
+              <Play size={13} aria-hidden="true" style={{ animation: scanning ? 'pulse 1s infinite' : 'none' }} />
               {scanning ? t('Kontroluji…', 'Scanning…') : t('Spustit AML kontrolu', 'Run AML scan')}
             </button>
           </div>}

--- a/openbank-admin-ui/src/test/aml-scan-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/aml-scan-a11y.guard.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const read = () => fs.readFileSync(path.join(process.cwd(), 'src/app/aml/page.tsx'), 'utf8')
+
+describe('AML scan action accessibility', () => {
+  it('exposes localized action state without changing the scan handler', () => {
+    const source = read()
+    expect(source).toContain('type="button" aria-label={t(\'Spustit AML kontrolu\', \'Run AML scan\')} aria-busy={scanning}')
+    expect(source).toContain('<Play size={13} aria-hidden="true"')
+    expect(source).toContain('onClick={triggerScan}')
+    expect(source).toContain('disabled={scanning || !serviceReachable}')
+  })
+})


### PR DESCRIPTION
## Summary
- expose AML scan busy state to assistive technology
- add explicit non-submit button semantics and localized accessible label
- hide decorative scan icon and add focused guard

Preserves triggerScan, BFF/escalation flow and compliance:view RBAC.\n\nRefs #5146