### PR TITLE
fix(admin-ui): label security severity filters

### DIFF
--- a/openbank-admin-ui/src/app/security/page.tsx
+++ b/openbank-admin-ui/src/app/security/page.tsx
@@ -273,9 +273,9 @@ export default function SecurityPage() {
                 <span style={{ fontSize: '13px', fontWeight: 700, color: 'var(--text-primary)' }}>
                   {t('Výsledky skenování', 'Scan Results')} <span style={{ fontWeight: 400, color: 'var(--text-tertiary)' }}>({results.length})</span>
                 </span>
-                <div style={{ display: 'flex', gap: '4px', background: 'var(--surface-2)', padding: '4px', borderRadius: '6px' }}>
+                <div role="group" aria-label={t('Filtr závažnosti nálezů', 'Finding severity filters')} style={{ display: 'flex', gap: '4px', background: 'var(--surface-2)', padding: '4px', borderRadius: '6px' }}>
                   {(['ALL', 'CRITICAL', 'HIGH'] as const).map(f => (
-                    <button key={f} onClick={() => setFilter(f)}
+                    <button key={f} type="button" aria-pressed={filter === f} onClick={() => setFilter(f)}
                       style={{ padding: '4px 10px', borderRadius: '4px', fontSize: '11px', fontWeight: 600, border: 'none', cursor: 'pointer',
                         background: filter === f ? 'var(--surface-1)' : 'transparent',
                         color: filter === f ? 'var(--text-primary)' : 'var(--text-tertiary)',

--- a/openbank-admin-ui/src/test/security-filter-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/security-filter-a11y.guard.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const read = () => fs.readFileSync(path.join(process.cwd(), 'src/app/security/page.tsx'), 'utf8')
+
+describe('security severity filter accessibility', () => {
+  it('exposes a labelled group of stateful filter buttons', () => {
+    const source = read()
+    expect(source).toContain('role="group" aria-label={t(\'Filtr závažnosti nálezů\', \'Finding severity filters\')}')
+    expect(source).toContain('type="button" aria-pressed={filter === f}')
+    expect(source).toContain('setFilter(f)')
+  })
+})


### PR DESCRIPTION
Adds localized group and pressed-state semantics to security scan severity filters. Preserves scan data, filtering, remediation links, and RBAC.

Closes #5909