### PR TITLE
fix(admin-ui): label consent lookup actions

### DIFF
--- a/openbank-admin-ui/src/app/consents/page.tsx
+++ b/openbank-admin-ui/src/app/consents/page.tsx
@@ -158,6 +158,8 @@ export default function ConsentsPage() {
               }}
             />
             <button
+              type="button"
+              aria-busy={loading}
               onClick={() => lookup()}
               disabled={loading || !term.trim()}
               style={{
@@ -168,9 +170,11 @@ export default function ConsentsPage() {
                 opacity: loading || !term.trim() ? 0.6 : 1,
               }}
             >
-              <Search size={15} /> {t('Vyhledat', 'Look up')}
+              <Search size={15} aria-hidden="true" /> {t('Vyhledat', 'Look up')}
             </button>
             <button
+              type="button"
+              aria-busy={loading}
               onClick={() => { setTerm(MARKETING_GRANTEE); void lookup(MARKETING_GRANTEE) }}
               disabled={loading}
               style={{

--- a/openbank-admin-ui/src/test/consents-lookup-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/consents-lookup-a11y.guard.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const read = () => fs.readFileSync(path.join(process.cwd(), 'src/app/consents/page.tsx'), 'utf8')
+
+describe('consent lookup accessibility', () => {
+  it('keeps lookup actions explicit and hides decorative icon', () => {
+    const source = read()
+    expect(source).toContain('type="button"\n              aria-busy={loading}\n              onClick={() => lookup()}')
+    expect(source).toContain('<Search size={15} aria-hidden="true" />')
+    expect(source).toContain('type="button"\n              aria-busy={loading}\n              onClick={() => { setTerm(MARKETING_GRANTEE); void lookup(MARKETING_GRANTEE) }}')
+    expect(source).toContain('lookup(MARKETING_GRANTEE)')
+  })
+})


### PR DESCRIPTION
Makes privacy-sensitive consent lookup actions explicit buttons with busy state and hides the decorative search icon. Preserves consent-service lookups, classification, and RBAC.

Refs #5910