### PR TITLE
fix(admin-ui): expose identity case action state

### DIFF
--- a/openbank-admin-ui/src/app/identity-cases/page.tsx
+++ b/openbank-admin-ui/src/app/identity-cases/page.tsx
@@ -195,13 +195,13 @@ function DecisionForm({
           style={{ fontSize: '13px', padding: '6px 8px', flex: '1 1 160px', minWidth: '140px' }}
         />
 
-        <button className="btn btn-primary" onClick={submit} disabled={busy} style={{ fontSize: '13px' }}>
-          <Check size={14} style={{ marginRight: '4px' }} />
+        <button type="button" aria-busy={busy} className="btn btn-primary" onClick={submit} disabled={busy} style={{ fontSize: '13px' }}>
+          <Check size={14} aria-hidden="true" style={{ marginRight: '4px' }} />
           {isSecond ? t('Potvrdit a rozhodnout', 'Confirm & decide') : t('Odeslat hlas', 'Submit vote')}
         </button>
 
         {isSecond && (
-          <button className="btn btn-secondary" onClick={reopen} disabled={busy} style={{ fontSize: '13px' }}>
+          <button type="button" aria-busy={busy} className="btn btn-secondary" onClick={reopen} disabled={busy} style={{ fontSize: '13px' }}>
             {t('Znovu otevřít', 'Reopen')}
           </button>
         )}
@@ -249,8 +249,8 @@ export default function IdentityCasesPage() {
         icon={<Fingerprint size={20} aria-hidden="true" />}
         title={t('Ověření identity — čtyři oči', 'Identity Verification — Four-Eyes')}
         subtitle={t('Nejednoznačné identity z onboardingu (kolize RČ nebo jmenovci). Rozhodnutí vyžaduje dva různé schvalovatele (ADR-0072 / ADR-0030).', 'Ambiguous onboarding identities (RČ collisions or namesakes). A decision requires two distinct approvers (ADR-0072 / ADR-0030).')}
-        actions={<button className="btn btn-secondary" onClick={load} disabled={loading} style={{ fontSize: '13px' }}>
-          <RefreshCw size={14} style={{ marginRight: '4px' }} />{t('Obnovit', 'Refresh')}
+        actions={<button type="button" aria-busy={loading} className="btn btn-secondary" onClick={load} disabled={loading} style={{ fontSize: '13px' }}>
+          <RefreshCw size={14} aria-hidden="true" style={{ marginRight: '4px' }} />{t('Obnovit', 'Refresh')}
         </button>}
       />
       {unavail ? (

--- a/openbank-admin-ui/src/test/identity-cases-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/identity-cases-a11y.guard.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const read = () => fs.readFileSync(path.join(process.cwd(), 'src/app/identity-cases/page.tsx'), 'utf8')
+
+describe('identity cases four-eyes accessibility', () => {
+  it('keeps decision and refresh controls explicit and stateful', () => {
+    const source = read()
+    expect(source).toContain('type="button" aria-busy={busy} className="btn btn-primary"')
+    expect(source).toContain('type="button" aria-busy={busy} className="btn btn-secondary"')
+    expect(source).toContain('type="button" aria-busy={loading} className="btn btn-secondary"')
+    expect(source).toContain('<Check size={14} aria-hidden="true"')
+    expect(source).toContain('<RefreshCw size={14} aria-hidden="true"')
+    expect(source).toContain('method: \'POST\'')
+  })
+})


### PR DESCRIPTION
Adds explicit button types, busy state, and decorative icon semantics to identity-case four-eyes actions. Preserves PID decision/reopen payloads, BFF endpoints, AuthGuard, and RBAC.

Refs #5916