### PR TITLE
fix(agent): correct the model-selection notes — I measured the cap, not the models

### DIFF
--- a/openbank-agent-service/CLAUDE.md
+++ b/openbank-agent-service/CLAUDE.md
@@ -47,6 +47,18 @@ JAVA_HOME=$(/usr/libexec/java_home -v 25) ./gradlew :openbank-agent-service:test
 
 ## Config gotchas
 
+- **A reasoning model spends `max_tokens` on REASONING before it emits any answer, so a low cap
+  returns an EMPTY `content` field — not a short answer.** Measured on `openai/gpt-oss-120b`
+  through the gateway: `max_tokens=40` gives `content=''` with `finish_reason=length` (the whole
+  budget went to reasoning), `128` truncates mid-sentence, `512` finishes normally in 189 tokens.
+  Both paid models in the picker are reasoning models, and the loop's `MAX_OUTPUT_TOKENS` is 512,
+  so this works today — but lowering that cap to save tokens turns replies into blanks, which the
+  dock renders as "(no reply)" and reads as a broken assistant. The same trap makes model
+  EVALUATION lie: `zai-org/GLM-5.2` and `moonshotai/Kimi-K3` were first measured at 120 tokens and
+  looked broken (empty content; Kimi's chain of thought where the answer should be, which is just a
+  truncated reasoning-prefixed stream). At 512 both answer cleanly. Measure a reasoning model at
+  the cap the caller actually sends, or you are measuring the cap.
+
 - `AGENT_MODEL_API_KEY` (or the legacy `GROQ_API_KEY` fallback) must be set for the
   `llama-3.3-70b-versatile` model; omit for mock-echo. Deployed, that key is the LiteLLM
   *virtual* key and `AGENT_MODEL_ENDPOINT` points at the in-cluster gateway — the provider

--- a/openbank-agent-service/src/main/resources/application.yaml
+++ b/openbank-agent-service/src/main/resources/application.yaml
@@ -204,11 +204,17 @@ model-gateway:
     # the same virtual key — a model entry here plus a route in litellm-config, no code change.
     #
     # WHY THESE TWO AND NOT WHATEVER IS TOP OF A LEADERBOARD: they were measured against a real
-    # Czech admin prompt through the gateway before being registered. gpt-oss-120b answered in
-    # 2.9s, DeepSeek-V4-Pro in 9.6s, both cleanly. Three others that look equally reasonable on
-    # paper were rejected by the same probe — Kimi-K3 leaked its chain of thought into the reply,
-    # GLM-5.2 returned empty content, Llama-4-Maverick answered HTTP 429 "Model busy". A config
-    # review cannot see any of that.
+    # Czech admin prompt through the gateway before being registered — gpt-oss-120b in 1-3s,
+    # DeepSeek-V4-Pro in 2.6-9.6s, both cleanly. Kimi-K3 was rejected on latency (44.7s) and
+    # Llama-4-Maverick answered HTTP 429 "Model busy"; GLM-5.2 is perfectly usable at 6.9s and is
+    # simply not needed as a third option. A config review cannot see any of that.
+    #
+    # BOTH REGISTERED MODELS ARE REASONING MODELS, which constrains one number here: the token
+    # budget is spent on reasoning BEFORE any answer text, so a low max_tokens returns an EMPTY
+    # content field rather than a short answer. Measured on gpt-oss-120b: 40 -> empty
+    # (finish_reason=length), 128 -> truncated mid-sentence, 512 -> finishes in 189 tokens. The
+    # loop's MAX_OUTPUT_TOKENS is 512, so this works; lowering it to save tokens would silently
+    # turn replies into blanks, which the UI renders as "(no reply)".
     #
     # Both stay `sensitivity: hosted`: they are off-cluster US providers, so the ADR-0031 D6
     # sensitive-context routing must not choose them. That tier still needs a self-hosted model,

--- a/openbank-infra/gitops/components/ai-platform/litellm-config.yaml
+++ b/openbank-infra/gitops/components/ai-platform/litellm-config.yaml
@@ -133,15 +133,26 @@ data:
       # inside this pod before being added — the same probe that caught Groq decommissioning
       # Llama Guard:
       #
-      #   openai/gpt-oss-120b          2.9s, clean Czech   <- fastest, ~35x cheaper per output token
-      #   deepseek-ai/DeepSeek-V4-Pro  9.6s, clean Czech   <- strongest
-      #   moonshotai/Kimi-K3          14.8s, LEAKED its chain of thought into the reply -> rejected
-      #   zai-org/GLM-5.2              8.0s, empty content within 120 tokens            -> rejected
-      #   meta-llama/Llama-4-Maverick  HTTP 429 "Model busy, retry later"                -> rejected
+      #   openai/gpt-oss-120b          1-3s, clean Czech   <- fastest, ~35x cheaper per output token
+      #   deepseek-ai/DeepSeek-V4-Pro  2.6-9.6s, clean Czech <- strongest
+      #   zai-org/GLM-5.2              6.9s, clean Czech    <- viable, simply not needed as a third
+      #   moonshotai/Kimi-K3          44.7s                 -> rejected on LATENCY alone
+      #   meta-llama/Llama-4-Maverick  HTTP 429 "Model busy, retry later" -> rejected
       #
-      # The three rejections are the reason to measure rather than pick from a leaderboard: all are
-      # current, well-regarded models that would have read fine in a config review and produced a
-      # visibly broken assistant.
+      # CORRECTION, kept here because the first version of this comment was wrong and the reason is
+      # worth more than the conclusion: GLM-5.2 and Kimi-K3 were first measured at max_tokens=120
+      # and looked BROKEN — empty content, and Kimi's chain of thought appearing where the answer
+      # should be. Both are REASONING models: the token budget is spent on reasoning first, so a
+      # small cap truncates before any answer is emitted, and a truncated reasoning-prefixed stream
+      # is what surfaced as "leaked chain of thought". At the 512 the callers actually use, both
+      # answer cleanly. Measuring a reasoning model at a small max_tokens measures the cap, not the
+      # model.
+      #
+      # gpt-oss-120b is a reasoning model too, and the same budget rule applies to it in
+      # production: at max_tokens=40 its `content` is EMPTY (finish_reason=length, the whole budget
+      # went to reasoning), at 128 it is truncated mid-sentence, and at 512 it finishes normally in
+      # 189 tokens. Callers here send 512 (agent-service MAX_OUTPUT_TOKENS), so this is fine — but
+      # anything that lowers that cap silently turns answers into blanks rather than short answers.
       - model_name: openai/gpt-oss-120b
         litellm_params:
           model: deepinfra/openai/gpt-oss-120b

--- a/openbank-infra/gitops/components/ai-platform/litellm.yaml
+++ b/openbank-infra/gitops/components/ai-platform/litellm.yaml
@@ -35,7 +35,7 @@ spec:
         # would leave agent-service's repointed call failing "model not found" with a green,
         # in-sync ArgoCD — the same silent-degradation shape as an `optional: true` secret ref.
         # BUMP THIS whenever litellm-config.yaml changes; that is what rolls the pod.
-        openbank.tech/litellm-config-revision: "11"
+        openbank.tech/litellm-config-revision: "12"
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
Two of the three models #5846 recorded as "rejected" were rejected for a reason that is an artifact
of **my own probe**, and the tree now carries that claim about live third-party models.

## What was wrong

`zai-org/GLM-5.2` and `moonshotai/Kimi-K3` were first measured at `max_tokens=120` and looked
broken — empty content, and Kimi's chain of thought sitting where the answer should be.

Both are **reasoning models**: the token budget is spent on reasoning *before* any answer text, so a
small cap truncates before the answer starts — and a truncated reasoning-prefixed stream is exactly
what "leaked chain of thought" looked like. Re-measured at the **512** the callers actually send:

| model | at 120 | at 512 |
|---|---|---|
| `zai-org/GLM-5.2` | empty | **clean Czech, 6.9s** |
| `moonshotai/Kimi-K3` | reasoning where the answer belongs | **clean Czech, 44.7s** |

So GLM-5.2 is perfectly usable and simply not needed as a third option; Kimi is rejected on
**latency alone**. Llama-4-Maverick's HTTP 429 stands.

## Why this matters beyond the comment

The same rule constrains production. Both models in the picker are reasoning models, and
`gpt-oss-120b` measured **through the gateway**:

| max_tokens | result |
|---|---|
| 40 | `content=''`, `finish_reason=length` — the whole budget went to reasoning |
| 128 | truncated mid-sentence |
| 512 | finishes normally, 189 tokens |

The loop sends 512, so this works today — but lowering that cap to save tokens would turn replies
into blanks, which the dock renders as "(no reply)" and reads as a broken assistant. Recorded in
`openbank-agent-service/CLAUDE.md` under Config gotchas.

`config-revision` is bumped for a comment-only edit: the gate treats any change to that ConfigMap as
one, and it is right to — nothing in it can tell a comment from a route.

## Linked issues

N/A — correction to #5846, no separate issue.
