### PR TITLE
fix(infra): let the gateway reach Langfuse — the trace callback was timing out

### DIFF
--- a/openbank-infra/CLAUDE.md
+++ b/openbank-infra/CLAUDE.md
@@ -142,6 +142,18 @@ out of it (they are path-scoped, not less important — several are live-inciden
   via `fleet-attestation.yml`) — it checks every image *declared* in gitops, incl. initContainers
   and sidecars, so a gap is caught while still latent. Green gate before any Enforce graduation
   (`rules.yaml: provenance.fleet_attestation_gate`).
+- **`gen-network-policies.py` emits INGRESS only, so a new in-cluster edge also needs the CALLER's
+  hand-written EGRESS rule — and the omission is silent in both directions.** Measured 2026-08-20:
+  LiteLLM's Langfuse trace callback died on `ConnectTimeout` to `langfuse.ai-platform.svc:3000`
+  while both pods were 1/1 Running, ArgoCD was Synced/Healthy, the generated
+  `langfuse-ingress-allow-list` correctly admitted the same namespace, and LiteLLM still answered
+  200 to every caller — the only symptom anywhere was `/api/public/traces` returning an empty list.
+  Same namespace is NOT the same as allowed: a pod carrying an egress policy is deny-by-default for
+  everything that policy does not name, and `networkpolicy-litellm-egress.yaml` named DNS, 443 to
+  the internet, and its own Postgres. Isolate it in one command — run a throwaway pod with no
+  egress policy in the same namespace and curl the target (HTTP 200 there + timeout from the
+  policed pod pins it to egress, not to the Service, DNS or the ingress allow-list). Note the
+  throwaway pod needs a `restricted` PodSecurity context or the namespace refuses it.
 - **A ConfigMap a pod parses ONCE at startup needs a pod-roll annotation, or the edit is a no-op
   against a green ArgoCD.** LiteLLM reads `--config` at boot and the ConfigMap is a plain volume
   mount, so a new model route reaches the pod's filesystem and the proxy keeps serving the list it

--- a/openbank-infra/gitops/components/ai-platform/networkpolicy-litellm-egress.yaml
+++ b/openbank-infra/gitops/components/ai-platform/networkpolicy-litellm-egress.yaml
@@ -30,6 +30,23 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+    # Trace export to the in-cluster Langfuse (ADR-0265). MEASURED, not assumed: without this rule
+    # every callback POST to langfuse.ai-platform.svc:3000 dies on a ConnectTimeout — same
+    # namespace is NOT the same as allowed, because this pod carries an egress policy and an
+    # egress policy is deny-by-default for everything it does not name. The failure is completely
+    # silent from the outside: LiteLLM answers 200 to the caller, the pod stays 1/1 Running,
+    # ArgoCD reports Synced and Healthy, and only `/api/public/traces` returning an empty list
+    # says otherwise — which is exactly the blind spot runbook 0012 flags and #5671 tracks.
+    #
+    # The generator cannot derive this one. gen-network-policies.py emits INGRESS from declared
+    # env URLs; the caller side of a new in-cluster edge is hand-written, and this file is where.
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: langfuse
+      ports:
+        - protocol: TCP
+          port: 3000
     # The deliberate internet hole: HTTPS to the LLM provider (DeepInfra). This is the only pod in
     # the fleet with 0.0.0.0/0:443 egress — the whole point of centralising the choke point here.
     - to:


### PR DESCRIPTION
**Langfuse shipped with #5670 and ingested nothing.** Measured right after the deploy:
`/api/public/traces` returns an empty list, and from inside the LiteLLM pod the Langfuse SDK's own
`auth_check()` dies on `httpx.ConnectTimeout`.

## Cause

`litellm-egress` names DNS, `0.0.0.0/0:443` and its own Postgres — nothing else. **Same namespace is
not the same as allowed:** a pod carrying an egress policy is deny-by-default for everything that
policy does not name, so every callback POST to `langfuse.ai-platform.svc:3000` hung until timeout.

## Isolated, not guessed

| from | result |
|---|---|
| throwaway pod, no egress policy, same namespace | **HTTP 200** |
| litellm pod (egress-policed) | **ConnectTimeout** |

That pins it to egress and rules out the Service, DNS, and the generated ingress allow-list (which
correctly admits the namespace).

## Why nothing caught it

This is precisely the blind spot runbook 0012 documents and #5671 tracks: LiteLLM answers 200 to
every caller, both pods stay 1/1 Running, ArgoCD reports Synced and Healthy, and Langfuse v2 exposes
no Prometheus endpoint — so "traces are landing" had no observable anywhere. It was broken from the
moment the component landed, and only an explicit read of the traces API said so.

`gen-network-policies.py` cannot cover this either: it derives **ingress** from declared env URLs, so
the caller side of a new in-cluster edge is hand-written. Recorded in `openbank-infra/CLAUDE.md`.

## Linked issues

Refs #5671
