### PR TITLE
fix(copilot): index the help corpus 90s after boot, not on the next 6h cron

### DIFF
--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/retrieval/HelpCorpusIndexer.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/retrieval/HelpCorpusIndexer.kt
@@ -68,8 +68,18 @@ class HelpCorpusIndexer(
         liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, EXPECTED_INTERVAL)
     }
 
+    // `every` + `delayed`, NOT a cron. A cron alone means a freshly deployed environment has an
+    // EMPTY index until the next scheduled hour — measured on the sandbox rollout: the table sat at
+    // 0 rows with the pod healthy, and every help search silently answered keyword-only for up to
+    // six hours. The delay is what makes a boot-time run safe: at t=0 the gateway route, the ESO
+    // secret and the database may all still be settling, and a run that fails then simply logs and
+    // is retried by the next tick — which is the property a one-shot @Startup would not have.
+    //
+    // SKIP rather than PROCEED on overlap: the run is idempotent by content hash, but two
+    // concurrent passes would embed the same stale chunks twice and pay for it twice.
     @Scheduled(
-        cron = "{copilot.retrieval.index-cron}",
+        every = "{copilot.retrieval.index-interval}",
+        delayed = "{copilot.retrieval.index-initial-delay}",
         concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
     )
     suspend fun reindex() {
@@ -137,7 +147,7 @@ class HelpCorpusIndexer(
 
         const val WORKFLOW_NAME = "copilot-help-index"
 
-        /** Matches the default cron (every 6h); the staleness rule fires at twice this. */
+        /** Matches the default interval (6h); the ADR-0237 staleness rule fires at twice this. */
         val EXPECTED_INTERVAL: Duration = Duration.ofHours(6)
 
         fun sha256(s: String): String =

--- a/openbank-copilot-service/src/main/resources/application.yaml
+++ b/openbank-copilot-service/src/main/resources/application.yaml
@@ -139,7 +139,14 @@ copilot:
     embedding-dimensions: ${COPILOT_EMBEDDING_DIMENSIONS:1024}
     embedding-api-key: ${COPILOT_EMBEDDING_API_KEY:}
     # Re-checks content hashes; embeds only what changed, so the steady-state cost is one query.
-    index-cron: ${COPILOT_INDEX_CRON:0 17 */6 * * ?}
+    #
+    # An INTERVAL with an initial delay, not a cron: a cron leaves a freshly deployed environment
+    # with an empty index — and therefore keyword-only search — until the next scheduled hour. The
+    # 90s delay is deliberate rather than 0: at boot the gateway route, the projected secret and the
+    # database connection may all still be settling, and a failed run here is harmless because the
+    # next tick retries it.
+    index-interval: ${COPILOT_INDEX_INTERVAL:6h}
+    index-initial-delay: ${COPILOT_INDEX_INITIAL_DELAY:90s}
   # OPA per-tool gate (ADR-0089 D3, ADR-0034). Off by default (advisory); flip to true in gitops
   # once copilot-opa-bundle.yaml is deployed and the sidecar is live (issue #998 advisory→enforce).
   opa:


### PR DESCRIPTION
Found by watching the sandbox rollout, not by reading the code: the copilot pod came up healthy,
`help_passage_embedding` sat at **0 rows**, and every help search would have answered keyword-only
until the next cron hour — up to **six hours** of a feature that is deployed, enabled and doing
nothing.

## Change

`every` + `delayed` instead of a cron, so the first index runs 90s after boot.

The delay is the part that matters, and it is why this is not simply an `@Startup` one-shot: at t=0
the gateway route, the projected secret and the database connection may all still be settling, and a
run that fails then just logs and is retried by the next tick. A one-shot has no second chance —
which is exactly the argument the original comment made for a cron. It was right about the retry and
wrong to buy it with a cold start.

## Note on what worked

The degradation was **visible the whole time** — `openbank_copilot_retrieval_total{mode="keyword_only"}`
is what made this findable at all, and the alert added in #5833 is deliberately gated so it does not
fire in this state (hybrid has never worked, so the feature is not "regressed"). Visible is not the
same as acceptable, hence the fix.

## Verification

`:openbank-copilot-service:test` green (indexer unit tests + the Quarkus boot test, which is what
would catch a malformed `@Scheduled` expression). `run-gates.py --group kotlin`: 19 gates green,
including the scheduler rules that require this method to stay a `suspend fun`.

## Linked issues

Refs #5671
