### PR TITLE
fix(admin-ui): label code quality controls

### DIFF
--- a/openbank-admin-ui/src/app/system/tests/page.tsx
+++ b/openbank-admin-ui/src/app/system/tests/page.tsx
@@ -587,17 +587,19 @@ export default function TestCoveragePage() {
               {t('Aktualizováno', 'Updated')} {lastRefresh.toLocaleTimeString(dateLocale)}
             </span>
           )}
-          <button onClick={load} disabled={testLoading || qualityLoading} className="btn btn-secondary btn-sm">
-            <RefreshCw size={13} style={{ animation: (testLoading || qualityLoading) ? 'spin 0.8s linear infinite' : 'none' }} />
+          <button type="button" onClick={load} disabled={testLoading || qualityLoading} aria-busy={testLoading || qualityLoading} className="btn btn-secondary btn-sm">
+            <RefreshCw size={13} aria-hidden="true" style={{ animation: (testLoading || qualityLoading) ? 'spin 0.8s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
         </div>}
       />
 
-      <div style={{ display: 'flex', gap: '2px', marginBottom: '20px', borderBottom: '1px solid var(--border)' }}>
+      <div role="group" aria-label={t('Přepínač pohledů kvality kódu', 'Code quality view')} style={{ display: 'flex', gap: '2px', marginBottom: '20px', borderBottom: '1px solid var(--border)' }}>
         {tabs.map(tabDef => (
           <button
             key={tabDef.id}
+            type="button"
+            aria-pressed={tab === tabDef.id}
             onClick={() => setTab(tabDef.id)}
             style={{
               display: 'flex', alignItems: 'center', gap: '6px',
@@ -609,7 +611,7 @@ export default function TestCoveragePage() {
               cursor: 'pointer', marginBottom: '-1px', transition: 'color 0.15s',
             }}
           >
-            {tabDef.icon}
+            <span aria-hidden="true">{tabDef.icon}</span>
             {tabDef.label}
             {tabDef.count !== undefined && tabDef.count > 0 && (
               <span style={{ fontSize: '10px', background: 'var(--surface-3)', borderRadius: '10px', padding: '1px 6px', color: 'var(--text-secondary)', fontWeight: 500 }}>

--- a/openbank-admin-ui/src/test/system-tests-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/system-tests-a11y.guard.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const read = () => fs.readFileSync(path.join(process.cwd(), 'src/app/system/tests/page.tsx'), 'utf8')
+
+describe('system code quality accessibility', () => {
+  it('exposes stateful view filters and a busy refresh action', () => {
+    const source = read()
+    expect(source).toContain('type="button" onClick={load} disabled={testLoading || qualityLoading} aria-busy={testLoading || qualityLoading}')
+    expect(source).toContain('<RefreshCw size={13} aria-hidden="true"')
+    expect(source).toContain('role="group" aria-label={t(\'Přepínač pohledů kvality kódu\', \'Code quality view\')}')
+    expect(source).toContain('type="button"\n            aria-pressed={tab === tabDef.id}')
+    expect(source).toContain('<span aria-hidden="true">{tabDef.icon}</span>')
+  })
+})


### PR DESCRIPTION
## Summary
- expose Code Quality view filters with localized pressed-state semantics
- label refresh busy state and hide decorative icons

Preserves existing test/quality fetches, tab state, data presentation, and RBAC.

Refs #5820