### PR TITLE
fix(audit): make anchor kms-key-id optional so the service boots

### DIFF
--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/signing/AnchorSignerProducer.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/signing/AnchorSignerProducer.kt
@@ -9,6 +9,7 @@ import jakarta.enterprise.inject.Produces
 import jakarta.inject.Singleton
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import software.amazon.awssdk.services.kms.KmsClient
+import java.util.Optional
 
 /** Selects the local development signer or the dedicated asymmetric KMS signer. */
 @Singleton
@@ -21,14 +22,29 @@ class AnchorSignerProducer {
             name = "openbank.audit.anchor.signing-key",
             defaultValue = "CHANGE_ME_LOCAL_DEV_ONLY",
         ) signingKey: String,
-        @ConfigProperty(name = "openbank.audit.anchor.kms-key-id", defaultValue = "") kmsKeyId: String,
+        // Optional<String>, NOT a plain String with defaultValue = "": application.yaml binds
+        // ${AUDIT_ANCHOR_KMS_KEY_ID:}, which DEFINES the property as the empty string, and SmallRye's
+        // converter treats an empty value as no value at all. A non-optional String therefore fails
+        // injection with SRCFG00040 before the method body runs, so the whole deployment aborts and
+        // the `require` below was dead code that could never report the missing key (#5844 shipped
+        // this way and left `main` red — no hmac deployment could boot either, since the kms branch
+        // is not even reached).
+        @ConfigProperty(name = "openbank.audit.anchor.kms-key-id") kmsKeyId: Optional<String>,
+    ): AnchorSigner = select(signer, signingKey, kmsKeyId) { KmsClient.builder().build() }
+
+    internal fun select(
+        signer: String,
+        signingKey: String,
+        kmsKeyId: Optional<String>,
+        kmsClient: () -> KmsClient,
     ): AnchorSigner = when (signer.trim().lowercase()) {
         "hmac" -> LocalHmacAnchorSigner(signingKey)
         "kms" -> {
-            require(kmsKeyId.isNotBlank()) {
+            val keyId = kmsKeyId.orElse("").trim()
+            require(keyId.isNotEmpty()) {
                 "openbank.audit.anchor.kms-key-id is required when signer=kms"
             }
-            AwsKmsAnchorSigner(KmsClient.builder().build(), kmsKeyId)
+            AwsKmsAnchorSigner(kmsClient(), keyId)
         }
         else -> error("Unsupported openbank.audit.anchor.signer '$signer' (use hmac or kms)")
     }

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/AnchorSignerBootIT.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/AnchorSignerBootIT.kt
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.audit.integration
+
+import com.openbank.audit.application.port.out.AnchorSigner
+import com.openbank.audit.infrastructure.signing.AnchorSignerProducer
+import com.openbank.audit.infrastructure.signing.AwsKmsAnchorSigner
+import com.openbank.audit.infrastructure.signing.LocalHmacAnchorSigner
+import com.openbank.audit.it.PostgresTestResource
+import io.mockk.mockk
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import software.amazon.awssdk.services.kms.KmsClient
+import java.util.Optional
+
+/**
+ * Regression coverage for the boot failure #5844 shipped: `kms-key-id` was injected as a plain
+ * `String` with `defaultValue = ""`, and `application.yaml` binds `${AUDIT_ANCHOR_KMS_KEY_ID:}`,
+ * so the property is DEFINED as empty. SmallRye reads an empty value as no value, injection threw
+ * `SRCFG00040`, and the whole Quarkus deployment aborted — `main` stayed red because every
+ * `@QuarkusTest` in the module then reports as SKIPPED rather than FAILED.
+ *
+ * The first test must be a real `@QuarkusTest`: the defect lives in CDI injection, so a unit test
+ * that calls the producer directly cannot see it. The other two cover the `require` that the old
+ * shape made unreachable dead code — injection threw before the method body ever ran.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class AnchorSignerBootIT {
+
+    @Inject
+    lateinit var signer: AnchorSigner
+
+    @Test
+    fun `boots with no kms-key-id configured and produces the default hmac signer`() {
+        assertThat(signer).isInstanceOf(LocalHmacAnchorSigner::class.java)
+    }
+
+    @Test
+    fun `signer=kms with no key fails with the intended message, not SRCFG00040`() {
+        assertThatThrownBy {
+            AnchorSignerProducer().select("kms", "irrelevant", Optional.empty()) {
+                error("the KMS client must not be built when the key id is missing")
+            }
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("openbank.audit.anchor.kms-key-id is required when signer=kms")
+
+        // An empty/blank value is the same case: application.yaml's `${AUDIT_ANCHOR_KMS_KEY_ID:}`
+        // yields "" rather than an absent Optional wherever the env var is set but empty.
+        assertThatThrownBy {
+            AnchorSignerProducer().select("kms", "irrelevant", Optional.of("  ")) {
+                error("the KMS client must not be built when the key id is blank")
+            }
+        }.hasMessage("openbank.audit.anchor.kms-key-id is required when signer=kms")
+    }
+
+    @Test
+    fun `signer=kms with a key produces the KMS signer`() {
+        val produced = AnchorSignerProducer()
+            .select("kms", "irrelevant", Optional.of("alias/openbank-audit-anchor")) { mockk<KmsClient>() }
+
+        assertThat(produced).isInstanceOf(AwsKmsAnchorSigner::class.java)
+        assertThat(produced.keyId).isEqualTo("alias/openbank-audit-anchor")
+    }
+}


### PR DESCRIPTION
## Why

`main` is red and has been since #5844 (`785df7a08`) merged with `all-green: FAILED`. Path-scoped CI meant no later `main` commit re-ran `build (openbank-audit-service)`, so it stayed invisible until #5751 became the first commit since to touch that module and inherited the red. **This unblocks #5751.**

`openbank-audit-service` cannot boot at all:

```
DeploymentException: ConfigurationException: Failed to load config value of type
  class java.lang.String for: openbank.audit.anchor.kms-key-id
  Suppressed: NoSuchElementException: SRCFG00040: ... defined as the empty String ("")
```

`AnchorSignerProducer` injected the KMS key as a plain `String` with `defaultValue = ""`. `application.yaml` binds `${AUDIT_ANCHOR_KMS_KEY_ID:}`, so the property is *defined* as the empty string, and SmallRye's converter reads an empty value as null. This is the footgun root `CLAUDE.md` already documents: an optional `@ConfigProperty` must be `Optional<String>`, not a plain `String`.

Note it broke the **default** `hmac` path too — the failure is in injection, before the `when` ever picks a branch. No deployment of this service could start.

## The second half

The `require(kmsKeyId.isNotBlank())` a few lines down was **dead code**: injection threw first, so the guard written for exactly the missing-key case could never run. Same shape as the repo's nonnull-JAX-RS-param lesson. Changing the type had to make that guard reachable, not just move the bug.

## What changed

- `kmsKeyId: Optional<String>` (no `defaultValue`).
- The signer selection moved into an `internal fun select(...)` taking a `() -> KmsClient` factory, so the kms branch is testable without resolving an AWS region or touching any live KMS.
- Behaviour: the service boots regardless of configuration; `signer=kms` without a key now fails loudly with the intended message.

## Verified by effect, both directions

Three boot cases, all green:

| case | result |
| --- | --- |
| no `kms-key-id`, default `hmac` signer | app boots, `LocalHmacAnchorSigner` injected |
| `signer=kms`, no key (and blank key) | `IllegalArgumentException: openbank.audit.anchor.kms-key-id is required when signer=kms` — not `SRCFG00040` |
| `signer=kms` with a key | `AwsKmsAnchorSigner`, correct key id |

The first assertion comes from a real `@QuarkusTest` on purpose: the defect is in CDI injection, so a unit test that constructs the producer directly cannot see it.

**Falsification** — reverting the parameter to a plain `String` with the empty default turns the new suite red with the exact `SRCFG00040`, `tests=3 skipped=2 failures=1`. Restored, the module is `tests=146 skipped=0 failures=0 errors=0` (`--rerun-tasks`, nothing `UP-TO-DATE`). `AuditChainRoundTripIT` — the one CI reports — passes, 5/5.

Worth recording: a boot failure reports tests as **SKIPPED**, not FAILED. That is why this read as "1 failed, 15 skipped" instead of 143 failures, and why nobody read it as a whole-service outage.

## Sibling check

No other `@ConfigProperty` in `openbank-audit-service` has this shape — this was the only one, introduced by #5844. Fleet-wide, three services carry in-code comments explaining precisely this trap (`campaign`, `card-issuance`, `notification`), so the lesson was already learned and re-broken. `openbank-customer-edge` has four field-injected `defaultValue = ""` properties that look like the same shape but sit in a booting service; not touched here, and not investigated — out of scope for a red-`main` fix.

Refs #5844
