### PR TITLE
fix(party): create the payee id sequence under the name Hibernate actually asks for

### DIFF
--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
@@ -152,7 +152,7 @@ class PartyResource {
     @RolesAllowed("ROLE_API")
     @Operation(summary = "Match phone-number hashes against parties who opted into being discoverable")
     suspend fun lookupDirectory(req: DirectoryLookupRequest): Response =
-        Response.ok(mapOf("matches" to partyUseCase.lookupByPhoneHashes(req.phoneHashes))).build()
+        Response.ok(mapOf("matches" to partyUseCase.lookupByPhoneHashes(req.hashes()))).build()
 
     /** Turn this party's pay-to-phone findability on or off. Revocable at any time. */
     @PUT
@@ -756,7 +756,20 @@ private const val GDPR_EXPORT_SCOPE =
         "subject-access response is a tracked follow-up (ADR-0118 §6)."
 
 /** Address-book hashes to match. See PhoneDirectory for what the hashing does and does not buy. */
-data class DirectoryLookupRequest(val phoneHashes: List<String> = emptyList())
+/**
+ * `List<String?>`, deliberately. Kotlin's non-null element type is a COMPILE-TIME property and
+ * Jackson does not enforce it inside a collection, so `{"phoneHashes":["abc",null]}` produced a
+ * `List<String>` holding a null and the first dereference threw
+ * `Parameter specified as non-null is null` — a 500 for malformed input (#5913). Declaring the
+ * element nullable makes the null representable, so it can be REJECTED instead of exploding; the
+ * rejection lives in [DirectoryLookupRequest.hashes].
+ */
+data class DirectoryLookupRequest(val phoneHashes: List<String?> = emptyList()) {
+    /** @throws IllegalArgumentException mapped to 400 by libs-runtime's shared mapper (never a service-local one, #526). */
+    fun hashes(): List<String> = phoneHashes.map {
+        requireNotNull(it) { "phoneHashes must not contain null entries" }
+    }
+}
 
 data class DiscoverableRequest(val discoverable: Boolean = false)
 

--- a/openbank-party-service/src/main/resources/db/migration/V19__fix_party_payees_sequence.sql
+++ b/openbank-party-service/src/main/resources/db/migration/V19__fix_party_payees_sequence.sql
@@ -1,0 +1,18 @@
+-- V18 created the pooled id sequence as the QUOTED "party_payees_SEQ", so Postgres kept its case.
+-- Hibernate emits the name UNQUOTED, which folds to lowercase, so the two never met and every
+-- PUT /api/v1/parties/{id}/payees answered 500 with
+--   SQLGrammarException: relation "party_payees_seq" does not exist
+-- from the day the endpoint shipped (#5913). V6 already fixed exactly this for the service's other
+-- three sequences; V18 reintroduced it.
+--
+-- Safe to drop rather than rename: the quoted sequence has never been read (every insert failed),
+-- so it holds no allocated state anything depends on. The lowercase sequence starts fresh, and
+-- party_payees is empty for the same reason.
+--
+-- Rollback:
+--   DROP SEQUENCE IF EXISTS party_payees_seq;
+--   CREATE SEQUENCE IF NOT EXISTS "party_payees_SEQ" INCREMENT BY 50;
+
+DROP SEQUENCE IF EXISTS "party_payees_SEQ";
+
+CREATE SEQUENCE IF NOT EXISTS party_payees_seq INCREMENT BY 50;

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/integration/PartyPayeeAndDirectoryIT.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/integration/PartyPayeeAndDirectoryIT.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.integration
+
+import com.openbank.party.it.PostgresRedpandaTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * The two party-service 500s the two-pass fuzz lane found once it could get past authentication
+ * (#5913). Neither was visible to the auth-on pass — a 403 fires before the handler runs — and
+ * neither is visible to any test that mocks the repository or hand-builds the request DTO.
+ *
+ * 1. `PUT /{id}/payees` answered 500 on EVERY call: `SQLGrammarException: relation
+ *    "party_payees_seq" does not exist`. `V18__party_payees.sql` created the pooled id sequence as
+ *    the QUOTED `"party_payees_SEQ"`, and a quoted identifier keeps its case in Postgres while the
+ *    unquoted name Hibernate emits folds to lowercase — so the two never meet. `V6` fixed exactly
+ *    this for the service's other three sequences and `V18` reintroduced it.
+ *
+ * 2. `POST /directory/lookup` answered 500 for a null INSIDE `phoneHashes`: Kotlin's element
+ *    non-nullability is erased past Jackson, so the null reached the handler and the first
+ *    dereference threw `Parameter specified as non-null is null`. A null at the TOP level of the body, and a null in
+ *    a scalar field, are already 400 — the fleet-wide guards from #3038 cover both, verified by
+ *    running these cases against the unfixed build. A null INSIDE a collection is not: the element
+ *    type is erased past Jackson, so it reached the handler and threw.
+ *
+ * Both assert the STATUS. "It did not crash" is the oracle that missed these: each returned a
+ * perfectly well-formed `INTERNAL_ERROR` body.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedpandaTestResource::class)
+class PartyPayeeAndDirectoryIT {
+
+    private val partyId = UUID.randomUUID()
+
+    @Test
+    @TestSecurity(user = "payee-it", roles = ["ROLE_OPERATOR"])
+    fun `saving a payee allocates an id instead of answering 500`() {
+        Given {
+            contentType("application/json")
+            body("""{"name":"Alice","iban":"CZ6508000000192000145399"}""")
+        } When {
+            put("/api/v1/parties/$partyId/payees")
+        } Then {
+            statusCode(200)
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "directory-it", roles = ["ROLE_API"])
+    fun `a null element inside phoneHashes is a 400, not a 500`() {
+        Given {
+            contentType("application/json")
+            body("""{"phoneHashes":["abc",null]}""")
+        } When {
+            post("/api/v1/parties/directory/lookup")
+        } Then {
+            statusCode(400)
+        }
+    }
+}


### PR DESCRIPTION
fix(party): create the payee id sequence under the name Hibernate actually asks for

Two 500s the two-pass fuzz lane found in party-service once it could get past
authentication (#5913). Neither was visible to the auth-on pass — a 403 fires
before the handler runs.

1. `PUT /api/v1/parties/{id}/payees` answered 500 on EVERY call:
   `SQLGrammarException: relation "party_payees_seq" does not exist`.
   `V18__party_payees.sql` created the pooled id sequence as the QUOTED
   `"party_payees_SEQ"`. A quoted identifier keeps its case in Postgres; the name
   Hibernate emits is unquoted and folds to lowercase, so the two never met.
   `V6__fix_hibernate_sequences.sql` fixed exactly this for the service's other
   three sequences and `V18` reintroduced it. `V19` drops the quoted sequence and
   creates the lowercase one, with the rollback in the file.

   Dropping rather than renaming is safe here precisely because the endpoint has
   never worked: every insert failed, so the quoted sequence holds no allocated
   state and `party_payees` is empty.

2. `POST /api/v1/parties/directory/lookup` answered 500 for a null INSIDE
   `phoneHashes`. Kotlin's element non-nullability is erased past Jackson, so the
   null reached the handler and the first dereference threw
   `Parameter specified as non-null is null`. `List<String?>` makes the null
   representable so it can be rejected as `IllegalArgumentException`, which
   libs-runtime's shared mapper turns into 400 (no service-local mapper, #526).

WHAT I MEASURED RATHER THAN ASSUMED

The obvious neighbouring cases are already correct and I did not "fix" them: a
null at the top level of the body, and a null in a scalar field
(`{"name":null,...}`), both answer 400 today — the fleet-wide guards from #3038
cover them. I found that by running those cases against the UNFIXED build first,
and dropped the two tests asserting them, because a test that is green before and
after the change is decoration.

`PartyPayeeAndDirectoryIT` asserts the STATUS, not the absence of an exception —
both endpoints returned a well-formed `INTERNAL_ERROR` body, so "it did not
crash" is the oracle that missed them. Falsified: both tests are red (500, 500)
on the unfixed build and green (200, 400) after.

Refs #5913
