### PR TITLE
fix(ledger): reject a null journal line as 400 instead of dereferencing it

### DIFF
--- a/docs/threat-models/openbank-ledger-service.md
+++ b/docs/threat-models/openbank-ledger-service.md
@@ -238,6 +238,21 @@ set) apply equally to the new `ledger.approval.decide` action.
 
 ## 8. Change log
 
+- **2026-08-20** — `POST /api/v1/journals` answered 500 for `"lines": [null]` (issue #5913, found
+  by the two-pass fuzz lane once it could reach past authentication). **No new trust boundary:**
+  the edge, route, `@RolesAllowed(Roles.OPERATOR)` gate and `@Authorize(action = "ledger.create")`
+  decision are all unchanged, and no input that was rejected before is accepted now — the change is
+  strictly the opposite direction, a request that used to reach the handler and throw is now
+  refused. **Denial of service (the reason this is in the threat model at all):** an unhandled NPE
+  on the posting path is an unauthenticated-shaped fault an OPERATOR-authenticated caller can
+  trigger at will with a one-byte payload, and each occurrence costs a stack unwind plus a
+  generic-mapper render; declaring the element nullable moves the rejection to deserialization-time
+  argument validation. **Information disclosure:** none either way — `GenericExceptionMapper`
+  already rendered an opaque `INTERNAL_ERROR` body, so the NPE never leaked a stack trace; that is
+  also why no monitoring saw it. **Repudiation:** unchanged; a rejected request posts nothing, so
+  there is no journal, no outbox row and no audit event to reconcile. Rollback: revert the commit —
+  the change is confined to the request DTO and carries no migration and no persisted state.
+
 - **2026-08-19** — `ApprovalResource` served only `PATCH /{id}` (decide), so a `ledger.reverse`
   four-eyes decision parked at 202 was discoverable only by whoever had been handed its approval
   id out of band — the ceremony completed only if the two operators were already talking, and the

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/LedgerResource.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/LedgerResource.kt
@@ -137,7 +137,7 @@ class LedgerResource(
             entryDate = LocalDate.parse(request.entryDate),
             valueDate = LocalDate.parse(request.valueDate),
             description = request.description,
-            lines = request.lines.map { it.toCommand() },
+            lines = request.requiredLines().map { it.toCommand() },
             postedBy = request.createdBy,
         )
         val entry = ledgerUseCase.postJournal(command)
@@ -209,8 +209,19 @@ data class PostJournalRequest(
     val valueDate: String,
     val description: String? = null,
     val createdBy: UUID,
-    val lines: List<PostJournalLineRequest>,
-)
+    /**
+     * `List<PostJournalLineRequest?>`, deliberately. Kotlin's element non-nullability is a
+     * COMPILE-TIME property, erased past Jackson, so `"lines": [null]` produced a list holding a
+     * null and the first dereference threw NPE — a 500 for malformed input (#5913). Declaring the
+     * element nullable makes the null representable so it can be REJECTED instead of exploding.
+     */
+    val lines: List<PostJournalLineRequest?>,
+) {
+    /** @throws IllegalArgumentException mapped to 400 by libs-runtime's shared mapper (never a service-local one, #526). */
+    fun requiredLines(): List<PostJournalLineRequest> = lines.map {
+        requireNotNull(it) { "lines must not contain null entries" }
+    }
+}
 
 data class ReverseJournalRequest(val reason: String, val reversedBy: UUID)
 

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/JournalMalformedLinesIT.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/JournalMalformedLinesIT.kt
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.integration
+
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * `POST /api/v1/journals` answered 500 for a null ELEMENT in the `lines` array — found by the
+ * two-pass fuzz lane once it could get past authentication (#5913). Kotlin's element
+ * non-nullability is a compile-time property that is erased past Jackson, so the null survived
+ * deserialization and `request.lines.map { it.toCommand() }` threw NPE.
+ *
+ * The neighbouring cases are already correct and are NOT asserted here: a null body and a null
+ * scalar field both answer 400 today, via the fleet-wide guards from #3038. Asserting those would
+ * be a test that is green before and after this change.
+ *
+ * The assertion is the STATUS. This endpoint answered 500 with a well-formed `INTERNAL_ERROR`
+ * body, so "it did not crash" is exactly the oracle that missed it.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.ledger.it.PostgresRedpandaTestResource::class)
+class JournalMalformedLinesIT {
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `a null element in the lines array is a 400, not a 500`() {
+        val today = LocalDate.now().toString()
+        val payload = """
+            {
+              "idempotencyKey": "${UUID.randomUUID()}",
+              "transactionId": "${UUID.randomUUID()}",
+              "entryDate": "$today",
+              "valueDate": "$today",
+              "description": "null line",
+              "createdBy": "00000000-0000-0000-0000-000000000099",
+              "lines": [null]
+            }
+        """.trimIndent()
+
+        Given {
+            contentType("application/json")
+            body(payload)
+        } When {
+            post("/api/v1/journals")
+        } Then {
+            statusCode(400)
+        }
+    }
+}


### PR DESCRIPTION
fix(ledger): reject a null journal line as 400 instead of dereferencing it

`POST /api/v1/journals` answered 500 for `"lines": [null]` — found by the
two-pass fuzz lane once it could get past authentication (#5913). Not visible to
the auth-on pass, because a 403 fires before the handler runs.

Kotlin's element non-nullability is a COMPILE-TIME property and is erased past
Jackson, so the null survived deserialization and
`request.lines.map { it.toCommand() }` threw NPE, which the generic mapper
rendered as 500. Declaring `List<PostJournalLineRequest?>` makes the null
representable, so it can be rejected as `IllegalArgumentException` — mapped to
400 by libs-runtime's shared mapper, never a service-local one (#526).

This is the collection-element form of the null-body class fixed fleet-wide in
#3038. Those guards read Kotlin's own nullability off the handler's parameter,
which is the right source of truth and cannot see inside a collection: the
element type is not on the parameter. A null body and a null scalar field both
answer 400 today — I ran both against the unfixed build to check, and did not
add tests for them, because a test that is green before and after the change is
decoration.

`JournalMalformedLinesIT` asserts the STATUS: this endpoint returned a
well-formed `INTERNAL_ERROR` body, so "it did not crash" is exactly the oracle
that missed it. Falsified: red (500) on the unfixed handler, green (400) after.
Full module suite 306 tests, 0 failures, 1 skipped (the broker-gated pact
verification, as on main).

Refs #5913
