### PR TITLE
fix(copilot): give every help chunk its own id — the index held ONE row, not 13

### DIFF
--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/HelpKnowledgeBase.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/HelpKnowledgeBase.kt
@@ -72,7 +72,7 @@ class HelpKnowledgeBase : com.openbank.copilot.application.port.out.CorpusSource
                 // Identity is (source, ordinal), NOT the content hash: keying by hash would make an
                 // edited paragraph a new row and leave the old one orphaned until the prune, and the
                 // prune is exactly the step that must not be load-bearing.
-                chunkId = sha256("${'$'}{p.source}#${'$'}n"),
+                chunkId = sha256("${p.source}#$n"),
                 source = p.source,
                 docTitle = p.docTitle,
                 ordinal = n,

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/application/HelpKnowledgeBaseChunksTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/application/HelpKnowledgeBaseChunksTest.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.copilot.application
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * The chunk id is the index's PRIMARY KEY, so a duplicate does not fail — it overwrites, and the
+ * indexer still reports how many chunks it embedded. That is exactly how this shipped: the log said
+ * "embedded and stored 13 chunk(s)" while the table held ONE row, because a mis-escaped template
+ * made the id a constant string for every passage.
+ *
+ * Asserting distinctness is therefore not a style check: it is the only place the difference between
+ * "13 stored" and "13 stored under one key" is visible without querying the database.
+ */
+class HelpKnowledgeBaseChunksTest {
+
+    private fun loaded(): HelpKnowledgeBase = HelpKnowledgeBase().also { it.load() }
+
+    @Test
+    fun `every chunk gets its own id`() {
+        val chunks = loaded().chunks()
+
+        assertThat(chunks).isNotEmpty
+        assertThat(chunks.map { it.chunkId }).doesNotHaveDuplicates()
+        assertThat(chunks.map { it.chunkId }.toSet()).hasSameSizeAs(chunks)
+    }
+
+    @Test
+    fun `the id is derived from source and ordinal, so it is stable across runs`() {
+        // Stability is what makes re-indexing an upsert rather than an append: the same corpus must
+        // produce the same keys, or every run would orphan the previous run's rows until the prune.
+        val first = loaded().chunks().map { it.chunkId }
+        val second = loaded().chunks().map { it.chunkId }
+
+        assertThat(second).isEqualTo(first)
+    }
+
+    @Test
+    fun `chunks carry their content and a hash of it`() {
+        val chunks = loaded().chunks()
+
+        assertThat(chunks).allSatisfy {
+            assertThat(it.content).isNotBlank()
+            assertThat(it.contentHash).isEqualTo(HelpKnowledgeBase.sha256(it.content))
+            assertThat(it.source).startsWith("help/")
+        }
+        // Distinct content must not collapse into one hash either — the indexer skips re-embedding
+        // on an unchanged hash, so a constant hash would freeze the index after the first run.
+        assertThat(chunks.map { it.contentHash }).doesNotHaveDuplicates()
+    }
+}


### PR DESCRIPTION
Caught by comparing the log against the database after the sandbox rollout:

```
log: "help index: embedded and stored 13 chunk(s) with model BAAI/bge-m3"
db:  SELECT count(*) FROM help_passage_embedding  ->  1
```

## Cause

A mis-escaped template made the chunk id a **constant**: `"${'$'}{p.source}#${'$'}n"` renders the
literal text `${p.source}#$n`, identical for every passage. That id is the table's primary key, so
13 upserts collapsed onto one row.

Nothing failed: no error, no rejected insert, and the indexer truthfully reported embedding 13
chunks — because it did embed 13 chunks. Semantic retrieval then searched a corpus of **one
paragraph** while every log line and metric said the index was built.

The escaping is an artifact of how the file was edited, and worth saying plainly: this was invisible
in review precisely because the *wrong* string looks like a correct interpolation.

## Test

Asserts the ids are distinct, stable across runs (that is what makes re-indexing an upsert rather
than an append), and that content hashes are distinct too — a constant hash would freeze the index
after the first run, since the indexer skips re-embedding on an unchanged hash.

**Falsified:** restoring the escaped form turns `every chunk gets its own id` red.

## Why no earlier test caught it

`HelpCorpusIndexerTest` drives a corpus the test itself constructs, with ids it chooses, so it can
never see an id-derivation bug; the real derivation had no test at all until now. The only other
witness was the row count in a live database.

## Linked issues

Refs #5671
