### PR TITLE
feat(libs): send the caller's trace id to the gateway so a Langfuse trace is addressable (ADR-0265 tail)

### DIFF
--- a/docs/runbooks/0012-ai-stack-enablement.md
+++ b/docs/runbooks/0012-ai-stack-enablement.md
@@ -21,7 +21,8 @@ degrade quietly rather than crash:
 **The Langfuse row is a real gap, not an oversight to be argued away.** Langfuse v2 exposes no
 Prometheus endpoint and LiteLLM's callback metrics are an Enterprise feature, so a green Langfuse
 pod with a rejected key is indistinguishable from an idle gateway. Until that is closed (#5671) the
-only proof is the manual check in step 4.
+only proof is the manual check in step 4 — which is now an exact lookup rather than a sample, because
+the caller chooses the trace id, but is still a check somebody has to run rather than one that fires.
 
 ## 1. Seed the secrets (operator, break-glass)
 
@@ -80,17 +81,38 @@ kubectl -n platform exec deploy/copilot-service -c copilot-service -- \
 kubectl -n platform exec deploy/copilot-service -c copilot-service -- \
   sh -c 'curl -s localhost:8085/q/metrics | grep copilot_retrieval'
 
-# Langfuse ingestion — the manual check, because no metric exists yet (#5671).
-# Drive one LLM call, then ask Langfuse whether it stored a trace:
+# Langfuse ingestion — still manual, but now ADDRESSED rather than sampled (#5671).
+#
+# `OpenAiCompatibleLlmGatewayClient` sends the caller's own W3C trace id as LiteLLM
+# `metadata.trace_id`, and LiteLLM passes metadata through to its logging callback — so the
+# Langfuse trace carries the SAME id as the calling service's OTel span. That turns the check
+# below from "is there any trace at all" into "is the trace for the call I just made there",
+# which is the difference between a sample and a probe.
+#
+# 1. Drive one real LLM call through a traced service and capture its trace id from the log
+#    line Quarkus already stamps with it (`traceId=`), e.g. a copilot chat request:
+kubectl -n platform logs deploy/copilot-service -c copilot-service --tail=200 \
+  | grep -oE 'traceId=[0-9a-f]{32}' | tail -1
+
+# 2. Ask Langfuse for THAT id (substitute it for $TID). 200 = ingestion works; 404 = it does not.
 kubectl -n ai-platform exec deploy/langfuse -- \
-  sh -c 'curl -s -u "$LANGFUSE_INIT_PROJECT_PUBLIC_KEY:$LANGFUSE_INIT_PROJECT_SECRET_KEY" \
-    localhost:3000/api/public/traces?limit=1'
+  sh -c 'curl -s -o /dev/null -w "%{http_code}\n" \
+    -u "$LANGFUSE_INIT_PROJECT_PUBLIC_KEY:$LANGFUSE_INIT_PROJECT_SECRET_KEY" \
+    localhost:3000/api/public/traces/'"$TID"
 ```
 
-A `data: []` from that last command after a known LLM call means the callback is not landing — check
-the LiteLLM pod log for a rejected key, and that `litellm-config-revision` was bumped so the pod
-actually re-read its config (LiteLLM parses `--config` once at startup; editing the ConfigMap alone
-changes nothing).
+A 404 for an id you know was sent means the callback is not landing — check the LiteLLM pod log for
+a rejected key, and that `litellm-config-revision` was bumped so the pod actually re-read its config
+(LiteLLM parses `--config` once at startup; editing the ConfigMap alone changes nothing).
+
+**Two ways this probe can still answer "no" for the wrong reason, and both are checkable.** If the
+calling service does not apply `quarkus-opentelemetry` there is no trace id to send, so LiteLLM mints
+its own and the lookup 404s while ingestion is fine — fall back to `?limit=1` to separate the cases.
+And an unsampled span yields OpenTelemetry's all-zero id, which the client refuses to send by design
+(it would fuse every untraced call onto one shared trace); step 1 will simply find no `traceId=` line.
+
+**What this still is not.** It is a probe a human runs, not a control that watches. Nothing alerts
+when ingestion stops, because there is no series to alert on — that half of #5671 is open.
 
 ## 5. Rollback
 

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/llm/TraceIdProvider.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/llm/TraceIdProvider.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.libs.llm
+
+/**
+ * Supplies the CALLER's own distributed-trace id, so a gateway-side Langfuse trace can be joined
+ * to the service span that caused it (ADR-0265 slice 3 tail, #5671).
+ *
+ * Without this the two evidence trails do not meet. LiteLLM mints its own trace id per request, so
+ * a Langfuse trace answers "what did the gateway see" and nothing links it to the copilot span, the
+ * audit envelope or the Temporal run that produced the prompt. Reconstructing an incident then means
+ * matching on wall-clock and model name, which is not an identifier.
+ *
+ * The second thing it buys is a FALSIFIABLE ingestion probe. Langfuse v2 exposes no Prometheus
+ * endpoint and LiteLLM's callback metrics are an Enterprise feature, so "traces are landing" has had
+ * no observable of any kind — a green Langfuse pod with a rejected callback key looks exactly like a
+ * healthy one. When the caller chooses the id, the check becomes: issue a call carrying a known id,
+ * then look that id up. Absence is then a negative result rather than an unanswerable question.
+ *
+ * [NONE] is the deliberate default for a caller that has no trace context. It returns null, and a
+ * null id emits **no metadata at all** — see [isValidTraceId].
+ */
+fun interface TraceIdProvider {
+
+    /** The current trace id, or null when there is no active trace. Must never throw. */
+    fun currentTraceId(): String?
+
+    companion object {
+        /** No trace context — the safe default; callers that supply nothing stay as they were. */
+        val NONE = TraceIdProvider { null }
+    }
+}
+
+/**
+ * True for a W3C trace id that identifies something: 32 lowercase hex characters, not all zeroes.
+ *
+ * The all-zero id is why this predicate exists rather than a null check. OpenTelemetry returns
+ * `00000000000000000000000000000000` from an INVALID span context — an unsampled call, a thread with
+ * no context, a service without the OTel extension — and it is a perfectly well-formed string. Sent
+ * as `metadata.trace_id` it would collapse every untraced call in the fleet onto one shared Langfuse
+ * trace, which is worse than sending nothing: the correlation would exist, be wrong, and look right.
+ * Same family as this repo's `Instant.EPOCH` default — a sentinel that every reader accepts.
+ */
+fun isValidTraceId(traceId: String?): Boolean = traceId != null &&
+    traceId.length == TRACE_ID_HEX_LENGTH &&
+    traceId.all { it in '0'..'9' || it in 'a'..'f' } &&
+    traceId.any { it != '0' }
+
+private const val TRACE_ID_HEX_LENGTH = 32

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClient.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClient.kt
@@ -53,6 +53,10 @@ class OpenAiCompatibleLlmGatewayClient(
     // stays a plain constructible class — `DomainMetrics` is the CDI bean that implements it, and
     // producing one from here would drag Micrometer into every consumer's Arc type closure.
     private val metrics: LlmCallMetricsPort = LlmCallMetricsPort.NONE,
+    // Defaults ON, because a correlation id nobody wires up is a correlation id that does not exist
+    // — and this is the one place all nine gateway callers pass through. The provider answers null
+    // wherever OpenTelemetry is absent, so switching it on costs nothing where there is no trace.
+    private val traceIds: TraceIdProvider = OtelTraceIdProvider,
 ) : LlmGatewayPort {
 
     private val log = Logger.getLogger(OpenAiCompatibleLlmGatewayClient::class.java)
@@ -72,11 +76,23 @@ class OpenAiCompatibleLlmGatewayClient(
             return null
         }
         val url = "${baseUrl.trimEnd('/')}/chat/completions"
+        // LiteLLM forwards `metadata` verbatim to its logging callbacks, so `trace_id` is what the
+        // gateway hands Langfuse instead of minting one — that is the whole join between the two
+        // evidence trails. Omitted entirely when there is no valid trace: an absent key leaves
+        // LiteLLM's own id generation in charge, whereas a placeholder would fuse unrelated calls
+        // onto one trace. Every other OpenAI-compatible backend ignores an unknown top-level field,
+        // and it is NON_NULL-serialized, so a null adds nothing to the wire.
+        // runCatching, not a bare call: [TraceIdProvider] documents that it must never throw, and a
+        // documented obligation is not an enforced one — a caller-supplied provider that breaks would
+        // otherwise propagate out of chat() and cost a completion for want of a correlation id. This
+        // read sits OUTSIDE the request try/catch, so nothing else would have caught it.
+        val traceId = runCatching { traceIds.currentTraceId() }.getOrNull()?.takeIf { isValidTraceId(it) }
         val body = ChatRequest(
             model = model,
             messages = listOf(ChatMessage("system", systemPrompt), ChatMessage("user", userPrompt)),
             temperature = temperature,
             maxTokens = maxTokens,
+            metadata = traceId?.let { ChatMetadata(traceId = it) },
         )
         // Nanos, not a Timer.Sample: the metrics port is a pure-domain interface and may not carry a
         // Micrometer type. Measured around the whole attempt, so a timeout — the slowest and most
@@ -142,7 +158,18 @@ internal data class ChatRequest(
     val temperature: Double = 0.2,
     @JsonProperty("max_tokens") val maxTokens: Int = 700,
     val stream: Boolean = false,
+    val metadata: ChatMetadata? = null,
 )
+
+/**
+ * The LiteLLM proxy's pass-through metadata block (ADR-0265 slice 3 tail, #5671).
+ *
+ * Only [traceId] is carried. It is the caller's own W3C trace id, which makes the Langfuse trace
+ * addressable by something the calling service already knows — both for incident reconstruction and
+ * as the only falsifiable ingestion probe available on Langfuse v2.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+internal data class ChatMetadata(@JsonProperty("trace_id") val traceId: String)
 
 internal data class ChatMessage(val role: String, val content: String)
 

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/llm/OtelTraceIdProvider.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/llm/OtelTraceIdProvider.kt
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.libs.llm
+
+/**
+ * Reads the ambient OpenTelemetry trace id, and returns null wherever OTel is not there to ask.
+ *
+ * Reflection, deliberately, rather than a compile-time dependency on `io.opentelemetry.api`. Nine
+ * services construct [OpenAiCompatibleLlmGatewayClient] and only some of them apply
+ * `quarkus-opentelemetry`; a direct reference would resolve against a `compileOnly` artifact here
+ * and then throw `NoClassDefFoundError` at runtime in the ones that do not carry it — on the LLM
+ * call path, turning a missing correlation id into a failed model call. The reflective read cannot
+ * do that: an absent class is one more null.
+ *
+ * It also keeps this module's `compileOnly` block from growing another version literal that must be
+ * re-pinned by hand on every Quarkus platform bump (see this module's `build.gradle.kts` for what
+ * that drift has already cost).
+ *
+ * Cost of the reflection is a handful of `Method.invoke`s against a network call — unmeasurable.
+ */
+object OtelTraceIdProvider : TraceIdProvider {
+
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
+    override fun currentTraceId(): String? = try {
+        val spanClass = Class.forName("io.opentelemetry.api.trace.Span")
+        val span = spanClass.getMethod("current").invoke(null)
+        val spanContext = spanClass.getMethod("getSpanContext").invoke(span)
+        val traceId = spanContext.javaClass.getMethod("getTraceId").invoke(spanContext) as? String
+        // Validated here, not just at the call site: an INVALID span context yields the
+        // all-zero id, which is a string this method must not hand out as an identifier.
+        traceId?.takeIf { isValidTraceId(it) }
+    } catch (ex: Exception) {
+        // OTel absent, shaded, or an API change. Correlation is best-effort by construction and
+        // must never be able to fail a model call, so every failure is the same answer: none.
+        null
+    } catch (ex: LinkageError) {
+        // NoClassDefFoundError / IncompatibleClassChangeError are Errors, not Exceptions — the
+        // exact gap that made an ONNX field initializer fail every endpoint of its bean (#3376).
+        null
+    }
+}

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/llm/LlmTraceCorrelationTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/llm/LlmTraceCorrelationTest.kt
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.libs.llm
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+
+/**
+ * Asserts what actually goes ON THE WIRE for trace correlation (ADR-0265 tail, #5671).
+ *
+ * Against a real in-JVM HTTP stub rather than a mocked client, because the property under test is a
+ * serialization one: `metadata.trace_id` present with the caller's id, and the `metadata` key ABSENT
+ * — not null, not a placeholder — whenever there is no valid trace. A mock of the client cannot
+ * distinguish an omitted JSON key from a null one, and that distinction is the whole point.
+ */
+class LlmTraceCorrelationTest {
+
+    private var server: HttpServer? = null
+    private var lastRequestBody: String? = null
+
+    @AfterEach
+    fun stop() {
+        server?.stop(0)
+    }
+
+    private fun startStub(): String {
+        val srv = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        srv.createContext("/v1/chat/completions") { ex: HttpExchange ->
+            lastRequestBody = ex.requestBody.readBytes().toString(StandardCharsets.UTF_8)
+            val bytes = OK_BODY.toByteArray(StandardCharsets.UTF_8)
+            ex.sendResponseHeaders(HTTP_OK, bytes.size.toLong())
+            ex.responseBody.use { it.write(bytes) }
+        }
+        srv.start()
+        server = srv
+        return "http://127.0.0.1:${srv.address.port}/v1"
+    }
+
+    private fun callWith(traceIds: TraceIdProvider): String {
+        val url = startStub()
+        val client = OpenAiCompatibleLlmGatewayClient(
+            baseUrl = url,
+            model = "test-model",
+            apiKey = "test-key",
+            traceIds = traceIds,
+        )
+        runBlocking { client.chat("sys", "user") }
+        return requireNotNull(lastRequestBody) { "the stub captured no request body" }
+    }
+
+    @Test
+    fun `a valid caller trace id is sent to the gateway as metadata trace_id`() {
+        val body = callWith { VALID_TRACE_ID }
+
+        assertThat(body).contains("\"metadata\"")
+        assertThat(body).contains("\"trace_id\":\"$VALID_TRACE_ID\"")
+    }
+
+    @Test
+    fun `no trace context sends no metadata key at all`() {
+        val body = callWith(TraceIdProvider.NONE)
+
+        assertThat(body).doesNotContain("metadata")
+        assertThat(body).doesNotContain("trace_id")
+        // Still a well-formed request: correlation is additive, never a precondition for the call.
+        assertThat(body).contains("\"model\":\"test-model\"")
+    }
+
+    @Test
+    fun `the all-zero OpenTelemetry invalid trace id is never sent`() {
+        // The case that motivates isValidTraceId: OTel returns this from an INVALID span context,
+        // it is a well-formed 32-hex string, and sending it would fuse every untraced call in the
+        // fleet onto one shared Langfuse trace — a correlation that exists, is wrong, and looks right.
+        val body = callWith { "0".repeat(TRACE_ID_LENGTH) }
+
+        assertThat(body).doesNotContain("metadata")
+        assertThat(body).doesNotContain("0000000000")
+    }
+
+    @Test
+    fun `a malformed trace id is rejected rather than forwarded`() {
+        assertThat(callWith { "not-a-trace-id" }).doesNotContain("metadata")
+        assertThat(callWith { VALID_TRACE_ID.uppercase() }).doesNotContain("metadata")
+        assertThat(callWith { VALID_TRACE_ID.dropLast(1) }).doesNotContain("metadata")
+    }
+
+    @Test
+    fun `a provider that throws cannot break the model call`() {
+        // Correlation is best-effort. OtelTraceIdProvider already swallows everything, but a caller
+        // may supply its own provider, and a failure to identify a trace must never cost a completion.
+        val url = startStub()
+        val client = OpenAiCompatibleLlmGatewayClient(
+            baseUrl = url,
+            model = "test-model",
+            apiKey = "test-key",
+            traceIds = { error("no trace backend") },
+        )
+
+        val answer = runBlocking { client.chat("sys", "user") }
+
+        // The completion still comes back, uncorrelated. Written first and RED: the trace read sits
+        // outside the request try/catch, so before the runCatching in chat() this propagated an
+        // IllegalStateException out of a call that would otherwise have succeeded.
+        assertThat(answer).isEqualTo("hi")
+        assertThat(lastRequestBody).doesNotContain("metadata")
+    }
+
+    @Test
+    fun `the OTel provider answers null when OpenTelemetry is not on the classpath`() {
+        // libs-runtime does not depend on io.opentelemetry, so this test IS the absent-OTel case:
+        // it proves the reflective read degrades to null instead of throwing NoClassDefFoundError
+        // on the LLM path in the services that do not carry the extension.
+        assertThat(OtelTraceIdProvider.currentTraceId()).isNull()
+    }
+
+    @Test
+    fun `isValidTraceId accepts only a 32-hex non-zero lowercase id`() {
+        assertThat(isValidTraceId(VALID_TRACE_ID)).isTrue()
+        assertThat(isValidTraceId(null)).isFalse()
+        assertThat(isValidTraceId("")).isFalse()
+        assertThat(isValidTraceId("0".repeat(TRACE_ID_LENGTH))).isFalse()
+        assertThat(isValidTraceId(VALID_TRACE_ID.uppercase())).isFalse()
+        assertThat(isValidTraceId(VALID_TRACE_ID + "a")).isFalse()
+        assertThat(isValidTraceId("g".repeat(TRACE_ID_LENGTH))).isFalse()
+    }
+
+    private companion object {
+        const val TRACE_ID_LENGTH = 32
+        const val VALID_TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736"
+        const val HTTP_OK = 200
+        const val OK_BODY = """{"choices":[{"message":{"role":"assistant","content":"hi"}}]}"""
+    }
+}


### PR DESCRIPTION
Part of the ADR-0265 tail (#5671). **Scoped around what already landed** — see the state check below.

## What was already done before this PR

The issue's "still unbuilt" list is largely stale. On live `main`:

| Issue item | State |
|---|---|
| Slice 1 — Kotlin reasoning graph, `reasoning:` reconciled | **done**, #5681 (merged) — `ReasoningGraph` in libs-domain, `agents.yaml` renamed `langgraph` → `kotlin-graph-over-temporal` |
| Slice 4 — pgvector retrieval | **done** — `V3__help_embeddings.sql`, `PgVectorPassageIndex`, `HybridHelpRetrieval`, `HelpCorpusIndexer`, `PgVectorPassageIndexIT` |
| `agents.yaml` observability/guardrails as-built notes | **done**, #5681 |

So this PR takes the next genuinely open item: **correlating the gateway-side Langfuse trace id with the calling service's own OTel trace**.

## What this changes

LiteLLM mints its own trace id per request. A Langfuse trace therefore answered *"what did the gateway see"* and nothing joined it to the copilot span, the audit envelope, or the Temporal run that produced the prompt — incident reconstruction meant matching on wall-clock and model name, which is not an identifier.

`OpenAiCompatibleLlmGatewayClient` — the single choke point all nine gateway callers pass through — now sends the caller's W3C trace id as LiteLLM `metadata.trace_id`, which LiteLLM forwards verbatim to its logging callback.

Two design points carry the weight:

- **The all-zero id is refused.** OpenTelemetry returns `00000000000000000000000000000000` from an INVALID span context, and it is a perfectly well-formed 32-hex string. Sent as metadata it would fuse every untraced call in the fleet onto one shared Langfuse trace — a correlation that exists, is wrong, and looks right. Same family as this repo's `Instant.EPOCH` default. No valid trace ⇒ the `metadata` key is **omitted**, leaving LiteLLM's own id generation in charge.
- **The OTel read is reflective, and defaults ON.** Only some of the nine callers apply `quarkus-opentelemetry`; a compile-time reference would resolve against a `compileOnly` artifact here and then throw `NoClassDefFoundError` on the LLM call path in the rest. `LinkageError` is caught alongside `Exception` — the gap that made an ONNX field initializer fail every endpoint of its bean (#3376). Defaulting the constructor parameter is what keeps this from being a mechanism nobody wires up.

## What this deliberately does NOT claim

**It does not close the Langfuse ingestion gap.** Langfuse v2 exposes no Prometheus endpoint and LiteLLM's callback metrics are Enterprise, so there is still no series to alert on. What it does is make the only available check *exact*: runbook 0012's probe was `traces?limit=1` — "is there **any** trace" — and is now a lookup of the id you know was sent. A probe a human runs, not a control that watches.

The runbook also now names the two ways that probe can answer "no" for the wrong reason (caller without the OTel extension; an unsampled span yielding the all-zero id), so a negative result is interpretable rather than alarming.

**The `agents.yaml` caveat is left exactly as it stands** — it says ingestion has no telemetry of its own and that #5671 tracks closing it. Both still true. No as-built note is upgraded, so no derived tail is touched.

**Not verified end to end, and cannot be right now.** Every LLM call in the sandbox currently fails `http_error` (41/41, #5736 — a credentials-class problem needing one in-cluster curl), so nothing downstream of a model call is exercisable. Everything below is wire-level and local.

## Still open on #5671 after this

- Langfuse ingestion **telemetry** (a series, not a probe)
- Langfuse trace retention policy
- SSO in front of the Langfuse UI

## Verification

7 wire-level tests against a real in-JVM `com.sun` HTTP stub, asserting the **serialized body** — a mocked client cannot distinguish an omitted JSON key from a null one, and that distinction is the property under test.

Falsified by breaking each guard and confirming the matching test goes red:

| Break | Result |
|---|---|
| drop the `isValidTraceId` filter | all-zero **and** malformed tests FAIL |
| force `metadata = null` | correlation test FAILS |
| remove the `runCatching` guard | throwing-provider test FAILS |

Restored: green. That last test **was written red** — the trace read sits outside the request try/catch, so before the guard a throwing provider propagated an exception out of a call that would otherwise have succeeded. The test found a real defect in my own first cut.

`:openbank-libs-domain:test :openbank-libs-runtime:test --rerun-tasks` — **709 tests, 0 failures, 0 skipped**. `ktlintCheck` + `detekt` green on both modules. `copilot-service`, `agent-service` and `devops-agent` recompile unchanged: the constructor gained a defaulted parameter, so no producer edit.

No CDI wiring, no config, no migration, no `agents.yaml`, no derived artefact.

## Linked issues

Refs #5671
Refs ADR-0265
