### PR TITLE
fix(copilot): record an LLM metric on every streaming outcome

### DIFF
--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/model/OpenAiCompatibleModelProvider.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/model/OpenAiCompatibleModelProvider.kt
@@ -74,8 +74,12 @@ class OpenAiCompatibleModelProvider : ModelProvider {
     override suspend fun complete(model: ModelDescriptor, request: ModelRequest): ModelResponse {
         val base = (model.endpoint ?: error("model '${model.id}' has no endpoint (base URL) configured"))
             .trimEnd('/')
+        // Which egress backend this attempt was addressed to (#5736). Derived from the endpoint the
+        // model descriptor carries, so it follows a repoint (direct provider -> LiteLLM gateway)
+        // without a second config knob to keep in step.
+        val provider = LlmCallMetricsPort.providerOf(base)
         if (apiKey.isBlank()) {
-            metrics.recordCall(model.id, LlmCallMetricsPort.OUTCOME_NOT_CONFIGURED, 0, 0, 0)
+            metrics.recordCall(model.id, LlmCallMetricsPort.OUTCOME_NOT_CONFIGURED, 0, 0, 0, provider)
         }
         require(apiKey.isNotBlank()) {
             "agent.model.openai.api-key is empty — set the backend API key (e.g. GROQ_API_KEY) to use model '${model.id}'"
@@ -102,6 +106,7 @@ class OpenAiCompatibleModelProvider : ModelProvider {
                 0,
                 0,
                 System.nanoTime() - startedAt,
+                provider,
             )
             throw ex
         }
@@ -114,6 +119,7 @@ class OpenAiCompatibleModelProvider : ModelProvider {
                 0,
                 0,
                 System.nanoTime() - startedAt,
+                provider,
             )
             error("model backend HTTP ${resp.statusCode()} for '${model.id}'")
         }
@@ -124,6 +130,7 @@ class OpenAiCompatibleModelProvider : ModelProvider {
             parsed.usage.inputTokens,
             parsed.usage.outputTokens,
             System.nanoTime() - startedAt,
+            provider,
         )
         return parsed
     }

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/model/OpenAiCompatibleModelProvider.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/model/OpenAiCompatibleModelProvider.kt
@@ -75,8 +75,12 @@ class OpenAiCompatibleModelProvider : ModelProvider {
     override suspend fun complete(model: ModelDescriptor, request: ModelRequest): ModelResponse {
         val base = (model.endpoint ?: error("model '${model.id}' has no endpoint (base URL) configured"))
             .trimEnd('/')
+        // Which egress backend this attempt was addressed to (#5736). Derived from the endpoint the
+        // model descriptor carries, so it follows a repoint (direct provider -> LiteLLM gateway)
+        // without a second config knob to keep in step.
+        val provider = LlmCallMetricsPort.providerOf(base)
         if (apiKey.isBlank()) {
-            metrics.recordCall(model.id, LlmCallMetricsPort.OUTCOME_NOT_CONFIGURED, 0, 0, 0)
+            metrics.recordCall(model.id, LlmCallMetricsPort.OUTCOME_NOT_CONFIGURED, 0, 0, 0, provider)
         }
         require(apiKey.isNotBlank()) {
             "copilot.model.api-key is empty — set the backend API key to use model '${model.id}'"
@@ -103,6 +107,7 @@ class OpenAiCompatibleModelProvider : ModelProvider {
                 0,
                 0,
                 System.nanoTime() - startedAt,
+                provider,
             )
             throw ex
         }
@@ -115,6 +120,7 @@ class OpenAiCompatibleModelProvider : ModelProvider {
                 0,
                 0,
                 System.nanoTime() - startedAt,
+                provider,
             )
             error("model backend HTTP ${resp.statusCode()} for '${model.id}'")
         }
@@ -125,6 +131,7 @@ class OpenAiCompatibleModelProvider : ModelProvider {
             parsed.usage.inputTokens,
             parsed.usage.outputTokens,
             System.nanoTime() - startedAt,
+            provider,
         )
         return parsed
     }

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/model/OpenAiCompatibleModelProvider.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/model/OpenAiCompatibleModelProvider.kt
@@ -18,11 +18,11 @@ import com.openbank.copilot.domain.model.StopReason
 import com.openbank.copilot.domain.model.ToolInvocation
 import com.openbank.copilot.domain.model.ToolSpec
 import com.openbank.libs.llm.LlmCallMetricsPort
-import com.openbank.libs.observability.LlmCallMetrics
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.eclipse.microprofile.config.ConfigProvider
 import org.jboss.logging.Logger
+import java.io.InputStream
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
@@ -54,8 +54,11 @@ class OpenAiCompatibleModelProvider : ModelProvider {
 
     // Field injection, not a constructor arg: the bean is instantiated by Arc, and detekt's
     // LongParameterList fires AT constructorThreshold rather than above it.
+    // Injected as the PORT, not the Micrometer impl: recordCall is what this class depends on, and
+    // a test must be able to substitute a probe that records what was emitted. LlmCallMetrics is
+    // the only bean implementing it, so CDI resolution is unchanged.
     @Inject
-    lateinit var metrics: LlmCallMetrics
+    lateinit var metrics: LlmCallMetricsPort
 
     // Resolved lazily (NOT @ConfigProperty-injected): an un-seeded/empty key would otherwise fail
     // config load at boot (SmallRye SRCFG00040 on an empty String binding) and CrashLoop the pod.
@@ -68,9 +71,19 @@ class OpenAiCompatibleModelProvider : ModelProvider {
 
     private val log = Logger.getLogger(OpenAiCompatibleModelProvider::class.java)
 
-    private val http: HttpClient by lazy {
+    private val defaultHttp: HttpClient by lazy {
         HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_S)).build()
     }
+
+    /**
+     * Test seam. A streaming outcome cannot be observed from a live call — every LLM call in this
+     * environment currently fails on credentials (#5736) — so the SSE source has to be stubbed to
+     * assert what gets recorded. Replaces the transport ONLY: request building, status handling and
+     * the SSE read loop all still run for real.
+     */
+    internal var httpOverride: HttpClient? = null
+
+    private val http: HttpClient get() = httpOverride ?: defaultHttp
 
     override suspend fun complete(model: ModelDescriptor, request: ModelRequest): ModelResponse {
         val base = (model.endpoint ?: error("model '${model.id}' has no endpoint (base URL) configured"))
@@ -151,19 +164,32 @@ class OpenAiCompatibleModelProvider : ModelProvider {
     ): ModelResponse {
         val base = (model.endpoint ?: error("model '${model.id}' has no endpoint (base URL) configured"))
             .trimEnd('/')
+        val provider = LlmCallMetricsPort.providerOf(base)
+        if (apiKey.isBlank()) {
+            metrics.recordCall(
+                model.id,
+                LlmCallMetricsPort.OUTCOME_NOT_CONFIGURED,
+                LlmCallMetricsPort.TOKENS_UNKNOWN,
+                LlmCallMetricsPort.TOKENS_UNKNOWN,
+                0,
+                provider,
+            )
+        }
         require(apiKey.isNotBlank()) {
             "copilot.model.api-key is empty — set the backend API key to use model '${model.id}'"
         }
         val payload = objectMapper.writeValueAsString(buildRequestBody(model, request).apply { put("stream", true) })
-        val httpRequest = HttpRequest.newBuilder(URI.create("$base/chat/completions"))
-            .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_S))
-            .header("Authorization", "Bearer $apiKey")
-            .header("Content-Type", "application/json")
-            .POST(HttpRequest.BodyPublishers.ofString(payload))
-            .build()
+        val httpRequest = streamRequest("$base/chat/completions", apiKey, payload, REQUEST_TIMEOUT_S)
 
         // BodyHandlers.ofInputStream() returns as soon as headers arrive; body is streamed on demand.
-        val resp = http.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+        val startedAt = System.nanoTime()
+        val resp = try {
+            http.send(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+        } catch (ex: java.io.IOException) {
+            // Nothing was ever answered: connect, DNS, TLS or a request timeout.
+            recordStream(metrics, model.id, LlmCallMetricsPort.OUTCOME_EXCEPTION, null, startedAt, provider)
+            throw ex
+        }
         if (resp.statusCode() !in OK_RANGE) {
             log.warnf(
                 "openai-compat backend %s returned HTTP %d (stream) for model %s",
@@ -171,20 +197,29 @@ class OpenAiCompatibleModelProvider : ModelProvider {
                 resp.statusCode(),
                 model.id,
             )
+            recordStream(metrics, model.id, LlmCallMetricsPort.OUTCOME_HTTP_ERROR, null, startedAt, provider)
             error("model backend HTTP ${resp.statusCode()} for '${model.id}'")
         }
 
         val acc = StreamAccumulator(model.id)
-        resp.body().bufferedReader().use { reader ->
-            for (line in reader.lineSequence()) {
-                val data = line.removePrefix("data: ").trimEnd()
-                when {
-                    data == "[DONE]" -> break
-                    data.isNotBlank() -> processDataLine(data, acc, onChunk)
-                }
-            }
+        try {
+            readSse(resp.body()) { data -> processDataLine(data, acc, onChunk) }
+            // Deliberately broad, and @Suppress'd for it: the point is that NO failure after the
+            // 200 may go unrecorded, and the ones worth catching are exactly the ones nobody
+            // enumerated in advance — a reset, an idle timeout, a truncated body, a decoding
+            // failure. Narrowing this to IOException would leave the rest silent again, which is
+            // the defect (#5878). The exception is rethrown unchanged.
+        } catch (@Suppress("TooGenericExceptionCaught") ex: Exception) {
+            // The 200 already happened and tokens may already be on the user's screen, so this is
+            // neither an http_error nor a call that never started — see OUTCOME_STREAM_ABORTED.
+            // Whatever `usage` was accumulated so far is a partial count of an unfinished
+            // generation, which is not the call's token cost, so it is reported as unknown.
+            log.warnf("openai-compat stream from %s aborted mid-flight for model %s", base, model.id)
+            recordStream(metrics, model.id, LlmCallMetricsPort.OUTCOME_STREAM_ABORTED, null, startedAt, provider)
+            throw ex
         }
 
+        recordStream(metrics, model.id, LlmCallMetricsPort.OUTCOME_SUCCESS, acc, startedAt, provider)
         val invocations = buildInvocations(acc)
         return ModelResponse(
             content = acc.contentBuf.toString(),
@@ -194,18 +229,6 @@ class OpenAiCompatibleModelProvider : ModelProvider {
             modelId = model.id,
             modelVersion = acc.modelVersion,
         )
-    }
-
-    /** Mutable accumulation state for one SSE stream. */
-    private class StreamAccumulator(defaultModelId: String) {
-        val contentBuf = StringBuilder()
-        var finishReason = "stop"
-        var modelVersion = defaultModelId
-        var inputTokens = 0
-        var outputTokens = 0
-        val toolIds = mutableMapOf<Int, String>()
-        val toolNames = mutableMapOf<Int, String>()
-        val toolArgBufs = mutableMapOf<Int, StringBuilder>()
     }
 
     /** Process one non-empty, non-[DONE] SSE data payload into [acc], emitting text to [onChunk]. */
@@ -238,9 +261,10 @@ class OpenAiCompatibleModelProvider : ModelProvider {
         }
 
         // Usage appears in the last data chunk before [DONE] on some backends.
-        chunk.path("usage").takeUnless { it.isMissingNode }?.let { u ->
+        chunk.path("usage").takeUnless { it.isMissingNode || it.isNull }?.let { u ->
             acc.inputTokens = u.path("prompt_tokens").asInt(0)
             acc.outputTokens = u.path("completion_tokens").asInt(0)
+            acc.usageReported = true
         }
     }
 
@@ -369,5 +393,75 @@ class OpenAiCompatibleModelProvider : ModelProvider {
         const val CONNECT_TIMEOUT_S = 10L
         const val REQUEST_TIMEOUT_S = 60L
         val OK_RANGE = 200..299
+    }
+}
+
+/** Mutable accumulation state for one SSE stream. */
+private class StreamAccumulator(defaultModelId: String) {
+    val contentBuf = StringBuilder()
+    var finishReason = "stop"
+    var modelVersion = defaultModelId
+    var inputTokens = 0
+    var outputTokens = 0
+
+    /** Whether a `usage` object was ever seen on the wire — "0 tokens" vs "never told". */
+    var usageReported = false
+    val toolIds = mutableMapOf<Int, String>()
+    val toolNames = mutableMapOf<Int, String>()
+    val toolArgBufs = mutableMapOf<Int, StringBuilder>()
+}
+
+/**
+ * One streaming outcome, recorded exactly once per attempt.
+ *
+ * Token accounting is the whole reason this is a helper rather than five inline calls. A
+ * streaming response has no single body to read `usage` from: an OpenAI-compatible backend may
+ * send a final usage chunk before `[DONE]`, and many send none at all. So [acc] is `null` for
+ * every failure path, and even on success the counts are only reported when the stream actually
+ * carried them — otherwise [LlmCallMetricsPort.TOKENS_UNKNOWN], never `0`, which would be
+ * indistinguishable from a genuinely free call and would quietly understate every cost rule
+ * reading `openbank_llm_tokens_total`.
+ */
+private fun recordStream(
+    metrics: LlmCallMetricsPort,
+    modelId: String,
+    outcome: String,
+    acc: StreamAccumulator?,
+    startedAt: Long,
+    provider: String,
+) {
+    val counted = acc?.takeIf { it.usageReported }
+    metrics.recordCall(
+        modelId,
+        outcome,
+        counted?.inputTokens ?: LlmCallMetricsPort.TOKENS_UNKNOWN,
+        counted?.outputTokens ?: LlmCallMetricsPort.TOKENS_UNKNOWN,
+        System.nanoTime() - startedAt,
+        provider,
+    )
+}
+
+/**
+ * Builds the streaming POST. Top-level, like the two declarations above: this class sits AT detekt's
+ * `TooManyFunctions` ceiling of 11, and these three carry no instance state.
+ */
+private fun streamRequest(url: String, apiKey: String, payload: String, timeoutSeconds: Long): HttpRequest =
+    HttpRequest.newBuilder(URI.create(url))
+        .timeout(Duration.ofSeconds(timeoutSeconds))
+        .header("Authorization", "Bearer $apiKey")
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(payload))
+        .build()
+
+/** Reads an SSE body line by line, handing each non-empty `data:` payload before `[DONE]` to [onData]. */
+private suspend fun readSse(body: InputStream, onData: suspend (String) -> Unit) {
+    body.bufferedReader().use { reader ->
+        for (line in reader.lineSequence()) {
+            val data = line.removePrefix("data: ").trimEnd()
+            when {
+                data == "[DONE]" -> return
+                data.isNotBlank() -> onData(data)
+            }
+        }
     }
 }

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/model/OpenAiCompatibleModelProviderStreamMetricsTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/model/OpenAiCompatibleModelProviderStreamMetricsTest.kt
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.copilot.infrastructure.model
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.openbank.copilot.domain.model.ChatMessage
+import com.openbank.copilot.domain.model.ChatRole
+import com.openbank.copilot.domain.model.ModelDescriptor
+import com.openbank.copilot.domain.model.ModelRequest
+import com.openbank.libs.llm.LlmCallMetricsPort
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.net.http.HttpClient
+
+/**
+ * `completeStream` recorded NO metric on any outcome (#5878), so the four cases below were each
+ * completely invisible: `openbank_llm_requests_total` counted only the non-streaming path.
+ *
+ * Everything is driven through a stubbed [HttpClient] rather than a live call — every LLM call in
+ * this environment currently fails on credentials (#5736), so a test that hoped for a real stream
+ * could not assert a success outcome at all. The stub replaces the transport only: the request is
+ * still built, the status still checked, and the real SSE read loop still parses the bytes.
+ *
+ * Each test asserts the metric that was RECORDED — outcome, provider and token semantics — not that
+ * a call ran without throwing. Falsified by deleting each `recordStream` emission in turn and
+ * confirming the matching test goes red.
+ */
+class OpenAiCompatibleModelProviderStreamMetricsTest {
+
+    private data class Recorded(
+        val model: String,
+        val outcome: String,
+        val promptTokens: Int,
+        val completionTokens: Int,
+        val durationNanos: Long,
+        val provider: String,
+    )
+
+    private val recorded = mutableListOf<Recorded>()
+
+    // The key is read live from MicroProfile Config on every call, so a system property is enough
+    // and no Quarkus boot is needed. Cleared again so the not_configured case can remove it.
+    @BeforeEach
+    fun seedKey() {
+        System.setProperty(KEY_PROPERTY, "test-key")
+    }
+
+    @AfterEach
+    fun clearKey() {
+        System.clearProperty(KEY_PROPERTY)
+    }
+
+    private val probe = object : LlmCallMetricsPort {
+        override fun recordCall(
+            model: String,
+            outcome: String,
+            promptTokens: Int,
+            completionTokens: Int,
+            durationNanos: Long,
+            provider: String,
+        ) {
+            recorded += Recorded(model, outcome, promptTokens, completionTokens, durationNanos, provider)
+        }
+    }
+
+    private fun provider(client: HttpClient?): OpenAiCompatibleModelProvider = OpenAiCompatibleModelProvider().also {
+        it.objectMapper = ObjectMapper().registerKotlinModule()
+        it.metrics = probe
+        it.httpOverride = client
+    }
+
+    private val descriptor = ModelDescriptor(
+        id = "deepseek-ai/DeepSeek-V3.2",
+        provider = "openai-compat",
+        endpoint = "http://litellm.ai-platform.svc:4000/v1",
+    )
+
+    private val request = ModelRequest(
+        model = "deepseek-ai/DeepSeek-V3.2",
+        messages = listOf(ChatMessage(role = ChatRole.USER, content = "jaký je můj zůstatek?")),
+    )
+
+    private fun sse(vararg lines: String): InputStream = ByteArrayInputStream(lines.joinToString("\n").toByteArray())
+
+    private suspend fun stream(client: HttpClient): Result<Unit> =
+        runCatching { provider(client).completeStream(descriptor, request) {} }.map { }
+
+    @Test
+    fun `a stream that completes records success with the accumulated token counts`(): Unit = runBlocking {
+        val client = StubHttpClient(
+            200,
+            sse(
+                """data: {"model":"deepseek-ai/DeepSeek-V3.2","choices":[{"delta":{"content":"Zůstatek"}}]}""",
+                """data: {"choices":[{"delta":{"content":" je 1000 CZK."},"finish_reason":"stop"}],""" +
+                    """"usage":{"prompt_tokens":31,"completion_tokens":7}}""",
+                "data: [DONE]",
+            ),
+        )
+        val chunks = mutableListOf<String>()
+        val response = provider(client).completeStream(descriptor, request) { chunks += it }
+
+        assertThat(chunks).containsExactly("Zůstatek", " je 1000 CZK.")
+        assertThat(response.content).isEqualTo("Zůstatek je 1000 CZK.")
+        assertThat(recorded).singleElement().satisfies({
+            assertThat(it.outcome).isEqualTo(LlmCallMetricsPort.OUTCOME_SUCCESS)
+            assertThat(it.model).isEqualTo("deepseek-ai/DeepSeek-V3.2")
+            assertThat(it.provider).isEqualTo(LlmCallMetricsPort.PROVIDER_LITELLM)
+            // Accumulated across chunks — the usage object arrives only in the last one.
+            assertThat(it.promptTokens).isEqualTo(31)
+            assertThat(it.completionTokens).isEqualTo(7)
+            assertThat(it.durationNanos).isPositive()
+        })
+    }
+
+    @Test
+    fun `a stream that reports no usage records unknown tokens, never zero`(): Unit = runBlocking {
+        // The common case: many OpenAI-compatible backends send no usage chunk when streaming.
+        val client = StubHttpClient(
+            200,
+            sse("""data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}""", "data: [DONE]"),
+        )
+        provider(client).completeStream(descriptor, request) {}
+
+        assertThat(recorded).singleElement().satisfies({
+            assertThat(it.outcome).isEqualTo(LlmCallMetricsPort.OUTCOME_SUCCESS)
+            // The distinction the whole issue turns on: 0 would be indistinguishable from a real
+            // zero and would silently understate openbank:llm_cost_usd_24h.
+            assertThat(it.promptTokens).isEqualTo(LlmCallMetricsPort.TOKENS_UNKNOWN)
+            assertThat(it.completionTokens).isEqualTo(LlmCallMetricsPort.TOKENS_UNKNOWN)
+            assertThat(it.promptTokens).isNotZero()
+        })
+    }
+
+    @Test
+    fun `a stream that fails after the 200 records stream_aborted, not success or http_error`(): Unit = runBlocking {
+        // A body that dies mid-flight: a real reset, idle timeout or truncated SSE surfaces exactly
+        // this way, AFTER a 200 and after tokens have already reached the user.
+        val body = object : InputStream() {
+            private val head = """data: {"choices":[{"delta":{"content":"Zůst"}}]}""".toByteArray()
+            private var i = 0
+            override fun read(): Int {
+                if (i >= head.size) throw IOException("connection reset by peer mid-stream")
+                return head[i++].toInt()
+            }
+        }
+        val delivered = mutableListOf<String>()
+        val ex = runCatching {
+            provider(StubHttpClient(200, body)).completeStream(descriptor, request) { delivered += it }
+        }.exceptionOrNull()
+
+        assertThat(ex).isInstanceOf(IOException::class.java)
+        assertThat(recorded).singleElement().satisfies({
+            assertThat(it.outcome).isEqualTo(LlmCallMetricsPort.OUTCOME_STREAM_ABORTED)
+            assertThat(it.outcome).isNotEqualTo(LlmCallMetricsPort.OUTCOME_SUCCESS)
+            assertThat(it.outcome).isNotEqualTo(LlmCallMetricsPort.OUTCOME_HTTP_ERROR)
+            assertThat(it.provider).isEqualTo(LlmCallMetricsPort.PROVIDER_LITELLM)
+            // A partial count of an unfinished generation is not the call's cost.
+            assertThat(it.promptTokens).isEqualTo(LlmCallMetricsPort.TOKENS_UNKNOWN)
+            assertThat(it.completionTokens).isEqualTo(LlmCallMetricsPort.TOKENS_UNKNOWN)
+        })
+    }
+
+    @Test
+    fun `a non-2xx before the stream opens records http_error`(): Unit = runBlocking {
+        val result = stream(StubHttpClient(401, sse("""{"error":"invalid api key"}""")))
+
+        assertThat(result.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
+        assertThat(recorded).singleElement().satisfies({
+            assertThat(it.outcome).isEqualTo(LlmCallMetricsPort.OUTCOME_HTTP_ERROR)
+            assertThat(it.provider).isEqualTo(LlmCallMetricsPort.PROVIDER_LITELLM)
+        })
+    }
+
+    @Test
+    fun `a transport failure before any response records exception`(): Unit = runBlocking {
+        val client = StubHttpClient(0, sse(), failWith = IOException("connect timed out"))
+        val result = stream(client)
+
+        assertThat(result.exceptionOrNull()).isInstanceOf(IOException::class.java)
+        assertThat(recorded).singleElement().satisfies({
+            assertThat(it.outcome).isEqualTo(LlmCallMetricsPort.OUTCOME_EXCEPTION)
+        })
+    }
+
+    @Test
+    fun `a blank api key records not_configured before the call leaves the process`(): Unit = runBlocking {
+        // The real degraded path — and it must be counted, not silent: `complete()` counted it and
+        // `completeStream()` did not.
+        System.clearProperty(KEY_PROPERTY)
+        val result = stream(StubHttpClient(200, sse("data: [DONE]")))
+
+        assertThat(result.exceptionOrNull()).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(recorded).singleElement().satisfies({
+            assertThat(it.outcome).isEqualTo(LlmCallMetricsPort.OUTCOME_NOT_CONFIGURED)
+            assertThat(it.provider).isEqualTo(LlmCallMetricsPort.PROVIDER_LITELLM)
+        })
+    }
+
+    private companion object {
+        const val KEY_PROPERTY = "copilot.model.api-key"
+    }
+}

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/model/StubHttpClient.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/model/StubHttpClient.kt
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.copilot.infrastructure.model
+
+import java.io.IOException
+import java.io.InputStream
+import java.net.Authenticator
+import java.net.CookieHandler
+import java.net.ProxySelector
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpHeaders
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.util.Optional
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLParameters
+import javax.net.ssl.SSLSession
+
+/**
+ * A stubbed SSE source. A real subclass of [HttpClient] rather than a lambda seam, so the provider's
+ * own request building, status handling and stream reading all run unchanged and only the bytes on
+ * the wire are ours. [failWith] simulates a transport failure that never produces a response.
+ */
+class StubHttpClient(
+    private val status: Int,
+    private val body: InputStream,
+    private val failWith: IOException? = null,
+) : HttpClient() {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any?> send(
+        request: HttpRequest,
+        responseBodyHandler: HttpResponse.BodyHandler<T>,
+    ): HttpResponse<T> {
+        failWith?.let { throw it }
+        return StubResponse(request, status, body) as HttpResponse<T>
+    }
+
+    override fun <T : Any?> sendAsync(
+        request: HttpRequest,
+        responseBodyHandler: HttpResponse.BodyHandler<T>,
+    ): CompletableFuture<HttpResponse<T>> = CompletableFuture.supplyAsync { send(request, responseBodyHandler) }
+
+    override fun <T : Any?> sendAsync(
+        request: HttpRequest,
+        responseBodyHandler: HttpResponse.BodyHandler<T>,
+        pushPromiseHandler: HttpResponse.PushPromiseHandler<T>?,
+    ): CompletableFuture<HttpResponse<T>> = sendAsync(request, responseBodyHandler)
+
+    override fun cookieHandler(): Optional<CookieHandler> = Optional.empty()
+    override fun connectTimeout(): Optional<Duration> = Optional.empty()
+    override fun followRedirects(): Redirect = Redirect.NEVER
+    override fun proxy(): Optional<ProxySelector> = Optional.empty()
+    override fun sslContext(): SSLContext = SSLContext.getDefault()
+    override fun sslParameters(): SSLParameters = SSLParameters()
+    override fun authenticator(): Optional<Authenticator> = Optional.empty()
+    override fun version(): Version = Version.HTTP_1_1
+    override fun executor(): Optional<Executor> = Optional.empty()
+
+    private class StubResponse(
+        private val request: HttpRequest,
+        private val status: Int,
+        private val body: InputStream,
+    ) : HttpResponse<InputStream> {
+        override fun statusCode(): Int = status
+        override fun request(): HttpRequest = request
+        override fun previousResponse(): Optional<HttpResponse<InputStream>> = Optional.empty()
+        override fun headers(): HttpHeaders = HttpHeaders.of(emptyMap()) { _, _ -> true }
+        override fun body(): InputStream = body
+        override fun sslSession(): Optional<SSLSession> = Optional.empty()
+        override fun uri(): URI = request.uri()
+        override fun version(): HttpClient.Version = HttpClient.Version.HTTP_1_1
+    }
+}

--- a/openbank-infra/gitops/components/observability/prometheus-rules-ai.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-ai.yaml
@@ -156,13 +156,35 @@ spec:
         # continuously while nothing is wrong. Add one only once a synthetic call runs on a known
         # interval, so that absence means something. Until then AiCallErrorRateHigh below is the
         # detector, and it only works while SOME calls are being attempted.
-        #
-        # Reliability. Deliberately excludes not_configured: a never-seeded agent is a different
+
+        # A call whose token usage the provider never reported. Same family as AiSpendUnpriced
+        # above and a trust alert about the cost figures rather than a cost alert: streaming
+        # backends may send no usage chunk at all, and recording 0 there would be a silent
+        # understatement, so those calls are counted here instead (#5878).
+        - alert: AiSpendUnmeasured
+          expr: sum by (model) (increase(openbank_llm_tokens_unreported_total[24h])) > 0
+          for: 1h
+          labels:
+            severity: warning
+            team: platform
+          annotations:
+            summary: "{{ $value | printf \"%.0f\" }} LLM calls to {{ $labels.model }} reported no token usage"
+            description: >-
+              These calls completed but the backend sent no `usage`, so their tokens are absent from
+              openbank_llm_tokens_total and every spend figure derived from it UNDERSTATES the real
+              cost by their share. Usually a streaming call against a backend that omits the final
+              usage chunk — set `stream_options.include_usage` for that model, or price the path
+              from the provider invoice instead of the dashboard.
+
+        # Reliability. `stream_aborted` (#5878) is in the numerator: a stream that dies after its
+        # 200 delivered a truncated answer to a waiting user, which is a failure — and it is the
+        # SSE path's characteristic failure, so leaving it out would make the interactive path the
+        # one this alert cannot see. Deliberately excludes not_configured: a never-seeded agent is a different
         # problem with a different fix, and folding it in here would make the error rate unusable.
         - alert: AiCallErrorRateHigh
           expr: |
             100 * (
-              sum by (model) (rate(openbank_llm_requests_total{outcome=~"http_error|exception"}[15m]))
+              sum by (model) (rate(openbank_llm_requests_total{outcome=~"http_error|exception|stream_aborted"}[15m]))
               /
               sum by (model) (rate(openbank_llm_requests_total{outcome!="not_configured"}[15m]))
             ) > 20

--- a/openbank-infra/gitops/components/observability/prometheus-rules-ai.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-ai.yaml
@@ -146,6 +146,17 @@ spec:
               figure on the AI dashboard UNDERSTATES the real cost by this model's share. Add the
               model to the price-book group in prometheus-rules-ai.yaml.
 
+        # No absence alert here, on purpose (#5736). The obvious companion to the rule below —
+        # `sum(rate(openbank_llm_requests_total{outcome="success"}[15m])) == 0` — is blind exactly
+        # when the path breaks completely: with no success series in existence the expression has
+        # no vector to compare and returns nothing, which is the same output as a healthy fleet.
+        # It would need `absent_over_time` guarding (same shape as #5733), and even guarded it
+        # cannot be written safely yet: LLM calls here are made by cron-scheduled agents and an
+        # interactive assistant, so silence is the RESTING state and an absence alert would fire
+        # continuously while nothing is wrong. Add one only once a synthetic call runs on a known
+        # interval, so that absence means something. Until then AiCallErrorRateHigh below is the
+        # detector, and it only works while SOME calls are being attempted.
+        #
         # Reliability. Deliberately excludes not_configured: a never-seeded agent is a different
         # problem with a different fix, and folding it in here would make the error rate unusable.
         - alert: AiCallErrorRateHigh

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/llm/LlmCallMetricsPort.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/llm/LlmCallMetricsPort.kt
@@ -38,8 +38,23 @@ interface LlmCallMetricsPort {
      * @param completionTokens from `usage.completion_tokens`; 0 when the provider omits it.
      * @param durationNanos wall-clock for the whole attempt, including a failed one — a timeout is
      *   the slowest and most interesting case, so timing only successes would hide it.
+     * @param provider the egress backend this attempt was ADDRESSED TO, from [providerOf] — the
+     *   gateway or vendor host the request went to, not the upstream vendor LiteLLM may route it on
+     *   to. A caller cannot observe the latter (that mapping lives in litellm-config), and a label
+     *   that claims knowledge the emitter does not have is worse than a coarse one. Defaulted to
+     *   [PROVIDER_UNKNOWN] so an un-migrated call site keeps compiling and stays honestly labelled
+     *   rather than silently mislabelled. It does NOT change what [outcome] means: the two tags are
+     *   independent, and every existing outcome vocabulary and alert keeps its meaning.
      */
-    fun recordCall(model: String, outcome: String, promptTokens: Int, completionTokens: Int, durationNanos: Long)
+    @Suppress("LongParameterList")
+    fun recordCall(
+        model: String,
+        outcome: String,
+        promptTokens: Int,
+        completionTokens: Int,
+        durationNanos: Long,
+        provider: String = PROVIDER_UNKNOWN,
+    )
 
     companion object {
         const val OUTCOME_SUCCESS = "success"
@@ -54,6 +69,48 @@ interface LlmCallMetricsPort {
          */
         const val OUTCOME_NOT_CONFIGURED = "not_configured"
 
+        // --- provider vocabulary (closed, like `outcome`) -------------------------------------
+        //
+        // Closed on purpose: this is a Prometheus label, and deriving it from a raw host would let
+        // any endpoint string become a new series. Anything unrecognised collapses to
+        // PROVIDER_OTHER, so a mis-set endpoint shows up as one extra series rather than a
+        // cardinality leak — and PROVIDER_UNKNOWN specifically means "the call site has not been
+        // migrated", which is a different fact from "the endpoint is not one we recognise".
+
+        /** In-cluster LiteLLM gateway (ADR-0174/0175) — the fleet's single egress choke point. */
+        const val PROVIDER_LITELLM = "litellm"
+        const val PROVIDER_GROQ = "groq"
+        const val PROVIDER_DEEPINFRA = "deepinfra"
+        const val PROVIDER_OPENAI = "openai"
+        const val PROVIDER_OLLAMA = "ollama"
+
+        /** A recognised call, an endpoint host that is not in the list above. */
+        const val PROVIDER_OTHER = "other"
+
+        /** The call site does not report a provider yet. */
+        const val PROVIDER_UNKNOWN = "unknown"
+
+        /**
+         * Classifies an OpenAI-compatible base URL into the closed vocabulary above.
+         *
+         * Substring matching on the host, not equality: the LiteLLM service is addressed as
+         * `litellm.ai-platform:4000` by some callers and `litellm.ai-platform.svc:4000` by others,
+         * and both are the same backend — a label that split them would answer "which provider"
+         * with "which spelling of the DNS name someone happened to configure". Malformed input
+         * yields [PROVIDER_OTHER] rather than throwing: a metrics helper may never break a call.
+         */
+        @Suppress("ReturnCount")
+        fun providerOf(baseUrl: String): String {
+            val host = runCatching { java.net.URI(baseUrl).host }.getOrNull()?.lowercase()
+                ?: return PROVIDER_OTHER
+            if (host.startsWith("litellm.") || host == "litellm") return PROVIDER_LITELLM
+            if (host.contains("groq.com")) return PROVIDER_GROQ
+            if (host.contains("deepinfra.com")) return PROVIDER_DEEPINFRA
+            if (host.contains("openai.com")) return PROVIDER_OPENAI
+            if (host.contains("ollama")) return PROVIDER_OLLAMA
+            return PROVIDER_OTHER
+        }
+
         /** Records nothing. The default for every caller that has not been wired. */
         val NONE: LlmCallMetricsPort = object : LlmCallMetricsPort {
             override fun recordCall(
@@ -62,6 +119,7 @@ interface LlmCallMetricsPort {
                 promptTokens: Int,
                 completionTokens: Int,
                 durationNanos: Long,
+                provider: String,
             ) = Unit
         }
     }

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/llm/LlmCallMetricsPort.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/llm/LlmCallMetricsPort.kt
@@ -32,10 +32,13 @@ interface LlmCallMetricsPort {
      * @param model the model id as sent upstream (e.g. `deepseek-ai/DeepSeek-V3.2`) — the same
      *   string the gateway config uses, so a cost rule can join on it without a mapping table.
      * @param outcome one of [OUTCOME_SUCCESS], [OUTCOME_HTTP_ERROR], [OUTCOME_EXCEPTION],
-     *   [OUTCOME_NOT_CONFIGURED]. A closed vocabulary: this tag is a Prometheus label and an
-     *   open-ended one (an exception message, a status code) would be a cardinality bomb.
-     * @param promptTokens from the response's `usage.prompt_tokens`; 0 when the provider omits it.
-     * @param completionTokens from `usage.completion_tokens`; 0 when the provider omits it.
+     *   [OUTCOME_STREAM_ABORTED], [OUTCOME_NOT_CONFIGURED]. A closed vocabulary: this tag is a
+     *   Prometheus label and an open-ended one (an exception message, a status code) would be a
+     *   cardinality bomb.
+     * @param promptTokens from the response's `usage.prompt_tokens`; 0 when the provider reported
+     *   zero, or [TOKENS_UNKNOWN] when it reported nothing at all. The two are not the same fact
+     *   and must not share a value — see [TOKENS_UNKNOWN].
+     * @param completionTokens from `usage.completion_tokens`; same [TOKENS_UNKNOWN] rule.
      * @param durationNanos wall-clock for the whole attempt, including a failed one — a timeout is
      *   the slowest and most interesting case, so timing only successes would hide it.
      * @param provider the egress backend this attempt was ADDRESSED TO, from [providerOf] — the
@@ -68,6 +71,41 @@ interface LlmCallMetricsPort {
          * never-configured agent look like a broken one — and vice versa, which is worse.
          */
         const val OUTCOME_NOT_CONFIGURED = "not_configured"
+
+        /**
+         * The response opened — status 2xx, headers received, possibly tokens already delivered to
+         * the user — and then the stream failed before it completed (#5878).
+         *
+         * Its own value, not folded into an existing one, because every alternative states
+         * something false. [OUTCOME_SUCCESS] would count a truncated answer as a delivered one —
+         * the `PushResult.skipped()`/`success = true` shape (ADR-0252 phase 0) that this repo has
+         * already paid for once. [OUTCOME_HTTP_ERROR] would be a lie about a call the backend
+         * answered 200 to, and would make the status-code hypothesis the first thing an operator
+         * checks the wrong one. [OUTCOME_EXCEPTION] is reserved for a call that never got a
+         * response at all, and the two have different causes (connect/DNS/TLS versus a mid-flight
+         * reset, an idle timeout or a truncated SSE body) and different fixes.
+         *
+         * It is a FAILURE and alerts as one: it is in the `AiCallErrorRateHigh` numerator alongside
+         * `http_error` and `exception`.
+         */
+        const val OUTCOME_STREAM_ABORTED = "stream_aborted"
+
+        /**
+         * "The provider never told us how many tokens this call used" — as opposed to `0`, which
+         * means it told us zero.
+         *
+         * Needed by the streaming path, which has no single response body to read `usage` from: an
+         * OpenAI-compatible backend MAY send a final usage chunk before `[DONE]` and many do not,
+         * and an aborted stream may end before one arrives. Recording `0` there would be
+         * indistinguishable from a real zero and would silently understate every rule that reads
+         * `openbank_llm_tokens_total` (`openbank:llm_cost_usd_24h:total`, `:by_model`,
+         * `openbank:llm_tokens_unpriced_24h`) with no signal anywhere that a figure was missing.
+         *
+         * Negative on purpose: it cannot be produced by summing real token counts, so it cannot be
+         * reached by accident. An implementation must not add it to the token counters; it should
+         * make the fact that a call went unmeasured observable in its own right.
+         */
+        const val TOKENS_UNKNOWN = -1
 
         // --- provider vocabulary (closed, like `outcome`) -------------------------------------
         //

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/llm/LlmCallMetricsPortProviderTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/llm/LlmCallMetricsPortProviderTest.kt
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.llm
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * `provider` is a Prometheus label, so the only two properties that matter are that it CLASSIFIES
+ * the endpoints the fleet actually configures, and that it cannot be made to emit an unbounded set
+ * of values by a mis-set endpoint. Both are asserted here; the values used are the literal strings
+ * from gitops (`http://litellm.ai-platform.svc:4000/v1`, `http://litellm.ai-platform:4000`) rather
+ * than tidied-up equivalents, because the two spellings of the same service are exactly what a
+ * naive host-equality implementation would split into two series.
+ */
+class LlmCallMetricsPortProviderTest {
+
+    @Test
+    fun `both spellings of the in-cluster gateway classify as one provider`() {
+        assertThat(LlmCallMetricsPort.providerOf("http://litellm.ai-platform.svc:4000/v1"))
+            .isEqualTo(LlmCallMetricsPort.PROVIDER_LITELLM)
+        assertThat(LlmCallMetricsPort.providerOf("http://litellm.ai-platform:4000"))
+            .isEqualTo(LlmCallMetricsPort.PROVIDER_LITELLM)
+    }
+
+    @Test
+    fun `the direct-to-vendor endpoints the local-dev defaults still use are classified`() {
+        // These are the application.yaml defaults a `quarkusDev` run takes, so a developer's calls
+        // are not silently lumped in with the deployed gateway's.
+        assertThat(LlmCallMetricsPort.providerOf("https://api.groq.com/openai/v1"))
+            .isEqualTo(LlmCallMetricsPort.PROVIDER_GROQ)
+        assertThat(LlmCallMetricsPort.providerOf("https://api.deepinfra.com/v1/openai"))
+            .isEqualTo(LlmCallMetricsPort.PROVIDER_DEEPINFRA)
+        assertThat(LlmCallMetricsPort.providerOf("https://api.openai.com/v1"))
+            .isEqualTo(LlmCallMetricsPort.PROVIDER_OPENAI)
+        assertThat(LlmCallMetricsPort.providerOf("http://ollama:11434/v1"))
+            .isEqualTo(LlmCallMetricsPort.PROVIDER_OLLAMA)
+    }
+
+    @Test
+    fun `an unrecognised or malformed endpoint collapses to one bounded value, never throws`() {
+        // The negative case the label exists to survive: anything else must NOT become its own
+        // series, and a metrics helper may never break the call it is describing.
+        assertThat(LlmCallMetricsPort.providerOf("https://some-new-vendor.example/v1"))
+            .isEqualTo(LlmCallMetricsPort.PROVIDER_OTHER)
+        assertThat(LlmCallMetricsPort.providerOf("not a url at all"))
+            .isEqualTo(LlmCallMetricsPort.PROVIDER_OTHER)
+        assertThat(LlmCallMetricsPort.providerOf("")).isEqualTo(LlmCallMetricsPort.PROVIDER_OTHER)
+    }
+
+    @Test
+    fun `an un-migrated call site is labelled unknown, not silently attributed to a provider`() {
+        // "not reported" and "reported as something we did not recognise" are different facts, and
+        // conflating them is how a half-migrated fleet reads as fully instrumented.
+        assertThat(LlmCallMetricsPort.PROVIDER_UNKNOWN).isNotEqualTo(LlmCallMetricsPort.PROVIDER_OTHER)
+        var seen: String? = null
+        val probe = object : LlmCallMetricsPort {
+            override fun recordCall(
+                model: String,
+                outcome: String,
+                promptTokens: Int,
+                completionTokens: Int,
+                durationNanos: Long,
+                provider: String,
+            ) {
+                seen = provider
+            }
+        }
+        probe.recordCall("m", LlmCallMetricsPort.OUTCOME_SUCCESS, 0, 0, 0)
+        assertThat(seen).isEqualTo(LlmCallMetricsPort.PROVIDER_UNKNOWN)
+    }
+}

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClient.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClient.kt
@@ -57,6 +57,9 @@ class OpenAiCompatibleLlmGatewayClient(
 
     private val log = Logger.getLogger(OpenAiCompatibleLlmGatewayClient::class.java)
 
+    // Derived once from the configured endpoint, not per call: it cannot change for a given client.
+    private val provider = LlmCallMetricsPort.providerOf(baseUrl)
+
     private val http: HttpClient = http ?: HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_S))
         .build()
@@ -68,7 +71,7 @@ class OpenAiCompatibleLlmGatewayClient(
             // Recorded, not silent: an agent that has never had a key looks identical to one that
             // is simply idle unless this series exists, and "the AI features were never switched
             // on" is exactly the state this repo keeps discovering months late.
-            metrics.recordCall(model, LlmCallMetricsPort.OUTCOME_NOT_CONFIGURED, 0, 0, 0)
+            metrics.recordCall(model, LlmCallMetricsPort.OUTCOME_NOT_CONFIGURED, 0, 0, 0, provider)
             return null
         }
         val url = "${baseUrl.trimEnd('/')}/chat/completions"
@@ -101,6 +104,7 @@ class OpenAiCompatibleLlmGatewayClient(
                     0,
                     0,
                     System.nanoTime() - startedAt,
+                    provider,
                 )
                 return null
             }
@@ -111,6 +115,7 @@ class OpenAiCompatibleLlmGatewayClient(
                 parsed.usage?.promptTokens ?: 0,
                 parsed.usage?.completionTokens ?: 0,
                 System.nanoTime() - startedAt,
+                provider,
             )
             parsed.choices.firstOrNull()?.message?.content?.takeIf { it.isNotBlank() }
         } catch (ex: Exception) {
@@ -121,6 +126,7 @@ class OpenAiCompatibleLlmGatewayClient(
                 0,
                 0,
                 System.nanoTime() - startedAt,
+                provider,
             )
             null
         }

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/LlmCallMetrics.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/LlmCallMetrics.kt
@@ -74,6 +74,18 @@ class LlmCallMetrics : LlmCallMetricsPort {
         // data", which is the same misreading the business dashboards hit with pinned-at-0 counters.
         recordTokens(registry, model, provider, "prompt", promptTokens)
         recordTokens(registry, model, provider, "completion", completionTokens)
+        // "the provider never reported usage" is its own fact, positively counted rather than left
+        // as an absence in openbank.llm.tokens (#5878). Without it, a streaming call whose backend
+        // sends no usage chunk is a request with no tokens — visually identical to a cheap call,
+        // and every cost rule reading openbank_llm_tokens_total understates by that call's share
+        // with nothing anywhere saying so. AiSpendUnmeasured reads this series.
+        val unknown = LlmCallMetricsPort.TOKENS_UNKNOWN
+        if (promptTokens == unknown || completionTokens == unknown) {
+            Counter.builder("openbank.llm.tokens.unreported")
+                .tags("model", model, "provider", provider, "outcome", outcome)
+                .register(registry)
+                .increment()
+        }
         Timer.builder("openbank.llm.call.duration")
             .tags("model", model, "outcome", outcome, "provider", provider)
             .publishPercentiles(P50, P95, P99)
@@ -82,6 +94,7 @@ class LlmCallMetrics : LlmCallMetricsPort {
             .record(Duration.ofNanos(durationNanos))
     }
 
+    /** [LlmCallMetricsPort.TOKENS_UNKNOWN] and a real zero both add nothing here — see above. */
     private fun recordTokens(registry: MeterRegistry, model: String, provider: String, kind: String, tokens: Int) {
         if (tokens <= 0) return
         Counter.builder("openbank.llm.tokens")

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/LlmCallMetrics.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/LlmCallMetrics.kt
@@ -31,11 +31,16 @@ import java.time.Duration
  * every consumer of openbank-libs-runtime, including the ones that never make an LLM call.
  *
  * Three series, tagged only with closed low-cardinality sets:
- *  - `openbank.llm.requests{model,outcome}` — call volume and reliability;
- *  - `openbank.llm.tokens{model,kind}` — `prompt` and `completion` separately, because every
- *    provider prices them differently, so a combined total cannot be costed at all;
- *  - `openbank.llm.call.duration{model,outcome}` — timed on failures too, since a timeout is the
- *    slowest and most interesting case.
+ *  - `openbank.llm.requests{model,outcome,provider}` — call volume and reliability;
+ *  - `openbank.llm.tokens{model,kind,provider}` — `prompt` and `completion` separately, because
+ *    every provider prices them differently, so a combined total cannot be costed at all;
+ *  - `openbank.llm.call.duration{model,outcome,provider}` — timed on failures too, since a timeout
+ *    is the slowest and most interesting case.
+ *
+ * `provider` is the egress backend the call was addressed to (see `LlmCallMetricsPort.providerOf`),
+ * a closed vocabulary like `outcome` and independent of it — adding it does not change what any
+ * `outcome` value means. The cost recording rules join `on (model, kind)`, so the extra label is
+ * carried harmlessly through them.
  *
  * **No cost metric here on purpose.** Price per token lives in the `openbank:llm_price_usd_per_token`
  * Prometheus recording rules, where a provider's rate-card change is a gitops edit that reloads in
@@ -50,35 +55,37 @@ class LlmCallMetrics : LlmCallMetricsPort {
 
     private fun reg(): MeterRegistry? = if (registryInstance.isResolvable) registryInstance.get() else null
 
+    @Suppress("LongParameterList") // mirrors the port; a 6th closed-vocabulary tag, not new state
     override fun recordCall(
         model: String,
         outcome: String,
         promptTokens: Int,
         completionTokens: Int,
         durationNanos: Long,
+        provider: String,
     ) {
         val registry = reg() ?: return
         Counter.builder("openbank.llm.requests")
-            .tags("model", model, "outcome", outcome)
+            .tags("model", model, "outcome", outcome, "provider", provider)
             .register(registry)
             .increment()
         // Skip zero increments: providers omit `usage` on an error, and a counter that only ever
         // sees 0 still creates the series — a flat line that reads as "no spend" rather than "no
         // data", which is the same misreading the business dashboards hit with pinned-at-0 counters.
-        recordTokens(registry, model, "prompt", promptTokens)
-        recordTokens(registry, model, "completion", completionTokens)
+        recordTokens(registry, model, provider, "prompt", promptTokens)
+        recordTokens(registry, model, provider, "completion", completionTokens)
         Timer.builder("openbank.llm.call.duration")
-            .tags("model", model, "outcome", outcome)
+            .tags("model", model, "outcome", outcome, "provider", provider)
             .publishPercentiles(P50, P95, P99)
             .publishPercentileHistogram()
             .register(registry)
             .record(Duration.ofNanos(durationNanos))
     }
 
-    private fun recordTokens(registry: MeterRegistry, model: String, kind: String, tokens: Int) {
+    private fun recordTokens(registry: MeterRegistry, model: String, provider: String, kind: String, tokens: Int) {
         if (tokens <= 0) return
         Counter.builder("openbank.llm.tokens")
-            .tags("model", model, "kind", kind)
+            .tags("model", model, "kind", kind, "provider", provider)
             .register(registry)
             .increment(tokens.toDouble())
     }

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClientTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClientTest.kt
@@ -61,6 +61,7 @@ class OpenAiCompatibleLlmGatewayClientTest {
             val promptTokens: Int,
             val completionTokens: Int,
             val durationNanos: Long,
+            val provider: String,
         )
 
         val calls = mutableListOf<Call>()
@@ -71,8 +72,9 @@ class OpenAiCompatibleLlmGatewayClientTest {
             promptTokens: Int,
             completionTokens: Int,
             durationNanos: Long,
+            provider: String,
         ) {
-            calls += Call(model, outcome, promptTokens, completionTokens, durationNanos)
+            calls += Call(model, outcome, promptTokens, completionTokens, durationNanos, provider)
         }
     }
 
@@ -176,6 +178,17 @@ class OpenAiCompatibleLlmGatewayClientTest {
     }
 
     @Test
+    fun `the recorded provider comes from the configured endpoint, not from a second knob`() {
+        // No network: the blank-key path records before sending, so this asserts the derivation
+        // against the literal endpoint string gitops sets (#5736) without a live gateway.
+        val metrics = RecordingMetrics()
+
+        runBlocking { client("http://litellm.ai-platform.svc:4000/v1", "", metrics).chat("s", "u") }
+
+        assertThat(metrics.calls.single().provider).isEqualTo(LlmCallMetricsPort.PROVIDER_LITELLM)
+    }
+
+    @Test
     fun `a non-2xx response is reported as http_error and still timed`() {
         val base = startStub(503, """{"error":"upstream unavailable"}""")
         val metrics = RecordingMetrics()
@@ -184,5 +197,7 @@ class OpenAiCompatibleLlmGatewayClientTest {
         val call = metrics.calls.single()
         assertThat(call.outcome).isEqualTo(LlmCallMetricsPort.OUTCOME_HTTP_ERROR)
         assertThat(call.durationNanos).isGreaterThan(0)
+        // An unrecognised endpoint must not invent a series of its own (the stub is on 127.0.0.1).
+        assertThat(call.provider).isEqualTo(LlmCallMetricsPort.PROVIDER_OTHER)
     }
 }

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/observability/LlmCallMetricsTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/observability/LlmCallMetricsTest.kt
@@ -175,4 +175,46 @@ class LlmCallMetricsTest {
         // The default handed to any caller not yet wired. It must be inert, not partially wired.
         LlmCallMetricsPort.NONE.recordCall("m", LlmCallMetricsPort.OUTCOME_SUCCESS, 10, 10, 10)
     }
+
+    @Test
+    fun `tokens the provider never reported are counted as unmeasured, not as a zero`() {
+        // The streaming path (#5878) often has no usage chunk to read, and `0` there would be
+        // indistinguishable from a free call. TOKENS_UNKNOWN must add nothing to the token series
+        // AND must leave a positive trace of its own, which is what AiSpendUnmeasured alerts on.
+        val reg = SimpleMeterRegistry()
+        withRegistry(reg).recordCall(
+            model = "deepseek-ai/DeepSeek-V3.2",
+            outcome = LlmCallMetricsPort.OUTCOME_SUCCESS,
+            promptTokens = LlmCallMetricsPort.TOKENS_UNKNOWN,
+            completionTokens = LlmCallMetricsPort.TOKENS_UNKNOWN,
+            durationNanos = 1_000,
+            provider = LlmCallMetricsPort.PROVIDER_LITELLM,
+        )
+
+        assertThat(reg.find("openbank.llm.tokens").counters()).isEmpty()
+        assertThat(
+            reg.find("openbank.llm.tokens.unreported")
+                .tag("model", "deepseek-ai/DeepSeek-V3.2")
+                .tag("provider", "litellm")
+                .tag("outcome", "success")
+                .counter()!!.count(),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `a call with real token counts leaves no unmeasured trace`() {
+        // The negative control: without it the assertion above passes against an implementation
+        // that counts EVERY call as unmeasured, which would make the alert fire constantly.
+        val reg = SimpleMeterRegistry()
+        withRegistry(reg).recordCall(
+            model = "deepseek-ai/DeepSeek-V3.2",
+            outcome = LlmCallMetricsPort.OUTCOME_SUCCESS,
+            promptTokens = 12,
+            completionTokens = 3,
+            durationNanos = 1_000,
+            provider = LlmCallMetricsPort.PROVIDER_LITELLM,
+        )
+
+        assertThat(reg.find("openbank.llm.tokens.unreported").counters()).isEmpty()
+    }
 }

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/observability/LlmCallMetricsTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/observability/LlmCallMetricsTest.kt
@@ -136,6 +136,41 @@ class LlmCallMetricsTest {
     }
 
     @Test
+    fun `provider tags all three series without changing what outcome means`() {
+        val reg = SimpleMeterRegistry()
+        withRegistry(reg).recordCall(
+            model = "deepseek-ai/DeepSeek-V3.2",
+            outcome = LlmCallMetricsPort.OUTCOME_SUCCESS,
+            promptTokens = 7,
+            completionTokens = 3,
+            durationNanos = 1_000_000,
+            provider = LlmCallMetricsPort.PROVIDER_LITELLM,
+        )
+
+        // All three, not just requests: a cost figure that cannot be split by egress backend cannot
+        // answer "which gateway is the spend going through", which is the question #5736 opened on.
+        assertThat(reg.find("openbank.llm.requests").tag("provider", "litellm").counter()!!.count())
+            .isEqualTo(1.0)
+        assertThat(reg.find("openbank.llm.tokens").tag("provider", "litellm").counters()).hasSize(2)
+        assertThat(reg.find("openbank.llm.call.duration").tag("provider", "litellm").timer()).isNotNull
+
+        // The point of the negative half: `outcome` still selects exactly what it selected before,
+        // so AiCallErrorRateHigh and the dashboard's outcome="success" filter are untouched.
+        assertThat(reg.find("openbank.llm.requests").tag("outcome", "success").counter()!!.count())
+            .isEqualTo(1.0)
+    }
+
+    @Test
+    fun `an un-migrated call site still emits, labelled unknown`() {
+        // The default must keep the series alive rather than dropping the call: a migration that
+        // silences a metric while it is half-done is worse than a coarse label.
+        val reg = SimpleMeterRegistry()
+        withRegistry(reg).recordCall("m", LlmCallMetricsPort.OUTCOME_HTTP_ERROR, 0, 0, 1)
+        assertThat(reg.find("openbank.llm.requests").tag("provider", "unknown").counter()!!.count())
+            .isEqualTo(1.0)
+    }
+
+    @Test
     fun `the no-op port records nothing and does not throw`() {
         // The default handed to any caller not yet wired. It must be inert, not partially wired.
         LlmCallMetricsPort.NONE.recordCall("m", LlmCallMetricsPort.OUTCOME_SUCCESS, 10, 10, 10)


### PR DESCRIPTION
Closes #5878. Stacked on #5877 (merged into this branch, so its diff drops out as it lands).

`OpenAiCompatibleModelProvider.complete()` records `metrics.recordCall(...)` on four outcomes. `completeStream()`, in the same class, recorded **nothing on any outcome** — so `openbank_llm_requests_total` counts only the non-streaming path (the 41 `http_error` in #5736 is an undercount), and a streaming-only failure was invisible everywhere. Streaming is the interactive path a person is waiting on, so it is the harder half to lose.

## The two decisions streaming forces

**1. When is the outcome known? → a new `stream_aborted` outcome.**

A stream can fail after a 200 and after tokens have already reached the user. Every existing value states something false about that: `success` counts a truncated answer as a delivered one (the `PushResult.skipped()` / `success = true` shape from ADR-0252 phase 0, and `LoggingDeadLetterSink` in #5761); `http_error` lies about a call the backend answered 200 to, and sends an operator to check status codes first; `exception` is reserved for a call that never got a response at all, and the two have different causes (connect/DNS/TLS versus a mid-flight reset, idle timeout or truncated SSE body) and different fixes.

It is a failure and alerts as one — added to the `AiCallErrorRateHigh` numerator alongside `http_error` and `exception`, because it is the SSE path's *characteristic* failure and leaving it out would make the interactive path the one that alert cannot see.

**2. Token counting → accumulate, and where that is impossible say so explicitly.**

The accumulator already sums `usage` across chunks, so a stream that carries a final usage chunk records real counts (asserted). Many OpenAI-compatible backends send none, and an aborted stream may end before one arrives. Those record `LlmCallMetricsPort.TOKENS_UNKNOWN` (`-1`), never `0` — `0` is indistinguishable from a real zero and would silently understate `openbank:llm_cost_usd_24h:total`, `:by_model` and `openbank:llm_tokens_unpriced_24h` with nothing anywhere saying a figure was missing. Negative on purpose: it cannot be produced by summing real counts, so it cannot be reached by accident.

Unknown is counted **positively** rather than left as an absence in `openbank.llm.tokens`: `LlmCallMetrics` increments `openbank.llm.tokens.unreported{model,provider,outcome}`, and the new `AiSpendUnmeasured` alert reads it — same shape as the existing `AiSpendUnpriced` trust alert (fires on a positive counter, so it is not an absence alert; none was added, for the reason #5877 wrote into `prometheus-rules-ai.yaml`).

## Verify by effect

Every LLM call in this environment currently fails on credentials (#5736), so no streaming outcome is observable live. The tests drive the provider through a stubbed `HttpClient` — transport only; request building, status handling and the real SSE read loop all still run — and assert the outcome, `provider` tag and token semantics that were **recorded**, not that nothing threw.

Falsification, each emission deleted in turn:

| removed | test that went red | other tests |
| --- | --- | --- |
| `OUTCOME_SUCCESS` | success with accumulated tokens; success without usage | rest green |
| `OUTCOME_STREAM_ABORTED` | mid-stream abort | rest green |
| `OUTCOME_HTTP_ERROR` | non-2xx before the stream opens | rest green |
| `OUTCOME_EXCEPTION` | transport failure before any response | rest green |
| `OUTCOME_NOT_CONFIGURED` | blank API key | rest green |
| `TOKENS_UNKNOWN` -> `0` | success without usage; mid-stream abort | rest green |
| the `tokens.unreported` counter | libs-runtime unmeasured-tokens test | negative control stays green |

The libs-runtime pair is deliberate: the positive test alone would pass against an implementation that counts *every* call as unmeasured, so a negative control asserts a call with real counts leaves no trace.

## Gate

Serialized, `--rerun-tasks`, exit code read from the redirected file (never a pipe):

- `:openbank-copilot-service:ktlintCheck` + `detekt` — green (the class sits AT detekt's `TooManyFunctions` ceiling of 11, so the three new stateless helpers are file-private top-level declarations, placed after the class so no annotation can bind to them)
- `:openbank-copilot-service:test` — **169 tests, 0 skipped, 0 failures**
- `:openbank-libs-domain:test` — 452 / 0 / 0 · `:openbank-libs-runtime:test` — 259 / 0 / 0
- `:openbank-copilot-service:quarkusBuild` — green (it is what validates injecting `LlmCallMetricsPort` instead of the Micrometer impl; `LlmCallMetrics` remains the only bean implementing it)

Refs #5736, #5877.
