### PR TITLE
ci(governance): gate sourceService against the module directory name

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1875,10 +1875,12 @@ gates:
   # could not see `val sourceService: String = SOURCE_SERVICE` and enumerated 17 of 21 producers
   # while printing a confident OK. Only the floor turned that into a visible number.
   #
-  # lending is BASELINED with its value and its reason (#5902): converging renames nine shipped
-  # event types and splits audit_entries a second time, so it is an open decision, not a tidy-up.
-  # The gate is green today without hiding the finding, and deleting that baseline entry is the
-  # visible act of taking the decision. ENFORCED.
+  # lending is a DECLARED EXCEPTION, not debt (#5902 decided: keep "lending"). The rows it already
+  # wrote are unrewritable by anyone — audit_entries is append-only at the DB and `source_service`
+  # is chain-hashed — so a rename could only add a fourth boundary on top of a split that can never
+  # be repaired. The boundary is documented in openbank-lending-service/CLAUDE.md instead. The
+  # baseline entry pins the (module, value) pair, so lending drifting to a third spelling still
+  # fails. ENFORCED.
   - id: source-service-convention
     name: "sourceService == module directory name (issues #5256/#5902, enforced)"
     group: kotlin

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1857,6 +1857,45 @@ gates:
   # #2187 ledger tie-out + FX revaluation, fx ČNB ingestion, billing cycle) — none had ever
   # run. It is a gate rather than a doc because the natural test cannot fail: calling the
   # method directly supplies the context the scheduler does not. ENFORCED.
+  # #5256/#5902. `source_service` is the column every audit and analytics query groups by, so a
+  # producer whose self-reported spelling disagrees with the fleet convention (module directory
+  # minus `openbank-`) splits itself off from audit-service's TopicAttribution fallback, which uses
+  # the module name. When such a producer later gains EVENT-sourced attribution its rows change
+  # spelling MID-STREAM and the group-by reports two producers where there is one — which is what
+  # PR #5399 did to lending's six upgraded event types on 2026-08-18.
+  #
+  # It is a gate rather than a doc because the natural probe cannot see it: `grep -c sourceService
+  # src/main` is non-zero for all 21 producers — it matches the field being MENTIONED (KDoc, a data
+  # class property, a consumer reading it back), never the value emitted — and that probe reported
+  # full conformance while lending disagreed at nine write sites. This check resolves the value at
+  # each write site through all four fleet idioms, follows a `const val` within the module, and
+  # refuses to guess an ambiguous one.
+  #
+  # min_subjects is inside the script as well as here, on purpose: the first draft of the regex
+  # could not see `val sourceService: String = SOURCE_SERVICE` and enumerated 17 of 21 producers
+  # while printing a confident OK. Only the floor turned that into a visible number.
+  #
+  # lending is BASELINED with its value and its reason (#5902): converging renames nine shipped
+  # event types and splits audit_entries a second time, so it is an open decision, not a tidy-up.
+  # The gate is green today without hiding the finding, and deleting that baseline entry is the
+  # visible act of taking the decision. ENFORCED.
+  - id: source-service-convention
+    name: "sourceService == module directory name (issues #5256/#5902, enforced)"
+    group: kotlin
+    mode: enforced
+    min_subjects: 20
+    rationale: >-
+      `source_service` is the column every audit and analytics query groups by, so a producer
+      whose self-reported spelling disagrees with the module name splits itself off from
+      audit-service's topic fallback — and the natural probe cannot see it, because
+      `grep -c sourceService` matches the field being mentioned, never the value emitted
+      (#5256, #5902).
+    review_after: 2027-02-20
+    selftest: python3 .github/scripts/check-source-service-convention.py --self-test
+    selftest_expect: pass
+    run: |
+      python3 .github/scripts/check-source-service-convention.py --root .
+
   - id: no-runblocking-in-a-scheduled-body
     name: "no runBlocking in a @Scheduled body (rules.yaml: scheduled_methods, enforced)"
     group: kotlin

--- a/.github/scripts/check-source-service-convention.py
+++ b/.github/scripts/check-source-service-convention.py
@@ -41,13 +41,24 @@
 #   decided. They carry no literal, so they are not this check's subject; flagging them would make
 #   the gate noise and silence is the correct verdict.
 #
-# WHY LENDING IS BASELINED RATHER THAN FIXED
-#   Converging lending to "lending-service" renames nine shipped event types and splits the already
-#   split `audit_entries` rows a SECOND time. Whether to converge + backfill, or to keep "lending"
-#   and document the boundary, is a decision recorded in #5902 — not something a gate should force
-#   by going red. So lending is baselined WITH its value and its reason: the gate is green today
-#   without hiding the finding, and deleting that baseline entry is the visible act of taking the
-#   decision. The baseline pins the VALUE, so lending drifting to some third spelling still fails.
+# WHY LENDING IS AN EXCEPTION — A SETTLED DECISION, NOT DEBT
+#   `openbank-lending-service` emits "lending". That is DECIDED and kept (#5902): the boundary it
+#   leaves in `audit_entries` is documented in `openbank-lending-service/CLAUDE.md` — which three
+#   aliases are one producer, which six event types and which nine days the "lending-service" window
+#   covers, and the query that reconciles them. Nothing here is waiting on anyone.
+#
+#   Renaming was rejected on cost, and the cost is structural rather than a matter of effort:
+#   `audit_entries` is append-only AT THE DATABASE (V2's `no_update_audit` / `no_delete_audit` rules
+#   are `DO INSTEAD NOTHING`, so a normalising UPDATE touches zero rows and reports success), and
+#   `source_service` is hashed into the ADR-0031/0133 `record_hash` chain, so rewriting it would
+#   break tamper-evidence for every affected row and every row after it. The existing rows cannot be
+#   converged by anyone, ever; a rename would only add a FOURTH boundary on top of them.
+#
+#   So this entry is not a TODO and should not be "cleaned up" — a future reader finding it must not
+#   read it as a rename nobody got around to. It stays until someone deliberately reopens #5902, and
+#   deleting it is what that reopening looks like. It pins the (module, VALUE) pair, so lending
+#   drifting to some third spelling still fails the gate — that is the property this entry exists to
+#   keep, and it survives independently of the decision above.
 #
 # EXIT CODES
 #   0  every producer's emitted value equals its module directory name (modulo the baseline)
@@ -79,11 +90,12 @@ MIN_PRODUCERS_DEFAULT = 20
 # keeps the entry from absorbing a future third spelling from the same producer.
 BASELINE = {
     ("openbank-lending-service", "lending"): (
-        "#5902 — nine shipped event types emit \"lending\" while the convention (and "
-        "audit-service's TopicAttribution fallback) says \"lending-service\". Converging renames "
-        "nine live types and splits audit_entries a second time, so the choice between "
-        "converge+backfill / keep-and-document is an open decision in #5902, not a tidy-up. "
-        "Remove this entry when that decision is taken."
+        "#5902 DECIDED: lending keeps \"lending\" and the audit_entries boundary is documented "
+        "instead (openbank-lending-service/CLAUDE.md). NOT debt, and NOT a rename awaiting "
+        "cleanup — the existing rows are unrewritable by anyone (audit_entries is append-only at "
+        "the DB and source_service is chain-hashed), so a rename could only add a fourth boundary "
+        "on top of a split that can never be repaired. This entry is permanent unless #5902 is "
+        "deliberately reopened. It pins the VALUE, so a third spelling from this module still fails."
     ),
 }
 
@@ -393,7 +405,8 @@ def run(root, min_producers, quiet=False):
         return 1
     print(
         f"sourceService convention: OK — {len(producers)} producer(s) checked, "
-        f"{len(BASELINE)} baselined. See #5902 for why the baselined set is an open decision.",
+        f"{len(BASELINE)} declared exception(s). See #5902 and BASELINE above: the exception is a "
+        f"settled decision with a documented boundary, not pending work.",
     )
     return 0
 

--- a/.github/scripts/check-source-service-convention.py
+++ b/.github/scripts/check-source-service-convention.py
@@ -35,11 +35,26 @@
 #   `const val SERVICE = "fx"` next to their `SOURCE_SERVICE = "fx-service"`, and picking the wrong
 #   one would produce a confident false verdict in either direction.
 #
-# PASS-THROUGH IS NOT A WRITE SITE
+# PASS-THROUGH IS NOT A WRITE SITE — BUT IT IS A WHITELIST, NOT A FALLBACK
 #   `"sourceService" to event.sourceService` (sepa-instant's publisher) and
 #   `node["sourceService"]?.asText()` (the audit/analytics consumers) copy a value someone else
 #   decided. They carry no literal, so they are not this check's subject; flagging them would make
 #   the gate noise and silence is the correct verdict.
+#
+#   The direction of the default is the load-bearing part. `_resolve` used to end in
+#   `return None, None`, so ANY expression it could not parse was reclassified as a pass-through:
+#   the site produced 0 findings AND 0 producers, so the module disappeared from the check
+#   entirely — invisible AND uncounted, which also put it beneath the MIN_PRODUCERS floor that is
+#   supposed to catch exactly this. Two ordinary Kotlin shapes reproduced it, and in both the
+#   module decides the value it emits:
+#       `"sourceService" to configuredSource`   // a @ConfigProperty-injected field
+#       `"sourceService" to sourceServiceName`  // a lowercase, non-`const` val
+#
+#   So the rule is now: a subject this gate cannot parse must never be indistinguishable from a
+#   subject that passed. Recognised pass-throughs (_PASSTHROUGH) are silent; everything else that
+#   cannot be resolved either FAILS, or appears in UNRESOLVED_ALLOWED with a written reason and is
+#   still COUNTED as a measured subject. Both lists are reverse ratchets, so neither can quietly
+#   outlive the code it describes.
 #
 # WHY LENDING IS AN EXCEPTION — A SETTLED DECISION, NOT DEBT
 #   `openbank-lending-service` emits "lending". That is DECIDED and kept (#5902): the boundary it
@@ -63,7 +78,8 @@
 # EXIT CODES
 #   0  every producer's emitted value equals its module directory name (modulo the baseline)
 #   1  a producer emits a value that is not its module name; or a write site whose value cannot be
-#      resolved; or a baseline entry that no longer matches anything (the reverse ratchet)
+#      resolved and is not an acknowledged skip; or a BASELINE / UNRESOLVED_ALLOWED entry that no
+#      longer matches anything (the reverse ratchet)
 #   2  the check could not run: the tree is missing, or fewer than --min-producers producers were
 #      found. Never conflated with 0 — an enumeration that finds nothing is a broken probe, not a
 #      clean fleet, and that is exactly how the original gap stayed invisible.
@@ -111,7 +127,11 @@ _KOTLIN_SITES = (
     # and a pattern without it enumerated 17 of the 21 producers while printing a confident OK —
     # the same "the probe cannot express the case, so it reports clean" failure this whole check
     # exists to close. The MIN_PRODUCERS floor below is what turned that into a visible number.
-    re.compile(r"\bsourceService\s*(?::\s*[A-Za-z_][A-Za-z0-9_.<>?]*\s*)?=\s*([^,)\n]+)"),
+    # `(?<![=!<>])=(?!=)` — an ASSIGNMENT, never a comparison. Without it,
+    # `if (envelope.sourceService == UNKNOWN_SERVICE)` parsed as a write site emitting
+    # "= UNKNOWN_SERVICE": the regex ate the first `=` as the assign and captured the rest.
+    # A comparison is a READ, and reporting one is the noise that gets a gate switched off.
+    re.compile(r"\bsourceService\s*(?::\s*[A-Za-z_][A-Za-z0-9_.<>?]*\s*)?(?<![=!<>])=(?!=)\s*([^,)\n]+)"),
     re.compile(r'"sourceService"\s+to\s+([^,)\n]+)'),
     re.compile(r'\bput\(\s*"sourceService"\s*,\s*([^,)\n]+)\)'),
 )
@@ -122,6 +142,40 @@ _STRING_LITERAL = re.compile(r'^"([^"]*)"$')
 _CONST_REF = re.compile(r"^(?:[A-Za-z_][A-Za-z0-9_]*\.)*([A-Z][A-Z0-9_]*)$")
 _INTERPOLATION = re.compile(r"^\$\{?(?:[A-Za-z_][A-Za-z0-9_]*\.)*([A-Z][A-Z0-9_]*)\}?$")
 _CONST_DECL = re.compile(r'\bconst\s+val\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?::\s*String\s*)?=\s*"([^"]*)"')
+
+# A RECOGNISED pass-through: the expression reads a `sourceService` that somebody else already
+# decided — `event.sourceService`, `cmd.payload?.sourceService`, a bare `sourceService` parameter.
+# This is a WHITELIST on purpose, and the direction matters more than the pattern: see _resolve.
+_PASSTHROUGH = re.compile(
+    r"^(?:"
+    # `event.sourceService`, `cmd.payload?.sourceService`, a bare `sourceService` parameter
+    r"(?:[A-Za-z_][A-Za-z0-9_]*\s*[?!]?\s*[.]\s*)*sourceService\s*[?!]*"
+    r"|"
+    # the inbound-envelope read the module header already names as a pass-through:
+    # `node["sourceService"]?.asText(`, `node.textOrNull("sourceService")`
+    r"[A-Za-z_][A-Za-z0-9_]*\s*(?:\[\s*\"sourceService\"\s*\]|\.\s*[A-Za-z_][A-Za-z0-9_]*\s*\(\s*\"sourceService\")"
+    r".*"
+    r")$",
+)
+
+# Write sites whose value this gate genuinely cannot resolve AND which have been looked at.
+# (module, expression) -> why it is knowingly skipped.
+#
+# This exists so an unresolvable site is COUNTED and NAMED rather than silently absent. It is a
+# reverse ratchet like BASELINE: an entry that stops matching is reported STALE, so the list
+# cannot quietly outlive the code it describes. Adding to it is a decision someone has to write
+# down — which is the property the old `return None, None` destroyed.
+UNRESOLVED_ALLOWED = {
+    ("openbank-audit-service", "resolvedSource.first"): (
+        "audit-service is the CONSUMER here, not a producer of its own claim. "
+        "`resolveSourceService(node, address)` (AuditConsumer.kt:218) returns the event's own "
+        "sourceService, else TopicAttribution's topic-derived value, else \"unknown\" — all three "
+        "are somebody else's attribution being copied onto the row. The pair is destructured "
+        "one line later into `sourceServiceSource`, which records WHICH of the three it was. "
+        "Not whitelisted by shape: `<val>.first` is far too generic to be a safe pass-through "
+        "pattern, so it is pinned to this module and this expression instead."
+    ),
+}
 
 
 def module_consts(module: pathlib.Path):
@@ -140,7 +194,27 @@ def module_consts(module: pathlib.Path):
 def _resolve(expr: str, consts):
     """(value, None) when the emitted value is knowable, (None, reason) when it is not.
 
-    (None, None) means "not a write site" — a pass-through of somebody else's value.
+    (None, None) means "not a write site" — a RECOGNISED pass-through of somebody else's value.
+
+    THE DEFAULT IS "REPORT", NOT "SKIP", AND THAT IS THE WHOLE POINT
+      This used to end in `return None, None`, so every expression the resolver could not parse
+      was silently reclassified as a pass-through. That made an unparseable write site produce
+      0 findings AND 0 producers — invisible AND uncounted, indistinguishable from a module that
+      genuinely conforms. Two shapes reproduced it, both of them ordinary Kotlin:
+
+        `"sourceService" to configuredSource`   // a @ConfigProperty-injected field
+        `"sourceService" to sourceServiceName`  // a lowercase, non-`const` val
+
+      Neither is a pass-through — the module decides the value in both — and either could have
+      emitted any spelling at all without this gate noticing. Worse, because the module was never
+      counted as a producer, the MIN_PRODUCERS floor could not see the loss either: the one
+      mechanism that exists here to catch a broken enumeration was itself blind to it.
+
+      So the pass-through set is now a WHITELIST (_PASSTHROUGH: an expression that reads a
+      `sourceService` somebody else set), and anything else that cannot be resolved is REPORTED
+      with the expression quoted. A subject the gate cannot parse must never be indistinguishable
+      from a subject that passed — if it cannot be resolved it fails, or it is counted as an
+      explicit skip with a reason. It is never silently absent.
     """
     expr = expr.strip().rstrip(",")
     lit = _STRING_LITERAL.match(expr)
@@ -157,19 +231,29 @@ def _resolve(expr: str, consts):
                 f"{len(values)} different values ({', '.join(sorted(values))}) — ambiguous"
             )
         return next(iter(values)), None
-    return None, None  # pass-through: event.sourceService, node[...], a parameter, ...
+    if _PASSTHROUGH.match(expr):
+        return None, None  # reads a sourceService someone else decided — not this module's claim
+    return None, (
+        f"value `{expr}` is not a string literal, a `const val` this module declares, or a "
+        f"recognised pass-through of somebody else's sourceService — this gate cannot tell what "
+        f"this producer emits. Emit a literal or a module-level `const val`, or extend "
+        f"_PASSTHROUGH in this script if it really is a pass-through."
+    )
 
 
 def scan(root):
-    """-> (findings, matched_baseline_keys, producers)
+    """-> (findings, matched_baseline_keys, producers, matched_skip_keys)
 
-    producers is the set of modules with at least one resolvable write site, i.e. the check's real
-    subject count. It is returned so the caller can refuse a vacuous run.
+    producers is the set of modules with at least one write site this check actually MEASURED —
+    resolved, or explicitly acknowledged as unresolvable. A site it could not parse and did not
+    acknowledge is a finding, never an absence, so the subject count can no longer shrink
+    silently when an idiom changes.
     """
     root = pathlib.Path(root)
     findings = []
     matched = set()
     producers = set()
+    matched_skips = set()
 
     for module in sorted(root.glob(f"{MODULE_PREFIX}*")):
         if not (module / "src" / "main").is_dir():
@@ -194,6 +278,13 @@ def scan(root):
                     if value is None:
                         if why is None:
                             continue  # pass-through, not a write site
+                        skip_key = (module.name, expr.strip().rstrip(","))
+                        if skip_key in UNRESOLVED_ALLOWED:
+                            # Acknowledged, and still COUNTED — an explicit skip is a measured
+                            # subject, unlike the silent one this replaced.
+                            matched_skips.add(skip_key)
+                            producers.add(module.name)
+                            continue
                         findings.append(f"{module.name}: {where} UNRESOLVED — {why}")
                         producers.add(module.name)
                         continue
@@ -208,7 +299,7 @@ def scan(root):
                         f'{module.name}: {where} emits sourceService="{value}", '
                         f'but the module directory says "{expected}"',
                     )
-    return findings, matched, producers
+    return findings, matched, producers, matched_skips
 
 
 # ---------------------------------------------------------------------------------------------
@@ -256,6 +347,38 @@ SELF_TEST_MODULES = {
         "A.kt": 'private const val SERVICE = "ambiguous-service"\nval m = mapOf("sourceService" to SERVICE)\n',
         "B.kt": 'private const val SERVICE = "something-else"\n',
     },
+    # THE TWO NEGATIVE CONTROLS THAT REPRODUCED THE PASS-THROUGH HOLE.
+    # Before the fix each of these produced 0 findings AND 0 producers: the value was unparseable,
+    # `_resolve` fell through to `return None, None`, and the module vanished from the check
+    # entirely — invisible AND uncounted, so even the MIN_PRODUCERS floor could not see the loss.
+    # Both are ordinary Kotlin, and in both the MODULE decides the value; neither is a pass-through.
+    "openbank-configprop-service": {
+        "E.kt": (
+            '@ConfigProperty(name = "openbank.audit.source-service")\n'
+            "lateinit var configuredSource: String\n"
+            'val m = mapOf("sourceService" to configuredSource)\n'
+        ),
+    },
+    "openbank-lowercaseval-service": {
+        "E.kt": (
+            'private val sourceServiceName = "totally-wrong"\n'
+            'val m = mapOf("sourceService" to sourceServiceName)\n'
+        ),
+    },
+    # Must NOT be flagged: a COMPARISON is a read. `sourceService == UNKNOWN_SERVICE` parsed as a
+    # write site emitting "= UNKNOWN_SERVICE" until the assignment pattern excluded `==`
+    # (live shape: analytics-sink's IngestAttributionMetrics).
+    "openbank-comparison-service": {
+        "E.kt": 'fun f(e: E) = e.sourceService == UNKNOWN_SERVICE\n',
+    },
+    # Must NOT be flagged: reading the field back off an inbound envelope, the shape the module
+    # header has always called a pass-through (analytics-sink / audit-service consumers).
+    "openbank-nodereader-service": {
+        "E.kt": (
+            'val a = node["sourceService"]?.asText() ?: UNKNOWN\n'
+            'val b = node.textOrNull("sourceService") ?: UNKNOWN\n'
+        ),
+    },
 }
 
 # module -> must it appear in the findings?
@@ -272,11 +395,27 @@ SELF_TEST_EXPECT = {
     "openbank-passthrough-service": False,
     "openbank-prose-only-service": False,
     "openbank-ambiguous-service": True,
+    "openbank-configprop-service": True,
+    "openbank-lowercaseval-service": True,
+    "openbank-comparison-service": False,
+    "openbank-nodereader-service": False,
 }
 
 # Modules with a resolvable write site. prose-only and passthrough must NOT be counted, or the
 # vacuity floor could be satisfied by modules the check never actually measured.
-SELF_TEST_PRODUCERS = {m for m in SELF_TEST_MODULES if m not in ("openbank-prose-only-service", "openbank-passthrough-service")}
+SELF_TEST_PRODUCERS = {
+    m
+    for m in SELF_TEST_MODULES
+    if m
+    not in (
+        "openbank-prose-only-service",
+        "openbank-passthrough-service",
+        # A comparison and an inbound read are not write sites, so neither makes its module a
+        # producer. They are here to prove the fix did not buy its strictness with noise.
+        "openbank-comparison-service",
+        "openbank-nodereader-service",
+    )
+}
 
 
 def _build_self_test_tree(root):
@@ -298,7 +437,7 @@ def self_test():
         with tempfile.TemporaryDirectory() as tmp:
             root = pathlib.Path(tmp)
             _build_self_test_tree(root)
-            findings, _, producers = scan(root)
+            findings, _, producers, _ = scan(root)
 
             flagged = {m for m in SELF_TEST_EXPECT if any(f.startswith(m + ":") for f in findings)}
             for module, want in sorted(SELF_TEST_EXPECT.items()):
@@ -314,7 +453,7 @@ def self_test():
 
             # A baseline entry silences its own VALUE only.
             BASELINE = {("openbank-bad-literal-service", "bad-literal"): "self-test"}
-            f2, matched2, _ = scan(root)
+            f2, matched2, _, _ = scan(root)
             cases.append((
                 "baseline silences its own (module, value)",
                 not any(f.startswith("openbank-bad-literal-service:") for f in f2) and matched2 == set(BASELINE),
@@ -327,7 +466,7 @@ def self_test():
             # A baseline pinned to a DIFFERENT value from the same module must not silence it —
             # this is what stops the entry absorbing a future third spelling.
             BASELINE = {("openbank-bad-literal-service", "some-third-spelling"): "self-test"}
-            f3, matched3, _ = scan(root)
+            f3, matched3, _, _ = scan(root)
             cases.append((
                 "baseline pinned to another value does not silence the module",
                 any(f.startswith("openbank-bad-literal-service:") for f in f3),
@@ -337,7 +476,7 @@ def self_test():
             # Vacuity: an emptied tree must refuse, not pass.
             with tempfile.TemporaryDirectory() as empty:
                 BASELINE = {}
-                _, _, no_producers = scan(empty)
+                _, _, no_producers, _ = scan(empty)
                 cases.append(("empty tree yields zero producers", no_producers == set()))
                 cases.append((
                     "run() refuses a vacuous tree with exit 2",
@@ -365,12 +504,12 @@ def run(root, min_producers, quiet=False):
             print(f"::error::root {root} does not exist — the check could not run. This is NOT a pass.")
         return 2
 
-    findings, matched, producers = scan(root)
+    findings, matched, producers, matched_skips = scan(root)
 
     # Unconditional, and BEFORE the floor check: a gate that found its corpus and then failed on it
     # must not also be reported as having lost its corpus (gatelib.subjects' own rule).
     if not quiet:
-        gatelib.subjects(len(producers), "modules with a resolvable sourceService write site")
+        gatelib.subjects(len(producers), "modules with a measured sourceService write site (resolved, or acknowledged-unresolvable)")
 
     if len(producers) < min_producers:
         if not quiet:
@@ -383,8 +522,9 @@ def run(root, min_producers, quiet=False):
         return 2
 
     stale = [k for k in BASELINE if k not in matched]
+    stale_skips = [k for k in UNRESOLVED_ALLOWED if k not in matched_skips]
     if quiet:
-        return 1 if (findings or stale) else 0
+        return 1 if (findings or stale or stale_skips) else 0
 
     for f in findings:
         print(f"FAIL  {f}")
@@ -394,9 +534,17 @@ def run(root, min_producers, quiet=False):
             f"was fixed, renamed or removed.\n"
             f"       Remove it from BASELINE in this script so the list keeps meaning something.",
         )
-    if findings or stale:
+    for module, expr in stale_skips:
         print(
-            f"\n{len(findings)} non-conforming write site(s), {len(stale)} stale baseline entr(ies) "
+            f'STALE  acknowledged-unresolvable entry ({module}, "{expr}") no longer matches any '
+            f"write site — the code was fixed, moved or the resolver learned to read it.\n"
+            f"       Remove it from UNRESOLVED_ALLOWED in this script so the list keeps meaning "
+            f"something.",
+        )
+    if findings or stale or stale_skips:
+        print(
+            f"\n{len(findings)} non-conforming write site(s), {len(stale)} stale baseline "
+            f"entr(ies), {len(stale_skips)} stale acknowledged-unresolvable entr(ies) "
             f"across {len(producers)} producer(s).\n"
             f"The value must be the module directory name without the `{MODULE_PREFIX}` prefix "
             f"(#5256), because that is what audit-service's TopicAttribution fallback uses; a "
@@ -405,6 +553,7 @@ def run(root, min_producers, quiet=False):
         return 1
     print(
         f"sourceService convention: OK — {len(producers)} producer(s) checked, "
+        f"{len(matched_skips)} acknowledged-unresolvable site(s) skipped WITH a reason, "
         f"{len(BASELINE)} declared exception(s). See #5902 and BASELINE above: the exception is a "
         f"settled decision with a documented boundary, not pending work.",
     )

--- a/.github/scripts/check-source-service-convention.py
+++ b/.github/scripts/check-source-service-convention.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# sourceService convention guard: the value a producer stamps on its own events must be its own
+# module directory name minus the `openbank-` prefix (issues #5256, #5902).
+#
+# WHY THIS EXISTS
+#   `source_service` is the column every audit/analytics query groups by — it is the documented way
+#   to detect a producer that has stopped emitting, or one that never started. A producer whose
+#   self-reported spelling disagrees with the fleet convention splits itself off from the topic
+#   fallback table (`audit-service`'s `TopicAttribution`), which uses the module name. When a
+#   producer later gains EVENT-sourced attribution, its rows change spelling MID-STREAM and every
+#   group-by silently reports two producers where there is one, with the boundary at a merge date.
+#   That happened: `openbank-lending-service` emits "lending", `TopicAttribution` says
+#   "lending-service", and PR #5399 flipped six of its nine event types from the topic-derived value
+#   to the event-derived one on 2026-08-18. See #5902.
+#
+# THE PROBE TRAP THIS CHECK EXISTS TO AVOID
+#   `grep -c sourceService src/main` returns non-zero for all 21 producers, because it sees the
+#   FIELD being mentioned — a KDoc paragraph, a data-class property, a consumer reading it back —
+#   and never its VALUE. That probe reported full conformance while lending disagreed with the
+#   convention at nine write sites. So this check resolves the emitted value at each WRITE SITE,
+#   through whichever of the fleet's four idioms is in use, and refuses to guess.
+#
+# THE FOUR WRITE-SITE IDIOMS IN THIS FLEET (all four are load-bearing; a check that knows one
+# reports "clean" about the other three)
+#   1. Kotlin named arg / property default   `sourceService = "account-service"`
+#   2. Map entry                             `"sourceService" to SOURCE_SERVICE`
+#   3. Jackson node                          `node.put("sourceService", "customer-edge")`
+#   4. Hand-built JSON string                `""""sourceService":"$SOURCE_SERVICE"}"""`
+#   Idioms 2 and 4 usually name a `const val`, so the resolver follows a simple-name const within
+#   the same module. A const name that resolves to more than one distinct value in a module is
+#   reported UNRESOLVED rather than guessed — several modules carry an unrelated metrics-tag
+#   `const val SERVICE = "fx"` next to their `SOURCE_SERVICE = "fx-service"`, and picking the wrong
+#   one would produce a confident false verdict in either direction.
+#
+# PASS-THROUGH IS NOT A WRITE SITE
+#   `"sourceService" to event.sourceService` (sepa-instant's publisher) and
+#   `node["sourceService"]?.asText()` (the audit/analytics consumers) copy a value someone else
+#   decided. They carry no literal, so they are not this check's subject; flagging them would make
+#   the gate noise and silence is the correct verdict.
+#
+# WHY LENDING IS BASELINED RATHER THAN FIXED
+#   Converging lending to "lending-service" renames nine shipped event types and splits the already
+#   split `audit_entries` rows a SECOND time. Whether to converge + backfill, or to keep "lending"
+#   and document the boundary, is a decision recorded in #5902 — not something a gate should force
+#   by going red. So lending is baselined WITH its value and its reason: the gate is green today
+#   without hiding the finding, and deleting that baseline entry is the visible act of taking the
+#   decision. The baseline pins the VALUE, so lending drifting to some third spelling still fails.
+#
+# EXIT CODES
+#   0  every producer's emitted value equals its module directory name (modulo the baseline)
+#   1  a producer emits a value that is not its module name; or a write site whose value cannot be
+#      resolved; or a baseline entry that no longer matches anything (the reverse ratchet)
+#   2  the check could not run: the tree is missing, or fewer than --min-producers producers were
+#      found. Never conflated with 0 — an enumeration that finds nothing is a broken probe, not a
+#      clean fleet, and that is exactly how the original gap stayed invisible.
+#
+# Run:  python3 .github/scripts/check-source-service-convention.py [--root .] [--self-test]
+
+import argparse
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import gatelib  # noqa: E402  — run-gates.py reads the SUBJECTS line this emits
+
+MODULE_PREFIX = "openbank-"
+
+# Producers on origin/main as of 2026-08-20 (measured by this script): 21. A run finding materially
+# fewer than this has not measured the fleet — it has failed to enumerate it. The floor is one below
+# today's count so a service legitimately retiring its events does not red the gate, and far enough
+# above zero that a broken enumeration cannot pass vacuously.
+MIN_PRODUCERS_DEFAULT = 20
+
+# (module, emitted value) -> why it is tolerated. Pinning the VALUE, not just the module, is what
+# keeps the entry from absorbing a future third spelling from the same producer.
+BASELINE = {
+    ("openbank-lending-service", "lending"): (
+        "#5902 — nine shipped event types emit \"lending\" while the convention (and "
+        "audit-service's TopicAttribution fallback) says \"lending-service\". Converging renames "
+        "nine live types and splits audit_entries a second time, so the choice between "
+        "converge+backfill / keep-and-document is an open decision in #5902, not a tidy-up. "
+        "Remove this entry when that decision is taken."
+    ),
+}
+
+# A line that is entirely a comment carries no write site. Stripping them is the whole reason this
+# check can be stricter than the grep that missed the gap: KDoc in this fleet discusses
+# `sourceService` far more often than code sets it.
+_COMMENT_LINE = re.compile(r"^\s*(//|\*|/\*)")
+
+# Idioms 1-3: the RHS is a Kotlin expression.
+_KOTLIN_SITES = (
+    # The optional `: String` matters: four producers declare the property as
+    #   `val sourceService: String = SOURCE_SERVICE`
+    # and a pattern without it enumerated 17 of the 21 producers while printing a confident OK —
+    # the same "the probe cannot express the case, so it reports clean" failure this whole check
+    # exists to close. The MIN_PRODUCERS floor below is what turned that into a visible number.
+    re.compile(r"\bsourceService\s*(?::\s*[A-Za-z_][A-Za-z0-9_.<>?]*\s*)?=\s*([^,)\n]+)"),
+    re.compile(r'"sourceService"\s+to\s+([^,)\n]+)'),
+    re.compile(r'\bput\(\s*"sourceService"\s*,\s*([^,)\n]+)\)'),
+)
+# Idiom 4: the value sits inside a hand-built JSON string, so it is already quoted.
+_JSON_SITE = re.compile(r'"sourceService"\s*:\s*\\?"([^"\\]*)\\?"')
+
+_STRING_LITERAL = re.compile(r'^"([^"]*)"$')
+_CONST_REF = re.compile(r"^(?:[A-Za-z_][A-Za-z0-9_]*\.)*([A-Z][A-Z0-9_]*)$")
+_INTERPOLATION = re.compile(r"^\$\{?(?:[A-Za-z_][A-Za-z0-9_]*\.)*([A-Z][A-Z0-9_]*)\}?$")
+_CONST_DECL = re.compile(r'\bconst\s+val\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?::\s*String\s*)?=\s*"([^"]*)"')
+
+
+def module_consts(module: pathlib.Path):
+    """simple const name -> set of distinct string values declared anywhere in the module's main."""
+    consts = {}
+    for f in sorted((module / "src" / "main").rglob("*.kt")):
+        for line in f.read_text(encoding="utf-8", errors="replace").splitlines():
+            if _COMMENT_LINE.match(line):
+                continue
+            m = _CONST_DECL.search(line)
+            if m:
+                consts.setdefault(m.group(1), set()).add(m.group(2))
+    return consts
+
+
+def _resolve(expr: str, consts):
+    """(value, None) when the emitted value is knowable, (None, reason) when it is not.
+
+    (None, None) means "not a write site" — a pass-through of somebody else's value.
+    """
+    expr = expr.strip().rstrip(",")
+    lit = _STRING_LITERAL.match(expr)
+    if lit:
+        return lit.group(1), None
+    ref = _CONST_REF.match(expr) or _INTERPOLATION.match(expr)
+    if ref:
+        values = consts.get(ref.group(1))
+        if not values:
+            return None, f"references {ref.group(1)}, which no `const val` in this module declares"
+        if len(values) > 1:
+            return None, (
+                f"references {ref.group(1)}, which this module declares with "
+                f"{len(values)} different values ({', '.join(sorted(values))}) — ambiguous"
+            )
+        return next(iter(values)), None
+    return None, None  # pass-through: event.sourceService, node[...], a parameter, ...
+
+
+def scan(root):
+    """-> (findings, matched_baseline_keys, producers)
+
+    producers is the set of modules with at least one resolvable write site, i.e. the check's real
+    subject count. It is returned so the caller can refuse a vacuous run.
+    """
+    root = pathlib.Path(root)
+    findings = []
+    matched = set()
+    producers = set()
+
+    for module in sorted(root.glob(f"{MODULE_PREFIX}*")):
+        if not (module / "src" / "main").is_dir():
+            continue
+        expected = module.name[len(MODULE_PREFIX):]
+        consts = None
+        for f in sorted((module / "src" / "main").rglob("*.kt")):
+            for lineno, line in enumerate(f.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+                if _COMMENT_LINE.match(line) or "sourceService" not in line:
+                    continue
+                exprs = [(m.group(1), False) for pat in _KOTLIN_SITES for m in pat.finditer(line)]
+                exprs += [(m.group(1), True) for m in _JSON_SITE.finditer(line)]
+                for expr, already_quoted in exprs:
+                    if consts is None:
+                        consts = module_consts(module)
+                    if already_quoted:
+                        interp = _INTERPOLATION.match(expr.strip())
+                        value, why = _resolve(expr, consts) if interp else (expr, None)
+                    else:
+                        value, why = _resolve(expr, consts)
+                    where = f"{f.relative_to(root)}:{lineno}"
+                    if value is None:
+                        if why is None:
+                            continue  # pass-through, not a write site
+                        findings.append(f"{module.name}: {where} UNRESOLVED — {why}")
+                        producers.add(module.name)
+                        continue
+                    producers.add(module.name)
+                    if value == expected:
+                        continue
+                    key = (module.name, value)
+                    if key in BASELINE:
+                        matched.add(key)
+                        continue
+                    findings.append(
+                        f'{module.name}: {where} emits sourceService="{value}", '
+                        f'but the module directory says "{expected}"',
+                    )
+    return findings, matched, producers
+
+
+# ---------------------------------------------------------------------------------------------
+# Self-test. Drives the REAL scan() over a synthetic tree — never a retyped classifier, which is
+# how a self-test ends up unable to see the rule it was written to guard.
+
+SELF_TEST_MODULES = {
+    # module dir -> {relative kt path: source}. Expected value is the dir minus openbank-.
+    "openbank-ok-literal-service": {"E.kt": '    sourceService = "ok-literal-service",\n'},
+    "openbank-ok-const-service": {
+        "E.kt": 'private const val SOURCE_SERVICE = "ok-const-service"\nval m = mapOf("sourceService" to SOURCE_SERVICE)\n',
+    },
+    "openbank-ok-json-service": {
+        "E.kt": 'private const val SOURCE_SERVICE = "ok-json-service"\nval s = """"sourceService":"$SOURCE_SERVICE"}"""\n',
+    },
+    "openbank-ok-put-service": {"E.kt": '    node.put("sourceService", "ok-put-service")\n'},
+    # The idiom that the first draft of this check could not see at all (4 of 21 producers).
+    "openbank-ok-typed-service": {
+        "E.kt": 'private const val SOURCE_SERVICE = "ok-typed-service"\nval sourceService: String = SOURCE_SERVICE\n',
+    },
+    "openbank-bad-typed-service": {
+        "E.kt": 'private const val SOURCE_SERVICE = "bad-typed"\nval sourceService: String = SOURCE_SERVICE\n',
+    },
+    "openbank-bad-literal-service": {"E.kt": '    sourceService = "bad-literal",\n'},
+    "openbank-bad-const-service": {
+        "E.kt": 'private const val SOURCE_SERVICE = "bad-const"\nval m = mapOf("sourceService" to SOURCE_SERVICE)\n',
+    },
+    "openbank-bad-json-service": {"E.kt": 'val s = """"sourceService":"bad-json"}"""\n'},
+    # Must NOT be flagged: a pass-through copies a value this module did not choose.
+    "openbank-passthrough-service": {"E.kt": '    mapOf("sourceService" to event.sourceService)\n'},
+    # Must NOT be flagged, and must NOT count as a producer: the grep trap that hid the gap. Every
+    # line here mentions the field, including a commented-out wrong assignment.
+    "openbank-prose-only-service": {
+        "E.kt": (
+            "/**\n"
+            " * `sourceService` is the producer's own claim. See [X.sourceService].\n"
+            ' * Historically this was sourceService = "wrong-on-purpose",\n'
+            " */\n"
+            "class X { val notTheField = 1 }\n"
+        ),
+    },
+    # Ambiguous const: two declarations, one value each, same simple name. Must be UNRESOLVED, not
+    # a coin flip — the shape that exists live (fx-service's SERVICE="fx" vs SOURCE_SERVICE).
+    "openbank-ambiguous-service": {
+        "A.kt": 'private const val SERVICE = "ambiguous-service"\nval m = mapOf("sourceService" to SERVICE)\n',
+        "B.kt": 'private const val SERVICE = "something-else"\n',
+    },
+}
+
+# module -> must it appear in the findings?
+SELF_TEST_EXPECT = {
+    "openbank-ok-literal-service": False,
+    "openbank-ok-const-service": False,
+    "openbank-ok-json-service": False,
+    "openbank-ok-put-service": False,
+    "openbank-ok-typed-service": False,
+    "openbank-bad-typed-service": True,
+    "openbank-bad-literal-service": True,
+    "openbank-bad-const-service": True,
+    "openbank-bad-json-service": True,
+    "openbank-passthrough-service": False,
+    "openbank-prose-only-service": False,
+    "openbank-ambiguous-service": True,
+}
+
+# Modules with a resolvable write site. prose-only and passthrough must NOT be counted, or the
+# vacuity floor could be satisfied by modules the check never actually measured.
+SELF_TEST_PRODUCERS = {m for m in SELF_TEST_MODULES if m not in ("openbank-prose-only-service", "openbank-passthrough-service")}
+
+
+def _build_self_test_tree(root):
+    for module, files in SELF_TEST_MODULES.items():
+        d = root / module / "src" / "main" / "kotlin"
+        d.mkdir(parents=True, exist_ok=True)
+        for name, src in files.items():
+            (d / name).write_text(src, encoding="utf-8")
+
+
+def self_test():
+    import tempfile
+
+    global BASELINE
+    saved = BASELINE
+    cases = []
+    try:
+        BASELINE = {}
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _build_self_test_tree(root)
+            findings, _, producers = scan(root)
+
+            flagged = {m for m in SELF_TEST_EXPECT if any(f.startswith(m + ":") for f in findings)}
+            for module, want in sorted(SELF_TEST_EXPECT.items()):
+                got = module in flagged
+                cases.append((f"{module} -> {'flag' if want else 'allow'}", got == want))
+            cases.append((
+                "no finding about a module we never declared",
+                len(flagged) == len(findings and flagged) and all(
+                    any(f.startswith(m + ":") for m in SELF_TEST_EXPECT) for f in findings
+                ),
+            ))
+            cases.append(("producer enumeration excludes prose-only and pass-through", producers == SELF_TEST_PRODUCERS))
+
+            # A baseline entry silences its own VALUE only.
+            BASELINE = {("openbank-bad-literal-service", "bad-literal"): "self-test"}
+            f2, matched2, _ = scan(root)
+            cases.append((
+                "baseline silences its own (module, value)",
+                not any(f.startswith("openbank-bad-literal-service:") for f in f2) and matched2 == set(BASELINE),
+            ))
+            cases.append((
+                "baseline does NOT silence a different producer",
+                any(f.startswith("openbank-bad-const-service:") for f in f2),
+            ))
+
+            # A baseline pinned to a DIFFERENT value from the same module must not silence it —
+            # this is what stops the entry absorbing a future third spelling.
+            BASELINE = {("openbank-bad-literal-service", "some-third-spelling"): "self-test"}
+            f3, matched3, _ = scan(root)
+            cases.append((
+                "baseline pinned to another value does not silence the module",
+                any(f.startswith("openbank-bad-literal-service:") for f in f3),
+            ))
+            cases.append(("a baseline matching nothing comes back stale", matched3 == set()))
+
+            # Vacuity: an emptied tree must refuse, not pass.
+            with tempfile.TemporaryDirectory() as empty:
+                BASELINE = {}
+                _, _, no_producers = scan(empty)
+                cases.append(("empty tree yields zero producers", no_producers == set()))
+                cases.append((
+                    "run() refuses a vacuous tree with exit 2",
+                    run(empty, MIN_PRODUCERS_DEFAULT, quiet=True) == 2,
+                ))
+    finally:
+        BASELINE = saved
+
+    cases.append((
+        "shipped BASELINE is well-formed",
+        all(isinstance(k, tuple) and len(k) == 2 and k[0].startswith(MODULE_PREFIX) and v for k, v in BASELINE.items()),
+    ))
+
+    failures = 0
+    for label, ok in cases:
+        print(f"{'pass' if ok else 'FAIL'}  {label}")
+        failures += 0 if ok else 1
+    print(f"\nself-test: {len(cases) - failures} passed, {failures} failed")
+    return 0 if failures == 0 else 2
+
+
+def run(root, min_producers, quiet=False):
+    if not pathlib.Path(root).is_dir():
+        if not quiet:
+            print(f"::error::root {root} does not exist — the check could not run. This is NOT a pass.")
+        return 2
+
+    findings, matched, producers = scan(root)
+
+    # Unconditional, and BEFORE the floor check: a gate that found its corpus and then failed on it
+    # must not also be reported as having lost its corpus (gatelib.subjects' own rule).
+    if not quiet:
+        gatelib.subjects(len(producers), "modules with a resolvable sourceService write site")
+
+    if len(producers) < min_producers:
+        if not quiet:
+            print(
+                f"::error::enumerated only {len(producers)} producer(s) with a resolvable "
+                f"sourceService write site, expected at least {min_producers}. The enumeration is "
+                f"broken (moved tree, changed idiom, bad --root) — a fleet that emits nothing is "
+                f"not a fleet that conforms.",
+            )
+        return 2
+
+    stale = [k for k in BASELINE if k not in matched]
+    if quiet:
+        return 1 if (findings or stale) else 0
+
+    for f in findings:
+        print(f"FAIL  {f}")
+    for module, value in stale:
+        print(
+            f'STALE  baseline entry ({module}, "{value}") no longer matches anything — the producer '
+            f"was fixed, renamed or removed.\n"
+            f"       Remove it from BASELINE in this script so the list keeps meaning something.",
+        )
+    if findings or stale:
+        print(
+            f"\n{len(findings)} non-conforming write site(s), {len(stale)} stale baseline entr(ies) "
+            f"across {len(producers)} producer(s).\n"
+            f"The value must be the module directory name without the `{MODULE_PREFIX}` prefix "
+            f"(#5256), because that is what audit-service's TopicAttribution fallback uses; a "
+            f"disagreement splits one producer into two in every group-by (#5902).",
+        )
+        return 1
+    print(
+        f"sourceService convention: OK — {len(producers)} producer(s) checked, "
+        f"{len(BASELINE)} baselined. See #5902 for why the baselined set is an open decision.",
+    )
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="sourceService convention guard (#5256, #5902)")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--min-producers", type=int, default=MIN_PRODUCERS_DEFAULT)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        return self_test()
+    return run(args.root, args.min_producers)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-audit-service/CLAUDE.md
+++ b/openbank-audit-service/CLAUDE.md
@@ -63,3 +63,13 @@
   MANUAL ack.** A missed ack stalls the partition and the audit trail stops dead — worse than the
   under-attribution being fixed. Ack explicitly, in a `finally`, and test it on the path most
   likely to skip it (an unparseable payload).
+- **`source_service` is not a stable key for `lending`, and only for `lending`.** Twenty of the
+  fleet's twenty-one producers emit their module directory name minus `openbank-` (#5256, now
+  enforced by `check-source-service-convention.py`); `openbank-lending-service` deliberately emits
+  `"lending"` while `TopicAttribution` maps `openbank.lending.events` to `"lending-service"`. Six of
+  its nine event types therefore changed spelling mid-stream when #5399 gave them their own
+  `sourceService` on 2026-08-18, and read `unknown` before #4270. Any `GROUP BY source_service`
+  splits that one producer into three aliases. The decision to keep `"lending"` rather than rename
+  and re-split is #5902; the windows, the six event types and the reconciliation query are written
+  down in `openbank-lending-service/CLAUDE.md`. Nothing to fix here — just do not read a
+  `source_service` histogram as a producer census without it.

--- a/openbank-lending-service/CLAUDE.md
+++ b/openbank-lending-service/CLAUDE.md
@@ -1,0 +1,66 @@
+# openbank-lending-service — service notes
+
+## Engineering notes
+
+- **`source_service` for this producer is `"lending"`, not `"lending-service"` — a settled
+  decision (#5902), not drift awaiting cleanup. Grouping `audit_entries` by `source_service`
+  splits this one producer into THREE aliases unless you account for it.** Every other producer in
+  the fleet emits its module directory name minus the `openbank-` prefix (#5256), and
+  `check-source-service-convention.py` now enforces exactly that; lending is the one deliberate
+  exception, baselined in that script with this reason. All nine of its outbox event types emit
+  the literal `"lending"` from `LendingService.kt`, `OriginationDecisionService.kt` and
+  `TerminationService.kt`.
+
+  The aliases exist because attribution changed underneath the events twice, so the value in a row
+  depends on *when* it was written, not on anything about the event:
+
+  | window | the 3 early types | the 6 later types |
+  |---|---|---|
+  | 2026-07-31 → 2026-08-09 | `lending` | `unknown` |
+  | 2026-08-09 → 2026-08-18 | `lending` (EVENT) | `lending-service` (TOPIC) |
+  | 2026-08-18 → now | `lending` | `lending` (EVENT) |
+
+  - **the 3 early types** — `credit.application.transition`, `credit.decision.evaluated`,
+    `credit.loan.transition` — carried `sourceService` from the day they shipped (ADR-0214 /
+    ADR-0215, 2026-07-31 and 2026-08-01), so they read `lending` for their whole history.
+  - **the 6 later types** — `loan.disbursed`, `loan.interest_accrued`, `loan.written_off`,
+    `loan.rescheduled`, `loan.stage_changed`, `loan.provisioned` — carried no `sourceService` at
+    all until PR #5399 (merged 2026-08-18). Before #4270 (2026-08-09) `AuditConsumer` read the
+    field or defaulted, so they stored `unknown`; between #4270 and #5399 they resolved through
+    `TopicAttribution`, whose table maps `openbank.lending.events` to `lending-service`; after
+    #5399 the producer's own value wins and they read `lending` like the rest.
+
+  So `source_service = 'lending-service'` exists **only** for those six event types and **only**
+  inside that nine-day window. It is a bounded artefact, which is what made keeping `"lending"`
+  the cheap option.
+
+  Any query grouping by `source_service` — the documented way to detect a producer that has
+  stopped emitting, or one that never started — must treat `lending`, `lending-service` and
+  (before 2026-08-09) `unknown` as one producer. `unknown` is the weakest of the three: it is the
+  fleet-wide "nobody said" sentinel, so it is not lending's alone, and only the `event_type`
+  narrows it. Establish the real row counts before relying on any of this:
+
+  ```sql
+  SELECT source_service, source_service_source, event_type,
+         min(recorded_at), max(recorded_at), count(*)
+  FROM audit_entries
+  WHERE source_service IN ('lending', 'lending-service', 'unknown')
+  GROUP BY 1, 2, 3
+  ORDER BY 3, 4;
+  ```
+
+- **The rows cannot be rewritten, so "we did not backfill" is a property of the table, not an
+  omission anyone can fix later.** `audit_entries` is append-only *at the database* — V2 installs
+  `no_update_audit` / `no_delete_audit` rules (`DO INSTEAD NOTHING`), so an `UPDATE` normalising
+  the spelling silently affects zero rows and reports success. Even with the rules removed it
+  would be the wrong act: `source_service` is one of the fields hashed into the ADR-0031 /
+  ADR-0133 `record_hash` chain, so rewriting it breaks tamper-evidence for every affected row and
+  every row after it. Reconciliation belongs in the query (or a view), never in the data. That is
+  half the reason the decision above is the cheap one.
+
+- **Do not "fix" the spelling to match the convention.** A rename touches nine shipped event types
+  and introduces a *fourth* boundary in `audit_entries` — a second split, on top of a split that
+  can never be repaired for the reason above. If the decision is ever revisited, removing lending's
+  entry from `check-source-service-convention.py`'s `BASELINE` is the visible act that reopens it;
+  the entry pins the `(module, value)` pair, so drifting to some third spelling fails the gate
+  today regardless.


### PR DESCRIPTION
## What this is

`source_service` is the column every audit and analytics query groups by — it is the documented way
to detect a producer that has stopped emitting, or one that never started. #5256 defines the value
as *the module directory name minus the `openbank-` prefix*. Nothing enforced it.

This PR **measures** the fleet, **enforces** the convention going forward, and records the one
producer that disagrees as a **declared, decided exception**.

> **The decision is taken (#5902): keep `lending`, document the boundary.** No rename, no backfill,
> no `TopicAttribution` change. Section 4 says why that is the cheap option and why it is permanent
> rather than deferred; section 5 is now the record of the decision, not a menu.

## 1. The measurement

Read the emitted value at each write site, not the field name. Full table, `origin/main`:

| module | emits | expected | |
|---|---|---|---|
| openbank-account-service | `account-service` | `account-service` | ok |
| openbank-balance-service | `balance-service` | `balance-service` | ok |
| openbank-card-issuance-service | `card-issuance-service` | `card-issuance-service` | ok |
| openbank-clearing-service | `clearing-service` | `clearing-service` | ok |
| openbank-consent-service | `consent-service` | `consent-service` | ok |
| openbank-customer-edge | `customer-edge` | `customer-edge` | ok |
| openbank-dispute-service | `dispute-service` | `dispute-service` | ok |
| openbank-document-service | `document-service` | `document-service` | ok |
| openbank-domestic-payment | `domestic-payment` | `domestic-payment` | ok |
| openbank-fx-service | `fx-service` | `fx-service` | ok |
| openbank-kyc-service | `kyc-service` | `kyc-service` | ok |
| **openbank-lending-service** | **`lending`** | **`lending-service`** | **MISMATCH, 9 write sites** |
| openbank-party-service | `party-service` | `party-service` | ok |
| openbank-sanctions-service | `sanctions-service` | `sanctions-service` | ok |
| openbank-sca-service | `sca-service` | `sca-service` | ok |
| openbank-security-scanner | `security-scanner` | `security-scanner` | ok |
| openbank-sepa-instant | `sepa-instant` | `sepa-instant` | ok |
| openbank-sepa-payment | `sepa-payment` | `sepa-payment` | ok |
| openbank-statement-service | `statement-service` | `statement-service` | ok |
| openbank-swift-service | `swift-service` | `swift-service` | ok |
| openbank-transaction-service | `transaction-service` | `transaction-service` | ok |

20 of 21 conform. Not producers, correctly not flagged: `openbank-audit-service` and
`openbank-analytics-sink` (consumers reading the field back), `openbank-libs-domain` (declares the
envelope), and `openbank-sepa-instant`'s publisher line, which forwards `event.sourceService`
rather than choosing a value.

## 2. What is already in `audit_entries` — three segments, not two

The issue describes one boundary. Reading the history there are **three**, because EVENT-sourced
attribution itself only arrived on 2026-08-09:

| window | mechanism | the 3 early types | the 6 upgraded types |
|---|---|---|---|
| 2026-07-31 -> 2026-08-09 | `node["sourceService"] ?: "unknown"` | `lending` | `unknown` |
| 2026-08-09 -> 2026-08-18 | #4270 adds EVENT, then TOPIC fallback | `lending` (EVENT) | `lending-service` (TOPIC) |
| 2026-08-18 -> now | #5399 adds the field to all six | `lending` | `lending` (EVENT) |

- early three: `credit.application.transition`, `credit.decision.evaluated`, `credit.loan.transition`
  (shipped 2026-07-31 / 08-01)
- upgraded six: `loan.disbursed`, `loan.interest_accrued`, `loan.written_off`, `loan.rescheduled`,
  `loan.stage_changed`, `loan.provisioned` (#5399, merged 2026-08-18T19:06:10Z)

So `source_service = 'lending-service'` exists in `audit_entries` **only** for those six types and
**only** in that nine-day window, and `'unknown'` covers them before it. That is narrower than "two
spellings with one boundary", and it changes the cost of a backfill.

No live DB was queried. The query that would settle the row counts:

```sql
SELECT source_service, source_service_source, event_type,
       min(recorded_at), max(recorded_at), count(*)
FROM audit_entries
WHERE source_service IN ('lending', 'lending-service', 'unknown')
GROUP BY 1, 2, 3
ORDER BY 3, 4;
```

`audit_entries` is append-only at the DB (`DO INSTEAD NOTHING`), so a "backfill" is not an `UPDATE`
— that is a fact the options below have to carry.

## 3. The gate

`.github/scripts/check-source-service-convention.py`, registered as `source-service-convention` in
the `kotlin` shard, `mode: enforced`, `min_subjects: 20`.

It resolves the value at each **write site** through all four idioms this fleet uses — named
arg/property default, map entry, `node.put`, hand-built JSON string — follows a `const val` within
the module, and reports an ambiguous const as UNRESOLVED rather than guessing (several modules carry
an unrelated metrics-tag `const val SERVICE = "fx"` beside `SOURCE_SERVICE = "fx-service"`).
Pass-through sites carry no literal and are correctly silent.

**The probe trap fired on this check's own first draft.** A pattern without the optional `: String`
could not see `val sourceService: String = SOURCE_SERVICE`, enumerated **17** of 21 producers, and
printed a confident `OK`. Only the `min_subjects` floor turned that into a visible number, which is
why the floor is declared in both `gates.yaml` and the script.

### Falsification — by effect, not by appearance

| fed | result |
|---|---|
| a real producer given a wrong value (`consent-service` -> `"consent"`) | exit 1, names the file:line |
| the lending baseline removed | exit 1, all nine write sites |
| an emptied producer list (`--root` at an empty dir) | **exit 2** — refuses, does not pass vacuously |
| the current tree | exit 0, `SUBJECTS=21` |

`--self-test` is 21 assertions driving the real `scan()` over a synthetic tree: both directions of
each of the four idioms, pass-through allowed, a prose-only module allowed **and excluded from the
producer count**, an ambiguous const reported, a baseline entry silencing only its own
`(module, value)`, a baseline pinned to a different value **not** silencing the module, and a
stale baseline reported.

## 4. lending is a declared exception — decided, not debt

`("openbank-lending-service", "lending")` is a **declared exception with the decision as its
reason**, not a rename anyone still owes. The entry, its header comment in the script and the
`gates.yaml` comment all now say so explicitly, so a future reader cannot mistake it for a TODO.

**It is permanent rather than deferred, and that is structural.** The rows lending has already
written cannot be converged *by anyone*:

- `audit_entries` is append-only **at the database** — V2 installs `no_update_audit` /
  `no_delete_audit` as `DO INSTEAD NOTHING`, so a normalising `UPDATE` affects **zero rows and
  reports success**;
- `source_service` is hashed into the ADR-0031 / ADR-0133 `record_hash` chain, so rewriting it would
  break tamper-evidence for every affected row **and every row after it**.

So a rename could only add a *fourth* boundary on top of a split that can never be repaired. That is
half the reason keeping `lending` is the cheap answer.

**The gate's behaviour is unchanged by the rewording, deliberately.** The entry still pins the
`(module, VALUE)` pair, so lending drifting to some third spelling still fails, and removing the
entry remains the visible act if #5902 is ever reopened.

## 5. Where the boundary is written down

The three-segment table is the valuable artefact and it does not belong only in a PR body. It now
lives in **`openbank-lending-service/CLAUDE.md`** (new, the repo's per-service-lore convention),
carrying all of it: that `lending` / `lending-service` / `unknown` are one producer; which three
event types read `lending` throughout and which six carry `lending-service` for those nine days;
that `GROUP BY source_service` therefore splits lending three ways; the reconciliation query above;
and the append-only + chain-hashed facts in full. `unknown` is flagged there as the weakest of the
three — it is the fleet-wide "nobody said" sentinel, not lending's alone, so only `event_type`
narrows it.

**`openbank-audit-service/CLAUDE.md`** gets a short pointer, because that is where a
`source_service` histogram gets read and must not be mistaken for a producer census.

This PR is still `Refs #5902`, not `Closes` — the issue closes when this merges.

## Verification

- `run-gates.py --group kotlin` -> **20/20 PASS**; `source-service-convention` reports `SUBJECTS=21`
- **The three negative cases re-run after the rewording, to prove it did not loosen the gate:**
  consent given `"consent"` -> exit 1; the lending entry removed -> exit 1 at all nine write sites;
  an emptied producer list -> exit 2. `--self-test` 21/21.
- `stale-comment-references` and `gate-lifecycle-metadata` -> PASS (the new `CLAUDE.md` is tracked
  and the gate entry declares `rationale` + `review_after`)
- `run-gates.py --all` -> 159 gates, `PASS=152`. The 7 remaining failures were confirmed
  **pre-existing on a pristine `origin/main` worktree** (base-dependent gates with no
  `$PR_DIFF_BASE` locally, plus litellm/loki/temporal/terraform), identical set, unchanged by this PR.
- `gate-lifecycle-metadata` passes: the new entry declares `rationale` + `review_after`.
- No Kotlin module is touched, so no gradle task applies. No `version.txt` / `openapi.yaml` /
  migration change. `.github/**` is outside every release package's paths, and the two `CLAUDE.md`
  files ride a `docs:` commit — a hidden type — so nothing releases on either axis.

Refs #5902, #5256, #5399
