### PR TITLE
fix(sca): publish the ScaStatus and ScaPurpose vocabularies the service actually uses

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -2186,6 +2186,42 @@ gates:
     run: |
       python3 .github/scripts/check-pact-provider-replay.py
 
+  # openapi enum vs the Kotlin enum behind it (issue #5895 / #5962, enforced).
+  #
+  # The axis the api-contract gate below structurally CANNOT see: oasdiff compares a spec to its
+  # own previous version, never to the implementation. So a spec enum hand-written once and never
+  # re-checked drifts forever and every gate stays green. openbank-kyc-service published
+  # `[IDENTITY, SANCTIONS, PEP, ADVERSE_MEDIA, SOURCE_OF_FUNDS]` against a domain
+  # `CheckType { IDENTITY, ADDRESS, PEP_SCREENING, SANCTIONS_SCREENING, ADVERSE_MEDIA }` from the
+  # day the file was written — three names misspelled, one real check unpublished, and one value
+  # that has never existed in the code. Its own PUT body was fiction in the same way.
+  #
+  # Pairing is by VALUE OVERLAP, not by name: nothing declares which Kotlin enum a spec enum
+  # serves, and matching on names would find almost none of them. An unpaired spec enum is not a
+  # finding (many are free-form vocabularies with no Kotlin type).
+  #
+  # RATCHET: the 27 drifts across 16 services that exist today are a BASELINE constant in the
+  # script (owned by #5962), so this is enforced from day one and number 28 is red at PR time. A
+  # baseline entry that no longer drifts also FAILS, so the list cannot rot into furniture — same
+  # contract as check-pact-provider-replay.py and check-adr-partial-followup.py above.
+  - id: openapi-enum-domain-drift
+    name: "openapi enum matches the domain enum it serves (issue #5962, enforced)"
+    group: api
+    mode: enforced
+    rationale: >
+      oasdiff compares a spec to its own previous version and never to the implementation, so a
+      spec enum hand-written once and never re-checked drifts forever with every gate green.
+      openbank-kyc-service published three misspelled check names, omitted a real check, and
+      advertised a value (SOURCE_OF_FUNDS) that has never existed in the code — from the day the
+      file was written until #5895, and 27 more pairings across 16 services still do (#5962).
+    review_after: '2027-02-20'
+    min_subjects: 100
+    selftest: |
+      python3 .github/scripts/check-openapi-enum-vs-domain.py --self-test
+    selftest_expect: pass
+    run: |
+      python3 .github/scripts/check-openapi-enum-vs-domain.py --enforce
+
   # ADR-0048 D5: api-contract gate — classify the API-contract bump from the
   # OpenAPI diff (oasdiff), independently of the release axis (version.txt):
   #   breaking  => info.version MAJOR (new URL major /api/v{N+1})

--- a/.github/scripts/check-openapi-enum-vs-domain.py
+++ b/.github/scripts/check-openapi-enum-vs-domain.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""openapi-enum-domain-drift gate — does a spec enum still match the Kotlin enum behind it?
+
+The axis nothing else watches. `oasdiff` (the api-contract gate, ADR-0048) compares a spec to
+its own PREVIOUS version, never to the implementation, so a spec enum that was hand-written once
+and never re-checked drifts silently and forever. openbank-kyc-service published
+`[IDENTITY, SANCTIONS, PEP, ADVERSE_MEDIA, SOURCE_OF_FUNDS]` against a domain
+`CheckType { IDENTITY, ADDRESS, PEP_SCREENING, SANCTIONS_SCREENING, ADVERSE_MEDIA }` from the day
+the file was written: three names misspelled, one real check unpublished, and one value
+(`SOURCE_OF_FUNDS`) that has never existed in the code at all (#5895). Everything was green the
+whole time, because nothing compared the two documents.
+
+## How a spec enum is paired with a Kotlin enum
+
+There is no declaration linking them, so pairing is by VALUE OVERLAP, not by name — a spec enum
+is rarely named after the class, and matching on names would find almost nothing:
+
+  * collect every `enum:` value-set in the service's openapi.yaml,
+  * collect every `enum class X { A, B, C }` value-set in that service's src/main,
+  * pair a spec set with a Kotlin set when they share at least MIN_OVERLAP of the smaller set,
+  * report a pairing whose sets are NOT equal.
+
+Overlap, not equality, is what makes the check able to fire: an enum that agrees perfectly pairs
+and passes, and one that has drifted still overlaps enough to be recognised as the same concept.
+An unpaired spec enum is NOT a finding — plenty are free-form vocabularies with no Kotlin type
+(sort orders, filter keywords), and reporting those would bury the real ones.
+
+## Ratchet, not a wall
+
+Existing drift is baselined in BASELINE below with the issue that owns it; a NEW drift fails.
+A baseline entry that no longer drifts also fails, so the list cannot outlive its justification
+(the KNOWN_UNCOVERED shape used by check-pact-provider-replay.py).
+
+Run `--self-test` to falsify it: it feeds the matcher the cases it MUST flag and the ones it
+MUST NOT, so the gate is not merely unfalsified-green.
+
+Usage:
+    check-openapi-enum-vs-domain.py [--enforce] [--self-test]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import gatelib  # noqa: E402  (path shim above must run first)
+
+# Share this fraction of the LARGER of the two sets, and at least MIN_SHARED values, to be
+# considered the same vocabulary. Two calibration points, both pinned by the self-test:
+#   * 0.4 rather than 0.5, because the #5895 drift the gate exists for shares exactly 2 of 5
+#     values (IDENTITY, ADVERSE_MEDIA) — at 0.5 the gate is green about its own motivating
+#     defect. Raising it back turns that case red rather than turning the gate quietly blind.
+#   * the LARGER set as denominator rather than the smaller, because the smaller one lets a
+#     long unrelated vocabulary that happens to contain two familiar names (2 of 8) pair with a
+#     5-value domain enum and be reported as drift.
+MIN_OVERLAP = 0.4
+MIN_SHARED = 2
+
+# Spec-vs-domain drift that exists today, each with the issue that owns it.
+# Format: "<service>:<sorted spec values>" -> reason
+BASELINE: dict[str, str] = {
+    "openbank-account-service:ACTIVE,CLOSED,FROZEN,PENDING":
+        "#5962 — AccountStatus: spec-only PENDING; undeclared DORMANT/PENDING_ACTIVATION",
+    "openbank-account-service:APPROVED,CANCELLED,PENDING,REJECTED":
+        "#5962 — WithdrawalProposalStatus: undeclared EXPIRED",
+    "openbank-campaign-service:BANNER,PUSH":
+        "#5962 — Channel: undeclared EMAIL",
+    "openbank-campaign-service:DRY_RUN,SENT,SUPPRESSED_CAP,SUPPRESSED_CONSENT,SUPPRESSED_QUIET_HOURS":
+        "#5962 — SendOutcome: undeclared CONVERTED/FAILED/SKIPPED_CONDITION/SUPPRESSED_LIST",
+    "openbank-card-issuance-service:MASTERCARD,VISA":
+        "#5962 — CardNetwork: undeclared AMEX/UNIONPAY",
+    "openbank-clearing-service:CZ_DOMESTIC,SEPA_SCT,SEPA_SCT_INST,SWIFT":
+        "#5962 — PaymentRail: spec-only CZ_DOMESTIC; undeclared DOMESTIC/INTERNAL",
+    "openbank-consent-service:ACTIVE,EXPIRED,PENDING,REJECTED,REVOKED":
+        "#5962 — ConsentStatus: spec-only PENDING; undeclared PENDING_SCA/SUPERSEDED",
+    "openbank-copilot-service:CARD_FREEZE,DISPUTE,PAYMENT":
+        "#5962 — ActionKind: undeclared FX_CONVERSION",
+    "openbank-document-service:DECLINED,SIGNED":
+        "#5962 — SignerStatus: undeclared PENDING",
+    "openbank-ledger-service:CUTOFF,LOCKED,TIED_OUT":
+        "#5962 — AccountingDayStatus: undeclared OPEN",
+    "openbank-lending-service:APPROVED,EXECUTED,PENDING,REJECTED":
+        "#5962 — CollateralStatus: spec-only EXECUTED",
+    "openbank-party-service:COMPANY_REGISTRATION,DRIVING_LICENSE,ID_CARD,PASSPORT":
+        "#5962 — DocumentType: spec-only DRIVING_LICENSE/ID_CARD; undeclared DRIVING_LICENCE/NATIONAL_ID/TAX_ID",
+    "openbank-party-service:EXPIRED,PENDING,REJECTED,VERIFIED":
+        "#5962 — KycStatus: spec-only PENDING/VERIFIED; undeclared APPROVED/IN_PROGRESS/NOT_STARTED",
+    "openbank-party-service:ACTIVE,CLOSED,PENDING_KYC,SUSPENDED":
+        "#5962 — PartyStatus: undeclared MERGED",
+    "openbank-pid-service:ACTIVE,CLOSED,SUSPENDED":
+        "#5962 — PartyStatus: spec-only CLOSED; undeclared DECEASED/TERMINATED",
+    "openbank-pid-service:LEGAL_ENTITY,NATURAL_PERSON":
+        "#5962 — PartyType: undeclared SOLE_TRADER",
+    "openbank-pid-service:INDIVIDUAL,LEGAL_ENTITY,SOLE_TRADER":
+        "#5962 — PartyType: spec-only INDIVIDUAL; undeclared NATURAL_PERSON",
+    "openbank-pid-service:EXPIRED,PENDING,REJECTED,VERIFIED":
+        "#5962 — Status: spec-only REJECTED/VERIFIED; undeclared COMPLETED",
+    "openbank-sanctions-service:CNB_DOMESTIC,EU_CONSOLIDATED,FATF_HIGH_RISK,HM_TREASURY,OFAC_SDN,UN_CONSOLIDATED":
+        "#5962 — SanctionsListType: undeclared PEP_GLOBAL",
+    "openbank-sca-service:EXPIRED,FAILED,PENDING,VERIFIED":
+        "#5962 — ScaStatus: spec-only VERIFIED; undeclared CANCELLED/COMPLETED",
+    "openbank-sepa-instant:ACCEPTED,RECALLED,REJECTED,SETTLED,SUBMITTED":
+        "#5962 — SctInstStatus: spec-only ACCEPTED/SUBMITTED; undeclared PENDING/PROCESSING/TIMEOUT",
+    "openbank-sepa-payment:COMPLETED,PROCESSING,RECALLED,REJECTED":
+        "#5962 — SepaPaymentStatus: spec-only RECALLED; undeclared CANCELLED/RECEIVED/RETURNED/VALIDATED",
+    "openbank-sepa-payment:COMPLETED,PENDING,PROCESSING,RECALLED,REJECTED":
+        "#5962 — SepaPaymentStatus: spec-only PENDING/RECALLED; undeclared CANCELLED/RECEIVED/RETURNED/VALIDATED",
+    "openbank-statement-service:RECONCILIATION,UNKNOWN,UPSTREAM":
+        "#5962 — CloseFailureReason: undeclared NOT_VIABLE",
+    "openbank-swift-service:ACKNOWLEDGED,FAILED,PENDING,REJECTED,SENT,VALIDATED":
+        "#5962 — SwiftStatus: undeclared COMPLETED",
+    "openbank-transaction-service:COMPLETED,FAILED,PENDING,REVERSED":
+        "#5962 — TransactionStatus: undeclared PROCESSING",
+    "openbank-transaction-service:CREDIT,DEBIT,FEE,REVERSAL":
+        "#5962 — TransactionType: undeclared ADJUSTMENT/INTEREST/TRANSFER",
+}
+
+SPEC_ENUM_INLINE = re.compile(r"enum:\s*\[([^\]]*)\]")
+SPEC_ENUM_BLOCK = re.compile(r"enum:[ \t]*\n((?:[ \t]*-[ \t]*\S+[ \t]*\n)+)")
+KOTLIN_ENUM = re.compile(r"enum\s+class\s+(\w+)\s*(?::[^{]*)?\{([^}]*)\}")
+BLOCK_ITEM = re.compile(r"^[ \t]*-[ \t]*[\"\']?([A-Za-z0-9_]+)[\"\']?[ \t]*$", re.M)
+# A constant is the leading identifier of a member; the rest of a member may be a constructor
+# call (`ACTIVE("active")`) or an override block, and must not be mined for tokens.
+MEMBER = re.compile(r"^\s*([A-Z][A-Z0-9_]*)\s*(?:\(|$)")
+LINE_COMMENT = re.compile(r"//[^\n]*")
+BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.S)
+VALUE = re.compile(r"[A-Z][A-Z0-9_]*")
+
+
+def _spec_values(raw: str) -> frozenset[str]:
+    """Values of an inline YAML flow sequence: `enum: [A, B, C]`, quotes optional."""
+    return frozenset(
+        v.strip().strip("\"'")
+        for v in raw.split(",")
+        if VALUE.fullmatch(v.strip().strip("\"'"))
+    )
+
+
+def _kotlin_values(body: str) -> frozenset[str]:
+    """Constants of a Kotlin enum body.
+
+    Comments are stripped FIRST. Without that the extractor mines ordinary KDoc prose for
+    capitalised tokens and invents constants — a first cut of this gate reported
+    `spec omits ['A', 'ADR', 'D1', 'NOT', 'OUTCOME']` across a dozen services, all of it words
+    out of doc comments. A drift gate whose findings are mostly noise gets baselined wholesale
+    and then protects nothing, so this is load-bearing, not tidiness.
+    Only the part before a `;` is constants; anything after it is ordinary class body.
+    """
+    body = LINE_COMMENT.sub("", BLOCK_COMMENT.sub("", body))
+    constants = body.split(";", 1)[0]
+    out = set()
+    for member in constants.split(","):
+        m = MEMBER.match(member)
+        if m:
+            out.add(m.group(1))
+    return frozenset(out)
+
+
+def spec_enums(text: str) -> set[frozenset[str]]:
+    out: set[frozenset[str]] = set()
+    for m in SPEC_ENUM_INLINE.finditer(text):
+        vals = _spec_values(m.group(1))
+        if len(vals) >= 2:
+            out.add(vals)
+    for m in SPEC_ENUM_BLOCK.finditer(text):
+        vals = frozenset(v for v in BLOCK_ITEM.findall(m.group(1)) if VALUE.fullmatch(v))
+        if len(vals) >= 2:
+            out.add(vals)
+    return out
+
+
+def kotlin_enums(root: Path) -> dict[str, frozenset[str]]:
+    out: dict[str, frozenset[str]] = {}
+    for kt in sorted(root.rglob("*.kt")):
+        for m in KOTLIN_ENUM.finditer(kt.read_text(encoding="utf-8", errors="replace")):
+            vals = _kotlin_values(m.group(2))
+            if len(vals) >= 2:
+                out[m.group(1)] = vals
+    return out
+
+
+def best_match(
+    spec: frozenset[str], domain: dict[str, frozenset[str]]
+) -> tuple[str, frozenset[str]] | None:
+    """The Kotlin enum sharing the most values with `spec`, if it clears MIN_OVERLAP."""
+    best: tuple[str, frozenset[str]] | None = None
+    best_n = 0
+    for name, vals in domain.items():
+        n = len(spec & vals)
+        if n > best_n:
+            best, best_n = (name, vals), n
+    if best is None or best_n < MIN_SHARED or best_n < MIN_OVERLAP * max(len(spec), len(best[1])):
+        return None
+    return best
+
+
+def scan(repo: Path) -> tuple[list[tuple[str, str, frozenset[str], str, frozenset[str]]], int]:
+    """Findings, and the number of spec-enum/Kotlin-enum PAIRINGS examined.
+
+    The subject count is pairings, not specs: a glob that still finds 50 specs while the Kotlin
+    source root has moved would pair nothing and report every one of them clean.
+    """
+    findings = []
+    pairings = 0
+    for spec in sorted(repo.glob("openbank-*/src/main/resources/openapi.yaml")):
+        service = spec.parts[len(repo.parts)]
+        src = repo / service / "src" / "main" / "kotlin"
+        if not src.is_dir():
+            continue
+        domain = kotlin_enums(src)
+        if not domain:
+            continue
+        for values in spec_enums(spec.read_text(encoding="utf-8", errors="replace")):
+            match = best_match(values, domain)
+            if match is None:
+                continue
+            pairings += 1
+            if match[1] == values:
+                continue
+            findings.append((service, str(spec.relative_to(repo)), values, match[0], match[1]))
+    return findings, pairings
+
+
+def key(service: str, values: frozenset[str]) -> str:
+    return f"{service}:{','.join(sorted(values))}"
+
+
+def self_test() -> int:
+    """Feed the matcher what it MUST flag and what it MUST NOT. A gate that has only ever
+    passed is unfalsified — every case below is the negative one for some part of the logic."""
+    domain = {
+        "CheckType": frozenset({"IDENTITY", "ADDRESS", "PEP_SCREENING", "SANCTIONS_SCREENING", "ADVERSE_MEDIA"}),
+        "CaseStatus": frozenset({"OPEN", "UNDER_REVIEW", "APPROVED", "REJECTED"}),
+    }
+    cases: list[tuple[str, frozenset[str], bool]] = [
+        # (name, spec values, must be reported as drift)
+        ("the real #5895 drift is flagged",
+         frozenset({"IDENTITY", "SANCTIONS", "PEP", "ADVERSE_MEDIA", "SOURCE_OF_FUNDS"}), True),
+        ("an exactly-matching enum is NOT flagged", domain["CheckType"], False),
+        ("a single phantom added value is flagged",
+         domain["CheckType"] | {"SOURCE_OF_FUNDS"}, True),
+        ("a single omitted value is flagged", domain["CheckType"] - {"ADDRESS"}, True),
+        ("an unrelated free-form vocabulary is NOT flagged (no pairing at all)",
+         frozenset({"ASC", "DESC"}), False),
+        ("a vocabulary overlapping by ONE value out of many does not pair",
+         frozenset({"IDENTITY", "AAA", "BBB", "CCC", "DDD", "EEE"}), False),
+        ("two shared values out of eight is coincidence, not the same vocabulary",
+         frozenset({"IDENTITY", "ADDRESS", "AAA", "BBB", "CCC", "DDD", "EEE", "FFF"}), False),
+        ("a different domain enum in the same service pairs with ITS OWN match",
+         domain["CaseStatus"], False),
+        ("drift in the second enum is still found",
+         frozenset({"OPEN", "UNDER_REVIEW", "APPROVED", "DECLINED"}), True),
+    ]
+    failures = 0
+    for name, values, must_flag in cases:
+        match = best_match(values, domain)
+        flagged = match is not None and match[1] != values
+        if flagged != must_flag:
+            print(f"  FAIL  {name}: expected flagged={must_flag}, got {flagged} (match={match})")
+            failures += 1
+        else:
+            print(f"  ok    {name}")
+
+    # The extractors, against the shapes that made a first cut of this gate report noise.
+    parser_cases: list[tuple[str, frozenset[str], frozenset[str]]] = [
+        ("a plain Kotlin enum body", _kotlin_values("IDENTITY, ADDRESS, PEP_SCREENING"),
+         frozenset({"IDENTITY", "ADDRESS", "PEP_SCREENING"})),
+        ("KDoc prose in the body is not a constant",
+         _kotlin_values("/** A hit MUST NOT auto-reject (ADR-0116 D1). */\n    PASSED,\n    FAILED"),
+         frozenset({"PASSED", "FAILED"})),
+        ("a line comment in the body is not a constant",
+         _kotlin_values("ACTIVE, // NOT the same as OPEN\n    CLOSED"),
+         frozenset({"ACTIVE", "CLOSED"})),
+        ("constructor arguments are not constants",
+         _kotlin_values('SEPA("sepa"), SWIFT("swift")'), frozenset({"SEPA", "SWIFT"})),
+        ("members after the `;` are not constants",
+         _kotlin_values("OPEN, CLOSED;\n    fun isOPEN() = this == OPEN"),
+         frozenset({"OPEN", "CLOSED"})),
+        ("lowercase tokens are not constants", _kotlin_values("identity, address"), frozenset()),
+        ("an inline spec enum", _spec_values("IDENTITY, ADDRESS"),
+         frozenset({"IDENTITY", "ADDRESS"})),
+        ("a quoted inline spec enum", _spec_values("'OPEN', \"CLOSED\""),
+         frozenset({"OPEN", "CLOSED"})),
+    ]
+    for name, got, want in parser_cases:
+        if got != want:
+            print(f"  FAIL  {name}: got {sorted(got)}, want {sorted(want)}")
+            failures += 1
+        else:
+            print(f"  ok    {name}")
+
+    block = spec_enums("        enum:\n          - OPEN\n          - CLOSED\n")
+    if block != {frozenset({"OPEN", "CLOSED"})}:
+        print(f"  FAIL  a block-style spec enum: {block}")
+        failures += 1
+    else:
+        print("  ok    a block-style spec enum")
+
+    print("self-test: " + ("FAILED" if failures else "passed"))
+    return 1 if failures else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--enforce", action="store_true")
+    ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--repo", default=".")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    repo = Path(args.repo).resolve()
+    level = "error" if args.enforce else "warning"
+    findings, pairings = scan(repo)
+    gatelib.subjects(pairings, "spec-enum/domain-enum pairing(s)")
+    seen = set()
+    new = 0
+
+    for service, rel, values, kt_name, kt_values in findings:
+        k = key(service, values)
+        seen.add(k)
+        if k in BASELINE:
+            continue
+        new += 1
+        missing = sorted(kt_values - values)
+        phantom = sorted(values - kt_values)
+        print(
+            f"::{level} file={rel}::openapi enum drifts from the domain enum "
+            f"`{kt_name}` it serves: spec omits {missing or 'nothing'}, "
+            f"spec advertises values the code does not have: {phantom or 'none'}. "
+            f"Reconcile the two, or (if the spec is right) rename the Kotlin enum."
+        )
+
+    stale = sorted(set(BASELINE) - seen)
+    for k in stale:
+        print(
+            f"::{level}::openapi-enum drift baseline entry `{k}` no longer drifts — "
+            f"drop it from BASELINE in {Path(__file__).name}."
+        )
+
+    if not new and not stale:
+        print(
+            f"openapi-enum-domain-drift: {len(findings)} paired enum(s) drift, "
+            f"all {len(BASELINE)} baselined; no new drift."
+        )
+        return 0
+    return 1 if args.enforce else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check-openapi-enum-vs-domain.py
+++ b/.github/scripts/check-openapi-enum-vs-domain.py
@@ -100,8 +100,6 @@ BASELINE: dict[str, str] = {
         "#5962 — Status: spec-only REJECTED/VERIFIED; undeclared COMPLETED",
     "openbank-sanctions-service:CNB_DOMESTIC,EU_CONSOLIDATED,FATF_HIGH_RISK,HM_TREASURY,OFAC_SDN,UN_CONSOLIDATED":
         "#5962 — SanctionsListType: undeclared PEP_GLOBAL",
-    "openbank-sca-service:EXPIRED,FAILED,PENDING,VERIFIED":
-        "#5962 — ScaStatus: spec-only VERIFIED; undeclared CANCELLED/COMPLETED",
     "openbank-sepa-instant:ACCEPTED,RECALLED,REJECTED,SETTLED,SUBMITTED":
         "#5962 — SctInstStatus: spec-only ACCEPTED/SUBMITTED; undeclared PENDING/PROCESSING/TIMEOUT",
     "openbank-sepa-payment:COMPLETED,PROCESSING,RECALLED,REJECTED":

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -776,6 +776,28 @@ touch `.github/`. What stays here is what fires from OUTSIDE that tree: editing
   close that; only a merge queue or up-to-date-branch enforcement would, and the repo has
   deliberately chosen detection over prevention. So the re-check above is still required — but
   a branch that has been sitting is the risk, not a branch that was created early.
+- **`oasdiff` compares a spec to its own PREVIOUS version, never to the implementation — so a spec
+  enum that was wrong from the first commit is wrong forever, and every gate stays green.** The
+  version axis is watched from both ends and the *truth* axis from neither.
+  `openbank-kyc-service` published `checkType` as
+  `[IDENTITY, SANCTIONS, PEP, ADVERSE_MEDIA, SOURCE_OF_FUNDS]` against a domain
+  `CheckType { IDENTITY, ADDRESS, PEP_SCREENING, SANCTIONS_SCREENING, ADVERSE_MEDIA }`: three
+  names misspelled, `ADDRESS` (a check `createCase` creates on every case) unpublished, and
+  `SOURCE_OF_FUNDS` a value that has never existed in the code. Its `UpdateCheckRequest` was
+  fiction in the same way — `required: [result]` with `result` carrying the status enum, against a
+  DTO of `(status: String, result: String?)`. So no client generated from that document could call
+  the endpoint at all, and nothing anywhere said so (#5895). It is not one service:
+  `check-openapi-enum-vs-domain.py` (gate `openapi-enum-domain-drift`, pairs a spec enum with the
+  Kotlin enum it serves by value overlap) found **27 more across 16 services** (#5962), several
+  advertising values the code lacks — which a generated client will send and the service will 400.
+  **Two consequences worth carrying.** Correcting one is *breaking* to `oasdiff` (removed enum
+  values) while being unbreakable in fact — the server is byte-identical — so it takes the
+  `correction` class in `check-api-contract.py`: MINOR, no URL major. That reclassification is
+  **mechanical, not declared**, and it only applies while the PR touches *nothing else* in that
+  service, so **put the drift test outside the service directory** or the gate demands a MAJOR it
+  also forbids. And when a downstream spec republishes the same vocabulary, it is evidence about
+  which side is canonical: `openbank-customer-edge` already carried the domain spelling verbatim,
+  which settled all five kyc names before any judgement call was needed.
 - **The same trap fires from an ALREADY-MERGED PR, which is the direction that gets missed.**
   Anticipating it is not the same as checking for it: the instinct is "am I racing anyone?", and that
   scans *open* PRs — but the number is just as easily consumed by something that landed while your

--- a/openbank-kyc-service/src/main/resources/openapi.yaml
+++ b/openbank-kyc-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: KYC Service API
-  version: 1.6.0
+  version: 1.7.0
   description: Know Your Customer case management — open cases, run checks, approve/reject.
   license:
     name: Apache-2.0
@@ -117,7 +117,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: [IDENTITY, SANCTIONS, PEP, ADVERSE_MEDIA, SOURCE_OF_FUNDS]
+            enum: [IDENTITY, ADDRESS, PEP_SCREENING, SANCTIONS_SCREENING, ADVERSE_MEDIA]
       requestBody:
         required: true
         content:
@@ -291,13 +291,18 @@ components:
 
     UpdateCheckRequest:
       type: object
-      required: [result]
+      required: [status]
       properties:
+        status:
+          type: string
+          description: >
+            The new CheckStatus. Values are the domain `CheckStatus` constants verbatim —
+            `KycResource.updateCheck` calls `CheckStatus.valueOf(req.status)`, so anything else
+            is rejected with 400.
+          enum: [PENDING, PASSED, FAILED, MANUAL_REVIEW]
         result:
           type: string
-          enum: [PASS, FAIL, PENDING, MANUAL_REVIEW]
-        notes:
-          type: string
+          description: Free-text outcome note recorded against the check. Optional.
 
     KycCaseApprovalRequest:
       type: object

--- a/openbank-sca-service/src/main/resources/openapi.yaml
+++ b/openbank-sca-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: SCA Service API
-  version: 1.5.0
+  version: 1.6.0
   description: >-
     Strong Customer Authentication — initiate and verify SCA challenges (OTP, TOTP, push,
     biometric). Decoupled device approval per ADR-0021: enrol a device credential and record a
@@ -206,14 +206,12 @@ components:
           enum: [OTP_SMS, OTP_EMAIL, TOTP, PUSH]
         purpose:
           type: string
-          # NOTE: this list does NOT match the ScaPurpose enum the service actually accepts
-          # (PAYMENT_INITIATION, CONSENT_GRANT, LOGIN, AGENT_ACTION, SENSITIVE_DATA_ACCESS,
-          # DOCUMENT_SIGNING, CARD_MANAGEMENT, DELEGATION_GRANT, DELEGATION_ACCEPT,
-          # SAVINGS_WITHDRAW_APPROVAL). PAYMENT_AUTHORIZATION / CONSENT / ACCOUNT_CHANGE have
-          # never been valid values. Pre-existing drift, deliberately NOT corrected here:
-          # deleting the three phantom values is a breaking spec change and belongs in its own
-          # PR. Only the new value is added, so this list is one entry less wrong than before.
-          enum: [PAYMENT_AUTHORIZATION, LOGIN, CONSENT, ACCOUNT_CHANGE, SAVINGS_WITHDRAW_APPROVAL]
+          # The ScaPurpose enum as the service accepts it. PAYMENT_AUTHORIZATION / CONSENT /
+          # ACCOUNT_CHANGE were published here for the life of the file and have never been
+          # valid values; the drift this comment used to describe is corrected as of #5962.
+          enum: [PAYMENT_INITIATION, CONSENT_GRANT, LOGIN, AGENT_ACTION, SENSITIVE_DATA_ACCESS,
+                 DOCUMENT_SIGNING, CARD_MANAGEMENT, DELEGATION_GRANT, DELEGATION_ACCEPT,
+                 SAVINGS_WITHDRAW_APPROVAL]
         contextData:
           type: object
 
@@ -237,7 +235,7 @@ components:
           type: string
         status:
           type: string
-          enum: [PENDING, VERIFIED, FAILED, EXPIRED]
+          enum: [PENDING, COMPLETED, FAILED, EXPIRED, CANCELLED]
         attemptsRemaining:
           type: integer
         expiresAt:


### PR DESCRIPTION
Refs #5962, ADR-0048.

Stacked on #5966 (which adds the gate and its `BASELINE`) — that branch is merged in, so its diff
drops out once #5966 lands. This PR's own work is two enums and one version line in
`openbank-sca-service/src/main/resources/openapi.yaml`, plus one `BASELINE` entry.

**Money-path service — 2 approvals required.**

## What was wrong

| spec said | code says | effect |
|---|---|---|
| `ScaChallengeResponse.status` `[PENDING, VERIFIED, FAILED, EXPIRED]` | `ScaStatus { PENDING, COMPLETED, FAILED, EXPIRED, CANCELLED }` | the server emits `COMPLETED`/`CANCELLED`, which the document does not declare, and has never emitted `VERIFIED`. A strict generated deserializer fails on the terminal success state |
| `InitiateScaRequest.purpose` `[PAYMENT_AUTHORIZATION, LOGIN, CONSENT, ACCOUNT_CHANGE, SAVINGS_WITHDRAW_APPROVAL]` | `ScaPurpose`, ten values | `PAYMENT_AUTHORIZATION`, `CONSENT`, `ACCOUNT_CHANGE` are rejected requests; seven real purposes — including `PAYMENT_INITIATION`, the primary one — were unpublished |

`status` is serialized straight off the domain type (`ScaResource.kt:120`, `status = c.status`) and
`purpose` deserializes directly into `ScaPurpose` (`InitiateScaRequest.purpose: ScaPurpose`), so
neither has any translation layer that could have absorbed the difference.

## Which side is right — the domain, and here the provider replay proves it

- **A committed pact asserts the value the spec omits.**
  `pacts/openbank-delegation-service-openbank-sca-service.json` contains
  `"status": "COMPLETED"` on this exact field, twice, and `"purpose": "DELEGATION_GRANT"` —
  another value the spec did not publish. That pact is replayed against the real provider by
  `ScaPactFolderProviderVerificationTest` (`@PactFolder`, ungated, runs on every PR), and it is
  **green in this branch: 3 interactions, 0 failures, 0 skipped**. So this is not a reading of the
  source — the running server was asked and answered `COMPLETED`.
- **The spec itself already said the `purpose` list was wrong, and deferred the fix to this PR.**
  The lines being replaced carried:
  "NOTE: this list does NOT match the ScaPurpose enum the service actually accepts ...
  PAYMENT_AUTHORIZATION / CONSENT / ACCOUNT_CHANGE have never been valid values. Pre-existing
  drift, deliberately NOT corrected here: deleting the three phantom values is a breaking spec
  change and belongs in its own PR."
- **`VERIFIED` was never renamed — it never existed.** `git log -S "VERIFIED"` over
  `openbank-sca-service` finds it only in `openapi.yaml`, at every revision.
- No admin-ui call site sends either field; the consent pact carries only `PENDING`, which both
  documents agree on.

## The `purpose` enum is one the gate could not see, and that is worth noting

`check-openapi-enum-vs-domain.py` pairs a spec enum to a Kotlin enum by value overlap against the
**larger** set. The `purpose` drift shared 2 values with a 10-value `ScaPurpose`, i.e. 0.2, under
`MIN_OVERLAP = 0.4` — so it never paired and was never reported, in the baseline or out of it.
The calibration is right (loosening it re-admits the coincidence findings #5966's self-test pins
down), but the consequence is real: **the more thoroughly a spec enum has drifted, the less likely
the gate is to pair it**, so the baseline of 27 is a floor, not a census. Visible in this PR's own
numbers — `SUBJECTS` goes 147 -> 148, because the corrected `purpose` enum now pairs. Same reason
`challengeType` is untouched below. Worth a note on #5962; not something to fix by moving the
threshold.

## Deliberately NOT fixed here

`InitiateScaRequest.challengeType` is declared `required` with enum `[OTP_SMS, OTP_EMAIL, TOTP, PUSH]`,
and the Kotlin DTO has **no such property at all** — the nearest thing is an optional
`preferredMethod: ScaMethod?` with values `{BIOMETRIC, PUSH_NOTIFICATION, TOTP}`. That is a
property-shape defect, not an enum drift: fixing it means deciding whether the field is renamed or
dropped and whether it stays required, which is an API judgement rather than a reconciliation.
Left for its own PR under #5962 rather than smuggled into a money-path spec change.

## Classification: `correction`, MINOR

```
::notice::api-contract gate: openbank-sca-service: spec-only PR — reclassifying 3 breaking
document change(s) (first: removed the enum value `ACCOUNT_CHANGE` of the request property
`purpose`) as a CORRECTION. ... Requiring MINOR instead.
api-contract gate: openbank-sca-service: correction change, info.version 1.5.0 -> 1.6.0 — OK.
```

`1.5.0` read off live `origin/main` immediately before the bump.
`check-threat-model-diff.py --base <live merge-base>` exits 0 — run, not assumed.

## Verification

- `./gradlew :openbank-sca-service:ktlintCheck :detekt :test` — `BUILD SUCCESSFUL`, exit 0, all
  three executed. **147 tests, 0 failures, 0 errors, 1 skipped** — the skip is
  `ScaPactProviderVerificationTest`, the broker-sourced class gated on `pactbroker.url`, which
  does not run locally by design. Its `@PactFolder` sibling did run, green, as above.
- `check-openapi-enum-vs-domain.py --self-test` passes; the gate then reports
  `26 paired enum(s) drift, all 26 baselined`, and fails on a stale entry.

Baseline: **27 -> 26** for this PR alone.
