### PR TITLE
feat(admin-ui): distinguish trace states and block incomplete regulatory exports

### DIFF
--- a/openbank-admin-ui/src/app/observability/traces/page.tsx
+++ b/openbank-admin-ui/src/app/observability/traces/page.tsx
@@ -84,6 +84,7 @@ export default function TraceExplorerPage() {
   const [selected, setSelected] = useState<string | null>(null)
   const [spans, setSpans] = useState<FlatSpan[] | null>(null)
   const [spansLoading, setSpansLoading] = useState(false)
+  const [spansUnavailable, setSpansUnavailable] = useState<UnavailableKind | null>(null)
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
 
   const loadTraces = useCallback(async () => {
@@ -118,14 +119,21 @@ export default function TraceExplorerPage() {
   const openTrace = useCallback(async (traceID: string) => {
     setSelected(traceID)
     setSpans(null)
+    setSpansUnavailable(null)
     setSpansLoading(true)
     try {
       const res = await fetch(`/api/tempo/api/traces/${traceID}`, { signal: AbortSignal.timeout(8000) })
-      if (!res.ok) { setSpans([]); return }
+      // A failed span fetch used to `setSpans([])`, which rendered the same "No data yet" panel
+      // as a trace that genuinely carries no spans — so a 502 from Tempo read to the operator as
+      // "this trace is empty". Keep the two apart (issue #5904).
+      if (!res.ok) {
+        setSpansUnavailable(res.status === 502 ? 'unreachable' : 'error')
+        return
+      }
       const json = await res.json()
       setSpans(flattenTrace(json))
     } catch {
-      setSpans([])
+      setSpansUnavailable('unreachable')
     } finally {
       setSpansLoading(false)
     }
@@ -150,7 +158,27 @@ export default function TraceExplorerPage() {
           </button>}
         />
 
-        {unavailable && !traces?.length ? (
+        {/*
+          Three distinct states, never collapsed into one another (issue #5904):
+          LOADING  — the first fetch is still in flight and we have nothing yet. Before this
+                     branch existed the page fell straight through to the grid and rendered an
+                     empty "Recent traces ()" card, which is byte-for-byte what a successful
+                     but empty search also renders. An operator could not tell "still asking"
+                     from "Tempo holds no traces".
+          EMPTY    — the search succeeded and returned zero traces (`kind: 'no_data'`). This is
+                     currently the HONEST state for admin-ui and openbank-app, which emit no
+                     spans at all (#5735); browser instrumentation is proposed in #5847.
+          FAILED   — the search could not be answered (`unreachable` / `error`).
+          A refresh over an existing list deliberately does NOT re-enter the loading branch —
+          `traces` is still populated, so the list stays put and only the button spins.
+        */}
+        {loading && !traces && !unavailable ? (
+          <div className="card" data-testid="trace-list-loading" role="status" aria-live="polite"
+            style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '8px', padding: '48px 0', color: 'var(--text-tertiary)', fontSize: '13px' }}>
+            <RefreshCw size={15} className="spin" aria-hidden="true" />
+            {t('Načítám trasy z Tempa…', 'Loading traces from Tempo…')}
+          </div>
+        ) : unavailable && !traces?.length ? (
           <DataUnavailable
             kind={unavailable.kind}
             service="tempo (observability)"
@@ -209,6 +237,8 @@ export default function TraceExplorerPage() {
                 <div style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--text-tertiary)', fontSize: '13px', padding: '24px 0', justifyContent: 'center' }}>
                   <RefreshCw size={14} className="spin" /> {t('Načítám spany…', 'Loading spans…')}
                 </div>
+              ) : spansUnavailable ? (
+                <DataUnavailable kind={spansUnavailable} service="tempo (observability)" feature={t('Spany trasy', 'Trace spans')} lang={t('cs', 'en') as 'cs' | 'en'} dense />
               ) : !spans?.length ? (
                 <DataUnavailable kind="no_data" feature={t('Spany trasy', 'Trace spans')} lang={t('cs', 'en') as 'cs' | 'en'} dense />
               ) : (

--- a/openbank-admin-ui/src/app/regulatory/page.tsx
+++ b/openbank-admin-ui/src/app/regulatory/page.tsx
@@ -8,6 +8,8 @@ import { useState } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl, type BffFailure } from '@/lib/services/bff'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
+import { blockReasonCopy, evaluateExportReadiness } from '@/lib/regulatory/exportReadiness'
+import { Ban } from 'lucide-react'
 import { FileText, CheckCircle2, AlertTriangle, ExternalLink, Calendar, Check, Eye, X, Table as TableIcon, FileJson, FileSpreadsheet, RefreshCw } from 'lucide-react'
 import { PageHeader } from '@/components/ui/PageHeader'
 
@@ -285,6 +287,9 @@ export default function RegulatoryPage() {
   }
 
   function exportJson(report: Report) {
+    // Guarded at the handler, not only by the disabled button: a disabled attribute is a UI
+    // affordance, not a control. Both paths must refuse the same inputs (issue #5904).
+    if (!evaluateExportReadiness(previewData).ok) return
     const rows = buildExportRows(report, previewData)
     const data = {
       ...Object.fromEntries(rows.map(r => [r.field, r.value])),
@@ -300,6 +305,7 @@ export default function RegulatoryPage() {
   }
 
   function exportCsv(report: Report) {
+    if (!evaluateExportReadiness(previewData).ok) return
     const rows = buildExportRows(report, previewData)
     const header = `${csvCell(t('Pole', 'Field'))},${csvCell(t('Hodnota', 'Value'))}`
     const body = rows.map(r => `${csvCell(r.field)},${csvCell(r.value)}`).join('\n')
@@ -315,6 +321,10 @@ export default function RegulatoryPage() {
     setDownloadMessage(id)
     setTimeout(() => setDownloadMessage(null), 3000)
   }
+
+  // Whether an export may be produced at all. Derived from the SAME `previewData` the operator is
+  // looking at, so the buttons can never disagree with the table above them (issue #5904).
+  const exportReadiness = evaluateExportReadiness(previewData)
 
   const implementedPreviewCount = REPORTS.filter(r => dataSourceOf(r) === 'implemented').length
   const catalogueOnlyCount = REPORTS.length - implementedPreviewCount
@@ -594,15 +604,32 @@ export default function RegulatoryPage() {
             {/* Footer: note + export actions */}
             <div style={{ padding: '14px 20px', borderTop: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '12px', flexWrap: 'wrap' }}>
               <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', maxWidth: '320px' }}>
+                {!exportReadiness.ok && (() => {
+                  const copy = blockReasonCopy(exportReadiness.reason, exportReadiness.templateIds, t('cs', 'en') as 'cs' | 'en')
+                  return (
+                    <div
+                      role="status"
+                      data-testid="export-blocked"
+                      data-block-reason={exportReadiness.reason}
+                      style={{ display: 'flex', gap: '8px', alignItems: 'flex-start', marginBottom: '8px', color: 'var(--danger)' }}
+                    >
+                      <Ban size={14} aria-hidden="true" style={{ flexShrink: 0, marginTop: '1px' }} />
+                      <span>
+                        <strong style={{ display: 'block' }}>{copy.title}</strong>
+                        <span style={{ color: 'var(--text-tertiary)' }}>{copy.detail}</span>
+                      </span>
+                    </div>
+                  )
+                })()}
                 {previewData.status === 'unsupported'
                   ? t('Tento katalogový výkaz zatím nemá implementovaný datový zdroj ani odeslání. Nezobrazuje fiktivní hodnoty.', 'This catalogue report has no implemented data source or submission path yet. It does not show fictional values.')
                   : t('FINREP/COREP se při načtení ověřují ve finrep-service nad ledger trial balance; při nedostupnosti se hodnoty nezobrazí. ClickHouse ani ČNB XBRL/SDAT přenos nejsou součástí tohoto náhledu.', 'FINREP/COREP are verified on load from finrep-service over the ledger trial balance; values are not shown when unavailable. ClickHouse and ČNB XBRL/SDAT transmission are not part of this preview.')}
               </div>
               <div style={{ display: 'flex', gap: '8px', flexShrink: 0 }}>
-                <button className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={() => exportCsv(preview)} disabled={previewData.status === 'loading'}>
+                <button className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={() => exportCsv(preview)} disabled={!exportReadiness.ok}>
                   <FileSpreadsheet size={13} /> {t('Export CSV', 'Export CSV')}
                 </button>
-                <button className="btn btn-primary" style={{ fontSize: '12px' }} onClick={() => exportJson(preview)} disabled={previewData.status === 'loading'}>
+                <button className="btn btn-primary" style={{ fontSize: '12px' }} onClick={() => exportJson(preview)} disabled={!exportReadiness.ok}>
                   <FileJson size={13} /> {t('Export JSON', 'Export JSON')}
                 </button>
               </div>

--- a/openbank-admin-ui/src/lib/regulatory/exportReadiness.ts
+++ b/openbank-admin-ui/src/lib/regulatory/exportReadiness.ts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+/**
+ * Export gate for the regulatory reporting surface (issue #5904).
+ *
+ * A regulatory export is an artefact people ACT on, so producing one from data the platform
+ * could not honestly derive is worse than producing nothing. Before this gate the CSV/JSON
+ * buttons were enabled in every state except `loading` — so an operator could download a file
+ * whose every value cell read "Zdroj dat není dostupný" ("data source unavailable") and whose
+ * filename, headers and shape were indistinguishable from a real return.
+ *
+ * The three words in the acceptance criterion map onto data that finrep-service actually emits;
+ * none of this is invented here:
+ *
+ *   - MISSING     — the templates were never obtained: still loading, the report has no data
+ *                   source wired at all, or the fetch failed. Also a template rendered with
+ *                   zero cells, which the contract says can never happen (`FinrepTemplate`
+ *                   always renders every row) and so means a malformed payload.
+ *   - INCOMPLETE  — `CorepCell.isDataGap` / `CorepTemplate.hasDataGaps`. Contract-REQUIRED
+ *                   fields (openbank-finrep-service/src/main/resources/openapi.yaml
+ *                   `required: [templateId, period, cells, hasDataGaps]`), genuinely computed
+ *                   by `C0100Mapper`, and documented there as "MUST NOT be read as an attested
+ *                   zero balance". This is the reason that actually fires today: the ledger's
+ *                   chart of accounts has no capital-structure GL accounts, so every C 01.00
+ *                   capital row is a flagged zero.
+ *   - UNBALANCED  — `FinrepTemplate.isBalanced === false`.
+ *
+ * ⚠ KNOWN GAP, deliberately not papered over — tracked as #5987:
+ * `isBalanced` is contract-required and serialised, but BOTH producers hardcode it —
+ * `F0101Mapper.kt:44` and `F0200Mapper.kt:44` both pass the literal `isBalanced = true`, and
+ * `FinrepTemplate.kt:17` defaults it to `true`. F01.01 additionally DERIVES equity as
+ * `assets − liabilities`, so its accounting identity holds algebraically and cannot be observed
+ * to fail. `FinrepService`'s own KDoc calls the value "computed ... and never looked at again";
+ * the first half of that is not true today. So the `unbalanced` branch below is a real check
+ * against the published contract that the current producer can never trigger. It is kept
+ * because the contract permits `false` and a UI that ignored it would silently export an
+ * unbalanced return the day the producer starts computing the field — but it must NOT be
+ * counted as live coverage. The gate's falsifiable, fires-today reason is `data_gaps`.
+ */
+
+export type PreviewLike =
+  | { status: 'idle' | 'loading' }
+  | { status: 'unavailable'; kind: string }
+  | { status: 'unsupported' }
+  | { status: 'ready'; templates: ReadonlyArray<TemplateLike> }
+
+export interface CellLike {
+  isDataGap?: boolean
+  gapReason?: string | null
+}
+
+export interface TemplateLike {
+  templateId: string
+  cells: ReadonlyArray<CellLike>
+  isBalanced?: boolean
+  hasDataGaps?: boolean
+}
+
+export type ExportBlockReason =
+  /** Templates not fetched yet — idle or in flight. */
+  | 'not_loaded'
+  /** This catalogue report has no implemented data source at all. */
+  | 'no_data_source'
+  /** The fetch to finrep-service failed (unreachable, unauthorized, …). */
+  | 'source_unavailable'
+  /** A template came back with no cells — malformed against the contract. */
+  | 'missing_cells'
+  /** At least one cell is a flagged data gap (`isDataGap`). */
+  | 'data_gaps'
+  /** A FINREP template reports its accounting identity does not hold. */
+  | 'unbalanced'
+
+export type ExportReadiness =
+  | { ok: true }
+  | { ok: false; reason: ExportBlockReason; templateIds: string[] }
+
+/**
+ * Decide whether a regulatory export may be produced. Ordered most-fundamental first, so the
+ * reason an operator is shown is the one they can act on: you cannot judge balance of data you
+ * never received.
+ */
+export function evaluateExportReadiness(data: PreviewLike): ExportReadiness {
+  if (data.status === 'unsupported') {
+    return { ok: false, reason: 'no_data_source', templateIds: [] }
+  }
+  if (data.status === 'unavailable') {
+    return { ok: false, reason: 'source_unavailable', templateIds: [] }
+  }
+  // Everything that is not `ready` is data we do not have: idle or still in flight. Tested via
+  // `!== 'ready'` rather than by listing the two so that a future PreviewData variant defaults to
+  // BLOCKED — an unknown state must never fall through into producing a regulatory file.
+  if (data.status !== 'ready') {
+    return { ok: false, reason: 'not_loaded', templateIds: [] }
+  }
+
+  if (data.templates.length === 0) {
+    return { ok: false, reason: 'missing_cells', templateIds: [] }
+  }
+
+  const empty = data.templates.filter(template => template.cells.length === 0)
+  if (empty.length > 0) {
+    return { ok: false, reason: 'missing_cells', templateIds: empty.map(template => template.templateId) }
+  }
+
+  // Unbalanced outranks data gaps: a return that does not balance is a supervisory defect on
+  // its own, independent of how completely it was populated.
+  const unbalanced = data.templates.filter(template => template.isBalanced === false)
+  if (unbalanced.length > 0) {
+    return { ok: false, reason: 'unbalanced', templateIds: unbalanced.map(template => template.templateId) }
+  }
+
+  const gapped = data.templates.filter(
+    template => template.hasDataGaps === true || template.cells.some(cell => cell.isDataGap === true),
+  )
+  if (gapped.length > 0) {
+    return { ok: false, reason: 'data_gaps', templateIds: gapped.map(template => template.templateId) }
+  }
+
+  return { ok: true }
+}
+
+/** Operator-facing copy for a block reason. Czech first, matching this surface's convention. */
+export function blockReasonCopy(
+  reason: ExportBlockReason,
+  templateIds: string[],
+  lang: 'cs' | 'en',
+): { title: string; detail: string } {
+  const list = templateIds.join(', ')
+  const cs = lang === 'cs'
+  switch (reason) {
+    case 'not_loaded':
+      return cs
+        ? { title: 'Export je zablokován: data nejsou načtena', detail: 'Načtěte šablony pro zvolené referenční datum. Export se odemkne až nad ověřenými daty.' }
+        : { title: 'Export blocked: data not loaded', detail: 'Load the templates for the chosen reference date. Export unlocks only over verified data.' }
+    case 'no_data_source':
+      return cs
+        ? { title: 'Export je zablokován: výkaz nemá datový zdroj', detail: 'Tento katalogový výkaz zatím není napojen na žádnou službu. Export by obsahoval jen zástupné texty, ne hodnoty.' }
+        : { title: 'Export blocked: report has no data source', detail: 'This catalogue report is not wired to any service yet. An export would carry placeholder text, not values.' }
+    case 'source_unavailable':
+      return cs
+        ? { title: 'Export je zablokován: zdroj dat není dostupný', detail: 'finrep-service neodpověděla, takže hodnoty nelze ověřit. Zkuste načtení zopakovat.' }
+        : { title: 'Export blocked: data source unavailable', detail: 'finrep-service did not answer, so the values cannot be verified. Try loading again.' }
+    case 'missing_cells':
+      return cs
+        ? { title: 'Export je zablokován: šablona je prázdná', detail: `Šablona ${list} se vrátila bez buněk. Podle kontraktu se vykresluje vždy každý řádek, takže jde o vadnou odpověď.` }
+        : { title: 'Export blocked: template is empty', detail: `Template ${list} returned no cells. The contract renders every row always, so this is a malformed response.` }
+    case 'data_gaps':
+      return cs
+        ? { title: 'Export je zablokován: neúplná data', detail: `Šablona ${list} obsahuje buňky označené jako datová mezera (isDataGap) — vykázané nuly, které platforma neumí doložit. Nesmí se odeslat jako doložený zůstatek.` }
+        : { title: 'Export blocked: incomplete data', detail: `Template ${list} contains cells flagged as data gaps (isDataGap) — reported zeros the platform cannot substantiate. They must not be filed as attested balances.` }
+    case 'unbalanced':
+      return cs
+        ? { title: 'Export je zablokován: výkaz nevychází', detail: `Šablona ${list} hlásí, že její účetní identita neplatí (isBalanced=false).` }
+        : { title: 'Export blocked: return does not balance', detail: `Template ${list} reports that its accounting identity does not hold (isBalanced=false).` }
+  }
+}

--- a/openbank-admin-ui/src/test/regulatory-export-gate.test.tsx
+++ b/openbank-admin-ui/src/test/regulatory-export-gate.test.tsx
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+/**
+ * A regulatory export must be BLOCKED on incomplete, missing or unbalanced data, and
+ * PERMITTED on complete data (issue #5904).
+ *
+ * Before this gate the CSV/JSON buttons were disabled only while `status === 'loading'`, so an
+ * operator could download a file whose every value read "Zdroj dat není dostupný" — same
+ * filename shape, same headers, same columns as a real return. A regulatory filing is the
+ * artefact people act on, which makes a successful-looking export over unusable data worse
+ * than no export at all.
+ *
+ * "Incomplete" is NOT invented here — it is `isDataGap` / `hasDataGaps`, contract-required
+ * fields in openbank-finrep-service's openapi.yaml, documented there as values the platform
+ * "could NOT honestly derive" which "MUST NOT be read as an attested zero balance".
+ *
+ * Deliberately out of scope, per the issue's own boundary: XBRL/DPM rendering and authenticated
+ * ČNB submission (#5914). Nothing here adds a submit path.
+ */
+
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import RegulatoryPage from '@/app/regulatory/page'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { evaluateExportReadiness } from '@/lib/regulatory/exportReadiness'
+
+afterEach(() => vi.unstubAllGlobals())
+
+const cell = (over: Record<string, unknown> = {}) => ({
+  rowRef: 'r010', colRef: 'c010', value: 100, currency: 'CZK', isDataGap: false, ...over,
+})
+
+// ── The decision function, exercised directly ────────────────────────────────
+describe('evaluateExportReadiness', () => {
+  it('permits a complete, balanced, gap-free set of templates', () => {
+    expect(evaluateExportReadiness({
+      status: 'ready',
+      templates: [{ templateId: 'F01.01', cells: [cell()], isBalanced: true, hasDataGaps: false }],
+    })).toEqual({ ok: true })
+  })
+
+  it.each([
+    ['not_loaded', { status: 'loading' as const }],
+    ['not_loaded', { status: 'idle' as const }],
+    ['no_data_source', { status: 'unsupported' as const }],
+    ['source_unavailable', { status: 'unavailable' as const, kind: 'unreachable' }],
+  ])('blocks with %s when the data was never obtained', (reason, data) => {
+    const verdict = evaluateExportReadiness(data)
+    expect(verdict.ok).toBe(false)
+    expect(verdict.ok === false && verdict.reason).toBe(reason)
+  })
+
+  it('blocks as INCOMPLETE on a cell flagged isDataGap', () => {
+    const verdict = evaluateExportReadiness({
+      status: 'ready',
+      templates: [{ templateId: 'C_01.00', cells: [cell({ isDataGap: true, gapReason: 'no capital GL accounts' })] }],
+    })
+    expect(verdict).toEqual({ ok: false, reason: 'data_gaps', templateIds: ['C_01.00'] })
+  })
+
+  it('blocks as INCOMPLETE on the derived hasDataGaps flag alone', () => {
+    const verdict = evaluateExportReadiness({
+      status: 'ready',
+      templates: [{ templateId: 'C_01.00', cells: [cell()], hasDataGaps: true }],
+    })
+    expect(verdict.ok === false && verdict.reason).toBe('data_gaps')
+  })
+
+  it('blocks as UNBALANCED when a template says its identity does not hold', () => {
+    const verdict = evaluateExportReadiness({
+      status: 'ready',
+      templates: [{ templateId: 'F01.01', cells: [cell()], isBalanced: false }],
+    })
+    expect(verdict).toEqual({ ok: false, reason: 'unbalanced', templateIds: ['F01.01'] })
+  })
+
+  it('blocks as MISSING when a template renders no cells at all', () => {
+    // The contract renders every row always, so zero cells is a malformed payload, not an
+    // empty period.
+    expect(evaluateExportReadiness({ status: 'ready', templates: [{ templateId: 'F02.00', cells: [] }] }))
+      .toEqual({ ok: false, reason: 'missing_cells', templateIds: ['F02.00'] })
+  })
+
+  it('reports unbalanced ahead of data gaps when a template is both', () => {
+    const verdict = evaluateExportReadiness({
+      status: 'ready',
+      templates: [{ templateId: 'F01.01', cells: [cell({ isDataGap: true })], isBalanced: false, hasDataGaps: true }],
+    })
+    expect(verdict.ok === false && verdict.reason).toBe('unbalanced')
+  })
+})
+
+// ── The surface: the buttons and the handler must agree with the verdict ─────
+/**
+ * Open the preview for CNB FINREP specifically — one of only two catalogue reports with a wired
+ * data source. Clicking whichever preview button happens to be first would land on a
+ * catalogue-only report and block with `no_data_source` every time, which would make the
+ * data_gaps / unbalanced cases untestable while still looking green.
+ */
+const FINREP_CARD = 'CNB — Finanční výkazy (FINREP)'
+
+async function openPreview(fetchImpl: (url: string) => Promise<Response>) {
+  vi.stubGlobal('fetch', vi.fn(fetchImpl))
+  render(<LanguageProvider><RegulatoryPage /></LanguageProvider>)
+  const card = (await screen.findAllByText(FINREP_CARD))[0].closest('.card')
+  if (!card) throw new Error(`no .card ancestor for "${FINREP_CARD}" — the report card markup changed`)
+  fireEvent.click(within(card as HTMLElement).getByRole('button', { name: /Preview export|Náhled exportu/i }))
+}
+
+const template = (over: Record<string, unknown>) =>
+  new Response(JSON.stringify({ templateId: 'F01.01', period: '2026-06-30', cells: [cell()], isBalanced: true, hasDataGaps: false, ...over }),
+    { status: 200, headers: { 'content-type': 'application/json' } })
+
+describe('Regulatory export gate — the surface', () => {
+  it('PERMITS export when every template is complete and balanced', async () => {
+    await openPreview(async () => template({}))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('export-blocked')).not.toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: /Export JSON/i })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /Export CSV/i })).toBeEnabled()
+  })
+
+  it('BLOCKS export, with a named reason, when a cell is a flagged data gap', async () => {
+    await openPreview(async () => template({ cells: [cell({ isDataGap: true, gapReason: 'no capital GL accounts' })], hasDataGaps: true }))
+
+    const banner = await screen.findByTestId('export-blocked')
+    expect(banner).toHaveAttribute('data-block-reason', 'data_gaps')
+    expect(screen.getByRole('button', { name: /Export JSON/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Export CSV/i })).toBeDisabled()
+  })
+
+  it('BLOCKS export when the data source is unreachable', async () => {
+    await openPreview(async () => new Response(JSON.stringify({ error: 'upstream_unreachable' }), { status: 502, headers: { 'content-type': 'application/json' } }))
+
+    const banner = await screen.findByTestId('export-blocked')
+    expect(banner).toHaveAttribute('data-block-reason', 'source_unavailable')
+    expect(screen.getByRole('button', { name: /Export JSON/i })).toBeDisabled()
+  })
+
+  it('produces NO file when a blocked export is invoked anyway', async () => {
+    // The disabled attribute is an affordance, not a control — the handler must refuse too.
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:stub')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    await openPreview(async () => template({ cells: [cell({ isDataGap: true })], hasDataGaps: true }))
+    await screen.findByTestId('export-blocked')
+
+    const jsonButton = screen.getByRole('button', { name: /Export JSON/i })
+    fireEvent.click(jsonButton)
+    // Fire the handler directly too, past the disabled attribute.
+    jsonButton.removeAttribute('disabled')
+    fireEvent.click(jsonButton)
+
+    expect(createObjectURL).not.toHaveBeenCalled()
+  })
+})

--- a/openbank-admin-ui/src/test/trace-explorer-states.test.tsx
+++ b/openbank-admin-ui/src/test/trace-explorer-states.test.tsx
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+/**
+ * Trace Explorer must render LOADING, EMPTY and FAILED as three distinguishable things
+ * (issue #5904).
+ *
+ * The defect this pins down is the UI form of a control that cannot report its own absence:
+ * a panel that looks identical for "the query returned nothing" and "the query never
+ * answered" tells the operator the system is healthy when it is blind. It matters here more
+ * than usual because the EMPTY state is currently the *honest* one — admin-ui and
+ * openbank-app emit no spans at all (#5735; browser instrumentation proposed in #5847) — so
+ * "no traces" is the expected steady state, and a failure hidden inside it would never be
+ * noticed.
+ *
+ * Each test asserts BOTH what is shown and what is NOT, because "renders something" is
+ * satisfied by all three states at once and would not detect a regression that collapses
+ * them back together.
+ */
+
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import TraceExplorerPage from '@/app/observability/traces/page'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { roles: ['ROLE_ADMIN'] } }, status: 'authenticated' }),
+  signIn: vi.fn(),
+}))
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+function renderPage() {
+  return render(<LanguageProvider><TraceExplorerPage /></LanguageProvider>)
+}
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+describe('Trace Explorer — loading / empty / failed are three distinct states', () => {
+  it('LOADING: shows an in-flight indicator, and neither the empty nor the failed panel', async () => {
+    // A fetch that never settles holds the page in its first-paint state.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(() => {})))
+    renderPage()
+
+    expect(await screen.findByTestId('trace-list-loading')).toBeInTheDocument()
+    expect(screen.getByText(/Loading traces from Tempo|Načítám trasy z Tempa/)).toBeInTheDocument()
+    // Must NOT claim there is no data, and must NOT claim a failure.
+    expect(screen.queryByText(/No data yet|Zatím žádná data/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/is not responding|neodpovídá|Failed to load|Načtení selhalo/)).not.toBeInTheDocument()
+  })
+
+  it('EMPTY: a successful search returning zero traces says "no data", not a failure', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => json({ traces: [] })))
+    renderPage()
+
+    expect(await screen.findByText(/No data yet|Zatím žádná data/)).toBeInTheDocument()
+    // The loading indicator must be gone, and this must not read as an outage.
+    expect(screen.queryByTestId('trace-list-loading')).not.toBeInTheDocument()
+    expect(screen.queryByText(/is not responding|neodpovídá/)).not.toBeInTheDocument()
+  })
+
+  it('FAILED: a 502 from the Tempo BFF says the source did not answer, not "no data"', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => json({ status: 'error', error: 'tempo_unreachable' }, 502)))
+    renderPage()
+
+    expect(await screen.findByText(/is not responding|neodpovídá/)).toBeInTheDocument()
+    // The distinction under test: a failure must never be dressed up as an empty result.
+    expect(screen.queryByText(/No data yet|Zatím žádná data/)).not.toBeInTheDocument()
+    expect(screen.queryByTestId('trace-list-loading')).not.toBeInTheDocument()
+  })
+
+  it('FAILED and EMPTY do not render the same text as each other', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => json({ traces: [] })))
+    const emptyView = renderPage()
+    await screen.findByText(/No data yet|Zatím žádná data/)
+    const emptyText = emptyView.container.textContent ?? ''
+    emptyView.unmount()
+    vi.unstubAllGlobals()
+
+    vi.stubGlobal('fetch', vi.fn(async () => json({ status: 'error' }, 502)))
+    const failedView = renderPage()
+    await screen.findByText(/is not responding|neodpovídá/)
+    const failedText = failedView.container.textContent ?? ''
+
+    expect(failedText).not.toEqual(emptyText)
+  })
+})
+
+describe('Trace Explorer — a failed SPAN fetch is not an empty trace', () => {
+  const TRACE = { traceID: 'abc123def456', rootServiceName: 'ledger', rootTraceName: 'GET /accounts', durationMs: 42 }
+
+  it('renders the failure panel, not "no data", when the span fetch 502s', async () => {
+    const fetchMock = vi.fn(async (url: string) =>
+      url.includes('/api/tempo/api/search') ? json({ traces: [TRACE] }) : json({ error: 'boom' }, 502))
+    vi.stubGlobal('fetch', fetchMock)
+    renderPage()
+
+    const traceButton = await screen.findByRole('button', { name: /ledger/ })
+    traceButton.click()
+
+    await waitFor(() => {
+      expect(screen.getByText(/is not responding|neodpovídá/)).toBeInTheDocument()
+    })
+    // Before the fix this path did `setSpans([])`, so it rendered the no_data panel.
+    expect(screen.queryByText(/No data yet.*Trace spans|Zatím žádná data.*Spany/)).not.toBeInTheDocument()
+  })
+
+  it('renders "no data" when the trace genuinely carries zero spans', async () => {
+    const fetchMock = vi.fn(async (url: string) =>
+      url.includes('/api/tempo/api/search') ? json({ traces: [TRACE] }) : json({ batches: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+    renderPage()
+
+    const traceButton = await screen.findByRole('button', { name: /ledger/ })
+    traceButton.click()
+
+    await waitFor(() => {
+      expect(screen.getByText(/No data yet|Zatím žádná data/)).toBeInTheDocument()
+    })
+    expect(screen.queryByText(/is not responding|neodpovídá/)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What

Two of the nine acceptance criteria in #5904 — **"Distinguish Trace Explorer loading, empty, and failed states"** and **"Block regulatory exports when data is incomplete, missing, or unbalanced"**. The other seven are untouched and remain open; see *Deliberately out of scope* below.

They belong together because they are one defect class: **a surface that renders identically whether or not it has evidence**. The issue's own framing is that operator surfaces "look empty or healthy without enough evidence" — the UI form of a control that cannot report its own absence. An export that succeeds on incomplete data is the same defect with worse consequences, because a regulatory filing is the artefact people act on.

## Trace Explorer — there were not three states

| State | Before | After |
|---|---|---|
| **Loading** | No branch at all. First paint fell through to the grid and rendered an empty `Recent traces ()` card — byte-for-byte what a successful-but-empty search renders. | A dedicated `role="status"` panel: *"Loading traces from Tempo…"* |
| **Empty** | `DataUnavailable kind="no_data"` | unchanged |
| **Failed** | `DataUnavailable kind="unreachable" / "error"` for the *list*; but a failed **span** fetch did `setSpans([])`, so a 502 from Tempo rendered the *"No data yet"* panel. | Span failures get their own `spansUnavailable` state and render the failure panel. |

A refresh over an existing list deliberately does **not** re-enter the loading branch — `traces` is still populated, so the list stays put and only the button spins.

### Why the empty state matters here specifically

`openbank-admin-ui` and `openbank-app` currently send **no traces at all** — neither appears in Tempo and `traces_spanmetrics_calls_total` has no series for them (#5735). So *empty is the honest state today*, which is precisely why a failure hidden inside it would never have been noticed.

Browser instrumentation is proposed in **#5847**, which is not merged and whose deploy hop is unverified. This PR **touches none of its files** — #5847 changes `next.config.mjs`, `layout.tsx`, `src/lib/telemetry/rum.ts`, `src/components/telemetry/RumScreenTracker.tsx`, a telemetry API route and two infra manifests; this PR changes the traces page, the regulatory page and adds one lib module plus two test files. No overlap, no contradiction: when #5847 lands and traces start arriving, this page stops showing the empty state on its own.

## Regulatory export — what "incomplete" resolves to in the data

**The codebase already had the notion; nothing is invented here.** `openbank-finrep-service`'s `openapi.yaml` declares these **required**:

- `CorepCell.isDataGap` — *"True when the value could NOT be honestly derived from data available in the platform today ... MUST NOT be read as an attested zero balance."*
- `CorepTemplate.hasDataGaps` — derived, true when any cell is a gap.
- `FinrepTemplate.isBalanced` — whether the accounting identity holds.

The admin-ui `RegulatoryTemplate` interface already carried all three. They were rendered only as **suffix text in the export rows** (`· DATOVÁ MEZERA`) and an amber font colour. Nothing blocked anything.

Before this change the CSV/JSON buttons were disabled **only** while `status === 'loading'`. So an operator could export from the `unavailable` and `unsupported` states and get a file whose every value cell read `Zdroj dat není dostupný` — with the same filename shape, the same headers and the same columns as a real return.

`evaluateExportReadiness` now blocks, most-fundamental reason first:

| Reason | Meaning | Fires today? |
|---|---|---|
| `not_loaded` | idle / in flight | yes |
| `no_data_source` | catalogue report with no service wired (6 of 8 reports) | yes |
| `source_unavailable` | the fetch to finrep-service failed | yes |
| `missing_cells` | a template rendered zero cells — malformed, the contract renders every row always | yes |
| `data_gaps` | `isDataGap` / `hasDataGaps` | **yes — the load-bearing one** |
| `unbalanced` | `isBalanced === false` | **no — see the gap below** |

An unknown future `PreviewData` variant defaults to **blocked**, so a new state cannot fall through into producing a regulatory file. The guard runs in the export handlers as well as on the buttons, because a `disabled` attribute is an affordance and not a control — there is a test that clicks past it.

### Named gap: `isBalanced` is a hardcoded `true` — filed as #5987

I did not assume the field worked. Both producers pass a literal:

- `F0101Mapper.kt:44` → `isBalanced = true,`
- `F0200Mapper.kt:44` → `isBalanced = true,`
- `FinrepTemplate.kt:17` → `val isBalanced: Boolean = true,`

`grep -rn "isBalanced = false" --include="*.kt" .` returns nothing repo-wide. F01.01 makes it structural: it **derives** equity as `assets - liabilities`, so the identity holds algebraically and cannot be observed to fail. `FinrepService`'s KDoc calls the value *"computed ... and never looked at again"* — the second half is now false, but the first half was never true.

So the `unbalanced` branch is a real check against the **published contract** that the **current producer can never trigger**. I kept it (the contract permits `false`, and a UI ignoring it would silently export an unbalanced return the day the producer starts computing the field) but it is **not counted as live coverage**, it is documented as such in the module header, and the underlying defect is filed as **#5987** rather than left as a sentence in a PR body.

## Deliberately out of scope

- **The other seven criteria of #5904** — test inventory, KYC name resolution, Customer 360 context, compliance-pack content, Temporal diagram labelling, and charter-backed agent identity in the approval queue. Separate work; this PR says `Refs`, not `Closes`.
- **XBRL/DPM generation and authenticated ČNB submission (#5914)**, per the issue's explicit boundary. **No submit path, fake or real, is added** — the existing footer text still says transmission is not connected, and the only thing this PR does to the export path is make it refuse more often.

## Verification — each assertion falsified

Not "it renders". Each state is asserted both for what it shows **and** what it must *not* show, then each fix was reverted to confirm the test actually detects its absence:

| Falsification | Result |
|---|---|
| Remove the trace-list loading branch (fall through to the grid, as before) | 🔴 `LOADING: shows an in-flight indicator…` fails |
| Restore `setSpans([])` on a failed span fetch | 🔴 `renders the failure panel, not "no data", when the span fetch 502s` fails |
| Remove the export gate (buttons back to `disabled={loading}`, handlers unguarded, no banner) | 🔴 3 tests fail, including `produces NO file when a blocked export is invoked anyway` |

There is also a test asserting the empty and failed renders are not string-equal to each other, so a future change that merges them is caught even if both individually still match their patterns.

One trap worth recording: the surface tests initially clicked whichever preview button came first, which is a catalogue-only report — every case blocked with `no_data_source` and the `data_gaps` / `unbalanced` paths were never reached. The helper now scopes to the CNB FINREP card by name and throws if that card's markup changes, rather than silently testing nothing.

**Gate results** (run in the worktree, `npm test` so the `pretest` hook bakes `governance.json` / `catalog.json`):

- `npm test` — **219 files / 1574 tests green**. First run showed 2 unrelated failures (`campaign-experience-preview`, `iaops-agent-card`), both `Test timed out in 5000ms`, both in files this PR does not touch and does not import; they pass in isolation and the second full run was clean. Load-induced flakes, recorded here rather than hidden.
- `npx tsc --noEmit` — clean (exit 0).
- `eslint` on all five touched files — **0 errors**. The 2 warnings on the traces page (`no-unused-eslint-disable`, `set-state-in-effect`) are on pre-existing lines and reproduce identically on clean `origin/main` with my changes stashed.

Refs #5904
