### PR TITLE
fix(sepa-payment): publish the real SepaPaymentStatus vocabulary and the transition body

### DIFF
--- a/.github/scripts/check-openapi-enum-vs-domain.py
+++ b/.github/scripts/check-openapi-enum-vs-domain.py
@@ -121,10 +121,6 @@ BASELINE: dict[str, str] = {
         "not an enum fix. The `Status` pairing is coincidental.",
     "openbank-sanctions-service:CNB_DOMESTIC,EU_CONSOLIDATED,FATF_HIGH_RISK,HM_TREASURY,OFAC_SDN,UN_CONSOLIDATED":
         "#5962 — SanctionsListType: undeclared PEP_GLOBAL",
-    "openbank-sepa-payment:COMPLETED,PROCESSING,RECALLED,REJECTED":
-        "#5962 — SepaPaymentStatus: spec-only RECALLED; undeclared CANCELLED/RECEIVED/RETURNED/VALIDATED",
-    "openbank-sepa-payment:COMPLETED,PENDING,PROCESSING,RECALLED,REJECTED":
-        "#5962 — SepaPaymentStatus: spec-only PENDING/RECALLED; undeclared CANCELLED/RECEIVED/RETURNED/VALIDATED",
     "openbank-statement-service:RECONCILIATION,UNKNOWN,UPSTREAM":
         "#5962 — CloseFailureReason: undeclared NOT_VIABLE",
     "openbank-swift-service:ACKNOWLEDGED,FAILED,PENDING,REJECTED,SENT,VALIDATED":

--- a/openbank-sepa-payment/src/main/resources/openapi.yaml
+++ b/openbank-sepa-payment/src/main/resources/openapi.yaml
@@ -6,7 +6,7 @@ info:
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.6 -> 1.7): additive
   # only — GET /approvals (the checker's queue, issue #5679) plus two additive fields on
   # ApprovalResponse (makerId, createdAt). No breaking change.
-  version: 1.7.0
+  version: 1.8.0
   description: >-
     SEPA credit transfer lifecycle — create, query, status transitions. On create, debtor and
     creditor names are synchronously screened against the sanctions lists (ADR-0032): a clean payment
@@ -63,7 +63,7 @@ paths:
           in: query
           schema:
             type: string
-            enum: [PENDING, PROCESSING, COMPLETED, REJECTED, RECALLED]
+            enum: [RECEIVED, VALIDATED, PROCESSING, COMPLETED, REJECTED, RETURNED, CANCELLED]
         - name: debtorAccountId
           in: query
           schema:
@@ -362,8 +362,16 @@ components:
       properties:
         targetStatus:
           type: string
-          enum: [PROCESSING, COMPLETED, REJECTED, RECALLED]
-        reason:
+          # The full SepaPaymentStatus vocabulary, which is what the endpoint parses. Which of
+          # these is reachable depends on the payment's current state (SepaPayment.canTransitionTo);
+          # an illegal transition is a 409, not a 400. RECEIVED is the creation state and is
+          # therefore never a legal target from any state.
+          enum: [RECEIVED, VALIDATED, PROCESSING, COMPLETED, REJECTED, RETURNED, CANCELLED]
+        rejectReason:
+          type: string
+          # Required by the domain when targetStatus is REJECTED.
+          enum: [INSUFFICIENT_FUNDS, INVALID_IBAN, ACCOUNT_CLOSED, ACCOUNT_FROZEN, INVALID_BIC, AMOUNT_LIMIT_EXCEEDED, AML_HOLD, SANCTIONS_HIT, TECHNICAL_ERROR]
+        rejectDetail:
           type: string
 
     SepaPaymentResponse:


### PR DESCRIPTION
Refs #5962, ADR-0048.

Stacked on #5966 (the gate and its `BASELINE`) and on the four service PRs already open against
#5962 (#5969, #5971, #5974, #5977) — all merged in, so their diffs drop out as they land. **This
PR's own work is one schema block, one enum line and one version line in
`openbank-sepa-payment/src/main/resources/openapi.yaml`, plus two `BASELINE` entries.**

**Money-path service — 2 approvals required.**

## What was wrong

The domain type is `SepaPaymentStatus { RECEIVED, VALIDATED, PROCESSING, COMPLETED, REJECTED,
RETURNED, CANCELLED }`. The published document named two states that do not exist and omitted four
that do, in two places:

| spec said | effect |
|---|---|
| `GET /sepa-payments` `status` filter `[PENDING, PROCESSING, COMPLETED, REJECTED, RECALLED]` | `SepaPaymentResource.kt:115` does `status?.let(SepaPaymentStatus::valueOf)` bare, so `PENDING` or `RECALLED` throws `IllegalArgumentException` -> **400** (libs-runtime maps IAE to 400). The two states a payment actually spends most of its life in, `RECEIVED` and `VALIDATED`, were unfilterable, along with `RETURNED` and `CANCELLED` |
| `TransitionStatusRequest.targetStatus` `[PROCESSING, COMPLETED, REJECTED, RECALLED]` | `SepaPaymentDtos.kt:53` does `SepaPaymentStatus.valueOf(targetStatus)`, so `RECALLED` -> 400. `VALIDATED`, `RETURNED` and `CANCELLED` — three of the six reachable transition targets, including the whole cancel path — could not be requested by any generated client |

**The same schema also declared a property the server does not read.** `TransitionStatusRequest`
carried `reason: string`; the Kotlin DTO is
`TransitionSepaPaymentStatusRequest(targetStatus, rejectReason, rejectDetail)`, and the domain
*requires* a reject reason when the target is `REJECTED`
(`SepaPayment.kt:67`: `require(targetStatus != REJECTED || reason != null)`). So a client
generated from this document could not reject a payment at all: it would send `reason`, the server
would bind `rejectReason = null`, and the required-field check would fail. That is the same defect
in the same request body, so it is fixed here — `reason` becomes `rejectReason` (typed with the
real `SepaRejectReason` vocabulary) plus `rejectDetail`.

## Which side is right — the service's own docs say so, in writing

`src/main/resources/docs/03-api.en.md:5` opens with a **Contract note**:

> the checked-in `openapi.yaml` is slightly behind the code in a few places (it lists status enum
> values `PENDING`/`RECALLED` ...). The authoritative behaviour is what `SepaPaymentResource`,
> `SepaPaymentDtos` and `ExceptionMappers` implement, described here.

Someone documented this exact drift, by name, instead of fixing it — the same pattern #5971 found
in clearing. The same file then republishes the real lifecycle at line 116
(`RECEIVED ──► VALIDATED ──► PROCESSING ──► COMPLETED`) and at line 83 states that the create
verdict is `VALIDATED` / `RECEIVED` / `REJECTED`.

Two further checks:

- **`RECALLED` and `PENDING` were never renamed — they never existed in this service.**
  `git log --all -S "RECALLED" --name-only -- openbank-sepa-payment` returns
  `openbank-sepa-payment/src/main/resources/openapi.yaml` and nothing else, at every revision:
  no Kotlin source, no migration. Same for `PENDING`.
- **`RECALLED` *is* real one service over, and that is the trap.**
  `openbank-sepa-instant`'s `SctInstStatus` genuinely has `RECALLED` (it has a recall endpoint;
  sepa-payment does not), and `openbank-customer-edge/openapi.yaml:1702` publishes it — for the
  *instant* lifecycle. A fleet grep for the literal therefore looks like corroboration and is not.
  Scoping the grep to the service is what distinguishes them.
- **DB** — `sepa_payments.status` is `VARCHAR(32)` with no CHECK constraint, so unlike account or
  transaction there is nothing stored to change, and no migration is needed.

## No consumer sends these values

- **admin-ui** — `payments/page.tsx:455` mentions `RECALLED` only in `statusColor`, a display-side
  lookup, and that page also renders SCT-Inst payments where the value is real. It never sends it.
- **pacts** — the three pacts naming sepa-payment (`-document-service`, `-transaction-service`,
  `-fraud-service`) all have sepa-payment as the **consumer**; there is no provider pact against
  this service, so nothing replays these routes.
- **fleet grep**, scoped per service as above, finds no producer of either literal for
  sepa-payment.

## Deliberately NOT fixed here

`SepaPaymentResponse` in this document declares nine properties against the DTO's twenty, and
spells `currency` as `currencyCode`. Its `status` carries no enum at all, so it is not a drift the
enum gate can see, and reconciling it is a schema rewrite rather than an enum reconciliation —
the split #5977 drew for pid. The `03-api.en.md` contract note also flags a stale `code/message`
error body and a stale local server port `8102`. Left for a follow-up under #5962.

## Classification: `correction`, MINOR

```
::notice::api-contract gate: openbank-sepa-payment: spec-only PR — reclassifying 3 breaking
document change(s) (first: removed the enum value `PENDING` from the `query` request parameter
`status`) as a CORRECTION. No other file in openbank-sepa-payment changed, so the served contract
is unchanged and a MAJOR bump would violate the ADR-0048 D2 URL-major invariant. Requiring MINOR
instead.
api-contract gate: openbank-sepa-payment: correction change, info.version 1.7.0 -> 1.8.0 — OK.
```

`1.7.0` read off live `origin/main` immediately before the bump; major stays 1, so no URL moves.
`openbank-infra/scripts/check-threat-model-diff.py --base <live merge-base> --enforce` exits 0 —
run, not assumed.

## One judgement call, stated

`targetStatus` publishes the **full** seven-value vocabulary rather than the six states
`canTransitionTo` can actually reach. The endpoint parses with a bare `valueOf`, so all seven are
accepted syntactically; which one is legal depends on the payment's current state, and an illegal
transition is answered **409**, not 400. Encoding the state machine in an enum would misdescribe
the failure mode, so the enum describes what the parser takes and a comment on the property
describes the state machine.

## Verification

- `./gradlew :openbank-sepa-payment:ktlintCheck :detekt :test` — `ktlintCheck` and `detekt`
  executed and passed; `test` executed (not `UP-TO-DATE`).
- **111 tests, 0 failures, 0 errors, 0 skipped.** No skip to explain: this service has no
  broker-gated provider class, because it is not a pact provider (see above).
  - Noted for honesty: the first run of this suite reported 1 failure,
    `SepaPaymentOutboxClaimIT > stale DISPATCHING row must be reclaimable, not stranded` — a
    wall-clock-dependent reclaim-window assertion, and not reachable from a change that touches
    only `openapi.yaml`. Re-run with `--rerun-tasks`: 0 failures, 0 skips.
- `check-openapi-enum-vs-domain.py --self-test` passes; the gate then reports
  `18 paired enum(s) drift, all 18 baselined`, and it fails on a stale entry in either direction,
  so both removals are proven genuinely reconciled.
  (`SUBJECTS` stays 148 rather than rising: the new `rejectReason` enum pairs cleanly with
  `SepaRejectReason` (+1), while the corrected filter and `targetStatus` are now byte-identical
  and collapse into one subject (-1).)

Baseline: **20 -> 18** for this PR alone.
