### PR TITLE
fix(deploy): select exact co-deploy pact versions

### DIFF
--- a/.github/scripts/can-i-deploy-gate.sh
+++ b/.github/scripts/can-i-deploy-gate.sh
@@ -95,15 +95,27 @@ BLOCKS_FILE="$(mktemp)"
 
 # ── #1985: co-deploy mode ───────────────────────────────────────────────────────
 # Services that block EACH OTHER cannot converge one deploy at a time; this asks
-# the broker whether THOSE versions are mutually compatible. Full reasoning in
+# the broker whether THOSE exact build versions are mutually compatible. Full reasoning in
 # derive-codeploy-set.py's header. It is a gate, not a bypass — a red verdict
 # deploys nothing — but a DIFFERENT question, so it is opt-in on workflow_dispatch
-# and never reachable from a push or a scheduled tick.
+# and never reachable from a push or a scheduled tick. Do not use `--latest main` here:
+# a later, unrelated main build can move that tag between selection and the question, turning
+# this into a verdict about a different image.
 if [ "${EVENT_NAME}" = "workflow_dispatch" ] \
    && [ "${INPUT_CODEPLOY}" = "true" ]; then
   CODEPLOY_ARGS=()
   for svc in $(echo "$SERVICES" | jq -r '.[]'); do
-    CODEPLOY_ARGS+=(--pacticipant "$svc" --latest main)
+    vpresent="$(bash .github/scripts/probe-pact-version.sh "$svc" "$GITHUB_SHA")"
+    sel_line="$(PACT_VERSION_PRESENT="$vpresent" EVENT_NAME="$GITHUB_EVENT_NAME" \
+      bash .github/scripts/resolve-can-i-deploy-selector.sh "$svc" "$GITHUB_SHA")"
+    read -ra CID_SELECTOR <<< "$(printf '%s' "$sel_line" | cut -f1)"
+    if [ "${CID_SELECTOR[0]}" = "REFUSE" ]; then
+      echo "::error::can-i-deploy co-deploy set cannot be asked safely for ${svc}: $(printf '%s' "$sel_line" | cut -f2)"
+      echo "deployable=[]" >> "$GITHUB_OUTPUT"
+      exit 1
+    fi
+    echo "    ${svc}: ${CID_SELECTOR[*]} ($(printf '%s' "$sel_line" | cut -f2))"
+    CODEPLOY_ARGS+=(--pacticipant "$svc" "${CID_SELECTOR[@]}")
   done
   echo "==> can-i-deploy CO-DEPLOY SET (#1985): $(echo "$SERVICES" | jq -r 'join(" ")')"
   if "$CLI" can-i-deploy "${CODEPLOY_ARGS[@]}" \

--- a/.github/scripts/test-resolve-can-i-deploy-selector.sh
+++ b/.github/scripts/test-resolve-can-i-deploy-selector.sh
@@ -108,8 +108,9 @@ check "push + no version → still latest/main (unchanged)" "--latest main" no p
 check "no EVENT_NAME + no version → latest/main" "--latest main" no
 
 # 8. A dispatch is only refused when the version is genuinely absent. With the version present
-#    the precise question is still the right one, dispatch or not.
-check "dispatch + version present → ask about THIS commit" "--version ${SHA}" yes workflow_dispatch
+#    the precise question is still the right one, dispatch or not. Co-deploy reuses this exact
+#    selector for every member: `--latest main` would instead ask about a later, unrelated image.
+check "dispatch/co-deploy + version present → ask about THIS commit" "--version ${SHA}" yes workflow_dispatch
 
 # 9. A dispatch with an inconclusive probe must NOT be refused: an unreachable broker is not
 #    evidence that the version is missing, and turning a probe outage into a hard stop would


### PR DESCRIPTION
Fixes the atomic co-deploy gate to resolve each selected service to its exact Pact version rather than querying a moving latest-main tag. The latter can evaluate a later, unrelated artifact and incorrectly reject the selected deployment.

Validation: bash -n .github/scripts/can-i-deploy-gate.sh; bash .github/scripts/test-resolve-can-i-deploy-selector.sh; git diff --check.

## Linked issues

Refs #5993