### PR TITLE
fix(sepa-instant): publish the real SctInstStatus vocabulary and reconcile the payment schemas

### DIFF
--- a/.github/scripts/check-openapi-enum-vs-domain.py
+++ b/.github/scripts/check-openapi-enum-vs-domain.py
@@ -103,8 +103,6 @@ BASELINE: dict[str, str] = {
         "not an enum fix. The `Status` pairing is coincidental.",
     "openbank-sanctions-service:CNB_DOMESTIC,EU_CONSOLIDATED,FATF_HIGH_RISK,HM_TREASURY,OFAC_SDN,UN_CONSOLIDATED":
         "#5962 — SanctionsListType: undeclared PEP_GLOBAL",
-    "openbank-sepa-instant:ACCEPTED,RECALLED,REJECTED,SETTLED,SUBMITTED":
-        "#5962 — SctInstStatus: spec-only ACCEPTED/SUBMITTED; undeclared PENDING/PROCESSING/TIMEOUT",
     "openbank-sepa-payment:COMPLETED,PROCESSING,RECALLED,REJECTED":
         "#5962 — SepaPaymentStatus: spec-only RECALLED; undeclared CANCELLED/RECEIVED/RETURNED/VALIDATED",
     "openbank-sepa-payment:COMPLETED,PENDING,PROCESSING,RECALLED,REJECTED":

--- a/openbank-sepa-instant/src/main/resources/openapi.yaml
+++ b/openbank-sepa-instant/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: SEPA Instant (SCT Inst) Service API
-  version: 1.4.0
+  version: 1.5.0
   description: >-
     SEPA Instant Credit Transfer — sub-10s settlement, recall support. On submit, debtor and creditor
     names are synchronously screened against the sanctions lists (ADR-0032): a clean payment proceeds
@@ -95,16 +95,16 @@ paths:
           schema:
             type: string
             format: uuid
-        - name: limit
-          in: query
-          schema:
-            type: integer
-            default: 20
-        - name: offset
+        - name: page
           in: query
           schema:
             type: integer
             default: 0
+        - name: size
+          in: query
+          schema:
+            type: integer
+            default: 20
       responses:
         '200':
           description: List of payments
@@ -213,26 +213,38 @@ components:
 
   schemas:
     SubmitSctInstRequest:
+      # Field-for-field with SubmitSctInstRequest in SctInstDtos.kt. `idempotencyKey`,
+      # `debtorIban` and `debtorName` are non-nullable there, so a body omitting any of them
+      # fails to deserialise; the `Idempotency-Key` header, when present, overrides the body
+      # field but does not make it optional (SctInstResource.submit reads `body.idempotencyKey`).
       type: object
-      required: [debtorAccountId, creditorIban, creditorName, amount, endToEndId]
+      required: [idempotencyKey, debtorAccountId, debtorIban, debtorName, creditorIban, creditorName, amount, endToEndId]
       properties:
+        idempotencyKey:
+          type: string
         debtorAccountId:
           type: string
           format: uuid
+        debtorIban:
+          type: string
+        debtorName:
+          type: string
         creditorIban:
           type: string
         creditorName:
           type: string
         creditorBic:
           type: string
+          nullable: true
         amount:
           type: number
-        currencyCode:
+        currency:
           type: string
           default: EUR
-        endToEndId:
-          type: string
         remittanceInfo:
+          type: string
+          nullable: true
+        endToEndId:
           type: string
 
     RecallRequest:
@@ -244,34 +256,38 @@ components:
           enum: [FRAUD, DUPLICATE, WRONG_AMOUNT, WRONG_BENEFICIARY]
 
     SctInstPaymentResponse:
+      # Field-for-field with SctInstPaymentResponse in SctInstDtos.kt, which SctInstResource
+      # .toResponse() populates directly from the SctInstPayment aggregate.
       type: object
+      required: [paymentId, status, debtorIban, creditorIban, amount, currency, endToEndId, createdAt]
       properties:
-        id:
+        paymentId:
           type: string
           format: uuid
-        endToEndId:
+        status:
           type: string
-        debtorAccountId:
+          enum: [PENDING, PROCESSING, SETTLED, REJECTED, TIMEOUT, RECALLED]
+        debtorIban:
           type: string
-          format: uuid
         creditorIban:
-          type: string
-        creditorName:
           type: string
         amount:
           type: number
-        currencyCode:
+        currency:
           type: string
-        status:
+        endToEndId:
           type: string
-          enum: [SUBMITTED, ACCEPTED, SETTLED, REJECTED, RECALLED]
-        submittedAt:
+        executionTimeoutAt:
           type: string
           format: date-time
+          nullable: true
         settledAt:
           type: string
           format: date-time
           nullable: true
+        createdAt:
+          type: string
+          format: date-time
 
     ApiError:
       type: object


### PR DESCRIPTION
Refs #5962, ADR-0048.

Stacked on #5966 (the gate and its `BASELINE`) and on the four service PRs already open against
#5962 (#5969, #5971, #5974, #5977) — all merged in, so their diffs drop out as they land. **This
PR's own work is `openbank-sepa-instant/src/main/resources/openapi.yaml` and one `BASELINE`
entry.**

**Money-path service — 2 approvals required.**

## What was wrong — the baselined enum

| spec said | code says | effect |
|---|---|---|
| `SctInstPaymentResponse.status` `[SUBMITTED, ACCEPTED, SETTLED, REJECTED, RECALLED]` | `SctInstStatus { PENDING, PROCESSING, SETTLED, REJECTED, TIMEOUT, RECALLED }` | the server emits `PENDING`, `PROCESSING` and `TIMEOUT` — including the status of **every** payment on creation — and the document declares none of them. It has never emitted `SUBMITTED` or `ACCEPTED`. A strict generated deserializer fails on the 201 response of a successful submit |

`status` is `p.status.name` straight off the domain enum (`SctInstResource.kt:114`), so there is no
translation layer that could have absorbed the difference.

### Which side is right — the domain, on two independent witnesses

1. **The service's own API docs already republish the code vocabulary and flag the spec as wrong.**
   `docs/03-api.en.md:61` gives `status` as
   `PENDING`/`PROCESSING`/`SETTLED`/`REJECTED`/`TIMEOUT`/`RECALLED`, and line 96 says outright that
   the checked-in `openapi.yaml` "uses a different status enum
   (`SUBMITTED/ACCEPTED/SETTLED/REJECTED/RECALLED`)" while "the running service uses the
   `PENDING/PROCESSING/SETTLED/REJECTED/TIMEOUT/RECALLED` enum". Someone wrote the drift down
   instead of fixing it — the same pattern #5971 found in clearing and #5990 in sepa-payment.
2. **A downstream spec already publishes the code list verbatim.**
   `openbank-customer-edge/src/main/resources/openapi.yaml:1702`:
   `status: {type: string, enum: [PENDING, PROCESSING, SETTLED, REJECTED, TIMEOUT, RECALLED]}`.
   A second document in another service agreeing with the code settles the spelling without a
   judgement call.

`SUBMITTED` and `ACCEPTED` were never renamed — they never existed:
`git log --all -S "ACCEPTED" --name-only -- openbank-sepa-instant` and the same for `SUBMITTED`
return **no** `.kt` or `.sql` file at any revision. There is no CHECK constraint on
`sct_inst_payments.status`, so nothing stored has to change and no migration is needed.

No consumer sends either value: admin-ui reads `status` for a colour pill only, and the single
pact naming this service (`openbank-sepa-instant-openbank-transaction-service.json`) has
sepa-instant as the **consumer**, so no provider replay touches these routes.

## Three further drifts found by hand, which the gate structurally cannot see

The issue notes that `27` is a floor rather than a census, and #5974 showed why: the gate pairs a
spec enum to a Kotlin enum by value overlap, so a *property* defect has no enum to pair and is
invisible. Fixing the enum alone here would have polished a schema that still describes a
different response — the split #5977 drew for pid. All three are in the same file, all three are
settled by reading the DTO the resource populates directly, and all three are fixed here:

1. **`SctInstPaymentResponse` shared only 5 of its 10 property names with the DTO.** The Kotlin
   type is `SctInstPaymentResponse(paymentId, status, debtorIban, creditorIban, amount, currency,
   endToEndId, executionTimeoutAt, settledAt, createdAt)`, populated field-for-field by
   `SctInstResource.toResponse()`. The document declared `id` (the field is `paymentId`),
   `debtorAccountId`, `creditorName` and `submittedAt` — **none of which the server ever sends** —
   spelled `currency` as `currencyCode`, and omitted `debtorIban`, `executionTimeoutAt` and
   `createdAt` entirely. Rewritten to match, `required` included.
2. **`SubmitSctInstRequest` omitted three properties that are non-nullable in Kotlin**, so a body
   built from the published document **cannot deserialise**: `idempotencyKey`, `debtorIban` and
   `debtorName`. (The `Idempotency-Key` header overrides the body field when present but does not
   make it optional — `SctInstResource.submit` reads `body.idempotencyKey` as the fallback, which
   requires the property to have bound.) It also spelled `currency` as `currencyCode`. Same
   defect shape as the `UpdateCheckRequest` rewrite in #5966.
3. **`GET /sepa-instant/debtor/{id}` published `limit`/`offset`; the resource takes `page`/`size`**
   (`@QueryParam("page") @DefaultValue("0")`, `@QueryParam("size") @DefaultValue("20")`). A client
   passing `limit=50` gets silently ignored parameters and the default page of 20 — the quiet
   failure, not a 400.

`docs/03-api.en.md:96` independently lists all three ("lists the submit body without
`idempotencyKey`/`debtorIban`/`debtorName` ... declares the debtor-list pagination as
`limit`/`offset` ... The running service uses `page`/`size`"), so this is not my reading of the
source alone.

## Deliberately NOT fixed here

- **`RecallRequest.reason` `[FRAUD, DUPLICATE, WRONG_AMOUNT, WRONG_BENEFICIARY]`.** The Kotlin type
  is `RecallRequest(val reason: String)` — a free string, passed through to the use case
  unvalidated. There is no Kotlin enum to reconcile against, which is exactly why the gate does not
  pair it and correctly does not report it. Whether the four values are an intended API constraint
  that the code fails to enforce, or spec fiction, is a product decision rather than a
  reconciliation, so it stays as it is.
- The stale local server port `8111` (the service listens on 8127), also named in the docs note.
  Cosmetic, and unrelated to the contract.

## Classification: `correction`, MINOR

```
::notice::api-contract gate: openbank-sepa-instant: spec-only PR — reclassifying 3 breaking
document change(s) (first: added the new required request property `debtorIban`) as a CORRECTION.
No other file in openbank-sepa-instant changed, so the served contract is unchanged and a MAJOR
bump would violate the ADR-0048 D2 URL-major invariant. Requiring MINOR instead.
api-contract gate: openbank-sepa-instant: correction change, info.version 1.4.0 -> 1.5.0 — OK.
```

Worth naming which half is breaking: the *response* changes (removing enum values and properties
the server never sent) are not breaking to `oasdiff` at all — a server promising less cannot break
a reader — and classified as `additive` on their own. It is the **request** half, item 2 above,
that reports `new-required-request-property`, and the clients that "break" are ones generated from
a document that could never have produced a deserialisable body. Same class as the aml precedent
(#2312/#2313) and kyc (#5966).

`1.4.0` read off live `origin/main` immediately before the bump; major stays 1, so the ADR-0048 D2
URL-major invariant holds and no URL moves.
`openbank-infra/scripts/check-threat-model-diff.py --base <live merge-base> --enforce` exits 0 —
run, not assumed.

## Verification

- `./gradlew :openbank-sepa-instant:ktlintCheck :detekt :test --rerun-tasks` — `BUILD SUCCESSFUL`,
  exit 0. `detekt`, `ktlintCheck` and `test` all executed; none `UP-TO-DATE`.
- **70 tests, 0 failures, 0 errors, 0 skipped.** No skip to explain: this service has no
  broker-gated provider class, because it is not a pact provider.
- `check-openapi-enum-vs-domain.py --self-test` passes; the gate then reports
  `19 paired enum(s) drift, all 19 baselined`, and it fails on a stale entry in either direction,
  so the removal is proven genuinely reconciled rather than merely deleted.

Baseline: **20 -> 19** for this PR alone.
