### PR TITLE
fix(libs): reject the NUL character at the request boundary instead of at Postgres

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,22 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
   named explicitly in the Kotlin use-site form `@field:Column(name = ...)` that a `@Column`-only
   regex cannot match. A gate that cries wolf about correct code is worth less than nothing, so it
   checks the convention, which is fully decidable.
+- **A NUL byte (U+0000) reaching Postgres is a 500, and it arrives ESCAPED — so a raw-byte scan of
+  the request finds nothing and reports clean.** Postgres cannot store U+0000 in any `text`/`varchar`
+  column (`invalid byte sequence for encoding "UTF8": 0x00`, SQLState 22021); Hibernate raises it at
+  flush, far past every handler, so `GenericExceptionMapper` renders a well-formed `INTERNAL_ERROR`
+  body — which is why "it did not crash" and "the response parsed" both pass against it. Rejected
+  fleet-wide now by `libs-runtime`'s `NulByteGuards` (#5913), and two things about it generalise.
+  First, the carrier: five services, **six** operations, and two of them carried the NUL in a QUERY
+  PARAMETER, not a body — those requests have no entity at all, so a Jackson-only guard is
+  structurally green about them. Enumerate the carriers from the fuzz artifacts before choosing where
+  a guard goes. Second, the wire form: inside JSON the character is the six ASCII characters of a
+  `\u0000` escape, legal JSON that Jackson decodes happily, so only the DECODED value answers the
+  question — scanning the stream for byte `0x00` sees nothing, and scanning for the escape as text
+  false-positives on a doubly-escaped backslash. Sibling of the `value too long` / duplicate-key
+  cases in the same issue, which are deliberately NOT this: a length limit is per-column and a
+  `ConstraintViolationException` is 409-or-400 depending on which constraint, so neither is decidable
+  fleet-wide. U+0000 is, because no valid request can carry it and no column can accept it.
 - **A Kotlin annotation binds to the NEXT declaration — a top-level function between `@Path` and its
   class silently steals it.** `McpEndpoint` had `@Path("/mcp")`, then a top-level
   `private fun String?.sanitizeForLog()`, then `class McpEndpoint`. The `@Path` bound to the

--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/integration/FxNulByteRejectionIT.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/integration/FxNulByteRejectionIT.kt
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.fx.integration
+
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * `POST /api/v1/fx/convert` answered **500** for a NUL character (U+0000) in a body string (#5913).
+ *
+ * All eight of fx-service's occurrences in that run were this one operation; the fuzzer's value
+ * landed in `toCurrency`, which reached Postgres as the `quote_currency=$2` bind of the rate lookup
+ * and produced `invalid byte sequence for encoding "UTF8": 0x00` (SQLState 22021) as an
+ * `org.hibernate.exception.DataException`. `GET /api/v1/fx/rates/{base}/{quote}` produced none, so
+ * the body is the only measured carrier here.
+ *
+ * The response was a well-formed `INTERNAL_ERROR` document, so the assertion is on the status.
+ *
+ * The fix is the shared boundary in `openbank-libs-runtime`
+ * (`com.openbank.libs.api.error.NulByteGuards`) rather than anything in this service — which makes
+ * this IT the check that the guard is discovered and registered inside a *running* Quarkus app, a
+ * thing no unit test over the guard classes can establish.
+ *
+ * **Falsification (run, not assumed):** with `NulByte.contains` forced to return false, this test
+ * answers 500 — the exact status and cause #5913 reported. The paired "does not reject everything"
+ * control lives in `TransactionNulByteRejectionIT` (a clean query string that must not be rejected)
+ * and in `NulByteGuardsTest`; it is deliberately not duplicated here, because `fx.convert` with a
+ * currency pair that has no stored rate answers 400 on its own, so a status-only control on this
+ * endpoint would discriminate nothing.
+ */
+@QuarkusTest
+@QuarkusTestResource(FxNulByteRejectionIT.InMemoryKafkaResource::class)
+@QuarkusTestResource(com.openbank.fx.it.PostgresRedisTestResource::class)
+class FxNulByteRejectionIT {
+
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> = InMemoryConnector.switchOutgoingChannelsToInMemory("fx-events-out")
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    /** The JSON escape for U+0000 as it travels on the wire: six ASCII characters, legal JSON. */
+    private val escapedNul = "\\u0000"
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `convert rejects a NUL in the toCurrency body field with 400`() {
+        val payload = """
+            {
+              "partyId": "${UUID.randomUUID()}",
+              "accountId": null,
+              "partyName": "Jan Novak",
+              "fromCurrency": "CZK",
+              "toCurrency": "${escapedNul}EUR",
+              "fromAmountMinorUnits": 100000
+            }
+        """.trimIndent()
+
+        Given {
+            contentType("application/json")
+            header("Idempotency-Key", UUID.randomUUID().toString())
+            body(payload)
+        } When {
+            post("/api/v1/fx/convert")
+        } Then {
+            statusCode(400)
+        }
+    }
+}

--- a/openbank-libs-runtime/build.gradle.kts
+++ b/openbank-libs-runtime/build.gradle.kts
@@ -74,6 +74,23 @@ dependencies {
     compileOnly("io.quarkus:quarkus-security:3.33.2")
     compileOnly("io.quarkus:quarkus-arc:3.33.2")
 
+    // NulByteGuards: the fleet-wide U+0000 rejection (#5913). jackson-databind supplies
+    // StringDeserializer/SimpleModule; quarkus-jackson supplies ObjectMapperCustomizer, the
+    // registration hook. Both compileOnly for the same reason as everything above — every real
+    // service already brings them via quarkus-rest-jackson.
+    //
+    // quarkus-jackson is pinned to 3.33.2, matching every sibling literal in this block rather
+    // than the 3.38.0 the platform actually resolves. That is deliberate and measured, not the
+    // rot this block's header warns about: resolving quarkus-jackson:3.38.0 STANDALONE (this
+    // module applies no Quarkus BOM) drags four POMs that `gradle/verification-metadata.xml` does
+    // not carry — io.smallrye.common:smallrye-common-{classloader,expression,function}:2.17.1 and
+    // smallrye-common-os:2.15.0 — and dependency verification then fails the build of every
+    // consuming service. Only the ObjectMapperCustomizer interface is compiled against, and it is
+    // identical across both versions. Correcting the whole block to the real BOM versions is the
+    // separate change the header calls for (#5482), and needs those checksums added with it.
+    compileOnly("com.fasterxml.jackson.core:jackson-databind:2.22.1")
+    compileOnly("io.quarkus:quarkus-jackson:3.33.2")
+
     // S3ObjectStore (ADR-0161 D2) compiles against the real AWS SDK v2 `s3` module
     // (S3Presigner ships in the same artifact — no separate presigner dependency).
     // compileOnly, matching the convention above: this is NOT part of the Quarkus
@@ -100,6 +117,11 @@ dependencies {
     // existed deleting it left every suite green. Both are compileOnly above, so the test source
     // set needs them explicitly; same pattern as quarkus-security and the FT API here.
     testImplementation("io.quarkus:quarkus-redis-client:3.33.2")
+    // NulByteGuardsTest drives the REAL ObjectMapper through the REAL customizer, so the module
+    // registration and the deserializer are both exercised rather than asserted about.
+    testImplementation("com.fasterxml.jackson.core:jackson-databind:2.22.1")
+    testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.22.1")
+    testImplementation("io.quarkus:quarkus-jackson:3.33.2")
     testImplementation("io.smallrye.reactive:mutiny-kotlin:3.1.1")
     // ResilientCallMetrics classifies CircuitBreakerOpenException; the API is compileOnly above.
     testImplementation("org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:4.1.1")

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/api/error/NulByteGuards.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/api/error/NulByteGuards.kt
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.api.error
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.deser.std.StringDeserializer
+import com.fasterxml.jackson.databind.module.SimpleModule
+import io.quarkus.jackson.ObjectMapperCustomizer
+import jakarta.inject.Singleton
+import jakarta.ws.rs.BadRequestException
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.container.ContainerRequestFilter
+import jakarta.ws.rs.ext.Provider
+
+/**
+ * Rejects the **NUL character (U+0000) in any JSON string** with 400, fleet-wide.
+ *
+ * ## The defect
+ *
+ * PostgreSQL cannot store U+0000 in a `text`/`varchar` column at all — the driver reports
+ * `invalid byte sequence for encoding "UTF8": 0x00`. That is thrown at flush, far past every
+ * handler, so it renders as a 500 through [GenericExceptionMapper].
+ *
+ * The first fuzz run to reach past authentication found this on **five money-path services** at
+ * once — dispute, interest, sdd, transaction, fx (#5913). Nothing about it is service-specific:
+ * the same character, the same driver, the same storage complaint.
+ *
+ * ## Why here, and why exactly one place
+ *
+ * The alternative was per-endpoint `require` calls, i.e. eleven judgement calls about a question
+ * that has only one answer. Unlike a field-length limit — which is genuinely per-column and
+ * per-domain — U+0000 is decidable with no domain knowledge whatsoever:
+ *
+ * - no valid request can carry it (it is a string terminator, not text), and
+ * - Postgres can never accept it, so the request cannot succeed whatever the handler does.
+ *
+ * So the input is unambiguously a client error, and the boundary belongs where every service
+ * shares it. This sits beside [RequiredBody] for the same reason and by the same precedent: a
+ * fleet-wide 500-to-400 correction no individual handler was in a position to make.
+ *
+ * ## Why a Jackson deserializer rather than a scan of the raw body
+ *
+ * The wire form matters. Hypothesis/schemathesis emits the character inside a JSON string, so it
+ * arrives **escaped** — legal JSON that Jackson decodes happily. A raw scan of the entity stream
+ * for byte `0x00` therefore finds nothing and would be a guard that reports clean; scanning for
+ * the escape sequence as literal text instead false-positives on a doubly-escaped backslash,
+ * which is four characters of text and contains no NUL. Only the **decoded** value answers the
+ * question, which is what a deserializer sees.
+ *
+ * It also reaches places a parameter-shaped check structurally cannot: strings nested in arrays,
+ * maps and sub-objects — exactly where the collection-element blind spot documented on
+ * [RequiredBody] lives.
+ *
+ * ## Why two classes: the body is not the only carrier
+ *
+ * This was measured, not assumed. Reading the six failing operations out of the fuzz run's own
+ * artifacts (#5913), **two of the six carry the NUL in a query parameter, not in a body** —
+ * `GET /api/v1/interest/rates?productId=%00...` and
+ * `GET /api/v1/transactions/search?referenceNumber=...%00...`, both percent-encoded on the URI and
+ * both landing as a bind parameter in a SELECT predicate. A Jackson-only guard would have been
+ * green about them: those requests carry no entity at all, so no deserializer ever runs.
+ *
+ * So the boundary is one decision expressed in the two places a string can enter — the decoded
+ * body ([NulByteRejectingStringDeserializer]) and the decoded URI ([NulByteParameterFilter]) —
+ * the same split, for the same reason, as [AbsentBodyRequestFilter] and [NullBodyReaderInterceptor].
+ *
+ * ## Status
+ *
+ * [DeserializationContext.reportInputMismatch] raises `MismatchedInputException`, which the
+ * RESTEasy Reactive Jackson reader already renders as **400**. Deliberately used in preference to
+ * throwing a bare `IllegalArgumentException`: Jackson's `WRAP_EXCEPTIONS` (on by default) re-wraps
+ * that into a `JsonMappingException`, so the resulting status would depend on wrapping behaviour
+ * rather than on an explicit decision.
+ */
+internal object NulByte {
+
+    const val NUL: Char = '\u0000'
+
+    const val MESSAGE: String = "contains the NUL character (U+0000), which is not accepted"
+
+    fun contains(value: String): Boolean = value.indexOf(NUL) >= 0
+}
+
+/**
+ * A [StringDeserializer] that rejects any decoded string containing [NulByte.NUL].
+ *
+ * Delegating to the standard deserializer first is deliberate: it keeps Jackson's coercion rules
+ * intact, so this only ever *adds* a rejection and never changes what an accepted request decodes
+ * to.
+ */
+internal class NulByteRejectingStringDeserializer : StringDeserializer() {
+
+    override fun deserialize(parser: JsonParser, context: DeserializationContext): String? {
+        val value = super.deserialize(parser, context)
+        if (value != null && NulByte.contains(value)) {
+            context.reportInputMismatch<Any>(String::class.java, "string ${NulByte.MESSAGE}")
+        }
+        return value
+    }
+}
+
+/** The Jackson module carrying [NulByteRejectingStringDeserializer]. Registered by [NulByteObjectMapperCustomizer]. */
+internal class NulByteModule : SimpleModule("openbank-nul-byte") {
+    init {
+        addDeserializer(String::class.java, NulByteRejectingStringDeserializer())
+    }
+}
+
+/**
+ * Installs [NulByteModule] on every service's `ObjectMapper`.
+ *
+ * `ObjectMapperCustomizer` is the mechanism Quarkus documents for this, and every Quarkus service
+ * in the fleet carries `quarkus-rest-jackson` (which brings `quarkus-jackson`). The only
+ * `openbank-libs-runtime` consumers that do not are `openbank-libs*` and `openbank-simulation`,
+ * none of which is a Quarkus application — so none of them runs CDI discovery over this class, and
+ * the `ClassNotFoundException`-at-ArC-init hazard that keeps `ConstraintViolationExceptionMapper`
+ * out of [CommonExceptionMappers] does not arise here.
+ */
+@Singleton
+class NulByteObjectMapperCustomizer : ObjectMapperCustomizer {
+    override fun customize(objectMapper: ObjectMapper) {
+        objectMapper.registerModule(NulByteModule())
+    }
+}
+
+/**
+ * Rejects [NulByte.NUL] in any **query or path parameter**.
+ *
+ * Reads only [jakarta.ws.rs.core.UriInfo], which is already decoded and already parsed — no entity
+ * stream is touched, so this stays non-blocking on the reactive stack.
+ *
+ * Not `@PreMatching`: path parameters are only populated once a resource has been matched, and
+ * `interest`'s and `transaction`'s failures came through the query string of matched operations.
+ * Path parameters carry no measured occurrence in the #5913 run and are covered here as defence in
+ * depth — the character is exactly as impossible there, and excluding them would be a distinction
+ * with no reason behind it.
+ *
+ * Throws `BadRequestException` rather than `IllegalArgumentException` purely for symmetry with
+ * [AbsentBodyRequestFilter]; both render as 400 through [WebApplicationExceptionMapper].
+ */
+@Provider
+class NulByteParameterFilter : ContainerRequestFilter {
+
+    override fun filter(requestContext: ContainerRequestContext) {
+        val uriInfo = requestContext.uriInfo
+        reject(uriInfo.queryParameters, "query parameter")
+        reject(uriInfo.pathParameters, "path parameter")
+    }
+
+    private fun reject(parameters: Map<String, List<String?>>, kind: String) {
+        for ((name, values) in parameters) {
+            if (values.any { it != null && NulByte.contains(it) }) {
+                throw BadRequestException("$kind '$name' ${NulByte.MESSAGE}")
+            }
+        }
+    }
+}

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/api/error/NulByteGuardsTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/api/error/NulByteGuardsTest.kt
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.api.error
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.ws.rs.BadRequestException
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.core.MultivaluedHashMap
+import jakarta.ws.rs.core.MultivaluedMap
+import jakarta.ws.rs.core.UriInfo
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * Drives the REAL customizer over a REAL `ObjectMapper`, so both halves are exercised: that the
+ * module is actually registered, and that the deserializer rejects what it claims to.
+ *
+ * The escaped form is what matters and is spelled out here. Every case sends the six ASCII
+ * characters `\u0000` on the wire — legal JSON, which Jackson decodes to a one-character string.
+ * That is the shape schemathesis produced against the five services in #5913, and the shape a raw
+ * `0x00` byte scan of the entity stream cannot see.
+ *
+ * [nulIsAcceptedWithoutTheCustomizer] is the falsification control: it is the same payload against
+ * a mapper with the guard absent, and it must PASS deserialization. Without it, every assertion
+ * below could be green for a reason that has nothing to do with this class.
+ */
+class NulByteGuardsTest {
+
+    private data class Payload(val name: String)
+
+    private data class Nested(val notes: List<String>, val tags: Map<String, String>)
+
+    /** The JSON escape for U+0000, written as source text so no control character enters this file. */
+    private val escapedNul = "\\u0000"
+
+    private fun guarded(): ObjectMapper =
+        ObjectMapper().registerKotlinModule().also { NulByteObjectMapperCustomizer().customize(it) }
+
+    private fun unguarded(): ObjectMapper = ObjectMapper().registerKotlinModule()
+
+    @Test
+    fun `a NUL in a top-level string field is rejected`() {
+        assertThatThrownBy { guarded().readValue("""{"name":"a${escapedNul}b"}""", Payload::class.java) }
+            .isInstanceOf(MismatchedInputException::class.java)
+            .hasMessageContaining("NUL")
+    }
+
+    @Test
+    fun `a NUL as the entire field value is rejected`() {
+        assertThatThrownBy { guarded().readValue("""{"name":"$escapedNul"}""", Payload::class.java) }
+            .isInstanceOf(MismatchedInputException::class.java)
+    }
+
+    /**
+     * The collection-element case. `RequiredBodyGuards` documents that reading nullability off the
+     * handler parameter structurally cannot see inside a collection; a deserializer-level guard can,
+     * and this is the assertion that says so.
+     */
+    @Test
+    fun `a NUL inside an array element is rejected`() {
+        assertThatThrownBy {
+            guarded().readValue("""{"notes":["ok","$escapedNul"],"tags":{}}""", Nested::class.java)
+        }.isInstanceOf(MismatchedInputException::class.java)
+    }
+
+    @Test
+    fun `a NUL inside a map value is rejected`() {
+        assertThatThrownBy {
+            guarded().readValue("""{"notes":[],"tags":{"k":"$escapedNul"}}""", Nested::class.java)
+        }.isInstanceOf(MismatchedInputException::class.java)
+    }
+
+    /**
+     * A doubly-escaped backslash is the false positive a raw-text scan for the escape sequence
+     * would produce: this string is the six literal characters `\u0000` and contains no NUL at all.
+     */
+    @Test
+    fun `a literal backslash-u-0000 text is accepted and decodes to six characters`() {
+        val decoded = guarded().readValue("""{"name":"\\u0000"}""", Payload::class.java)
+        assertThat(decoded.name).isEqualTo("""\u0000""")
+        assertThat(decoded.name).doesNotContain(NulByte.NUL.toString())
+    }
+
+    @Test
+    fun `ordinary strings are untouched`() {
+        assertThat(guarded().readValue("""{"name":"Jan Novak"}""", Payload::class.java).name)
+            .isEqualTo("Jan Novak")
+    }
+
+    /**
+     * FALSIFICATION CONTROL — remove the guard and the same payload must be accepted.
+     *
+     * This is the assertion that makes the four rejections above mean something: it fails the day
+     * the customizer stops registering the module, or the day some other Jackson default starts
+     * rejecting the payload for an unrelated reason.
+     */
+    @Test
+    fun nulIsAcceptedWithoutTheCustomizer() {
+        assertThatCode {
+            val decoded = unguarded().readValue("""{"name":"a${escapedNul}b"}""", Payload::class.java)
+            assertThat(decoded.name).hasSize(3)
+            assertThat(decoded.name).contains(NulByte.NUL.toString())
+        }.doesNotThrowAnyException()
+    }
+
+    // ---- NulByteParameterFilter ------------------------------------------------------------
+    //
+    // Two of the six operations in #5913 carried the NUL in a QUERY STRING, not a body:
+    // `GET /api/v1/interest/rates?productId=%00...` and
+    // `GET /api/v1/transactions/search?referenceNumber=...%00...`. Those requests have no entity,
+    // so no deserializer runs and every assertion above is silent about them. These are the cases
+    // that make the filter non-redundant.
+
+    private fun request(
+        query: Map<String, String> = emptyMap(),
+        path: Map<String, String> = emptyMap(),
+    ): ContainerRequestContext {
+        fun mv(m: Map<String, String>): MultivaluedMap<String, String> =
+            MultivaluedHashMap<String, String>().apply { m.forEach { (k, v) -> add(k, v) } }
+        val uriInfo = mockk<UriInfo>()
+        every { uriInfo.queryParameters } returns mv(query)
+        every { uriInfo.pathParameters } returns mv(path)
+        val context = mockk<ContainerRequestContext>()
+        every { context.uriInfo } returns uriInfo
+        return context
+    }
+
+    /** interest: `GET /api/v1/interest/rates?productId=%00...` — decoded, the value starts with NUL. */
+    @Test
+    fun `a NUL in a query parameter is rejected`() {
+        assertThatThrownBy {
+            NulByteParameterFilter().filter(request(query = mapOf("productId" to "${NulByte.NUL}x")))
+        }.isInstanceOf(BadRequestException::class.java)
+            .hasMessageContaining("productId")
+            .hasMessageContaining("NUL")
+    }
+
+    /** transaction: `GET /api/v1/transactions/search?referenceNumber=...%00...` — NUL mid-value. */
+    @Test
+    fun `a NUL mid-value in a query parameter is rejected`() {
+        assertThatThrownBy {
+            NulByteParameterFilter().filter(
+                request(query = mapOf("referenceNumber" to "+ab${NulByte.NUL}cd", "type" to "DEBIT")),
+            )
+        }.isInstanceOf(BadRequestException::class.java).hasMessageContaining("referenceNumber")
+    }
+
+    @Test
+    fun `a NUL in a path parameter is rejected`() {
+        assertThatThrownBy {
+            NulByteParameterFilter().filter(request(path = mapOf("transactionId" to "a${NulByte.NUL}")))
+        }.isInstanceOf(BadRequestException::class.java).hasMessageContaining("transactionId")
+    }
+
+    /**
+     * FALSIFICATION CONTROL for the filter — an ordinary request must pass through untouched.
+     *
+     * Without this, "the filter rejects things" would be equally true of a filter that rejects
+     * every request, which would take the whole fleet down rather than fix five services.
+     */
+    @Test
+    fun `ordinary query and path parameters pass through`() {
+        assertThatCode {
+            NulByteParameterFilter().filter(
+                request(
+                    query = mapOf("productId" to "SAVINGS-01", "from" to "2026-01-01"),
+                    path = mapOf("transactionId" to "9f1c2d3e-0000-4a5b-8c9d-1e2f3a4b5c6d"),
+                ),
+            )
+        }.doesNotThrowAnyException()
+    }
+}

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/integration/TransactionNulByteRejectionIT.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/integration/TransactionNulByteRejectionIT.kt
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.integration
+
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import org.hamcrest.Matchers.not
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * The two `openbank-transaction-service` operations from #5913 that answered **500** for a NUL
+ * character (U+0000) in a string, driven over real HTTP against a real Postgres.
+ *
+ * Both failed identically at the driver — `invalid byte sequence for encoding "UTF8": 0x00`
+ * (SQLState 22021), surfaced as `org.hibernate.exception.DataException` and rendered by
+ * `GenericExceptionMapper` as a well-formed `INTERNAL_ERROR` body. **That body is why an oracle of
+ * "it did not crash" or "the response parsed" passes against the defect**, and why every assertion
+ * here is on the status code.
+ *
+ * They are two different carriers, which is the reason both are here rather than one standing in
+ * for the other:
+ *
+ * - `GET /api/v1/transactions/search?referenceNumber=…` — the NUL arrives **percent-encoded in the
+ *   query string**. The request has no entity at all, so a body-side guard never runs.
+ * - `POST /api/v1/transactions/{id}/reverse` — the NUL arrives in the **JSON body**, escaped, in
+ *   `idempotencyKey`.
+ *
+ * The fix is a single shared boundary in `openbank-libs-runtime`
+ * (`com.openbank.libs.api.error.NulByteGuards`), so this IT is also the check that it is actually
+ * *registered* in a running service: a unit test over the guard classes cannot tell a discovered
+ * CDI bean and JAX-RS provider from an undiscovered one.
+ *
+ * The `search` rejection is paired with a **control** sending the same request without the NUL,
+ * which must NOT answer 400 — without it, a guard that rejected every request would pass this class
+ * while taking the service down. `reverse` has no such control, for a reason recorded at the bottom
+ * of this file.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.transaction.it.PostgresRedpandaTestResource::class)
+class TransactionNulByteRejectionIT {
+
+    /** U+0000 written as a Kotlin escape — no control character enters this source file. */
+    private val nul = "\u0000"
+
+    /** The JSON escape for U+0000 as it travels on the wire: six ASCII characters, legal JSON. */
+    private val escapedNul = "\\u0000"
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_VIEWER"])
+    fun `search rejects a NUL in the referenceNumber query parameter with 400`() {
+        Given {
+            queryParam("referenceNumber", "+ab${nul}cd")
+            queryParam("type", "DEBIT")
+        } When {
+            get("/api/v1/transactions/search")
+        } Then {
+            statusCode(400)
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_VIEWER"])
+    fun `search accepts the same referenceNumber without the NUL`() {
+        Given {
+            queryParam("referenceNumber", "+abcd")
+            queryParam("type", "DEBIT")
+        } When {
+            get("/api/v1/transactions/search")
+        } Then {
+            statusCode(not(400))
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `reverse rejects a NUL in the idempotencyKey body field with 400`() {
+        Given {
+            contentType("application/json")
+            body("""{"idempotencyKey":"ab${escapedNul}cd","reason":"customer dispute"}""")
+        } When {
+            post("/api/v1/transactions/${UUID.randomUUID()}/reverse")
+        } Then {
+            statusCode(400)
+        }
+    }
+
+    // No status-only control exists for `reverse`, and that is a measured fact rather than an
+    // omission: the same body WITHOUT the NUL also answers 400, because a random transactionId is
+    // not found and the use case reports that as an IllegalArgumentException. A `not(400)` control
+    // was written here first and went red for exactly that reason.
+    //
+    // What discriminates on this endpoint is the falsification, which was run: with
+    // `NulByte.contains` forced to false, both rejection tests above answer **500** — the status
+    // and the cause the issue reported. `search accepts the same referenceNumber without the NUL`
+    // carries the other half of the property, that the guard does not simply reject everything.
+}


### PR DESCRIPTION
## What this fixes

Issue #5913 Class B, shape 4, **NUL-byte half only**: five money-path services answered **500** when a request string contained the NUL character (U+0000). Postgres cannot store U+0000 in a `text`/`varchar` column at all, so the driver reports `invalid byte sequence for encoding "UTF8": 0x00` (SQLState 22021), Hibernate raises `DataException` far past every handler, and `GenericExceptionMapper` renders it as `INTERNAL_ERROR`.

Explicitly **not** in scope, and untouched: the `ConstraintViolationException` mapper (409-vs-400 is a human decision on the money path), `value too long` (balance, sanctions), `date out of range` (interest), `CharConversionException` (notification).

## Where the boundary is, and why one place

`openbank-libs-runtime`, in `com.openbank.libs.api.error.NulByteGuards` — beside `RequiredBodyGuards`, by the same precedent.

Unlike a field-length limit, which is genuinely per-column and per-domain, U+0000 needs no domain knowledge: no valid request can carry it, and Postgres can never accept it, so the request cannot succeed whatever the handler does. Five per-endpoint `require` calls would have been five judgement calls about a question with one answer.

Two classes, because **the body is not the only carrier**. This was measured, not assumed — reading the six failing operations out of the fuzz run's own artifacts:

| service | operation | carrier |
|---|---|---|
| dispute | `POST /api/v1/complaints` | body, `description` |
| interest | `GET /api/v1/interest/rates` | **query parameter** `productId` |
| sdd | `POST /api/v1/sdd/mandates` | body (field undetermined — schemathesis deduplicated the request) |
| transaction | `GET /api/v1/transactions/search` | **query parameter** `referenceNumber` |
| transaction | `POST /api/v1/transactions/{id}/reverse` | body, `idempotencyKey` |
| fx | `POST /api/v1/fx/convert` | body, `toCurrency` |

All six carry the identical Postgres line and the same exception class, so the shape is genuinely shared. But the issue names five services and there are **six operations**, and two of them carry the NUL in a query string — those requests have no entity at all, so a Jackson-only guard would have been green about them. Hence:

- `NulByteRejectingStringDeserializer` (registered fleet-wide by `NulByteObjectMapperCustomizer`) — every decoded JSON string, including inside arrays, maps and sub-objects.
- `NulByteParameterFilter` — every decoded query and path parameter. Reads only `UriInfo`, touches no entity stream, so it stays non-blocking on the reactive stack.

No service-local exception mapper is added anywhere (#526).

### Why a deserializer and not a scan of the raw body

The wire form decides this. The fuzzer's NUL arrives **escaped** inside a JSON string — legal JSON that Jackson decodes happily. A raw scan of the entity stream for byte `0x00` finds nothing and would be a guard that reports clean; scanning for the escape sequence as literal text instead false-positives on a doubly-escaped backslash, which is six characters of text containing no NUL. Only the decoded value answers the question. There is a test for each direction.

## Verify by effect

Every assertion is on the **status code**. All six operations returned a well-formed `INTERNAL_ERROR` document, so an oracle of "it did not crash" or "the response parsed" passes against the defect.

Falsification was run, not assumed — `NulByte.contains` forced to return `false`, then the same suites re-run:

| test | with the guard | guard removed |
|---|---|---|
| `NulByteGuardsTest` (11 tests) | 11 green | **7 red**, 4 controls stay green |
| `TransactionNulByteRejectionIT` — `GET /transactions/search?referenceNumber=…` | **400** | **500** |
| `TransactionNulByteRejectionIT` — `POST /transactions/{id}/reverse` | **400** | **500** |
| `FxNulByteRejectionIT` — `POST /fx/convert` | **400** | **500** |

The two ITs are real HTTP against a real Postgres (Testcontainers). They are also the only thing that can establish the guard is *discovered and registered* inside a running Quarkus app — a unit test over the guard classes cannot tell a registered provider from an unregistered one.

The 4 green-under-falsification tests are the controls, and they are load-bearing in the other direction: they assert that ordinary strings, ordinary query parameters and a doubly-escaped backslash are **accepted**. Without them, "the guard rejects things" would be equally true of a guard that rejected every request.

### One control was deleted because it discriminated nothing

A `not(400)` control on `POST /transactions/{id}/reverse` was written first and went red: the same body **without** the NUL also answers 400, because a random `transactionId` is not found and the use case reports that as an `IllegalArgumentException`. A status-only control cannot discriminate on that endpoint, so it was removed and the reason recorded in the file rather than left as a passing decoration.

### What is not verified per-endpoint

`dispute`, `interest` and `sdd` have no IT here. Both **carriers** are covered by real-HTTP tests (query parameter and body), on the two money-path services, and the boundary those three go through is the same code — but that is mechanism coverage, not per-endpoint verification, and it is stated rather than implied.

## Gates run locally

| module | exit | tests | failures | skipped |
|---|---|---|---|---|
| `:openbank-libs-runtime:ktlintCheck detekt test koverVerify` | 0 | 265 | 0 | 0 |
| `:openbank-transaction-service:ktlintCheck detekt test` | 0 | 143 | 0 | 1 |
| `:openbank-fx-service:ktlintCheck detekt test` | 0 | 159 | 0 | 1 |

Every task ran (`--rerun-tasks`); nothing reported `UP-TO-DATE`. The counts are read out of the JUnit XML, not the console, because a boot failure reports tests as SKIPPED rather than FAILED — and the skips here are accounted for: `TransactionPactProviderVerificationTest` and `FxPactProviderVerificationTest`, the broker-sourced pact classes gated on `pactbroker.url`, which do not run on a PR by design. Each run redirected to a file with `$?` read directly rather than through a pipe.

Also run:

- `python3 openbank-infra/scripts/check-threat-model-diff.py --base origin/main --enforce` — **passes**. The changes to `openbank-transaction-service` and `openbank-fx-service` are test-only; no money-path trust boundary moves.
- `python3 .github/scripts/run-gates.py --all` — 158 gates. The remaining failures are all environmental and reproduce identically without this change: four gates refuse to run without `PR_DIFF_BASE` (they pass once it is exported, including `threat-model-updated-on-trust-boundary-change`, `db-migration-gate` and `schema-compat-gate`), `api-contract-gate` needs `sudo` to install `oasdiff`, `loki-rule-load-test` needs `BASE_REF`, and `release-scope-mismatch-gate` needs `PR_TITLE`. None is caused by this diff.

One thing worth flagging: `openbank-libs-runtime` applies no Quarkus BOM, so pinning `quarkus-jackson` to the platform's real `3.38.0` resolves it standalone and drags four `io.smallrye.common` POMs that `gradle/verification-metadata.xml` does not carry — dependency verification then fails the build of every consuming service. It is pinned to `3.33.2` alongside every sibling literal in that block, with the reason recorded in place.

## Release scope

`fix(libs)`. `openbank-libs-runtime` has no `version.txt`, so it is not a released component and there is no version to bump. No `openapi.yaml` change: a 500 that should always have been a 400 was never part of the published contract.

Money-path applies (transaction, fx) — 2 approvals per ADR-0030.

A CLAUDE.md bullet records the two things that generalise: that the character arrives escaped (so a raw-byte probe reports clean), and that the carrier set had to be enumerated from the fuzz artifacts rather than assumed to be the body.

Refs #5913
