### PR TITLE
feat(admin-ui): clarify cluster topology controls

### DIFF
--- a/openbank-admin-ui/src/app/docs/cluster/page.tsx
+++ b/openbank-admin-ui/src/app/docs/cluster/page.tsx
@@ -111,7 +111,8 @@ function ContainerAnatomy({ anatomy, lang }: { anatomy: Topology['imageAnatomy']
             const on = open === st.id
             const discarded = st.id === 'build'
             return (
-              <button key={st.id} onClick={() => setOpen(st.id)} style={{
+              <button key={st.id} onClick={() => setOpen(st.id)} type="button"
+                aria-expanded={on} aria-controls={on ? `cluster-anatomy-panel-${st.id}` : undefined} style={{
                 textAlign: 'left', display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', borderRadius: 7, cursor: 'pointer',
                 background: on ? 'rgba(50,108,229,0.18)' : 'rgba(255,255,255,0.03)',
                 border: `1px solid ${on ? K8S_BLUE : 'rgba(255,255,255,0.06)'}`,
@@ -120,8 +121,8 @@ function ContainerAnatomy({ anatomy, lang }: { anatomy: Topology['imageAnatomy']
               }}>
                 <span style={{ width: 7, height: 7, borderRadius: '50%', background: m.color, flexShrink: 0 }} />
                 <span style={{ fontSize: 12.5, fontWeight: 600, color: '#e2e8f0', flex: 1 }}>{st.label}</span>
-                {st.id === 'sign' && <BadgeCheck size={14} style={{ color: '#34d399' }} />}
-                <ChevronRight size={13} style={{ color: '#64748b', transform: on ? 'rotate(90deg)' : 'none', transition: 'transform .15s' }} />
+                {st.id === 'sign' && <BadgeCheck aria-hidden="true" size={14} style={{ color: '#34d399' }} />}
+                <ChevronRight aria-hidden="true" size={13} style={{ color: '#64748b', transform: on ? 'rotate(90deg)' : 'none', transition: 'transform .15s' }} />
               </button>
             )
           })}
@@ -135,7 +136,7 @@ function ContainerAnatomy({ anatomy, lang }: { anatomy: Topology['imageAnatomy']
       {/* detail of the open slice */}
       <div>
         {anatomy.steps.filter(s => s.id === open).map(st => (
-          <div key={st.id} className="card" style={{ padding: 16, borderLeft: `3px solid ${STATUS[st.status].color}` }}>
+          <div key={st.id} id={`cluster-anatomy-panel-${st.id}`} role="region" aria-label={st.label} className="card" style={{ padding: 16, borderLeft: `3px solid ${STATUS[st.status].color}` }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
               <h4 style={{ fontSize: 15, fontWeight: 700, color: 'var(--text-primary)', margin: 0 }}>{st.label}</h4>
               <StatusPill s={st.status} lang={lang} />
@@ -190,8 +191,8 @@ export default function ClusterDossierPage() {
               'How the platform is split across namespaces, how it is secured (defense in depth), and how the default service image is built and hardened — plan vs reality, derived from GitOps (ADR-0081).',
             )}
         icon={<Boxes aria-hidden="true" size={20} style={{ color: K8S_BLUE }} />}
-        actions={<button onClick={load} disabled={loading} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
-          <RefreshCw size={14} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
+        actions={<button onClick={load} disabled={loading} type="button" aria-busy={loading} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
+          <RefreshCw aria-hidden="true" size={14} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
         </button>}
       />
 
@@ -237,8 +238,10 @@ export default function ClusterDossierPage() {
               <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(180px,1fr))', gap: 8, paddingLeft: 34 }}>
                 {items.map(nsItem => {
                   const on = openNs === nsItem.name
+                  const panelId = `cluster-ns-panel-${nsItem.name.replace(/[^a-zA-Z0-9_-]/g, '-')}`
                   return (
-                    <button key={nsItem.name} onClick={() => setOpenNs(on ? null : nsItem.name)} style={{
+                    <button key={nsItem.name} onClick={() => setOpenNs(on ? null : nsItem.name)} type="button"
+                      aria-expanded={on} aria-controls={on ? panelId : undefined} style={{
                       textAlign: 'left', cursor: 'pointer', padding: '10px 12px', borderRadius: 9,
                       background: on ? `${g.color}10` : 'var(--surface)', border: `1px solid ${on ? g.color : 'var(--border)'}`,
                       transition: 'all .12s',
@@ -248,7 +251,7 @@ export default function ClusterDossierPage() {
                         <code style={{ fontSize: 12.5, fontWeight: 700, color: 'var(--text-primary)', fontFamily: 'var(--font-mono, monospace)' }}>{nsItem.name}</code>
                       </div>
                       {on && (
-                        <div style={{ marginTop: 6, fontSize: 11.5, color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+                        <div id={panelId} role="region" aria-label={nsItem.name} style={{ marginTop: 6, fontSize: 11.5, color: 'var(--text-secondary)', lineHeight: 1.5 }}>
                           {nsItem.role}
                           <div style={{ marginTop: 4, fontSize: 10.5, color: 'var(--text-tertiary)' }}>
                             {t('Izolace: ', 'Isolation: ')}{(c.networkPolicies ?? 0) > 0 ? t('NetworkPolicy nasazeny, fleet-wide aktivace probíhá (#854)', 'NetworkPolicies deployed, fleet-wide activation in progress (#854)') : t('zatím bez NetworkPolicy', 'no NetworkPolicy yet')}

--- a/openbank-admin-ui/src/test/cluster-topology-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/cluster-topology-a11y.guard.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(join(process.cwd(), 'src/app/docs/cluster/page.tsx'), 'utf8')
+
+describe('cluster topology controls accessibility contract', () => {
+  it('exposes controlled anatomy and namespace disclosures', () => {
+    expect(page).toContain('type="button"')
+    expect(page).toContain('aria-expanded={on} aria-controls={on ? `cluster-anatomy-panel-${st.id}` : undefined}')
+    expect(page).toContain('id={`cluster-anatomy-panel-${st.id}`} role="region"')
+    expect(page).toContain('const panelId = `cluster-ns-panel-${nsItem.name.replace(/[^a-zA-Z0-9_-]/g, \'-\')}`')
+    expect(page).toContain('aria-expanded={on} aria-controls={on ? panelId : undefined}')
+    expect(page).toContain('id={panelId} role="region" aria-label={nsItem.name}')
+  })
+
+  it('announces refresh progress and hides decorative icons', () => {
+    expect(page).toContain('type="button" aria-busy={loading}')
+    expect(page).toContain('<RefreshCw aria-hidden="true"')
+    expect(page).toContain('<BadgeCheck aria-hidden="true"')
+    expect(page).toContain('<ChevronRight aria-hidden="true"')
+  })
+})


### PR DESCRIPTION
## Summary
- make container anatomy and namespace details keyboard/disclosure accessible
- add truthful refresh busy state and decorative icon semantics
- preserve GitOps-derived topology, hardening data, read-only behavior, and RBAC

## Validation
- targeted ESLint (pre-existing hook warning only)
- git diff --check
- local Vitest unavailable due optional Rolldown native binding

Refs #6000