### PR TITLE
feat(admin-ui): resolve KYC parties and charter-back approval identity

### DIFF
--- a/openbank-admin-ui/src/app/api/governance/agent-identities/route.ts
+++ b/openbank-admin-ui/src/app/api/governance/agent-identities/route.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// The enforced agent registry, projected to just what the approval queue needs to attribute
+// a proposal to a charter (issue #5904). Reads openbank-libs/governance/agents.yaml through
+// the shared loader — no second source of truth for "what does agents.yaml actually say".
+//
+// `available: false` is a first-class answer, not an error: agents.yaml is bundled into the
+// image by Dockerfile COPY, and an image built without it must make the queue say "identity
+// unverifiable" rather than silently report every proposer as unchartered.
+
+import { NextResponse } from 'next/server'
+import { loadAgentCharters } from '@/lib/governance/agentCharters'
+import type { AgentIdentityRegistry } from '@/lib/governance/agentIdentity'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  try {
+    const { available, agents } = await loadAgentCharters()
+    const body: AgentIdentityRegistry = {
+      available,
+      agents: agents.map(a => ({
+        id: a.id,
+        plane: a.plane,
+        charter: a.charter,
+        requiresHuman: a.requiresHuman,
+      })),
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ available: false, agents: [] } satisfies AgentIdentityRegistry)
+  }
+}

--- a/openbank-admin-ui/src/app/approvals/page.tsx
+++ b/openbank-admin-ui/src/app/approvals/page.tsx
@@ -12,9 +12,11 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useSession } from 'next-auth/react'
-import { CheckCircle2, XCircle, Clock, ClipboardCheck, RefreshCw, ShieldCheck, AlertTriangle, Bot } from 'lucide-react'
+import { CheckCircle2, XCircle, Clock, ClipboardCheck, RefreshCw, ShieldCheck, AlertTriangle } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader } from '@/components/ui/PageHeader'
+import { AgentIdentityBadge } from '@/components/approvals/AgentIdentityBadge'
+import { resolveAgentIdentity, type AgentIdentityRegistry } from '@/lib/governance/agentIdentity'
 import { AuthGuard, Can } from '@/components/auth/AuthGuard'
 
 interface Proposal {
@@ -59,6 +61,11 @@ export default function ApprovalsPage() {
   const [busyId, setBusyId] = useState<string | null>(null)
   const [reasons, setReasons] = useState<Record<string, string>>({})
   const [error, setError] = useState<string | null>(null)
+  // The enforced charter registry (agents.yaml). `null` while it is still being fetched or
+  // after the fetch failed — resolveAgentIdentity turns both into `unverifiable`, and
+  // `registryLoading` keeps the two apart in the UI (#5904).
+  const [registry, setRegistry] = useState<AgentIdentityRegistry | null>(null)
+  const [registryLoading, setRegistryLoading] = useState(true)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -83,6 +90,25 @@ export default function ApprovalsPage() {
   }, [])
 
   useEffect(() => { void load() }, [load])
+
+  // Charter lookup is deliberately a separate read from the queue: a registry that cannot be
+  // read must degrade the IDENTITY column only, never blank the queue itself.
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetch('/api/governance/agent-identities', { cache: 'no-store' })
+        if (!res.ok) throw new Error('registry')
+        const body = (await res.json()) as AgentIdentityRegistry
+        if (!cancelled) setRegistry(body)
+      } catch {
+        if (!cancelled) setRegistry(null)
+      } finally {
+        if (!cancelled) setRegistryLoading(false)
+      }
+    })()
+    return () => { cancelled = true }
+  }, [])
 
   const decide = async (p: Proposal, approve: boolean) => {
     setBusyId(p.id)
@@ -205,23 +231,26 @@ export default function ApprovalsPage() {
       <div style={{ display: 'grid', gap: 12 }}>
         {pending.map(p => {
           const m = STATE_META[p.state]
-          const aiGenerated = /assistant|agent|\bai\b/i.test(p.proposedBy)
+          // Provenance comes from the enforced charter registry, never from the shape of the
+          // proposedBy string. `unresolved` means agents.yaml has no such actor; `unverifiable`
+          // means we could not read agents.yaml and must not claim either way (#5904).
+          const identity = resolveAgentIdentity(p.proposedBy, registry)
+          const chartered = identity.status === 'chartered'
+          // The ADR-0080 caution stands whenever AI authorship is established OR cannot be
+          // ruled out. Only a positively unchartered actor drops it.
+          const cautionAi = identity.status !== 'unresolved'
           return (
-            <div key={p.id} className="card" style={{ padding: 18, borderLeft: `3px solid ${aiGenerated ? '#d97706' : m.color}` }}>
+            <div key={p.id} className="card" style={{ padding: 18, borderLeft: `3px solid ${chartered ? '#d97706' : m.color}` }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 10, marginBottom: 8 }}>
                 <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--text-primary)', display: 'flex', alignItems: 'center', gap: 8 }}>
                   {p.title}
-                  {aiGenerated && (
-                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 10, fontWeight: 700, color: '#b45309', background: '#fffbeb', border: '1px solid #fcd34d', padding: '2px 7px', borderRadius: 20, textTransform: 'uppercase', letterSpacing: '0.04em' }}>
-                      <Bot size={11} /> {t('AI návrh', 'AI-generated')}
-                    </span>
-                  )}
+                  <AgentIdentityBadge identity={identity} loading={registryLoading} lang={language} />
                 </div>
                 <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, flexShrink: 0, fontSize: 11, fontWeight: 700, color: m.color, background: m.bg, border: `1px solid ${m.border}`, padding: '2px 8px', borderRadius: 20 }}>
                   <m.Icon size={11} /> {t(m.cs, m.en)}
                 </span>
               </div>
-              {aiGenerated && (
+              {cautionAi && !registryLoading && (
                 <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12, color: '#b45309', background: '#fffbeb', border: '1px solid #fcd34d', borderRadius: 6, padding: '8px 10px', marginBottom: 8 }}>
                   <AlertTriangle size={14} style={{ flexShrink: 0 }} />
                   {t(

--- a/openbank-admin-ui/src/app/kyc/page.tsx
+++ b/openbank-admin-ui/src/app/kyc/page.tsx
@@ -11,6 +11,7 @@ import { DataUnavailable, type UnavailableKind } from '@/components/feedback/Dat
 import { ShieldCheck, Search, RefreshCw, ChevronRight } from 'lucide-react'
 import Link from 'next/link'
 import { PageHeader, StatusBadge } from '@/components/ui'
+import { PartyLookup } from '@/components/kyc/PartyLookup'
 import { Can } from '@/components/auth/AuthGuard'
 
 const KYC_SERVICE = '/api/svc/kyc-service'
@@ -86,7 +87,7 @@ export default function KycPage() {
         <div style={{ position: 'relative', flex: 1, maxWidth: '300px' }}>
           <Search aria-hidden="true" size={14} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-muted)' }} />
           <label className="sr-only" htmlFor="kyc-search">{t('Hledat KYC případy', 'Search KYC cases')}</label>
-          <input id="kyc-search" className="input" style={{ paddingLeft: '32px', width: '100%' }} placeholder={t('Hledat podle ID nebo stavu…', 'Search by ID or status…')} value={search} onChange={e => setSearch(e.target.value)} />
+          <input id="kyc-search" className="input" style={{ paddingLeft: '32px', width: '100%' }} placeholder={t('Filtrovat načtené případy (ID / stav)…', 'Filter loaded cases (ID / status)…')} value={search} onChange={e => setSearch(e.target.value)} />
         </div>
         <label className="sr-only" htmlFor="kyc-party-id">{t('Filtrovat podle Party ID', 'Filter by Party ID')}</label>
         <input id="kyc-party-id" className="input" style={{ width: '280px', fontFamily: 'var(--font-mono)', fontSize: '12px' }} placeholder={t('Filtrovat podle Party ID (UUID)…', 'Filter by Party ID (UUID)…')} value={partyId} onChange={e => setPartyId(e.target.value)} />

--- a/openbank-admin-ui/src/components/approvals/AgentIdentityBadge.tsx
+++ b/openbank-admin-ui/src/components/approvals/AgentIdentityBadge.tsx
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Renders the charter-backed identity of whoever proposed a queued item (issue #5904).
+// The three outcomes of lib/governance/agentIdentity are rendered as three visibly
+// different things; see that module for why `unresolved` and `unverifiable` must not
+// collapse into one badge.
+
+import { Bot, ShieldQuestion, UserRound } from 'lucide-react'
+import type { AgentIdentity } from '@/lib/governance/agentIdentity'
+
+interface Props {
+  identity: AgentIdentity
+  /** True while the charter registry is still being fetched — neither absence nor failure yet. */
+  loading?: boolean
+  lang?: 'cs' | 'en'
+}
+
+const chip: React.CSSProperties = {
+  display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 10, fontWeight: 700,
+  padding: '2px 7px', borderRadius: 20, textTransform: 'uppercase', letterSpacing: '0.04em',
+}
+
+export function AgentIdentityBadge({ identity, loading = false, lang = 'en' }: Props) {
+  const cs = lang === 'cs'
+
+  if (loading) {
+    return (
+      <span
+        data-testid="agent-identity"
+        data-state="loading"
+        style={{ ...chip, color: 'var(--text-tertiary)', background: 'var(--surface-2)', border: '1px solid var(--border)' }}
+      >
+        {cs ? 'Ověřuji charter…' : 'Checking charter…'}
+      </span>
+    )
+  }
+
+  if (identity.status === 'chartered') {
+    const { charter } = identity
+    return (
+      <span
+        data-testid="agent-identity"
+        data-state="chartered"
+        data-agent-id={charter.id}
+        title={charter.charter}
+        style={{ ...chip, color: '#b45309', background: '#fffbeb', border: '1px solid #fcd34d' }}
+      >
+        <Bot size={11} aria-hidden="true" />
+        {charter.id}
+        <span style={{ fontWeight: 600, opacity: 0.8, textTransform: 'none' }}>
+          · {cs ? 'charter' : 'charter'} · {charter.plane}
+        </span>
+      </span>
+    )
+  }
+
+  if (identity.status === 'unresolved') {
+    return (
+      <span
+        data-testid="agent-identity"
+        data-state="unresolved"
+        style={{ ...chip, color: 'var(--text-secondary)', background: 'var(--surface-2)', border: '1px solid var(--border)' }}
+      >
+        <UserRound size={11} aria-hidden="true" />
+        {cs ? 'Bez charteru v agents.yaml' : 'No charter in agents.yaml'}
+      </span>
+    )
+  }
+
+  return (
+    <span
+      data-testid="agent-identity"
+      data-state="unverifiable"
+      style={{ ...chip, color: '#b91c1c', background: '#fef2f2', border: '1px solid #fca5a5' }}
+    >
+      <ShieldQuestion size={11} aria-hidden="true" />
+      {cs ? 'Identitu nelze ověřit — registr charterů nedostupný' : 'Identity unverifiable — charter registry unavailable'}
+    </span>
+  )
+}

--- a/openbank-admin-ui/src/components/kyc/PartyLookup.tsx
+++ b/openbank-admin-ui/src/components/kyc/PartyLookup.tsx
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Resolve a KYC customer by name, company or party UUID through party-service (#5904).
+// The lookup itself lives in lib/party/resolveParty; this renders its outcomes so that a
+// lookup which FAILED never looks like a lookup that found nothing.
+
+'use client'
+
+import { useCallback, useState } from 'react'
+import { Search, Loader2, SearchX, ServerOff } from 'lucide-react'
+import { resolveParty, partyLabel, MIN_TERM_LENGTH, type PartyResolution, type PartyLookupFailure } from '@/lib/party/resolveParty'
+
+interface Props {
+  onSelect: (partyId: string) => void
+  lang?: 'cs' | 'en'
+  /** Injected in tests; defaults to the real resolver. */
+  resolve?: typeof resolveParty
+}
+
+function failureCopy(reason: PartyLookupFailure, cs: boolean): string {
+  switch (reason) {
+    case 'search_unavailable':
+      return cs
+        ? 'Vyhledávání podle jména je právě nedostupné (party-service vrátila 404 — schopnost party-search je vypnutá). Toto NENÍ důkaz, že zákazník neexistuje.'
+        : 'Name search is unavailable right now (party-service answered 404 — the party-search capability is off). This is NOT evidence that no such customer exists.'
+    case 'not_deployed':
+      return cs
+        ? 'Party-service není v tomto prostředí nasazená — vyhledání zákazníka neproběhlo.'
+        : 'Party-service is not deployed in this environment — the lookup did not run.'
+    case 'scaled_to_zero':
+      return cs
+        ? 'Party-service je uspaná (scale-to-zero) — vyhledání neproběhlo. Zkus to za chvíli znovu.'
+        : 'Party-service is idle (scaled to zero) — the lookup did not run. Retry in a moment.'
+    case 'unauthorized':
+      return cs
+        ? 'Chybí oprávnění pro čtení party-service — vyhledání neproběhlo.'
+        : 'Not authorised to read party-service — the lookup did not run.'
+    case 'unreachable':
+      return cs
+        ? 'Party-service neodpověděla (timeout nebo síťová chyba) — vyhledání neproběhlo.'
+        : 'Party-service did not answer (timeout or network error) — the lookup did not run.'
+    default:
+      return cs
+        ? 'Vyhledání zákazníka selhalo — výsledek nelze považovat za prázdný.'
+        : 'The customer lookup failed — the result must not be read as empty.'
+  }
+}
+
+export function PartyLookup({ onSelect, lang = 'en', resolve = resolveParty }: Props) {
+  const cs = lang === 'cs'
+  const [query, setQuery] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [result, setResult] = useState<PartyResolution>({ status: 'idle' })
+
+  const run = useCallback(async () => {
+    setBusy(true)
+    try {
+      setResult(await resolve(query))
+    } finally {
+      setBusy(false)
+    }
+  }, [query, resolve])
+
+  return (
+    <div data-testid="party-lookup">
+      <div style={{ display: 'flex', gap: '10px', marginBottom: '12px' }}>
+        <div style={{ position: 'relative', flex: 1, maxWidth: '420px' }}>
+          <Search size={14} aria-hidden="true" style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-muted)' }} />
+          <input
+            className="input"
+            style={{ paddingLeft: '32px', width: '100%' }}
+            aria-label={cs ? 'Najít zákazníka podle jména, firmy nebo UUID' : 'Find a customer by name, company or UUID'}
+            placeholder={cs ? 'Jméno, firma nebo Party UUID…' : 'Name, company or party UUID…'}
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') void run() }}
+          />
+        </div>
+        <button className="btn btn-secondary" onClick={() => void run()} disabled={busy}>
+          {busy ? <Loader2 size={13} aria-hidden="true" /> : null}
+          {cs ? 'Najít zákazníka' : 'Find customer'}
+        </button>
+      </div>
+
+      {busy && (
+        <div data-testid="lookup-state" data-state="loading" className="card" style={{ padding: 12, marginBottom: 12, fontSize: 13, color: 'var(--text-secondary)' }}>
+          {cs ? 'Hledám v party-service…' : 'Looking up party-service…'}
+        </div>
+      )}
+
+      {!busy && result.status === 'too_short' && (
+        <div data-testid="lookup-state" data-state="too_short" className="card" style={{ padding: 12, marginBottom: 12, fontSize: 13, color: 'var(--text-secondary)' }}>
+          {cs
+            ? `Zadej aspoň ${MIN_TERM_LENGTH} znaky — party-service kratší dotaz odmítá a vrátila by prázdnou stránku.`
+            : `Enter at least ${MIN_TERM_LENGTH} characters — party-service rejects a shorter term and would return an empty page.`}
+        </div>
+      )}
+
+      {!busy && result.status === 'none' && (
+        <div data-testid="lookup-state" data-state="none" className="card" style={{ padding: 12, marginBottom: 12, fontSize: 13, color: 'var(--text-secondary)', display: 'flex', gap: 8, alignItems: 'center' }}>
+          <SearchX size={15} aria-hidden="true" />
+          {result.mode === 'uuid'
+            ? (cs ? 'Party s tímto UUID v party-service neexistuje.' : 'No party with this UUID exists in party-service.')
+            : (cs ? 'Vyhledávání proběhlo a neodpovídá mu žádný zákazník.' : 'The search ran and no customer matches.')}
+        </div>
+      )}
+
+      {!busy && result.status === 'failed' && (
+        <div data-testid="lookup-state" data-state="failed" className="card" style={{ padding: 12, marginBottom: 12, fontSize: 13, color: '#92400e', background: '#fffbeb', border: '1px solid #fcd34d', display: 'flex', gap: 8, alignItems: 'center' }}>
+          <ServerOff size={15} aria-hidden="true" />
+          {failureCopy(result.reason, cs)}
+        </div>
+      )}
+
+      {!busy && result.status === 'ok' && (
+        <div data-testid="lookup-state" data-state="matches" className="card" style={{ padding: 0, marginBottom: 12, overflow: 'hidden' }}>
+          {result.matches.map(m => (
+            <button
+              key={m.id}
+              data-testid="party-match"
+              onClick={() => onSelect(m.id)}
+              style={{ display: 'block', width: '100%', textAlign: 'left', padding: '10px 14px', border: 0, borderTop: '1px solid var(--border)', background: 'transparent', cursor: 'pointer' }}
+            >
+              <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)' }}>{partyLabel(m)}</div>
+              <div style={{ fontSize: 11, color: 'var(--text-tertiary)', fontFamily: 'var(--font-mono)' }}>
+                {m.id}{m.kycStatus ? ` · KYC ${m.kycStatus}` : ''}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/lib/governance/agentIdentity.ts
+++ b/openbank-admin-ui/src/lib/governance/agentIdentity.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Charter-backed agent identity for the approval queue (issue #5904).
+//
+// WHAT THIS REPLACES
+// /approvals decided whether a queued proposal was agent-made with
+// `/assistant|agent|\bai\b/i.test(proposal.proposedBy)` — a regex over a free-text string
+// the row happened to carry. That is a guess dressed as provenance: "risk-agent-review"
+// (a human desk) matches, a real charter id like `compliance-officer` or `pid-verifier`
+// does not, and either way the badge asserts something the bank cannot evidence.
+//
+// WHERE THE IDENTITY COMES FROM
+// openbank-libs/governance/agents.yaml is the enforced registry (ADR-0031 D1) — the same
+// document the OPA agent bundles are derived from, so it is what actually decides what an
+// agent may do. If a proposer is not in it, the bank has no charter for that actor and the
+// queue must SAY so rather than render a plausible-looking name.
+//
+// THREE STATES, ON PURPOSE
+//   chartered    — the proposer maps to an agents.yaml entry; show what the charter says.
+//   unresolved   — the registry was read and contains no such id. Real evidence of absence.
+//   unverifiable — the registry could not be read at all (not bundled into the image, or
+//                  the route failed). NOT the same as absence, and must not render as it:
+//                  an unreadable registry would otherwise mark every agent proposal as
+//                  "not a chartered agent", which is the reassuring-looking wrong answer.
+
+/** The charter fields the queue renders. Subset of lib/governance/agentCharters.ts. */
+export interface CharterIdentity {
+  id: string
+  plane: string
+  charter: string
+  requiresHuman: string[]
+}
+
+export interface AgentIdentityRegistry {
+  /** False when agents.yaml could not be read — the registry is absent, not empty. */
+  available: boolean
+  agents: CharterIdentity[]
+}
+
+export type AgentIdentity =
+  | { status: 'chartered'; raw: string; charter: CharterIdentity }
+  | { status: 'unresolved'; raw: string }
+  | { status: 'unverifiable'; raw: string }
+
+/**
+ * Identity forms a proposal's `proposedBy` can legitimately take for the SAME charter.
+ * Deliberately a closed list of exact rewrites — no substring or fuzzy matching, because a
+ * near-miss that resolves is worse than one that shows as unresolved.
+ */
+function candidateIds(raw: string): string[] {
+  const v = raw.trim().toLowerCase()
+  if (!v) return []
+  const forms = new Set<string>([v])
+  // Keycloak service accounts: `service-account-<clientId>`.
+  if (v.startsWith('service-account-')) forms.add(v.slice('service-account-'.length))
+  // Runtime-qualified forms seen on proposal rows.
+  if (v.startsWith('agent:')) forms.add(v.slice('agent:'.length))
+  if (v.startsWith('openbank-')) forms.add(v.slice('openbank-'.length))
+  for (const f of [...forms]) if (f.endsWith('-service')) forms.add(f.slice(0, -'-service'.length))
+  return [...forms]
+}
+
+export function resolveAgentIdentity(
+  proposedBy: string | null | undefined,
+  registry: AgentIdentityRegistry | null,
+): AgentIdentity {
+  const raw = (proposedBy ?? '').trim()
+  // No registry (still loading, fetch failed, or agents.yaml absent from the image) — we
+  // cannot claim the actor is unchartered, only that we could not check.
+  if (!registry || !registry.available) return { status: 'unverifiable', raw }
+  if (!raw) return { status: 'unresolved', raw }
+
+  const byId = new Map(registry.agents.map(a => [a.id.toLowerCase(), a]))
+  for (const candidate of candidateIds(raw)) {
+    const hit = byId.get(candidate)
+    if (hit) return { status: 'chartered', raw, charter: hit }
+  }
+  return { status: 'unresolved', raw }
+}

--- a/openbank-admin-ui/src/lib/party/resolveParty.ts
+++ b/openbank-admin-ui/src/lib/party/resolveParty.ts
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Resolve a KYC operator's free-text query to real parties through party-service
+// (issue #5904: "Resolve KYC customers by name/company/UUID through party-service").
+//
+// WHY THIS IS A LOOKUP AND NOT A CLIENT-SIDE FILTER
+// The KYC screen used to `Array.filter` the KYC cases it had already loaded and call the
+// input a search box. That can only ever match a party id the operator already had on
+// screen, and it can never find a customer BY NAME at all — party names are not in the
+// KYC case payload. party-service owns the searchable business keys, so the lookup has to
+// go there.
+//
+// WHAT PARTY-SERVICE ACTUALLY EXPOSES (verified against the resource + repository, not
+// only against openapi.yaml):
+//   GET /api/v1/parties/{id}     — PartyResource.getParty, exact id.
+//   GET /api/v1/parties/search   — PartyResource.searchParties, `q` >= 2 chars,
+//                                  cursor-paginated, case-insensitive substring over
+//                                  legalName, tradingName, email, phone, taxId and
+//                                  registrationNumber (PartyRepositoryImpl
+//                                  .searchByBusinessKeys). So "by name" and "by company"
+//                                  are both real server-side modes. Birth number is
+//                                  deliberately NOT searchable (GDPR data-minimisation).
+//
+// THE ONE TRAP THAT DECIDES THE FAILURE STATES
+// /search is annotated `@FeatureFlag(flag = "party-search")`. When that flag is off the
+// libs interceptor throws FeatureDisabledException and party-service's FeatureDisabledMapper
+// answers **404**. A search that legitimately matches nothing answers **200 with an empty
+// page** — PartyService.searchParties never 404s for "no match". Therefore a 404 from
+// /search means "this bank cannot search right now", never "this customer does not exist",
+// and rendering it as an empty result would be exactly the "looks empty without enough
+// evidence" failure #5904 exists to remove. The two outcomes get different states here.
+
+import { svcUrl, classifyBffFailure, type BffFailure } from '@/lib/services/bff'
+
+export const PARTY_SERVICE = 'party-service'
+
+/** Minimum term length party-service accepts; below this it returns an empty page by design. */
+export const MIN_TERM_LENGTH = 2
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export type PartyLookupMode = 'uuid' | 'term'
+
+/** Data-minimised party summary — the shape /search and /{id} both project. */
+export interface PartyMatch {
+  id: string
+  legalName: string | null
+  tradingName: string | null
+  kycStatus: string | null
+  status: string | null
+}
+
+/**
+ * `search_unavailable` is its own reason and never collapses into `none`: it is the
+ * flag-gated /search endpoint answering 404, i.e. the capability is absent. Everything
+ * else is the ordinary BFF failure vocabulary.
+ */
+export type PartyLookupFailure = BffFailure | 'search_unavailable'
+
+export type PartyResolution =
+  /** Nothing typed yet — not a result, not a failure. */
+  | { status: 'idle' }
+  /** Typed, but shorter than party-service will accept; asking would return a vacuous empty page. */
+  | { status: 'too_short' }
+  | { status: 'ok'; mode: PartyLookupMode; matches: PartyMatch[] }
+  /** The lookup ran and the bank genuinely holds no such party. */
+  | { status: 'none'; mode: PartyLookupMode }
+  /** The lookup did not run to a conclusion. Distinct from `none` on purpose. */
+  | { status: 'failed'; mode: PartyLookupMode; reason: PartyLookupFailure }
+
+export function isUuid(value: string): boolean {
+  return UUID_RE.test(value.trim())
+}
+
+function toMatch(raw: unknown): PartyMatch | null {
+  if (!raw || typeof raw !== 'object') return null
+  const o = raw as Record<string, unknown>
+  const id = typeof o.id === 'string' ? o.id : typeof o.partyId === 'string' ? o.partyId : null
+  if (!id) return null
+  const str = (v: unknown): string | null => (typeof v === 'string' && v.length > 0 ? v : null)
+  return {
+    id,
+    legalName: str(o.legalName) ?? str(o.name),
+    tradingName: str(o.tradingName),
+    kycStatus: str(o.kycStatus),
+    status: str(o.status),
+  }
+}
+
+function matchesFrom(body: unknown): PartyMatch[] {
+  const rows = Array.isArray(body)
+    ? body
+    : Array.isArray((body as { data?: unknown })?.data)
+      ? ((body as { data: unknown[] }).data)
+      : Array.isArray((body as { items?: unknown })?.items)
+        ? ((body as { items: unknown[] }).items)
+        : []
+  return rows.map(toMatch).filter((m): m is PartyMatch => m !== null)
+}
+
+type Fetcher = typeof fetch
+
+/**
+ * Resolve `query` to parties. Never throws: a transport error is a `failed` resolution,
+ * because a thrown promise upstream is how a failed lookup ends up rendered as "nothing found".
+ */
+export async function resolveParty(query: string, fetcher: Fetcher = fetch): Promise<PartyResolution> {
+  const q = query.trim()
+  if (q.length === 0) return { status: 'idle' }
+
+  const mode: PartyLookupMode = isUuid(q) ? 'uuid' : 'term'
+  if (mode === 'term' && q.length < MIN_TERM_LENGTH) return { status: 'too_short' }
+
+  const url = mode === 'uuid'
+    ? svcUrl(PARTY_SERVICE, `/api/v1/parties/${encodeURIComponent(q)}`)
+    : svcUrl(PARTY_SERVICE, '/api/v1/parties/search', { q, limit: '20' })
+
+  let res: Response
+  try {
+    res = await fetcher(url, { signal: AbortSignal.timeout(6000), cache: 'no-store' })
+  } catch {
+    return { status: 'failed', mode, reason: 'unreachable' }
+  }
+
+  if (!res.ok) {
+    const kind = await classifyBffFailure(res)
+    // A genuine 404 means opposite things on the two endpoints, so it must not share a state.
+    if (kind === 'not_found') {
+      return mode === 'uuid'
+        ? { status: 'none', mode }
+        : { status: 'failed', mode, reason: 'search_unavailable' }
+    }
+    return { status: 'failed', mode, reason: kind }
+  }
+
+  let body: unknown
+  try {
+    body = await res.json()
+  } catch {
+    return { status: 'failed', mode, reason: 'error' }
+  }
+
+  const matches = mode === 'uuid'
+    ? [toMatch(body)].filter((m): m is PartyMatch => m !== null)
+    : matchesFrom(body)
+
+  return matches.length > 0 ? { status: 'ok', mode, matches } : { status: 'none', mode }
+}
+
+/** Human label for a match, without inventing one when party-service minimised it away. */
+export function partyLabel(m: PartyMatch): string {
+  return m.tradingName ?? m.legalName ?? m.id
+}

--- a/openbank-admin-ui/src/test/approvals-agent-identity.test.tsx
+++ b/openbank-admin-ui/src/test/approvals-agent-identity.test.tsx
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+// #5904 — "Render charter-backed agent identity in the approval queue".
+// The identity must come from openbank-libs/governance/agents.yaml (the document OPA
+// enforces), and an actor absent from it must render as UNRESOLVED — never as a
+// plausible-looking string, and never confused with "we could not read the registry".
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { render, screen } from '@testing-library/react'
+import { parse } from 'yaml'
+import { describe, expect, it } from 'vitest'
+import { resolveAgentIdentity, type AgentIdentityRegistry } from '@/lib/governance/agentIdentity'
+import { AgentIdentityBadge } from '@/components/approvals/AgentIdentityBadge'
+
+interface RawRegistry { agents: { id: string; plane?: string; charter?: string }[] }
+
+// Read the REAL enforced registry, not a fixture — a fixture cannot notice that the id
+// the queue resolves against has been renamed in agents.yaml.
+const raw = parse(readFileSync(
+  path.resolve(process.cwd(), '../openbank-libs/governance/agents.yaml'),
+  'utf8',
+)) as RawRegistry
+
+const registry: AgentIdentityRegistry = {
+  available: true,
+  agents: raw.agents.map(a => ({
+    id: a.id, plane: a.plane ?? '—', charter: a.charter ?? '', requiresHuman: [],
+  })),
+}
+
+const KNOWN = raw.agents[0].id
+
+describe('resolveAgentIdentity', () => {
+  it('resolves every id agents.yaml actually declares', () => {
+    for (const a of raw.agents) {
+      const out = resolveAgentIdentity(a.id, registry)
+      expect(out.status).toBe('chartered')
+      if (out.status === 'chartered') expect(out.charter.id).toBe(a.id)
+    }
+    expect(raw.agents.length).toBeGreaterThan(0)
+  })
+
+  it('resolves the Keycloak service-account form of a charter id', () => {
+    const out = resolveAgentIdentity(`service-account-${KNOWN}`, registry)
+    expect(out.status).toBe('chartered')
+    if (out.status === 'chartered') expect(out.charter.id).toBe(KNOWN)
+  })
+
+  it('reports an actor absent from agents.yaml as unresolved', () => {
+    // The old approval queue matched /assistant|agent|\bai\b/ over proposedBy, so this
+    // string alone earned an "AI-generated" badge with no charter behind it.
+    const out = resolveAgentIdentity('risk-agent-review-desk', registry)
+    expect(out.status).toBe('unresolved')
+  })
+
+  it('does NOT resolve a near-miss by substring', () => {
+    expect(resolveAgentIdentity(`${KNOWN}-shadow`, registry).status).toBe('unresolved')
+  })
+
+  it('reports unverifiable — not unresolved — when the registry could not be read', () => {
+    expect(resolveAgentIdentity(KNOWN, null).status).toBe('unverifiable')
+    expect(resolveAgentIdentity(KNOWN, { available: false, agents: [] }).status).toBe('unverifiable')
+  })
+
+  it('never claims an empty proposer is chartered', () => {
+    expect(resolveAgentIdentity('', registry).status).toBe('unresolved')
+    expect(resolveAgentIdentity(null, registry).status).toBe('unresolved')
+  })
+})
+
+describe('AgentIdentityBadge — the states render distinguishably', () => {
+  function stateOf(node: React.ReactElement): { state: string | null; text: string } {
+    const { unmount } = render(node)
+    const el = screen.getByTestId('agent-identity')
+    const out = { state: el.getAttribute('data-state'), text: el.textContent ?? '' }
+    unmount()
+    return out
+  }
+
+  it('shows the charter id for a chartered proposer', () => {
+    const out = stateOf(<AgentIdentityBadge identity={resolveAgentIdentity(KNOWN, registry)} />)
+    expect(out.state).toBe('chartered')
+    expect(out.text).toContain(KNOWN)
+  })
+
+  it('unresolved and unverifiable are different badges with different copy', () => {
+    const unresolved = stateOf(<AgentIdentityBadge identity={resolveAgentIdentity('nobody-desk', registry)} />)
+    const unverifiable = stateOf(<AgentIdentityBadge identity={resolveAgentIdentity('nobody-desk', null)} />)
+
+    expect(unresolved.state).toBe('unresolved')
+    expect(unverifiable.state).toBe('unverifiable')
+    expect(unresolved.state).not.toBe(unverifiable.state)
+    expect(unresolved.text).not.toBe(unverifiable.text)
+    expect(unverifiable.text).toMatch(/unverifiable/i)
+  })
+
+  it('loading is its own state, not a premature verdict', () => {
+    const out = stateOf(<AgentIdentityBadge identity={resolveAgentIdentity(KNOWN, null)} loading />)
+    expect(out.state).toBe('loading')
+    expect(out.text).not.toMatch(/unverifiable/i)
+  })
+
+  it('never prints the raw proposedBy string as if it were an identity', () => {
+    const out = stateOf(<AgentIdentityBadge identity={resolveAgentIdentity('totally-made-up-agent', registry)} />)
+    expect(out.text).not.toContain('totally-made-up-agent')
+  })
+})

--- a/openbank-admin-ui/src/test/party-lookup.test.tsx
+++ b/openbank-admin-ui/src/test/party-lookup.test.tsx
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+// #5904 — "Resolve KYC customers by name/company/UUID through party-service".
+// The load-bearing assertions are the negative ones: a lookup that FAILED must render
+// differently from a lookup that legitimately found nothing.
+
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { resolveParty, isUuid, partyLabel } from '@/lib/party/resolveParty'
+import { PartyLookup } from '@/components/kyc/PartyLookup'
+
+const UUID = '3f2504e0-4f89-11d3-9a0c-0305e82c3301'
+
+function res(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('resolveParty — party-service lookup', () => {
+  it('classifies a UUID apart from a name term', () => {
+    expect(isUuid(UUID)).toBe(true)
+    expect(isUuid('Novak')).toBe(false)
+  })
+
+  it('resolves a known UUID through GET /api/v1/parties/{id}', async () => {
+    const fetcher = vi.fn(async () => res(200, { id: UUID, legalName: 'Jan Novák', kycStatus: 'VERIFIED' }))
+    const out = await resolveParty(UUID, fetcher as unknown as typeof fetch)
+
+    expect(out).toEqual({
+      status: 'ok',
+      mode: 'uuid',
+      matches: [{ id: UUID, legalName: 'Jan Novák', tradingName: null, kycStatus: 'VERIFIED', status: null }],
+    })
+    expect(String(fetcher.mock.calls[0][0])).toBe(`/api/svc/party-service/api/v1/parties/${UUID}`)
+  })
+
+  it('resolves a company name through GET /api/v1/parties/search?q=', async () => {
+    const fetcher = vi.fn(async () => res(200, {
+      data: [{ id: UUID, legalName: 'Acme s.r.o.', tradingName: 'Acme' }],
+      pagination: { limit: 20, hasNextPage: false },
+    }))
+    const out = await resolveParty('Acme', fetcher as unknown as typeof fetch)
+
+    expect(out.status).toBe('ok')
+    if (out.status !== 'ok') throw new Error('unreachable')
+    expect(out.mode).toBe('term')
+    expect(partyLabel(out.matches[0])).toBe('Acme')
+    // The path is asserted as a LITERAL, not derived from the module under test.
+    expect(String(fetcher.mock.calls[0][0])).toBe('/api/svc/party-service/api/v1/parties/search?q=Acme&limit=20')
+  })
+
+  it('reports a real empty search result as `none`', async () => {
+    const fetcher = vi.fn(async () => res(200, { data: [], pagination: { limit: 20, hasNextPage: false } }))
+    expect(await resolveParty('Zzzz', fetcher as unknown as typeof fetch)).toEqual({ status: 'none', mode: 'term' })
+  })
+
+  it('reports a 404 from /search as a FAILED lookup, never as `none`', async () => {
+    // party-service answers 404 when the party-search feature flag is off
+    // (FeatureDisabledMapper). A genuine no-match is a 200 with an empty page, so a 404
+    // here can only mean the capability is absent.
+    const fetcher = vi.fn(async () => res(404, { code: 'NOT_FOUND', message: "feature 'party-search' is not enabled" }))
+    expect(await resolveParty('Novak', fetcher as unknown as typeof fetch))
+      .toEqual({ status: 'failed', mode: 'term', reason: 'search_unavailable' })
+  })
+
+  it('reports a 404 for a UUID as `none` — that endpoint is not flag-gated', async () => {
+    const fetcher = vi.fn(async () => res(404, { code: 'NOT_FOUND', message: 'party not found' }))
+    expect(await resolveParty(UUID, fetcher as unknown as typeof fetch)).toEqual({ status: 'none', mode: 'uuid' })
+  })
+
+  it('maps the BFF failure vocabulary to failed, not to none', async () => {
+    const cases: [number, unknown, string][] = [
+      [404, { error: 'Unknown service: party-service' }, 'not_deployed'],
+      [503, { error: 'scaled_to_zero' }, 'scaled_to_zero'],
+      [401, { error: 'unauthorized' }, 'unauthorized'],
+      [502, { error: 'upstream_unreachable' }, 'unreachable'],
+    ]
+    for (const [status, body, reason] of cases) {
+      const out = await resolveParty('Novak', (async () => res(status, body)) as unknown as typeof fetch)
+      expect(out).toEqual({ status: 'failed', mode: 'term', reason })
+    }
+  })
+
+  it('treats a thrown fetch (timeout/network) as failed', async () => {
+    const fetcher = vi.fn(async () => { throw new Error('aborted') })
+    expect(await resolveParty('Novak', fetcher as unknown as typeof fetch))
+      .toEqual({ status: 'failed', mode: 'term', reason: 'unreachable' })
+  })
+
+  it('refuses a sub-2-character term instead of asking for a vacuous empty page', async () => {
+    const fetcher = vi.fn()
+    expect(await resolveParty('N', fetcher as unknown as typeof fetch)).toEqual({ status: 'too_short' })
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+})
+
+describe('PartyLookup — the three rendered states are distinguishable', () => {
+  async function runWith(resolution: Awaited<ReturnType<typeof resolveParty>>) {
+    const onSelect = vi.fn()
+    const { unmount } = render(<PartyLookup onSelect={onSelect} resolve={async () => resolution} />)
+    await userEvent.type(screen.getByRole('textbox'), 'Novak')
+    await userEvent.click(screen.getByRole('button', { name: /find customer/i }))
+    const el = await screen.findByTestId('lookup-state')
+    const out = { state: el.getAttribute('data-state'), text: el.textContent ?? '', onSelect }
+    unmount()
+    return out
+  }
+
+  it('renders matches and hands the party id back on click', async () => {
+    const onSelect = vi.fn()
+    render(<PartyLookup onSelect={onSelect} resolve={async () => ({
+      status: 'ok', mode: 'term',
+      matches: [{ id: UUID, legalName: 'Jan Novák', tradingName: null, kycStatus: 'VERIFIED', status: null }],
+    })} />)
+    await userEvent.type(screen.getByRole('textbox'), 'Novak')
+    await userEvent.click(screen.getByRole('button', { name: /find customer/i }))
+    await userEvent.click(await screen.findByTestId('party-match'))
+    expect(onSelect).toHaveBeenCalledWith(UUID)
+  })
+
+  it('a legitimate no-match and a failed lookup do not render the same', async () => {
+    const none = await runWith({ status: 'none', mode: 'term' })
+    const failed = await runWith({ status: 'failed', mode: 'term', reason: 'search_unavailable' })
+
+    expect(none.state).toBe('none')
+    expect(failed.state).toBe('failed')
+    expect(none.state).not.toBe(failed.state)
+    expect(none.text).not.toBe(failed.text)
+    // The failed copy must say the emptiness is not evidence.
+    expect(failed.text).toMatch(/NOT evidence/i)
+    expect(none.text).not.toMatch(/NOT evidence/i)
+  })
+
+  it('shows a loading state while the lookup is in flight', async () => {
+    let release: (v: Awaited<ReturnType<typeof resolveParty>>) => void = () => {}
+    const pending = new Promise<Awaited<ReturnType<typeof resolveParty>>>(r => { release = r })
+    render(<PartyLookup onSelect={vi.fn()} resolve={() => pending} />)
+    await userEvent.type(screen.getByRole('textbox'), 'Novak')
+    await userEvent.click(screen.getByRole('button', { name: /find customer/i }))
+
+    expect((await screen.findByTestId('lookup-state')).getAttribute('data-state')).toBe('loading')
+    release({ status: 'none', mode: 'term' })
+    await waitFor(async () =>
+      expect((await screen.findByTestId('lookup-state')).getAttribute('data-state')).toBe('none'))
+  })
+})


### PR DESCRIPTION
Two of the nine acceptance criteria on #5904. PR #5988 has the Trace Explorer states and the regulatory export gate; the remaining five (test inventory, Customer 360 context, compliance-pack content, Temporal diagram labelling, and the release-gate criterion) are untouched here.

## 1. Resolve KYC customers by name / company / UUID through party-service

**What party-service actually exposes** — established from `PartyResource` and `PartyRepositoryImpl`, not only from `openapi.yaml`:

| Endpoint | Mode | Notes |
|---|---|---|
| `GET /api/v1/parties/{id}` | exact UUID | not feature-gated |
| `GET /api/v1/parties/search?q=` | name / company / business key | `q` >= 2 chars, cursor-paginated; case-insensitive substring over `legalName`, `tradingName`, `email`, `phone`, `taxId`, `registrationNumber` |

So both lookup modes the UI needs are real server-side modes. No client-side filter over a full list is involved. Birth number is deliberately not searchable (GDPR data-minimisation) and nothing here changes that.

**The trap that decides the failure states.** `/search` carries `@FeatureFlag(flag = "party-search")`. When the flag is off, `FeatureDisabledMapper` answers **404**. A search that legitimately matches nothing answers **200 with an empty page** — `PartyService.searchParties` never 404s for a no-match. So a 404 from `/search` means "this bank cannot search right now", never "this customer does not exist", and it renders as a failed lookup with copy that says the emptiness is not evidence.

The KYC page previously ran `cases.filter(...)` behind a box labelled "Search by ID or status". That box remains, relabelled honestly as "Filter loaded cases" — it can never find a customer by name, because a KYC case payload carries no party name.

**Three states:** `loading` (lookup in flight) · `none` (the lookup ran; nothing matches — worded differently for the UUID and the term case) · `failed` (with a typed reason: `search_unavailable`, `not_deployed`, `scaled_to_zero`, `unauthorized`, `unreachable`, `error`). Plus `too_short`, which refuses to ask party-service for a page it would return empty by construction.

## 2. Charter-backed agent identity in the approval queue

The queue decided AI provenance with a regex over a string in the row:

```
const aiGenerated = /assistant|agent|\bai\b/i.test(p.proposedBy)
```

That is a guess dressed as provenance. `risk-agent-review-desk` (a human desk) earns the badge; a real charter id like `compliance-officer` does not.

Identity now comes from `openbank-libs/governance/agents.yaml` — the enforced registry the OPA agent bundles are derived from, so it is what actually decides what an agent may do. A new BFF route projects it through the existing `loadAgentCharters()` loader (no second source of truth). Matching is a closed list of exact rewrites (bare id, `service-account-<id>`, `agent:<id>`, `openbank-` / `-service` trims) — no substring matching, because a near-miss that resolves is worse than one that shows as unresolved.

**Three states:** `chartered` (shows the charter id, plane and `requires_human`) · `unresolved` (the registry was read and holds no such actor — real evidence of absence) · `unverifiable` (the registry could not be read; `agents.yaml` is bundled by Dockerfile COPY, and an image built without it must not mark every proposer as unchartered). Plus a `loading` badge so an in-flight fetch is not a premature verdict. The ADR-0080 caution now shows whenever AI authorship is established *or* cannot be ruled out; only a positively unchartered actor drops it.

`src/app/api/approvals/pending/route.ts` is **not touched** — that file is heavily contended and the identity resolution belongs on the client, against the charter registry. Its source count is 10 before and 10 after (`lending`, `sanctions`, `transaction`, `domesticPayment`, `clearing`, `fx`, `ledger`, `swift`, `sepaPayment`, `agent`).

## Falsification

Every guarantee was broken and the corresponding test confirmed red (baseline 22/22 green, restored after each):

| Mutation | Result |
|---|---|
| `/search` 404 collapses into `none` | 1 failed |
| `unverifiable` collapses into `unresolved` | 2 failed |
| charter matching becomes fuzzy substring | 1 failed |
| badge renders one state for unresolved + unverifiable | 1 failed |
| `PartyLookup` drops its loading state | 1 failed |

The charter test reads the real `agents.yaml` rather than a fixture, so a renamed agent id breaks it.

## Verification

- `npm test` — 221 files, 1584 tests, all passing
- `npx tsc --noEmit` — clean
- `eslint` on every touched file — 0 errors; the 2 `react-hooks/set-state-in-effect` warnings are pre-existing (confirmed identical on `origin/main`)

Refs #5904
