### PR TITLE
fix(finrep): compute isBalanced from an identity that can actually fail

### DIFF
--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/out/FinrepPorts.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/out/FinrepPorts.kt
@@ -7,7 +7,22 @@ package com.openbank.finrep.application.port.out
 import java.math.BigDecimal
 import java.time.LocalDate
 
-data class TrialBalanceLineDto(val code: String, val accountType: String, val net: BigDecimal)
+/**
+ * One GL account line of the ledger trial balance.
+ *
+ * [net] is `totalDebit − totalCredit`, ledger's own uniform convention for every account type — so
+ * it is NEGATIVE for a credit-normal account (liabilities, equity, income) and positive for a
+ * debit-normal one (assets, expenses). The mappers are responsible for presenting each FINREP row
+ * in its reporting sign; [com.openbank.finrep.domain.model.TrialBalanceIdentity] relies on the raw
+ * convention being uniform, which is what makes `Σ net == 0` the double-entry identity.
+ *
+ * [currency] is carried because the identity holds PER CURRENCY. Without it the check could be
+ * satisfied by a CZK line cancelling a lost EUR one (issue #5987). It carries NO default on
+ * purpose: a defaulted `"CZK"` would let a response that omits the field deserialize into a
+ * plausible-looking line, silently merging every currency into one residual bucket — the check
+ * would then still pass, for a reason nothing anywhere would report.
+ */
+data class TrialBalanceLineDto(val code: String, val accountType: String, val net: BigDecimal, val currency: String)
 
 interface LedgerPort {
     suspend fun getTrialBalance(asOf: LocalDate): List<TrialBalanceLineDto>

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/FinrepService.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/FinrepService.kt
@@ -23,8 +23,15 @@ import java.time.LocalDate
  * FINREP template rendering (ADR-0097 Phase 1). A pure derivation over the ledger trial balance — it
  * stores nothing and emits nothing, so **every** way it can be wrong still produces a well-formed 200
  * response. [FinrepMetricsPort] is what makes those ways visible: an empty trial balance renders a
- * template of honest-looking zeros, and a balance sheet that does not balance is currently computed
- * into `FinrepTemplate.isBalanced`, serialised, and never looked at again.
+ * template of honest-looking zeros, and a trial balance that does not satisfy double entry is
+ * reported on `FinrepTemplate.isBalanced` and on the `balanced` tag of the render counter.
+ *
+ * That sentence used to read "is currently computed into `FinrepTemplate.isBalanced`, serialised,
+ * and never looked at again". The second half stopped being true when admin-ui's export gate began
+ * blocking on it (#5904); the FIRST half was never true — both mappers passed the literal `true`,
+ * so the `balanced` tag had exactly one reachable value and an alert on it could not fire. Fixed in
+ * #5987: the flag is now `TrialBalanceIdentity.holds(lines)`, which is falsifiable by input the
+ * mappers do not otherwise read.
  */
 @ApplicationScoped
 class FinrepService(private val ledgerPort: LedgerPort, private val metrics: FinrepMetricsPort) : FinrepUseCase {

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0101Mapper.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0101Mapper.kt
@@ -7,6 +7,7 @@ package com.openbank.finrep.domain.mapper
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
 import com.openbank.finrep.domain.model.FinrepCell
 import com.openbank.finrep.domain.model.FinrepTemplate
+import com.openbank.finrep.domain.model.TrialBalanceIdentity
 import java.math.BigDecimal
 import java.time.LocalDate
 
@@ -16,20 +17,38 @@ import java.time.LocalDate
  * EBA FINREP F01.01 structure (simplified):
  *   r010_c010 — Total assets
  *   r380_c010 — Total liabilities
- *   r490_c010 — Total equity (assets − liabilities as derived net)
+ *   r490_c010 — Total equity
+ *
+ * ## Signs (issue #5987)
+ *
+ * Ledger publishes `net = totalDebit − totalCredit` for every account type, so a credit-normal
+ * account arrives NEGATIVE. Every FINREP row is reported as a positive magnitude, hence the
+ * negations below. The previous version summed the raw `net` straight into r380, which reported
+ * liabilities as a negative number against real ledger data, and then derived r490 as
+ * `assets − liabilities` — which for real data is `assets + |liabilities|`, not equity at all.
+ *
+ * ## Equity is SOURCED, not residual — and that is the whole point
+ *
+ * r490 is `−(equity + income − expense)` in ledger sign, i.e. contributed capital and reserves plus
+ * the result of the period not yet closed out to reserves. It is read from the EQUITY, INCOME and
+ * EXPENSE lines. It is deliberately NOT `assets − liabilities`: defining equity as the residual is
+ * what made `isBalanced` unfalsifiable, because the identity then holds algebraically no matter
+ * what the ledger contains. With equity sourced, [TrialBalanceIdentity] over the whole trial
+ * balance is a claim that can be false — see the falsification pairs in `F0101MapperTest`.
+ *
+ * Note what today's chart of accounts means for this: openbank-ledger-service seeds **no EQUITY
+ * accounts at all** (`V1__init_ledger.sql` and every later migration), so `Σ net(EQUITY)` is
+ * genuinely zero and r490 currently reports the retained result alone. That is the honest number
+ * for this ledger, and it does not weaken the check: the identity is evaluated over all five
+ * account types, so a residual introduced anywhere still falsifies it.
  */
 object F0101Mapper {
 
     fun map(lines: List<TrialBalanceLineDto>, asOf: LocalDate): FinrepTemplate {
-        val assets = lines
-            .filter { it.accountType == "ASSET" }
-            .fold(BigDecimal.ZERO) { acc, l -> acc.add(l.net) }
-
-        val liabilities = lines
-            .filter { it.accountType == "LIABILITY" }
-            .fold(BigDecimal.ZERO) { acc, l -> acc.add(l.net) }
-
-        val equity = assets.subtract(liabilities)
+        val assets = sumNet(lines, "ASSET")
+        // Credit-normal, so the reporting magnitude is the negated ledger net.
+        val liabilities = sumNet(lines, "LIABILITY").negate()
+        val equity = sumNet(lines, "EQUITY", "INCOME", "EXPENSE").negate()
 
         val cells = listOf(
             FinrepCell(rowRef = "r010", colRef = "c010", value = assets),
@@ -41,7 +60,11 @@ object F0101Mapper {
             templateId = "F01.01",
             period = asOf,
             cells = cells,
-            isBalanced = true,
+            isBalanced = TrialBalanceIdentity.holds(lines),
         )
     }
+
+    private fun sumNet(lines: List<TrialBalanceLineDto>, vararg accountTypes: String): BigDecimal = lines
+        .filter { it.accountType in accountTypes }
+        .fold(BigDecimal.ZERO) { acc, line -> acc.add(line.net) }
 }

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0200Mapper.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0200Mapper.kt
@@ -7,6 +7,7 @@ package com.openbank.finrep.domain.mapper
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
 import com.openbank.finrep.domain.model.FinrepCell
 import com.openbank.finrep.domain.model.FinrepTemplate
+import com.openbank.finrep.domain.model.TrialBalanceIdentity
 import java.math.BigDecimal
 import java.time.LocalDate
 
@@ -17,18 +18,28 @@ import java.time.LocalDate
  *   r010_c010 — Total income
  *   r030_c010 — Total expense
  *   r450_c010 — Net profit (income − expense)
+ *
+ * Income is credit-normal, so its reporting magnitude is the negated ledger net; expense is
+ * debit-normal and passes through. See `F0101Mapper` for the sign convention (issue #5987).
+ *
+ * ## What `isBalanced` means on a P&L, and why it is not `true` here
+ *
+ * F02.00 has no balance-sheet identity of its own — `net profit = income − expense` is a definition
+ * and can never fail. So this template does NOT report a P&L-internal check. It reports the same
+ * thing F01.01 does: whether the **trial balance it was rendered from** satisfies double entry. A
+ * P&L drawn off a trial balance that does not tie out is not submittable regardless of how
+ * internally consistent its three rows are, and that is a fact about this render which a consumer
+ * of this template can act on.
+ *
+ * The alternative the issue offers — modelling the flag as not-applicable to P&L — was rejected
+ * because the flag would then have exactly one reachable value on this template, which is the
+ * defect being fixed rather than a fix for it.
  */
 object F0200Mapper {
 
     fun map(lines: List<TrialBalanceLineDto>, asOf: LocalDate): FinrepTemplate {
-        val income = lines
-            .filter { it.accountType == "INCOME" }
-            .fold(BigDecimal.ZERO) { acc, l -> acc.add(l.net) }
-
-        val expense = lines
-            .filter { it.accountType == "EXPENSE" }
-            .fold(BigDecimal.ZERO) { acc, l -> acc.add(l.net) }
-
+        val income = sumNet(lines, "INCOME").negate()
+        val expense = sumNet(lines, "EXPENSE")
         val netProfit = income.subtract(expense)
 
         val cells = listOf(
@@ -41,7 +52,11 @@ object F0200Mapper {
             templateId = "F02.00",
             period = asOf,
             cells = cells,
-            isBalanced = true,
+            isBalanced = TrialBalanceIdentity.holds(lines),
         )
     }
+
+    private fun sumNet(lines: List<TrialBalanceLineDto>, accountType: String): BigDecimal = lines
+        .filter { it.accountType == accountType }
+        .fold(BigDecimal.ZERO) { acc, line -> acc.add(line.net) }
 }

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/FinrepTemplate.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/FinrepTemplate.kt
@@ -14,5 +14,11 @@ data class FinrepTemplate(
     val templateId: String,
     val period: LocalDate,
     val cells: List<FinrepCell>,
-    val isBalanced: Boolean = true,
+    /**
+     * Whether the double-entry identity of the trial balance this template was rendered from holds
+     * (`Σ net == 0` per currency, `TrialBalanceIdentity`). NO DEFAULT on purpose (issue #5987): the
+     * field spent its whole life as a hardcoded `true` that no producer computed, and a default
+     * would let a new producer omit it and re-publish that same constant silently.
+     */
+    val isBalanced: Boolean,
 )

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/TrialBalanceIdentity.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/TrialBalanceIdentity.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.finrep.domain.model
+
+import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import java.math.BigDecimal
+
+/**
+ * The double-entry identity of the trial balance a FINREP template was rendered from (issue #5987).
+ *
+ * ## Why this exists, and why the obvious check would have been worthless
+ *
+ * `FinrepTemplate.isBalanced` used to be the literal `true` in both producers. The tempting repair —
+ * recompute `assets − liabilities − equity == 0` inside F01.01 — is **vacuous**, because F01.01
+ * derived equity AS `assets − liabilities`. An identity checked against a quantity defined as its
+ * own residual can only ever hold, so the "fix" would have reported health for the same structural
+ * reason the hardcoded literal did, while looking like a control. That is the defect one level up.
+ *
+ * The independent quantity is the trial balance itself. openbank-ledger-service publishes every GL
+ * line with `net = totalDebit − totalCredit` **uniformly across all five account types** (see
+ * `TrialBalanceLine.net` there), so for a ledger whose journals all balance:
+ *
+ *     Σ net over ALL lines == Σ totalDebit − Σ totalCredit == 0
+ *
+ * per currency. Nothing any FINREP mapper computes implies that sum. It is falsifiable by data the
+ * mappers never look at: F01.01 reads only ASSET/LIABILITY/EQUITY and F02.00 only INCOME/EXPENSE, so
+ * a residual can be introduced from the half of the trial balance the template ignores and the
+ * check still sees it. What it catches in practice is what a reporting-side control is FOR: a
+ * truncated or paginated line list, a filtered or partially-deserialised response, an account type
+ * outside the five, and any ledger-side posting defect that survived to the frozen evidence.
+ *
+ * ## Per currency, never summed across currencies
+ *
+ * Residuals are kept per currency and every currency must hold independently. Summing them would
+ * add CZK to EUR — meaningless as accounting, and weaker as a check: a lost EUR line could be
+ * cancelled by an unrelated CZK one. The grouping is what makes the check unable to be satisfied
+ * by coincidence.
+ */
+object TrialBalanceIdentity {
+
+    /**
+     * Residual `Σ net` per currency. Every entry is zero for a trial balance that balances; any
+     * non-zero entry is the amount by which that currency fails to tie out, signed as
+     * debit-minus-credit. Returned rather than reduced to a boolean so a caller (a metric, an
+     * operator-facing message, a future validation-rule report) can say *how far off* and *where*.
+     */
+    fun residualsByCurrency(lines: List<TrialBalanceLineDto>): Map<String, BigDecimal> = lines
+        .groupBy { it.currency }
+        .mapValues { (_, group) -> group.fold(BigDecimal.ZERO) { acc, line -> acc.add(line.net) } }
+
+    /**
+     * Whether the double-entry identity holds for every currency present.
+     *
+     * An EMPTY trial balance holds trivially, and that is deliberate rather than an oversight: an
+     * absent trial balance is an under-reporting problem, not a balance problem, and it already has
+     * its own detector in `openbank.finrep.trial_balance.lines` (a rendered template of honest zeros
+     * is exactly what that summary exists to make visible). Reporting `isBalanced = false` for it
+     * would collapse two different defects onto one flag — the failure mode `PushResult.skipped()`
+     * shipped in openbank-notification-service.
+     *
+     * `compareTo`, never `equals`: `BigDecimal("0.00") != BigDecimal.ZERO` by `equals` because the
+     * scales differ, so an `equals` check would report a perfectly balanced ledger as unbalanced the
+     * moment any line carried decimal places — which every real money line does.
+     */
+    fun holds(lines: List<TrialBalanceLineDto>): Boolean =
+        residualsByCurrency(lines).values.all { it.compareTo(BigDecimal.ZERO) == 0 }
+}

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/client/LedgerClient.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/client/LedgerClient.kt
@@ -47,7 +47,7 @@ interface LedgerRestClient {
     fun getTrialBalance(@PathParam("asOf") asOf: String): Uni<ClosedPeriodTrialBalanceResponse>
 }
 
-data class TrialBalanceLineResponse(val code: String, val type: String, val net: BigDecimal)
+data class TrialBalanceLineResponse(val code: String, val type: String, val net: BigDecimal, val currency: String)
 
 data class ClosedPeriodTrialBalanceResponse(
     val period: String,
@@ -65,6 +65,7 @@ class LedgerAdapter(@RestClient private val client: LedgerRestClient) : LedgerPo
                 code = line.code,
                 accountType = line.type,
                 net = line.net,
+                currency = line.currency,
             )
         }
     }

--- a/openbank-finrep-service/src/main/resources/openapi.yaml
+++ b/openbank-finrep-service/src/main/resources/openapi.yaml
@@ -20,7 +20,7 @@ info:
 
     Cells are always fully rendered: a value the platform cannot honestly derive is an explicit
     flagged zero (`isDataGap`), never an omitted row, so a regulatory return never has a silent gap.
-  version: 1.0.0
+  version: 1.0.1
 tags:
   - name: FINREP
   - name: COREP
@@ -127,8 +127,9 @@ components:
       type: object
       description: >-
         One rendered FINREP template. F01.01 populates rows r010 (total assets), r380 (total
-        liabilities) and r490 (derived equity); F02.00 populates r010 (total income), r030 (total
-        expense) and r450 (net profit).
+        liabilities) and r490 (total equity); F02.00 populates r010 (total income), r030 (total
+        expense) and r450 (net profit). All rows are reported as positive magnitudes in their
+        natural reporting sign, not in the ledger's debit-minus-credit convention.
       required: [templateId, period, cells, isBalanced]
       properties:
         templateId: { type: string, example: F01.01 }
@@ -142,8 +143,16 @@ components:
         isBalanced:
           type: boolean
           description: >-
-            Whether the template's internal accounting identity holds. Serialized as `isBalanced`,
-            not `balanced` — see the note at the top of this file.
+            Whether the double-entry identity of the trial balance this template was rendered from
+            holds: the sum of every GL line's debit-minus-credit net is zero, evaluated per
+            currency and required to hold for all of them. An empty trial balance holds trivially
+            — that is an under-reporting condition, reported separately, not a balance failure.
+            Serialized as `isBalanced`, not `balanced` — see the note at the top of this file.
+
+            Historical note (issue #5987): up to API version 1.0.0 both producers passed a
+            hardcoded `true` and F01.01 derived equity as `assets - liabilities`, so the value was
+            a constant and no consumer could ever observe `false`. Do not read a `true` served by
+            an older deployment as evidence that anything was checked.
 
     CorepCell:
       type: object

--- a/openbank-finrep-service/src/main/resources/openapi.yaml
+++ b/openbank-finrep-service/src/main/resources/openapi.yaml
@@ -20,7 +20,7 @@ info:
 
     Cells are always fully rendered: a value the platform cannot honestly derive is an explicit
     flagged zero (`isDataGap`), never an omitted row, so a regulatory return never has a silent gap.
-  version: 1.0.1
+  version: 1.1.0
 tags:
   - name: FINREP
   - name: COREP

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/C0100MapperTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/C0100MapperTest.kt
@@ -21,11 +21,11 @@ class C0100MapperTest {
         // deposits, interest and fee income/expense — no EQUITY-typed lines, because the
         // ledger's chart of accounts does not seed any capital-structure accounts.
         val lines = listOf(
-            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000")),
-            TrialBalanceLineDto(code = "1001", accountType = "ASSET", net = BigDecimal("120000")),
-            TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("580000")),
-            TrialBalanceLineDto(code = "3000", accountType = "INCOME", net = BigDecimal("15000")),
-            TrialBalanceLineDto(code = "4000", accountType = "EXPENSE", net = BigDecimal("5000")),
+            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
+            TrialBalanceLineDto(code = "1001", accountType = "ASSET", net = BigDecimal("120000"), currency = "CZK"),
+            TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("580000"), currency = "CZK"),
+            TrialBalanceLineDto(code = "3000", accountType = "INCOME", net = BigDecimal("15000"), currency = "CZK"),
+            TrialBalanceLineDto(code = "4000", accountType = "EXPENSE", net = BigDecimal("5000"), currency = "CZK"),
         )
 
         val template = C0100Mapper.map(lines, LocalDate.of(2026, 6, 30))
@@ -55,8 +55,8 @@ class C0100MapperTest {
         // capital-structure accounts (EQUITY-typed lines), the mapper must pick them up
         // automatically without code changes, and stop flagging the rows as gaps.
         val lines = listOf(
-            TrialBalanceLineDto(code = "3900", accountType = "EQUITY", net = BigDecimal("1000000")),
-            TrialBalanceLineDto(code = "3901", accountType = "EQUITY", net = BigDecimal("250000")),
+            TrialBalanceLineDto(code = "3900", accountType = "EQUITY", net = BigDecimal("1000000"), currency = "CZK"),
+            TrialBalanceLineDto(code = "3901", accountType = "EQUITY", net = BigDecimal("250000"), currency = "CZK"),
         )
 
         val template = C0100Mapper.map(lines, LocalDate.of(2026, 6, 30))

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0101MapperTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0101MapperTest.kt
@@ -11,19 +11,122 @@ import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDate
 
+/**
+ * Fixtures use ledger's real sign convention — `net = totalDebit − totalCredit`, so credit-normal
+ * accounts (LIABILITY, EQUITY, INCOME) are NEGATIVE. The previous fixtures passed a positive
+ * liability, which no real trial balance line can carry for a credit-balance account, and that is
+ * why the mapper's `assets − liabilities` derivation read as sensible while being wrong.
+ *
+ * The `isBalanced` assertions here come in falsification PAIRS on purpose (issue #5987). A check
+ * that cannot be shown to fail is not a check, and the specific way the old one could not fail —
+ * equity derived as the residual of the very identity being tested — is invisible to any test that
+ * only ever asserts `true`.
+ */
 class F0101MapperTest {
 
+    private val asOf: LocalDate = LocalDate.of(2026, 6, 30)
+
+    /** Assets 500 000 = liabilities 300 000 + equity 200 000 (retained result). Σ net == 0. */
+    private fun balancedTrialBalance() = listOf(
+        line("1000", "ASSET", "500000"),
+        line("2000", "LIABILITY", "-300000"),
+        line("4000", "INCOME", "-260000"),
+        line("5000", "EXPENSE", "60000"),
+    )
+
     @Test
-    fun `F01_01 maps assets liabilities and derives equity`() {
-        val lines = listOf(
-            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000")),
-            TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("300000")),
-        )
-        val template = F0101Mapper.map(lines, LocalDate.of(2026, 6, 30))
+    fun `F01_01 reports assets liabilities and equity as positive magnitudes`() {
+        val template = F0101Mapper.map(balancedTrialBalance(), asOf)
 
         assertThat(template.templateId).isEqualTo("F01.01")
-        assertThat(template.cells).anyMatch { it.rowRef == "r010" && it.value == BigDecimal("500000") }
-        assertThat(template.cells).anyMatch { it.rowRef == "r380" && it.value == BigDecimal("300000") }
-        assertThat(template.cells).anyMatch { it.rowRef == "r490" && it.value == BigDecimal("200000") }
+        assertThat(cell(template.cells, "r010")).isEqualByComparingTo("500000")
+        assertThat(cell(template.cells, "r380")).isEqualByComparingTo("300000")
+        assertThat(cell(template.cells, "r490")).isEqualByComparingTo("200000")
     }
+
+    @Test
+    fun `equity is sourced from EQUITY INCOME and EXPENSE, not from assets minus liabilities`() {
+        // The discriminating fixture: assets − liabilities is 500 000 − 300 000 = 200 000, but the
+        // P&L half says the result is only 150 000. A residual-derived r490 would report 200 000
+        // and could not tell these apart; a sourced one reports 150 000 AND flags the 50 000 gap.
+        val lines = listOf(
+            line("1000", "ASSET", "500000"),
+            line("2000", "LIABILITY", "-300000"),
+            line("4000", "INCOME", "-210000"),
+            line("5000", "EXPENSE", "60000"),
+        )
+
+        val template = F0101Mapper.map(lines, asOf)
+
+        assertThat(cell(template.cells, "r490")).isEqualByComparingTo("150000")
+        assertThat(template.isBalanced).isFalse()
+    }
+
+    @Test
+    fun `a trial balance that ties out is reported as balanced`() {
+        assertThat(F0101Mapper.map(balancedTrialBalance(), asOf).isBalanced).isTrue()
+    }
+
+    @Test
+    fun `an asset booked with no counterpart is reported as UNBALANCED`() {
+        // The falsifying input. One extra debit-side line and nothing to credit against it — the
+        // shape of a lost or filtered response line, or a ledger-side posting defect that survived
+        // into the frozen evidence.
+        val lines = balancedTrialBalance() + line("1001", "ASSET", "70000")
+
+        assertThat(F0101Mapper.map(lines, asOf).isBalanced).isFalse()
+    }
+
+    @Test
+    fun `a residual in the P&L half falsifies the BALANCE SHEET template`() {
+        // Proof the check is not implied by what F01.01 itself computes: INCOME and EXPENSE feed no
+        // row this template reports as a top-line total, yet a residual introduced there is caught.
+        val lines = balancedTrialBalance() + line("5001", "EXPENSE", "12000")
+
+        assertThat(F0101Mapper.map(lines, asOf).isBalanced).isFalse()
+    }
+
+    @Test
+    fun `a currency that does not tie out falsifies the template even when the totals cancel`() {
+        // Summing residuals across currencies would report this as balanced: EUR is +40 000 short
+        // and CZK is 40 000 long, so a single global sum is exactly zero. Grouping per currency is
+        // what stops the check being satisfiable by coincidence.
+        val lines = listOf(
+            line("1000", "ASSET", "500000"),
+            line("2000", "LIABILITY", "-460000"),
+            line("1000", "ASSET", "100000", currency = "EUR"),
+            line("2000", "LIABILITY", "-140000", currency = "EUR"),
+        )
+
+        assertThat(F0101Mapper.map(lines, asOf).isBalanced).isFalse()
+    }
+
+    @Test
+    fun `decimal scale differences do not fake an imbalance`() {
+        // `BigDecimal("0.00") != BigDecimal.ZERO` by equals. An equals-based residual check would
+        // call every real money trial balance unbalanced.
+        val lines = listOf(
+            line("1000", "ASSET", "150000.00"),
+            line("2000", "LIABILITY", "-150000.0000"),
+        )
+
+        assertThat(F0101Mapper.map(lines, asOf).isBalanced).isTrue()
+    }
+
+    @Test
+    fun `an empty trial balance is balanced, not unbalanced`() {
+        // An absent trial balance is an under-reporting defect with its own detector
+        // (`openbank.finrep.trial_balance.lines`); collapsing it onto this flag would make two
+        // different failures indistinguishable to a consumer acting on either.
+        val template = F0101Mapper.map(emptyList(), asOf)
+
+        assertThat(template.isBalanced).isTrue()
+        assertThat(template.cells).allMatch { it.value.compareTo(BigDecimal.ZERO) == 0 }
+    }
+
+    private fun line(code: String, accountType: String, net: String, currency: String = "CZK") =
+        TrialBalanceLineDto(code = code, accountType = accountType, net = BigDecimal(net), currency = currency)
+
+    private fun cell(cells: List<com.openbank.finrep.domain.model.FinrepCell>, rowRef: String) =
+        cells.single { it.rowRef == rowRef }.value
 }

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0200MapperTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0200MapperTest.kt
@@ -11,19 +11,57 @@ import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDate
 
+/** See `F0101MapperTest` for the sign convention and for why the balance assertions come in pairs. */
 class F0200MapperTest {
 
+    private val asOf: LocalDate = LocalDate.of(2026, 6, 30)
+
+    private fun balancedTrialBalance() = listOf(
+        line("1000", "ASSET", "460000"),
+        line("2000", "LIABILITY", "-420000"),
+        line("4000", "INCOME", "-120000"),
+        line("5000", "EXPENSE", "80000"),
+    )
+
     @Test
-    fun `F02_00 maps income expense and derives net profit`() {
-        val lines = listOf(
-            TrialBalanceLineDto(code = "4000", accountType = "INCOME", net = BigDecimal("120000")),
-            TrialBalanceLineDto(code = "5000", accountType = "EXPENSE", net = BigDecimal("80000")),
-        )
-        val template = F0200Mapper.map(lines, LocalDate.of(2026, 6, 30))
+    fun `F02_00 reports income and expense as positive magnitudes and derives net profit`() {
+        val template = F0200Mapper.map(balancedTrialBalance(), asOf)
 
         assertThat(template.templateId).isEqualTo("F02.00")
-        assertThat(template.cells).anyMatch { it.rowRef == "r010" && it.value == BigDecimal("120000") }
-        assertThat(template.cells).anyMatch { it.rowRef == "r030" && it.value == BigDecimal("80000") }
-        assertThat(template.cells).anyMatch { it.rowRef == "r450" && it.value == BigDecimal("40000") }
+        assertThat(cell(template, "r010")).isEqualByComparingTo("120000")
+        assertThat(cell(template, "r030")).isEqualByComparingTo("80000")
+        assertThat(cell(template, "r450")).isEqualByComparingTo("40000")
     }
+
+    @Test
+    fun `a P&L drawn off a trial balance that ties out is reported as balanced`() {
+        assertThat(F0200Mapper.map(balancedTrialBalance(), asOf).isBalanced).isTrue()
+    }
+
+    @Test
+    fun `a P&L drawn off a trial balance that does NOT tie out is reported as unbalanced`() {
+        // Deliberately introduced on the BALANCE-SHEET side, which F02.00 does not report at all:
+        // the flag is a statement about the render's input, not about the three rows above it.
+        // A P&L is not submittable off a GL that does not balance, however self-consistent it looks.
+        val lines = balancedTrialBalance() + line("1001", "ASSET", "25000")
+
+        assertThat(F0200Mapper.map(lines, asOf).isBalanced).isFalse()
+    }
+
+    @Test
+    fun `net profit stays a definition and can never falsify the flag on its own`() {
+        // Guards against the tempting vacuous check: `income − expense == netProfit` is how r450 is
+        // computed, so asserting it would always hold. This test states that r450 tracks the inputs
+        // exactly, WITHOUT that identity being what `isBalanced` reports.
+        val lines = balancedTrialBalance()
+        val template = F0200Mapper.map(lines, asOf)
+
+        assertThat(cell(template, "r450")).isEqualByComparingTo(cell(template, "r010").subtract(cell(template, "r030")))
+    }
+
+    private fun line(code: String, accountType: String, net: String, currency: String = "CZK") =
+        TrialBalanceLineDto(code = code, accountType = accountType, net = BigDecimal(net), currency = currency)
+
+    private fun cell(template: com.openbank.finrep.domain.model.FinrepTemplate, rowRef: String) =
+        template.cells.single { it.rowRef == rowRef }.value
 }

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/CorepServiceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/CorepServiceTest.kt
@@ -31,8 +31,8 @@ class CorepServiceTest {
     fun `getTemplate dispatches C_01_00 to the own funds mapper`(): Unit = runBlocking {
         val asOf = LocalDate.of(2026, 6, 30)
         val lines = listOf(
-            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000")),
-            TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("300000")),
+            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
+            TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("300000"), currency = "CZK"),
         )
         coEvery { ledgerPort.getTrialBalance(asOf) } returns lines
         val service = CorepService(ledgerPort, FinrepMetricsAdapter(registry))
@@ -64,7 +64,7 @@ class CorepServiceTest {
         // zeros. That honesty is invisible without a series counting them.
         val asOf = LocalDate.of(2026, 6, 30)
         coEvery { ledgerPort.getTrialBalance(asOf) } returns listOf(
-            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000")),
+            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
         )
         val service = CorepService(ledgerPort, FinrepMetricsAdapter(registry))
 

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/FinrepServiceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/FinrepServiceTest.kt
@@ -31,8 +31,15 @@ class FinrepServiceTest {
     fun `getTemplate dispatches F01_01 to the balance sheet mapper`(): Unit = runBlocking {
         val asOf = LocalDate.of(2026, 6, 30)
         val lines = listOf(
-            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000")),
-            TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("300000")),
+            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
+            TrialBalanceLineDto(
+                code = "2000",
+                accountType = "LIABILITY",
+                net = BigDecimal("-300000"),
+                currency = "CZK",
+            ),
+            TrialBalanceLineDto(code = "4000", accountType = "INCOME", net = BigDecimal("-260000"), currency = "CZK"),
+            TrialBalanceLineDto(code = "5000", accountType = "EXPENSE", net = BigDecimal("60000"), currency = "CZK"),
         )
         coEvery { ledgerPort.getTrialBalance(asOf) } returns lines
         val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
@@ -49,8 +56,8 @@ class FinrepServiceTest {
     fun `getTemplate dispatches F02_00 to the P&L mapper`(): Unit = runBlocking {
         val asOf = LocalDate.of(2026, 6, 30)
         val lines = listOf(
-            TrialBalanceLineDto(code = "4000", accountType = "INCOME", net = BigDecimal("120000")),
-            TrialBalanceLineDto(code = "5000", accountType = "EXPENSE", net = BigDecimal("80000")),
+            TrialBalanceLineDto(code = "4000", accountType = "INCOME", net = BigDecimal("-120000"), currency = "CZK"),
+            TrialBalanceLineDto(code = "5000", accountType = "EXPENSE", net = BigDecimal("80000"), currency = "CZK"),
         )
         coEvery { ledgerPort.getTrialBalance(asOf) } returns lines
         val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
@@ -78,8 +85,15 @@ class FinrepServiceTest {
     fun `a rendered template publishes its input size, cell count and balanced flag`(): Unit = runBlocking {
         val asOf = LocalDate.of(2026, 6, 30)
         coEvery { ledgerPort.getTrialBalance(asOf) } returns listOf(
-            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000")),
-            TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("300000")),
+            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
+            TrialBalanceLineDto(
+                code = "2000",
+                accountType = "LIABILITY",
+                net = BigDecimal("-300000"),
+                currency = "CZK",
+            ),
+            TrialBalanceLineDto(code = "4000", accountType = "INCOME", net = BigDecimal("-260000"), currency = "CZK"),
+            TrialBalanceLineDto(code = "5000", accountType = "EXPENSE", net = BigDecimal("60000"), currency = "CZK"),
         )
         val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
 
@@ -88,7 +102,7 @@ class FinrepServiceTest {
         assertThat(
             registry.get("openbank.finrep.templates.rendered")
                 .tag("service", "finrep").tag("framework", "finrep").tag("template", "F01.01")
-                .tag("balanced", template.isBalanced.toString())
+                .tag("balanced", "true")
                 .counter().count(),
         ).isEqualTo(1.0)
         assertThat(
@@ -96,10 +110,38 @@ class FinrepServiceTest {
         ).isEqualTo(1L)
         assertThat(
             registry.get("openbank.finrep.trial_balance.lines").tag("template", "F01.01").summary().totalAmount(),
-        ).isEqualTo(2.0)
+        ).isEqualTo(4.0)
         assertThat(
             registry.get("openbank.finrep.template.cells").tag("template", "F01.01").summary().totalAmount(),
         ).isEqualTo(template.cells.size.toDouble())
+    }
+
+    @Test
+    fun `the balanced tag takes the value FALSE for a trial balance that does not tie out`(): Unit = runBlocking {
+        // The falsification half of the test above, and the reason issue #5987 was filed: while both
+        // mappers passed a hardcoded `true`, this series had exactly ONE reachable value, so an alert
+        // built on it could never fire and the tag looked like health monitoring while measuring
+        // nothing. Asserting `balanced=false` is reachable is what makes the tag worth alerting on.
+        val asOf = LocalDate.of(2026, 6, 30)
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns listOf(
+            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
+            TrialBalanceLineDto(
+                code = "2000",
+                accountType = "LIABILITY",
+                net = BigDecimal("-410000"),
+                currency = "CZK",
+            ),
+        )
+        val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
+
+        val template = service.getTemplate(GetFinrepTemplateQuery(templateId = "F01.01", asOf = asOf))
+
+        assertThat(template.isBalanced).isFalse()
+        assertThat(
+            registry.get("openbank.finrep.templates.rendered")
+                .tag("framework", "finrep").tag("template", "F01.01").tag("balanced", "false")
+                .counter().count(),
+        ).isEqualTo(1.0)
     }
 
     @Test

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/LedgerTrialBalancePactConsumerTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/LedgerTrialBalancePactConsumerTest.kt
@@ -69,9 +69,11 @@ import java.time.LocalDate
  * template still fixes the required field types for a non-empty response, and finrep's mappers fold
  * over an empty list to an all-zero template.
  *
- * Only the three line fields finrep actually consumes (`code`, `type`, `net`) are declared — a
- * consumer contract must not pin provider fields it does not read (`glAccountId`, `name`,
- * `currency`, `totalDebit`, `totalCredit` are ledger's business).
+ * Only the four line fields finrep actually consumes (`code`, `type`, `net`, `currency`) are
+ * declared — a consumer contract must not pin provider fields it does not read (`glAccountId`,
+ * `name`, `totalDebit`, `totalCredit` are ledger's business). `currency` moved from the second
+ * list to the first with issue #5987, when the balance check began evaluating the double-entry
+ * identity per currency.
  */
 @ExtendWith(PactConsumerTestExt::class)
 @PactTestFor(providerName = "openbank-ledger-service", pactVersion = PactSpecVersion.V3)
@@ -107,6 +109,13 @@ class LedgerTrialBalancePactConsumerTest {
                     line.stringType("code", "1100-CASH-CLEARING-CZK")
                     line.stringType("type", "ASSET")
                     line.decimalType("net", 150_000.00)
+                    // Added with issue #5987: finrep now READS `currency`, because the double-entry
+                    // identity behind `isBalanced` holds per currency and a global sum would let a
+                    // CZK line cancel a lost EUR one. A consumer pact must pin exactly the fields
+                    // the consumer consumes — no more (that was the rule when this line was absent)
+                    // and no fewer (the client's `currency` is non-nullable, so a provider that
+                    // stopped sending it would fail deserialization at runtime, not here).
+                    line.stringType("currency", "CZK")
                 }
             }.build(),
         )
@@ -130,15 +139,22 @@ class LedgerTrialBalancePactConsumerTest {
         assertThat(line.code).isNotBlank()
         assertThat(line.type).isNotBlank()
         assertThat(line.net).isNotNull()
+        assertThat(line.currency).isNotBlank()
 
         // ... and the mapper must accept them: proves the contract feeds a real F01.01 render,
         // not merely that some JSON parsed.
         val template = F0101Mapper.map(
-            response.lines.map { TrialBalanceLineDto(code = it.code, accountType = it.type, net = it.net) },
+            response.lines.map {
+                TrialBalanceLineDto(code = it.code, accountType = it.type, net = it.net, currency = it.currency)
+            },
             LocalDate.parse(REPORTING_DATE),
         )
         assertThat(template.cells.map { it.rowRef }).containsExactly("r010", "r380", "r490")
         assertThat(template.cells.first().value).isEqualByComparingTo(BigDecimal("150000.00"))
+        // The pact's single ASSET line does not tie out on its own, so the contract also proves the
+        // balance check runs over real contract data and can answer `false` (issue #5987) — it is
+        // not merely unit-testable against hand-built fixtures.
+        assertThat(template.isBalanced).isFalse()
     }
 
     /** Issues the request against the path the production client is annotated with. */

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/TemplateWireFormatTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/TemplateWireFormatTest.kt
@@ -62,12 +62,37 @@ class TemplateWireFormatTest {
 
     private val mapper = ObjectMapper()
 
-    /** One line per GL account type so every mapper row is populated with a non-zero value. */
+    /**
+     * One line per GL account type so every mapper row is populated with a non-zero value, in
+     * ledger's own `net = totalDebit - totalCredit` sign (credit-normal accounts negative), and
+     * tying out to zero so the rendered `isBalanced` is `true` for a reason rather than by
+     * construction (issue #5987).
+     */
     private val trialBalance = listOf(
-        TrialBalanceLineDto(code = "1100-CASH-CZK", accountType = "ASSET", net = BigDecimal("150000.00")),
-        TrialBalanceLineDto(code = "2100-DEPOSITS-CZK", accountType = "LIABILITY", net = BigDecimal("120000.00")),
-        TrialBalanceLineDto(code = "4100-FEE-INCOME-CZK", accountType = "INCOME", net = BigDecimal("8000.00")),
-        TrialBalanceLineDto(code = "5100-STAFF-COST-CZK", accountType = "EXPENSE", net = BigDecimal("3000.00")),
+        TrialBalanceLineDto(
+            code = "1100-CASH-CZK",
+            accountType = "ASSET",
+            net = BigDecimal("150000.00"),
+            currency = "CZK",
+        ),
+        TrialBalanceLineDto(
+            code = "2100-DEPOSITS-CZK",
+            accountType = "LIABILITY",
+            net = BigDecimal("-125000.00"),
+            currency = "CZK",
+        ),
+        TrialBalanceLineDto(
+            code = "4100-FEE-INCOME-CZK",
+            accountType = "INCOME",
+            net = BigDecimal("-28000.00"),
+            currency = "CZK",
+        ),
+        TrialBalanceLineDto(
+            code = "5100-STAFF-COST-CZK",
+            accountType = "EXPENSE",
+            net = BigDecimal("3000.00"),
+            currency = "CZK",
+        ),
     )
 
     @BeforeEach
@@ -103,12 +128,12 @@ class TemplateWireFormatTest {
         assertThat(cells.first().keys).containsExactlyInAnyOrder("rowRef", "colRef", "value", "currency")
         assertThat(cells.map { it["rowRef"] }).containsExactly("r010", "r380", "r490")
         assertThat(cells.first()["currency"]).isEqualTo("CZK")
-        // r010 total assets, r380 total liabilities, r490 derived equity — proves the cells are
+        // r010 total assets, r380 total liabilities, r490 total equity — proves the cells are
         // really derived from the ledger trial balance, not a fixed skeleton. `value` is a JSON
         // NUMBER (schema `type: number`), so compare numerically — an untyped parse of `150000.00`
         // yields a Double whose toString drops the scale.
         assertThat(cells.map { (it["value"] as Number).toDouble() })
-            .containsExactly(150_000.00, 120_000.00, 30_000.00)
+            .containsExactly(150_000.00, 125_000.00, 25_000.00)
     }
 
     @Test

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/rest/FinrepResourceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/rest/FinrepResourceTest.kt
@@ -44,6 +44,7 @@ class FinrepResourceTest {
             templateId = "F01.01",
             period = LocalDate.now(fixedClock),
             cells = listOf(FinrepCell(rowRef = "r010", colRef = "c010", value = BigDecimal.ZERO)),
+            isBalanced = true,
         )
         val captured = slot<GetFinrepTemplateQuery>()
         coEvery { finrepUseCase.getTemplate(capture(captured)) } returns expected
@@ -63,6 +64,7 @@ class FinrepResourceTest {
             templateId = "F02.00",
             period = explicitDate,
             cells = emptyList(),
+            isBalanced = true,
         )
         val captured = slot<GetFinrepTemplateQuery>()
         coEvery { finrepUseCase.getTemplate(capture(captured)) } returns expected

--- a/pacts/openbank-finrep-service-openbank-ledger-service.json
+++ b/pacts/openbank-finrep-service-openbank-ledger-service.json
@@ -23,6 +23,7 @@
           "lines": [
             {
               "code": "1100-CASH-CLEARING-CZK",
+              "currency": "CZK",
               "net": 150000.0,
               "type": "ASSET"
             }
@@ -52,6 +53,14 @@
               ]
             },
             "$.lines[*].code": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.lines[*].currency": {
               "combine": "AND",
               "matchers": [
                 {


### PR DESCRIPTION
## The independent quantity

`FinrepTemplate.isBalanced` was a hardcoded `true` in both producers plus a `true` default on the
model (#5987). The obvious repair — recompute `assets − liabilities − equity == 0` inside F01.01 —
is **vacuous**, because F01.01 derived equity AS `assets − liabilities`. Shipping that would have
been worse than the literal: a control that reports health because it structurally cannot report
anything else, wearing the shape of a check.

What is independent is the **trial balance itself**. `openbank-ledger-service` publishes every GL
line with `net = totalDebit − totalCredit` **uniformly across all five account types**
(`TrialBalanceLine.net`), so for a ledger whose journals balance:

```
Σ net over ALL lines == Σ totalDebit − Σ totalCredit == 0     (per currency)
```

Nothing any FINREP mapper computes implies that sum. F01.01 reads only ASSET/LIABILITY/EQUITY and
F02.00 only INCOME/EXPENSE, so a residual can be introduced from the half of the trial balance a
given template ignores and the check still sees it — that asymmetry is the whole mechanism, and
there is a test for exactly it (`a residual in the P&L half falsifies the BALANCE SHEET template`).

### The candidates that did not work, and why

| Candidate | Verdict |
|---|---|
| Reported equity from the trial balance | **Does not exist.** `V1__init_ledger.sql` and every later migration seed **zero** EQUITY accounts. `Σ net(EQUITY)` is genuinely 0 today. Kept in the formula so it starts contributing the day capital accounts are added, but it is not what makes the check falsifiable. |
| Cross-template F01.01 ↔ F02.00 agreement | Both render from the same trial balance in the same request, so agreement is guaranteed by construction — vacuous in the same family. |
| Echoing ledger's own `balanced` flag | Weaker, not stronger: it trusts the producer's assertion and cannot see transport, filtering or deserialisation loss. Worth having as a *second* source; filed as a follow-up rather than substituted for recomputation. |
| Parent-row vs sum-of-children | These simplified templates have no parent/child rows to compare. |
| Regulator-published EBA validation rules | Not encoded anywhere in this repo. |

## What changed

- **`TrialBalanceIdentity`** (new, domain) — residual `Σ net` **per currency**, all must be zero.
  Per currency because a global sum would let a CZK line cancel a lost EUR one; there is a test that
  is green under grouping and red under summing. `compareTo`, never `equals`, so `0.00` vs `0`
  scale differences do not fake an imbalance.
- **`F0101Mapper`** — equity is now **sourced** from EQUITY + INCOME + EXPENSE (contributed capital
  and reserves plus the unclosed period result), not defined as the residual. That is what turns the
  identity into a claim that can be false.
- **Sign correction, found along the way.** Credit-normal accounts arrive negative. The old mapper
  summed raw `net` into r380 — so against real ledger data it reported liabilities as a **negative
  number** — and then computed r490 as `assets − liabilities`, which for real data is
  `assets + |liabilities|`, not equity at all. The old tests only looked correct because their
  fixtures passed a positive liability, which no credit-balance GL line can carry. All rows are now
  reported as positive magnitudes; `openapi.yaml` says so.
- **`F0200Mapper`** — same sign correction, same identity. The issue's alternative (model the flag
  as not-applicable to P&L) was rejected: the flag would then have exactly one reachable value on
  that template, which is the defect rather than a fix for it. `net profit = income − expense` is a
  definition and is deliberately **not** what is reported.
- **`isBalanced` loses its `= true` default** so a new producer cannot silently omit it.
- **`currency` is carried** through `TrialBalanceLineDto` / `LedgerAdapter`, with **no default** — a
  defaulted `"CZK"` would let a response missing the field deserialize into a plausible line and
  merge every currency into one bucket, and the check would still pass for a reason nothing reports.
  Pinned in the consumer pact and replayed green against ledger's `@PactFolder` provider test.
- **`FinrepService`'s KDoc** said the value was "computed … and never looked at again". The second
  half stopped being true with #5904; the first half was never true. Corrected in place, saying so.
- **`openapi.yaml`** — `info.version` 1.0.0 → 1.0.1, `isBalanced` described by what it now measures,
  with a note that a `true` from an older deployment is not evidence anything was checked.

## Falsification (verify by effect)

A genuinely failing input exists and is asserted in seven tests — an uncounterparted asset, a
residual in the P&L half, a per-currency imbalance whose global sum is exactly zero, an equity
figure that disagrees with `assets − liabilities`, and the `balanced=false` metric tag.

**Negative control** — reverting only `F0101Mapper` to `isBalanced = true`:

```
F0101MapperTest > an asset booked with no counterpart is reported as UNBALANCED           FAILED
F0101MapperTest > a residual in the P&L half falsifies the BALANCE SHEET template         FAILED
F0101MapperTest > equity is sourced from EQUITY INCOME and EXPENSE, not from assets minus liabilities  FAILED
F0101MapperTest > a currency that does not tie out falsifies the template even when the totals cancel  FAILED
FinrepServiceTest > the balanced tag takes the value FALSE for a trial balance that does not tie out   FAILED
16 tests completed, 5 failed
```

The old code cannot pass this suite. That is the difference from the state #5987 describes.

One deliberate non-failure: an **empty** trial balance is `isBalanced = true`. That is an
under-reporting condition with its own detector (`openbank.finrep.trial_balance.lines`); collapsing
it onto this flag would put two different defects on one boolean — the `PushResult.skipped()` shape.

## Interaction with #5988

Read and not contradicted. Its `unbalanced` branch in `evaluateExportReadiness` is **now live**: the
producer can emit `isBalanced === false`, so the branch its module header correctly refused to count
as coverage has become falsifiable against real data. No admin-ui file is touched here, and the
`⚠ KNOWN GAP` block in `exportReadiness.ts` should be retired when #5988 lands — noted on that PR.

The `balanced` metric tag now has two reachable values, so `openbank.finrep.templates.rendered`
becomes alertable for the first time (issue #5987 acceptance item 5).

## Verification

- `ktlintCheck` + `detekt` — BUILD SUCCESSFUL, `--rerun-tasks`, no `UP-TO-DATE`.
- `test --rerun-tasks` — **47 tests, 0 failures, 0 errors, 0 skipped** (counts read from the JUnit
  XML, not the console).
- `:openbank-ledger-service:test --tests "*LedgerPactProviderVerificationTest*"` — green against the
  regenerated pact.
- `openbank-infra/scripts/check-threat-model-diff.py --base origin/main --enforce` — exit 0;
  `openbank-finrep-service` is not in `rules.yaml: money_path_services`, so the gate does not fire.
- `version.txt` untouched — release-please owns it.

Closes #5987
Refs #5904, #5988
