### PR TITLE
fix(product-catalog): return canonical product IDs

### DIFF
--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/persistence/PostgresProductRepository.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/persistence/PostgresProductRepository.kt
@@ -109,5 +109,12 @@ class PostgresProductRepository(
         doc = mapper.writeValueAsString(p)
     }
 
-    private fun ProductEntity.toDomain(): Product = mapper.readValue(doc, Product::class.java).copy(revision = revision)
+    // `doc` retains the pre-ADR-0105 seed alias (for example `prod-003`) so a database
+    // upgrade does not need to rewrite JSONB. The relational primary key is the canonical
+    // product identity, however, and it is the only id the v1 API may expose: downstream
+    // account records hold that UUID and must be able to round-trip it through this resource.
+    private fun ProductEntity.toDomain(): Product = mapper.readValue(doc, Product::class.java).copy(
+        id = id.toString(),
+        revision = revision,
+    )
 }

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/ProductCatalogResourceTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/ProductCatalogResourceTest.kt
@@ -353,17 +353,21 @@ class ProductCatalogResourceTest {
     }
 
     @Test
-    fun `GET product by canonical account UUID resolves the seeded product (ADR-0105)`() {
+    fun `GET product by canonical account UUID resolves and returns the canonical identity (ADR-0105)`() {
         // account-service references the CZK current/savings products by the UUID it stamps on
         // accounts.product_id; the catalogue must resolve those UUIDs to the same products.
         val current = (
-            Given { this } When { get("/api/v1/products/00000000-0000-0000-0000-0000000000c2") } Then
-                { statusCode(200) }
+            Given { this } When { get("/api/v1/products/00000000-0000-0000-0000-0000000000c2") } Then {
+                statusCode(200)
+                body("id", equalTo("00000000-0000-0000-0000-0000000000c2"))
+            }
             ).extract().body().asString()
         assertThat(current).contains("CURRENT_CZK")
         val savings = (
-            Given { this } When { get("/api/v1/products/00000000-0000-0000-0000-0000000000c3") } Then
-                { statusCode(200) }
+            Given { this } When { get("/api/v1/products/00000000-0000-0000-0000-0000000000c3") } Then {
+                statusCode(200)
+                body("id", equalTo("00000000-0000-0000-0000-0000000000c3"))
+            }
             ).extract().body().asString()
         assertThat(savings).contains("SAVINGS_CZK")
     }

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/contract/ProductCatalogPactBrokerProviderVerificationTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/contract/ProductCatalogPactBrokerProviderVerificationTest.kt
@@ -96,6 +96,25 @@ class ProductCatalogPactBrokerProviderVerificationTest {
         // Intentionally empty — see the KDoc above.
     }
 
+    /**
+     * No seeding: `CURRENT_PERSONAL` carries four seeded fees in `ProductSeed` on every boot.
+     * Keep this broker replay state in lock-step with the always-on `@PactFolder` verifier so a
+     * newly published billing pact cannot pass on a PR and then strand at `can-i-deploy`.
+     */
+    @State("a product with fees exists for code CURRENT_PERSONAL")
+    fun feeBearingProductIsSeeded() {
+        // Intentionally empty — see the KDoc above.
+    }
+
+    /**
+     * The pact-pinned UUID is deliberately absent from `ProductSeed`; the seeded catalogue
+     * already satisfies the account consumer's negative lookup state.
+     */
+    @State("no product exists with id 00000000-0000-0000-0000-000000000fff")
+    fun unknownProductIdIsAbsent() {
+        // Intentionally empty — see the KDoc above.
+    }
+
     @State("trusted insurance term-life schema version 1 is installed")
     fun trustedInsuranceSchemaIsInstalled() {
         // CatalogPackSeeder installs the trusted test pack before provider verification.

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/contract/ProductCatalogPactStateParityTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/contract/ProductCatalogPactStateParityTest.kt
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.productcatalog.contract
+
+import au.com.dius.pact.provider.junitsupport.State
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * The PR-time folder replay and main-push broker replay exercise the same provider pacts. Their
+ * state handlers therefore form one contract surface: missing a state in the broker verifier lets
+ * a PR pass and only blocks deployment later at `can-i-deploy`.
+ */
+class ProductCatalogPactStateParityTest {
+    @Test
+    fun `broker and folder provider verifiers declare identical Pact states`() {
+        assertThat(statesOf(ProductCatalogPactBrokerProviderVerificationTest::class.java))
+            .containsExactlyInAnyOrderElementsOf(statesOf(ProductCatalogPactProviderVerificationTest::class.java))
+    }
+
+    private fun statesOf(type: Class<*>): Set<String> = type.declaredMethods
+        .flatMap { method -> method.getAnnotation(State::class.java)?.value?.asList().orEmpty() }
+        .toSet()
+}


### PR DESCRIPTION
Closes #6012

Restores the ADR-0105 UUID round-trip at the v1 read boundary: persistence keeps legacy JSONB aliases internally, while API responses return the relational canonical UUID. The real-HTTP regression proves the returned identity equals the requested account UUID.

This directly addresses the failed account-service → product-catalog Pact deployment gate; no contract gate is weakened.