### PR TITLE
fix(sanctions): publish PEP_GLOBAL, the seeded list the spec omitted

### DIFF
--- a/.github/scripts/check-openapi-enum-vs-domain.py
+++ b/.github/scripts/check-openapi-enum-vs-domain.py
@@ -119,8 +119,6 @@ BASELINE: dict[str, str] = {
     "openbank-pid-service:EXPIRED,PENDING,REJECTED,VERIFIED":
         "#5962 — UpdateKycRequest.kycStatus: the property does not exist; needs a schema fix, "
         "not an enum fix. The `Status` pairing is coincidental.",
-    "openbank-sanctions-service:CNB_DOMESTIC,EU_CONSOLIDATED,FATF_HIGH_RISK,HM_TREASURY,OFAC_SDN,UN_CONSOLIDATED":
-        "#5962 — SanctionsListType: undeclared PEP_GLOBAL",
     "openbank-sepa-payment:COMPLETED,PROCESSING,RECALLED,REJECTED":
         "#5962 — SepaPaymentStatus: spec-only RECALLED; undeclared CANCELLED/RECEIVED/RETURNED/VALIDATED",
     "openbank-sepa-payment:COMPLETED,PENDING,PROCESSING,RECALLED,REJECTED":

--- a/openbank-sanctions-service/src/main/resources/openapi.yaml
+++ b/openbank-sanctions-service/src/main/resources/openapi.yaml
@@ -6,7 +6,7 @@ info:
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.1 -> 1.2): additive
   # only — GET /approvals (the checker's queue, issue #3472) plus two additive fields on
   # ApprovalResponse (makerId, createdAt). No breaking change.
-  version: 1.2.0
+  version: 1.3.0
   description: >-
     Real-time sanctions screening against EU, UN, OFAC, HM Treasury and CNB lists. PATCH
     /approvals/{id} decides a four-eyes approval paused by the platform's ADR-0155 maker-checker
@@ -420,7 +420,7 @@ components:
           type: array
           items:
             type: string
-            enum: [OFAC_SDN, EU_CONSOLIDATED, UN_CONSOLIDATED, HM_TREASURY, FATF_HIGH_RISK, CNB_DOMESTIC]
+            enum: [OFAC_SDN, EU_CONSOLIDATED, UN_CONSOLIDATED, HM_TREASURY, FATF_HIGH_RISK, PEP_GLOBAL, CNB_DOMESTIC]
         reviewedBy:
           type: string
           nullable: true
@@ -440,7 +440,7 @@ components:
       properties:
         listType:
           type: string
-          enum: [OFAC_SDN, EU_CONSOLIDATED, UN_CONSOLIDATED, HM_TREASURY, FATF_HIGH_RISK, CNB_DOMESTIC]
+          enum: [OFAC_SDN, EU_CONSOLIDATED, UN_CONSOLIDATED, HM_TREASURY, FATF_HIGH_RISK, PEP_GLOBAL, CNB_DOMESTIC]
         matchType:
           type: string
           enum: [EXACT, FUZZY, PHONETIC, ALIAS]


### PR DESCRIPTION
Refs #5962, ADR-0048.

Stacked on #5966 (the gate and its `BASELINE`) and on the service PRs already open against
#5962 — all merged in, so their diffs drop out as they land. **This PR's own work is two enum
lines and one version line in `openbank-sanctions-service/src/main/resources/openapi.yaml`, plus
one `BASELINE` entry.**

**Money-path service — 2 approvals required.**

## What was wrong

The omission shape, and an unusually clear one: the value is not merely reachable, it is
**seeded data shipped in the repo**.

| spec said | code says | effect |
|---|---|---|
| `SanctionsCheckResponse.checkedLists` and `SanctionsMatch.listType` both `[OFAC_SDN, EU_CONSOLIDATED, UN_CONSOLIDATED, HM_TREASURY, FATF_HIGH_RISK, CNB_DOMESTIC]` | `SanctionsListType { OFAC_SDN, EU_CONSOLIDATED, UN_CONSOLIDATED, HM_TREASURY, FATF_HIGH_RISK, PEP_GLOBAL, CNB_DOMESTIC }` | `PEP_GLOBAL` is returned by the server on both fields and declared by neither. A strict generated deserializer fails on any PEP hit |

Nothing 400s here — the defect is that a whole sanctions list is invisible to every consumer of
the contract, on both the "which lists did you screen against" field and the per-match field.

## Which side is right — the domain, and the migrations settle it without a judgement call

`PEP_GLOBAL` is not a name someone might have renamed; it is **populated data**:

1. **It is a seeded row in the list registry.** `V3__create_sanctions_lists.sql:23`:
   ```sql
   ('PEP_GLOBAL', 'PEP Global List',
    'https://data.opensanctions.org/datasets/latest/peps/targets.simple.csv', 6,45,'MON,TUE,WED,THU,FRI'),
   ```
   `sanctions_lists.list_type` is `UNIQUE`, and this row carries its own ingestion schedule — the
   list is screened on a weekday cron, not hypothetically supported.
2. **It is the `list_type` of dozens of seeded entries.** `V6__seed_sanctions_entries.sql` inserts
   `PEP_GLOBAL` rows for real PEPs. Any check matching one of them returns the value the document
   does not declare.

`git log -S "PEP_GLOBAL"` scoped to `openbank-sanctions-service` finds it in the Kotlin enum and
in the migrations, and never as a renamed spelling of anything else — this is an omission, not a
rename.

## Classification

Purely additive to two response enums, so this is not the `correction` case the sibling PRs
needed — the real gate says so:

```
api-contract gate: openbank-sanctions-service: additive change, info.version 1.2.0 -> 1.3.0 — OK (required >= MINOR).
```

`info.version` read off freshly fetched `origin/main` immediately before the bump (`1.2.0`).

## Verification

- `check-openapi-enum-vs-domain.py --enforce` — green, baseline 19 -> 18, no stale entry.
- `ktlintCheck`, `detekt`, `test` all **executed** (none `UP-TO-DATE`): 93 tests, 0 failures,
  **1 skipped** — `SanctionsPactBrokerProviderVerificationTest`, the expected broker-gated class;
  its `@PactFolder` sibling `SanctionsPactProviderVerificationTest` ran.
- `check-threat-model-diff.py --enforce` — rc=0 (spec-only, no trust boundary moved).
