### PR TITLE
fix(swift): publish COMPLETED, the terminal status the pact already asserts

### DIFF
--- a/.github/scripts/check-openapi-enum-vs-domain.py
+++ b/.github/scripts/check-openapi-enum-vs-domain.py
@@ -111,8 +111,6 @@ BASELINE: dict[str, str] = {
         "#5962 — SepaPaymentStatus: spec-only PENDING/RECALLED; undeclared CANCELLED/RECEIVED/RETURNED/VALIDATED",
     "openbank-statement-service:RECONCILIATION,UNKNOWN,UPSTREAM":
         "#5962 — CloseFailureReason: undeclared NOT_VIABLE",
-    "openbank-swift-service:ACKNOWLEDGED,FAILED,PENDING,REJECTED,SENT,VALIDATED":
-        "#5962 — SwiftStatus: undeclared COMPLETED",
 }
 
 SPEC_ENUM_INLINE = re.compile(r"enum:\s*\[([^\]]*)\]")

--- a/openbank-swift-service/src/main/resources/openapi.yaml
+++ b/openbank-swift-service/src/main/resources/openapi.yaml
@@ -9,7 +9,7 @@ info:
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.2 -> 1.3): additive
   # only — GET /swift/approvals (the checker's queue, issue #5679) plus two additive fields on
   # ApprovalResponse (makerId, createdAt). No breaking change.
-  version: "1.3.0"
+  version: "1.4.0"
   description: |
     SWIFT MT/MX message dispatch, acknowledgement, and status tracking.
     Supports MT103 (customer credit transfer), MT202 (bank transfer), MT900/910/940/950 (confirmations/statements).
@@ -505,7 +505,7 @@ components:
 
     SwiftStatus:
       type: string
-      enum: [PENDING, VALIDATED, SENT, ACKNOWLEDGED, REJECTED, FAILED]
+      enum: [PENDING, VALIDATED, SENT, ACKNOWLEDGED, REJECTED, FAILED, COMPLETED]
       description: |
         - PENDING: Received, awaiting validation
         - VALIDATED: Passed BIC/format checks, queued for dispatch
@@ -513,6 +513,8 @@ components:
         - ACKNOWLEDGED: ACK received from receiving bank
         - REJECTED: Rejected by receiving bank
         - FAILED: Internal processing failure
+        - COMPLETED: Settled end-to-end; the terminal success state the
+          `swift.message.status-changed` event carries (see the committed pact)
 
     SwiftPriority:
       type: string


### PR DESCRIPTION
Refs #5962, ADR-0048.

Stacked on #5966 (the gate and its `BASELINE`) and on the service PRs already open against
#5962 — all merged in, so their diffs drop out as they land. **This PR's own work is one enum
line, two description lines and one version line in
`openbank-swift-service/src/main/resources/openapi.yaml`, plus one `BASELINE` entry.**

**Money-path service — 2 approvals required.**

## What was wrong

| spec said | code says | effect |
|---|---|---|
| `SwiftStatus` `[PENDING, VALIDATED, SENT, ACKNOWLEDGED, REJECTED, FAILED]` | `SwiftStatus { PENDING, VALIDATED, SENT, ACKNOWLEDGED, REJECTED, FAILED, COMPLETED }` | `COMPLETED` — the terminal success state — is emitted by the server and declared by nothing. A strict generated deserializer fails on exactly the outcome every successful payment reaches |

The published `description:` block enumerated all six declared values with a gloss each, so the
omission was not a truncated list someone would notice: the document read as complete.

## Which side is right — the domain, and here a green provider replay proves it

This is the strongest witness class available, and unlike the sibling PRs it did not need the
database (swift's `status` column is free `VARCHAR(20)` with no CHECK):

**A committed pact asserts the omitted value, and the provider replays it on every PR.**
`pacts/openbank-transaction-service-openbank-swift-service.json` carries a message interaction
described literally as *"a swift.message.status-changed event with status COMPLETED"*, with
contents `"status": "COMPLETED"` and a matching rule pinning the field to

```
"regex": "VALIDATED|SENT|COMPLETED|REJECTED"
```

so the consumer's contract names `COMPLETED` as a value it must handle. That pact is replayed
against the real provider by `SwiftPactFolderProviderVerificationTest` — `@PactFolder`, ungated,
runs on every PR (it exists precisely because the broker-sourced class never did; see #2319).

**I measured the replay rather than reading the annotation:** in this branch's run that class
reported `tests="1" skipped="0" failures="0" errors="0"`. A green replay of a pact that asserts
`COMPLETED` is direct evidence the server emits it.

This is also the same value the #2319 drift was about — the issue calls it out by name. The pact
side was fixed then; the published spec was not.

## Classification

Purely additive — one value added to a response enum, no removal:

```
api-contract gate: openbank-swift-service: additive change, info.version 1.3.0 -> 1.4.0 — OK (required >= MINOR).
```

No `correction` reclassification needed. `info.version` read off freshly fetched `origin/main`
immediately before the bump (`"1.3.0"`, quoted in this spec — the quoting is preserved).

## Verification

- `check-openapi-enum-vs-domain.py --enforce` — green, baseline 19 -> 18, no stale entry.
- `ktlintCheck`, `detekt`, `test` all **executed** (none `UP-TO-DATE`): 62 tests, 0 failures,
  **1 skipped** — `SwiftMessagePactProviderVerificationTest`, the expected `@PactBroker`-gated
  class; its `@PactFolder` sibling ran green as quoted above.
- `check-threat-model-diff.py --enforce` — rc=0 (spec-only, no trust boundary moved).
