### PR TITLE
fix(card-issuance): reconcile IssueCardRequest with the DTO it describes

### DIFF
--- a/.github/scripts/check-openapi-enum-vs-domain.py
+++ b/.github/scripts/check-openapi-enum-vs-domain.py
@@ -70,8 +70,6 @@ BASELINE: dict[str, str] = {
         "#5962 — Channel: undeclared EMAIL",
     "openbank-campaign-service:DRY_RUN,SENT,SUPPRESSED_CAP,SUPPRESSED_CONSENT,SUPPRESSED_QUIET_HOURS":
         "#5962 — SendOutcome: undeclared CONVERTED/FAILED/SKIPPED_CONDITION/SUPPRESSED_LIST",
-    "openbank-card-issuance-service:MASTERCARD,VISA":
-        "#5962 — CardNetwork: undeclared AMEX/UNIONPAY",
     "openbank-consent-service:ACTIVE,EXPIRED,PENDING,REJECTED,REVOKED":
         "#5962 — ConsentStatus: spec-only PENDING; undeclared PENDING_SCA/SUPERSEDED",
     "openbank-copilot-service:CARD_FREEZE,DISPUTE,PAYMENT":

--- a/openbank-card-issuance-service/src/main/resources/openapi.yaml
+++ b/openbank-card-issuance-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Card Issuance Service API
-  version: 1.7.0
+  version: 1.8.0
   description: Debit/credit card lifecycle — issue, activate, block, suspend, resume, cancel;
     synthetic PAN vault, product-catalog entitlements, and additional-cardholder cards issued
     under a delegation grant (ADR-0249 D1/D2).
@@ -586,7 +586,8 @@ components:
 
     IssueCardRequest:
       type: object
-      required: [partyId, accountId, cardType, cardNetwork]
+      required: [partyId, accountId, productCode, cardType, network, cardholderName,
+                 embossedName, currency]
       properties:
         partyId:
           type: string
@@ -594,16 +595,32 @@ components:
         accountId:
           type: string
           format: uuid
+        productCode:
+          type: string
         cardType:
           type: string
           enum: [DEBIT, CREDIT, PREPAID, VIRTUAL, SINGLE_USE]
-        cardNetwork:
+        network:
           type: string
-          enum: [VISA, MASTERCARD]
+          enum: [VISA, MASTERCARD, AMEX, UNIONPAY]
+        cardholderName:
+          type: string
         embossedName:
           type: string
+        currency:
+          type: string
+          description: ISO 4217 alphabetic code.
+        dailyLimitMinorUnits:
+          type: integer
+          format: int64
+          default: 500000
+        monthlyLimitMinorUnits:
+          type: integer
+          format: int64
+          default: 5000000
         deliveryAddress:
-          type: object
+          type: string
+          nullable: true
         delegationGrantId:
           type: string
           format: uuid


### PR DESCRIPTION
Refs #5962, ADR-0048.

Stacked on #5966 (the gate and its `BASELINE`) and on the service PRs already open against
#5962 — all merged in, so their diffs drop out as they land. **This PR's own work is one schema
block and one version line in `openbank-card-issuance-service/src/main/resources/openapi.yaml`,
plus one `BASELINE` entry.**

Not a money-path service (`rules.yaml: money_path_services`) — 1 approval.

## The baselined enum was a symptom; the schema around it was the defect

The baseline entry says *"CardNetwork: undeclared AMEX/UNIONPAY"*. Comparing `IssueCardRequest`'s
**properties** against the Kotlin DTO — the method finding from the previous tranche — shows the
enum is the least of it: **a body generated from the published document cannot deserialise**, so
`POST /api/v1/cards` has never been callable from a generated client.

| spec declared | Kotlin `IssueCardRequest` |
|---|---|
| `required: [partyId, accountId, cardType, cardNetwork]`; properties `partyId, accountId, cardType, cardNetwork, embossedName, deliveryAddress, delegationGrantId` | `partyId, accountId, productCode, cardType, network, cardholderName, embossedName, currency, dailyLimitMinorUnits = 500_000, monthlyLimitMinorUnits = 5_000_000, deliveryAddress: String? = null, delegationGrantId: UUID? = null` |

Four independent falsehoods in one schema:

1. **The network property has the wrong name.** The spec calls it `cardNetwork`; the DTO field is
   `network`, non-nullable with no default. Jackson binds nothing, and construction fails — so the
   enum drift is secondary to the property never arriving at all.
2. **Three non-nullable, defaultless fields were undeclared**: `productCode`, `cardholderName`,
   `currency`. Each alone is enough to fail deserialisation.
3. **`deliveryAddress` had the wrong type** — declared `type: object`, the field is `String?`.
4. **The enum**: `[VISA, MASTERCARD]` against `CardNetwork { VISA, MASTERCARD, AMEX, UNIONPAY }`,
   so no generated client could request an Amex or UnionPay card.

`dailyLimitMinorUnits` / `monthlyLimitMinorUnits` were also unpublished; they are now declared with
their Kotlin defaults so a caller can see both that they are optional and what they default to.

## Which side is right — the document contradicts itself, which settles it

No external witness was needed: **this spec already publishes the full vocabulary twice**, and
only the request site disagrees.

- `CardResponse.network` — `enum: [VISA, MASTERCARD, AMEX, UNIONPAY]`
- `CardEntitlementsResponse.networks[]` — `enum: [VISA, MASTERCARD, AMEX, UNIONPAY]`
- `IssueCardRequest.cardNetwork` — `enum: [VISA, MASTERCARD]`

So as published, an Amex card can be **returned** and listed as **entitled**, but not
**requested**. A document that names the same vocabulary in three places and abbreviates it in one
is a hand-edit that was never re-checked, not a deliberate restriction — and the DTOs confirm it:
all three sites are the same `CardNetwork` type (`CardDtos.kt` lines 18, 43, 95, 111).

The property renames are equally settled by the DTO, which is the thing the endpoint actually
deserialises into.

## Classification

Spec-only PR, so the removals reclassify — confirmed with the real gate:

```
::notice::api-contract gate: openbank-card-issuance-service: spec-only PR — reclassifying 6 breaking
document change(s) (first: added the new required request property `cardholderName`) as a CORRECTION.
api-contract gate: openbank-card-issuance-service: correction change, info.version 1.7.0 -> 1.8.0 — OK (required >= MINOR).
```

MINOR, so no URL major moves (ADR-0048 D2). `info.version` read off freshly fetched `origin/main`
immediately before the bump (`1.7.0`).

## Verification

- `check-openapi-enum-vs-domain.py --enforce` — green, baseline 19 -> 18, no stale entry.
  (`SUBJECTS` falls 148 -> 147: the `{VISA, MASTERCARD}` value-set stops existing as a distinct
  pairing once it becomes the four-value set the other two sites already used.)
- YAML parses.
- `ktlintCheck` and `detekt` both **executed** and passed. `test`: 189 tests, 0 failures,
  **1 skipped** — `CardIssuancePactBrokerProviderVerificationTest`, the expected broker-gated
  class; the `@PactFolder` sibling ran green (`tests="1" failures="0"`).
  The first `test` run failed one case with `QuarkusBindException` — the documented
  port-contention flake, not a real failure; a serialized re-run was `BUILD SUCCESSFUL`.
- `check-threat-model-diff.py --enforce` — rc=0 (spec-only, no trust boundary moved).

## What this does not do

No Kotlin changed. The server behaves exactly as before; the published document now describes it.
