### PR TITLE
docs: fix the ADR-0073 citations no ADR-0073 grep can find (#5785)

### DIFF
--- a/openbank-admin-ui/src/components/docs/BpmnView.tsx
+++ b/openbank-admin-ui/src/components/docs/BpmnView.tsx
@@ -16,7 +16,7 @@
 // the coverage table; an `event` node is a message catch/throw point. This is
 // what the old hardcoded page could not express (it had a single dashed edge and
 // no event nodes), so the heavily event-driven reality (outbox + Kafka,
-// ADR-0050/0073) was invisible.
+// ADR-0003/0050) was invisible.
 // ---------------------------------------------------------------------------
 
 import { useState } from 'react'

--- a/openbank-admin-ui/src/lib/docs/bpmn/schema.ts
+++ b/openbank-admin-ui/src/lib/docs/bpmn/schema.ts
@@ -17,7 +17,7 @@
 //
 // Async is a first-class concept here (the whole reason this replaced the
 // hardcoded page): the real fleet is heavily event-driven (transactional outbox
-// + Kafka, ADR-0050/0073). A flow with `kind: async` is an event/outbox edge
+// + Kafka, ADR-0003/0050). A flow with `kind: async` is an event/outbox edge
 // (dashed, carries an optional Kafka `topic`); a step may `emits`/`consumes`
 // domain-event topics; a node of type `event` is a message catch/throw point.
 // ---------------------------------------------------------------------------

--- a/openbank-party-service/CLAUDE.md
+++ b/openbank-party-service/CLAUDE.md
@@ -44,3 +44,21 @@ Three things to keep true when touching this:
   life of the service. `PartyOutboxWriteIT` drives the REST endpoints (a `Panache.withTransaction`
   repo called from a bare `@QuarkusTest` thread throws "No current Vertx context found" — only an
   HTTP request carries a context) and asserts the row with a plain JDBC read.
+
+## `V8__party_aml_status.sql` cites the wrong ADR, permanently (#5785)
+
+The header comment of `src/main/resources/db/migration/V8__party_aml_status.sql` reads
+
+```
+-- AML screening outcome — second key of the KYC+AML activation gate (ADR-0073).
+```
+
+**ADR-0073 is "Hardware-backed credential storage for the customer app"** — mobile
+Keystore/Keychain secrets, nothing to do with the activation gate. The decision that actually
+covers `parties.aml_status` as the second key of the two-key activation gate is
+**ADR-0267 — Event-driven onboarding account lifecycle** (§2).
+
+The citation cannot be corrected. Flyway checksums the **whole migration file, comments
+included**, so editing an applied migration fails startup with `checksum mismatch`. This note is
+the correction; do not "fix" the SQL. If you are reading `V8` for the AML status column, read
+ADR-0267, not ADR-0073.


### PR DESCRIPTION
Closes #5785 (the remainder — see "What this PR does NOT cover" below).

## How the subjects were enumerated (a second, different probe)

The issue's `~26` came from a `ADR-0073` grep. I re-enumerated two ways:

1. `git grep -E 'ADR[-_ ]?0073|adr/0073|0073-customer-app' origin/main -- . ':!docs/adr'`
   → **29 citations in 26 files**.
2. A deliberately looser probe — bare `0073` anywhere on `origin/main` — which finds what
   probe 1 structurally cannot: the **slash-compound form** `ADR-00XX/0073`.
   → **10 further citations in 9 files** that no `ADR-0073` grep will ever return.

So the real corpus is **39 citations / 35 files**, not ~26. The 10 extra are the whole reason
this PR exists at all: five sibling PRs already cover the trees the issue lists.

## Classification of all 39

| class | n | disposition |
|---|---|---|
| Correct as-is — genuine credential storage (`ADR-0021/0073` SCA + device-bound credentials; `app-status.json`; `agents.yaml` `related_adrs`) | 10 | left untouched |
| Stale, already fixed or in an open sibling PR (infra #5836, aml #5829, balance #5826, kyc #5827, onboarding #5830, account #5784) | 20 | not touched here — someone else's live branch |
| Immutable derived data (5 × `CHANGELOG.md`, release-please generated) | 5 | cannot change |
| Immutable by Flyway checksum (`V8__party_aml_status.sql`) | 1 | **note added instead** |
| Stale and covered by nothing — this PR | 2 | **fixed** |
| Inside `docs/adr/` (cross-references, correct) | excluded from scope | — |

## What this PR changes

**1. `docs(admin-ui)` — 2 sites.** `BpmnView.tsx` and `bpmn/schema.ts` both cited
`"outbox + Kafka, ADR-0050/0073"`. ADR-0050 is right (regulatory-grade outbox dispatch);
ADR-0073 is *"Hardware-backed credential storage for the customer app"* and decides nothing
about event-driven flows. Repointed to **`ADR-0003/0050`** (transactional outbox for Kafka +
its dispatch ADR). These are the slash-form sites probe 1 could not see.

**2. `docs(party)` — the one site that can never be edited.**
`V8__party_aml_status.sql` carries the wrong citation in its header comment, and Flyway
checksums comments, so an applied migration must not be touched. The correction now lives in
`openbank-party-service/CLAUDE.md`, which is path-loaded when anyone works in that tree.

## Two findings worth acting on separately

- **The issue names ADR-0266 as the replacement. On `main` that is wrong.** ADR-0266 is
  *"MGM Fixed-Reward Growth Incentives"*; the onboarding lifecycle ADR landed as
  **ADR-0267** after a number collision. Anything citing 0266 for onboarding is wrong again.
- **PR #5836 (`docs/infra-adr-citation-fix`) is stale against that renumber** — it cites
  `ADR-0266` 22 times and re-adds a duplicate `docs/adr/0266-event-driven-onboarding-account-lifecycle.md`.
  #5829/#5830/#5826 each carry 2 leftover `ADR-0266` lines. Flagged on those PRs; their
  branches are live parallel work and are not touched here.

## Verification

`PR_DIFF_BASE=origin/main python3 .github/scripts/run-gates.py --all` → **155/158 PASS**.
The 3 non-passes are environmental and reproduce independently of this diff:
`api-contract-gate` needs `sudo` to install `oasdiff` locally, `loki-rule-load-test`'s
self-test dies on an unbound `BASE_REF`, and one advisory WARN. No ADR file is touched, so
the derived registry (`README.md`/`DIGEST.md`/`index.json`) is untouched by design.

Commit type is `docs` on purpose: no release for either component.
