### PR TITLE
fix(product-catalog): return the canonical product id from v1 reads

### DIFF
--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/persistence/PostgresProductRepository.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/persistence/PostgresProductRepository.kt
@@ -109,5 +109,18 @@ class PostgresProductRepository(
         doc = mapper.writeValueAsString(p)
     }
 
-    private fun ProductEntity.toDomain(): Product = mapper.readValue(doc, Product::class.java).copy(revision = revision)
+    /**
+     * Reads the persisted document back into the domain, with the RELATIONAL columns winning over the
+     * JSONB body for the two fields the database owns: `id` and `row_version`.
+     *
+     * `products.id` is the canonical UUID account-service stores in `accounts.product_id` (V1
+     * migration, ADR-0105); the `doc` body merely retains whatever identifier its writer serialised —
+     * for a row authored before the canonical id existed, or restored/edited out of band, that is the
+     * `prod-NNN` legacy alias. Trusting the body there would serialise the alias out of every `/api/v1`
+     * read while the row is addressed by its UUID, so the id would not round-trip. The v2 -> v1
+     * projection already refuses a revision whose `legacyDocument` renames the canonical product
+     * (`BankV1CompatibilityProjector.validatedProjection`); this is the same invariant on the read side.
+     */
+    private fun ProductEntity.toDomain(): Product = mapper.readValue(doc, Product::class.java)
+        .copy(id = id.toString(), revision = revision)
 }

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/ProductCatalogResourceTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/ProductCatalogResourceTest.kt
@@ -237,6 +237,56 @@ class ProductCatalogResourceTest {
         }
     }
 
+    /**
+     * A row whose JSONB `doc` retained the `prod-NNN` legacy alias as its `id` (a document authored
+     * before the canonical UUID existed, or restored out of band) must still answer `/api/v1` reads
+     * with the canonical UUID from `products.id` — account-service stores that UUID in
+     * `accounts.product_id` and needs it to round-trip. Same shape as the raw-insert fixture in
+     * `legacy invalid draft cannot bypass validation through activation` above.
+     */
+    @Test
+    fun `v1 reads return the canonical id even when the stored document retains the legacy alias`() {
+        val canonicalId = "00000000-0000-0000-0000-000000006012"
+        val legacyAlias = "prod-901"
+        val document =
+            """{"id":"$legacyAlias","code":"P0_LEGACY_ALIAS","name":"Legacy alias","type":"SAVINGS",""" +
+                """"currency":"EUR","status":"ACTIVE",""" +
+                """"fees":[{"id":"fee-901","name":"Maintenance","type":"MONTHLY","amount":1.0,""" +
+                """"currency":"EUR","frequency":"MONTHLY"}]}"""
+        dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                """INSERT INTO products (id, code, legacy_code, type, status, currency, doc) """ +
+                    """VALUES (CAST(? AS uuid), ?, ?, 'SAVINGS', 'ACTIVE', 'EUR', to_jsonb(CAST(? AS text)))""",
+            ).use { statement ->
+                statement.setString(1, canonicalId)
+                statement.setString(2, "P0_LEGACY_ALIAS")
+                statement.setString(3, legacyAlias)
+                statement.setString(4, document)
+                assertThat(statement.executeUpdate()).isEqualTo(1)
+            }
+        }
+
+        // Addressed by the canonical UUID.
+        Given { this } When { get("/api/v1/products/$canonicalId") } Then {
+            statusCode(200)
+            body("id", equalTo(canonicalId))
+        }
+        // Addressed by the legacy alias — same canonical id in the body.
+        Given { this } When { get("/api/v1/products/$legacyAlias") } Then {
+            statusCode(200)
+            body("id", equalTo(canonicalId))
+        }
+        // The collection read and the derived fee schedule carry the same identity.
+        Given { this } When { get("/api/v1/products") } Then {
+            statusCode(200)
+            body("find { it.code == 'P0_LEGACY_ALIAS' }.id", equalTo(canonicalId))
+        }
+        Given { this } When { get("/api/v1/fees") } Then {
+            statusCode(200)
+            body("find { it.productCode == 'P0_LEGACY_ALIAS' }.productId", equalTo(canonicalId))
+        }
+    }
+
     @Test
     fun `generic update cannot bypass status or active product immutability guards`() {
         val current = (


### PR DESCRIPTION
Closes #6012

## The defect

`PostgresProductRepository.toDomain()` rebuilt the domain `Product` from the JSONB `doc` alone, taking only `row_version` from the relational columns:

```kotlin
private fun ProductEntity.toDomain(): Product =
    mapper.readValue(doc, Product::class.java).copy(revision = revision)
```

`products.id` is the canonical UUID account-service stores in `accounts.product_id` — the V1 migration says so in as many words ("`id` is the durable canonical UUID account-service references; ... `legacy_code` is the prod-NNN alias"). The document body, by contrast, merely retains whatever identifier its writer serialised. For a row authored before the canonical id existed, or restored/edited out of band, that is the `prod-NNN` legacy alias — and every `/api/v1` read then serialised the alias while the row was addressed by its UUID, so the id did not round-trip.

The fix makes the relational column win at the read boundary. It is the read-side twin of `BankV1CompatibilityProjector.validatedProjection`, which already refuses a v2 revision whose `legacyDocument` renames the canonical product ("mapped banking revision changed the canonical product id") — the same invariant existed on the write path and not on the read path.

## Scope, stated honestly

No writer on `main` can currently produce the divergence: the seeder writes `p.copy(id = canonical.toString())`, `applyFrom` derives both column and doc from the same `Product`, and `newEntity` would throw on a non-UUID id. So this is a **latent** boundary gap that a restore, an out-of-band edit, or a pre-canonical dataset turns live — not a defect reachable through the HTTP API today. The fixture in the new test is exactly the shape of the existing `legacy invalid draft cannot bypass validation through activation` test, which already models "a row some other writer put there".

## Independent witness

`pacts/openbank-account-service-openbank-product-catalog.json` pins `$.id` to `3f20a53e-5ea4-307a-8a0f-9605728381ba` with **no matcher** — an exact-value expectation that the canonical UUID round-trips on `GET /api/v1/products/{id}`. It is replayed by the `@PactFolder` provider test on every PR build of this module, and stays green here.

Contrast `pacts/openbank-card-issuance-service-openbank-product-catalog.json`, whose author wrote `"id": "prod-003"` for the same field — under a `type` matcher, so it cannot tell a UUID from an alias. Two consumers, two beliefs about the same field, and only one of them checked.

## Coverage and negative control

New HTTP test `v1 reads return the canonical id even when the stored document retains the legacy alias`: seeds a row whose `doc` retains `prod-901`, then asserts the canonical id on GET by UUID, GET by legacy alias, the collection read, and the derived `/api/v1/fees` schedule.

**Negative control** — with only the repository change reverted and the test kept:

```
com.openbank.productcatalog.ProductCatalogResourceTest tests 21 fail 1 err 0 skip 0
  ## v1 reads return the canonical id even when the stored document retains the legacy alias()
  JSON path id doesn't match.
  Expected: 00000000-0000-0000-0000-000000006012
    Actual: prod-901
```

Exactly one failure, on the new test, with the alias as the actual value. The other 20 tests in the class stayed green, so the test discriminates the fix and nothing else.

## Verification

Exit codes read directly from the command, not through a pipe:

- `:openbank-product-catalog:ktlintCheck :openbank-product-catalog:detekt --rerun-tasks` → exit `0`; `ktlintMainSourceSetCheck`, `ktlintTestSourceSetCheck` and `detekt` all appear in the task output.
- `:openbank-product-catalog:test --rerun-tasks` (whole module) → exit `0`. Aggregated from the JUnit XML, not the console: **113 tests, 0 failures, 0 errors, 1 skipped**. The single skip is `ProductCatalogPactBrokerProviderVerificationTest`, broker-sourced and gated on `pactbroker.url` by design; the `@PactFolder` replay ran.

No `openapi.yaml` change: the response shape is unchanged, only the value of an existing field is corrected, so no `info.version` bump under ADR-0048. No migration, no event-schema change.

## Not verified

Not checked against the live database — whether any deployed row actually has `doc->>'id'` diverging from `products.id` is unestablished here (live systems were read-only/out of scope for this change). If such rows exist, this PR fixes the symptom at the read boundary; healing the stored documents would be separate work.
