### PR TITLE
fix(observability): the Loki ruler never loaded a single rule — `loki.ruler` is not a chart key

### DIFF
--- a/.github/scripts/check-loki-rules.py
+++ b/.github/scripts/check-loki-rules.py
@@ -221,8 +221,8 @@ def self_test(since: str | None = None) -> int:
     could invalidate it, and stays silent on the ones that cannot.
     """
     if not shutil.which("docker"):
-        print("::warning title=Loki rules::docker not available — cannot run the self-test.")
-        return 0
+        print("::warning title=Loki rules::docker not available — cannot run the LOAD-TEST half "
+              "of the self-test. The wiring half below needs no docker and still runs.")
     if since:
         changed, detail = rule_inputs_changed(since)
         if not changed:
@@ -231,6 +231,35 @@ def self_test(since: str | None = None) -> int:
             return 0
         print(f"check-loki-rules --self-test: {detail}")
     failures = []
+
+    # The wiring half, falsified first: it needs no docker, so it runs even where the load test
+    # cannot. Feed it the exact defect #5734 was — the block keyed `ruler` instead of
+    # `rulerConfig` — and require it to flag. A gate that has only ever seen a passing input has
+    # not been shown to be able to fail.
+    print("self-test: the wiring case the gate MUST flag")
+    with tempfile.TemporaryDirectory() as td:
+        app = yaml.safe_load(LOKI_APP.read_text(encoding="utf-8"))
+        loki = app["spec"]["source"]["helm"]["valuesObject"]["loki"]
+        loki["ruler"] = loki.pop("rulerConfig")          # the pre-#5734 shape, verbatim
+        broken = Path(td) / "loki-broken.yaml"
+        broken.write_text(yaml.safe_dump(app, sort_keys=False))
+        flagged = check_ruler_wiring(broken)
+    print(f"  {'ok  ' if flagged else 'FAIL'} `loki.ruler:` instead of `loki.rulerConfig:` is "
+          f"rejected" + (f" ({len(flagged)} problem(s))" if flagged else ""))
+    if not flagged:
+        failures.append("silently-dropped ruler key accepted")
+
+    print("self-test: the wiring case the gate MUST pass")
+    live = check_ruler_wiring()
+    print(f"  {'ok  ' if not live else 'FAIL'} the committed loki.yaml is accepted"
+          + ("" if not live else f" — {live[0]}"))
+    if live:
+        failures.append("committed loki.yaml rejected")
+
+    if not shutil.which("docker"):
+        # Reached only when docker appeared between the guard above and here; keep it honest.
+        return 1 if failures else 0
+
     good = {"good": yaml.safe_dump({"groups": [{
         "name": "selftest.good", "interval": "5m", "rules": [{
             "alert": "SelfTestGood",
@@ -271,6 +300,109 @@ def self_test(since: str | None = None) -> int:
 # workflow can never be a required check (a required context that never reports blocks every PR
 # that misses its paths), and a step that silently no-ops reads exactly like a step that passed.
 # This one says which it did.
+LOKI_APP = REPO / "openbank-infra" / "gitops" / "apps" / "loki.yaml"
+
+
+def check_ruler_wiring(app_file: Path = LOKI_APP) -> list[str]:
+    """Assert the DEPLOYED chart values actually produce the ruler this gate simulates.
+
+    WHY THIS EXISTS, AND WHY THE LOAD TEST ABOVE COULD NOT SEE IT (issue #5734). The load test
+    boots Loki with LOKI_CONFIG — a ruler section written to mirror apps/loki.yaml. It therefore
+    validates the rules against the config the repo MEANT to deploy, and is structurally blind to
+    whether that config is the one that actually runs. It was not. From #3060 until 2026-08-20 the
+    block in apps/loki.yaml was keyed `loki.ruler:`; the grafana/loki chart's key is
+    `loki.rulerConfig:`, and Helm discards an unknown value key silently. So the live ruler ran on
+    defaults — rule storage `s3` instead of `local:/rules`, and an EMPTY alertmanager_url — while
+    the sidecar dutifully wrote three rule files to /rules/fake that nothing ever read. Measured
+    live: `/prometheus/api/v1/rules` returned zero groups with all three files present on disk.
+    Every log-based alert in the estate had never evaluated, and the load test was green
+    throughout, about a config nobody deployed.
+
+    Deliberately offline and unconditional: no docker, no chart download, no network, single-digit
+    milliseconds. This is the half of the check that must never be skipped, because the failure it
+    catches produces no error anywhere else — not in Helm, not in ArgoCD, not in the pod's health.
+
+    Nothing here is hardcoded that can be derived: the expected rule directory comes from the
+    sidecar's own `folder`, so moving the sidecar moves the assertion with it.
+    """
+    problems: list[str] = []
+    try:
+        app = yaml.safe_load(app_file.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as ex:
+        return [f"could not read {app_file}: {ex}"]
+
+    values = (((app or {}).get("spec") or {}).get("source") or {}).get("helm", {}).get(
+        "valuesObject") or {}
+    loki = values.get("loki") or {}
+
+    # (1) The key itself. `ruler` is the Loki CONFIG name and the intuitive guess; `rulerConfig`
+    #     is the CHART name and the only one that survives templating.
+    if "ruler" in loki:
+        problems.append(
+            "loki.yaml sets `loki.ruler:` — not a chart key. The grafana/loki chart calls it "
+            "`loki.rulerConfig:`, and Helm drops unknown value keys SILENTLY, so every setting "
+            "under it is inert and the ruler runs on defaults (s3 rule storage, no "
+            "alertmanager_url). Rename the key to `rulerConfig`.")
+    ruler = loki.get("rulerConfig")
+    if not isinstance(ruler, dict):
+        problems.append(
+            "loki.yaml declares no `loki.rulerConfig:` block, so the Loki ruler has no rule "
+            "storage and no Alertmanager — every loki_rule ConfigMap in this repo would be "
+            "written to disk and never read.")
+        return problems
+
+    # (2) Rule storage must be LOCAL and point at the directory the sidecar writes into.
+    #     Derived from the sidecar's folder rather than restated, so the two cannot drift.
+    sidecar_folder = ((values.get("sidecar") or {}).get("rules") or {}).get("folder")
+    storage = ruler.get("storage") or {}
+    if storage.get("type") != "local":
+        problems.append(
+            f"loki.rulerConfig.storage.type is {storage.get('type')!r}, not 'local'. Rules reach "
+            f"this ruler as files written by the k8s-sidecar; any other storage type makes the "
+            f"ruler read somewhere nothing writes and load zero groups.")
+    directory = (storage.get("local") or {}).get("directory")
+    if sidecar_folder and directory:
+        # The sidecar writes into <directory>/<tenant>; single-tenant Loki calls the tenant `fake`.
+        if not str(sidecar_folder).rstrip("/").startswith(str(directory).rstrip("/") + "/"):
+            problems.append(
+                f"the sidecar writes rules to {sidecar_folder!r} but the ruler reads "
+                f"{directory!r} — the ruler will never see them.")
+    elif not directory:
+        problems.append("loki.rulerConfig.storage.local.directory is unset — the ruler has no "
+                        "rule directory to read.")
+
+    # (3) A rule that fires and is delivered nowhere is the same write-only control this whole
+    #     issue is about, one layer up.
+    if not (ruler.get("alertmanager_url") or "").strip():
+        problems.append(
+            "loki.rulerConfig.alertmanager_url is empty — a rule can evaluate and fire, and the "
+            "alert is dropped on the floor with no error anywhere.")
+
+    # (4) Keep the simulation honest: the ruler this gate boots must match the deployed one on the
+    #     two settings that decide whether rules load at all. Otherwise the load test drifts back
+    #     into being green about a config nobody runs, which is exactly how #5734 happened.
+    sim = (yaml.safe_load(LOKI_CONFIG) or {}).get("ruler") or {}
+    sim_dir = ((sim.get("storage") or {}).get("local") or {}).get("directory")
+    if (sim.get("storage") or {}).get("type") != storage.get("type") or sim_dir != directory:
+        problems.append(
+            f"this gate boots a ruler with storage "
+            f"{(sim.get('storage') or {}).get('type')!r}:{sim_dir!r} but loki.yaml deploys "
+            f"{storage.get('type')!r}:{directory!r}. The load test would be validating rules "
+            f"against a ruler the estate does not run — update LOKI_CONFIG in this file.")
+    return problems
+
+
+def run_wiring_gate() -> int:
+    problems = check_ruler_wiring()
+    if not problems:
+        print("check-loki-rules: the deployed Loki ruler is wired to read these rules and to "
+              "deliver what they fire.")
+        return 0
+    for p in problems:
+        print(f"::error title=Loki ruler wiring::{p}")
+    return 1
+
+
 RULE_INPUTS = [
     "openbank-infra/gitops/components",       # where loki_rule ConfigMaps live
     "openbank-infra/gitops/apps/loki.yaml",   # the ruler config the rules load under
@@ -319,8 +451,15 @@ def main() -> int:
                          "BOTH the gate and --self-test — each boots Loki, and the self-test boots "
                          "it twice. Omit to always run.")
     args = ap.parse_args()
+    # ALWAYS, and before anything else: offline, no docker, no --since skip. The load test can be
+    # skipped when no rule changed; this cannot, because it does not check the rules — it checks
+    # that a ruler capable of loading them exists at all, and that regresses from an edit to
+    # loki.yaml that touches no rule file.
+    wiring = run_wiring_gate()
     if args.self_test:
-        return self_test(args.since)
+        return self_test(args.since) or wiring
+    if wiring:
+        return wiring
     if args.since:
         changed, detail = rule_inputs_changed(args.since)
         if not changed:

--- a/openbank-infra/gitops/apps/loki.yaml
+++ b/openbank-infra/gitops/apps/loki.yaml
@@ -110,7 +110,23 @@ spec:
           # (HR000068 schedulers that had never run, SRCFG00040 at boot, the persist-vs-merge
           # duplicate-key 500s, fx-service's "skipping its revaluation leg"), and no metric existed
           # for any of them.
-          ruler:
+          #
+          # THE KEY IS `rulerConfig`, NOT `ruler` (issue #5734). This block was written as
+          # `loki.ruler:` from #3060 until 2026-08-20. That is not a chart key — the grafana/loki
+          # chart calls it `loki.rulerConfig` — and Helm drops an unknown value key SILENTLY, with
+          # no error, no warning, and a perfectly healthy pod. So for the whole life of the Loki
+          # ruler, EVERY line below was inert and the ruler ran on defaults: rule storage stayed
+          # `s3` (pointed at the ruler bucket, which nothing writes to) instead of `local:/rules`
+          # where the sidecar puts the rules, and `alertmanager_url` stayed EMPTY. Measured live
+          # against `/config` and `/prometheus/api/v1/rules` on 2026-08-20: three rule ConfigMaps
+          # present on disk under /rules/fake, and the ruler reporting ZERO rule groups loaded.
+          # Every log-based alert in this estate — silent-failures, endpoint-availability, and the
+          # Falco runtime alerts added hours earlier by #5850 — had therefore never evaluated once,
+          # and could not have delivered anything if it had.
+          # Same family as the 21 Argo Rollouts with zero series (mis-nested Helm keys dropped
+          # without a word); `check-loki-rules.py` now asserts this key renders, so it cannot
+          # silently revert.
+          rulerConfig:
             enable_api: true
             # Rules come from ConfigMaps in git via the chart's k8s-sidecar (see sidecar.rules
             # below), so the ruler reads them off local disk. This deliberately does NOT use the


### PR DESCRIPTION
## The finding

#5850 (merged this morning) tuned the Falco ruleset and added three Loki alert rules for #5734. Those rules are correct. **They have never evaluated, and neither has any other log-based alert in this estate.**

The `ruler:` block in `gitops/apps/loki.yaml` has been keyed `loki.ruler:` since #3060 wired it up. The grafana/loki chart's key is **`loki.rulerConfig:`**. Helm discards an unknown value key silently — no error, no warning, a perfectly healthy pod — so every line of that block was inert and the ruler ran on chart defaults.

Measured live against the sandbox, 2026-08-20:

```
GET /config              ruler.storage.type      = "s3"          (declared: local)
                         ruler.storage.local     = {directory:""} (declared: /rules)
                         ruler.rule_path         = "/var/loki/rules-temp" (declared: /tmp/loki-rules)
                         ruler.alertmanager_url  = ""            (declared: kube-prometheus-stack-alertmanager:9093)
                         ruler.ring.kvstore.store= "memberlist"  (declared: inmemory)
                         ruler.remote_write.enabled = false      (declared: true)

exec loki-sc-rules -- find /rules -type f
                         /rules/fake/silent-failures.yaml
                         /rules/fake/endpoint-availability.yaml
                         /rules/fake/falco-runtime.yaml

GET /prometheus/api/v1/rules   ->  {"data":{"groups":[]}}        <-- ZERO groups loaded
```

Every key in the declared block is at its Loki default. The two that *appear* to have taken effect (`enable_api`, `enable_alertmanager_v2`) are Loki's own defaults, so they are not evidence either. The sidecar dutifully writes three rule files to a directory the ruler is not configured to read, and the ruler has nowhere to deliver anything it might fire.

Confirmed independently by rendering the repo's own `valuesObject` through chart 6.55.0 twice — as committed, and with the key renamed:

```
as-is   ruler:  {storage: {type: s3, s3: {...}}, wal: {...}}          <-- matches live /config exactly
fixed   ruler:  {alertmanager_url: ..., enable_api: true, remote_write: {enabled: true, ...},
                 ring: {kvstore: {store: inmemory}}, rule_path: /tmp/loki-rules,
                 storage: {type: local, local: {directory: /rules}}, wal: {...}}
```

Same family as the 21 Argo Rollouts that had zero series from mis-nested Helm keys.

## So the honest answer to #5734

Falco's events **do** reach a system an alert could read — Loki, via Alloy, and the `openbank-soc` panels prove it. #5850 put correct rules in front of them. What was missing is one layer lower: the ruler that would evaluate those rules was never configured, and the Alertmanager it would deliver to was never set. The runtime-security control was write-only for the reason nobody had looked at, and it stayed write-only after the PR that set out to fix it.

## By-rule breakdown, and the split that matters

The issue's ~33k/day is not the alertable volume. Split by rule **and by priority** — the priority column decides which of these an alert can ever see:

| rule | stock priority | pre-tune (per 6h) | post-tune (per 6h) |
|---|---|---:|---:|
| Contact K8S API Server From Container | NOTICE | 5263 | 1156 |
| Run shell untrusted | NOTICE | 685 | 138 |
| Drop and execute new binary in container | **CRITICAL** | 106 | **0** |
| Falco internal: syscall event drop | CRITICAL (self-report) | ~1 | ~1 |
| (lines with no rule field — agent startup/internal) | — | 178 | 51 |

Query (Loki instant, 6h windows either side of the #5850 sync at ~09:50Z):

```
sum by (rule) (count_over_time({namespace="falco"} | json | __error__="" [6h]))
```

So: **the Critical-or-above volume an alert actually sees went from ~424/day to 0/day.** #5850's tuning is correct and its arc-reaper attribution holds — the exception is scoped to one namespace AND one pod-name prefix AND three process names, so a drop-and-execute anywhere else, or a different binary in that same pod, still fires. The 78% cut on the NOTICE rules buys log volume and dashboard signal only; no alert here can see them.

## Why each alert is non-vacuous at t=0 on a cold pod

Re-derived after the tuning, because the tuning changed the assumption two of them were written under — not carried over from #5850's reasoning.

- **`FalcoCriticalRuntimeDetection`** — `count_over_time(...)>0`, no `for`. The series is real and reachable: it carried 106 events per 6h before the tuning. It reads Loki's stored data, so a cold ruler or Falco pod does not synthesise a boot-time value. Currently 0 firing, which is the correct resting state and the whole point.
- **`FalcoSyscallEventDrops`** — 3/day measured, `for: 5m`, `warning`. Rate-limited by Falco itself, so that is a real count of windows and not a suppressed flood.
- **`FalcoAgentSilent`** — `absent_over_time([30m])`, `for: 15m`. **This is the one the tuning put at risk**, since it depends on Falco never going quiet and the tuning cut volume 78%. Measured rather than assumed: over 94 rolling 30m buckets since the tuning landed, the **minimum** was 53 lines and **zero** buckets were empty. It will not false-fire, and a genuinely dark agent still trips it.
- **The four pre-existing rules** (`SchedulerMissingVertxContext`, `ConfigPropertyMissingAtBoot`, `PanacheAssignedIdInsertOnly`, `FxRevaluationSkippedAllLegs`) and the one recording rule (`openbank:service_no_ready_endpoints:rate1m`) — these evaluate for the **first time ever** when this merges, which is the real risk of this change. All seven alert expressions plus the recording rule were dry-evaluated against live Loki: every one parses, and **every one returns zero series right now**. Turning the ruler on produces a quiet live control, not an activation storm.

## The guard

`check-loki-rules.py` was green throughout all of this, and could not have been otherwise: it boots Loki with a `LOKI_CONFIG` written to *mirror* `apps/loki.yaml`, so it validated the rules against the config the repo meant to deploy and was structurally blind to whether that was the config running.

Added `check_ruler_wiring()` — offline, no docker, no network, unconditional (it is not scoped by `--since`, because the failure it catches comes from editing `loki.yaml` without touching any rule file). It asserts the chart key is `rulerConfig` and not `ruler`, that rule storage is `local` pointing at the directory **derived from the sidecar's own `folder`** rather than restated, that `alertmanager_url` is non-empty, and that the ruler this gate simulates still matches the one deployed — so the load test cannot drift back into being green about a config nobody runs.

Falsified in both directions, which is the only thing that makes it worth having:

```
key reverted to `loki.ruler:`   ->  exit 1, names the defect
key as committed                ->  exit 0, ruler accepts all 3 groups
                                    (openbank.logs.falco-runtime, .silent-failures, .endpoint-availability)
--self-test                     ->  flags the pre-#5734 shape, accepts the committed one
```

## Verified / not verified

**Verified:** the live ruler config and its zero loaded groups; the rule files present on disk; both chart renders; that `/tmp` is a writable emptyDir mount so `rule_path` is safe; the pre/post-tuning by-rule split; the `FalcoAgentSilent` minimum-bucket floor; that all 8 committed rules parse and none currently fire; the gate's negative and positive cases; `run-gates.py --all` = 155 PASS (the two failures are local-environment artifacts — an unset `BASE_REF` and `sudo` for the oasdiff install — both pass when run properly, and neither touches this diff).

**Not verified:** that an alert reaches a human end-to-end. That needs this merged and synced, then a known-positive fired, and it is #5734's step 3 — I could not do it without mutating the cluster. **Until that is done the control is not proven**, and #5850's promotion criterion (flip `FalcoCriticalRuntimeDetection` to `critical` once it has fired on fewer than 1 day in 7) still stands. I also did not verify the Prometheus remote-write receiver accepts the ruler's recording-rule writes, only that the endpoint is the one already carrying k6 journey traffic.

## Follow-up, not done here

The residual 1156/6h of `Contact K8S API Server From Container` is **Strimzi's entity-operator** (`user-operator`, fabric8 `JdkHttpClientFa` under `tini`, ns `messaging`). #5850's exception is scoped `k8s.pod.name startswith "strimzi-cluster-operator"`, which does not cover it. That is a one-line tuning with the same justification as the existing macro, deliberately left out of this PR to keep it to the wiring defect and to avoid conflicting with `falco.yaml` hours after #5850 touched it. It is NOTICE, so it cannot reach any alert — log volume only.

Closes #5734
