### PR TITLE
feat(settlement): alert on settlements that stopped advancing (#5705)

### DIFF
--- a/openbank-infra/gitops/components/payments/prometheus-rules.yaml
+++ b/openbank-infra/gitops/components/payments/prometheus-rules.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Per-service PrometheusRule alerts for the payments namespace (money-path, ADR-0077/0079).
 # Covers: transaction-service, clearing-service, swift-service, sepa-payment, sepa-instant,
-# domestic-payment, sdd-service. Complements the fleet-wide tier-1 rules with payment-rail
+# domestic-payment, sdd-service, settlement-service. Complements the fleet-wide tier-1 rules with payment-rail
 # specific saga and settlement observability.
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -276,3 +276,94 @@ spec:
               {{ $value | humanizePercentage }} of fraud-scoring attempts on {{ $labels.service }}
               returned an invented verdict over the last 30m — a flapping fraud-service or an open
               circuit breaker, rather than a clean outage.
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-settlement-progress-alerts
+  namespace: payments
+  labels:
+    app.kubernetes.io/part-of: openbank
+    app.kubernetes.io/name: settlement-service
+spec:
+  groups:
+    # settlement-service — a declared money_path_service (rules.yaml) — had NO rule of its own and
+    # emitted NO application metric at all until #5705. It was not un-monitored, which is what made
+    # it hard to see: the pod is scraped by the fleet PodMonitor, `PaymentServiceDown` in
+    # prometheus-rules-tier1.yaml covers `namespace="payments"` and so covers this container, and
+    # both Pyrra money-path SLOs exist for it. Every one of those measures whether the service
+    # ANSWERS. None measures whether the debit -> credit -> ledger-book saga it accepted PROGRESSES,
+    # and a settlement whose workflow stopped advancing answers nothing at all — its originating
+    # request returned 2xx in milliseconds, hours before.
+    #
+    # There is deliberately no SettlementServiceDown rule here: PaymentServiceDown already owns
+    # `up{job="observability/openbank-services", namespace="payments"}`, and a second rule over the
+    # same target would page twice for one outage.
+    #
+    # Scope: this document is the PROGRESS half of #5705 only — "is this settlement still moving".
+    # The OUTCOME half ("what did settlements do") is PR #5723's saga-step and terminal-state
+    # counters, which this deliberately does not duplicate; the two are complementary and the
+    # rule names, the metric names and the PrometheusRule object name are disjoint so they can
+    # land in either order. Nothing here is a throughput floor: that is the shape #5733 deleted
+    # twice from this file (ClearingSettlementWindowMissed, SwiftMtMessageProcessingStalled).
+    # settlement-service is REST- and Temporal-driven with no @Scheduled sweep and no @Incoming
+    # consumer, so an idle hour is the normal resting state, not a fault. What an idle service
+    # must still never have is a settlement that stopped advancing, and that is an age.
+    - name: openbank.settlement.progress
+      rules:
+        - alert: SettlementStrandedMidSaga
+          # PENDING / DEBITED / CREDITED are hand-off states the Temporal workflow drives through
+          # in seconds. DEBITED is the one that matters most: the payer has been debited, the payee
+          # has not been credited, and the funds are in neither account.
+          #
+          # 3h is derived from the code, not guessed. SettlementWorkflowImpl sets a per-activity
+          # scheduleToCloseTimeout of 2h (SCHEDULE_TO_CLOSE_HOURS), so a settlement can legitimately
+          # sit in any one of these states for up to 2h while its next activity retries before the
+          # workflow gives up and compensates. 3h clears that ceiling with an hour of slack, so this
+          # rule cannot fire on a slow-but-working retry — only on a settlement whose workflow is
+          # gone (worker not polling, Temporal unreachable, or a run lost).
+          expr: |
+            max by (status) (
+              openbank_settlement_non_terminal_oldest_age_seconds{
+                service="settlement", status=~"PENDING|DEBITED|CREDITED"
+              }
+            ) > 10800
+          for: 15m
+          labels:
+            severity: critical
+            service: settlement
+          annotations:
+            summary: "Settlement stranded in {{ $labels.status }} for over three hours"
+            description: >-
+              The oldest settlement in {{ $labels.status }} is {{ $value | humanizeDuration }} old,
+              past the 2h per-activity scheduleToClose ceiling of the settlement workflow. In DEBITED
+              the payer's funds have left and have not arrived; in CREDITED the money has moved but
+              was never booked to the general ledger. Check whether the Temporal worker for task
+              queue `openbank-settlement` is polling and whether a run exists for `settlement-<id>`.
+        - alert: SettlementStuckAfterCompensation
+          # The three *_REVERSED states mean the saga already unwound: money was moved and moved
+          # back. SettlementWorkflowImpl always calls rejectSettlement after compensating, so these
+          # states are transient by construction and a row parked in one has a workflow that died
+          # between the compensation and the terminal write — funds are safe, the record is not.
+          #
+          # 8h, again from the code: the longest legitimate compensation chain starts at
+          # LEDGER_REVERSED and still owes reverseCredit + reverseDebit + rejectSettlement, three
+          # activities at 2h scheduleToClose each. 8h clears that 6h worst case. Warning rather than
+          # critical because no customer money is in limbo — only the settlement record is.
+          expr: |
+            max by (status) (
+              openbank_settlement_non_terminal_oldest_age_seconds{
+                service="settlement", status=~"REVERSED|CREDITED_REVERSED|LEDGER_REVERSED"
+              }
+            ) > 28800
+          for: 30m
+          labels:
+            severity: warning
+            service: settlement
+          annotations:
+            summary: "Settlement stuck in compensation state {{ $labels.status }} for over eight hours"
+            description: >-
+              The oldest settlement in {{ $labels.status }} is {{ $value | humanizeDuration }} old.
+              Its compensations ran but it never reached REJECTED, so the settlements table now
+              disagrees with the ledger about a settlement that was unwound. Reconcile before the
+              next accounting-day close.

--- a/openbank-settlement-service/build.gradle.kts
+++ b/openbank-settlement-service/build.gradle.kts
@@ -18,6 +18,8 @@ dependencies {
     implementation(libs.quarkus.jdbc.postgresql)
     implementation(libs.quarkus.smallrye.health)
     implementation(libs.quarkus.micrometer.registry.prometheus)
+    // SettlementStrandedGauge's 30s refresh tick (issue #5705).
+    implementation(libs.quarkus.scheduler)
     implementation(libs.quarkus.opentelemetry)
     implementation(libs.quarkus.oidc)
     implementation(libs.quarkus.rest.client.reactive.jackson)
@@ -39,6 +41,17 @@ dependencies {
     testImplementation(libs.quarkus.test.security)
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
+    // Test-only (#5705): SettlementStrandedGaugeTest and SettlementActivitiesImplTest assert the
+    // alert expressions in gitops/components/payments/prometheus-rules.yaml against a real
+    // Prometheus scrape, so the dot->underscore mapping, the counter's `_total` suffix and the tag
+    // ordering come from Micrometer rather than from these tests' idea of them. Runtime already
+    // ships the registry via quarkus-micrometer-registry-prometheus, but as the `-simpleclient`
+    // variant (package io.micrometer.prometheus); only the compile classpath needs the
+    // io.micrometer.prometheusmetrics one. Same version, same rationale and same CVE pin as
+    // openbank-campaign-service's and openbank-domestic-payment's copies: 1.14.5 -> 1.17.0 for
+    // GHSA-g3pr-3p32-fp23 / CVE-2026-40984 (HIGH DoS; the 1.14.x line has no fix), and this
+    // literal — not quarkus-bom's constraint — is what dependency-review scans.
+    testImplementation("io.micrometer:micrometer-registry-prometheus:1.17.0")
     testImplementation(libs.rest.assured.kotlin)
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/port/out/SettlementPorts.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/port/out/SettlementPorts.kt
@@ -6,6 +6,7 @@ package com.openbank.settlement.application.port.out
 
 import com.openbank.settlement.domain.model.Settlement
 import com.openbank.settlement.domain.model.SettlementStatus
+import java.time.Instant
 import java.util.UUID
 
 interface SettlementRepository {
@@ -20,6 +21,21 @@ interface SettlementRepository {
      * workflow-id reuse policy instead.)
      */
     suspend fun claimForProcessing(id: UUID): Boolean
+
+    /**
+     * How many settlements are in [status] right now. Feeds the stranded-settlement gauges
+     * (issue #5705) — see `SettlementStrandedGauge` for why age, not error rate, is the only
+     * signal that can see a settlement whose saga stopped advancing.
+     */
+    suspend fun countByStatus(status: SettlementStatus): Long
+
+    /**
+     * `created_at` of the oldest settlement in [status], or `null` when none is in that state.
+     * `null` must be reported as an age of zero, never as the last age seen: a state that
+     * emptied and keeps publishing its old age is an alert that fires after the problem is
+     * fixed, which is how an alert earns being ignored.
+     */
+    suspend fun oldestCreatedAt(status: SettlementStatus): Instant?
 }
 
 interface DebitPort {

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGauge.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGauge.kt
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.infrastructure.observability
+
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
+import com.openbank.settlement.application.port.out.SettlementRepository
+import com.openbank.settlement.domain.model.SettlementStatus
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import io.quarkus.runtime.Startup
+import io.quarkus.runtime.StartupEvent
+import io.quarkus.scheduler.Scheduled
+import jakarta.annotation.PostConstruct
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Publishes how long settlements have been sitting in a **non-terminal** state (issue #5705).
+ *
+ *  - `openbank_settlement_non_terminal{service="settlement",status="..."}` — how many settlements
+ *    are in that state right now.
+ *  - `openbank_settlement_non_terminal_oldest_age_seconds{service="settlement",status="..."}` —
+ *    age of the oldest one, or `0` when there are none.
+ *
+ * ### Why age, and not a throughput counter
+ *
+ * settlement-service is REST- and Temporal-driven: `POST /settlements` starts a workflow, and the
+ * service has no `@Scheduled` sweep and no `@Incoming` consumer for settlement traffic. So "no
+ * settlement completed in the last hour" is the NORMAL resting state, not a fault. A throughput
+ * floor over such a flow is precisely the mistake #5733 deleted twice from this domain's rules
+ * (`ClearingSettlementWindowMissed`, `SwiftMtMessageProcessingStalled`) — it asserts a cadence the
+ * code does not have, so it is either permanently firing or permanently ignored.
+ *
+ * What settlement *does* have is a state machine that must make progress. A settlement stuck in
+ * [SettlementStatus.DEBITED] is the money-path failure this service can produce: the payer has
+ * been debited, the payee has not been credited, and the funds are in neither account. Nothing
+ * else in the fleet can see it. `PaymentServiceDown` is green (the pod is healthy), the Pyrra
+ * availability and latency SLOs are green (the originating request answered 2xx in milliseconds
+ * and the workflow's later failure is not that span), and there is no error rate to raise because
+ * a workflow that stopped advancing throws nothing on the request path. The ONLY observable that
+ * separates a stranded settlement from a healthy one is its age — same shape, same reasoning, as
+ * `DomesticPaymentStrandedGauge` in openbank-domestic-payment (#3273).
+ *
+ * ### Scope
+ *
+ * This is the PROGRESS half of #5705 — "is this settlement still moving". The OUTCOME half
+ * ("what did settlements do": origination, per-step and terminal-state counters) is PR #5723's
+ * `SettlementMetricsPort`, and is deliberately not duplicated here. The two answer different
+ * questions and neither substitutes for the other: a counter cannot see one settlement that
+ * stopped while traffic flows normally around it, and an age gauge cannot see a rejection rate.
+ *
+ * ### Which states are published
+ *
+ * Terminal states ([SettlementStatus.BOOKED], [SettlementStatus.REJECTED]) are not published:
+ * their age only grows and would alert forever. Everything else is published, including the three
+ * compensation states — `SettlementWorkflowImpl` always calls `rejectSettlement` after
+ * compensating, so a row parked in `REVERSED` / `CREDITED_REVERSED` / `LEDGER_REVERSED` means the
+ * unwinding ran and the record never reached its terminal state.
+ *
+ * ### t=0 on a cold pod
+ *
+ * Every series is created in [register] at startup and initialised to `0`. A freshly started pod
+ * therefore publishes `0` for each status rather than an absent series, so a `> threshold` rule
+ * cannot fire during or after a deploy, and `absent()` over these series means "the pod is not
+ * exporting", not "no settlements". The gauges hold no seeded age at all, so there is no
+ * `Instant.EPOCH` fourth state here — the boot reading and the healthy reading are the same
+ * number, deliberately.
+ *
+ * ### Why the refresh loop carries its own liveness heartbeat
+ *
+ * The gauges are only as trustworthy as the tick that refreshes them: a frozen [refresh] leaves
+ * every age stuck at its last value, which reads as healthy. [refresh] therefore records a
+ * success against `DomainMetrics.registerWorkflowLiveness`, whose 30s cadence IS a real cadence,
+ * so the fleet `WorkflowLivenessStale` rule (2x interval, `for: 15m`) covers the collector without
+ * anyone asserting a cadence on settlement traffic itself. The age gauge behind that rule is
+ * seeded at REGISTRATION, not `Instant.EPOCH`, so it does not fire 15 minutes after every deploy.
+ *
+ * Micrometer samples a gauge supplier synchronously on the Prometheus scrape (worker) thread while
+ * these values come from reactive queries, so a scheduled `suspend` tick refreshes cached
+ * [AtomicLong]s on the right context and the suppliers read those caches cheaply and lock-free. A
+ * plain (non-`suspend`) `@Scheduled` method has no Vert.x context and would abort with `HR000068`
+ * on the first reactive Panache call, silently.
+ */
+@Startup
+@ApplicationScoped
+class SettlementStrandedGauge(
+    private val settlementRepository: SettlementRepository,
+    private val registry: MeterRegistry?,
+    private val clock: Clock,
+    private val domainMetrics: DomainMetrics,
+) {
+    // CDI constructor: MeterRegistry is optional (absent when no Prometheus registry is on the
+    // classpath, e.g. in slim test slices). Without an explicit @Inject constructor, ArC sees two
+    // constructors, registers no bean, and the @Startup hook silently never runs.
+    @Inject
+    constructor(
+        settlementRepository: SettlementRepository,
+        registryInstance: Instance<MeterRegistry>,
+        clock: Clock,
+        domainMetrics: DomainMetrics,
+    ) : this(
+        settlementRepository,
+        if (registryInstance.isResolvable) registryInstance.get() else null,
+        clock,
+        domainMetrics,
+    )
+
+    private val counts: Map<SettlementStatus, AtomicLong> = NON_TERMINAL.associateWith { AtomicLong(0) }
+    private val oldestAgeSeconds: Map<SettlementStatus, AtomicLong> = NON_TERMINAL.associateWith { AtomicLong(0) }
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    @PostConstruct
+    fun register() {
+        val r = registry ?: return
+        NON_TERMINAL.forEach { status ->
+            gauge(r, NON_TERMINAL_METRIC, status, counts.getValue(status))
+            gauge(r, OLDEST_AGE_METRIC, status, oldestAgeSeconds.getValue(status))
+        }
+    }
+
+    fun onStart(@Observes @Suppress("UNUSED_PARAMETER") ev: StartupEvent) {
+        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, Duration.ofSeconds(REFRESH_INTERVAL_SECONDS))
+    }
+
+    private fun gauge(r: MeterRegistry, name: String, status: SettlementStatus, holder: AtomicLong) {
+        Gauge.builder(name, holder) { it.get().toDouble() }
+            .tag("service", SERVICE)
+            .tag("status", status.name)
+            .strongReference(true)
+            .register(r)
+    }
+
+    @Scheduled(
+        every = "30s",
+        delayed = "15s",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+    )
+    suspend fun refresh() {
+        val now = Instant.now(clock)
+        NON_TERMINAL.forEach { status ->
+            counts.getValue(status).set(settlementRepository.countByStatus(status))
+            // Absent oldest row means the state is empty — report 0, not a stale previous age.
+            val oldest = settlementRepository.oldestCreatedAt(status)
+            oldestAgeSeconds.getValue(status).set(
+                oldest?.let { maxOf(0L, Duration.between(it, now).seconds) } ?: 0L,
+            )
+        }
+        liveness?.recordSuccess()
+    }
+
+    companion object {
+        const val SERVICE = "settlement"
+
+        /** Dotted Micrometer names; Prometheus renders the underscored forms the rules read. */
+        const val NON_TERMINAL_METRIC = "openbank.settlement.non_terminal"
+        const val OLDEST_AGE_METRIC = "openbank.settlement.non_terminal.oldest.age.seconds"
+
+        private const val WORKFLOW_NAME = "settlement-stranded-gauge"
+        private const val REFRESH_INTERVAL_SECONDS = 30L
+
+        /**
+         * States a settlement must move out of. Everything except the two terminal states
+         * ([SettlementStatus.BOOKED], [SettlementStatus.REJECTED]) — a settlement in any of these
+         * has been accepted and is still owed an outcome, so its age is meaningful.
+         */
+        val NON_TERMINAL: List<SettlementStatus> = listOf(
+            SettlementStatus.PENDING,
+            SettlementStatus.DEBITED,
+            SettlementStatus.CREDITED,
+            SettlementStatus.REVERSED,
+            SettlementStatus.CREDITED_REVERSED,
+            SettlementStatus.LEDGER_REVERSED,
+        )
+    }
+}

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/persistence/SettlementRepositoryImpl.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/persistence/SettlementRepositoryImpl.kt
@@ -13,6 +13,7 @@ import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepositoryBase
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
 import java.time.Clock
+import java.time.Instant
 import java.util.UUID
 
 /** Panache reactive repository keyed by the domain UUID (not a surrogate id). */
@@ -62,6 +63,15 @@ class SettlementRepositoryImpl(private val repo: SettlementPanacheRepo, private 
                 entity?.toDomain() ?: throw IllegalArgumentException("Settlement $id not found")
             }
     }.awaitSuspending()
+
+    // Both queries are served by idx_settlements_status_created_at (V2). They run every 30s from
+    // SettlementStrandedGauge.refresh(), so they must not be sequential scans.
+    override suspend fun countByStatus(status: SettlementStatus): Long =
+        Panache.withSession { repo.count("status", status.name) }.awaitSuspending()
+
+    override suspend fun oldestCreatedAt(status: SettlementStatus): Instant? = Panache.withSession {
+        repo.find("status = ?1 order by createdAt asc", status.name).firstResult()
+    }.awaitSuspending()?.createdAt
 
     private fun SettlementEntity.toDomain() = Settlement(
         id = id,

--- a/openbank-settlement-service/src/main/resources/db/migration/V2__settlements_status_created_at_index.sql
+++ b/openbank-settlement-service/src/main/resources/db/migration/V2__settlements_status_created_at_index.sql
@@ -1,0 +1,11 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Supports the stranded-settlement gauges (issue #5705): every 30s the gauge asks, per
+-- non-terminal status, `count(*)` and `min(created_at)`. Without an index those are two
+-- sequential scans of `settlements` per status per tick — six statuses, 120 scans a minute,
+-- growing with the table. A composite (status, created_at) serves both: the count from an
+-- index-only scan, the oldest row from the first entry of the status prefix.
+--
+-- Rollback note: additive and non-locking in effect (a fresh index on an existing table).
+-- Rollback = DROP INDEX IF EXISTS idx_settlements_status_created_at;
+CREATE INDEX IF NOT EXISTS idx_settlements_status_created_at
+    ON settlements (status, created_at);

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGaugeTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGaugeTest.kt
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.settlement.infrastructure.observability
+
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.settlement.application.port.out.SettlementRepository
+import com.openbank.settlement.domain.model.SettlementStatus
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * Unit cover for the #5705 stranded-settlement gauges.
+ *
+ * The point of the metric is that a settlement whose saga stopped advancing is invisible to every
+ * other signal — the originating request answered 2xx in milliseconds, the pod is healthy, and no
+ * error is thrown anywhere — so the ONLY thing that distinguishes it from a healthy settlement is
+ * age. These assertions are therefore on the age arithmetic, on the empty-state behaviour, and on
+ * the exact PROMETHEUS-RENDERED series names the alert rules read; not on "a gauge was registered".
+ */
+class SettlementStrandedGaugeTest {
+
+    private val now: Instant = Instant.parse("2026-08-20T12:00:00Z")
+    private val clock: Clock = Clock.fixed(now, ZoneOffset.UTC)
+
+    private class StubRepository(
+        private val counts: Map<SettlementStatus, Long>,
+        private val oldest: Map<SettlementStatus, Instant>,
+    ) : SettlementRepository {
+        override suspend fun countByStatus(status: SettlementStatus): Long = counts[status] ?: 0L
+        override suspend fun oldestCreatedAt(status: SettlementStatus): Instant? = oldest[status]
+
+        override suspend fun create(settlement: com.openbank.settlement.domain.model.Settlement) = error("unused")
+        override suspend fun findById(id: UUID) = error("unused")
+        override suspend fun updateStatus(id: UUID, status: SettlementStatus) = error("unused")
+        override suspend fun claimForProcessing(id: UUID): Boolean = error("unused")
+    }
+
+    private fun gaugeValue(registry: SimpleMeterRegistry, name: String, status: SettlementStatus): Double =
+        registry.get(name).tag("service", "settlement").tag("status", status.name).gauge().value()
+
+    private fun newGauge(repo: SettlementRepository, registry: io.micrometer.core.instrument.MeterRegistry?) =
+        SettlementStrandedGauge(repo, registry, clock, domainMetrics = mockk<DomainMetrics>(relaxed = true))
+
+    @Test
+    fun `publishes the age of the oldest settlement in each non-terminal state`(): Unit = runBlocking {
+        val registry = SimpleMeterRegistry()
+        val repo = StubRepository(
+            counts = mapOf(SettlementStatus.DEBITED to 4L, SettlementStatus.PENDING to 1L),
+            oldest = mapOf(
+                // DEBITED is the money-path failure: the payer is debited, the payee is not
+                // credited, and the funds are in neither account.
+                SettlementStatus.DEBITED to now.minus(Duration.ofHours(9)),
+                SettlementStatus.PENDING to now.minus(Duration.ofMinutes(5)),
+            ),
+        )
+        val gauge = newGauge(repo, registry)
+        gauge.register()
+
+        gauge.refresh()
+
+        assertThat(gaugeValue(registry, SettlementStrandedGauge.NON_TERMINAL_METRIC, SettlementStatus.DEBITED))
+            .isEqualTo(4.0)
+        assertThat(gaugeValue(registry, SettlementStrandedGauge.OLDEST_AGE_METRIC, SettlementStatus.DEBITED))
+            .describedAs("9h must cross the 10800s SettlementStrandedMidSaga threshold, not merely be non-zero")
+            .isEqualTo(Duration.ofHours(9).seconds.toDouble())
+        assertThat(gaugeValue(registry, SettlementStrandedGauge.OLDEST_AGE_METRIC, SettlementStatus.PENDING))
+            .isEqualTo(300.0)
+    }
+
+    /**
+     * An emptied state must report 0, not the last age it saw. Holding the previous value would
+     * keep the alert firing after the settlements cleared — which is how an alert earns being
+     * ignored, and this issue exists because a signal nobody trusts is the same as no signal.
+     */
+    @Test
+    fun `an emptied state reports zero rather than a stale age`(): Unit = runBlocking {
+        val registry = SimpleMeterRegistry()
+        var oldest = mapOf(SettlementStatus.CREDITED to now.minus(Duration.ofHours(6)))
+        val repo = object : SettlementRepository by StubRepository(emptyMap(), emptyMap()) {
+            override suspend fun countByStatus(status: SettlementStatus) = if (oldest.containsKey(status)) 1L else 0L
+            override suspend fun oldestCreatedAt(status: SettlementStatus) = oldest[status]
+        }
+        val gauge = newGauge(repo, registry)
+        gauge.register()
+
+        gauge.refresh()
+        assertThat(gaugeValue(registry, SettlementStrandedGauge.OLDEST_AGE_METRIC, SettlementStatus.CREDITED))
+            .isEqualTo(21600.0)
+
+        oldest = emptyMap()
+        gauge.refresh()
+
+        assertThat(gaugeValue(registry, SettlementStrandedGauge.OLDEST_AGE_METRIC, SettlementStatus.CREDITED)).isZero()
+        assertThat(gaugeValue(registry, SettlementStrandedGauge.NON_TERMINAL_METRIC, SettlementStatus.CREDITED))
+            .isZero()
+    }
+
+    /** Terminal states must not be published — their age only grows and would alert forever. */
+    @Test
+    fun `terminal states are not published and every compensation state is`() {
+        val registry = SimpleMeterRegistry()
+        newGauge(StubRepository(emptyMap(), emptyMap()), registry).register()
+
+        val published = registry.meters
+            .filter { it.id.name == SettlementStrandedGauge.NON_TERMINAL_METRIC }
+            .mapNotNull { it.id.getTag("status") }
+            .toSet()
+
+        assertThat(published).containsExactlyInAnyOrder(
+            "PENDING",
+            "DEBITED",
+            "CREDITED",
+            "REVERSED",
+            "CREDITED_REVERSED",
+            "LEDGER_REVERSED",
+        )
+        assertThat(published).doesNotContain("BOOKED", "REJECTED")
+        // The published set must be exactly "every status minus the two terminal ones", derived
+        // from the enum rather than restated — a status added later must not silently go unwatched.
+        assertThat(published).isEqualTo(
+            (SettlementStatus.entries.map { it.name } - setOf("BOOKED", "REJECTED")).toSet(),
+        )
+    }
+
+    /**
+     * The cold-pod contract, asserted on the exact strings the PrometheusRule reads.
+     *
+     * Registration alone puts every series at 0, so a `> threshold` rule cannot fire during or
+     * after a deploy, and `absent()` over these names means "the pod is not exporting" rather than
+     * "no settlements". Asserting the RENDERED text is the point: the rule spells
+     * `openbank_settlement_non_terminal_oldest_age_seconds`, the code spells
+     * `openbank.settlement.non_terminal.oldest.age.seconds`, and nothing else in CI checks that
+     * those two are the same series (#5733 shipped a critical money-path alert that were not).
+     */
+    @Test
+    fun `renders the exact series the alert rules read, at zero, before any refresh`() {
+        val prometheus = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        newGauge(StubRepository(emptyMap(), emptyMap()), prometheus).register()
+
+        val scraped = prometheus.scrape()
+
+        assertThat(scraped).contains(
+            """openbank_settlement_non_terminal_oldest_age_seconds{service="settlement",status="DEBITED"} 0.0""",
+        )
+        assertThat(scraped).contains(
+            """openbank_settlement_non_terminal{service="settlement",status="PENDING"} 0.0""",
+        )
+    }
+
+    /** A missing Prometheus registry must not break startup — the gauge is optional telemetry. */
+    @Test
+    fun `registers nothing and does not throw when no registry is present`(): Unit = runBlocking {
+        val gauge = newGauge(StubRepository(emptyMap(), emptyMap()), null)
+        gauge.register()
+        gauge.refresh()
+    }
+}

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/persistence/SettlementRepositoryImplIT.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/persistence/SettlementRepositoryImplIT.kt
@@ -56,6 +56,37 @@ class SettlementRepositoryImplIT {
         updatedAt = Instant.now(),
     )
 
+    /**
+     * Real-Postgres cover for the two queries the #5705 stranded gauges call every 30s. They are
+     * the only part of this change that can fail purely at runtime: `find("status = ?1 order by
+     * createdAt asc")` is an HQL string, so a wrong property name compiles cleanly and throws on
+     * first execution — and the caller is a `@Scheduled` tick whose exception nobody is watching,
+     * which would leave the gauges frozen at 0 and the alerts permanently, silently quiet. A stub
+     * repository cannot detect that; only this can.
+     */
+    @Test
+    fun `countByStatus and oldestCreatedAt answer from a real database`() {
+        val status = SettlementStatus.LEDGER_REVERSED // unused by the other tests in this class
+        val before = onVertxContext { repository.countByStatus(status) }
+
+        val older = newSettlement(status).copy(createdAt = Instant.parse("2020-01-01T00:00:00Z"))
+        val newer = newSettlement(status).copy(createdAt = Instant.parse("2026-01-01T00:00:00Z"))
+        onVertxContext { repository.create(newer) }
+        onVertxContext { repository.create(older) }
+
+        assertThat(onVertxContext { repository.countByStatus(status) }).isEqualTo(before + 2)
+        assertThat(onVertxContext { repository.oldestCreatedAt(status) })
+            .describedAs("must be the OLDEST row, not merely any row — inserted newest-first on purpose")
+            .isEqualTo(older.createdAt)
+    }
+
+    /** An empty state must answer null, which the gauge renders as an age of 0 rather than a stale one. */
+    @Test
+    fun `oldestCreatedAt is null for a state holding no settlements`() {
+        assertThat(onVertxContext { repository.oldestCreatedAt(SettlementStatus.CREDITED_REVERSED) }).isNull()
+        assertThat(onVertxContext { repository.countByStatus(SettlementStatus.CREDITED_REVERSED) }).isZero()
+    }
+
     @Test
     fun `create persists the settlement and findById reads it back`() {
         val settlement = newSettlement()


### PR DESCRIPTION
## What this is

The **progress half** of #5705 for `openbank-settlement-service`: a signal that can distinguish
*"settlement is running normally"* from *"this settlement stopped moving three hours ago"*.

`openbank-settlement-service` is a declared `money_path_service` (`rules.yaml`) that emitted no
application metric of any kind. Verified on `origin/main` before touching anything:

```
$ grep -rlE "micrometer|MeterRegistry" openbank-settlement-service/src/main
(no output — 20 .kt files)
```

It was not un-monitored, which is what made it hard to see. The pod is scraped by the fleet
PodMonitor, `PaymentServiceDown` (`prometheus-rules-tier1.yaml`) covers `namespace="payments"` and
therefore this container, and both Pyrra money-path SLOs exist for it. **Every one of those measures
whether the service ANSWERS.** None measures whether the debit → credit → ledger-book saga it
accepted PROGRESSES — and a settlement whose workflow stopped advancing answers nothing at all, its
originating request having returned 2xx in milliseconds, hours before.

## Relationship to #5723 — resolved by subtraction, not by competing

**#5723 is open, mergeable, and does the other half of this issue well.** These two PRs are
complementary and were made disjoint on purpose; they can land in either order.

| | #5723 (outcome) | this PR (progress) |
|---|---|---|
| question | *what did settlements do* | *is this settlement still moving* |
| signal | origination / saga-step / terminal-state counters | per-status age + count of non-terminal settlements |
| catches | rejection rate, compensation rate, step failures, "accepted N and finished none" | one settlement stranded in `DEBITED` while traffic flows normally around it |
| `PrometheusRule` object | `openbank-settlement-alerts` | `openbank-settlement-progress-alerts` |
| metrics | `openbank_settlement_{originated,saga_steps,terminal}_total` | `openbank_settlement_non_terminal{,_oldest_age_seconds}` |

An earlier draft of this branch also carried a saga-step counter. It was **removed**: #5723's port
strictly subsumes it (it carries currency, amount and cycle duration, which mine did not), and
shipping a weaker duplicate of a series that already has an open PR is how two copies of one rule
end up in the same file to drift apart later. What is left here is only what #5723 structurally
cannot provide.

One note on #5723 for its own reviewer, not a blocker for this PR: its `SettlementServiceDown`
duplicates `PaymentServiceDown`, which already owns
`up{job="observability/openbank-services", namespace="payments"}` — that is a second page for one
outage. This PR deliberately adds no `*ServiceDown` rule for the same reason.

## What was added

**`SettlementStrandedGauge`** (mirrors `DomesticPaymentStrandedGauge`, #3273 — same failure shape,
same reasoning):

- `openbank_settlement_non_terminal{service="settlement",status=…}` — how many settlements are in
  that state right now.
- `openbank_settlement_non_terminal_oldest_age_seconds{service="settlement",status=…}` — the age of
  the oldest, or `0` when the state is empty.

Published for all six non-terminal states (`PENDING`, `DEBITED`, `CREDITED`, and the three
`*_REVERSED` compensation states). `BOOKED` and `REJECTED` are not published: a terminal row's age
only grows and would alert forever. `DEBITED` is the state that matters most — the payer has been
debited, the payee has not been credited, and the funds are in neither account.

Supporting changes: `countByStatus` / `oldestCreatedAt` on `SettlementRepository`, and Flyway
`V2__settlements_status_created_at_index.sql` (composite `(status, created_at)`) so the 30s refresh
is not twelve sequential scans a minute. **Rollback note:** additive;
`DROP INDEX IF EXISTS idx_settlements_status_created_at`.

## Two alert rules, and why neither is vacuous at t=0 on a cold pod

`SettlementStrandedMidSaga` (critical) — `PENDING|DEBITED|CREDITED` older than **3h**, `for: 15m`.
`SettlementStuckAfterCompensation` (warning) — the three `*_REVERSED` states older than **8h**,
`for: 30m`.

**Thresholds are derived from the code, not guessed.** `SettlementWorkflowImpl` sets a per-activity
`scheduleToCloseTimeout` of 2h (`SCHEDULE_TO_CLOSE_HOURS`), so a settlement can legitimately sit in
any single state for up to 2h while its next activity retries; 3h clears that with an hour of slack.
The longest legitimate compensation chain starts at `LEDGER_REVERSED` and still owes
`reverseCredit` + `reverseDebit` + `rejectSettlement` — three activities at 2h each, so 8h clears
that 6h worst case.

**Cold-pod behaviour.** Every series is created in `@PostConstruct` at `0`, before any traffic, so a
freshly started pod publishes `0` per status rather than an absent series. A `> threshold` rule
therefore cannot fire during or after a deploy, and `absent()` over these names means *"the pod is
not exporting"* rather than *"no settlements"*. There is **no seeded age** anywhere in this gauge —
the boot reading and the healthy reading are the same number by construction, so there is no
`Instant.EPOCH` fourth state of the kind that made `WorkflowLivenessStale` fire 15 minutes after
every deploy (#2239 / #4208). An absent series would have been the real hazard: a PromQL comparison
over one matches nothing, which renders *identically* to a healthy zero — exactly how
`openbank_transaction_sagas_stuck_total` sat unfireable in this same file until #5733.

**The collector watches itself.** The gauges are only as trustworthy as the tick that refreshes
them; a frozen `refresh()` leaves every age stuck at its last value, which reads as healthy. So
`refresh()` records a success against `DomainMetrics.registerWorkflowLiveness`, whose 30s cadence
**is** a real cadence — the existing fleet `WorkflowLivenessStale` rule then covers the collector
without anyone asserting a cadence on settlement traffic, which is the thing settlement does not
have. `refresh()` is a `suspend fun`, not `runBlocking` in a plain `@Scheduled` method, so it
carries a Vert.x context and does not abort with `HR000068`.

## How I confirmed the series will exist

The failure this repo keeps paying for is a rule over a series nothing emits, and no CI gate checks
for it. So the tests assert the **rendered Prometheus scrape text**, as literals, not
`registry.get(...)`:

```kotlin
assertThat(scraped).contains(
    """openbank_settlement_non_terminal_oldest_age_seconds{service="settlement",status="DEBITED"} 0.0""",
)
```

That is the exact string `SettlementStrandedMidSaga` matches. The code spells
`openbank.settlement.non_terminal.oldest.age.seconds`; nothing else in CI checks that the dotted
name and the underscored one are the same series.

Also asserted: the age arithmetic against a fixed `Clock`; that an emptied state reports `0` and not
a stale age (an alert that keeps firing after the problem is fixed is how an alert earns being
ignored); and that the published status set equals *every* enum value minus the two terminal ones,
derived from `SettlementStatus.entries` rather than restated — so a status added later cannot
silently go unwatched.

**Negative control.** Deleting the two `gauge(...)` calls from `register()` turns
`renders the exact series the alert rules read, at zero, before any refresh` **red**
(`MeterNotFoundException`), and reverting restores green. The test can detect the absence of the
thing it tests.

## What remains

- **#5723's outcome counters** — origination, per-step and terminal-state rates. Deliberately not in
  this PR; if #5723 is closed rather than merged, that half of #5705 is still owed.
- **The compensation adapters are still stubs.** `reverseDebit` and `reverseCredit` only write a
  status row and log `"stub: wire reversal to balance-service"` — they do not actually reverse money
  at balance-service. `SettlementStuckAfterCompensation` will now make a stalled unwind visible, but
  the unwind itself is not yet real. That predates this PR and is not in its scope; it deserves its
  own issue.

Closes #5705
