### PR TITLE
fix(fraud): dedupe both aggregates against the applied-id set, not a last-writer marker (#5789)

### DIFF
--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/application/port/out/FraudMetricsPort.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/application/port/out/FraudMetricsPort.kt
@@ -25,4 +25,15 @@ interface FraudMetricsPort {
      * model is calibrated and safe before any enforce phase — it never reflects a honoured decision.
      */
     fun recordShadowScore(score: Double)
+
+    /**
+     * Record that a transaction signal was recognised as ALREADY APPLIED to [aggregate] and was
+     * therefore not applied again (issue #5789). This is the only series that makes redelivery
+     * visible at all: a suppressed replay writes no row, logs nothing and changes no counter, so
+     * without this the guard working and the guard being absent look identical from outside the
+     * database. Read it as "how often is the dedupe guard load-bearing" — a sustained non-zero rate
+     * is normal after a rebalance or a DLQ replay; a permanently flat zero while redeliveries are
+     * known to happen means the guard is not being reached.
+     */
+    fun recordSignalReplaySuppressed(aggregate: String)
 }

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/application/port/out/FraudMetricsPort.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/application/port/out/FraudMetricsPort.kt
@@ -36,4 +36,18 @@ interface FraudMetricsPort {
      * known to happen means the guard is not being reached.
      */
     fun recordSignalReplaySuppressed(aggregate: String)
+
+    /**
+     * Record that a transaction signal arrived with **no `occurredAt`** and that processing time was
+     * substituted for it (issue #6044). Every velocity bucket and payee-history row written from
+     * such a signal asserts a business time nobody measured, and — because the bucket is part of the
+     * primary key — a replay of that same signal will not land in the same row, so the redelivery
+     * guard cannot reach it. The substitution is otherwise completely silent: it writes a normal row
+     * and logs nothing, exactly like the ingest-time substitution #3883 found in the audit
+     * consumer. This counter is the only thing that distinguishes "every producer sends an event
+     * time" from "we have been inventing them". `openbank.transactions.transaction.initiated`
+     * declares `occurredAt` as required, so the expected value is a flat ZERO; any non-zero rate is
+     * a producer defect, not a tolerable degradation.
+     */
+    fun recordSignalMissingEventTime()
 }

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/application/port/out/VelocityAggregateRepository.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/application/port/out/VelocityAggregateRepository.kt
@@ -7,6 +7,7 @@ package com.openbank.fraud.application.port.out
 import com.openbank.fraud.domain.model.VelocityAggregate
 import com.openbank.fraud.domain.model.VelocityWindow
 import java.math.BigDecimal
+import java.time.Instant
 import java.util.UUID
 
 /** Stores and queries per-account rolling velocity aggregates (ADR-0084 §2). */
@@ -22,8 +23,25 @@ interface VelocityAggregateRepository {
      * not applied — the windows converge independently rather than as one transaction. A null
      * [transactionId] carries no identity and is therefore never deduplicated (same contract as
      * [PayeeHistoryRepository.recordPayment]).
+     *
+     * The window bucket is derived from [occurredAt] — the event's own business time — and never
+     * from the moment the signal is processed (issue #6044). Processing time puts a redelivery that
+     * crosses an hour, day or week boundary into a DIFFERENT row from the original, and the
+     * idempotency above is per row, so no guard of any design could recognise it there. Bucketing on
+     * event time is therefore what makes the redelivery guard reach a delayed replay at all; it also
+     * makes the aggregate mean "transactions that OCCURRED in this window" rather than "signals that
+     * were PROCESSED in it", which is the only reading that reconciles against the source
+     * transactions. The caller is responsible for supplying a real event time; see
+     * [com.openbank.fraud.infrastructure.messaging.TransactionSignalConsumer] for what it does when
+     * the event carries none.
      */
-    suspend fun recordTransaction(accountId: UUID, amount: BigDecimal, currency: String, transactionId: UUID?)
+    suspend fun recordTransaction(
+        accountId: UUID,
+        amount: BigDecimal,
+        currency: String,
+        transactionId: UUID?,
+        occurredAt: Instant,
+    )
 
     /**
      * Returns the current aggregate for [accountId] in [window] for [currency], or null.

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/messaging/TransactionSignalConsumer.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/messaging/TransactionSignalConsumer.kt
@@ -6,6 +6,7 @@ package com.openbank.fraud.infrastructure.messaging
 
 import com.fasterxml.jackson.core.JacksonException
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.fraud.application.port.out.FraudMetricsPort
 import com.openbank.fraud.application.port.out.PayeeHistoryRepository
 import com.openbank.fraud.application.port.out.VelocityAggregateRepository
 import com.openbank.fraud.application.usecase.FeatureOnlineUpdater
@@ -51,6 +52,7 @@ class TransactionSignalConsumer(
     private val featureUpdater: FeatureOnlineUpdater,
     private val objectMapper: ObjectMapper,
     private val clock: Clock,
+    private val metrics: FraudMetricsPort,
 ) {
     private val log = Logger.getLogger(TransactionSignalConsumer::class.java)
 
@@ -70,15 +72,31 @@ class TransactionSignalConsumer(
         val accountId = signal.sourceAccountId ?: return
         val amount = signal.amount ?: BigDecimal.ZERO
         val currency = signal.currencyCode ?: "CZK"
+        // Issue #6044. occurredAt is REQUIRED on TransactionInitiatedEvent, so the fallback should
+        // never be taken; if it is, every row written from this signal carries a business time
+        // nobody measured, and the redelivery guard cannot reach a later replay of it (the replay
+        // would substitute a different processing time and so target a different velocity bucket
+        // row). Substituting silently is what made the audit consumer's ingest-time fallback
+        // invisible for 7 of its 21 topics (#3883); this one is counted, so the absent case is
+        // visible from outside the database instead of being indistinguishable from a healthy one.
+        val eventTime = signal.occurredAt ?: run {
+            metrics.recordSignalMissingEventTime()
+            log.warnf(
+                "transaction.initiated signal for account %s carries no occurredAt; substituting processing time. " +
+                    "Velocity bucketing and redelivery dedupe are both degraded for this signal (#6044).",
+                accountId,
+            )
+            Instant.now(clock)
+        }
         @Suppress("TooGenericExceptionCaught") // DB / reactive layer exceptions have no common base
         runBlocking {
             try {
-                velocityRepo.recordTransaction(accountId, amount, currency, signal.aggregateId)
+                velocityRepo.recordTransaction(accountId, amount, currency, signal.aggregateId, eventTime)
                 log.debugf("Velocity aggregate updated for account %s amount=%s %s", accountId, amount, currency)
             } catch (ex: Exception) {
                 log.warnf(ex, "Failed to record velocity aggregate for account %s", accountId)
             }
-            recordPayeeHistory(accountId, signal)
+            recordPayeeHistory(accountId, signal, eventTime)
             // ADR-0140 online feature store (shadow plane). Best-effort: a feature-store failure must
             // never break the velocity path. Skip silently when the event carries no business time.
             val occurredAt = signal.occurredAt ?: return@runBlocking
@@ -94,13 +112,13 @@ class TransactionSignalConsumer(
      * ADR-0084 §3 v4: best-effort payee-history update. Skipped silently when the signal carries no
      * `targetAccountId` (e.g. an external-rail payment with no internal counterparty account) — same
      * "missing signal degrades gracefully, never breaks the velocity path" contract as the feature
-     * store update below. Falls back to [clock] when `occurredAt` is absent so a history row is still
-     * recorded (unlike the feature store, which requires a business timestamp to stay meaningful).
+     * store update below. [eventTime] is the signal's `occurredAt`, or processing time when it
+     * carries none, so a history row is still recorded (unlike the feature store, which requires a
+     * business timestamp to stay meaningful) — the substitution is counted by the caller (#6044).
      */
     @Suppress("TooGenericExceptionCaught") // DB / reactive layer exceptions have no common base
-    private suspend fun recordPayeeHistory(accountId: UUID, signal: TransactionInitiatedSignal) {
+    private suspend fun recordPayeeHistory(accountId: UUID, signal: TransactionInitiatedSignal, occurredAt: Instant) {
         val payeeIdentifier = signal.targetAccountId?.toString() ?: return
-        val occurredAt = signal.occurredAt ?: Instant.now(clock)
         try {
             payeeHistoryRepo.recordPayment(accountId, payeeIdentifier, signal.aggregateId, occurredAt)
             log.debugf("Payee history updated for account %s payee %s", accountId, payeeIdentifier)

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/observability/FraudMetricsAdapter.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/observability/FraudMetricsAdapter.kt
@@ -55,6 +55,16 @@ class FraudMetricsAdapter(private val registry: MeterRegistry?) : FraudMetricsPo
         }
     }
 
+    override fun recordSignalReplaySuppressed(aggregate: String) {
+        registry?.let { r ->
+            Counter.builder("openbank.fraud.signal.replay.suppressed")
+                .tag("service", SERVICE)
+                .tag("aggregate", aggregate)
+                .register(r)
+                .increment()
+        }
+    }
+
     companion object {
         private const val SERVICE = "fraud"
     }

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/observability/FraudMetricsAdapter.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/observability/FraudMetricsAdapter.kt
@@ -65,6 +65,15 @@ class FraudMetricsAdapter(private val registry: MeterRegistry?) : FraudMetricsPo
         }
     }
 
+    override fun recordSignalMissingEventTime() {
+        registry?.let { r ->
+            Counter.builder("openbank.fraud.signal.missing.event.time")
+                .tag("service", SERVICE)
+                .register(r)
+                .increment()
+        }
+    }
+
     companion object {
         private const val SERVICE = "fraud"
     }

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/persistence/PayeeHistoryRepositoryImpl.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/persistence/PayeeHistoryRepositoryImpl.kt
@@ -86,6 +86,17 @@ class PayeeHistoryRepositoryImpl(
         // Residual bound (a decision, not an oversight): the set is bounded by a COUNT of signals,
         // not by elapsed time — a replay arriving after $5 further payments to the same payee is
         // applied again. See V6__applied_signal_ledger.sql.
+        // NULL-safety of the membership test (the union's cost, and the reason for array_remove):
+        // last_transaction_id is NULL for the whole life of a row after a signal that carried no
+        // aggregateId, and `x = ANY (array containing NULL)` evaluates to NULL — not FALSE — in
+        // Postgres. Without array_remove, `NOT (...)` is then NULL, the ON CONFLICT ... WHERE is not
+        // true, and every later genuinely-new signal to that row is silently dropped forever: the row
+        // freezes and the counts UNDERCOUNT, so a rule that should fire does not. The old
+        // IS DISTINCT FROM guard was NULL-safe, so this would have been a regression against main.
+        // applied_transaction_ids itself can never hold a NULL element (the INSERT path array_removes
+        // it, fraud_append_applied refuses to append it, and the V6 backfill array_removes it), so the
+        // union with the scalar marker is the only way a NULL reaches this array — array_remove is
+        // scoped exactly to that, and a NULL signal stays "applied unconditionally, not remembered".
         private const val UPSERT_SQL =
             """
             INSERT INTO payee_history
@@ -102,7 +113,9 @@ class PayeeHistoryRepositoryImpl(
                 updated_at              = NOW()
             WHERE EXCLUDED.last_transaction_id IS NULL
                OR NOT (EXCLUDED.last_transaction_id = ANY (
-                       array_append(payee_history.applied_transaction_ids, payee_history.last_transaction_id)))
+                       array_remove(
+                           array_append(payee_history.applied_transaction_ids,
+                                        payee_history.last_transaction_id), NULL)))
             """
 
         private const val SELECT_SQL =

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/persistence/PayeeHistoryRepositoryImpl.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/persistence/PayeeHistoryRepositoryImpl.kt
@@ -4,12 +4,14 @@
 
 package com.openbank.fraud.infrastructure.persistence
 
+import com.openbank.fraud.application.port.out.FraudMetricsPort
 import com.openbank.fraud.application.port.out.PayeeHistoryRepository
 import com.openbank.fraud.domain.model.PayeeHistory
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import io.vertx.mutiny.pgclient.PgPool
 import io.vertx.mutiny.sqlclient.Tuple
 import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.config.inject.ConfigProperty
 import java.time.Instant
 import java.util.UUID
 
@@ -20,7 +22,12 @@ import java.util.UUID
  * transaction does not double-count `payment_count`.
  */
 @ApplicationScoped
-class PayeeHistoryRepositoryImpl(private val pool: PgPool) : PayeeHistoryRepository {
+class PayeeHistoryRepositoryImpl(
+    private val pool: PgPool,
+    private val metrics: FraudMetricsPort,
+    @ConfigProperty(name = "openbank.fraud.applied-signal-window", defaultValue = "100")
+    private val appliedSignalWindow: Int,
+) : PayeeHistoryRepository {
 
     override suspend fun recordPayment(
         accountId: UUID,
@@ -28,14 +35,19 @@ class PayeeHistoryRepositoryImpl(private val pool: PgPool) : PayeeHistoryReposit
         transactionId: UUID?,
         occurredAt: Instant,
     ) {
-        pool.preparedQuery(UPSERT_SQL).execute(
+        val result = pool.preparedQuery(UPSERT_SQL).execute(
             Tuple.of(
                 accountId.toString(),
                 payeeIdentifier,
                 occurredAt.toOffsetDateTime(),
                 transactionId?.toString(),
-            ),
+            ).addInteger(appliedSignalWindow),
         ).awaitSuspending()
+        // rowCount 0 means the ON CONFLICT ... WHERE was false: this (account, payee) row has
+        // already applied this transaction id and the increment was suppressed.
+        if (result.rowCount() == 0) {
+            metrics.recordSignalReplaySuppressed(AGGREGATE_NAME)
+        }
     }
 
     override suspend fun findHistory(accountId: UUID, payeeIdentifier: String): PayeeHistory? {
@@ -53,27 +65,44 @@ class PayeeHistoryRepositoryImpl(private val pool: PgPool) : PayeeHistoryReposit
     }
 
     companion object {
-        // Idempotency guard: only increment when the incoming transaction id is either absent
-        // (transactionId == NULL — the signal carries no aggregateId, so it cannot be deduplicated;
-        // matches the existing velocity_aggregates path, which has no dedup at all) or genuinely
-        // different from the last one recorded. A redelivered Kafka message for the SAME
-        // transactionId matches payee_history.last_transaction_id and the WHERE clause is false, so
-        // the DO UPDATE is skipped entirely (Postgres leaves the existing row untouched) — no
-        // double-count, and first_seen_at is preserved (only ever set on INSERT).
+        private const val AGGREGATE_NAME = "payee_history"
+
+        // Idempotency guard, issue #5789 (superseding the V3 last-writer marker, which has shipped
+        // since V3 and only ever caught a replay that was consecutive for this row).
+        // applied_transaction_ids is the SET of ids this (account, payee) row has actually applied,
+        // trimmed to the most recent $5 entries by fraud_append_applied (V6); the WHERE tests
+        // membership of that set, so a replay is suppressed however many other payments to the same
+        // payee landed in between. A signal with no transaction id (NULL) carries no identity to
+        // deduplicate by, is applied unconditionally as before, and is not remembered.
+        //
+        // The marker is NOT merely diagnostic in the guard: it is unioned into the set being tested.
+        // That covers the cutover window a backfill alone cannot — during a rolling deploy a pod still
+        // running the V5/V3 code writes last_transaction_id and leaves applied_transaction_ids empty, so
+        // a row touched after the migration but before the last old pod drains would otherwise carry no
+        // memory of the id it just applied. Unioning makes the new guard strictly stronger than the old
+        // one in every state, never weaker; outside that window the marker is always already the last
+        // element of the set and the union adds nothing.
+        // first_seen_at is still only ever set on INSERT, so a suppressed replay cannot move it.
+        // Residual bound (a decision, not an oversight): the set is bounded by a COUNT of signals,
+        // not by elapsed time — a replay arriving after $5 further payments to the same payee is
+        // applied again. See V6__applied_signal_ledger.sql.
         private const val UPSERT_SQL =
             """
             INSERT INTO payee_history
                 (account_id, payee_identifier, first_seen_at, last_paid_at, payment_count,
-                 last_transaction_id, updated_at)
-            VALUES ($1::uuid, $2, $3, $3, 1, $4::uuid, NOW())
+                 last_transaction_id, applied_transaction_ids, updated_at)
+            VALUES ($1::uuid, $2, $3, $3, 1, $4::uuid, array_remove(ARRAY[$4::uuid], NULL), NOW())
             ON CONFLICT (account_id, payee_identifier)
             DO UPDATE SET
-                last_paid_at        = EXCLUDED.last_paid_at,
-                payment_count       = payee_history.payment_count + 1,
-                last_transaction_id = EXCLUDED.last_transaction_id,
-                updated_at          = NOW()
+                last_paid_at            = EXCLUDED.last_paid_at,
+                payment_count           = payee_history.payment_count + 1,
+                last_transaction_id     = EXCLUDED.last_transaction_id,
+                applied_transaction_ids = fraud_append_applied(
+                    payee_history.applied_transaction_ids, EXCLUDED.last_transaction_id, $5),
+                updated_at              = NOW()
             WHERE EXCLUDED.last_transaction_id IS NULL
-               OR payee_history.last_transaction_id IS DISTINCT FROM EXCLUDED.last_transaction_id
+               OR NOT (EXCLUDED.last_transaction_id = ANY (
+                       array_append(payee_history.applied_transaction_ids, payee_history.last_transaction_id)))
             """
 
         private const val SELECT_SQL =

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImpl.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImpl.kt
@@ -103,6 +103,17 @@ class VelocityAggregateRepositoryImpl(
         // by a COUNT of signals, not by elapsed time. A replay that arrives after $7 further signals to
         // this same (account, window, currency, bucket) row has been evicted from the set and is applied
         // again. See V6__applied_signal_ledger.sql for why a count window was chosen over a ledger table.
+        // NULL-safety of the membership test (the union's cost, and the reason for array_remove):
+        // last_transaction_id is NULL for the whole life of a row after a signal that carried no
+        // aggregateId, and `x = ANY (array containing NULL)` evaluates to NULL — not FALSE — in
+        // Postgres. Without array_remove, `NOT (...)` is then NULL, the ON CONFLICT ... WHERE is not
+        // true, and every later genuinely-new signal to that row is silently dropped forever: the row
+        // freezes and the counts UNDERCOUNT, so a rule that should fire does not. The old
+        // IS DISTINCT FROM guard was NULL-safe, so this would have been a regression against main.
+        // applied_transaction_ids itself can never hold a NULL element (the INSERT path array_removes
+        // it, fraud_append_applied refuses to append it, and the V6 backfill array_removes it), so the
+        // union with the scalar marker is the only way a NULL reaches this array — array_remove is
+        // scoped exactly to that, and a NULL signal stays "applied unconditionally, not remembered".
         private const val UPSERT_SQL =
             """
             INSERT INTO velocity_aggregates
@@ -119,7 +130,9 @@ class VelocityAggregateRepositoryImpl(
                 updated_at              = NOW()
             WHERE EXCLUDED.last_transaction_id IS NULL
                OR NOT (EXCLUDED.last_transaction_id = ANY (
-                       array_append(velocity_aggregates.applied_transaction_ids, velocity_aggregates.last_transaction_id)))
+                       array_remove(
+                           array_append(velocity_aggregates.applied_transaction_ids,
+                                        velocity_aggregates.last_transaction_id), NULL)))
             """
 
         private const val SELECT_SQL =

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImpl.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImpl.kt
@@ -35,10 +35,14 @@ class VelocityAggregateRepositoryImpl(
         amount: BigDecimal,
         currency: String,
         transactionId: UUID?,
+        occurredAt: Instant,
     ) {
-        val now = Instant.now(clock)
+        // Issue #6044: the bucket comes from the event's own time, never from Instant.now(clock).
+        // window_start is part of the PK, so a redelivery processed on the other side of an hour
+        // boundary would otherwise target a different ROW — and the applied-id guard below is per
+        // row, so it would not see the first application and would count the replay again.
         VelocityWindow.entries.forEach { window ->
-            val start = window.bucketStart(now).toOffsetDateTime()
+            val start = window.bucketStart(occurredAt).toOffsetDateTime()
             val result = pool.preparedQuery(UPSERT_SQL).execute(
                 Tuple.of(
                     accountId.toString(),

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImpl.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImpl.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.fraud.infrastructure.persistence
 
+import com.openbank.fraud.application.port.out.FraudMetricsPort
 import com.openbank.fraud.application.port.out.VelocityAggregateRepository
 import com.openbank.fraud.domain.model.VelocityAggregate
 import com.openbank.fraud.domain.model.VelocityWindow
@@ -11,6 +12,7 @@ import io.smallrye.mutiny.coroutines.awaitSuspending
 import io.vertx.mutiny.pgclient.PgPool
 import io.vertx.mutiny.sqlclient.Tuple
 import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.config.inject.ConfigProperty
 import java.math.BigDecimal
 import java.time.Clock
 import java.time.Instant
@@ -20,8 +22,13 @@ import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 @ApplicationScoped
-class VelocityAggregateRepositoryImpl(private val pool: PgPool, private val clock: Clock) :
-    VelocityAggregateRepository {
+class VelocityAggregateRepositoryImpl(
+    private val pool: PgPool,
+    private val clock: Clock,
+    private val metrics: FraudMetricsPort,
+    @ConfigProperty(name = "openbank.fraud.applied-signal-window", defaultValue = "100")
+    private val appliedSignalWindow: Int,
+) : VelocityAggregateRepository {
 
     override suspend fun recordTransaction(
         accountId: UUID,
@@ -32,7 +39,7 @@ class VelocityAggregateRepositoryImpl(private val pool: PgPool, private val cloc
         val now = Instant.now(clock)
         VelocityWindow.entries.forEach { window ->
             val start = window.bucketStart(now).toOffsetDateTime()
-            pool.preparedQuery(UPSERT_SQL).execute(
+            val result = pool.preparedQuery(UPSERT_SQL).execute(
                 Tuple.of(
                     accountId.toString(),
                     window.name,
@@ -40,8 +47,13 @@ class VelocityAggregateRepositoryImpl(private val pool: PgPool, private val cloc
                     start,
                     amount,
                     transactionId?.toString(),
-                ),
+                ).addInteger(appliedSignalWindow),
             ).awaitSuspending()
+            // rowCount 0 means the ON CONFLICT ... WHERE was false: this row has already applied
+            // this transaction id, so the increment was suppressed. Nothing else records that.
+            if (result.rowCount() == 0) {
+                metrics.recordSignalReplaySuppressed(AGGREGATE_NAME)
+            }
         }
     }
 
@@ -67,27 +79,47 @@ class VelocityAggregateRepositoryImpl(private val pool: PgPool, private val cloc
     }
 
     companion object {
-        // Redelivery guard (#5716), mirroring payee_history's: only apply when the incoming
-        // transaction id is either absent (NULL — the signal carries no aggregateId, so it cannot be
-        // deduplicated) or genuinely different from the one this row last applied. A redelivered
-        // Kafka message for the SAME aggregateId makes the WHERE false, so the DO UPDATE is skipped
-        // entirely and Postgres leaves the row untouched — no double-count of either the count or
-        // the amount. The marker is per row, so the three window statements converge independently:
-        // a retry after a partial failure re-applies only the windows it had not reached.
+        private const val AGGREGATE_NAME = "velocity_aggregates"
+
+        // Redelivery guard, issue #5789 (superseding the #5716 last-writer marker). applied_transaction_ids
+        // is the SET of ids this row has actually applied, most recent last, trimmed to the most recent
+        // $7 entries by fraud_append_applied (V6). The WHERE tests membership of that set, so a replay is
+        // suppressed however many other signals reached this row in between — the A, B, A ordering the
+        // marker could not catch. A signal with no aggregateId (NULL) carries no identity to deduplicate
+        // by and is applied unconditionally, exactly as before, and is not remembered.
+        //
+        // The marker is NOT merely diagnostic in the guard: it is unioned into the set being tested.
+        // That covers the cutover window a backfill alone cannot — during a rolling deploy a pod still
+        // running the V5/V3 code writes last_transaction_id and leaves applied_transaction_ids empty, so
+        // a row touched after the migration but before the last old pod drains would otherwise carry no
+        // memory of the id it just applied. Unioning makes the new guard strictly stronger than the old
+        // one in every state, never weaker; outside that window the marker is always already the last
+        // element of the set and the union adds nothing.
+        // The marker is still maintained in last_transaction_id as a diagnostic, but nothing reads it as
+        // a guard any more. The guard remains PER ROW, so the three window statements still converge
+        // independently after a partial failure: a retry re-applies only the windows it had not reached.
+        //
+        // Residual bound, stated because it is a design decision and not an oversight: the set is bounded
+        // by a COUNT of signals, not by elapsed time. A replay that arrives after $7 further signals to
+        // this same (account, window, currency, bucket) row has been evicted from the set and is applied
+        // again. See V6__applied_signal_ledger.sql for why a count window was chosen over a ledger table.
         private const val UPSERT_SQL =
             """
             INSERT INTO velocity_aggregates
                 (account_id, velocity_window, currency, window_start, transaction_count, total_amount,
-                 last_transaction_id, updated_at)
-            VALUES ($1::uuid, $2, $3, $4, 1, $5, $6::uuid, NOW())
+                 last_transaction_id, applied_transaction_ids, updated_at)
+            VALUES ($1::uuid, $2, $3, $4, 1, $5, $6::uuid, array_remove(ARRAY[$6::uuid], NULL), NOW())
             ON CONFLICT (account_id, velocity_window, currency, window_start)
             DO UPDATE SET
-                transaction_count   = velocity_aggregates.transaction_count + 1,
-                total_amount        = velocity_aggregates.total_amount + EXCLUDED.total_amount,
-                last_transaction_id = EXCLUDED.last_transaction_id,
-                updated_at          = NOW()
+                transaction_count       = velocity_aggregates.transaction_count + 1,
+                total_amount            = velocity_aggregates.total_amount + EXCLUDED.total_amount,
+                last_transaction_id     = EXCLUDED.last_transaction_id,
+                applied_transaction_ids = fraud_append_applied(
+                    velocity_aggregates.applied_transaction_ids, EXCLUDED.last_transaction_id, $7),
+                updated_at              = NOW()
             WHERE EXCLUDED.last_transaction_id IS NULL
-               OR velocity_aggregates.last_transaction_id IS DISTINCT FROM EXCLUDED.last_transaction_id
+               OR NOT (EXCLUDED.last_transaction_id = ANY (
+                       array_append(velocity_aggregates.applied_transaction_ids, velocity_aggregates.last_transaction_id)))
             """
 
         private const val SELECT_SQL =

--- a/openbank-fraud-service/src/main/resources/db/migration/V6__applied_signal_ledger.sql
+++ b/openbank-fraud-service/src/main/resources/db/migration/V6__applied_signal_ledger.sql
@@ -1,0 +1,80 @@
+-- Issue #5789: both fraud aggregates deduplicated redelivery with a LAST-WRITER marker
+-- (payee_history since V3, velocity_aggregates since V5), which only catches a replay that is
+-- consecutive for that row. The reachable failure is not exotic: the source topic
+-- openbank.transactions.transaction.initiated is keyed by the transaction aggregateId, so two
+-- signals for the same account are two different keys and any at-least-once replay of an
+-- uncommitted offset window re-delivers them in the order A, B. After B the marker holds B, so the
+-- replayed A is DISTINCT FROM it and is applied a second time — and so is B after it. The marker
+-- therefore protects a replay window of exactly one record.
+--
+-- The fix is the applied-event set the marker was standing in for: each aggregate row remembers the
+-- ids it has actually applied, and the upsert's WHERE tests membership of that set rather than
+-- equality with the newest entry.
+--
+-- Bound (the design decision, stated rather than hidden): the set is bounded by a COUNT window, not
+-- by a duration — the most recent N ids applied to that row, N configurable via
+-- openbank.fraud.applied-signal-window (default 100). Chosen over a time-bounded ledger table
+-- because it needs no retention sweep to stay bounded (a per-row array is trimmed on every write,
+-- so it cannot grow without a scheduler running), and it stays inside the one statement that
+-- already applies the increment, so the memory of "applied" and the effect of applying commit
+-- together with no window in between. The cost is that the guarantee is expressed in events rather
+-- than in time: a replay that arrives after N further signals to the SAME row is once again
+-- re-applied. For velocity_aggregates a row is one (account, window, currency, bucket), so N=100 is
+-- 100 transactions inside that bucket; for payee_history it is 100 payments to the same payee.
+--
+-- Backfill: each existing row already carries exactly one applied id in last_transaction_id, so the
+-- set is seeded from it and the protection that exists today is not lost at cutover. Rows whose
+-- marker is NULL (no signal recorded yet, or a signal with no aggregateId) seed to an empty set.
+-- last_transaction_id is deliberately KEPT and is still part of the guard: the upsert tests membership
+-- of applied_transaction_ids UNIONED with last_transaction_id. That is what covers the rolling-deploy
+-- window this backfill cannot — a pod still running the V5/V3 code writes the marker and leaves the
+-- new column untouched, so a row it applies after this migration runs would otherwise remember nothing.
+-- The union makes the new guard strictly stronger than the old one in every state, never weaker.
+--
+-- Rollback:
+--   DROP FUNCTION IF EXISTS fraud_append_applied(UUID[], UUID, INT);
+--   ALTER TABLE velocity_aggregates DROP COLUMN applied_transaction_ids;
+--   ALTER TABLE payee_history       DROP COLUMN applied_transaction_ids;
+-- (last_transaction_id is untouched by this migration, so a rollback returns both tables to the
+-- V3/V5 last-writer guard rather than to no guard at all.)
+
+ALTER TABLE velocity_aggregates
+    ADD COLUMN applied_transaction_ids UUID[] NOT NULL DEFAULT '{}';
+
+ALTER TABLE payee_history
+    ADD COLUMN applied_transaction_ids UUID[] NOT NULL DEFAULT '{}';
+
+UPDATE velocity_aggregates
+   SET applied_transaction_ids = array_remove(ARRAY[last_transaction_id], NULL)
+ WHERE last_transaction_id IS NOT NULL;
+
+UPDATE payee_history
+   SET applied_transaction_ids = array_remove(ARRAY[last_transaction_id], NULL)
+ WHERE last_transaction_id IS NOT NULL;
+
+-- Append new_id and keep only the most recent `cap` entries. IMMUTABLE so it can be used inside the
+-- upsert's SET without blocking the planner. A cap <= 0 is clamped to 1 so a misconfiguration
+-- degrades to the old last-writer behaviour rather than to an empty set (which would be NO guard).
+CREATE OR REPLACE FUNCTION fraud_append_applied(ids UUID[], new_id UUID, cap INT)
+RETURNS UUID[]
+LANGUAGE sql
+IMMUTABLE
+AS $$
+    SELECT CASE
+               WHEN cardinality(a) > GREATEST(cap, 1)
+                   THEN a[cardinality(a) - GREATEST(cap, 1) + 1 : cardinality(a)]
+               ELSE a
+           END
+      FROM (
+          -- A signal with no aggregateId carries no identity to deduplicate by, so it is applied
+          -- unconditionally and must NOT be remembered: appending NULL would grow the set with
+          -- entries that can never match anything.
+          SELECT CASE
+                     WHEN new_id IS NULL THEN COALESCE(ids, '{}'::uuid[])
+                     ELSE array_append(COALESCE(ids, '{}'::uuid[]), new_id)
+                 END AS a
+      ) s
+$$;
+
+GRANT ALL ON ALL TABLES IN SCHEMA public TO openbank;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO openbank;

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/messaging/TransactionSignalConsumerTest.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/messaging/TransactionSignalConsumerTest.kt
@@ -7,6 +7,7 @@ package com.openbank.fraud.infrastructure.messaging
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.kotlinModule
+import com.openbank.fraud.application.port.out.FraudMetricsPort
 import com.openbank.fraud.application.port.out.PayeeHistoryRepository
 import com.openbank.fraud.application.port.out.VelocityAggregateRepository
 import com.openbank.fraud.application.usecase.FeatureOnlineUpdater
@@ -30,10 +31,11 @@ class TransactionSignalConsumerTest {
     private val objectMapper = ObjectMapper()
         .registerModule(kotlinModule())
         .registerModule(JavaTimeModule())
+    private val metrics = mockk<FraudMetricsPort>(relaxed = true)
     private val fixedClock = Clock.fixed(Instant.parse("2026-07-09T00:00:00Z"), ZoneOffset.UTC)
 
     private val consumer =
-        TransactionSignalConsumer(velocityRepo, payeeHistoryRepo, featureUpdater, objectMapper, fixedClock)
+        TransactionSignalConsumer(velocityRepo, payeeHistoryRepo, featureUpdater, objectMapper, fixedClock, metrics)
 
     @Test
     fun `happy path records velocity for valid signal`() {
@@ -49,7 +51,68 @@ class TransactionSignalConsumerTest {
 
         consumer.onTransactionInitiated(payload)
 
-        coVerify(exactly = 1) { velocityRepo.recordTransaction(accountId, BigDecimal("250.00"), "CZK", any()) }
+        coVerify(exactly = 1) { velocityRepo.recordTransaction(accountId, BigDecimal("250.00"), "CZK", any(), any()) }
+    }
+
+    /**
+     * Issue #6044: the velocity bucket must be derived from the event's own business time. The
+     * repository is what applies it, but the consumer is the only place that can supply it — and it
+     * used to supply nothing, leaving the repository to read its clock. Asserted here as the exact
+     * `occurredAt` from the wire, not merely "some Instant": a fallback to processing time is
+     * precisely the bug, and `any()` would agree with it.
+     */
+    @Test
+    fun `forwards the event occurredAt to the velocity repository as the bucket time`() {
+        val accountId = UUID.randomUUID()
+        val occurredAt = Instant.parse("2026-07-09T10:59:00Z")
+        val eventTimeSlot = slot<Instant>()
+        coEvery {
+            velocityRepo.recordTransaction(any(), any(), any(), any(), capture(eventTimeSlot))
+        } returns Unit
+        val payload = """
+            {
+              "aggregateId": "${UUID.randomUUID()}",
+              "sourceAccountId": "$accountId",
+              "amount": "250.00",
+              "currencyCode": "CZK",
+              "occurredAt": "$occurredAt"
+            }
+        """.trimIndent()
+
+        consumer.onTransactionInitiated(payload)
+
+        assertThat(eventTimeSlot.captured).isEqualTo(occurredAt)
+        // Nothing was substituted, so the substitution must not be reported.
+        coVerify(exactly = 0) { metrics.recordSignalMissingEventTime() }
+    }
+
+    /**
+     * `occurredAt` is required on `TransactionInitiatedEvent`, so this should never happen — which is
+     * exactly why it must be counted rather than absorbed. Processing time is still substituted (a
+     * velocity row with an invented bucket beats no velocity row at all for a fraud control), but the
+     * substitution is now visible from outside the database. #3883 is the precedent: the audit
+     * consumer substituted ingest time for 7 of its 21 topics and nothing anywhere said so.
+     */
+    @Test
+    fun `counts the substitution when the signal carries no occurredAt`() {
+        val accountId = UUID.randomUUID()
+        val eventTimeSlot = slot<Instant>()
+        coEvery {
+            velocityRepo.recordTransaction(any(), any(), any(), any(), capture(eventTimeSlot))
+        } returns Unit
+        val payload = """
+            {
+              "aggregateId": "${UUID.randomUUID()}",
+              "sourceAccountId": "$accountId",
+              "amount": "250.00",
+              "currencyCode": "CZK"
+            }
+        """.trimIndent()
+
+        consumer.onTransactionInitiated(payload)
+
+        coVerify(exactly = 1) { metrics.recordSignalMissingEventTime() }
+        assertThat(eventTimeSlot.captured).isEqualTo(Instant.parse("2026-07-09T00:00:00Z"))
     }
 
     @Test
@@ -58,7 +121,7 @@ class TransactionSignalConsumerTest {
         val aggregateId = UUID.randomUUID()
         val transactionIdSlot = slot<UUID>()
         coEvery {
-            velocityRepo.recordTransaction(any(), any(), any(), capture(transactionIdSlot))
+            velocityRepo.recordTransaction(any(), any(), any(), capture(transactionIdSlot), any())
         } returns Unit
         val payload = """
             {
@@ -108,7 +171,7 @@ class TransactionSignalConsumerTest {
     fun `bad JSON is dropped without calling repository`() {
         consumer.onTransactionInitiated("not-valid-json{{{")
 
-        coVerify(exactly = 0) { velocityRepo.recordTransaction(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { velocityRepo.recordTransaction(any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -117,14 +180,14 @@ class TransactionSignalConsumerTest {
 
         consumer.onTransactionInitiated(payload)
 
-        coVerify(exactly = 0) { velocityRepo.recordTransaction(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { velocityRepo.recordTransaction(any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `missing amount defaults to zero`() {
         val accountId = UUID.randomUUID()
         val amountSlot = slot<BigDecimal>()
-        coEvery { velocityRepo.recordTransaction(any(), capture(amountSlot), any(), any()) } returns Unit
+        coEvery { velocityRepo.recordTransaction(any(), capture(amountSlot), any(), any(), any()) } returns Unit
 
         val payload = """{"sourceAccountId": "$accountId", "currencyCode": "CZK"}"""
         consumer.onTransactionInitiated(payload)
@@ -136,7 +199,7 @@ class TransactionSignalConsumerTest {
     fun `missing currencyCode defaults to CZK`() {
         val accountId = UUID.randomUUID()
         val currencySlot = slot<String>()
-        coEvery { velocityRepo.recordTransaction(any(), any(), capture(currencySlot), any()) } returns Unit
+        coEvery { velocityRepo.recordTransaction(any(), any(), capture(currencySlot), any(), any()) } returns Unit
 
         val payload = """{"sourceAccountId": "$accountId", "amount": "50.00"}"""
         consumer.onTransactionInitiated(payload)
@@ -147,7 +210,7 @@ class TransactionSignalConsumerTest {
     @Test
     fun `repository exception is caught and does not propagate`() {
         val accountId = UUID.randomUUID()
-        coEvery { velocityRepo.recordTransaction(any(), any(), any(), any()) } throws RuntimeException("DB down")
+        coEvery { velocityRepo.recordTransaction(any(), any(), any(), any(), any()) } throws RuntimeException("DB down")
 
         val payload = """{"sourceAccountId": "$accountId", "amount": "100.00", "currencyCode": "CZK"}"""
 
@@ -231,6 +294,6 @@ class TransactionSignalConsumerTest {
         // Must not throw, and must not prevent the velocity path from running
         consumer.onTransactionInitiated(payload)
 
-        coVerify(exactly = 1) { velocityRepo.recordTransaction(accountId, BigDecimal("100.00"), "CZK", any()) }
+        coVerify(exactly = 1) { velocityRepo.recordTransaction(accountId, BigDecimal("100.00"), "CZK", any(), any()) }
     }
 }

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/PayeeHistoryRepositoryImplIT.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/PayeeHistoryRepositoryImplIT.kt
@@ -4,9 +4,12 @@
 
 package com.openbank.fraud.infrastructure.persistence
 
+import com.openbank.fraud.application.port.out.FraudMetricsPort
 import com.openbank.fraud.application.port.out.PayeeHistoryRepository
+import com.openbank.fraud.domain.model.FraudVerdict
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
+import io.vertx.mutiny.pgclient.PgPool
 import jakarta.inject.Inject
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -26,6 +29,9 @@ class PayeeHistoryRepositoryImplIT {
 
     @Inject
     lateinit var repository: PayeeHistoryRepository
+
+    @Inject
+    lateinit var pool: PgPool
 
     @Test
     fun `a payee with no recorded payment is new (findHistory returns null)`(): Unit = runBlocking {
@@ -119,4 +125,74 @@ class PayeeHistoryRepositoryImplIT {
 
         assertThat(historyForB).isNull()
     }
+    /**
+     * Issue #5789 — the defect the V3 last-writer marker has never caught, and which was treated
+     * throughout the #5698 sweep as "the one that already guards". The marker stored the LAST id
+     * applied, so a replay of A arriving after B is `IS DISTINCT FROM` the marker and increments
+     * `payment_count` a second time. payee_history feeds first-time-payee detection, so a spurious
+     * re-application moves a fraud signal, not just a counter.
+     */
+    @Test
+    fun `an out-of-order replay after another payment is not counted twice`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val payeeIdentifier = UUID.randomUUID().toString()
+        val a = UUID.randomUUID()
+        val b = UUID.randomUUID()
+
+        repository.recordPayment(accountId, payeeIdentifier, a, Instant.now())
+        repository.recordPayment(accountId, payeeIdentifier, b, Instant.now())
+        // The replay of A, landing after B.
+        repository.recordPayment(accountId, payeeIdentifier, a, Instant.now())
+
+        val history = repository.findHistory(accountId, payeeIdentifier)
+        assertThat(history!!.paymentCount).isEqualTo(2L)
+    }
+
+    /** Both ids replayed after each other, in the order an uncommitted offset window is re-delivered. */
+    @Test
+    fun `replaying a whole uncommitted window counts neither payment twice`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val payeeIdentifier = UUID.randomUUID().toString()
+        val a = UUID.randomUUID()
+        val b = UUID.randomUUID()
+
+        repository.recordPayment(accountId, payeeIdentifier, a, Instant.now())
+        repository.recordPayment(accountId, payeeIdentifier, b, Instant.now())
+        repository.recordPayment(accountId, payeeIdentifier, a, Instant.now())
+        repository.recordPayment(accountId, payeeIdentifier, b, Instant.now())
+
+        val history = repository.findHistory(accountId, payeeIdentifier)
+        assertThat(history!!.paymentCount).isEqualTo(2L)
+    }
+
+    /**
+     * A suppressed replay leaves no trace of its own — no row written, nothing logged. This asserts
+     * the one series that makes it visible.
+     */
+    @Test
+    fun `a suppressed replay is counted`(): Unit = runBlocking {
+        val suppressed = mutableListOf<String>()
+        val repo = PayeeHistoryRepositoryImpl(
+            pool,
+            object : FraudMetricsPort {
+                override fun recordVerdict(verdict: FraudVerdict, rail: String) = Unit
+                override fun recordShadowScore(score: Double) = Unit
+                override fun recordSignalReplaySuppressed(aggregate: String) {
+                    suppressed.add(aggregate)
+                }
+            },
+            100,
+        )
+        val accountId = UUID.randomUUID()
+        val payeeIdentifier = UUID.randomUUID().toString()
+        val a = UUID.randomUUID()
+
+        repo.recordPayment(accountId, payeeIdentifier, a, Instant.now())
+        assertThat(suppressed).isEmpty()
+
+        repo.recordPayment(accountId, payeeIdentifier, a, Instant.now())
+
+        assertThat(suppressed).containsExactly("payee_history")
+    }
+
 }

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/PayeeHistoryRepositoryImplIT.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/PayeeHistoryRepositoryImplIT.kt
@@ -125,6 +125,7 @@ class PayeeHistoryRepositoryImplIT {
 
         assertThat(historyForB).isNull()
     }
+
     /**
      * Issue #5789 — the defect the V3 last-writer marker has never caught, and which was treated
      * throughout the #5698 sweep as "the one that already guards". The marker stored the LAST id
@@ -194,5 +195,4 @@ class PayeeHistoryRepositoryImplIT {
 
         assertThat(suppressed).containsExactly("payee_history")
     }
-
 }

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/PayeeHistoryRepositoryImplIT.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/PayeeHistoryRepositoryImplIT.kt
@@ -221,6 +221,8 @@ class PayeeHistoryRepositoryImplIT {
                 override fun recordSignalReplaySuppressed(aggregate: String) {
                     suppressed.add(aggregate)
                 }
+
+                override fun recordSignalMissingEventTime() = Unit
             },
             100,
         )

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/PayeeHistoryRepositoryImplIT.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/PayeeHistoryRepositoryImplIT.kt
@@ -127,6 +127,46 @@ class PayeeHistoryRepositoryImplIT {
     }
 
     /**
+     * Issue #5789 follow-up, payee_history side of the same defect: a payment with no transaction id
+     * parks a NULL in `last_transaction_id`, which is unioned into the array the membership test runs
+     * over. `x = ANY (array containing NULL)` is NULL, so `NOT (...)` is NULL, the
+     * `ON CONFLICT ... WHERE` is not true, and every later payment to that payee is silently dropped —
+     * `payment_count` freezes. payee_history feeds first-time-payee detection, so a frozen row keeps a
+     * genuine payee looking newer than it is.
+     *
+     * The sequence INTERLEAVES on purpose: consecutive NULLs both take the
+     * `EXCLUDED.last_transaction_id IS NULL` branch and short-circuit before the membership test.
+     */
+    @Test
+    fun `a payment without a transaction id does not freeze the row against later payments`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val payeeIdentifier = UUID.randomUUID().toString()
+
+        repository.recordPayment(accountId, payeeIdentifier, UUID.randomUUID(), Instant.now())
+        repository.recordPayment(accountId, payeeIdentifier, null, Instant.now())
+        repository.recordPayment(accountId, payeeIdentifier, UUID.randomUUID(), Instant.now())
+        repository.recordPayment(accountId, payeeIdentifier, UUID.randomUUID(), Instant.now())
+
+        val history = repository.findHistory(accountId, payeeIdentifier)
+        assertThat(history!!.paymentCount).isEqualTo(4L)
+    }
+
+    /** The other side: dedupe must still suppress a replay once a NULL has passed through the row. */
+    @Test
+    fun `dedupe still suppresses a replay after a payment without a transaction id`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val payeeIdentifier = UUID.randomUUID().toString()
+        val c = UUID.randomUUID()
+
+        repository.recordPayment(accountId, payeeIdentifier, c, Instant.now())
+        repository.recordPayment(accountId, payeeIdentifier, null, Instant.now())
+        repository.recordPayment(accountId, payeeIdentifier, c, Instant.now())
+
+        val history = repository.findHistory(accountId, payeeIdentifier)
+        assertThat(history!!.paymentCount).isEqualTo(2L)
+    }
+
+    /**
      * Issue #5789 — the defect the V3 last-writer marker has never caught, and which was treated
      * throughout the #5698 sweep as "the one that already guards". The marker stored the LAST id
      * applied, so a replay of A arriving after B is `IS DISTINCT FROM` the marker and increments

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/PayeeHistoryRepositoryImplTest.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/PayeeHistoryRepositoryImplTest.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.fraud.infrastructure.persistence
 
+import com.openbank.fraud.application.port.out.FraudMetricsPort
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -31,7 +32,8 @@ class PayeeHistoryRepositoryImplTest {
 
     private val pool = mockk<PgPool>()
 
-    private val repository = PayeeHistoryRepositoryImpl(pool)
+    private val metrics = mockk<FraudMetricsPort>(relaxed = true)
+    private val repository = PayeeHistoryRepositoryImpl(pool, metrics, APPLIED_SIGNAL_WINDOW)
 
     private fun emptyRowIterator(): RowIterator<Row> {
         val iter = mockk<RowIterator<Row>>()
@@ -52,6 +54,9 @@ class PayeeHistoryRepositoryImplTest {
     private fun mockRowSet(iter: RowIterator<Row>): RowSet<Row> {
         val rowSet = mockk<RowSet<Row>>()
         every { rowSet.iterator() } returns iter
+        // Non-zero rowCount = "the upsert applied". The suppressed (rowCount 0) case is only
+        // decidable against a real database — see PayeeHistoryRepositoryImplIT.
+        every { rowSet.rowCount() } returns 1
         return rowSet
     }
 
@@ -108,5 +113,9 @@ class PayeeHistoryRepositoryImplTest {
         assertThat(result.firstSeenAt).isEqualTo(firstSeen.toInstant())
         assertThat(result.lastPaidAt).isEqualTo(lastPaid.toInstant())
         assertThat(result.paymentCount).isEqualTo(4L)
+    }
+
+    private companion object {
+        const val APPLIED_SIGNAL_WINDOW = 100
     }
 }

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplIT.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplIT.kt
@@ -143,6 +143,56 @@ class VelocityAggregateRepositoryImplIT {
         assertAllWindows(accountId, count = 2L, total = "20.00")
     }
 
+    /**
+     * Issue #5789 follow-up: a signal with no aggregateId must not POISON the row.
+     *
+     * The dedupe set is tested as `EXCLUDED.last_transaction_id = ANY (array_append(applied_ids,
+     * last_transaction_id))`, and `last_transaction_id` is NULL for the whole life of the row after a
+     * signal that carried no aggregateId. `x = ANY (array containing NULL)` is NULL, not FALSE, in
+     * Postgres — so `NOT (...)` is NULL, the `ON CONFLICT ... WHERE` is not true, and every later
+     * genuinely-new signal to that row is silently dropped forever. The row freezes.
+     *
+     * The sequence must INTERLEAVE: two NULLs back to back both take the
+     * `EXCLUDED.last_transaction_id IS NULL` branch, which short-circuits before the membership test
+     * is ever reached, so a repeated-NULL test cannot see this. C, NULL, D, E can: the NULL parks a
+     * NULL in `last_transaction_id`, and D and E then have to survive the membership test.
+     *
+     * Direction of harm: velocity counts are UNDERCOUNTED, so a velocity rule that should fire does
+     * not. Against the pre-#5789 `IS DISTINCT FROM` guard this is a REGRESSION — that form was
+     * NULL-safe.
+     */
+    @Test
+    fun `a signal without a transaction id does not freeze the row against later signals`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, UUID.randomUUID())
+        // No aggregateId: applied unconditionally, and deliberately not remembered.
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, null)
+        // Two genuinely new signals, after the NULL. Both must still count.
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, UUID.randomUUID())
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, UUID.randomUUID())
+
+        assertAllWindows(accountId, count = 4L, total = "40.00")
+    }
+
+    /**
+     * The guard must still SUPPRESS after a NULL has passed through — a NULL-safe membership test
+     * that simply always evaluated true would pass the freeze test above while silently disabling
+     * dedupe. This is the other side of that: replay of C after the NULL is still a replay.
+     */
+    @Test
+    fun `dedupe still suppresses a replay after a signal without a transaction id`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val c = UUID.randomUUID()
+
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, c)
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, null)
+        // Replay of C, after the NULL. Must be suppressed.
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, c)
+
+        assertAllWindows(accountId, count = 2L, total = "20.00")
+    }
+
     @Test
     fun `currencies are deduplicated independently`(): Unit = runBlocking {
         val accountId = UUID.randomUUID()

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplIT.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplIT.kt
@@ -175,12 +175,12 @@ class VelocityAggregateRepositoryImplIT {
     fun `a signal without a transaction id does not freeze the row against later signals`(): Unit = runBlocking {
         val accountId = UUID.randomUUID()
 
-        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, UUID.randomUUID())
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, UUID.randomUUID(), eventTime)
         // No aggregateId: applied unconditionally, and deliberately not remembered.
-        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, null)
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, null, eventTime)
         // Two genuinely new signals, after the NULL. Both must still count.
-        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, UUID.randomUUID())
-        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, UUID.randomUUID())
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, UUID.randomUUID(), eventTime)
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, UUID.randomUUID(), eventTime)
 
         assertAllWindows(accountId, count = 4L, total = "40.00")
     }
@@ -195,10 +195,10 @@ class VelocityAggregateRepositoryImplIT {
         val accountId = UUID.randomUUID()
         val c = UUID.randomUUID()
 
-        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, c)
-        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, null)
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, c, eventTime)
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, null, eventTime)
         // Replay of C, after the NULL. Must be suppressed.
-        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, c)
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, c, eventTime)
 
         assertAllWindows(accountId, count = 2L, total = "20.00")
     }

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplIT.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplIT.kt
@@ -4,7 +4,9 @@
 
 package com.openbank.fraud.infrastructure.persistence
 
+import com.openbank.fraud.application.port.out.FraudMetricsPort
 import com.openbank.fraud.application.port.out.VelocityAggregateRepository
+import com.openbank.fraud.domain.model.FraudVerdict
 import com.openbank.fraud.domain.model.VelocityWindow
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
@@ -155,6 +157,98 @@ class VelocityAggregateRepositoryImplIT {
         assertThat(eur!!.transactionCount).isEqualTo(1L)
         assertThat(eur.totalAmount).isEqualByComparingTo("100.00")
     }
+
+    /**
+     * Issue #5789 — the defect the V5 last-writer marker could not catch. The marker stored the LAST
+     * id applied, not the set of ids applied, so an A, B, A delivery order found the marker holding
+     * B when the replayed A arrived, `IS DISTINCT FROM` it, and applied A a second time. This is not
+     * an exotic ordering: `openbank.transactions.transaction.initiated` is keyed by the transaction
+     * aggregateId, so two signals for one account are two different keys, and any at-least-once
+     * replay of an uncommitted offset window re-delivers A after B has already been applied.
+     *
+     * Correct total after A, B, A is two applications, not three.
+     */
+    @Test
+    fun `an out-of-order replay after another signal is not applied twice`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val a = UUID.randomUUID()
+        val b = UUID.randomUUID()
+
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
+        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b)
+        // The replay of A, landing after B — the last-writer marker holds B here and let this through.
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
+
+        assertAllWindows(accountId, count = 2L, total = "140.00")
+    }
+
+    /** The same, one step longer: both ids replayed after the other, in the order Kafka replays them. */
+    @Test
+    fun `replaying a whole uncommitted window applies neither signal twice`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val a = UUID.randomUUID()
+        val b = UUID.randomUUID()
+
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
+        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b)
+        // Rebalance: the consumer resumes from the last committed offset and re-delivers A then B.
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
+        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b)
+
+        assertAllWindows(accountId, count = 2L, total = "140.00")
+    }
+
+    /**
+     * A suppressed replay writes no row, logs nothing and moves no counter, so before #5789 the guard
+     * working and the guard being absent were indistinguishable from outside the database. This is the
+     * series that tells them apart: one increment per suppressed row-write, i.e. three per suppressed
+     * signal (one per velocity window).
+     */
+    @Test
+    fun `a suppressed replay is counted`(): Unit = runBlocking {
+        val suppressed = mutableListOf<String>()
+        val repo = VelocityAggregateRepositoryImpl(pool, Clock.systemUTC(), recordingMetrics(suppressed), 100)
+        val accountId = UUID.randomUUID()
+        val a = UUID.randomUUID()
+
+        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
+        assertThat(suppressed).describedAs("a first application is not a suppression").isEmpty()
+
+        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
+
+        assertThat(suppressed).containsExactly("velocity_aggregates", "velocity_aggregates", "velocity_aggregates")
+    }
+
+    /**
+     * The stated residual bound, asserted rather than only documented: the applied-signal set is
+     * bounded by a COUNT of signals to the same row, not by elapsed time. With the window set to 1 the
+     * guard degrades exactly to the old last-writer marker, and the A, B, A replay double-counts again
+     * — which is what the default of 100 buys, and what a smaller value would give back.
+     */
+    @Test
+    fun `the applied-signal window bounds how far back a replay can be suppressed`(): Unit = runBlocking {
+        val repo = VelocityAggregateRepositoryImpl(pool, Clock.systemUTC(), noopMetrics(), 1)
+        val accountId = UUID.randomUUID()
+        val a = UUID.randomUUID()
+        val b = UUID.randomUUID()
+
+        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
+        repo.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b)
+        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
+
+        // A has been evicted from a one-entry set, so it applies again: 3 applications, 240.00.
+        assertAllWindows(accountId, count = 3L, total = "240.00")
+    }
+
+    private fun recordingMetrics(sink: MutableList<String>): FraudMetricsPort = object : FraudMetricsPort {
+        override fun recordVerdict(verdict: FraudVerdict, rail: String) = Unit
+        override fun recordShadowScore(score: Double) = Unit
+        override fun recordSignalReplaySuppressed(aggregate: String) {
+            sink.add(aggregate)
+        }
+    }
+
+    private fun noopMetrics(): FraudMetricsPort = recordingMetrics(mutableListOf())
 
     private companion object {
         const val CURRENCY = "CZK"

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplIT.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplIT.kt
@@ -12,6 +12,7 @@ import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import io.vertx.mutiny.pgclient.PgPool
+import io.vertx.mutiny.sqlclient.Row
 import io.vertx.mutiny.sqlclient.Tuple
 import jakarta.inject.Inject
 import kotlinx.coroutines.runBlocking
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.Clock
 import java.time.Instant
+import java.time.ZoneOffset
 import java.util.UUID
 
 /**
@@ -43,6 +45,14 @@ class VelocityAggregateRepositoryImplIT {
     @Inject
     lateinit var pool: PgPool
 
+    /**
+     * The business time carried by every signal a test records, fixed once per test instance (JUnit
+     * builds a fresh one per test). Fixing it matters twice over: the bucket is now derived from the
+     * event's own time (#6044), and holding it constant stops a test that happens to straddle an
+     * hour boundary mid-run from splitting its own writes across two rows.
+     */
+    private val eventTime: Instant = Instant.now(Clock.systemUTC())
+
     private suspend fun assertAllWindows(accountId: UUID, count: Long, total: String) {
         VelocityWindow.entries.forEach { window ->
             val aggregate = repository.findAggregate(accountId, window, CURRENCY)
@@ -58,7 +68,7 @@ class VelocityAggregateRepositoryImplIT {
     fun `a first signal is recorded in every window`(): Unit = runBlocking {
         val accountId = UUID.randomUUID()
 
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, UUID.randomUUID())
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, UUID.randomUUID(), eventTime)
 
         assertAllWindows(accountId, count = 1L, total = "100.00")
     }
@@ -68,10 +78,10 @@ class VelocityAggregateRepositoryImplIT {
         val accountId = UUID.randomUUID()
         val transactionId = UUID.randomUUID()
 
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId, eventTime)
         // Redelivery of the exact same Kafka message (same aggregateId) — must be a no-op.
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId)
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId, eventTime)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId, eventTime)
 
         assertAllWindows(accountId, count = 1L, total = "100.00")
     }
@@ -80,12 +90,12 @@ class VelocityAggregateRepositoryImplIT {
     fun `a genuinely new signal after a redelivery still counts`(): Unit = runBlocking {
         val accountId = UUID.randomUUID()
         val firstTransactionId = UUID.randomUUID()
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, firstTransactionId)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, firstTransactionId, eventTime)
         // Replay of the first signal — must not count.
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, firstTransactionId)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, firstTransactionId, eventTime)
 
         // A genuinely different transaction — must count.
-        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, UUID.randomUUID())
+        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, UUID.randomUUID(), eventTime)
 
         assertAllWindows(accountId, count = 2L, total = "140.00")
     }
@@ -104,7 +114,7 @@ class VelocityAggregateRepositoryImplIT {
     fun `a retry after a partial per-window failure converges to the correct total`(): Unit = runBlocking {
         val accountId = UUID.randomUUID()
         val transactionId = UUID.randomUUID()
-        val h1Start = VelocityWindow.H1.bucketStart(Instant.now(Clock.systemUTC()))
+        val h1Start = VelocityWindow.H1.bucketStart(eventTime)
 
         // The interrupted first attempt: H1 applied, H24 and D7 never reached.
         pool.preparedQuery(
@@ -125,7 +135,7 @@ class VelocityAggregateRepositoryImplIT {
         ).awaitSuspending()
 
         // The redelivery re-runs the full per-window loop.
-        repository.recordTransaction(accountId, BigDecimal("70.00"), CURRENCY, transactionId)
+        repository.recordTransaction(accountId, BigDecimal("70.00"), CURRENCY, transactionId, eventTime)
 
         assertAllWindows(accountId, count = 1L, total = "70.00")
     }
@@ -137,8 +147,8 @@ class VelocityAggregateRepositoryImplIT {
         // No aggregateId on the wire means no identity to deduplicate by — the pre-#5716 behaviour
         // is preserved rather than silently dropping the second signal. Same contract as
         // payee_history.
-        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, null)
-        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, null)
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, null, eventTime)
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, null, eventTime)
 
         assertAllWindows(accountId, count = 2L, total = "20.00")
     }
@@ -198,9 +208,9 @@ class VelocityAggregateRepositoryImplIT {
         val accountId = UUID.randomUUID()
         val transactionId = UUID.randomUUID()
 
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId, eventTime)
         // A different currency is a different row, so the same id does not suppress it.
-        repository.recordTransaction(accountId, BigDecimal("100.00"), "EUR", transactionId)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), "EUR", transactionId, eventTime)
 
         assertAllWindows(accountId, count = 1L, total = "100.00")
         val eur = repository.findAggregate(accountId, VelocityWindow.H1, "EUR")
@@ -224,10 +234,10 @@ class VelocityAggregateRepositoryImplIT {
         val a = UUID.randomUUID()
         val b = UUID.randomUUID()
 
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
-        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a, eventTime)
+        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b, eventTime)
         // The replay of A, landing after B — the last-writer marker holds B here and let this through.
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a, eventTime)
 
         assertAllWindows(accountId, count = 2L, total = "140.00")
     }
@@ -239,11 +249,11 @@ class VelocityAggregateRepositoryImplIT {
         val a = UUID.randomUUID()
         val b = UUID.randomUUID()
 
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
-        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a, eventTime)
+        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b, eventTime)
         // Rebalance: the consumer resumes from the last committed offset and re-delivers A then B.
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
-        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a, eventTime)
+        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b, eventTime)
 
         assertAllWindows(accountId, count = 2L, total = "140.00")
     }
@@ -261,10 +271,10 @@ class VelocityAggregateRepositoryImplIT {
         val accountId = UUID.randomUUID()
         val a = UUID.randomUUID()
 
-        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
+        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a, eventTime)
         assertThat(suppressed).describedAs("a first application is not a suppression").isEmpty()
 
-        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
+        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a, eventTime)
 
         assertThat(suppressed).containsExactly("velocity_aggregates", "velocity_aggregates", "velocity_aggregates")
     }
@@ -282,12 +292,123 @@ class VelocityAggregateRepositoryImplIT {
         val a = UUID.randomUUID()
         val b = UUID.randomUUID()
 
-        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
-        repo.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b)
-        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
+        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a, eventTime)
+        repo.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b, eventTime)
+        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a, eventTime)
 
         // A has been evicted from a one-entry set, so it applies again: 3 applications, 240.00.
         assertAllWindows(accountId, count = 3L, total = "240.00")
+    }
+
+    /**
+     * Issue #6044 — the half of #5789 the applied-id set cannot reach, because it is not a dedupe
+     * defect at all: the bucket used to come from `Instant.now(clock)` at PROCESSING time, and
+     * `window_start` is part of the primary key. A signal that occurred at 10:59 and is redelivered
+     * at 11:00 therefore hit a DIFFERENT ROW from the original, and the applied-id set lives on the
+     * row — so the replay met an empty set, was not recognised, and was counted a second time. No
+     * value of `openbank.fraud.applied-signal-window` changes that; the set it consults is the wrong
+     * row's.
+     *
+     * The delivery is built here exactly as it happens: the SAME signal (same id, same `occurredAt`,
+     * one minute before the hour) applied twice, with the two repository instances differing ONLY in
+     * the clock they would have bucketed by — 10:59 for the original delivery, 11:00 for the replay.
+     * With the bucket taken from `occurredAt` both target the 10:00 row, the guard sees the id, and
+     * the correct total is one application.
+     */
+    @Test
+    fun `a replay processed after the hour boundary is not counted again in the next bucket`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val transactionId = UUID.randomUUID()
+        val occurredAt = Instant.parse("2026-07-09T10:59:00Z")
+
+        val atOriginalDelivery = repositoryAt("2026-07-09T10:59:01Z")
+        val afterTheBoundary = repositoryAt("2026-07-09T11:00:02Z")
+
+        atOriginalDelivery.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId, occurredAt)
+        // The redelivery: same event, same occurredAt, processed on the other side of 11:00.
+        afterTheBoundary.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId, occurredAt)
+
+        // The double-count, stated independently of which rows exist: across EVERY H1 bucket this
+        // account has, the signal must have been applied exactly once. Asserting only the 10:00 row
+        // would miss the defect — under processing-time bucketing that row also reads 1, and the
+        // second application sits in a row the assertion never looks at.
+        assertAppliedAcrossAllBuckets(accountId, VelocityWindow.H1, count = 1L, total = "100.00")
+        // Both applications landed on the bucket the event belongs to...
+        assertBucket(accountId, VelocityWindow.H1, occurredAt, count = 1L, total = "100.00")
+        // ...and nothing at all was written into the 11:00 bucket the replay used to create.
+        assertNoBucket(accountId, VelocityWindow.H1, Instant.parse("2026-07-09T11:00:02Z"))
+    }
+
+    /**
+     * The same defect one level up: it is not only replays. Two signals that OCCURRED in the same
+     * hour but were processed either side of the boundary — an ordinary consumer lag or pod roll —
+     * used to be split across two rows, so neither the H1 count nor the H1 sum the scorer reads was
+     * ever the truth about that hour. Event-time bucketing puts both where they happened.
+     */
+    @Test
+    fun `two signals from the same hour processed either side of the boundary land in one bucket`(): Unit =
+        runBlocking {
+            val accountId = UUID.randomUUID()
+            val hour = Instant.parse("2026-07-09T10:00:00Z")
+
+            repositoryAt("2026-07-09T10:20:00Z")
+                .recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, UUID.randomUUID(), hour.plusSeconds(600))
+            repositoryAt("2026-07-09T11:00:30Z")
+                .recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, UUID.randomUUID(), hour.plusSeconds(3000))
+
+            assertBucket(accountId, VelocityWindow.H1, hour, count = 2L, total = "140.00")
+        }
+
+    /** A repository whose clock reads [instant] — the moment a signal is PROCESSED, nothing else. */
+    private fun repositoryAt(instant: String): VelocityAggregateRepository = VelocityAggregateRepositoryImpl(
+        pool,
+        Clock.fixed(Instant.parse(instant), ZoneOffset.UTC),
+        noopMetrics(),
+        100,
+    )
+
+    /** Reads one bucket row directly — [findAggregate] can only ask about the CURRENT window. */
+    private suspend fun selectBucket(accountId: UUID, window: VelocityWindow, at: Instant): Row? = pool.preparedQuery(
+        """
+            SELECT transaction_count, total_amount
+            FROM velocity_aggregates
+            WHERE account_id = $1::uuid AND velocity_window = $2 AND currency = $3 AND window_start = $4
+            """,
+    ).execute(
+        Tuple.of(accountId.toString(), window.name, CURRENCY, window.bucketStart(at).toOffsetDateTime()),
+    ).awaitSuspending().firstOrNull()
+
+    private suspend fun assertBucket(accountId: UUID, window: VelocityWindow, at: Instant, count: Long, total: String) {
+        val row = selectBucket(accountId, window, at)
+        assertThat(row).describedAs("row for the %s bucket containing %s", window, at).isNotNull
+        assertThat(row!!.getLong(0)).describedAs("count in the bucket containing %s", at).isEqualTo(count)
+        assertThat(
+            row.getBigDecimal(1),
+        ).describedAs("total in the bucket containing %s", at).isEqualByComparingTo(total)
+    }
+
+    /** Every bucket row for this (account, window, currency), summed — where a double-count shows up. */
+    private suspend fun assertAppliedAcrossAllBuckets(
+        accountId: UUID,
+        window: VelocityWindow,
+        count: Long,
+        total: String,
+    ) {
+        val row = pool.preparedQuery(
+            """
+            SELECT COALESCE(SUM(transaction_count), 0), COALESCE(SUM(total_amount), 0)
+            FROM velocity_aggregates
+            WHERE account_id = $1::uuid AND velocity_window = $2 AND currency = $3
+            """,
+        ).execute(Tuple.of(accountId.toString(), window.name, CURRENCY)).awaitSuspending().first()
+        assertThat(row.getLong(0)).describedAs("applications across all %s buckets", window).isEqualTo(count)
+        assertThat(row.getBigDecimal(1)).describedAs("total across all %s buckets", window).isEqualByComparingTo(total)
+    }
+
+    private suspend fun assertNoBucket(accountId: UUID, window: VelocityWindow, at: Instant) {
+        assertThat(selectBucket(accountId, window, at))
+            .describedAs("no %s row should exist for the bucket containing %s", window, at)
+            .isNull()
     }
 
     private fun recordingMetrics(sink: MutableList<String>): FraudMetricsPort = object : FraudMetricsPort {
@@ -296,6 +417,8 @@ class VelocityAggregateRepositoryImplIT {
         override fun recordSignalReplaySuppressed(aggregate: String) {
             sink.add(aggregate)
         }
+
+        override fun recordSignalMissingEventTime() = Unit
     }
 
     private fun noopMetrics(): FraudMetricsPort = recordingMetrics(mutableListOf())

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplTest.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.fraud.infrastructure.persistence
 
 import com.openbank.fraud.domain.model.VelocityWindow
+import com.openbank.fraud.application.port.out.FraudMetricsPort
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -29,7 +30,9 @@ class VelocityAggregateRepositoryImplTest {
 
     private val pool = mockk<PgPool>()
 
-    private val repository = VelocityAggregateRepositoryImpl(pool, Clock.systemUTC())
+    private val metrics = mockk<FraudMetricsPort>(relaxed = true)
+    private val repository =
+        VelocityAggregateRepositoryImpl(pool, Clock.systemUTC(), metrics, APPLIED_SIGNAL_WINDOW)
 
     private fun emptyRowIterator(): RowIterator<Row> {
         val iter = mockk<RowIterator<Row>>()
@@ -50,6 +53,9 @@ class VelocityAggregateRepositoryImplTest {
     private fun mockRowSet(iter: RowIterator<Row>): RowSet<Row> {
         val rowSet = mockk<RowSet<Row>>()
         every { rowSet.iterator() } returns iter
+        // A non-zero rowCount means "the upsert applied" — the suppressed case is asserted against a
+        // real database in VelocityAggregateRepositoryImplIT, which is the only place it is decidable.
+        every { rowSet.rowCount() } returns 1
         return rowSet
     }
 
@@ -128,5 +134,9 @@ class VelocityAggregateRepositoryImplTest {
         assertThat(epochDays % 7).isEqualTo(0L)
         // Must be <= today
         assertThat(start).isBeforeOrEqualTo(now.truncatedTo(ChronoUnit.DAYS))
+    }
+
+    private companion object {
+        const val APPLIED_SIGNAL_WINDOW = 100
     }
 }

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplTest.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplTest.kt
@@ -73,7 +73,13 @@ class VelocityAggregateRepositoryImplTest {
         val pq = mockPreparedQuery(rowSet)
         every { pool.preparedQuery(any<String>()) } returns pq
 
-        repository.recordTransaction(UUID.randomUUID(), BigDecimal("100.00"), "CZK", UUID.randomUUID())
+        repository.recordTransaction(
+            UUID.randomUUID(),
+            BigDecimal("100.00"),
+            "CZK",
+            UUID.randomUUID(),
+            Instant.parse("2026-07-09T10:30:00Z"),
+        )
 
         // recordTransaction calls upsert once per window (H1, H24, D7)
         verify(exactly = 3) { pool.preparedQuery(any<String>()) }

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplTest.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplTest.kt
@@ -4,8 +4,8 @@
 
 package com.openbank.fraud.infrastructure.persistence
 
-import com.openbank.fraud.domain.model.VelocityWindow
 import com.openbank.fraud.application.port.out.FraudMetricsPort
+import com.openbank.fraud.domain.model.VelocityWindow
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot


### PR DESCRIPTION
Closes #5789.

Both fraud aggregates deduplicated redelivery with a **last-writer marker** — `payee_history` since
V3, `velocity_aggregates` since V5 (#5786) — so an `A, B, A` delivery order found the marker holding
`B` when the replayed `A` arrived, `IS DISTINCT FROM` it, and applied `A` a second time. This
replaces the marker on both tables with the applied-event set the issue asked for.

## The ordering is reachable today, and not only through a DLQ replay

The issue frames the exposure as a DLQ replay, which depends on #5715 (rethrow) and #5751 (DLQ
wiring) — both still **open**. The defect does not wait for them:

- `openbank.transactions.transaction.initiated` is published with the **transaction aggregateId** as
  the Kafka key (`OutboxKafkaHeaders.partitionKey` = `entry.aggregateId`). Two signals for the same
  account are therefore two different keys — Kafka orders per key, and nothing orders two signals
  for one account relative to each other.
- The consumer is at-least-once with periodic offset commits. Any rebalance, pod roll or crash
  re-delivers the whole uncommitted window from the last committed offset. On the deployed
  single-partition topic (`gitops/components/payments/kafka-topic.yaml`, `partitions: 1`) a window
  containing `A, B` for the same account replays as `A, B` — and after the original `B` the marker
  is `B`, so **both** re-apply.

The marker therefore protected a replay window of exactly **one record**. The negative control below
measures precisely that: replaying a two-record window took `payment_count` from 2 to 4.

## Nothing noticed it, and nothing noticed the guard working either

`FraudMetricsPort` had only `recordVerdict` and `recordShadowScore`. A suppressed replay writes no
row, logs nothing and moves no counter, and there is no reconciliation of either aggregate against
the source transactions — so "the guard is working" and "the guard is absent" were indistinguishable
from outside the database, in both directions (over-count and under-count). This PR adds
`openbank_fraud_signal_replay_suppressed_total{aggregate}`, incremented when the upsert returns
`rowCount 0`, i.e. exactly when a re-application was suppressed. It is a distinct signal, not a flag
shared with the success path.

## The change

- **`V6__applied_signal_ledger.sql`** — `applied_transaction_ids UUID[]` on both tables, backfilled
  from each row's existing `last_transaction_id` so today's protection is not lost at cutover, plus
  an `IMMUTABLE` `fraud_append_applied(ids, new_id, cap)` that appends and trims.
- **Both repositories** — the upsert's `WHERE` now tests **membership of the applied set** instead of
  equality with the newest entry, and appends the id in the same statement, so the memory of
  "applied" and the effect of applying commit together. A signal with no aggregateId is still applied
  unconditionally and is not remembered (no identity to deduplicate by). The guard stays **per row**,
  so the three velocity windows still converge independently after a partial failure.
- The set is unioned with `last_transaction_id` when tested. That covers the **rolling-deploy window
  a backfill cannot**: a pod still running the V5/V3 code writes the marker and leaves the new column
  untouched, so a row it applies after the migration runs would otherwise remember nothing. The
  union makes the new guard strictly stronger than the old one in every state, never weaker. This
  was not designed in — it was found by the pre-existing partial-failure IT going red, which builds
  exactly that legacy row shape by hand.

## The design decision, stated rather than picked silently

The issue left three things open. What this PR decides:

**Bound: a COUNT window, not a duration, and not a ledger table.** The set is the most recent `N` ids
applied to that row, `N` from `openbank.fraud.applied-signal-window` (default 100).

- *Why not a time-bounded ledger table:* it needs a retention sweep to stay bounded, and a scheduler
  that silently stops running is exactly how this repo has lost controls before. A per-row array is
  trimmed on every write, so it cannot grow without anything running.
- *Why one column per table rather than one shared ledger:* keeping the set on the aggregate row is
  what lets the claim and the increment be one statement against one row — no second table to keep
  atomic with the first, and no key-encoding to keep in sync between Kotlin and a backfill.
- *Cost, and it is a real one:* the guarantee is expressed in events rather than in time. A replay
  arriving after `N` further signals to the **same row** is applied again. For `velocity_aggregates` a
  row is one (account, window, currency, bucket), so `N=100` is 100 transactions inside that bucket;
  for `payee_history` it is 100 payments to the same payee. If a duration guarantee is later required
  (e.g. "any replay within the topic's 7-day retention"), that is a ledger table and a sweep, and it
  is a different PR — this one does not foreclose it.

This bound is **asserted, not just documented**: `the applied-signal window bounds how far back a
replay can be suppressed` sets the window to 1, shows the guard degrading exactly to the old
last-writer marker, and shows `A, B, A` double-counting again.

## Verification

Real-Postgres ITs (`PostgresRedisTestResource`), not mocked repositories — a mocked `PgPool` cannot
tell an upsert that double-counts from one that does not.

Four new failing-first tests construct the actual out-of-order delivery on both tables: the `A, B, A`
replay, and the whole-uncommitted-window `A, B, A, B` replay.

**Negative control** — reverting *only* the two production `WHERE` clauses back to
`IS DISTINCT FROM`, keeping the migration, the tests and the metric:

```
PayeeHistoryRepositoryImplIT        10 tests, 2 failed
  RED: an out-of-order replay after another payment is not counted twice   expected: 2 but was: 3
  RED: replaying a whole uncommitted window counts neither payment twice   expected: 2 but was: 4
VelocityAggregateRepositoryImplIT   10 tests, 2 failed
  RED: an out-of-order replay after another signal is not applied twice    expected: 2 but was: 3
  RED: replaying a whole uncommitted window applies neither signal twice   expected: 2 but was: 4
```

Exactly the four new tests go red and nothing else does. Restored, the module is
`175 tests / 0 failures / 0 errors / 1 skipped` (the skip is the broker-gated
`FraudPactProviderVerificationTest`, which is `@EnabledIfSystemProperty(pactbroker.url)` off
main-push — the `@PactFolder` sibling ran).

Also run: `:openbank-fraud-service:quarkusBuild` (CDI/ArC wiring of the two new `@ConfigProperty`
constructor parameters), `ktlintCheck`, `detekt`, and the repo gate manifest.

## Not verified

- No live system was touched. The claim that the deployed topic is single-partition is read from
  `gitops/components/payments/kafka-topic.yaml`, not from a broker.
- The migration is exercised by Flyway on the test container, not against a populated database; the
  backfill is asserted indirectly (the partial-failure IT builds a legacy-shaped row by hand).
- No attempt was made to establish whether double-counting has already occurred in a real
  environment — that needs the aggregate reconciled against the source transactions, which is the
  reconciliation this change makes possible to alert on but does not itself add.

## Noticed in passing, deliberately not fixed here

`VelocityAggregateRepositoryImpl` picks `window_start` from `Instant.now(clock)` at **processing**
time, not from the event's `occurredAt`. A replay that crosses an hour boundary therefore lands in a
different bucket row from the original, where no guard of any design can recognise it. That is a
distinct defect (processing-time vs event-time bucketing) with a different fix and a different blast
radius, and folding it in would change what the aggregate means.
