### PR TITLE
fix(infra): repoint the decommissioned Groq llama-3.3 route and alert on total LLM failure

### DIFF
--- a/openbank-infra/gitops/components/ai-platform/litellm-config.yaml
+++ b/openbank-infra/gitops/components/ai-platform/litellm-config.yaml
@@ -35,27 +35,42 @@ data:
           input_cost_per_token: 0.00000026
           output_cost_per_token: 0.00000038
       # agent-service's admin-UI assistant model (#1919). It sends `model-gateway.models[].id`
-      # verbatim, so the model_name MUST stay `llama-3.3-70b-versatile` — that is what repointing
-      # agent-service at this gateway costs: an endpoint + key change, nothing else. The Groq key
-      # is projected here from the SAME OpenBao path agent-service used to read it from, so the
-      # provider credential moves into this pod rather than being duplicated (ADR-0175).
+      # verbatim, so the model_name MUST stay `llama-3.3-70b-versatile` — the caller-facing id is
+      # part of the contract with agent-service and the admin-UI model picker, and only the
+      # PROVIDER behind it moves.
+      #
+      # PROVIDER IS DEEPINFRA, NOT GROQ, AND THAT WAS MEASURED (#5736). Groq has decommissioned
+      # `llama-3.3-70b-versatile`. Its live catalogue is 13 models and does not contain it; asked
+      # for it anyway, Groq answers 404:
+      #   {"error":{"message":"The model `llama-3.3-70b-versatile` does not exist or you do not
+      #    have access to it.","type":"invalid_request_error","code":"model_not_found"}}
+      # This is the SECOND time a Groq id in this file died under us — the llama-guard route below
+      # went the same way — so read a Groq model id here as a claim about someone else's catalogue
+      # with a shelf life, never as a constant. The discriminator that matters: a dead KEY answers
+      # 401/403 on every model, a dead MODEL answers 404 on one while its siblings still return
+      # 200. Both were probed from inside this pod before this line changed.
+      #
+      # DeepInfra serves the same weights as `meta-llama/Llama-3.3-70B-Instruct-Turbo` (confirmed
+      # present in its 185-model catalogue), on the DeepInfra key already projected here — so this
+      # is a provider move, not a model substitution, and it adds no new secret.
       - model_name: llama-3.3-70b-versatile
         litellm_params:
-          model: groq/llama-3.3-70b-versatile
-          api_key: os.environ/GROQ_API_KEY
+          model: deepinfra/meta-llama/Llama-3.3-70B-Instruct-Turbo
+          api_key: os.environ/DEEPINFRA_API_KEY
           # Lower ceiling: this route serves only agent-service's admin-UI assistant, a single
           # interactive surface, where the ops models serve every scheduled agent. A shared ceiling
           # would let a runaway ops loop starve the interactive one, or vice versa.
           max_budget: 5
           budget_duration: 1d
-          # Declared for the same reason, even though LiteLLM's built-in map DOES currently price
-          # this model correctly (it reported 5.9e-07 / 7.9e-07, matching Groq's published
-          # $0.59 / $0.79 per million tokens). Relying on that is relying on a table inside a
-          # pinned dependency: a version bump that drops or renames the entry silently returns to
-          # costing every call $0 — the same failure as above, and equally silent. In git the
-          # number is auditable and a gate can check it.
-          input_cost_per_token: 0.00000059
-          output_cost_per_token: 0.00000079
+          # Declared, not inherited — the same reasoning as DeepSeek above, and now with a second
+          # reason: the price that used to sit here was GROQ's, and it survived the provider being
+          # dead. A price map keyed by a model id cannot notice that the id no longer resolves, so
+          # it would have kept costing a route that returned nothing but 404s.
+          # DeepInfra's own published price for this model
+          # (api.deepinfra.com/models/meta-llama/Llama-3.3-70B-Instruct-Turbo:
+          # cents_per_input_token 1e-05, cents_per_output_token 3.2e-05), cents -> USD per token.
+          input_cost_per_token: 0.0000001
+          output_cost_per_token: 0.00000032
       # Content-safety classifier (ADR-0031 guardrails). Groq serves Llama Guard 4 on the same key
       # already projected here, so this adds a route and no new provider, no new secret and no GPU.
       # Callers send `meta-llama/llama-guard-4-12b` verbatim (copilot `content-safety.model`).

--- a/openbank-infra/gitops/components/ai-platform/litellm.yaml
+++ b/openbank-infra/gitops/components/ai-platform/litellm.yaml
@@ -35,7 +35,7 @@ spec:
         # would leave agent-service's repointed call failing "model not found" with a green,
         # in-sync ArgoCD — the same silent-degradation shape as an `optional: true` secret ref.
         # BUMP THIS whenever litellm-config.yaml changes; that is what rolls the pod.
-        openbank.tech/litellm-config-revision: "12"
+        openbank.tech/litellm-config-revision: "13"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/observability/prometheus-rules-ai.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-ai.yaml
@@ -36,20 +36,24 @@ spec:
     - name: openbank.ai.price-book
       interval: 1h
       rules:
-        # Authoritative: BerriAI/litellm model_prices_and_context_window.json, entry
-        # `groq/llama-3.3-70b-versatile` — $0.59/M input, $0.79/M output.
+        # DeepInfra's published rate card for `meta-llama/Llama-3.3-70B-Instruct-Turbo`, the route
+        # the caller-facing id `llama-3.3-70b-versatile` now resolves to — $0.10/M input,
+        # $0.32/M output. It carried Groq's $0.59/$0.79 until #5736, and kept carrying it for the
+        # whole time Groq had decommissioned the model and every call 404'd: a price keyed by a
+        # model id cannot notice the id no longer resolves. Keep this in lockstep with
+        # litellm-config.yaml's input_cost_per_token/output_cost_per_token for the same route.
         - record: openbank:llm_price_usd_per_token
-          expr: vector(0.00000059)
+          expr: vector(0.0000001)
           labels:
             model: llama-3.3-70b-versatile
             kind: prompt
-            price_source: litellm-map
+            price_source: provider-rate-card
         - record: openbank:llm_price_usd_per_token
-          expr: vector(0.00000079)
+          expr: vector(0.00000032)
           labels:
             model: llama-3.3-70b-versatile
             kind: completion
-            price_source: litellm-map
+            price_source: provider-rate-card
         # APPROXIMATE. LiteLLM's price map has no `deepinfra/deepseek-ai/DeepSeek-V3.2` entry — the
         # newest DeepInfra DeepSeek it knows is V3.1 ($0.27/M input, $1.00/M output), used here as
         # the nearest published sibling. Every panel and alert built on this carries
@@ -199,6 +203,53 @@ spec:
               NOT page — nothing is down. It means the AI features are silently off: the agents
               still answer, with their non-model path. Check the gateway pod, the provider status
               and the API key.
+
+        # Alerts on the SUCCESS state, and exists because AiCallErrorRateHigh above cannot see a
+        # low-rate caller failing totally (#5736).
+        #
+        # MEASURED, not reasoned: `llama-3.3-70b-versatile` returned 404 on every call for 8h40m
+        # while its only caller ran twice an hour. AiCallErrorRateHigh went `pending` at 04:04 and
+        # was still only `pending` at 12:44 — 44 evaluation points, and it NEVER reached `firing`.
+        # A caller with a 30-minute period increments the counter once per `rate(...[15m])` window,
+        # so the ratio is 100% for about 15 minutes and then decays to nothing, resetting the
+        # `for: 15m` timer just short of maturity, forever. The alert was healthy, loaded and
+        # evaluating the whole time. Nothing was wrong with it except that its window is shorter
+        # than its subject's period — which is a property of the CALLER, not of the alert, so no
+        # threshold tuning fixes it and the same hole reopens for the next infrequent caller.
+        #
+        # So this one is deliberately rate-free. `increase(...[6h])` spans any caller that runs at
+        # least once in six hours, and `unless` is a set difference rather than a ratio: it needs
+        # no `outcome="success"` series to exist. That matters here more than it looks — a model
+        # that has NEVER once succeeded has no success series at all, so the arithmetic form
+        # (`success / total == 0`) matches nothing and is blind in exactly the total-failure case
+        # it would be written for. Same shape as #5733.
+        #
+        # Value at t=0 on a cold pod: every counter starts at 0, so the left side (`> 0`) yields no
+        # series and the rule is silent — no boot-time false positive, and no `for:` needed to
+        # suppress one. A model nobody calls is likewise absent from both sides and stays silent;
+        # "not deployed" is a different question and deliberately not this alert's (see the
+        # no-absence-alert note above). `for: 30m` only debounces a single failure at the edge of
+        # the window.
+        - alert: AiModelNeverSucceeds
+          expr: |
+            (sum by (model) (increase(openbank_llm_requests_total{outcome!="not_configured"}[6h])) > 0)
+            unless
+            (sum by (model) (increase(openbank_llm_requests_total{outcome="success"}[6h])) > 0)
+          for: 30m
+          labels:
+            severity: warning
+            team: platform
+          annotations:
+            summary: "Every LLM call to {{ $labels.model }} is failing — not one has succeeded in 6h"
+            description: >-
+              The gateway is answering and every answer is an error, so this is not an outage of
+              the gateway and the pod is Ready. Callers degrade to their deterministic fallback,
+              which is why nothing else goes red. Check the MODEL first: a provider that
+              decommissioned this id answers 404 `model_not_found` while its siblings still return
+              200, whereas a dead or unseeded key answers 401/403 on every model — the two need
+              opposite fixes and the metric label `http_error` distinguishes neither. Probe the
+              provider's own model list from inside the gateway pod; a model id in git is a claim
+              about someone else's catalogue, not a constant.
 
         # The gap this whole PR exists to close. An agent whose key was never seeded returns null
         # forever and logs one warning at startup; nothing else anywhere says so.


### PR DESCRIPTION
Closes #5736

## 41/41 was a hypothesis. Re-measured, it is wrong — and the real shape is more useful.

`outcome` has **four** values live, not one. The aggregate hid a working path and a
dead one sitting next to each other.

**Exact query** (against the sandbox Prometheus, `kube-prometheus-stack-prometheus`
in `observability`, measured 2026-08-20 ~18:15 UTC):

```promql
sum by (container, model, outcome) (increase(openbank_llm_requests_total[24h]))
```

| caller (`container`) | `model` | `outcome` | 24h | 6h | 1h |
|---|---|---|---:|---:|---:|
| agent-service | `openai/gpt-oss-120b` | **success** | 18 | 18 | 4 |
| agent-service | `llama-3.3-70b-versatile` | **http_error** | 14 | 1 | 0 |
| copilot-service | `BAAI/bge-m3` | success | 0 | 0 | 0 |
| copilot-service | `meta-llama/llama-guard-4-12b` | exception | 0 | 0 | 0 |

`openbank_llm_tokens_total` also has series now (27 800 prompt / 1 880 completion on
`openai/gpt-oss-120b`), so the dashboard's success-latency panel and the cost recording
rules are no longer empty. The issue's snapshot predates the gateway repoint that fixed
the other routes; **one** route stayed broken and that is the whole remaining defect.

Note what the `container` split buys: the same pod, the same gateway, the same
credential, one model working and one failing. That single fact eliminates the gateway,
the network and the key before any log is read.

## The status code and the error

Not "http_error" — **HTTP 404**, from Groq, via Loki (`{namespace="ai-platform"}`,
LiteLLM's own proxy log, 48h):

```
litellm.NotFoundError: GroqException - {"error":{"message":"The model
`llama-3.3-70b-versatile` does not exist or you do not have access to it.",
"type":"invalid_request_error","code":"model_not_found"}}
```

That message is ambiguous by design ("does not exist **or** you do not have access"),
so it was not taken at face value. Probed the provider's catalogue from **inside** the
gateway pod, on the gateway's own credential:

- `GET https://api.groq.com/openai/v1/models` → 200, **13 models**, and
  `llama-3.3-70b-versatile` is **not among them**.
- The key is fine: it authenticates and lists. A dead key answers 401/403 on every
  model; a dead model answers 404 on one while its siblings answer 200. Measured both
  directions rather than inferring one.

**A model id is an unverified claim about someone else's catalogue.** This is the second
time a Groq id in this file has died under us — the `llama-guard` route went the same way
and the config already documents it two entries below. First probe attempt returned
`error code: 1010` on *every* request including `/models`; that was Cloudflare rejecting
`Python-urllib`, i.e. a broken probe, not evidence. Redone with `httpx` (what LiteLLM
itself uses) before any conclusion was drawn.

## Which caller, and why it matters more than "AI features are off"

`AGENT_OVERSIGHT_CRON` is `0 0/30 * * * ?` and `AGENT_OVERSIGHT_ENABLED=true`; the
`compliance-officer` charter is pinned to `model: llama-3.3-70b-versatile`
(`openbank-agent-service/src/main/resources/application.yaml`). The log timestamps land
on `12:00:02` / `12:30:01` — exactly that period.

So the failing route is not the interactive assistant (that runs on
`AGENT_DEFAULT_MODEL=openai/gpt-oss-120b` and succeeds). It is the **unattended
compliance oversight sweep**, degrading to its deterministic fallback twice an hour with
nothing anywhere going red.

## Does anything alert on it today? It tried for 8h40m and could not.

`AiCallErrorRateHigh` is loaded, `health=ok`, and was evaluating throughout. It went
**`pending` at 04:04 and was still only `pending` at 12:44 — 44 evaluation points, never
once `firing`.**

```promql
ALERTS{alertname="AiCallErrorRateHigh"}    # alertstate is "pending" at every one of 44 points
max_over_time((100 * sum(rate(openbank_llm_requests_total{outcome=~"http_error|exception|stream_aborted"}[15m]))
  / sum(rate(openbank_llm_requests_total{outcome!="not_configured"}[15m])))[24h:5m])   # = 100
```

The error rate really did reach 100%. The rule really was healthy. It cannot fire anyway:
a caller with a **30-minute period** increments the counter once per `rate(...[15m])`
window, so the ratio is 100% for about 15 minutes and then decays to zero, resetting the
`for: 15m` timer just short of maturity — forever. The window is shorter than the
subject's period, which is a property of the *caller*, so no threshold tuning fixes it
and the hole reopens for the next infrequent caller.

This is not the `loki.ruler` class from #6032 — this rule genuinely loads and evaluates
in Prometheus. It is the narrower failure: a control that evaluates correctly and is
structurally incapable of reaching its own firing state.

## What changed

**1. The dead route** (`litellm-config.yaml`) — repointed to
`deepinfra/meta-llama/Llama-3.3-70B-Instruct-Turbo`, confirmed present in DeepInfra's
185-model catalogue, on the DeepInfra key already projected into the pod. The
caller-facing `model_name` stays `llama-3.3-70b-versatile`: that id is the contract with
agent-service and the admin-UI picker, and only the provider moves. Same precedent as the
llama-guard route. No new secret, no caller change, no test churn.

`litellm.yaml`'s `openbank.tech/litellm-config-revision` bumped 12 → 13 — LiteLLM parses
`--config` once at boot, so without the bump ArgoCD reports Synced and Healthy over a pod
still serving the old model list.

**2. The price book** (`prometheus-rules-ai.yaml`) — carried Groq's $0.59/$0.79 for a
route that returned nothing but 404s, because a price keyed by a model id cannot notice
the id no longer resolves. Now DeepInfra's published $0.10/$0.32, `price_source:
provider-rate-card`, in lockstep with the config's `input_cost_per_token`.

**3. `AiModelNeverSucceeds`** — alerts on the SUCCESS state, which is the real control
here: "the gateway is answering and every answer is an error" is a different question
from an error-rate threshold.

```promql
(sum by (model) (increase(openbank_llm_requests_total{outcome!="not_configured"}[6h])) > 0)
unless
(sum by (model) (increase(openbank_llm_requests_total{outcome="success"}[6h])) > 0)
```
`for: 30m`.

Two deliberate choices:

- **Rate-free.** `increase(...[6h])` spans any caller running at least once in six hours,
  so it does not inherit the period sensitivity above.
- **`unless`, not a ratio.** A model that has never once succeeded has **no
  `outcome="success"` series at all**, so the arithmetic form (`success / total == 0`)
  matches nothing and is blind in exactly the total-failure case it exists for — the trap
  #5736 itself flagged, same shape as #5733. Set difference needs no such series.

**Value at t=0 on a cold pod:** every counter starts at 0, the left side (`> 0`) yields
no series, the rule is silent. No boot-time false positive, and no `for:` is needed to
suppress one. A model nobody calls is absent from both sides and also stays silent —
"not deployed" is a different question and deliberately not this alert's.

## Verified

- **The series exists and the rule matches it.** Evaluated the new expression against
  live Prometheus over 24h at 5m step: **true for 166 consecutive points (13h45m)** on
  `{model="llama-3.3-70b-versatile"}`. `for: 30m` is 6 points, so it would have fired at
  ~05:00 and stayed firing — against the 44 non-consecutive `pending` points the existing
  alert managed. Not reasoned; measured on the real outage.
- **The rule file loads.** `promtool check rules` on the extracted `spec.groups` →
  `SUCCESS: 13 rules found` (was 12), exit 0.
- **The probe is not vacuous.** Negative control: same file with `unless` corrupted →
  exit 1, `FAILED ... "AiModelNeverSucceeds": could not parse expression`. Exit codes read
  from `$?` on redirected output, not from a pipeline.
- Both edited YAML files parse; `run-gates.py --all` with `PR_DIFF_BASE=origin/main`.

## Not verified / deliberately out of scope

- **The repointed route was not exercised end-to-end.** Doing so requires the config to
  be deployed and the pod rolled, which is a cluster write; all live work here was
  read-only. What *is* established is that DeepInfra serves the target id and the key
  reaches it. First real evidence will be `openbank_llm_requests_total{model=
  "llama-3.3-70b-versatile", outcome="success"}` appearing after the roll.
- **The unset `provider` label** (`LlamaGuardContentSafetyAdapter`,
  `OpenAiCompatibleEmbeddingAdapter` omit the argument, defaulting to `unknown`) is real
  and was confirmed, but it is a libs-runtime Kotlin change that rebuilds the fleet. Left
  out of a gitops PR on purpose — worth its own issue.
- **`AiSpendUnpriced` is firing right now** for `openai/gpt-oss-120b`: the price book has
  no entry for it, nor for `DeepSeek-V4-Pro`, `llama-guard-4-12b` or `bge-m3`, all of
  which the gateway serves. Pre-existing, separate from this issue, and it means the
  gateway's *working* model is currently costed at nothing.
