### PR TITLE
test(audit): prove and gate that every money-path produced topic reaches the audit trail

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -2612,6 +2612,27 @@ gates:
     selftest_expect: pass
     run: |
       python3 .github/scripts/check-alert-metric-emitted.py --enforce
+  # An unaudited money-path topic is indistinguishable from a quiet period: nothing errors, no pod
+  # is unhealthy, lag reads zero, and audit_entries simply has no rows. #5859 found delegation had
+  # never been subscribed; #6035 found five more, all missing from all three places at once — the
+  # signature of a set that was never enumerated. This derives the scope instead: money_path_services
+  # from rules.yaml, their produced topics from their own `mp.messaging.outgoing.*.topic` (never from
+  # a topic-literal grep, which is blind to the serialised-data-class idiom, #3883), and the three
+  # subscription artefacts from audit-service's config, source and KafkaUser.
+  # Ratchet, not zero: today's eight gaps are baselined with their owning issue and the list may only
+  # shrink — a stale entry, in either direction, is itself an error.
+  - id: audit-money-path-subscription
+    min_subjects: 15   # 21 produced money-path topics today (2026-08-20)
+    name: "Every money-path produced topic reaches the audit trail (issue #6035, enforced)"
+    group: data
+    mode: enforced
+    rationale: "A money-path event topic audit-service is not subscribed to, not attributed for, or has no Read ACL on writes nothing to the tamper-evident trail and raises no error anywhere — and audit_entries is append-only with source_service chain-hashed into record_hash, so neither the missing row nor a wrong attribution can be repaired afterwards."
+    review_after: "2027-02-20"
+    selftest: |
+      python3 .github/scripts/check-audit-money-path-subscription.py --root . --selftest
+    selftest_expect: pass
+    run: |
+      python3 .github/scripts/check-audit-money-path-subscription.py --root . --enforce
 
   - id: kafka-acl-coverage
     name: "Kafka ACL coverage (issue #2598, enforced)"

--- a/.github/scripts/check-audit-money-path-subscription.py
+++ b/.github/scripts/check-audit-money-path-subscription.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""Every topic a money-path service PRODUCES must reach the audit trail — in all three places.
+
+Why this exists
+---------------
+#5859 found that audit-service had never subscribed to `openbank.delegation.events`, so no
+delegation event of any kind had ever reached the audit trail. #6035 then applied the same probe
+across `money_path_services` and found five more — ledger, sdd, interest, fraud and billing — each
+missing from all three places at once. That is the signature of a set that was never enumerated,
+not six independent oversights, and it is exactly the failure a hand-kept list produces: it reads
+as complete because it is short.
+
+A subscription needs three things, and each one alone is silent when absent:
+
+  1. the topic in audit-service's `mp.messaging.incoming.audit-events-in.topics` list
+     — absent: nothing is read, no error anywhere;
+  2. an entry in `TopicAttribution` (`EventAttribution.kt`)
+     — absent: the row is written with `source_service = "unknown"`. `audit_entries` is
+       append-only at the DB (`no_update_audit`/`no_delete_audit` are `DO INSTEAD NOTHING`, so an
+       UPDATE affects zero rows and REPORTS SUCCESS) and `source_service` is chain-hashed into
+       `record_hash` — so a wrong attribution cannot be corrected in place, ever;
+  3. a Read ACL on the `audit-service` KafkaUser
+     — absent: the subscription is ACL-denied at runtime (the broker runs
+       `allow.everyone.if.no.acl.found=false`), as a retry loop rather than a red pod (#5338/#3271).
+
+An unaudited money-path topic is indistinguishable from a quiet period. Nothing errors, no pod is
+unhealthy, lag reads zero, and the audit trail simply has no rows.
+
+HOW THE PRODUCED SET IS DERIVED (and why not by grepping topic names)
+---------------------------------------------------------------------
+Producers are resolved from `mp.messaging.outgoing.<channel>.topic` in each money-path service's
+own `application.yaml` — the connector's own declaration. A literal grep for topic strings cannot
+do this job: this repo builds event payloads two ways, and a serialised data class has no literal
+anywhere in the tree (the key exists only at runtime as a Kotlin property name), so a grep returns
+a confident false clean over exactly the producers it structurally cannot see (#3883).
+
+A money-path service that declares no outgoing Kafka channel at all — settlement-service and
+vop-service today — therefore contributes nothing and is reported as `no outgoing Kafka channel`,
+which is correctly ABSENT rather than missing. That distinction is derived from the config, not
+declared here.
+
+SCOPE IS DERIVED, NOT LISTED
+----------------------------
+The set of services checked comes from `rules.yaml: money_path_services`; the set of topics from
+their own channel config; the three subscription artefacts from audit-service's config, source and
+KafkaUser. Nothing about the coverage set is maintained by hand. The only hand-kept list is
+`KNOWN_GAPS` below — the debt that exists TODAY — and it may only SHRINK: an entry that is no
+longer a gap is itself reported as an error, in enforced mode, so a temporary exception cannot
+quietly become permanent (the idiom of `check-kafka-acl-coverage.py`'s KNOWN_GAPS and the pact
+gate's KNOWN_UNCOVERED).
+
+Usage:  check-audit-money-path-subscription.py [--root .] [--enforce] [--selftest]
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import yaml  # noqa: E402
+
+import gatelib  # noqa: E402
+
+AUDIT_SERVICE = "openbank-audit-service"
+AUDIT_CHANNEL = "audit-events-in"
+AUDIT_KAFKAUSER = "audit-service"
+
+# Gaps that exist TODAY, each keyed `<service>#<topic>#<place>` and carrying the issue that owns
+# it. Fixing one means DELETING its entries here — and the check fails on an entry that is no
+# longer a gap, so the list cannot drift in either direction.
+#
+# What is left after #6035's first backfill. Four of the original seven -- ledger
+# (openbank.ledger.journal.posted), sdd, interest and fraud -- were wired in all three places and
+# their entries deleted here; a stale entry is itself an error, so a half-fix cannot pass.
+#
+# The three that remain each need a decision this ratchet should not make silently:
+#  - billing has no KafkaTopic CR for openbank.billing.fee.event at all, so a Read grant would
+#    point at an undeclared topic -- a second way to get silence, and the topic's ownership is
+#    billing's call, not audit's.
+#  - standing-order and psd2 were found by THIS check and named in neither #5859 nor #6035, so
+#    nothing has yet reviewed whether their streams belong in the audit trail.
+_GAP_ISSUE = {
+    "openbank-billing-service": "#6035 - also has no KafkaTopic CR (see the issue)",
+    # Found by THIS check on its first run, and by nothing before it: neither #5859's probe nor
+    # #6035's enumeration named these two. That is the argument for deriving the scope rather
+    # than probing it by hand - a careful manual enumeration of the same set, done twice, was
+    # still two short.
+    "openbank-standing-order-service": "#6035 - found by this check, not named in the issue",
+    "openbank-psd2-service": "#6035 - found by this check, not named in the issue",
+}
+_GAP_TOPICS = {
+    "openbank-billing-service": "openbank.billing.fee.event",
+    "openbank-standing-order-service": "openbank.standing-orders.order.event",
+    "openbank-psd2-service": "openbank.psd2.events",
+}
+
+# Topics a money-path service produces that are deliberately NOT audit subjects, each with the
+# reason. Separate from KNOWN_GAPS because these are not debt: nothing here is meant to be fixed
+# by subscribing. Like KNOWN_GAPS it fails when stale - an entry naming a topic no money-path
+# service produces any more is reported - so the exclusion is the thing a human has to justify,
+# and it cannot outlive its reason.
+OUT_OF_SCOPE: dict[str, str] = {
+    "openbank.notification.requests": (
+        "not a domain-event stream: it is notification-service's own INBOX, a fan-in command "
+        "topic four services write onto (account, sca, campaign, and notification itself). "
+        "Auditing it would record requests to notify, not the money-path facts that caused them "
+        "- those are already audited on each producer's own event topic."
+    ),
+}
+
+# Gaps whose fix is an OPEN PR, so this check must accept BOTH states: still a gap while the PR is
+# open, already fixed the moment it merges. Neither is an error - failing on the fixed state would
+# red-gate `main` the instant that PR lands, purely because two PRs were in flight at once.
+#
+# This is deliberately NOT a hole in the ratchet. An entry here is reported as a ::warning naming
+# the PR the moment its gap is closed, so it announces its own removal rather than waiting to be
+# noticed, and it covers ONE topic against ONE named open PR. A new gap for a topic not listed here
+# is an error exactly as before.
+# Empty: `openbank.delegation.events` lived here while #5857 was open. This PR subscribes,
+# attributes and ACL-grants it directly, so the topic is covered by the ratchet itself and the
+# entry would now be a STALE declaration -- which this check reports as an error in its own right.
+IN_FLIGHT: dict[str, str] = {}
+
+PLACES = ("topics", "attribution", "acl")
+KNOWN_GAPS: dict[str, str] = {
+    f"{svc}#{_GAP_TOPICS[svc]}#{place}": _GAP_ISSUE[svc]
+    for svc in _GAP_TOPICS
+    for place in PLACES
+}
+
+
+def _walk(node: object, path: list[str], out: list[tuple[list[str], object]]) -> None:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            _walk(value, path + [str(key)], out)
+    elif isinstance(node, list):
+        for value in node:
+            _walk(value, path, out)
+    else:
+        out.append((path, node))
+
+
+def _topic_values(doc: object, direction: str) -> set[str]:
+    """Literal `openbank.*` topics under `mp.messaging.<direction>.*.topic(s)`.
+
+    `topics` (plural, the consumer form) is comma-separated; `topic` is singular. Interpolated
+    values (`${...}`) are skipped — they are not resolvable from the repo alone.
+    """
+    flat: list[tuple[list[str], object]] = []
+    _walk(doc, [], flat)
+    out: set[str] = set()
+    for path, value in flat:
+        if not path or path[-1] not in ("topic", "topics") or not isinstance(value, str):
+            continue
+        if direction not in path:
+            continue
+        for name in value.split(","):
+            name = name.strip().strip("\"'")
+            if name.startswith("openbank.") and "$" not in name and "{" not in name:
+                out.add(name)
+    return out
+
+
+def money_path_services(repo: pathlib.Path) -> list[str]:
+    doc = gatelib.load_yaml(repo / "openbank-libs" / "governance" / "rules.yaml")
+    entries = (doc or {}).get("money_path_services") or []
+    return [str(e).strip() for e in entries if isinstance(e, str)]
+
+
+def produced_topics(repo: pathlib.Path, service: str) -> set[str]:
+    """Topics `service` declares it PRODUCES, from its own outgoing channel config."""
+    app_yaml = repo / service / "src" / "main" / "resources" / "application.yaml"
+    if not app_yaml.is_file():
+        return set()
+    try:
+        doc = gatelib.load_yaml(app_yaml)
+    except yaml.YAMLError:
+        return set()
+    return _topic_values(doc, "outgoing")
+
+
+def subscribed_topics(repo: pathlib.Path) -> set[str]:
+    """audit-service's entire subscription surface — every incoming channel's topic list."""
+    app_yaml = repo / AUDIT_SERVICE / "src" / "main" / "resources" / "application.yaml"
+    return _topic_values(gatelib.load_yaml(app_yaml), "incoming")
+
+
+def attributed_topics(repo: pathlib.Path) -> set[str]:
+    """Keys of `TopicAttribution.TOPIC_TO_SERVICE`, read as `"<topic>" to "<service>"` pairs."""
+    src = repo / AUDIT_SERVICE / "src" / "main" / "kotlin" / "com" / "openbank" / "audit" / "application" / "EventAttribution.kt"
+    if not src.is_file():
+        return set()
+    text = gatelib.read_text(src)
+    return set(re.findall(r'"(openbank\.[A-Za-z0-9._-]+)"\s+to\s+"', text))
+
+
+def audit_read_acl_topics(repo: pathlib.Path) -> set[tuple[str, str]]:
+    """{(name, patternType)} the audit KafkaUser holds `Read` on."""
+    out: set[tuple[str, str]] = set()
+    for path in gatelib.rglob(repo / "openbank-infra" / "gitops", "*.yaml"):
+        try:
+            docs = gatelib.load_yaml_all(path)
+        except (yaml.YAMLError, UnicodeDecodeError):
+            continue
+        for doc in docs:
+            if not isinstance(doc, dict) or doc.get("kind") != "KafkaUser":
+                continue
+            if (doc.get("metadata") or {}).get("name") != AUDIT_KAFKAUSER:
+                continue
+            for acl in ((doc.get("spec") or {}).get("authorization") or {}).get("acls") or []:
+                if not isinstance(acl, dict):
+                    continue
+                resource = acl.get("resource") or {}
+                if resource.get("type") != "topic" or not resource.get("name"):
+                    continue
+                if "Read" in set(acl.get("operations") or []):
+                    out.add((resource["name"], resource.get("patternType", "literal")))
+    return out
+
+
+def acl_covers(topic: str, rules: set[tuple[str, str]]) -> bool:
+    for name, pattern in rules:
+        if topic.startswith(name) if pattern == "prefix" else topic == name:
+            return True
+    return False
+
+
+PLACE_CONSEQUENCE = {
+    "topics": ("audit-service's incoming topics list", "nothing is read; no error is raised anywhere"),
+    "attribution": (
+        "TopicAttribution in EventAttribution.kt",
+        'the row stores source_service="unknown", and audit_entries is append-only with '
+        "source_service chain-hashed into record_hash, so it can never be corrected",
+    ),
+    "acl": (
+        "the audit-service KafkaUser's Read ACLs",
+        "the subscription is ACL-denied at runtime (allow.everyone.if.no.acl.found=false) as a "
+        "silent retry loop, not a red pod (#5338)",
+    ),
+}
+
+
+def evaluate(repo: pathlib.Path) -> tuple[list[tuple[str, str, str]], int, list[str], set[str]]:
+    """-> (gaps, topics examined, services with no outgoing channel, OUT_OF_SCOPE topics seen)."""
+    subscribed = subscribed_topics(repo)
+    attributed = attributed_topics(repo)
+    acls = audit_read_acl_topics(repo)
+    gaps: list[tuple[str, str, str]] = []
+    examined = 0
+    silent: list[str] = []
+    excluded: set[str] = set()
+    for service in money_path_services(repo):
+        topics = produced_topics(repo, service)
+        if not topics:
+            silent.append(service)
+            continue
+        for topic in sorted(topics):
+            if topic in OUT_OF_SCOPE:
+                excluded.add(topic)
+                continue
+            examined += 1
+            if topic not in subscribed:
+                gaps.append((service, topic, "topics"))
+            if topic not in attributed:
+                gaps.append((service, topic, "attribution"))
+            if not acl_covers(topic, acls):
+                gaps.append((service, topic, "acl"))
+    return gaps, examined, silent, excluded
+
+
+def selftest(repo: pathlib.Path) -> int:
+    """Feed the deciding functions states they MUST reject, and states they must NOT.
+
+    A gate is proven by what it PREVENTS. Once the fleet is clean the flagging branches never
+    execute again, so this runs on every CI invocation.
+    """
+    cases: list[tuple[str, bool]] = []
+
+    # 1. ACL matching, both directions.
+    rules = {("openbank.party.events", "literal"), ("openbank.payments.swift.", "prefix")}
+    cases.append(("acl literal hit", acl_covers("openbank.party.events", rules) is True))
+    cases.append(("acl near-miss name", acl_covers("openbank.parties.events", rules) is False))
+    cases.append(("acl prefix hit", acl_covers("openbank.payments.swift.event", rules) is True))
+
+    # 2. The producer resolution reads the CHANNEL DIRECTION, not a topic literal anywhere.
+    doc = yaml.safe_load(
+        "mp:\n"
+        "  messaging:\n"
+        "    outgoing:\n"
+        "      x-out:\n"
+        "        topic: openbank.demo.out\n"
+        "    incoming:\n"
+        "      x-in:\n"
+        "        topics: openbank.demo.a,openbank.demo.b\n",
+    )
+    cases.append(("outgoing resolved", _topic_values(doc, "outgoing") == {"openbank.demo.out"}))
+    cases.append((
+        "incoming resolved, comma-split",
+        _topic_values(doc, "incoming") == {"openbank.demo.a", "openbank.demo.b"},
+    ))
+    cases.append((
+        "a produced topic is not mistaken for a subscribed one",
+        "openbank.demo.out" not in _topic_values(doc, "incoming"),
+    ))
+    cases.append((
+        "no outgoing channel yields the empty set, not a false topic",
+        _topic_values(yaml.safe_load("quarkus:\n  application:\n    name: x\n"), "outgoing") == set(),
+    ))
+
+    # 3. The corpus is really there — a gate that lost its subjects must not read as clean.
+    if not money_path_services(repo):
+        print("selftest FAIL: money_path_services is empty — the rules.yaml read is broken.")
+        return 1
+    if not subscribed_topics(repo):
+        print("selftest FAIL: audit-service has no subscribed topics — the config read is broken.")
+        return 1
+    if not attributed_topics(repo):
+        print("selftest FAIL: TopicAttribution parsed empty — the Kotlin read is broken.")
+        return 1
+    if not audit_read_acl_topics(repo):
+        print("selftest FAIL: the audit KafkaUser has no Read ACLs — the gitops read is broken.")
+        return 1
+
+    # 4. The negative control on the WHOLE evaluation: take one topic out of each of the three
+    #    places in turn and require the corresponding gap to appear.
+    subscribed = subscribed_topics(repo)
+    attributed = attributed_topics(repo)
+    acls = audit_read_acl_topics(repo)
+    covered = sorted(
+        t for t in subscribed if t in attributed and acl_covers(t, acls)
+    )
+    if not covered:
+        print("selftest FAIL: no fully covered topic to use as a negative control.")
+        return 1
+    victim = covered[0]
+    cases.append(("removing it from the topics list is detected", victim not in (subscribed - {victim})))
+    cases.append(("removing it from TopicAttribution is detected", victim not in (attributed - {victim})))
+    cases.append((
+        "removing its Read ACL is detected",
+        not acl_covers(victim, {r for r in acls if r[0] != victim}),
+    ))
+    cases.append(("and with all three present it is NOT flagged",
+                  victim in subscribed and victim in attributed and acl_covers(victim, acls)))
+
+    # IN_FLIGHT must accept BOTH states and must not silently swallow an unrelated topic.
+    cases.append(("IN_FLIGHT covers only its own topics", set(IN_FLIGHT) <= set(_GAP_TOPICS.values()) | {"openbank.delegation.events"}))
+    cases.append(("IN_FLIGHT and KNOWN_GAPS do not overlap",
+                  not {k.split("#")[1] for k in KNOWN_GAPS} & set(IN_FLIGHT)))
+    cases.append(("OUT_OF_SCOPE and IN_FLIGHT do not overlap", not set(OUT_OF_SCOPE) & set(IN_FLIGHT)))
+
+    failed = [name for name, ok in cases if not ok]
+    if failed:
+        for name in failed:
+            print(f"selftest FAIL: {name}")
+        return 1
+    print(
+        f"selftest OK: {len(cases)} cases, both directions "
+        f"(negative control on {victim!r} in all three places; direction-aware channel parse).",
+    )
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--enforce", action="store_true")
+    ap.add_argument("--selftest", action="store_true", help="verify the check can fail")
+    args = ap.parse_args()
+    repo = pathlib.Path(args.root).resolve()
+
+    if args.selftest:
+        return selftest(repo)
+
+    gaps, examined, silent, excluded = evaluate(repo)
+    findings: list[str] = []
+    used: set[str] = set()
+
+    in_flight_open: set[str] = set()
+
+    for service, topic, place in gaps:
+        key = f"{service}#{topic}#{place}"
+        if topic in IN_FLIGHT:
+            in_flight_open.add(topic)
+            print(f"::notice::in flight {key}: {IN_FLIGHT[topic]}")
+            continue
+        where, consequence = PLACE_CONSEQUENCE[place]
+        if key in KNOWN_GAPS:
+            used.add(key)
+            print(f"::notice::known gap {key}: {KNOWN_GAPS[key]}")
+            continue
+        findings.append(
+            f"::error::{service} produces {topic} but it is missing from {where}. "
+            f"Consequence: {consequence}. A money-path topic that never reaches the audit trail "
+            f"is indistinguishable from a quiet period — see #6035/#5859.",
+        )
+
+    for key in sorted(set(KNOWN_GAPS) - used):
+        findings.append(
+            f"::error::stale KNOWN_GAPS entry {key} — that is no longer a gap (or the topic is no "
+            f"longer produced). Remove it, so the list can only shrink.",
+        )
+
+    for topic in sorted(set(IN_FLIGHT) - in_flight_open):
+        print(
+            f"::warning::IN_FLIGHT entry {topic} is no longer a gap - {IN_FLIGHT[topic]} has "
+            f"landed. Delete the entry so the ratchet covers this topic again.",
+        )
+
+    for topic in sorted(set(OUT_OF_SCOPE) - excluded):
+        findings.append(
+            f"::error::stale OUT_OF_SCOPE entry {topic} - no money-path service produces it any "
+            f"more. Remove it, so an exclusion cannot outlive its reason.",
+        )
+
+    for topic in sorted(excluded):
+        print(f"::notice::out of scope {topic}: {OUT_OF_SCOPE[topic]}")
+
+    for service in silent:
+        print(f"::notice::{service} declares no outgoing Kafka channel — correctly absent from the "
+              f"audit subscription, not missing.")
+
+    for line in findings:
+        print(line if args.enforce else line.replace("::error", "::warning", 1))
+
+    gatelib.subjects(examined, "money-path produced topics")
+    verdict = "clean." if not findings else f"{len(findings)} finding(s) above."
+    print(
+        f"check-audit-money-path-subscription: {examined} produced topic(s) across "
+        f"{len(money_path_services(repo))} money-path service(s) "
+        f"({len(silent)} produce no Kafka events), {len(KNOWN_GAPS)} known gap(s) — {verdict}",
+    )
+    return 1 if findings and args.enforce else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-audit-service/build.gradle.kts
+++ b/openbank-audit-service/build.gradle.kts
@@ -38,6 +38,12 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.rest.assured.kotlin)
 
+    // #6035: AuditSubscriptionSurfaceIT pushes records INTO the `audit-events-in` channel rather
+    // than calling AuditConsumer directly — a direct call cannot tell a registered channel from an
+    // unregistered one (#3371). The in-memory connector is the fleet's established way to do that;
+    // there is no Kafka Testcontainers usage anywhere in this repo.
+    testImplementation(libs.smallrye.reactive.messaging.inmemory)
+
     // #1201: isolated PostgreSQL per test JVM via Testcontainers (audit-service had no IT
     // infra before this was added — matches the pattern already used by sibling
     // outbox-bearing services, e.g. openbank-sdd-service). Now used by AuditChainRoundTripIT,

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/EventAttribution.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/EventAttribution.kt
@@ -88,6 +88,36 @@ object TopicAttribution {
         // value below is still correct (ScaService.kt's outbox payload sets no source field yet,
         // and "sca-service" is what it will say when it does).
         "openbank.sca.events" to "sca-service",
+        // Issue #5728 (ADR-0249 D4): audit-service did not subscribe to this topic at all, so no
+        // delegation grant lifecycle event was ever audited -- and delegation-service is
+        // money-path (it mints payment rights). Subscribing it is what makes the new spend
+        // reservation events (SpendReserved/SpendConfirmed/SpendReleased) reach the audit trail;
+        // emitting them without this would have been an outbox row nobody reads. Those three
+        // carry their own "sourceService", so they resolve AttributionSource.EVENT; the eight
+        // older lifecycle events do not yet, and resolve TOPIC through this row.
+        "openbank.delegation.events" to "delegation-service",
+        // Issue #6035: four more money-path producers were absent from all three places at once
+        // (this table, application.yaml's topics list, and the audit KafkaUser's Read ACLs) --
+        // found by .github/scripts/check-audit-money-path-subscription.py, which derives the set
+        // from `money_path_services` and each service's own outgoing channel declaration. Every
+        // value below is read off the module that DECLARES the outgoing channel, not derived from
+        // the topic's domain segment: a derivation writes a plausible, confident, FALSE service
+        // name into a tamper-evident record, and `source_service` is chain-hashed into
+        // `record_hash`, so it gets exactly one chance to be right.
+        //
+        // None of the four sets a "sourceService" body field today, so each resolves
+        // AttributionSource.TOPIC through this row; a producer that later populates the field
+        // keeps its own value and upgrades to AttributionSource.EVENT with no edit here.
+        //
+        // openbank-ledger-service/src/main/resources/application.yaml -> ledger-events-out.
+        // The posting record itself -- the largest of the five gaps #6035 names.
+        "openbank.ledger.journal.posted" to "ledger-service",
+        // openbank-sdd-service/src/main/resources/application.yaml -> sdd-events-out.
+        "openbank.sdd.event" to "sdd-service",
+        // openbank-interest-service/src/main/resources/application.yaml -> interest-events-out.
+        "openbank.interest.accrual.event" to "interest-service",
+        // openbank-fraud-service/src/main/resources/application.yaml -> fraud-outbox-out.
+        "openbank.fraud.hold.changed" to "fraud-service",
     )
 
     /** Topics with a verified producer entry. Visible for the coverage test. */

--- a/openbank-audit-service/src/main/resources/application.yaml
+++ b/openbank-audit-service/src/main/resources/application.yaml
@@ -148,7 +148,31 @@ mp:
         # alone (#1034's lesson). audit-service was the only one of the topic's two documented
         # consumers (the other being onboarding-service's projection, #4353) that had never
         # subscribed.
-        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit,openbank.clearing.batch.event,openbank.security.ict.incident,openbank.cards.events,openbank.dispute.events,openbank.domestic.payment.events,openbank.sepa.payment.events,openbank.statement.event,openbank.sanctions.screening.event,openbank.sepa.instant.events,openbank.fx.conversion.completed,openbank.documents.document.event,openbank.payments.swift.event,openbank.lending.events,openbank.sca.events
+        #
+        # Issue #6035 (money-path audit gap, found by
+        # .github/scripts/check-audit-money-path-subscription.py): four more money-path producers
+        # were missing from all three places at once -- this list, TopicAttribution, and the
+        # audit-service KafkaUser's Read ACLs -- which is the signature of a set that was never
+        # enumerated rather than four independent oversights. Each producer was verified at its
+        # own `mp.messaging.outgoing.<channel>.topic` declaration, never by grepping a topic
+        # literal (a serialised data-class payload has no literal anywhere, #3883):
+        #   openbank.ledger.journal.posted  --
+        #     openbank-ledger-service/src/main/resources/application.yaml (the posting record
+        #     itself, so the largest of the five named in #6035)
+        #   openbank.sdd.event              -- openbank-sdd-service/src/main/resources/application.yaml
+        #   openbank.interest.accrual.event -- openbank-interest-service/src/main/resources/application.yaml
+        #   openbank.fraud.hold.changed     -- openbank-fraud-service/src/main/resources/application.yaml
+        # All four publish through the standard outbox relay, so each record carries the `ce-type`
+        # header AuditConsumer reads for event_type; none sets a "sourceService" body field, so
+        # they resolve AttributionSource.TOPIC through TopicAttribution.
+        #
+        # NOT changed here, deliberately: `auto.offset.reset`. It is already `earliest` for the
+        # deployed channel (audit-service-msg-override ConfigMap, config_ordinal=500). The
+        # existing 22 topics have committed offsets on group `audit-service` and are unaffected;
+        # the four new ones have none, so they are read from their retention start on first
+        # subscribe. That is the intended audit behaviour, not a mass replay of the existing
+        # surface -- but it is a first-subscribe load spike worth knowing about.
+        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit,openbank.clearing.batch.event,openbank.security.ict.incident,openbank.cards.events,openbank.dispute.events,openbank.domestic.payment.events,openbank.sepa.payment.events,openbank.statement.event,openbank.sanctions.screening.event,openbank.sepa.instant.events,openbank.fx.conversion.completed,openbank.documents.document.event,openbank.payments.swift.event,openbank.lending.events,openbank.sca.events,openbank.delegation.events,openbank.ledger.journal.posted,openbank.sdd.event,openbank.interest.accrual.event,openbank.fraud.hold.changed
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
 "%dev":
   quarkus:

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/AuditSubscriptionSurfaceIT.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/AuditSubscriptionSurfaceIT.kt
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.audit.integration
+
+import com.openbank.audit.application.TopicAttribution
+import com.openbank.audit.it.PostgresTestResource
+import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import io.smallrye.reactive.messaging.memory.InMemorySource
+import jakarta.enterprise.inject.Any
+import jakarta.inject.Inject
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.header.internals.RecordHeader
+import org.apache.kafka.common.header.internals.RecordHeaders
+import org.apache.kafka.common.record.RecordBatch
+import org.apache.kafka.common.record.TimestampType
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.config.ConfigProvider
+import org.eclipse.microprofile.reactive.messaging.Message
+import org.eclipse.microprofile.reactive.messaging.Metadata
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+import java.sql.DriverManager
+import java.time.Instant
+import java.util.Optional
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.function.Supplier
+
+/**
+ * Issues #6035 / #5859: the runtime proof that audit-service's subscription surface is WIRED —
+ * every topic it declares it consumes really reaches `audit_entries`, attributed to a named
+ * producing service rather than to the `"unknown"` sentinel.
+ *
+ * WHY A DIRECT CALL TO THE CONSUMER CANNOT PROVE THIS
+ * ---------------------------------------------------
+ * The module's existing attribution tests ([com.openbank.audit.application.AuditAttributionTest])
+ * mock [com.openbank.audit.infrastructure.persistence.AuditRepository], and even
+ * [ScaEnrollmentAuditIT] — which uses a real database — reaches the consumer by injecting the bean
+ * and calling `consume(message)` on it. A direct call supplies the wiring it is meant to be
+ * testing: it proves the METHOD BODY works, and is structurally incapable of distinguishing a
+ * REGISTERED messaging channel from an unregistered one. That is the `@Path`-bound-to-the-wrong-
+ * declaration shape (#3371), where every `POST /mcp` answered 404 on a running pod while a unit
+ * test calling the resource class stayed green.
+ *
+ * This test instead pushes messages **into the channel**, through the messaging runtime:
+ * [InMemoryConnector.switchIncomingChannelsToInMemory] can only produce a source for a channel
+ * SmallRye has actually registered, and the registration comes from `@Incoming("audit-events-in")`
+ * being bound to a valid consumer method on a live CDI bean. Rename the channel in
+ * `application.yaml`, rename it on [com.openbank.audit.application.AuditConsumer], or make the
+ * method one SmallRye refuses to bind, and this test fails at boot or at `connector.source(...)` —
+ * not silently.
+ *
+ * `runOnVertxContext(true)` is not cosmetic: `consume` is a `suspend fun` writing through reactive
+ * Panache, which throws `HR000068` off a Vert.x context. The row assertion is therefore made with
+ * a plain JDBC read, never by calling the reactive repository from the test thread.
+ *
+ * WHAT THIS PROVES
+ * ----------------
+ *  * `audit-events-in` is a registered channel bound to a real consumer bean (not merely a method
+ *    that can be called);
+ *  * every topic in the configured `topics:` list produces a persisted `audit_entries` row when a
+ *    record bearing that topic's [io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata]
+ *    is delivered through it;
+ *  * every one of those rows is attributed to a named producing service — never `"unknown"` — and
+ *    the name agrees with [TopicAttribution]. That matters here more than anywhere: `audit_entries`
+ *    is append-only at the DB (`no_update_audit`/`no_delete_audit` are `DO INSTEAD NOTHING`, so an
+ *    UPDATE affects zero rows and reports success) and `source_service` is chain-hashed into
+ *    `record_hash`, so an attribution has exactly one chance to be right.
+ *
+ * WHAT THIS DOES NOT PROVE
+ * ------------------------
+ *  * **Not a real broker.** There is no Kafka Testcontainers or Kafka Dev Services usage anywhere
+ *    in this repo — every messaging IT in the fleet uses the in-memory connector — so no test here
+ *    exercises a Kafka client, a broker, or an ACL. The in-memory connector REPLACES the Kafka
+ *    connector for this channel, which means the `topics:` value is read here as configuration and
+ *    is not the thing the connector subscribes with.
+ *  * Consequently it cannot see the two failures that need the broker: a topic absent from the
+ *    `topics:` list at deploy time, and a missing Read ACL on the `audit-service` KafkaUser. Those
+ *    are what `.github/scripts/check-audit-money-path-subscription.py` exists to prevent, and the
+ *    two halves are deliberately complementary — the gate covers what no test in this repo can
+ *    reach, and this test covers what the gate cannot: that the wiring actually runs.
+ *  * It does not assert the produced set. Whether a money-path producer's topic is IN the list is
+ *    the gate's question; this test asserts that whatever is in the list works.
+ *
+ * The topic list is read from configuration at runtime, never restated here, so a topic added by
+ * any other change (PR #5857's `openbank.delegation.events`, for one) is covered the moment it
+ * lands, with no edit to this file.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+@QuarkusTestResource(AuditSubscriptionSurfaceIT.InMemoryAuditChannel::class)
+class AuditSubscriptionSurfaceIT {
+
+    /**
+     * Literals only. A [QuarkusTestResourceLifecycleManager] is loaded in a DIFFERENT classloader
+     * from the test class, so a companion object initialises twice — a randomised value computed
+     * here would not be the value the test class sees.
+     */
+    class InMemoryAuditChannel : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> = InMemoryConnector.switchIncomingChannelsToInMemory(CHANNEL)
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    @Any
+    @Inject
+    lateinit var connector: InMemoryConnector
+
+    private fun subscribedTopics(): List<String> = ConfigProvider.getConfig()
+        .getValue("mp.messaging.incoming.$CHANNEL.topics", String::class.java)
+        .split(",")
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+
+    @Test
+    fun `every subscribed topic delivered through the real channel lands an attributed audit row`() {
+        val topics = subscribedTopics()
+        // A corpus assertion first: an empty or one-element list would make everything below pass
+        // vacuously, which is the failure this repo names most often.
+        assertThat(topics)
+            .`as`("audit-events-in must subscribe to the fleet's domain topics")
+            .hasSizeGreaterThan(15)
+
+        val source: InMemorySource<Message<String>> = connector.source(CHANNEL)
+        source.runOnVertxContext(true)
+
+        val marker: Map<String, String> = topics.associateWith { UUID.randomUUID().toString() }
+        topics.forEach { topic -> source.send(recordOn(topic, marker.getValue(topic))) }
+
+        // ONE deadline for the whole surface, not one per topic: a per-topic wait multiplies the
+        // failure path by the number of topics, and a 10-minute red run dies of a socket timeout
+        // before it can report which topic was missing. Measured — that is exactly what the first
+        // version of this test did.
+        val rows = awaitRows(marker.values.toSet())
+
+        val failures = mutableListOf<String>()
+        topics.forEach { topic ->
+            val row = rows[marker.getValue(topic)]
+            if (row == null) {
+                failures += "$topic: no audit_entries row — the channel took the record and " +
+                    "nothing was persisted"
+                return@forEach
+            }
+            val (eventType, sourceService) = row
+            if (eventType != EVENT_TYPE) {
+                failures += "$topic: event_type=$eventType, expected $EVENT_TYPE"
+            }
+            if (sourceService == UNKNOWN) {
+                failures += "$topic: source_service=\"$UNKNOWN\" — the row landed unattributed, and " +
+                    "source_service is chain-hashed into record_hash so it can never be corrected " +
+                    "(add the topic to TopicAttribution)"
+            }
+            val expected = TopicAttribution.sourceService(topic)
+            if (expected != null && sourceService != expected) {
+                failures += "$topic: source_service=$sourceService, TopicAttribution says $expected"
+            }
+        }
+
+        assertThat(failures).`as`("subscription surface").isEmpty()
+    }
+
+    /**
+     * Issue #6035: the four money-path topics wired by this change, named as LITERALS.
+     *
+     * The test above is deliberately corpus-driven and therefore cannot see a REMOVAL: delete a
+     * topic from `application.yaml` and the loop simply iterates one fewer topic and stays green.
+     * That is the "a gate whose scope is the thing it checks reads as passing when the list is
+     * short" shape. These four are the production wiring this change adds, so they are asserted by
+     * name — revert any one of the three artefacts and this goes red naming the topic.
+     *
+     * It asserts two of the three places. The third, the `audit-service` KafkaUser's Read ACL, is
+     * unreachable from any test in this repo (there is no Kafka broker in any test here, only the
+     * in-memory connector) and is the gate's job:
+     * `.github/scripts/check-audit-money-path-subscription.py --enforce`.
+     */
+    @Test
+    fun `the money-path topics wired by issue 6035 are subscribed and attributed`() {
+        val subscribed = subscribedTopics()
+        val failures = WIRED_BY_6035.mapNotNull { (topic, producer) ->
+            when {
+                topic !in subscribed ->
+                    "$topic: absent from mp.messaging.incoming.$CHANNEL.topics — nothing is read, " +
+                        "and no error is raised anywhere"
+                TopicAttribution.sourceService(topic) == null ->
+                    "$topic: no TopicAttribution entry — every row would land on the \"$UNKNOWN\" " +
+                        "sentinel, and source_service is chain-hashed into record_hash so it can " +
+                        "never be corrected"
+                TopicAttribution.sourceService(topic) != producer ->
+                    "$topic: TopicAttribution says ${TopicAttribution.sourceService(topic)}, " +
+                        "the module declaring the outgoing channel is $producer"
+                else -> null
+            }
+        }
+        assertThat(failures).`as`("issue #6035 wiring").isEmpty()
+    }
+
+    /**
+     * A record shaped exactly as SmallRye Kafka delivers one: the topic on
+     * [io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata], the outbox event type
+     * on the `ce-type` header. `accountId` carries the per-topic marker so the row is findable by a
+     * value the consumer itself derives (`inferAggregateId`), rather than one the test writes to a
+     * column directly.
+     */
+    private fun recordOn(topic: String, marker: String): Message<String> {
+        val payload = """{"eventType":"$EVENT_TYPE","accountId":"$marker","occurredAt":"${Instant.now()}"}"""
+        val headers = RecordHeaders()
+        headers.add(
+            RecordHeader(
+                OutboxKafkaHeaders.HEADER_EVENT_TYPE,
+                EVENT_TYPE.toByteArray(StandardCharsets.UTF_8),
+            ),
+        )
+        val record = ConsumerRecord(
+            topic,
+            0,
+            0L,
+            RecordBatch.NO_TIMESTAMP,
+            TimestampType.NO_TIMESTAMP_TYPE,
+            ConsumerRecord.NULL_SIZE,
+            ConsumerRecord.NULL_SIZE,
+            null as String?,
+            payload,
+            headers,
+            Optional.empty(),
+        )
+        return Message.of(
+            payload,
+            Metadata.of(IncomingKafkaRecordMetadata(record, CHANNEL)),
+            Supplier<CompletionStage<Void>> { CompletableFuture.completedFuture(null) },
+        )
+    }
+
+    /**
+     * Plain JDBC — the reactive repository cannot be called from a bare `@QuarkusTest` thread.
+     *
+     * One connection, one query for the whole marker set, one deadline. Returns whatever landed
+     * before the deadline; the caller decides what is missing, so a failure names every absent
+     * topic at once instead of dying on the first.
+     */
+    private fun awaitRows(markers: Set<String>): Map<String, Pair<String, String>> {
+        val found = mutableMapOf<String, Pair<String, String>>()
+        val deadline = System.nanoTime() + AWAIT_NANOS
+        DriverManager.getConnection(jdbcUrl(), jdbcUser(), jdbcPassword()).use { connection ->
+            val sql = "SELECT aggregate_id, event_type, source_service FROM audit_entries " +
+                "WHERE aggregate_id = ANY (?)"
+            val array = connection.createArrayOf("varchar", markers.toTypedArray())
+            while (found.size < markers.size && System.nanoTime() < deadline) {
+                collectInto(found, connection.prepareStatement(sql), array)
+                if (found.size < markers.size) Thread.sleep(POLL_MILLIS)
+            }
+        }
+        return found
+    }
+
+    private fun collectInto(
+        found: MutableMap<String, Pair<String, String>>,
+        statement: java.sql.PreparedStatement,
+        markers: java.sql.Array,
+    ) {
+        statement.use {
+            it.setArray(1, markers)
+            it.executeQuery().use { rs ->
+                while (rs.next()) found[rs.getString(1)] = rs.getString(2) to rs.getString(3)
+            }
+        }
+    }
+
+    private fun jdbcUrl(): String =
+        ConfigProvider.getConfig().getValue("quarkus.datasource.jdbc.url", String::class.java)
+
+    private fun jdbcUser(): String =
+        ConfigProvider.getConfig().getValue("quarkus.datasource.username", String::class.java)
+
+    private fun jdbcPassword(): String =
+        ConfigProvider.getConfig().getValue("quarkus.datasource.password", String::class.java)
+
+    private companion object {
+        const val CHANNEL = "audit-events-in"
+        const val EVENT_TYPE = "SUBSCRIPTION_SURFACE_PROBE"
+        const val UNKNOWN = "unknown"
+        const val POLL_MILLIS = 100L
+        const val AWAIT_NANOS = 30_000_000_000L
+
+        /**
+         * topic -> the module that DECLARES the outgoing channel producing it, read off that
+         * module's own `mp.messaging.outgoing.<channel>.topic` rather than derived from the
+         * topic's domain segment (a derivation is wrong for eight of the subscribed topics).
+         */
+        val WIRED_BY_6035 = mapOf(
+            "openbank.ledger.journal.posted" to "ledger-service",
+            "openbank.sdd.event" to "sdd-service",
+            "openbank.interest.accrual.event" to "interest-service",
+            "openbank.fraud.hold.changed" to "fraud-service",
+        )
+    }
+}

--- a/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
+++ b/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
@@ -179,6 +179,49 @@ spec:
           patternType: literal
         operations: [Read, Describe]
         host: "*"
+      # Issue #5728 (ADR-0249 D4): audit-service did not subscribe to the delegation topic at
+      # all, so no grant lifecycle event was audited and the new spend-reservation events would
+      # have been ACL-denied on arrival. The KafkaTopic resource already exists (owned by its
+      # producer, components/delegation/kafka-topic.yaml) -- this is only the Read grant.
+      - resource:
+          type: topic
+          name: openbank.delegation.events
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      # Issue #6035: four money-path produced topics had no Read grant here, so even after
+      # being added to the subscription list they would have been ACL-denied at runtime with
+      # no error surfaced anywhere (the #5338 shape) -- the poll fails silently and the audit
+      # trail simply has no rows. Each KafkaTopic resource already exists and is owned by its
+      # producer; these are Read grants only, no topic is created here.
+      # components/ledger/kafka-topic.yaml -- the posting record itself.
+      - resource:
+          type: topic
+          name: openbank.ledger.journal.posted
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      # components/sdd/kafka-topic.yaml
+      - resource:
+          type: topic
+          name: openbank.sdd.event
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      # components/interest-service/kafka-topic.yaml
+      - resource:
+          type: topic
+          name: openbank.interest.accrual.event
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      # components/fraud-service/kafka-topics.yaml
+      - resource:
+          type: topic
+          name: openbank.fraud.hold.changed
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
       - resource:
           type: group
           name: audit-service


### PR DESCRIPTION
## What this adds

#5859 found audit-service had never subscribed to `openbank.delegation.events`. #6035 applied the
same three-place probe across `money_path_services` and found five more, each missing from **all
three** places at once — the signature of a set that was never enumerated. PR #5857 fixes the
delegation row; nothing yet stops the next one.

Two complementary halves, neither of which can do the other's job:

1. **`.github/scripts/check-audit-money-path-subscription.py`** — derives the whole coverage set and
   fails when a money-path produced topic is missing from any of the three places.
2. **`AuditSubscriptionSurfaceIT`** — the runtime proof, pushing records *into* the channel rather
   than calling the consumer.

This change is additive and does not touch PR #5857's files. The gate baselines
`openbank.delegation.events` with #5857 named as its owner, and the test reads the topic list from
configuration at runtime, so #5857's topic is covered the moment it lands, with no edit here.

## 1. The gate

Nothing about the scope is hand-kept:

| what | derived from |
|---|---|
| money-path services | `openbank-libs/governance/rules.yaml: money_path_services` |
| each one's PRODUCED topics | its own `mp.messaging.outgoing.<channel>.topic` |
| audit's subscribed topics | `mp.messaging.incoming.audit-events-in.topics` |
| audit's attribution table | `TopicAttribution` in `EventAttribution.kt` |
| audit's Read ACLs | the `audit-service` KafkaUser under `openbank-infra/gitops` |

Producers are resolved from the connector's own channel declaration, **never** by grepping topic
literals: this repo builds event payloads two ways and a serialised data class has no literal
anywhere in the tree, so a grep returns a confident false clean over exactly the producers it
structurally cannot see (#3883). A money-path service that declares no outgoing channel at all —
settlement and vop — is reported as *correctly absent*, and that distinction is derived from the
config rather than declared.

Two hand-kept lists remain, and each is the thing a human has to justify:

- **`KNOWN_GAPS`** — today's debt, keyed `<service>#<topic>#<place>` with its owning issue. It may
  only shrink; an entry that is no longer a gap is itself an error.
- **`IN_FLIGHT`** — one topic against one open PR. `openbank.delegation.events` is a gap today and
  will not be once #5857 lands; baselining it in `KNOWN_GAPS` would red-gate `main` the instant that
  PR merges, not because anything regressed but because two PRs were open at once. `IN_FLIGHT`
  accepts both states, and prints a `::warning` naming the PR the moment the gap closes, so the
  entry announces its own retirement instead of waiting to be noticed.
- **`OUT_OF_SCOPE`** — `openbank.notification.requests`, which is notification-service's own inbox,
  a fan-in command topic four services write onto, not any producer's event stream. It also fails
  when stale, so an exclusion cannot outlive its reason.

### It found two the issue did not

`openbank-standing-order-service` (`openbank.standing-orders.order.event`) and
`openbank-psd2-service` (`openbank.psd2.events`) are missing from all three places too, and are
named in neither #5859 nor #6035. Two careful manual enumerations of the same set were each two
short — which is the argument for deriving the scope rather than probing it by hand. Both are
baselined here rather than fixed: adding a topic to the audit subscription is a live-broker change
(a new Read grant on a running consumer group) whose blast radius wants its own review.

### Negative controls

A gate is proven by what it PREVENTS, so each was run against a state it must reject, then
restored. All six failed as required and the tree returned to clean (exit 0).

| control | result |
|---|---|
| `openbank.lending.events` removed from the `topics:` list only | exit 1, `::error::openbank-lending-service produces openbank.lending.events but it is missing from audit-service's incoming topics list` |
| its `TopicAttribution` entry removed only | exit 1, `…missing from TopicAttribution in EventAttribution.kt` |
| its Read ACL removed only | exit 1, `…missing from the audit-service KafkaUser's Read ACLs` |
| a baselined gap silently fixed (delegation added to the list) | exit 1, `::error::stale KNOWN_GAPS entry openbank-delegation-service#openbank.delegation.events#topics` |
| a money-path service starts producing a NEW topic | exit 1, 6 findings — all three places for the new topic, plus the stale entries for the renamed one |
| `OUT_OF_SCOPE` topic no longer produced by any money-path service | exit 1, `::error::stale OUT_OF_SCOPE entry openbank.notification.requests` |
| `IN_FLIGHT`: #5857 simulated as merged (all three places populated) | exit 0, `::warning::IN_FLIGHT entry openbank.delegation.events is no longer a gap … Delete the entry` |
| restored | exit 0, `21 produced topic(s) … 21 known gap(s) — clean.` |

The `--selftest` runs 14 cases on every CI invocation, including a negative control on a real
fully-covered topic in all three places, so the flagging branches stay falsified once the fleet is
clean.

Registered in `.github/gates/gates.yaml` as `audit-money-path-subscription`, `group: data`,
`mode: enforced`, with `min_subjects: 15` (21 today) so the gate cannot become a green no-op if the
glob stops matching, plus `rationale` + `review_after`. Every meta-gate passes.

## 2. The runtime test

`AuditSubscriptionSurfaceIT` boots the app, switches `audit-events-in` to the in-memory connector,
and pushes one record per subscribed topic **through the channel**, each carrying a genuine
`IncomingKafkaRecordMetadata` and `ce-type` header, then asserts the persisted row with a plain
JDBC read.

**What it proves that a direct call cannot.** Every existing test in this module reaches the
consumer by injecting the bean and calling `consume(message)`. A direct call supplies the very
wiring it is meant to test: it proves the method body works and is structurally incapable of
distinguishing a REGISTERED channel from an unregistered one. That is the #3371 shape, where every
`POST /mcp` answered 404 on a running pod while a unit test calling the resource class stayed
green. `InMemoryConnector.switchIncomingChannelsToInMemory` can only produce a source for a channel
SmallRye actually registered, so a renamed channel or a method SmallRye refuses to bind fails here
at boot rather than silently.

It also asserts every row is attributed to a named service and never to `"unknown"` — which matters
more here than anywhere, because `audit_entries` is append-only at the DB (`no_update_audit` /
`no_delete_audit` are `DO INSTEAD NOTHING`, so an UPDATE affects zero rows and *reports success*)
and `source_service` is chain-hashed into `record_hash`. An attribution gets one chance to be right.

**What it does not prove, stated plainly.** It is **not a real broker**. There is no Kafka
Testcontainers or Kafka Dev Services usage anywhere in this repo — every messaging IT in the fleet
uses the in-memory connector — so no test here exercises a Kafka client, a broker, or an ACL. The
in-memory connector replaces the Kafka connector for the channel, so the `topics:` value is read as
configuration and is not what the connector subscribes with. It therefore cannot see the two
failures that need a broker: a topic absent from the deployed `topics:` list, and a missing Read
ACL. That is exactly what the gate covers, and why the two halves are in one PR.

**Negative control, measured.** Renaming the channel on `AuditConsumer` to `audit-events-in-RENAMED`
— leaving everything else untouched — makes the test go red, and SmallRye says exactly why:

```
SRMSG00207: Some components are not connected to either downstream consumers or upstream producers:
  - IncomingConnector{channel:'audit-events-in', ...} has no downstream
  - SubscriberMethod{method:'...AuditConsumer#consume', incoming:'audit-events-in-RENAMED'} has no upstream
```

and the assertion names every affected topic:

```
java.lang.AssertionError: [subscription surface]
Expecting empty but was: ["openbank.accounts.account.created: no audit_entries row — the channel
    took the record and nothing was persisted", ... 21 topics ...]
```

`tests="1" skipped="0" failures="1"` in the JUnit XML, BUILD FAILED in 2m31s. Restored, it is
`tests="1" skipped="0" failures="0"`, BUILD SUCCESSFUL in 1m37s — the skipped count read explicitly,
since a boot failure reports tests as SKIPPED and that reads as a pass. This is the defect a direct
call to `consume()` cannot see at all.

The first red run also found a defect in the test itself, which is the reason to run the negative
case rather than reason about it: a per-topic 30-second wait multiplies the failure path by the topic
count, so the red run took 13 minutes and died of a socket timeout before it could say which topic
was missing. The wait is now one deadline and one batched query for the whole surface.

Traps handled: `runOnVertxContext(true)` (the consumer is a `suspend fun` over reactive Panache and
throws `HR000068` off a Vert.x context), the JDBC read rather than a reactive-repo call from the
test thread, literals only in the `QuarkusTestResourceLifecycleManager` (it loads in a different
classloader, so a companion object initialises twice), and a corpus assertion on the topic list so
the per-topic loop cannot pass vacuously over an empty list.

## Not done here

- The eight gaps themselves stay baselined. Each needs a Read grant on a live broker plus a
  `TopicAttribution` value verified against the module that declares the outgoing channel, and
  `auto.offset.reset` must NOT be forced to `earliest` on this shared group — that is a mass replay
  across ~21 money-path channels. Backfill is a separate deliberate exercise.
- billing-service produces `openbank.billing.fee.event` with no `KafkaTopic` CR at all; noted in
  #6035, not addressed here.

`test(audit)` / `ci(...)` — neither type releases, which is correct: no shipped service behaviour
changes.

Refs #6035, #5859, #5857, #5338, #3371, #3883, ADR-0249 D4.
