### PR TITLE
fix(settlement): actually reverse money in the compensation path (#6037)

### DIFF
--- a/docs/threat-models/openbank-settlement-service.md
+++ b/docs/threat-models/openbank-settlement-service.md
@@ -71,7 +71,7 @@ replacing the former in-memory stub), so settlement state is durable across rest
 
 | ID | Threat | Mitigation |
 |----|--------|------------|
-| T1 | Replayed debit activity credits twice | `referenceId = workflowRunId + activityId` stored before side-effect; idempotency guard in balance-service |
+| T1 | Replayed debit or reversal activity moves money twice | Corrected 2026-08-20 (#6037). The reference id is **not** `workflowRunId + activityId` as this row previously claimed — that would change on every workflow run and defeat the guard. It is a pure function of the settlement id (`settlement-debit-<id>`, `settlement-credit-<id>`, and for compensation `settlement-debit-reversal-<id>` / `settlement-credit-reversal-<id>`), so every Temporal retry re-sends an identical key. balance-service deduplicates durably on the `balance_movement` primary key `(account_id, currency, reference_id, operation)`, applying mutation and marker in one transaction and answering a duplicate 200 with `applied = false`. The reversal namespace is deliberately distinct from the forward one rather than relying on `operation` alone to separate the rows. |
 | T2 | Settlement DB record modified out-of-band (bypassing workflow) | Postgres row-level security; audit trail in `openbank-libs/audit` |
 | T3 | Temporal workflow history modified | Temporal's history is append-only; CNPG backups every 30 days |
 
@@ -80,7 +80,7 @@ replacing the former in-memory stub), so settlement state is durable across rest
 | ID | Threat | Mitigation |
 |----|--------|------------|
 | R1 | Settlement denied by payer ("I never authorised this") | Temporal workflow execution ID links to the initiating payment ID in `sepa-payment-service` / `domestic-payment-service`; full chain queryable from admin UI |
-| R2 | Compensation claimed to have run when it did not | Temporal activity history records every attempt; compensation activities update status to `REVERSED`/`CREDITED_REVERSED`/`LEDGER_REVERSED` atomically |
+| R2 | Compensation claimed to have run when it did not | **This threat was realised, not mitigated, from ADR-0101 P3 until #6037.** The cited mitigation — "compensation activities update status to `REVERSED`/`CREDITED_REVERSED`/`LEDGER_REVERSED` atomically" — *was* the defect: updating the status column was the **only** thing `reverseDebit`/`reverseCredit`/`reverseBookToLedger` did. They logged `"stub: wire reversal to balance-service"` and returned success, so the status row asserted an unwind that had moved no money. Now: the two balance reversals issue real counter-movements to balance-service before writing a status, a refused reversal is recorded as `REVERSAL_FAILED` (not as success), and the unimplemented ledger reversal throws a non-retryable `ApplicationFailure` and records `LEDGER_REVERSAL_UNSUPPORTED`. Verified by `SettlementReversalIT`, which asserts the outbound HTTP request over real HTTP and the resulting row over plain JDBC — a mocked port cannot tell a counterparty call from a no-op. |
 
 ### I — Information disclosure
 
@@ -138,12 +138,48 @@ replacing the former in-memory stub), so settlement state is durable across rest
    (`legacySettle`) is deleted. This closes a compensation gap: the legacy path flipped a mid-flight
    failure straight to `REJECTED` **without reversing an already-moved debit/credit**, whereas
    `SettlementWorkflow` runs `reverseBookToLedger → reverseCredit → reverseDebit` before rejecting.
+   **Correction (#6037):** that last sentence was true only of the ordering. Until #6037 all three
+   compensation activities were stubs, so the Temporal path unwound exactly as much money as the
+   legacy path it replaced — none — while recording that it had. The gap is closed for the two
+   balance movements as of #6037; the ledger half remains open, as risk 5 below.
    Flip pre-conditions are verified: Temporal server healthy, `openbank-settlement` namespace
    registered, `settlement_activity.rego` present (risk 2). Worker registration is gated on
    `openbank.settlement.worker.enabled` (default true; false in `%test`). **Cutover risk:** with no
    fallback path, a settlement cannot be processed if the Temporal worker is not registered or the
    frontend is unreachable — a sandbox canary must confirm the worker registers and a real settlement
    drives `PENDING → BOOKED` before merge, and the deterministic simulation (ADR-0100/0115) stays green.
+
+5. **A settlement that fails after `bookToLedger` leaves the GL entry standing (issue #6037).**
+   `reverseBookToLedger` is deliberately NOT implemented and fails loudly
+   (`LEDGER_REVERSAL_UNSUPPORTED` + a non-retryable `ApplicationFailure`) rather than reporting a
+   reversal it did not perform. ledger-service does expose `POST /api/v1/journals/{journalId}/reverse`,
+   but three things must be decided before settlement-service may call it: (a) `ledger.reverse` is
+   maker-checker gated, so a service-account call queues for approval instead of posting, and granting
+   a machine that action is a `rules.yaml: shared_m2m_matrix_write_grants` decision — an automatic GL
+   reversal driven by a failed saga is close to what maker-checker exists to prevent; (b) settlement
+   does not retain the journal id (`bookToLedger` discards the response), so it must be persisted or
+   re-resolved via `GET /api/v1/journals/transaction/{transactionId}`; (c) the endpoint answers 409
+   when the entry's fiscal period is ATTESTED, and the accounting convention there is to correct
+   forward in the open period, which is a different posting. **Operational consequence:** such a
+   settlement unwinds both balance movements and needs a manual correcting entry in the general
+   ledger. It is visible as a `LEDGER_REVERSAL_UNSUPPORTED` row and an ERROR log line, and is
+   announced at boot by `SettlementCompensationCapabilities`.
+
+6. **A reversal can be legitimately refused and the money stays moved (issue #6037).**
+   balance-service enforces `booked - amount >= overdraftFloor` on every debit, so if the payee has
+   already moved the credited funds out, `reverseCredit` is refused with 422 and no retry resolves
+   it. The row records `REVERSAL_FAILED` and the audit event carries `AuditResult.FAILURE`.
+   Recovering those funds is a collections/dispute process, not an API call — this is a real
+   property of the world, and the design records it rather than smoothing it into a success.
+
+7. **A debit applied by balance-service but not observed by settlement-service is not compensated
+   (pre-existing, not addressed by #6037).** `SettlementWorkflowImpl` registers the `reverseDebit`
+   compensation only *after* `debitPayer` returns, so a debit that balance-service applied while the
+   response was lost — or that succeeded before the subsequent status update failed — leaves money
+   moved with no compensation registered. The idempotent `referenceId` means a retry does not
+   double-debit, and the row is left non-terminal (visible to the `SettlementStuckAfterCompensation`
+   alert in #6036), but no automatic unwind occurs. Closing this needs the compensation registered
+   before the call, which changes the saga's shape.
 
 4. **2-approval gate** — money-path rule requires 2 approvals. This PR has 1 (automated review).
    Second approval from a human committer required before merge per rules.yaml.
@@ -187,6 +223,18 @@ replacing the former in-memory stub), so settlement state is durable across rest
 - Settlement money-bug (2026-06-19, root cause: missing intermediate-state timeout in hand-rolled saga)
 
 ## Change log
+
+- **2026-08-20** (#6037) — **The compensation path did not reverse money.** `reverseDebit`,
+  `reverseCredit` and `reverseBookToLedger` wrote a status row, logged
+  `"stub: wire reversal to balance-service"`, and reported success; no call reached balance-service
+  or ledger-service. R2 above named this exact threat and listed the stub as its mitigation, and
+  residual risk 3 credited the Temporal migration with closing a compensation gap it had not closed.
+  T1's stated idempotency key (`workflowRunId + activityId`) was also not the one the code sends,
+  and would not have worked if it were — it changes per run. Both rows and risk 3 are corrected
+  above; risks 5-7 are added for what remains open. Reachability was measured before deciding
+  urgency: the live sandbox `settlements` table held **zero rows** with `n_tup_ins = 0` and no
+  statistics reset, so the compensation path has never run there and no money is currently
+  unreturned. The defect was pre-deployment, not an incident.
 
 - **2026-08-16** (#3921) — S2's mitigation was corrected and the outbound OIDC client was
   configured for the first time; both belong together. The prior text credited "Service mesh mTLS

--- a/openbank-settlement-service/build.gradle.kts
+++ b/openbank-settlement-service/build.gradle.kts
@@ -45,6 +45,10 @@ dependencies {
     testImplementation(libs.testcontainers.postgresql)
     // Consumer-driven contract for the ledger-service postJournal call (ADR-0063, issue #468).
     testImplementation(libs.pact.consumer)
+    // Real-HTTP stand-in for balance-service so the reversal adapters' REST calls actually leave
+    // the process in SettlementReversalIT (#6037) — a mocked port cannot prove a money movement
+    // was addressed to anyone. Same use as sepa-payment's simulator resources.
+    testImplementation(libs.wiremock.standalone)
 }
 
 kover {

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/port/out/SettlementReversalPorts.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/port/out/SettlementReversalPorts.kt
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.application.port.out
+
+import java.util.UUID
+
+/**
+ * Compensation ports for the ADR-0101 P3 settlement saga (issue #6037).
+ *
+ * Declared in their own file rather than alongside [DebitPort]/[CreditPort] in `SettlementPorts.kt`
+ * only to stay disjoint from the two settlement PRs in flight (#6036, #5723) that both edit that
+ * file; there is no design reason to keep them apart.
+ *
+ * **Why these are separate ports rather than a `reverse()` on [DebitPort]/[CreditPort]:** the
+ * reversal of a debit is a *credit* and vice-versa, so folding them into the forward ports would
+ * put a credit behind an interface named `DebitPort`. Keeping them separate also keeps the
+ * reference-id namespaces visibly distinct, which is the whole idempotency mechanism (below).
+ *
+ * ## Idempotency
+ *
+ * balance-service deduplicates money movements durably on the primary key
+ * `(account_id, currency, reference_id, operation)` of its `balance_movement` table
+ * (`V8__balance_movement_idempotency.sql`), applying the mutation and the marker row in one
+ * transaction. A duplicate is answered 200 with the already-moved balance and `applied = false`,
+ * not an error. There is no `Idempotency-Key` header on that API, and balance-service does not use
+ * the shared `openbank-libs-domain` [com.openbank.libs.idempotency.IdempotencyStore] — the
+ * reference id *is* the idempotency key.
+ *
+ * Each reversal therefore carries a reference id that is a pure function of the settlement id, so a
+ * Temporal activity retry re-sends the identical key and balance-service swallows it. The reversal
+ * ids are deliberately in a **different namespace** from the forward ids
+ * (`settlement-debit-reversal-<id>` vs `settlement-debit-<id>`): sharing the forward id would rely
+ * on `operation` alone to separate the two rows, which works today but silently couples the
+ * reversal's idempotency to a detail of the counterparty's primary key.
+ */
+interface ReverseDebitPort {
+    /**
+     * Return the payer's debited funds by issuing the opposite movement — a **credit** of the same
+     * amount and currency to `payerAccountId`, keyed `settlement-debit-reversal-<settlementId>`.
+     *
+     * Throws if balance-service refuses or is unreachable; the caller must not record a successful
+     * reversal in that case.
+     */
+    suspend fun reverseDebit(settlementId: UUID)
+}
+
+interface ReverseCreditPort {
+    /**
+     * Take back the payee's credited funds by issuing the opposite movement — a **debit** of the
+     * same amount and currency from `payeeAccountId`, keyed
+     * `settlement-credit-reversal-<settlementId>`.
+     *
+     * **This call can legitimately fail and no retry will fix it.** balance-service enforces
+     * `booked - amount >= overdraftFloor` on every debit, so if the payee has already moved the
+     * credited funds out of the account the reversal is refused (422). That is a true fact about
+     * the world — funds that have left cannot be clawed back through this API — and it must be
+     * recorded as such rather than smoothed into a success. See
+     * [com.openbank.settlement.domain.model.SettlementStatus.REVERSAL_FAILED].
+     */
+    suspend fun reverseCredit(settlementId: UUID)
+}

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImpl.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImpl.kt
@@ -10,11 +10,14 @@ import com.openbank.libs.audit.AuditResult
 import com.openbank.settlement.application.port.out.CreditPort
 import com.openbank.settlement.application.port.out.DebitPort
 import com.openbank.settlement.application.port.out.LedgerPort
+import com.openbank.settlement.application.port.out.ReverseCreditPort
+import com.openbank.settlement.application.port.out.ReverseDebitPort
 import com.openbank.settlement.application.port.out.SettlementRepository
 import com.openbank.settlement.domain.model.Settlement
 import com.openbank.settlement.domain.model.SettlementStatus
 import io.quarkus.vertx.VertxContextSupport
 import io.smallrye.mutiny.coroutines.asUni
+import io.temporal.failure.ApplicationFailure
 import jakarta.enterprise.context.ApplicationScoped
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -39,6 +42,8 @@ open class SettlementActivitiesImpl(
     private val creditPort: CreditPort,
     private val ledgerPort: LedgerPort,
     private val auditPublisher: AuditEventPublisher,
+    private val reverseDebitPort: ReverseDebitPort,
+    private val reverseCreditPort: ReverseCreditPort,
 ) : SettlementActivities {
 
     private val log = Logger.getLogger(SettlementActivitiesImpl::class.java)
@@ -68,33 +73,100 @@ open class SettlementActivitiesImpl(
     }
 
     override fun reverseDebit(settlementId: UUID): Unit = runOnVertxContext {
-        log.warnf(
-            "Reversing debit for settlement %s (compensation — stub: wire reversal to balance-service)",
-            settlementId,
-        )
-        val settlement = settlementRepository.updateStatus(settlementId, SettlementStatus.REVERSED)
-        audit("settlement.reverse-debit", settlement)
-        Unit
+        compensate(
+            settlementId = settlementId,
+            operation = "settlement.reverse-debit",
+            onSuccess = SettlementStatus.REVERSED,
+        ) { reverseDebitPort.reverseDebit(settlementId) }
     }
 
     override fun reverseCredit(settlementId: UUID): Unit = runOnVertxContext {
-        log.warnf(
-            "Reversing credit for settlement %s (compensation — stub: wire reversal to balance-service)",
-            settlementId,
-        )
-        val settlement = settlementRepository.updateStatus(settlementId, SettlementStatus.CREDITED_REVERSED)
-        audit("settlement.reverse-credit", settlement)
-        Unit
+        compensate(
+            settlementId = settlementId,
+            operation = "settlement.reverse-credit",
+            onSuccess = SettlementStatus.CREDITED_REVERSED,
+        ) { reverseCreditPort.reverseCredit(settlementId) }
     }
 
+    /**
+     * NOT IMPLEMENTED — fails loudly rather than reporting a reversal that did not happen.
+     *
+     * ledger-service does expose `POST /api/v1/journals/{journalId}/reverse`, but settlement-service
+     * cannot use it as things stand, for three independent reasons, each needing a decision this
+     * service cannot make on its own (issue #6037):
+     *
+     *  1. **Maker-checker.** `ledger.reverse` is an approval-gated action — a call from
+     *     settlement-service's service account lands in ledger's PENDING approval queue rather than
+     *     posting. Granting a machine that action is a `rules.yaml: shared_m2m_matrix_write_grants`
+     *     decision, not a code change, and an *automatic* GL reversal driven by a failed saga is
+     *     precisely the thing maker-checker exists to prevent.
+     *  2. **No journal id is retained.** `bookToLedger` discards the `JournalResponse`, so the id
+     *     would have to be persisted (a migration) or re-resolved via
+     *     `GET /api/v1/journals/transaction/{transactionId}`.
+     *  3. **Period locks.** The endpoint answers 409 when the original entry's fiscal period is
+     *     ATTESTED, so a reversal is not always available and the saga needs a defined behaviour
+     *     for that case — correcting forward in the open period is the accounting convention, which
+     *     is a different posting from a reversal.
+     *
+     * Throwing a **non-retryable** failure is deliberate: a retryable one would burn all five
+     * attempts (~75 s of backoff) delaying the two compensations that *do* work, and would still
+     * end in the same place. `SettlementWorkflowImpl` catches `ActivityFailure` per compensation and
+     * continues, so this failure does not block `reverseCredit`/`reverseDebit`.
+     *
+     * The status is recorded first, so the row says
+     * [SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED] — an operator sees *which* half of the unwind
+     * did not happen — rather than the old `LEDGER_REVERSED`, which claimed it had.
+     */
     override fun reverseBookToLedger(settlementId: UUID): Unit = runOnVertxContext {
-        log.warnf(
-            "Reversing ledger booking for settlement %s (compensation — stub: wire reversal to ledger-service)",
+        log.errorf(
+            "Ledger booking for settlement %s was NOT reversed: settlement-service cannot reverse a " +
+                "journal (ledger.reverse is maker-checker gated and no journal id is retained). " +
+                "The GL still carries this settlement's posting and needs a manual correcting entry.",
             settlementId,
         )
-        val settlement = settlementRepository.updateStatus(settlementId, SettlementStatus.LEDGER_REVERSED)
-        audit("settlement.reverse-ledger-book", settlement)
-        Unit
+        val settlement =
+            settlementRepository.updateStatus(settlementId, SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED)
+        audit("settlement.reverse-ledger-book", settlement, result = AuditResult.FAILURE)
+        throw ApplicationFailure.newNonRetryableFailure(
+            "Ledger reversal is not implemented for settlement $settlementId; GL correction required",
+            "LedgerReversalUnsupported",
+        )
+    }
+
+    /**
+     * Runs one balance-service compensation and records **what actually happened**.
+     *
+     * Order matters and mirrors the forward activities: the money call goes first, and the status
+     * is written only once it has returned. A status written before the call — which is all the
+     * pre-#6037 stubs did — is a claim the code has not yet earned.
+     *
+     * On failure the row is moved to [SettlementStatus.REVERSAL_FAILED] (money still moved), a
+     * FAILURE audit event is published, and the exception is **rethrown** so Temporal retries and
+     * the workflow sees the failure. A later successful attempt overwrites the status with the real
+     * outcome, so `REVERSAL_FAILED` is the resting state only when every attempt failed.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun compensate(
+        settlementId: UUID,
+        operation: String,
+        onSuccess: SettlementStatus,
+        movement: suspend () -> Unit,
+    ) {
+        try {
+            movement()
+        } catch (ex: Throwable) {
+            log.errorf(
+                ex,
+                "Compensation %s FAILED for settlement %s — the money has NOT been returned",
+                operation,
+                settlementId,
+            )
+            val failed = settlementRepository.updateStatus(settlementId, SettlementStatus.REVERSAL_FAILED)
+            audit(operation, failed, result = AuditResult.FAILURE)
+            throw ex
+        }
+        val settlement = settlementRepository.updateStatus(settlementId, onSuccess)
+        audit(operation, settlement)
     }
 
     override fun rejectSettlement(settlementId: UUID): Unit = runOnVertxContext {

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementCompensationCapabilities.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementCompensationCapabilities.kt
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.application.workflow
+
+import io.quarkus.runtime.Startup
+import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
+
+/**
+ * Announces at boot which settlement compensations can actually return money (issue #6037).
+ *
+ * `@Startup` is load-bearing, not decoration. `@ApplicationScoped` beans are **lazy** in Quarkus —
+ * the bean is created via a client proxy on first use — so a warning written in an `init {}` block
+ * or a constructor of a plain `@ApplicationScoped` bean never reaches a pod log until something
+ * touches it, which for a compensation path can be never. That is exactly how
+ * `PdfBoxPadesSealAdapter`'s "every PAdES seal is worthless as evidence" warning managed to never
+ * once appear in production (#1299). Compensation is by definition the rare path, so a capability
+ * gap that is only announced when compensation runs is announced too late to act on.
+ *
+ * This is deliberately a plain log line rather than a boot-time `check()` that refuses to start:
+ * the ledger half being unimplemented does not make the service unsafe to run — the forward path
+ * and both balance reversals are real — it makes one specific failure mode need a manual GL
+ * correction. Refusing to boot would take a working money path offline over it.
+ */
+@Startup
+@ApplicationScoped
+class SettlementCompensationCapabilities {
+
+    private val log = Logger.getLogger(SettlementCompensationCapabilities::class.java)
+
+    init {
+        log.info(
+            "Settlement compensation capabilities: reverseDebit=WIRED (balance-service credit), " +
+                "reverseCredit=WIRED (balance-service debit), reverseBookToLedger=NOT IMPLEMENTED.",
+        )
+        log.warn(
+            "reverseBookToLedger cannot reverse a general-ledger posting: ledger.reverse is " +
+                "maker-checker gated and no journal id is retained. A settlement that fails after " +
+                "bookToLedger will unwind both balance movements but leave the GL entry standing, " +
+                "and will be marked LEDGER_REVERSAL_UNSUPPORTED for manual correction. See #6037.",
+        )
+    }
+}

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/domain/model/Settlement.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/domain/model/Settlement.kt
@@ -8,14 +8,51 @@ import java.math.BigDecimal
 import java.time.Instant
 import java.util.UUID
 
+/**
+ * Settlement saga states.
+ *
+ * The three compensation outcomes below are deliberately **four** values, not one (issue #6037).
+ * Until this was fixed, `reverseDebit`/`reverseCredit`/`reverseBookToLedger` wrote
+ * `REVERSED`/`CREDITED_REVERSED`/`LEDGER_REVERSED` and moved no money at all, so the one thing an
+ * operator could observe — the status column — asserted an unwind that had not happened. That is
+ * the same shape as `PushResult.skipped()` carrying `success = true`: an outcome structurally
+ * unable to report the thing that went wrong. A compensation that was *attempted and refused*, and
+ * one that is *not implemented*, are different facts from a compensation that *worked*, and each
+ * now has its own value.
+ */
 enum class SettlementStatus {
     PENDING,
     DEBITED,
     CREDITED,
     BOOKED,
     REJECTED,
+
+    /** Payer debit reversed: balance-service accepted (or had already applied) the counter-credit. */
     REVERSED,
+
+    /** Payee credit reversed: balance-service accepted (or had already applied) the counter-debit. */
     CREDITED_REVERSED,
+
+    /**
+     * A balance reversal was **attempted and did not succeed** — the money is still moved.
+     * The common cause is a payee who has spent the credited funds, which balance-service refuses
+     * with 422 and which no retry resolves. Recovery is a collections/dispute process.
+     */
+    REVERSAL_FAILED,
+
+    /**
+     * The ledger booking was **not** reversed because settlement-service cannot reverse a journal
+     * (see `SettlementActivitiesImpl.reverseBookToLedger`). Distinct from [LEDGER_REVERSED], which
+     * is what the old stub wrote while doing nothing.
+     */
+    LEDGER_REVERSAL_UNSUPPORTED,
+
+    /**
+     * Deprecated and **never written** since #6037. Retained so the value keeps its meaning for any
+     * consumer that pinned the old enum; the code path that produced it only ever updated this
+     * column and never reversed anything in the general ledger.
+     */
+    @Deprecated("Never produced; the stub that wrote it reversed nothing. See LEDGER_REVERSAL_UNSUPPORTED.")
     LEDGER_REVERSED,
 }
 

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/adapter/BalanceReverseCreditAdapter.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/adapter/BalanceReverseCreditAdapter.kt
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.infrastructure.adapter
+
+import com.openbank.settlement.application.port.out.ReverseCreditPort
+import com.openbank.settlement.application.port.out.SettlementRepository
+import com.openbank.settlement.infrastructure.client.BalanceRestClient
+import com.openbank.settlement.infrastructure.client.MoneyMovementRequest
+import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.future.await
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.jboss.logging.Logger
+import java.util.UUID
+
+/**
+ * Reverses the settlement credit by debiting the payee (issue #6037). Mirror image of
+ * [BalanceReverseDebitAdapter]; see that class for why the opposite movement is the reversal.
+ *
+ * Unlike the debit reversal, this one can be **refused for a reason no retry resolves**:
+ * balance-service's `Balance.applyDebit` requires `booked - amount >= overdraftFloor`, so a payee
+ * who has already moved the funds out cannot be debited back and the call answers 422. The caller
+ * records [com.openbank.settlement.domain.model.SettlementStatus.REVERSAL_FAILED] for that case —
+ * the money is genuinely still with the payee, and recovering it is a collections/dispute process,
+ * not an API call.
+ */
+@ApplicationScoped
+class BalanceReverseCreditAdapter(
+    @RestClient private val balanceClient: BalanceRestClient,
+    private val settlementRepository: SettlementRepository,
+) : ReverseCreditPort {
+
+    private val log = Logger.getLogger(BalanceReverseCreditAdapter::class.java)
+
+    companion object {
+        /** Reference-id namespace; see `SettlementReversalPorts.kt` for why it is not the forward id. */
+        fun referenceId(settlementId: UUID) = "settlement-credit-reversal-$settlementId"
+    }
+
+    override suspend fun reverseCredit(settlementId: UUID) {
+        val settlement = requireNotNull(settlementRepository.findById(settlementId)) {
+            "Settlement $settlementId not found"
+        }
+        log.warnf(
+            "Reversing credit: debiting payee %s for settlement %s (%s %s)",
+            settlement.payeeAccountId,
+            settlementId,
+            settlement.amount,
+            settlement.currency,
+        )
+        balanceClient.debit(
+            settlement.payeeAccountId,
+            MoneyMovementRequest(
+                amount = settlement.amount,
+                currency = settlement.currency,
+                referenceId = referenceId(settlementId),
+                description = "Settlement credit reversal $settlementId",
+            ),
+        ).subscribeAsCompletionStage().await()
+    }
+}

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/adapter/BalanceReverseDebitAdapter.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/adapter/BalanceReverseDebitAdapter.kt
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.infrastructure.adapter
+
+import com.openbank.settlement.application.port.out.ReverseDebitPort
+import com.openbank.settlement.application.port.out.SettlementRepository
+import com.openbank.settlement.infrastructure.client.BalanceRestClient
+import com.openbank.settlement.infrastructure.client.MoneyMovementRequest
+import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.future.await
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.jboss.logging.Logger
+import java.util.UUID
+
+/**
+ * Reverses the settlement debit by crediting the payer back (issue #6037).
+ *
+ * balance-service exposes no `/reverse` endpoint — its full path list is `{accountId}`,
+ * `{accountId}/{currency}`, `overdraft-limit`, `holds`, `holds/{holdId}`, `credit`, `debit`,
+ * `initialize`, `reconciliation`, `reconciliation/latest`, `approvals/{id}`. The only "undo"
+ * primitives it offers are releasing a hold and issuing the opposite movement. Settlement moves
+ * money with `debit`/`credit`, not holds, so the opposite movement is the reversal. This mirrors
+ * [BalanceDebitAdapter] exactly — same client, same request DTO, same account resolution — with
+ * the verb and the reference-id namespace flipped.
+ */
+@ApplicationScoped
+class BalanceReverseDebitAdapter(
+    @RestClient private val balanceClient: BalanceRestClient,
+    private val settlementRepository: SettlementRepository,
+) : ReverseDebitPort {
+
+    private val log = Logger.getLogger(BalanceReverseDebitAdapter::class.java)
+
+    companion object {
+        /** Reference-id namespace; see `SettlementReversalPorts.kt` for why it is not the forward id. */
+        fun referenceId(settlementId: UUID) = "settlement-debit-reversal-$settlementId"
+    }
+
+    override suspend fun reverseDebit(settlementId: UUID) {
+        val settlement = requireNotNull(settlementRepository.findById(settlementId)) {
+            "Settlement $settlementId not found"
+        }
+        log.warnf(
+            "Reversing debit: crediting payer %s back for settlement %s (%s %s)",
+            settlement.payerAccountId,
+            settlementId,
+            settlement.amount,
+            settlement.currency,
+        )
+        balanceClient.credit(
+            settlement.payerAccountId,
+            MoneyMovementRequest(
+                amount = settlement.amount,
+                currency = settlement.currency,
+                referenceId = referenceId(settlementId),
+                description = "Settlement debit reversal $settlementId",
+            ),
+        ).subscribeAsCompletionStage().await()
+    }
+}

--- a/openbank-settlement-service/src/main/resources/openapi.yaml
+++ b/openbank-settlement-service/src/main/resources/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.3"
 info:
   title: OpenBank Settlement Service
-  version: "1.1.1"
+  version: "1.2.0"
   description: "Settlement orchestration service (ADR-0101 P3)"
 paths:
   /api/v1/settlements:
@@ -53,6 +53,24 @@ components:
         currency: { type: string }
         status:
           type: string
-          enum: [PENDING, DEBITED, CREDITED, BOOKED, REJECTED, REVERSED, CREDITED_REVERSED, LEDGER_REVERSED]
+          description: >
+            Settlement saga state. The compensation outcomes are distinct values on purpose
+            (issue #6037): REVERSED and CREDITED_REVERSED mean balance-service accepted the
+            counter-movement and the money is back; REVERSAL_FAILED means a reversal was attempted
+            and refused (typically the payee has spent the funds) and the money is still moved;
+            LEDGER_REVERSAL_UNSUPPORTED means the general-ledger posting was not reversed and needs
+            a manual correcting entry. LEDGER_REVERSED is deprecated and is no longer produced —
+            the code path that wrote it updated this column without reversing anything.
+          enum:
+            - PENDING
+            - DEBITED
+            - CREDITED
+            - BOOKED
+            - REJECTED
+            - REVERSED
+            - CREDITED_REVERSED
+            - REVERSAL_FAILED
+            - LEDGER_REVERSAL_UNSUPPORTED
+            - LEDGER_REVERSED
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImplTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImplTest.kt
@@ -10,14 +10,19 @@ import com.openbank.libs.audit.AuditResult
 import com.openbank.settlement.application.port.out.CreditPort
 import com.openbank.settlement.application.port.out.DebitPort
 import com.openbank.settlement.application.port.out.LedgerPort
+import com.openbank.settlement.application.port.out.ReverseCreditPort
+import com.openbank.settlement.application.port.out.ReverseDebitPort
 import com.openbank.settlement.application.port.out.SettlementRepository
 import com.openbank.settlement.domain.model.Settlement
 import com.openbank.settlement.domain.model.SettlementStatus
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.mockk
+import io.temporal.failure.ApplicationFailure
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
@@ -35,6 +40,8 @@ class SettlementActivitiesImplTest {
     private val creditPort: CreditPort = mockk(relaxed = true)
     private val ledgerPort: LedgerPort = mockk(relaxed = true)
     private val auditPublisher: AuditEventPublisher = mockk(relaxed = true)
+    private val reverseDebitPort: ReverseDebitPort = mockk(relaxed = true)
+    private val reverseCreditPort: ReverseCreditPort = mockk(relaxed = true)
 
     private lateinit var activities: SettlementActivitiesImpl
 
@@ -53,7 +60,15 @@ class SettlementActivitiesImplTest {
     fun setUp() {
         // TestableActivities overrides runOnVertxContext to run synchronously — the production impl
         // needs a real Vert.x context (VertxContextSupport), which a plain unit test does not have.
-        activities = TestableActivities(settlementRepository, debitPort, creditPort, ledgerPort, auditPublisher)
+        activities = TestableActivities(
+            settlementRepository,
+            debitPort,
+            creditPort,
+            ledgerPort,
+            auditPublisher,
+            reverseDebitPort,
+            reverseCreditPort,
+        )
         coEvery { settlementRepository.updateStatus(any(), any()) } answers {
             settlement(firstArg(), secondArg())
         }
@@ -102,28 +117,90 @@ class SettlementActivitiesImplTest {
         coVerify { settlementRepository.updateStatus(id, SettlementStatus.BOOKED) }
     }
 
+    // ---- Compensation (issue #6037) --------------------------------------------------------
+    // These four tests replace three that asserted the DEFECT: they read
+    // `reverseDebit does not call debit port and sets REVERSED status` and passed precisely
+    // because no money moved. A test that pins a stub's behaviour makes the stub permanent.
+
     @Test
-    fun `reverseDebit does not call debit port and sets REVERSED status`() {
+    fun `reverseDebit calls the reversal port and only then sets REVERSED`() {
         val id = UUID.randomUUID()
+
         activities.reverseDebit(id)
-        coVerify(exactly = 0) { debitPort.debit(any()) }
+
+        coVerify(exactly = 1) { reverseDebitPort.reverseDebit(id) }
         coVerify { settlementRepository.updateStatus(id, SettlementStatus.REVERSED) }
+        // Ordering is the point: a status written before the money call is a claim not yet earned.
+        coVerifyOrder {
+            reverseDebitPort.reverseDebit(id)
+            settlementRepository.updateStatus(id, SettlementStatus.REVERSED)
+        }
     }
 
     @Test
-    fun `reverseCredit does not call credit port and sets CREDITED_REVERSED status`() {
+    fun `reverseCredit calls the reversal port and only then sets CREDITED_REVERSED`() {
         val id = UUID.randomUUID()
+
         activities.reverseCredit(id)
-        coVerify(exactly = 0) { creditPort.credit(any()) }
-        coVerify { settlementRepository.updateStatus(id, SettlementStatus.CREDITED_REVERSED) }
+
+        coVerify(exactly = 1) { reverseCreditPort.reverseCredit(id) }
+        coVerifyOrder {
+            reverseCreditPort.reverseCredit(id)
+            settlementRepository.updateStatus(id, SettlementStatus.CREDITED_REVERSED)
+        }
     }
 
     @Test
-    fun `reverseBookToLedger does not call ledger port and sets LEDGER_REVERSED status`() {
+    fun `a refused reversal records REVERSAL_FAILED, audits FAILURE and rethrows`() {
         val id = UUID.randomUUID()
-        activities.reverseBookToLedger(id)
+        // balance-service refuses the counter-debit: the payee has spent the funds (422).
+        coEvery { reverseCreditPort.reverseCredit(id) } throws IllegalStateException("insufficient funds")
+        val events = mutableListOf<AuditEvent>()
+        coEvery { auditPublisher.publish(capture(events)) } returns Unit
+
+        assertThatThrownBy { activities.reverseCredit(id) }
+            .isInstanceOf(IllegalStateException::class.java)
+
+        // The money did NOT come back, so the row must not say CREDITED_REVERSED.
+        coVerify { settlementRepository.updateStatus(id, SettlementStatus.REVERSAL_FAILED) }
+        coVerify(exactly = 0) { settlementRepository.updateStatus(id, SettlementStatus.CREDITED_REVERSED) }
+        assertThat(events).singleElement().satisfies({ e ->
+            assertThat(e.operation).isEqualTo("settlement.reverse-credit")
+            assertThat(e.result).isEqualTo(AuditResult.FAILURE)
+            assertThat(e.payload["status"]).isEqualTo("REVERSAL_FAILED")
+        })
+    }
+
+    @Test
+    fun `reverseBookToLedger fails loudly as unsupported instead of claiming a reversal`() {
+        val id = UUID.randomUUID()
+        val events = mutableListOf<AuditEvent>()
+        coEvery { auditPublisher.publish(capture(events)) } returns Unit
+
+        assertThatThrownBy { activities.reverseBookToLedger(id) }
+            .isInstanceOf(ApplicationFailure::class.java)
+            .hasMessageContaining("Ledger reversal is not implemented")
+
         coVerify(exactly = 0) { ledgerPort.book(any()) }
-        coVerify { settlementRepository.updateStatus(id, SettlementStatus.LEDGER_REVERSED) }
+        // Its own value, never the old LEDGER_REVERSED, which asserted an unwind that never ran.
+        coVerify { settlementRepository.updateStatus(id, SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED) }
+        @Suppress("DEPRECATION")
+        coVerify(exactly = 0) { settlementRepository.updateStatus(id, SettlementStatus.LEDGER_REVERSED) }
+        assertThat(events).singleElement().satisfies({ e ->
+            assertThat(e.result).isEqualTo(AuditResult.FAILURE)
+        })
+    }
+
+    @Test
+    fun `the unsupported ledger reversal is NON-retryable so it cannot delay the balance unwinds`() {
+        // SettlementWorkflowImpl runs compensations LIFO and catches ActivityFailure per step, so a
+        // retryable failure here would burn five attempts of backoff before reverseCredit and
+        // reverseDebit — the two that actually return money — even got to run.
+        assertThatThrownBy { activities.reverseBookToLedger(UUID.randomUUID()) }
+            .isInstanceOfSatisfying(ApplicationFailure::class.java) { failure ->
+                assertThat(failure.isNonRetryable).isTrue()
+                assertThat(failure.type).isEqualTo("LedgerReversalUnsupported")
+            }
     }
 
     @Test
@@ -158,6 +235,16 @@ private class TestableActivities(
     creditPort: CreditPort,
     ledgerPort: LedgerPort,
     auditPublisher: AuditEventPublisher,
-) : SettlementActivitiesImpl(settlementRepository, debitPort, creditPort, ledgerPort, auditPublisher) {
+    reverseDebitPort: ReverseDebitPort,
+    reverseCreditPort: ReverseCreditPort,
+) : SettlementActivitiesImpl(
+    settlementRepository,
+    debitPort,
+    creditPort,
+    ledgerPort,
+    auditPublisher,
+    reverseDebitPort,
+    reverseCreditPort,
+) {
     override fun <T> runOnVertxContext(block: suspend () -> T): T = runBlocking { block() }
 }

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/integration/SettlementReversalIT.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/integration/SettlementReversalIT.kt
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.integration
+
+import com.openbank.settlement.application.workflow.SettlementActivities
+import com.openbank.settlement.it.BalanceServiceWireMockResource
+import com.openbank.settlement.it.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.temporal.failure.ApplicationFailure
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.eclipse.microprofile.config.ConfigProvider
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.sql.DriverManager
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * The proof for issue #6037: settlement compensation actually returns money.
+ *
+ * ## Why this test and not a unit test
+ *
+ * The defect was three activities that wrote a status row, logged
+ * `"stub: wire reversal to balance-service"`, and reported success. Every existing unit test agreed
+ * with them — `SettlementActivitiesImplTest` literally asserted
+ * `reverseDebit does not call debit port` — because a mocked port cannot distinguish "called the
+ * counterparty" from "did nothing". So this test mocks **nothing** on the path it is checking:
+ *
+ *  - the real CDI [com.openbank.settlement.application.workflow.SettlementActivitiesImpl] bean,
+ *    with its real `VertxContextSupport` bridge (a Temporal activity thread carries no Vert.x
+ *    context, which is why the reactive repository cannot simply be called from a bare
+ *    `@QuarkusTest` thread — the production bridge is what makes it work here too);
+ *  - the real reversal adapters and the real `BalanceRestClient`, so an actual HTTP request leaves
+ *    the process and is asserted against by URL, verb and body;
+ *  - a real Postgres (Testcontainers) with the real Flyway migrations;
+ *  - **plain JDBC** for both the seed and the assertion, so the reactive persistence layer is never
+ *    asked to confirm its own work.
+ *
+ * ## What it does and does not establish
+ *
+ * It establishes that a counter-movement of the right amount, currency, account and reference id is
+ * **issued to balance-service**, and that the settlement row records the outcome that actually
+ * occurred. It does not establish that balance-service applied it — settlement-service cannot
+ * observe another service's ledger, and claiming otherwise would be the `accepted`-vs-`delivered`
+ * mistake. The applying half is balance-service's own dedup/overdraft tests over
+ * `balance_movement`.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+@QuarkusTestResource(BalanceServiceWireMockResource::class)
+class SettlementReversalIT {
+
+    @Inject
+    lateinit var activities: SettlementActivities
+
+    private val amount = BigDecimal("125.50")
+
+    @BeforeEach
+    fun resetStubs() {
+        BalanceServiceWireMockResource.reset()
+    }
+
+    private fun jdbc() = DriverManager.getConnection(
+        ConfigProvider.getConfig().getValue("quarkus.datasource.jdbc.url", String::class.java),
+        ConfigProvider.getConfig().getValue("quarkus.datasource.username", String::class.java),
+        ConfigProvider.getConfig().getValue("quarkus.datasource.password", String::class.java),
+    )
+
+    /** Seeds a settlement directly with JDBC — no reactive repository involved. */
+    private fun seedSettlement(status: String): Triple<UUID, UUID, UUID> {
+        val id = UUID.randomUUID()
+        val payer = UUID.randomUUID()
+        val payee = UUID.randomUUID()
+        val now = Timestamp.from(Instant.now())
+        jdbc().use { c ->
+            c.prepareStatement(
+                """
+                INSERT INTO settlements
+                    (id, payer_account_id, payee_account_id, amount, currency, status, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """.trimIndent(),
+            ).use { ps ->
+                ps.setObject(1, id)
+                ps.setObject(2, payer)
+                ps.setObject(3, payee)
+                ps.setBigDecimal(4, amount)
+                ps.setString(5, "CZK")
+                ps.setString(6, status)
+                ps.setTimestamp(7, now)
+                ps.setTimestamp(8, now)
+                ps.executeUpdate()
+            }
+        }
+        return Triple(id, payer, payee)
+    }
+
+    private fun readStatus(id: UUID): String = jdbc().use { c ->
+        c.prepareStatement("SELECT status FROM settlements WHERE id = ?").use { ps ->
+            ps.setObject(1, id)
+            ps.executeQuery().use { rs ->
+                assertThat(rs.next()).`as`("settlement row $id exists").isTrue()
+                rs.getString(1)
+            }
+        }
+    }
+
+    private fun readUpdatedAt(id: UUID): Instant = jdbc().use { c ->
+        c.prepareStatement("SELECT updated_at FROM settlements WHERE id = ?").use { ps ->
+            ps.setObject(1, id)
+            ps.executeQuery().use { rs ->
+                rs.next()
+                rs.getTimestamp(1).toInstant()
+            }
+        }
+    }
+
+    @Test
+    fun `reverseDebit issues a real counter-credit to the payer and records REVERSED`() {
+        val (id, payer, _) = seedSettlement("DEBITED")
+        val before = Instant.now()
+
+        activities.reverseDebit(id)
+
+        // The money movement left the process, addressed to the PAYER, as a CREDIT.
+        BalanceServiceWireMockResource.server.verify(
+            BalanceServiceWireMockResource.creditRequestsTo(payer)
+                .withRequestBody(
+                    com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath(
+                        "$[?(@.referenceId == 'settlement-debit-reversal-$id')]",
+                    ),
+                )
+                .withRequestBody(
+                    com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath(
+                        "$[?(@.amount == 125.50)]",
+                    ),
+                )
+                .withRequestBody(
+                    com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath(
+                        "$[?(@.currency == 'CZK')]",
+                    ),
+                ),
+        )
+        assertThat(readStatus(id)).isEqualTo("REVERSED")
+        // Recency, not non-nullity: an Instant.EPOCH or an untouched row would pass `isNotNull`.
+        assertThat(readUpdatedAt(id)).isBetween(before.minusSeconds(1), Instant.now().plusSeconds(1))
+    }
+
+    @Test
+    fun `reverseCredit issues a real counter-debit to the payee and records CREDITED_REVERSED`() {
+        val (id, _, payee) = seedSettlement("CREDITED")
+
+        activities.reverseCredit(id)
+
+        BalanceServiceWireMockResource.server.verify(
+            BalanceServiceWireMockResource.debitRequestsTo(payee)
+                .withRequestBody(
+                    com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath(
+                        "$[?(@.referenceId == 'settlement-credit-reversal-$id')]",
+                    ),
+                ),
+        )
+        assertThat(readStatus(id)).isEqualTo("CREDITED_REVERSED")
+    }
+
+    /**
+     * A retried Temporal activity must not reverse twice. settlement-service's half of that
+     * guarantee is that the reference id is a pure function of the settlement id, so every attempt
+     * carries the same key and balance-service's `(account_id, currency, reference_id, operation)`
+     * primary key collapses them. This asserts the stable key across attempts — the collapsing
+     * itself is balance-service's `balance_movement` dedup, tested there.
+     */
+    @Test
+    fun `a retried reversal re-sends an identical reference id rather than a fresh one`() {
+        val (id, payer, _) = seedSettlement("DEBITED")
+
+        activities.reverseDebit(id)
+        activities.reverseDebit(id)
+
+        val requests = BalanceServiceWireMockResource.server.findAll(
+            BalanceServiceWireMockResource.creditRequestsTo(payer),
+        )
+        assertThat(requests).hasSize(2)
+        assertThat(requests.map { it.bodyAsString })
+            .allMatch { it.contains("settlement-debit-reversal-$id") }
+        assertThat(requests[0].bodyAsString).isEqualTo(requests[1].bodyAsString)
+    }
+
+    @Test
+    fun `a refused counter-debit records REVERSAL_FAILED and never claims the money came back`() {
+        val (id, _, payee) = seedSettlement("CREDITED")
+        BalanceServiceWireMockResource.stubDebitRefusedInsufficientFunds()
+
+        assertThatThrownBy { activities.reverseCredit(id) }
+            .`as`("a refused reversal must surface, not be swallowed into a success")
+            .isInstanceOf(Throwable::class.java)
+
+        // The request WAS made — this is not a skipped call.
+        BalanceServiceWireMockResource.server.verify(
+            BalanceServiceWireMockResource.debitRequestsTo(payee),
+        )
+        assertThat(readStatus(id))
+            .`as`("money is still with the payee, so the row must not say CREDITED_REVERSED")
+            .isEqualTo("REVERSAL_FAILED")
+    }
+
+    @Test
+    fun `reverseBookToLedger fails loudly and marks the GL entry as needing manual correction`() {
+        val (id, _, _) = seedSettlement("BOOKED")
+
+        // The failure reaches the caller unwrapped through the Vert.x-context bridge, so Temporal
+        // sees the ApplicationFailure itself and honours its non-retryable flag.
+        assertThatThrownBy { activities.reverseBookToLedger(id) }
+            .isInstanceOfSatisfying(ApplicationFailure::class.java) { failure ->
+                assertThat(failure.isNonRetryable).isTrue()
+                assertThat(failure.type).isEqualTo("LedgerReversalUnsupported")
+            }
+
+        assertThat(readStatus(id)).isEqualTo("LEDGER_REVERSAL_UNSUPPORTED")
+        // It must not silently pretend to have reversed anything, and it must not call balance.
+        assertThat(
+            BalanceServiceWireMockResource.server.findAll(
+                com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor(
+                    com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching(
+                        "/api/v1/balances/.*",
+                    ),
+                ),
+            ),
+        ).isEmpty()
+    }
+}

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/it/BalanceServiceWireMockResource.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/it/BalanceServiceWireMockResource.kt
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.it
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.okJson
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import java.util.UUID
+
+/**
+ * Stands in for `openbank-balance-service` over **real HTTP** so the reversal adapters' REST-client
+ * calls actually leave the process (issue #6037). This is the part a mocked port cannot establish:
+ * a unit test that mocks `ReverseDebitPort` proves the activity calls *something*, not that a
+ * money movement was ever addressed to balance-service.
+ *
+ * Also stubs an OIDC token endpoint, because both REST clients carry
+ * `OidcClientRequestReactiveFilter` and would otherwise dial the real realm to mint a bearer token.
+ * Same shape as sepa-payment's `DocumentServiceWireMockResource`.
+ */
+class BalanceServiceWireMockResource : QuarkusTestResourceLifecycleManager {
+
+    override fun start(): Map<String, String> {
+        server = WireMockServer(options().dynamicPort())
+        server.start()
+
+        server.stubFor(
+            post(urlEqualTo("/token")).willReturn(
+                okJson("""{"access_token":"test-token","token_type":"Bearer","expires_in":300}"""),
+            ),
+        )
+        stubMovementsAccepted()
+
+        val base = server.baseUrl()
+        return mapOf(
+            "quarkus.rest-client.balance-api.url" to base,
+            "quarkus.oidc-client.enabled" to "true",
+            "quarkus.oidc-client.auth-server-url" to base,
+            "quarkus.oidc-client.discovery-enabled" to "false",
+            "quarkus.oidc-client.token-path" to "/token",
+            "quarkus.oidc-client.client-id" to "openbank-services",
+            "quarkus.oidc-client.credentials.secret" to "test-secret",
+            "quarkus.oidc-client.grant.type" to "client",
+        )
+    }
+
+    override fun stop() {
+        if (isStarted()) server.stop()
+    }
+
+    companion object {
+        lateinit var server: WireMockServer
+
+        fun isStarted() = ::server.isInitialized
+
+        private const val CREDIT_PATH = "/api/v1/balances/[^/]+/credit"
+        private const val DEBIT_PATH = "/api/v1/balances/[^/]+/debit"
+
+        fun reset() {
+            server.resetRequests()
+            server.resetMappings()
+            server.stubFor(
+                post(urlEqualTo("/token")).willReturn(
+                    okJson("""{"access_token":"test-token","token_type":"Bearer","expires_in":300}"""),
+                ),
+            )
+            stubMovementsAccepted()
+        }
+
+        /** Both movement verbs succeed, echoing a balance back. */
+        fun stubMovementsAccepted() {
+            val body = """
+                {"accountId":"00000000-0000-0000-0000-000000000001","currency":"CZK",
+                 "availableBalance":0.00,"currentBalance":0.00}
+            """.trimIndent()
+            server.stubFor(post(urlPathMatching(CREDIT_PATH)).willReturn(okJson(body)))
+            server.stubFor(post(urlPathMatching(DEBIT_PATH)).willReturn(okJson(body)))
+        }
+
+        /**
+         * The payee has already spent the credited funds: balance-service's overdraft guard
+         * (`Balance.applyDebit`) refuses the counter-debit with 422. No retry resolves this.
+         */
+        fun stubDebitRefusedInsufficientFunds() {
+            server.stubFor(
+                post(urlPathMatching(DEBIT_PATH)).willReturn(
+                    com.github.tomakehurst.wiremock.client.WireMock.aResponse()
+                        .withStatus(422)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""{"title":"Insufficient funds","status":422}"""),
+                ),
+            )
+        }
+
+        fun creditRequestsTo(accountId: UUID): RequestPatternBuilder =
+            postRequestedFor(urlEqualTo("/api/v1/balances/$accountId/credit"))
+
+        fun debitRequestsTo(accountId: UUID): RequestPatternBuilder =
+            postRequestedFor(urlEqualTo("/api/v1/balances/$accountId/debit"))
+    }
+}


### PR DESCRIPTION
## What

`openbank-settlement-service`'s compensation path did not reverse money. `reverseDebit` and
`reverseCredit` wrote a status row, logged `"stub: wire reversal to balance-service"`, and
reported success. `reverseBookToLedger` was the same stub against ledger-service.

The saga reported success, so the status column, the audit event and the Temporal history all
agreed the unwind had completed. Same shape as `PushResult.skipped()` carrying `success = true`:
an outcome structurally unable to report the thing that went wrong.

Closes #6037. Refs #5705, #6036.

## Is the path reachable, and is money currently unreturned?

**Reachable, but it has never run — no money is currently unreturned.** Measured read-only against
the live sandbox primary (`settlement-service-db-2`, database `openbank_settlement`):

```
select count(*) from settlements;                          ->  0
select status, count(*) from settlements group by status;   ->  (0 rows)
select relname, n_tup_ins, n_tup_upd, n_tup_del, n_live_tup
  from pg_stat_user_tables where relname='settlements';
  -> settlements | 0 | 0 | 0 | 0
select stats_reset from pg_stat_database
  where datname='openbank_settlement';                      ->  NULL (never reset)
```

No row has ever been inserted, so nothing has ever been in a `*_REVERSED` state. This was a
**pre-deployment defect, not an incident** — which is why this PR fixes it properly rather than
racing a hotfix. The caveat: this is the sandbox, and PG statistics survive a clean shutdown but
reset on a crash; the empty table plus `n_tup_del = 0` is the stronger of the two signals.

Reachability itself is real: `SettlementWorkflowImpl` registers each compensation after its
forward activity succeeds, so a `creditPayee` failure would have left the payer debited and never
refunded, and a `bookToLedger` failure would have left both balances moved.

## The correct counterparty call — not invented

balance-service has **no reversal endpoint**. Its complete path list is `{accountId}`,
`{accountId}/{currency}`, `overdraft-limit`, `holds`, `holds/{holdId}`, `credit`, `debit`,
`initialize`, `reconciliation`, `reconciliation/latest`, `approvals/{id}`. Its only undo
primitives are releasing a hold and issuing the opposite movement. Settlement moves money with
`debit`/`credit`, not holds, so **the opposite movement is the reversal**:

| Compensation | Call | Reference id |
|---|---|---|
| `reverseDebit` | `POST /api/v1/balances/{payerAccountId}/credit` | `settlement-debit-reversal-<id>` |
| `reverseCredit` | `POST /api/v1/balances/{payeeAccountId}/debit` | `settlement-credit-reversal-<id>` |

Same `BalanceRestClient`, same `MoneyMovementRequest`, same account resolution as the forward
adapters — verb and reference-id namespace flipped. settlement-service is the fleet's only caller
of these two endpoints, so there was no existing reversal idiom to mirror; that absence is itself
part of the finding.

## Idempotency

balance-service deduplicates durably on the `balance_movement` primary key
`(account_id, currency, reference_id, operation)`, applying mutation and marker in one
transaction and answering a duplicate 200 with `applied = false`. There is no `Idempotency-Key`
header on that API and balance-service does not use the shared `openbank-libs` `IdempotencyStore`
(that store is a REST response cache keyed on a caller header — the wrong tool here). **The
reference id is the idempotency key**, and it is a pure function of the settlement id, so a
retried Temporal activity re-sends an identical key.

The reversal ids are deliberately in a different namespace from the forward ids rather than
reusing them: sharing the forward id would work today but would rest the whole guarantee on
`operation` alone being part of the counterparty's primary key.

## What each outcome now says

Per the "own enum value, never a shared success flag" rule:

- `REVERSED` / `CREDITED_REVERSED` — balance-service accepted the counter-movement.
- `REVERSAL_FAILED` — **new.** Attempted and refused; the money is still moved. balance-service
  enforces `booked - amount >= overdraftFloor` on every debit, so a payee who has spent the funds
  makes `reverseCredit` fail with 422 and no retry resolves it. Recovering those funds is a
  collections/dispute process, not an API call.
- `LEDGER_REVERSAL_UNSUPPORTED` — **new.** The GL posting was not reversed.
- `LEDGER_REVERSED` — deprecated, never written again.

The status is written only **after** the money call returns; the pre-fix code wrote it first,
which is the whole defect in one line.

## Which half did I ship, loud-failure or real wiring? Both, deliberately split

**Real wiring** for `reverseDebit` and `reverseCredit` — the issue's actual scope, and an
unambiguous mirror of the forward path.

**Loud failure** for `reverseBookToLedger`, which the issue does not name but which is the same
defect. ledger-service *does* expose `POST /api/v1/journals/{journalId}/reverse`, and I did not
wire it because three separate decisions block it, none of them mine to make:

1. **Maker-checker.** `ledger.reverse` is approval-gated — a service-account call queues rather
   than posts. Granting a machine that action is a `rules.yaml: shared_m2m_matrix_write_grants`
   decision, and an automatic GL reversal driven by a failed saga is close to the thing
   maker-checker exists to prevent.
2. **No journal id is retained.** `bookToLedger` discards the response, so the id needs persisting
   (a migration) or re-resolving via `GET /api/v1/journals/transaction/{transactionId}`.
3. **Period locks.** The endpoint answers 409 for an ATTESTED fiscal period, and the accounting
   convention there is to correct forward in the open period — a different posting, not a reversal.

So it throws a **non-retryable** `ApplicationFailure` and records `LEDGER_REVERSAL_UNSUPPORTED`.
Non-retryable matters: a retryable failure would burn five attempts (~75 s of backoff) ahead of
the two compensations that *do* return money, and end in the same place. `SettlementWorkflowImpl`
catches `ActivityFailure` per compensation, so this does not block them.

`SettlementCompensationCapabilities` announces the gap **at boot** via `@Startup` — load-bearing,
because `@ApplicationScoped` is lazy and an `init {}` gate on a rare path is announced too late to
act on (the `PdfBoxPadesSealAdapter` warning that never once appeared in a pod log, #1299).

## Proof, and the negative control

`SettlementReversalIT` mocks nothing on the path it checks: the real CDI activity bean over its
real `VertxContextSupport` bridge, the real adapters and `BalanceRestClient`, a real Testcontainers
Postgres with the real migrations, and **plain JDBC** for both seed and assertion, so the reactive
layer never confirms its own work. A `BalanceServiceWireMockResource` stands in for balance-service
over real HTTP, so the outbound request is asserted by URL, verb and body.

**Negative control — restored the three stub bodies, changed nothing else, re-ran only this IT:**

```
tests=5 failures=5 errors=0 skipped=0
```

All five red, with the failure naming the defect directly:

```
reverseDebit issues a real counter-credit to the payer and records REVERSED
  VerificationException: Expected at least one request matching:
    { "url": "/api/v1/balances/<payer>/credit", "method": "POST",
      "bodyPatterns": [ { "matchesJsonPath":
        "$[?(@.referenceId == 'settlement-debit-reversal-<id>')]" } ] }

a retried reversal re-sends an identical reference id rather than a fresh one
  AssertionError: Expected size: 2 but was: 0 in: []

a refused counter-debit records REVERSAL_FAILED ...   AssertionError: Expecting code to raise a throwable.
reverseBookToLedger fails loudly ...                  AssertionError: Expecting code to raise a throwable.
```

Restored the production file and it returns to 5/5 green. The test can detect the defect's absence.

**What it does not establish:** that balance-service *applied* the movement. settlement-service
cannot observe another service's ledger, and claiming otherwise would be the `accepted`-vs-
`delivered` mistake. The applying half is balance-service's own `balance_movement` dedup and
overdraft tests.

Three unit tests that asserted the defect verbatim (`reverseDebit does not call debit port and
sets REVERSED status`) are replaced — they passed *because* no money moved.

## Threat model

`docs/threat-models/openbank-settlement-service.md` did not merely miss this; it documented it as
mitigated.

- **R2** — "Compensation claimed to have run when it did not" — listed as its mitigation
  *"compensation activities update status to REVERSED/CREDITED_REVERSED/LEDGER_REVERSED
  atomically"*. That mitigation **was** the defect: the status update was the only thing happening.
- **T1** — claimed `referenceId = workflowRunId + activityId`. That is not what the code sends,
  and would not have worked if it were: it changes per run, so a retry would not dedupe.
- **Residual risk 3** credited the Temporal migration with closing a compensation gap. The ordering
  was right; the reversals were no-ops, so it unwound exactly as much money as the legacy path it
  replaced — none.

All three corrected, plus new residual risks 5-7 (the ledger gap, the legitimately-refused
reversal, and a pre-existing one this PR does **not** fix: a debit applied by balance-service but
never observed by settlement-service registers no compensation at all).

## Verification

Gradle serialized, output to files, exit code read directly (never through a pipe), `--rerun-tasks`:

| Check | Result |
|---|---|
| `:openbank-settlement-service:test` | **48 tests, 0 failures, 0 errors, 0 SKIPPED** (read from JUnit XML) |
| `ktlintCheck`, `detekt`, `koverVerify` | pass |
| `quarkusBuild` | pass — validates the CDI wiring for two new beans and a changed constructor |
| `run-gates.py --all` | 158 gates, 151 pass |
| `threat-model-updated-on-trust-boundary-change` | **PASS** |
| `db-migration-gate`, `schema-compat-gate` | PASS (no migration — `status VARCHAR(32)` already fits the longest new value at 27 chars) |
| `check-api-contract.py --enforce` | **`additive change, info.version 1.1.1 -> 1.2.0 — OK (required >= MINOR)`** |

`info.version` was re-read off live `origin/main` immediately before bumping, not off the branch
base. `version.txt` is untouched — release-please owns it, and `fix(settlement)` over a path
outside `exclude-paths` releases.

The SKIPPED count is called out because an earlier run reported `48 tests / 16 skipped / 1 failure`
— a `QuarkusBindException` from a parallel agent's JVM holding port 8081, not a code failure. I
waited for the port and re-ran rather than reading a boot failure as a pass.

**Not verified:** no end-to-end run against a live balance-service (the sandbox has never had a
settlement row); the two remaining `run-gates.py` failures (`litellm-config-revision`,
`loki-rule-load-test`) touch files this PR does not, and I did not baseline them against `main`.

## Coordination

Disjoint from the two settlement PRs in flight, checked by 3-dot diff:

- **#6036** (`feat/settlement-metrics-5705`) — overlaps only on `build.gradle.kts`.
- **#5723** (`feat/settlement-service-metrics`) — overlaps on `build.gradle.kts`,
  `SettlementActivitiesImpl.kt` and `SettlementActivitiesImplTest.kt`. Unavoidable: it wraps every
  activity in a `step(...)` metrics helper, and this PR changes the bodies of three of them.
  The resolution is mechanical — its `step(SettlementStep.REVERSE_DEBIT) { ... }` wrapper around
  this PR's `compensate(...)` body — and whichever lands second should do it deliberately rather
  than take one side. Its `SettlementStepOutcome` is also worth extending: a compensation that
  wrote `REVERSAL_FAILED` is not `COMPLETED`.

## Review

Money-path: **2 approvals + threat model** per `rules.yaml`. I have not merged this and will not.
