### PR TITLE
feat(analytics): fail closed without durable backfill

### DIFF
--- a/docs/adr/0160-end-to-end-integration-liveness-and-drift-detection-standard.md
+++ b/docs/adr/0160-end-to-end-integration-liveness-and-drift-detection-standard.md
@@ -10,6 +10,13 @@ tags: [governance, observability, ci]
 summary: "Turn end-to-end liveness claims into CI-checked facts through four mechanisms: an event-consumer liveness gate, a lineage-vs-code audit, a shared workflow-liveness watchdog, and drift qualification, each shipped advisory-first."
 ---
 
+> **Delivery update (2026-08-20):** Mechanisms 1 and 3 are enforced in CI, including
+> the scheduler adoption ratchet and the real cron/liveness integration coverage added
+> through ADR-0237. The remaining producer-only topics are explicit, reviewable
+> allowlist entries or tracked business gaps; this ADR does not treat an allowlist as
+> a working consumer. Mechanism 2/4 production lineage and sustained-drift evidence
+> still require the corresponding fleet/runtime checks.
+
 # ADR-0160 — End-to-end integration liveness and drift-detection standard
 
 > **Delivery note (2026-07-13, updated same day).** Mechanism 1 shipped and validated: PR #995

--- a/docs/adr/0172-cryptographic-key-management-and-lifecycle.md
+++ b/docs/adr/0172-cryptographic-key-management-and-lifecycle.md
@@ -10,6 +10,13 @@ tags: [crypto-keys, secrets, compliance]
 summary: "This ADR becomes the platform's key inventory of record with custody and rotation per key class, and sets a preference order from no key at all through short-lived leaves to long-lived keys, ending the circular ADR-0007/0094 deferral."
 ---
 
+> **Delivery update (2026-08-20):** D6 is now shipped as the provider-neutral
+> [`0012-cryptographic-key-compromise`](../runbooks/0012-cryptographic-key-compromise.md)
+> runbook. It defines durable incident declaration, evidence preservation, fail-closed
+> containment, replacement verification, and closure artifacts. It intentionally does
+> not claim that a live KMS rotation or tabletop has been executed; those remain
+> operational acceptance evidence for D1/D6.
+
 # ADR-0172 — Cryptographic key management and lifecycle
 
 ## Context

--- a/docs/runbooks/0012-cryptographic-key-compromise.md
+++ b/docs/runbooks/0012-cryptographic-key-compromise.md
@@ -1,0 +1,30 @@
+# Cryptographic key-compromise response (ADR-0172)
+
+This provider-neutral runbook covers suspected compromise of a signing, encryption,
+issuer, or trust-anchor key. Provider commands and identifiers remain environment-local.
+
+## Declare and preserve
+
+1. Create a P1/P2 entry in the durable ICT register (`POST /api/v1/ict-incidents`),
+   recording key class, identifier, suspected-use window, and affected artifacts. Never
+   put key material in the incident record.
+2. Freeze KMS/OpenBao, CI, audit, and admission-verifier logs before rotating anything.
+3. Disable new use at the enforcement boundary and fail closed; do not fall back to a
+   generated key.
+
+## Contain and recover
+
+1. Provision a separately approved replacement key and publish its public trust material
+   through the reviewed deployment path.
+2. Quarantine artifacts signed during the suspect window. Rotation does not invalidate
+   historical signatures; re-verify using key version and transparency-log evidence.
+3. For encryption keys, scope re-encryption or crypto-shredding under legal-hold and
+   backup approval; do not destroy the old key during forensics.
+4. Mark the incident `CONTAINED`, then `RESOLVED` only after verifier tests reject the
+   old key and accept the replacement. Record RTO/RPO and regulator report ID.
+
+## Closure evidence
+
+Attach the inventory diff, access-log query, replacement public-material digest, verifier
+output, affected scope, report ID, and blameless RCA. A live KMS rotation or tabletop is
+an operational acceptance item; this runbook does not claim that it has run.

--- a/openbank-admin-ui/src/app/api/security/incidents/route.ts
+++ b/openbank-admin-ui/src/app/api/security/incidents/route.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache-2.0 license.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { resolveInClusterBaseUrl } from '@/lib/discovery'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+/** Read-only BFF for the durable DORA ICT incident register (ADR-0146). */
+export async function GET(request: Request) {
+  const token = (await auth())?.user?.accessToken
+  if (!token) return NextResponse.json({ available: false, reason: 'unauthorized' }, { status: 200 })
+  const url = new URL(request.url)
+  const query = url.searchParams.toString()
+  const base = await resolveInClusterBaseUrl('security-scanner-service') ?? process.env.SECURITY_SCANNER_URL
+  if (!base) return NextResponse.json({ available: false, reason: 'not_deployed' }, { status: 200 })
+  try {
+    const response = await fetch(`${base}/api/v1/ict-incidents${query ? `?${query}` : ''}`, {
+      headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' },
+      cache: 'no-store',
+      signal: AbortSignal.timeout(10_000),
+    })
+    if (!response.ok) return NextResponse.json({ available: false, reason: response.status === 401 || response.status === 403 ? 'unauthorized' : 'error' }, { status: 200 })
+    return NextResponse.json({ available: true, incidents: await response.json() }, { status: 200 })
+  } catch {
+    return NextResponse.json({ available: false, reason: 'unreachable' }, { status: 200 })
+  }
+}

--- a/openbank-admin-ui/src/app/security/incidents/page.tsx
+++ b/openbank-admin-ui/src/app/security/incidents/page.tsx
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache-2.0 license.
+
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { AlertTriangle, RefreshCw } from 'lucide-react'
+import { AuthGuard } from '@/components/auth/AuthGuard'
+import { PageHeader } from '@/components/ui/PageHeader'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+
+type Incident = { id: string; title: string; severity: string; status: string; category: string; detectedAt: string; affectedServices: string[]; reportedToRegulator: boolean }
+type Envelope = { available: true; incidents: Incident[] } | { available: false; reason: string }
+
+export default function IncidentsPage() {
+  const { t } = useLanguage()
+  const [data, setData] = useState<Envelope | null>(null)
+  const [loading, setLoading] = useState(true)
+  const load = useCallback(async () => {
+    setLoading(true)
+    try { setData(await (await fetch('/api/security/incidents', { cache: 'no-store' })).json() as Envelope) }
+    catch { setData({ available: false, reason: 'unreachable' }) }
+    finally { setLoading(false) }
+  }, [])
+  useEffect(() => { void load() }, [load])
+  return <AuthGuard permission="system:view"><div style={{ padding: '28px 32px', maxWidth: 1400 }}>
+    <PageHeader icon={<AlertTriangle size={20} />} title={t('ICT incidenty', 'ICT incidents')} subtitle={t('DORA registr incidentů (trvalá evidence)', 'DORA incident register (durable evidence)')} actions={<button onClick={() => void load()} disabled={loading} className="btn btn-secondary btn-sm"><RefreshCw size={13} /> {t('Obnovit', 'Refresh')}</button>} />
+    {data?.available === false && <p role="status">{t('Registr není dostupný: ', 'Register unavailable: ')}{data.reason}</p>}
+    {data?.available && data.incidents.length === 0 && <p role="status">{t('Žádné evidované incidenty.', 'No recorded incidents.')}</p>}
+    {data?.available && data.incidents.length > 0 && <div style={{ overflowX: 'auto' }}><table><thead><tr><th>{t('Název', 'Title')}</th><th>{t('Závažnost', 'Severity')}</th><th>{t('Stav', 'Status')}</th><th>{t('Zjištěno', 'Detected')}</th><th>{t('Regulátor', 'Regulator')}</th><th>{t('Služby', 'Services')}</th></tr></thead><tbody>{data.incidents.map(i => <tr key={i.id}><td>{i.title}</td><td>{i.severity}</td><td>{i.status}</td><td>{new Date(i.detectedAt).toLocaleString()}</td><td>{i.reportedToRegulator ? '✓' : '—'}</td><td>{i.affectedServices.join(', ')}</td></tr>)}</tbody></table></div>}
+  </div></AuthGuard>
+}

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/port/out/BackfillSource.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/port/out/BackfillSource.kt
@@ -28,3 +28,14 @@ interface BackfillSource {
     /** Raw event payloads (same shape the live topics carry) for [window], narrowed per [request]. */
     suspend fun read(window: BackfillWindow, request: BackfillRequest): List<String>
 }
+
+/**
+ * Raised when a recovery request reaches a deployment without a durable replay reader.
+ *
+ * An empty result is not a successful backfill: it would produce a green COMPLETED report while
+ * ingesting no rows and hide an unrecoverable evidence gap. Deployments must bind an outbox/export
+ * adapter before enabling recovery operations.
+ */
+class DurableBackfillUnavailableException : IllegalStateException(
+    "No durable analytics backfill reader is configured; bind an outbox or archive export adapter",
+)

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/port/out/BackfillSource.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/port/out/BackfillSource.kt
@@ -36,6 +36,7 @@ interface BackfillSource {
  * ingesting no rows and hide an unrecoverable evidence gap. Deployments must bind an outbox/export
  * adapter before enabling recovery operations.
  */
-class DurableBackfillUnavailableException : IllegalStateException(
-    "No durable analytics backfill reader is configured; bind an outbox or archive export adapter",
-)
+class DurableBackfillUnavailableException :
+    IllegalStateException(
+        "No durable analytics backfill reader is configured; bind an outbox or archive export adapter",
+    )

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/NoOpBackfillSource.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/NoOpBackfillSource.kt
@@ -21,7 +21,6 @@ import jakarta.enterprise.inject.Default
 @ApplicationScoped
 @Default
 class NoOpBackfillSource : BackfillSource {
-    override suspend fun read(window: BackfillWindow, request: BackfillRequest): List<String> {
+    override suspend fun read(window: BackfillWindow, request: BackfillRequest): List<String> =
         throw DurableBackfillUnavailableException()
-    }
 }

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/NoOpBackfillSource.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/NoOpBackfillSource.kt
@@ -5,31 +5,23 @@
 package com.openbank.analytics.infrastructure.reconcile
 
 import com.openbank.analytics.application.port.out.BackfillSource
+import com.openbank.analytics.application.port.out.DurableBackfillUnavailableException
 import com.openbank.libs.analytics.BackfillRequest
 import com.openbank.libs.analytics.BackfillWindow
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.inject.Default
-import org.jboss.logging.Logger
 
 /**
- * Default [BackfillSource] that yields nothing and logs that no durable reader is configured.
+ * Default [BackfillSource] that fails closed when no durable reader is configured.
  *
- * Keeps the service offline-buildable and the backfill orchestration fully exercisable (planning,
- * chunking, dedupe, tagging, reporting) without binding to a specific source-of-record reader.
- * Replace with an outbox/export-backed `@Alternative @Priority(...)` adapter in production.
+ * Keeps the service offline-buildable while making accidental recovery requests visible. Replace
+ * with an outbox/export-backed `@Alternative @Priority(...)` adapter before enabling backfills in
+ * production.
  */
 @ApplicationScoped
 @Default
 class NoOpBackfillSource : BackfillSource {
-    private val log = Logger.getLogger(NoOpBackfillSource::class.java)
-
     override suspend fun read(window: BackfillWindow, request: BackfillRequest): List<String> {
-        log.warnf(
-            "NoOpBackfillSource: no durable reader wired; window=%s..%s source=%s returns 0 events",
-            window.from,
-            window.to,
-            request.source,
-        )
-        return emptyList()
+        throw DurableBackfillUnavailableException()
     }
 }

--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/RecoveryFlowsTest.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/RecoveryFlowsTest.kt
@@ -9,8 +9,10 @@ import com.openbank.analytics.application.port.out.AnalyticsSink
 import com.openbank.analytics.application.port.out.BackfillSource
 import com.openbank.analytics.application.port.out.DeadLetterRecord
 import com.openbank.analytics.application.port.out.DeadLetterSink
+import com.openbank.analytics.application.port.out.DurableBackfillUnavailableException
 import com.openbank.analytics.application.port.out.IntegrityAnchor
 import com.openbank.analytics.application.port.out.WormArchive
+import com.openbank.analytics.infrastructure.reconcile.NoOpBackfillSource
 import com.openbank.libs.analytics.AnalyticsEnvelope
 import com.openbank.libs.analytics.BackfillRequest
 import com.openbank.libs.analytics.BackfillWindow
@@ -92,6 +94,24 @@ class RecoveryFlowsTest {
         consumer.consume(Message.of("broken"))
 
         assertThat(dlq.records.map { it.contentHash }.distinct()).hasSize(1)
+    }
+
+    @Test
+    fun `unconfigured durable backfill fails closed instead of reporting an empty success`() = runBlocking<Unit> {
+        val request = BackfillRequest(
+            source = IngestSource.BACKFILL,
+            from = Instant.parse("2026-01-01T00:00:00Z"),
+            to = Instant.parse("2026-01-01T01:00:00Z"),
+            reason = "replay outage gap",
+            requestedBy = "ops-1",
+        )
+
+        assertThat(runCatching {
+            NoOpBackfillSource().read(
+                BackfillWindow(request.from, request.to),
+                request,
+            )
+        }.exceptionOrNull()).isInstanceOf(DurableBackfillUnavailableException::class.java)
     }
 
     @Test

--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/RecoveryFlowsTest.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/RecoveryFlowsTest.kt
@@ -106,12 +106,14 @@ class RecoveryFlowsTest {
             requestedBy = "ops-1",
         )
 
-        assertThat(runCatching {
-            NoOpBackfillSource().read(
-                BackfillWindow(request.from, request.to),
-                request,
-            )
-        }.exceptionOrNull()).isInstanceOf(DurableBackfillUnavailableException::class.java)
+        assertThat(
+            runCatching {
+                NoOpBackfillSource().read(
+                    BackfillWindow(request.from, request.to),
+                    request,
+                )
+            }.exceptionOrNull(),
+        ).isInstanceOf(DurableBackfillUnavailableException::class.java)
     }
 
     @Test

--- a/openbank-security-scanner/src/main/resources/docs/01-overview.cs.md
+++ b/openbank-security-scanner/src/main/resources/docs/01-overview.cs.md
@@ -7,7 +7,7 @@
 - **Prověřování všech 27 fleet služeb** každých 30 minut přes HTTP — kontrola dosažitelnosti přes `/q/health`, security headerů na API portu a expozice aktuátorů.
 - **Spouštění 6 kontrol OWASP Top 10** na každé službě: security headery (A05), citlivá data v health endpointu (A02), expozice OpenAPI (A05 info-disclosure), neautentizované aktuátorové endpointy (A01), CORS wildcard (A05) a dosažitelnost služby (A05).
 - **Skórování každé služby** 0–100 a přiřazení písmenkového grade (A+ → F), výpočet `PlatformSecurityReport` pokrývajícího všechny služby.
-- **Správu ICT incidentů** — compliance důstojníci mohou hlásit, sledovat a aktualizovat životní cyklus DORA-grade ICT incidentů přes API `IctIncidentResource`. Incidenty jsou drženy v in-memory mapě, ne v databázi.
+- **Správu ICT incidentů** — compliance důstojníci mohou hlásit, sledovat a aktualizovat životní cyklus DORA-grade ICT incidentů přes API `IctIncidentResource`. Incidenty jsou trvale uloženy v registru `ict_incidents` a zůstávají dostupné po restartu podu.
 - **Vysílání eventů ICT incidentů** přímo do Kafka topicu `openbank.security.ict.incident`. Žádný outbox a žádná transakční záruka neexistuje; výsledky skenů se jako eventy nepublikují vůbec.
 
 ## Co služba NEDĚLÁ

--- a/openbank-security-scanner/src/main/resources/docs/01-overview.en.md
+++ b/openbank-security-scanner/src/main/resources/docs/01-overview.en.md
@@ -7,7 +7,7 @@
 - **Probes all 27 fleet services** every 30 minutes via HTTP, checking reachability through `/q/health`, security headers on the API port, and actuator exposure.
 - **Runs 6 OWASP Top 10 checks** on each service: security headers (A05), sensitive data in health endpoint (A02), OpenAPI exposure (A05 info-disclosure), unauthenticated actuator endpoints (A01), CORS wildcard misconfiguration (A05), and service reachability (A05).
 - **Scores each service** 0–100 and assigns a letter grade (A+ → F), computing a `PlatformSecurityReport` covering all services.
-- **Manages ICT incidents** — compliance officers can report, track, and update the lifecycle of DORA-grade ICT incidents through the `IctIncidentResource` API. Incidents are held in an in-memory map, not a database.
+- **Manages ICT incidents** — compliance officers can report, track, and update the lifecycle of DORA-grade ICT incidents through the `IctIncidentResource` API. Incidents are persisted in the `ict_incidents` register and remain queryable across pod restarts.
 - **Emits ICT incident events** directly to the Kafka topic `openbank.security.ict.incident`. There is no outbox and no transactional guarantee; scan results are not published as events at all.
 
 ## What the service does NOT do

--- a/openbank-security-scanner/src/main/resources/docs/02-architecture.en.md
+++ b/openbank-security-scanner/src/main/resources/docs/02-architecture.en.md
@@ -59,7 +59,7 @@ com.openbank.securityscanner/          ◄── the only package root
 │   └── IctIncident                    IctIncident, IncidentSeverity, IncidentStatus, IncidentCategory
 ├── application/
 │   ├── SecurityScannerService         scan pipeline, in-memory result cache
-│   └── IctIncidentService             DORA incident lifecycle, in-memory store,
+│   └── IctIncidentService             DORA incident lifecycle, durable Postgres store,
 │                                      direct @Channel Kafka emitter
 └── infrastructure/
     └── rest/

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/scheduler/PeriodCloseScheduler.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/scheduler/PeriodCloseScheduler.kt
@@ -9,8 +9,9 @@ import com.openbank.statement.application.port.`in`.RunCloseUseCase
 import com.openbank.statement.domain.model.CloseTrigger
 import io.quarkus.scheduler.Scheduled
 import io.smallrye.mutiny.coroutines.awaitSuspending
-import jakarta.annotation.PostConstruct
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
+import io.quarkus.runtime.StartupEvent
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.time.Duration
@@ -36,9 +37,9 @@ class PeriodCloseScheduler(
     private val log = Logger.getLogger(PeriodCloseScheduler::class.java)
     private var liveness: WorkflowLivenessRecorder? = null
 
-    @PostConstruct
-    fun registerLiveness() {
-        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, EXPECTED_INTERVAL)
+    /** Register only when this opt-in scheduler is enabled, avoiding false stale alerts by default. */
+    fun onStart(@Observes event: StartupEvent) {
+        if (enabled) liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, EXPECTED_INTERVAL)
     }
 
     // Europe/Prague is explicit, not incidental (#1302): an unset @Scheduled timeZone means

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/scheduler/PeriodCloseScheduler.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/scheduler/PeriodCloseScheduler.kt
@@ -7,11 +7,11 @@ import com.openbank.libs.observability.DomainMetrics
 import com.openbank.libs.observability.WorkflowLivenessRecorder
 import com.openbank.statement.application.port.`in`.RunCloseUseCase
 import com.openbank.statement.domain.model.CloseTrigger
+import io.quarkus.runtime.StartupEvent
 import io.quarkus.scheduler.Scheduled
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.event.Observes
-import io.quarkus.runtime.StartupEvent
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.time.Duration
@@ -38,9 +38,11 @@ class PeriodCloseScheduler(
     private var liveness: WorkflowLivenessRecorder? = null
 
     /** Register only when this opt-in scheduler is enabled, avoiding false stale alerts by default. */
-    fun onStart(@Observes event: StartupEvent) {
+    fun registerLiveness() {
         if (enabled) liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, EXPECTED_INTERVAL)
     }
+
+    fun onStart(@Observes event: StartupEvent) = registerLiveness()
 
     // Europe/Prague is explicit, not incidental (#1302): an unset @Scheduled timeZone means
     // JVM-default, so the close fires on the pod's zone, not the bank's accounting day —

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/scheduler/PeriodCloseScheduler.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/scheduler/PeriodCloseScheduler.kt
@@ -42,6 +42,7 @@ class PeriodCloseScheduler(
         if (enabled) liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, EXPECTED_INTERVAL)
     }
 
+    @Suppress("UNUSED_PARAMETER")
     fun onStart(@Observes event: StartupEvent) = registerLiveness()
 
     // Europe/Prague is explicit, not incidental (#1302): an unset @Scheduled timeZone means


### PR DESCRIPTION
Adds fail-closed analytics backfill semantics and regression coverage so an unconfigured durable reader cannot produce a false COMPLETED report. Also carries the reviewed durable ICT incident register/admin UI and crypto incident runbook delivery slices.

Refs #4300