### PR TITLE
fix(admin-ui): clarify closing controls

### DIFF
--- a/openbank-admin-ui/src/app/day-end/page.tsx
+++ b/openbank-admin-ui/src/app/day-end/page.tsx
@@ -69,7 +69,7 @@ function ClosingsContent() {
       <PageHeader breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span>{t('Účetnictví', 'Accounting')}</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Závěrky', 'Closings')}</span></div>} icon={<CalendarClock size={20} aria-hidden="true" />} title={t('Závěrky', 'Closings')} subtitle={t('Denní tie-out (EoD) a měsíční uzávěrka výpisů (EoM)', 'Daily tie-out (EoD) and monthly statement close (EoM)')} />
 
       {/* Tab nav — same pattern as /payments */}
-      <div style={{ display: 'flex', gap: '2px', marginBottom: '20px', borderBottom: '1px solid var(--border)' }}>
+      <div role="group" aria-label={t('Typ závěrky', 'Closing type')} style={{ display: 'flex', gap: '2px', marginBottom: '20px', borderBottom: '1px solid var(--border)' }}>
         {([
           { key: 'eod' as Tab, icon: Scale, labelCs: 'Závěrka dne (EoD)', labelEn: 'Day-end (EoD)' },
           { key: 'eom' as Tab, icon: CalendarCheck2, labelCs: 'Měsíční uzávěrka (EoM)', labelEn: 'Month-end (EoM)' },
@@ -77,14 +77,14 @@ function ClosingsContent() {
           const Icon = item.icon
           const isActive = tab === item.key
           return (
-            <button key={item.key} type="button" onClick={() => changeTab(item.key)}
+            <button key={item.key} type="button" aria-pressed={isActive} aria-label={t(item.labelCs, item.labelEn)} onClick={() => changeTab(item.key)}
               style={{
                 display: 'flex', alignItems: 'center', gap: '6px', padding: '10px 18px', fontSize: '13px',
                 fontWeight: isActive ? 700 : 500, color: isActive ? 'var(--accent)' : 'var(--text-secondary)',
                 border: 'none', borderBottom: isActive ? '2px solid var(--accent)' : '2px solid transparent',
                 background: 'transparent', cursor: 'pointer', marginBottom: '-1px', transition: 'all 0.15s ease',
               }}>
-              <Icon size={14} />
+              <Icon size={14} aria-hidden="true" />
               {t(item.labelCs, item.labelEn)}
             </button>
           )
@@ -195,8 +195,8 @@ function EodPanel() {
               <Clock size={12} /> {lastRefreshed.toLocaleTimeString(locale)}
             </span>
           )}
-          <button className="btn btn-secondary" onClick={() => refresh(true)} disabled={refreshing}>
-            <RefreshCw size={13} className={refreshing ? 'animate-spin' : undefined} />
+          <button type="button" className="btn btn-secondary" aria-busy={refreshing} aria-label={t('Obnovit denní závěrku', 'Refresh day-end close')} onClick={() => refresh(true)} disabled={refreshing}>
+            <RefreshCw size={13} aria-hidden="true" className={refreshing ? 'animate-spin' : undefined} />
             {t('Obnovit', 'Refresh')}
           </button>
         </div>
@@ -602,18 +602,21 @@ function EomPanel() {
               <Clock size={12} /> {lastRefreshed.toLocaleTimeString(locale)}
             </span>
           )}
-          <button className="btn btn-secondary" onClick={() => load(true)} disabled={refreshing}>
-            <RefreshCw size={13} className={refreshing ? 'animate-spin' : undefined} />
+          <button type="button" className="btn btn-secondary" aria-busy={refreshing} aria-label={t('Obnovit měsíční závěrku', 'Refresh month-end close')} onClick={() => load(true)} disabled={refreshing}>
+            <RefreshCw size={13} aria-hidden="true" className={refreshing ? 'animate-spin' : undefined} />
             {t('Obnovit', 'Refresh')}
           </button>
           {canTrigger && (
             <button
+              type="button"
+              aria-busy={triggering}
+              aria-label={triggering ? t('Spouštím catch-up uzávěrku', 'Starting catch-up close') : t('Spustit catch-up uzávěrku', 'Run catch-up close')}
               className="btn btn-primary"
               onClick={() => void trigger()}
               disabled={triggering || running || unavailable !== null}
               title={t('Spustit dohánějící uzávěrku nyní (idempotentní)', 'Run a catch-up close now (idempotent)')}
             >
-              <Play size={13} className={triggering ? 'animate-spin' : undefined} />
+              <Play size={13} aria-hidden="true" className={triggering ? 'animate-spin' : undefined} />
               {triggering ? t('Spouštím…', 'Starting…') : t('Spustit catch-up', 'Run catch-up')}
             </button>
           )}

--- a/openbank-admin-ui/src/test/day-end-controls-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/day-end-controls-a11y.guard.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+describe('day-end controls expose workflow state', () => {
+  it('keeps closing tabs, refresh and catch-up actions named and busy-aware', () => {
+    const source = fs.readFileSync(path.join(process.cwd(), 'src/app/day-end/page.tsx'), 'utf8')
+    expect(source).toContain('role="group" aria-label={t(\'Typ závěrky\', \'Closing type\')}')
+    expect(source).toContain('aria-pressed={isActive}')
+    expect(source).toContain('aria-busy={refreshing}')
+    expect(source).toContain('aria-label={t(\'Obnovit denní závěrku\', \'Refresh day-end close\')}')
+    expect(source).toContain('aria-label={t(\'Obnovit měsíční závěrku\', \'Refresh month-end close\')}')
+    expect(source).toContain('aria-busy={triggering}')
+    expect(source).toContain('<Play size={13} aria-hidden="true"')
+  })
+})


### PR DESCRIPTION
## Summary
- expose EoD/EoM closing tabs as named stateful controls
- add busy semantics and labels to refresh/catch-up actions
- preserve closings RBAC, BFF URLs, idempotent trigger and data flows

## Validation
- `git diff --check`
- `npm run type-check` (passed with workspace dependencies)
- focused guard source reviewed; local Vitest blocked by missing optional rolldown binding

Closes #5968