### PR TITLE
fix(fraud): bucket velocity aggregates by event time, so a replay crossing an hour boundary cannot land in a different row (#6044)

### DIFF
--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/application/port/out/FraudMetricsPort.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/application/port/out/FraudMetricsPort.kt
@@ -36,4 +36,18 @@ interface FraudMetricsPort {
      * known to happen means the guard is not being reached.
      */
     fun recordSignalReplaySuppressed(aggregate: String)
+
+    /**
+     * Record that a transaction signal arrived with **no `occurredAt`** and that processing time was
+     * substituted for it (issue #6044). Every velocity bucket and payee-history row written from
+     * such a signal asserts a business time nobody measured, and — because the bucket is part of the
+     * primary key — a replay of that same signal will not land in the same row, so the redelivery
+     * guard cannot reach it. The substitution is otherwise completely silent: it writes a normal row
+     * and logs nothing, exactly like the ingest-time substitution #3883 found in the audit
+     * consumer. This counter is the only thing that distinguishes "every producer sends an event
+     * time" from "we have been inventing them". `openbank.transactions.transaction.initiated`
+     * declares `occurredAt` as required, so the expected value is a flat ZERO; any non-zero rate is
+     * a producer defect, not a tolerable degradation.
+     */
+    fun recordSignalMissingEventTime()
 }

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/application/port/out/VelocityAggregateRepository.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/application/port/out/VelocityAggregateRepository.kt
@@ -7,6 +7,7 @@ package com.openbank.fraud.application.port.out
 import com.openbank.fraud.domain.model.VelocityAggregate
 import com.openbank.fraud.domain.model.VelocityWindow
 import java.math.BigDecimal
+import java.time.Instant
 import java.util.UUID
 
 /** Stores and queries per-account rolling velocity aggregates (ADR-0084 §2). */
@@ -22,8 +23,25 @@ interface VelocityAggregateRepository {
      * not applied — the windows converge independently rather than as one transaction. A null
      * [transactionId] carries no identity and is therefore never deduplicated (same contract as
      * [PayeeHistoryRepository.recordPayment]).
+     *
+     * The window bucket is derived from [occurredAt] — the event's own business time — and never
+     * from the moment the signal is processed (issue #6044). Processing time puts a redelivery that
+     * crosses an hour, day or week boundary into a DIFFERENT row from the original, and the
+     * idempotency above is per row, so no guard of any design could recognise it there. Bucketing on
+     * event time is therefore what makes the redelivery guard reach a delayed replay at all; it also
+     * makes the aggregate mean "transactions that OCCURRED in this window" rather than "signals that
+     * were PROCESSED in it", which is the only reading that reconciles against the source
+     * transactions. The caller is responsible for supplying a real event time; see
+     * [com.openbank.fraud.infrastructure.messaging.TransactionSignalConsumer] for what it does when
+     * the event carries none.
      */
-    suspend fun recordTransaction(accountId: UUID, amount: BigDecimal, currency: String, transactionId: UUID?)
+    suspend fun recordTransaction(
+        accountId: UUID,
+        amount: BigDecimal,
+        currency: String,
+        transactionId: UUID?,
+        occurredAt: Instant,
+    )
 
     /**
      * Returns the current aggregate for [accountId] in [window] for [currency], or null.

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/messaging/TransactionSignalConsumer.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/messaging/TransactionSignalConsumer.kt
@@ -6,6 +6,7 @@ package com.openbank.fraud.infrastructure.messaging
 
 import com.fasterxml.jackson.core.JacksonException
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.fraud.application.port.out.FraudMetricsPort
 import com.openbank.fraud.application.port.out.PayeeHistoryRepository
 import com.openbank.fraud.application.port.out.VelocityAggregateRepository
 import com.openbank.fraud.application.usecase.FeatureOnlineUpdater
@@ -51,6 +52,7 @@ class TransactionSignalConsumer(
     private val featureUpdater: FeatureOnlineUpdater,
     private val objectMapper: ObjectMapper,
     private val clock: Clock,
+    private val metrics: FraudMetricsPort,
 ) {
     private val log = Logger.getLogger(TransactionSignalConsumer::class.java)
 
@@ -70,15 +72,31 @@ class TransactionSignalConsumer(
         val accountId = signal.sourceAccountId ?: return
         val amount = signal.amount ?: BigDecimal.ZERO
         val currency = signal.currencyCode ?: "CZK"
+        // Issue #6044. occurredAt is REQUIRED on TransactionInitiatedEvent, so the fallback should
+        // never be taken; if it is, every row written from this signal carries a business time
+        // nobody measured, and the redelivery guard cannot reach a later replay of it (the replay
+        // would substitute a different processing time and so target a different velocity bucket
+        // row). Substituting silently is what made the audit consumer's ingest-time fallback
+        // invisible for 7 of its 21 topics (#3883); this one is counted, so the absent case is
+        // visible from outside the database instead of being indistinguishable from a healthy one.
+        val eventTime = signal.occurredAt ?: run {
+            metrics.recordSignalMissingEventTime()
+            log.warnf(
+                "transaction.initiated signal for account %s carries no occurredAt; substituting processing time. " +
+                    "Velocity bucketing and redelivery dedupe are both degraded for this signal (#6044).",
+                accountId,
+            )
+            Instant.now(clock)
+        }
         @Suppress("TooGenericExceptionCaught") // DB / reactive layer exceptions have no common base
         runBlocking {
             try {
-                velocityRepo.recordTransaction(accountId, amount, currency, signal.aggregateId)
+                velocityRepo.recordTransaction(accountId, amount, currency, signal.aggregateId, eventTime)
                 log.debugf("Velocity aggregate updated for account %s amount=%s %s", accountId, amount, currency)
             } catch (ex: Exception) {
                 log.warnf(ex, "Failed to record velocity aggregate for account %s", accountId)
             }
-            recordPayeeHistory(accountId, signal)
+            recordPayeeHistory(accountId, signal, eventTime)
             // ADR-0140 online feature store (shadow plane). Best-effort: a feature-store failure must
             // never break the velocity path. Skip silently when the event carries no business time.
             val occurredAt = signal.occurredAt ?: return@runBlocking
@@ -94,13 +112,13 @@ class TransactionSignalConsumer(
      * ADR-0084 §3 v4: best-effort payee-history update. Skipped silently when the signal carries no
      * `targetAccountId` (e.g. an external-rail payment with no internal counterparty account) — same
      * "missing signal degrades gracefully, never breaks the velocity path" contract as the feature
-     * store update below. Falls back to [clock] when `occurredAt` is absent so a history row is still
-     * recorded (unlike the feature store, which requires a business timestamp to stay meaningful).
+     * store update below. [eventTime] is the signal's `occurredAt`, or processing time when it
+     * carries none, so a history row is still recorded (unlike the feature store, which requires a
+     * business timestamp to stay meaningful) — the substitution is counted by the caller (#6044).
      */
     @Suppress("TooGenericExceptionCaught") // DB / reactive layer exceptions have no common base
-    private suspend fun recordPayeeHistory(accountId: UUID, signal: TransactionInitiatedSignal) {
+    private suspend fun recordPayeeHistory(accountId: UUID, signal: TransactionInitiatedSignal, occurredAt: Instant) {
         val payeeIdentifier = signal.targetAccountId?.toString() ?: return
-        val occurredAt = signal.occurredAt ?: Instant.now(clock)
         try {
             payeeHistoryRepo.recordPayment(accountId, payeeIdentifier, signal.aggregateId, occurredAt)
             log.debugf("Payee history updated for account %s payee %s", accountId, payeeIdentifier)

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/observability/FraudMetricsAdapter.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/observability/FraudMetricsAdapter.kt
@@ -65,6 +65,15 @@ class FraudMetricsAdapter(private val registry: MeterRegistry?) : FraudMetricsPo
         }
     }
 
+    override fun recordSignalMissingEventTime() {
+        registry?.let { r ->
+            Counter.builder("openbank.fraud.signal.missing.event.time")
+                .tag("service", SERVICE)
+                .register(r)
+                .increment()
+        }
+    }
+
     companion object {
         private const val SERVICE = "fraud"
     }

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImpl.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImpl.kt
@@ -35,10 +35,14 @@ class VelocityAggregateRepositoryImpl(
         amount: BigDecimal,
         currency: String,
         transactionId: UUID?,
+        occurredAt: Instant,
     ) {
-        val now = Instant.now(clock)
+        // Issue #6044: the bucket comes from the event's own time, never from Instant.now(clock).
+        // window_start is part of the PK, so a redelivery processed on the other side of an hour
+        // boundary would otherwise target a different ROW — and the applied-id guard below is per
+        // row, so it would not see the first application and would count the replay again.
         VelocityWindow.entries.forEach { window ->
-            val start = window.bucketStart(now).toOffsetDateTime()
+            val start = window.bucketStart(occurredAt).toOffsetDateTime()
             val result = pool.preparedQuery(UPSERT_SQL).execute(
                 Tuple.of(
                     accountId.toString(),

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/messaging/TransactionSignalConsumerTest.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/messaging/TransactionSignalConsumerTest.kt
@@ -7,6 +7,7 @@ package com.openbank.fraud.infrastructure.messaging
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.kotlinModule
+import com.openbank.fraud.application.port.out.FraudMetricsPort
 import com.openbank.fraud.application.port.out.PayeeHistoryRepository
 import com.openbank.fraud.application.port.out.VelocityAggregateRepository
 import com.openbank.fraud.application.usecase.FeatureOnlineUpdater
@@ -30,10 +31,11 @@ class TransactionSignalConsumerTest {
     private val objectMapper = ObjectMapper()
         .registerModule(kotlinModule())
         .registerModule(JavaTimeModule())
+    private val metrics = mockk<FraudMetricsPort>(relaxed = true)
     private val fixedClock = Clock.fixed(Instant.parse("2026-07-09T00:00:00Z"), ZoneOffset.UTC)
 
     private val consumer =
-        TransactionSignalConsumer(velocityRepo, payeeHistoryRepo, featureUpdater, objectMapper, fixedClock)
+        TransactionSignalConsumer(velocityRepo, payeeHistoryRepo, featureUpdater, objectMapper, fixedClock, metrics)
 
     @Test
     fun `happy path records velocity for valid signal`() {
@@ -49,7 +51,68 @@ class TransactionSignalConsumerTest {
 
         consumer.onTransactionInitiated(payload)
 
-        coVerify(exactly = 1) { velocityRepo.recordTransaction(accountId, BigDecimal("250.00"), "CZK", any()) }
+        coVerify(exactly = 1) { velocityRepo.recordTransaction(accountId, BigDecimal("250.00"), "CZK", any(), any()) }
+    }
+
+    /**
+     * Issue #6044: the velocity bucket must be derived from the event's own business time. The
+     * repository is what applies it, but the consumer is the only place that can supply it — and it
+     * used to supply nothing, leaving the repository to read its clock. Asserted here as the exact
+     * `occurredAt` from the wire, not merely "some Instant": a fallback to processing time is
+     * precisely the bug, and `any()` would agree with it.
+     */
+    @Test
+    fun `forwards the event occurredAt to the velocity repository as the bucket time`() {
+        val accountId = UUID.randomUUID()
+        val occurredAt = Instant.parse("2026-07-09T10:59:00Z")
+        val eventTimeSlot = slot<Instant>()
+        coEvery {
+            velocityRepo.recordTransaction(any(), any(), any(), any(), capture(eventTimeSlot))
+        } returns Unit
+        val payload = """
+            {
+              "aggregateId": "${UUID.randomUUID()}",
+              "sourceAccountId": "$accountId",
+              "amount": "250.00",
+              "currencyCode": "CZK",
+              "occurredAt": "$occurredAt"
+            }
+        """.trimIndent()
+
+        consumer.onTransactionInitiated(payload)
+
+        assertThat(eventTimeSlot.captured).isEqualTo(occurredAt)
+        // Nothing was substituted, so the substitution must not be reported.
+        coVerify(exactly = 0) { metrics.recordSignalMissingEventTime() }
+    }
+
+    /**
+     * `occurredAt` is required on `TransactionInitiatedEvent`, so this should never happen — which is
+     * exactly why it must be counted rather than absorbed. Processing time is still substituted (a
+     * velocity row with an invented bucket beats no velocity row at all for a fraud control), but the
+     * substitution is now visible from outside the database. #3883 is the precedent: the audit
+     * consumer substituted ingest time for 7 of its 21 topics and nothing anywhere said so.
+     */
+    @Test
+    fun `counts the substitution when the signal carries no occurredAt`() {
+        val accountId = UUID.randomUUID()
+        val eventTimeSlot = slot<Instant>()
+        coEvery {
+            velocityRepo.recordTransaction(any(), any(), any(), any(), capture(eventTimeSlot))
+        } returns Unit
+        val payload = """
+            {
+              "aggregateId": "${UUID.randomUUID()}",
+              "sourceAccountId": "$accountId",
+              "amount": "250.00",
+              "currencyCode": "CZK"
+            }
+        """.trimIndent()
+
+        consumer.onTransactionInitiated(payload)
+
+        coVerify(exactly = 1) { metrics.recordSignalMissingEventTime() }
+        assertThat(eventTimeSlot.captured).isEqualTo(Instant.parse("2026-07-09T00:00:00Z"))
     }
 
     @Test
@@ -58,7 +121,7 @@ class TransactionSignalConsumerTest {
         val aggregateId = UUID.randomUUID()
         val transactionIdSlot = slot<UUID>()
         coEvery {
-            velocityRepo.recordTransaction(any(), any(), any(), capture(transactionIdSlot))
+            velocityRepo.recordTransaction(any(), any(), any(), capture(transactionIdSlot), any())
         } returns Unit
         val payload = """
             {
@@ -108,7 +171,7 @@ class TransactionSignalConsumerTest {
     fun `bad JSON is dropped without calling repository`() {
         consumer.onTransactionInitiated("not-valid-json{{{")
 
-        coVerify(exactly = 0) { velocityRepo.recordTransaction(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { velocityRepo.recordTransaction(any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -117,14 +180,14 @@ class TransactionSignalConsumerTest {
 
         consumer.onTransactionInitiated(payload)
 
-        coVerify(exactly = 0) { velocityRepo.recordTransaction(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { velocityRepo.recordTransaction(any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `missing amount defaults to zero`() {
         val accountId = UUID.randomUUID()
         val amountSlot = slot<BigDecimal>()
-        coEvery { velocityRepo.recordTransaction(any(), capture(amountSlot), any(), any()) } returns Unit
+        coEvery { velocityRepo.recordTransaction(any(), capture(amountSlot), any(), any(), any()) } returns Unit
 
         val payload = """{"sourceAccountId": "$accountId", "currencyCode": "CZK"}"""
         consumer.onTransactionInitiated(payload)
@@ -136,7 +199,7 @@ class TransactionSignalConsumerTest {
     fun `missing currencyCode defaults to CZK`() {
         val accountId = UUID.randomUUID()
         val currencySlot = slot<String>()
-        coEvery { velocityRepo.recordTransaction(any(), any(), capture(currencySlot), any()) } returns Unit
+        coEvery { velocityRepo.recordTransaction(any(), any(), capture(currencySlot), any(), any()) } returns Unit
 
         val payload = """{"sourceAccountId": "$accountId", "amount": "50.00"}"""
         consumer.onTransactionInitiated(payload)
@@ -147,7 +210,7 @@ class TransactionSignalConsumerTest {
     @Test
     fun `repository exception is caught and does not propagate`() {
         val accountId = UUID.randomUUID()
-        coEvery { velocityRepo.recordTransaction(any(), any(), any(), any()) } throws RuntimeException("DB down")
+        coEvery { velocityRepo.recordTransaction(any(), any(), any(), any(), any()) } throws RuntimeException("DB down")
 
         val payload = """{"sourceAccountId": "$accountId", "amount": "100.00", "currencyCode": "CZK"}"""
 
@@ -231,6 +294,6 @@ class TransactionSignalConsumerTest {
         // Must not throw, and must not prevent the velocity path from running
         consumer.onTransactionInitiated(payload)
 
-        coVerify(exactly = 1) { velocityRepo.recordTransaction(accountId, BigDecimal("100.00"), "CZK", any()) }
+        coVerify(exactly = 1) { velocityRepo.recordTransaction(accountId, BigDecimal("100.00"), "CZK", any(), any()) }
     }
 }

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/PayeeHistoryRepositoryImplIT.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/PayeeHistoryRepositoryImplIT.kt
@@ -181,6 +181,8 @@ class PayeeHistoryRepositoryImplIT {
                 override fun recordSignalReplaySuppressed(aggregate: String) {
                     suppressed.add(aggregate)
                 }
+
+                override fun recordSignalMissingEventTime() = Unit
             },
             100,
         )

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplIT.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplIT.kt
@@ -12,6 +12,7 @@ import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import io.vertx.mutiny.pgclient.PgPool
+import io.vertx.mutiny.sqlclient.Row
 import io.vertx.mutiny.sqlclient.Tuple
 import jakarta.inject.Inject
 import kotlinx.coroutines.runBlocking
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.Clock
 import java.time.Instant
+import java.time.ZoneOffset
 import java.util.UUID
 
 /**
@@ -43,6 +45,14 @@ class VelocityAggregateRepositoryImplIT {
     @Inject
     lateinit var pool: PgPool
 
+    /**
+     * The business time carried by every signal a test records, fixed once per test instance (JUnit
+     * builds a fresh one per test). Fixing it matters twice over: the bucket is now derived from the
+     * event's own time (#6044), and holding it constant stops a test that happens to straddle an
+     * hour boundary mid-run from splitting its own writes across two rows.
+     */
+    private val eventTime: Instant = Instant.now(Clock.systemUTC())
+
     private suspend fun assertAllWindows(accountId: UUID, count: Long, total: String) {
         VelocityWindow.entries.forEach { window ->
             val aggregate = repository.findAggregate(accountId, window, CURRENCY)
@@ -58,7 +68,7 @@ class VelocityAggregateRepositoryImplIT {
     fun `a first signal is recorded in every window`(): Unit = runBlocking {
         val accountId = UUID.randomUUID()
 
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, UUID.randomUUID())
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, UUID.randomUUID(), eventTime)
 
         assertAllWindows(accountId, count = 1L, total = "100.00")
     }
@@ -68,10 +78,10 @@ class VelocityAggregateRepositoryImplIT {
         val accountId = UUID.randomUUID()
         val transactionId = UUID.randomUUID()
 
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId, eventTime)
         // Redelivery of the exact same Kafka message (same aggregateId) — must be a no-op.
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId)
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId, eventTime)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId, eventTime)
 
         assertAllWindows(accountId, count = 1L, total = "100.00")
     }
@@ -80,12 +90,12 @@ class VelocityAggregateRepositoryImplIT {
     fun `a genuinely new signal after a redelivery still counts`(): Unit = runBlocking {
         val accountId = UUID.randomUUID()
         val firstTransactionId = UUID.randomUUID()
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, firstTransactionId)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, firstTransactionId, eventTime)
         // Replay of the first signal — must not count.
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, firstTransactionId)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, firstTransactionId, eventTime)
 
         // A genuinely different transaction — must count.
-        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, UUID.randomUUID())
+        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, UUID.randomUUID(), eventTime)
 
         assertAllWindows(accountId, count = 2L, total = "140.00")
     }
@@ -104,7 +114,7 @@ class VelocityAggregateRepositoryImplIT {
     fun `a retry after a partial per-window failure converges to the correct total`(): Unit = runBlocking {
         val accountId = UUID.randomUUID()
         val transactionId = UUID.randomUUID()
-        val h1Start = VelocityWindow.H1.bucketStart(Instant.now(Clock.systemUTC()))
+        val h1Start = VelocityWindow.H1.bucketStart(eventTime)
 
         // The interrupted first attempt: H1 applied, H24 and D7 never reached.
         pool.preparedQuery(
@@ -125,7 +135,7 @@ class VelocityAggregateRepositoryImplIT {
         ).awaitSuspending()
 
         // The redelivery re-runs the full per-window loop.
-        repository.recordTransaction(accountId, BigDecimal("70.00"), CURRENCY, transactionId)
+        repository.recordTransaction(accountId, BigDecimal("70.00"), CURRENCY, transactionId, eventTime)
 
         assertAllWindows(accountId, count = 1L, total = "70.00")
     }
@@ -137,8 +147,8 @@ class VelocityAggregateRepositoryImplIT {
         // No aggregateId on the wire means no identity to deduplicate by — the pre-#5716 behaviour
         // is preserved rather than silently dropping the second signal. Same contract as
         // payee_history.
-        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, null)
-        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, null)
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, null, eventTime)
+        repository.recordTransaction(accountId, BigDecimal("10.00"), CURRENCY, null, eventTime)
 
         assertAllWindows(accountId, count = 2L, total = "20.00")
     }
@@ -148,9 +158,9 @@ class VelocityAggregateRepositoryImplIT {
         val accountId = UUID.randomUUID()
         val transactionId = UUID.randomUUID()
 
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId, eventTime)
         // A different currency is a different row, so the same id does not suppress it.
-        repository.recordTransaction(accountId, BigDecimal("100.00"), "EUR", transactionId)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), "EUR", transactionId, eventTime)
 
         assertAllWindows(accountId, count = 1L, total = "100.00")
         val eur = repository.findAggregate(accountId, VelocityWindow.H1, "EUR")
@@ -174,10 +184,10 @@ class VelocityAggregateRepositoryImplIT {
         val a = UUID.randomUUID()
         val b = UUID.randomUUID()
 
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
-        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a, eventTime)
+        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b, eventTime)
         // The replay of A, landing after B — the last-writer marker holds B here and let this through.
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a, eventTime)
 
         assertAllWindows(accountId, count = 2L, total = "140.00")
     }
@@ -189,11 +199,11 @@ class VelocityAggregateRepositoryImplIT {
         val a = UUID.randomUUID()
         val b = UUID.randomUUID()
 
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
-        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a, eventTime)
+        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b, eventTime)
         // Rebalance: the consumer resumes from the last committed offset and re-delivers A then B.
-        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
-        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b)
+        repository.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a, eventTime)
+        repository.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b, eventTime)
 
         assertAllWindows(accountId, count = 2L, total = "140.00")
     }
@@ -211,10 +221,10 @@ class VelocityAggregateRepositoryImplIT {
         val accountId = UUID.randomUUID()
         val a = UUID.randomUUID()
 
-        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
+        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a, eventTime)
         assertThat(suppressed).describedAs("a first application is not a suppression").isEmpty()
 
-        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
+        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a, eventTime)
 
         assertThat(suppressed).containsExactly("velocity_aggregates", "velocity_aggregates", "velocity_aggregates")
     }
@@ -232,12 +242,123 @@ class VelocityAggregateRepositoryImplIT {
         val a = UUID.randomUUID()
         val b = UUID.randomUUID()
 
-        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
-        repo.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b)
-        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a)
+        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a, eventTime)
+        repo.recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, b, eventTime)
+        repo.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, a, eventTime)
 
         // A has been evicted from a one-entry set, so it applies again: 3 applications, 240.00.
         assertAllWindows(accountId, count = 3L, total = "240.00")
+    }
+
+    /**
+     * Issue #6044 — the half of #5789 the applied-id set cannot reach, because it is not a dedupe
+     * defect at all: the bucket used to come from `Instant.now(clock)` at PROCESSING time, and
+     * `window_start` is part of the primary key. A signal that occurred at 10:59 and is redelivered
+     * at 11:00 therefore hit a DIFFERENT ROW from the original, and the applied-id set lives on the
+     * row — so the replay met an empty set, was not recognised, and was counted a second time. No
+     * value of `openbank.fraud.applied-signal-window` changes that; the set it consults is the wrong
+     * row's.
+     *
+     * The delivery is built here exactly as it happens: the SAME signal (same id, same `occurredAt`,
+     * one minute before the hour) applied twice, with the two repository instances differing ONLY in
+     * the clock they would have bucketed by — 10:59 for the original delivery, 11:00 for the replay.
+     * With the bucket taken from `occurredAt` both target the 10:00 row, the guard sees the id, and
+     * the correct total is one application.
+     */
+    @Test
+    fun `a replay processed after the hour boundary is not counted again in the next bucket`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val transactionId = UUID.randomUUID()
+        val occurredAt = Instant.parse("2026-07-09T10:59:00Z")
+
+        val atOriginalDelivery = repositoryAt("2026-07-09T10:59:01Z")
+        val afterTheBoundary = repositoryAt("2026-07-09T11:00:02Z")
+
+        atOriginalDelivery.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId, occurredAt)
+        // The redelivery: same event, same occurredAt, processed on the other side of 11:00.
+        afterTheBoundary.recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, transactionId, occurredAt)
+
+        // The double-count, stated independently of which rows exist: across EVERY H1 bucket this
+        // account has, the signal must have been applied exactly once. Asserting only the 10:00 row
+        // would miss the defect — under processing-time bucketing that row also reads 1, and the
+        // second application sits in a row the assertion never looks at.
+        assertAppliedAcrossAllBuckets(accountId, VelocityWindow.H1, count = 1L, total = "100.00")
+        // Both applications landed on the bucket the event belongs to...
+        assertBucket(accountId, VelocityWindow.H1, occurredAt, count = 1L, total = "100.00")
+        // ...and nothing at all was written into the 11:00 bucket the replay used to create.
+        assertNoBucket(accountId, VelocityWindow.H1, Instant.parse("2026-07-09T11:00:02Z"))
+    }
+
+    /**
+     * The same defect one level up: it is not only replays. Two signals that OCCURRED in the same
+     * hour but were processed either side of the boundary — an ordinary consumer lag or pod roll —
+     * used to be split across two rows, so neither the H1 count nor the H1 sum the scorer reads was
+     * ever the truth about that hour. Event-time bucketing puts both where they happened.
+     */
+    @Test
+    fun `two signals from the same hour processed either side of the boundary land in one bucket`(): Unit =
+        runBlocking {
+            val accountId = UUID.randomUUID()
+            val hour = Instant.parse("2026-07-09T10:00:00Z")
+
+            repositoryAt("2026-07-09T10:20:00Z")
+                .recordTransaction(accountId, BigDecimal("100.00"), CURRENCY, UUID.randomUUID(), hour.plusSeconds(600))
+            repositoryAt("2026-07-09T11:00:30Z")
+                .recordTransaction(accountId, BigDecimal("40.00"), CURRENCY, UUID.randomUUID(), hour.plusSeconds(3000))
+
+            assertBucket(accountId, VelocityWindow.H1, hour, count = 2L, total = "140.00")
+        }
+
+    /** A repository whose clock reads [instant] — the moment a signal is PROCESSED, nothing else. */
+    private fun repositoryAt(instant: String): VelocityAggregateRepository = VelocityAggregateRepositoryImpl(
+        pool,
+        Clock.fixed(Instant.parse(instant), ZoneOffset.UTC),
+        noopMetrics(),
+        100,
+    )
+
+    /** Reads one bucket row directly — [findAggregate] can only ask about the CURRENT window. */
+    private suspend fun selectBucket(accountId: UUID, window: VelocityWindow, at: Instant): Row? = pool.preparedQuery(
+        """
+            SELECT transaction_count, total_amount
+            FROM velocity_aggregates
+            WHERE account_id = $1::uuid AND velocity_window = $2 AND currency = $3 AND window_start = $4
+            """,
+    ).execute(
+        Tuple.of(accountId.toString(), window.name, CURRENCY, window.bucketStart(at).toOffsetDateTime()),
+    ).awaitSuspending().firstOrNull()
+
+    private suspend fun assertBucket(accountId: UUID, window: VelocityWindow, at: Instant, count: Long, total: String) {
+        val row = selectBucket(accountId, window, at)
+        assertThat(row).describedAs("row for the %s bucket containing %s", window, at).isNotNull
+        assertThat(row!!.getLong(0)).describedAs("count in the bucket containing %s", at).isEqualTo(count)
+        assertThat(
+            row.getBigDecimal(1),
+        ).describedAs("total in the bucket containing %s", at).isEqualByComparingTo(total)
+    }
+
+    /** Every bucket row for this (account, window, currency), summed — where a double-count shows up. */
+    private suspend fun assertAppliedAcrossAllBuckets(
+        accountId: UUID,
+        window: VelocityWindow,
+        count: Long,
+        total: String,
+    ) {
+        val row = pool.preparedQuery(
+            """
+            SELECT COALESCE(SUM(transaction_count), 0), COALESCE(SUM(total_amount), 0)
+            FROM velocity_aggregates
+            WHERE account_id = $1::uuid AND velocity_window = $2 AND currency = $3
+            """,
+        ).execute(Tuple.of(accountId.toString(), window.name, CURRENCY)).awaitSuspending().first()
+        assertThat(row.getLong(0)).describedAs("applications across all %s buckets", window).isEqualTo(count)
+        assertThat(row.getBigDecimal(1)).describedAs("total across all %s buckets", window).isEqualByComparingTo(total)
+    }
+
+    private suspend fun assertNoBucket(accountId: UUID, window: VelocityWindow, at: Instant) {
+        assertThat(selectBucket(accountId, window, at))
+            .describedAs("no %s row should exist for the bucket containing %s", window, at)
+            .isNull()
     }
 
     private fun recordingMetrics(sink: MutableList<String>): FraudMetricsPort = object : FraudMetricsPort {
@@ -246,6 +367,8 @@ class VelocityAggregateRepositoryImplIT {
         override fun recordSignalReplaySuppressed(aggregate: String) {
             sink.add(aggregate)
         }
+
+        override fun recordSignalMissingEventTime() = Unit
     }
 
     private fun noopMetrics(): FraudMetricsPort = recordingMetrics(mutableListOf())

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplTest.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/persistence/VelocityAggregateRepositoryImplTest.kt
@@ -73,7 +73,13 @@ class VelocityAggregateRepositoryImplTest {
         val pq = mockPreparedQuery(rowSet)
         every { pool.preparedQuery(any<String>()) } returns pq
 
-        repository.recordTransaction(UUID.randomUUID(), BigDecimal("100.00"), "CZK", UUID.randomUUID())
+        repository.recordTransaction(
+            UUID.randomUUID(),
+            BigDecimal("100.00"),
+            "CZK",
+            UUID.randomUUID(),
+            Instant.parse("2026-07-09T10:30:00Z"),
+        )
 
         // recordTransaction calls upsert once per window (H1, H24, D7)
         verify(exactly = 3) { pool.preparedQuery(any<String>()) }


### PR DESCRIPTION
Closes #6044.

## Stacking — read this first

**This PR is stacked on #6040** (`fix/fraud-dedupe-ordering-5789`) and its base is that branch, not `main`. The diff shown here is my change alone. It is not a disjoint change and could not be: #6040 rewrites `VelocityAggregateRepositoryImpl`'s upsert SQL and constructor, and this PR changes the same function's signature and the line that computes its bucket. Branching from `main` would have produced a guaranteed conflict in the same method, and — worse — the two changes are about the *same* replay, so reviewing them apart from each other loses the argument. **Merge #6040 first.**

Evidence for the overlap rather than an assertion of it: `git diff origin/main origin/fix/fraud-dedupe-ordering-5789 -- .../VelocityAggregateRepositoryImpl.kt` and this PR's diff of the same file both touch `recordTransaction`'s parameter list and body.

**No migration**, so there is no `V6`/`V7` collision to resolve with #6040 or with anything on `main`. The schema is unchanged; only the value written into the existing `window_start` column changes.

## The defect

`window_start` is part of the `velocity_aggregates` primary key, and it was derived from `Instant.now(clock)` — the moment the Kafka record is **processed**:

```kotlin
val now = Instant.now(clock)
VelocityWindow.entries.forEach { window ->
    val start = window.bucketStart(now).toOffsetDateTime()
```

So a signal that occurred at 10:59 and is redelivered at 11:00 addresses a **different row** from the original. #6040's applied-id set lives on the row, so the replay meets an empty set, is not recognised, and is applied a second time. This is not a case a larger `openbank.fraud.applied-signal-window` reaches — the set it consults belongs to the wrong row. It is the residual #6040 named in its own "noticed in passing, deliberately not fixed here".

The delivery is ordinary, not exotic: `TransactionSignalConsumer` is at-least-once with periodic offset commits, so a rebalance, pod roll or crash re-delivers the uncommitted window with no bound on the delay, and hour boundaries arrive once an hour.

## Is `occurredAt` actually there, and is it trustworthy?

Yes, and this was established by reading the **serialised type**, not by grepping for a quoted field name — this repo builds event payloads two ways and a string grep can only see the hand-built maps (#3883).

- `TransactionInitiatedEvent` (`openbank-transaction-service/.../domain/event/TransactionEvents.kt`) declares `override val occurredAt: Instant` as a **required, non-defaulted** constructor parameter. There is no `Instant.EPOCH` default for a caller to silently take — the trap that made every AML decision record 1970.
- `LoggingTransactionEventPublisher.initiatedPayload` serialises the whole event with `objectMapper.writeValueAsString(...)` and sets `occurredAt = Instant.now(clock)` at the moment the transaction is initiated. That is a genuine business time, not an ingest time substituted downstream.
- The payload is stored **verbatim** in the outbox and relayed unchanged, so a replay carries the *same* `occurredAt` as the original delivery. That property is what makes the fix work at all: same event, same time, same row.
- `docs/asyncapi/openbank-events.yaml` records which channels carry no event time. `openbank.transactions.transaction.initiated` is not among them.
- `TransactionSignalConsumer` already parses `occurredAt` and already uses it for the payee-history row and the ADR-0140 feature store. **Only the velocity path ignored it.**

## The missing case is now visible instead of silent

`occurredAt` is required on the wire, so the absent case should never occur — which is exactly why it must be counted rather than absorbed. The consumer still substitutes processing time (a fraud control with an invented bucket beats no row at all), but it now logs a warning and increments `openbank_fraud_signal_missing_event_time_total{service="fraud"}`.

Silence is the failure mode here: the audit consumer substitutes ingest time for **7 of its 21 topics** and nothing anywhere says so (#3883). The same substitution already existed one line down in this file — `recordPayeeHistory` fell back to the clock, unremarked — and now shares the counter. **The expected value of this series is a flat zero**; any non-zero rate is a producer defect, not a tolerable degradation.

## The semantics trade-off, stated rather than assumed

Bucketing on event time changes what the aggregate **means**: "transactions that OCCURRED in this window" instead of "signals that were PROCESSED in it".

- **Why that is the right meaning.** It is the only one that is stable under replay, and the only one that can be reconciled against the source transactions — the reconciliation #6040 makes possible to alert on. Under processing time the H1 count was never a fact about any hour; it was a fact about the consumer's schedule.
- **The cost, and it is real.** A late-arriving signal now increments a bucket that is already in the past. Nothing in this service closes, finalises or snapshots a bucket — rows are only ever read for the current window, and no downstream reads a past one — so no reader is invalidated. But it is a behaviour change and it belongs here rather than in a changelog line.
- **What did NOT change, and is a genuine open product question.** `findAggregate` still derives the current bucket from `Instant.now(clock)`. That is right for "score the transaction happening now", and it is what the scorer wants. Whether scoring should instead read the bucket of the **scored transaction's own event time** is a different question with a different blast radius (it changes what the rules see, not only where writes land), and it is not decided here. Under normal operation the two agree: a live signal's `occurredAt` is milliseconds old and falls in the current bucket. They diverge exactly at a boundary or a replay — which is the case this PR is about, and where the write side is unambiguously wrong today.
- **Deliberately unchanged:** a signal with no `aggregateId` is still applied unconditionally and never remembered, and the guard is still per row, so the three windows still converge independently after a partial failure.

## Proof

Written failing-first, against **real Postgres** (`PostgresRedisTestResource`), as #6040's ITs are — a mocked `PgPool` cannot tell a write that lands in the right row from one that does not.

Two new ITs. The first constructs the exact delivery: the same signal (same id, same `occurredAt` at 10:59) applied through two repository instances differing **only** in the clock they would bucket by — 10:59:01 for the original delivery, 11:00:02 for the replay. The second is the same defect without a replay at all: two signals that occurred in the same hour, processed either side of the boundary, used to be split across two rows so neither the count nor the sum the scorer reads was ever the truth about that hour.

The first test's primary assertion is deliberately **across every H1 bucket for the account**, not on one row. Asserting only the 10:00 row would agree with the defect — that row also reads 1, and the second application is sitting in a row the assertion never looks at.

### Negative control

Reverting **only** the production line (`window.bucketStart(occurredAt)` → `window.bucketStart(Instant.now(clock))`), keeping the tests, the port signature and the metric:

```
VelocityAggregateRepositoryImplIT   12 tests, 2 failed, 0 skipped

RED: a replay processed after the hour boundary is not counted again in the next bucket
     [applications across all H1 buckets]
     expected: 1L
      but was: 2L

RED: two signals from the same hour processed either side of the boundary land in one bucket
     [count in the bucket containing 2026-07-09T10:00:00Z]
     expected: 2L
      but was: 1L
```

Exactly the two new tests go red; the other ten — including all four of #6040's dedupe tests — stay green, which is the point: the applied-id guard is working and still cannot see this.

## Verified

Gradle run serialised, output to files, exit code read directly (never through a pipe), `--rerun-tasks`, totals read from the JUnit XML rather than the console:

- `:openbank-fraud-service:test` — **179 tests, 0 failures, 0 errors, 1 skipped**. The skip is `FraudPactProviderVerificationTest`, `@EnabledIfSystemProperty(pactbroker.url)`; its `@PactFolder` sibling ran. 179 = #6040's 175 + the 4 tests added here.
- `:openbank-fraud-service:quarkusBuild` — green. The consumer gained a constructor parameter, and CDI/ArC wiring is not validated by unit tests.
- `ktlintCheck`, `detekt` — green (re-run on their own after the test run, since Gradle stops at the first failing task).
- Gate manifest, `PR_DIFF_BASE=origin/main`, per shard in the foreground: `security` (includes **threat-model coverage** and **threat-model-updated-on-trust-boundary-change**, both PASS), `kotlin`, `lint`, `registry`, `data` — all exit 0.

## Not verified

- **The `api` shard fails locally for an environmental reason, not a finding**: the `api-contract` gate tries to install `oasdiff` and needs `sudo`, which has no terminal here (`sudo: a terminal is required to read the password`). No `openapi.yaml` is touched by this PR. CI is the authority on it.
- No live system was touched — no cluster, DB, Kafka, Prometheus or AWS read or written. Every claim about the producer, the topic and the payload is read from the repository at `origin/main`.
- Whether double-counting from a boundary-crossing replay has actually occurred in a real environment. That needs the aggregate reconciled against the source transactions; this PR does not add that reconciliation (nor did #6040).
- No backfill or repair of aggregate rows already written into the wrong bucket. Existing rows are left as they are: the counts self-heal as their windows roll off, and there is no safe general repair without the reconciliation above.

## Release

`fix(fraud)` touching `src/main` — release-please cuts the patch. `version.txt` is not hand-edited. No API contract change, so no `openapi.yaml` version bump.
