### PR TITLE
fix(audit): subscribe the audit trail to the ledger, sdd, interest and fraud money-path topics

### DIFF
--- a/.github/scripts/check-audit-money-path-subscription.py
+++ b/.github/scripts/check-audit-money-path-subscription.py
@@ -75,15 +75,17 @@ AUDIT_KAFKAUSER = "audit-service"
 # it. Fixing one means DELETING its entries here — and the check fails on an entry that is no
 # longer a gap, so the list cannot drift in either direction.
 #
-# All six are #6035 / #5859: the same six topics missing from all three places at once. They are
-# not drive-by-fixable from this PR: adding a topic to the audit subscription is a live-broker
-# change (a new Read grant on a running consumer group) whose blast radius wants its own review,
-# and PR #5857 is already in flight for the delegation row.
+# What is left after #6035's first backfill. Four of the original seven -- ledger
+# (openbank.ledger.journal.posted), sdd, interest and fraud -- were wired in all three places and
+# their entries deleted here; a stale entry is itself an error, so a half-fix cannot pass.
+#
+# The three that remain each need a decision this ratchet should not make silently:
+#  - billing has no KafkaTopic CR for openbank.billing.fee.event at all, so a Read grant would
+#    point at an undeclared topic -- a second way to get silence, and the topic's ownership is
+#    billing's call, not audit's.
+#  - standing-order and psd2 were found by THIS check and named in neither #5859 nor #6035, so
+#    nothing has yet reviewed whether their streams belong in the audit trail.
 _GAP_ISSUE = {
-    "openbank-ledger-service": "#6035 - the posting record itself, the largest of the five",
-    "openbank-sdd-service": "#6035",
-    "openbank-interest-service": "#6035",
-    "openbank-fraud-service": "#6035",
     "openbank-billing-service": "#6035 - also has no KafkaTopic CR (see the issue)",
     # Found by THIS check on its first run, and by nothing before it: neither #5859's probe nor
     # #6035's enumeration named these two. That is the argument for deriving the scope rather
@@ -93,10 +95,6 @@ _GAP_ISSUE = {
     "openbank-psd2-service": "#6035 - found by this check, not named in the issue",
 }
 _GAP_TOPICS = {
-    "openbank-ledger-service": "openbank.ledger.journal.posted",
-    "openbank-sdd-service": "openbank.sdd.event",
-    "openbank-interest-service": "openbank.interest.accrual.event",
-    "openbank-fraud-service": "openbank.fraud.hold.changed",
     "openbank-billing-service": "openbank.billing.fee.event",
     "openbank-standing-order-service": "openbank.standing-orders.order.event",
     "openbank-psd2-service": "openbank.psd2.events",

--- a/openbank-admin-ui/src/app/docs/cloud-architecture/page.tsx
+++ b/openbank-admin-ui/src/app/docs/cloud-architecture/page.tsx
@@ -154,7 +154,7 @@ const NAMESPACES: NS[] = [
 
 function StatusDot({ status }: { status: Status }) {
   const m = STATUS_META[status]
-  return <m.Icon size={13} style={{ color: m.color, flexShrink: 0 }} />
+  return <m.Icon aria-hidden="true" size={13} style={{ color: m.color, flexShrink: 0 }} />
 }
 
 type CloudNodeBoxProps = { n: Node; selectedId: string | null; liveStatus: Record<string, InfraStatusResult> | null; t: (cs: string, en: string) => string; onSelect: (node: Node) => void }
@@ -165,7 +165,7 @@ function CloudNodeBox({ n, selectedId, liveStatus, t, onSelect }: CloudNodeBoxPr
   const probeId = INFRA_PROBE_MAP[n.id]
   const probe = probeId && liveStatus ? liveStatus[probeId] : null
   const pm = probe ? PROBE_META[probe.status] : null
-  return <button onClick={() => onSelect(n)} title={t(...n.desc)} style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '6px 10px', borderRadius: '8px', cursor: 'pointer', background: m.bg, border: `1px solid ${active ? m.color : m.border}`, boxShadow: active ? `0 0 0 2px ${m.color}55` : 'none', color: 'var(--text-primary)', fontSize: '12px', fontWeight: 600, fontFamily: 'inherit', textAlign: 'left' }}>
+  return <button type="button" onClick={() => onSelect(n)} title={t(...n.desc)} aria-label={`${t(...n.name)} — ${t(...m.label)}`} aria-pressed={active} aria-controls={active ? 'cloud-architecture-selection' : undefined} style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '6px 10px', borderRadius: '8px', cursor: 'pointer', background: m.bg, border: `1px solid ${active ? m.color : m.border}`, boxShadow: active ? `0 0 0 2px ${m.color}55` : 'none', color: 'var(--text-primary)', fontSize: '12px', fontWeight: 600, fontFamily: 'inherit', textAlign: 'left' }}>
     <StatusDot status={n.status} />
     {t(...n.name)}
     {pm && <span style={{ display: 'inline-flex', alignItems: 'center', gap: '2px', marginLeft: '4px', padding: '1px 5px', borderRadius: '10px', background: pm.bg, border: `1px solid ${pm.color}44`, fontSize: '10px', fontWeight: 700, color: pm.color }}><pm.Icon size={9} aria-hidden="true" />{pm.label}</span>}
@@ -235,20 +235,23 @@ export default function CloudArchitecturePage() {
         })}
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginLeft: 'auto', fontSize: '11px', color: 'var(--text-secondary)', flexWrap: 'wrap' }}>
           <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-            <Info size={13} />
+            <Info aria-hidden="true" size={13} />
             {t('Diagram = strategie (ADR-0027); badge', 'Diagram = strategy (ADR-0027); badge')}
             <span style={{ display: 'inline-flex', alignItems: 'center', gap: '2px', padding: '1px 5px', borderRadius: '10px', background: '#ecfdf5', border: '1px solid #6ee7b744', fontSize: '10px', fontWeight: 700, color: '#059669' }}>
-              <Wifi size={9} />UP
+              <Wifi aria-hidden="true" size={9} />UP
             </span>
             {t('= živý probe z EKS openbank-sandbox.', '= live probe from EKS openbank-sandbox.')}
           </span>
           {checkedAt && <span>{t('Naposledy:', 'Last:')} {checkedAt}</span>}
           <button
+            type="button"
             onClick={() => void fetchStatus()}
             disabled={refreshing}
+            aria-busy={refreshing}
+            aria-label={t('Obnovit stav infrastruktury', 'Refresh infrastructure status')}
             style={{ display: 'flex', alignItems: 'center', gap: '4px', background: 'none', border: '1px solid var(--border)', borderRadius: '6px', padding: '3px 8px', cursor: refreshing ? 'not-allowed' : 'pointer', color: 'var(--text-secondary)', fontSize: '11px', fontFamily: 'inherit', opacity: refreshing ? 0.6 : 1 }}
           >
-            <RefreshCw size={11} style={{ animation: refreshing ? 'spin 1s linear infinite' : 'none' }} />
+            <RefreshCw aria-hidden="true" size={11} style={{ animation: refreshing ? 'spin 1s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
         </div>
@@ -298,14 +301,14 @@ export default function CloudArchitecturePage() {
         </div>
 
         {selected && (
-          <div className="card" style={{ padding: '18px', position: 'sticky', top: '16px' }}>
+          <div id="cloud-architecture-selection" className="card" role="region" aria-label={t('Detail architektonického prvku', 'Architecture element details')} style={{ padding: '18px', position: 'sticky', top: '16px' }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '10px' }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                 <StatusDot status={selected.status} />
                 <span style={{ fontSize: '15px', fontWeight: 700, color: 'var(--text-primary)' }}>{t(...selected.name)}</span>
               </div>
-              <button onClick={() => setSelected(null)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)', padding: 0 }}>
-                <X size={16} />
+              <button type="button" onClick={() => setSelected(null)} aria-label={t('Zavřít detail architektury', 'Close architecture details')} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)', padding: 0 }}>
+                <X aria-hidden="true" size={16} />
               </button>
             </div>
             <span style={{

--- a/openbank-admin-ui/src/app/infrastructure/topology/page.tsx
+++ b/openbank-admin-ui/src/app/infrastructure/topology/page.tsx
@@ -6,7 +6,7 @@
 import { useState, useEffect } from 'react'
 import {
   Network, RefreshCw, Play, Pause, CheckCircle2, XCircle, HelpCircle,
-  Cloud, GitBranch, Database, Eye, Server,
+  Cloud, GitBranch, Database, Eye, Server, X,
 } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { edgeGeometry, mixHex, pathId } from '@/components/topology/geometry'
@@ -244,9 +244,9 @@ export default function InfraTopologyPage() {
 
       {/* Controls */}
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px', flexWrap: 'wrap', gap: '12px' }}>
-        <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+        <div role="group" aria-label={t('Filtrování vrstev infrastruktury', 'Infrastructure layer filters')} style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
           {(['all', ...GROUP_ORDER] as const).map(key => (
-            <button key={key} onClick={() => setFilter(key)}
+            <button key={key} type="button" onClick={() => setFilter(key)} aria-pressed={filter === key}
               style={{
                 padding: '5px 12px', fontSize: '12px', fontWeight: 600, borderRadius: '20px',
                 border: `1px solid ${filter === key ? 'var(--accent)' : 'var(--border)'}`,
@@ -258,18 +258,18 @@ export default function InfraTopologyPage() {
           ))}
         </div>
         <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
-          <button onClick={() => setFlow(v => !v)} aria-pressed={flow} title={t('Přepnout tok dat', 'Toggle data flow')}
+          <button type="button" onClick={() => setFlow(v => !v)} aria-pressed={flow} aria-label={t(flow ? 'Pozastavit tok dat' : 'Spustit tok dat', flow ? 'Pause data flow' : 'Start data flow')} title={t('Přepnout tok dat', 'Toggle data flow')}
             style={{
               display: 'flex', alignItems: 'center', gap: '5px', padding: '5px 10px', fontSize: '12px', fontWeight: 600,
               borderRadius: '20px', cursor: 'pointer', fontFamily: 'inherit',
               border: `1px solid ${flow ? 'var(--accent)' : 'var(--border)'}`,
               background: flow ? 'var(--accent)' : 'var(--surface)', color: flow ? '#fff' : 'var(--text-secondary)',
             }}>
-            {flow ? <Pause size={13} /> : <Play size={13} />}{t('Tok dat', 'Data flow')}
+            {flow ? <Pause aria-hidden="true" size={13} /> : <Play aria-hidden="true" size={13} />}{t('Tok dat', 'Data flow')}
           </button>
-          <button onClick={load} disabled={isChecking} className="btn btn-secondary"
+          <button type="button" onClick={load} disabled={isChecking} aria-busy={isChecking} aria-label={t('Obnovit stav infrastruktury', 'Refresh infrastructure status')} className="btn btn-secondary"
             style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px' }}>
-            <RefreshCw size={14} className={isChecking ? 'animate-spin' : ''} />
+            <RefreshCw aria-hidden="true" size={14} className={isChecking ? 'animate-spin' : ''} />
             {isChecking ? t('Zjišťuji…', 'Checking...') : t('Obnovit stav', 'Refresh Status')}
           </button>
         </div>
@@ -340,7 +340,7 @@ export default function InfraTopologyPage() {
               const st = statusOf(n.id)
               const x = p.cx - p.w / 2, y = p.cy - PILL_H / 2
               return (
-                <g key={n.id} role="button" tabIndex={0} aria-label={n.label}
+                <g key={n.id} role="button" tabIndex={0} aria-label={n.label} aria-pressed={isSel} aria-controls={isSel ? 'infra-topology-selection' : undefined}
                   style={{ cursor: 'pointer', transition: 'opacity 0.15s' }} opacity={emphasized ? 1 : 0.25}
                   onClick={() => setSelected(s => s === n.id ? null : n.id)}
                   onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelected(s => s === n.id ? null : n.id) } }}
@@ -370,7 +370,7 @@ export default function InfraTopologyPage() {
                ['data', t('Data (spravuje · používá · zálohuje)', 'Data (manages · uses · backs up)')],
                ['flow', t('Tok (škálování · telemetrie · alerty)', 'Flow (scale · telemetry · alerts)')]] as [EdgeCat, string][]).map(([cat, lbl]) => (
               <div key={cat} style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
-                <svg width="30" height="10"><line x1="0" y1="5" x2="30" y2="5" stroke={CAT_COLOR[cat]} strokeWidth="1.6" strokeDasharray={CAT_DASHED[cat] ? '5,3' : undefined} markerEnd={`url(#ix-arrow-${cat})`} /></svg>
+                <svg aria-hidden="true" width="30" height="10"><line x1="0" y1="5" x2="30" y2="5" stroke={CAT_COLOR[cat]} strokeWidth="1.6" strokeDasharray={CAT_DASHED[cat] ? '5,3' : undefined} markerEnd={`url(#ix-arrow-${cat})`} /></svg>
                 {lbl}
               </div>
             ))}
@@ -382,21 +382,24 @@ export default function InfraTopologyPage() {
 
         {/* Detail panel */}
         {selectedNode && (
-          <div className="card" style={{ padding: '20px', alignSelf: 'start' }}>
+          <div id="infra-topology-selection" className="card" role="region" aria-label={t('Detail infrastrukturní komponenty', 'Infrastructure component details')} style={{ padding: '20px', alignSelf: 'start' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '14px' }}>
               <div style={{ width: '28px', height: '28px', borderRadius: '8px', background: `${GROUPS[selectedNode.group].color}1a`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: GROUPS[selectedNode.group].color }}>
-                {(() => { const I = GROUPS[selectedNode.group].Icon; return <I size={16} /> })()}
+                {(() => { const I = GROUPS[selectedNode.group].Icon; return <I aria-hidden="true" size={16} /> })()}
               </div>
               <div style={{ fontSize: '14px', fontWeight: 700, color: 'var(--text-primary)' }}>{selectedNode.label}</div>
+              <button type="button" aria-label={t('Zavřít detail infrastruktury', 'Close infrastructure details')} onClick={() => setSelected(null)} style={{ marginLeft: 'auto', background: 'none', border: 'none', color: 'var(--text-secondary)', cursor: 'pointer', padding: '2px' }}>
+                <X aria-hidden="true" size={16} />
+              </button>
               {statusOf(selectedNode.id) && (
                 <div style={{
                   marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: '4px', padding: '2px 8px',
                   borderRadius: '12px', fontSize: '11px', fontWeight: 600,
                   background: `${statusColor(statusOf(selectedNode.id)!)}22`, color: statusColor(statusOf(selectedNode.id)!),
                 }}>
-                  {statusOf(selectedNode.id) === 'UP' && <CheckCircle2 size={12} />}
-                  {statusOf(selectedNode.id) === 'DOWN' && <XCircle size={12} />}
-                  {statusOf(selectedNode.id) === 'UNKNOWN' && <HelpCircle size={12} />}
+                  {statusOf(selectedNode.id) === 'UP' && <CheckCircle2 aria-hidden="true" size={12} />}
+                  {statusOf(selectedNode.id) === 'DOWN' && <XCircle aria-hidden="true" size={12} />}
+                  {statusOf(selectedNode.id) === 'UNKNOWN' && <HelpCircle aria-hidden="true" size={12} />}
                   {statusOf(selectedNode.id)}
                 </div>
               )}
@@ -452,7 +455,7 @@ export default function InfraTopologyPage() {
                 background: 'var(--accent-bg)', color: 'var(--accent)', borderRadius: 'var(--r-md)', fontSize: '12px',
                 fontWeight: 600, textDecoration: 'none', marginTop: '4px', border: '1px solid var(--accent-border, transparent)',
               }}>
-                <Server size={14} /> {t('Otevřít přehled infrastruktury', 'Open infrastructure overview')}
+                <Server aria-hidden="true" size={14} /> {t('Otevřít přehled infrastruktury', 'Open infrastructure overview')}
               </a>
             </div>
           </div>

--- a/openbank-admin-ui/src/app/observability/traces/page.tsx
+++ b/openbank-admin-ui/src/app/observability/traces/page.tsx
@@ -152,7 +152,7 @@ export default function TraceExplorerPage() {
           title={t('Trace Explorer', 'Trace Explorer')}
           subtitle={t('Sleduj jeden požadavek napříč službami — distribuované trasy z Tempa s časováním každého spanu.', 'Watch a single request hop across services — distributed traces from Tempo with per-span timing.')}
           breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Trasování', 'Tracing')}</span></div>}
-          actions={<button onClick={loadTraces} className="btn btn-secondary" disabled={loading} style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+          actions={<button type="button" onClick={loadTraces} className="btn btn-secondary" disabled={loading} aria-busy={loading} aria-label={t('Obnovit trasy z Tempa', 'Refresh traces from Tempo')} style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
             <RefreshCw size={14} aria-hidden="true" className={loading ? 'spin' : undefined} />
             {t('Obnovit', 'Refresh')}
           </button>}
@@ -188,7 +188,7 @@ export default function TraceExplorerPage() {
         ) : (
           <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 340px) minmax(0, 1fr)', gap: '20px', alignItems: 'start' }}>
             {/* Trace list */}
-            <div className="card" style={{ padding: '8px' }}>
+            <div className="card" role="region" aria-label={t('Seznam posledních tras', 'Recent traces list')} style={{ padding: '8px' }}>
               <div style={{
                 fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.06em',
                 color: 'var(--text-tertiary)', fontWeight: 700, padding: '8px 10px 6px',
@@ -199,7 +199,7 @@ export default function TraceExplorerPage() {
                 {(traces ?? []).map(tr => {
                   const active = tr.traceID === selected
                   return (
-                    <button key={tr.traceID} onClick={() => openTrace(tr.traceID)}
+                    <button key={tr.traceID} type="button" onClick={() => openTrace(tr.traceID)} aria-pressed={active} aria-label={`${tr.rootServiceName ?? t('neznámá služba', 'unknown service')} — ${tr.rootTraceName ?? tr.traceID.slice(0, 12)}`}
                       style={{
                         textAlign: 'left', border: 'none', cursor: 'pointer',
                         display: 'flex', alignItems: 'center', gap: '8px',
@@ -220,7 +220,7 @@ export default function TraceExplorerPage() {
                           {fmtDuration(tr.durationMs)}
                         </span>
                       )}
-                      <ChevronRight size={12} style={{ color: 'var(--text-tertiary)', flexShrink: 0 }} />
+                      <ChevronRight aria-hidden="true" size={12} style={{ color: 'var(--text-tertiary)', flexShrink: 0 }} />
                     </button>
                   )
                 })}
@@ -230,12 +230,12 @@ export default function TraceExplorerPage() {
             {/* Waterfall */}
             <div className="card" style={{ padding: '20px', minWidth: 0 }}>
               {!selected ? (
-                <div style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--text-tertiary)', fontSize: '13px', padding: '24px 0', justifyContent: 'center' }}>
-                  <Activity size={15} /> {t('Vyber trasu vlevo pro zobrazení span waterfall.', 'Pick a trace on the left to see the span waterfall.')}
+                <div role="status" style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--text-tertiary)', fontSize: '13px', padding: '24px 0', justifyContent: 'center' }}>
+                  <Activity aria-hidden="true" size={15} /> {t('Vyber trasu vlevo pro zobrazení span waterfall.', 'Pick a trace on the left to see the span waterfall.')}
                 </div>
               ) : spansLoading ? (
-                <div style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--text-tertiary)', fontSize: '13px', padding: '24px 0', justifyContent: 'center' }}>
-                  <RefreshCw size={14} className="spin" /> {t('Načítám spany…', 'Loading spans…')}
+                <div role="status" aria-live="polite" style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--text-tertiary)', fontSize: '13px', padding: '24px 0', justifyContent: 'center' }}>
+                  <RefreshCw aria-hidden="true" size={14} className="spin" /> {t('Načítám spany…', 'Loading spans…')}
                 </div>
               ) : spansUnavailable ? (
                 <DataUnavailable kind={spansUnavailable} service="tempo (observability)" feature={t('Spany trasy', 'Trace spans')} lang={t('cs', 'en') as 'cs' | 'en'} dense />
@@ -248,7 +248,7 @@ export default function TraceExplorerPage() {
                       {selected.slice(0, 24)}…
                     </span>
                     <span style={{ display: 'inline-flex', alignItems: 'center', gap: '5px', fontSize: '12px', color: 'var(--text-secondary)' }}>
-                      <Clock size={12} /> {fmtDuration(traceTotal / 1e6)} · {spans.length} {t('spanů', 'spans')}
+                      <Clock aria-hidden="true" size={12} /> {fmtDuration(traceTotal / 1e6)} · {spans.length} {t('spanů', 'spans')}
                     </span>
                   </div>
                   <div style={{ display: 'flex', flexDirection: 'column', gap: '3px' }}>

--- a/openbank-admin-ui/src/test/cloud-architecture-controls-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/cloud-architecture-controls-a11y.guard.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(join(process.cwd(), 'src/app/docs/cloud-architecture/page.tsx'), 'utf8')
+
+describe('cloud architecture controls accessibility contract', () => {
+  it('names nodes and exposes selection state without dangling references', () => {
+    expect(page).toContain('type="button"')
+    expect(page).toContain('aria-label={`${t(...n.name)} — ${t(...m.label)}`}')
+    expect(page).toContain('aria-pressed={active} aria-controls={active ? \'cloud-architecture-selection\' : undefined}')
+    expect(page).toContain('id="cloud-architecture-selection" className="card" role="region"')
+  })
+
+  it('announces refresh progress and labels the detail close action', () => {
+    expect(page).toContain('type="button"')
+    expect(page).toContain('aria-busy={refreshing}')
+    expect(page).toContain('aria-label={t(\'Zavřít detail architektury\', \'Close architecture details\')}')
+    expect(page).toContain('<RefreshCw aria-hidden="true"')
+    expect(page).toContain('<X aria-hidden="true"')
+    expect(page).toContain('<Info aria-hidden="true"')
+  })
+})

--- a/openbank-admin-ui/src/test/infrastructure-topology-controls-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/infrastructure-topology-controls-a11y.guard.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(join(process.cwd(), 'src/app/infrastructure/topology/page.tsx'), 'utf8')
+
+describe('infrastructure topology controls accessibility contract', () => {
+  it('labels layer filters and exposes node selection state', () => {
+    expect(page).toContain('role="group" aria-label={t(\'Filtrování vrstev infrastruktury\', \'Infrastructure layer filters\')}')
+    expect(page).toContain('type="button" onClick={() => setFilter(key)} aria-pressed={filter === key}')
+    expect(page).toContain('role="button" tabIndex={0} aria-label={n.label} aria-pressed={isSel} aria-controls={isSel ? \'infra-topology-selection\' : undefined}')
+    expect(page).toContain('id="infra-topology-selection" className="card" role="region"')
+  })
+
+  it('announces flow/refresh state and labels detail actions', () => {
+    expect(page).toContain('aria-label={t(flow ? \'Pozastavit tok dat\' : \'Spustit tok dat\', flow ? \'Pause data flow\' : \'Start data flow\')}')
+    expect(page).toContain('type="button" onClick={load} disabled={isChecking} aria-busy={isChecking}')
+    expect(page).toContain('aria-label={t(\'Zavřít detail infrastruktury\', \'Close infrastructure details\')}')
+    expect(page).toContain('<RefreshCw aria-hidden="true"')
+    expect(page).toContain('<Play aria-hidden="true"')
+    expect(page).toContain('<Pause aria-hidden="true"')
+    expect(page).toContain('<X aria-hidden="true"')
+  })
+})

--- a/openbank-admin-ui/src/test/trace-explorer-controls-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/trace-explorer-controls-a11y.guard.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(join(process.cwd(), 'src/app/observability/traces/page.tsx'), 'utf8')
+
+describe('trace explorer controls accessibility contract', () => {
+  it('names the refresh action and exposes the trace selection state', () => {
+    expect(page).toContain('type="button" onClick={loadTraces} className="btn btn-secondary" disabled={loading} aria-busy={loading}')
+    expect(page).toContain('role="region" aria-label={t(\'Seznam posledních tras\', \'Recent traces list\')}')
+    expect(page).toContain('type="button" onClick={() => openTrace(tr.traceID)} aria-pressed={active}')
+    expect(page).toContain('aria-label={`${tr.rootServiceName ?? t(\'neznámá služba\', \'unknown service\')} — ${tr.rootTraceName ?? tr.traceID.slice(0, 12)}`}')
+  })
+
+  it('keeps loading announcements and decorative icons out of the accessibility tree', () => {
+    expect(page).toContain('<RefreshCw aria-hidden="true"')
+    expect(page).toContain('<ChevronRight aria-hidden="true"')
+    expect(page).toContain('<Activity aria-hidden="true"')
+    expect(page).toContain('<Clock aria-hidden="true"')
+  })
+})

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/EventAttribution.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/EventAttribution.kt
@@ -88,6 +88,14 @@ object TopicAttribution {
         // value below is still correct (ScaService.kt's outbox payload sets no source field yet,
         // and "sca-service" is what it will say when it does).
         "openbank.sca.events" to "sca-service",
+        // Issue #5728 (ADR-0249 D4): audit-service did not subscribe to this topic at all, so no
+        // delegation grant lifecycle event was ever audited -- and delegation-service is
+        // money-path (it mints payment rights). Subscribing it is what makes the new spend
+        // reservation events (SpendReserved/SpendConfirmed/SpendReleased) reach the audit trail;
+        // emitting them without this would have been an outbox row nobody reads. Those three
+        // carry their own "sourceService", so they resolve AttributionSource.EVENT; the eight
+        // older lifecycle events do not yet, and resolve TOPIC through this row.
+        "openbank.delegation.events" to "delegation-service",
     )
 
     /** Topics with a verified producer entry. Visible for the coverage test. */

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/EventAttribution.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/EventAttribution.kt
@@ -96,6 +96,28 @@ object TopicAttribution {
         // carry their own "sourceService", so they resolve AttributionSource.EVENT; the eight
         // older lifecycle events do not yet, and resolve TOPIC through this row.
         "openbank.delegation.events" to "delegation-service",
+        // Issue #6035: four more money-path producers were absent from all three places at once
+        // (this table, application.yaml's topics list, and the audit KafkaUser's Read ACLs) --
+        // found by .github/scripts/check-audit-money-path-subscription.py, which derives the set
+        // from `money_path_services` and each service's own outgoing channel declaration. Every
+        // value below is read off the module that DECLARES the outgoing channel, not derived from
+        // the topic's domain segment: a derivation writes a plausible, confident, FALSE service
+        // name into a tamper-evident record, and `source_service` is chain-hashed into
+        // `record_hash`, so it gets exactly one chance to be right.
+        //
+        // None of the four sets a "sourceService" body field today, so each resolves
+        // AttributionSource.TOPIC through this row; a producer that later populates the field
+        // keeps its own value and upgrades to AttributionSource.EVENT with no edit here.
+        //
+        // openbank-ledger-service/src/main/resources/application.yaml -> ledger-events-out.
+        // The posting record itself -- the largest of the five gaps #6035 names.
+        "openbank.ledger.journal.posted" to "ledger-service",
+        // openbank-sdd-service/src/main/resources/application.yaml -> sdd-events-out.
+        "openbank.sdd.event" to "sdd-service",
+        // openbank-interest-service/src/main/resources/application.yaml -> interest-events-out.
+        "openbank.interest.accrual.event" to "interest-service",
+        // openbank-fraud-service/src/main/resources/application.yaml -> fraud-outbox-out.
+        "openbank.fraud.hold.changed" to "fraud-service",
     )
 
     /** Topics with a verified producer entry. Visible for the coverage test. */

--- a/openbank-audit-service/src/main/resources/application.yaml
+++ b/openbank-audit-service/src/main/resources/application.yaml
@@ -148,7 +148,30 @@ mp:
         # alone (#1034's lesson). audit-service was the only one of the topic's two documented
         # consumers (the other being onboarding-service's projection, #4353) that had never
         # subscribed.
-        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit,openbank.clearing.batch.event,openbank.security.ict.incident,openbank.cards.events,openbank.dispute.events,openbank.domestic.payment.events,openbank.sepa.payment.events,openbank.statement.event,openbank.sanctions.screening.event,openbank.sepa.instant.events,openbank.fx.conversion.completed,openbank.documents.document.event,openbank.payments.swift.event,openbank.lending.events,openbank.sca.events,openbank.delegation.events
+        #
+        # Issue #6035 (money-path audit gap, found by
+        # .github/scripts/check-audit-money-path-subscription.py): four more money-path producers
+        # were missing from all three places at once -- this list, TopicAttribution, and the
+        # audit-service KafkaUser's Read ACLs -- which is the signature of a set that was never
+        # enumerated rather than four independent oversights. Each producer was verified at its
+        # own `mp.messaging.outgoing.<channel>.topic` declaration, never by grepping a topic
+        # literal (a serialised data-class payload has no literal anywhere, #3883):
+        #   openbank.ledger.journal.posted  -- openbank-ledger-service/application.yaml (the
+        #     posting record itself, so the largest of the five named in #6035)
+        #   openbank.sdd.event              -- openbank-sdd-service/application.yaml
+        #   openbank.interest.accrual.event -- openbank-interest-service/application.yaml
+        #   openbank.fraud.hold.changed     -- openbank-fraud-service/application.yaml
+        # All four publish through the standard outbox relay, so each record carries the `ce-type`
+        # header AuditConsumer reads for event_type; none sets a "sourceService" body field, so
+        # they resolve AttributionSource.TOPIC through TopicAttribution.
+        #
+        # NOT changed here, deliberately: `auto.offset.reset`. It is already `earliest` for the
+        # deployed channel (audit-service-msg-override ConfigMap, config_ordinal=500). The
+        # existing 22 topics have committed offsets on group `audit-service` and are unaffected;
+        # the four new ones have none, so they are read from their retention start on first
+        # subscribe. That is the intended audit behaviour, not a mass replay of the existing
+        # surface -- but it is a first-subscribe load spike worth knowing about.
+        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit,openbank.clearing.batch.event,openbank.security.ict.incident,openbank.cards.events,openbank.dispute.events,openbank.domestic.payment.events,openbank.sepa.payment.events,openbank.statement.event,openbank.sanctions.screening.event,openbank.sepa.instant.events,openbank.fx.conversion.completed,openbank.documents.document.event,openbank.payments.swift.event,openbank.lending.events,openbank.sca.events,openbank.delegation.events,openbank.ledger.journal.posted,openbank.sdd.event,openbank.interest.accrual.event,openbank.fraud.hold.changed
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
 "%dev":
   quarkus:

--- a/openbank-audit-service/src/main/resources/application.yaml
+++ b/openbank-audit-service/src/main/resources/application.yaml
@@ -148,7 +148,7 @@ mp:
         # alone (#1034's lesson). audit-service was the only one of the topic's two documented
         # consumers (the other being onboarding-service's projection, #4353) that had never
         # subscribed.
-        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit,openbank.clearing.batch.event,openbank.security.ict.incident,openbank.cards.events,openbank.dispute.events,openbank.domestic.payment.events,openbank.sepa.payment.events,openbank.statement.event,openbank.sanctions.screening.event,openbank.sepa.instant.events,openbank.fx.conversion.completed,openbank.documents.document.event,openbank.payments.swift.event,openbank.lending.events,openbank.sca.events
+        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit,openbank.clearing.batch.event,openbank.security.ict.incident,openbank.cards.events,openbank.dispute.events,openbank.domestic.payment.events,openbank.sepa.payment.events,openbank.statement.event,openbank.sanctions.screening.event,openbank.sepa.instant.events,openbank.fx.conversion.completed,openbank.documents.document.event,openbank.payments.swift.event,openbank.lending.events,openbank.sca.events,openbank.delegation.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
 "%dev":
   quarkus:

--- a/openbank-audit-service/src/main/resources/application.yaml
+++ b/openbank-audit-service/src/main/resources/application.yaml
@@ -156,11 +156,12 @@ mp:
         # enumerated rather than four independent oversights. Each producer was verified at its
         # own `mp.messaging.outgoing.<channel>.topic` declaration, never by grepping a topic
         # literal (a serialised data-class payload has no literal anywhere, #3883):
-        #   openbank.ledger.journal.posted  -- openbank-ledger-service/application.yaml (the
-        #     posting record itself, so the largest of the five named in #6035)
-        #   openbank.sdd.event              -- openbank-sdd-service/application.yaml
-        #   openbank.interest.accrual.event -- openbank-interest-service/application.yaml
-        #   openbank.fraud.hold.changed     -- openbank-fraud-service/application.yaml
+        #   openbank.ledger.journal.posted  --
+        #     openbank-ledger-service/src/main/resources/application.yaml (the posting record
+        #     itself, so the largest of the five named in #6035)
+        #   openbank.sdd.event              -- openbank-sdd-service/src/main/resources/application.yaml
+        #   openbank.interest.accrual.event -- openbank-interest-service/src/main/resources/application.yaml
+        #   openbank.fraud.hold.changed     -- openbank-fraud-service/src/main/resources/application.yaml
         # All four publish through the standard outbox relay, so each record carries the `ce-type`
         # header AuditConsumer reads for event_type; none sets a "sourceService" body field, so
         # they resolve AttributionSource.TOPIC through TopicAttribution.

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/AuditSubscriptionSurfaceIT.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/AuditSubscriptionSurfaceIT.kt
@@ -167,6 +167,41 @@ class AuditSubscriptionSurfaceIT {
     }
 
     /**
+     * Issue #6035: the four money-path topics wired by this change, named as LITERALS.
+     *
+     * The test above is deliberately corpus-driven and therefore cannot see a REMOVAL: delete a
+     * topic from `application.yaml` and the loop simply iterates one fewer topic and stays green.
+     * That is the "a gate whose scope is the thing it checks reads as passing when the list is
+     * short" shape. These four are the production wiring this change adds, so they are asserted by
+     * name — revert any one of the three artefacts and this goes red naming the topic.
+     *
+     * It asserts two of the three places. The third, the `audit-service` KafkaUser's Read ACL, is
+     * unreachable from any test in this repo (there is no Kafka broker in any test here, only the
+     * in-memory connector) and is the gate's job:
+     * `.github/scripts/check-audit-money-path-subscription.py --enforce`.
+     */
+    @Test
+    fun `the money-path topics wired by issue 6035 are subscribed and attributed`() {
+        val subscribed = subscribedTopics()
+        val failures = WIRED_BY_6035.mapNotNull { (topic, producer) ->
+            when {
+                topic !in subscribed ->
+                    "$topic: absent from mp.messaging.incoming.$CHANNEL.topics — nothing is read, " +
+                        "and no error is raised anywhere"
+                TopicAttribution.sourceService(topic) == null ->
+                    "$topic: no TopicAttribution entry — every row would land on the \"$UNKNOWN\" " +
+                        "sentinel, and source_service is chain-hashed into record_hash so it can " +
+                        "never be corrected"
+                TopicAttribution.sourceService(topic) != producer ->
+                    "$topic: TopicAttribution says ${TopicAttribution.sourceService(topic)}, " +
+                        "the module declaring the outgoing channel is $producer"
+                else -> null
+            }
+        }
+        assertThat(failures).`as`("issue #6035 wiring").isEmpty()
+    }
+
+    /**
      * A record shaped exactly as SmallRye Kafka delivers one: the topic on
      * [io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata], the outbox event type
      * on the `ce-type` header. `accountId` carries the per-topic marker so the row is findable by a
@@ -252,5 +287,17 @@ class AuditSubscriptionSurfaceIT {
         const val UNKNOWN = "unknown"
         const val POLL_MILLIS = 100L
         const val AWAIT_NANOS = 30_000_000_000L
+
+        /**
+         * topic -> the module that DECLARES the outgoing channel producing it, read off that
+         * module's own `mp.messaging.outgoing.<channel>.topic` rather than derived from the
+         * topic's domain segment (a derivation is wrong for eight of the subscribed topics).
+         */
+        val WIRED_BY_6035 = mapOf(
+            "openbank.ledger.journal.posted" to "ledger-service",
+            "openbank.sdd.event" to "sdd-service",
+            "openbank.interest.accrual.event" to "interest-service",
+            "openbank.fraud.hold.changed" to "fraud-service",
+        )
     }
 }

--- a/openbank-contracts/openbank-delegation-service/asyncapi.yaml
+++ b/openbank-contracts/openbank-delegation-service/asyncapi.yaml
@@ -78,6 +78,12 @@ channels:
         $ref: '#/components/messages/DelegationRenounced'
       DelegationExpired:
         $ref: '#/components/messages/DelegationExpired'
+      SpendReserved:
+        $ref: '#/components/messages/SpendReserved'
+      SpendConfirmed:
+        $ref: '#/components/messages/SpendConfirmed'
+      SpendReleased:
+        $ref: '#/components/messages/SpendReleased'
 
 operations:
   publishDelegationEvents:
@@ -96,6 +102,13 @@ operations:
       read model so that enforcing a delegation never requires a synchronous call to
       delegation-service. When either merges, add it here; a consumer absent from this list is a
       consumer nobody has agreed to keep compatible.
+
+      **`openbank-audit-service` subscribes as of #5728** (ADR-0249 D4). It was not subscribed to
+      this topic before, so no delegation event of any kind reached the audit trail — which is why
+      adding the spend-reservation events below without the subscription would have been an outbox
+      row nobody reads. It consumes every message on this channel generically (no per-type logic),
+      so a new event type does not break it; what it needs is `sourceService`, which the three
+      Spend* messages carry and the eight lifecycle messages do not yet.
     messages:
       - $ref: '#/channels/delegationEvents/messages/DelegationOffered'
       - $ref: '#/channels/delegationEvents/messages/DelegationActivated'
@@ -105,6 +118,9 @@ operations:
       - $ref: '#/channels/delegationEvents/messages/DelegationReinstated'
       - $ref: '#/channels/delegationEvents/messages/DelegationRenounced'
       - $ref: '#/channels/delegationEvents/messages/DelegationExpired'
+      - $ref: '#/channels/delegationEvents/messages/SpendReserved'
+      - $ref: '#/channels/delegationEvents/messages/SpendConfirmed'
+      - $ref: '#/channels/delegationEvents/messages/SpendReleased'
 
 components:
   messageTraits:
@@ -247,6 +263,28 @@ components:
                 `{"code":"CZK"}` while every consumer reads this as text. Matches the fleet's
                 event convention (AccountEvents, LedgerEvents).
 
+    # ADR-0249 D3/D4 — one unit of delegated spend. `aggregateId` is still the GRANT, not the
+    # reservation: the partition key is `aggregateId`, and keying on the reservation would let a
+    # consumer see spend against an authority whose revocation it has not applied yet.
+    reservation:
+      type: object
+      required: [reservationId, amount]
+      properties:
+        reservationId:
+          type: string
+          format: uuid
+          description: The unit of spend. Unique; NOT the partition key.
+        amount:
+          type: object
+          required: [amount, currency]
+          properties:
+            amount: { type: string, format: decimal }
+            currency:
+              type: string
+              minLength: 3
+              maxLength: 3
+              description: ISO 4217, flat — same `EventMoney` shape as `perTransactionLimit`.
+
   messages:
     DelegationOffered:
       name: DelegationOffered
@@ -385,3 +423,80 @@ components:
           - $ref: '#/components/schemas/envelope'
           - $ref: '#/components/schemas/parties'
           - $ref: '#/components/schemas/resource'
+
+    SpendReserved:
+      name: SpendReserved
+      title: Headroom was taken under the grant's cumulative ceilings
+      summary: |
+        Emitted by `SpendReservationService.reserve` and written to `delegation_outbox` in the SAME
+        transaction as the reservation row, so a committed reservation always has its event.
+
+        Emitted only for a NEWLY created reservation. An idempotent replay returns the reservation
+        an earlier call created and emits nothing — it created no state, so a second event would
+        claim a second spend. A refusal creates nothing and emits nothing either; a refused reserve
+        is visible as the absence of this event, not as an event of its own.
+
+        `idempotencyKey` is the caller's opaque key for the payment this reservation backs — the
+        only link from the audit trail to the money movement that consumed the headroom.
+      contentType: application/json
+      traits:
+        - $ref: '#/components/messageTraits/outboxHeaders'
+      payload:
+        allOf:
+          - $ref: '#/components/schemas/envelope'
+          - $ref: '#/components/schemas/parties'
+          - $ref: '#/components/schemas/reservation'
+          - type: object
+            required: [idempotencyKey]
+            properties:
+              idempotencyKey:
+                type: string
+
+    SpendConfirmed:
+      name: SpendConfirmed
+      title: The money moved — the headroom stays consumed
+      summary: |
+        Terminal for the reservation. Emitted only when the compare-and-set in
+        `SpendReservationRepository.settle` actually won: the losing side of a confirm/release race
+        changed nothing, and a re-confirm of an already-CONFIRMED reservation is a no-op replay, so
+        neither emits. One reservation therefore yields at most one settlement event.
+      contentType: application/json
+      traits:
+        - $ref: '#/components/messageTraits/outboxHeaders'
+      payload:
+        allOf:
+          - $ref: '#/components/schemas/envelope'
+          - $ref: '#/components/schemas/parties'
+          - $ref: '#/components/schemas/reservation'
+          - type: object
+            required: [settledAt]
+            properties:
+              settledAt:
+                type: string
+                format: date-time
+                description: >-
+                  When the reservation left RESERVED. Distinct from `occurredAt` only in intent:
+                  both are this call's clock reading, and neither has a default — an `occurredAt`
+                  that defaults is the Instant.EPOCH shape (#3874/#3883) that reads as 1970.
+
+    SpendReleased:
+      name: SpendReleased
+      title: The payment did not happen — the headroom comes back
+      summary: |
+        Terminal for the reservation, and the only settlement that RESTORES headroom. Same
+        emit-once-on-a-won-CAS rule as `SpendConfirmed`. A release is refused outright once the
+        reservation is CONFIRMED, so this event can never re-open a ceiling already spent through.
+      contentType: application/json
+      traits:
+        - $ref: '#/components/messageTraits/outboxHeaders'
+      payload:
+        allOf:
+          - $ref: '#/components/schemas/envelope'
+          - $ref: '#/components/schemas/parties'
+          - $ref: '#/components/schemas/reservation'
+          - type: object
+            required: [settledAt]
+            properties:
+              settledAt:
+                type: string
+                format: date-time

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/port/out/SpendReservationPorts.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/port/out/SpendReservationPorts.kt
@@ -9,6 +9,7 @@ import com.openbank.delegation.domain.model.SpendDecision
 import com.openbank.delegation.domain.model.SpendReservation
 import com.openbank.delegation.domain.model.SpendReservationState
 import com.openbank.delegation.domain.model.SpendWindow
+import com.openbank.libs.domain.event.DomainEvent
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -36,10 +37,17 @@ interface SpendReservationRepository {
      * [decide] is invoked with the totals of every RESERVED and CONFIRMED reservation on this grant
      * inside [window], denominated in [candidate]'s currency. It is called at most once, and only
      * after the concurrency guarantee is in place.
+     *
+     * [auditEvent] is written to the outbox INSIDE the same transaction as the insert, so a
+     * committed reservation always has its audit event and a rolled-back one never does
+     * (ADR-0249 D4, issue #5728). It is built from the reservation that was actually created, and
+     * is invoked ONLY on [ReserveOutcome.Created] — a replay created no state and so is not a
+     * second reservation to audit, and a refusal created none at all.
      */
     suspend fun reserve(
         candidate: SpendReservation,
         window: SpendWindow,
+        auditEvent: (SpendReservation) -> DomainEvent,
         decide: (CountedSpend) -> SpendDecision,
     ): ReserveOutcome
 
@@ -49,11 +57,16 @@ interface SpendReservationRepository {
      * Move a reservation out of RESERVED under a compare-and-set on its current state, so a
      * confirm and a release racing on the same reservation cannot both land. Returns null when the
      * row was not in RESERVED — the caller decides whether that is a replay or a conflict.
+     *
+     * [auditEvent] is written to the outbox in the same transaction as the state change, and only
+     * when the compare-and-set actually won: the losing side of a confirm/release race changed
+     * nothing, so auditing it would record a settlement that never happened.
      */
     suspend fun settle(
         grantId: UUID,
         reservationId: UUID,
         target: SpendReservationState,
         settledAt: OffsetDateTime,
+        auditEvent: (SpendReservation) -> DomainEvent,
     ): SpendReservation?
 }

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/usecase/SpendReservationService.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/usecase/SpendReservationService.kt
@@ -11,12 +11,17 @@ import com.openbank.delegation.application.port.`in`.ReserveSpendUseCase
 import com.openbank.delegation.application.port.out.DelegationRepository
 import com.openbank.delegation.application.port.out.ReserveOutcome
 import com.openbank.delegation.application.port.out.SpendReservationRepository
+import com.openbank.delegation.domain.event.EventMoney
+import com.openbank.delegation.domain.event.SpendConfirmed
+import com.openbank.delegation.domain.event.SpendReleased
+import com.openbank.delegation.domain.event.SpendReserved
 import com.openbank.delegation.domain.model.DelegationGrant
 import com.openbank.delegation.domain.model.SpendCeilings
 import com.openbank.delegation.domain.model.SpendDecision
 import com.openbank.delegation.domain.model.SpendReservation
 import com.openbank.delegation.domain.model.SpendReservationState
 import com.openbank.delegation.domain.model.SpendWindows
+import com.openbank.libs.domain.event.DomainEvent
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import java.time.Clock
@@ -64,6 +69,20 @@ class SpendReservationService(
         val outcome = reservationRepository.reserve(
             candidate = candidate,
             window = SpendWindows.windowAt(now),
+            // ADR-0249 D4 (#5728). `now` is this call's real clock reading, not a default: an
+            // `occurredAt` that defaults is the Instant.EPOCH shape (#3874/#3883) that every
+            // isNotNull() assertion in the fleet agreed with while the trail claimed 1970.
+            auditEvent = { reservation ->
+                SpendReserved(
+                    aggregateId = grant.id,
+                    reservationId = reservation.id,
+                    grantorPartyId = grant.grantorPartyId,
+                    granteePartyId = grant.granteePartyId,
+                    amount = EventMoney(reservation.amount.amount, reservation.amount.currency.code),
+                    idempotencyKey = reservation.idempotencyKey,
+                    occurredAt = now.toInstant(),
+                )
+            },
         ) { counted -> SpendCeilings.evaluate(grant, command.amount, counted, now) }
 
         return when (outcome) {
@@ -97,8 +116,11 @@ class SpendReservationService(
         callerPartyId: CallerPartyId,
         target: SpendReservationState,
     ): SpendReservation {
-        loadForGrantee(delegationId, callerPartyId)
-        val settled = reservationRepository.settle(delegationId, reservationId, target, OffsetDateTime.now(clock))
+        val grant = loadForGrantee(delegationId, callerPartyId)
+        val now = OffsetDateTime.now(clock)
+        val settled = reservationRepository.settle(delegationId, reservationId, target, now) { reservation ->
+            settlementEvent(grant, reservation, target, now)
+        }
         if (settled != null) return settled
 
         val current = reservationRepository.findById(delegationId, reservationId)
@@ -107,6 +129,50 @@ class SpendReservationService(
         throw SpendReservationStateException(
             "reservation $reservationId is ${current.state} and cannot become $target",
         )
+    }
+
+    /**
+     * ADR-0249 D4 — the confirmation and the release halves of "every grant, reservation,
+     * confirmation and revocation is an audit event" (#5728).
+     *
+     * Built here rather than in the repository because the grantor/grantee pair belongs to the
+     * grant, which the use case has already loaded and authorised against; the repository sees
+     * only the reservation row.
+     */
+    private fun settlementEvent(
+        grant: DelegationGrant,
+        reservation: SpendReservation,
+        target: SpendReservationState,
+        now: OffsetDateTime,
+    ): DomainEvent {
+        val amount = EventMoney(reservation.amount.amount, reservation.amount.currency.code)
+        val settledAt = reservation.settledAt ?: now
+        return when (target) {
+            SpendReservationState.CONFIRMED -> SpendConfirmed(
+                aggregateId = grant.id,
+                reservationId = reservation.id,
+                grantorPartyId = grant.grantorPartyId,
+                granteePartyId = grant.granteePartyId,
+                amount = amount,
+                settledAt = settledAt,
+                occurredAt = now.toInstant(),
+            )
+
+            SpendReservationState.RELEASED -> SpendReleased(
+                aggregateId = grant.id,
+                reservationId = reservation.id,
+                grantorPartyId = grant.grantorPartyId,
+                granteePartyId = grant.granteePartyId,
+                amount = amount,
+                settledAt = settledAt,
+                occurredAt = now.toInstant(),
+            )
+
+            // `settle` is only ever reached from confirm() or release(); RESERVED is not a target
+            // the compare-and-set accepts, so this branch is unreachable rather than a state to
+            // audit. Failing loudly beats inventing an event type for it.
+            SpendReservationState.RESERVED -> error("RESERVED is not a settlement target")
+        }
     }
 
     /**

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/domain/event/DelegationEvents.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/domain/event/DelegationEvents.kt
@@ -151,3 +151,89 @@ data class DelegationExpired(
     override val eventType = "DelegationExpired"
     override val version = 1L
 }
+
+/*
+ * ADR-0249 D4 — the reservation half of "every grant, reservation, confirmation and revocation is
+ * an audit event" (issue #5728).
+ *
+ * Until these existed, the D3 reserve/confirm/release path moved real money on a delegated
+ * authority and wrote nothing to the outbox at all, while this ADR was the compliance-facing
+ * record claiming it did. Card issuance/revocation was the only audited half.
+ *
+ * **Why `aggregateId` is the GRANT and not the reservation.** `OutboxKafkaHeaders.partitionKey`
+ * returns `aggregateId`, so keying on the grant puts a reserve and a revoke of the same grant on
+ * one partition, in order. Keying on the reservation would let a consumer see spend against an
+ * authority whose revocation it has not applied yet. The reservation keeps its own id in
+ * [SpendReserved.reservationId] and friends, which is what identifies the unit of spend.
+ *
+ * **Why PascalCase and not SCREAMING_SNAKE_CASE.** These share one topic
+ * (`openbank.delegation.events`) with the eight lifecycle events above, whose `eventType` is
+ * PascalCase and whose only in-tree consumers (`CardDelegationEventConsumer`, the account-service
+ * twin) match those strings literally. The SCREAMING_SNAKE spelling belongs to a different
+ * producer and a different topic — `EdgeAuditPublisher`'s `openbank.customer.audit`, where
+ * `CUSTOMER_DELEGATED_CARD_ISSUED` lives. Putting a second idiom into this stream would make the
+ * topic's own convention unstateable.
+ */
+
+/**
+ * Producing service, read by `AuditConsumer.resolveSourceService` as the strongest
+ * (EVENT-sourced) attribution — issues #3994/#5256, where producers omitting it landed every
+ * audit row as `"unknown"` with no error, because the consumer falls back to `?: "unknown"`.
+ *
+ * These are serialised data classes, so the wire key is this Kotlin property name and a grep for
+ * a quoted `"sourceService"` finds nothing here; `SpendReservationEventsTest` asserts it off real
+ * serialised JSON rather than off the property.
+ */
+internal const val DELEGATION_SOURCE_SERVICE = "delegation-service"
+
+/** Headroom was taken under the grant's ceilings — before the money moves. */
+data class SpendReserved(
+    override val aggregateId: UUID,
+    val reservationId: UUID,
+    val grantorPartyId: UUID,
+    val granteePartyId: UUID,
+    val amount: EventMoney,
+    /**
+     * The caller's key for the spend this reservation backs — the only link from the audit trail
+     * to the payment that consumed the headroom. Opaque and caller-chosen; never a PII field.
+     */
+    val idempotencyKey: String,
+    override val occurredAt: Instant,
+) : DomainEvent(occurredAt) {
+    override val aggregateType = "DelegationGrant"
+    override val eventType = "SpendReserved"
+    override val version = 1L
+    val sourceService: String = DELEGATION_SOURCE_SERVICE
+}
+
+/** The money moved: the headroom stays consumed. Terminal for this reservation. */
+data class SpendConfirmed(
+    override val aggregateId: UUID,
+    val reservationId: UUID,
+    val grantorPartyId: UUID,
+    val granteePartyId: UUID,
+    val amount: EventMoney,
+    val settledAt: OffsetDateTime,
+    override val occurredAt: Instant,
+) : DomainEvent(occurredAt) {
+    override val aggregateType = "DelegationGrant"
+    override val eventType = "SpendConfirmed"
+    override val version = 1L
+    val sourceService: String = DELEGATION_SOURCE_SERVICE
+}
+
+/** The payment did not happen: the headroom comes back. Terminal for this reservation. */
+data class SpendReleased(
+    override val aggregateId: UUID,
+    val reservationId: UUID,
+    val grantorPartyId: UUID,
+    val granteePartyId: UUID,
+    val amount: EventMoney,
+    val settledAt: OffsetDateTime,
+    override val occurredAt: Instant,
+) : DomainEvent(occurredAt) {
+    override val aggregateType = "DelegationGrant"
+    override val eventType = "SpendReleased"
+    override val version = 1L
+    val sourceService: String = DELEGATION_SOURCE_SERVICE
+}

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/persistence/repository/SpendReservationRepositoryImpl.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/persistence/repository/SpendReservationRepositoryImpl.kt
@@ -4,6 +4,8 @@
 
 package com.openbank.delegation.infrastructure.persistence.repository
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.delegation.application.port.out.DelegationOutboxRepository
 import com.openbank.delegation.application.port.out.ReserveOutcome
 import com.openbank.delegation.application.port.out.SpendReservationRepository
 import com.openbank.delegation.domain.model.CountedSpend
@@ -12,6 +14,8 @@ import com.openbank.delegation.domain.model.SpendReservation
 import com.openbank.delegation.domain.model.SpendReservationState
 import com.openbank.delegation.domain.model.SpendWindow
 import com.openbank.delegation.infrastructure.persistence.entity.SpendReservationEntity
+import com.openbank.libs.domain.event.DomainEvent
+import com.openbank.libs.persistence.outbox.OutboxMessage
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.PanacheRepository
 import io.smallrye.mutiny.Uni
@@ -43,18 +47,27 @@ import java.util.UUID
  * (same serialisation, but keyed on a number with no referential integrity, so a lock could be
  * taken on a grant that does not exist).
  *
+ * ADR-0249 D4 (issue #5728) adds the third: the audit event for a reserve or a settle is written
+ * to `delegation_outbox` INSIDE these same transactions, by the same rule the grant lifecycle
+ * already follows in `DelegationRepositoryImpl`. A separate publish after the commit would be a
+ * second failure point on a money path — the reservation would be real and the audit trail would
+ * not, which is the exact overclaim ADR-0249's Consequences section made about this path.
+ *
  * Idempotency is the second, independent guarantee: `uq_delegation_spend_idempotency` makes a
  * repeated key a database fact rather than a read-then-write, so even a retry that somehow escapes
  * the lock cannot double-count — it violates the constraint instead.
  */
 @ApplicationScoped
-class SpendReservationRepositoryImpl :
-    SpendReservationRepository,
+class SpendReservationRepositoryImpl(
+    private val outboxRepository: DelegationOutboxRepository,
+    private val objectMapper: ObjectMapper,
+) : SpendReservationRepository,
     PanacheRepository<SpendReservationEntity> {
 
     override suspend fun reserve(
         candidate: SpendReservation,
         window: SpendWindow,
+        auditEvent: (SpendReservation) -> DomainEvent,
         decide: (CountedSpend) -> SpendDecision,
     ): ReserveOutcome = Panache.withTransaction {
         Panache.getSession().flatMap { session ->
@@ -63,7 +76,7 @@ class SpendReservationRepositoryImpl :
                     if (existing != null) {
                         Uni.createFrom().item(ReserveOutcome.Replayed(existing.toDomain()) as ReserveOutcome)
                     } else {
-                        countAndInsert(session, candidate, window, decide)
+                        countAndInsert(session, candidate, window, auditEvent, decide)
                     }
                 }
             }
@@ -88,6 +101,7 @@ class SpendReservationRepositoryImpl :
         reservationId: UUID,
         target: SpendReservationState,
         settledAt: OffsetDateTime,
+        auditEvent: (SpendReservation) -> DomainEvent,
     ): SpendReservation? = Panache.withTransaction {
         find("id = ?1 and grantId = ?2", reservationId, grantId).firstResult<SpendReservationEntity>()
             .flatMap { before ->
@@ -101,8 +115,14 @@ class SpendReservationRepositoryImpl :
                         reservationId,
                         grantId,
                         SpendReservationState.RESERVED,
-                    ).map { count ->
-                        if (count > 0L) before.toDomain().copy(state = target, settledAt = settledAt) else null
+                    ).flatMap { count ->
+                        if (count > 0L) {
+                            val settled = before.toDomain().copy(state = target, settledAt = settledAt)
+                            outboxRepository.persistInTransaction(outboxMessage(auditEvent(settled)))
+                                .replaceWith(settled)
+                        } else {
+                            Uni.createFrom().nullItem()
+                        }
                     }
                 }
             }
@@ -121,15 +141,25 @@ class SpendReservationRepositoryImpl :
         session: Mutiny.Session,
         candidate: SpendReservation,
         window: SpendWindow,
+        auditEvent: (SpendReservation) -> DomainEvent,
         decide: (CountedSpend) -> SpendDecision,
     ): Uni<ReserveOutcome> = countedSpend(session, candidate, window).flatMap { counted ->
         when (val decision = decide(counted)) {
             is SpendDecision.Refused -> Uni.createFrom().item(ReserveOutcome.Refused(decision) as ReserveOutcome)
 
             SpendDecision.Allowed -> session.persist(SpendReservationEntity.fromDomain(candidate))
+                .flatMap { outboxRepository.persistInTransaction(outboxMessage(auditEvent(candidate))) }
                 .replaceWith(ReserveOutcome.Created(candidate) as ReserveOutcome)
         }
     }
+
+    /** Same shape as `DelegationRepositoryImpl.outboxMessage` — one outbox, one envelope. */
+    private fun outboxMessage(event: DomainEvent): OutboxMessage = OutboxMessage(
+        aggregateId = event.aggregateId,
+        eventType = event.eventType,
+        payload = objectMapper.writeValueAsString(event),
+        createdAt = event.occurredAt,
+    )
 
     /**
      * RESERVED and CONFIRMED count, RELEASED does not, and only rows in the SAME currency as the

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/application/usecase/SpendReservationServiceTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/application/usecase/SpendReservationServiceTest.kt
@@ -9,6 +9,9 @@ import com.openbank.delegation.application.port.`in`.ReserveSpendResult
 import com.openbank.delegation.application.port.out.DelegationRepository
 import com.openbank.delegation.application.port.out.ReserveOutcome
 import com.openbank.delegation.application.port.out.SpendReservationRepository
+import com.openbank.delegation.domain.event.SpendConfirmed
+import com.openbank.delegation.domain.event.SpendReleased
+import com.openbank.delegation.domain.event.SpendReserved
 import com.openbank.delegation.domain.model.CountedSpend
 import com.openbank.delegation.domain.model.DelegationCapability
 import com.openbank.delegation.domain.model.DelegationGrant
@@ -19,6 +22,7 @@ import com.openbank.delegation.domain.model.SpendRefusalReason
 import com.openbank.delegation.domain.model.SpendReservation
 import com.openbank.delegation.domain.model.SpendReservationState
 import com.openbank.delegation.domain.model.SpendWindow
+import com.openbank.libs.domain.event.DomainEvent
 import com.openbank.libs.domain.money.Money
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -216,14 +220,118 @@ class SpendReservationServiceTest {
      * Counts for real instead of returning canned answers, so the "reserved counts / confirmed
      * counts / released does not" rule is exercised by every test above rather than restated.
      */
+    // --- ADR-0249 D4 audit events (issue #5728) ---
+    //
+    // The ADR's Consequences section claims "every grant, reservation, confirmation and revocation
+    // is an audit event". Before #5728 this path emitted NOTHING, and the claim was checked by
+    // nobody. These assert the CONTENT — event type, both party ids, the reservation id, the
+    // amount, `sourceService` and a real clock reading — not merely that something was emitted:
+    // "the publisher was called" cannot tell a correct event from an empty one.
+
+    @Test
+    fun `a created reservation emits SpendReserved naming both parties, the reservation and the amount`() {
+        val result = reserve("1500.00", key = "payment-7")
+
+        val event = reservations.events.single()
+        assertThat(event).isInstanceOf(SpendReserved::class.java)
+        val reserved = event as SpendReserved
+        assertThat(reserved.eventType).isEqualTo("SpendReserved")
+        assertThat(reserved.aggregateType).isEqualTo("DelegationGrant")
+        // The GRANT is the aggregate/partition key; the reservation is a field. Keying on the
+        // reservation would let a consumer see spend against an authority whose revocation it has
+        // not applied yet.
+        assertThat(reserved.aggregateId).isEqualTo(currentGrant.id)
+        assertThat(reserved.reservationId).isEqualTo(result.reservation.id)
+        assertThat(reserved.grantorPartyId).isEqualTo(grantor)
+        assertThat(reserved.granteePartyId).isEqualTo(grantee)
+        assertThat(reserved.amount.amount).isEqualByComparingTo(BigDecimal("1500.00"))
+        assertThat(reserved.amount.currency).isEqualTo("CZK")
+        assertThat(reserved.idempotencyKey).isEqualTo("payment-7")
+        assertThat(reserved.sourceService).isEqualTo("delegation-service")
+    }
+
+    @Test
+    fun `confirm emits SpendConfirmed and release emits SpendReleased, each once`() {
+        val toConfirm = reserve("100.00")
+        val toRelease = reserve("200.00")
+        runBlocking { service.confirm(currentGrant.id, toConfirm.reservation.id, grantee) }
+        runBlocking { service.release(currentGrant.id, toRelease.reservation.id, grantee) }
+
+        val confirmed = reservations.events.filterIsInstance<SpendConfirmed>().single()
+        assertThat(confirmed.eventType).isEqualTo("SpendConfirmed")
+        assertThat(confirmed.aggregateId).isEqualTo(currentGrant.id)
+        assertThat(confirmed.reservationId).isEqualTo(toConfirm.reservation.id)
+        assertThat(confirmed.grantorPartyId).isEqualTo(grantor)
+        assertThat(confirmed.granteePartyId).isEqualTo(grantee)
+        assertThat(confirmed.amount.amount).isEqualByComparingTo(BigDecimal("100.00"))
+        assertThat(confirmed.settledAt).isEqualTo(now)
+        assertThat(confirmed.sourceService).isEqualTo("delegation-service")
+
+        val released = reservations.events.filterIsInstance<SpendReleased>().single()
+        assertThat(released.eventType).isEqualTo("SpendReleased")
+        assertThat(released.reservationId).isEqualTo(toRelease.reservation.id)
+        assertThat(released.amount.amount).isEqualByComparingTo(BigDecimal("200.00"))
+        assertThat(released.settledAt).isEqualTo(now)
+        assertThat(released.sourceService).isEqualTo("delegation-service")
+    }
+
+    @Test
+    fun `a replay and a refusal emit no event`() {
+        reserve("3000.00", key = "payment-42")
+        reserve("3000.00", key = "payment-42")
+        assertThatThrownBy { reserve("2500.00") }
+            .isInstanceOf(SpendReservationRefusedException::class.java)
+
+        // One reservation exists, so exactly one SpendReserved may. A replay created no state and
+        // a refusal created none at all; an event for either would claim a spend that never
+        // happened.
+        assertThat(reservations.events.filterIsInstance<SpendReserved>()).hasSize(1)
+    }
+
+    @Test
+    fun `a no-op re-confirm emits no second event`() {
+        val first = reserve("100.00")
+        runBlocking { service.confirm(currentGrant.id, first.reservation.id, grantee) }
+        runBlocking { service.confirm(currentGrant.id, first.reservation.id, grantee) }
+
+        assertThat(reservations.events.filterIsInstance<SpendConfirmed>()).hasSize(1)
+    }
+
+    @Test
+    fun `occurredAt is a real clock reading, not a default`() {
+        // Deliberately NOT the fixed clock the other tests use, and deliberately NOT isNotNull():
+        // `Instant.EPOCH` defaults passed every isNotNull() assertion in this fleet while the
+        // whole trail claimed 1970-01-01 (#3874/#3883). Only recency can tell them apart.
+        val realClockService = SpendReservationService(delegationRepository, reservations, Clock.systemUTC())
+        val before = Instant.now()
+        runBlocking {
+            realClockService.reserve(
+                ReserveSpendCommand(
+                    callerPartyId = grantee,
+                    delegationId = currentGrant.id,
+                    amount = czk("10.00"),
+                    idempotencyKey = "wall-clock",
+                ),
+            )
+        }
+        val after = Instant.now()
+
+        val reserved = reservations.events.filterIsInstance<SpendReserved>().single()
+        assertThat(reserved.occurredAt).isBetween(before, after)
+    }
+
     private class InMemorySpendReservationRepository : SpendReservationRepository {
         private val rows = ConcurrentHashMap<UUID, SpendReservation>()
 
         fun all(): List<SpendReservation> = rows.values.toList()
 
+        /** Every audit event the service handed us, in order — see [emitted]. */
+        val events = mutableListOf<DomainEvent>()
+
         override suspend fun reserve(
             candidate: SpendReservation,
             window: SpendWindow,
+            auditEvent: (SpendReservation) -> DomainEvent,
             decide: (CountedSpend) -> SpendDecision,
         ): ReserveOutcome {
             rows.values.firstOrNull {
@@ -246,6 +354,10 @@ class SpendReservationServiceTest {
                 is SpendDecision.Refused -> ReserveOutcome.Refused(decision)
                 SpendDecision.Allowed -> {
                     rows[candidate.id] = candidate
+                    // The real repository writes the outbox row inside the insert's transaction
+                    // and ONLY for a Created outcome; the fake mirrors that rule so a test can
+                    // tell an emitted event from an unemitted one.
+                    events += auditEvent(candidate)
                     ReserveOutcome.Created(candidate)
                 }
             }
@@ -259,6 +371,7 @@ class SpendReservationServiceTest {
             reservationId: UUID,
             target: SpendReservationState,
             settledAt: OffsetDateTime,
+            auditEvent: (SpendReservation) -> DomainEvent,
         ): SpendReservation? {
             val existing = findById(grantId, reservationId) ?: return null
             if (existing.state != SpendReservationState.RESERVED) return null
@@ -268,6 +381,7 @@ class SpendReservationServiceTest {
                 SpendReservationState.RESERVED -> return null
             }
             rows[reservationId] = settled
+            events += auditEvent(settled)
             return settled
         }
     }

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/domain/event/SpendReservationEventsTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/domain/event/SpendReservationEventsTest.kt
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.delegation.domain.event
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * ADR-0249 D4 (issue #5728) — what these events actually put ON THE WIRE.
+ *
+ * Asserted off serialised JSON, not off the Kotlin properties. These are serialised data classes,
+ * so `sourceService` exists on the wire only as a property name: a grep for a quoted
+ * `"sourceService"` in this service returns nothing, and a test reading `event.sourceService`
+ * would pass even if Jackson never emitted the field (the card-issuance twin,
+ * `CardEventsTest`, makes the same point for the same reason).
+ *
+ * `sourceService` is what `AuditConsumer.resolveSourceService` reads as the strongest
+ * (EVENT-sourced) attribution. Omitting it is silent: the consumer falls back to `?: "unknown"`
+ * with no error, which is how the fleet reached 76% unattributed rows (#3994/#5256).
+ */
+class SpendReservationEventsTest {
+
+    // WRITE_DATES_AS_TIMESTAMPS disabled to match the CDI ObjectMapper the outbox actually
+    // serialises with (Quarkus disables it by default). A bare ObjectMapper would render
+    // `occurredAt` as an epoch decimal here and as ISO-8601 in production — the test would then
+    // be describing a wire format nothing emits.
+    private val mapper = ObjectMapper()
+        .registerModule(JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
+    private val grant: UUID = UUID.randomUUID()
+    private val reservation: UUID = UUID.randomUUID()
+    private val grantor: UUID = UUID.randomUUID()
+    private val grantee: UUID = UUID.randomUUID()
+    private val at: Instant = Instant.parse("2026-08-20T09:15:00Z")
+    private val settled: OffsetDateTime = OffsetDateTime.ofInstant(at, ZoneOffset.UTC)
+    private val money = EventMoney(BigDecimal("1250.00"), "CZK")
+
+    @Test
+    fun `SpendReserved carries sourceService, the grant as aggregate and the reservation as a field`() {
+        val node = mapper.readTree(
+            mapper.writeValueAsString(
+                SpendReserved(grant, reservation, grantor, grantee, money, "payment-7", at),
+            ),
+        )
+
+        assertThat(node.get("sourceService").asText()).isEqualTo("delegation-service")
+        assertThat(node.get("eventType").asText()).isEqualTo("SpendReserved")
+        assertThat(node.get("aggregateType").asText()).isEqualTo("DelegationGrant")
+        assertThat(node.get("aggregateId").asText()).isEqualTo(grant.toString())
+        assertThat(node.get("reservationId").asText()).isEqualTo(reservation.toString())
+        assertThat(node.get("grantorPartyId").asText()).isEqualTo(grantor.toString())
+        assertThat(node.get("granteePartyId").asText()).isEqualTo(grantee.toString())
+        assertThat(node.get("idempotencyKey").asText()).isEqualTo("payment-7")
+        // Flat `currency: String`, not the domain CurrencyCode — Jackson renders that as
+        // {"code":"CZK"} while every consumer of this topic reads the field as text.
+        assertThat(node.get("amount").get("currency").asText()).isEqualTo("CZK")
+        assertThat(node.get("amount").get("amount").decimalValue()).isEqualByComparingTo(BigDecimal("1250.00"))
+    }
+
+    @Test
+    fun `SpendConfirmed carries sourceService on the wire`() {
+        val node = mapper.readTree(
+            mapper.writeValueAsString(
+                SpendConfirmed(grant, reservation, grantor, grantee, money, settled, at),
+            ),
+        )
+
+        assertThat(node.get("sourceService").asText()).isEqualTo("delegation-service")
+        assertThat(node.get("eventType").asText()).isEqualTo("SpendConfirmed")
+        assertThat(node.get("reservationId").asText()).isEqualTo(reservation.toString())
+        assertThat(node.hasNonNull("settledAt")).isTrue()
+    }
+
+    @Test
+    fun `SpendReleased carries sourceService on the wire`() {
+        val node = mapper.readTree(
+            mapper.writeValueAsString(
+                SpendReleased(grant, reservation, grantor, grantee, money, settled, at),
+            ),
+        )
+
+        assertThat(node.get("sourceService").asText()).isEqualTo("delegation-service")
+        assertThat(node.get("eventType").asText()).isEqualTo("SpendReleased")
+        assertThat(node.get("reservationId").asText()).isEqualTo(reservation.toString())
+    }
+
+    @Test
+    fun `occurredAt has no default — a caller must pass a clock reading`() {
+        // The Instant.EPOCH shape (#3874/#3883): a defaulted business time is a value every
+        // isNotNull() assertion agrees with and no reader can distinguish from a real one. There
+        // is no no-arg construction to test here BECAUSE the parameter is required, which is the
+        // property under test; this asserts the value that is passed survives serialisation.
+        val node = mapper.readTree(
+            mapper.writeValueAsString(
+                SpendReserved(grant, reservation, grantor, grantee, money, "k", at),
+            ),
+        )
+
+        assertThat(Instant.parse(node.get("occurredAt").asText())).isEqualTo(at)
+        assertThat(Instant.parse(node.get("occurredAt").asText())).isAfter(Instant.EPOCH)
+    }
+}

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/integration/SpendReservationOutboxWriteIT.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/integration/SpendReservationOutboxWriteIT.kt
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.delegation.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.delegation.it.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.config.ConfigProvider
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.sql.Connection
+import java.sql.DriverManager
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * ADR-0249 D4 (issue #5728) — the spend-reservation audit trail, proved by the only means that can.
+ *
+ * **Why an IT and not a unit test.** The guarantee is that the reservation row and its outbox row
+ * commit TOGETHER. A mocked repository cannot show that: it can only show that the use case handed
+ * an event to something. So this drives the real REST endpoint (the only way to get a Vert.x
+ * context for the reactive repository) and reads both tables with plain JDBC — the fleet pattern
+ * from `LendingOutboxWriteIT` and `ConsentRevocationOutboxIT`.
+ *
+ * **What it asserts is CONTENT, not presence.** An outbox row exists is a weak claim; the row must
+ * name the right event type, the right grant and reservation, both parties, the amount, a real
+ * `occurredAt`, and `sourceService` — which `AuditConsumer` falls back to `"unknown"` for, with no
+ * error, when a producer omits it (#3994/#5256).
+ */
+@QuarkusTest
+@QuarkusTestResource(SpendReservationOutboxWriteIT.InMemoryKafkaResource::class)
+@QuarkusTestResource(PostgresTestResource::class)
+class SpendReservationOutboxWriteIT {
+
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> =
+            InMemoryConnector.switchOutgoingChannelsToInMemory("delegation-events-out")
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    private val mapper = ObjectMapper()
+    private val grantor: UUID = UUID.randomUUID()
+    private val grantee: UUID = UUID.randomUUID()
+
+    private fun jdbc(): Connection {
+        val url = ConfigProvider.getConfig().getValue("quarkus.datasource.jdbc.url", String::class.java)
+        return DriverManager.getConnection(url, "openbank", "openbank_secret")
+    }
+
+    private fun seedGrant(): UUID {
+        val id = UUID.randomUUID()
+        jdbc().use { c ->
+            c.prepareStatement(
+                """
+                insert into delegation_grants
+                    (id, grantor_party_id, grantee_party_id, resource_type, resource_id, approval_policy,
+                     daily_limit_amount, daily_limit_currency, valid_from, valid_to, status, created_at, updated_at)
+                values (?, ?, ?, 'ACCOUNT', ?, 'SOLO', 5000.00, 'CZK',
+                        now() - interval '1 day', now() + interval '30 days', 'ACTIVE', now(), now())
+                """.trimIndent(),
+            ).use { ps ->
+                ps.setObject(1, id)
+                ps.setObject(2, grantor)
+                ps.setObject(3, grantee)
+                ps.setObject(4, UUID.randomUUID())
+                ps.executeUpdate()
+            }
+            c.prepareStatement(
+                "insert into delegation_capabilities (grant_id, capability) values (?, 'ACCOUNT_INITIATE_PAYMENT')",
+            ).use { ps ->
+                ps.setObject(1, id)
+                ps.executeUpdate()
+            }
+        }
+        return id
+    }
+
+    /** Outbox payloads for one grant, newest last. Read with plain JDBC — no ORM in the assertion. */
+    private fun outboxPayloads(grantId: UUID, eventType: String): List<String> = jdbc().use { c ->
+        c.prepareStatement(
+            "select payload from delegation_outbox where aggregate_id = ? and event_type = ? order by id",
+        ).use { ps ->
+            ps.setObject(1, grantId)
+            ps.setString(2, eventType)
+            ps.executeQuery().use { rs ->
+                buildList { while (rs.next()) add(rs.getString(1)) }
+            }
+        }
+    }
+
+    private fun reserve(grantId: UUID, amount: String, key: String): String = RestAssured.given()
+        .contentType(ContentType.JSON)
+        .header(CUSTOMER_PARTY_HEADER, grantee.toString())
+        .body("""{"amount": $amount, "currency": "CZK", "idempotencyKey": "$key"}""")
+        .post("/api/v1/delegations/$grantId/reservations")
+        .then().statusCode(HTTP_CREATED)
+        .extract().path("reservationId")
+
+    private fun settle(grantId: UUID, reservationId: String, verb: String) {
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .header(CUSTOMER_PARTY_HEADER, grantee.toString())
+            .post("/api/v1/delegations/$grantId/reservations/$reservationId/$verb")
+            .then().statusCode(HTTP_OK)
+    }
+
+    @Test
+    @TestSecurity(user = "svc", roles = ["ROLE_API"])
+    fun `a reserve commits its audit event in the same transaction as the reservation row`() {
+        val before = Instant.now()
+        val grantId = seedGrant()
+
+        val reservationId = reserve(grantId, "1250.00", "payment-7")
+
+        val payloads = outboxPayloads(grantId, "SpendReserved")
+        assertThat(payloads).hasSize(1)
+        val node = mapper.readTree(payloads.single())
+        assertThat(node.get("eventType").asText()).isEqualTo("SpendReserved")
+        assertThat(node.get("aggregateType").asText()).isEqualTo("DelegationGrant")
+        assertThat(node.get("aggregateId").asText()).isEqualTo(grantId.toString())
+        assertThat(node.get("reservationId").asText()).isEqualTo(reservationId)
+        assertThat(node.get("grantorPartyId").asText()).isEqualTo(grantor.toString())
+        assertThat(node.get("granteePartyId").asText()).isEqualTo(grantee.toString())
+        assertThat(node.get("idempotencyKey").asText()).isEqualTo("payment-7")
+        assertThat(node.get("amount").get("amount").decimalValue()).isEqualByComparingTo(BigDecimal("1250.00"))
+        assertThat(node.get("amount").get("currency").asText()).isEqualTo("CZK")
+        // The attribution field AuditConsumer falls back to "unknown" for, silently (#3994/#5256).
+        assertThat(node.get("sourceService").asText()).isEqualTo("delegation-service")
+        // Recency, never isNotNull(): Instant.EPOCH passes isNotNull() and reads as 1970
+        // (#3874/#3883). Only a bounded window can tell a real clock reading from a default.
+        assertThat(Instant.parse(node.get("occurredAt").asText())).isBetween(before, Instant.now())
+    }
+
+    @Test
+    @TestSecurity(user = "svc", roles = ["ROLE_API"])
+    fun `confirm and release each commit their own audit event`() {
+        val before = Instant.now()
+        val grantId = seedGrant()
+        val toConfirm = reserve(grantId, "100.00", "to-confirm")
+        val toRelease = reserve(grantId, "200.00", "to-release")
+
+        settle(grantId, toConfirm, "confirm")
+        settle(grantId, toRelease, "release")
+
+        val confirmed = mapper.readTree(outboxPayloads(grantId, "SpendConfirmed").single())
+        assertThat(confirmed.get("reservationId").asText()).isEqualTo(toConfirm)
+        assertThat(confirmed.get("grantorPartyId").asText()).isEqualTo(grantor.toString())
+        assertThat(confirmed.get("granteePartyId").asText()).isEqualTo(grantee.toString())
+        assertThat(confirmed.get("amount").get("amount").decimalValue()).isEqualByComparingTo(BigDecimal("100.00"))
+        assertThat(confirmed.get("sourceService").asText()).isEqualTo("delegation-service")
+        assertThat(Instant.parse(confirmed.get("occurredAt").asText())).isBetween(before, Instant.now())
+        assertThat(confirmed.hasNonNull("settledAt")).isTrue()
+
+        val released = mapper.readTree(outboxPayloads(grantId, "SpendReleased").single())
+        assertThat(released.get("reservationId").asText()).isEqualTo(toRelease)
+        assertThat(released.get("amount").get("amount").decimalValue()).isEqualByComparingTo(BigDecimal("200.00"))
+        assertThat(released.get("sourceService").asText()).isEqualTo("delegation-service")
+    }
+
+    @Test
+    @TestSecurity(user = "svc", roles = ["ROLE_API"])
+    fun `a replayed reserve and a no-op re-confirm write no second outbox row`() {
+        val grantId = seedGrant()
+        val reservationId = reserve(grantId, "100.00", "same-key")
+        reserve(grantId, "100.00", "same-key")
+
+        settle(grantId, reservationId, "confirm")
+        settle(grantId, reservationId, "confirm")
+
+        // One reservation and one settlement happened, so one event of each may exist. A second
+        // would claim a spend that never took headroom.
+        assertThat(outboxPayloads(grantId, "SpendReserved")).hasSize(1)
+        assertThat(outboxPayloads(grantId, "SpendConfirmed")).hasSize(1)
+    }
+
+    @Test
+    @TestSecurity(user = "svc", roles = ["ROLE_API"])
+    fun `a refused reserve leaves neither a reservation row nor an outbox row`() {
+        val grantId = seedGrant()
+        reserve(grantId, "4000.00", "first")
+
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .header(CUSTOMER_PARTY_HEADER, grantee.toString())
+            .body("""{"amount": 2000.00, "currency": "CZK", "idempotencyKey": "refused"}""")
+            .post("/api/v1/delegations/$grantId/reservations")
+            .then().statusCode(HTTP_CONFLICT)
+
+        // Atomicity in the other direction: nothing committed, so nothing was audited. If the
+        // event were published outside the transaction, this row would exist.
+        assertThat(outboxPayloads(grantId, "SpendReserved")).hasSize(1)
+    }
+
+    private companion object {
+        const val CUSTOMER_PARTY_HEADER = "X-Customer-Party-Id"
+        const val HTTP_OK = 200
+        const val HTTP_CREATED = 201
+        const val HTTP_CONFLICT = 409
+    }
+}

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/out/FinrepPorts.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/out/FinrepPorts.kt
@@ -7,7 +7,22 @@ package com.openbank.finrep.application.port.out
 import java.math.BigDecimal
 import java.time.LocalDate
 
-data class TrialBalanceLineDto(val code: String, val accountType: String, val net: BigDecimal)
+/**
+ * One GL account line of the ledger trial balance.
+ *
+ * [net] is `totalDebit − totalCredit`, ledger's own uniform convention for every account type — so
+ * it is NEGATIVE for a credit-normal account (liabilities, equity, income) and positive for a
+ * debit-normal one (assets, expenses). The mappers are responsible for presenting each FINREP row
+ * in its reporting sign; [com.openbank.finrep.domain.model.TrialBalanceIdentity] relies on the raw
+ * convention being uniform, which is what makes `Σ net == 0` the double-entry identity.
+ *
+ * [currency] is carried because the identity holds PER CURRENCY. Without it the check could be
+ * satisfied by a CZK line cancelling a lost EUR one (issue #5987). It carries NO default on
+ * purpose: a defaulted `"CZK"` would let a response that omits the field deserialize into a
+ * plausible-looking line, silently merging every currency into one residual bucket — the check
+ * would then still pass, for a reason nothing anywhere would report.
+ */
+data class TrialBalanceLineDto(val code: String, val accountType: String, val net: BigDecimal, val currency: String)
 
 interface LedgerPort {
     suspend fun getTrialBalance(asOf: LocalDate): List<TrialBalanceLineDto>

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/FinrepService.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/FinrepService.kt
@@ -23,8 +23,15 @@ import java.time.LocalDate
  * FINREP template rendering (ADR-0097 Phase 1). A pure derivation over the ledger trial balance — it
  * stores nothing and emits nothing, so **every** way it can be wrong still produces a well-formed 200
  * response. [FinrepMetricsPort] is what makes those ways visible: an empty trial balance renders a
- * template of honest-looking zeros, and a balance sheet that does not balance is currently computed
- * into `FinrepTemplate.isBalanced`, serialised, and never looked at again.
+ * template of honest-looking zeros, and a trial balance that does not satisfy double entry is
+ * reported on `FinrepTemplate.isBalanced` and on the `balanced` tag of the render counter.
+ *
+ * That sentence used to read "is currently computed into `FinrepTemplate.isBalanced`, serialised,
+ * and never looked at again". The second half stopped being true when admin-ui's export gate began
+ * blocking on it (#5904); the FIRST half was never true — both mappers passed the literal `true`,
+ * so the `balanced` tag had exactly one reachable value and an alert on it could not fire. Fixed in
+ * #5987: the flag is now `TrialBalanceIdentity.holds(lines)`, which is falsifiable by input the
+ * mappers do not otherwise read.
  */
 @ApplicationScoped
 class FinrepService(private val ledgerPort: LedgerPort, private val metrics: FinrepMetricsPort) : FinrepUseCase {

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0101Mapper.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0101Mapper.kt
@@ -7,6 +7,7 @@ package com.openbank.finrep.domain.mapper
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
 import com.openbank.finrep.domain.model.FinrepCell
 import com.openbank.finrep.domain.model.FinrepTemplate
+import com.openbank.finrep.domain.model.TrialBalanceIdentity
 import java.math.BigDecimal
 import java.time.LocalDate
 
@@ -16,20 +17,38 @@ import java.time.LocalDate
  * EBA FINREP F01.01 structure (simplified):
  *   r010_c010 — Total assets
  *   r380_c010 — Total liabilities
- *   r490_c010 — Total equity (assets − liabilities as derived net)
+ *   r490_c010 — Total equity
+ *
+ * ## Signs (issue #5987)
+ *
+ * Ledger publishes `net = totalDebit − totalCredit` for every account type, so a credit-normal
+ * account arrives NEGATIVE. Every FINREP row is reported as a positive magnitude, hence the
+ * negations below. The previous version summed the raw `net` straight into r380, which reported
+ * liabilities as a negative number against real ledger data, and then derived r490 as
+ * `assets − liabilities` — which for real data is `assets + |liabilities|`, not equity at all.
+ *
+ * ## Equity is SOURCED, not residual — and that is the whole point
+ *
+ * r490 is `−(equity + income − expense)` in ledger sign, i.e. contributed capital and reserves plus
+ * the result of the period not yet closed out to reserves. It is read from the EQUITY, INCOME and
+ * EXPENSE lines. It is deliberately NOT `assets − liabilities`: defining equity as the residual is
+ * what made `isBalanced` unfalsifiable, because the identity then holds algebraically no matter
+ * what the ledger contains. With equity sourced, [TrialBalanceIdentity] over the whole trial
+ * balance is a claim that can be false — see the falsification pairs in `F0101MapperTest`.
+ *
+ * Note what today's chart of accounts means for this: openbank-ledger-service seeds **no EQUITY
+ * accounts at all** (`V1__init_ledger.sql` and every later migration), so `Σ net(EQUITY)` is
+ * genuinely zero and r490 currently reports the retained result alone. That is the honest number
+ * for this ledger, and it does not weaken the check: the identity is evaluated over all five
+ * account types, so a residual introduced anywhere still falsifies it.
  */
 object F0101Mapper {
 
     fun map(lines: List<TrialBalanceLineDto>, asOf: LocalDate): FinrepTemplate {
-        val assets = lines
-            .filter { it.accountType == "ASSET" }
-            .fold(BigDecimal.ZERO) { acc, l -> acc.add(l.net) }
-
-        val liabilities = lines
-            .filter { it.accountType == "LIABILITY" }
-            .fold(BigDecimal.ZERO) { acc, l -> acc.add(l.net) }
-
-        val equity = assets.subtract(liabilities)
+        val assets = sumNet(lines, "ASSET")
+        // Credit-normal, so the reporting magnitude is the negated ledger net.
+        val liabilities = sumNet(lines, "LIABILITY").negate()
+        val equity = sumNet(lines, "EQUITY", "INCOME", "EXPENSE").negate()
 
         val cells = listOf(
             FinrepCell(rowRef = "r010", colRef = "c010", value = assets),
@@ -41,7 +60,11 @@ object F0101Mapper {
             templateId = "F01.01",
             period = asOf,
             cells = cells,
-            isBalanced = true,
+            isBalanced = TrialBalanceIdentity.holds(lines),
         )
     }
+
+    private fun sumNet(lines: List<TrialBalanceLineDto>, vararg accountTypes: String): BigDecimal = lines
+        .filter { it.accountType in accountTypes }
+        .fold(BigDecimal.ZERO) { acc, line -> acc.add(line.net) }
 }

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0200Mapper.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0200Mapper.kt
@@ -7,6 +7,7 @@ package com.openbank.finrep.domain.mapper
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
 import com.openbank.finrep.domain.model.FinrepCell
 import com.openbank.finrep.domain.model.FinrepTemplate
+import com.openbank.finrep.domain.model.TrialBalanceIdentity
 import java.math.BigDecimal
 import java.time.LocalDate
 
@@ -17,18 +18,28 @@ import java.time.LocalDate
  *   r010_c010 — Total income
  *   r030_c010 — Total expense
  *   r450_c010 — Net profit (income − expense)
+ *
+ * Income is credit-normal, so its reporting magnitude is the negated ledger net; expense is
+ * debit-normal and passes through. See `F0101Mapper` for the sign convention (issue #5987).
+ *
+ * ## What `isBalanced` means on a P&L, and why it is not `true` here
+ *
+ * F02.00 has no balance-sheet identity of its own — `net profit = income − expense` is a definition
+ * and can never fail. So this template does NOT report a P&L-internal check. It reports the same
+ * thing F01.01 does: whether the **trial balance it was rendered from** satisfies double entry. A
+ * P&L drawn off a trial balance that does not tie out is not submittable regardless of how
+ * internally consistent its three rows are, and that is a fact about this render which a consumer
+ * of this template can act on.
+ *
+ * The alternative the issue offers — modelling the flag as not-applicable to P&L — was rejected
+ * because the flag would then have exactly one reachable value on this template, which is the
+ * defect being fixed rather than a fix for it.
  */
 object F0200Mapper {
 
     fun map(lines: List<TrialBalanceLineDto>, asOf: LocalDate): FinrepTemplate {
-        val income = lines
-            .filter { it.accountType == "INCOME" }
-            .fold(BigDecimal.ZERO) { acc, l -> acc.add(l.net) }
-
-        val expense = lines
-            .filter { it.accountType == "EXPENSE" }
-            .fold(BigDecimal.ZERO) { acc, l -> acc.add(l.net) }
-
+        val income = sumNet(lines, "INCOME").negate()
+        val expense = sumNet(lines, "EXPENSE")
         val netProfit = income.subtract(expense)
 
         val cells = listOf(
@@ -41,7 +52,11 @@ object F0200Mapper {
             templateId = "F02.00",
             period = asOf,
             cells = cells,
-            isBalanced = true,
+            isBalanced = TrialBalanceIdentity.holds(lines),
         )
     }
+
+    private fun sumNet(lines: List<TrialBalanceLineDto>, accountType: String): BigDecimal = lines
+        .filter { it.accountType == accountType }
+        .fold(BigDecimal.ZERO) { acc, line -> acc.add(line.net) }
 }

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/FinrepTemplate.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/FinrepTemplate.kt
@@ -14,5 +14,11 @@ data class FinrepTemplate(
     val templateId: String,
     val period: LocalDate,
     val cells: List<FinrepCell>,
-    val isBalanced: Boolean = true,
+    /**
+     * Whether the double-entry identity of the trial balance this template was rendered from holds
+     * (`Σ net == 0` per currency, `TrialBalanceIdentity`). NO DEFAULT on purpose (issue #5987): the
+     * field spent its whole life as a hardcoded `true` that no producer computed, and a default
+     * would let a new producer omit it and re-publish that same constant silently.
+     */
+    val isBalanced: Boolean,
 )

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/TrialBalanceIdentity.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/TrialBalanceIdentity.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.finrep.domain.model
+
+import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import java.math.BigDecimal
+
+/**
+ * The double-entry identity of the trial balance a FINREP template was rendered from (issue #5987).
+ *
+ * ## Why this exists, and why the obvious check would have been worthless
+ *
+ * `FinrepTemplate.isBalanced` used to be the literal `true` in both producers. The tempting repair —
+ * recompute `assets − liabilities − equity == 0` inside F01.01 — is **vacuous**, because F01.01
+ * derived equity AS `assets − liabilities`. An identity checked against a quantity defined as its
+ * own residual can only ever hold, so the "fix" would have reported health for the same structural
+ * reason the hardcoded literal did, while looking like a control. That is the defect one level up.
+ *
+ * The independent quantity is the trial balance itself. openbank-ledger-service publishes every GL
+ * line with `net = totalDebit − totalCredit` **uniformly across all five account types** (see
+ * `TrialBalanceLine.net` there), so for a ledger whose journals all balance:
+ *
+ *     Σ net over ALL lines == Σ totalDebit − Σ totalCredit == 0
+ *
+ * per currency. Nothing any FINREP mapper computes implies that sum. It is falsifiable by data the
+ * mappers never look at: F01.01 reads only ASSET/LIABILITY/EQUITY and F02.00 only INCOME/EXPENSE, so
+ * a residual can be introduced from the half of the trial balance the template ignores and the
+ * check still sees it. What it catches in practice is what a reporting-side control is FOR: a
+ * truncated or paginated line list, a filtered or partially-deserialised response, an account type
+ * outside the five, and any ledger-side posting defect that survived to the frozen evidence.
+ *
+ * ## Per currency, never summed across currencies
+ *
+ * Residuals are kept per currency and every currency must hold independently. Summing them would
+ * add CZK to EUR — meaningless as accounting, and weaker as a check: a lost EUR line could be
+ * cancelled by an unrelated CZK one. The grouping is what makes the check unable to be satisfied
+ * by coincidence.
+ */
+object TrialBalanceIdentity {
+
+    /**
+     * Residual `Σ net` per currency. Every entry is zero for a trial balance that balances; any
+     * non-zero entry is the amount by which that currency fails to tie out, signed as
+     * debit-minus-credit. Returned rather than reduced to a boolean so a caller (a metric, an
+     * operator-facing message, a future validation-rule report) can say *how far off* and *where*.
+     */
+    fun residualsByCurrency(lines: List<TrialBalanceLineDto>): Map<String, BigDecimal> = lines
+        .groupBy { it.currency }
+        .mapValues { (_, group) -> group.fold(BigDecimal.ZERO) { acc, line -> acc.add(line.net) } }
+
+    /**
+     * Whether the double-entry identity holds for every currency present.
+     *
+     * An EMPTY trial balance holds trivially, and that is deliberate rather than an oversight: an
+     * absent trial balance is an under-reporting problem, not a balance problem, and it already has
+     * its own detector in `openbank.finrep.trial_balance.lines` (a rendered template of honest zeros
+     * is exactly what that summary exists to make visible). Reporting `isBalanced = false` for it
+     * would collapse two different defects onto one flag — the failure mode `PushResult.skipped()`
+     * shipped in openbank-notification-service.
+     *
+     * `compareTo`, never `equals`: `BigDecimal("0.00") != BigDecimal.ZERO` by `equals` because the
+     * scales differ, so an `equals` check would report a perfectly balanced ledger as unbalanced the
+     * moment any line carried decimal places — which every real money line does.
+     */
+    fun holds(lines: List<TrialBalanceLineDto>): Boolean =
+        residualsByCurrency(lines).values.all { it.compareTo(BigDecimal.ZERO) == 0 }
+}

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/client/LedgerClient.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/client/LedgerClient.kt
@@ -47,7 +47,7 @@ interface LedgerRestClient {
     fun getTrialBalance(@PathParam("asOf") asOf: String): Uni<ClosedPeriodTrialBalanceResponse>
 }
 
-data class TrialBalanceLineResponse(val code: String, val type: String, val net: BigDecimal)
+data class TrialBalanceLineResponse(val code: String, val type: String, val net: BigDecimal, val currency: String)
 
 data class ClosedPeriodTrialBalanceResponse(
     val period: String,
@@ -65,6 +65,7 @@ class LedgerAdapter(@RestClient private val client: LedgerRestClient) : LedgerPo
                 code = line.code,
                 accountType = line.type,
                 net = line.net,
+                currency = line.currency,
             )
         }
     }

--- a/openbank-finrep-service/src/main/resources/openapi.yaml
+++ b/openbank-finrep-service/src/main/resources/openapi.yaml
@@ -20,7 +20,7 @@ info:
 
     Cells are always fully rendered: a value the platform cannot honestly derive is an explicit
     flagged zero (`isDataGap`), never an omitted row, so a regulatory return never has a silent gap.
-  version: 1.0.0
+  version: 1.1.0
 tags:
   - name: FINREP
   - name: COREP
@@ -127,8 +127,9 @@ components:
       type: object
       description: >-
         One rendered FINREP template. F01.01 populates rows r010 (total assets), r380 (total
-        liabilities) and r490 (derived equity); F02.00 populates r010 (total income), r030 (total
-        expense) and r450 (net profit).
+        liabilities) and r490 (total equity); F02.00 populates r010 (total income), r030 (total
+        expense) and r450 (net profit). All rows are reported as positive magnitudes in their
+        natural reporting sign, not in the ledger's debit-minus-credit convention.
       required: [templateId, period, cells, isBalanced]
       properties:
         templateId: { type: string, example: F01.01 }
@@ -142,8 +143,16 @@ components:
         isBalanced:
           type: boolean
           description: >-
-            Whether the template's internal accounting identity holds. Serialized as `isBalanced`,
-            not `balanced` — see the note at the top of this file.
+            Whether the double-entry identity of the trial balance this template was rendered from
+            holds: the sum of every GL line's debit-minus-credit net is zero, evaluated per
+            currency and required to hold for all of them. An empty trial balance holds trivially
+            — that is an under-reporting condition, reported separately, not a balance failure.
+            Serialized as `isBalanced`, not `balanced` — see the note at the top of this file.
+
+            Historical note (issue #5987): up to API version 1.0.0 both producers passed a
+            hardcoded `true` and F01.01 derived equity as `assets - liabilities`, so the value was
+            a constant and no consumer could ever observe `false`. Do not read a `true` served by
+            an older deployment as evidence that anything was checked.
 
     CorepCell:
       type: object

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/C0100MapperTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/C0100MapperTest.kt
@@ -21,11 +21,11 @@ class C0100MapperTest {
         // deposits, interest and fee income/expense — no EQUITY-typed lines, because the
         // ledger's chart of accounts does not seed any capital-structure accounts.
         val lines = listOf(
-            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000")),
-            TrialBalanceLineDto(code = "1001", accountType = "ASSET", net = BigDecimal("120000")),
-            TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("580000")),
-            TrialBalanceLineDto(code = "3000", accountType = "INCOME", net = BigDecimal("15000")),
-            TrialBalanceLineDto(code = "4000", accountType = "EXPENSE", net = BigDecimal("5000")),
+            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
+            TrialBalanceLineDto(code = "1001", accountType = "ASSET", net = BigDecimal("120000"), currency = "CZK"),
+            TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("580000"), currency = "CZK"),
+            TrialBalanceLineDto(code = "3000", accountType = "INCOME", net = BigDecimal("15000"), currency = "CZK"),
+            TrialBalanceLineDto(code = "4000", accountType = "EXPENSE", net = BigDecimal("5000"), currency = "CZK"),
         )
 
         val template = C0100Mapper.map(lines, LocalDate.of(2026, 6, 30))
@@ -55,8 +55,8 @@ class C0100MapperTest {
         // capital-structure accounts (EQUITY-typed lines), the mapper must pick them up
         // automatically without code changes, and stop flagging the rows as gaps.
         val lines = listOf(
-            TrialBalanceLineDto(code = "3900", accountType = "EQUITY", net = BigDecimal("1000000")),
-            TrialBalanceLineDto(code = "3901", accountType = "EQUITY", net = BigDecimal("250000")),
+            TrialBalanceLineDto(code = "3900", accountType = "EQUITY", net = BigDecimal("1000000"), currency = "CZK"),
+            TrialBalanceLineDto(code = "3901", accountType = "EQUITY", net = BigDecimal("250000"), currency = "CZK"),
         )
 
         val template = C0100Mapper.map(lines, LocalDate.of(2026, 6, 30))

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0101MapperTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0101MapperTest.kt
@@ -11,19 +11,122 @@ import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDate
 
+/**
+ * Fixtures use ledger's real sign convention — `net = totalDebit − totalCredit`, so credit-normal
+ * accounts (LIABILITY, EQUITY, INCOME) are NEGATIVE. The previous fixtures passed a positive
+ * liability, which no real trial balance line can carry for a credit-balance account, and that is
+ * why the mapper's `assets − liabilities` derivation read as sensible while being wrong.
+ *
+ * The `isBalanced` assertions here come in falsification PAIRS on purpose (issue #5987). A check
+ * that cannot be shown to fail is not a check, and the specific way the old one could not fail —
+ * equity derived as the residual of the very identity being tested — is invisible to any test that
+ * only ever asserts `true`.
+ */
 class F0101MapperTest {
 
+    private val asOf: LocalDate = LocalDate.of(2026, 6, 30)
+
+    /** Assets 500 000 = liabilities 300 000 + equity 200 000 (retained result). Σ net == 0. */
+    private fun balancedTrialBalance() = listOf(
+        line("1000", "ASSET", "500000"),
+        line("2000", "LIABILITY", "-300000"),
+        line("4000", "INCOME", "-260000"),
+        line("5000", "EXPENSE", "60000"),
+    )
+
     @Test
-    fun `F01_01 maps assets liabilities and derives equity`() {
-        val lines = listOf(
-            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000")),
-            TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("300000")),
-        )
-        val template = F0101Mapper.map(lines, LocalDate.of(2026, 6, 30))
+    fun `F01_01 reports assets liabilities and equity as positive magnitudes`() {
+        val template = F0101Mapper.map(balancedTrialBalance(), asOf)
 
         assertThat(template.templateId).isEqualTo("F01.01")
-        assertThat(template.cells).anyMatch { it.rowRef == "r010" && it.value == BigDecimal("500000") }
-        assertThat(template.cells).anyMatch { it.rowRef == "r380" && it.value == BigDecimal("300000") }
-        assertThat(template.cells).anyMatch { it.rowRef == "r490" && it.value == BigDecimal("200000") }
+        assertThat(cell(template.cells, "r010")).isEqualByComparingTo("500000")
+        assertThat(cell(template.cells, "r380")).isEqualByComparingTo("300000")
+        assertThat(cell(template.cells, "r490")).isEqualByComparingTo("200000")
     }
+
+    @Test
+    fun `equity is sourced from EQUITY INCOME and EXPENSE, not from assets minus liabilities`() {
+        // The discriminating fixture: assets − liabilities is 500 000 − 300 000 = 200 000, but the
+        // P&L half says the result is only 150 000. A residual-derived r490 would report 200 000
+        // and could not tell these apart; a sourced one reports 150 000 AND flags the 50 000 gap.
+        val lines = listOf(
+            line("1000", "ASSET", "500000"),
+            line("2000", "LIABILITY", "-300000"),
+            line("4000", "INCOME", "-210000"),
+            line("5000", "EXPENSE", "60000"),
+        )
+
+        val template = F0101Mapper.map(lines, asOf)
+
+        assertThat(cell(template.cells, "r490")).isEqualByComparingTo("150000")
+        assertThat(template.isBalanced).isFalse()
+    }
+
+    @Test
+    fun `a trial balance that ties out is reported as balanced`() {
+        assertThat(F0101Mapper.map(balancedTrialBalance(), asOf).isBalanced).isTrue()
+    }
+
+    @Test
+    fun `an asset booked with no counterpart is reported as UNBALANCED`() {
+        // The falsifying input. One extra debit-side line and nothing to credit against it — the
+        // shape of a lost or filtered response line, or a ledger-side posting defect that survived
+        // into the frozen evidence.
+        val lines = balancedTrialBalance() + line("1001", "ASSET", "70000")
+
+        assertThat(F0101Mapper.map(lines, asOf).isBalanced).isFalse()
+    }
+
+    @Test
+    fun `a residual in the P&L half falsifies the BALANCE SHEET template`() {
+        // Proof the check is not implied by what F01.01 itself computes: INCOME and EXPENSE feed no
+        // row this template reports as a top-line total, yet a residual introduced there is caught.
+        val lines = balancedTrialBalance() + line("5001", "EXPENSE", "12000")
+
+        assertThat(F0101Mapper.map(lines, asOf).isBalanced).isFalse()
+    }
+
+    @Test
+    fun `a currency that does not tie out falsifies the template even when the totals cancel`() {
+        // Summing residuals across currencies would report this as balanced: EUR is +40 000 short
+        // and CZK is 40 000 long, so a single global sum is exactly zero. Grouping per currency is
+        // what stops the check being satisfiable by coincidence.
+        val lines = listOf(
+            line("1000", "ASSET", "500000"),
+            line("2000", "LIABILITY", "-460000"),
+            line("1000", "ASSET", "100000", currency = "EUR"),
+            line("2000", "LIABILITY", "-140000", currency = "EUR"),
+        )
+
+        assertThat(F0101Mapper.map(lines, asOf).isBalanced).isFalse()
+    }
+
+    @Test
+    fun `decimal scale differences do not fake an imbalance`() {
+        // `BigDecimal("0.00") != BigDecimal.ZERO` by equals. An equals-based residual check would
+        // call every real money trial balance unbalanced.
+        val lines = listOf(
+            line("1000", "ASSET", "150000.00"),
+            line("2000", "LIABILITY", "-150000.0000"),
+        )
+
+        assertThat(F0101Mapper.map(lines, asOf).isBalanced).isTrue()
+    }
+
+    @Test
+    fun `an empty trial balance is balanced, not unbalanced`() {
+        // An absent trial balance is an under-reporting defect with its own detector
+        // (`openbank.finrep.trial_balance.lines`); collapsing it onto this flag would make two
+        // different failures indistinguishable to a consumer acting on either.
+        val template = F0101Mapper.map(emptyList(), asOf)
+
+        assertThat(template.isBalanced).isTrue()
+        assertThat(template.cells).allMatch { it.value.compareTo(BigDecimal.ZERO) == 0 }
+    }
+
+    private fun line(code: String, accountType: String, net: String, currency: String = "CZK") =
+        TrialBalanceLineDto(code = code, accountType = accountType, net = BigDecimal(net), currency = currency)
+
+    private fun cell(cells: List<com.openbank.finrep.domain.model.FinrepCell>, rowRef: String) =
+        cells.single { it.rowRef == rowRef }.value
 }

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0200MapperTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0200MapperTest.kt
@@ -11,19 +11,57 @@ import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDate
 
+/** See `F0101MapperTest` for the sign convention and for why the balance assertions come in pairs. */
 class F0200MapperTest {
 
+    private val asOf: LocalDate = LocalDate.of(2026, 6, 30)
+
+    private fun balancedTrialBalance() = listOf(
+        line("1000", "ASSET", "460000"),
+        line("2000", "LIABILITY", "-420000"),
+        line("4000", "INCOME", "-120000"),
+        line("5000", "EXPENSE", "80000"),
+    )
+
     @Test
-    fun `F02_00 maps income expense and derives net profit`() {
-        val lines = listOf(
-            TrialBalanceLineDto(code = "4000", accountType = "INCOME", net = BigDecimal("120000")),
-            TrialBalanceLineDto(code = "5000", accountType = "EXPENSE", net = BigDecimal("80000")),
-        )
-        val template = F0200Mapper.map(lines, LocalDate.of(2026, 6, 30))
+    fun `F02_00 reports income and expense as positive magnitudes and derives net profit`() {
+        val template = F0200Mapper.map(balancedTrialBalance(), asOf)
 
         assertThat(template.templateId).isEqualTo("F02.00")
-        assertThat(template.cells).anyMatch { it.rowRef == "r010" && it.value == BigDecimal("120000") }
-        assertThat(template.cells).anyMatch { it.rowRef == "r030" && it.value == BigDecimal("80000") }
-        assertThat(template.cells).anyMatch { it.rowRef == "r450" && it.value == BigDecimal("40000") }
+        assertThat(cell(template, "r010")).isEqualByComparingTo("120000")
+        assertThat(cell(template, "r030")).isEqualByComparingTo("80000")
+        assertThat(cell(template, "r450")).isEqualByComparingTo("40000")
     }
+
+    @Test
+    fun `a P&L drawn off a trial balance that ties out is reported as balanced`() {
+        assertThat(F0200Mapper.map(balancedTrialBalance(), asOf).isBalanced).isTrue()
+    }
+
+    @Test
+    fun `a P&L drawn off a trial balance that does NOT tie out is reported as unbalanced`() {
+        // Deliberately introduced on the BALANCE-SHEET side, which F02.00 does not report at all:
+        // the flag is a statement about the render's input, not about the three rows above it.
+        // A P&L is not submittable off a GL that does not balance, however self-consistent it looks.
+        val lines = balancedTrialBalance() + line("1001", "ASSET", "25000")
+
+        assertThat(F0200Mapper.map(lines, asOf).isBalanced).isFalse()
+    }
+
+    @Test
+    fun `net profit stays a definition and can never falsify the flag on its own`() {
+        // Guards against the tempting vacuous check: `income − expense == netProfit` is how r450 is
+        // computed, so asserting it would always hold. This test states that r450 tracks the inputs
+        // exactly, WITHOUT that identity being what `isBalanced` reports.
+        val lines = balancedTrialBalance()
+        val template = F0200Mapper.map(lines, asOf)
+
+        assertThat(cell(template, "r450")).isEqualByComparingTo(cell(template, "r010").subtract(cell(template, "r030")))
+    }
+
+    private fun line(code: String, accountType: String, net: String, currency: String = "CZK") =
+        TrialBalanceLineDto(code = code, accountType = accountType, net = BigDecimal(net), currency = currency)
+
+    private fun cell(template: com.openbank.finrep.domain.model.FinrepTemplate, rowRef: String) =
+        template.cells.single { it.rowRef == rowRef }.value
 }

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/CorepServiceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/CorepServiceTest.kt
@@ -31,8 +31,8 @@ class CorepServiceTest {
     fun `getTemplate dispatches C_01_00 to the own funds mapper`(): Unit = runBlocking {
         val asOf = LocalDate.of(2026, 6, 30)
         val lines = listOf(
-            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000")),
-            TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("300000")),
+            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
+            TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("300000"), currency = "CZK"),
         )
         coEvery { ledgerPort.getTrialBalance(asOf) } returns lines
         val service = CorepService(ledgerPort, FinrepMetricsAdapter(registry))
@@ -64,7 +64,7 @@ class CorepServiceTest {
         // zeros. That honesty is invisible without a series counting them.
         val asOf = LocalDate.of(2026, 6, 30)
         coEvery { ledgerPort.getTrialBalance(asOf) } returns listOf(
-            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000")),
+            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
         )
         val service = CorepService(ledgerPort, FinrepMetricsAdapter(registry))
 

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/FinrepServiceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/FinrepServiceTest.kt
@@ -31,8 +31,15 @@ class FinrepServiceTest {
     fun `getTemplate dispatches F01_01 to the balance sheet mapper`(): Unit = runBlocking {
         val asOf = LocalDate.of(2026, 6, 30)
         val lines = listOf(
-            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000")),
-            TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("300000")),
+            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
+            TrialBalanceLineDto(
+                code = "2000",
+                accountType = "LIABILITY",
+                net = BigDecimal("-300000"),
+                currency = "CZK",
+            ),
+            TrialBalanceLineDto(code = "4000", accountType = "INCOME", net = BigDecimal("-260000"), currency = "CZK"),
+            TrialBalanceLineDto(code = "5000", accountType = "EXPENSE", net = BigDecimal("60000"), currency = "CZK"),
         )
         coEvery { ledgerPort.getTrialBalance(asOf) } returns lines
         val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
@@ -49,8 +56,8 @@ class FinrepServiceTest {
     fun `getTemplate dispatches F02_00 to the P&L mapper`(): Unit = runBlocking {
         val asOf = LocalDate.of(2026, 6, 30)
         val lines = listOf(
-            TrialBalanceLineDto(code = "4000", accountType = "INCOME", net = BigDecimal("120000")),
-            TrialBalanceLineDto(code = "5000", accountType = "EXPENSE", net = BigDecimal("80000")),
+            TrialBalanceLineDto(code = "4000", accountType = "INCOME", net = BigDecimal("-120000"), currency = "CZK"),
+            TrialBalanceLineDto(code = "5000", accountType = "EXPENSE", net = BigDecimal("80000"), currency = "CZK"),
         )
         coEvery { ledgerPort.getTrialBalance(asOf) } returns lines
         val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
@@ -78,8 +85,15 @@ class FinrepServiceTest {
     fun `a rendered template publishes its input size, cell count and balanced flag`(): Unit = runBlocking {
         val asOf = LocalDate.of(2026, 6, 30)
         coEvery { ledgerPort.getTrialBalance(asOf) } returns listOf(
-            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000")),
-            TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("300000")),
+            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
+            TrialBalanceLineDto(
+                code = "2000",
+                accountType = "LIABILITY",
+                net = BigDecimal("-300000"),
+                currency = "CZK",
+            ),
+            TrialBalanceLineDto(code = "4000", accountType = "INCOME", net = BigDecimal("-260000"), currency = "CZK"),
+            TrialBalanceLineDto(code = "5000", accountType = "EXPENSE", net = BigDecimal("60000"), currency = "CZK"),
         )
         val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
 
@@ -88,7 +102,7 @@ class FinrepServiceTest {
         assertThat(
             registry.get("openbank.finrep.templates.rendered")
                 .tag("service", "finrep").tag("framework", "finrep").tag("template", "F01.01")
-                .tag("balanced", template.isBalanced.toString())
+                .tag("balanced", "true")
                 .counter().count(),
         ).isEqualTo(1.0)
         assertThat(
@@ -96,10 +110,38 @@ class FinrepServiceTest {
         ).isEqualTo(1L)
         assertThat(
             registry.get("openbank.finrep.trial_balance.lines").tag("template", "F01.01").summary().totalAmount(),
-        ).isEqualTo(2.0)
+        ).isEqualTo(4.0)
         assertThat(
             registry.get("openbank.finrep.template.cells").tag("template", "F01.01").summary().totalAmount(),
         ).isEqualTo(template.cells.size.toDouble())
+    }
+
+    @Test
+    fun `the balanced tag takes the value FALSE for a trial balance that does not tie out`(): Unit = runBlocking {
+        // The falsification half of the test above, and the reason issue #5987 was filed: while both
+        // mappers passed a hardcoded `true`, this series had exactly ONE reachable value, so an alert
+        // built on it could never fire and the tag looked like health monitoring while measuring
+        // nothing. Asserting `balanced=false` is reachable is what makes the tag worth alerting on.
+        val asOf = LocalDate.of(2026, 6, 30)
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns listOf(
+            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
+            TrialBalanceLineDto(
+                code = "2000",
+                accountType = "LIABILITY",
+                net = BigDecimal("-410000"),
+                currency = "CZK",
+            ),
+        )
+        val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
+
+        val template = service.getTemplate(GetFinrepTemplateQuery(templateId = "F01.01", asOf = asOf))
+
+        assertThat(template.isBalanced).isFalse()
+        assertThat(
+            registry.get("openbank.finrep.templates.rendered")
+                .tag("framework", "finrep").tag("template", "F01.01").tag("balanced", "false")
+                .counter().count(),
+        ).isEqualTo(1.0)
     }
 
     @Test

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/LedgerTrialBalancePactConsumerTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/LedgerTrialBalancePactConsumerTest.kt
@@ -69,9 +69,11 @@ import java.time.LocalDate
  * template still fixes the required field types for a non-empty response, and finrep's mappers fold
  * over an empty list to an all-zero template.
  *
- * Only the three line fields finrep actually consumes (`code`, `type`, `net`) are declared — a
- * consumer contract must not pin provider fields it does not read (`glAccountId`, `name`,
- * `currency`, `totalDebit`, `totalCredit` are ledger's business).
+ * Only the four line fields finrep actually consumes (`code`, `type`, `net`, `currency`) are
+ * declared — a consumer contract must not pin provider fields it does not read (`glAccountId`,
+ * `name`, `totalDebit`, `totalCredit` are ledger's business). `currency` moved from the second
+ * list to the first with issue #5987, when the balance check began evaluating the double-entry
+ * identity per currency.
  */
 @ExtendWith(PactConsumerTestExt::class)
 @PactTestFor(providerName = "openbank-ledger-service", pactVersion = PactSpecVersion.V3)
@@ -107,6 +109,13 @@ class LedgerTrialBalancePactConsumerTest {
                     line.stringType("code", "1100-CASH-CLEARING-CZK")
                     line.stringType("type", "ASSET")
                     line.decimalType("net", 150_000.00)
+                    // Added with issue #5987: finrep now READS `currency`, because the double-entry
+                    // identity behind `isBalanced` holds per currency and a global sum would let a
+                    // CZK line cancel a lost EUR one. A consumer pact must pin exactly the fields
+                    // the consumer consumes — no more (that was the rule when this line was absent)
+                    // and no fewer (the client's `currency` is non-nullable, so a provider that
+                    // stopped sending it would fail deserialization at runtime, not here).
+                    line.stringType("currency", "CZK")
                 }
             }.build(),
         )
@@ -130,15 +139,22 @@ class LedgerTrialBalancePactConsumerTest {
         assertThat(line.code).isNotBlank()
         assertThat(line.type).isNotBlank()
         assertThat(line.net).isNotNull()
+        assertThat(line.currency).isNotBlank()
 
         // ... and the mapper must accept them: proves the contract feeds a real F01.01 render,
         // not merely that some JSON parsed.
         val template = F0101Mapper.map(
-            response.lines.map { TrialBalanceLineDto(code = it.code, accountType = it.type, net = it.net) },
+            response.lines.map {
+                TrialBalanceLineDto(code = it.code, accountType = it.type, net = it.net, currency = it.currency)
+            },
             LocalDate.parse(REPORTING_DATE),
         )
         assertThat(template.cells.map { it.rowRef }).containsExactly("r010", "r380", "r490")
         assertThat(template.cells.first().value).isEqualByComparingTo(BigDecimal("150000.00"))
+        // The pact's single ASSET line does not tie out on its own, so the contract also proves the
+        // balance check runs over real contract data and can answer `false` (issue #5987) — it is
+        // not merely unit-testable against hand-built fixtures.
+        assertThat(template.isBalanced).isFalse()
     }
 
     /** Issues the request against the path the production client is annotated with. */

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/TemplateWireFormatTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/TemplateWireFormatTest.kt
@@ -62,12 +62,37 @@ class TemplateWireFormatTest {
 
     private val mapper = ObjectMapper()
 
-    /** One line per GL account type so every mapper row is populated with a non-zero value. */
+    /**
+     * One line per GL account type so every mapper row is populated with a non-zero value, in
+     * ledger's own `net = totalDebit - totalCredit` sign (credit-normal accounts negative), and
+     * tying out to zero so the rendered `isBalanced` is `true` for a reason rather than by
+     * construction (issue #5987).
+     */
     private val trialBalance = listOf(
-        TrialBalanceLineDto(code = "1100-CASH-CZK", accountType = "ASSET", net = BigDecimal("150000.00")),
-        TrialBalanceLineDto(code = "2100-DEPOSITS-CZK", accountType = "LIABILITY", net = BigDecimal("120000.00")),
-        TrialBalanceLineDto(code = "4100-FEE-INCOME-CZK", accountType = "INCOME", net = BigDecimal("8000.00")),
-        TrialBalanceLineDto(code = "5100-STAFF-COST-CZK", accountType = "EXPENSE", net = BigDecimal("3000.00")),
+        TrialBalanceLineDto(
+            code = "1100-CASH-CZK",
+            accountType = "ASSET",
+            net = BigDecimal("150000.00"),
+            currency = "CZK",
+        ),
+        TrialBalanceLineDto(
+            code = "2100-DEPOSITS-CZK",
+            accountType = "LIABILITY",
+            net = BigDecimal("-125000.00"),
+            currency = "CZK",
+        ),
+        TrialBalanceLineDto(
+            code = "4100-FEE-INCOME-CZK",
+            accountType = "INCOME",
+            net = BigDecimal("-28000.00"),
+            currency = "CZK",
+        ),
+        TrialBalanceLineDto(
+            code = "5100-STAFF-COST-CZK",
+            accountType = "EXPENSE",
+            net = BigDecimal("3000.00"),
+            currency = "CZK",
+        ),
     )
 
     @BeforeEach
@@ -103,12 +128,12 @@ class TemplateWireFormatTest {
         assertThat(cells.first().keys).containsExactlyInAnyOrder("rowRef", "colRef", "value", "currency")
         assertThat(cells.map { it["rowRef"] }).containsExactly("r010", "r380", "r490")
         assertThat(cells.first()["currency"]).isEqualTo("CZK")
-        // r010 total assets, r380 total liabilities, r490 derived equity — proves the cells are
+        // r010 total assets, r380 total liabilities, r490 total equity — proves the cells are
         // really derived from the ledger trial balance, not a fixed skeleton. `value` is a JSON
         // NUMBER (schema `type: number`), so compare numerically — an untyped parse of `150000.00`
         // yields a Double whose toString drops the scale.
         assertThat(cells.map { (it["value"] as Number).toDouble() })
-            .containsExactly(150_000.00, 120_000.00, 30_000.00)
+            .containsExactly(150_000.00, 125_000.00, 25_000.00)
     }
 
     @Test

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/rest/FinrepResourceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/rest/FinrepResourceTest.kt
@@ -44,6 +44,7 @@ class FinrepResourceTest {
             templateId = "F01.01",
             period = LocalDate.now(fixedClock),
             cells = listOf(FinrepCell(rowRef = "r010", colRef = "c010", value = BigDecimal.ZERO)),
+            isBalanced = true,
         )
         val captured = slot<GetFinrepTemplateQuery>()
         coEvery { finrepUseCase.getTemplate(capture(captured)) } returns expected
@@ -63,6 +64,7 @@ class FinrepResourceTest {
             templateId = "F02.00",
             period = explicitDate,
             cells = emptyList(),
+            isBalanced = true,
         )
         val captured = slot<GetFinrepTemplateQuery>()
         coEvery { finrepUseCase.getTemplate(capture(captured)) } returns expected

--- a/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
+++ b/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
@@ -47,7 +47,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: admin-ui
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-admin-ui:sandbox-4d728be5c
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-admin-ui:sandbox-39b4fdd62
           ports:
             - name: http
               containerPort: 3000

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -54,7 +54,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: agent-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-agent-service:sandbox-e62a4765
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-agent-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -42,7 +42,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: aml-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-aml-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-aml-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -53,7 +53,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: anacredit-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-anacredit-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-anacredit-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -50,7 +50,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ap2-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-ap2-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-ap2-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -43,7 +43,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: audit-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-audit-service:sandbox-87b9c00c
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-audit-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
+++ b/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
@@ -189,6 +189,39 @@ spec:
           patternType: literal
         operations: [Read, Describe]
         host: "*"
+      # Issue #6035: four money-path produced topics had no Read grant here, so even after
+      # being added to the subscription list they would have been ACL-denied at runtime with
+      # no error surfaced anywhere (the #5338 shape) -- the poll fails silently and the audit
+      # trail simply has no rows. Each KafkaTopic resource already exists and is owned by its
+      # producer; these are Read grants only, no topic is created here.
+      # components/ledger/kafka-topic.yaml -- the posting record itself.
+      - resource:
+          type: topic
+          name: openbank.ledger.journal.posted
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      # components/sdd/kafka-topic.yaml
+      - resource:
+          type: topic
+          name: openbank.sdd.event
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      # components/interest-service/kafka-topic.yaml
+      - resource:
+          type: topic
+          name: openbank.interest.accrual.event
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      # components/fraud-service/kafka-topics.yaml
+      - resource:
+          type: topic
+          name: openbank.fraud.hold.changed
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
       - resource:
           type: group
           name: audit-service

--- a/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
+++ b/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
@@ -179,6 +179,16 @@ spec:
           patternType: literal
         operations: [Read, Describe]
         host: "*"
+      # Issue #5728 (ADR-0249 D4): audit-service did not subscribe to the delegation topic at
+      # all, so no grant lifecycle event was audited and the new spend-reservation events would
+      # have been ACL-denied on arrival. The KafkaTopic resource already exists (owned by its
+      # producer, components/delegation/kafka-topic.yaml) -- this is only the Read grant.
+      - resource:
+          type: topic
+          name: openbank.delegation.events
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
       - resource:
           type: group
           name: audit-service

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -45,7 +45,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: balance-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-balance-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-balance-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -48,7 +48,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: campaign-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-campaign-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-campaign-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -39,7 +39,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: consent-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-consent-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-consent-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -50,7 +50,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: copilot-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-copilot-service:sandbox-f4ba9569
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-copilot-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/delegation/delegation-service.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-service.yaml
@@ -63,7 +63,7 @@ spec:
             # be DISPATCHED explicitly (`-f services=openbank-delegation-service`): the push
             # path only matches <svc>/src/main or build.gradle.kts, and this change touches
             # neither. The auto-deploy gitops PR then rewrites the pin to the built sha.
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-delegation-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-delegation-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             # HTTP 8126 and management 8090 — both read off the service's own

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -35,7 +35,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: dispute-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-dispute-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-dispute-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - {name: http, containerPort: 8135}

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -66,7 +66,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: document-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/engagement/engagement-service.yaml
+++ b/openbank-infra/gitops/components/engagement/engagement-service.yaml
@@ -67,7 +67,7 @@ spec:
           # src/main (this merge itself, first) triggers auto-deploy to build a real image and
           # open a gitops PR replacing this with the actual sha. Until then, Kyverno's
           # cosign-signature/SBOM-attestation admission policies reject a tag nothing ever pushed.
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-engagement-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-engagement-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/finrep/finrep-service.yaml
+++ b/openbank-infra/gitops/components/finrep/finrep-service.yaml
@@ -42,7 +42,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: finrep-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-finrep-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-finrep-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -33,7 +33,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: fraud-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-fraud-service:sandbox-1fd21708
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-fraud-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - {name: http, containerPort: 8133}

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -32,7 +32,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: fx-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-fx-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-fx-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - {name: http, containerPort: 8119}

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -49,7 +49,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ledger-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-ledger-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-ledger-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -50,7 +50,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mcp-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-mcp-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-mcp-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -66,7 +66,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: notification-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-notification-service:sandbox-7af1e375
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-notification-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/onboarding/onboarding-service.yaml
+++ b/openbank-infra/gitops/components/onboarding/onboarding-service.yaml
@@ -55,7 +55,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: onboarding-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-onboarding-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-onboarding-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -36,7 +36,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: party-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-party-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-party-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -53,7 +53,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: transaction-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-transaction-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-transaction-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1091,7 +1091,7 @@ spec:
         - name: sepa-instant
 
 
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sepa-instant:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sepa-instant:sandbox-14ad7f7a
 
           imagePullPolicy: IfNotPresent
           ports:
@@ -1410,7 +1410,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: clearing-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-clearing-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-clearing-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1708,7 +1708,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: standing-order-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-standing-order-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-standing-order-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1985,7 +1985,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: card-issuance-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-card-issuance-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-card-issuance-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -2263,7 +2263,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: settlement-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-settlement-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-settlement-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -2691,7 +2691,7 @@ spec:
         - name: swift-service
 
 
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-swift-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-swift-service:sandbox-14ad7f7a
 
           imagePullPolicy: IfNotPresent
           ports:
@@ -3004,7 +3004,7 @@ spec:
       containers:
         - name: vop-service
 
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-vop-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-vop-service:sandbox-14ad7f7a
 
           imagePullPolicy: IfNotPresent
           ports:

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -43,7 +43,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: pid-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-pid-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-pid-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -38,7 +38,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: psd2-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-psd2-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-psd2-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - {name: http, containerPort: 8107}

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -60,7 +60,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: sanctions-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sanctions-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sanctions-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -39,7 +39,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: sca-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sca-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sca-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/sdd/sdd-service.yaml
+++ b/openbank-infra/gitops/components/sdd/sdd-service.yaml
@@ -42,7 +42,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: sdd-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sdd-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sdd-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -43,7 +43,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: tpp-registry-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-tpp-registry-service:sandbox-226727f4
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-tpp-registry-service:sandbox-14ad7f7a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/persistence/PostgresProductRepository.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/persistence/PostgresProductRepository.kt
@@ -109,5 +109,12 @@ class PostgresProductRepository(
         doc = mapper.writeValueAsString(p)
     }
 
-    private fun ProductEntity.toDomain(): Product = mapper.readValue(doc, Product::class.java).copy(revision = revision)
+    // `doc` retains the pre-ADR-0105 seed alias (for example `prod-003`) so a database
+    // upgrade does not need to rewrite JSONB. The relational primary key is the canonical
+    // product identity, however, and it is the only id the v1 API may expose: downstream
+    // account records hold that UUID and must be able to round-trip it through this resource.
+    private fun ProductEntity.toDomain(): Product = mapper.readValue(doc, Product::class.java).copy(
+        id = id.toString(),
+        revision = revision,
+    )
 }

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/ProductCatalogResourceTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/ProductCatalogResourceTest.kt
@@ -353,17 +353,21 @@ class ProductCatalogResourceTest {
     }
 
     @Test
-    fun `GET product by canonical account UUID resolves the seeded product (ADR-0105)`() {
+    fun `GET product by canonical account UUID resolves and returns the canonical identity (ADR-0105)`() {
         // account-service references the CZK current/savings products by the UUID it stamps on
         // accounts.product_id; the catalogue must resolve those UUIDs to the same products.
         val current = (
-            Given { this } When { get("/api/v1/products/00000000-0000-0000-0000-0000000000c2") } Then
-                { statusCode(200) }
+            Given { this } When { get("/api/v1/products/00000000-0000-0000-0000-0000000000c2") } Then {
+                statusCode(200)
+                body("id", equalTo("00000000-0000-0000-0000-0000000000c2"))
+            }
             ).extract().body().asString()
         assertThat(current).contains("CURRENT_CZK")
         val savings = (
-            Given { this } When { get("/api/v1/products/00000000-0000-0000-0000-0000000000c3") } Then
-                { statusCode(200) }
+            Given { this } When { get("/api/v1/products/00000000-0000-0000-0000-0000000000c3") } Then {
+                statusCode(200)
+                body("id", equalTo("00000000-0000-0000-0000-0000000000c3"))
+            }
             ).extract().body().asString()
         assertThat(savings).contains("SAVINGS_CZK")
     }

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/contract/ProductCatalogPactBrokerProviderVerificationTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/contract/ProductCatalogPactBrokerProviderVerificationTest.kt
@@ -96,6 +96,25 @@ class ProductCatalogPactBrokerProviderVerificationTest {
         // Intentionally empty — see the KDoc above.
     }
 
+    /**
+     * No seeding: `CURRENT_PERSONAL` carries four seeded fees in `ProductSeed` on every boot.
+     * Keep this broker replay state in lock-step with the always-on `@PactFolder` verifier so a
+     * newly published billing pact cannot pass on a PR and then strand at `can-i-deploy`.
+     */
+    @State("a product with fees exists for code CURRENT_PERSONAL")
+    fun feeBearingProductIsSeeded() {
+        // Intentionally empty — see the KDoc above.
+    }
+
+    /**
+     * The pact-pinned UUID is deliberately absent from `ProductSeed`; the seeded catalogue
+     * already satisfies the account consumer's negative lookup state.
+     */
+    @State("no product exists with id 00000000-0000-0000-0000-000000000fff")
+    fun unknownProductIdIsAbsent() {
+        // Intentionally empty — see the KDoc above.
+    }
+
     @State("trusted insurance term-life schema version 1 is installed")
     fun trustedInsuranceSchemaIsInstalled() {
         // CatalogPackSeeder installs the trusted test pack before provider verification.

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/contract/ProductCatalogPactStateParityTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/contract/ProductCatalogPactStateParityTest.kt
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.productcatalog.contract
+
+import au.com.dius.pact.provider.junitsupport.State
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * The PR-time folder replay and main-push broker replay exercise the same provider pacts. Their
+ * state handlers therefore form one contract surface: missing a state in the broker verifier lets
+ * a PR pass and only blocks deployment later at `can-i-deploy`.
+ */
+class ProductCatalogPactStateParityTest {
+    @Test
+    fun `broker and folder provider verifiers declare identical Pact states`() {
+        assertThat(statesOf(ProductCatalogPactBrokerProviderVerificationTest::class.java))
+            .containsExactlyInAnyOrderElementsOf(statesOf(ProductCatalogPactProviderVerificationTest::class.java))
+    }
+
+    private fun statesOf(type: Class<*>): Set<String> = type.declaredMethods
+        .flatMap { method -> method.getAnnotation(State::class.java)?.value?.asList().orEmpty() }
+        .toSet()
+}

--- a/pacts/openbank-finrep-service-openbank-ledger-service.json
+++ b/pacts/openbank-finrep-service-openbank-ledger-service.json
@@ -23,6 +23,7 @@
           "lines": [
             {
               "code": "1100-CASH-CLEARING-CZK",
+              "currency": "CZK",
               "net": 150000.0,
               "type": "ASSET"
             }
@@ -52,6 +53,14 @@
               ]
             },
             "$.lines[*].code": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.lines[*].currency": {
               "combine": "AND",
               "matchers": [
                 {


### PR DESCRIPTION
## What this does

Wires **four** of the seven money-path produced topics that #6047's gate baselined as `KNOWN_GAPS`
into audit-service's subscription — in **all three** places at once, with the corresponding
baseline entries deleted so a half-fix could not pass:

| topic | producer (module declaring the outgoing channel) | why |
|---|---|---|
| `openbank.ledger.journal.posted` | `openbank-ledger-service` (`ledger-events-out`) | **the posting record itself** — the largest of the five #6035 names |
| `openbank.sdd.event` | `openbank-sdd-service` (`sdd-events-out`) | direct-debit collection lifecycle |
| `openbank.interest.accrual.event` | `openbank-interest-service` (`interest-events-out`) | accrual + withholding remittance |
| `openbank.fraud.hold.changed` | `openbank-fraud-service` (`fraud-outbox-out`) | funds holds |

Three artefacts per topic: `mp.messaging.incoming.audit-events-in.topics`, `TopicAttribution` in
`EventAttribution.kt`, and a Read/Describe ACL on the `audit-service` KafkaUser. Every attribution
value is read off the module that **declares the outgoing channel**, never derived from the topic's
domain segment — `source_service` is chain-hashed into `record_hash` and `audit_entries` is
append-only at the DB (`no_update_audit`/`no_delete_audit` are `DO INSTEAD NOTHING`, so an UPDATE
affects zero rows and *reports success*), so an attribution gets exactly one chance to be right.

Each topic's `KafkaTopic` CR already exists and is owned by its producer; nothing here creates a
topic.

## Left deliberately, with reasons

- **`openbank-billing-service` / `openbank.billing.fee.event`** — there is **no `KafkaTopic` CR for
  it anywhere** under `openbank-infra/gitops`. A Read grant pointing at an undeclared topic is a
  second way to get silence, and who declares it is billing's call, not audit's. Stays baselined.
- **`openbank-standing-order-service` / `openbank.standing-orders.order.event`** and
  **`openbank-psd2-service` / `openbank.psd2.events`** — found by #6047's gate and named in neither
  #5859 nor #6035, so nothing has yet reviewed whether those streams belong in the audit trail.
  Wiring them here would smuggle that decision into a backfill PR. Stays baselined.

Gate baseline: **21 known gaps → 9**. `Refs #6035` rather than `Closes` for exactly that reason.

## Stacking

Branched from **#6047's** `test/audit-subscription-guard-6035` — the gate script whose `KNOWN_GAPS`
entries this PR must delete exists **only** on that branch (`git show origin/main:.github/scripts/
check-audit-money-path-subscription.py` → absent). Then `origin/main` and **#5857's**
`fix/spend-reservation-audit-events` were merged in.

Merging #5857 in was not optional. Its delegation fix edits the **same three files**, and the
`topics:` value is a **single line** — any independent addition to it is a guaranteed textual
conflict no ordering avoids. Both branches are ancestors of this one
(`git merge-base --is-ancestor`, verified for each), so this PR cannot conflict with either by
construction, and nothing of theirs is removed: `git diff origin/fix/spend-reservation-audit-events
HEAD` removes 0 lines from `EventAttribution.kt` and from `kafka-audit-mtls.yaml`, and the final
`topics:` list is 26 entries = the 21 on main + #5857's delegation + these four, counted rather than
eyeballed (a clean merge silently drops neighbouring list additions — the `.release-please-manifest.json`
56→55 shape).

#6047's `IN_FLIGHT` entry for `openbank.delegation.events` is **left alone**: it is #5857/#6047's to
retire, and it is a `::warning`, not an error.

## `auto.offset.reset` — NOT changed, and the reason is not the one in the issue

#6035 warns against forcing `earliest` on this shared group. Reading the deployed config, it is
**already** `earliest` — `openbank-infra/gitops/components/audit/audit-service-msg-override.yaml`
sets `mp.messaging.incoming.audit-events-in.auto.offset.reset=earliest` at `config_ordinal=500`
(a properties file precisely because a dotted YAML leaf key is silently quoted by SmallRye and never
reaches the connector). Nothing is changed here, and the consequence is worth stating plainly: the
existing 22 topics have committed offsets on group `audit-service` and are untouched, but the four
new ones have none, so each is read from its retention start on first subscribe. That is the
intended audit behaviour rather than a mass replay of the existing surface — but it is a
first-subscribe load spike, and it is a *deploy-time* fact this repo cannot test.

## The shared-channel risk, measured rather than assumed

`audit-events-in` declares **no `failure-strategy` and no dead-letter wiring anywhere** (grepped
across `openbank-audit-service/src/main/resources` and `openbank-infra/gitops/components/audit`:
zero hits), so SmallRye's default `fail` applies — and on a shared channel that would mean a poison
record on any one of 26 topics halts all 26.

It cannot fire here, and not by luck: `AuditConsumer.consume(Message<String>)` acks in a `finally`
and the inner `consume(payload, address)` catches `Exception` around the whole body, so the consumer
**never nacks**. The real exposure is the other one — a record that fails to store is logged at
`error` and dropped, and the audit trail is one row short with no nack, no DLQ and no counter for
the drop. That is pre-existing and deliberate (the KDoc argues an audit path that drops is better
than one that stalls), it is not introduced or widened in kind here, and this PR does not change it;
widening the surface by four topics widens its *reach*, which is worth a follow-up decision rather
than a drive-by change to error handling in this PR.

## Proof

**The gate, before → after** (`--enforce`; without the flag it prints `::warning` and exits 0, so
both were run with it — #2392's shape):

```
before: 21 produced topic(s) across 23 money-path service(s) …, 21 known gap(s) — clean.   exit 0
after:  21 produced topic(s) across 23 money-path service(s) …,  9 known gap(s) — clean.   exit 0
```

**Gate negative controls** — each artefact reverted alone, then restored:

| control | result |
|---|---|
| ledger removed from the `topics:` list only | exit 1 — `::error::openbank-ledger-service produces openbank.ledger.journal.posted but it is missing from audit-service's incoming topics list` |
| its `TopicAttribution` entry removed only | exit 1 — `…missing from TopicAttribution in EventAttribution.kt` |
| its Read ACL removed only | exit 1 — `…missing from the audit-service KafkaUser's Read ACLs` |
| baseline entry re-added while the topic is wired | exit 1 — 3 × `::error::stale KNOWN_GAPS entry openbank-ledger-service#openbank.ledger.journal.posted#{topics,attribution,acl}` |
| `--selftest` | `selftest OK: 14 cases, both directions` |

**The test.** `AuditSubscriptionSurfaceIT` (from #6047) reads the topic list from configuration, so
it picks up the four new topics with no edit — and it is exactly there that it has a blind spot: it
is corpus-driven, so **deleting** a topic makes the loop iterate one fewer topic and stay green
(the "a gate whose scope is the thing it checks reads as passing when the list is short" shape).
So a second test names these four as **literals** and asserts each is both subscribed and attributed
to the module that declares its outgoing channel.

**Test negative control, measured.** Reverting only the production wiring for
`openbank.ledger.journal.posted` (topics list + `TopicAttribution`, leaving everything else):

```
java.lang.AssertionError: [issue #6035 wiring]
Expecting empty but was: ["openbank.ledger.journal.posted: absent from
  mp.messaging.incoming.audit-events-in.topics — nothing is read, and no error is raised anywhere"]
```

`tests="2" skipped="0" failures="1"`, BUILD FAILED — **and the corpus-driven test passed in the same
run**, which is the measurement that justifies adding the second test rather than an argument for it.
Restored: `tests="2" skipped="0" failures="0"`.

**What no test in this repo can reach.** There is no Kafka broker in any test here (in-memory
connector fleet-wide), so the in-memory connector cannot see a topic missing from the *deployed*
`topics:` list or a missing Read ACL — the two failures that actually silence a subscription. Those
are the gate's job, and that is why both halves moved together.

## Verified

- `:openbank-audit-service:test --rerun-tasks` → **148 tests, 0 skipped, 0 failures, 0 errors**,
  read from the JUnit XML (a boot failure reports SKIPPED and reads as a pass).
- `:openbank-audit-service:ktlintCheck :openbank-audit-service:detekt
  :openbank-audit-service:quarkusBuild` → BUILD SUCCESSFUL (quarkusBuild included because CDI wiring
  is not validated by ktlint + unit tests).
- `check-threat-model-diff.py --enforce` → exit 0 against **both** `origin/main` and this PR's base.
- `PR_DIFF_BASE=origin/main run-gates.py --all` → 159 gates, 155 PASS. One failure was mine —
  `stale-comment-references` on four abbreviated config paths in a comment — and is fixed in the
  second commit (gate re-run: exit 0). The other three do not reproduce as content failures:
  `api-contract-gate` dies on `sudo: a password is required` fetching `oasdiff` (and this PR touches
  no `openapi.yaml`), `loki-rule-load-test` and `release-scope-mismatch` on `BASE_REF`/`PR_TITLE`
  unbound — all three are CI-environment variables absent from a local shell.

## Not verified

Anything requiring the live broker: that the Read ACL is accepted by Strimzi, that the new
partitions have data, and the first-subscribe read volume. No live system was touched.

`fix(audit)` — audit-service ships a config + attribution change, so it releases, which is correct.

Refs #6035, #5859, #5857, #6047, #5338, ADR-0249 D4.
