### PR TITLE
fix(admin-ui): align account lifecycle permissions

### DIFF
--- a/openbank-admin-ui/src/app/accounts/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/accounts/[id]/page.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link'
 import { ArrowLeft, RefreshCw, Lock, Unlock, XCircle, AlertCircle } from 'lucide-react'
 import { accountApi } from '@/lib/api'
 import { EntityChip } from '@/components/entities/EntityChip'
+import { Can } from '@/components/auth/AuthGuard'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader } from '@/components/ui/PageHeader'
 import type { Account, AccountBalance } from '@/types'
@@ -105,24 +106,33 @@ export default function AccountDetailPage() {
           <span className={STATUS_PILL[account.status] ?? 'pill pill-neutral'}>{account.status}</span>
           <Link href="/accounts" className="btn btn-secondary"><ArrowLeft size={13} aria-hidden="true"/> {t('Zpět', 'Back')}</Link>
           {account.status === 'ACTIVE' && (
-            <button className="btn btn-secondary" onClick={() => requestAction('freeze')} disabled={acting}>
-              <Lock size={13} aria-hidden="true"/> {t('Zmrazit', 'Freeze')}
-            </button>
+            <Can permission="accounts:freeze">
+              <button type="button" className="btn btn-secondary" onClick={() => requestAction('freeze')} disabled={acting} aria-busy={acting} aria-label={t('Zmrazit účet', 'Freeze account')}>
+                <Lock size={13} aria-hidden="true"/> {t('Zmrazit', 'Freeze')}
+              </button>
+            </Can>
           )}
           {account.status === 'FROZEN' && (
-            <button className="btn btn-secondary" onClick={() => requestAction('unfreeze')} disabled={acting}>
-              <Unlock size={13} aria-hidden="true"/> {t('Odzmrazit', 'Unfreeze')}
-            </button>
+            <Can permission="accounts:freeze">
+              <button type="button" className="btn btn-secondary" onClick={() => requestAction('unfreeze')} disabled={acting} aria-busy={acting} aria-label={t('Odmrazit účet', 'Unfreeze account')}>
+                <Unlock size={13} aria-hidden="true"/> {t('Odzmrazit', 'Unfreeze')}
+              </button>
+            </Can>
           )}
           {account.status !== 'CLOSED' && (
-            <button
-              className="btn btn-secondary"
-              onClick={() => requestAction('close')}
-              disabled={acting}
-              style={{ color: 'var(--danger)', borderColor: 'var(--danger-border)' }}
-            >
-              <XCircle size={13} aria-hidden="true"/> {t('Zrušit účet', 'Close')}
-            </button>
+            <Can permission="accounts:close">
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={() => requestAction('close')}
+                disabled={acting}
+                aria-busy={acting}
+                aria-label={t('Zrušit účet', 'Close account')}
+                style={{ color: 'var(--danger)', borderColor: 'var(--danger-border)' }}
+              >
+                <XCircle size={13} aria-hidden="true"/> {t('Zrušit účet', 'Close')}
+              </button>
+            </Can>
           )}
         </div>}
       />

--- a/openbank-admin-ui/src/test/account-lifecycle-rbac.guard.test.ts
+++ b/openbank-admin-ui/src/test/account-lifecycle-rbac.guard.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const root = resolve(__dirname, '..')
+const page = readFileSync(resolve(root, 'app/accounts/[id]/page.tsx'), 'utf8')
+const roles = readFileSync(resolve(root, 'lib/auth/roles.ts'), 'utf8')
+
+describe('account lifecycle controls respect mutation permissions', () => {
+  it('keeps lifecycle visibility aligned with the permission matrix', () => {
+    expect(roles).toContain('"accounts:freeze":          [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE]')
+    expect(roles).toContain('"accounts:close":           [ROLES.ADMIN]')
+    expect(page).toMatch(/<Can permission="accounts:freeze">[\s\S]*requestAction\('freeze'\)/)
+    expect(page).toMatch(/<Can permission="accounts:freeze">[\s\S]*requestAction\('unfreeze'\)/)
+    expect(page).toMatch(/<Can permission="accounts:close">[\s\S]*requestAction\('close'\)/)
+  })
+
+  it('keeps lifecycle controls named and explicit buttons', () => {
+    expect(page).toContain('aria-label={t(\'Zmrazit účet\', \'Freeze account\')}')
+    expect(page).toContain('aria-label={t(\'Odmrazit účet\', \'Unfreeze account\')}')
+    expect(page).toContain('aria-label={t(\'Zrušit účet\', \'Close account\')}')
+    expect(page).toContain('aria-busy={acting}')
+    expect(page).toContain('type="button"')
+  })
+})


### PR DESCRIPTION
## Summary
- hide account freeze/unfreeze/close actions unless the session has the matching mutation permission
- add localized action names, busy state, and explicit button semantics
- add a guard for the account lifecycle permission matrix

## Verification
- `git diff --check`
- `npm run type-check`
- focused Vitest guard (blocked locally by missing optional Rolldown native binding)

Closes #5020