### PR TITLE
fix(observability): make the RUM cardinality alerts capable of firing, and stop the empty board reading as no traffic

### DIFF
--- a/docs/runbooks/0013-rum-cardinality.md
+++ b/docs/runbooks/0013-rum-cardinality.md
@@ -1,0 +1,95 @@
+# Runbook 0013 — RUM cardinality budgets (and reading an empty Mobile RUM board)
+
+Status: Active
+Owner: Platform / Observability
+Related: ADR-0088 (mobile RUM, D4 + O2), ADR-0147 (cross-repo delivery status),
+`docs/threat-models/rum-ingest-gateway.md`, issue #5735
+
+Both alerts in `openbank-infra/gitops/components/observability/prometheusrule-rum-cardinality.yaml`
+point their `runbook_url` here. Until #5735 that URL pointed at a repo path that has never existed,
+in an org that is not this one.
+
+## What these alerts actually watch
+
+Tempo's metrics-generator turns every ingested span into `traces_spanmetrics_*`, labelled with
+exactly:
+
+```
+service, span_name, span_kind, status_code   (+ __metrics_gen_instance)
+```
+
+`openbank-infra/gitops/apps/tempo.yaml` configures **no** `dimensions:` customisation, so that list
+is the whole vocabulary. There is no `route` label and no `screen_name` label, in this cluster,
+for any service.
+
+The mobile app names its screen spans `screen.<NAME>` (observed: `screen.HOME`), so **the screen
+name is the span name**. That is why `RumScreenCardinalityHigh` counts `by (span_name)`.
+
+| Alert | Expression subject | Budget |
+|---|---|---|
+| `RumSpanMetricsCardinalityHigh` | total RUM series for `service=~"openbank-app.*"` | 100 |
+| `RumScreenCardinalityHigh` | distinct `span_name` values for the same selector | 50 |
+
+## If one fires
+
+1. Find the offending values:
+   ```bash
+   kubectl -n observability port-forward svc/kube-prometheus-stack-prometheus 19090:9090 &
+   curl -sG --data-urlencode \
+     'query=topk(30, count by (span_name) (traces_spanmetrics_calls_total{service=~"openbank-app.*"}))' \
+     http://127.0.0.1:19090/api/v1/query | python3 -m json.tool
+   ```
+2. The usual cause is a dynamic id interpolated into a screen name
+   (`screen.ACCOUNT_1f0c…` rather than `screen.ACCOUNT_DETAIL`). The fix belongs in the app
+   (`JiRaska/openbank-app`), not here.
+3. The stop-gap that *is* in this repo: add a `transform` processor entry in
+   `openbank-infra/gitops/apps/rum-gateway.yaml` to normalise the span name before it reaches
+   Tempo. Note the gateway already runs `probabilistic_sampler` at 25%, so cardinality is being
+   measured on a quarter of the real traffic — a firing alert means roughly 4x that many distinct
+   values were actually produced.
+
+## If the Mobile RUM dashboard is EMPTY (the common case, and not these alerts' job)
+
+**Do not read an empty board as an incident.** These are *budget* alerts; they are silent when
+there is no data, by design. Absence is signalled by the weekly `rum-attribute-audit` CronJob,
+which exits 1 with `rum-mobile-signal-absent`.
+
+Measured 2026-08-20 against the sandbox, this is the state to expect:
+
+- `openbank-app` **does** reach Tempo, and its spans **do** join the backend trace — a single trace
+  contained `screen.HOME` (from the app) and `POST /api/v1/copilot/chat/stream` (from
+  `openbank-copilot-service`, `user_agent.original: ktor-client`). Tap → backend context
+  propagation works.
+- It arrives in **bursts of one or two spans**, hours apart, because RUM is off by default,
+  OIDC/consent-gated, and only debug builds with a logged-in session emit at all. One trace in six
+  hours is the normal reading, not a fault.
+- The span carries only `party_id`; its resource carries `service.name` plus
+  `redaction.redacted.count=3` — the gateway's strict allow-list dropped the app's three
+  `telemetry.sdk.*` attributes. That is the redaction processor working as designed.
+- `screen.name`, `app.version` and `device.model` are **not sent by the app**, so the gateway's
+  allow-list entries for them are currently unused. Populating them is app-side work in
+  `JiRaska/openbank-app` (ADR-0088 D4a/D4c) and cannot be done from this repo.
+
+### Why `openbank-admin-ui` is absent, deliberately
+
+ADR-0088 D4 rejected browser/JS RUM as the "wrong surface": an internal operator console with a
+handful of users. The gateway is built to match that decision and would reject admin-ui even if
+the SDK were added — it emits no CORS headers at all (so a cross-origin browser export is blocked
+before auth), and its OIDC authenticator accepts only customer-realm tokens with the RUM audience.
+Admin-ui's own CSP `connect-src` (`openbank-admin-ui/src/proxy.ts`) does not list the gateway
+either. Wiring admin-ui RUM is therefore an ADR-level reversal, not a config change.
+
+## Verifying a change to these rules
+
+Any edit must keep a positive control green. The expression *shape* over a service that certainly
+emits has to return a value:
+
+```bash
+curl -sG --data-urlencode \
+  'query=count(count by (span_name) (traces_spanmetrics_calls_total{service="openbank-ledger-service"}))' \
+  http://127.0.0.1:19090/api/v1/query
+```
+
+This returned `6` on 2026-08-20. If your edit makes that return nothing, the expression is broken —
+not the data. Checking only the RUM selector cannot tell those two apart, which is precisely how
+the pre-#5735 rules survived for two months while matching zero series.

--- a/openbank-infra/gitops/components/observability/dashboard-openbank-rum.yaml
+++ b/openbank-infra/gitops/components/observability/dashboard-openbank-rum.yaml
@@ -1,15 +1,34 @@
-# Mobile RUM dashboard (ADR-0088 §D4). Visualises the Real-User-Monitoring spans
-# the KMP app now emits (Android android-agent + iOS Ktor OTLP exporter) via the
-# hardened ingest gateway → Tempo. RED panels are driven by the Tempo metrics-
-# generator span-metrics (traces_spanmetrics_*, service="openbank-app") — same
-# zero-extra-instrumentation source as the backend RED board (ADR-0082). The raw
-# traces panel uses TraceQL on Tempo so you can open a device span and follow it
-# straight into the backend trace (one trace id, tap→ledger). Crash-free health
-# lives on the companion "Mobile Crashes" board (GlitchTip).
+# Mobile RUM dashboard (ADR-0088 D4). Visualises the Real-User-Monitoring spans
+# the KMP app emits via the hardened ingest gateway (ADR-0089) -> Tempo. RED panels
+# are driven by the Tempo metrics-generator span-metrics (traces_spanmetrics_*,
+# service="openbank-app") -- same zero-extra-instrumentation source as the backend
+# RED board (ADR-0082). The raw traces panel uses TraceQL on Tempo so you can open a
+# device span and follow it straight into the backend trace (one trace id,
+# tap -> ledger). Crash-free health lives on the companion "Mobile Crashes" board
+# (GlitchTip).
 #
-# Populates once a device with a debug build logs in and navigates (RUM is off by
-# default / OIDC-gated; spans carry only the pseudonymous party_id, dropped at the
-# gateway until O6). If panels are empty, drive some screens on the phone first.
+# ANDROID ONLY, as of 2026-08-20 (#5735). ADR-0088 D4c (iOS parity) is still a no-op
+# stub pending SPM vendoring; this header used to claim an "iOS Ktor OTLP exporter"
+# was live, and it is not. Delivery for both halves is in JiRaska/openbank-app, a
+# separate repo (ADR-0147) -- nothing in THIS repo can change what the app emits.
+#
+# READING AN EMPTY BOARD -- see docs/runbooks/0013-rum-cardinality.md.
+# Empty is the normal state and does not mean the app has no traffic. RUM is off by
+# default, OIDC/consent-gated, debug builds only, and the gateway samples at 25%, so
+# the measured arrival rate is a burst of one or two spans every few hours. Verified
+# 2026-08-20: exactly one openbank-app trace in a 6h window, and it correctly joined
+# the backend trace (screen.HOME + POST /api/v1/copilot/chat/stream in one trace id),
+# so ingest and context propagation both work -- it is volume that is absent.
+#
+# The per-screen panels below key on span_name (the app names screen spans
+# "screen.<NAME>", e.g. screen.HOME), NOT on the screen.name ATTRIBUTE. The attribute
+# is currently never set by the app, but that does not break these panels.
+# app.version / device.model are likewise unset app-side; no panel here uses them.
+#
+# openbank-admin-ui is deliberately NOT on this board: ADR-0088 D4 rejected browser
+# RUM as the wrong surface (internal operator console). The gateway also emits no
+# CORS headers and accepts only customer-realm tokens, so admin-ui could not export
+# here without an ADR-level reversal.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -38,7 +57,7 @@ data:
           "title": "How to read this board",
           "type": "text",
           "gridPos": { "h": 4, "w": 24, "x": 0, "y": 0 },
-          "options": { "mode": "markdown", "content": "**Mobile RUM** — device-side spans from the KMP app (Android + iOS) through the hardened ingest gateway → Tempo.\n\n- **R/E/D** below come from Tempo span-metrics (`service=openbank-app`), no extra instrumentation.\n- **Screen views** = `screen.<name>` spans emitted per navigation; the active screen span's W3C context flows onto the next API call, so a RUM trace continues **tap → ledger** (open it in the *RUM traces* panel).\n- **Off by default / OIDC-gated**: only debug builds with a logged-in session emit. Only the pseudonymous `party_id` identifies a session (dropped at the gateway until O6). Crash-free health → *Mobile Crashes* board." }
+          "options": { "mode": "markdown", "content": "**Mobile RUM** \u2014 device-side spans from the KMP app (**Android only** \u2014 iOS is still a stub, ADR-0088 D4c) through the hardened ingest gateway \u2192 Tempo.\n\n- **Empty is normal.** RUM is off by default, OIDC/consent-gated, debug builds only, and the gateway samples at 25%. Measured 2026-08-20: ~1 trace per 6h. An empty board is **not** evidence the app has no traffic \u2014 see `docs/runbooks/0013-rum-cardinality.md` before escalating.\n- **R/E/D** come from Tempo span-metrics (`service=openbank-app`), no extra instrumentation.\n- **Screen panels key on `span_name`** (`screen.<NAME>`), not on the `screen.name` attribute \u2014 which the app does not currently set. Fixing that is app-side work in `JiRaska/openbank-app`.\n- Tap \u2192 ledger works: a device span and the backend span share one trace id. Open one in the *RUM traces* panel.\n- **admin-ui is not here on purpose**: ADR-0088 D4 rejected browser RUM as the wrong surface.\n- Only the pseudonymous `party_id` identifies a session. Crash-free health \u2192 *Mobile Crashes* board." }
         },
         {
           "title": "Screen-view rate (per screen)",

--- a/openbank-infra/gitops/components/observability/prometheusrule-rum-cardinality.yaml
+++ b/openbank-infra/gitops/components/observability/prometheusrule-rum-cardinality.yaml
@@ -1,13 +1,52 @@
-# RUM gateway cardinality budget alerts (ADR-0088 O2).
-# Fires when the number of unique `route` or `screen` label values seen by Tempo
-# over the last hour exceeds the agreed ADR-0088 budgets (route ≤ 100, screen ≤ 50).
-# High cardinality from mobile apps can explode Tempo's index and query latency;
-# catching it early lets SREs add a transform/routing processor before it compounds.
+# RUM cardinality budget alerts (ADR-0088 O2).
 #
-# Metric source: Tempo span-metrics-generator emits
-#   traces_spanmetrics_calls_total{route="...", screen="...",...}
-# into the in-cluster Prometheus. The `count(count by (route) (...))` idiom counts
-# the number of distinct label values without pulling all series into memory.
+# Fires when the number of distinct RUM span-metric label values exceeds the
+# ADR-0088 budgets. High cardinality from mobile apps can explode Tempo's index
+# and query latency; catching it early lets SREs add a transform/routing
+# processor before it compounds.
+#
+# ---------------------------------------------------------------------------
+# 2026-08-20 (#5735): BOTH rules in this file were structurally unable to fire.
+# Measured against the live sandbox Prometheus, not inferred:
+#
+#   count(traces_spanmetrics_calls_total{service_name=~".+"})  -> 0 series
+#
+# Tempo's metrics-generator labels span-metrics with exactly:
+#   service, span_name, span_kind, status_code   (+ __metrics_gen_instance)
+#
+# So every clause of the old expressions was wrong, independently:
+#   * `service_name=` -- that label does not exist; the label is `service`.
+#     A selector on a non-existent label matches nothing, always.
+#   * `="rum-gateway"` -- the gateway is a pass-through collector, not a span
+#     PRODUCER. span-metrics carry the emitting service, which is `openbank-app`
+#     (verified present as a `service` label value). The dashboard
+#     `dashboard-openbank-rum.yaml` already selects `service=~"openbank-app.*"`;
+#     these rules disagreed with the dashboard they were meant to protect.
+#   * `by (route)` / `by (screen_name)` -- neither dimension is exported.
+#     `tempo.yaml` configures no `dimensions:` customisation, so span-metrics
+#     have the four labels above and nothing else. `count by (<absent label>)`
+#     collapses every series into one, so the count is 1 and never exceeds a
+#     budget of 50 or 100 even when data flows.
+#
+# What is actually measurable today, and what these rules now use:
+#   * The RUM screen IS the span name -- the app emits spans literally named
+#     `screen.HOME`, so `count by (span_name)` IS the screen-cardinality count.
+#   * There is no `http.route` dimension to count. Adding one to Tempo would
+#     change span-metrics for all ~43 services at once (a cardinality risk in
+#     itself), so the route budget is expressed as a TOTAL series budget for
+#     the RUM service instead, and the alert is renamed to say so rather than
+#     naming a dimension that is not there.
+#
+# Positive control for anyone changing these: the same expression shape over a
+# service that definitely emits must return a value --
+#   count(count by (span_name) (traces_spanmetrics_calls_total{service="openbank-ledger-service"}))
+# returned 6 on 2026-08-20. If your edit makes that return nothing, the
+# expression is broken, not the data.
+#
+# NOTE ON EMPTINESS: these are BUDGET alerts. They stay silent while RUM has no
+# data, and that is correct -- absence is covered by the `rum-attribute-audit`
+# CronJob (which exits 1 on `rum-mobile-signal-absent`), not by an alert here.
+# ---------------------------------------------------------------------------
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -20,25 +59,27 @@ spec:
     - name: rum.cardinality
       interval: 5m
       rules:
-        - alert: RumRouteCardinalityHigh
+        - alert: RumSpanMetricsCardinalityHigh
           expr: |
-            count(count by (route) (traces_spanmetrics_calls_total{service_name="rum-gateway"})) > 100
+            count(traces_spanmetrics_calls_total{service=~"openbank-app.*"}) > 100
           for: 10m
           labels:
             severity: warning
             component: rum-gateway
           annotations:
-            summary: "RUM route cardinality exceeds budget (ADR-0088 O2)"
+            summary: "RUM span-metrics cardinality exceeds budget (ADR-0088 O2)"
             description: >
-              {{ $value }} unique `route` label values seen on Tempo span-metrics in the last 10 minutes.
+              {{ $value }} distinct RUM span-metric series for the mobile app in the last 10 minutes.
               Budget is 100. High cardinality inflates Tempo index and query latency.
-              Inspect the rum-gateway transform processor allow-list or add a routing processor to cap
-              the `http.route` attribute cardinality.
-            runbook_url: "https://github.com/openbank/openbank/blob/main/docs/runbooks/rum-cardinality.md"
+              Was `count by (route)` until #5735; Tempo exports no `http.route` dimension, so this
+              counts total series (span_name x span_kind x status_code) instead.
+              Inspect the rum-gateway `transform` processor allow-list, or normalise the span names
+              the app emits, before adding a routing processor.
+            runbook_url: "https://github.com/JiRaska/open-bank-oss/blob/main/docs/runbooks/0013-rum-cardinality.md"
 
         - alert: RumScreenCardinalityHigh
           expr: |
-            count(count by (screen_name) (traces_spanmetrics_calls_total{service_name="rum-gateway"})) > 50
+            count(count by (span_name) (traces_spanmetrics_calls_total{service=~"openbank-app.*"})) > 50
           for: 10m
           labels:
             severity: warning
@@ -46,7 +87,8 @@ spec:
           annotations:
             summary: "RUM screen cardinality exceeds budget (ADR-0088 O2)"
             description: >
-              {{ $value }} unique `screen_name` label values seen on Tempo span-metrics in the last 10 minutes.
-              Budget is 50. Check the mobile SDK for unbounded screen-name generation (e.g. dynamic IDs in
-              screen names). Add a transform processor entry to normalise or drop high-cardinality values.
-            runbook_url: "https://github.com/openbank/openbank/blob/main/docs/runbooks/rum-cardinality.md"
+              {{ $value }} unique RUM screen span names (`screen.<NAME>`) in the last 10 minutes.
+              Budget is 50. Check the mobile SDK for unbounded screen-name generation (e.g. dynamic
+              IDs interpolated into screen names). Add a transform processor entry to normalise or
+              drop high-cardinality values.
+            runbook_url: "https://github.com/JiRaska/open-bank-oss/blob/main/docs/runbooks/0013-rum-cardinality.md"


### PR DESCRIPTION
## Summary

Everything in #5735 that lives in **this** repo. The headline finding is not the one the issue expected: the pipeline is not broken, but the two alerts that were supposed to watch it could never fire, and the dashboard was telling readers three things that were not true.

The app-side tail is split out as #6069 (delivery in `JiRaska/openbank-app`, ADR-0147).

## What is actually happening (measured, not inferred)

All read-only, against the live sandbox on 2026-08-20.

**Spans DO arrive, and they DO join the backend trace.** One `openbank-app` trace in a 6h window, dumped in full:

```
RESOURCE ATTRS: service.name = openbank-app, redaction.redacted.count = 3
  SPAN: screen.HOME (SPAN_KIND_INTERNAL)   party_id = <pseudonymous uuid>
```

The same trace id also carried `POST /api/v1/copilot/chat/stream` from `openbank-copilot-service` (`user_agent.original: ktor-client`). So ingest, auth, redaction and W3C context propagation all work — tap → backend is real. `redaction.redacted.count = 3` is the gateway allow-list dropping the app's three `telemetry.sdk.*` attributes, by design.

**The board is empty because of volume, not plumbing.** RUM is off by default, OIDC/consent-gated, debug-builds-only, and the gateway samples at 25%. ~1 trace per 6h is the measured normal.

## Per-panel breakdown

`$app` is a hidden dashboard constant = `openbank-app`.

| # | Panel | Query | Verdict |
|---|---|---|---|
| 1 | How to read this board | (text) | **Was wrong on 3 counts** — fixed here |
| 2 | Screen-view rate (per screen) | `sum by (span_name) (rate(traces_spanmetrics_calls_total{service=~"$app.*"}[5m]))` | **Query correct.** Empty from volume only |
| 3 | App span p95/p99 (D) | `histogram_quantile(…, traces_spanmetrics_latency_bucket{service=~"$app.*"})` | **Query correct.** Metric exists (770 series fleet-wide) |
| 4 | RUM span error rate (E) | `…{service=~"$app.*",status_code="STATUS_CODE_ERROR"}` | **Query correct.** `status_code` is a real label |
| 5 | Top screens (5m) | `topk(15, sum by (span_name) (rate(…{service=~"$app.*"}[5m])))` | **Query correct.** Empty from volume only |
| 6 | RUM traces (TraceQL) | `{ resource.service.name="openbank-app" }` | **Works.** Returned a real trace |

**The issue's premise on panels 2 and 5 does not hold.** It reasoned that `screen.name = 0` makes the two per-screen panels impossible. They key on `span_name`, not on the attribute, and the app already names its spans `screen.HOME`. Confirmed:

```
count(count by (span_name) (traces_spanmetrics_calls_total{service=~"openbank-app.*"}))   -> returns data
```

So no panel query needed changing. Five of six were already right.

## The real defect: two alerts that could never fire

`prometheusrule-rum-cardinality.yaml` had shipped for ~2 months matching zero series, on three independent counts:

```
count(traces_spanmetrics_calls_total{service_name=~".+"})   ->  0 series   (fleet-wide)
```

Tempo's metrics-generator labels span-metrics with exactly `service, span_name, span_kind, status_code`. Therefore:

- `service_name=` — not a label here. The label is `service`. A selector on an absent label matches nothing, always.
- `="rum-gateway"` — a pass-through collector, not a span producer. The emitting service is `openbank-app`, which is what the dashboard these rules protect already selects.
- `by (route)` / `by (screen_name)` — dimensions Tempo does not export (`tempo.yaml` sets no `dimensions:`). `count by (<absent label>)` collapses to one series, so the count is `1` and never exceeds a budget of 50 or 100 *even with data flowing*.

Same family as the Loki-ruler finding in #6032: a control that reads as healthy because it never reached its subject.

### Fixed to dimensions that exist

- `RumScreenCardinalityHigh` → `count(count by (span_name) (…{service=~"openbank-app.*"})) > 50`. The screen name *is* the span name.
- `RumRouteCardinalityHigh` → renamed **`RumSpanMetricsCardinalityHigh`**, `count(…{service=~"openbank-app.*"}) > 100`. There is no `http.route` dimension, and adding one to Tempo would change span-metrics for all ~43 services at once — a cardinality risk in itself. Better to measure what exists than to keep an alert named after a label that is not there. No registry or dashboard referenced the old name.

### Verified in both directions

| Probe | Result |
|---|---|
| New exprs over `openbank-app`, 12h range | returns data during the burst window |
| Old exprs, same window | **0 series** (negative control) |
| Positive control: same shape over `openbank-ledger-service` | **6** |

The positive control is the point: checking only the RUM selector cannot distinguish "expression broken" from "no RUM data", which is exactly how these survived.

## Also in this PR

- **`docs/runbooks/0013-rum-cardinality.md`** — both alerts' `runbook_url` already pointed at a runbook, at a path in an org that is not this repo. Now it exists, and covers the case people will actually hit: how to read an empty board without escalating.
- **Dashboard header corrected.** It claimed a live "iOS Ktor OTLP exporter" (ADR-0088 D4c is still a stub); it did not say an empty board is normal rather than evidence of no traffic; and it did not record that admin-ui is absent by decision.

## `NEXT_PUBLIC_*` finding (checked specifically)

Confirmed the known trap, though it is not the cause here. Admin-ui's Docker build passes only `BUILD_VERSION` / `BUILD_GIT_SHA` / `BUILD_DATE` as build args. Every `NEXT_PUBLIC_*` set in the k8s manifests is **runtime container env and never reaches the client bundle** — the bundle always gets the `next.config.mjs` defaults. GlitchTip works only because its DSN has a hardcoded default baked in `next.config.mjs`. Anyone wiring browser telemetry later must add an `ARG`/`ENV` plus a `--build-arg`, or a baked default — runtime env will silently do nothing.

## Why admin-ui is not instrumented here

Not an oversight, and deliberately not changed:

1. **ADR-0088 D4 rejected browser RUM outright** as the "wrong surface" — an internal operator console with ~2 users. Adding it is an ADR reversal, not a config change.
2. The gateway would reject it anyway: **no `cors:` block at all**, so a cross-origin browser OTLP export fails preflight before auth; and its OIDC authenticator accepts only customer-realm tokens with the RUM audience.
3. Admin-ui's own CSP `connect-src` (`src/proxy.ts`) does not list the gateway.
4. `@sentry/nextjs` is present with `tracesSampleRate: 0` and the comment "Errors-only (no performance/RUM)" — a deliberate setting, not an accident.

Recorded in the dashboard header and the runbook so the next person does not re-derive it.

## Privacy

No telemetry behaviour is changed by this PR — no new collector, no new attribute, no new field on the wire. Flagging what I found rather than shipping it: the gateway's allow-list already permits `screen.name` and `http.route`, either of which becomes a PII carrier the moment an account or party id is interpolated into it. #6069 carries that constraint for the app-side work. The one identifier on the wire today is the pseudonymous `party_id`, server-bound by the gateway's `transform` processor (ADR-0088 O6) rather than trusted from the device.

## What is NOT fixed, and where it lives

`screen.name`, `app.version`, `device.model`, `x-correlation-id` are unset **by the app**, whose source is `JiRaska/openbank-app` (ADR-0147; `docs/adr/known-repos.txt`). Nothing in this repo can change what the app emits. Split out as **#6069** with the measured evidence and the privacy constraint. ADR-0088 stays `delivery-status: partial` — correctly.

## Verification

- `run-gates.py --group gitops` → **PASS=32**, 1 UNFALSIFIED (`loki-rule-load-test`), reproduced identically on pristine `origin/main` and caused by `BASE_REF` being unset locally (CI sets it) — pre-existing and environmental.
- `--group lint` → **20/20 PASS** (yamllint clean on both edited YAMLs).
- `--group registry` → **26/26 PASS**. `--group supplychain` → 22 PASS, 1 advisory WARN (`release-scope-mismatch`, `PR_TITLE: unbound variable` locally).
- YAML parse + embedded dashboard JSON re-parsed: 6 panels preserved, title unchanged.
- Alert expressions evaluated against live Prometheus with positive and negative controls (table above).

**Not verified:** that the corrected alerts actually *fire* — that needs cardinality above budget, which requires RUM traffic that does not exist yet. What is proven is that they now select real series, which is what they could not do before. Also not verified in a browser: the CORS/CSP claims for admin-ui are read from config and from the absence of a `cors:` block, not from a live cross-origin request.

Closes #5735
Refs #6069, ADR-0088, ADR-0147
