### PR TITLE
fix(sepa-payment): record who processed a pacs.004 return, durably

### DIFF
--- a/docs/threat-models/openbank-sepa-payment.md
+++ b/docs/threat-models/openbank-sepa-payment.md
@@ -102,7 +102,7 @@ from clearing-simulator (cluster-internal, `ROLE_SERVICE`). New trust boundary:
 |---|---|---|
 | **S**poofing | Rogue caller posts a forged pacs.004 to `/returns` | Endpoint requires `ROLE_SERVICE` (OIDC client-credentials); cluster-internal only (NetworkPolicy); clearing-simulator identity verified by OIDC CC token |
 | **T**ampering | Malformed or XXE-injected pacs.004 XML | `Pacs004Reader` (openbank-libs) configures `XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES = false` and `IS_RESOLVING_ENTITY_REFERENCES = false` before parsing |
-| **R**epudiation | Denial of having processed a return | All `/returns` invocations logged via existing `AuditService` with correlation id, `OrgnlEndToEndId`, reason code, and actor identity |
+| **R**epudiation | Denial of having processed a return | Every `/returns` invocation writes a `sepa.payment.returned` non-repudiation record into `sepa_payment_outbox` **in the same transaction as the `RETURNED` transition** (`SepaPaymentService.handlePaymentReturn` -> `SepaPaymentRepository.updateWithEvidence`), carrying the `OrgnlEndToEndId`, the pacs.004 reason code, the correlation id, whether the ledger reversal actually happened, and the **authenticated** actor — `SecurityContext.actorName`/`actorType`, derived server-side in `SepaPaymentResource`, never read from the pacs.004 body. The outbox dispatcher (`openbank.outbox.dispatch-enabled: true`) publishes it to `openbank.sepa.payment.events`, which openbank-audit-service already consumes into the append-only, hash-chained `audit_entries` store. Proved end to end by `SepaPaymentReturnAuditEvidenceIT` — real HTTP + real Postgres, row read back over an independent JDBC connection (issue #6056; before it, this row credited an `AuditService` present in no source file, and the service had no audit publisher of any kind) |
 | **I**nfo disclosure | Return reason codes (AC04, AM09, etc.) visible to unauthorised parties | Reason codes and return details accessible to `ROLE_OPERATOR`/`ROLE_ADMIN` only; `ROLE_VIEWER` sees payment status (`RETURNED`) but not raw reason code |
 | **D**oS | Replay of the same pacs.004 | `RETURNED` transition is idempotent — a second call with the same `OrgnlEndToEndId` returns 409 (already RETURNED), no double-reversal |
 | **E**oP | Reversal credited to wrong account | `transaction-service /reverse` validates that the transaction being reversed is owned by the payment's `debtorAccountId`; cross-account reversals are rejected with 403 |
@@ -140,6 +140,34 @@ unreachable document-service fails only the download, never a payment transition
 simply stops existing).
 
 ## 6. Change log
+
+- **2026-08-20** — The `/returns` non-repudiation control now exists (issue #6056). It did not
+  before: the R row of §5a credited an `AuditService` that is present in no source file in this
+  repository, and `openbank-sepa-payment/src/main` contained no audit publisher of any kind. The
+  two things that did happen — an application log line and the payment row's own status transition
+  — are both written by the same code path whose behaviour a repudiation dispute puts in question,
+  so neither could ever be evidence against it.
+  - **What was built**: a `SepaPaymentReturnedEvent` (`sepa.payment.returned`) written into the
+    existing transactional outbox in the SAME transaction as the `RETURNED` transition, so the
+    record and the act commit together or neither does. It carries `OrgnlEndToEndId`, the pacs.004
+    reason code, the correlation id, the measured `reversalPerformed` outcome, and the actor.
+  - **Where the evidence lands**: `openbank.sepa.payment.events` -> openbank-audit-service's
+    `AuditConsumer` -> the append-only, hash-chained `audit_entries` table. **Deliberately not**
+    `com.openbank.libs.audit.AuditEventPublisher`: the only implementation of that interface in
+    this repository is `LoggingAuditEventPublisher`, and a log line is not an evidentiary record.
+    The field names match what `AuditConsumer` actually reads (`eventType`, `actorId`, `actorType`,
+    `correlationId`, `occurredAt`, `sourceService`, `paymentId`), so the row is EVENT-attributed
+    rather than landing on its `"unknown"` sentinels — `source_service` is chain-hashed into
+    `record_hash`, so attribution cannot be corrected afterwards.
+  - **Attribution is server-derived**, from `SecurityContext`, never from the request body. The
+    pacs.004 carries no actor field and none is read from it; a record whose actor is supplied by
+    the party whose action is in dispute is not a control.
+  - **No new trust boundary, no new caller, no API change**: same endpoint, same role gate
+    (`ROLE_API`/`ROLE_ADMIN`), same OPA action, same topic, same request and response bodies. The
+    only new data on the wire is the evidence event itself, on an existing internal topic.
+  - **Risk class**: accountability/evidence (DORA Art. 17 reconstruction). **Rollback**: revert the
+    commit — the return path returns to transitioning with no record, i.e. the state this entry
+    describes as the defect.
 
 - **2026-08-19** — `ApprovalResource` served only `PATCH /{id}` (decide), so a
   `sepaPayment.transitionStatus` four-eyes decision parked at 202 was discoverable only by

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/port/in/SepaPaymentPorts.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/port/in/SepaPaymentPorts.kt
@@ -40,7 +40,22 @@ data class TransitionSepaPaymentStatusCommand(
     val rejectDetail: String? = null,
 )
 
-data class HandlePaymentReturnCommand(val pacs004Xml: String)
+/**
+ * An inbound pacs.004 return, together with the **server-derived** identity of the caller that
+ * presented it (issue #6056).
+ *
+ * [actorId], [actorType] and [correlationId] are resolved in the REST adapter from the
+ * `SecurityContext` and the request context that `CorrelationIdRequestFilter` populated — never
+ * from the request body. A repudiation control whose actor is supplied by the party whose action
+ * is in dispute records nothing (the shape #4754 found elsewhere in this fleet), so the pacs.004
+ * XML deliberately carries no actor field and none is read from it.
+ */
+data class HandlePaymentReturnCommand(
+    val pacs004Xml: String,
+    val actorId: String,
+    val actorType: String,
+    val correlationId: String?,
+)
 
 interface SepaPaymentUseCase {
     suspend fun createPayment(command: CreateSepaPaymentCommand): SepaPayment

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/port/out/SepaPaymentPorts.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/port/out/SepaPaymentPorts.kt
@@ -44,6 +44,21 @@ interface SepaPaymentRepository {
 
     /** Update a payment and enqueue a domain-event outbox message, atomically. */
     suspend fun update(payment: SepaPayment, outboxMessage: SepaPaymentOutboxMessage): SepaPayment
+
+    /**
+     * As [update], plus a second outbox message carrying the non-repudiation evidence for the same
+     * act — both rows and the aggregate change commit in ONE transaction (issue #6056).
+     *
+     * A separate method rather than a defaulted third parameter on [update]: an overload or a
+     * default argument on an interface this service's tests mock would let a call site silently
+     * resolve to the evidence-free variant, which is the one failure this method exists to make
+     * impossible.
+     */
+    suspend fun updateWithEvidence(
+        payment: SepaPayment,
+        outboxMessage: SepaPaymentOutboxMessage,
+        evidenceMessage: SepaPaymentOutboxMessage,
+    ): SepaPayment
 }
 
 /**
@@ -63,4 +78,19 @@ interface SepaPaymentEventPublisher {
     fun paymentCreatedPayload(payment: SepaPayment): String
 
     fun statusChangedPayload(previous: SepaPayment, current: SepaPayment): String
+
+    /**
+     * Serializes the `/returns` non-repudiation record (issue #6056). Every argument is either
+     * read off the pacs.004 itself or derived server-side from the security context — nothing
+     * here originates in a caller-supplied body field.
+     */
+    fun returnEvidencePayload(
+        payment: SepaPayment,
+        originalEndToEndId: String,
+        returnReasonCode: String?,
+        actorId: String,
+        actorType: String,
+        correlationId: String?,
+        reversalPerformed: Boolean,
+    ): String
 }

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/usecase/SepaPaymentService.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/usecase/SepaPaymentService.kt
@@ -17,6 +17,7 @@ import com.openbank.sepa.application.port.out.SepaPaymentEventPublisher
 import com.openbank.sepa.application.port.out.SepaPaymentOutboxMessage
 import com.openbank.sepa.application.port.out.SepaPaymentRepository
 import com.openbank.sepa.application.workflow.SepaPaymentWorkflow
+import com.openbank.sepa.domain.event.RETURN_EVIDENCE_EVENT_TYPE
 import com.openbank.sepa.domain.model.SepaPayment
 import com.openbank.sepa.domain.model.SepaPaymentStatus
 import com.openbank.sepa.domain.model.SepaRejectReason
@@ -132,26 +133,42 @@ class SepaPaymentService(
         return received
     }
 
+    /**
+     * @param evidencePayload when non-null, a non-repudiation record written into the outbox in the
+     * SAME transaction as the transition (issue #6056). Only the `/returns` path supplies one today.
+     */
     private suspend fun persistTransition(
         payment: SepaPayment,
         target: SepaPaymentStatus,
         reason: SepaRejectReason?,
         detail: String?,
         transactionId: UUID? = payment.transactionId,
+        evidencePayload: String? = null,
     ): SepaPayment {
         val now = Instant.now(clock)
         val updated = payment.transitionTo(target, reason, detail, clock).let {
             if (transactionId != null) it.copy(transactionId = transactionId) else it
         }
-        val saved = paymentRepository.update(
-            payment = updated,
-            outboxMessage = SepaPaymentOutboxMessage(
-                aggregateId = updated.id,
-                eventType = PAYMENT_STATUS_CHANGED_EVENT,
-                payload = eventPublisher.statusChangedPayload(payment, updated),
-                createdAt = now,
-            ),
+        val statusMessage = SepaPaymentOutboxMessage(
+            aggregateId = updated.id,
+            eventType = PAYMENT_STATUS_CHANGED_EVENT,
+            payload = eventPublisher.statusChangedPayload(payment, updated),
+            createdAt = now,
         )
+        val saved = if (evidencePayload == null) {
+            paymentRepository.update(payment = updated, outboxMessage = statusMessage)
+        } else {
+            paymentRepository.updateWithEvidence(
+                payment = updated,
+                outboxMessage = statusMessage,
+                evidenceMessage = SepaPaymentOutboxMessage(
+                    aggregateId = updated.id,
+                    eventType = RETURN_EVIDENCE_EVENT_TYPE,
+                    payload = evidencePayload,
+                    createdAt = now,
+                ),
+            )
+        }
 
         val terminalOutcomes = setOf(
             SepaPaymentStatus.COMPLETED,
@@ -234,6 +251,7 @@ class SepaPaymentService(
         if (payment.status == SepaPaymentStatus.RETURNED) return payment
 
         val txId = payment.transactionId
+        var reversalPerformed = false
         if (txId != null) {
             try {
                 reversalPort.reverseTransaction(
@@ -241,6 +259,7 @@ class SepaPaymentService(
                     idempotencyKey = "sepa-reversal-${payment.id}",
                     reason = returnMsg.returnReasonCode ?: "return",
                 )
+                reversalPerformed = true
             } catch (ex: ReversalUnavailableException) {
                 log.warnf(
                     ex,
@@ -260,6 +279,18 @@ class SepaPaymentService(
             SepaPaymentStatus.RETURNED,
             null,
             returnMsg.returnReasonCode,
+            // The evidence record and the transition commit together (issue #6056). `reversalPerformed`
+            // is the measured outcome of the call above, not the intent — an evidence record that
+            // claims a reversal a `ReversalUnavailableException` prevented would be worse than none.
+            evidencePayload = eventPublisher.returnEvidencePayload(
+                payment = payment,
+                originalEndToEndId = endToEndId,
+                returnReasonCode = returnMsg.returnReasonCode,
+                actorId = command.actorId,
+                actorType = command.actorType,
+                correlationId = command.correlationId,
+                reversalPerformed = reversalPerformed,
+            ),
         )
     }
 

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/domain/event/SepaPaymentEvents.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/domain/event/SepaPaymentEvents.kt
@@ -47,6 +47,51 @@ data class SepaPaymentStatusChangedEvent(
     val sourceService: String = "sepa-payment",
 )
 
+/**
+ * The non-repudiation record of one `POST /api/v1/sepa-payments/returns` invocation (issue #6056).
+ *
+ * **Why this exists next to [SepaPaymentStatusChangedEvent].** The status-changed event already
+ * says that a payment reached `RETURNED`; it does not say **who** presented the pacs.004 that
+ * caused it, under which correlation id, or against which original end-to-end reference. Those
+ * are exactly the facts a denial-of-having-processed-a-return dispute turns on, and the threat
+ * model's R row credited an `AuditService` that has never existed in this repository.
+ *
+ * **Where the evidence actually lands.** This is written into `sepa_payment_outbox` in the SAME
+ * transaction as the `RETURNED` transition (so the record and the act commit together or not at
+ * all), dispatched to `openbank.sepa.payment.events`, and consumed by openbank-audit-service's
+ * `AuditConsumer` into the append-only, hash-chained `audit_entries` table. It is deliberately
+ * NOT routed through `com.openbank.libs.audit.AuditEventPublisher`: the only implementation of
+ * that interface in this repository is `LoggingAuditEventPublisher`, and a log line written by
+ * the same code path whose behaviour is in dispute is not evidence.
+ *
+ * The field names are chosen to match what `AuditConsumer` reads, so the row is attributed rather
+ * than landing on its `"unknown"`/absent sentinels: `eventType`, `actorId`, `actorType`,
+ * `correlationId`, `occurredAt`, `sourceService`, and `paymentId` (which maps to the `PAYMENT`
+ * aggregate type).
+ */
+data class SepaPaymentReturnedEvent(
+    val paymentId: UUID,
+    /** `OrgnlEndToEndId` from the pacs.004 — the reference the dispute would be raised against. */
+    val originalEndToEndId: String,
+    /** pacs.004 `RtrRsnInf/Rsn/Cd` (AC04, AM09, ...); null when the message carried none. */
+    val returnReasonCode: String?,
+    /** Server-derived principal name of the caller that presented the pacs.004. Never from the body. */
+    val actorId: String,
+    /** Most-specific role held by that principal (`SecurityContext.actorType`). */
+    val actorType: String,
+    val correlationId: String?,
+    /** Whether the ledger reversal was actually performed, or skipped (no txId / reversal down). */
+    val reversalPerformed: Boolean,
+    val occurredAt: Instant,
+    /** Stated explicitly so the audit row is EVENT-attributed rather than topic-inferred (#3994). */
+    val eventType: String = RETURN_EVIDENCE_EVENT_TYPE,
+    /** See [SepaPaymentCreatedEvent.sourceService] (#3994/#5256). */
+    val sourceService: String = "sepa-payment",
+)
+
+/** Outbox/`ce-type` discriminator for [SepaPaymentReturnedEvent]. */
+const val RETURN_EVIDENCE_EVENT_TYPE = "sepa.payment.returned"
+
 fun SepaPayment.toStatusChangedEvent(previousStatus: SepaPaymentStatus, clock: Clock) = SepaPaymentStatusChangedEvent(
     paymentId = id,
     previousStatus = previousStatus,

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/kafka/KafkaSepaPaymentEventPublisher.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/kafka/KafkaSepaPaymentEventPublisher.kt
@@ -9,6 +9,7 @@ import com.openbank.libs.persistence.outbox.OutboxEntry
 import com.openbank.libs.persistence.outbox.OutboxEventPublisher
 import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
 import com.openbank.sepa.application.port.out.SepaPaymentEventPublisher
+import com.openbank.sepa.domain.event.SepaPaymentReturnedEvent
 import com.openbank.sepa.domain.event.toCreatedEvent
 import com.openbank.sepa.domain.event.toStatusChangedEvent
 import com.openbank.sepa.domain.model.SepaPayment
@@ -32,6 +33,27 @@ class KafkaSepaPaymentEventPublisher(
 
     override fun statusChangedPayload(previous: SepaPayment, current: SepaPayment): String =
         objectMapper.writeValueAsString(current.toStatusChangedEvent(previous.status, java.time.Clock.systemUTC()))
+
+    override fun returnEvidencePayload(
+        payment: SepaPayment,
+        originalEndToEndId: String,
+        returnReasonCode: String?,
+        actorId: String,
+        actorType: String,
+        correlationId: String?,
+        reversalPerformed: Boolean,
+    ): String = objectMapper.writeValueAsString(
+        SepaPaymentReturnedEvent(
+            paymentId = payment.id,
+            originalEndToEndId = originalEndToEndId,
+            returnReasonCode = returnReasonCode,
+            actorId = actorId,
+            actorType = actorType,
+            correlationId = correlationId,
+            reversalPerformed = reversalPerformed,
+            occurredAt = java.time.Instant.now(java.time.Clock.systemUTC()),
+        ),
+    )
 
     override suspend fun publish(entry: OutboxEntry) {
         val kafkaHeaders = RecordHeaders()

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/persistence/repository/SepaPaymentRepositoryImpl.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/persistence/repository/SepaPaymentRepositoryImpl.kt
@@ -13,6 +13,7 @@ import com.openbank.sepa.infrastructure.persistence.mapper.toDomain
 import com.openbank.sepa.infrastructure.persistence.mapper.toEntity
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
+import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
 import java.util.UUID
@@ -57,18 +58,39 @@ class SepaPaymentRepositoryImpl(private val outboxRepository: SepaPaymentOutboxR
     }.awaitSuspending().map { it.toDomain() }
 
     override suspend fun update(payment: SepaPayment, outboxMessage: SepaPaymentOutboxMessage): SepaPayment =
-        Panache.withTransaction {
-            find("paymentId", payment.id).firstResult()
-                .invoke { entity ->
-                    if (entity != null) {
-                        entity.status = payment.status.name
-                        entity.rejectReason = payment.rejectReason?.name
-                        entity.rejectDetail = payment.rejectDetail
-                        entity.submittedAt = payment.submittedAt
-                        entity.completedAt = payment.completedAt
-                        entity.updatedAt = payment.updatedAt
-                    }
+        updateWithMessages(payment, listOf(outboxMessage))
+
+    override suspend fun updateWithEvidence(
+        payment: SepaPayment,
+        outboxMessage: SepaPaymentOutboxMessage,
+        evidenceMessage: SepaPaymentOutboxMessage,
+    ): SepaPayment = updateWithMessages(payment, listOf(outboxMessage, evidenceMessage))
+
+    /**
+     * The single write path: the aggregate change and EVERY accompanying outbox message inside one
+     * `Panache.withTransaction`. The evidence row must not be able to commit without the transition
+     * (it would assert an act that did not happen) nor the transition without the evidence row
+     * (issue #6056 — that is the state this service shipped in).
+     */
+    private suspend fun updateWithMessages(
+        payment: SepaPayment,
+        outboxMessages: List<SepaPaymentOutboxMessage>,
+    ): SepaPayment = Panache.withTransaction {
+        find("paymentId", payment.id).firstResult()
+            .invoke { entity ->
+                if (entity != null) {
+                    entity.status = payment.status.name
+                    entity.rejectReason = payment.rejectReason?.name
+                    entity.rejectDetail = payment.rejectDetail
+                    entity.submittedAt = payment.submittedAt
+                    entity.completedAt = payment.completedAt
+                    entity.updatedAt = payment.updatedAt
                 }
-                .flatMap { outboxRepository.persistWithinCurrentTransaction(outboxMessage).replaceWith(payment) }
-        }.awaitSuspending()
+            }
+            .flatMap {
+                outboxMessages.fold(Uni.createFrom().voidItem()) { chain, message ->
+                    chain.flatMap { outboxRepository.persistWithinCurrentTransaction(message).replaceWithVoid() }
+                }.replaceWith(payment)
+            }
+    }.awaitSuspending()
 }

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/rest/SepaPaymentResource.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/rest/SepaPaymentResource.kt
@@ -7,6 +7,9 @@ package com.openbank.sepa.infrastructure.rest
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.libs.authz.Authorize
 import com.openbank.libs.idempotency.IdempotencyStore
+import com.openbank.libs.security.actorName
+import com.openbank.libs.security.actorType
+import com.openbank.libs.web.ApiVersionResponseFilter
 import com.openbank.sepa.application.port.`in`.HandlePaymentReturnCommand
 import com.openbank.sepa.application.port.`in`.ListSepaPaymentsQuery
 import com.openbank.sepa.application.port.`in`.PaymentConfirmationUseCase
@@ -26,8 +29,11 @@ import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.core.Context
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
+import jakarta.ws.rs.core.SecurityContext
 import org.eclipse.microprofile.openapi.annotations.Operation
 import org.eclipse.microprofile.openapi.annotations.tags.Tag
 import java.net.URI
@@ -141,8 +147,28 @@ class SepaPaymentResource(
     @RolesAllowed("ROLE_API", "ROLE_ADMIN")
     @Authorize(action = "sepaPayment.handleReturn")
     @Operation(summary = "Handle inbound pacs.004 payment return from clearing")
-    suspend fun handlePaymentReturn(pacs004Xml: String): Response {
-        val payment = paymentUseCase.handlePaymentReturn(HandlePaymentReturnCommand(pacs004Xml))
+    suspend fun handlePaymentReturn(
+        pacs004Xml: String,
+        @Context securityContext: SecurityContext,
+        @Context requestContext: ContainerRequestContext,
+    ): Response {
+        // Issue #6056. The actor is taken from the SECURITY CONTEXT and the correlation id from the
+        // property `CorrelationIdRequestFilter` set on this request — never from the pacs.004 body.
+        // The whole point of the record is that the party whose action is in dispute does not get
+        // to write the part of it that names them.
+        //
+        // `correlationId` is read from the request property rather than the MDC accessor in
+        // libs-security: this handler is `suspend`, and MDC is not guaranteed to survive the
+        // dispatch onto a coroutine, whereas the request property is on the request itself. It is
+        // the same value the response's `X-Correlation-ID` header carries.
+        val payment = paymentUseCase.handlePaymentReturn(
+            HandlePaymentReturnCommand(
+                pacs004Xml = pacs004Xml,
+                actorId = securityContext.actorName,
+                actorType = securityContext.actorType,
+                correlationId = requestContext.getProperty(ApiVersionResponseFilter.CORRELATION_ID_KEY)?.toString(),
+            ),
+        )
         return Response.ok(payment.toResponse()).build()
     }
 }

--- a/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/application/usecase/SepaPaymentServiceTest.kt
+++ b/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/application/usecase/SepaPaymentServiceTest.kt
@@ -23,6 +23,8 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
 import io.temporal.client.WorkflowClient
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -70,8 +72,12 @@ class SepaPaymentServiceTest {
 
         coEvery { paymentRepository.save(any(), any()) } answers { firstArg() }
         coEvery { paymentRepository.update(any(), any()) } answers { firstArg() }
+        coEvery { paymentRepository.updateWithEvidence(any(), any(), any()) } answers { firstArg() }
         every { eventPublisher.paymentCreatedPayload(any()) } returns "{\"event\":\"created\"}"
         every { eventPublisher.statusChangedPayload(any(), any()) } returns "{\"event\":\"status-changed\"}"
+        every {
+            eventPublisher.returnEvidencePayload(any(), any(), any(), any(), any(), any(), any())
+        } returns "{\"event\":\"returned\"}"
     }
 
     @Test
@@ -210,6 +216,17 @@ class SepaPaymentServiceTest {
 
     private val pacs004Builder = Pacs004Builder()
 
+    /**
+     * The actor/correlation triple the REST adapter derives server-side (issue #6056). Written once
+     * here so a test cannot accidentally assert against an actor a caller could have chosen.
+     */
+    private fun returnCommand(xml: String) = HandlePaymentReturnCommand(
+        pacs004Xml = xml,
+        actorId = "service-account-openbank-services",
+        actorType = "ROLE_API",
+        correlationId = "corr-6056",
+    )
+
     private fun pacs004Xml(endToEndId: String, reasonCode: String? = "AC04"): String = pacs004Builder.build(
         PaymentReturn(
             messageId = "MSG-001",
@@ -229,10 +246,60 @@ class SepaPaymentServiceTest {
         val existing = payment(status = SepaPaymentStatus.PROCESSING)
         coEvery { paymentRepository.findByEndToEndId(existing.endToEndId) } returns existing
 
-        val result = service.handlePaymentReturn(HandlePaymentReturnCommand(pacs004Xml(existing.endToEndId)))
+        val result = service.handlePaymentReturn(returnCommand(pacs004Xml(existing.endToEndId)))
 
         assertThat(result.status).isEqualTo(SepaPaymentStatus.RETURNED)
-        coVerify { paymentRepository.update(match { it.status == SepaPaymentStatus.RETURNED }, any()) }
+        // The evidence-carrying write path, not the plain one — a return that transitions without
+        // its non-repudiation record is the defect this fixes (issue #6056).
+        coVerify {
+            paymentRepository.updateWithEvidence(
+                match { it.status == SepaPaymentStatus.RETURNED },
+                any(),
+                any(),
+            )
+        }
+        coVerify(exactly = 0) { paymentRepository.update(any(), any()) }
+    }
+
+    @Test
+    fun `handlePaymentReturn writes the evidence outbox message in the same call as the transition`(): Unit =
+        runBlocking {
+            val existing = payment(status = SepaPaymentStatus.PROCESSING)
+            coEvery { paymentRepository.findByEndToEndId(existing.endToEndId) } returns existing
+            val evidence = slot<SepaPaymentOutboxMessage>()
+            val statusMessage = slot<SepaPaymentOutboxMessage>()
+            coEvery {
+                paymentRepository.updateWithEvidence(any(), capture(statusMessage), capture(evidence))
+            } answers { firstArg() }
+
+            service.handlePaymentReturn(returnCommand(pacs004Xml(existing.endToEndId)))
+
+            assertThat(evidence.captured.eventType).isEqualTo("sepa.payment.returned")
+            assertThat(evidence.captured.aggregateId).isEqualTo(existing.id)
+            assertThat(statusMessage.captured.eventType).isEqualTo("sepa.payment.status-changed")
+        }
+
+    @Test
+    fun `handlePaymentReturn takes the actor from the command, never from the pacs004 body`(): Unit = runBlocking {
+        val existing = payment(status = SepaPaymentStatus.PROCESSING)
+        coEvery { paymentRepository.findByEndToEndId(existing.endToEndId) } returns existing
+
+        service.handlePaymentReturn(returnCommand(pacs004Xml(existing.endToEndId, reasonCode = "AM09")))
+
+        verify {
+            eventPublisher.returnEvidencePayload(
+                payment = any(),
+                originalEndToEndId = existing.endToEndId,
+                returnReasonCode = "AM09",
+                actorId = "service-account-openbank-services",
+                actorType = "ROLE_API",
+                correlationId = "corr-6056",
+                // No transactionId on the seeded payment, so no reversal was performed. The record
+                // must say so: an evidence row claiming a reversal that did not happen is worse
+                // than none at all.
+                reversalPerformed = false,
+            )
+        }
     }
 
     @Test
@@ -240,7 +307,7 @@ class SepaPaymentServiceTest {
         val existing = payment(status = SepaPaymentStatus.RETURNED)
         coEvery { paymentRepository.findByEndToEndId(existing.endToEndId) } returns existing
 
-        val result = service.handlePaymentReturn(HandlePaymentReturnCommand(pacs004Xml(existing.endToEndId)))
+        val result = service.handlePaymentReturn(returnCommand(pacs004Xml(existing.endToEndId)))
 
         assertThat(result.status).isEqualTo(SepaPaymentStatus.RETURNED)
         coVerify(exactly = 0) { paymentRepository.update(any(), any()) }
@@ -249,7 +316,7 @@ class SepaPaymentServiceTest {
     @Test
     fun `handlePaymentReturn throws for invalid XML`() {
         assertThatThrownBy {
-            runBlocking { service.handlePaymentReturn(HandlePaymentReturnCommand("not-xml")) }
+            runBlocking { service.handlePaymentReturn(returnCommand("not-xml")) }
         }.isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("Invalid pacs.004")
     }
@@ -261,7 +328,7 @@ class SepaPaymentServiceTest {
         val xml = pacs004Xml(unknownE2eId)
 
         assertThatThrownBy {
-            runBlocking { service.handlePaymentReturn(HandlePaymentReturnCommand(xml)) }
+            runBlocking { service.handlePaymentReturn(returnCommand(xml)) }
         }.isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("No payment found for endToEndId")
     }

--- a/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/integration/SepaPaymentReturnAuditEvidenceIT.kt
+++ b/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/integration/SepaPaymentReturnAuditEvidenceIT.kt
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sepa.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.libs.iso20022.Pacs004Builder
+import com.openbank.libs.iso20022.PaymentReturn
+import com.openbank.libs.iso20022.SettlementMethod
+import com.openbank.sepa.application.port.out.SepaPaymentOutboxMessage
+import com.openbank.sepa.application.port.out.SepaPaymentRepository
+import com.openbank.sepa.domain.model.SepaPayment
+import com.openbank.sepa.domain.model.SepaPaymentStatus
+import com.openbank.sepa.domain.model.SepaPaymentType
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.vertx.VertxContextSupport
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import jakarta.ws.rs.core.MediaType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.config.ConfigProvider
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.sql.DriverManager
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Issue #6056 — proves that `POST /api/v1/sepa-payments/returns` leaves a durable non-repudiation
+ * record, attributed to the AUTHENTICATED caller.
+ *
+ * **Why this test and not a unit test.** The threat model's R row credited a control that did not
+ * exist, and the reason nobody noticed is that every existing test of the return path mocks the
+ * repository — a mocked repository can only ever confirm that a method was called, never that a
+ * row exists. So this drives the real HTTP endpoint (RestAssured + `@TestSecurity`, which is also
+ * the only way the `SecurityContext` the actor is derived from is populated at all) against a real
+ * Postgres, and reads the row back over **plain JDBC** — a second, independent connection that
+ * shares no code with the write path. Reading it back through the service's own reactive
+ * repository would ask the code under test whether it did its job.
+ *
+ * (The reactive Panache repository cannot be called from a bare `@QuarkusTest` thread at all —
+ * `No current Vertx context found` — hence `onEventLoop` for the seeding step, the pattern
+ * `SepaPaymentOutboxClaimIT` and `PaymentConfirmationSimulatorIT` already use.)
+ *
+ * What the evidence row is: an outbox row on `openbank.sepa.payment.events`, a topic
+ * openbank-audit-service already consumes into the append-only, hash-chained `audit_entries`
+ * table. This test proves the producing half — the row is written, in the same transaction as the
+ * transition, with the right fields. The consuming half is audit-service's own suite.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.sepa.it.PostgresRedisTestResource::class)
+class SepaPaymentReturnAuditEvidenceIT {
+
+    @Inject
+    lateinit var repository: SepaPaymentRepository
+
+    @Inject
+    lateinit var objectMapper: ObjectMapper
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    private fun seedProcessingPayment(): SepaPayment {
+        val id = UUID.randomUUID()
+        val toSave = SepaPayment(
+            id = id,
+            idempotencyKey = "it-return-$id",
+            type = SepaPaymentType.SCT,
+            status = SepaPaymentStatus.PROCESSING,
+            debtorAccountId = UUID.randomUUID(),
+            debtorIban = "DE89370400440532013000",
+            debtorName = "Alice Debtor",
+            creditorIban = "FR1420041010050500013M02606",
+            creditorName = "Bob Creditor",
+            creditorBic = "BNPAFRPPXXX",
+            amount = BigDecimal("42.50"),
+            currency = "EUR",
+            remittanceInfo = "IT return evidence",
+            endToEndId = "E2E-IT-RET-$id",
+            rejectReason = null,
+            rejectDetail = null,
+            // Deliberately no transactionId: the ledger reversal is then skipped, so this test needs
+            // no transaction-service stub AND it pins the honest `reversalPerformed = false` case.
+            submittedAt = Instant.now(),
+            completedAt = null,
+            createdAt = Instant.now(),
+            updatedAt = Instant.now(),
+        )
+        return onEventLoop {
+            repository.save(
+                payment = toSave,
+                outboxMessage = SepaPaymentOutboxMessage(
+                    aggregateId = toSave.id,
+                    eventType = "sepa.payment.created",
+                    payload = "{}",
+                    createdAt = Instant.now(),
+                ),
+            )
+        }
+    }
+
+    private fun pacs004(endToEndId: String, reasonCode: String): String = Pacs004Builder().build(
+        PaymentReturn(
+            messageId = "MSG-IT-6056",
+            creationDateTime = OffsetDateTime.now(),
+            settlementMethod = SettlementMethod.CLRG,
+            returnId = "RTR-IT-6056",
+            originalEndToEndId = endToEndId,
+            originalTransactionId = "TX-IT-6056",
+            returnedAmount = BigDecimal("42.50"),
+            currency = "EUR",
+            returnReasonCode = reasonCode,
+        ),
+    )
+
+    /** A second, independent connection — nothing here shares code with the write path. */
+    private fun outboxPayloads(aggregateId: UUID, eventType: String): List<String> {
+        val cfg = ConfigProvider.getConfig()
+        val url = cfg.getValue("quarkus.datasource.jdbc.url", String::class.java)
+        val user = cfg.getValue("quarkus.datasource.username", String::class.java)
+        val password = cfg.getValue("quarkus.datasource.password", String::class.java)
+        val payloads = mutableListOf<String>()
+        DriverManager.getConnection(url, user, password).use { conn ->
+            val sql = "select payload from sepa_payment_outbox where aggregate_id = ? and event_type = ?"
+            conn.prepareStatement(sql).use { st ->
+                st.setObject(1, aggregateId)
+                st.setString(2, eventType)
+                val rs = st.executeQuery()
+                while (rs.next()) payloads.add(rs.getString("payload"))
+            }
+        }
+        return payloads
+    }
+
+    @Test
+    @TestSecurity(user = "service-account-openbank-services", roles = ["ROLE_API"])
+    fun `a return leaves a durable evidence row naming the authenticated caller`() {
+        val payment = seedProcessingPayment()
+
+        Given {
+            contentType(MediaType.APPLICATION_XML)
+            header("X-Correlation-ID", "corr-it-6056")
+            body(pacs004(payment.endToEndId, "AM09"))
+        } When {
+            post("/api/v1/sepa-payments/returns")
+        } Then {
+            statusCode(200)
+        }
+
+        val evidence = outboxPayloads(payment.id, "sepa.payment.returned")
+        assertThat(evidence)
+            .describedAs("exactly one non-repudiation record for one return invocation")
+            .hasSize(1)
+
+        val node = objectMapper.readTree(evidence.single())
+        // The actor is the AUTHENTICATED principal. The pacs.004 body carries no actor field and
+        // none is read from it — a repudiation record the disputing party fills in records nothing.
+        assertThat(node.path("actorId").asText()).isEqualTo("service-account-openbank-services")
+        assertThat(node.path("actorType").asText()).isEqualTo("ROLE_API")
+        assertThat(node.path("correlationId").asText()).isEqualTo("corr-it-6056")
+        assertThat(node.path("originalEndToEndId").asText()).isEqualTo(payment.endToEndId)
+        assertThat(node.path("returnReasonCode").asText()).isEqualTo("AM09")
+        assertThat(node.path("paymentId").asText()).isEqualTo(payment.id.toString())
+        assertThat(node.path("reversalPerformed").asBoolean()).isFalse()
+        // These four are what audit-service's AuditConsumer reads; getting them wrong lands the row
+        // on its "unknown"/absent sentinels, and `source_service` is chain-hashed into `record_hash`
+        // so attribution cannot be corrected after the fact.
+        assertThat(node.path("eventType").asText()).isEqualTo("sepa.payment.returned")
+        assertThat(node.path("sourceService").asText()).isEqualTo("sepa-payment")
+        assertThat(node.path("occurredAt").asText()).isNotBlank()
+        assertThat(Instant.parse(node.path("occurredAt").asText()))
+            .describedAs("a real event time, not an Instant.EPOCH placeholder")
+            .isAfter(Instant.now().minusSeconds(600))
+
+        // The transition itself still commits its own status-changed event — the evidence row is
+        // additive, and both were written in ONE transaction with the payment row.
+        assertThat(outboxPayloads(payment.id, "sepa.payment.status-changed")).hasSize(1)
+    }
+}


### PR DESCRIPTION
Closes #6056. Refs #6037, #6048, #6059.

## Which fix, and why

The issue offered two honest answers: build the record, or delete the claim and re-open the risk.
**This PR builds the record.** `/returns` is a money-path reversal driven by an inbound pacs.004
from a service caller — "who presented the message that reversed this payment, under which
correlation id, against which original end-to-end reference" is exactly the question a dispute
turns on, and it had no answer. Deleting a true-but-unimplemented claim to make the document
self-consistent would have left the risk unmitigated and looked resolved; PR #6059 correctly
takes the document to "this control does not exist" in the meantime, and this PR is the code half
that lets that row become a positive claim again.

## What the audit publisher in this repo actually is

`com.openbank.libs.audit.AuditEventPublisher` has exactly **one** implementation:
`LoggingAuditEventPublisher`. It writes a structured log line. That is not an evidentiary record,
and it is written by the same code path whose behaviour a repudiation dispute puts in question —
so this PR deliberately does **not** route through it. Five services in this fleet credit an
"AuditEvent per action" against that interface; this is not a sixth.

The durable store is `openbank-audit-service`'s `audit_entries` — append-only at the DB
(`no_update_audit` / `no_delete_audit` are `DO INSTEAD NOTHING`) and hash-chained. It is fed by
`AuditConsumer`, which already subscribes to `openbank.sepa.payment.events`. So the evidence path
that exists here is the transactional outbox, and that is the one used.

## What changed

- `SepaPaymentReturnedEvent` (`sepa.payment.returned`) — the non-repudiation record: `paymentId`,
  `originalEndToEndId`, `returnReasonCode`, `actorId`, `actorType`, `correlationId`,
  `reversalPerformed`, `occurredAt`, `sourceService`.
- `SepaPaymentRepository.updateWithEvidence` — writes the status-changed message **and** the
  evidence message with the aggregate change in ONE `Panache.withTransaction`. A separate method
  rather than a defaulted parameter on `update`, so no call site can silently resolve to the
  evidence-free variant.
- `SepaPaymentResource.handlePaymentReturn` now derives the actor from `SecurityContext`
  (`actorName`/`actorType`) and the correlation id from the request property
  `CorrelationIdRequestFilter` set. **Nothing is read from the request body** — the pacs.004
  carries no actor field and none is consulted. (Several services in this fleet take
  `reviewedBy`/`operatorId` from the caller; that defeats the control entirely.)
- `reversalPerformed` is the **measured** outcome of the reversal call, not the intent: a
  `ReversalUnavailableException` or a missing `transactionId` records `false`. An evidence row
  claiming a reversal that did not happen would be worse than no row.
- Field names match what `AuditConsumer` actually reads, so the row is EVENT-attributed rather
  than landing on its `"unknown"` sentinels. `source_service` is chain-hashed into `record_hash`,
  so attribution cannot be corrected afterwards — it had to be right the first time.
- Threat model §5a **R** row rewritten to the control that now exists, plus a §6 change-log entry.

Dispatch is already enabled (`openbank.outbox.dispatch-enabled: true` in this service's
`application.yaml`), so the row does not sit in the outbox undispatched.

## Proof that a row actually lands

`SepaPaymentReturnAuditEvidenceIT` (new) — real HTTP (`RestAssured` + `@TestSecurity`, which is
also the only way the `SecurityContext` the actor comes from is populated at all) against a real
Testcontainers Postgres, and the row is read back over a **plain JDBC connection** that shares no
code with the write path. Reading it back through the service's own reactive repository would be
asking the code under test whether it did its job; a mocked repository cannot establish existence
at all, which is why every pre-existing test of this path was blind to the defect.

It asserts exactly one `sepa.payment.returned` row for one invocation, the authenticated actor
(`service-account-openbank-services` / `ROLE_API`, from the token, not the body), the correlation
id, the `OrgnlEndToEndId`, the reason code, `reversalPerformed = false`, a real `occurredAt`
(recency, not non-nullity), and that the status-changed event still commits alongside it.

**Negative control**: with only the production change reverted (`updateWithEvidence` call replaced
by the plain `update`, evidence payload dropped) the test fails as
`exactly one non-repudiation record for one return invocation` — expected size 1, actual 0.

## No API or trust-boundary change

Same endpoint, same role gate, same OPA action, same topic, same request/response bodies. No
`openapi.yaml` change, no migration. The only new thing on the wire is the evidence event, on an
existing cluster-internal topic that audit-service already consumes.

## Coordination

#6059 edits the same §5a R row (to the "does not exist" correction). Whichever lands second takes
a one-line conflict; the correct resolution is this PR's positive row, since the control it
describes is in the same commit.

Money-path: 2 approvals + threat model per ADR-0030. Not auto-merged.
