### PR TITLE
fix(admin-ui): gate DevOps HITL decisions

### DIFF
--- a/openbank-admin-ui/src/app/devops/page.tsx
+++ b/openbank-admin-ui/src/app/devops/page.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { AuthGuard } from '@/components/auth/AuthGuard'
+import { useAuth } from '@/lib/auth/useAuth'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import type { UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { AgentInsightsPanel } from '@/components/agent/AgentInsightsPanel'
@@ -225,6 +226,8 @@ function toAgentFinding(f: DevOpsFinding, t: (cs: string, en: string) => string)
 
 function DevOpsContent() {
   const { t, language } = useLanguage()
+  const { hasPermission } = useAuth()
+  const canDecide = hasPermission('devops:decide')
   const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const numberLocale = dateLocale
   const [dora, setDora] = useState<DoraData | null>(null)
@@ -234,6 +237,7 @@ function DevOpsContent() {
   const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
   const [deciding, setDeciding] = useState<string | null>(null)
+  const [decisionError, setDecisionError] = useState<string | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -266,19 +270,27 @@ function DevOpsContent() {
   // graceful-state rule (no raw HTTP status in the UI).
   const decide = useCallback(async (id: string, action: 'approve' | 'reject') => {
     setDeciding(id)
+    setDecisionError(null)
     try {
-      await fetch('/api/devops/decide', {
+      const res = await fetch('/api/devops/decide', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id, action }),
       })
+      if (!res.ok) {
+        setDecisionError(t(
+          'Rozhodnutí se nepodařilo uložit. Pravděpodobně nemáte oprávnění nebo je služba nedostupná.',
+          'The decision could not be saved. You may not have permission or the service is unavailable.',
+        ))
+        return
+      }
       await load()
     } catch {
-      // swallow — the next 60s refresh reconciles state
+      setDecisionError(t('Služba DevOps neodpovídá. Zkuste to prosím znovu.', 'The DevOps service did not respond. Please try again.'))
     } finally {
       setDeciding(null)
     }
-  }, [load])
+  }, [load, t])
 
   useEffect(() => { load() }, [load])
   useEffect(() => {
@@ -429,11 +441,16 @@ function DevOpsContent() {
             )}
             findings={findings.map(f => toAgentFinding(f, t))}
             emptyMessage={t('Žádné aktivní DevOps nálezy — pipeline v pořádku', 'No active DevOps findings — pipeline healthy')}
-            onApprove={id => decide(id, 'approve')}
-            onReject={id => decide(id, 'reject')}
-            decideLabels={{ approve: t('Schválit', 'Approve'), reject: t('Odmítnout', 'Reject') }}
-            decidingId={deciding}
+            onApprove={canDecide ? id => decide(id, 'approve') : undefined}
+            onReject={canDecide ? id => decide(id, 'reject') : undefined}
+            decideLabels={canDecide ? { approve: t('Schválit', 'Approve'), reject: t('Odmítnout', 'Reject') } : undefined}
+            decidingId={canDecide ? deciding : null}
           />
+          {decisionError && (
+            <div role="alert" style={{ marginBottom: '20px', padding: '12px 16px', borderRadius: '8px', background: 'var(--danger-bg)', border: '1px solid var(--danger-border)', color: 'var(--danger-text)', fontSize: '12px' }}>
+              {decisionError}
+            </div>
+          )}
 
           {/* Data source guidance */}
           {dora && (!dora.sources.git || !dora.sources.prometheus) && (

--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -156,6 +156,9 @@ export const PERMISSIONS = {
   // @RolesAllowed/rego to have verified against, because these pages proxy telemetry
   // (Prometheus, Holmes, k8s) rather than calling a service with its own RBAC.
   "system:view":              [ROLES.ADMIN, ROLES.OPERATOR, ROLES.DEMO],
+  // DevOps findings are readable by system:view, but the devops-agent POST approval/rejection
+  // endpoints are ADMIN-only. Keep HITL decision authority explicit in the UI matrix.
+  "devops:decide":             [ROLES.ADMIN],
   "system:config":            [ROLES.ADMIN],
   // Docs
   "docs:view":                [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER, ROLES.COMPLIANCE, ROLES.PAYMENTS, ROLES.AUDITOR],

--- a/openbank-admin-ui/src/test/devops-hitl-rbac.guard.test.ts
+++ b/openbank-admin-ui/src/test/devops-hitl-rbac.guard.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = path.resolve(process.cwd(), 'src')
+const page = fs.readFileSync(path.join(root, 'app/devops/page.tsx'), 'utf8')
+const roles = fs.readFileSync(path.join(root, 'lib/auth/roles.ts'), 'utf8')
+
+describe('DevOps HITL authority contract', () => {
+  it('keeps read access broad but gates decisions to the backend-authorized role', () => {
+    expect(roles).toContain('"system:view":              [ROLES.ADMIN, ROLES.OPERATOR, ROLES.DEMO]')
+    expect(roles).toContain('"devops:decide":             [ROLES.ADMIN]')
+    expect(page).toContain("<AuthGuard permission=\"system:view\">")
+    expect(page).toContain("hasPermission('devops:decide')")
+    expect(page).toContain("onApprove={canDecide ? id => decide(id, 'approve') : undefined}")
+    expect(page).toContain("onReject={canDecide ? id => decide(id, 'reject') : undefined}")
+  })
+
+  it('reports failed decision writes instead of silently refreshing', () => {
+    expect(page).toContain('if (!res.ok)')
+    expect(page).toContain('decisionError')
+    expect(page).toContain('role="alert"')
+  })
+})


### PR DESCRIPTION
Closes #1915

- keep DevOps findings readable for system:view operators
- gate approve/reject to backend-authorized ADMIN via devops:decide
- surface non-2xx and timeout failures instead of silently refreshing
- add source guard for authority and failure feedback

Type-check and diff-check pass; Vitest is blocked locally by missing Rolldown native binding.