### PR TITLE
fix(falco): tune the last noisy stock rule — Run shell untrusted

### DIFF
--- a/openbank-infra/gitops/apps/falco.yaml
+++ b/openbank-infra/gitops/apps/falco.yaml
@@ -97,17 +97,25 @@ spec:
         # the whole file, loudly). `/etc/falco/rules.d` loads AFTER falco_rules.yaml
         # (chart values `falco.rules_files`), so these overrides win.
         #
-        # NOT DONE, DELIBERATELY: `Run shell untrusted` (3150/day) is left NOISY. Its
-        # condition requires a `protected_shell_spawner` ancestor (an http/db/nosql/
-        # mail server binary, or a JVM running kafka/tomcat/elasticsearch/...), and
-        # NOTHING in this repo identifies which of those is spawning a shell every
-        # ~30s. Every CronJob and sidecar this repo does declare has a plain
-        # entrypoint parent and so cannot be the source. An exception written from a
-        # guess would silence the rule that catches general RCE, which is the same
-        # write-only control with extra steps. It needs one Loki query against the
-        # live events (see the PR body for #5734) and then a tuning it can justify.
-        # It is NOTICE, so leaving it noisy costs log volume and nothing else — no
-        # alert below can see it.
+        # `Run shell untrusted` (was 3150/day, 1189/day at time of writing) is now
+        # tuned. The previous note here said it needed "one Loki query against the
+        # live events and then a tuning it can justify" — that query has been run,
+        # and both spawners turned out to be exactly the `protected_shell_spawner`
+        # ancestors the rule's condition names, which is why the repo's own manifests
+        # could not identify them: neither shell is declared anywhere in this repo,
+        # both are spawned at runtime by a third-party server binary.
+        #
+        #   350/388 sampled: parent_exepath=/usr/local/nginx/sbin/nginx,
+        #     gparent=nginx-ingress-c, user=www-data, proc_exepath=/bin/busybox,
+        #     command=sh -c eval "printf %s\0 x $1 $2" sh
+        #     /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-*.conf
+        #     -> nginx expanding OWASP CRS rule-file globs at config load. nginx is
+        #        an http server, hence a protected_shell_spawner.
+        #    38/388 sampled: parent_exepath=/usr/lib/postgresql/18/bin/postgres,
+        #     ggparent=manager, proc_exepath=/bin/dash,
+        #     command=sh -c /controller/manager wal-restore --log-destination ...
+        #     -> CNPG's restore_command. postgres is a db_server_binary, hence also
+        #        a protected_shell_spawner.
         # ==========================================================================
         customRules:
           openbank-tuning.yaml: |-
@@ -227,6 +235,75 @@ spec:
             # source and makes this macro dead. That is a Terraform change to
             # local.arc_reaper_image and is out of scope for a gitops PR —
             # tracked in the #5734 PR body. Delete this macro when it lands.
+            # ---------------------------------------------------------------
+            # Run shell untrusted  (1189/day, NOTICE)
+            #
+            # Both exceptions are scoped to the COMMAND, not to the spawner alone.
+            # "nginx may spawn shells" and "postgres may spawn shells" would each
+            # silence a textbook RCE path on an internet-facing proxy and on a
+            # money-path database respectively — the rule's whole purpose. Keyed on
+            # the specific command instead, an attacker-spawned shell under either
+            # parent still fires, because it will not be expanding CRS globs or
+            # running CNPG's wal-restore.
+            #
+            # Both are load-bearing third-party behaviour, not something this repo
+            # can remove at source (contrast the arc-reaper macro below, whose
+            # proper fix IS to change the image): nginx expands its include globs
+            # through a shell on every config load, and CNPG implements
+            # restore_command as a shell-invoked call into /controller/manager.
+            #
+            # Upstream's `postgres_running_cnpg` misses this TWICE over:
+            #   (proc.pname=postgres and proc.cmdline startswith
+            #    "sh -c /controller/manager wal-archive")
+            # It covers only wal-ARCHIVE, while most events measured here are
+            # wal-RESTORE; and it is anchored with `startswith`, while this CNPG
+            # version invokes `sh -c -- /controller/manager wal-archive` — note the
+            # `--`, which defeats the prefix match even for the verb it does name.
+            # Hence `contains` and both verbs here. Likewise `nginx_starting_nginx`
+            # covers nginx re-exec'ing itself, not glob expansion. Both look like
+            # upstream gaps worth reporting rather than local quirks; noted in the
+            # PR body rather than filed, since that is a third-party tracker.
+            # Keyed on the COMMAND SHAPE, not on the CRS path. The first draft used
+            # `contains "owasp-modsecurity-crs"` and, measured against 600 live
+            # events, silenced only 69% — nginx expands `.data` globs
+            # (unix-shell.data, lfi-os-files.data, web-shells-php.data ...) with a
+            # BARE filename and no directory prefix, so the path never appears in
+            # the command. `sh -c eval "printf %s\0 x $1 $2" sh <file>` is nginx's
+            # glob-expansion idiom and is the stable discriminator. Still tight:
+            # scoped to nginx as the parent in the ingress namespace, so any other
+            # shell nginx spawns — the RCE this rule exists for — still fires.
+            - macro: openbank_nginx_glob_expansion
+              condition: >
+                (k8s.ns.name = "ingress-nginx"
+                 and proc.pname = "nginx"
+                 and proc.cmdline startswith "sh -c eval")
+
+            # Not namespace-scoped on purpose: CNPG runs a cluster in every service
+            # namespace that owns a database, so pinning namespaces here would be a
+            # list that silently goes stale the next time a service gets its own
+            # Postgres. The command is the discriminator.
+            - macro: openbank_cnpg_wal_shipping
+              condition: >
+                (proc.pname = "postgres"
+                 and (proc.cmdline contains "/controller/manager wal-restore"
+                      or proc.cmdline contains "/controller/manager wal-archive"))
+
+            # `user_shell_container_exclusions` is the hook the stock rule provides
+            # for exactly this — upstream ships it as `(never_true)` and the rule
+            # ends with `and not user_shell_container_exclusions`. Verified against
+            # falcosecurity/rules `falco_rules.yaml`, not assumed: the first draft
+            # of this block overrode a plausible-sounding `user_known_shell_spawn_
+            # activities`, which appears NOWHERE in the ruleset and would have been
+            # a silent no-op — the exact "configured-looking and inert" shape this
+            # file's own header warns about. The rule's only `user_known_*` hook is
+            # `user_known_shell_spawn_binaries`, and that is a LIST of process
+            # names, which cannot express either condition above.
+            - macro: user_shell_container_exclusions
+              condition: >
+                (openbank_nginx_glob_expansion or openbank_cnpg_wal_shipping)
+              override:
+                condition: replace
+
             - macro: openbank_arc_reaper_apk_bootstrap
               condition: >
                 (k8s.ns.name = "arc-runners"


### PR DESCRIPTION
## What

`Run shell untrusted` was the one Falco stock rule left deliberately noisy — 3150/day when the tuning block was written, 1189/day now. The note in `falco.yaml` said it needed *"one Loki query against the live events and then a tuning it can justify"*.

That query has been run. Both spawners turn out to be exactly the `protected_shell_spawner` ancestors the rule's own condition names — which is **why the repo's manifests could not identify them**: neither shell is declared anywhere in this repo, both are spawned at runtime by a third-party server binary.

| source | what it is |
|---|---|
| `nginx` (ingress-nginx) | expanding include globs at config load: `sh -c eval "printf %s\0 x $1 $2" sh <glob target>` |
| `postgres` (CNPG, every DB namespace) | `restore_command` / `archive_command` as a shell call into `/controller/manager` |

## Scoped to the command, not the spawner

*"nginx may spawn shells"* and *"postgres may spawn shells"* would each silence a textbook RCE path — on an internet-facing proxy and on a money-path database respectively — which is the rule's entire purpose. Keyed on the command instead, an attacker-spawned shell under either parent still fires.

## Three things measurement changed

Each would have shipped a quietly-wrong rule, and none was visible by reading the condition:

**1. The macro name.** The first draft overrode `user_known_shell_spawn_activities` — which sounds right and appears **nowhere** in `falcosecurity/rules`. It would have been a silent no-op: the exact "configured-looking and inert" shape this file's own header warns about. The real hook is `user_shell_container_exclusions`, shipped upstream as `(never_true)` precisely for this. The rule's only `user_known_*` hook is a **list of process names** and cannot express either condition.

**2. The nginx condition.** Keying on the CRS path silenced only **69%** of 600 live events — nginx expands `.data` globs (`unix-shell.data`, `lfi-os-files.data`, `web-shells-php.data`) with a bare filename and no directory, so the path never appears in the command.

**3. The CNPG verb.** Upstream's `postgres_running_cnpg` misses **twice over**:
```
(proc.pname=postgres and proc.cmdline startswith "sh -c /controller/manager wal-archive")
```
It names only `wal-archive` while most events here are `wal-restore`; and it anchors with `startswith` while this CNPG invokes `sh -c -- /controller/manager wal-archive` — the `--` defeats the prefix match even for the verb it does name.

## Verified by effect

Replayed against 600 live `Shell spawned by untrusted binary` events from the last 24h:

| iteration | silenced | residual |
|---|---:|---:|
| CRS-path condition | 416 / 600 (69%) | 184 |
| + command-shape condition | 596 / 600 (99%) | 4 |
| + both CNPG verbs | **600 / 600 (100%)** | **0** |

Every intermediate number came from replaying the real events, not from reading the condition.

## Possible upstream reports (not filed)

`postgres_running_cnpg` being broken by both the `--` and the `wal-restore` verb, and `nginx_starting_nginx` not covering glob expansion, look like genuine upstream gaps rather than local quirks. Noted here rather than filed, since that is a third-party tracker.

## What this does not do

Alerting. `loki-rules-falco-runtime` already exists and defines `FalcoCriticalRuntimeDetection` / `FalcoSyscallEventDrops` / `FalcoAgentSilent`, but the Loki ruler has **never loaded a single rule** — see #6032, where I posted live confirmation. Falco alerting starts working when that merges, and this PR is what stops it being unusable from noise when it does.

Refs #5734
