### PR TITLE
fix(agent): default the model endpoint to the LiteLLM gateway, not decommissioned Groq

### DIFF
--- a/.github/scripts/check-external-feeds.py
+++ b/.github/scripts/check-external-feeds.py
@@ -172,7 +172,6 @@ FEEDS = [
 # Each needs a reason. This list is the thing a human has to justify, not the coverage.
 NOT_PROBED = [
     ("https://api.github.com", "authenticated API, not a data feed; failure is loud at call time"),
-    ("https://api.groq.com/openai/v1", "authenticated LLM gateway (ADR-0139); needs a key"),
     ("https://api.deepinfra.com/v1/openai", "authenticated LLM gateway; needs a key"),
     ("https://integrate.api.nvidia.com/v1", "authenticated LLM gateway; needs a key"),
     ("https://s3.eu-north-1.amazonaws.com", "AWS endpoint, reached with SigV4 credentials"),

--- a/openbank-agent-service/src/main/resources/application.yaml
+++ b/openbank-agent-service/src/main/resources/application.yaml
@@ -186,22 +186,30 @@ model-gateway:
     - id: mock-echo
       provider: mock
       sensitivity: hosted
-    # Groq — free, fast, OpenAI-compatible. `id` is sent verbatim as the upstream model name.
-    # Served by the single `openai-compat` adapter; needs an API key (see agent.model.openai).
+    # `id` is sent verbatim as the upstream model name, and is the CALLER-FACING id: it is a
+    # `model_name` in litellm-config, never a provider's own id. Served by the single
+    # `openai-compat` adapter; needs an API key (see agent.model.openai).
     #
-    # ADR-0174/0175 (#1919): in a deployed environment the endpoint is repointed at the in-cluster
-    # LiteLLM gateway (`http://litellm.ai-platform.svc:4000/v1`) via AGENT_MODEL_ENDPOINT, so the
-    # gateway is the single pod allowed to leave the cluster to a US LLM provider and the provider
-    # key never lands in this pod. The model id is unchanged — litellm-config maps
-    # `llama-3.3-70b-versatile` to `groq/llama-3.3-70b-versatile` — so this is an endpoint + key
-    # change only. The direct-to-Groq URL stays the default for local dev / `./gradlew quarkusDev`,
-    # where there is no gateway to route through.
+    # ADR-0174/0175 (#1919): the LiteLLM gateway is the single pod allowed to leave the cluster to
+    # a US LLM provider, so the provider key never lands in this pod. The endpoint therefore
+    # DEFAULTS to the in-cluster gateway — the same value the deployment sets in
+    # AGENT_MODEL_ENDPOINT — which is also the fleet convention (`LLM_GATEWAY_URL` in
+    # finops-agent, docs-truth-agent, governance-auditor, release-steward, flaky-test-hunter and
+    # authz-policy-auditor). Local dev reaches it with `kubectl port-forward -n ai-platform
+    # svc/litellm 4000:4000`, or overrides AGENT_MODEL_ENDPOINT; nothing here is needed for the
+    # build or the tests, which run on `mock-echo`.
+    #
+    # It used to default direct-to-Groq. That was wrong in two ways once #6041 landed: Groq
+    # DECOMMISSIONED `llama-3.3-70b-versatile` (404 `model_not_found`, issue #5736), and the two
+    # ids below have never been Groq ids at all — the gateway resolves all three to DeepInfra.
+    # A provider base-URL hard-coded next to a caller-facing id is the bug: it asserts a mapping
+    # this file cannot see. There are now ZERO `model: groq/` routes in litellm-config.
     - id: llama-3.3-70b-versatile
       provider: openai-compat
-      endpoint: ${AGENT_MODEL_ENDPOINT:https://api.groq.com/openai/v1}
+      endpoint: ${AGENT_MODEL_ENDPOINT:http://litellm.ai-platform.svc:4000/v1}
       sensitivity: hosted
-    # Paid alternatives to the free Groq tier above, served through the SAME gateway endpoint and
-    # the same virtual key — a model entry here plus a route in litellm-config, no code change.
+    # Alternatives to the entry above, served through the SAME gateway endpoint and the same
+    # virtual key — a model entry here plus a route in litellm-config, no code change.
     #
     # WHY THESE TWO AND NOT WHATEVER IS TOP OF A LEADERBOARD: they were measured against a real
     # Czech admin prompt through the gateway before being registered — gpt-oss-120b in 1-3s,
@@ -221,11 +229,11 @@ model-gateway:
     # which is the `vLLM` line ADR-0265 left as planned.
     - id: openai/gpt-oss-120b
       provider: openai-compat
-      endpoint: ${AGENT_MODEL_ENDPOINT:https://api.groq.com/openai/v1}
+      endpoint: ${AGENT_MODEL_ENDPOINT:http://litellm.ai-platform.svc:4000/v1}
       sensitivity: hosted
     - id: deepseek-ai/DeepSeek-V4-Pro
       provider: openai-compat
-      endpoint: ${AGENT_MODEL_ENDPOINT:https://api.groq.com/openai/v1}
+      endpoint: ${AGENT_MODEL_ENDPOINT:http://litellm.ai-platform.svc:4000/v1}
       sensitivity: hosted
     # The SAME openai-compat adapter serves any OpenAI-shaped backend — just change endpoint+key:
     # - id: qwen2.5                       # self-hosted Ollama for the SELF_HOSTED (sensitive) tier

--- a/openbank-agent-service/src/main/resources/docs/05-operations.cs.md
+++ b/openbank-agent-service/src/main/resources/docs/05-operations.cs.md
@@ -19,7 +19,7 @@
 | `QUARKUS_OIDC_AUTH_SERVER_URL` | `http://localhost:8080/realms/openbank` | issuer Keycloak realmu |
 | `OIDC_TLS_VERIFICATION` | `none` | nastavte na `required` v reálném HTTPS deployi |
 | `AGENT_DEFAULT_MODEL` | `mock-echo` | default model id gateway |
-| `AGENT_MODEL_ENDPOINT` | `https://api.groq.com/openai/v1` | base URL `openai-compat` backendu. V nasazeném prostředí nastavte na `http://litellm.ai-platform.svc:4000/v1` — in-cluster LiteLLM gateway, jediný workload, který smí komunikovat s hostovaným LLM providerem (ADR-0174/0175) |
+| `AGENT_MODEL_ENDPOINT` | `http://litellm.ai-platform.svc:4000/v1` | base URL `openai-compat` backendu. Výchozí je in-cluster LiteLLM gateway, jediný workload, který smí komunikovat s hostovaným LLM providerem (ADR-0174/0175) — stejná hodnota, jakou nastavuje nasazení. Registrovaná model id jsou `model_name` gateway, ne id providera, takže přímá URL providera je neobsluhuje (#5736) |
 | `AGENT_MODEL_API_KEY` | *(fallback na `GROQ_API_KEY`)* | klíč pro `openai-compat` backend. V nasazení jde o **virtuální** klíč LiteLLM, nikoli klíč providera (OpenBao/ESO — nikdy v gitu) |
 | `GROQ_API_KEY` | *(prázdné)* | legacy/local-dev fallback předchozího, při přímé komunikaci s Groq |
 | `AGENT_POLICY_ENFORCEMENT` | `advisory` | `advisory` (jen audit) nebo `block` (vynutit DENY) — ADR-0031 D9 |

--- a/openbank-agent-service/src/main/resources/docs/05-operations.en.md
+++ b/openbank-agent-service/src/main/resources/docs/05-operations.en.md
@@ -19,7 +19,7 @@
 | `QUARKUS_OIDC_AUTH_SERVER_URL` | `http://localhost:8080/realms/openbank` | Keycloak realm issuer |
 | `OIDC_TLS_VERIFICATION` | `none` | set to `required` in a real HTTPS deploy |
 | `AGENT_DEFAULT_MODEL` | `mock-echo` | gateway default model id |
-| `AGENT_MODEL_ENDPOINT` | `https://api.groq.com/openai/v1` | base URL of the `openai-compat` backend. In a deployed environment set to `http://litellm.ai-platform.svc:4000/v1` — the in-cluster LiteLLM gateway, the only workload permitted to egress to a hosted LLM provider (ADR-0174/0175) |
+| `AGENT_MODEL_ENDPOINT` | `http://litellm.ai-platform.svc:4000/v1` | base URL of the `openai-compat` backend. Defaults to the in-cluster LiteLLM gateway, the only workload permitted to egress to a hosted LLM provider (ADR-0174/0175) — the same value the deployment sets. The registered model ids are gateway `model_name`s, not provider ids, so a direct-to-provider base URL does not serve them (#5736) |
 | `AGENT_MODEL_API_KEY` | *(falls back to `GROQ_API_KEY`)* | key for the `openai-compat` backend. Deployed, this is the LiteLLM **virtual** key, not a provider key (OpenBao/ESO — never in git) |
 | `GROQ_API_KEY` | *(empty)* | legacy/local-dev fallback for the above when talking to Groq directly |
 | `AGENT_POLICY_ENFORCEMENT` | `advisory` | `advisory` (audit-only) or `block` (enforce DENY) — ADR-0031 D9 |

--- a/openbank-agent-service/src/test/kotlin/com/openbank/agent/infrastructure/model/ModelGatewayRoutingOverrideTest.kt
+++ b/openbank-agent-service/src/test/kotlin/com/openbank/agent/infrastructure/model/ModelGatewayRoutingOverrideTest.kt
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test
  *
  * This guards the two config seams the GitOps manifest drives:
  *  - `AGENT_MODEL_ENDPOINT` overrides the `llama-3.3-70b-versatile` entry's base URL (it is
- *    `${AGENT_MODEL_ENDPOINT:https://api.groq.com/openai/v1}` in the committed config). Without the
+ *    `${AGENT_MODEL_ENDPOINT:http://litellm.ai-platform.svc:4000/v1}` in the committed config). Without the
  *    placeholder the endpoint is baked into the image and repointing is impossible from GitOps.
  *  - `AGENT_MODEL_API_KEY` overrides `agent.model.openai.api-key`, which is
  *    `${AGENT_MODEL_API_KEY:${GROQ_API_KEY:}}` — a *nested* default, so a deploy still on a


### PR DESCRIPTION
Refs #5736

#6041 repointed the deployed route to DeepInfra via the LiteLLM gateway config and
deliberately scoped itself to gitops. This is the in-repo tail.

## Re-verified on live `origin/main` — both findings stand, and one is wider than reported

- `openbank-agent-service/src/main/resources/application.yaml:201` did still default to
  `https://api.groq.com/openai/v1`, for the id Groq decommissioned. Confirmed.
- The comment above it did still assert litellm-config maps `llama-3.3-70b-versatile` to
  `groq/llama-3.3-70b-versatile`. There are **zero** `model: groq/` routes left in that
  file. Confirmed.
- **Not in the report: it is three entries, not one.** `openai/gpt-oss-120b` and
  `deepseek-ai/DeepSeek-V4-Pro` carried the same Groq default, and those ids have never
  been Groq ids in the first place — the gateway resolves both to DeepInfra. So the
  default was unusable for all three, and the one that got noticed is only the one that
  used to work.

That is the actual bug class here: **a provider base-URL hard-coded next to a
caller-facing id.** The `id` in this file is a LiteLLM `model_name`, not a provider's own
id; pairing it with a direct-to-provider URL asserts a mapping this file cannot see and
nothing validates.

## The default I chose, and why

`http://litellm.ai-platform.svc:4000/v1` — the in-cluster gateway.

- It is **exactly** what the deployment already sets (`AGENT_MODEL_ENDPOINT` in
  `gitops/components/agent/agent-service.yaml`), so local dev and prod now traverse the
  same route instead of two routes only one of which is exercised.
- It is the **fleet convention**: six services default to the gateway
  (`LLM_GATEWAY_URL: http://litellm.ai-platform:4000` — finops-agent, docs-truth-agent,
  governance-auditor, release-steward, flaky-test-hunter, authz-policy-auditor). Three
  default direct-to-DeepInfra. **Nobody but agent-service defaulted to Groq.**
- The provider key then never needs to exist in this pod (ADR-0174/0175).

Cost: a dev with no cluster gets connection-refused rather than a reply. That is
strictly better than the 404 `model_not_found` it replaced — a refused connection names
its own cause. And it changes nothing for the build or the tests, which run on
`mock-echo` (`default-model` is untouched).

## Evidence the ids are currently served — read from the running gateway, not from a file

A model id is an unverified claim about someone else's catalogue, and this repo has now
been bitten by that twice. So the ids were not taken from the committed config. Probed
the **running** LiteLLM pod's own on-disk config (`--config /etc/litellm/config.yaml`,
read-only, no credential involved, so nothing here depends on a key being valid):

| registered `id` | gateway `model_name` present | resolves to |
|---|---|---|
| `llama-3.3-70b-versatile` | yes | `deepinfra/meta-llama/Llama-3.3-70B-Instruct-Turbo` |
| `openai/gpt-oss-120b` | yes | `deepinfra/openai/gpt-oss-120b` |
| `deepseek-ai/DeepSeek-V4-Pro` | yes | `deepinfra/deepseek-ai/DeepSeek-V4-Pro` |

All three resolve, and the pod is serving #6041's post-repoint mapping — i.e. the roll
happened, which is a second thing the file alone could not tell you. No id was changed
in this PR; only the endpoint they are reached through.

## The gate caught its own stale declaration, and that is not incidental

Removing the last `api.groq.com` from a scanned YAML made `check-external-feeds.py` fail:

```
DRIFT stale NOT_PROBED entry: https://api.groq.com/openai/v1 ... is no longer in any scanned YAML
```

It is enforced in both directions, so the dead declaration could not quietly become
permanent. Dropped the entry. **Negative control:** the same script on unmodified
`origin/main` exits 0 — so the failure was caused by this change and the gate is not
merely always-red.

## Sweep for the same shape — one more, filed separately

Checked every `src/main/resources/application.yaml` in the fleet for a hard-defaulted
provider base-URL or model id.

- **`openbank-copilot-service` is the same shape** and is left for its own change: it
  defaults to `https://integrate.api.nvidia.com/v1` + `mistralai/mistral-nemotron` while
  its deployment routes to the gateway with `deepseek-ai/DeepSeek-V3.2`. The gateway does
  not serve `mistralai/mistral-nemotron`, and whether NVIDIA still does is a question I
  did **not** answer (no key, no read-only probe available). Not folded in here: a
  different service, a different provider, and an unverified id is exactly what this PR
  is about not shipping. Issue filed.
- The three DeepInfra-direct services (`case-coordinator-agent`,
  `control-liveness-sentinel`, `devops-agent`) all default to
  `https://api.deepinfra.com/v1/openai` + `deepseek-ai/DeepSeek-V3.2`. Provider and id
  agree, and the gateway serves that `model_name` too. Not a defect.

Also fixed the stale default in `docs/05-operations.{en,cs}.md` (the env-var table still
printed the Groq URL as the default) and the KDoc in `ModelGatewayRoutingOverrideTest`
that quotes the committed default verbatim.

## Verified

- `:openbank-agent-service:test :quarkusBuild --rerun-tasks` → BUILD SUCCESSFUL. JUnit
  XML across 28 result files: **tests=159 failures=0 errors=0 skipped=0** — skipped read
  explicitly, not inferred from the failure count. `quarkus-app/` populated (fast-jar), so
  no `SRCFG00040` and no CDI/config regression.
- `:ktlintCheck :detekt --rerun-tasks` → exit 0.
- YAML parses.
- Gates run per shard in the foreground with `PR_DIFF_BASE=origin/main`, exit codes read
  from `$?` on redirected output (never off a pipeline):
  lint 20/20 · data 16/16 · registry 26/26 · kotlin 19/19 · security 14/14 ·
  supplychain 22 PASS + 1 advisory WARN · gitops 32 PASS + 1 UNFALSIFIED.

## Not verified

- **The two local-environment gate results above are environmental, not verdicts on this
  diff.** `api-contract` failed asking for `sudo` to install `oasdiff`; the advisory
  `release-scope-mismatch` failed on `PR_TITLE: unbound variable`; gitops
  `loki-rule-load-test` reported UNFALSIFIED. This diff touches no `openapi.yaml`, no
  gitops file and no Loki rule. CI is the real reading on all three.
- **The new default was not exercised end-to-end.** Doing so means actually calling the
  gateway, which needs a virtual key. What is established is that the gateway serves all
  three `model_name`s right now, and that the deployed pod already uses this exact URL.
- Whether NVIDIA still serves `mistralai/mistral-nemotron` (see the sweep).
