### PR TITLE
fix(admin-ui): align lending compliance RBAC

### DIFF
--- a/openbank-admin-ui/src/app/lending/compliance-packs/page.tsx
+++ b/openbank-admin-ui/src/app/lending/compliance-packs/page.tsx
@@ -23,6 +23,7 @@ import { CheckCircle2, Clock, RefreshCw, ShieldCheck, ScrollText, AlertTriangle 
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { svcUrl } from '@/lib/services/bff'
 import { PageHeader } from '@/components/ui/PageHeader'
+import { AuthGuard, Can } from '@/components/auth/AuthGuard'
 
 /** Mirrors lending-service `PackActivationView`. `listActive()` synthesises id = all-zero UUID for
  *  every row (it projects the in-memory registry, not a workflow row) — never key a list on it. */
@@ -177,6 +178,7 @@ export default function CompliancePacksPage() {
   )
 
   return (
+    <AuthGuard permission="lending:compliance:view">
     <div>
       <PageHeader
         breadcrumb={<div className="breadcrumb">
@@ -190,7 +192,7 @@ export default function CompliancePacksPage() {
           'Jurisdikční úvěrové compliance packy (ADR-0212 D4). Maker navrhne, JINÝ compliance principál rozhodne. Aktivovaný pack platí okamžitě — bez release služby.',
           'Jurisdictional credit compliance packs (ADR-0212 D4). A maker proposes, a DIFFERENT compliance principal decides. An activated pack takes effect immediately — no service release.',
         )}
-        actions={<button onClick={() => void load()} disabled={loading} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
+        actions={<button type="button" onClick={() => void load()} disabled={loading} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
           <RefreshCw aria-hidden="true" size={14} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
         </button>}
       />
@@ -278,6 +280,7 @@ export default function CompliancePacksPage() {
               </div>
             </div>
             <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              <Can permission="lending:compliance:decide" fallback={<span style={{ color: 'var(--text-tertiary)', fontSize: 12 }}>{t('Rozhodnutí je pouze pro compliance principály.', 'Decisions are limited to compliance principals.')}</span>}>
               <input
                 className="input"
                 type="text"
@@ -287,12 +290,13 @@ export default function CompliancePacksPage() {
                 onChange={e => setReasons(r => ({ ...r, [p.id]: e.target.value }))}
                 style={{ fontSize: 12 }}
               />
-              <button className="btn btn-primary" disabled={busyId === p.id} onClick={() => void decide(p.id, true)} style={{ fontSize: 12 }}>
+              <button type="button" className="btn btn-primary" disabled={busyId === p.id} onClick={() => void decide(p.id, true)} style={{ fontSize: 12 }}>
                 {t('Schválit', 'Approve')}
               </button>
-              <button className="btn btn-secondary" disabled={busyId === p.id} onClick={() => void decide(p.id, false)} style={{ fontSize: 12 }}>
+              <button type="button" className="btn btn-secondary" disabled={busyId === p.id} onClick={() => void decide(p.id, false)} style={{ fontSize: 12 }}>
                 {t('Zamítnout', 'Reject')}
               </button>
+              </Can>
             </div>
           </div>
         ))}
@@ -303,6 +307,7 @@ export default function CompliancePacksPage() {
         )}
       </div>
 
+      <Can permission="lending:compliance:propose">
       <div className="section-title" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
         <ScrollText aria-hidden="true" size={15} /> {t('Navrhnout pack (maker)', 'Propose a pack (maker)')}
       </div>
@@ -321,6 +326,7 @@ export default function CompliancePacksPage() {
           style={{ width: '100%', fontFamily: 'monospace', fontSize: 12, padding: 8, borderRadius: 6, border: '1px solid var(--border)', background: 'var(--surface)', color: 'var(--text)' }}
         />
         <button
+          type="button"
           className="btn btn-primary"
           style={{ marginTop: 8, fontSize: 12 }}
           disabled={busyId === 'propose' || packJson.trim().length === 0}
@@ -329,6 +335,8 @@ export default function CompliancePacksPage() {
           {t('Navrhnout', 'Propose')}
         </button>
       </div>
+      </Can>
     </div>
+    </AuthGuard>
   )
 }

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -84,9 +84,7 @@ const complianceNav: NavItem[] = [
   { nameCs: 'Segmenty',           nameEn: 'Segments',         href: '/segments',          icon: Target,                permission: 'compliance:view' },
   { nameCs: 'Souhlasy',           nameEn: 'Consents',         href: '/consents',          icon: FileSignature,           permission: 'compliance:view' },
   // ADR-0212 D4: four-eyes activation of the jurisdictional credit compliance packs. Filed under
-  // compliance, not lending, because the backing endpoints are ROLE_COMPLIANCE/ROLE_ADMIN — a
-  // lending officer cannot propose or decide one.
-  { nameCs: 'Úvěrové compliance packy', nameEn: 'Credit Compliance Packs', href: '/lending/compliance-packs', icon: ShieldCheck, permission: 'compliance:view' },
+  { nameCs: 'Úvěrové compliance packy', nameEn: 'Credit Compliance Packs', href: '/lending/compliance-packs', icon: ShieldCheck, permission: 'lending:compliance:view' },
   { nameCs: 'Auditní záznamy',    nameEn: 'Audit Log',        href: '/audit',             icon: ScrollText,            permission: 'audit:view' },
   { nameCs: 'Regulatorní',        nameEn: 'Regulatory',       href: '/regulatory',        icon: FileText,              permission: 'regulatory:view' },
 ]

--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -14,6 +14,8 @@ export const ROLES = {
   AUDITOR:    "ROLE_AUDITOR",
   API:        "ROLE_API",
   SUPERVISOR: "ROLE_SUPERVISOR",
+  LENDING_OFFICER: "ROLE_LENDING_OFFICER",
+  CREDIT_RISK: "ROLE_CREDIT_RISK",
   KYC:        "ROLE_KYC",
   KYC_OPENER: "ROLE_KYC_OPENER",
   KYC_REVIEWER: "ROLE_KYC_REVIEWER",
@@ -49,6 +51,11 @@ export const PERMISSIONS = {
   "payments:view":        [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER, ROLES.PAYMENTS, ROLES.SUPERVISOR],
   "payments:create":      [ROLES.ADMIN, ROLES.OPERATOR, ROLES.PAYMENTS],
   "payments:approve":     [ROLES.ADMIN, ROLES.PAYMENTS, ROLES.SUPERVISOR],
+  // Lending compliance-pack reads include the operational lending roles accepted by
+  // CompliancePackResource.listActive; maker/checker writes remain compliance/admin only.
+  "lending:compliance:view":    [ROLES.ADMIN, ROLES.COMPLIANCE, ROLES.CREDIT_RISK, ROLES.LENDING_OFFICER],
+  "lending:compliance:propose": [ROLES.ADMIN, ROLES.COMPLIANCE],
+  "lending:compliance:decide":  [ROLES.ADMIN, ROLES.COMPLIANCE],
   // Card-issuance deliberately has a narrower read role than the wider payments
   // workspace: its GET endpoints accept only VIEWER/OPERATOR/ADMIN, and every
   // lifecycle writes except block/cancel accept only OPERATOR/ADMIN. Compliance
@@ -212,8 +219,9 @@ const ROUTE_PREFIXES: ReadonlyArray<readonly [Permission, readonly string[]]> = 
   ['sanctions:view', ['/sanctions']],
   ['compliance:view', [
     '/aml', '/fraud', '/disputes', '/consents', '/customer-360', '/campaigns',
-    '/segments', '/lending/compliance-packs', '/docs/compliance', '/docs/bcp',
+    '/segments', '/docs/compliance', '/docs/bcp',
   ]],
+  ['lending:compliance:view', ['/lending/compliance-packs']],
   ['system:view', [
     '/approvals', '/devops', '/finops', '/iaops', '/infrastructure', '/observability', '/temporal',
     '/security', '/notifications', '/system',

--- a/openbank-admin-ui/src/test/compliance-packs-console.test.tsx
+++ b/openbank-admin-ui/src/test/compliance-packs-console.test.tsx
@@ -19,7 +19,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest'
 import React from 'react'
 import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react'
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
-import { SessionProvider } from '@/components/auth/SessionProvider'
+import { SessionProvider } from 'next-auth/react'
 import CompliancePacksPage from '@/app/lending/compliance-packs/page'
 
 const PROPOSAL_ID = '019fb939-3e0a-7716-a1ed-7854754c8786'
@@ -40,7 +40,11 @@ const PENDING = [{
 const ACTIVE = [{ ...PENDING[0], id: '00000000-0000-0000-0000-000000000000', state: 'EXECUTED', proposedBy: '-' }]
 
 function Providers({ children }: { children: React.ReactNode }) {
-  return React.createElement(SessionProvider, null, React.createElement(LanguageProvider, null, children))
+  return React.createElement(
+    SessionProvider,
+    { session: { user: { roles: ['ROLE_COMPLIANCE'], email: 'compliance@openbank.local' } } as never },
+    React.createElement(LanguageProvider, null, children),
+  )
 }
 
 type Case = { active?: { status: number; body: unknown }; pending?: { status: number; body: unknown }; decide?: { status: number; body: unknown } }

--- a/openbank-admin-ui/src/test/lending-compliance-rbac.guard.test.ts
+++ b/openbank-admin-ui/src/test/lending-compliance-rbac.guard.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const root = resolve(__dirname, '..')
+const page = readFileSync(resolve(root, 'app/lending/compliance-packs/page.tsx'), 'utf8')
+const roles = readFileSync(resolve(root, 'lib/auth/roles.ts'), 'utf8')
+const sidebar = readFileSync(resolve(root, 'components/layout/Sidebar.tsx'), 'utf8')
+
+describe('lending compliance-pack UI permissions mirror service roles', () => {
+  it('keeps active-pack reads available to the service-authorized lending roles', () => {
+    expect(roles).toContain('"lending:compliance:view":    [ROLES.ADMIN, ROLES.COMPLIANCE, ROLES.CREDIT_RISK, ROLES.LENDING_OFFICER]')
+    expect(page).toContain('<AuthGuard permission="lending:compliance:view">')
+    expect(sidebar).toContain("href: '/lending/compliance-packs'")
+    expect(sidebar).toContain("permission: 'lending:compliance:view'")
+  })
+
+  it('gates maker/checker writes to compliance principals and administrators', () => {
+    expect(roles).toContain('"lending:compliance:propose": [ROLES.ADMIN, ROLES.COMPLIANCE]')
+    expect(roles).toContain('"lending:compliance:decide":  [ROLES.ADMIN, ROLES.COMPLIANCE]')
+    expect(page).toContain('<Can permission="lending:compliance:propose">')
+    expect(page).toContain('<Can permission="lending:compliance:decide"')
+    expect(page).toContain('type="button" className="btn btn-primary"')
+    expect(page).toContain('type="button" className="btn btn-secondary"')
+  })
+})

--- a/openbank-admin-ui/src/test/route-permissions.test.ts
+++ b/openbank-admin-ui/src/test/route-permissions.test.ts
@@ -33,7 +33,7 @@ describe('route permission projection (ADR-0229 D3)', () => {
     expect(permissionForPath('/dashboard')).toBe('dashboard:view')
     expect(permissionForPath('/accounts/new')).toBe('accounts:create')
     expect(permissionForPath('/cards/sample')).toBe('cards:view')
-    expect(permissionForPath('/lending/compliance-packs')).toBe('compliance:view')
+    expect(permissionForPath('/lending/compliance-packs')).toBe('lending:compliance:view')
     expect(permissionForPath('/system/config')).toBe('system:config')
   })
 })


### PR DESCRIPTION
Closes #1915

- align compliance-pack reads with lending-service active endpoint roles
- gate maker/checker proposal and decision writes to compliance/admin
- preserve existing BFF endpoints and two-eyes payloads
- add role and route regression guards

Type-check and diff-check pass; focused Vitest is environment-blocked by missing Rolldown native binding.