### PR TITLE
fix(admin-ui): align audience workflow rbac

### DIFF
--- a/openbank-admin-ui/src/app/segments/new/page.tsx
+++ b/openbank-admin-ui/src/app/segments/new/page.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/navigation'
 import { ArrowLeft, CheckCircle2, ShieldCheck, Users } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader } from '@/components/ui'
+import { AuthGuard } from '@/components/auth/AuthGuard'
 
 /** A deliberately small, typed composer. It sends no query language or arbitrary JSON path. */
 export default function NewAudiencePage() {
@@ -34,7 +35,7 @@ export default function NewAudiencePage() {
   const validName = /^[a-z0-9][a-z0-9-]*$/.test(name)
   const validTenure = minDays.trim() === '' || (Number.isInteger(Number(minDays)) && Number(minDays) >= 0)
 
-  return (
+  return <AuthGuard permission="campaign:create">
     <div className="mx-auto max-w-4xl space-y-6">
       <Link href="/segments" className="inline-flex items-center gap-2 text-sm font-medium text-slate-500 transition hover:text-violet-700"><ArrowLeft className="h-4 w-4" />{t('Zpět do knihovny publik', 'Back to audience library')}</Link>
       <PageHeader title={t('Nové publikum', 'New audience')} subtitle={t('Sestavte bezpečný návrh z pravidel, která platforma umí skutečně vyhodnotit.', 'Compose a safe draft from rules the platform can actually evaluate.')} icon={<Users className="h-6 w-6" />} />
@@ -49,10 +50,10 @@ export default function NewAudiencePage() {
             <label htmlFor="segment-min-days" className="block rounded-xl border border-slate-200 p-4 text-sm text-slate-700"><span className="font-semibold">{t('Minimální délka vztahu (volitelné)', 'Minimum relationship age (optional)')}</span><input id="segment-min-days" inputMode="numeric" value={minDays} onChange={e => setMinDays(e.target.value)} placeholder="30" className="mt-3 block w-full rounded-lg border border-slate-200 px-3 py-2" /><span className="mt-2 block text-xs text-slate-500">{t('Prázdné = bez omezení podle délky vztahu.', 'Blank = no relationship-age restriction.')}</span></label>
           </fieldset>
           {error && <p role="alert" className="mt-4 rounded-xl bg-rose-50 p-3 text-sm text-rose-700">{error}</p>}
-          <button disabled={!validName || !validTenure || saving} className="mt-6 inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-violet-700 disabled:cursor-not-allowed disabled:opacity-40"><CheckCircle2 className="h-4 w-4" />{saving ? t('Ukládám…', 'Saving…') : t('Vytvořit návrh', 'Create draft')}</button>
+          <button type="submit" disabled={!validName || !validTenure || saving} className="mt-6 inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-violet-700 disabled:cursor-not-allowed disabled:opacity-40"><CheckCircle2 className="h-4 w-4" />{saving ? t('Ukládám…', 'Saving…') : t('Vytvořit návrh', 'Create draft')}</button>
         </form>
         <aside className="rounded-2xl border border-emerald-100 bg-[linear-gradient(160deg,#f6fffb,#fff)] p-6 shadow-sm"><ShieldCheck className="h-6 w-6 text-emerald-600" /><h2 className="mt-4 text-lg font-semibold tracking-tight text-slate-900">{t('Co se stane dál', 'What happens next')}</h2><ol className="mt-4 space-y-4 text-sm leading-6 text-slate-600"><li><strong className="text-slate-900">1. {t('Návrh', 'Draft')}</strong><br />{t('Můžete bezpečně zkontrolovat aktuální dosah stejným evaluátorem jako při zařazení do kampaně.', 'You can safely check current reach with the same evaluator used for campaign enrolment.')}</li><li><strong className="text-slate-900">2. {t('Schválení', 'Approval')}</strong><br />{t('Jiný člověk schválí přesnou, verzovanou definici. Autor ji nemůže schválit sám.', 'A different person approves the exact versioned definition. The maker cannot approve it.')}</li><li><strong className="text-slate-900">3. {t('Použití', 'Use')}</strong><br />{t('Teprve schválené publikum lze vybrat do kampaně; souhlas a limity se stále ověřují při doručení.', 'Only an approved audience can be chosen in a campaign; consent and caps are still checked at delivery.')}</li></ol></aside>
       </section>
     </div>
-  )
+  </AuthGuard>
 }

--- a/openbank-admin-ui/src/app/segments/page.tsx
+++ b/openbank-admin-ui/src/app/segments/page.tsx
@@ -10,6 +10,7 @@ import { ArrowRight, Clock3, Plus, ShieldCheck, Sparkles, Users } from 'lucide-r
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader } from '@/components/ui'
+import { AuthGuard, Can } from '@/components/auth/AuthGuard'
 
 // Read-only by design. ADR-0201 D1: a segment is a versioned artifact defined in code, reviewed and
 // released like anything else — "no free-form SQL from a UI". A marketer picks from this catalogue;
@@ -97,6 +98,7 @@ export default function SegmentsPage() {
     if (!p) {
       return (
         <button
+          type="button"
           onClick={() => loadPreview(s)}
           className="rounded-lg border border-violet-200 bg-white px-3 py-1.5 text-xs font-semibold text-violet-700 transition hover:border-violet-400 hover:bg-violet-50"
           data-audience-count={key(s)}
@@ -132,7 +134,7 @@ export default function SegmentsPage() {
     )
   }
 
-  return (
+  return <AuthGuard permission="campaign:view">
     <div className="space-y-6">
       <PageHeader
         title={t('Publika', 'Audiences')}
@@ -141,7 +143,7 @@ export default function SegmentsPage() {
           'Choose an audience by intent, verify its current reach, then go straight to designing the journey.',
         )}
         icon={<Users className="h-6 w-6" />}
-        actions={<Link href="/segments/new" className="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-violet-700"><Plus className="h-4 w-4" />{t('Vytvořit publikum', 'Create audience')}</Link>}
+        actions={<Can permission="campaign:create"><Link href="/segments/new" className="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-violet-700"><Plus className="h-4 w-4" />{t('Vytvořit publikum', 'Create audience')}</Link></Can>}
       />
 
       {loading && <p className="text-sm text-muted-foreground">{t('Načítám…', 'Loading…')}</p>}
@@ -196,7 +198,7 @@ export default function SegmentsPage() {
                     data-use-audience={key(s)}
                   >
                     {t('Použít v kampani', 'Use in campaign')} <ArrowRight className="h-3.5 w-3.5" />
-                  </Link> : s.state === 'DRAFT' ? <button onClick={() => lifecycle(s, 'submit')} className="rounded-lg bg-violet-700 px-3 py-2 text-xs font-semibold text-white transition hover:bg-violet-800">{t('Odeslat ke schválení', 'Submit for approval')}</button> : <button onClick={() => lifecycle(s, 'approve')} className="rounded-lg bg-emerald-600 px-3 py-2 text-xs font-semibold text-white transition hover:bg-emerald-700">{t('Schválit publikum', 'Approve audience')}</button>}
+                  </Link> : s.state === 'DRAFT' ? <Can permission="campaign:submit" fallback={<span className="text-xs text-muted-foreground">{t('Čeká na oprávněného autora', 'Awaiting an authorized author')}</span>}><button type="button" onClick={() => lifecycle(s, 'submit')} className="rounded-lg bg-violet-700 px-3 py-2 text-xs font-semibold text-white transition hover:bg-violet-800">{t('Odeslat ke schválení', 'Submit for approval')}</button></Can> : <Can permission="campaign:activate" fallback={<span className="text-xs text-muted-foreground">{t('Čeká na oprávněného schvalovatele', 'Awaiting an authorized approver')}</span>}><button type="button" onClick={() => lifecycle(s, 'approve')} className="rounded-lg bg-emerald-600 px-3 py-2 text-xs font-semibold text-white transition hover:bg-emerald-700">{t('Schválit publikum', 'Approve audience')}</button></Can>}
                 </div>
                 <p className="mt-3 flex items-center gap-1.5 text-[.68rem] text-slate-400"><Clock3 className="h-3 w-3" />{t('Dosah se mění s aktuálním stavem; verze pravidel zůstává stejná.', 'Reach changes with current state; the rule version stays fixed.')}</p>
               </article>
@@ -205,5 +207,5 @@ export default function SegmentsPage() {
         </>
       )}
     </div>
-  )
+  </AuthGuard>
 }

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -81,7 +81,7 @@ const complianceNav: NavItem[] = [
   { nameCs: 'Spory',              nameEn: 'Disputes',         href: '/disputes',          icon: MessageSquareWarning,  permission: 'compliance:view' },
   { nameCs: 'Customer 360',        nameEn: 'Customer 360',     href: '/customer-360',      icon: Users,                 permission: 'compliance:view' },
   { nameCs: 'Kampaně',            nameEn: 'Campaigns',        href: '/campaigns',         icon: Megaphone,             permission: 'compliance:view' },
-  { nameCs: 'Segmenty',           nameEn: 'Segments',         href: '/segments',          icon: Target,                permission: 'compliance:view' },
+  { nameCs: 'Segmenty',           nameEn: 'Segments',         href: '/segments',          icon: Target,                permission: 'campaign:view' },
   { nameCs: 'Souhlasy',           nameEn: 'Consents',         href: '/consents',          icon: FileSignature,           permission: 'compliance:view' },
   // ADR-0212 D4: four-eyes activation of the jurisdictional credit compliance packs. Filed under
   { nameCs: 'Úvěrové compliance packy', nameEn: 'Credit Compliance Packs', href: '/lending/compliance-packs', icon: ShieldCheck, permission: 'lending:compliance:view' },

--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -56,6 +56,12 @@ export const PERMISSIONS = {
   "lending:compliance:view":    [ROLES.ADMIN, ROLES.COMPLIANCE, ROLES.CREDIT_RISK, ROLES.LENDING_OFFICER],
   "lending:compliance:propose": [ROLES.ADMIN, ROLES.COMPLIANCE],
   "lending:compliance:decide":  [ROLES.ADMIN, ROLES.COMPLIANCE],
+  // Campaign-service audience endpoints use campaign.read for catalogue/preview, while
+  // creation and lifecycle transitions are restricted to HUMAN operators/admins.
+  "campaign:view":          [ROLES.ADMIN, ROLES.OPERATOR, ROLES.AUDITOR],
+  "campaign:create":        [ROLES.ADMIN, ROLES.OPERATOR],
+  "campaign:submit":        [ROLES.ADMIN, ROLES.OPERATOR],
+  "campaign:activate":      [ROLES.ADMIN, ROLES.OPERATOR],
   // Card-issuance deliberately has a narrower read role than the wider payments
   // workspace: its GET endpoints accept only VIEWER/OPERATOR/ADMIN, and every
   // lifecycle writes except block/cancel accept only OPERATOR/ADMIN. Compliance
@@ -219,8 +225,10 @@ const ROUTE_PREFIXES: ReadonlyArray<readonly [Permission, readonly string[]]> = 
   ['sanctions:view', ['/sanctions']],
   ['compliance:view', [
     '/aml', '/fraud', '/disputes', '/consents', '/customer-360', '/campaigns',
-    '/segments', '/docs/compliance', '/docs/bcp',
+    '/docs/compliance', '/docs/bcp',
   ]],
+  ['campaign:view', ['/segments']],
+  ['campaign:create', ['/segments/new']],
   ['lending:compliance:view', ['/lending/compliance-packs']],
   ['system:view', [
     '/approvals', '/devops', '/finops', '/iaops', '/infrastructure', '/observability', '/temporal',

--- a/openbank-admin-ui/src/test/audience-library.test.tsx
+++ b/openbank-admin-ui/src/test/audience-library.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import SegmentsPage from '@/app/segments/page'
+import { SessionProvider } from 'next-auth/react'
 
 describe('audience library', () => {
   it('uses the real segment preview and carries its version into campaign authoring', async () => {
@@ -14,7 +15,8 @@ describe('audience library', () => {
       return { ok: true, json: async () => ({ state: 'ok', items: [{ name: 'actives', version: 1, rules: ['party status is ACTIVE'] }] }) }
     }))
 
-    const { container } = render(React.createElement(LanguageProvider, null, React.createElement(SegmentsPage)))
+    const session = { user: { roles: ['ROLE_OPERATOR'] }, expires: '2099-01-01' }
+    const { container } = render(React.createElement(SessionProvider, { session }, React.createElement(LanguageProvider, null, React.createElement(SegmentsPage))))
     await waitFor(() => expect(screen.getByText('Active customers')).toBeTruthy())
 
     const start = container.querySelector('[data-use-audience="actives@1"]') as HTMLAnchorElement

--- a/openbank-admin-ui/src/test/segments-rbac.guard.test.ts
+++ b/openbank-admin-ui/src/test/segments-rbac.guard.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { hasPermission, permissionForPath, ROLES } from '@/lib/auth/roles'
+
+const root = path.resolve(process.cwd(), 'src')
+const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8')
+
+describe('segments audience RBAC contract', () => {
+  it('maps the route and action permissions to campaign-service authorization', () => {
+    expect(permissionForPath('/segments')).toBe('campaign:view')
+    expect(permissionForPath('/segments/new')).toBe('campaign:create')
+    expect(hasPermission([ROLES.ADMIN], 'campaign:create')).toBe(true)
+    expect(hasPermission([ROLES.OPERATOR], 'campaign:create')).toBe(true)
+    expect(hasPermission([ROLES.AUDITOR], 'campaign:view')).toBe(true)
+    expect(hasPermission([ROLES.AUDITOR], 'campaign:create')).toBe(false)
+    expect(hasPermission([ROLES.COMPLIANCE], 'campaign:view')).toBe(false)
+  })
+
+  it('keeps audience writes behind matching Can/AuthGuard gates', () => {
+    const list = read('app/segments/page.tsx')
+    const create = read('app/segments/new/page.tsx')
+    expect(list).toContain('<AuthGuard permission="campaign:view">')
+    expect(list).toContain('<Can permission="campaign:create">')
+    expect(list).toContain('<Can permission="campaign:submit"')
+    expect(list).toContain('<Can permission="campaign:activate"')
+    expect(create).toContain('<AuthGuard permission="campaign:create">')
+    expect(create).toContain('method: \'POST\'')
+  })
+})


### PR DESCRIPTION
## Summary
- align Segments/Audiences read and write permissions with campaign-service OPA actions
- gate audience creation, submit, and approval controls with truthful fallbacks
- add route/action RBAC guard coverage

Preserves existing audience GET/POST endpoints and lifecycle payloads.

Closes #0