### PR TITLE
fix(admin-ui): align identity case rbac

### DIFF
--- a/openbank-admin-ui/src/app/identity-cases/page.tsx
+++ b/openbank-admin-ui/src/app/identity-cases/page.tsx
@@ -9,6 +9,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader } from '@/components/ui/PageHeader'
+import { AuthGuard, Can } from '@/components/auth/AuthGuard'
 import { Fingerprint, RefreshCw, ShieldAlert, Users, Check } from 'lucide-react'
 
 const SVC = 'pid-service'
@@ -243,7 +244,7 @@ export default function IdentityCasesPage() {
     load()
   }, [load])
 
-  return (
+  return <AuthGuard permission="identity-cases:view">
     <div>
       <PageHeader
         icon={<Fingerprint size={20} aria-hidden="true" />}
@@ -327,11 +328,13 @@ export default function IdentityCasesPage() {
                 ))}
               </div>
 
-              <DecisionForm c={c} onDecided={load} />
+              <Can permission="identity-cases:decide" fallback={<div style={{ marginTop: '12px', color: 'var(--text-secondary)', fontSize: '12px' }}>{t('Rozhodnutí může provést pouze oprávněný schvalovatel.', 'Only an authorized approver can decide this case.')}</div>}>
+                <DecisionForm c={c} onDecided={load} />
+              </Can>
             </div>
           ))}
         </div>
       )}
     </div>
-  )
+  </AuthGuard>
 }

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -55,7 +55,7 @@ const customerNav: NavItem[] = [
   { nameCs: 'Strany',      nameEn: 'Parties',    href: '/parties',    icon: Users,          permission: 'parties:view' },
   { nameCs: 'KYC',         nameEn: 'KYC',         href: '/kyc',        icon: ShieldCheck,    permission: 'kyc:view' },
   { nameCs: 'Onboarding',  nameEn: 'Onboarding',  href: '/onboarding', icon: ClipboardList,  permission: 'onboarding:view' },
-  { nameCs: 'Ověření identity', nameEn: 'Identity Cases', href: '/identity-cases', icon: Fingerprint, permission: 'onboarding:view' },
+  { nameCs: 'Ověření identity', nameEn: 'Identity Cases', href: '/identity-cases', icon: Fingerprint, permission: 'identity-cases:view' },
   { nameCs: 'Delegovaný přístup', nameEn: 'Delegated Access', href: '/delegations', icon: Share2, permission: 'delegations:view' },
 ]
 

--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -98,6 +98,10 @@ export const PERMISSIONS = {
   // further; do not add ROLES.DEMO to another line here without first confirming its
   // backend accepts VIEWER-tier reads.
   "onboarding:view":      [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE, ROLES.KYC, ROLES.KYC_OPENER, ROLES.KYC_REVIEWER, ROLES.DEMO],
+  // PID identity cases expose PII and four-eyes decisions only to the roles accepted by
+  // VerificationCaseResource; KYC split roles and demo must not see a 403 cockpit.
+  "identity-cases:view":  [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE],
+  "identity-cases:decide":[ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE],
   // Delegated access (ADR-0232 / ADR-0230). Mirrors delegation-service's own class-level
   // @RolesAllowed(ROLE_API, ROLE_OPERATOR, ROLE_ADMIN) minus ROLE_API, which is the M2M
   // identity and never a console session — listing it here would render a section for a
@@ -211,7 +215,8 @@ const ROUTE_PREFIXES: ReadonlyArray<readonly [Permission, readonly string[]]> = 
   ['regulatory:view', ['/regulatory']],
   ['audit:view', ['/audit']],
   ['kyc:view', ['/kyc']],
-  ['onboarding:view', ['/onboarding', '/identity-cases']],
+  ['onboarding:view', ['/onboarding']],
+  ['identity-cases:view', ['/identity-cases']],
   ['parties:create', ['/parties/new']],
   ['parties:view', ['/parties']],
   ['transactions:view', ['/transactions']],

--- a/openbank-admin-ui/src/test/identity-cases-rbac.guard.test.ts
+++ b/openbank-admin-ui/src/test/identity-cases-rbac.guard.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { hasPermission, permissionForPath, ROLES } from '@/lib/auth/roles'
+
+const root = path.resolve(process.cwd(), 'src')
+const page = fs.readFileSync(path.join(root, 'app/identity-cases/page.tsx'), 'utf8')
+
+describe('identity cases RBAC contract', () => {
+  it('matches PID verification-case roles and route scope', () => {
+    expect(permissionForPath('/identity-cases')).toBe('identity-cases:view')
+    expect(hasPermission([ROLES.ADMIN], 'identity-cases:view')).toBe(true)
+    expect(hasPermission([ROLES.OPERATOR], 'identity-cases:decide')).toBe(true)
+    expect(hasPermission([ROLES.COMPLIANCE], 'identity-cases:decide')).toBe(true)
+    expect(hasPermission([ROLES.KYC_REVIEWER], 'identity-cases:view')).toBe(false)
+    expect(hasPermission([ROLES.DEMO], 'identity-cases:view')).toBe(false)
+  })
+
+  it('keeps PID reads and four-eyes writes behind matching gates', () => {
+    expect(page).toContain('<AuthGuard permission="identity-cases:view">')
+    expect(page).toContain('<Can permission="identity-cases:decide"')
+    expect(page).toContain('/api/v1/parties/cases/${c.id}/decision')
+    expect(page).toContain('/api/v1/parties/cases/${c.id}/reopen')
+  })
+})


### PR DESCRIPTION
## Summary
- align Identity Cases route/read access with pid-service authorization
- gate decision/reopen controls behind dedicated decision permission
- preserve PID endpoints, verdict/link/notes payloads and four-eyes behavior

Closes #0