### PR TITLE
fix(admin-ui): align approval inbox RBAC

### DIFF
--- a/openbank-admin-ui/src/app/approvals/page.tsx
+++ b/openbank-admin-ui/src/app/approvals/page.tsx
@@ -15,6 +15,7 @@ import { useSession } from 'next-auth/react'
 import { CheckCircle2, XCircle, Clock, ClipboardCheck, RefreshCw, ShieldCheck, AlertTriangle, Bot } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader } from '@/components/ui/PageHeader'
+import { AuthGuard, Can } from '@/components/auth/AuthGuard'
 
 interface Proposal {
   id: string
@@ -119,6 +120,7 @@ export default function ApprovalsPage() {
   )
 
   return (
+    <AuthGuard permission="approvals:view">
     <div>
       <PageHeader
         breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Schvalování', 'Approvals')}</span></div>}
@@ -236,21 +238,23 @@ export default function ApprovalsPage() {
                 {t('Navrhl', 'Proposed by')} <b>{p.proposedBy}</b> · {new Date(p.proposedAt).toLocaleString(dateLocale)}
               </div>
               <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-                <input
-                  aria-label={t('Důvod rozhodnutí návrhu', 'Proposal decision reason')}
-                  placeholder={t('Důvod rozhodnutí (volitelné)', 'Decision reason (optional)')}
-                  value={reasons[p.id] || ''}
-                  onChange={e => setReasons(r => ({ ...r, [p.id]: e.target.value }))}
-                  style={{ flex: 1, minWidth: 180, fontSize: 12, padding: '6px 10px', borderRadius: 6, border: '1px solid var(--border)', background: 'var(--surface)', color: 'var(--text-primary)' }}
-                />
-                <button type="button" aria-label={t(`Schválit návrh ${p.title}`, `Approve proposal ${p.title}`)} aria-busy={busyId === p.id} onClick={() => decide(p, true)} disabled={busyId === p.id}
-                  style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12, fontWeight: 600, padding: '6px 14px', borderRadius: 6, border: '1px solid #6ee7b7', background: '#ecfdf5', color: '#059669', cursor: 'pointer' }}>
-                  <CheckCircle2 aria-hidden="true" size={14} /> {t('Schválit', 'Approve')}
-                </button>
-                <button type="button" aria-label={t(`Zamítnout návrh ${p.title}`, `Reject proposal ${p.title}`)} aria-busy={busyId === p.id} onClick={() => decide(p, false)} disabled={busyId === p.id}
-                  style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12, fontWeight: 600, padding: '6px 14px', borderRadius: 6, border: '1px solid #fca5a5', background: '#fef2f2', color: '#dc2626', cursor: 'pointer' }}>
-                  <XCircle aria-hidden="true" size={14} /> {t('Zamítnout', 'Reject')}
-                </button>
+                <Can permission="agent:decide" fallback={<span style={{ color: 'var(--text-tertiary)', fontSize: 12 }}>{t('Rozhodování vyžaduje oprávnění agenta.', 'Decision access requires agent authorization.')}</span>}>
+                  <input
+                    aria-label={t('Důvod rozhodnutí návrhu', 'Proposal decision reason')}
+                    placeholder={t('Důvod rozhodnutí (volitelné)', 'Decision reason (optional)')}
+                    value={reasons[p.id] || ''}
+                    onChange={e => setReasons(r => ({ ...r, [p.id]: e.target.value }))}
+                    style={{ flex: 1, minWidth: 180, fontSize: 12, padding: '6px 10px', borderRadius: 6, border: '1px solid var(--border)', background: 'var(--surface)', color: 'var(--text-primary)' }}
+                  />
+                  <button type="button" aria-label={t(`Schválit návrh ${p.title}`, `Approve proposal ${p.title}`)} aria-busy={busyId === p.id} onClick={() => decide(p, true)} disabled={busyId === p.id}
+                    style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12, fontWeight: 600, padding: '6px 14px', borderRadius: 6, border: '1px solid #6ee7b7', background: '#ecfdf5', color: '#059669', cursor: 'pointer' }}>
+                    <CheckCircle2 aria-hidden="true" size={14} /> {t('Schválit', 'Approve')}
+                  </button>
+                  <button type="button" aria-label={t(`Zamítnout návrh ${p.title}`, `Reject proposal ${p.title}`)} aria-busy={busyId === p.id} onClick={() => decide(p, false)} disabled={busyId === p.id}
+                    style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12, fontWeight: 600, padding: '6px 14px', borderRadius: 6, border: '1px solid #fca5a5', background: '#fef2f2', color: '#dc2626', cursor: 'pointer' }}>
+                    <XCircle aria-hidden="true" size={14} /> {t('Zamítnout', 'Reject')}
+                  </button>
+                </Can>
               </div>
             </div>
           )
@@ -292,5 +296,6 @@ export default function ApprovalsPage() {
         </>
       )}
     </div>
+    </AuthGuard>
   )
 }

--- a/openbank-admin-ui/src/components/layout/Header.tsx
+++ b/openbank-admin-ui/src/components/layout/Header.tsx
@@ -88,7 +88,7 @@ export function Header({ mobileNavOpen, onMenuToggle }: { mobileNavOpen?: boolea
     .find(r => roles.includes(r))
   const roleInfo = primaryRole ? ROLE_LABELS[primaryRole] : null
   const canReadDocs = hasPermission(roles, 'docs:view')
-  const canViewApprovals = hasPermission(roles, 'system:view')
+  const canViewApprovals = hasPermission(roles, 'approvals:view')
   const initials = user?.name
     ? user.name.split(' ').map((n: string) => n[0]).join('').toUpperCase().slice(0, 2)
     : user?.email?.[0]?.toUpperCase() ?? 'U'

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -122,7 +122,7 @@ const platformNav: NavItem[] = [
   { nameCs: 'Temporal', nameEn: 'Temporal', href: '/temporal', icon: Zap,        permission: 'system:view' },
   { nameCs: 'Tok workflow', nameEn: 'Workflow Flow', href: '/temporal/flow', icon: Workflow, permission: 'system:view' },
   { nameCs: 'Observability', nameEn: 'Observability', href: '/observability', icon: Activity, permission: 'system:view' },
-  { nameCs: 'Schvalování', nameEn: 'Approvals', href: '/approvals', icon: ClipboardCheck, permission: 'system:view' },
+  { nameCs: 'Schvalování', nameEn: 'Approvals', href: '/approvals', icon: ClipboardCheck, permission: 'approvals:view' },
 ]
 
 // Internal tool UIs, reachable at /tools/<tool> on this same host behind the

--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -184,6 +184,10 @@ export const PERMISSIONS = {
   // expose compliance's authorized read/execute path instead.
   "agent:view":               [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE],
   "agent:execute":            [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE],
+  // Agent proposal reads/decisions are exposed by ProposalResource to these human roles;
+  // demo/system-view users must not see an actionable approval queue that the backend rejects.
+  "approvals:view":           [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE],
+  "agent:decide":             [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE],
   // DevOps findings are readable by system:view, but the devops-agent POST approval/rejection
   // endpoints are ADMIN-only. Keep HITL decision authority explicit in the UI matrix.
   "devops:decide":             [ROLES.ADMIN],
@@ -241,8 +245,9 @@ const ROUTE_PREFIXES: ReadonlyArray<readonly [Permission, readonly string[]]> = 
   ['campaign:view', ['/campaigns']],
   ['campaign:create', ['/campaigns/new']],
   ['lending:compliance:view', ['/lending/compliance-packs']],
+  ['approvals:view', ['/approvals']],
   ['system:view', [
-    '/approvals', '/devops', '/finops', '/iaops', '/infrastructure', '/observability', '/temporal',
+    '/devops', '/finops', '/iaops', '/infrastructure', '/observability', '/temporal',
     '/security', '/notifications', '/system',
   ]],
   ['agent:view', ['/system/agent']],

--- a/openbank-admin-ui/src/test/approvals-rbac.guard.test.ts
+++ b/openbank-admin-ui/src/test/approvals-rbac.guard.test.ts
@@ -1,0 +1,25 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { hasPermission, permissionForPath, ROLES } from '@/lib/auth/roles'
+
+const page = fs.readFileSync(path.join(process.cwd(), 'src/app/approvals/page.tsx'), 'utf8')
+const sidebar = fs.readFileSync(path.join(process.cwd(), 'src/components/layout/Sidebar.tsx'), 'utf8')
+const header = fs.readFileSync(path.join(process.cwd(), 'src/components/layout/Header.tsx'), 'utf8')
+
+describe('approval inbox RBAC truthfulness', () => {
+  it('matches ProposalResource roles and protects the actionable workflow', () => {
+    expect(hasPermission([ROLES.ADMIN], 'approvals:view')).toBe(true)
+    expect(hasPermission([ROLES.OPERATOR], 'approvals:view')).toBe(true)
+    expect(hasPermission([ROLES.COMPLIANCE], 'approvals:view')).toBe(true)
+    expect(hasPermission([ROLES.DEMO], 'approvals:view')).toBe(false)
+    expect(hasPermission([ROLES.COMPLIANCE], 'agent:decide')).toBe(true)
+    expect(hasPermission([ROLES.DEMO], 'agent:decide')).toBe(false)
+    expect(permissionForPath('/approvals')).toBe('approvals:view')
+    expect(page).toContain('<AuthGuard permission="approvals:view">')
+    expect(page).toContain('<Can permission="agent:decide"')
+    expect(page).toContain('Decision access requires agent authorization.')
+    expect(sidebar).toContain("href: '/approvals', icon: ClipboardCheck, permission: 'approvals:view'")
+    expect(header).toContain("hasPermission(roles, 'approvals:view')")
+  })
+})


### PR DESCRIPTION
## Linked issues
N/A — this is a bounded RBAC truthfulness correction for the existing Approval Inbox workflow.

Aligns the Approval Inbox route and decision controls with agent-service ProposalResource roles. Adds explicit approvals:view and agent:decide permissions, protects the page and actions, and keeps existing BFF payloads unchanged.