### PR TITLE
fix(admin-ui): clarify FinOps budget state

### DIFF
--- a/openbank-admin-ui/src/app/api/finops/ai-costs/route.ts
+++ b/openbank-admin-ui/src/app/api/finops/ai-costs/route.ts
@@ -95,7 +95,9 @@ export async function GET() {
 
     if (tokens24h == null && cost24h == null) continue
 
-    const budgetMonthlyUsd: number | null = null  // TODO: read from agents.yaml limits.monthly_budget_usd
+    // No monthly USD budget is configured in the current agents.yaml contract. Keep this
+    // explicitly unavailable so consumers cannot render a fabricated budget percentage.
+    const budgetMonthlyUsd: number | null = null
     const burnRate: AgentCostEntry['burnRate'] =
       cost24h == null ? 'normal'
       : cost24h > 10 ? 'exceeded'

--- a/openbank-admin-ui/src/app/iaops/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/page.tsx
@@ -560,11 +560,11 @@ function IAOpsContent() {
                         )}
                       </div>
 
-                      {/* Cost / Budget column */}
+                      {/* Cost / Budget column: a missing budget is an explicit state, never an implied zero. */}
                       {costEntry && (
                         <div style={{ padding: '8px 10px', borderRadius: '8px', background: 'var(--surface)', border: '1px solid var(--border)', marginBottom: '10px' }}>
                           <div style={{ fontSize: '10px', fontWeight: 700, color: 'var(--text-tertiary)', marginBottom: '6px', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
-                            {t('Náklady / Budget', 'Cost / Budget')}
+                            {t('Náklady / rozpočet', 'Cost / Budget status')}
                           </div>
                           <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
                             <span style={{ fontSize: '11px', color: 'var(--text-secondary)' }}>
@@ -582,6 +582,11 @@ function IAOpsContent() {
                                   {budgetPct.toFixed(0)}%
                                 </span>
                               </div>
+                            )}
+                            {budgetPct == null && (
+                              <span role="status" style={{ fontSize: '10px', color: 'var(--text-tertiary)', lineHeight: 1.4 }}>
+                                {t('Měsíční rozpočet není nastaven; intenzita používá denní prahy.', 'Monthly budget is not configured; burn rate uses daily thresholds ($1 / $5 / $10).')}
+                              </span>
                             )}
                           </div>
                         </div>

--- a/openbank-admin-ui/src/test/iaops-truthfulness.guard.test.ts
+++ b/openbank-admin-ui/src/test/iaops-truthfulness.guard.test.ts
@@ -14,4 +14,16 @@ describe('IAOps agent capability truthfulness', () => {
     expect(source).not.toContain("alert(t('Funkce přijde v P4 (HITL backend)'")
     expect(source).not.toContain("{t('Spustit analýzu', 'Trigger Analysis')}")
   })
+
+  it('does not imply an unconfigured monthly budget or hide burn-rate semantics', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/iaops/page.tsx'), 'utf8')
+    const costsRoute = readFileSync(path.resolve(__dirname, '../app/api/finops/ai-costs/route.ts'), 'utf8')
+
+    expect(source).toContain("Cost / Budget status")
+    expect(source).toContain('Monthly budget is not configured; burn rate uses daily thresholds ($1 / $5 / $10).')
+    expect(source).toContain('role="status"')
+    expect(source).not.toContain("t('Náklady / Budget', 'Cost / Budget')")
+    expect(costsRoute).toContain('No monthly USD budget is configured in the current agents.yaml contract.')
+    expect(costsRoute).not.toContain('TODO: read from agents.yaml limits.monthly_budget_usd')
+  })
 })


### PR DESCRIPTION
Refs #6123

- explicitly label missing monthly FinOps budget instead of silently hiding it
- document daily burn-rate thresholds used by the read-only panel
- retain null budget contract and add truthfulness guard

No Prometheus queries, anomaly/proposal flows, RBAC, or mutations changed.