### PR TITLE
perf(admin-ui): bound FinOps cost refresh

### DIFF
--- a/openbank-admin-ui/src/app/api/finops/ai-costs/route.ts
+++ b/openbank-admin-ui/src/app/api/finops/ai-costs/route.ts
@@ -7,6 +7,7 @@ import { NextResponse } from 'next/server'
 // Langfuse→Prometheus bridge metrics (ADR-0112 P1). Falls back to mock data
 // when the bridge is not yet deployed (sandbox / local dev).
 export const dynamic = 'force-dynamic'
+const PROMETHEUS_QUERY_TIMEOUT_MS = 5_000
 
 export interface AgentCostEntry {
   agentId: string
@@ -46,7 +47,7 @@ export interface FinOpsAnomaly {
 async function fetchFromPrometheus(query: string, prometheusUrl: string): Promise<number | null> {
   try {
     const url = `${prometheusUrl}/api/v1/query?query=${encodeURIComponent(query)}`
-    const res = await fetch(url)
+    const res = await fetch(url, { signal: AbortSignal.timeout(PROMETHEUS_QUERY_TIMEOUT_MS) })
     if (!res.ok) return null
     const json = await res.json() as { data?: { result?: Array<{ value?: [unknown, string] }> } }
     const result = json?.data?.result?.[0]?.value?.[1]
@@ -80,18 +81,20 @@ export async function GET() {
   const agents: AgentCostEntry[] = []
 
   for (const agentId of agentIds) {
-    const tokens24h = await fetchFromPrometheus(
-      `sum(increase(langfuse_agent_tokens_total{agent_id="${agentId}"}[24h]))`, prometheusUrl
-    )
-    const cost24h = await fetchFromPrometheus(
-      `sum(increase(langfuse_agent_tokens_total{agent_id="${agentId}"}[24h]) * on(model) group_left() langfuse_model_cost_per_token)`, prometheusUrl
-    )
-    const cost7d = await fetchFromPrometheus(
-      `sum(increase(langfuse_agent_tokens_total{agent_id="${agentId}"}[7d]) * on(model) group_left() langfuse_model_cost_per_token)`, prometheusUrl
-    )
-    const cost30d = await fetchFromPrometheus(
-      `sum(increase(langfuse_agent_tokens_total{agent_id="${agentId}"}[30d]) * on(model) group_left() langfuse_model_cost_per_token)`, prometheusUrl
-    )
+    const [tokens24h, cost24h, cost7d, cost30d] = await Promise.all([
+      fetchFromPrometheus(
+        `sum(increase(langfuse_agent_tokens_total{agent_id="${agentId}"}[24h]))`, prometheusUrl
+      ),
+      fetchFromPrometheus(
+        `sum(increase(langfuse_agent_tokens_total{agent_id="${agentId}"}[24h]) * on(model) group_left() langfuse_model_cost_per_token)`, prometheusUrl
+      ),
+      fetchFromPrometheus(
+        `sum(increase(langfuse_agent_tokens_total{agent_id="${agentId}"}[7d]) * on(model) group_left() langfuse_model_cost_per_token)`, prometheusUrl
+      ),
+      fetchFromPrometheus(
+        `sum(increase(langfuse_agent_tokens_total{agent_id="${agentId}"}[30d]) * on(model) group_left() langfuse_model_cost_per_token)`, prometheusUrl
+      ),
+    ])
 
     if (tokens24h == null && cost24h == null) continue
 

--- a/openbank-admin-ui/src/test/finops-ai-costs-latency.guard.test.ts
+++ b/openbank-admin-ui/src/test/finops-ai-costs-latency.guard.test.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import path from 'path'
+
+describe('FinOps AI cost refresh resilience', () => {
+  it('bounds Prometheus calls and does not serialize independent metrics', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/api/finops/ai-costs/route.ts'), 'utf8')
+
+    expect(source).toContain('PROMETHEUS_QUERY_TIMEOUT_MS = 5_000')
+    expect(source).toContain('AbortSignal.timeout(PROMETHEUS_QUERY_TIMEOUT_MS)')
+    expect(source).toContain('const [tokens24h, cost24h, cost7d, cost30d] = await Promise.all([')
+    expect(source).not.toContain('const tokens24h = await fetchFromPrometheus(')
+  })
+})


### PR DESCRIPTION
Refs #6131

- bound each Prometheus query with a 5s timeout and preserve null fallback
- parallelize independent per-agent metrics to avoid serial refresh stalls
- add focused latency guard

No response-shape, RBAC, anomaly, or mutation changes.