### PR TITLE
fix(admin-ui): localize DORA incident timestamps

### DIFF
--- a/openbank-admin-ui/src/app/security/incidents/page.tsx
+++ b/openbank-admin-ui/src/app/security/incidents/page.tsx
@@ -13,7 +13,8 @@ type Incident = { id: string; title: string; severity: string; status: string; c
 type Envelope = { available: true; incidents: Incident[] } | { available: false; reason: string }
 
 export default function IncidentsPage() {
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [data, setData] = useState<Envelope | null>(null)
   const [loading, setLoading] = useState(true)
   const load = useCallback(async () => {
@@ -24,9 +25,9 @@ export default function IncidentsPage() {
   }, [])
   useEffect(() => { void load() }, [load])
   return <AuthGuard permission="system:view"><div style={{ padding: '28px 32px', maxWidth: 1400 }}>
-    <PageHeader icon={<AlertTriangle size={20} />} title={t('ICT incidenty', 'ICT incidents')} subtitle={t('DORA registr incidentů (trvalá evidence)', 'DORA incident register (durable evidence)')} actions={<button onClick={() => void load()} disabled={loading} className="btn btn-secondary btn-sm"><RefreshCw size={13} /> {t('Obnovit', 'Refresh')}</button>} />
+    <PageHeader icon={<AlertTriangle size={20} aria-hidden="true" />} title={t('ICT incidenty', 'ICT incidents')} subtitle={t('DORA registr incidentů (trvalá evidence)', 'DORA incident register (durable evidence)')} actions={<button type="button" onClick={() => void load()} disabled={loading} className="btn btn-secondary btn-sm"><RefreshCw aria-hidden="true" size={13} /> {t('Obnovit', 'Refresh')}</button>} />
     {data?.available === false && <p role="status">{t('Registr není dostupný: ', 'Register unavailable: ')}{data.reason}</p>}
     {data?.available && data.incidents.length === 0 && <p role="status">{t('Žádné evidované incidenty.', 'No recorded incidents.')}</p>}
-    {data?.available && data.incidents.length > 0 && <div style={{ overflowX: 'auto' }}><table><thead><tr><th>{t('Název', 'Title')}</th><th>{t('Závažnost', 'Severity')}</th><th>{t('Stav', 'Status')}</th><th>{t('Zjištěno', 'Detected')}</th><th>{t('Regulátor', 'Regulator')}</th><th>{t('Služby', 'Services')}</th></tr></thead><tbody>{data.incidents.map(i => <tr key={i.id}><td>{i.title}</td><td>{i.severity}</td><td>{i.status}</td><td>{new Date(i.detectedAt).toLocaleString()}</td><td>{i.reportedToRegulator ? '✓' : '—'}</td><td>{i.affectedServices.join(', ')}</td></tr>)}</tbody></table></div>}
+    {data?.available && data.incidents.length > 0 && <div style={{ overflowX: 'auto' }}><table><thead><tr><th>{t('Název', 'Title')}</th><th>{t('Závažnost', 'Severity')}</th><th>{t('Stav', 'Status')}</th><th>{t('Zjištěno', 'Detected')}</th><th>{t('Regulátor', 'Regulator')}</th><th>{t('Služby', 'Services')}</th></tr></thead><tbody>{data.incidents.map(i => <tr key={i.id}><td>{i.title}</td><td>{i.severity}</td><td>{i.status}</td><td>{new Date(i.detectedAt).toLocaleString(dateLocale)}</td><td>{i.reportedToRegulator ? '✓' : '—'}</td><td>{i.affectedServices.join(', ')}</td></tr>)}</tbody></table></div>}
   </div></AuthGuard>
 }

--- a/openbank-admin-ui/src/test/dora-incidents-locale.guard.test.ts
+++ b/openbank-admin-ui/src/test/dora-incidents-locale.guard.test.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache-2.0 license.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import path from 'path'
+
+describe('DORA incident locale contract', () => {
+  it('formats evidence timestamps with the active operator locale', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/security/incidents/page.tsx'), 'utf8')
+
+    expect(source).toContain("const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'")
+    expect(source).toContain('toLocaleString(dateLocale)')
+    expect(source).not.toContain('toLocaleString()')
+    expect(source).toContain('AuthGuard permission="system:view"')
+  })
+})


### PR DESCRIPTION
Refs #6135

- format incident evidence timestamps using the active cs-CZ/en-GB locale
- hide decorative header/refresh icons and declare refresh button type
- add focused locale guard

Read-only incidents API, AuthGuard, and data semantics remain unchanged.