### PR TITLE
fix(libs): keep the LLM gateway chat() inside the detekt LongMethod budget

### DIFF
--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClient.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClient.kt
@@ -68,17 +68,12 @@ class OpenAiCompatibleLlmGatewayClient(
         .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_S))
         .build()
 
-    @Suppress("TooGenericExceptionCaught") // IOException + parse errors have no common base worth splitting
-    override suspend fun chat(systemPrompt: String, userPrompt: String): String? {
-        if (apiKey.isBlank()) {
-            log.warn("LLM api-key not seeded — skipping call (degraded to deterministic fallback)")
-            // Recorded, not silent: an agent that has never had a key looks identical to one that
-            // is simply idle unless this series exists, and "the AI features were never switched
-            // on" is exactly the state this repo keeps discovering months late.
-            metrics.recordCall(model, LlmCallMetricsPort.OUTCOME_NOT_CONFIGURED, 0, 0, 0, provider)
-            return null
-        }
-        val url = "${baseUrl.trimEnd('/')}/chat/completions"
+    /**
+     * Builds the chat request body. Extracted from [chat] purely so that method stays inside the
+     * detekt `LongMethod` budget — it crossed it at 61 lines when the trace-id correlation landed
+     * (#5959), which reddened the full-fleet lint gate (#6023).
+     */
+    private fun buildRequest(systemPrompt: String, userPrompt: String): ChatRequest {
         // LiteLLM forwards `metadata` verbatim to its logging callbacks, so `trace_id` is what the
         // gateway hands Langfuse instead of minting one — that is the whole join between the two
         // evidence trails. Omitted entirely when there is no valid trace: an absent key leaves
@@ -90,13 +85,27 @@ class OpenAiCompatibleLlmGatewayClient(
         // otherwise propagate out of chat() and cost a completion for want of a correlation id. This
         // read sits OUTSIDE the request try/catch, so nothing else would have caught it.
         val traceId = runCatching { traceIds.currentTraceId() }.getOrNull()?.takeIf { isValidTraceId(it) }
-        val body = ChatRequest(
+        return ChatRequest(
             model = model,
             messages = listOf(ChatMessage("system", systemPrompt), ChatMessage("user", userPrompt)),
             temperature = temperature,
             maxTokens = maxTokens,
             metadata = traceId?.let { ChatMetadata(traceId = it) },
         )
+    }
+
+    @Suppress("TooGenericExceptionCaught") // IOException + parse errors have no common base worth splitting
+    override suspend fun chat(systemPrompt: String, userPrompt: String): String? {
+        if (apiKey.isBlank()) {
+            log.warn("LLM api-key not seeded — skipping call (degraded to deterministic fallback)")
+            // Recorded, not silent: an agent that has never had a key looks identical to one that
+            // is simply idle unless this series exists, and "the AI features were never switched
+            // on" is exactly the state this repo keeps discovering months late.
+            metrics.recordCall(model, LlmCallMetricsPort.OUTCOME_NOT_CONFIGURED, 0, 0, 0, provider)
+            return null
+        }
+        val url = "${baseUrl.trimEnd('/')}/chat/completions"
+        val body = buildRequest(systemPrompt, userPrompt)
         // Nanos, not a Timer.Sample: the metrics port is a pure-domain interface and may not carry a
         // Micrometer type. Measured around the whole attempt, so a timeout — the slowest and most
         // interesting case — is timed too rather than being dropped with the exception.


### PR DESCRIPTION
## Root cause

The full-fleet lint gate is **failing on a real finding — it is not OOMing and not
skipped**. Run [32444464374](https://github.com/JiRaska/open-bank-oss/actions/runs/32444464374)
reports exactly one violation across the whole fleet:

```
openbank-libs-runtime/src/main/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClient.kt:72:26:
  The function chat is too long (61). The maximum length is 60. [LongMethod]
> Task :openbank-libs-runtime:detekt FAILED
BUILD FAILED in 5m 43s
1140 actionable tasks: 360 executed, 780 from cache
```

`chat()` crossed the 60-line budget by **one line** when the trace-id correlation landed
in #5959 (`14ad7f7a5`). Path-scoped PR CI does not run `detekt` on modules the PR did not
touch in a way that triggers it, so the violation was invisible until the post-merge
full-fleet run — exactly the drift class `fleet-lint.yml` exists to catch.

## Fix

Extract the request-body construction (trace-id read + `ChatRequest`) into a private
`buildRequest()`. Pure decomposition, no behavioural change, no `@Suppress`, no baseline
entry.

## Evidence

- `1140 actionable tasks` — the healthy full-fleet total per #5949. The run **completed**;
  it was not truncated.
- The classifier emitted `kind=lint`, not `kind=infra`; the log contains no
  `OutOfMemoryError` / `GC overhead` / `daemon disappeared`.
- Local, serialized, exit code read directly (not through a pipe):
  `:openbank-libs-runtime:testClasses detekt ktlintCheck` → `EXIT=0`, `BUILD SUCCESSFUL`,
  and `> Task :openbank-libs-runtime:detekt` / `:ktlintCheck` both appear in the task list
  (Gradle stops at the first failure, so their presence is what proves they ran).
- `OpenAiCompatibleLlmGatewayClientTest` (10 tests) and `LlmTraceCorrelationTest` (7 tests)
  — 17 tests, 0 failures, 0 skipped, read from the JUnit XML.

## #6023 and #5949 are TWO defects, not one

#5949 (heap headroom) is **real and still open**, but it is not what is failing here. The
same run's sampler printed:

> `fleet-lint` peaked at **94%** of its configured `-Xmx` (warn at 85%) …
> Peak **concurrent** heap across all live JVMs: **8368 MiB** (20 JVMs in that sample).

94% is under the line but the build did not OOM and did not abort — it reached all 1140
tasks and failed on a genuine violation. So the heap ratchet is a latent risk, not this
outage. This PR therefore `Closes #6023` and only `Refs #5949`.

**What remains for #5949** (deliberately not done here, so a live-gate fix is not held up
by a sizing debate): raise `GRADLE_OPTS -Xmx` above `6g` with stated headroom, make the
85% warning actionable rather than informational (fail above a ceiling, or have the
fleet-health watch open an issue on breach the way the lint watch does), and report a
truncated run distinctly from a failing one.

Closes #6023
Refs #5949
