### PR TITLE
fix(infra): except Strimzi entity-operator from Contact K8S API Server rule

### DIFF
--- a/openbank-infra/gitops/apps/falco.yaml
+++ b/openbank-infra/gitops/apps/falco.yaml
@@ -180,12 +180,54 @@ spec:
                 (k8s.ns.name = "messaging"
                  and k8s.pod.name startswith "strimzi-cluster-operator")
 
+            # (5) Strimzi's ENTITY operator (issue #6033) — the pod that hosts
+            # the user-operator and topic-operator, both fabric8 Kubernetes
+            # clients whose entire job is to reconcile KafkaUser / KafkaTopic
+            # custom resources through the API server. (4) does not cover it:
+            # the pod is named after the Kafka CR
+            # (`components/kafka/kafka.yaml`: `openbank-cluster`), not after the
+            # cluster operator, so the `strimzi-cluster-operator` prefix cannot
+            # match. Measured 2026-08-21 over a 6h window, this one pod is 726
+            # of the rule's 793 remaining events (92%).
+            #
+            # SCOPE: namespace AND pod-name prefix AND container name AND
+            # parent process — one dimension tighter than (4), because a
+            # two-container pod running a JVM is a bigger thing to except than
+            # a single-purpose operator pod. Concretely, all of these still
+            # fire: the Kafka brokers, Apicurio, kafka-ui and the kafka-exporter
+            # in ns `messaging`; a pod with this name prefix in any other
+            # namespace; a third container injected into this pod as a sidecar;
+            # and — the one that matters — any process in these two containers
+            # that is not the operator JVM itself, since an exec'd shell, curl
+            # or kubectl has the JVM (or a shell) as its parent, never `tini`.
+            #
+            # RESIDUAL, stated, and it is the same one macro (3) already
+            # accepts for the admin-ui BFF: code execution INSIDE the operator
+            # JVM would no longer trip THIS rule, because it would inherit the
+            # excepted process identity. It still trips the shell-spawn,
+            # drop-and-execute and sensitive-file rules, and the operator's
+            # RBAC is what caps the damage. Everything else in the pod, the
+            # namespace and the cluster keeps this rule's coverage.
+            #
+            # Not keyed on `proc.name`: those are JVM thread names truncated to
+            # 15 characters (`JdkHttpClientFa`, `HttpClient-1-Se`,
+            # `operator-thread`), which are a property of the JDK's internal
+            # naming and would rot on any Strimzi or JDK bump. `container.name`
+            # is set by the operator that creates the pod and is stable.
+            - macro: openbank_strimzi_entity_operator
+              condition: >
+                (k8s.ns.name = "messaging"
+                 and k8s.pod.name startswith "openbank-cluster-entity-operator"
+                 and container.name in (user-operator, topic-operator)
+                 and proc.pname = "tini")
+
             - macro: user_known_contact_k8s_api_server_activities
               condition: >
                 (openbank_controller_namespaces
                  or openbank_kubectl_cronjob_image
                  or openbank_admin_ui_bff
-                 or openbank_strimzi_operator)
+                 or openbank_strimzi_operator
+                 or openbank_strimzi_entity_operator)
               override:
                 condition: replace
 


### PR DESCRIPTION
## What this changes

One macro added to `openbank-infra/gitops/apps/falco.yaml`, extending the
`user_known_contact_k8s_api_server_activities` override that #5850 introduced, to cover
Strimzi's **entity-operator** pod.

Closes #6033.

## Re-measured, not inherited

#6032 measured 1156 events per 6h. That was a hypothesis by the time I started, so it was
re-run. Live Loki, instant query, 2026-08-21T07:17Z:

```
sum by (rule) (count_over_time({namespace="falco"} | json | __error__="" [6h]))

  793  Contact K8S API Server From Container
  158  (no rule field — Falco agent startup/internal lines)
    1  Falco internal: syscall event drop
```

`Run shell untrusted` and `Drop and execute new binary in container` are both at **0** — #5850's
tuning holds.

Split of the 793 by workload (note: the naive `sum by (pod)` is wrong here — `pod` is already a
Loki stream label carrying the *Falco DaemonSet* pod, so it shadows the JSON field; the extraction
has to be renamed):

```
sum by (wns, wpod, wcont) (count_over_time({namespace="falco"}
  | json rule="rule",
         wns="output_fields[\"k8s.ns.name\"]",
         wpod="output_fields[\"k8s.pod.name\"]",
         wcont="output_fields[\"container.name\"]"
  | rule="Contact K8S API Server From Container" [6h]))

  490  messaging / openbank-cluster-entity-operator-<hash-a> / user-operator
  203  messaging / openbank-cluster-entity-operator-<hash-a> / topic-operator
   23  messaging / openbank-cluster-entity-operator-<hash-b> / user-operator
   10  messaging / openbank-cluster-entity-operator-<hash-b> / topic-operator
   65  ~40 distinct <svc>-db-N pods, container `postgres`, proc `manager`  (1-4 each)
    3  (no fields)
```

Two entity-operator ReplicaSet hashes because the pod rolled ~5h into the window; both carry the
same name prefix.

**The issue's premise is 92%, not 100%.** 726/793 is the entity-operator. The other 65 are CNPG's
instance manager calling the API server from inside each `postgres` container — 1–4 events per
database, spread across ~40 of them. That is not tuned here (see below).

## The exception

```yaml
- macro: openbank_strimzi_entity_operator
  condition: >
    (k8s.ns.name = "messaging"
     and k8s.pod.name startswith "openbank-cluster-entity-operator"
     and container.name in (user-operator, topic-operator)
     and proc.pname = "tini")
```

Four dimensions — one tighter than the existing `openbank_strimzi_operator`, deliberately, because
a two-container pod running a JVM is a bigger thing to except than a single-purpose operator pod.
The pod prefix is the Kafka CR name (`components/kafka/kafka.yaml`: `openbank-cluster`), which is
why `strimzi-cluster-operator` never matched it.

`proc.name` is **not** used: the observed values are `JdkHttpClientFa`, `HttpClient-1-Se`,
`operator-thread`, `java` — JVM thread names truncated to 15 chars by the kernel's `comm`. They are
a property of the JDK's internal naming and would rot on any Strimzi or JDK bump. `container.name`
is assigned by the operator that creates the pod and is stable.

## What still fires

This is the whole review of the change, so concretely — every one of these still trips this rule
after the merge:

- The Kafka brokers, Apicurio, `kafka-ui` and `kafka-exporter` in ns `messaging` — pod-name prefix.
- A pod named `openbank-cluster-entity-operator-*` in **any other namespace** — namespace pinned.
- A third container injected into this pod as a sidecar — `container.name` is a closed two-item list.
- **Any process in these two containers that is not the operator JVM itself.** An exec'd shell,
  `curl`, `kubectl` or a dropped binary has the JVM (or a shell) as its parent, never `tini`;
  `tini` is PID 1 and only the operator JVM is its child. This is the dimension that makes the
  exception a description of one process rather than of a pod.
- All ~60 openbank application namespaces, untouched by any macro in this file, where a call to the
  API server remains anomalous by construction.

**Residual, stated plainly** — it is the same one macro (3) already accepts for the admin-ui BFF:
code execution *inside* the operator JVM would no longer trip **this** rule, because it inherits the
excepted process identity. It still trips the shell-spawn, drop-and-execute and sensitive-file
rules, and the operator's own RBAC caps what its token can do.

## Expected residual, and what becomes visible

Same window, with the entity-operator pods excluded:

```
| wpod!~"openbank-cluster-entity-operator.*"   ->  69 events / 6h   (all proc `manager`)
```

So the rule goes **793 -> ~69 per 6h** (~3170/day -> ~275/day), a 91% cut.

What becomes visible is the CNPG instance-manager tail: today it is 8% of the rule and invisible in
the noise; afterwards it is ~100% of it, at 1–4 events per database pod. That is the first time this
rule's output is readable at all. It is deliberately **not** tuned in this PR — it is diffuse
(~40 pods, no single hot workload), it is a different subsystem from the one #6033 is about, and
tuning it would mean a macro keyed on `proc.pname = "containerd-shim"`, i.e. on being PID 1, which
is far too loose to write without its own measurement. Worth a follow-up issue, not a rider here.

## Honest bound on the value

This rule is priority **NOTICE**. As #6032 establishes, no alert in this estate can see a NOTICE
event — and after #6032 lands, the alerts that will finally evaluate are the Critical ones. So this
change **detects nothing new and prevents no incident**. What it buys is log volume and a dashboard
panel whose top row stops being one Kafka operator. That also bounds the risk it carries: the
exception cannot mute an alert, because there is no alert on this rule to mute.

## Verification

- `falco --validate` against Falco **0.44.1** (the exact version pinned in this file), stock
  `falco_rules.yaml` + the extracted `customRules` content: **Ok**, exit 0.
- **Negative control**, because a validator that cannot fail proves nothing: the same run with
  `proc.pname` misspelled to `proc.pnameXX` exits **1** with
  `LOAD_ERR_COMPILE_CONDITION ... nonexistent field`. The error traces *through*
  `rule 'Contact K8S API Server From Container' -> ... -> user_known_contact_k8s_api_server_activities`,
  which independently proves the override is genuinely wired into the stock rule and not an inert
  macro nobody references — the "configured-looking and inert" failure this file's own header warns
  about, and the one that cost #6032 its Loki ruler.
- `valuesObject` parses as YAML and the `customRules` string parses as a Falco rules document; the
  macro list is the 4 existing + 1 new.

**Not verified:** nothing was applied to the cluster — this is a gitops-only change and ArgoCD will
sync it. The post-merge event rate is a projection from the measured split, not an observation.

## Ruleset validation is absent from CI — worth knowing

There is **no gate anywhere in this repo that validates the Falco ruleset.** `grep -rli falco`
across `.github/` returns exactly one file (`check-openssf-gold-evidence.py`, which only counts it
as evidence). So a syntax error, a misspelled field, or a macro overriding a hook that does not
exist would reach the cluster and Falco would refuse to load the rules file — with a healthy pod and
a Synced ArgoCD, exactly the shape #5850's header comment warns about and the shape #6032 found in
the Loki ruler. The `falco --validate` invocation above is ~10 lines of workflow and is a natural
follow-up; not bundled here so this PR stays one macro.

Refs #5734, #5850, #6032.
