### PR TITLE
fix(observability): price book evaluated hourly, read every 5m — 1-in-12 duty cycle

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-ai.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-ai.yaml
@@ -34,7 +34,29 @@ spec:
     # `price_source` is carried deliberately: it is the difference between a number we can defend
     # and one we cannot, and it stays visible on the dashboard rather than living in a comment.
     - name: openbank.ai.price-book
-      interval: 1h
+      # 1m, not 1h. These rules are `vector(<constant>)` — evaluation is free, and the interval
+      # is not a cost knob here, it is what decides whether the series EXISTS when its consumers
+      # look.
+      #
+      # At 1h the price book was invisible for 55 minutes of every 60. Prometheus answers an
+      # instant query from a 5-minute lookback window, so a series written once an hour is
+      # resolvable for 5 of those 60 minutes — a 1-in-12 duty cycle. Measured against the live
+      # sandbox 2026-08-21, group lastEvaluation 06:26:11Z:
+      #
+      #   query at eval + 60s   -> 9 price series
+      #   query at eval + 600s  -> 0
+      #   query at eval + 3600s -> 0
+      #
+      # `openbank.ai.spend` below runs at 5m and joins `on (model, kind)` against this, so 11 of
+      # every 12 of its evaluations saw NO price and produced no cost sample. That is why
+      # `openbank:llm_cost_usd_24h:total` had no series at all, why AiFleetDailySpendHigh — the
+      # 25 USD/day ceiling — could not fire, and why AiSpendUnpriced fired for a model that IS
+      # priced: `unless on (model)` against a stale price series reports everything as unpriced.
+      #
+      # #6063 added the missing model prices and was correct; it just landed on a rule group its
+      # consumers could not see. Verified there: 9 series exist at eval+60s, so the entries
+      # themselves work.
+      interval: 1m
       rules:
         # DeepInfra's published rate card for `meta-llama/Llama-3.3-70B-Instruct-Turbo`, the route
         # the caller-facing id `llama-3.3-70b-versatile` now resolves to — $0.10/M input,


### PR DESCRIPTION
## What

#6063 added the missing model prices and was **correct**. It landed on a rule group its consumers could not see.

`openbank.ai.price-book` ran at `interval: 1h`. Prometheus answers an instant query from a **5-minute lookback window**, so a series written once an hour is resolvable for 5 of those 60 minutes — a **1-in-12 duty cycle**.

Measured against the live sandbox 2026-08-21, group `lastEvaluation 06:26:11Z`:

```
query at eval + 60s   -> 9 price series
query at eval + 600s  -> 0
query at eval + 3600s -> 0
```

## Why it mattered, and why each symptom looked like something else

`openbank.ai.spend` runs at `5m` and joins `on (model, kind)` against the price book, so **11 of every 12** of its evaluations saw no price and produced no cost sample:

- `openbank:llm_cost_usd_24h:total` had **no series**, so the AI dashboard's cost panels stayed blank *after a fix that was supposed to fill them*.
- `AiFleetDailySpendHigh` — the 25 USD/day ceiling its own comment calls the thing that *"actually protects the card"* — **could not fire**: a threshold over an absent series matches nothing.
- `AiSpendUnpriced` **fired for `openai/gpt-oss-120b`, a model that is now priced**. `unless on (model)` against a stale price series reports everything as unpriced — so the alert whose job is to prove the price book complete was instead reporting the lookback window.

That last one is the sharp edge: the estate's own falsifiability check was returning a false positive, which is worse than it being silent.

## The fix

`interval: 1h` → `1m`.

The interval is **not a cost knob here**: these rules are `vector(<constant>)`, so evaluation is free and the only thing the interval decides is whether the series exists when something looks. 1m keeps it continuously resolvable for the 5m consumer with margin.

## How it was found

By verifying #6063's **effect** on the live estate rather than trusting the merge. The rule group loaded with 9 rules and `health=ok`, no errors, correct `lastEvaluation` — which is exactly what a working price book also looks like. Only querying the series at different offsets from the evaluation timestamp distinguished the two.

Refs #5736
