### PR TITLE
fix(admin-ui): localize delegation timestamps

### DIFF
--- a/openbank-admin-ui/src/app/delegations/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/delegations/[id]/page.tsx
@@ -33,9 +33,20 @@ import {
 
 type CheckOutcome = { granted: boolean; reason?: string | null; code?: string | null }
 
+function formatDelegationTimestamp(
+  value: string | null | undefined,
+  locale: string,
+): string {
+  if (!value) return '—'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString(locale, { dateStyle: 'medium', timeStyle: 'short' })
+}
+
 export default function DelegationDetailPage() {
   const { t, language } = useLanguage()
   const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const params = useParams<{ id: string }>()
   const id = params?.id
 
@@ -108,19 +119,19 @@ export default function DelegationDetailPage() {
               <dd>{formatCeiling(grant.monthlyLimit, numberLocale)}</dd>
 
               <dt style={{ color: 'var(--text-tertiary)' }}>{t('Platnost od', 'Valid from')}</dt>
-              <dd>{grant.validFrom ?? '—'}</dd>
+              <dd>{formatDelegationTimestamp(grant.validFrom, dateLocale)}</dd>
 
               <dt style={{ color: 'var(--text-tertiary)' }}>{t('Platnost do', 'Valid until')}</dt>
-              <dd>{grant.validTo ?? t('bez omezení', 'no expiry')}</dd>
+              <dd>{grant.validTo ? formatDelegationTimestamp(grant.validTo, dateLocale) : t('bez omezení', 'no expiry')}</dd>
 
               <dt style={{ color: 'var(--text-tertiary)' }}>{t('Vytvořeno', 'Created')}</dt>
-              <dd>{grant.createdAt ?? '—'}</dd>
+              <dd>{formatDelegationTimestamp(grant.createdAt, dateLocale)}</dd>
 
               <dt style={{ color: 'var(--text-tertiary)' }}>{t('Naposledy změněno', 'Last changed')}</dt>
-              <dd>{grant.updatedAt ?? '—'}</dd>
+              <dd>{formatDelegationTimestamp(grant.updatedAt, dateLocale)}</dd>
 
               <dt style={{ color: 'var(--text-tertiary)' }}>{t('Ukončeno', 'Closed')}</dt>
-              <dd>{grant.closedAt ? `${grant.closedAt} — ${grant.closedReason ?? ''}` : '—'}</dd>
+              <dd>{grant.closedAt ? `${formatDelegationTimestamp(grant.closedAt, dateLocale)} — ${grant.closedReason ?? ''}` : '—'}</dd>
             </dl>
           </div>
 

--- a/openbank-admin-ui/src/test/delegation-detail-locale.guard.test.ts
+++ b/openbank-admin-ui/src/test/delegation-detail-locale.guard.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('delegation detail timestamp locale contract', () => {
+  it('formats timeline timestamps with the active locale and preserves invalid raw values', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/delegations/[id]/page.tsx'), 'utf8')
+
+    expect(source).toContain("const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'")
+    expect(source).toContain('toLocaleString(locale, { dateStyle: \'medium\', timeStyle: \'short\' })')
+    expect(source).toContain('if (Number.isNaN(date.getTime())) return value')
+    expect(source).toContain('formatDelegationTimestamp(grant.validFrom, dateLocale)')
+    expect(source).toContain('formatDelegationTimestamp(grant.closedAt, dateLocale)')
+    expect(source).not.toMatch(/grant\.(validFrom|validTo|createdAt|updatedAt|closedAt) \?\? '—'/)
+  })
+})


### PR DESCRIPTION
## Summary
- format delegation validity and lifecycle timestamps using the active operator locale
- preserve raw backend values when timestamps are invalid
- add a focused source guard for the locale contract

## Verification
- git diff --check
- npm run type-check
- focused Vitest blocked by missing native @rolldown/binding-darwin-x64 in the environment

Refs #6152