### PR TITLE
fix(observability): price DeepSeek-V4-Pro and correct three LLM prices against the provider's own rate card

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -2407,6 +2407,23 @@ gates:
     run: |
       python3 .github/scripts/check-dashboard-metric-emitted.py --enforce
 
+  # Scope is DERIVED from litellm-config.yaml's `model_name` keys, never a list in the script.
+  # A gate whose subject set is a hand-kept list of the thing it checks reads as PASSING when the
+  # list is short, never as UNCHECKED — so adding a model to the gateway is what grows this gate,
+  # and forgetting the price book is what reddens it.
+  - id: llm-price-book
+    name: "every gateway-routable LLM model is priced, and the price agrees with litellm-config (issue #6045, enforced)"
+    group: data
+    mode: enforced
+    min_subjects: 6   # 6 model_name routes in litellm-config.yaml today (2026-08-21)
+    rationale: "An unpriced model is costed at $0, so the spend dashboards and the 25 USD/day AiFleetDailySpendHigh ceiling understate real cost with no error anywhere; and a price book that disagrees with the gateway's own declared cost means the control that meters and the control that alerts are enforcing two different numbers. AiSpendUnpriced detects the first at runtime, but only once the model carries traffic and only if somebody actions it — it fired for openai/gpt-oss-120b and nobody did."
+    review_after: "2027-02-21"
+    selftest: |
+      python3 .github/scripts/check-llm-price-book.py --selftest
+    selftest_expect: pass
+    run: |
+      python3 .github/scripts/check-llm-price-book.py --enforce
+
   - id: alert-metric-emitted
     name: "every alert rule depends on a metric some code emits (issue #5733, enforced)"
     group: data

--- a/.github/scripts/check-llm-price-book.py
+++ b/.github/scripts/check-llm-price-book.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Every model the LiteLLM gateway can route must have an LLM price-book entry, and the
+price must agree with the gateway's own declared cost.
+
+Issue #6045. Two independent failure modes, one gate:
+
+1. MISSING PRICE. `openbank:llm_price_usd_per_token` in prometheus-rules-ai.yaml is joined
+   `on (model, kind)` by the spend rules. A model served by the gateway with no entry is
+   costed at ZERO -- the spend figure is silently too low and no error appears anywhere.
+   AiSpendUnpriced does detect this at runtime, but only once the model carries traffic, and
+   only if somebody actions the alert (it fired for openai/gpt-oss-120b and nobody did).
+   This gate fails at PR time instead, before the first untracked token.
+
+2. PRICE DISAGREEMENT. litellm-config.yaml declares input_cost_per_token/output_cost_per_token
+   per route -- that is what LiteLLM meters and what the per-model max_budget bites on. The
+   Prometheus price book is a SECOND copy of the same numbers, feeding the dashboards and the
+   25 USD/day AiFleetDailySpendHigh ceiling. Nothing kept them in lockstep, and on 2026-08-21
+   they disagreed on three figures, the worst by 2.6x on the model carrying 100% of live
+   traffic. The config file's own comment already asks for lockstep; this makes it checkable.
+
+THE SUBJECT SET IS DERIVED, NEVER HAND-KEPT. The models come from the `model_name` keys of
+litellm-config.yaml's `model_list`. A gate whose scope is a hand-maintained list of the thing
+it checks reads as PASSING when the list is short, never as UNCHECKED.
+
+Exclusions carry a reason and fail STALE IN BOTH DIRECTIONS: an exclusion for a model that is
+no longer served fails, and an exclusion for a model that now HAS a price fails too -- so a
+temporary waiver cannot quietly become permanent.
+
+Usage:
+  check-llm-price-book.py --enforce
+  check-llm-price-book.py --selftest
+"""
+import sys
+import re
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import gatelib  # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+LITELLM = ROOT / "openbank-infra/gitops/components/ai-platform/litellm-config.yaml"
+RULES = ROOT / "openbank-infra/gitops/components/observability/prometheus-rules-ai.yaml"
+
+# Models deliberately absent from a price-book KIND. Keyed (model, kind) -> reason.
+# Both directions are checked: a stale entry here fails the gate.
+EXCLUSIONS = {
+    ("BAAI/bge-m3", "completion"): (
+        "Embeddings generate no completion tokens -- measured, the adapter emits kind=prompt "
+        "and nothing else. A completion price here would price tokens that cannot exist."
+    ),
+}
+
+
+def _dedent_block(text, start, indent):
+    """Return the lines of a YAML block starting at `start` while indent > `indent`."""
+    out = []
+    for line in text[start:].splitlines()[1:]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            out.append(line)
+            continue
+        if len(line) - len(line.lstrip()) <= indent:
+            break
+        out.append(line)
+    return out
+
+
+def parse_litellm(text):
+    """model_name -> {'input': float|None, 'output': float|None}.
+
+    Deliberately a line scanner rather than a YAML load: the config lives inside a ConfigMap
+    `data:` string, so a yaml.safe_load gives one giant scalar, and the embedded document is
+    what we need. Anchored on the two-space `- model_name:` list items.
+    """
+    models = {}
+    current = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        m = re.match(r"^\s*-\s*model_name:\s*(\S+)\s*$", line)
+        if m:
+            current = m.group(1)
+            models[current] = {"input": None, "output": None}
+            continue
+        if current is None:
+            continue
+        m = re.match(r"^\s*input_cost_per_token:\s*([0-9.eE+-]+)\s*$", line)
+        if m:
+            models[current]["input"] = float(m.group(1))
+            continue
+        m = re.match(r"^\s*output_cost_per_token:\s*([0-9.eE+-]+)\s*$", line)
+        if m:
+            models[current]["output"] = float(m.group(1))
+    return models
+
+
+def parse_price_book(text):
+    """(model, kind) -> (value, price_source) from openbank:llm_price_usd_per_token rules."""
+    book = {}
+    for m in re.finditer(
+        r"-\s*record:\s*openbank:llm_price_usd_per_token\s*\n"
+        r"\s*expr:\s*vector\(\s*([0-9.eE+-]+)\s*\)\s*\n"
+        r"\s*labels:\s*\n"
+        r"((?:\s*#.*\n|\s+\w+:\s*\S+\s*\n)+)",
+        text,
+    ):
+        value = float(m.group(1))
+        labels = dict(
+            re.findall(r"^\s+(\w+):\s*(\S+)\s*$", m.group(2), re.M)
+        )
+        if "model" in labels and "kind" in labels:
+            book[(labels["model"], labels["kind"])] = (
+                value,
+                labels.get("price_source", "(unset)"),
+            )
+    return book
+
+
+# The gateway's declared cost is per (model, kind); map the price-book `kind` onto the
+# litellm-config key that declares the same number.
+KIND_TO_CONFIG_KEY = {"prompt": "input", "completion": "output"}
+
+
+def check(litellm_text, rules_text):
+    """Return a list of failure strings. Empty list == pass."""
+    served = parse_litellm(litellm_text)
+    book = parse_price_book(rules_text)
+    failures = []
+
+    if not served:
+        return ["no model_name entries parsed from litellm-config.yaml -- the gate has no "
+                "subjects, which is a broken probe, not a pass"]
+    if not book:
+        return ["no openbank:llm_price_usd_per_token rules parsed from prometheus-rules-ai.yaml "
+                "-- the gate has no price book to check against"]
+
+    for model in sorted(served):
+        for kind, cfg_key in KIND_TO_CONFIG_KEY.items():
+            declared = served[model][cfg_key]
+            excluded = (model, kind) in EXCLUSIONS
+            entry = book.get((model, kind))
+
+            if entry is None:
+                if excluded:
+                    continue
+                failures.append(
+                    f"UNPRICED: model '{model}' is routable by the LiteLLM gateway but has no "
+                    f"openbank:llm_price_usd_per_token entry for kind='{kind}'. Every {kind} "
+                    f"token it burns is costed at $0, so openbank:llm_cost_usd_24h:total "
+                    f"understates real spend and AiFleetDailySpendHigh cannot bite. Add the "
+                    f"entry to the openbank.ai.price-book group in prometheus-rules-ai.yaml, "
+                    f"or declare an EXCLUSIONS reason in this script."
+                )
+                continue
+
+            if excluded:
+                failures.append(
+                    f"STALE EXCLUSION: ('{model}', '{kind}') is listed in EXCLUSIONS but the "
+                    f"price book now HAS an entry for it. Remove the exclusion."
+                )
+                continue
+
+            value, source = entry
+            if value <= 0:
+                failures.append(
+                    f"ZERO PRICE: ('{model}', '{kind}') is priced at {value}, which is "
+                    f"indistinguishable from no price at all -- it makes the join succeed while "
+                    f"costing every token at nothing, which is worse than being unpriced "
+                    f"because AiSpendUnpriced then cannot see it."
+                )
+                continue
+
+            if declared is None:
+                continue  # gateway declares no cost for this direction; nothing to compare.
+            if abs(value - declared) > declared * 1e-6:
+                failures.append(
+                    f"PRICE DISAGREEMENT: ('{model}', '{kind}') is {value:g} in the Prometheus "
+                    f"price book (price_source={source}) but {declared:g} in litellm-config.yaml "
+                    f"({cfg_key}_cost_per_token). LiteLLM meters and enforces max_budget on its "
+                    f"own number; the dashboards and AiFleetDailySpendHigh use the other. They "
+                    f"must be the same figure from the same source."
+                )
+
+    for (model, kind), reason in sorted(EXCLUSIONS.items()):
+        if model not in served:
+            failures.append(
+                f"STALE EXCLUSION: ('{model}', '{kind}') is listed in EXCLUSIONS but that model "
+                f"is no longer routable by the gateway. Remove it. Reason on file: {reason}"
+            )
+
+    return failures
+
+
+SELFTEST_LITELLM = """
+    model_list:
+      - model_name: alpha/model-one
+        litellm_params:
+          model: deepinfra/alpha/model-one
+          input_cost_per_token: 0.000001
+          output_cost_per_token: 0.000002
+      - model_name: beta/model-two
+        litellm_params:
+          model: deepinfra/beta/model-two
+          input_cost_per_token: 0.000003
+          output_cost_per_token: 0.000004
+"""
+
+SELFTEST_RULES_GOOD = """
+        - record: openbank:llm_price_usd_per_token
+          expr: vector(0.000001)
+          labels:
+            model: alpha/model-one
+            kind: prompt
+            price_source: provider-rate-card
+        - record: openbank:llm_price_usd_per_token
+          expr: vector(0.000002)
+          labels:
+            model: alpha/model-one
+            kind: completion
+            price_source: provider-rate-card
+        - record: openbank:llm_price_usd_per_token
+          expr: vector(0.000003)
+          labels:
+            model: beta/model-two
+            kind: prompt
+            price_source: provider-rate-card
+        - record: openbank:llm_price_usd_per_token
+          expr: vector(0.000004)
+          labels:
+            model: beta/model-two
+            kind: completion
+            price_source: provider-rate-card
+"""
+
+
+def selftest():
+    """Prove the gate by what it PREVENTS, on fixtures, not on the live files."""
+    import copy  # noqa: F401  (kept for clarity of intent)
+    global EXCLUSIONS
+    saved = EXCLUSIONS
+    EXCLUSIONS = {}
+    ok = True
+
+    def case(name, litellm, rules, must_fail, needle=None):
+        nonlocal ok
+        f = check(litellm, rules)
+        failed = bool(f)
+        if failed != must_fail:
+            print(f"  SELFTEST FAIL [{name}]: expected "
+                  f"{'failure' if must_fail else 'pass'}, got {f or 'pass'}")
+            ok = False
+            return
+        if needle and not any(needle in x for x in f):
+            print(f"  SELFTEST FAIL [{name}]: message did not name '{needle}': {f}")
+            ok = False
+            return
+        print(f"  ok [{name}]")
+
+    case("baseline passes", SELFTEST_LITELLM, SELFTEST_RULES_GOOD, False)
+
+    # NEGATIVE CONTROL 1: remove one price-book entry.
+    removed = SELFTEST_RULES_GOOD.replace(
+        """        - record: openbank:llm_price_usd_per_token
+          expr: vector(0.000004)
+          labels:
+            model: beta/model-two
+            kind: completion
+            price_source: provider-rate-card
+""", "")
+    case("missing entry fails, naming the model", SELFTEST_LITELLM, removed, True,
+         "beta/model-two")
+
+    # NEGATIVE CONTROL 2: a price that disagrees with the gateway config.
+    wrong = SELFTEST_RULES_GOOD.replace("vector(0.000003)", "vector(0.000009)")
+    case("disagreeing price fails", SELFTEST_LITELLM, wrong, True, "PRICE DISAGREEMENT")
+
+    # NEGATIVE CONTROL 3: a zero price (join succeeds, cost is nothing).
+    zeroed = SELFTEST_RULES_GOOD.replace("vector(0.000003)", "vector(0.0)")
+    case("zero price fails", SELFTEST_LITELLM, zeroed, True, "ZERO PRICE")
+
+    # NEGATIVE CONTROL 4: a new gateway model with no price at all.
+    grown = SELFTEST_LITELLM + """      - model_name: gamma/model-three
+        litellm_params:
+          model: deepinfra/gamma/model-three
+          input_cost_per_token: 0.000005
+          output_cost_per_token: 0.000006
+"""
+    case("new gateway model fails", grown, SELFTEST_RULES_GOOD, True, "gamma/model-three")
+
+    # NEGATIVE CONTROL 5: stale exclusion, both directions.
+    EXCLUSIONS = {("beta/model-two", "completion"): "test"}
+    case("exclusion covering a priced entry fails", SELFTEST_LITELLM, SELFTEST_RULES_GOOD,
+         True, "STALE EXCLUSION")
+    EXCLUSIONS = {("ghost/model", "prompt"): "test"}
+    case("exclusion for an unserved model fails", SELFTEST_LITELLM, SELFTEST_RULES_GOOD,
+         True, "STALE EXCLUSION")
+
+    # And the exclusion working as intended.
+    EXCLUSIONS = {("beta/model-two", "completion"): "test"}
+    case("honoured exclusion passes", SELFTEST_LITELLM, removed, False)
+
+    # BROKEN-PROBE CONTROL: empty inputs must FAIL, never pass vacuously.
+    EXCLUSIONS = {}
+    case("empty config fails", "", SELFTEST_RULES_GOOD, True, "no subjects")
+    case("empty rules fails", SELFTEST_LITELLM, "", True, "no price book")
+
+    EXCLUSIONS = saved
+    return ok
+
+
+def main():
+    if "--selftest" in sys.argv:
+        print("check-llm-price-book self-test")
+        sys.exit(0 if selftest() else 1)
+
+    litellm_text = LITELLM.read_text()
+    rules_text = RULES.read_text()
+    served = parse_litellm(litellm_text)
+    book = parse_price_book(rules_text)
+    failures = check(litellm_text, rules_text)
+
+    print(f"LiteLLM gateway routes {len(served)} model(s); price book carries "
+          f"{len(book)} (model, kind) entr(ies).")
+    for model in sorted(served):
+        print(f"  - {model}")
+    # Printed unconditionally, on the failure path too: a gate that found its corpus and then
+    # failed on it must not also be reported as having lost its corpus.
+    gatelib.subjects(len(served), "model_name routes in litellm-config.yaml")
+
+    if failures:
+        print(f"\nFAIL: {len(failures)} finding(s)\n")
+        for f in failures:
+            print(f"  * {f}\n")
+        sys.exit(1)
+    print("\nOK: every gateway-routable model is priced, and every price agrees with "
+          "litellm-config.yaml.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/openbank-infra/gitops/components/observability/prometheus-rules-ai.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-ai.yaml
@@ -76,24 +76,25 @@ spec:
             model: llama-3.3-70b-versatile
             kind: completion
             price_source: provider-rate-card
-        # APPROXIMATE. LiteLLM's price map has no `deepinfra/deepseek-ai/DeepSeek-V3.2` entry — the
-        # newest DeepInfra DeepSeek it knows is V3.1 ($0.27/M input, $1.00/M output), used here as
-        # the nearest published sibling. Every panel and alert built on this carries
-        # price_source="nearest-sibling" so the estimate is never mistaken for a billed figure.
-        # Replace with the real rate card when DeepInfra publishes V3.2, or when the invoice
-        # disagrees — the invoice is the authority, this is a leading indicator.
+        # WAS a nearest-sibling estimate off LiteLLM's map (V3.1, $0.27/M in, $1.00/M out),
+        # because "litellm's map has no V3.2 entry" was taken to mean no published rate existed.
+        # It does — DeepInfra publishes its own, api.deepinfra.com/models/deepseek-ai/DeepSeek-V3.2
+        # returns cents_per_input_token 2.6e-05 / cents_per_output_token 3.8e-05 for the exact id
+        # this gateway routes to, and litellm-config.yaml has carried those very numbers all along.
+        # The sibling estimate overstated COMPLETION by 2.6x. Read the provider's own rate card
+        # before reaching for another vendor's map of it (#6045).
         - record: openbank:llm_price_usd_per_token
-          expr: vector(0.00000027)
+          expr: vector(0.00000026)
           labels:
             model: deepseek-ai/DeepSeek-V3.2
             kind: prompt
-            price_source: nearest-sibling
+            price_source: provider-rate-card
         - record: openbank:llm_price_usd_per_token
-          expr: vector(0.00000100)
+          expr: vector(0.00000038)
           labels:
             model: deepseek-ai/DeepSeek-V3.2
             kind: completion
-            price_source: nearest-sibling
+            price_source: provider-rate-card
         # openai/gpt-oss-120b — the model the gateway ACTUALLY serves traffic on, and it was
         # missing from this file. Measured 2026-08-19: 32660 tokens in 24h on this model and 1306
         # on BAAI/bge-m3, while the only two priced models (llama-3.3-70b-versatile,
@@ -107,22 +108,28 @@ spec:
         # actioned it, which is why the gap survived — the falsifiability check worked and the
         # response to it did not.
         #
-        # Authoritative: BerriAI/litellm model_prices_and_context_window.json, entry
-        # `deepinfra/openai/gpt-oss-120b` — $0.05/M input, $0.45/M output. Exact match for the
-        # provider this gateway routes to (litellm-config: model `deepinfra/openai/gpt-oss-120b`),
-        # not a sibling.
+        # CORRECTED (#6045), and this is the model carrying 100% of live traffic, so it is the
+        # figure that mattered most. It was taken from BerriAI/litellm's map
+        # (`deepinfra/openai/gpt-oss-120b`, $0.05/M in / $0.45/M out) and that map is a THIRD
+        # PARTY'S COPY of DeepInfra's rate card, which had drifted: DeepInfra's own
+        # api.deepinfra.com/models/openai/gpt-oss-120b returns cents_per_input_token 3.7e-06 and
+        # cents_per_output_token 1.7e-05 — $0.037/M in, $0.17/M out. The map OVERSTATED output by
+        # 2.6x and input by 35%, so every spend panel and the 25 USD/day AiFleetDailySpendHigh
+        # ceiling were reading high on the only model with traffic. litellm-config.yaml carried
+        # the correct provider figures the whole time; the two files simply had nothing keeping
+        # them in lockstep. `check-llm-price-book.py` is now that thing.
         - record: openbank:llm_price_usd_per_token
-          expr: vector(0.00000005)
+          expr: vector(0.000000037)
           labels:
             model: openai/gpt-oss-120b
             kind: prompt
-            price_source: litellm-map
+            price_source: provider-rate-card
         - record: openbank:llm_price_usd_per_token
-          expr: vector(0.00000045)
+          expr: vector(0.00000017)
           labels:
             model: openai/gpt-oss-120b
             kind: completion
-            price_source: litellm-map
+            price_source: provider-rate-card
         # meta-llama/llama-guard-4-12b. Authoritative: litellm entry
         # `deepinfra/meta-llama/Llama-Guard-4-12B` — $0.18/M both directions. Zero traffic today,
         # priced anyway: the point of this file is that turning a served model on must not also
@@ -155,12 +162,31 @@ spec:
             model: BAAI/bge-m3
             kind: prompt
             price_source: nearest-sibling
-        # deepseek-ai/DeepSeek-V4-Pro is served by the gateway and is deliberately NOT priced
-        # here: litellm's map has no DeepInfra entry for it and no DeepInfra DeepSeek newer than
-        # V3.1, so there is no same-provider sibling to reason from, and the cross-provider
-        # figures for V4-Pro span 1.74e-06 to 2.4e-06 input — a 38% spread that would be a guess
-        # dressed as a price. It carries no traffic today; if it starts, AiSpendUnpriced fires and
-        # names it, which is the correct behaviour rather than a silently wrong number.
+        # deepseek-ai/DeepSeek-V4-Pro. This entry used to be a deliberate ABSENCE, on the
+        # reasoning that litellm's map has no DeepInfra entry for it and the cross-provider
+        # figures span 1.74e-06 to 2.4e-06 — a 38% spread that would be a guess dressed as a
+        # price. Leaving it out was the right call given that premise; the premise was wrong.
+        # DeepInfra publishes the rate directly: api.deepinfra.com/models/deepseek-ai/DeepSeek-V4-Pro
+        # returns cents_per_input_token 0.00013 / cents_per_output_token 0.00026 — $1.30/M in,
+        # $2.60/M out — and litellm-config.yaml already declares exactly those two numbers on this
+        # route. So the authoritative same-provider figure was one HTTP GET and one sibling file
+        # away, and "no published rate exists" was really "the map I looked in did not have one".
+        #
+        # It carries no traffic today (0 tokens over 7d, measured 2026-08-21). Priced anyway: the
+        # point of this file is that turning a served model on must not also turn the cost figures
+        # into an understatement.
+        - record: openbank:llm_price_usd_per_token
+          expr: vector(0.0000013)
+          labels:
+            model: deepseek-ai/DeepSeek-V4-Pro
+            kind: prompt
+            price_source: provider-rate-card
+        - record: openbank:llm_price_usd_per_token
+          expr: vector(0.0000026)
+          labels:
+            model: deepseek-ai/DeepSeek-V4-Pro
+            kind: completion
+            price_source: provider-rate-card
 
     # ── Derived spend ─────────────────────────────────────────────────────────
     - name: openbank.ai.spend


### PR DESCRIPTION
Closes #6045

## The issue's premise is stale, and re-measuring is what found the real defect

`AiSpendUnpriced` is **not firing**, and three of the four ids it names are already priced —
#6063 added them and #6041 fixed the rule-group interval that was making the whole price book
invisible 55 minutes of every 60. Measured against the sandbox Prometheus
(`prometheus-kube-prometheus-stack-prometheus-0` in `observability`, 2026-08-21 08:11Z):

```promql
ALERTS{alertname="AiSpendUnpriced"}                 -> no series
openbank:llm_tokens_unpriced_24h                    -> no series
openbank:llm_price_usd_per_token                    -> 9 series
```

An empty result is exactly what a broken probe returns, so it was falsified before being
believed. Two controls: `count(up)` returned 244, and the unpriced expression was re-run with
one model held out of the price book —

```promql
sum by (model) (increase(openbank_llm_tokens_total[24h])
  unless on (model) (openbank:llm_price_usd_per_token{model!="openai/gpt-oss-120b"}))
-> {model="openai/gpt-oss-120b"} 65482.3
```

It produces a series when there is something to find. (My first attempt at all of this queried
`kube-prometheus-stack-prometheus-0` — the wrong pod name — and returned silence that looked
exactly like "no alert".)

## Traffic: the untracked spend was never material

```promql
sum by (model,kind) (increase(openbank_llm_tokens_total[24h]))
sum by (model)      (increase(openbank_llm_tokens_total[7d]))
```

| model | 24h tokens | 7d tokens | 24h requests |
|---|---:|---:|---:|
| `openai/gpt-oss-120b` | 65 482 (61 275 prompt / 4 208 completion) | 65 482 | 44 success |
| `BAAI/bge-m3` | 0 | 0 | 0 |
| `meta-llama/llama-guard-4-12b` | 0 | 0 | 0 (`exception`) |
| `deepseek-ai/DeepSeek-V4-Pro` | 0 | 0 | 0 |

`openbank:llm_cost_usd_24h:total` = **USD 0.00496/day**. The issue asked whether this was
material before prioritising; it is not — roughly USD 1.80/year. This is hygiene, and the
guard is the part worth having.

## The real defect: the two price copies disagreed, on the model with all the traffic

`litellm-config.yaml` declares `input_cost_per_token`/`output_cost_per_token` per route — that
is what LiteLLM meters and what `max_budget` bites on. The Prometheus price book is a **second
copy** of the same numbers, feeding the dashboards and the 25 USD/day `AiFleetDailySpendHigh`
ceiling. The config file's own comment asks for lockstep; nothing enforced it, and they had
drifted.

## Every price, and where it came from

Read from the provider directly, `GET https://api.deepinfra.com/models/<id>`, converting
`cents_per_*_token` to USD/token. That is the same rate card `litellm-config.yaml` already
cites — which is how the disagreement was diagnosed: the gateway config was right everywhere,
and the price book was the copy that had drifted.

| model | kind | was | now | provider rate card | note |
|---|---|---:|---:|---:|---|
| `openai/gpt-oss-120b` | prompt | 5e-08 | **3.7e-08** | 3.7e-06 ¢ | was +35% |
| `openai/gpt-oss-120b` | completion | 4.5e-07 | **1.7e-07** | 1.7e-05 ¢ | **was 2.6x high** |
| `deepseek-ai/DeepSeek-V3.2` | prompt | 2.7e-07 | **2.6e-07** | 2.6e-05 ¢ | |
| `deepseek-ai/DeepSeek-V3.2` | completion | 1.0e-06 | **3.8e-07** | 3.8e-05 ¢ | **was 2.6x high** |
| `deepseek-ai/DeepSeek-V4-Pro` | prompt | *absent* | **1.3e-06** | 1.3e-04 ¢ | newly priced |
| `deepseek-ai/DeepSeek-V4-Pro` | completion | *absent* | **2.6e-06** | 2.6e-04 ¢ | newly priced |
| `llama-3.3-70b-versatile` | both | 1e-07 / 3.2e-07 | unchanged | 1e-05 / 3.2e-05 ¢ | already correct |
| `meta-llama/llama-guard-4-12b` | both | 1.8e-07 | unchanged | 1.8e-05 ¢ | already correct |
| `BAAI/bge-m3` | prompt | 1e-08 | unchanged | 1e-06 ¢ | already correct |

Both wrong figures came from a **third party's copy** of DeepInfra's rate card — BerriAI/litellm's
map, or a "nearest sibling" drawn from it — while DeepInfra publishes the rate itself. Every
`price_source` those rows carried (`litellm-map`, `nearest-sibling`) is now `provider-rate-card`.

`deepseek-ai/DeepSeek-V4-Pro` was **deliberately** left unpriced, on the stated reasoning that no
same-provider figure existed and cross-provider figures spanned 38%. That was a sound call on a
wrong premise: the provider publishes it, and `litellm-config.yaml` already declared exactly those
two numbers on that route. "No published rate exists" was really "the map I looked in did not
have one".

`BAAI/bge-m3` keeps having **no completion entry** — embeddings emit no completion tokens, and a
price for tokens that cannot exist is worse than none. That is now a declared exclusion with a
reason rather than an accident.

## The ids were read from the RUNNING gateway, not from the committed config

```
kubectl get <litellm pod> -n ai-platform -o jsonpath='{.spec.containers[*].args}'
  -> ["--config","/etc/litellm/config.yaml","--port","4000"]
kubectl exec <litellm pod> -n ai-platform -- cat /etc/litellm/config.yaml
```

Six `model_name` routes, matching the committed file exactly. So the set that got priced is the
set actually served.

## The guard — `check-llm-price-book.py`

**Scope is DERIVED**, from `litellm-config.yaml`'s `model_name` keys. A gate whose subject set is
a hand-kept list of the thing it checks reads as PASSING when the list is short, never as
UNCHECKED — so adding a route to the gateway is what grows this gate, and forgetting the price
book is what reddens it. It fails on:

- a served model with no price-book entry for a kind,
- a price that **disagrees** with `litellm-config.yaml` (the drift above),
- a literal `0` price — which makes the join succeed while costing nothing, so `AiSpendUnpriced`
  cannot even see it,
- a **stale exclusion in either direction**: an exclusion for a model no longer served, and an
  exclusion for a model that now *has* a price.

### Proven by what it prevents

Exit codes read from `$?` after redirecting to a file, not from a pipeline.

Against **unfixed `main`**, before any price edit — it found all six real defects on its own:

```
$ python3 .github/scripts/check-llm-price-book.py --enforce > /tmp/live-before.out 2>&1
LIVE_BEFORE_EXIT=1     # 4x PRICE DISAGREEMENT, 2x UNPRICED (DeepSeek-V4-Pro)
```

After the fix, and the negative control on the **live** files — remove one entry, restore it:

```
LIVE_AFTER_EXIT=0
LIVE_NEGATIVE_EXIT=1
  * UNPRICED: model 'openai/gpt-oss-120b' is routable by the LiteLLM gateway but has no
    openbank:llm_price_usd_per_token entry for kind='prompt'. ...
LIVE_RESTORED_EXIT=0
```

`--self-test` covers ten cases including two **broken-probe controls** (an empty config and an
empty price book must FAIL, never pass vacuously):

```
$ python3 .github/scripts/check-llm-price-book.py --selftest ; echo $?
  ok [baseline passes] / [missing entry fails, naming the model] / [disagreeing price fails]
  ok [zero price fails] / [new gateway model fails]
  ok [exclusion covering a priced entry fails] / [exclusion for an unserved model fails]
  ok [honoured exclusion passes] / [empty config fails] / [empty rules fails]
0
```

Registered in `.github/gates/gates.yaml` as `llm-price-book` (group `data`, `mode: enforced`,
`min_subjects: 6`, `rationale`, `review_after: 2027-02-21`), and it emits `SUBJECTS=6` on both
the pass and fail paths so the floor is actually checkable.

## The config-revision bump was NOT needed — checked, not assumed

`openbank.tech/litellm-config-revision` must be bumped when `litellm-config.yaml` changes,
because LiteLLM parses `--config` once at boot. **This PR does not touch that file** — the
gateway config was already correct; it is the Prometheus copy that was wrong. The price book
lives in `prometheus-rules-ai.yaml`, a `PrometheusRule` CR that prometheus-operator reloads in
place. The existing `litellm-config-revision` gate agrees:

```
$ PR_DIFF_BASE=<merge-base> python3 .github/scripts/run-gates.py --only litellm-config-revision
REV_EXIT=0
```

The live pod's annotation reads `"13"`, matching the committed manifest — no drift either.

## Verification

- `promtool check rules` on the extracted rule groups: **exit 0, 20 rules found**.
- `run-gates.py --only llm-price-book`: **exit 0**, PASS=1.
- `run-gates.py --group data`: PASS=19, 2 FAIL — both diff-gates (`db-migration`,
  `schema-compat`) refusing to run without `PR_DIFF_BASE`. Confirmed pre-existing by running
  them on a pristine `origin/main` worktree: same exit 1.
- `run-gates.py --group gitops` after committing: PASS=31, `loki-rule-load-test` unfalsified
  (pre-existing, fails on pristine `main` too), `litellm-config-revision` passes once
  `PR_DIFF_BASE` is set. `gen-network-policies-drift-gate` failed only while the tree had
  uncommitted changes — that gate diffs the whole gitops tree — and passes after the commit.
- Groups were run **in the foreground per shard**; `--all` was not trusted (#6068).

**Not verified:** that Prometheus has reloaded the corrected rules — this is a gitops change and
nothing here was applied to the cluster. The corrected spend figures will be ~2.6x lower on the
completion side once ArgoCD syncs; the recorded history keeps the old values.

## Adjacent finding, not fixed here

**PR #5833 is stale and would regress this file.** Diffed by content, not filename: it reverts
`interval: 1m` back to `1h` — the exact defect #6041 fixed, which made the whole price book
invisible for 55 minutes of every hour — and reverts `llama-3.3-70b-versatile` to Groq's
$0.59/$0.79, for a model Groq has decommissioned. It should be rebased or closed rather than
merged.

Refs #5736, #6041, #6063
