### PR TITLE
fix(finrep): require the ledger's own balance verdict to agree

### DIFF
--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/out/FinrepMetricsPort.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/out/FinrepMetricsPort.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.finrep.application.port.out
 
+import com.openbank.finrep.domain.model.BalanceVerdict
 import java.time.Duration
 
 /**
@@ -47,6 +48,12 @@ interface FinrepMetricsPort {
 /**
  * One rendered template's shape. `balanced` is null for frameworks that define no balance identity
  * (COREP), which the adapter renders as a distinct tag value rather than pretending it balanced.
+ *
+ * [balanceVerdict] carries WHY `balanced` has the value it has (issue #6011): the two sources
+ * agreeing, the two sources disagreeing, or the producer publishing no verdict at all. It is a
+ * separate field rather than more values on `balanced` because `balanced` is what a submission
+ * gate reads and the verdict is what an operator has to act on, and those are different questions.
+ * Null for COREP, exactly like `balanced`.
  */
 data class TemplateRender(
     val framework: RegulatoryFramework,
@@ -55,6 +62,7 @@ data class TemplateRender(
     val cells: Int,
     val dataGapCells: Int,
     val balanced: Boolean?,
+    val balanceVerdict: BalanceVerdict?,
     val duration: Duration,
 )
 

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/out/FinrepPorts.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/out/FinrepPorts.kt
@@ -24,6 +24,22 @@ import java.time.LocalDate
  */
 data class TrialBalanceLineDto(val code: String, val accountType: String, val net: BigDecimal, val currency: String)
 
+/**
+ * One ledger trial-balance read: the lines, plus the balance verdict the PRODUCER published with
+ * them (issue #6011).
+ *
+ * [ledgerReportsBalanced] used to be deserialised and dropped on the floor in `LedgerAdapter`. It is
+ * carried now because agreement between it and finrep's own recomputation is a check neither side
+ * can make alone — see [com.openbank.finrep.domain.model.TrialBalanceAssurance] for the three
+ * inputs that make them disagree.
+ *
+ * NULLABLE, and no default: `null` means the response carried no verdict, which is a different fact
+ * from a verdict of `false`. A non-null `Boolean` here would let jackson-module-kotlin coerce an
+ * absent field to `false` and report a contract change as an accounting failure; a default of `true`
+ * would do the opposite and re-publish the producer's assertion without the producer.
+ */
+data class TrialBalanceSnapshot(val lines: List<TrialBalanceLineDto>, val ledgerReportsBalanced: Boolean?)
+
 interface LedgerPort {
-    suspend fun getTrialBalance(asOf: LocalDate): List<TrialBalanceLineDto>
+    suspend fun getTrialBalance(asOf: LocalDate): TrialBalanceSnapshot
 }

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/CorepService.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/CorepService.kt
@@ -11,7 +11,7 @@ import com.openbank.finrep.application.port.out.LedgerPort
 import com.openbank.finrep.application.port.out.RegulatoryFramework
 import com.openbank.finrep.application.port.out.TemplateFailureReason
 import com.openbank.finrep.application.port.out.TemplateRender
-import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
 import com.openbank.finrep.domain.mapper.C0100Mapper
 import com.openbank.finrep.domain.model.CorepTemplate
 import jakarta.enterprise.context.ApplicationScoped
@@ -33,9 +33,9 @@ class CorepService(private val ledgerPort: LedgerPort, private val metrics: Finr
 
     override suspend fun getTemplate(query: GetCorepTemplateQuery): CorepTemplate {
         val startedAt = System.nanoTime()
-        val lines = trialBalance(query.asOf)
+        val snapshot = trialBalance(query.asOf)
         val template = when (query.templateId) {
-            "C_01.00" -> C0100Mapper.map(lines, query.asOf)
+            "C_01.00" -> C0100Mapper.map(snapshot.lines, query.asOf)
             else -> {
                 metrics.templateFailed(RegulatoryFramework.COREP, TemplateFailureReason.UNKNOWN_TEMPLATE)
                 throw IllegalArgumentException("Unknown or unimplemented COREP template: ${query.templateId}")
@@ -45,11 +45,13 @@ class CorepService(private val ledgerPort: LedgerPort, private val metrics: Finr
             TemplateRender(
                 framework = RegulatoryFramework.COREP,
                 templateId = template.templateId,
-                trialBalanceLines = lines.size,
+                trialBalanceLines = snapshot.lines.size,
                 cells = template.cells.size,
                 dataGapCells = template.cells.count { it.isDataGap },
                 // COREP defines no balance-sheet identity, so "balanced" is neither true nor false.
                 balanced = null,
+                // ... and therefore no cross-check verdict either: there is nothing to agree with.
+                balanceVerdict = null,
                 duration = Duration.ofNanos(System.nanoTime() - startedAt),
             ),
         )
@@ -62,7 +64,7 @@ class CorepService(private val ledgerPort: LedgerPort, private val metrics: Finr
      * REST-client failure mode (connect, timeout, 5xx, deserialisation) means the same thing here.
      */
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun trialBalance(asOf: LocalDate): List<TrialBalanceLineDto> = try {
+    private suspend fun trialBalance(asOf: LocalDate): TrialBalanceSnapshot = try {
         ledgerPort.getTrialBalance(asOf)
     } catch (e: Exception) {
         metrics.templateFailed(RegulatoryFramework.COREP, TemplateFailureReason.LEDGER_UNAVAILABLE)

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/FinrepService.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/FinrepService.kt
@@ -11,7 +11,7 @@ import com.openbank.finrep.application.port.out.LedgerPort
 import com.openbank.finrep.application.port.out.RegulatoryFramework
 import com.openbank.finrep.application.port.out.TemplateFailureReason
 import com.openbank.finrep.application.port.out.TemplateRender
-import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
 import com.openbank.finrep.domain.mapper.F0101Mapper
 import com.openbank.finrep.domain.mapper.F0200Mapper
 import com.openbank.finrep.domain.model.FinrepTemplate
@@ -38,10 +38,10 @@ class FinrepService(private val ledgerPort: LedgerPort, private val metrics: Fin
 
     override suspend fun getTemplate(query: GetFinrepTemplateQuery): FinrepTemplate {
         val startedAt = System.nanoTime()
-        val lines = trialBalance(query.asOf)
+        val snapshot = trialBalance(query.asOf)
         val template = when (query.templateId) {
-            "F01.01" -> F0101Mapper.map(lines, query.asOf)
-            "F02.00" -> F0200Mapper.map(lines, query.asOf)
+            "F01.01" -> F0101Mapper.map(snapshot, query.asOf)
+            "F02.00" -> F0200Mapper.map(snapshot, query.asOf)
             else -> {
                 metrics.templateFailed(RegulatoryFramework.FINREP, TemplateFailureReason.UNKNOWN_TEMPLATE)
                 throw IllegalArgumentException("Unknown FINREP template: ${query.templateId}")
@@ -51,11 +51,12 @@ class FinrepService(private val ledgerPort: LedgerPort, private val metrics: Fin
             TemplateRender(
                 framework = RegulatoryFramework.FINREP,
                 templateId = template.templateId,
-                trialBalanceLines = lines.size,
+                trialBalanceLines = snapshot.lines.size,
                 cells = template.cells.size,
                 // FINREP cells carry no data-gap flag; only COREP C 01.00 has unavailable inputs today.
                 dataGapCells = 0,
                 balanced = template.isBalanced,
+                balanceVerdict = template.balanceVerdict,
                 duration = Duration.ofNanos(System.nanoTime() - startedAt),
             ),
         )
@@ -68,7 +69,7 @@ class FinrepService(private val ledgerPort: LedgerPort, private val metrics: Fin
      * REST-client failure mode (connect, timeout, 5xx, deserialisation) means the same thing here.
      */
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun trialBalance(asOf: LocalDate): List<TrialBalanceLineDto> = try {
+    private suspend fun trialBalance(asOf: LocalDate): TrialBalanceSnapshot = try {
         ledgerPort.getTrialBalance(asOf)
     } catch (e: Exception) {
         metrics.templateFailed(RegulatoryFramework.FINREP, TemplateFailureReason.LEDGER_UNAVAILABLE)

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0101Mapper.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0101Mapper.kt
@@ -5,8 +5,11 @@
 package com.openbank.finrep.domain.mapper
 
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
+import com.openbank.finrep.domain.model.BalanceVerdict
 import com.openbank.finrep.domain.model.FinrepCell
 import com.openbank.finrep.domain.model.FinrepTemplate
+import com.openbank.finrep.domain.model.TrialBalanceAssurance
 import com.openbank.finrep.domain.model.TrialBalanceIdentity
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -44,7 +47,8 @@ import java.time.LocalDate
  */
 object F0101Mapper {
 
-    fun map(lines: List<TrialBalanceLineDto>, asOf: LocalDate): FinrepTemplate {
+    fun map(snapshot: TrialBalanceSnapshot, asOf: LocalDate): FinrepTemplate {
+        val lines = snapshot.lines
         val assets = sumNet(lines, "ASSET")
         // Credit-normal, so the reporting magnitude is the negated ledger net.
         val liabilities = sumNet(lines, "LIABILITY").negate()
@@ -56,11 +60,13 @@ object F0101Mapper {
             FinrepCell(rowRef = "r490", colRef = "c010", value = equity),
         )
 
+        val assessment = TrialBalanceAssurance.assess(snapshot)
         return FinrepTemplate(
             templateId = "F01.01",
             period = asOf,
             cells = cells,
-            isBalanced = TrialBalanceIdentity.holds(lines),
+            isBalanced = assessment.verdict == BalanceVerdict.AGREED_BALANCED,
+            balanceVerdict = assessment.verdict,
         )
     }
 

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0200Mapper.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0200Mapper.kt
@@ -5,9 +5,11 @@
 package com.openbank.finrep.domain.mapper
 
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
+import com.openbank.finrep.domain.model.BalanceVerdict
 import com.openbank.finrep.domain.model.FinrepCell
 import com.openbank.finrep.domain.model.FinrepTemplate
-import com.openbank.finrep.domain.model.TrialBalanceIdentity
+import com.openbank.finrep.domain.model.TrialBalanceAssurance
 import java.math.BigDecimal
 import java.time.LocalDate
 
@@ -37,7 +39,8 @@ import java.time.LocalDate
  */
 object F0200Mapper {
 
-    fun map(lines: List<TrialBalanceLineDto>, asOf: LocalDate): FinrepTemplate {
+    fun map(snapshot: TrialBalanceSnapshot, asOf: LocalDate): FinrepTemplate {
+        val lines = snapshot.lines
         val income = sumNet(lines, "INCOME").negate()
         val expense = sumNet(lines, "EXPENSE")
         val netProfit = income.subtract(expense)
@@ -48,11 +51,13 @@ object F0200Mapper {
             FinrepCell(rowRef = "r450", colRef = "c010", value = netProfit),
         )
 
+        val assessment = TrialBalanceAssurance.assess(snapshot)
         return FinrepTemplate(
             templateId = "F02.00",
             period = asOf,
             cells = cells,
-            isBalanced = TrialBalanceIdentity.holds(lines),
+            isBalanced = assessment.verdict == BalanceVerdict.AGREED_BALANCED,
+            balanceVerdict = assessment.verdict,
         )
     }
 

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/BalanceAssurance.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/BalanceAssurance.kt
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.finrep.domain.model
+
+import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
+import java.math.BigDecimal
+
+/**
+ * The outcome of cross-checking finrep's own double-entry recomputation against the balance verdict
+ * openbank-ledger-service published with the same frozen trial balance (issue #6011).
+ *
+ * Four values, never one boolean. A cross-check that answers only "balanced / not balanced" folds
+ * three genuinely different defects onto one flag — the shape `PushResult.skipped()` shipped in
+ * openbank-notification-service, where a disabled adapter reported `success = true` and every
+ * push in an environment with no credentials was counted as delivered.
+ */
+enum class BalanceVerdict {
+    /** Both sources agree the trial balance ties out. The only value that permits a submission. */
+    AGREED_BALANCED,
+
+    /**
+     * Both sources agree it does NOT tie out. A ledger-side accounting defect: the evidence finrep
+     * was given is internally consistent, and it is consistently wrong.
+     */
+    AGREED_IMBALANCED,
+
+    /**
+     * The two sources DISAGREE. Not an accounting defect — an evidence defect: the lines finrep
+     * evaluated are not the lines ledger evaluated. See [TrialBalanceAssurance] for exactly how
+     * that can happen.
+     */
+    SOURCES_DISAGREE,
+
+    /**
+     * Ledger published no verdict at all. Distinct from `false` on purpose: `false` is ledger
+     * asserting an imbalance, absence is ledger asserting nothing, and treating the two alike would
+     * report a shape change as an accounting failure (or, the other way round, let a response that
+     * lost the field deserialize into a plausible `false`).
+     */
+    LEDGER_FLAG_ABSENT,
+}
+
+/**
+ * Both sides of the check, kept separable so a consumer can tell which one objected.
+ *
+ * [ownIdentityHolds] is finrep's recomputation ([TrialBalanceIdentity]); [ledgerReportsBalanced] is
+ * the producer's own assertion, `null` when the response carried none. [residualsByCurrency] says
+ * by how much and in which currency finrep's side failed, so an operator gets a number rather than
+ * a bit.
+ */
+data class BalanceAssessment(
+    val ownIdentityHolds: Boolean,
+    val ledgerReportsBalanced: Boolean?,
+    val residualsByCurrency: Map<String, BigDecimal>,
+    val verdict: BalanceVerdict,
+)
+
+/**
+ * Cross-check of the two independent balance verdicts on one frozen trial balance (issue #6011).
+ *
+ * ## Why this is not the vacuous shape #6010 fixed
+ *
+ * The trap one level up is a check whose two sides move together, so it structurally cannot
+ * disagree — `isBalanced = true` hardcoded (#5987), then the tempting repair of recomputing an
+ * identity against a quantity defined as its own residual (#6010). This check has to survive the
+ * same question: *what input makes the two sides differ?*
+ *
+ * They are computed from different columns, by different services, over different moments:
+ *
+ *  - ledger's flag is `Σ totalDebit == Σ totalCredit` over the whole line set **as the response
+ *    object was constructed** (`PeriodTrialBalance.isBalanced`), a single scalar, with **no
+ *    currency grouping**;
+ *  - finrep's is `Σ net == 0` **per currency** over the lines that actually **arrived and
+ *    deserialised**.
+ *
+ * Three concrete inputs make them differ, and all three are tested:
+ *
+ *  1. **A truncated response that is internally balanced.** Lines are lost after ledger computed
+ *     its scalar — a paginated or capped `lines` array, a filtering proxy, a partial
+ *     deserialisation — and the survivors happen to still sum to zero. finrep's recomputation is
+ *     satisfied, ledger's flag (over the full set) is not. This is the failure mode a
+ *     derive-only reporting service cannot otherwise see: it renders a well-formed 200 either way,
+ *     of honest-looking but under-reported figures. `openbank.finrep.trial_balance.lines` only
+ *     shows a collapse to zero, not a partial loss.
+ *  2. **Offsetting residuals in different currencies.** A +100 CZK residual against a −100 EUR one
+ *     sums to zero globally, so ledger's ungrouped scalar says balanced while finrep's per-currency
+ *     identity does not. Journals balance per currency here (ADR-0025), so finrep is right and the
+ *     disagreement is real information about the producer's weaker check.
+ *  3. **A line whose `net` is not `totalDebit − totalCredit`** on the wire — a producer mapping
+ *     defect, invisible to ledger's own flag, which never reads `net`.
+ *
+ * Case 1 is the one that motivated the issue, and note the direction: finrep's recomputation ALONE
+ * passes it. Neither source can catch it alone; only the agreement can.
+ *
+ * ## Why absence fails closed
+ *
+ * [BalanceVerdict.LEDGER_FLAG_ABSENT] does not permit a submission. Ledger's frozen-trial-balance
+ * response declares `balanced` unconditionally and the committed pact pins it, so an absent flag
+ * means the response is not the response this service contracted for — which is precisely when a
+ * regulatory return should not be produced as if nothing were wrong. It gets its own verdict rather
+ * than being folded into `AGREED_IMBALANCED` so that "the contract changed" never reads as "the
+ * bank's books do not balance".
+ */
+object TrialBalanceAssurance {
+
+    fun assess(snapshot: TrialBalanceSnapshot): BalanceAssessment {
+        val residuals = TrialBalanceIdentity.residualsByCurrency(snapshot.lines)
+        val ownHolds = residuals.values.all { it.compareTo(BigDecimal.ZERO) == 0 }
+        val ledgerSays = snapshot.ledgerReportsBalanced
+        val verdict = when {
+            ledgerSays == null -> BalanceVerdict.LEDGER_FLAG_ABSENT
+            ledgerSays != ownHolds -> BalanceVerdict.SOURCES_DISAGREE
+            ownHolds -> BalanceVerdict.AGREED_BALANCED
+            else -> BalanceVerdict.AGREED_IMBALANCED
+        }
+        return BalanceAssessment(
+            ownIdentityHolds = ownHolds,
+            ledgerReportsBalanced = ledgerSays,
+            residualsByCurrency = residuals,
+            verdict = verdict,
+        )
+    }
+}

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/FinrepTemplate.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/FinrepTemplate.kt
@@ -15,10 +15,23 @@ data class FinrepTemplate(
     val period: LocalDate,
     val cells: List<FinrepCell>,
     /**
-     * Whether the double-entry identity of the trial balance this template was rendered from holds
-     * (`Σ net == 0` per currency, `TrialBalanceIdentity`). NO DEFAULT on purpose (issue #5987): the
-     * field spent its whole life as a hardcoded `true` that no producer computed, and a default
-     * would let a new producer omit it and re-publish that same constant silently.
+     * Whether this template may be treated as balanced — TRUE only when finrep's own recomputation
+     * (`Σ net == 0` per currency, `TrialBalanceIdentity`) and openbank-ledger-service's published
+     * verdict AGREE that it is, i.e. [balanceVerdict] is [BalanceVerdict.AGREED_BALANCED]
+     * (issue #6011). Requiring both is what makes a truncated-but-internally-balanced response
+     * visible: finrep's recomputation alone passes it.
+     *
+     * NO DEFAULT on purpose (issue #5987): the field spent its whole life as a hardcoded `true`
+     * that no producer computed, and a default would let a new producer omit it and re-publish that
+     * same constant silently.
      */
     val isBalanced: Boolean,
+    /**
+     * WHICH of the two sources objected, and whether they objected together (issue #6011).
+     * [isBalanced] is deliberately a strict function of this field, never an independent boolean:
+     * a plain imbalance, a disagreement between the two sources and a missing producer verdict are
+     * three different defects with three different owners, and collapsing them onto one flag is the
+     * `PushResult.skipped()` failure this repo already paid for once.
+     */
+    val balanceVerdict: BalanceVerdict,
 )

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/client/LedgerClient.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/client/LedgerClient.kt
@@ -6,6 +6,7 @@ package com.openbank.finrep.infrastructure.client
 
 import com.openbank.finrep.application.port.out.LedgerPort
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
 import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
 import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
@@ -49,24 +50,44 @@ interface LedgerRestClient {
 
 data class TrialBalanceLineResponse(val code: String, val type: String, val net: BigDecimal, val currency: String)
 
+/**
+ * Ledger's frozen trial balance as it arrives on the wire.
+ *
+ * [balanced] is NULLABLE (issue #6011), although ledger declares it unconditionally and the
+ * committed pact pins it. A non-null `Boolean` here is not the stricter choice it looks like:
+ * jackson-module-kotlin coerces an absent JSON field to `false` for a non-null Boolean without a
+ * default, so a response that lost the field would deserialize into ledger asserting an imbalance —
+ * a contract defect reported as an accounting one, with nothing anywhere able to tell them apart.
+ * Nullable makes absence its own fact, which `TrialBalanceAssurance` renders as
+ * `BalanceVerdict.LEDGER_FLAG_ABSENT`.
+ */
 data class ClosedPeriodTrialBalanceResponse(
     val period: String,
-    val balanced: Boolean,
+    val balanced: Boolean?,
     val lines: List<TrialBalanceLineResponse>,
 )
 
 @ApplicationScoped
 class LedgerAdapter(@RestClient private val client: LedgerRestClient) : LedgerPort {
 
-    override suspend fun getTrialBalance(asOf: LocalDate): List<TrialBalanceLineDto> {
+    /**
+     * Maps the lines AND carries ledger's own `balanced` verdict through (issue #6011). The verdict
+     * used to be deserialised here and then silently dropped, so the one check finrep could not
+     * make for itself — whether the lines it received are the lines ledger evaluated — was
+     * unavailable to it.
+     */
+    override suspend fun getTrialBalance(asOf: LocalDate): TrialBalanceSnapshot {
         val response = client.getTrialBalance(asOf.toString()).awaitSuspending()
-        return response.lines.map { line ->
-            TrialBalanceLineDto(
-                code = line.code,
-                accountType = line.type,
-                net = line.net,
-                currency = line.currency,
-            )
-        }
+        return TrialBalanceSnapshot(
+            lines = response.lines.map { line ->
+                TrialBalanceLineDto(
+                    code = line.code,
+                    accountType = line.type,
+                    net = line.net,
+                    currency = line.currency,
+                )
+            },
+            ledgerReportsBalanced = response.balanced,
+        )
     }
 }

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/observability/FinrepMetricsAdapter.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/observability/FinrepMetricsAdapter.kt
@@ -20,9 +20,24 @@ import jakarta.inject.Inject
  * Micrometer adapter for [FinrepMetricsPort] (ADR-0077 Tier C). Emits, all tagged
  * `service="finrep"`:
  *
- *  - `openbank_finrep_templates_rendered_total{framework,template,balanced}` — render rate, and for
- *    FINREP whether the balance sheet actually balanced. `balanced="false"` is a supervisory defect,
- *    not a warning; `balanced="not_applicable"` is COREP, which defines no such identity.
+ *  - `openbank_finrep_templates_rendered_total{framework,template,balanced,balance_verdict}` —
+ *    render rate, and for FINREP whether the balance sheet actually balanced. `balanced="false"` is
+ *    a supervisory defect, not a warning; `balanced="not_applicable"` is COREP, which defines no
+ *    such identity.
+ *
+ *    `balance_verdict` says WHICH of the two independent sources objected (issue #6011), a bounded
+ *    four-value tag from `BalanceVerdict`. The one worth alerting on separately is
+ *    `sources_disagree`: it is not an accounting defect at all but an EVIDENCE defect — the lines
+ *    finrep evaluated are not the lines ledger evaluated, i.e. the response was truncated,
+ *    filtered or paginated between the two services. That case renders a well-formed 200 of
+ *    under-reported figures and, when the survivors happen to still tie out, passes finrep's own
+ *    recomputation; `trial_balance.lines` only shows a collapse to ZERO, not a partial loss.
+ *    `ledger_flag_absent` is a contract change, not a books problem, and is deliberately not the
+ *    same series as `agreed_imbalanced`.
+ *
+ *    The tag is named for what it establishes — an agreement or disagreement between two published
+ *    verdicts — never "verified" or "reconciled", neither of which this service is in a position to
+ *    claim about a ledger it only reads.
  *  - `openbank_finrep_template_render_duration_seconds{framework,template}` — includes the ledger
  *    trial-balance hop, which is the only I/O on the path.
  *  - `openbank_finrep_trial_balance_lines{framework,template}` — the size of the input the report was
@@ -58,6 +73,7 @@ class FinrepMetricsAdapter(private val registry: MeterRegistry?) : FinrepMetrics
             .tag("framework", framework)
             .tag("template", render.templateId)
             .tag("balanced", render.balanced?.toString() ?: NOT_APPLICABLE)
+            .tag("balance_verdict", render.balanceVerdict?.name?.lowercase() ?: NOT_APPLICABLE)
             .description("Rendered FINREP/COREP templates")
             .register(r)
             .increment()

--- a/openbank-finrep-service/src/main/resources/openapi.yaml
+++ b/openbank-finrep-service/src/main/resources/openapi.yaml
@@ -20,7 +20,7 @@ info:
 
     Cells are always fully rendered: a value the platform cannot honestly derive is an explicit
     flagged zero (`isDataGap`), never an omitted row, so a regulatory return never has a silent gap.
-  version: 1.1.0
+  version: 1.2.0
 tags:
   - name: FINREP
   - name: COREP
@@ -130,7 +130,7 @@ components:
         liabilities) and r490 (total equity); F02.00 populates r010 (total income), r030 (total
         expense) and r450 (net profit). All rows are reported as positive magnitudes in their
         natural reporting sign, not in the ledger's debit-minus-credit convention.
-      required: [templateId, period, cells, isBalanced]
+      required: [templateId, period, cells, isBalanced, balanceVerdict]
       properties:
         templateId: { type: string, example: F01.01 }
         period:
@@ -153,6 +153,22 @@ components:
             hardcoded `true` and F01.01 derived equity as `assets - liabilities`, so the value was
             a constant and no consumer could ever observe `false`. Do not read a `true` served by
             an older deployment as evidence that anything was checked.
+
+            Since API version 1.2.0 (issue #6011) `true` additionally requires that
+            openbank-ledger-service's OWN published `balanced` verdict for the same frozen trial
+            balance agrees — it is exactly `balanceVerdict == AGREED_BALANCED`. Requiring both is
+            what makes a truncated response visible: lines lost in transport whose survivors happen
+            to still sum to zero satisfy this service's recomputation on their own.
+        balanceVerdict:
+          type: string
+          enum: [AGREED_BALANCED, AGREED_IMBALANCED, SOURCES_DISAGREE, LEDGER_FLAG_ABSENT]
+          description: >-
+            Which of the two independent balance verdicts objected (issue #6011). `AGREED_BALANCED`
+            and `AGREED_IMBALANCED` are the two sources agreeing; `SOURCES_DISAGREE` means the lines
+            this service evaluated are not the lines the ledger evaluated (a truncated, filtered or
+            paginated response — an evidence defect, not an accounting one); `LEDGER_FLAG_ABSENT`
+            means the ledger response carried no verdict at all, which is a contract change rather
+            than a statement about the books, and is kept distinct from a verdict of `false`.
 
     CorepCell:
       type: object

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0101MapperTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0101MapperTest.kt
@@ -5,7 +5,9 @@
 package com.openbank.finrep
 
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
 import com.openbank.finrep.domain.mapper.F0101Mapper
+import com.openbank.finrep.domain.model.BalanceVerdict
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
@@ -36,7 +38,7 @@ class F0101MapperTest {
 
     @Test
     fun `F01_01 reports assets liabilities and equity as positive magnitudes`() {
-        val template = F0101Mapper.map(balancedTrialBalance(), asOf)
+        val template = F0101Mapper.map(tb(balancedTrialBalance(), ledgerSays = true), asOf)
 
         assertThat(template.templateId).isEqualTo("F01.01")
         assertThat(cell(template.cells, "r010")).isEqualByComparingTo("500000")
@@ -56,7 +58,7 @@ class F0101MapperTest {
             line("5000", "EXPENSE", "60000"),
         )
 
-        val template = F0101Mapper.map(lines, asOf)
+        val template = F0101Mapper.map(tb(lines, ledgerSays = false), asOf)
 
         assertThat(cell(template.cells, "r490")).isEqualByComparingTo("150000")
         assertThat(template.isBalanced).isFalse()
@@ -64,7 +66,7 @@ class F0101MapperTest {
 
     @Test
     fun `a trial balance that ties out is reported as balanced`() {
-        assertThat(F0101Mapper.map(balancedTrialBalance(), asOf).isBalanced).isTrue()
+        assertThat(F0101Mapper.map(tb(balancedTrialBalance(), ledgerSays = true), asOf).isBalanced).isTrue()
     }
 
     @Test
@@ -74,7 +76,7 @@ class F0101MapperTest {
         // into the frozen evidence.
         val lines = balancedTrialBalance() + line("1001", "ASSET", "70000")
 
-        assertThat(F0101Mapper.map(lines, asOf).isBalanced).isFalse()
+        assertThat(F0101Mapper.map(tb(lines, ledgerSays = false), asOf).isBalanced).isFalse()
     }
 
     @Test
@@ -83,7 +85,7 @@ class F0101MapperTest {
         // row this template reports as a top-line total, yet a residual introduced there is caught.
         val lines = balancedTrialBalance() + line("5001", "EXPENSE", "12000")
 
-        assertThat(F0101Mapper.map(lines, asOf).isBalanced).isFalse()
+        assertThat(F0101Mapper.map(tb(lines, ledgerSays = false), asOf).isBalanced).isFalse()
     }
 
     @Test
@@ -98,7 +100,14 @@ class F0101MapperTest {
             line("2000", "LIABILITY", "-140000", currency = "EUR"),
         )
 
-        assertThat(F0101Mapper.map(lines, asOf).isBalanced).isFalse()
+        // NOTE the ledger flag passed here is `true`, and that is what a real ledger would send:
+        // its own verdict is a single UNGROUPED scalar (`Σ totalDebit == Σ totalCredit`), which
+        // this fixture satisfies exactly. So this is also a live SOURCES_DISAGREE case — the
+        // per-currency grouping is finrep seeing something the producer's own check cannot.
+        val template = F0101Mapper.map(tb(lines, ledgerSays = true), asOf)
+
+        assertThat(template.isBalanced).isFalse()
+        assertThat(template.balanceVerdict).isEqualTo(BalanceVerdict.SOURCES_DISAGREE)
     }
 
     @Test
@@ -110,7 +119,7 @@ class F0101MapperTest {
             line("2000", "LIABILITY", "-150000.0000"),
         )
 
-        assertThat(F0101Mapper.map(lines, asOf).isBalanced).isTrue()
+        assertThat(F0101Mapper.map(tb(lines, ledgerSays = true), asOf).isBalanced).isTrue()
     }
 
     @Test
@@ -118,11 +127,20 @@ class F0101MapperTest {
         // An absent trial balance is an under-reporting defect with its own detector
         // (`openbank.finrep.trial_balance.lines`); collapsing it onto this flag would make two
         // different failures indistinguishable to a consumer acting on either.
-        val template = F0101Mapper.map(emptyList(), asOf)
+        val template = F0101Mapper.map(tb(emptyList(), ledgerSays = true), asOf)
 
         assertThat(template.isBalanced).isTrue()
         assertThat(template.cells).allMatch { it.value.compareTo(BigDecimal.ZERO) == 0 }
     }
+
+    /**
+     * The ledger verdict is passed EXPLICITLY at every call site, never derived from `lines`
+     * (issue #6011). Deriving it here would make both sides of the cross-check move together and
+     * every `SOURCES_DISAGREE` case in this file structurally unreachable — the same vacuity
+     * #6010 removed one level down.
+     */
+    private fun tb(lines: List<TrialBalanceLineDto>, ledgerSays: Boolean?) =
+        TrialBalanceSnapshot(lines = lines, ledgerReportsBalanced = ledgerSays)
 
     private fun line(code: String, accountType: String, net: String, currency: String = "CZK") =
         TrialBalanceLineDto(code = code, accountType = accountType, net = BigDecimal(net), currency = currency)

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0200MapperTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0200MapperTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.finrep
 
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
 import com.openbank.finrep.domain.mapper.F0200Mapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -25,7 +26,7 @@ class F0200MapperTest {
 
     @Test
     fun `F02_00 reports income and expense as positive magnitudes and derives net profit`() {
-        val template = F0200Mapper.map(balancedTrialBalance(), asOf)
+        val template = F0200Mapper.map(tb(balancedTrialBalance(), ledgerSays = true), asOf)
 
         assertThat(template.templateId).isEqualTo("F02.00")
         assertThat(cell(template, "r010")).isEqualByComparingTo("120000")
@@ -35,7 +36,7 @@ class F0200MapperTest {
 
     @Test
     fun `a P&L drawn off a trial balance that ties out is reported as balanced`() {
-        assertThat(F0200Mapper.map(balancedTrialBalance(), asOf).isBalanced).isTrue()
+        assertThat(F0200Mapper.map(tb(balancedTrialBalance(), ledgerSays = true), asOf).isBalanced).isTrue()
     }
 
     @Test
@@ -45,7 +46,7 @@ class F0200MapperTest {
         // A P&L is not submittable off a GL that does not balance, however self-consistent it looks.
         val lines = balancedTrialBalance() + line("1001", "ASSET", "25000")
 
-        assertThat(F0200Mapper.map(lines, asOf).isBalanced).isFalse()
+        assertThat(F0200Mapper.map(tb(lines, ledgerSays = false), asOf).isBalanced).isFalse()
     }
 
     @Test
@@ -54,10 +55,14 @@ class F0200MapperTest {
         // computed, so asserting it would always hold. This test states that r450 tracks the inputs
         // exactly, WITHOUT that identity being what `isBalanced` reports.
         val lines = balancedTrialBalance()
-        val template = F0200Mapper.map(lines, asOf)
+        val template = F0200Mapper.map(tb(lines, ledgerSays = true), asOf)
 
         assertThat(cell(template, "r450")).isEqualByComparingTo(cell(template, "r010").subtract(cell(template, "r030")))
     }
+
+    /** Ledger's verdict is explicit per call site, never derived from `lines` (issue #6011). */
+    private fun tb(lines: List<TrialBalanceLineDto>, ledgerSays: Boolean?) =
+        TrialBalanceSnapshot(lines = lines, ledgerReportsBalanced = ledgerSays)
 
     private fun line(code: String, accountType: String, net: String, currency: String = "CZK") =
         TrialBalanceLineDto(code = code, accountType = accountType, net = BigDecimal(net), currency = currency)

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/CorepServiceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/CorepServiceTest.kt
@@ -7,6 +7,7 @@ package com.openbank.finrep.application.usecase
 import com.openbank.finrep.application.port.inbound.GetCorepTemplateQuery
 import com.openbank.finrep.application.port.out.LedgerPort
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
 import com.openbank.finrep.infrastructure.observability.FinrepMetricsAdapter
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.coEvery
@@ -34,7 +35,7 @@ class CorepServiceTest {
             TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
             TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("300000"), currency = "CZK"),
         )
-        coEvery { ledgerPort.getTrialBalance(asOf) } returns lines
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns snapshot(lines, ledgerSays = true)
         val service = CorepService(ledgerPort, FinrepMetricsAdapter(registry))
 
         val template = service.getTemplate(GetCorepTemplateQuery(templateId = "C_01.00", asOf = asOf))
@@ -48,7 +49,7 @@ class CorepServiceTest {
     @Test
     fun `getTemplate throws for an unknown or unimplemented COREP template id`(): Unit = runBlocking {
         val asOf = LocalDate.of(2026, 6, 30)
-        coEvery { ledgerPort.getTrialBalance(asOf) } returns emptyList()
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns snapshot(emptyList(), ledgerSays = true)
         val service = CorepService(ledgerPort, FinrepMetricsAdapter(registry))
 
         assertThatThrownBy {
@@ -63,8 +64,11 @@ class CorepServiceTest {
         // ADR-0097 forbids silent gaps, so C 01.00's capital-structure rows ship as explicit flagged
         // zeros. That honesty is invisible without a series counting them.
         val asOf = LocalDate.of(2026, 6, 30)
-        coEvery { ledgerPort.getTrialBalance(asOf) } returns listOf(
-            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns snapshot(
+            listOf(
+                TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
+            ),
+            ledgerSays = true,
         )
         val service = CorepService(ledgerPort, FinrepMetricsAdapter(registry))
 
@@ -81,7 +85,7 @@ class CorepServiceTest {
     @Test
     fun `COREP is tagged balanced=not_applicable rather than pretending it balanced`(): Unit = runBlocking {
         val asOf = LocalDate.of(2026, 6, 30)
-        coEvery { ledgerPort.getTrialBalance(asOf) } returns emptyList()
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns snapshot(emptyList(), ledgerSays = true)
         val service = CorepService(ledgerPort, FinrepMetricsAdapter(registry))
 
         service.getTemplate(GetCorepTemplateQuery(templateId = "C_01.00", asOf = asOf))
@@ -97,7 +101,7 @@ class CorepServiceTest {
     @Test
     fun `an unimplemented COREP template is counted as a framework-tagged failure`(): Unit = runBlocking {
         val asOf = LocalDate.of(2026, 6, 30)
-        coEvery { ledgerPort.getTrialBalance(asOf) } returns emptyList()
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns snapshot(emptyList(), ledgerSays = true)
         val service = CorepService(ledgerPort, FinrepMetricsAdapter(registry))
 
         assertThatThrownBy {
@@ -109,4 +113,13 @@ class CorepServiceTest {
                 .tag("framework", "corep").tag("reason", "unknown_template").counter().count(),
         ).isEqualTo(1.0)
     }
+
+    /**
+     * The ledger verdict is passed EXPLICITLY at every call site, never derived from the lines
+     * (issue #6011). Deriving it would make both sides of the cross-check move together, and every
+     * disagreement case in this file would become structurally unreachable — the vacuity #6010
+     * removed one level down, reintroduced in the test instead of the production code.
+     */
+    private fun snapshot(lines: List<TrialBalanceLineDto>, ledgerSays: Boolean?) =
+        TrialBalanceSnapshot(lines = lines, ledgerReportsBalanced = ledgerSays)
 }

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/FinrepServiceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/FinrepServiceTest.kt
@@ -7,6 +7,8 @@ package com.openbank.finrep.application.usecase
 import com.openbank.finrep.application.port.inbound.GetFinrepTemplateQuery
 import com.openbank.finrep.application.port.out.LedgerPort
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
+import com.openbank.finrep.domain.model.BalanceVerdict
 import com.openbank.finrep.infrastructure.observability.FinrepMetricsAdapter
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.coEvery
@@ -41,7 +43,7 @@ class FinrepServiceTest {
             TrialBalanceLineDto(code = "4000", accountType = "INCOME", net = BigDecimal("-260000"), currency = "CZK"),
             TrialBalanceLineDto(code = "5000", accountType = "EXPENSE", net = BigDecimal("60000"), currency = "CZK"),
         )
-        coEvery { ledgerPort.getTrialBalance(asOf) } returns lines
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns snapshot(lines, ledgerSays = true)
         val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
 
         val template = service.getTemplate(GetFinrepTemplateQuery(templateId = "F01.01", asOf = asOf))
@@ -59,7 +61,7 @@ class FinrepServiceTest {
             TrialBalanceLineDto(code = "4000", accountType = "INCOME", net = BigDecimal("-120000"), currency = "CZK"),
             TrialBalanceLineDto(code = "5000", accountType = "EXPENSE", net = BigDecimal("80000"), currency = "CZK"),
         )
-        coEvery { ledgerPort.getTrialBalance(asOf) } returns lines
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns snapshot(lines, ledgerSays = true)
         val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
 
         val template = service.getTemplate(GetFinrepTemplateQuery(templateId = "F02.00", asOf = asOf))
@@ -71,7 +73,7 @@ class FinrepServiceTest {
     @Test
     fun `getTemplate throws for an unknown template id`(): Unit = runBlocking {
         val asOf = LocalDate.of(2026, 6, 30)
-        coEvery { ledgerPort.getTrialBalance(asOf) } returns emptyList()
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns snapshot(emptyList(), ledgerSays = true)
         val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
 
         assertThatThrownBy {
@@ -84,16 +86,29 @@ class FinrepServiceTest {
     @Test
     fun `a rendered template publishes its input size, cell count and balanced flag`(): Unit = runBlocking {
         val asOf = LocalDate.of(2026, 6, 30)
-        coEvery { ledgerPort.getTrialBalance(asOf) } returns listOf(
-            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
-            TrialBalanceLineDto(
-                code = "2000",
-                accountType = "LIABILITY",
-                net = BigDecimal("-300000"),
-                currency = "CZK",
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns snapshot(
+            listOf(
+                TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
+                TrialBalanceLineDto(
+                    code = "2000",
+                    accountType = "LIABILITY",
+                    net = BigDecimal("-300000"),
+                    currency = "CZK",
+                ),
+                TrialBalanceLineDto(
+                    code = "4000",
+                    accountType = "INCOME",
+                    net = BigDecimal("-260000"),
+                    currency = "CZK",
+                ),
+                TrialBalanceLineDto(
+                    code = "5000",
+                    accountType = "EXPENSE",
+                    net = BigDecimal("60000"),
+                    currency = "CZK",
+                ),
             ),
-            TrialBalanceLineDto(code = "4000", accountType = "INCOME", net = BigDecimal("-260000"), currency = "CZK"),
-            TrialBalanceLineDto(code = "5000", accountType = "EXPENSE", net = BigDecimal("60000"), currency = "CZK"),
+            ledgerSays = true,
         )
         val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
 
@@ -103,6 +118,7 @@ class FinrepServiceTest {
             registry.get("openbank.finrep.templates.rendered")
                 .tag("service", "finrep").tag("framework", "finrep").tag("template", "F01.01")
                 .tag("balanced", "true")
+                .tag("balance_verdict", "agreed_balanced")
                 .counter().count(),
         ).isEqualTo(1.0)
         assertThat(
@@ -123,23 +139,100 @@ class FinrepServiceTest {
         // built on it could never fire and the tag looked like health monitoring while measuring
         // nothing. Asserting `balanced=false` is reachable is what makes the tag worth alerting on.
         val asOf = LocalDate.of(2026, 6, 30)
-        coEvery { ledgerPort.getTrialBalance(asOf) } returns listOf(
-            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
-            TrialBalanceLineDto(
-                code = "2000",
-                accountType = "LIABILITY",
-                net = BigDecimal("-410000"),
-                currency = "CZK",
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns snapshot(
+            listOf(
+                TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
+                TrialBalanceLineDto(
+                    code = "2000",
+                    accountType = "LIABILITY",
+                    net = BigDecimal("-410000"),
+                    currency = "CZK",
+                ),
             ),
+            ledgerSays = false,
         )
         val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
 
         val template = service.getTemplate(GetFinrepTemplateQuery(templateId = "F01.01", asOf = asOf))
 
         assertThat(template.isBalanced).isFalse()
+        assertThat(template.balanceVerdict).isEqualTo(BalanceVerdict.AGREED_IMBALANCED)
         assertThat(
             registry.get("openbank.finrep.templates.rendered")
                 .tag("framework", "finrep").tag("template", "F01.01").tag("balanced", "false")
+                .tag("balance_verdict", "agreed_imbalanced")
+                .counter().count(),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `a TRUNCATED response that still ties out is blocked and reported as a disagreement`(): Unit = runBlocking {
+        // Issue #6011, and the case neither source can catch alone. Ledger sealed a trial balance
+        // that does NOT tie out and said so (`balanced = false`); the lines that reached finrep are
+        // a subset that happens to sum to zero per currency — a capped or paginated `lines` array,
+        // a filtering proxy, a partial deserialisation. finrep's own recomputation (#6010) is
+        // SATISFIED here, so on its own it renders a well-formed 200 of under-reported figures, and
+        // `trial_balance.lines` shows no collapse either, because lines did arrive.
+        val asOf = LocalDate.of(2026, 6, 30)
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns snapshot(
+            listOf(
+                TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
+                TrialBalanceLineDto(
+                    code = "2000",
+                    accountType = "LIABILITY",
+                    net = BigDecimal("-500000"),
+                    currency = "CZK",
+                ),
+            ),
+            ledgerSays = false,
+        )
+        val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
+
+        val template = service.getTemplate(GetFinrepTemplateQuery(templateId = "F01.01", asOf = asOf))
+
+        assertThat(template.balanceVerdict).isEqualTo(BalanceVerdict.SOURCES_DISAGREE)
+        assertThat(template.isBalanced).isFalse()
+        // The disagreement gets its OWN series value: an operator has to be able to tell "the books
+        // do not balance" (ledger's problem) from "the evidence I was given is not the evidence
+        // ledger sealed" (transport's problem). One boolean cannot say which.
+        assertThat(
+            registry.get("openbank.finrep.templates.rendered")
+                .tag("framework", "finrep").tag("template", "F01.01").tag("balanced", "false")
+                .tag("balance_verdict", "sources_disagree")
+                .counter().count(),
+        ).isEqualTo(1.0)
+        assertThat(
+            registry.get("openbank.finrep.trial_balance.lines").tag("template", "F01.01").summary().totalAmount(),
+        ).describedAs("the line-count detector sees nothing wrong — lines DID arrive").isEqualTo(2.0)
+    }
+
+    @Test
+    fun `a ledger response carrying NO verdict is blocked, and not as an imbalance`(): Unit = runBlocking {
+        // Absence is a third state. Ledger declares `balanced` unconditionally and the committed
+        // pact pins it, so a response without one is a contract change — which must block a
+        // regulatory submission, but must never be reported as the bank's books failing to balance.
+        val asOf = LocalDate.of(2026, 6, 30)
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns snapshot(
+            listOf(
+                TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000"), currency = "CZK"),
+                TrialBalanceLineDto(
+                    code = "2000",
+                    accountType = "LIABILITY",
+                    net = BigDecimal("-500000"),
+                    currency = "CZK",
+                ),
+            ),
+            ledgerSays = null,
+        )
+        val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
+
+        val template = service.getTemplate(GetFinrepTemplateQuery(templateId = "F01.01", asOf = asOf))
+
+        assertThat(template.balanceVerdict).isEqualTo(BalanceVerdict.LEDGER_FLAG_ABSENT)
+        assertThat(template.isBalanced).isFalse()
+        assertThat(
+            registry.get("openbank.finrep.templates.rendered")
+                .tag("template", "F01.01").tag("balance_verdict", "ledger_flag_absent")
                 .counter().count(),
         ).isEqualTo(1.0)
     }
@@ -149,7 +242,7 @@ class FinrepServiceTest {
         // This is the under-reporting detector: a truncated ledger response renders a well-formed
         // template of honest-looking zeros, and `trial_balance.lines` is the only series that shows it.
         val asOf = LocalDate.of(2026, 6, 30)
-        coEvery { ledgerPort.getTrialBalance(asOf) } returns emptyList()
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns snapshot(emptyList(), ledgerSays = true)
         val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
 
         service.getTemplate(GetFinrepTemplateQuery(templateId = "F01.01", asOf = asOf))
@@ -164,7 +257,7 @@ class FinrepServiceTest {
         // Cardinality contract: the template id is a path parameter, so tagging the failure with it
         // would let any client mint unbounded series.
         val asOf = LocalDate.of(2026, 6, 30)
-        coEvery { ledgerPort.getTrialBalance(asOf) } returns emptyList()
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns snapshot(emptyList(), ledgerSays = true)
         val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
 
         assertThatThrownBy {
@@ -194,4 +287,13 @@ class FinrepServiceTest {
         // No render happened, so nothing must claim one did.
         assertThat(registry.find("openbank.finrep.templates.rendered").counters()).isEmpty()
     }
+
+    /**
+     * The ledger verdict is passed EXPLICITLY at every call site, never derived from the lines
+     * (issue #6011). Deriving it would make both sides of the cross-check move together, and every
+     * disagreement case in this file would become structurally unreachable — the vacuity #6010
+     * removed one level down, reintroduced in the test instead of the production code.
+     */
+    private fun snapshot(lines: List<TrialBalanceLineDto>, ledgerSays: Boolean?) =
+        TrialBalanceSnapshot(lines = lines, ledgerReportsBalanced = ledgerSays)
 }

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/LedgerTrialBalancePactConsumerTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/LedgerTrialBalancePactConsumerTest.kt
@@ -15,7 +15,9 @@ import au.com.dius.pact.core.model.annotations.Pact
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
 import com.openbank.finrep.domain.mapper.F0101Mapper
+import com.openbank.finrep.domain.model.BalanceVerdict
 import com.openbank.finrep.infrastructure.client.ClosedPeriodTrialBalanceResponse
 import com.openbank.finrep.infrastructure.client.LedgerRestClient
 import io.restassured.RestAssured.given
@@ -144,9 +146,12 @@ class LedgerTrialBalancePactConsumerTest {
         // ... and the mapper must accept them: proves the contract feeds a real F01.01 render,
         // not merely that some JSON parsed.
         val template = F0101Mapper.map(
-            response.lines.map {
-                TrialBalanceLineDto(code = it.code, accountType = it.type, net = it.net, currency = it.currency)
-            },
+            TrialBalanceSnapshot(
+                lines = response.lines.map {
+                    TrialBalanceLineDto(code = it.code, accountType = it.type, net = it.net, currency = it.currency)
+                },
+                ledgerReportsBalanced = response.balanced,
+            ),
             LocalDate.parse(REPORTING_DATE),
         )
         assertThat(template.cells.map { it.rowRef }).containsExactly("r010", "r380", "r490")
@@ -155,6 +160,12 @@ class LedgerTrialBalancePactConsumerTest {
         // balance check runs over real contract data and can answer `false` (issue #5987) — it is
         // not merely unit-testable against hand-built fixtures.
         assertThat(template.isBalanced).isFalse()
+        // And the contract body is itself a disagreement: it declares `balanced: true` alongside a
+        // lines array that does not tie out. That is exactly the wire shape a truncated response
+        // has — a producer verdict computed over lines the consumer did not all receive — so the
+        // cross-check of issue #6011 is exercised against contract data rather than a fixture.
+        assertThat(response.balanced).isTrue()
+        assertThat(template.balanceVerdict).isEqualTo(BalanceVerdict.SOURCES_DISAGREE)
     }
 
     /** Issues the request against the path the production client is annotated with. */

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/TemplateWireFormatTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/TemplateWireFormatTest.kt
@@ -6,6 +6,7 @@ package com.openbank.finrep.contract
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
 import com.openbank.finrep.infrastructure.client.LedgerAdapter
 import com.openbank.libs.security.Roles
 import io.mockk.coEvery
@@ -98,7 +99,11 @@ class TemplateWireFormatTest {
     @BeforeEach
     fun installLedgerStub() {
         val ledger = mockk<LedgerAdapter>()
-        coEvery { ledger.getTrialBalance(any()) } returns trialBalance
+        coEvery { ledger.getTrialBalance(any()) } returns TrialBalanceSnapshot(
+            lines = trialBalance,
+            // Ledger's own verdict for this fixture, passed explicitly: it ties out (issue #6011).
+            ledgerReportsBalanced = true,
+        )
         QuarkusMock.installMockForType(ledger, LedgerAdapter::class.java)
     }
 
@@ -117,10 +122,12 @@ class TemplateWireFormatTest {
     fun `the FINREP template wire format matches the published openapi schema`() {
         val json = getJson("/api/v1/finrep/templates/F01.01", LocalDate.of(2026, 6, 30))
 
-        assertThat(json.keys).containsExactlyInAnyOrder("templateId", "period", "cells", "isBalanced")
+        assertThat(json.keys).containsExactlyInAnyOrder("templateId", "period", "cells", "isBalanced", "balanceVerdict")
         assertThat(json["templateId"]).isEqualTo("F01.01")
         assertThat(json["period"]).isEqualTo("2026-06-30")
         assertThat(json["isBalanced"]).isEqualTo(true)
+        // The verdict is served as the ENUM NAME, which is what `openapi.yaml` documents (#6011).
+        assertThat(json["balanceVerdict"]).isEqualTo("AGREED_BALANCED")
 
         @Suppress("UNCHECKED_CAST")
         val cells = json["cells"] as List<Map<*, *>>

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/domain/TrialBalanceAssuranceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/domain/TrialBalanceAssuranceTest.kt
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.finrep.domain
+
+import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
+import com.openbank.finrep.domain.model.BalanceVerdict
+import com.openbank.finrep.domain.model.TrialBalanceAssurance
+import com.openbank.finrep.domain.model.TrialBalanceIdentity
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+/**
+ * The cross-check between finrep's own recomputation and openbank-ledger-service's published
+ * verdict (issue #6011).
+ *
+ * Every test here exists to answer one question: **what input makes the two sides disagree?** A
+ * cross-check whose sides cannot disagree is worse than no check — it wears the shape of a control
+ * while reporting a constant, which is precisely the defect #5987 and #6010 removed one level down.
+ * The disagreement cases are therefore the point of this file, and the agreement cases are only
+ * here to prove the disagreement is not reported unconditionally.
+ */
+class TrialBalanceAssuranceTest {
+
+    /**
+     * THE case the issue was filed for: a truncated response that is internally balanced.
+     *
+     * The full sealed trial balance is the four lines below plus a fifth, `1001 ASSET 70 000`,
+     * which does not tie out — so ledger, evaluating `Σ totalDebit == Σ totalCredit` over the full
+     * set at the moment it built the response, published `balanced = false`. Something between the
+     * two services then dropped lines (a capped or paginated `lines` array, a filtering proxy, a
+     * partial deserialisation), and what arrived happens to sum to zero per currency.
+     *
+     * finrep's own recomputation is therefore SATISFIED — that is the whole difficulty, and why
+     * #6010's identity check cannot see this on its own. Only the disagreement can.
+     */
+    @Test
+    fun `a truncated response whose survivors still tie out is caught by the disagreement alone`() {
+        val survivors = listOf(
+            line("1000", "ASSET", "500000"),
+            line("2000", "LIABILITY", "-300000"),
+            line("4000", "INCOME", "-260000"),
+            line("5000", "EXPENSE", "60000"),
+        )
+        // Established first, so this test states plainly that the stronger single check passes here.
+        assertThat(TrialBalanceIdentity.holds(survivors))
+            .describedAs("finrep's own recomputation must PASS, or this test proves nothing")
+            .isTrue()
+
+        val assessment = TrialBalanceAssurance.assess(
+            TrialBalanceSnapshot(lines = survivors, ledgerReportsBalanced = false),
+        )
+
+        assertThat(assessment.verdict).isEqualTo(BalanceVerdict.SOURCES_DISAGREE)
+        assertThat(assessment.ownIdentityHolds).isTrue()
+        assertThat(assessment.ledgerReportsBalanced).isFalse()
+    }
+
+    /**
+     * The other direction, and it is not symmetric: offsetting residuals in two currencies.
+     *
+     * Ledger's verdict is a single scalar over all currencies at once, so +40 000 CZK against
+     * −40 000 EUR nets to zero and it publishes `balanced = true`. finrep evaluates per currency
+     * (ADR-0025: journals balance within each currency), so neither currency ties out.
+     */
+    @Test
+    fun `offsetting residuals in two currencies disagree with ledger's ungrouped scalar`() {
+        val lines = listOf(
+            line("1000", "ASSET", "500000"),
+            line("2000", "LIABILITY", "-460000"),
+            line("1000", "ASSET", "100000", currency = "EUR"),
+            line("2000", "LIABILITY", "-140000", currency = "EUR"),
+        )
+        // The premise: summed across currencies this really is zero, which is what ledger sums.
+        assertThat(lines.fold(BigDecimal.ZERO) { acc, l -> acc.add(l.net) }).isEqualByComparingTo(BigDecimal.ZERO)
+
+        val assessment = TrialBalanceAssurance.assess(
+            TrialBalanceSnapshot(lines = lines, ledgerReportsBalanced = true),
+        )
+
+        assertThat(assessment.verdict).isEqualTo(BalanceVerdict.SOURCES_DISAGREE)
+        assertThat(assessment.ownIdentityHolds).isFalse()
+        assertThat(assessment.residualsByCurrency["CZK"]).isEqualByComparingTo("40000")
+        assertThat(assessment.residualsByCurrency["EUR"]).isEqualByComparingTo("-40000")
+    }
+
+    /**
+     * A dropped line that does NOT leave the survivors balanced is the easy case — both sources
+     * object, and finrep's recomputation would have caught it alone. Present so the file does not
+     * only contain the hard case, and to pin that this is NOT reported as a disagreement: an
+     * accounting defect and an evidence defect have different owners.
+     */
+    @Test
+    fun `both sources objecting is an agreed imbalance, never a disagreement`() {
+        val assessment = TrialBalanceAssurance.assess(
+            TrialBalanceSnapshot(
+                lines = listOf(line("1000", "ASSET", "500000"), line("2000", "LIABILITY", "-410000")),
+                ledgerReportsBalanced = false,
+            ),
+        )
+
+        assertThat(assessment.verdict).isEqualTo(BalanceVerdict.AGREED_IMBALANCED)
+    }
+
+    @Test
+    fun `both sources agreeing is the only verdict that permits a submission`() {
+        val assessment = TrialBalanceAssurance.assess(
+            TrialBalanceSnapshot(
+                lines = listOf(line("1000", "ASSET", "500000"), line("2000", "LIABILITY", "-500000")),
+                ledgerReportsBalanced = true,
+            ),
+        )
+
+        assertThat(assessment.verdict).isEqualTo(BalanceVerdict.AGREED_BALANCED)
+    }
+
+    /**
+     * An ABSENT verdict is a third state, not `false`. Ledger declares `balanced` unconditionally
+     * and the committed pact pins it, so absence means the response is not the response this
+     * service contracted for — a shape problem, which must never be reported as "the bank's books
+     * do not balance", and must never be permitted to pass as a submission either.
+     */
+    @Test
+    fun `an absent ledger verdict is its own state, distinguishable from a false one`() {
+        val balancedLines = listOf(line("1000", "ASSET", "500000"), line("2000", "LIABILITY", "-500000"))
+
+        val absent = TrialBalanceAssurance.assess(
+            TrialBalanceSnapshot(lines = balancedLines, ledgerReportsBalanced = null),
+        )
+        val explicitlyFalse = TrialBalanceAssurance.assess(
+            TrialBalanceSnapshot(lines = balancedLines, ledgerReportsBalanced = false),
+        )
+
+        assertThat(absent.verdict).isEqualTo(BalanceVerdict.LEDGER_FLAG_ABSENT)
+        assertThat(absent.ledgerReportsBalanced).isNull()
+        // The discriminating assertion: the two must not collapse onto one value. With `balanced`
+        // deserialised as a non-null Boolean, jackson-module-kotlin coerces an absent field to
+        // `false` and these two inputs become indistinguishable at this layer.
+        assertThat(absent.verdict).isNotEqualTo(explicitlyFalse.verdict)
+        assertThat(explicitlyFalse.verdict).isEqualTo(BalanceVerdict.SOURCES_DISAGREE)
+    }
+
+    /** Every verdict must be reachable, or the enum is documentation rather than a measurement. */
+    @Test
+    fun `all four verdicts are reachable from real snapshots`() {
+        val balanced = listOf(line("1000", "ASSET", "1"), line("2000", "LIABILITY", "-1"))
+        val imbalanced = listOf(line("1000", "ASSET", "1"))
+        val reached = listOf(
+            TrialBalanceSnapshot(balanced, true),
+            TrialBalanceSnapshot(imbalanced, false),
+            TrialBalanceSnapshot(imbalanced, true),
+            TrialBalanceSnapshot(balanced, null),
+        ).map { TrialBalanceAssurance.assess(it).verdict }
+
+        assertThat(reached).containsExactlyInAnyOrderElementsOf(BalanceVerdict.entries)
+    }
+
+    private fun line(code: String, accountType: String, net: String, currency: String = "CZK") =
+        TrialBalanceLineDto(code = code, accountType = accountType, net = BigDecimal(net), currency = currency)
+}

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/observability/FinrepMetricsAdapterTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/observability/FinrepMetricsAdapterTest.kt
@@ -7,6 +7,7 @@ package com.openbank.finrep.infrastructure.observability
 import com.openbank.finrep.application.port.out.RegulatoryFramework
 import com.openbank.finrep.application.port.out.TemplateFailureReason
 import com.openbank.finrep.application.port.out.TemplateRender
+import com.openbank.finrep.domain.model.BalanceVerdict
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -33,13 +34,43 @@ class FinrepMetricsAdapterTest {
 
     @Test
     fun `a null balanced flag renders as not_applicable, never as true`() {
-        adapter.templateRendered(render(framework = RegulatoryFramework.COREP, template = "C_01.00", balanced = null))
+        adapter.templateRendered(
+            render(
+                framework = RegulatoryFramework.COREP,
+                template = "C_01.00",
+                balanced = null,
+                balanceVerdict = null,
+            ),
+        )
 
         assertThat(
             registry.get("openbank.finrep.templates.rendered")
                 .tag("framework", "corep").tag("balanced", "not_applicable").counter().count(),
         ).isEqualTo(1.0)
         assertThat(registry.find("openbank.finrep.templates.rendered").tag("balanced", "true").counters()).isEmpty()
+        // Same rule for the verdict tag (issue #6011): COREP has no second source to agree with, so
+        // it must not borrow one of the four FINREP verdict values.
+        assertThat(
+            registry.get("openbank.finrep.templates.rendered")
+                .tag("framework", "corep").tag("balance_verdict", "not_applicable").counter().count(),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `each balance verdict renders as its own tag value`() {
+        // Issue #6011: the point of the verdict is that "the two sources disagree" is a DIFFERENT
+        // series from "both agree it does not balance". If they shared a tag value, the truncation
+        // case would be unalertable — indistinguishable from an ordinary ledger imbalance.
+        BalanceVerdict.entries.forEachIndexed { i, verdict ->
+            adapter.templateRendered(render(template = "F01.0$i", balanced = false, balanceVerdict = verdict))
+        }
+
+        assertThat(
+            BalanceVerdict.entries.map { verdict ->
+                registry.get("openbank.finrep.templates.rendered")
+                    .tag("balance_verdict", verdict.name.lowercase()).counters().size
+            },
+        ).allMatch { it == 1 }
     }
 
     @Test
@@ -84,6 +115,7 @@ class FinrepMetricsAdapterTest {
         cells: Int = 20,
         dataGapCells: Int = 0,
         balanced: Boolean? = true,
+        balanceVerdict: BalanceVerdict? = BalanceVerdict.AGREED_BALANCED,
     ) = TemplateRender(
         framework = framework,
         templateId = template,
@@ -91,6 +123,7 @@ class FinrepMetricsAdapterTest {
         cells = cells,
         dataGapCells = dataGapCells,
         balanced = balanced,
+        balanceVerdict = balanceVerdict,
         duration = Duration.ofMillis(33),
     )
 }

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/rest/FinrepResourceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/rest/FinrepResourceTest.kt
@@ -6,6 +6,7 @@ package com.openbank.finrep.infrastructure.rest
 
 import com.openbank.finrep.application.port.inbound.FinrepUseCase
 import com.openbank.finrep.application.port.inbound.GetFinrepTemplateQuery
+import com.openbank.finrep.domain.model.BalanceVerdict
 import com.openbank.finrep.domain.model.FinrepCell
 import com.openbank.finrep.domain.model.FinrepTemplate
 import io.mockk.coEvery
@@ -45,6 +46,7 @@ class FinrepResourceTest {
             period = LocalDate.now(fixedClock),
             cells = listOf(FinrepCell(rowRef = "r010", colRef = "c010", value = BigDecimal.ZERO)),
             isBalanced = true,
+            balanceVerdict = BalanceVerdict.AGREED_BALANCED,
         )
         val captured = slot<GetFinrepTemplateQuery>()
         coEvery { finrepUseCase.getTemplate(capture(captured)) } returns expected
@@ -65,6 +67,7 @@ class FinrepResourceTest {
             period = explicitDate,
             cells = emptyList(),
             isBalanced = true,
+            balanceVerdict = BalanceVerdict.AGREED_BALANCED,
         )
         val captured = slot<GetFinrepTemplateQuery>()
         coEvery { finrepUseCase.getTemplate(capture(captured)) } returns expected


### PR DESCRIPTION
## The input that makes the two sides disagree

finrep already recomputes the double-entry identity itself (#6010). Ledger publishes its own
verdict. The question this PR had to answer before writing a line of code is the one #6010 asked
one level down: **what input makes the two disagree?** If none exists, the cross-check is a control
that structurally cannot report anything, which is worse than no control.

Three exist, and they follow from the two sides being computed differently:

| | ledger's `balanced` | finrep's recomputation |
|---|---|---|
| formula | `Σ totalDebit == Σ totalCredit` | `Σ net == 0` |
| grouping | **none** — one global scalar | **per currency** |
| over which lines | the full set, as the response object was built | the lines that arrived and deserialised |

1. **A truncated response that is internally balanced** — the case the issue was filed for. Lines
   are lost *after* ledger computed its scalar (a capped or paginated `lines` array, a filtering
   proxy, a partial deserialisation) and the survivors happen to still sum to zero per currency.
   **finrep's own recomputation PASSES**, so #6010's check cannot see it; `trial_balance.lines`
   cannot either, because lines did arrive — it only shows a collapse to zero. Only the
   disagreement catches it. Test: `a truncated response whose survivors still tie out is caught by
   the disagreement alone`, and end-to-end through the use case in
   `a TRUNCATED response that still ties out is blocked and reported as a disagreement`.
2. **Offsetting residuals in two currencies** — +40 000 CZK against −40 000 EUR nets to zero, so
   ledger's ungrouped scalar says balanced and finrep's per-currency identity does not. Journals
   balance per currency here (ADR-0025), so finrep is right and the disagreement is real
   information about the producer's weaker check.
3. **A line whose `net` is not `totalDebit − totalCredit`** on the wire — a producer mapping
   defect, invisible to ledger's own flag, which never reads `net`.

Note (1) and (2) point in opposite directions, so neither side is simply "the strict one".

The committed **pact body is itself case (1)**: it declares `balanced: true` next to a single ASSET
line that does not tie out. `LedgerTrialBalancePactConsumerTest` now asserts the cross-check answers
`SOURCES_DISAGREE` against that contract data, not only against hand-built fixtures.

## What changed

- **`LedgerPort` returns `TrialBalanceSnapshot(lines, ledgerReportsBalanced)`.** The flag was
  deserialised in `LedgerAdapter` and dropped on the floor.
- **`TrialBalanceAssurance` → `BalanceVerdict`**, four values, never one boolean:
  `AGREED_BALANCED` / `AGREED_IMBALANCED` / `SOURCES_DISAGREE` / `LEDGER_FLAG_ABSENT`. An
  accounting defect, an evidence defect and a contract change have three different owners; the
  `PushResult.skipped()` incident is what collapsing them costs.
- **`FinrepTemplate.isBalanced` is now exactly `verdict == AGREED_BALANCED`** — a strict function of
  the verdict, never an independent boolean that could drift from it. `balanceVerdict` is served
  alongside it, so admin-ui's export gate can say *which* source objected.
- **The client DTO's `balanced` is nullable.** A non-null `Boolean` is not the stricter choice it
  looks like: jackson-module-kotlin coerces an absent field to `false`, so a response that lost the
  field would deserialize into ledger asserting an imbalance — a contract defect reported as an
  accounting one, indistinguishable from the real thing. Absence now has its own verdict, and it
  fails closed (it blocks) without being reported as the books failing to balance.
- **Metric:** `openbank_finrep_templates_rendered_total` gains `balance_verdict`, a bounded
  four-value tag. Named for what it establishes — an agreement between two published verdicts —
  not "verified" or "reconciled", neither of which a service that only reads the ledger can claim.
  `sources_disagree` is the value worth alerting on separately.
- `openapi.yaml` `info.version` 1.1.0 → 1.2.0 (additive; `oasdiff` classifies it as such, see below).

## Proof — negative controls, not just green

Failing test first, then the production change reverted to confirm each test can detect its absence:

| Reverted | Result |
|---|---|
| `isBalanced = assessment.verdict == AGREED_BALANCED` → `assessment.ownIdentityHolds` (i.e. #6010's behaviour, the flag ignored again) | `a TRUNCATED response that still ties out is blocked…` **FAILED** — `Expecting value to be false but was true`; `a ledger response carrying NO verdict…` **FAILED** |
| `ledgerReportsBalanced` → `ledgerReportsBalanced ?: false` (absent collapsed onto false) | `an absent ledger verdict is its own state…` **FAILED** — `expected: LEDGER_FLAG_ABSENT but was: SOURCES_DISAGREE`; `all four verdicts are reachable…` **FAILED** — `elements not found: [LEDGER_FLAG_ABSENT]` |

The ledger verdict is passed **explicitly at every test call site**, never derived from the lines —
deriving it would make both sides move together and every disagreement case in the suite
structurally unreachable, which is the vacuity #6010 removed, reintroduced in the test instead of
the production code.

## Verified

- `:openbank-finrep-service:detekt ktlintCheck test quarkusBuild --rerun-tasks` → BUILD SUCCESSFUL;
  JUnit XML totals **56 tests / 0 failures / 0 errors / 0 skipped**.
- `check-api-contract.py --enforce` (local `oasdiff`): *additive change, info.version 1.1.0 → 1.2.0
  — OK (required >= MINOR)*.
- Gate shards `kotlin` (19/19), `registry` (26/26), `lint` (20/20) PASS; `api` 6/7 with the only
  failure being the api-contract gate refusing to run without `PR_DIFF_BASE`, which passes when
  given one (above).
- `check-threat-model-diff.py` PASS, `check-pact-provider-replay.py` PASS. The pact regenerates
  byte-identical — no `@Pact` method changed.

## Not verified

- No live-cluster or live-ledger run: the disagreement cases are unit- and contract-level. Whether
  any real truncation exists today is unknown; this makes it *observable*, it does not claim it
  happens.
- admin-ui is untouched. It blocks export on `isBalanced === false`, so a disagreement blocks
  correctly, but its message still reads "the return does not balance" — wrong wording for an
  evidence defect. Worth a follow-up, along with the now-stale comment in `exportReadiness.ts`
  claiming both producers hardcode the flag.
- No alert rule added. A counter tag needs no cold-pod t=0 reasoning (an absent series is absent,
  not "decades old" like a gauge), but an alert on `sources_disagree` should be written against a
  rate over the render counter, not an absence.

Closes #6011
Refs #5987, #6010
