### PR TITLE
fix(admin-ui): externalise the OTel packages or the tracing emits nothing

### DIFF
--- a/openbank-admin-ui/next.config.mjs
+++ b/openbank-admin-ui/next.config.mjs
@@ -28,7 +28,26 @@ const nextConfig = {
   // that endpoint (this is exactly why /api/test-results 404'd in the sandbox).
   // Marking it external keeps it in node_modules and lets outputFileTracing copy
   // it into the standalone bundle intact.
-  serverExternalPackages: ['pg'],
+  // The OpenTelemetry packages are external for the SAME reason as `pg` above, plus one
+  // that is specific to instrumentation: `@opentelemetry/instrumentation-undici` works by
+  // PATCHING undici at module-load time. Bundling changes module identity, so the patch
+  // applies to webpack's copy and never to the module Next.js actually calls — the SDK
+  // starts, reports nothing wrong, and emits no spans.
+  //
+  // Measured on the standalone artifact rather than inferred: with only `pg` external,
+  // `.next/standalone/node_modules/@opentelemetry` contained exactly ONE entry — `api`.
+  // The SDK, the OTLP exporter, the undici instrumentation, resources and
+  // semantic-conventions were all bundled away, and the deployed pod produced zero spans
+  // while booting cleanly with no error in its log.
+  serverExternalPackages: [
+    'pg',
+    '@opentelemetry/sdk-node',
+    '@opentelemetry/exporter-trace-otlp-proto',
+    '@opentelemetry/instrumentation-undici',
+    '@opentelemetry/resources',
+    '@opentelemetry/semantic-conventions',
+    '@opentelemetry/api',
+  ],
   env: {
     NEXT_PUBLIC_API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8100',
     // Default to the public https host (consistent with KC_URL above) — never a cleartext


### PR DESCRIPTION
## What

#6153 merged, deployed cleanly, and produced **zero spans**. The pod was `Ready` with 0 restarts and not one error in its log — which is exactly what working tracing also looks like.

Found by verifying the deployed effect rather than trusting the merge.

## Cause

`output: 'standalone'` plus `serverExternalPackages: ['pg']`. Everything else is bundled by webpack, and **instrumentation cannot survive that**: `@opentelemetry/instrumentation-undici` works by *patching undici at module-load time*, so bundling changes module identity and the patch lands on webpack's copy — never on the module Next.js actually calls out through.

Measured on the artifact, not inferred:

```
before:  .next/standalone/node_modules/@opentelemetry  ->  1 entry (api)
after:                                                  -> 29 entries
```

The SDK, the OTLP exporter, the undici instrumentation, `resources` and `semantic-conventions` were all bundled away.

## The symptom is not what it looks like

"The SDK failed to start" would have been the wrong diagnosis and would send the next reader hunting in the wrong place. With `OTEL_LOG_LEVEL=debug` against the standalone server, the SDK starts in **both** builds — the difference is *where from*:

```
before:  setGlobalPropagator ...  at .next/server/instrumentation.js:193
after:   NodeSDK.start ...        at node_modules/@opentelemetry/sdk-node/build/src/sdk.js
                                  via runInstrumentationHookIfAvailable
```

So it ran, installed a propagator into its own bundled copy of the API, reported nothing wrong, and instrumented nothing. **Healthy-looking and inert** — the same shape as the Loki ruler (#6032) and the hourly price book (#6151) earlier in this sweep.

The config's existing comment already described this mechanism for `pg`: *"If webpack bundles it into a route, those requires break in the standalone image."* Instrumentation is the case where it breaks **silently** instead of loudly.

## Verified, both directions

- Standalone build green; output goes 1 → 29 `@opentelemetry` packages.
- SDK confirmed loading from `node_modules` at runtime via the debug stack frames above.
- **Falsified**: reverted the config, rebuilt, and confirmed it goes back to 1 package with the propagator back inside the webpack chunk.
- Full admin-ui suite **1621/1621**.

## After merge

Re-check by effect, not by the deploy going green: `openbank-admin-ui` should appear in Tempo's service list once an operator action drives an outbound BFF call, and `traces_spanmetrics_calls_total{service="openbank-admin-ui"}` should follow. Worth allowing a real operator session rather than a short window — this console has ~2 users, and a too-short window is how I misread the mobile RUM signal earlier in #5735.

Refs #5735
