### PR TITLE
fix(admin-ui): give each balance verdict its own export-block message

### DIFF
--- a/openbank-admin-ui/src/app/regulatory/page.tsx
+++ b/openbank-admin-ui/src/app/regulatory/page.tsx
@@ -8,7 +8,7 @@ import { useState } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl, type BffFailure } from '@/lib/services/bff'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
-import { blockReasonCopy, evaluateExportReadiness } from '@/lib/regulatory/exportReadiness'
+import { blockReasonCopy, evaluateExportReadiness, type BalanceVerdict } from '@/lib/regulatory/exportReadiness'
 import { Ban } from 'lucide-react'
 import { FileText, CheckCircle2, AlertTriangle, ExternalLink, Calendar, Check, Eye, X, Table as TableIcon, FileJson, FileSpreadsheet, RefreshCw } from 'lucide-react'
 import { PageHeader } from '@/components/ui/PageHeader'
@@ -38,6 +38,8 @@ interface RegulatoryTemplate {
   period: string
   cells: RegulatoryCell[]
   isBalanced?: boolean
+  /** Which of the two independent balance verdicts objected (finrep, issue #6011). */
+  balanceVerdict?: BalanceVerdict
   hasDataGaps?: boolean
 }
 

--- a/openbank-admin-ui/src/lib/regulatory/exportReadiness.ts
+++ b/openbank-admin-ui/src/lib/regulatory/exportReadiness.ts
@@ -25,19 +25,30 @@
  *                   zero balance". This is the reason that actually fires today: the ledger's
  *                   chart of accounts has no capital-structure GL accounts, so every C 01.00
  *                   capital row is a flagged zero.
- *   - UNBALANCED  — `FinrepTemplate.isBalanced === false`.
+ *   - UNBALANCED  — `FinrepTemplate.isBalanced === false`, refined by the optional
+ *                   `balanceVerdict` into the three distinct defects below.
  *
- * ⚠ KNOWN GAP, deliberately not papered over — tracked as #5987:
- * `isBalanced` is contract-required and serialised, but BOTH producers hardcode it —
- * `F0101Mapper.kt:44` and `F0200Mapper.kt:44` both pass the literal `isBalanced = true`, and
- * `FinrepTemplate.kt:17` defaults it to `true`. F01.01 additionally DERIVES equity as
- * `assets − liabilities`, so its accounting identity holds algebraically and cannot be observed
- * to fail. `FinrepService`'s own KDoc calls the value "computed ... and never looked at again";
- * the first half of that is not true today. So the `unbalanced` branch below is a real check
- * against the published contract that the current producer can never trigger. It is kept
- * because the contract permits `false` and a UI that ignored it would silently export an
- * unbalanced return the day the producer starts computing the field — but it must NOT be
- * counted as live coverage. The gate's falsifiable, fires-today reason is `data_gaps`.
+ * `isBalanced` is no longer hardcoded by its producers. #6010 (issue #5987) made it a real
+ * computation: `F0101Mapper` and `F0200Mapper` both pass `TrialBalanceIdentity.holds(lines)`,
+ * and F01.01 stopped deriving equity as `assets - liabilities` (it now sources EQUITY/INCOME/
+ * EXPENSE), so the identity can be observed to fail instead of holding algebraically. #6163
+ * (issue #6011) then added `balanceVerdict`, which says WHICH of two independent verdicts
+ * objected - finrep's own identity check, and the balance flag the ledger sealed onto the
+ * trial balance it served:
+ *
+ *   - `AGREED_BALANCED`    - both agree it balances. The only value for which `isBalanced` is true.
+ *   - `AGREED_IMBALANCED`  - both agree it does not: a genuine accounting defect.
+ *   - `SOURCES_DISAGREE`   - the trial-balance lines finrep received are not the lines the ledger
+ *                            sealed (a truncated or filtered response, e.g. an unread page). An
+ *                            EVIDENCE defect: the numbers cannot be attributed to the ledger at
+ *                            all, so nothing can be concluded about whether they balance.
+ *   - `LEDGER_FLAG_ABSENT` - the ledger response carried no verdict at all. A CONTRACT change,
+ *                            kept separate so that "the contract moved" never reads as "the books
+ *                            do not balance".
+ *
+ * The field is optional here on purpose: it is required by finrep's contract but this UI must
+ * stay readable against a deployment that predates #6163. A `false` `isBalanced` with no verdict
+ * blocks under the plain unbalanced reason.
  */
 
 export type PreviewLike =
@@ -51,10 +62,17 @@ export interface CellLike {
   gapReason?: string | null
 }
 
+/**
+ * Which of the two independent balance verdicts objected (finrep openapi.yaml, issue #6011).
+ * Optional: a deployment predating #6163 serves `isBalanced` alone.
+ */
+export type BalanceVerdict = 'AGREED_BALANCED' | 'AGREED_IMBALANCED' | 'SOURCES_DISAGREE' | 'LEDGER_FLAG_ABSENT'
+
 export interface TemplateLike {
   templateId: string
   cells: ReadonlyArray<CellLike>
   isBalanced?: boolean
+  balanceVerdict?: BalanceVerdict
   hasDataGaps?: boolean
 }
 
@@ -69,8 +87,12 @@ export type ExportBlockReason =
   | 'missing_cells'
   /** At least one cell is a flagged data gap (`isDataGap`). */
   | 'data_gaps'
-  /** A FINREP template reports its accounting identity does not hold. */
+  /** A FINREP template reports its accounting identity does not hold, and the ledger agrees. */
   | 'unbalanced'
+  /** finrep and the ledger disagree about the balance - the lines received are not the lines sealed. */
+  | 'balance_sources_disagree'
+  /** The ledger's trial-balance response carried no balance verdict at all. */
+  | 'ledger_verdict_absent'
 
 export type ExportReadiness =
   | { ok: true }
@@ -105,9 +127,26 @@ export function evaluateExportReadiness(data: PreviewLike): ExportReadiness {
   }
 
   // Unbalanced outranks data gaps: a return that does not balance is a supervisory defect on
-  // its own, independent of how completely it was populated.
+  // its own, independent of how completely it was populated. All three non-balanced verdicts
+  // block; they differ only in what the operator is being told to go and fix.
   const unbalanced = data.templates.filter(template => template.isBalanced === false)
   if (unbalanced.length > 0) {
+    // Ordered by how fundamental the defect is, on the same principle as the checks above: a
+    // missing verdict means the contract moved, and disagreeing sources mean the figures cannot
+    // be attributed to the ledger at all - neither says anything about whether the books
+    // balance, so neither may be reported to an operator as an accounting failure.
+    const idsFor = (verdict: BalanceVerdict) =>
+      unbalanced.filter(template => template.balanceVerdict === verdict).map(template => template.templateId)
+
+    const absent = idsFor('LEDGER_FLAG_ABSENT')
+    if (absent.length > 0) {
+      return { ok: false, reason: 'ledger_verdict_absent', templateIds: absent }
+    }
+    const disagree = idsFor('SOURCES_DISAGREE')
+    if (disagree.length > 0) {
+      return { ok: false, reason: 'balance_sources_disagree', templateIds: disagree }
+    }
+    // AGREED_IMBALANCED, plus a template from a deployment that serves no verdict at all.
     return { ok: false, reason: 'unbalanced', templateIds: unbalanced.map(template => template.templateId) }
   }
 
@@ -152,7 +191,15 @@ export function blockReasonCopy(
         : { title: 'Export blocked: incomplete data', detail: `Template ${list} contains cells flagged as data gaps (isDataGap) — reported zeros the platform cannot substantiate. They must not be filed as attested balances.` }
     case 'unbalanced':
       return cs
-        ? { title: 'Export je zablokován: výkaz nevychází', detail: `Šablona ${list} hlásí, že její účetní identita neplatí (isBalanced=false).` }
-        : { title: 'Export blocked: return does not balance', detail: `Template ${list} reports that its accounting identity does not hold (isBalanced=false).` }
+        ? { title: 'Export je zablokován: výkaz nevychází', detail: `Šablona ${list} hlásí, že její účetní identita neplatí, a ledger se s tím shoduje (balanceVerdict=AGREED_IMBALANCED). Jde o účetní vadu — rozdíl je nutné dohledat v hlavní knize.` }
+        : { title: 'Export blocked: return does not balance', detail: `Template ${list} reports that its accounting identity does not hold, and the ledger agrees (balanceVerdict=AGREED_IMBALANCED). This is an accounting defect — the difference has to be traced in the general ledger.` }
+    case 'balance_sources_disagree':
+      return cs
+        ? { title: 'Export je zablokován: zdroje se o vyváženosti neshodují', detail: `U šablony ${list} se rozchází vlastní kontrola finrepu s příznakem, který zapečetil ledger (balanceVerdict=SOURCES_DISAGREE). Řádky obratové předvahy, které finrep dostal, tedy nejsou ty, které ledger zapečetil — zkrácená nebo filtrovaná odpověď (např. nepřečtená stránka). Jde o vadu doložitelnosti, ne o účetní rozdíl: o vyváženosti výkazu zatím nelze říct nic.` }
+        : { title: 'Export blocked: the two balance sources disagree', detail: `For template ${list}, finrep's own identity check and the flag the ledger sealed do not agree (balanceVerdict=SOURCES_DISAGREE). The trial-balance lines finrep received are therefore not the lines the ledger sealed — a truncated or filtered response, e.g. an unread page. This is an evidence defect, not an accounting one: nothing can yet be concluded about whether the return balances.` }
+    case 'ledger_verdict_absent':
+      return cs
+        ? { title: 'Export je zablokován: ledger nevrátil verdikt o vyváženosti', detail: `Odpověď ledgeru pro šablonu ${list} neobsahovala žádný příznak vyváženosti (balanceVerdict=LEDGER_FLAG_ABSENT). Nezávislá kontrola tak chybí — jde o změnu kontraktu, kterou je nutné vyřešit v ledgeru, ne o nevycházející výkaz.` }
+        : { title: 'Export blocked: the ledger returned no balance verdict', detail: `The ledger response for template ${list} carried no balance flag at all (balanceVerdict=LEDGER_FLAG_ABSENT). The independent check is therefore missing — this is a contract change to resolve in the ledger, not a return that fails to balance.` }
   }
 }

--- a/openbank-admin-ui/src/test/regulatory-export-gate.test.tsx
+++ b/openbank-admin-ui/src/test/regulatory-export-gate.test.tsx
@@ -24,7 +24,7 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import RegulatoryPage from '@/app/regulatory/page'
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
-import { evaluateExportReadiness } from '@/lib/regulatory/exportReadiness'
+import { blockReasonCopy, evaluateExportReadiness } from '@/lib/regulatory/exportReadiness'
 
 afterEach(() => vi.unstubAllGlobals())
 
@@ -68,12 +68,70 @@ describe('evaluateExportReadiness', () => {
     expect(verdict.ok === false && verdict.reason).toBe('data_gaps')
   })
 
-  it('blocks as UNBALANCED when a template says its identity does not hold', () => {
+  it('blocks as UNBALANCED when a template says its identity does not hold and carries no verdict', () => {
+    // A deployment predating #6163 serves `isBalanced` alone. It must still block, under the
+    // plain accounting reason.
     const verdict = evaluateExportReadiness({
       status: 'ready',
       templates: [{ templateId: 'F01.01', cells: [cell()], isBalanced: false }],
     })
     expect(verdict).toEqual({ ok: false, reason: 'unbalanced', templateIds: ['F01.01'] })
+  })
+
+  // ── balanceVerdict (#6163 / issue #6011): three non-balanced verdicts, three defects ──────
+  it.each([
+    ['AGREED_IMBALANCED' as const, 'unbalanced'],
+    ['SOURCES_DISAGREE' as const, 'balance_sources_disagree'],
+    ['LEDGER_FLAG_ABSENT' as const, 'ledger_verdict_absent'],
+  ])('blocks %s under its own reason %s', (balanceVerdict, reason) => {
+    const verdict = evaluateExportReadiness({
+      status: 'ready',
+      templates: [{ templateId: 'F01.01', cells: [cell()], isBalanced: false, balanceVerdict }],
+    })
+    expect(verdict).toEqual({ ok: false, reason, templateIds: ['F01.01'] })
+  })
+
+  it('permits AGREED_BALANCED — the only verdict for which isBalanced is true', () => {
+    expect(evaluateExportReadiness({
+      status: 'ready',
+      templates: [{ templateId: 'F01.01', cells: [cell()], isBalanced: true, balanceVerdict: 'AGREED_BALANCED', hasDataGaps: false }],
+    })).toEqual({ ok: true })
+  })
+
+  it('names only the templates carrying the reported verdict, not every non-balanced one', () => {
+    // Otherwise an operator is sent to look at F02.00 for a defect it does not have.
+    const verdict = evaluateExportReadiness({
+      status: 'ready',
+      templates: [
+        { templateId: 'F02.00', cells: [cell()], isBalanced: false, balanceVerdict: 'AGREED_IMBALANCED' },
+        { templateId: 'F01.01', cells: [cell()], isBalanced: false, balanceVerdict: 'SOURCES_DISAGREE' },
+      ],
+    })
+    expect(verdict).toEqual({ ok: false, reason: 'balance_sources_disagree', templateIds: ['F01.01'] })
+  })
+
+  it('reports an absent ledger verdict ahead of disagreeing sources', () => {
+    // Both are claims about the evidence rather than the books; a missing flag is the more
+    // fundamental of the two, because with no flag there is nothing left to disagree with.
+    const verdict = evaluateExportReadiness({
+      status: 'ready',
+      templates: [
+        { templateId: 'F01.01', cells: [cell()], isBalanced: false, balanceVerdict: 'SOURCES_DISAGREE' },
+        { templateId: 'F02.00', cells: [cell()], isBalanced: false, balanceVerdict: 'LEDGER_FLAG_ABSENT' },
+      ],
+    })
+    expect(verdict).toEqual({ ok: false, reason: 'ledger_verdict_absent', templateIds: ['F02.00'] })
+  })
+
+  it('blocks on isBalanced === false even when the verdict claims agreement', () => {
+    // finrep computes `isBalanced` as `verdict == AGREED_BALANCED`, so this pair cannot come
+    // from a correct producer. The gate must still refuse rather than trust the friendlier field.
+    const verdict = evaluateExportReadiness({
+      status: 'ready',
+      templates: [{ templateId: 'F01.01', cells: [cell()], isBalanced: false, balanceVerdict: 'AGREED_BALANCED' }],
+    })
+    expect(verdict.ok).toBe(false)
+    expect(verdict.ok === false && verdict.reason).toBe('unbalanced')
   })
 
   it('blocks as MISSING when a template renders no cells at all', () => {
@@ -89,6 +147,33 @@ describe('evaluateExportReadiness', () => {
       templates: [{ templateId: 'F01.01', cells: [cell({ isDataGap: true })], isBalanced: false, hasDataGaps: true }],
     })
     expect(verdict.ok === false && verdict.reason).toBe('unbalanced')
+  })
+})
+
+// ── Operator copy: each verdict must say what is actually wrong ──────────────
+describe('blockReasonCopy for the balance verdicts', () => {
+  it.each(['cs', 'en'] as const)('does not call an evidence defect an accounting one (%s)', lang => {
+    const disagree = blockReasonCopy('balance_sources_disagree', ['F01.01'], lang)
+    const absent = blockReasonCopy('ledger_verdict_absent', ['F01.01'], lang)
+    const imbalanced = blockReasonCopy('unbalanced', ['F01.01'], lang)
+
+    // The old copy said "the return does not balance / výkaz nevychází" for all three. That
+    // sentence is only true of AGREED_IMBALANCED.
+    const doesNotBalance = lang === 'cs' ? 'nevychází' : 'does not balance'
+    expect(imbalanced.title).toContain(doesNotBalance)
+    expect(disagree.title).not.toContain(doesNotBalance)
+    expect(absent.title).not.toContain(doesNotBalance)
+
+    // Each names the verdict it is about, so the message can be traced to the field.
+    expect(disagree.detail).toContain('SOURCES_DISAGREE')
+    expect(absent.detail).toContain('LEDGER_FLAG_ABSENT')
+    expect(imbalanced.detail).toContain('AGREED_IMBALANCED')
+
+    // All three are still a block.
+    for (const copy of [disagree, absent, imbalanced]) {
+      expect(copy.title).toContain(lang === 'cs' ? 'zablokován' : 'blocked')
+      expect(copy.detail).toContain('F01.01')
+    }
   })
 })
 


### PR DESCRIPTION
Closes the admin-ui half of issue #6011: openbank-finrep-service now serves `balanceVerdict` on `FinrepTemplate` (PR #6163), and the export gate was still describing all three non-balanced values with one sentence.

## The wrong message

`src/lib/regulatory/exportReadiness.ts` blocked on `isBalanced === false` with:

> Export je zablokován: výkaz nevychází / the return does not balance (isBalanced=false)

That is true of exactly one of the four verdicts:

| verdict | what it means | what the operator must do |
| --- | --- | --- |
| `AGREED_BALANCED` | both sources agree it balances | nothing — the only value for which `isBalanced` is true |
| `AGREED_IMBALANCED` | both agree it does not | accounting defect: trace the difference in the general ledger |
| `SOURCES_DISAGREE` | the trial-balance lines finrep received are not the lines the ledger sealed (truncated/filtered response, e.g. an unread page) | evidence defect: nothing can yet be concluded about balance |
| `LEDGER_FLAG_ABSENT` | the ledger response carried no verdict at all | contract change, to resolve in the ledger |

Sending someone to the general ledger for a difference that may not exist is the cost, and in the `SOURCES_DISAGREE` case it also hides what is actually wrong — the figures cannot be attributed to the ledger at all.

## What changed

- Three block reasons where there was one: `unbalanced`, `balance_sources_disagree`, `ledger_verdict_absent`, each with its own Czech/English title and detail naming the verdict it is about. **All three still block.**
- `templateIds` is scoped to the templates carrying the reported verdict, not every non-balanced template — otherwise an operator is pointed at a template that has a different defect.
- Ordered most-fundamental first, on the same principle as the existing checks: absent flag, then disagreeing sources, then the accounting failure. The first two are claims about the evidence and must never surface as accounting failures.
- `balanceVerdict` is **optional** in `TemplateLike` on purpose. It is contract-required by finrep, but this UI must stay readable against a deployment predating #6163; a `false` `isBalanced` with no verdict blocks under the plain unbalanced reason.

## The stale comment (item 2)

The header comment still read:

> `isBalanced` is contract-required and serialised, but BOTH producers hardcode it — `F0101Mapper.kt:44` and `F0200Mapper.kt:44` both pass the literal `isBalanced = true`

Doubly stale. #6010 (issue #5987) made both mappers pass `TrialBalanceIdentity.holds(lines)` and stopped F01.01 deriving equity as `assets − liabilities` (it now sources EQUITY/INCOME/EXPENSE), so the identity can be observed to fail rather than holding algebraically; #6163 then added the verdict. Replaced with what the four verdicts mean and why the field is optional here.

## Tests

Extended `src/test/regulatory-export-gate.test.tsx`: the three verdicts under their own reasons, `AGREED_BALANCED` permitted, precedence between an absent flag and disagreeing sources, `templateId` scoping across a mixed set, a no-verdict payload still blocking, an `isBalanced: false` + `AGREED_BALANCED` pair the gate must refuse rather than trust the friendlier field, and copy assertions that neither evidence defect carries the "nevychází / does not balance" wording.

**Verified negatively, not just green:** with the two new branches removed, 4 of the new tests fail. `npm test` (pretest bakes the CI artifacts): 243 files / 1631 tests passing.

No version bump — release-please cuts admin-ui releases from the commit type, matching the surrounding admin-ui fixes.

Refs #6011
Refs #6163
