### PR TITLE
fix(observability): guard HighLatencyP99 on sample density

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-tier1.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-tier1.yaml
@@ -82,15 +82,57 @@ spec:
           annotations:
             summary: "High error rate on {{ $labels.service }}"
             description: ">10% of spans on {{ $labels.service }} are erroring at >0.5 err/s (5m window)."
+        # SAMPLE-DENSITY GUARD, ADDED BY #6054. Without the second clause this rule was
+        # STRUCTURALLY UNABLE TO FIRE for sparse subjects, and could not be fixed by widening
+        # the window. `histogram_quantile(0.99, ...)` over a window holding ~15 spans does not
+        # return a 99th percentile — it returns the top populated bucket, i.e. the MAXIMUM. For
+        # `openbank-agent-service`, whose slow traffic is a 30-minute LLM oversight sweep
+        # (`agent.oversight.cron`), that maximum is the top finite bucket (5s) on EVERY run, so
+        # the condition is true by construction for the ~4 minutes the [5m] window still holds
+        # the run, and then has no samples left. Measured live over 12h on 2026-08-21
+        # (20:32Z-08:32Z): 26 `pending` episodes, lengths [3,4,4,...,4,2] minutes, start-gaps
+        # 30m — length capped at the rate window, gap equal to the cron period. `for: 10m` never
+        # matured, 0 firing.
+        #
+        # Widening the window is NOT the fix and was measured, not assumed: at [45m] the same
+        # expression is true for 311 consecutive minutes (#6054 replay, and the #6053 table),
+        # because the sweep is ALWAYS slower than 2s. So the two available settings are
+        # never-firing and never-clearing; there is no third. The histogram's top finite bucket
+        # is 5s, so no threshold above 5s is even expressible here — latency of a multi-second
+        # LLM batch job is not a question this metric can answer at any window.
+        #
+        # The guard is derived from the data rather than from a service list, so it needs no
+        # maintenance as services come and go. Measured separation over the same 12h, calls per
+        # 5m window: the 31 request-driven services have p50 >= 71.6 (lowest min 26.4, and each
+        # spends <=1.1% of the window under 30 with a longest run of 4m); the 11 sparse subjects
+        # peak at 21.7. Replaying old-vs-new over the window: every one of the 57 condition-true
+        # points on request-driven services is preserved with identical run lengths, and 119
+        # points on sparse subjects (101 of them agent-service) are dropped. At t=0 on a cold pod
+        # `increase(...calls_total[5m])` is 0, the guard is false and the rule is silent, so this
+        # adds no boot-time firing — it can only ever make the rule quieter, never louder.
+        #
+        # What this deliberately does NOT do: it does not give the 11 sparse subjects a latency
+        # alert. For `agent-oversight-sweep` the deployed compensating control is
+        # `WorkflowLivenessStale` over `openbank_workflow_last_success_age_seconds` (ADR-0237),
+        # verified loaded and reporting for that workflow. Per-run DURATION remains uncovered and
+        # is tracked separately — it needs a run timer, not a span-percentile rule.
+        #
+        # The `and`-guard shape is this file's own convention: `HighErrorRate` directly above
+        # carries the same absolute-rate floor for the same reason.
         - alert: HighLatencyP99
           expr: |
             histogram_quantile(0.99, sum by (service, le) (rate(traces_spanmetrics_latency_bucket[5m]))) > 2
+            and
+            sum by (service) (increase(traces_spanmetrics_calls_total[5m])) >= 30
           for: 10m
           labels:
             severity: warning
           annotations:
             summary: "P99 latency >2s on {{ $labels.service }}"
-            description: "{{ $labels.service }} p99 span latency above 2s for >10m."
+            description: >-
+              {{ $labels.service }} p99 span latency above 2s for >10m, over a 5m window holding
+              at least 30 spans. Subjects below that density are excluded on purpose (#6054):
+              a p99 of ~15 samples is the maximum, not a percentile.
         - alert: OutboxBacklogStuck
           expr: openbank_outbox_backlog > 100
           for: 15m


### PR DESCRIPTION
Closes #6054
Refs #6053, #6041, #5736

## TL;DR

The issue framed this as a window-vs-period retune with a fleet-wide-latency-cost trade-off to
decide. **Re-measuring changed the answer: that trade-off does not exist, because both settings
are broken.** The narrow window can never fire; the wide window can never clear. What the rule
actually lacks is a **sample-density guard**, which is derivable from the data, costs the
request-driven fleet nothing measurable, and needs no service list.

## 1. Re-measurement

Live Prometheus, read-only, via a local port-forward. **Retention here is 12h**; every number
below rests on the window **2026-08-20T20:32Z – 2026-08-21T08:32Z** and nothing is claimed
outside it. In particular I do **not** claim "never" — I claim "not once in 12 hours, with a
mechanism that explains why".

```
GET /api/v1/query_range
  query = ALERTS{alertname="HighLatencyP99"}
  start = now-12h, end = now, step = 60
```

Thirteen services went `pending`. **Zero reached `firing`.** Grouping each into episodes
(2-minute tolerance):

| service | episodes | lengths (min) | start-gaps (min) | verdict |
|---|---:|---|---|---|
| **openbank-agent-service** | **26** | `[3,4,4,4,4,4,4,4,4,4,4,5,4,4,4,4,4,4,4,4,4,4,4,4,4,2]` | `30` ×22 (two outliers, `6`/`24`, around a pod restart) | **cannot mature** |
| openbank-billing-service | 2 | `[5,4]` | `[92]` | transient |
| openbank-document-service | 2 | `[5,5]` | `[83]` | transient |
| openbank-fx-service | 2 | `[5,4]` | `[302]` | transient |
| openbank-sdd-service | 2 | `[4,4]` | `[388]` | transient |
| audit, balance, copilot, dispute, mcp, onboarding, sanctions, sca | 1 each | `4–7` | — | transient |

**The signature is still there and agent-service is still the only service carrying it.** Length
capped at the `[5m]` rate window, gap equal to the 30-minute `agent.oversight.cron` period. The
other twelve have irregular gaps or a single episode — `for:` doing its job.

The rule is loaded and evaluating (`/api/v1/rules?type=alert`: `health=ok`, group
`openbank.tier1.health`, last eval `08:36:14Z`) — so this is not a #6032-style never-loaded rule.

### The mechanism is worse than "window shorter than period"

Reading the underlying series rather than only `ALERTS`:

```
histogram_quantile(0.99, sum by (service, le)
  (rate(traces_spanmetrics_latency_bucket{service="openbank-agent-service"}[5m])))
→ 5.00 during every sweep, 0.10 between sweeps

sum by (service) (rate(traces_spanmetrics_calls_total{service="openbank-agent-service"}[5m]))
→ peaks at 0.071 /s ≈ 21 spans per 5m window
```

`5.00` is the **top finite bucket** — the available `le` values are
`0.1, 0.25, 0.5, 1, 2, 5, +Inf`, so the sweep genuinely lands in `(5s, +Inf]`. And with ~15–21
spans in the window, `histogram_quantile(0.99, …)` is not estimating a 99th percentile at all:
it returns the top populated bucket, i.e. the **maximum**. The rule is therefore asking *"was any
single span slower than 2s"*, which for an LLM oversight sweep is **true by construction, on
every run, forever.**

## 2. Enumerating the cron-driven subjects — two methods, two different answers, both useful

**Method A — repo derivation.** `@Scheduled(cron = "{agent.oversight.cron}")` in
`OversightService.kt`, resolved through `application.yaml`, gives the 30-minute cadence, and it
matches the 30-minute gap in the live `ALERTS` history exactly. This is the method #6053 used
(142 cadences resolved). **But it answers the wrong question here.** agent-service emits spans in
458 of 720 minutes — it is not span-silent between sweeps. A service "having a cron" does not tell
you whether the fleet rule can mature for it.

**Method B — empirical density over the rule's real subject universe.** The rule's subjects are
whatever carries a `service` label on `traces_spanmetrics_latency_bucket`: **42** over the window.
For each, `sum by (service) (increase(traces_spanmetrics_calls_total[5m]))` across 721 points:

| cohort | n | calls per 5m |
|---|---:|---|
| **request-driven** | **31** | p50 **≥ 71.6** for every member; lowest observed floor 26.4 |
| **sparse** | **11** | **max 21.7** — `security-scanner` 5.3, `clearing-simulator` 5.3, `case-coordinator-agent` 16.8, `ap2` 15.8, `mcp` 16.8, `settlement` 15.8, `vop` 16.8, `copilot` 17.9, `agent-service` 20.9, `sepa-instant` 21.7, `audit-service` 12.6 median (bursts to 1268 on real traffic) |

Nothing sits between 21.7 and 71.6. **The two methods disagree and the disagreement is the
finding: the class is 11 subjects, not 1, and "cron-driven" is not the property that defines it —
sample density is.** `security-scanner` and `clearing-simulator` are sparser than agent-service
and were merely never slow enough to go `pending`; they share the blindness silently.

## 3. The three options, costed against measurement

**(a) Widen the window fleet-wide — refuted, not merely expensive.** The issue and #6053 both
replayed `[45m]` and got **311 consecutive true minutes**. That is not "the alert finally
matures"; it is the alert **never clearing again**, because the sweep is always slower than 2s.
The cost is not detection latency for ~25 services — it is converting a silent alert into a
permanently-firing one on the exact control estate where *"critical is the resting state"* is
already a known failure. And it cannot be rescued by raising the threshold: the top finite bucket
is **5s**, so no threshold above 5 is expressible with this histogram at all.

**(b) A second rule scoped to the cron subjects.** Inherits (a)'s refutation — a wider window for
that cohort produces a permanently-firing rule — plus two rules to keep in sync and a subject list
that goes stale. Rejected.

**(c) Leave it and document.** Honest, but leaves 26 misleading `pending` episodes per 12h on a
signal whose whole job is to make a real problem visible, and leaves 10 further subjects blind
without saying so.

**(d) — shipped — guard on sample density.** One clause, no list, no second rule:

```promql
histogram_quantile(0.99, sum by (service, le) (rate(traces_spanmetrics_latency_bucket[5m]))) > 2
and
sum by (service) (increase(traces_spanmetrics_calls_total[5m])) >= 30
```

It states in the rule what was previously only true by accident: this expression is a latency SLO
**only where the window holds enough samples for a p99 to mean something**. The scope is **derived
from the data on every evaluation** — there is no list to go stale, and a service that gains or
loses traffic moves cohort by itself. It is also this file's own convention: `HighErrorRate`,
directly above, already carries an absolute-rate floor for exactly this reason.

`30` is not a fudge factor — it is the midpoint of a measured empty band (21.7 → 26.4/71.6), and
the cost of the choice is quantified below.

## 4. Replay — would it have fired, and what does it cost the other 31?

Old vs new, same expressions, same 12h window, `step=60`:

| service | old true points | new true points | old max run | new max run |
|---|---:|---:|---:|---:|
| **agent-service** | **101** | **0** | 5m | 0 |
| mcp-service | 7 | 0 | 7m | 0 |
| copilot-service | 7 | 0 | 7m | 0 |
| audit-service | 4 | 0 | 4m | 0 |
| balance, dispute, sanctions, sca | 4 | **4** | 4m | **4m** |
| sdd | 8 | **8** | 4m | **4m** |
| billing, fx | 9 | **9** | 5m | **5m** |
| document | 10 | **10** | 5m | **5m** |
| onboarding | 5 | **5** | 5m | **5m** |

**Every single condition-true point on a request-driven service is preserved, with identical run
lengths. 119 points that could never have matured are dropped.** No episode in the window reached
`for: 10m` on either expression, so I make no claim that this PR *causes* a firing — the honest
statement is that it removes 119 points that were structurally incapable of firing and **retains
100% of the points that were capable of it.**

Detection cost to the 31 request-driven services, measured rather than argued: each spends at most
**1.1% of the window** below 30 calls/5m, with a **longest consecutive dip of 4 minutes** — shorter
than `for: 10m`, so a dip alone cannot reset a timer that was going to mature. (At a threshold of
50 the longest dip grows to 6m, which is why 30 was chosen over 50.)

## 5. t=0 on a cold pod

Not argued — measured, on a real restart. `agent-service-7c88498679-d554b` started at
**07:48:05Z**, inside the retention window. Evaluating from t−2m to t+25m:

```
OLD expression : true at +13m, +14m, +15m, +16m   (the first sweep after boot)
guard value    : 0, 0, 0, 2.03, 2.02, 2.01, 2.01, 0 … max 5.07 across the entire boot window
NEW expression : EMPTY for the whole window
```

So the pre-change rule produced a 4-minute `pending` episode **13 minutes after every restart**,
and the guarded rule is silent at boot. Structurally this is guaranteed rather than lucky:
`A and B ⊆ A`, so the change can only ever make this rule quieter, never louder — there is no
boot-time false positive it could introduce.

## 6. What this deliberately does not do

It does not give the 11 sparse subjects a latency alert, and the rule now says so in both a
comment block and the alert description rather than leaving it implicit.

For `agent-oversight-sweep` the compensating control already exists and is **verified live, not
assumed**: `WorkflowLivenessStale` over `openbank_workflow_last_success_age_seconds` (ADR-0237)
is loaded, `health=ok`, and reporting for that workflow (`age=350s`, `openbank_workflow_success_recorded=1`).
That covers *did it run*. Per-run **duration** stays uncovered, and `traces_spanmetrics` cannot
cover it at any window because the histogram saturates at 5s — it needs a run timer on the sweep
itself. Filed as a follow-up rather than smuggled in here.

## 7. Verification

Exit codes read from `$?`, output redirected to files, never from a pipeline.

* `promtool check rules` v3.14.0 on the extracted `spec`: **rc=0**, 9 rules found.
* **Negative control, because a green check proves nothing until it can go red:** the same file
  with one bracket removed from *this rule's new clause* → **rc=1**,
  `group "openbank.tier1.health", rule 4, "HighLatencyP99": could not parse expression`. The check
  can see this rule.
* Both expressions were submitted verbatim to the **live Prometheus parser** via `query_range` —
  `status: success` on every call. That is where the replay tables above come from, so the
  expression is proven to parse and evaluate against real data, not only against `promtool`.
* Gates, foreground, one at a time (`run-gates.py --all` intermittently exits 0 with empty output,
  #6068): `yamllint` **PASS**, `alert-metric-emitted` **PASS** (122 rules, self-test 7 cases),
  `critical-alert-egress` **PASS** (self-test 17 cases). `traces_spanmetrics_calls_total` is
  already an emitted metric used by `HighErrorRate`, so the new clause introduces no dead
  dependency.
* No cluster mutation: read-only `query`, `query_range`, `series`, `rules`, `runtimeinfo` and a
  port-forward. No `apply`/`edit`/`patch`/`delete`/`scale`.

**Not verified:** that the amended rule loads in the live ruler — that is only observable after
merge and reconcile, and per #6032 "it is in the repo" proves nothing. The pre-image is confirmed
loaded and the post-image is confirmed parseable by the same Prometheus build; the gap between
those two is a post-merge check, not a claim made here.

## Coordination

**#6053 is open and unmerged, and this PR is coupled to it in one direction.** File-level content
is disjoint (`git diff origin/main origin/fix/alert-window-vs-subject-period --
…/prometheus-rules-tier1.yaml` is **empty**), but #6053's
`.github/gates/alert-subject-period-baseline.yaml` lists `HighLatencyP99` as frozen debt with the
pre-fix evidence inline. **If this merges first, that baseline entry describes a rule that no
longer has the shape it records**, and #6053's gate fails in the "listed rule has since declared"
direction by design. Whoever lands second should drop or re-word that entry. Flagging rather than
editing another live branch.
