### PR TITLE
fix(deploy): refuse a co-deploy Pact matrix asked at a moving tag

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -960,6 +960,26 @@ gates:
     run: |
       bash .github/scripts/test-resolve-can-i-deploy-selector.sh
 
+  # The CO-DEPLOY narrowing of the selector above (#5993). The shared selector's
+  # `--latest main` fallback is correct per service (ADR-0092) and wrong in the atomic
+  # co-deploy matrix, which asks ONE question about a whole set: a moving tag there is a
+  # verdict about a later, unrelated build. The `unknown` branch — broker probe
+  # inconclusive — is the fail-OPEN one: it can answer GREEN about a pair nobody is
+  # deploying, with nothing red anywhere to notice. The self-test's load-bearing cases are
+  # the negative controls: every probe answer that is not an exact version must REFUSE, and
+  # no branch may emit a moving tag. Delegate straight to the shared selector again and
+  # they go red.
+  - id: can-i-deploy-codeploy-selector-unit-test
+    selftest_exempt: "is-a-test-suite — the run: IS the checker's own --self-test"
+    name: "can-i-deploy co-deploy version selector unit test (issue #5993, enforced)"
+    group: supplychain
+    mode: enforced
+    rationale: "The atomic co-deploy matrix asks ONE broker question about a whole service set, so it is only meaningful when every pacticipant is pinned to the version being deployed; the shared per-service selector's documented `--latest main` fallback silently made it a verdict about whatever build currently carries the moving main tag, which can answer GREEN for a pair nobody is deploying and leaves nothing red anywhere to notice."
+    review_after: "2027-02-21"
+    min_subjects: 21   # 21 assertions across every probe answer the resolver can be handed
+    run: |
+      bash .github/scripts/resolve-codeploy-selector.sh --self-test
+
   # The equivalence proof that lets a reconcile deploy at all (#3432). The selector above decides
   # WHICH version to ask about; on a manual dispatch the honest answer used to be "none, refuse"
   # for every service, because no pact version can exist for a sha services-ci never built. This

--- a/.github/scripts/can-i-deploy-gate.sh
+++ b/.github/scripts/can-i-deploy-gate.sh
@@ -118,6 +118,7 @@ if [ "${EVENT_NAME}" = "workflow_dispatch" ] \
     use_explicit_versions=true
   fi
   CODEPLOY_ARGS=()
+  codeploy_skipped=()
   for svc in $(echo "$SERVICES" | jq -r '.[]'); do
     if [ "$use_explicit_versions" = true ]; then
       pact_version="$(jq -r --arg svc "$svc" '.[$svc] // empty' <<< "$explicit_versions")"
@@ -134,19 +135,45 @@ if [ "${EVENT_NAME}" = "workflow_dispatch" ] \
       CID_SELECTOR=(--version "$pact_version")
       echo "    ${svc}: --version ${pact_version} (explicit version proven byte-identical to deploy ref)"
     else
+      # #5993: the co-deploy matrix may ONLY be asked at exact versions. The shared
+      # selector is right for the per-service loop below, where `--latest main` is a
+      # documented ADR-0092 fallback — but here that moving tag makes the one question
+      # this branch exists to ask a question about a DIFFERENT artifact, and on the
+      # `unknown` (broker probe inconclusive) path it can answer GREEN for a pair that is
+      # not being deployed. resolve-codeploy-selector.sh narrows it to exact | SKIP |
+      # REFUSE; its --self-test asserts no branch can ever emit a moving tag again.
       vpresent="$(bash .github/scripts/probe-pact-version.sh "$svc" "$GITHUB_SHA")"
-      sel_line="$(PACT_VERSION_PRESENT="$vpresent" EVENT_NAME="$GITHUB_EVENT_NAME" \
-        bash .github/scripts/resolve-can-i-deploy-selector.sh "$svc" "$GITHUB_SHA")"
+      sel_line="$(PACT_VERSION_PRESENT="$vpresent" \
+        bash .github/scripts/resolve-codeploy-selector.sh "$svc" "$GITHUB_SHA")"
       read -ra CID_SELECTOR <<< "$(printf '%s' "$sel_line" | cut -f1)"
       if [ "${CID_SELECTOR[0]}" = "REFUSE" ]; then
         echo "::error::can-i-deploy co-deploy set cannot be asked safely for ${svc}: $(printf '%s' "$sel_line" | cut -f2)"
         echo "deployable=[]" >> "$GITHUB_OUTPUT"
         exit 1
       fi
+      if [ "${CID_SELECTOR[0]}" = "SKIP" ]; then
+        # Not a pacticipant at all — no contracts either way, so it cannot break any pair.
+        # It stays in the deploy set and leaves the MATRIX, which is the per-service loop's
+        # 404 rule applied here. Pinning it to `--latest main` instead made the whole set
+        # read as a contract break that does not exist.
+        echo "    ${svc}: not in the matrix ($(printf '%s' "$sel_line" | cut -f2))"
+        codeploy_skipped+=("$svc")
+        continue
+      fi
       echo "    ${svc}: ${CID_SELECTOR[*]} ($(printf '%s' "$sel_line" | cut -f2))"
     fi
     CODEPLOY_ARGS+=(--pacticipant "$svc" "${CID_SELECTOR[@]}")
   done
+  if [ "${#CODEPLOY_ARGS[@]}" -eq 0 ]; then
+    # Every requested service turned out to have no contracts in the broker. There is no
+    # matrix to ask, and asking `can-i-deploy` with zero pacticipants is a CLI error that
+    # would read as a contract break. Nothing here can break a contract, so the set is
+    # deployable — but say so explicitly rather than letting an empty question answer it.
+    echo "  ✓ none of the requested services is a Pacticipant — no contracts to check (ADR-0092)"
+    echo "deployable=${SERVICES}" >> "$GITHUB_OUTPUT"
+    echo "blocked=[]" >> "$GITHUB_OUTPUT"
+    exit 0
+  fi
   echo "==> can-i-deploy CO-DEPLOY SET (#1985): $(echo "$SERVICES" | jq -r 'join(" ")')"
   if "$CLI" can-i-deploy "${CODEPLOY_ARGS[@]}" \
        --broker-base-url "$PACT_BROKER_URL" \
@@ -159,6 +186,10 @@ if [ "${EVENT_NAME}" = "workflow_dispatch" ] \
     {
       echo "### can-i-deploy: co-deploy set verified (#1985)"
       echo "Asked as ONE question, not per service: \`$(echo "$SERVICES" | jq -r 'join(" ")')\`"
+      if [ "${#codeploy_skipped[@]}" -gt 0 ]; then
+        echo ""
+        echo "Not in the matrix (no contracts in the broker, ADR-0092): \`${codeploy_skipped[*]}\`"
+      fi
     } >> "$GITHUB_STEP_SUMMARY"
     exit 0
   fi

--- a/.github/scripts/resolve-codeploy-selector.sh
+++ b/.github/scripts/resolve-codeploy-selector.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+#
+# ---------------------------------------------------------------------------------------
+# WHICH Pact version the ATOMIC CO-DEPLOY matrix (#1985) may ask about — issue #5993.
+#
+# The co-deploy branch of can-i-deploy-gate.sh asks the broker ONE question about a whole
+# set of services at once: "are these exact build versions mutually deployable?". That
+# question is only meaningful if every pacticipant in it is pinned to the version actually
+# being deployed. The gate's own comment has said so since #1985 — "Do not use `--latest
+# main` here: a later, unrelated main build can move that tag between selection and the
+# question, turning this into a verdict about a different image" — and the code could still
+# produce exactly that, because it delegated the choice to resolve-can-i-deploy-selector.sh
+# and took whatever came back.
+#
+# That selector is right for the PER-SERVICE path, where `--latest main` is a deliberate,
+# documented fallback (ADR-0092: a service path-scoped CI skipped on this commit has no
+# version, and `--version` would error). Two of its branches emit it:
+#
+#   absent   the broker has never heard of this pacticipant — no contracts either way
+#   unknown  the broker probe was inconclusive (non-2xx / unreachable / malformed answer)
+#
+# On the per-service path both are harmless-to-benign. In the co-deploy matrix they are not
+# the same defect at all, and only one of them is loud:
+#
+#   * `unknown` FAILS OPEN. The broker answers about whatever version currently carries the
+#     moving `main` tag for that pacticipant — a later, unrelated build — and can return
+#     GREEN for a pair that is not the pair being deployed. Nothing is red anywhere; the
+#     deploy proceeds on a verdict about a different artifact. This is the #5993 defect: a
+#     control that reports healthy because it structurally cannot report otherwise.
+#   * `absent` fails closed, confusingly: `can-i-deploy --pacticipant <unknown> --latest main`
+#     errors, and the whole set reads as "not mutually deployable" — a contract break that
+#     does not exist. The per-service path already has the right answer for this case (a
+#     service with NO contracts cannot break any consumer/provider expectation, so it is
+#     trivially deployable, ADR-0092); the co-deploy path had no equivalent, so it is given
+#     one here as SKIP — dropped from the matrix, not silently pinned to a moving tag.
+#
+# So this script is the co-deploy-specific NARROWING of the shared selector, not a second
+# copy of it: it delegates the decision and then refuses anything that is not an exact
+# version. Acceptance from #5993, verbatim: "resolve each participant to its exact selected
+# Pact version, or to a proven tree-equivalent version, and refuse when that cannot be
+# established."
+#
+# USAGE
+#   PACT_VERSION_PRESENT=<probe-pact-version.sh output> \
+#     resolve-codeploy-selector.sh <service> <deploy-sha>
+#
+# OUTPUT (one line, tab-separated: <decision>\t<human reason>)
+#   --version <sha>   pin this pacticipant to that exact version; put it in the matrix
+#   SKIP              not a pacticipant at all — leave it OUT of the matrix, still deployable
+#   REFUSE            no exact version can be established — the caller must deploy NOTHING
+#
+# Exit status is 0 in all three cases: the decision is the stdout line, so a caller cannot
+# mistake "refused" for "the script crashed".
+#
+# Self-test: `resolve-codeploy-selector.sh --self-test` drives every branch, including the
+# negative controls this file exists for (unknown/no/garbage must REFUSE, never emit a
+# moving tag). Wired into .github/gates/gates.yaml.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SHARED="${HERE}/resolve-can-i-deploy-selector.sh"
+
+emit() { printf '%s\t%s\n' "$1" "$2"; }
+
+resolve_one() { # <svc> <sha>; reads PACT_VERSION_PRESENT
+  local svc="$1" sha="$2" present="${PACT_VERSION_PRESENT:-unknown}" sel_line sel why
+  if [ "$present" = "absent" ]; then
+    emit "SKIP" \
+      "the broker has never heard of ${svc} — it publishes no consumer pact and verifies no provider pact, so there is no contract for the matrix to check; it is left OUT of the co-deploy question rather than pinned to the moving main tag (ADR-0092)"
+    return 0
+  fi
+  sel_line="$(PACT_VERSION_PRESENT="$present" EVENT_NAME=workflow_dispatch \
+    bash "$SHARED" "$svc" "$sha")"
+  sel="$(printf '%s' "$sel_line" | cut -f1)"
+  why="$(printf '%s' "$sel_line" | cut -f2-)"
+  case "$sel" in
+    "--version "*)
+      emit "$sel" "$why"
+      ;;
+    *)
+      # Everything else — REFUSE from the shared selector, and every path that would have
+      # produced `--latest main`. A co-deploy matrix asked at a moving tag is a verdict
+      # about artifacts that are not being deployed, in either direction (#5993).
+      emit "REFUSE" \
+        "no exact Pact version can be established for ${svc} at ${sha} (probe said '${present}'; the shared selector offered '${sel}') — a co-deploy matrix must be asked at the versions being deployed, and a moving 'latest main' tag can answer about a later, unrelated build (#5993, #1985)"
+      ;;
+  esac
+}
+
+if [ "${1:-}" = "--self-test" ] || [ "${1:-}" = "--selftest" ]; then
+  SHA="0e32873f8c52d37e1b6530e5bd5e94275e5cefae"
+  OTHER="1111111111111111111111111111111111111111"
+  fails=0
+  # Every assertion below is a SUBJECT: one probe answer the resolver can be handed. The
+  # count is printed at the end and floored in .github/gates/gates.yaml (#4339) — a suite
+  # that quietly stops driving cases would otherwise pass by examining nothing.
+  subjects=0
+  check() { # <label> <want-decision> <present>
+    local label="$1" want="$2" present="$3" got
+    subjects=$((subjects + 1))
+    got="$(PACT_VERSION_PRESENT="$present" resolve_one openbank-demo-service "$SHA" | cut -f1)"
+    if [ "$got" = "$want" ]; then echo "  ok   ${label} -> ${got}"
+    else echo "  FAIL ${label}: want '${want}', got '${got}'"; fails=$((fails + 1)); fi
+  }
+  echo "resolve-codeploy-selector.sh (#5993)"
+  # THE POSITIVE CONTROL — an exact version for the deployed sha is what the matrix wants.
+  check "version present -> pin this commit"            "--version ${SHA}"   yes
+  # ...and the #3432 equivalence, which is an exact version number too.
+  check "tree-equivalent version -> pin that version"   "--version ${OTHER}" "equivalent:${OTHER}"
+  # THE NEGATIVE CONTROLS. Each of these produced, or could produce, a matrix asked at a
+  # moving tag before #5993. None of them may ever emit a selector again.
+  check "broker probe inconclusive -> REFUSE"           REFUSE               unknown
+  check "no version for this sha -> REFUSE"             REFUSE               no
+  check "unparseable probe answer -> REFUSE"            REFUSE               "not-a-probe-answer"
+  check "equivalence sha is not 40-hex -> REFUSE"       REFUSE               "equivalent:HEAD"
+  # A pacticipant the broker does not know has no contracts to break — it leaves the matrix.
+  check "unknown pacticipant -> SKIP"                   SKIP                 absent
+  # Unset must behave as the worst case, never as 'yes'.
+  subjects=$((subjects + 1))
+  got_unset="$(unset PACT_VERSION_PRESENT; resolve_one openbank-demo-service "$SHA" | cut -f1)"
+  if [ "$got_unset" = "REFUSE" ]; then echo "  ok   unset probe -> REFUSE"
+  else echo "  FAIL unset probe: want 'REFUSE', got '${got_unset}'"; fails=$((fails + 1)); fi
+  # NOTHING may ever come back as a moving tag, whatever the probe said. This is the
+  # assertion that fails if someone delegates straight to the shared selector again.
+  for p in yes no unknown absent "equivalent:${OTHER}" "equivalent:HEAD" garbage; do
+    subjects=$((subjects + 1))
+    line="$(PACT_VERSION_PRESENT="$p" resolve_one openbank-demo-service "$SHA" | cut -f1)"
+    if [ "$line" = "--latest main" ]; then
+      echo "  FAIL present=${p} emitted a MOVING TAG: ${line}"; fails=$((fails + 1))
+    else
+      echo "  ok   present=${p} did not emit a moving tag"
+    fi
+  done
+  # Every branch must carry a non-empty reason — the gate prints it, and a blank reason is
+  # how a refused deploy becomes unexplainable after the fact.
+  for p in yes no unknown absent "equivalent:${OTHER}"; do
+    subjects=$((subjects + 1))
+    reason="$(PACT_VERSION_PRESENT="$p" resolve_one openbank-demo-service "$SHA" | cut -f2-)"
+    if [ -n "$reason" ]; then echo "  ok   reason present for present=${p}"
+    else echo "  FAIL reason missing for present=${p}"; fails=$((fails + 1)); fi
+  done
+  # A selector must be usable as literal CLI args without the caller re-splitting it.
+  subjects=$((subjects + 1))
+  read -ra sel_arr <<< "$(PACT_VERSION_PRESENT=yes resolve_one openbank-demo-service "$SHA" | cut -f1)"
+  if [ "${#sel_arr[@]}" -eq 2 ] && [ "${sel_arr[0]}" = "--version" ] && [ "${sel_arr[1]}" = "$SHA" ]; then
+    echo "  ok   selector splits into exactly the two CLI args"
+  else
+    echo "  FAIL selector split: got ${#sel_arr[@]} arg(s): ${sel_arr[*]}"; fails=$((fails + 1))
+  fi
+  echo "SUBJECTS=${subjects}  # probe answers driven through the resolver"
+  if [ "$fails" -ne 0 ]; then echo "FAILED: ${fails} case(s)"; exit 1; fi
+  echo "PASS: the co-deploy matrix is pinned to exact versions or refused — never asked at a moving tag"
+  exit 0
+fi
+
+SVC="${1:-}"
+SHA="${2:-}"
+if [ -z "$SVC" ] || [ -z "$SHA" ]; then
+  echo "usage: PACT_VERSION_PRESENT=<probe output> $0 <service> <sha>" >&2
+  echo "       $0 --self-test" >&2
+  exit 2
+fi
+resolve_one "$SVC" "$SHA"


### PR DESCRIPTION
## What was evaluated before, and at which versions

The atomic co-deploy branch of `.github/scripts/can-i-deploy-gate.sh` (#1985) asks the broker **one** question about a whole service set. It resolved each pacticipant through the shared `resolve-can-i-deploy-selector.sh` and used whatever came back. That selector is correct for the per-service loop, where `--latest main` is a deliberate ADR-0092 fallback — but two of its branches emit exactly that, and the co-deploy branch took it:

- `unknown` — the broker probe was inconclusive (non-2xx, unreachable, malformed answer)
- `absent` — the broker has never heard of this pacticipant

So the matrix could be asked at the **moving `main` tag**, i.e. about whatever build currently carries it rather than the artifacts the dispatch selected. The gate's own comment has forbidden this since #1985 ("Do not use `--latest main` here: a later, unrelated main build can move that tag between selection and the question, turning this into a verdict about a different image"); the code could still produce it.

#5991 and #5998 fixed the two paths that had an exact answer available (this commit's version, and an explicitly supplied version proven tree-equivalent). The two fallback branches were still open, which is what this PR closes.

## Which way it fails

**`unknown` fails OPEN**, and that is the serious half. Reproduced against `origin/main`'s gate with a stubbed broker returning 500 on the version endpoint and a stubbed pact CLI, for the exact four-service set in the issue's acceptance criterion (`product-catalog`, `account`, `interest`, `lending`):

```
gate exit=0
deployable=["openbank-product-catalog-service","openbank-account-service","openbank-interest-service","openbank-lending-service"]
can-i-deploy --pacticipant openbank-product-catalog-service --latest main \
             --pacticipant openbank-account-service          --latest main \
             --pacticipant openbank-interest-service         --latest main \
             --pacticipant openbank-lending-service          --latest main ...
```

A green verdict about four versions nobody is deploying, with nothing red anywhere to notice — same defect class as the rest of this repo's fail-open controls: it reports healthy because it structurally cannot report otherwise.

`absent` fails closed, but wrongly: `can-i-deploy` on a pacticipant the broker does not know errors, and the whole set then reads as a contract break that does not exist. The per-service loop already has the right rule for that case (no contracts ⇒ nothing to break ⇒ deployable); the co-deploy path had no equivalent.

## What is evaluated now

New `.github/scripts/resolve-codeploy-selector.sh` — the co-deploy-specific **narrowing** of the shared selector, not a second copy. It delegates the decision and then admits only exact versions:

| probe answer | decision |
|---|---|
| `yes` | `--version <deploy sha>` — in the matrix |
| `equivalent:<sha>` (#3432 tree-equivalence) | `--version <sha>` — in the matrix |
| `absent` | `SKIP` — out of the matrix, still deployable (ADR-0092) |
| `no` / `unknown` / unset / anything unparseable | `REFUSE` — `deployable=[]`, deploy nothing |

The version set is derived per participant from the deploy inputs and the broker probe; there is no hand-kept list anywhere. Branch protection and every other Pact behaviour are untouched — the explicit `codeploy_pact_versions` path from #5998, the per-service loop, the block classifier and the reconcile-tick silencing rule are all unchanged.

## Negative control

Exit codes read from `$?` after redirecting output to a file, never off a pipeline.

**Unit, harness falsified.** A copy of the new resolver regressed to the pre-#5993 behaviour (accept `--latest …` from the shared selector, drop the `absent` short-circuit) is rejected by its own self-test:

```
NEGATIVE_EXIT=1   FAILED: 7 case(s)
  FAIL broker probe inconclusive -> REFUSE: want 'REFUSE', got '--latest main'
  FAIL unknown pacticipant -> SKIP: want 'SKIP', got '--latest main'
  FAIL present=unknown emitted a MOVING TAG: --latest main
  ...
POSITIVE_EXIT=0   PASS: the co-deploy matrix is pinned to exact versions or refused
```

**End-to-end, against the real gate script** with a stubbed broker + stubbed pact CLI, same four-service set:

| case | gate exit | `deployable` |
|---|---|---|
| A — broker probe inconclusive (the fail-open case) | **1** | `[]` |
| B — exact versions, compatible (CLI verdict 0) | **0** | all four |
| C — exact versions, genuinely incompatible (CLI verdict 1) | **1** | `[]` |

In B and C the CLI is invoked with `--pacticipant <svc> --version <sha>` for all four services — the versions being deployed — recorded from the stub's own argv. Case A on `origin/main`'s gate is exit **0** with all four deployable; that difference is the fix.

## What was NOT verified

- **Nothing was run against the real Pact broker, and nothing was deployed.** The broker has no public ingress (ADR-0056), so this could not be exercised from a PR lane in any case; the CLI and the broker HTTP calls were stubbed and the argv asserted instead. What is proven is which question the gate asks and how it behaves on each answer — not the broker's answer itself.
- The `absent → SKIP` and all-participants-skipped branches are covered by the unit self-test and by reading the gate, not by an end-to-end run.

## Gates

`--group lint` 20/20 PASS (the new gate carries `rationale`, `review_after`, `min_subjects: 21`, and the self-test prints `SUBJECTS=`), `--group supplychain` 23/24, `kotlin` 19/19, `registry` 26/26. Every remaining failure in `supplychain`/`api`/`data`/`gitops`/`security` is `PR_DIFF_BASE is empty` or `BASE_REF: unbound variable` — local-environment only, present on unmodified `origin/main` too.

Note: this touches a workflow-adjacent path, so auto-merge is not available here. That is expected.

## Linked issues

Closes #5993
