### PR TITLE
fix(admin-ui): localize feedback timestamps

### DIFF
--- a/openbank-admin-ui/src/app/feedback/page.tsx
+++ b/openbank-admin-ui/src/app/feedback/page.tsx
@@ -36,9 +36,17 @@ const CATEGORY_LABEL_EN: Record<string, string> = {
   BUG: 'Bug', IDEA: 'Idea', CONFUSING: 'Confusing',
 }
 
+function formatFeedbackTimestamp(value: string | null | undefined, locale: string): string {
+  if (!value) return '—'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString(locale, { dateStyle: 'medium', timeStyle: 'short' })
+}
+
 export default function ScreenFeedbackPage() {
   const { language } = useLanguage()
   const cs = language === 'cs'
+  const dateLocale = cs ? 'cs-CZ' : 'en-GB'
   const [data, setData] = useState<ScreenFeedbackBoard | null>(null)
   const [loading, setLoading] = useState(true)
 
@@ -125,7 +133,7 @@ export default function ScreenFeedbackPage() {
           <tbody>
             {data.recent.map((r) => (
               <tr key={r.reference}>
-                <td>{r.occurredAt}</td>
+                <td>{formatFeedbackTimestamp(r.occurredAt, dateLocale)}</td>
                 <td>{r.screenId}</td>
                 <td>{catLabel(r.category)}</td>
                 <td>{r.comment}</td>

--- a/openbank-admin-ui/src/test/screen-feedback-locale.guard.test.ts
+++ b/openbank-admin-ui/src/test/screen-feedback-locale.guard.test.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('screen feedback timestamp locale contract', () => {
+  it('formats report timestamps with the active locale and preserves invalid raw values', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/feedback/page.tsx'), 'utf8')
+
+    expect(source).toContain("const dateLocale = cs ? 'cs-CZ' : 'en-GB'")
+    expect(source).toContain("toLocaleString(locale, { dateStyle: 'medium', timeStyle: 'short' })")
+    expect(source).toContain('if (Number.isNaN(date.getTime())) return value')
+    expect(source).toContain('formatFeedbackTimestamp(r.occurredAt, dateLocale)')
+    expect(source).not.toContain('<td>{r.occurredAt}</td>')
+  })
+})


### PR DESCRIPTION
## Summary
- format Screen Feedback occurredAt values with the active operator locale
- preserve raw values when timestamps are invalid
- add a focused source guard for the locale contract

## Verification
- git diff --check
- npm run type-check (blocked by missing pre-existing OpenTelemetry packages in local node_modules)

Refs #6159