### PR TITLE
ci(transaction): fail fast when the test Kafka broker is gone, instead of burning the 45-minute job timeout

### DIFF
--- a/openbank-transaction-service/build.gradle.kts
+++ b/openbank-transaction-service/build.gradle.kts
@@ -98,6 +98,23 @@ kover {
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 
+tasks.withType<Test> {
+    // Fail fast, not fail wide (issue #5940). This module boots a real Kafka producer against a
+    // Redpanda Testcontainer, and Quarkus tears that container down whenever the set of
+    // @QuarkusTestResource classes changes between test classes. A producer left over from the
+    // previous boot then retries against a dead port. On job 96416555756 that left the job with no
+    // output but reconnect attempts from 12:09:46Z until it was cancelled at the 45-minute fleet
+    // job timeout at 12:43:38Z, and `build/test-results/` was never written — so the job burned a
+    // full runner slot and produced no JUnit XML to diagnose from.
+    //
+    // The Kafka client bounds in src/test/resources/application.properties are the direct fix. This
+    // is the backstop for anything else in this module that can stall past a test boundary: JUnit
+    // kills the test at 8 minutes and the module goes RED with a named test, instead of sitting on
+    // a runner until the fleet job timeout takes the whole matrix down with it. Same guard and same
+    // value as openbank-swift-service, added there for the same failure shape (#2320 item 3).
+    systemProperty("junit.jupiter.execution.timeout.default", "8m")
+}
+
 // Mutation testing on the money-path domain (ADR-0063 / ADR-0030 D3; fleet rollout #1266). Weekly +
 // manual via pitest.yml, advisory — never a per-PR gate. info.solidsoft.pitest 1.19.0 supports Gradle 9.
 pitest {

--- a/openbank-transaction-service/build.gradle.kts
+++ b/openbank-transaction-service/build.gradle.kts
@@ -2,6 +2,8 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
+import java.time.Duration
+
 plugins {
     id("openbank.quarkus-service")
     // Inline version (not the shared catalog) so enabling mutation testing stays path-scoped to
@@ -113,6 +115,21 @@ tasks.withType<Test> {
     // a runner until the fleet job timeout takes the whole matrix down with it. Same guard and same
     // value as openbank-swift-service, added there for the same failure shape (#2320 item 3).
     systemProperty("junit.jupiter.execution.timeout.default", "8m")
+
+    // The JUnit timeout above only fires while a test is RUNNING, and the #5940 hang was not that:
+    // the last test activity was at 12:09:46Z and the job was cancelled at 12:43:38Z, with seven
+    // `Terminate orphan process: pid (java)` at teardown. A Kafka producer's network thread is
+    // non-daemon and keeps reconnecting for as long as the producer object is open, so a leaked
+    // Quarkus application from a previous boot can hold its JVM alive after every test has
+    // finished — a state no per-test timeout can observe.
+    //
+    // Gradle's task timeout does cover it: it bounds the whole task, forked JVM included. At 25
+    // minutes the module fails with a named task, 20 minutes inside the 45-minute fleet job
+    // timeout, which is what lets the `build/test-results/**/*.xml` upload actually run. In the
+    // #5940 job it did not: `No files were found with the provided path:
+    // openbank-transaction-service/build/test-results/`. A cancelled job produces no report at
+    // all, so the cost is not just the runner slot — it is that nothing survives to diagnose from.
+    timeout.set(Duration.ofMinutes(25))
 }
 
 // Mutation testing on the money-path domain (ADR-0063 / ADR-0030 D3; fleet rollout #1266). Weekly +

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/it/PostgresRedpandaTestResource.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/it/PostgresRedpandaTestResource.kt
@@ -5,6 +5,7 @@
 package com.openbank.transaction.it
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import org.jboss.logging.Logger
 import org.opentest4j.TestAbortedException
 import org.testcontainers.DockerClientFactory
 import org.testcontainers.containers.GenericContainer
@@ -71,8 +72,28 @@ class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
+        // Say out loud that the broker is going away (issue #5940). Quarkus calls stop() whenever
+        // the set of @QuarkusTestResource classes changes between test classes, so this runs
+        // mid-run, not only at the end — and any Kafka producer belonging to the previous boot is
+        // still open and will start failing against a port that no longer exists. Without this
+        // line the only evidence is a wall of "could not be established" with nothing explaining
+        // what happened to the broker, which is exactly how #5940 read for 37 minutes.
+        redpanda?.let { rp ->
+            LOG.infof(
+                "Stopping Redpanda test container (bootstrap=%s) — producers from the current " +
+                    "Quarkus boot will fail to reach it after this point",
+                rp.bootstrapServers,
+            )
+        }
         redis?.stop()
         redpanda?.stop()
         postgres?.stop()
+        redis = null
+        redpanda = null
+        postgres = null
+    }
+
+    private companion object {
+        private val LOG: Logger = Logger.getLogger(PostgresRedpandaTestResource::class.java)
     }
 }

--- a/openbank-transaction-service/src/test/resources/application.properties
+++ b/openbank-transaction-service/src/test/resources/application.properties
@@ -30,3 +30,29 @@ quarkus.log.category."com.openbank".level=INFO
 
 # Random HTTP port — prevents port-8081 conflict in parallel Pact provider CI runs
 quarkus.http.test-port=0
+
+# --- Kafka client bounds for tests (issue #5940) ---------------------------------
+# Why: transaction-service boots a real outgoing Kafka channel
+# (@Channel("transaction-events-out")), backed by a Redpanda Testcontainer from
+# PostgresRedpandaTestResource. Quarkus restarts the app whenever the set of
+# @QuarkusTestResource classes changes between test classes, which calls stop() on
+# the resource and kills that Redpanda container — while any producer belonging to
+# the previous boot is still open. With stock Kafka client defaults that producer
+# reconnects forever against the now-dead mapped port. On job 96416555756 the last
+# real test activity was at 12:09:46Z and the job then emitted nothing but
+# "Connection to node -1 (localhost/127.0.0.1:32771) could not be established"
+# until it was cancelled at the 45-minute job timeout at 12:43:38Z — 247 retry
+# lines, no build/test-results/ written at all, so not even a JUnit XML to read.
+#
+# These bounds do not make the broker reachable; they make an unreachable broker
+# fail in seconds and say so, instead of burning a full runner slot and naming
+# nothing. Keep delivery.timeout.ms >= request.timeout.ms + linger.ms.
+kafka.max.block.ms=5000
+kafka.request.timeout.ms=5000
+kafka.delivery.timeout.ms=10000
+kafka.reconnect.backoff.max.ms=1000
+kafka.retries=3
+# Bound the producer close on app shutdown too: a channel holding an undeliverable
+# record must not stall the test JVM's exit (SmallRye default is 10s but is only
+# applied per channel, so state it explicitly for the one outgoing channel).
+mp.messaging.outgoing.transaction-events-out.close-timeout=5000


### PR DESCRIPTION
## Root cause

`build (openbank-transaction-service)` was cancelled at the 45-minute job timeout while doing
nothing. The tests were not slow — they had stopped.

From job `96416555756` (head `f77c32458`):

- last real test activity: `12:09:46Z` (`Failed to deserialise SchemeAcceptedEvent, dropping: not-json`)
- from there to cancellation at `12:43:38Z`: **247** lines of nothing but
  `[Producer clientId=kafka-producer-transaction-events-out] Connection to node -1 (localhost/127.0.0.1:32771) could not be established`
- the decisive line at the end:
  `No files were found with the provided path: openbank-transaction-service/build/test-results/`

That last one is what makes this worth fixing properly. The `test` task never completed, so **no
JUnit XML was written at all** — the job burned a full runner slot and produced nothing to diagnose
from. Not a boot failure reporting as SKIPPED; there was no report to read either way.

### Why the broker went away

The issue text hypothesised an OOM-killed container, and treated "only one broker port ever appears"
as evidence *against* a container being reaped between test-resource restarts. The log says the
opposite. There are exactly **two** `Ryuk has been disabled` banners — one at `12:04:33Z`, one at
`12:05:12Z` — i.e. two container sets. The producer retries begin at `12:05:11Z`, one second before
the second set starts.

So Redpanda did not die mysteriously. Quarkus restarts the application whenever the set of
`@QuarkusTestResource` classes changes between test classes (this module has classes declaring
`PostgresRedpandaTestResource` alone and classes declaring it *plus* `LedgerWireMockResource`), and
that restart calls `stop()` on the resource, which stops the Redpanda container — while a Kafka
producer belonging to the *previous* boot is still open. The single-port evidence is consistent with
this rather than against it: only the orphaned producer logs failures, because the producers on the
new boot connect successfully and successful connections are not logged.

With stock Kafka client defaults that orphaned producer reconnects forever, and the job sits there
until the fleet job timeout takes it down.

## What changes

Nothing here makes the broker reachable. The point is that an unreachable broker must fail in
seconds and name itself, instead of costing 45 minutes and naming nothing.

1. **`src/test/resources/application.properties`** — bound the Kafka client in tests:
   `max.block.ms=5000`, `request.timeout.ms=5000`, `delivery.timeout.ms=10000`,
   `reconnect.backoff.max.ms=1000`, `retries=3`, plus an explicit `close-timeout` on the
   `transaction-events-out` channel so a channel holding an undeliverable record cannot stall the
   test JVM's exit. An emit against a dead broker now throws within seconds.

2. **`build.gradle.kts`** — `junit.jupiter.execution.timeout.default = 8m`, the backstop for
   anything else in this module that can stall past a test boundary. JUnit kills the test and the
   module goes **RED with a named test**, instead of sitting on a runner until the fleet job timeout
   takes the whole matrix down. Same guard, same value, and the same failure shape as
   `openbank-swift-service` (#2320 item 3).

3. **`build.gradle.kts`** — a Gradle **task**-level `timeout` of 25 minutes on `test`. This is the
   guard that actually covers the observed shape, and the reason the JUnit timeout alone is not
   enough: the hang was *not* inside a running test. The last test activity was `12:09:46Z`,
   cancellation was `12:43:38Z`, and teardown reported seven `Terminate orphan process: pid (java)`.
   A Kafka producer's network thread is non-daemon and reconnects for as long as the producer object
   is open, so a leaked Quarkus application from a previous boot can hold its JVM alive after every
   test has finished — a state no per-test timeout can observe. Gradle's task timeout bounds the
   whole task including the forked JVM, and firing 20 minutes inside the fleet job timeout is what
   lets the `test-results/**/*.xml` upload actually run.

4. **`PostgresRedpandaTestResource.stop()`** — log the bootstrap address when the container is torn
   down, and null the fields. `stop()` runs mid-run, not only at the end, and without this line the
   only evidence is a wall of `could not be established` with nothing explaining what happened to the
   broker. That is exactly how this read for 37 minutes.

## Notes

- **This is not a divergence from a fleet convention.** 12 services use Redpanda Testcontainers
  (`git grep -l RedpandaContainer`), including a shared
  `openbank-libs-testing/.../PostgresRedpandaTestResource`. transaction-service needs a real broker
  because it boots a real outgoing `@Channel` emitter. The in-memory connector is the convention for
  services that switch channels; it is not the convention here.
- **The dotted-YAML-leaf-key trap is present in `application.yaml` and is deliberately left alone.**
  `auto.offset.reset` and `group.id` under `mp.messaging.incoming.payment-scheme-accepted` do not
  resolve through SmallRye's YAML source; the file already documents this in place, and the deployed
  value comes from the `transaction-service-msg-override` ConfigMap in gitops (#686). Forcing
  `earliest` onto a running consumer group would be a mass replay on a money-path channel. Out of
  scope here.

## Verification

**Verified locally** (`--rerun-tasks`, exit code read from the redirected run, not through a pipe):

```
:openbank-transaction-service:ktlintCheck  BUILD SUCCESSFUL (exit 0)
:openbank-transaction-service:detekt       BUILD SUCCESSFUL (exit 0)
:openbank-transaction-service:test         BUILD SUCCESSFUL (exit 0)
:openbank-transaction-service:quarkusBuild BUILD SUCCESSFUL (exit 0)
```

JUnit XML totals across 35 report files, read from the XML rather than the console:
`tests=144 failures=0 errors=0 skipped=1`. The single skip is
`TransactionPactProviderVerificationTest`, the broker-sourced Pact class gated on `pactbroker.url`
— the repo's sanctioned pattern, not a boot failure. `test` and `quarkusBuild` both appear in the
executed task list; neither was skipped behind an earlier failure.

**Not verified locally, and worth stating plainly:**

- The `build.gradle.kts` changes (the JUnit timeout, the Gradle task timeout, the `Duration`
  import) were added after that green run, and this machine could not complete a second one — three
  other Gradle daemons from parallel sessions on this box wedged the build on
  `buildLogic.lock` twice. CI is uncontended and is the real check for these. **This PR's own
  `build (openbank-transaction-service)` job is the verification**: it exercises the changed build
  script on the exact module that was hanging.
- **The 45-minute hang itself was not reproduced locally.** It is a CI-environment failure mode —
  a local run of this module is green precisely because the container teardown races differently.
  The log evidence above is what establishes the cause; no local run should be read as evidence
  about it, which is exactly how it was missed the first time.
- I have **not** proven by effect that the 25-minute task timeout fires (that would need a
  deliberately hanging test). It is a stock Gradle `Task.timeout`.

Closes #5940
Refs #5043, #4754, #686, #2320
