### PR TITLE
fix(governance): reflect KMS audit anchors

### DIFF
--- a/openbank-admin-ui/ai-governance-snapshot.json
+++ b/openbank-admin-ui/ai-governance-snapshot.json
@@ -78,7 +78,7 @@
       "id": "D5",
       "title": "AI-attributed, tamper-evident audit",
       "status": "partial",
-      "detail": "Every tool-call decision (agent.mcp.tool_call), tool-execution outcome (agent.mcp.tool_exec) and model completion emits an AuditEvent (actorType=AI_AGENT) with model_id, prompt_hash, policy_decision. Hash-chain live (audit_entries.record_hash/prev_hash, V5) + periodic externally-signed anchors (audit_anchor, V6): GET /api/v1/audit/anchors/verify detects wholesale rewrites; default signer is HMAC-SHA256 with key held outside the audit DB. Remaining: AI-attribution payload fields in the release evidence bundle and the production KMS/cosign-keyed anchor signer (asymmetric, third-party verifiable)."
+      "detail": "Every tool-call decision (agent.mcp.tool_call), tool-execution outcome (agent.mcp.tool_exec) and model completion emits an AuditEvent (actorType=AI_AGENT) with model_id, prompt_hash, policy_decision. Hash-chain live (audit_entries.record_hash/prev_hash, V5) + periodic externally-signed anchors (audit_anchor, V6): GET /api/v1/audit/anchors/verify detects wholesale rewrites. The sandbox deployment requests the AWS KMS asymmetric signer, and the implementation records the immutable KMS key identity with each signature. Remaining: independently attested runtime evidence of captured KMS-signed anchors and AI-attribution payload fields in the release evidence bundle."
     },
     {
       "id": "D6",
@@ -174,11 +174,11 @@
       "Model completions audited (agent.model.complete)",
       "Audit envelope + Kafka pipeline",
       "Hash-chain (record_hash/prev_hash, V5)",
-      "Externally-signed anchors (V6, HMAC-SHA256 key outside DB)"
+      "Externally-signed anchors (V6; AWS KMS signer configured in sandbox)"
     ],
     "planned": [
       "By-actor live query endpoint (audit-service)",
-      "Production KMS/cosign anchor signer (asymmetric, third-party verifiable)",
+      "Independently attested runtime evidence of KMS-signed anchors",
       "ai_attribution populated in evidence bundle",
       "Approval decisions (human_approver, reason)"
     ]
@@ -358,7 +358,7 @@
     "provenance": {
       "curated": {
         "source": "openbank-libs/governance/ai-rollout.yaml",
-        "sha256": "0fa2e67d34cc0ff7"
+        "sha256": "2bd1d114462d2c5f"
       },
       "generatedBy": ".github/scripts/gen-ai-governance-snapshot.py"
     }

--- a/openbank-libs/governance/ai-rollout.yaml
+++ b/openbank-libs/governance/ai-rollout.yaml
@@ -105,10 +105,11 @@ decisions:
       (agent.mcp.tool_exec) and model completion emits an AuditEvent (actorType=AI_AGENT)
       with model_id, prompt_hash, policy_decision. Hash-chain live
       (audit_entries.record_hash/prev_hash, V5) + periodic externally-signed anchors
-      (audit_anchor, V6): GET /api/v1/audit/anchors/verify detects wholesale rewrites;
-      default signer is HMAC-SHA256 with key held outside the audit DB. Remaining:
-      AI-attribution payload fields in the release evidence bundle and the production
-      KMS/cosign-keyed anchor signer (asymmetric, third-party verifiable).
+      (audit_anchor, V6): GET /api/v1/audit/anchors/verify detects wholesale rewrites.
+      The sandbox deployment requests the AWS KMS asymmetric signer, and the implementation
+      records the immutable KMS key identity with each signature. Remaining: independently
+      attested runtime evidence of captured KMS-signed anchors and AI-attribution payload
+      fields in the release evidence bundle.
   - id: D6
     title: Open, model-agnostic stack
     status: partial
@@ -194,9 +195,9 @@ auditTrail:
     - Model completions audited (agent.model.complete)
     - Audit envelope + Kafka pipeline
     - Hash-chain (record_hash/prev_hash, V5)
-    - Externally-signed anchors (V6, HMAC-SHA256 key outside DB)
+    - Externally-signed anchors (V6; AWS KMS signer configured in sandbox)
   planned:
     - By-actor live query endpoint (audit-service)
-    - Production KMS/cosign anchor signer (asymmetric, third-party verifiable)
+    - Independently attested runtime evidence of KMS-signed anchors
     - ai_attribution populated in evidence bundle
     - Approval decisions (human_approver, reason)


### PR DESCRIPTION
## Summary
- replace stale HMAC/pending-KMS D5 wording with the deployed sandbox KMS signer
- retain D5 as partial because `ai_attribution` is still absent from release evidence
- regenerate the derived AIOps governance snapshot

## Verification
- `/opt/homebrew/bin/python3 .github/scripts/gen-ai-governance-snapshot.py --check`
- `/opt/homebrew/bin/python3 .github/scripts/gen-ai-governance-snapshot.py --self-test`
- `npx vitest run src/test/iaops-governance-route.test.ts src/test/derived-artifact-determinism.test.ts`
- `git diff --check`

Closes #6185