### PR TITLE
fix(admin-ui): expose feedback refresh state

### DIFF
--- a/openbank-admin-ui/src/app/feedback/page.tsx
+++ b/openbank-admin-ui/src/app/feedback/page.tsx
@@ -96,7 +96,14 @@ export default function ScreenFeedbackPage() {
         icon={<MessageSquare size={18} aria-hidden="true" />}
         title={cs ? 'Zpětná vazba k obrazovkám' : 'Screen feedback'}
         subtitle={cs ? 'Kvalitativní signály z operátorských obrazovek.' : 'Qualitative signals from operator screens.'}
-        actions={<button className="btn btn-secondary" onClick={() => void load()}>
+        actions={<button
+          type="button"
+          className="btn btn-secondary"
+          onClick={() => void load()}
+          disabled={loading}
+          aria-busy={loading}
+          aria-label={cs ? 'Obnovit zpětnou vazbu k obrazovkám' : 'Refresh screen feedback'}
+        >
           <RefreshCw size={16} aria-hidden="true" /> {cs ? 'Obnovit' : 'Refresh'}
         </button>}
       />

--- a/openbank-admin-ui/src/test/screen-feedback-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/screen-feedback-refresh.guard.test.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('screen feedback refresh contract', () => {
+  it('prevents overlapping loads and exposes localized busy semantics', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/feedback/page.tsx'), 'utf8')
+
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={cs ? 'Obnovit zpětnou vazbu k obrazovkám' : 'Refresh screen feedback'}")
+    expect(source).toContain("fetch('/api/feedback/screen-feedback'")
+  })
+})


### PR DESCRIPTION
## Summary
- prevent overlapping Screen Feedback refresh requests while loading
- expose localized accessible name and busy state
- add a focused source guard

## Verification
- git diff --check

Refs #6172