### PR TITLE
ci(governance): catch the @ConfigProperty shape that stopped audit-service booting

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1702,12 +1702,33 @@ gates:
   # application.yaml is PARSED, not grepped — a comment naming a property must not count as
   # supplying it, or a stale comment marks a service that cannot boot as configured.
   #
-  # ENFORCED: 38 required declarations, 0 findings. Proven by deleting one real key and watching it
-  # name the exact file, property and missing env var.
+  # Extended for #5946 with the two blind spots that let #5844 merge red and sit on main for days
+  # while every check was green:
+  #   * `defaultValue = ""` is NOT a default. Measured — SRCFG00014, "required but it could not be
+  #     found in any config source", thrown by ConfigRecorder.validateConfigProperties at STARTUP.
+  #     The original check skipped any declaration containing the token `defaultValue`.
+  #   * A property DEFINED as empty (`key: ${VAR:}`) into a non-Optional target is SRCFG00040. The
+  #     original check counted a key present in application.yaml as "supplied".
+  #     #5844 had BOTH, so both escape hatches fired on the one shape they most needed to catch.
+  #   * CONFIG_RE required `val`/`var`, so a @Produces METHOD PARAMETER — #5844's exact shape — was
+  #     invisible to it. 487 -> 515 declarations matched after the fix.
+  #
+  # ENFORCED: 46 required declarations, 481 subjects, 0 findings. Negative control (#5946): restore
+  # the pre-#5944 AnchorSignerProducer and it exits 1 naming the file, line, property and the
+  # `${AUDIT_ANCHOR_KMS_KEY_ID:}` value; restore the fix and it exits 0. Neither existing
+  # @ConfigProperty gate goes red against that revert — both were re-run against it to check.
   - id: configproperty-supplied
-    name: "a required @ConfigProperty has a value (SRCFG00040, enforced)"
+    name: "a required @ConfigProperty has a value (SRCFG00014/SRCFG00040, enforced)"
     group: kotlin
     mode: enforced
+    rationale: >-
+      A @ConfigProperty with no resolvable value does not warn, it stops the service booting, and
+      any require()/check() written below it is dead code that never runs. #5844 shipped that shape
+      into openbank-audit-service and left main red for days: path-scoped CI never rebuilt the
+      untouched module, and a module that cannot boot reports its tests as SKIPPED, which reads as
+      a pass. Documented in four places and re-broken anyway — prose is not a control.
+    review_after: '2027-02-21'
+    min_subjects: 240
     selftest: |
       python3 .github/scripts/check-configproperty-supplied.py --self-test
     run: |

--- a/.github/scripts/check-configproperty-supplied.py
+++ b/.github/scripts/check-configproperty-supplied.py
@@ -32,12 +32,59 @@ purely from their Deployment env and say nothing about it in `application.yaml`.
 only the source its author happened to think of reports the author's imagination back as a finding —
 learned expensively on a different gate the same night (#3444/#3453).
 
-WHAT IT DOES NOT CHECK
-----------------------
-That the value is CORRECT, or that a `defaultValue` is a sensible one. An empty-string default is
-still the silent-placeholder shape that #2872 defect 2 actually had — it boots and fails later — but
-flagging every `defaultValue = ""` is a judgement call with no mechanical answer, so it is out of
-scope rather than guessed at.
+WHAT IT ALSO CHECKS (#5946) — "DEFINED AS EMPTY"
+------------------------------------------------
+A second, opposite failure: the property IS supplied, and supplied as nothing.
+
+`application.yaml` lines of the form `key: ${SOME_ENV:}` DEFINE the property as the empty string
+when the env var is unset. SmallRye reads an empty value as no value, so injection into a
+non-`Optional` target throws `SRCFG00040` and **Quarkus never starts** — and any `require()` below
+it is dead code that can never run. That is #5844: `openbank.audit.anchor.kms-key-id` was a plain
+`String` bound to `${AUDIT_ANCHOR_KMS_KEY_ID:}`, `main` was red for days, and path-scoped CI never
+re-ran the module to say so.
+
+The first check above could not see it, and the reason is worth stating because it is the general
+trap: that check SKIPS any declaration carrying a `defaultValue`, and it counts a key present in
+`application.yaml` as "supplied". #5844 had both. A guard whose two escape hatches are exactly the
+two properties of the defect reports it as clean.
+
+AND `defaultValue = ""` IS NOT A DEFAULT — MEASURED, NOT ASSUMED
+----------------------------------------------------------------
+Measured 2026-08-21 with a throwaway `@ConfigProperty(name = "…defined.nowhere", defaultValue = "")`
+injected into a plain `String` inside a real `@QuarkusTest`. Quarkus did not start:
+
+    DeploymentException: Failed to load config value of type class java.lang.String
+      for: openbank.test.issue5946.defined.nowhere
+    Suppressed: SRCFG00014: The config property … is required but it could not be found
+      in any config source
+      at io.quarkus.arc.runtime.ConfigRecorder.validateConfigProperties(ConfigRecorder.java:70)
+
+Two things fall out of that stack trace, and both contradict what #5946 guessed at:
+
+  * An EMPTY `defaultValue` is not a value. SmallRye reports the property as absent from every
+    config source, so `defaultValue = ""` leaves the declaration exactly as required as one with
+    no `defaultValue` at all. The original check skipped anything carrying the token
+    `defaultValue`, which is why the shape sailed through.
+  * `ConfigRecorder.validateConfigProperties` runs at STARTUP, over every injection point at once.
+    `@ApplicationScoped` laziness does not defer it — the bean's scope is irrelevant, the service
+    simply does not boot. #5946 hypothesised a latent first-use failure; it is a boot failure.
+
+So an empty `defaultValue` is treated here as no default, and the "must be supplied somewhere"
+rule above applies to it unchanged.
+
+THE SECOND ARM: DEFINED, AS EMPTY
+---------------------------------
+    property is DEFINED in the service's application.yaml with a value that resolves empty
+    AND the injection target is not Optional<…>          =>  SRCFG00040 at injection
+
+That one is #5844 itself, and it is checked BEFORE the "is it supplied" question, because the
+answer to that question is yes — supplied as nothing.
+
+WHAT IT STILL DOES NOT CHECK
+----------------------------
+That a value is CORRECT, or that a non-empty `defaultValue` is a sensible one. And it cannot see a
+value defined as empty by a source outside this repo (a ConfigMap literal ""), because there is
+nothing here to read.
 
 Usage:  check-configproperty-supplied.py [--enforce] [--self-test]
 """
@@ -59,12 +106,26 @@ COMPONENTS = REPO / "openbank-infra/gitops/components"
 WORKLOADS = {"Deployment", "Rollout", "StatefulSet", "DaemonSet"}
 SKIP_PREFIXES = ("openbank-libs",)
 
+# Known-and-accepted defined-as-empty injections, if any ever need to be. Empty today (#5946
+# closed the only one). An entry needs `path::property  # reason` and is reported when it stops
+# matching, so a debt cannot quietly become permanent.
+EMPTY_BASELINE_FILE = pathlib.Path(__file__).with_name("configproperty-defined-as-empty-baseline.txt")
+EMPTY_BASELINE = {
+    line.split("#", 1)[0].strip()
+    for line in (EMPTY_BASELINE_FILE.read_text().splitlines() if EMPTY_BASELINE_FILE.exists() else [])
+    if line.split("#", 1)[0].strip()
+}
+
 # `@ConfigProperty(name = "x.y")` followed by the declaration whose type decides whether it is
 # required. Kotlin allows annotations and modifiers in between, hence the tolerant middle.
 CONFIG_RE = re.compile(
     r'@ConfigProperty\s*\(\s*name\s*=\s*"([^"]+)"([^)]*)\)'
     r'\s*(?:@\w+(?:\([^)]*\))?\s*)*'
-    r'(?:private\s+|internal\s+|public\s+)?(?:lateinit\s+)?va[lr]\s+\w+\s*:\s*([A-Za-z_][\w.]*)',
+    # `va[lr]` is OPTIONAL on purpose. A @Produces METHOD PARAMETER has neither — and that is
+    # precisely the #5844 shape, so the pattern that required them was structurally unable to see
+    # the defect this gate was extended to catch (#5946). Same class of blind spot as the
+    # `defaultValue` skip below: the check could not express the failure it was named for.
+    r'(?:private\s+|internal\s+|public\s+)?(?:lateinit\s+)?(?:va[lr]\s+)?(\w+)\s*:\s*([A-Za-z_][\w.]*)',
     re.S,
 )
 
@@ -123,16 +184,69 @@ def declared_keys(application_yaml: pathlib.Path) -> set[str]:
     return keys
 
 
-def findings(repo: pathlib.Path = REPO) -> tuple[list[str], int]:
+# `${SOME_ENV:}` — an expansion whose fallback is empty. Unset env var => the property is DEFINED
+# as the empty string, which is not the same as absent and is the whole point of #5946.
+EMPTY_EXPANSION = re.compile(r"^\$\{[A-Za-z_][A-Za-z0-9_]*:\s*\}$")
+
+# Type names that carry absence explicitly. Written as a suffix match because both the imported
+# short form and the fully-qualified `java.util.Optional` occur in this tree — matching only the
+# short form silently reclassifies two correct beans (notification, product-catalog) as defects.
+OPTIONAL_TYPES = ("Optional", "OptionalInt", "OptionalLong", "OptionalDouble")
+
+
+def is_optional(type_name: str) -> bool:
+    return type_name.rsplit(".", 1)[-1] in OPTIONAL_TYPES
+
+
+def empty_valued_keys(application_yaml: pathlib.Path) -> dict[str, str]:
+    """Dotted property names whose value in this file RESOLVES EMPTY.
+
+    Three shapes, all equivalent to SmallRye: a `${VAR:}` expansion with an empty fallback, a
+    literal empty/blank scalar, and a key with no value at all (YAML null).
+
+    Parsed, not grepped, for the same reason as declared_keys: a commented-out line must not count.
+    """
+    if not application_yaml.is_file():
+        return {}
+    try:
+        doc = gatelib.load_yaml(application_yaml) or {}
+    except (yaml.YAMLError, OSError, UnicodeDecodeError):
+        return {}
+
+    def walk(node, prefix=""):
+        if not isinstance(node, dict):
+            return
+        for key, value in node.items():
+            path = f"{prefix}{key}"
+            if value is None:
+                yield path, ""
+            elif isinstance(value, str) and (value.strip() == "" or EMPTY_EXPANSION.match(value.strip())):
+                yield path, value
+            yield from walk(value, path + ".")
+
+    out = dict(walk(doc))
+    # A `%profile` root defines the same property names one level down.
+    for key, value in doc.items():
+        if isinstance(key, str) and key.startswith("%"):
+            out.update(dict(walk(value)))
+    return out
+
+
+def findings(repo: pathlib.Path = REPO) -> tuple[list[str], int, int]:
     env = deployment_env(repo / "openbank-infra/gitops/components")
     out: list[str] = []
     required = 0
+    empty_shaped = 0
+    empty_keys_seen = 0
+    subjects = 0
 
     for main in gatelib.glob(repo, "openbank-*/src/main"):
         service = main.parts[len(repo.parts)]
         if service.startswith(SKIP_PREFIXES):
             continue
         keys = declared_keys(main / "resources/application.yaml")
+        empty = empty_valued_keys(main / "resources/application.yaml")
+        empty_keys_seen += len(empty)
         short = service.removeprefix("openbank-")
         supplied_env: set[str] = set()
         for candidate in (service, short, f"{short}-service"):
@@ -144,13 +258,46 @@ def findings(repo: pathlib.Path = REPO) -> tuple[list[str], int]:
             except OSError:
                 continue
             for match in CONFIG_RE.finditer(text):
-                prop, params, type_name = match.group(1), match.group(2), match.group(3)
-                if "defaultValue" in params or type_name == "Optional":
+                prop, params, type_name = match.group(1), match.group(2), match.group(4)
+                # Every @ConfigProperty declaration this gate looked at, whatever the verdict.
+                # `required` counts only the subset that must be supplied, so it is the wrong
+                # number for a collapse floor: it would keep shrinking as the fleet correctly
+                # adopts Optional and real defaults.
+                subjects += 1
+                rel = source.relative_to(repo)
+                line = text[: match.start()].count("\n") + 1
+
+                # #5946: a value DEFINED as empty outranks any annotation defaultValue, so this
+                # arm is deliberately checked BEFORE the two skips below — those skips are exactly
+                # what hid #5844 for days.
+                if not is_optional(type_name) and prop in empty:
+                    empty_shaped += 1
+                    key = f"{rel}::{prop}"
+                    if key not in EMPTY_BASELINE:
+                        out.append(
+                            f"{rel}:{line}: @ConfigProperty(\"{prop}\") is injected into a "
+                            f"non-Optional {type_name}, and {service}'s application.yaml DEFINES it "
+                            f"as empty (`{empty[prop]}`). SmallRye reads an empty value as no "
+                            f"value, so injection throws SRCFG00040 and the service never starts — "
+                            f"before any require()/check() in the body can run. This is #5844 "
+                            f"exactly. Declare it Optional<{type_name}> and handle absence, or give "
+                            f"the yaml expansion a real non-empty fallback.")
+                    continue
+
+                # An empty defaultValue is NOT a default (SRCFG00014, measured — see the module
+                # docstring), so it must not buy an exemption here.
+                # Only a LITERAL `defaultValue = ""` counts as absent. `defaultValue` given as a
+                # named constant (`DEFAULT_CACHE_TTL_MS`, `OpaSidecarPolicyDecisionPoint.
+                # DEFAULT_BASE_URL`) is a real default and must stay exempt — reading "no string
+                # literal" as "no default" turned three correct beans into findings while this
+                # arm was being written. A constant whose own value is "" is out of reach here
+                # and is left to the boot-time failure it causes.
+                empty_default = re.search(r'defaultValue\s*=\s*""(?!")', params) is not None
+                if (("defaultValue" in params and not empty_default) or is_optional(type_name)):
                     continue
                 required += 1
                 if prop in keys or env_key(prop) in supplied_env:
                     continue
-                rel = source.relative_to(repo)
                 out.append(
                     f"{rel}: @ConfigProperty(\"{prop}\") is required — not Optional, no "
                     f"defaultValue — and no value is supplied. It is absent from "
@@ -161,7 +308,34 @@ def findings(repo: pathlib.Path = REPO) -> tuple[list[str], int]:
     if required == 0:
         out.append("no required @ConfigProperty was found anywhere — the scan is broken. "
                    "Not reporting a clean run on that.")
-    return out, required
+
+    # The empty-value arm reports clean by finding nothing, so it needs its own liveness proof:
+    # if the YAML walk stops recognising `${VAR:}` at all, it goes silent instead of red. Every
+    # service in this tree carries the four Kafka SSL `${...:}` lines, so zero fleet-wide means
+    # the parser broke, not that the fleet is clean.
+    if repo == REPO and empty_keys_seen == 0:
+        out.append("the defined-as-empty scan matched no `${VAR:}` value in any application.yaml. "
+                   "That has never been true of this tree — the YAML walk is broken. Not "
+                   "reporting a clean run on that.")
+
+    # Stale in BOTH directions: a baselined empty-value site that no longer matches is a line
+    # nobody deleted, and a frozen list that cannot shrink quietly becomes permanent.
+    if repo == REPO:
+        live = {
+            f"{s.relative_to(repo)}::{m.group(1)}"
+            for main in gatelib.glob(repo, "openbank-*/src/main")
+            if not main.parts[len(repo.parts)].startswith(SKIP_PREFIXES)
+            for empty_keys in [empty_valued_keys(main / "resources/application.yaml")]
+            for s in gatelib.rglob(main, "*.kt")
+            for m in CONFIG_RE.finditer(gatelib.read_text(s, errors="ignore"))
+            if m.group(1) in empty_keys and not is_optional(m.group(4))
+        }
+        for entry in sorted(EMPTY_BASELINE - live):
+            out.append(f"{entry} is baselined as a known defined-as-empty injection but no longer "
+                       f"matches anything — the defect is gone, delete the line from "
+                       f"{EMPTY_BASELINE_FILE.name}.")
+
+    return out, required, empty_shaped, subjects
 
 
 def selftest() -> int:
@@ -183,8 +357,41 @@ def selftest() -> int:
     comment = "# openbank.demo.url comes from the Deployment env\nquarkus:\n  http:\n    port: 8080\n"
     empty = "quarkus:\n  http:\n    port: 8080\n"
 
+    # #5946 fixtures. `anchor` is the EXACT pre-#5944 AnchorSignerProducer shape, down to the
+    # `defaultValue = ""` and the `${VAR:}` binding — the negative control this gate exists for.
+    anchor = ('@ConfigProperty(name = "openbank.audit.anchor.kms-key-id", defaultValue = "") '
+              'kmsKeyId: String,\n')
+    anchor_fixed = ('@ConfigProperty(name = "openbank.audit.anchor.kms-key-id") '
+                    'kmsKeyId: Optional<String>,\n')
+    anchor_fqn = ('@ConfigProperty(name = "openbank.audit.anchor.kms-key-id") '
+                  'kmsKeyId: java.util.Optional<String>,\n')
+    anchor_yaml = ("openbank:\n  audit:\n    anchor:\n"
+                   "      kms-key-id: ${AUDIT_ANCHOR_KMS_KEY_ID:}\n")
+    anchor_yaml_real = ("openbank:\n  audit:\n    anchor:\n"
+                        "      kms-key-id: ${AUDIT_ANCHOR_KMS_KEY_ID:alias/audit}\n")
+    anchor_yaml_null = "openbank:\n  audit:\n    anchor:\n      kms-key-id:\n"
+    # `defaultValue = ""` is NOT a default — measured, SRCFG00014 (see the module docstring). The
+    # four real customer-edge beans of this shape stay green only because their gitops workload
+    # supplies every one of them as an env var, which the `edge_supplied` fixture stands in for.
+    edge = ('@ConfigProperty(name = "openbank.upstream.client-secret", defaultValue = "")\n'
+            '    var clientSecret: String = ""\n')
+    edge_supplied = "openbank:\n  upstream:\n    client-secret: ${UPSTREAM_SECRET:changeme}\n"
+    const_default = ('@ConfigProperty(name = "opa.url", defaultValue = DEFAULT_BASE_URL)\n'
+                     '    lateinit var opaUrl: String\n')
+
     cases = [
         ("required and supplied", required, supplied, 1, 0),
+        # -- #5946 --
+        ("yaml defines it as empty, target is a plain String — THE #5844 SHAPE",
+         anchor, anchor_yaml, 0, 1),
+        ("same, expressed as a YAML null value", anchor, anchor_yaml_null, 0, 1),
+        ("same property, target made Optional — the #5944 fix", anchor_fixed, anchor_yaml, 0, 0),
+        ("Optional written fully-qualified", anchor_fqn, anchor_yaml, 0, 0),
+        ("plain String, but the expansion has a real fallback", anchor, anchor_yaml_real, 1, 0),
+        # SRCFG00014: an empty defaultValue is not a value, so this is required and unsupplied.
+        ("empty defaultValue and supplied nowhere — the SRCFG00014 shape", edge, empty, 1, 1),
+        ("empty defaultValue but supplied in yaml — must NOT flag", edge, edge_supplied, 1, 0),
+        ("defaultValue given as a named CONSTANT is a real default", const_default, empty, 0, 0),
         ("required and supplied under a profile root", required, profile, 1, 0),
         ("required and NOT supplied — the SRCFG00040 shape", required, empty, 1, 1),
         ("only a COMMENT names it", required, comment, 1, 1),
@@ -195,7 +402,7 @@ def selftest() -> int:
         with tempfile.TemporaryDirectory() as d:
             root = pathlib.Path(d)
             service(root, decl, app_yaml)
-            got, req = findings(root)
+            got, req, _, _ = findings(root)
         if req != want_required:
             print(f"selftest FAIL: {label} — expected {want_required} required property, saw {req}")
             return 1
@@ -206,13 +413,15 @@ def selftest() -> int:
             return 1
 
     with tempfile.TemporaryDirectory() as d:
-        got, req = findings(pathlib.Path(d))
+        got, req, _, _ = findings(pathlib.Path(d))
         if req != 0 or not got:
             print("selftest FAIL: an empty tree did not report that it found nothing.")
             return 1
 
     print(f"selftest OK: {len(cases)} fixture(s) — supplied, profile-scoped, unsupplied, "
-          f"comment-only, defaultValue, Optional, plus the empty-scan guard.")
+          f"comment-only, defaultValue, Optional, the #5844 defined-as-empty shape and its "
+          f"#5944 fix, a YAML null, a real fallback, an FQN Optional, a bare empty "
+          f"defaultValue, plus the empty-scan guard.")
     return 0
 
 
@@ -224,11 +433,14 @@ def main() -> int:
     if args.self_test:
         return selftest()
 
-    found, required = findings()
+    found, required, empty_shaped, subjects = findings()
     for line in found:
         print(("::error::" if args.enforce else "::warning::") + line)
-    print(f"check-configproperty-supplied: {required} required @ConfigProperty declaration(s) — "
+    print(f"check-configproperty-supplied: {required} required @ConfigProperty declaration(s), "
+          f"{empty_shaped} injected from a defined-as-empty yaml value "
+          f"({len(EMPTY_BASELINE)} baselined) — "
           f"{'clean.' if not found else f'{len(found)} finding(s) above.'}")
+    print(f"SUBJECTS={subjects}")
     return 1 if found and args.enforce else 0
 
 

--- a/.github/scripts/check-gate-lifecycle-metadata.py
+++ b/.github/scripts/check-gate-lifecycle-metadata.py
@@ -136,7 +136,6 @@ DEBT = {
     "opa-sidecar-bundle-shape": DEBT_MARKER,
     "kafka-cert-reader-grant": DEBT_MARKER,
     "extension-bean-config": DEBT_MARKER,
-    "configproperty-supplied": DEBT_MARKER,
     "route-exports": DEBT_MARKER,
     "compliance-matrix": DEBT_MARKER,
     "openssf-gold-evidence": DEBT_MARKER,

--- a/.github/scripts/check-gate-subject-floor.py
+++ b/.github/scripts/check-gate-subject-floor.py
@@ -90,7 +90,6 @@ DEBT = {
     "compliance-matrix": DEBT_MARKER,
     "compliance-page-evidence": DEBT_MARKER,
     "configproperty-kotlin-defaults": DEBT_MARKER,
-    "configproperty-supplied": DEBT_MARKER,
     "critical-alert-egress": DEBT_MARKER,
     "db-backup-association-gate": DEBT_MARKER,
     "db-migration-gate": DEBT_MARKER,

--- a/.github/scripts/configproperty-defined-as-empty-baseline.txt
+++ b/.github/scripts/configproperty-defined-as-empty-baseline.txt
@@ -1,0 +1,13 @@
+# Known-and-accepted `@ConfigProperty` injections whose application.yaml value resolves EMPTY
+# (`${VAR:}`, a literal "", or a YAML null) into a NON-Optional target.
+#
+# SmallRye reads an empty value as no value, so each such injection throws SRCFG00040 and the
+# service does not start (#5844 / #5946). There is no good reason for an entry here — the fix is
+# `Optional<...>` or a real fallback — so this file is EMPTY on purpose, and an entry needs a
+# written reason next to it.
+#
+# Format:  <path/to/File.kt>::<property.name>   # why this one is accepted
+#
+# Enforced in BOTH directions by check-configproperty-supplied.py: a new occurrence not listed
+# here fails the gate, and a listed entry that no longer matches anything fails it too, so a debt
+# cannot quietly become permanent by outliving the code it described.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,19 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
 - **Always fast-jar, never uber-jar.** Service Dockerfiles use `-Dquarkus.package.jar.type=fast-jar`
   and COPY `quarkus-app/`; an uber-jar leaves `quarkus-app/` empty → crashlooping pod.
 - **`@ConfigProperty` optional fields must be `Optional<String>`,** not plain `String`, or a missing
-  value throws `SRCFG00040` at boot. Use `Optional<String>` + `defaultValue`.
+  value throws `SRCFG00040` at boot. Use `Optional<String>` + `defaultValue`. **`defaultValue = ""`
+  is NOT a way to make one optional** — measured 2026-08-21, SmallRye answers `SRCFG00014: required
+  but it could not be found in any config source`, so an empty default leaves the property exactly
+  as required as no default at all. Nor does bean scope help: validation happens once at STARTUP in
+  `ConfigRecorder.validateConfigProperties`, over every injection point, so an `@ApplicationScoped`
+  bean's laziness defers nothing and the service simply does not boot. This bullet had existed for
+  months and audit-service shipped the shape anyway (#5844) — prose is not a control, so
+  `check-configproperty-supplied.py` now enforces both halves, plus the sibling case where
+  `application.yaml` DEFINES the value as empty (`key: ${VAR:}`), which no `defaultValue` rescues.
+  Two things made #5844 cost days rather than minutes, and both generalise: a module CI never
+  rebuilt stays red on `main` unseen, and **a service that cannot boot reports its tests as
+  SKIPPED** — that module read `1 failed, 15 skipped` instead of 143 failures, and a skip count
+  scans as a pass. Read the SKIPPED number, not just the failure count.
 - **Kotlin JUnit5 + `runBlocking` silent drop.** `fun foo() = runBlocking { }` infers a non-`Unit`
   return type and JUnit5 ignores the method. Write `fun foo(): Unit = runBlocking { }` or use a
   coroutine test runner.

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/integration/EmptyDefaultConfigPropertyBootIT.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/integration/EmptyDefaultConfigPropertyBootIT.kt
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.customeredge.integration
+
+import com.openbank.customeredge.infrastructure.rest.KeycloakAdminClient
+import com.openbank.customeredge.infrastructure.rest.UpstreamClient
+import com.openbank.customeredge.infrastructure.webauthn.EnrollmentTicketService
+import com.openbank.customeredge.infrastructure.webauthn.WebAuthnKeycloakClient
+import io.quarkus.test.junit.QuarkusTest
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Settles the sibling question #5946 left open, and locks in the invariant the answer produced.
+ *
+ * Four `openbank-customer-edge` properties carry the same shape as the `@ConfigProperty` that
+ * stopped `openbank-audit-service` booting (#5844): a plain, non-`Optional` `String` with
+ * `defaultValue = ""`. #5946 guessed these were safer than the audit-service case because the
+ * beans are `@ApplicationScoped` and therefore lazy, so a failure would land on first use.
+ *
+ * Both halves of that guess are wrong, measured 2026-08-21 with a throwaway
+ * `@ConfigProperty(name = "openbank.test.issue5946.defined.nowhere", defaultValue = "")` on a plain
+ * `String` in this module. Quarkus did not start at all:
+ *
+ * ```
+ * DeploymentException: Failed to load config value of type class java.lang.String
+ *   for: openbank.test.issue5946.defined.nowhere
+ * Suppressed: SRCFG00014: The config property … is required but it could not be found
+ *   in any config source
+ *   at io.quarkus.arc.runtime.ConfigRecorder.validateConfigProperties(ConfigRecorder.java:70)
+ * ```
+ *
+ * So an empty `defaultValue` is not a value — SmallRye reports the property as absent from every
+ * source — and `ConfigRecorder` validates every injection point at STARTUP, which no bean scope
+ * defers. The four below are therefore required properties, and customer-edge boots only because
+ * every one of them is supplied: by `RedpandaRedisTestResource` here, and by ExternalSecrets-backed
+ * env vars on the gitops workload. Drop any one of those and the service does not start.
+ *
+ * That is what this test pins. Each assertion below names the supplied value, so removing a
+ * supplier turns the whole class red — as a boot failure, which is the point of #5946: a module
+ * that cannot start reports its tests as SKIPPED, and a skip count reads like a pass.
+ *
+ * `check-configproperty-supplied.py` enforces the same rule statically across the fleet.
+ *
+ * It has to be a `@QuarkusTest`: the behaviour lives in Arc's config validation, and a unit test
+ * that constructs the bean by hand supplies the very value the framework does not.
+ */
+@QuarkusTest
+class EmptyDefaultConfigPropertyBootIT {
+
+    @Inject
+    lateinit var upstream: UpstreamClient
+
+    @Inject
+    lateinit var keycloakAdmin: KeycloakAdminClient
+
+    @Inject
+    lateinit var webAuthn: WebAuthnKeycloakClient
+
+    @Inject
+    lateinit var enrollmentTickets: EnrollmentTicketService
+
+    @Test
+    fun `the four required secrets are supplied, so the service boots and they inject non-empty`() {
+        // Asserting the supplied VALUE is what makes this non-vacuous: an `isNotNull` or `isEmpty`
+        // assertion would pass just as well against a bean whose @ConfigProperty was never applied.
+        assertThat(upstream.clientSecret).isEqualTo("test-upstream-secret")
+        assertThat(keycloakAdmin.adminClientSecret).isEqualTo("test-keycloak-admin-secret")
+        assertThat(webAuthn.clientSecret).isEqualTo("test-webauthn-kc-client-secret")
+        assertThat(enrollmentTickets.secret).isEqualTo("test-enrollment-ticket-secret")
+    }
+}


### PR DESCRIPTION
Closes #5946. Refs #5844, #5944.

`#5844` shipped a plain-`String` `@ConfigProperty` with `defaultValue = ""`,
`openbank-audit-service` could not boot, and `main` stayed red for days because
path-scoped CI never rebuilt the untouched module. The instance was fixed in #5944.
This is the class.

## What the two existing @ConfigProperty gates catch, and miss

Verified here, not taken on trust — both were run against a working tree with the
pre-#5944 `AnchorSignerProducer` restored:

| gate | verdict vs the reverted producer | why |
|---|---|---|
| `check-configproperty-kotlin-defaults.py` | **exit 0** (`99 baselined, 0 new`) | different shape: a *Kotlin* default on the parameter (`val x: Boolean = false`). #5844 had no Kotlin default. |
| `check-configproperty-supplied.py` (as on `main`) | **exit 0** (`42 required, clean`) | three independent blind spots, below. |

Neither would have gone red. So this extends the second gate rather than adding a
third overlapping one.

### The three blind spots, each measured

1. **`defaultValue = ""` is not a default.** The check skipped any declaration
   containing the token `defaultValue`. Measured with a throwaway
   `@ConfigProperty(name = "openbank.test.issue5946.defined.nowhere", defaultValue = "")`
   on a plain `String` in a real `@QuarkusTest` — Quarkus did not start:

   ```
   DeploymentException: Failed to load config value of type class java.lang.String
     for: openbank.test.issue5946.defined.nowhere
   Suppressed: SRCFG00014: The config property … is required but it could not be
     found in any config source
     at io.quarkus.arc.runtime.ConfigRecorder.validateConfigProperties(ConfigRecorder.java:70)
   ```

   That stack trace also settles the second half of #5946's guess: validation runs at
   **STARTUP**, over every injection point at once. `@ApplicationScoped` laziness
   defers nothing — it is a boot failure, not a latent first-use one.

2. **A property DEFINED as empty.** `application.yaml`'s `kms-key-id: ${AUDIT_ANCHOR_KMS_KEY_ID:}`
   defines the property *as the empty string*, which is SRCFG00040 into a non-`Optional`
   target and which no `defaultValue` rescues. The check counted a key present in
   `application.yaml` as "supplied". #5844 had **both** 1 and 2, so both of the gate's
   escape hatches fired on the one shape it was named for.

3. **`CONFIG_RE` required `val`/`var`,** so a `@Produces` **method parameter** — #5844's
   exact shape — was structurally invisible to it. `487 → 515` declarations matched
   after the fix; strictly a superset.

Only a **literal** `defaultValue = ""` counts as absent. `defaultValue = DEFAULT_CACHE_TTL_MS`
or `= OpaSidecarPolicyDecisionPoint.DEFAULT_BASE_URL` is a real default and stays exempt —
reading "no string literal" as "no default" turned three correct beans (mcp, notification ×2)
into findings while this arm was being written, and that near-miss is recorded in the code.

## Enumeration — two methods, both counts

Subject: `@ConfigProperty` on a non-`Optional` `String` across `openbank-*/src/main/**/*.kt`.

| method | how | no `defaultValue` | `defaultValue = ""` |
|---|---|---|---|
| A | whole-file regex, annotation ∪ following declaration | **119** | **4** |
| B | line-oriented: enumerate every annotation site first, then pair by forward scan | **119** | **4** |

Method B exists to audit A's pairing rather than to repeat it: it counted **532**
`@ConfigProperty` sites and paired **531**, the single unpaired one being
`TrustListKeyResolver`'s `Optional<String>` (correct, and out of subject either way).
The four empty-default hits are exactly the four `openbank-customer-edge` properties
#5946 names, in both methods.

A third pass intersected *yaml values that resolve empty* with *non-`Optional` injection
points*: **0 on `main` today** (#5944 fixed the only one), and 2 near-misses in
notification and product-catalog that are correctly `java.util.Optional` — which is why
the gate matches the Optional type name by suffix, not by the imported short form.

## The four customer-edge properties

They are **real required properties, not latent lazy failures** — and they are **not
defects today**. `EmptyDefaultConfigPropertyBootIT` (new, a real `@QuarkusTest`) boots the
service and pins each one:

```
openbank.upstream.client-secret                 test-upstream-secret
openbank.edge.keycloak-admin-client-secret      test-keycloak-admin-secret
openbank.webauthn.kc-client-secret              test-webauthn-kc-client-secret
openbank.webauthn.enrollment-ticket-secret      test-enrollment-ticket-secret
```

customer-edge boots only because **every one of them is supplied** — by
`RedpandaRedisTestResource` under test, and by ExternalSecrets-backed env vars on the
gitops workload (all four are in `customer-edge.yaml`). Drop any one supplier and the
service does not start. The gate agrees: it now classifies all four as *required*, finds
them supplied via gitops env, and stays green. The test asserts the supplied **values**,
so it is not the vacuous "is not null" it would be otherwise, and removing a supplier
turns the class red.

No fix needed, so none made. What was missing was the measurement and the pin.

## Negative control — read from `$?`, not a pipeline

```
$ python3 .github/scripts/check-configproperty-supplied.py --enforce   # pre-#5944 shape restored
NEGATIVE_CONTROL_EXIT=1
::error::…/AnchorSignerProducer.kt:24: @ConfigProperty("openbank.audit.anchor.kms-key-id")
  is injected into a non-Optional String, and openbank-audit-service's application.yaml
  DEFINES it as empty (`${AUDIT_ANCHOR_KMS_KEY_ID:}`). SmallRye reads an empty value as no
  value, so injection throws SRCFG00040 and the service never starts — before any
  require()/check() in the body can run. This is #5844 exactly. Declare it Optional<String>
  and handle absence, or give the yaml expansion a real non-empty fallback.
check-configproperty-supplied: 46 required, 1 injected from a defined-as-empty yaml value

$ python3 .github/scripts/check-configproperty-supplied.py --enforce   # #5944 fix restored
POSITIVE_CONTROL_EXIT=0
check-configproperty-supplied: 46 required @ConfigProperty declaration(s), 0 injected from a
  defined-as-empty yaml value (0 baselined) — clean.
SUBJECTS=481
```

Baseline staleness, the other direction — adding an entry that matches nothing:

```
STALE_EXIT=1
::error::…AnchorSignerProducer.kt::openbank.audit.anchor.kms-key-id is baselined as a known
  defined-as-empty injection but no longer matches anything — the defect is gone, delete the
  line from configproperty-defined-as-empty-baseline.txt.
```

`--self-test`: **14 fixtures, exit 0**, including the #5844 shape, its #5944 fix, a YAML
null, an FQN `Optional`, a real `${VAR:fallback}`, a constant `defaultValue`, and the
SRCFG00014 empty-default-unsupplied shape. The empty-value arm also carries its own
liveness guard: it reports clean by finding nothing, so it fails outright if it matches no
`${VAR:}` anywhere in the tree — every service here has four Kafka SSL ones, so zero means
the YAML walk broke, not that the fleet is clean.

The baseline file is **empty on purpose** and derived scope, not a hand-kept list: the
subject set comes from the `.kt` sources × each service's `application.yaml`. Stale in both
directions.

## Gate registration

`configproperty-supplied` gains `rationale`, `review_after: 2027-02-21` and
`min_subjects: 240` (481 today), and is removed from the debt lists in both
`check-gate-lifecycle-metadata.py` and `check-gate-subject-floor.py`. It now prints
`SUBJECTS=`, counting **all** declarations examined rather than the required subset —
`required` would shrink as the fleet correctly adopts `Optional`, which is the wrong
direction for a collapse floor.

## The other half of #5946: the invisibility — reported, not built

A guard catches the shape. It does not catch "a service CI never rebuilt is broken on
`main`". Read `services-ci.yml`: the nightly 03:00 full-fleet `:build` **does** rebuild
every module and would have seen this within 24h, and `nightly-health-alert` **does** open
an issue. The gap is one step later — that issue names no module:

> The scheduled full-fleet build failed — a service on `main` no longer compiles or its
> tests are red … **Investigate which module is red in the run** and open a fix PR.

**#5659 is open right now**, refreshed today (2026-08-21), saying exactly that. A human has
to open a 30-way matrix and read it. Meanwhile `main-red-watch.yml`, for push-triggered
runs, already names the failing job *including the service* —
`main is red: Services CI — build (openbank-analytics-sink) / …`. The capability exists in
this repo and is simply not applied to the nightly.

**What it would take:** in `services-ci.yml`'s `nightly-health-alert` `github-script` step,
list the failed matrix jobs in the body/comment, from
`/actions/runs/<id>/attempts/<n>/jobs` — the same attempt-scoped endpoint
`check-main-red-watch.py` R4 already mandates. Small. Not built here: it is a scheduled
workflow that cannot be falsified from a PR branch, and mixing it in would put an
unverifiable change next to a verified one. Worth its own issue.

Separately, and worth stating because it is the reason the redness read as mild: **a module
that cannot boot reports its tests as SKIPPED.** audit-service read `1 failed, 15 skipped`
rather than 143 failures. That is now a bullet in root `CLAUDE.md` — read the SKIPPED count,
not just the failure count. Note this PR's own IT hit exactly that while being written
(`tests=2 failures=1 skipped=1`), which is how the SRCFG00014 evidence above was obtained.

## Verified

- `run-gates.py --group kotlin` — **19/19 PASS**, exit 0 (shards run in the foreground; `--all`
  intermittently returns 0 with empty output, #6068). `registry` 26/26, `lint` 20/20.
- `check-gate-subject-floor.py --enforce` exit 0 · `check-gate-lifecycle-metadata.py --enforce`
  exit 0, 0 overdue.
- `:openbank-customer-edge:test --tests '*EmptyDefaultConfigPropertyBootIT*' ktlintCheck detekt`
  — BUILD SUCCESSFUL; JUnit XML read directly: **`tests=1 failures=0 errors=0 skipped=0`**.

## Not verified

- Not run: the other five gate shards (`api`, `data`, `gitops`, `security`, `supplychain`) —
  nothing here touches their subjects.
- The gate cannot see a value defined as empty by a source outside this repo (a ConfigMap
  literal `""`), and does not evaluate a `defaultValue` given as a named constant whose own
  value is `""`. Both are stated in the module docstring rather than guessed at.
- The `SUBJECTS=481` floor of 240 is the repo's usual "roughly half" convention, not a
  measured collapse threshold.
