### PR TITLE
fix(falco): except CNPG's instance manager, the last of the API-server noise

### DIFF
--- a/openbank-infra/gitops/apps/falco.yaml
+++ b/openbank-infra/gitops/apps/falco.yaml
@@ -221,13 +221,35 @@ spec:
                  and container.name in (user-operator, topic-operator)
                  and proc.pname = "tini")
 
+            # (6) CNPG's INSTANCE manager. (1) already excepts ns `cnpg-system`, which holds
+            # the CNPG *operator* — but the instance manager is a different process that runs
+            # inside every database pod, so it lives in `ledger`, `accounts`,
+            # `security-scanner` and every other namespace that owns a Postgres. Those hold the
+            # business data path and must NOT get a blanket namespace exception, which is why
+            # this is scoped to the binary instead.
+            #
+            # It is the container entrypoint (parent=containerd-shim, command=manager) and its
+            # job is to watch its own Cluster CR through the API server. Measured 2026-08-21
+            # AFTER the earlier tuning landed: 71 events in 6h (~284/day) and 5 of the 5
+            # remaining events in the last hour — i.e. 100% of what this rule still reports.
+            #
+            # SCOPE: the exepath AND the process name. `/controller/manager` is a CNPG-specific
+            # path no other workload in this estate has. Still firing: any OTHER process in a
+            # database pod (postgres itself, a debug shell, anything dropped in) reaching the
+            # API server, which is the case this rule exists for.
+            - macro: openbank_cnpg_instance_manager
+              condition: >
+                (proc.exepath = "/controller/manager"
+                 and proc.name = "manager")
+
             - macro: user_known_contact_k8s_api_server_activities
               condition: >
                 (openbank_controller_namespaces
                  or openbank_kubectl_cronjob_image
                  or openbank_admin_ui_bff
                  or openbank_strimzi_operator
-                 or openbank_strimzi_entity_operator)
+                 or openbank_strimzi_entity_operator
+                 or openbank_cnpg_instance_manager)
               override:
                 condition: replace
 


### PR DESCRIPTION
## What

After #6075's tuning landed, `Contact K8S API Server From Container` still fired **5 times in the last hour** — and all 5 were one source: **CNPG's instance manager**.

Macro (1) already excepts ns `cnpg-system`, which holds the CNPG *operator*. The instance manager is a different process: it runs **inside every database pod**, so it lives in `ledger`, `accounts`, `security-scanner` and every other namespace that owns a Postgres.

Those namespaces hold the business data path and must not get a blanket namespace exception — exactly the reasoning this file already applies to ns `messaging` and ns `admin-ui`. So this is scoped to the binary:

```
proc.exepath = /controller/manager and proc.name = manager
```

It is the container entrypoint (`parent=containerd-shim`, `command=manager`) and its job is to watch its own `Cluster` CR through the API server.

## Measured, not projected

| window | result |
|---|---|
| 6h sample, 100 events | **71 silenced** by this macro |
| last 1h, post-deploy | **5 of 5** — 100% of what the rule still reports |

The other 29 in the 6h sample are Strimzi JVM processes from **before** the tuning deployed (falco pods restarted 07:40 and 11:50); the entity-operator macro covers them and none appear in the last hour. Worth stating explicitly, because a 6h window straddling a rollout is exactly the kind of denominator that makes a fix look partial when it is not.

## Still firing, deliberately

Any **other** process in a database pod — postgres itself, a debug shell, anything dropped in — reaching the API server. `/controller/manager` is a CNPG-specific path no other workload in this estate has, so the exception cannot widen past it.

## Why this matters for #5734

Cumulative effect of this and #6075, measured:

```
before:  ~33,000 events/day
now:     5 in the last hour, and `Drop and execute new binary in container` silent
```

That is the **precondition** for alerting. An alert on an untuned 33k/day ruleset gets muted within a day, which is worse than no alert — and #5734's whole point is that the runtime-security control is currently write-only. Alerting itself still waits on #6032 (the Loki ruler has never loaded a single rule).

Refs #5734
