### PR TITLE
docs: record three observability footguns the audit measured

### DIFF
--- a/openbank-admin-ui/CLAUDE.md
+++ b/openbank-admin-ui/CLAUDE.md
@@ -288,6 +288,25 @@ npx eslint .            # lint
   manifest test enforces it, so a colliding topic caption is fixed by shortening the node label, not
   by dropping the topic.
 
+- **A `standalone` build silently un-instruments OpenTelemetry unless every OTel package is in
+  `serverExternalPackages`.** `@opentelemetry/instrumentation-*` works by PATCHING a module at
+  load time; webpack bundling changes module identity, so the patch lands on webpack's copy and
+  never on the module Next.js actually calls out through. The SDK still starts, installs a global
+  propagator into its own bundled copy of `@opentelemetry/api`, logs nothing wrong — and emits
+  zero spans. Measured on the artifact (#6164): with only `pg` external,
+  `.next/standalone/node_modules/@opentelemetry` held exactly ONE entry (`api`); with the OTel
+  packages listed, 29. **"The SDK failed to start" is the wrong diagnosis** and sends the next
+  reader hunting in the wrong place — with `OTEL_LOG_LEVEL=debug` it starts in BOTH builds, and
+  the only difference is the stack frame: `.next/server/instrumentation.js` (broken) versus
+  `node_modules/@opentelemetry/sdk-node/build/src/sdk.js` (working). The pod is Ready with 0
+  restarts and a clean log either way.
+- **Nothing unauthenticated reaches a backend, so a smoke test cannot prove BFF tracing works.**
+  `src/proxy.ts` sends every path except `/auth`, `/privacy` and `/.well-known/` to login
+  (ADR-0080 P0, post-pentest). Every other route answers 307 before the handler runs, `/privacy`
+  is static, and `/api/auth/*` is served locally — so no outbound `fetch` happens and no span can
+  exist. Verifying tracing end-to-end needs a real operator session; the synthetic journey does
+  not help either, it only GETs `/`.
+
 <!-- BEGIN:nextjs-agent-rules -->
 
 # This is NOT the Next.js you know

--- a/openbank-infra/CLAUDE.md
+++ b/openbank-infra/CLAUDE.md
@@ -332,3 +332,44 @@ out of it (they are path-scoped, not less important — several are live-inciden
   directly.** Only `allow` also applies `hard_denied` / `charter_denied` / `skill_ok` — calling
   `charter_allowed` alone lets a fleet-wide hard-denied tool tier or a charter's own `tools.deny`
   glob silently reach a REST action anyway.
+
+### Prometheus / Loki rules — configured-looking and inert
+
+- **A recording rule's `interval` decides whether its output EXISTS for its consumers, not just
+  how fresh it is.** Prometheus answers an instant query from a 5-minute lookback window, so a
+  group at `interval: 1h` is resolvable for 5 of every 60 minutes — a 1-in-12 duty cycle.
+  `openbank.ai.price-book` ran hourly while `openbank.ai.spend` joined against it every 5m, so 11
+  of every 12 spend evaluations saw no price: `openbank:llm_cost_usd_24h:total` had NO SERIES,
+  `AiFleetDailySpendHigh` (the 25 USD/day ceiling) could not fire, and `AiSpendUnpriced` fired for
+  a model that WAS priced — `unless on (model)` against a stale price series reports everything as
+  unpriced, so the check meant to prove the price book complete was reporting the lookback window
+  instead. Measured at the group's own `lastEvaluation`: 9 series at eval+60s, 0 at eval+600s
+  (#6151). For a `vector(<constant>)` rule the interval is not a cost knob — evaluation is free.
+- **`loki.ruler` is not a chart key; it is `loki.rulerConfig`.** Helm drops unknown keys silently,
+  so a detailed, well-commented ruler block can sit in git while the deployed config has
+  `alertmanager_url` EMPTY and `storage.type: s3` instead of the sidecar's local directory. Three
+  rule ConfigMaps (`falco-runtime`, `endpoint-availability`, `silent-failures`) had never been
+  evaluated — `/prometheus/api/v1/rules` returned `groups: []` — and even a loaded rule would have
+  been delivered nowhere (#6032). Two plausible hypotheses that are NOT the cause, so nobody
+  re-runs them: restarting Loki does not fix it, and the rules volume IS shared with the loki
+  container (the sidecar writes `/rules/fake/*.yaml` and `ls` from either container shows them).
+  **Read `GET /config` on the pod and diff it against the values file** — that is the only probe
+  that distinguishes "configured" from "in effect".
+
+### A gate can run, print a healthy subject count, and have measured nothing
+
+- **A history-dependent gate must state which history it got.** `check-flyway-version-commit-order`
+  needed three attempts, and each intermediate version RAN and returned a confident verdict: first
+  from an empty order map (`origin/main` does not resolve on a PR checkout), then from the wrong
+  history (implicit HEAD is the PR merge commit, so it measured "order including this PR"), then
+  from a truncated one — **the gates shard checks out at `fetch-depth: 1`, and on a shallow repo
+  `git log --diff-filter=A` reports EVERY file as added at the graft point**, so all 355 migrations
+  shared one position, the per-service sort fell through to its version tiebreak, everything looked
+  monotonic and the gate was green. It printed `355 migrations ordered` throughout. Detect
+  shallowness (`git rev-parse --is-shallow-repository`), deepen in place rather than making the
+  whole shard pay `fetch-depth: 0`, pick the LONGEST candidate ref rather than the first that
+  answers, and refuse to report when the history is shorter than the corpus.
+- **Only the both-ways baseline caught all three.** With no violations found, every baselined entry
+  reads as stale, which is the one observable that separates "clean" from "measured nothing". A
+  baseline that can only be checked in the violation direction cannot do this — it is the whole
+  argument for the idiom, and it caught the checker rather than the corpus three times running.


### PR DESCRIPTION
Docs only. No code or config changes.

Per `CLAUDE.md`'s knowledge-capture rule: operational footguns belong in the path-scoped guide, not in a PR nobody re-reads. All three cost real debugging time in the 2026-08-19..21 observability sweep, and all three share one shape — **the thing looks configured and is inert**.

## `openbank-admin-ui/CLAUDE.md`

**A `standalone` build silently un-instruments OpenTelemetry** unless every OTel package is in `serverExternalPackages`. Instrumentation patches modules at load time, so bundling makes the patch land on webpack's copy and never on the module Next.js calls out through.

Includes the measurement (**1 vs 29** packages in `.next/standalone/node_modules/@opentelemetry`) and — explicitly — the diagnosis that is **wrong**: *"the SDK failed to start."* It starts in both builds; only the stack frame differs. Stating the wrong answer is the point, so the next reader does not lose the same hour I did.

**Nothing unauthenticated reaches a backend**, so a smoke test cannot prove BFF tracing works. Worth writing down because the obvious probe returns 307 and reads like a failure *of the tracing*, when it is `proxy.ts` doing its job.

## `openbank-infra/CLAUDE.md`

**A recording rule's `interval` decides whether its output EXISTS for its consumers**, not just how fresh it is. Hourly against a 5m consumer and a 5m lookback is a 1-in-12 duty cycle — it made a 25 USD/day spend ceiling unfirable and made `AiSpendUnpriced` report the lookback window instead of the price book.

**`loki.ruler` is not a chart key** (it is `loki.rulerConfig`). Includes the two hypotheses that are **not** the cause — restarting Loki does not fix it, and the volume *is* shared — so nobody re-runs them, plus the one probe that settles it: `GET /config` diffed against the values file.

**A gate can run, print a healthy subject count, and have measured nothing** — three distinct ways, one being that the gates shard checks out at `fetch-depth: 1` and shallow history reports every file as added at the graft point. Plus why only a both-ways baseline can see any of it: with no violations found, every baselined entry reads as stale, and that is the only observable separating "clean" from "measured nothing".

## Why these three and not more

Each is non-obvious, cost real time, and is invisible to every check you would normally run — the pod is Ready, the rule group is `health=ok`, the gate is green. Findings that were merely *bugs* are in their own PRs; these are the ones where the **investigation** was the expensive part.


## Linked issues

Refs #5628, #5734, #5735, #5736

Docs-only distillation of the 2026-08-19..21 observability audit. Each lesson comes from a defect fixed under one of those issues, but the lesson is the part that outlives the fix:

- Next.js standalone / OTel externals → the tracing work under #5735 (fixed in #6164)
- recording-rule interval vs lookback → #5736 (fixed in #6151)
- `loki.ruler` vs `rulerConfig` → the alerting blocker on #5734 (fixed in #6032)
- gates measuring the wrong history → the Flyway gate built for #5628 (fixed across #5688)
