### PR TITLE
fix(observability): declare subject_period for AiModelNeverSucceeds

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-ai.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-ai.yaml
@@ -355,6 +355,7 @@ spec:
             severity: warning
             team: platform
           annotations:
+            subject_period: continuous
             summary: "Every LLM call to {{ $labels.model }} is failing — not one has succeeded in 6h"
             description: >-
               The gateway is answering and every answer is an error, so this is not an outage of


### PR DESCRIPTION
## What

The \`check-alert-window-vs-subject-period\` gate (#5736, enforced) started failing
fleet-wide: \`AiModelNeverSucceeds\` has a \`[6h]\` range window and no \`subject_period\`
annotation, so the gate can't check the window against its subject.

Every open PR's \`gates (gitops)\` job was failing on this — the gate scans the whole
tree, not just the PR diff, so a single undeclared annotation on \`main\` blocked
everyone downstream (confirmed while investigating unrelated CI failures on #5972,
#6086, #5875, #6192, all with unrelated diffs, all failing on the identical error).

## Fix

\`AiModelNeverSucceeds\` is traffic-driven, not scheduled — matches the shape of
customer-edge's alerts, which already declare \`subject_period: continuous\` for the
same reason. Declared it here too.

## Verification

\`\`\`
$ python3 .github/scripts/check-alert-window-vs-subject-period.py
SUBJECTS=122  # alert rules
check-alert-window-vs-subject-period: 50 windowed alert rule(s); 142 periodic subject(s)...
check-alert-window-vs-subject-period: no findings.
\`\`\`