### PR TITLE
feat(agent): put the content-safety classifier on the operator plane too

### DIFF
--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/AgentChatService.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/AgentChatService.kt
@@ -55,6 +55,8 @@ class AgentChatService {
 
     @Inject lateinit var injectionGuard: PromptInjectionGuard
 
+    @Inject lateinit var contentSafety: AgentContentSafetyGuard
+
     // D7 (ADR-0031): one OTel span per governed run, exported to the existing Tempo backend.
     // Field-injected by Quarkus; defaults to the global tracer (a no-op when no SDK is installed,
     // e.g. in unit tests) so the loop never depends on tracing being wired.
@@ -230,6 +232,28 @@ class AgentChatService {
         // D6 guardrail: scan user-supplied input for known injection phrasings BEFORE the model
         // sees anything. In block mode a hit ends the run here (audited as DENIED); the charter
         // filter + OPA gate below still bound whatever a missed phrasing could reach.
+        // Model-based classifier AFTER the deterministic one, on the same messages: the regex set is
+        // free and cannot be talked out of a match, so it runs first and the network call only
+        // happens for what it lets through. Only the LAST user message is classified — the earlier
+        // turns were classified when they arrived, and re-classifying the whole history would pay
+        // for every turn again on every turn.
+        history.lastOrNull { it.role == ChatRole.USER }?.let { msg ->
+            if (contentSafety.checkUserInput(identity, msg.content)) {
+                return LoopResult(
+                    outcome = ChatOutcome(
+                        reply = UNSAFE_REFUSAL,
+                        model = modelId ?: gateway.defaultModelId(),
+                        toolCalls = emptyList(),
+                    ),
+                    promptHash = AgentRunAuditor.promptHash(
+                        listOf(ChatMessage(ChatRole.SYSTEM, systemPrompt)) + history,
+                    ),
+                    totalTokens = 0,
+                    auditResult = AuditResult.DENIED,
+                    detail = "content_safety",
+                )
+            }
+        }
         history.filter { it.role == ChatRole.USER }.forEach { msg ->
             val detection = injectionGuard.scanUserInput(identity, msg.content)
             if (detection != null && injectionGuard.blocks()) {
@@ -322,6 +346,18 @@ class AgentChatService {
                     log.infof(
                         "D4: proposal detected in assistant reply for agent=%s",
                         ASSISTANT_IDENTITY.agentId,
+                    )
+                }
+                // Output side: an unsafe completion is not predictable from a safe-looking
+                // question, and an assistant that renders unsafe content into an admin screen has
+                // laundered it through a trusted UI. Checked before the reply leaves the loop.
+                if (contentSafety.checkAssistantOutput(identity, finalReply)) {
+                    return LoopResult(
+                        outcome = ChatOutcome(reply = UNSAFE_REFUSAL, model = lastModel, toolCalls = record),
+                        promptHash = promptHash,
+                        totalTokens = totalTokens,
+                        auditResult = AuditResult.DENIED,
+                        detail = "content_safety_output",
                     )
                 }
                 return LoopResult(
@@ -430,6 +466,10 @@ class AgentChatService {
         const val INSTRUMENTATION_NAME = "openbank-agent-service"
         const val RUN_SPAN = "agent.run"
         const val MAX_ITERATIONS = 5
+
+        /** Deliberately says nothing about WHICH rule matched — that detail is in the audit trail. */
+        const val UNSAFE_REFUSAL =
+            "I can't help with that. If you believe this is a mistake, the decision is in the audit trail."
 
         // Kept small to stay well under the free Groq tier's 12k tokens/min budget: a tool round
         // is 2+ completions, each carrying the prompt + tool schemas + (capped) results.

--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/AgentContentSafetyGuard.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/AgentContentSafetyGuard.kt
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.agent.application
+
+import com.openbank.agent.domain.policy.AgentIdentity
+import com.openbank.libs.audit.AuditEvent
+import com.openbank.libs.audit.AuditEventPublisher
+import com.openbank.libs.audit.AuditResult
+import com.openbank.libs.llm.ContentSafetyMetricsPort
+import com.openbank.libs.llm.ContentSafetyPort
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.jboss.logging.Logger
+
+/**
+ * Model-based content safety for the CONTROL-PLANE reasoning loop (ADR-0031 guardrails,
+ * ADR-0265 slice 2) — the same Llama Guard classifier the customer copilot uses, on the operator
+ * side, beside the deterministic [PromptInjectionGuard].
+ *
+ * ## Why this exists at all when the operator is a trusted human
+ *
+ * The trust boundary is not the operator, it is the DATA. Everything a tool returns — a transaction
+ * memo, a merchant name, a proposal title someone typed weeks ago — reaches the model as text, and
+ * the deterministic filter matches phrasings we already know. The classifier is what covers the
+ * ones we do not, and the output side is where an operator-facing surface is most exposed: an
+ * assistant that renders unsafe content into an admin screen has laundered it through a trusted UI.
+ *
+ * ## Posture
+ *
+ * `agent.content-safety.fail-closed` decides what an unreachable classifier means, and defaults to
+ * FALSE here for the same reason as on the help surface: refusing an operator's read-only question
+ * because a classifier is down is a worse outcome than answering it, and the charter tool allow-list,
+ * the OPA gate and the HITL proposal queue all still bound what any answer can cause. Every
+ * unavailable verdict is audited and counted regardless, so the degraded state is legible rather
+ * than assumed — that visibility is the whole reason the verdict is three-valued.
+ */
+@ApplicationScoped
+class AgentContentSafetyGuard(
+    private val safety: ContentSafetyPort,
+    private val auditPublisher: AuditEventPublisher,
+    private val metrics: ContentSafetyMetricsPort,
+    // No Kotlin default on a @ConfigProperty parameter: a defaulted one makes Arc build the bean
+    // through a synthetic constructor and skip config entirely, which for a fail-closed switch
+    // means it could never be turned on.
+    @ConfigProperty(name = "agent.content-safety.fail-closed", defaultValue = "false")
+    private val failClosed: Boolean,
+) {
+
+    private val log = Logger.getLogger(AgentContentSafetyGuard::class.java)
+
+    /** True when the operator's message must not reach the model. */
+    suspend fun checkUserInput(identity: AgentIdentity, text: String): Boolean =
+        check(identity, ContentSafetyPort.SafetyRole.USER, text)
+
+    /** True when the drafted answer must not reach the operator. */
+    suspend fun checkAssistantOutput(identity: AgentIdentity, text: String): Boolean =
+        check(identity, ContentSafetyPort.SafetyRole.ASSISTANT, text)
+
+    private suspend fun check(identity: AgentIdentity, role: ContentSafetyPort.SafetyRole, text: String): Boolean {
+        if (text.isBlank()) return false
+        val verdict = safety.classify(role, text)
+        if (verdict.decision == ContentSafetyPort.Decision.SAFE) return false
+        val blocked = verdict.isBlocking(failClosed)
+
+        log.warnf(
+            "guardrail: content-safety decision=%s agent=%s role=%s categories=%s reason=%s action=%s",
+            verdict.decision,
+            identity.agentId,
+            role,
+            verdict.categories.joinToString(","),
+            verdict.reason,
+            if (blocked) "blocked" else "allowed",
+        )
+        metrics.recordClassification(verdict.model, role.name.lowercase(), verdict.decision.name.lowercase(), blocked)
+        auditPublisher.publish(
+            AuditEvent(
+                actorId = identity.agentId,
+                actorType = "AI_AGENT",
+                operation = "agent.guardrail.content_safety",
+                resourceType = "agent",
+                resourceId = identity.agentId,
+                result = if (blocked) AuditResult.DENIED else AuditResult.SUCCESS,
+                payload = mapOf(
+                    // ADR-0031 D5: every AI-attributed event names the model that acted. Here that
+                    // is the CLASSIFIER, not the chat model — the two are different models and the
+                    // one that produced this verdict is the one an auditor needs.
+                    "model_id" to verdict.model,
+                    "decision" to verdict.decision.name.lowercase(),
+                    "categories" to verdict.categories.joinToString(","),
+                    "reason" to verdict.reason,
+                    "role" to role.name.lowercase(),
+                    "fail_closed" to failClosed.toString(),
+                    "action" to if (blocked) "blocked" else "allowed",
+                ),
+            ),
+        )
+        return blocked
+    }
+}

--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/model/AgentContentSafetyProducer.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/model/AgentContentSafetyProducer.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.agent.infrastructure.model
+
+import com.openbank.libs.llm.ContentSafetyMetricsPort
+import com.openbank.libs.llm.ContentSafetyPort
+import com.openbank.libs.llm.LlamaGuardContentSafetyAdapter
+import com.openbank.libs.llm.LlmCallMetricsPort
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.jboss.logging.Logger
+import java.util.Optional
+
+/**
+ * Builds agent-service's [ContentSafetyPort] — Llama Guard through the in-cluster LiteLLM gateway
+ * (ADR-0174), the same route and the same virtual key the assistant's chat model already uses.
+ *
+ * Produced here rather than in `openbank-libs-runtime`: a `@Produces` in the shared library drags
+ * its dependencies into the Arc type closure of every service that consumes the library, including
+ * the ones that never make an LLM call.
+ *
+ * Disabled by default, and when disabled it produces [ContentSafetyPort.DISABLED] — which reports
+ * `UNAVAILABLE` for every classification, never `SAFE`, so an unwired guardrail shows up in
+ * `openbank_guardrail_classifications{decision="unavailable"}` instead of looking like a clean bill
+ * of health.
+ */
+@ApplicationScoped
+class AgentContentSafetyProducer(
+    private val safetyMetrics: ContentSafetyMetricsPort,
+    private val callMetrics: LlmCallMetricsPort,
+    // No Kotlin defaults on @ConfigProperty parameters — a defaulted one makes Arc build the bean
+    // through a synthetic constructor and skip config entirely, so the guardrail could never be
+    // switched on whatever the environment said.
+    @ConfigProperty(name = "agent.content-safety.enabled", defaultValue = "false")
+    private val enabled: Boolean,
+    // Optional<String>, not String: a missing plain-typed value throws SRCFG00040 at boot.
+    @ConfigProperty(name = "agent.content-safety.endpoint")
+    private val endpoint: Optional<String>,
+    @ConfigProperty(name = "agent.content-safety.model", defaultValue = "meta-llama/llama-guard-4-12b")
+    private val model: String,
+    @ConfigProperty(name = "agent.content-safety.api-key")
+    private val apiKey: Optional<String>,
+) {
+
+    private val log = Logger.getLogger(AgentContentSafetyProducer::class.java)
+
+    @Produces
+    @ApplicationScoped
+    fun contentSafety(): ContentSafetyPort {
+        val url = endpoint.orElse("").trim()
+        if (!enabled || url.isEmpty()) {
+            log.infof(
+                "agent content-safety guardrail DISABLED (enabled=%s, endpoint=%s) — every " +
+                    "classification will report 'unavailable'",
+                enabled,
+                if (url.isEmpty()) "<unset>" else url,
+            )
+            return ContentSafetyPort.DISABLED
+        }
+        log.infof("agent content-safety guardrail active — model=%s via %s", model, url)
+        return LlamaGuardContentSafetyAdapter(
+            baseUrl = url,
+            model = model,
+            apiKey = apiKey.orElse(""),
+            metrics = safetyMetrics,
+            callMetrics = callMetrics,
+        )
+    }
+}

--- a/openbank-agent-service/src/main/resources/application.yaml
+++ b/openbank-agent-service/src/main/resources/application.yaml
@@ -339,6 +339,21 @@ agent:
           - query.payments.readonly
           - query.disputes.readonly
           - query.observability.readonly
+  # Model-based content safety (Llama Guard via the LiteLLM gateway, ADR-0031 guardrails /
+  # ADR-0265). Complements the deterministic filter above; neither replaces the other. Off by
+  # default, and when off every classification reports `unavailable` rather than `safe`, so the
+  # state is visible in openbank_guardrail_classifications{decision="unavailable"} instead of
+  # looking like a clean bill of health.
+  content-safety:
+    enabled: ${AGENT_CONTENT_SAFETY_ENABLED:false}
+    # The in-cluster gateway; the provider key never reaches this pod (ADR-0175).
+    endpoint: ${AGENT_CONTENT_SAFETY_ENDPOINT:}
+    model: ${AGENT_CONTENT_SAFETY_MODEL:meta-llama/llama-guard-4-12b}
+    api-key: ${AGENT_CONTENT_SAFETY_API_KEY:}
+    # What an UNAVAILABLE verdict means on the operator plane. false: refusing an operator's
+    # read-only question because a classifier is down is worse than answering it, and the charter
+    # allow-list, the OPA gate and the HITL queue still bound what any answer can cause.
+    fail-closed: ${AGENT_CONTENT_SAFETY_FAIL_CLOSED:false}
 
 mp:
   messaging:

--- a/openbank-agent-service/src/test/kotlin/com/openbank/agent/application/AgentChatServiceTest.kt
+++ b/openbank-agent-service/src/test/kotlin/com/openbank/agent/application/AgentChatServiceTest.kt
@@ -51,6 +51,13 @@ class AgentChatServiceTest {
         every { it.blocks() } returns true
     }
 
+    // Content safety is a separate governance step with its own test; here it must return a
+    // definite "nothing blocked" so the loop assertions are about the loop.
+    private val passThroughContentSafety = mockk<AgentContentSafetyGuard>().also {
+        coEvery { it.checkUserInput(any(), any()) } returns false
+        coEvery { it.checkAssistantOutput(any(), any()) } returns false
+    }
+
     // Kill switch that never halts (the default for the loop tests; the halt path has its own test).
     private val noHaltKillSwitch = mockk<KillSwitchService>().also {
         every { it.haltReason(any()) } returns null
@@ -100,6 +107,7 @@ class AgentChatServiceTest {
                 this.charterRegistry = mockk { every { allowedCapabilities(any()) } returns emptySet() }
                 this.runAuditor = this@AgentChatServiceTest.runAuditor
                 this.injectionGuard = passThroughGuard
+                this.contentSafety = passThroughContentSafety
                 this.killSwitch = noHaltKillSwitch
             }
 
@@ -154,6 +162,7 @@ class AgentChatServiceTest {
                 this.charterRegistry = mockk { every { allowedCapabilities(any()) } returns emptySet() }
                 this.runAuditor = this@AgentChatServiceTest.runAuditor
                 this.injectionGuard = passThroughGuard
+                this.contentSafety = passThroughContentSafety
                 this.killSwitch = noHaltKillSwitch
             }
 
@@ -188,6 +197,7 @@ class AgentChatServiceTest {
                 this.charterRegistry = mockk { every { allowedCapabilities(any()) } returns emptySet() }
                 this.runAuditor = this@AgentChatServiceTest.runAuditor
                 this.injectionGuard = passThroughGuard
+                this.contentSafety = passThroughContentSafety
                 this.killSwitch = noHaltKillSwitch
             }
 
@@ -223,6 +233,7 @@ class AgentChatServiceTest {
                 this.charterRegistry = mockk { every { allowedCapabilities(any()) } returns emptySet() }
                 this.runAuditor = this@AgentChatServiceTest.runAuditor
                 this.injectionGuard = passThroughGuard
+                this.contentSafety = passThroughContentSafety
                 this.killSwitch = noHaltKillSwitch
             }
 
@@ -259,6 +270,7 @@ class AgentChatServiceTest {
                 this.charterRegistry = mockk { every { allowedCapabilities(any()) } returns emptySet() }
                 this.runAuditor = this@AgentChatServiceTest.runAuditor
                 this.injectionGuard = guard
+                this.contentSafety = passThroughContentSafety
                 this.killSwitch = noHaltKillSwitch
             }
 
@@ -293,6 +305,7 @@ class AgentChatServiceTest {
                 this.charterRegistry = mockk { every { allowedCapabilities(any()) } returns emptySet() }
                 this.runAuditor = this@AgentChatServiceTest.runAuditor
                 this.injectionGuard = passThroughGuard
+                this.contentSafety = passThroughContentSafety
                 this.killSwitch = haltedSwitch
             }
 

--- a/openbank-agent-service/src/test/kotlin/com/openbank/agent/application/AgentChatServiceTracingTest.kt
+++ b/openbank-agent-service/src/test/kotlin/com/openbank/agent/application/AgentChatServiceTracingTest.kt
@@ -72,6 +72,10 @@ class AgentChatServiceTracingTest {
                 coEvery { sanitizeToolResult(any(), any()) } answers { secondArg() }
                 every { blocks() } returns true
             }
+            contentSafety = mockk {
+                coEvery { checkUserInput(any(), any()) } returns false
+                coEvery { checkAssistantOutput(any(), any()) } returns false
+            }
             killSwitch = mockk { every { haltReason(any()) } returns null }
             tracer = tracerProvider.get("test")
         }

--- a/openbank-agent-service/src/test/kotlin/com/openbank/agent/application/AgentContentSafetyGuardTest.kt
+++ b/openbank-agent-service/src/test/kotlin/com/openbank/agent/application/AgentContentSafetyGuardTest.kt
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.agent.application
+
+import com.openbank.agent.domain.policy.AgentIdentity
+import com.openbank.libs.audit.AuditEvent
+import com.openbank.libs.audit.AuditEventPublisher
+import com.openbank.libs.audit.AuditResult
+import com.openbank.libs.llm.ContentSafetyMetricsPort
+import com.openbank.libs.llm.ContentSafetyPort
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * The bank's policy over a classifier verdict on the OPERATOR plane. What is asserted is the pair
+ * that decides whether this control is real: an unreachable classifier must be visible as
+ * `unavailable` (never `safe`), and whether that blocks must follow the surface's declared posture
+ * rather than a default nobody chose.
+ */
+class AgentContentSafetyGuardTest {
+
+    private val identity = AgentIdentity(agentId = "ui-assistant", plane = "control", modelId = "test-chat-model")
+
+    private class RecordingAudit : AuditEventPublisher {
+        val events = mutableListOf<AuditEvent>()
+        override suspend fun publish(event: AuditEvent) {
+            events += event
+        }
+    }
+
+    private class RecordingMetrics : ContentSafetyMetricsPort {
+        data class Call(val model: String, val role: String, val decision: String, val blocked: Boolean)
+
+        val calls = mutableListOf<Call>()
+        override fun recordClassification(model: String, role: String, decision: String, blocked: Boolean) {
+            calls += Call(model, role, decision, blocked)
+        }
+    }
+
+    private fun port(verdict: ContentSafetyPort.SafetyVerdict) = object : ContentSafetyPort {
+        override suspend fun classify(
+            role: ContentSafetyPort.SafetyRole,
+            text: String,
+        ): ContentSafetyPort.SafetyVerdict = verdict
+    }
+
+    private fun guard(
+        verdict: ContentSafetyPort.SafetyVerdict,
+        failClosed: Boolean,
+    ): Triple<AgentContentSafetyGuard, RecordingAudit, RecordingMetrics> {
+        val audit = RecordingAudit()
+        val metrics = RecordingMetrics()
+        return Triple(AgentContentSafetyGuard(port(verdict), audit, metrics, failClosed), audit, metrics)
+    }
+
+    private val guardModel = "meta-llama/llama-guard-4-12b"
+
+    private val safe = ContentSafetyPort.SafetyVerdict(ContentSafetyPort.Decision.SAFE, model = guardModel)
+
+    private fun unsafe(vararg codes: String) =
+        ContentSafetyPort.SafetyVerdict(ContentSafetyPort.Decision.UNSAFE, codes.toList(), guardModel)
+
+    private val unavailable = ContentSafetyPort.SafetyVerdict(
+        ContentSafetyPort.Decision.UNAVAILABLE,
+        model = guardModel,
+        reason = ContentSafetyPort.REASON_TRANSPORT,
+    )
+
+    @Test
+    fun `a safe verdict passes and is not audited`(): Unit = runBlocking {
+        val (g, audit, metrics) = guard(safe, failClosed = false)
+
+        assertThat(g.checkUserInput(identity, "which services are deployed?")).isFalse()
+        // Safe is the overwhelming majority of traffic; auditing it would bury the interesting rows.
+        assertThat(audit.events).isEmpty()
+        assertThat(metrics.calls).isEmpty()
+    }
+
+    @Test
+    fun `an unsafe verdict blocks and is audited as DENIED, naming the CLASSIFIER model`(): Unit = runBlocking {
+        val (g, audit, _) = guard(unsafe("S2"), failClosed = false)
+
+        assertThat(g.checkUserInput(identity, "…")).isTrue()
+        val e = audit.events.single()
+        assertThat(e.result).isEqualTo(AuditResult.DENIED)
+        assertThat(e.operation).isEqualTo("agent.guardrail.content_safety")
+        assertThat(e.actorType).isEqualTo("AI_AGENT")
+        assertThat(e.actorId).isEqualTo("ui-assistant")
+        // ADR-0031 D5, and enforced fleet-wide by AgentAuditAttributionTest: an AI-attributed event
+        // names the model that acted — here the classifier, not the chat model on the identity.
+        assertThat(e.payload["model_id"]).isEqualTo(guardModel)
+        assertThat(e.payload["categories"]).isEqualTo("S2")
+    }
+
+    @Test
+    fun `an unreachable classifier does not block on the operator plane, but is recorded`(): Unit = runBlocking {
+        val (g, audit, metrics) = guard(unavailable, failClosed = false)
+
+        assertThat(g.checkUserInput(identity, "which services are deployed?")).isFalse()
+        assertThat(audit.events.single().result).isEqualTo(AuditResult.SUCCESS)
+        assertThat(audit.events.single().payload["decision"]).isEqualTo("unavailable")
+        assertThat(metrics.calls.single())
+            .isEqualTo(RecordingMetrics.Call(guardModel, "user", "unavailable", false))
+    }
+
+    @Test
+    fun `the same unreachable classifier blocks when the surface declares fail-closed`(): Unit = runBlocking {
+        val (g, audit, metrics) = guard(unavailable, failClosed = true)
+
+        assertThat(g.checkUserInput(identity, "…")).isTrue()
+        assertThat(audit.events.single().result).isEqualTo(AuditResult.DENIED)
+        assertThat(metrics.calls.single().blocked).isTrue()
+    }
+
+    @Test
+    fun `assistant output is classified in the assistant role`(): Unit = runBlocking {
+        val (g, audit, metrics) = guard(unsafe("S9"), failClosed = false)
+
+        assertThat(g.checkAssistantOutput(identity, "…")).isTrue()
+        assertThat(metrics.calls.single().role).isEqualTo("assistant")
+        assertThat(audit.events.single().payload["role"]).isEqualTo("assistant")
+    }
+
+    @Test
+    fun `blank text never reaches the classifier`(): Unit = runBlocking {
+        val (g, audit, metrics) = guard(unsafe("S2"), failClosed = true)
+
+        assertThat(g.checkAssistantOutput(identity, "  ")).isFalse()
+        assertThat(audit.events).isEmpty()
+        assertThat(metrics.calls).isEmpty()
+    }
+
+    @Test
+    fun `the disabled port reports unavailable, so an unwired guardrail is never a clean bill`(): Unit = runBlocking {
+        val audit = RecordingAudit()
+        val metrics = RecordingMetrics()
+        val g = AgentContentSafetyGuard(ContentSafetyPort.DISABLED, audit, metrics, failClosed = false)
+
+        assertThat(g.checkUserInput(identity, "ahoj")).isFalse()
+        assertThat(metrics.calls.single().decision).isEqualTo("unavailable")
+    }
+}

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/ContentSafetyGuard.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/ContentSafetyGuard.kt
@@ -89,11 +89,14 @@ class ContentSafetyGuard(
                 resourceId = customerId,
                 result = if (blocked) AuditResult.DENIED else AuditResult.SUCCESS,
                 payload = mapOf(
+                    // ADR-0031 D5 names this key `model_id` fleet-wide, and agent-service has a
+                    // test that enforces it on every AI_AGENT event. Same rule, same key here —
+                    // and it is the CLASSIFIER's model, not the chat model.
+                    "model_id" to verdict.model,
                     "decision" to verdict.decision.name.lowercase(),
                     "categories" to verdict.categories.joinToString(","),
                     "reason" to verdict.reason,
                     "role" to role.name.lowercase(),
-                    "model" to verdict.model,
                     "fail_closed" to failClosed.toString(),
                     "action" to if (blocked) "blocked" else "allowed",
                 ),

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -109,6 +109,27 @@ spec:
               value: http://litellm.ai-platform.svc:4000/v1
             # LiteLLM virtual key (OpenBao litellm/KEY_AGENT_SERVICE via ESO), not a provider key.
             # Optional so an un-seeded key degrades the chat call instead of CrashLooping the pod.
+            # Model-based content safety on the operator plane (ADR-0265). Same gateway, same
+            # virtual key as the chat model — no second credential and no second egress path.
+            - name: AGENT_CONTENT_SAFETY_ENABLED
+              value: "true"
+            - name: AGENT_CONTENT_SAFETY_ENDPOINT
+              value: http://litellm.ai-platform.svc:4000/v1
+            - name: AGENT_CONTENT_SAFETY_MODEL
+              value: meta-llama/llama-guard-4-12b
+            # fail-closed stays FALSE here, deliberately: refusing an operator's read-only question
+            # because a classifier is unreachable is worse than answering it, and the charter tool
+            # allow-list, the OPA gate and the HITL proposal queue still bound what any answer can
+            # cause. Every unavailable verdict is audited and counted regardless, so this is a
+            # declared posture rather than a silent one.
+            - name: AGENT_CONTENT_SAFETY_FAIL_CLOSED
+              value: "false"
+            - name: AGENT_CONTENT_SAFETY_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: agent-service-secrets
+                  key: AGENT_MODEL_API_KEY
+                  optional: true
             - name: AGENT_MODEL_API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
The guardrail shipped for the customer copilot only. **Measured on the sandbox:** a real admin-UI
assistant turn produced LLM traffic and **no** guardrail classification, because agent-service had
the deterministic injection filter and nothing model-based. That gap is why
`openbank_guardrail_classifications` had no series to read.

## Why the operator plane needs it

The trust boundary is not the operator, it is the **data**. Everything a tool returns — a transaction
memo, a merchant name, a proposal title typed weeks ago — reaches the model as text, and the regex
set only matches phrasings we already know. The **output** side matters more here than on the
customer surface: an assistant that renders unsafe content into an admin screen has laundered it
through a trusted UI.

## Posture, stated rather than defaulted

`fail-closed=false`: refusing an operator's read-only question because the classifier is down is
worse than answering it, and the charter tool allow-list, the OPA gate and the HITL proposal queue
still bound what any answer can cause. Unavailable verdicts are audited and counted either way, so
the degraded state stays legible — that is the entire reason the verdict is three-valued.

Only the **last** user message is classified: earlier turns were classified when they arrived, and
re-classifying the whole history would pay for every turn again on every turn.

## Two things the existing tests caught

- `AgentAuditAttributionTest` rejected the new audit event: ADR-0031 D5 requires `model_id` on every
  `AI_AGENT` event and the payload used `model`. Fixed here **and** in copilot's guard, which had
  the same key and no test to catch it — so this PR closes a live D5 violation on the customer side
  as well.
- The loop tests fail closed on an unset `lateinit` collaborator, so the wiring could not be added
  without every test declaring what the guard should answer. That is the test suite doing its job.

## Verification

`:openbank-agent-service:test` and `:openbank-copilot-service:test` green (run serially — two
concurrent Gradle runs on one machine trip `QuarkusBindException` on the HTTP port). detekt + ktlint
green. `run-gates.py --group kotlin --group gitops --group security`: no failures attributable to
this branch.

Sandbox env is enabled in the same PR, so the metric becomes observable on the next admin-UI turn.

## Linked issues

Refs #5671
