### PR TITLE
feat(audit): make D5 audit anchors independently verifiable offline

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -983,6 +983,8 @@ gates:
     group: security
     mode: enforced
     min_subjects: 10   # 1 acceptance + 7 rejections + 2 distinct UNVERIFIABLE outcomes
+    rationale: "The offline anchor verifier is the only D5 control an auditor can run without trusting the bank, and nothing in CI can exercise it against production data; its rejection paths would otherwise be code that has never run, so a tool whose only observed behaviour is VERIFIED would read as tamper-evidence while being decoration — and the party it misleads is a regulator rather than a developer."
+    review_after: "2027-02-21"
     run: |
       python3 .github/scripts/verify-audit-anchors.py --self-test
 

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -963,6 +963,29 @@ gates:
     run: |
       bash .github/scripts/test-auto-deploy-reconcile-lag.sh
 
+  # Offline audit-anchor verifier self-test (ADR-0031 D5, issue #5838). The gate this
+  # falsifies is not a CI check on the repo — it is the tool a THIRD PARTY runs, on their own
+  # machine, to decide whether OpenBank's audit log was tampered with. Nothing in CI can
+  # exercise it against production data, and that is exactly why its rejection paths need a
+  # home here: a verifier whose only observed behaviour is "VERIFIED" is decoration, and the
+  # party it would mislead is an auditor or a regulator rather than a developer.
+  #
+  # The suite constructs, from a throwaway EC key and no infrastructure, the four tamperings
+  # the anchors exist to catch (altered entry, deleted entry, re-ordered pair, chain gap),
+  # three the anchor row itself must catch (edited row, foreign-key signature, backwards
+  # re-anchor), and — the case this repo has paid for before (PushResult.skipped(), #4348) —
+  # the two ABSENCE cases that must land on their own outcome rather than sharing one with
+  # success: no anchors at all, and an unsigned anchor. One clean range is accepted, because
+  # ten rejections prove nothing if the tool rejects everything.
+  - id: audit-anchor-offline-verifier-unit-test
+    selftest_exempt: "is-a-test-suite — the run: IS the verifier's own --self-test"
+    name: "offline audit-anchor verifier self-test (ADR-0031 D5)"
+    group: security
+    mode: enforced
+    min_subjects: 10   # 1 acceptance + 7 rejections + 2 distinct UNVERIFIABLE outcomes
+    run: |
+      python3 .github/scripts/verify-audit-anchors.py --self-test
+
   # can-i-deploy block classifier unit test (issue #2549). The reconcile probe above
   # decides WHICH stranded services to re-drive; this one decides whether a block that
   # survives the re-drive is a build-queue lag (self-clearing) or a contract regression

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -974,7 +974,7 @@ gates:
   # the anchors exist to catch (altered entry, deleted entry, re-ordered pair, chain gap),
   # three the anchor row itself must catch (edited row, foreign-key signature, backwards
   # re-anchor), and — the case this repo has paid for before (PushResult.skipped(), #4348) —
-  # the two ABSENCE cases that must land on their own outcome rather than sharing one with
+  # the four cases that must land on their own outcome rather than sharing one with
   # success: no anchors at all, and an unsigned anchor. One clean range is accepted, because
   # ten rejections prove nothing if the tool rejects everything.
   - id: audit-anchor-offline-verifier-unit-test
@@ -982,7 +982,7 @@ gates:
     name: "offline audit-anchor verifier self-test (ADR-0031 D5)"
     group: security
     mode: enforced
-    min_subjects: 10   # 1 acceptance + 7 rejections + 2 distinct UNVERIFIABLE outcomes
+    min_subjects: 13   # 2 acceptances + 7 rejections + 4 distinct UNVERIFIABLE outcomes
     rationale: "The offline anchor verifier is the only D5 control an auditor can run without trusting the bank, and nothing in CI can exercise it against production data; its rejection paths would otherwise be code that has never run, so a tool whose only observed behaviour is VERIFIED would read as tamper-evidence while being decoration — and the party it misleads is a regulator rather than a developer."
     review_after: "2027-02-21"
     run: |

--- a/.github/scripts/verify-audit-anchors.py
+++ b/.github/scripts/verify-audit-anchors.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# OFFLINE, THIRD-PARTY AUDIT-ANCHOR VERIFIER (ADR-0031 D5, issue #5838).
+#
+# WHY THIS EXISTS
+#   `GET /api/v1/audit/anchors/verify` is audit-service checking its own database with its own
+#   signer bean. That is a useful self-check and it is NOT independent verification: the one
+#   component whose tampering the anchor exists to detect is the component rendering the verdict.
+#   Anyone who can rewrite `audit_entries` can equally serve a hand-written "INTACT".
+#
+#   This script is the other half. It runs on a laptop with no access to the bank, and takes only:
+#     * an anchor export      (public evidence — the signed checkpoints)
+#     * a public key in PEM   (public by construction; also obtainable straight from AWS KMS
+#                              `GetPublicKey`, which is the point — you need not ask OpenBank)
+#     * optionally an entry export, to check the log actually matches what was attested
+#   It re-implements the canonical forms from first principles rather than importing the
+#   service's own code, so a change to the producer that breaks the contract shows up here as a
+#   rejection rather than being silently mirrored.
+#
+# WHAT IT CAN AND CANNOT ESTABLISH — read this before quoting a green run.
+#   CAN:  that each anchor row is exactly what was signed (digest recomputation);
+#         that the signature is valid under a key the producer does not hold at rest;
+#         that the anchor sequence was not truncated, re-ordered or re-anchored backwards;
+#         and, with --entries, that the exported log reproduces the attested chain head.
+#   CANNOT: prove an anchor EXISTS for a period. A producer that never captured an anchor, or
+#         quietly dropped a range before exporting, presents nothing to reject. Absence of
+#         evidence is reported as UNVERIFIABLE (exit 3), never as VERIFIED. Nor is there a
+#         trusted time source here: `signedAt` is the producer's own claim. An external
+#         timestamping authority / transparency log would close both, and does not exist yet.
+#
+# OUTCOMES ARE FOUR, NOT TWO. A skipped/absent check must never share a result with a passing
+# one (this repo already paid for that with PushResult.skipped(), #4348):
+#   0  VERIFIED     every anchor recomputed, signature-valid, sequence sound
+#   2  TAMPERED     something was rejected — the message names what
+#   3  UNVERIFIABLE nothing to verify, or no key for the recorded key id (HMAC anchors land here:
+#                   a shared secret is by definition not third-party verifiable)
+#   4  INPUT_ERROR  bad arguments or malformed export
+#
+# Usage:
+#   verify-audit-anchors.py --anchors anchors.json --public-key kms-pub.pem [--entries entries.json]
+#   verify-audit-anchors.py --self-test
+
+import argparse
+import base64
+import datetime as dt
+import hashlib
+import json
+import pathlib
+import sys
+
+EXIT_VERIFIED = 0
+EXIT_TAMPERED = 2
+EXIT_UNVERIFIABLE = 3
+EXIT_INPUT_ERROR = 4
+
+GENESIS_HASH = "0" * 64
+
+
+# ── canonical forms, re-implemented from the specification, not imported ──────────────────
+
+def java_instant_to_string(instant: dt.datetime) -> str:
+    """Reproduce java.time.Instant.toString() exactly.
+
+    The chain hash covers `occurredAt.toString()` / `recordedAt.toString()`, so a Python
+    rendering that differs by a single character rejects every honest row. Java prints the
+    fraction in groups of 3, 6 or 9 digits and omits it entirely when zero -- it does NOT
+    zero-pad to a fixed width the way isoformat() does.
+    """
+    instant = instant.astimezone(dt.timezone.utc)
+    micros = instant.microsecond
+    base = instant.strftime("%Y-%m-%dT%H:%M:%S")
+    if micros == 0:
+        return base + "Z"
+    if micros % 1000 == 0:
+        return f"{base}.{micros // 1000:03d}Z"
+    return f"{base}.{micros:06d}Z"
+
+
+def parse_instant(text: str) -> dt.datetime:
+    """Parse an ISO-8601 instant, truncated to microseconds as TIMESTAMPTZ stores it."""
+    cleaned = text.strip().replace("Z", "+00:00")
+    parsed = dt.datetime.fromisoformat(cleaned)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def sha256_hex(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def anchor_digest(last_entry_id, last_record_hash, chained_count, chain_status, signed_at) -> str:
+    """AuditAnchor.digest -- SHA-256 over the pipe-joined attested fields."""
+    canonical = "|".join([
+        last_entry_id or "",
+        last_record_hash or "",
+        str(chained_count),
+        chain_status,
+        str(int(signed_at.timestamp() * 1000)),
+    ])
+    return sha256_hex(canonical)
+
+
+def chain_hash(prev_hash: str, entry: dict) -> str:
+    """AuditRepository.chainHash -- SHA-256 over prev_hash and the evidential fields."""
+    canonical = "|".join([
+        prev_hash,
+        entry["entryId"],
+        entry["eventType"],
+        entry["aggregateType"],
+        entry["aggregateId"],
+        entry.get("actorId") or "",
+        entry.get("actorType") or "",
+        sha256_hex(entry["payload"]),
+        entry["sourceService"],
+        entry.get("correlationId") or "",
+        java_instant_to_string(parse_instant(entry["occurredAt"])),
+        java_instant_to_string(parse_instant(entry["recordedAt"])),
+    ])
+    return sha256_hex(canonical)
+
+
+# ── signature verification (public key only) ──────────────────────────────────────────────
+
+def verify_signature(public_key_pem: str, digest_hex: str, signature_b64: str):
+    """True/False for a decidable answer, None when this key cannot speak to this signature.
+
+    The service signs the ASCII digest string with KMS MessageType.RAW + ECDSA_SHA_256, so KMS
+    hashes it; verification is therefore a plain ECDSA-over-SHA256 of those same ASCII bytes.
+    """
+    try:
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+        from cryptography.exceptions import InvalidSignature
+    except ImportError:  # pragma: no cover - dependency is declared in the runbook
+        return None
+    try:
+        key = serialization.load_pem_public_key(public_key_pem.encode("utf-8"))
+        signature = base64.b64decode(signature_b64, validate=True)
+    except Exception:
+        return False
+    message = digest_hex.encode("utf-8")
+    try:
+        if isinstance(key, ec.EllipticCurvePublicKey):
+            key.verify(signature, message, ec.ECDSA(hashes.SHA256()))
+        elif isinstance(key, rsa.RSAPublicKey):
+            key.verify(signature, message, padding.PKCS1v15(), hashes.SHA256())
+        else:
+            return None
+        return True
+    except InvalidSignature:
+        return False
+    except Exception:
+        return False
+
+
+# ── the verifier ──────────────────────────────────────────────────────────────────────────
+
+class Findings:
+    def __init__(self):
+        self.rejections = []
+        self.unverifiable = []
+        self.verified = 0
+
+    def reject(self, message):
+        self.rejections.append(message)
+
+    def cannot_verify(self, message):
+        self.unverifiable.append(message)
+
+
+def verify_anchor_bundle(anchors, public_key_pem, findings):
+    """Recompute, signature-check and sequence-check every anchor."""
+    ordered = sorted(anchors, key=lambda a: parse_instant(a["signedAt"]))
+    previous = None
+    for anchor in ordered:
+        signed_at = parse_instant(anchor["signedAt"])
+        label = f"anchor signedAt={anchor['signedAt']} count={anchor.get('chainedCount')}"
+
+        recomputed = anchor_digest(
+            anchor.get("lastEntryId"),
+            anchor.get("lastRecordHash"),
+            anchor["chainedCount"],
+            anchor["chainStatus"],
+            signed_at,
+        )
+        if recomputed != anchor["anchorDigest"]:
+            findings.reject(
+                f"ANCHOR DIGEST MISMATCH: {label} -- the stored anchor row was edited after "
+                f"signing (stored {anchor['anchorDigest'][:16]}..., "
+                f"recomputed {recomputed[:16]}...)"
+            )
+            previous = anchor
+            continue
+
+        if anchor.get("chainStatus") != "INTACT":
+            findings.reject(
+                f"ANCHOR ATTESTS A BROKEN CHAIN: {label} -- the producer itself recorded "
+                f"chainStatus={anchor.get('chainStatus')} at capture time"
+            )
+
+        signature = anchor.get("signature")
+        if not signature:
+            findings.cannot_verify(
+                f"UNSIGNED ANCHOR: {label} -- captured with no signature, so it attests nothing "
+                f"a third party can check"
+            )
+        elif not public_key_pem:
+            findings.cannot_verify(f"NO PUBLIC KEY SUPPLIED for keyId={anchor.get('keyId')}: {label}")
+        else:
+            outcome = verify_signature(public_key_pem, recomputed, signature)
+            if outcome is False:
+                findings.reject(
+                    f"INVALID SIGNATURE: {label} keyId={anchor.get('keyId')} -- the signature "
+                    f"does not verify under the supplied public key"
+                )
+            elif outcome is None:
+                findings.cannot_verify(
+                    f"KEY CANNOT VERIFY THIS ANCHOR: {label} keyId={anchor.get('keyId')} -- "
+                    f"symmetric or unsupported key material (an HMAC anchor is not "
+                    f"third-party verifiable by construction)"
+                )
+            else:
+                findings.verified += 1
+
+        if previous is not None:
+            if anchor["chainedCount"] < previous["chainedCount"]:
+                findings.reject(
+                    f"ANCHOR SEQUENCE WENT BACKWARDS: {label} attests {anchor['chainedCount']} "
+                    f"entries after an earlier anchor attested {previous['chainedCount']} -- the "
+                    f"log was truncated or re-anchored over a shortened range"
+                )
+            if parse_instant(anchor["signedAt"]) == parse_instant(previous["signedAt"]) \
+                    and anchor["anchorDigest"] != previous["anchorDigest"]:
+                findings.reject(
+                    f"TWO DIFFERENT ANCHORS AT THE SAME INSTANT: {label} -- a forked history"
+                )
+        previous = anchor
+    return ordered
+
+
+def verify_entries_against_anchors(entries, ordered_anchors, findings):
+    """Recompute the record-hash chain and confirm it reproduces every attested head."""
+    expected_prev = GENESIS_HASH
+    positions = {}
+    for index, entry in enumerate(entries, start=1):
+        entry_id = entry.get("entryId")
+        stored_prev = entry.get("prevHash")
+        stored_record = entry.get("recordHash")
+        if stored_record is None:
+            findings.cannot_verify(
+                f"UNCHAINED ENTRY at position {index} (entryId={entry_id}): written before the "
+                f"V5 hash chain, so it cannot be verified retroactively"
+            )
+            continue
+        if entry.get("hashVersion") is None:
+            findings.cannot_verify(
+                f"LEGACY HASH VERSION at position {index} (entryId={entry_id}): hashed in the "
+                f"pre-#3586 canonical form whose digits the database truncated"
+            )
+            continue
+        if stored_prev != expected_prev:
+            findings.reject(
+                f"CHAIN LINK BROKEN at position {index} (entryId={entry_id}): prevHash "
+                f"{str(stored_prev)[:16]}... does not match the preceding record hash "
+                f"{expected_prev[:16]}... -- an entry was DELETED, RE-ORDERED or INSERTED here"
+            )
+            expected_prev = stored_record
+            positions[entry_id] = (index, stored_record)
+            continue
+        recomputed = chain_hash(stored_prev, entry)
+        if recomputed != stored_record:
+            findings.reject(
+                f"ENTRY ALTERED at position {index} (entryId={entry_id}): recomputed record hash "
+                f"{recomputed[:16]}... does not match the stored {stored_record[:16]}... -- the "
+                f"row's evidential fields were modified after it was written"
+            )
+        expected_prev = stored_record
+        positions[entry_id] = (index, stored_record)
+
+    for anchor in ordered_anchors:
+        attested_id = anchor.get("lastEntryId")
+        if attested_id is None:
+            continue
+        label = f"anchor signedAt={anchor['signedAt']}"
+        if attested_id not in positions:
+            findings.reject(
+                f"ATTESTED HEAD IS MISSING FROM THE LOG: {label} attests entryId={attested_id}, "
+                f"which does not appear in the exported entries -- the attested entry was DELETED"
+            )
+            continue
+        position, record_hash = positions[attested_id]
+        if record_hash != anchor.get("lastRecordHash"):
+            findings.reject(
+                f"ATTESTED HEAD HASH MISMATCH: {label} attests lastRecordHash "
+                f"{str(anchor.get('lastRecordHash'))[:16]}... but the log now holds "
+                f"{record_hash[:16]}... for that entry -- the log was rewritten under the anchor"
+            )
+        if position != anchor.get("chainedCount"):
+            findings.reject(
+                f"CHAIN LENGTH GAP: {label} attests {anchor.get('chainedCount')} chained entries "
+                f"up to entryId={attested_id}, but that entry now sits at position {position} -- "
+                f"{anchor.get('chainedCount') - position} entries are MISSING from the log"
+            )
+
+
+def run(anchors, public_key_pem, entries):
+    findings = Findings()
+    if not anchors:
+        findings.cannot_verify(
+            "NO ANCHORS: the export contains no checkpoints at all. Nothing was attested, so "
+            "nothing can be verified -- this is NOT the same result as a verified log."
+        )
+        return findings, EXIT_UNVERIFIABLE
+    ordered = verify_anchor_bundle(anchors, public_key_pem, findings)
+    if entries is not None:
+        verify_entries_against_anchors(entries, ordered, findings)
+    if findings.rejections:
+        return findings, EXIT_TAMPERED
+    if findings.unverifiable or findings.verified == 0:
+        return findings, EXIT_UNVERIFIABLE
+    return findings, EXIT_VERIFIED
+
+
+def report(findings, code, anchors, entries):
+    verdict = {
+        EXIT_VERIFIED: "VERIFIED",
+        EXIT_TAMPERED: "TAMPERED",
+        EXIT_UNVERIFIABLE: "UNVERIFIABLE",
+    }[code]
+    print(f"verdict: {verdict}")
+    print(f"anchors examined: {len(anchors)}  signature-verified: {findings.verified}")
+    if entries is None:
+        print("entries: NOT SUPPLIED -- the attested heads were not checked against a log. "
+              "Signature validity alone does not establish that the log still matches.")
+    else:
+        print(f"entries examined: {len(entries)}")
+    for message in findings.rejections:
+        print(f"  REJECTED: {message}")
+    for message in findings.unverifiable:
+        print(f"  UNVERIFIABLE: {message}")
+    if code == EXIT_VERIFIED:
+        print("Every anchor recomputed to its stored digest and verified under the supplied "
+              "public key. Note what this does NOT show: that an anchor exists for every period, "
+              "and that signedAt is a trustworthy time (it is the producer's own claim).")
+
+
+# ── self-test: the verifier is only worth what it REJECTS ─────────────────────────────────
+
+def self_test():
+    """Falsify the verifier: it must reject four distinct tamperings and accept a clean log.
+
+    Every case is constructed here from scratch with a throwaway EC key, so the test needs no
+    cluster, no database and no KMS. A verifier that could only ever answer VERIFIED would pass
+    a test that only fed it good data -- so the good case is one of six, not the whole suite.
+    """
+    try:
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import ec
+    except ImportError:
+        print("SELF-TEST CANNOT RUN: python 'cryptography' is not installed.", file=sys.stderr)
+        return EXIT_INPUT_ERROR
+
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("utf-8")
+
+    def make_entries(count):
+        built = []
+        prev = GENESIS_HASH
+        for i in range(count):
+            entry = {
+                "entryId": f"00000000-0000-0000-0000-00000000000{i}",
+                "eventType": "payment.initiated",
+                "aggregateType": "Payment",
+                "aggregateId": f"PMT-{i}",
+                "actorId": "operator-1",
+                "actorType": "HUMAN",
+                "payload": json.dumps({"amount": 100 + i}),
+                "sourceService": "openbank-payment-service",
+                "correlationId": f"corr-{i}",
+                "occurredAt": f"2026-08-21T10:0{i}:00Z",
+                "recordedAt": f"2026-08-21T10:0{i}:01Z",
+                "prevHash": prev,
+                "hashVersion": 1,
+            }
+            entry["recordHash"] = chain_hash(prev, entry)
+            prev = entry["recordHash"]
+            built.append(entry)
+        return built
+
+    def make_anchor(entries):
+        head = entries[-1]
+        signed_at = parse_instant("2026-08-21T11:00:00Z")
+        digest = anchor_digest(head["entryId"], head["recordHash"], len(entries), "INTACT", signed_at)
+        signature = private_key.sign(digest.encode("utf-8"), ec.ECDSA(hashes.SHA256()))
+        return {
+            "lastEntryId": head["entryId"],
+            "lastRecordHash": head["recordHash"],
+            "chainedCount": len(entries),
+            "chainStatus": "INTACT",
+            "anchorDigest": digest,
+            "signature": base64.b64encode(signature).decode("ascii"),
+            "keyId": "arn:aws:kms:eu-north-1:000000000000:key/self-test",
+            "signedAt": "2026-08-21T11:00:00Z",
+        }
+
+    failures = []
+    cases = 0
+
+    def expect(name, entries, anchors, want_code, want_phrase):
+        nonlocal cases
+        cases += 1
+        findings, code = run(anchors, pem, entries)
+        messages = " | ".join(findings.rejections + findings.unverifiable)
+        if code != want_code:
+            failures.append(f"{name}: expected exit {want_code}, got {code} ({messages})")
+        elif want_phrase and want_phrase not in messages:
+            failures.append(f"{name}: expected a message naming '{want_phrase}', got: {messages}")
+        else:
+            print(f"  ok  {name}: exit {code}"
+                  + (f" -- {want_phrase}" if want_phrase else " -- accepted"))
+
+    # 1. the control: an untampered range must be ACCEPTED, or every rejection below is vacuous.
+    clean = make_entries(4)
+    expect("clean range is accepted", clean, [make_anchor(clean)], EXIT_VERIFIED, "")
+
+    # 2. an ALTERED entry -- the classic in-place edit the DB rules silently allow to no-op.
+    altered = json.loads(json.dumps(clean))
+    anchor_for_altered = make_anchor(clean)
+    altered[1]["payload"] = json.dumps({"amount": 999999})
+    expect("altered entry is rejected", altered, [anchor_for_altered],
+           EXIT_TAMPERED, "ENTRY ALTERED")
+
+    # 3. a DELETED entry -- the count no longer reaches the attested head.
+    deleted = json.loads(json.dumps(clean))
+    del deleted[1]
+    expect("deleted entry is rejected", deleted, [make_anchor(clean)],
+           EXIT_TAMPERED, "CHAIN LINK BROKEN")
+
+    # 4. a RE-ORDERED pair -- both rows are individually valid; only the links disagree.
+    reordered = json.loads(json.dumps(clean))
+    reordered[1], reordered[2] = reordered[2], reordered[1]
+    expect("re-ordered pair is rejected", reordered, [make_anchor(clean)],
+           EXIT_TAMPERED, "CHAIN LINK BROKEN")
+
+    # 5. a GAP -- a self-consistent shorter log that an internal walk alone would call INTACT.
+    truncated = make_entries(2)
+    gap_anchor = make_anchor(clean)
+    expect("gap in the chain is rejected", truncated, [gap_anchor],
+           EXIT_TAMPERED, "ATTESTED HEAD IS MISSING FROM THE LOG")
+
+    # 6. an EDITED ANCHOR ROW -- digest recomputation catches it before any signature check.
+    edited = make_anchor(clean)
+    edited["chainedCount"] = 99
+    expect("edited anchor row is rejected", clean, [edited],
+           EXIT_TAMPERED, "ANCHOR DIGEST MISMATCH")
+
+    # 7. a FORGED SIGNATURE under a foreign key.
+    forged = make_anchor(clean)
+    other = ec.generate_private_key(ec.SECP256R1())
+    forged["signature"] = base64.b64encode(
+        other.sign(forged["anchorDigest"].encode("utf-8"), ec.ECDSA(hashes.SHA256()))
+    ).decode("ascii")
+    expect("foreign-key signature is rejected", clean, [forged],
+           EXIT_TAMPERED, "INVALID SIGNATURE")
+
+    # 8. NO ANCHORS must be its own outcome, never a pass (the PushResult.skipped() lesson).
+    expect("absent anchors are UNVERIFIABLE, not verified", clean, [],
+           EXIT_UNVERIFIABLE, "NO ANCHORS")
+
+    # 9. an UNSIGNED anchor is likewise not a verification.
+    unsigned = make_anchor(clean)
+    unsigned["signature"] = None
+    expect("unsigned anchor is UNVERIFIABLE", clean, [unsigned],
+           EXIT_UNVERIFIABLE, "UNSIGNED ANCHOR")
+
+    # 10. an anchor that went BACKWARDS -- a re-anchor over a shortened range.
+    long_anchor = make_anchor(clean)
+    short = make_entries(2)
+    short_anchor = make_anchor(short)
+    short_anchor["signedAt"] = "2026-08-21T12:00:00Z"
+    signed_at = parse_instant(short_anchor["signedAt"])
+    short_anchor["anchorDigest"] = anchor_digest(
+        short_anchor["lastEntryId"], short_anchor["lastRecordHash"], 2, "INTACT", signed_at)
+    short_anchor["signature"] = base64.b64encode(
+        private_key.sign(short_anchor["anchorDigest"].encode("utf-8"), ec.ECDSA(hashes.SHA256()))
+    ).decode("ascii")
+    expect("backwards re-anchor is rejected", None, [long_anchor, short_anchor],
+           EXIT_TAMPERED, "ANCHOR SEQUENCE WENT BACKWARDS")
+
+    if failures:
+        print("\nSELF-TEST FAILED:", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+    # The runner checks this against gates.yaml `min_subjects`, so a suite that silently
+    # stopped constructing cases cannot read as a pass on the strength of the ones left.
+    print(f"SUBJECTS={cases}")
+    print(f"\nself-test: {cases}/{cases} cases behaved as specified "
+          "(1 acceptance, 7 rejections, 2 distinct UNVERIFIABLE outcomes)")
+    return 0
+
+
+def load_json(path, what):
+    try:
+        return json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"cannot read {what} from {path}: {exc}", file=sys.stderr)
+        sys.exit(EXIT_INPUT_ERROR)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--anchors", help="anchor export from GET /api/v1/audit/anchors")
+    parser.add_argument("--public-key", help="PEM public key (KMS GetPublicKey)")
+    parser.add_argument("--entries", help="optional audit-entry export, to check attested heads")
+    parser.add_argument("--self-test", action="store_true", help="falsify this verifier")
+    args = parser.parse_args()
+
+    if args.self_test:
+        sys.exit(self_test())
+    if not args.anchors:
+        print("--anchors is required (or use --self-test)", file=sys.stderr)
+        sys.exit(EXIT_INPUT_ERROR)
+
+    anchors = load_json(args.anchors, "anchor export")
+    if isinstance(anchors, dict):
+        anchors = anchors.get("anchors", [])
+    if not isinstance(anchors, list):
+        print("anchor export must be a JSON array of anchors", file=sys.stderr)
+        sys.exit(EXIT_INPUT_ERROR)
+
+    entries = None
+    if args.entries:
+        entries = load_json(args.entries, "entry export")
+        if isinstance(entries, dict):
+            entries = entries.get("entries", [])
+        if not isinstance(entries, list):
+            print("entry export must be a JSON array of entries", file=sys.stderr)
+            sys.exit(EXIT_INPUT_ERROR)
+
+    public_key_pem = None
+    if args.public_key:
+        try:
+            public_key_pem = pathlib.Path(args.public_key).read_text(encoding="utf-8")
+        except Exception as exc:
+            print(f"cannot read public key from {args.public_key}: {exc}", file=sys.stderr)
+            sys.exit(EXIT_INPUT_ERROR)
+
+    findings, code = run(anchors, public_key_pem, entries)
+    report(findings, code, anchors, entries)
+    sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/verify-audit-anchors.py
+++ b/.github/scripts/verify-audit-anchors.py
@@ -171,7 +171,21 @@ class Findings:
         self.unverifiable.append(message)
 
 
-def verify_anchor_bundle(anchors, public_key_pem, findings):
+def is_symmetric_key_id(key_id: str) -> bool:
+    """True when the recorded key id names a shared secret rather than a key pair.
+
+    `LocalHmacAnchorSigner` records the fixed literal `local-hmac-sha256`; an asymmetric anchor
+    records the immutable KMS key id (an `arn:aws:kms:...` / `key/...` reference) that `Sign`
+    returned. The distinction has to be drawn BEFORE verification is attempted, because an HMAC
+    signature fed to an ECDSA verify is indistinguishable from a forgery -- and reporting the
+    platform's whole pre-cutover history as forged is a far more damaging error than declining
+    to rule on it.
+    """
+    lowered = key_id.strip().lower()
+    return lowered.startswith("local-") or "hmac" in lowered
+
+
+def verify_anchor_bundle(anchors, public_key_pem, findings, public_key_id=None):
     """Recompute, signature-check and sequence-check every anchor."""
     ordered = sorted(anchors, key=lambda a: parse_instant(a["signedAt"]))
     previous = None
@@ -202,25 +216,41 @@ def verify_anchor_bundle(anchors, public_key_pem, findings):
             )
 
         signature = anchor.get("signature")
+        key_id = anchor.get("keyId") or ""
         if not signature:
             findings.cannot_verify(
                 f"UNSIGNED ANCHOR: {label} -- captured with no signature, so it attests nothing "
                 f"a third party can check"
             )
+        elif is_symmetric_key_id(key_id):
+            # NOT a rejection. A symmetric key cannot produce a signature any public key can
+            # check, so this anchor is outside what a third party can decide -- calling it
+            # TAMPERED would be a false accusation, and on this platform it would be levelled at
+            # every anchor captured before the KMS cutover.
+            findings.cannot_verify(
+                f"SYMMETRIC (HMAC) ANCHOR: {label} keyId={key_id} -- signed with a shared "
+                f"secret, so it is not third-party verifiable by construction. Only the "
+                f"producer can check it, which is precisely what an anchor must not require."
+            )
+        elif public_key_id and key_id != public_key_id:
+            findings.cannot_verify(
+                f"KEY GENERATION MISMATCH: {label} was signed by keyId={key_id}, but the "
+                f"supplied public key is for {public_key_id} -- fetch that generation's key "
+                f"before drawing any conclusion about this anchor."
+            )
         elif not public_key_pem:
-            findings.cannot_verify(f"NO PUBLIC KEY SUPPLIED for keyId={anchor.get('keyId')}: {label}")
+            findings.cannot_verify(f"NO PUBLIC KEY SUPPLIED for keyId={key_id}: {label}")
         else:
             outcome = verify_signature(public_key_pem, recomputed, signature)
             if outcome is False:
                 findings.reject(
-                    f"INVALID SIGNATURE: {label} keyId={anchor.get('keyId')} -- the signature "
-                    f"does not verify under the supplied public key"
+                    f"INVALID SIGNATURE: {label} keyId={key_id} -- the signature does not "
+                    f"verify under the public key recorded for that same key id"
                 )
             elif outcome is None:
                 findings.cannot_verify(
-                    f"KEY CANNOT VERIFY THIS ANCHOR: {label} keyId={anchor.get('keyId')} -- "
-                    f"symmetric or unsupported key material (an HMAC anchor is not "
-                    f"third-party verifiable by construction)"
+                    f"KEY CANNOT VERIFY THIS ANCHOR: {label} keyId={key_id} -- unsupported "
+                    f"key material, or python 'cryptography' is not installed"
                 )
             else:
                 findings.verified += 1
@@ -306,7 +336,7 @@ def verify_entries_against_anchors(entries, ordered_anchors, findings):
             )
 
 
-def run(anchors, public_key_pem, entries):
+def run(anchors, public_key_pem, entries, public_key_id=None):
     findings = Findings()
     if not anchors:
         findings.cannot_verify(
@@ -314,7 +344,7 @@ def run(anchors, public_key_pem, entries):
             "nothing can be verified -- this is NOT the same result as a verified log."
         )
         return findings, EXIT_UNVERIFIABLE
-    ordered = verify_anchor_bundle(anchors, public_key_pem, findings)
+    ordered = verify_anchor_bundle(anchors, public_key_pem, findings, public_key_id)
     if entries is not None:
         verify_entries_against_anchors(entries, ordered, findings)
     if findings.rejections:
@@ -493,6 +523,34 @@ def self_test():
     expect("backwards re-anchor is rejected", None, [long_anchor, short_anchor],
            EXIT_TAMPERED, "ANCHOR SEQUENCE WENT BACKWARDS")
 
+    # 11. an HMAC anchor must be UNVERIFIABLE, NOT tampered. Regression test for a real defect:
+    # the first cut of this tool fed the HMAC signature to an ECDSA verify, which of course
+    # failed, and reported all 1186 pre-cutover production anchors as forged. A false accusation
+    # of tampering is the most expensive wrong answer this tool can give.
+    hmac_anchor = make_anchor(clean)
+    hmac_anchor["keyId"] = "local-hmac-sha256"
+    hmac_anchor["signature"] = base64.b64encode(b"an-hmac-tag-not-an-ecdsa-signature").decode("ascii")
+    expect("HMAC anchor is UNVERIFIABLE, not tampered", clean, [hmac_anchor],
+           EXIT_UNVERIFIABLE, "SYMMETRIC (HMAC) ANCHOR")
+
+    # 12. a key for a DIFFERENT generation must likewise decline rather than accuse.
+    other_generation = make_anchor(clean)
+    other_generation["keyId"] = "arn:aws:kms:eu-north-1:000000000000:key/some-other-generation"
+    findings, code = run([other_generation], pem, None,
+                         "arn:aws:kms:eu-north-1:000000000000:key/self-test")
+    cases += 1
+    messages = " | ".join(findings.rejections + findings.unverifiable)
+    if code != EXIT_UNVERIFIABLE or "KEY GENERATION MISMATCH" not in messages:
+        failures.append(f"key-generation mismatch: expected UNVERIFIABLE, got {code} ({messages})")
+    else:
+        print("  ok  wrong key generation is UNVERIFIABLE, not tampered: "
+              f"exit {code} -- KEY GENERATION MISMATCH")
+
+    # 13. ...but the matching generation must still VERIFY, or 12 passes by refusing everything.
+    matching = make_anchor(clean)
+    matching["keyId"] = "arn:aws:kms:eu-north-1:000000000000:key/self-test"
+    expect("matching key generation still verifies", clean, [matching], EXIT_VERIFIED, "")
+
     if failures:
         print("\nSELF-TEST FAILED:", file=sys.stderr)
         for failure in failures:
@@ -502,7 +560,7 @@ def self_test():
     # stopped constructing cases cannot read as a pass on the strength of the ones left.
     print(f"SUBJECTS={cases}")
     print(f"\nself-test: {cases}/{cases} cases behaved as specified "
-          "(1 acceptance, 7 rejections, 2 distinct UNVERIFIABLE outcomes)")
+          "(2 acceptances, 7 rejections, 4 distinct UNVERIFIABLE outcomes)")
     return 0
 
 
@@ -518,6 +576,9 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--anchors", help="anchor export from GET /api/v1/audit/anchors")
     parser.add_argument("--public-key", help="PEM public key (KMS GetPublicKey)")
+    parser.add_argument("--public-key-id",
+                        help="key id the --public-key belongs to; anchors signed by any other "
+                             "generation are reported UNVERIFIABLE rather than invalid")
     parser.add_argument("--entries", help="optional audit-entry export, to check attested heads")
     parser.add_argument("--self-test", action="store_true", help="falsify this verifier")
     args = parser.parse_args()
@@ -552,7 +613,7 @@ def main():
             print(f"cannot read public key from {args.public_key}: {exc}", file=sys.stderr)
             sys.exit(EXIT_INPUT_ERROR)
 
-    findings, code = run(anchors, public_key_pem, entries)
+    findings, code = run(anchors, public_key_pem, entries, args.public_key_id)
     report(findings, code, anchors, entries)
     sys.exit(code)
 

--- a/docs/adr/0031-ai-agent-governance-and-operations.md
+++ b/docs/adr/0031-ai-agent-governance-and-operations.md
@@ -20,7 +20,25 @@ summary: "AI agents run as least-privilege workloads declared in agents.yaml, pa
   - `agent.model.complete` (`ModelGateway`): captures `model_id`, `model_version`, `prompt_hash` — ✅
   - `agent.run` (`AgentRunAuditor`): captures `model_id`, `prompt_hash`, `tool_calls[]` — ✅
   - `agent.mcp.tool_call` (`AgentPolicyGate`): captures `policy_decision` (ALLOW/DENY) — ✅; `model_id` NOT YET captured — fix in flight on branch `feat/agent-charter-model-id` (issue #3667; `prompt_hash` and `tool_calls` are architecturally N/A at the gate — the gate runs before any LLM call)
-  - Production KMS/cosign-keyed anchor signer (asymmetric, third-party-verifiable) — ⬜ Planned
+  - Production KMS/cosign-keyed anchor signer (asymmetric) — 🟢 Built. `AwsKmsAnchorSigner`
+    (ECC_NIST_P256, ECDSA_SHA_256) under Pod Identity holding only Sign/Verify/GetPublicKey;
+    `AUDIT_ANCHOR_SIGNING_REQUIRED=true` in gitops, so a signer failure aborts capture rather
+    than storing an unsigned row that would later read as a checkpoint.
+  - Offline third-party verification — 🟢 Built (issue #5838).
+    `.github/scripts/verify-audit-anchors.py` recomputes each anchor digest and checks its
+    signature from **public material only**, importing no OpenBank code; both canonical forms are
+    pinned to shared test vectors from either side (`OfflineVerifierConformanceTest` in Kotlin,
+    `--self-test` in Python). See runbook 0014. `GET /api/v1/audit/anchors/verify` is explicitly
+    NOT this control: it is the suspect component grading itself against the very database whose
+    tampering the anchor exists to detect.
+  - **D5 stays 🟡 Partial, and the public control score does not advance.** Two gaps are
+    structural, not backlog: (a) the verifier can reject a forged anchor but cannot reject an
+    ABSENT one — a period never anchored, or a range dropped before export, presents nothing to
+    reject, so completeness rests on reading the capture cadence, not on the signature; and
+    (b) `signedAt` is the producer's own claim, so a backdated history signed with a live key
+    still verifies. Closing either needs an external RFC 3161 timestamping authority or a public
+    transparency log — ⬜ Planned, neither exists in this platform today. Describing what ships
+    here as full independent verification would overstate it.
 - **D6 (technology stack)** — See D6 section; amended 2026-08-03 (issue #3676).
 - **D8 (AGPL agent-runtime public repo)** — ⬜ Planned (issue JiRaska/open-bank#224).
 

--- a/docs/runbooks/0014-independent-audit-anchor-verification.md
+++ b/docs/runbooks/0014-independent-audit-anchor-verification.md
@@ -1,0 +1,143 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+-->
+
+# Runbook 0014 — Independently verifying the audit anchors (ADR-0031 D5)
+
+**Audience:** an external auditor, a regulator, or an incident responder who must decide whether
+OpenBank's audit log was tampered with — **without taking OpenBank's word for it**.
+
+**Issue:** #5838. **Tool:** `.github/scripts/verify-audit-anchors.py`.
+
+---
+
+## 1. Why `GET /api/v1/audit/anchors/verify` is not the answer
+
+audit-service already exposes an endpoint that walks the hash chain, re-checks every anchor
+signature and returns `INTACT`/`BROKEN`. It is a genuinely useful operational control and it is
+**not independent verification**, for one structural reason:
+
+> The component rendering the verdict is the component whose tampering the anchor exists to detect.
+
+Anyone able to rewrite `audit_entries` is equally able to serve a hand-written `INTACT`, and the
+endpoint reads the same database and uses the same signer bean. Its green is evidence about a
+*healthy* system, and says nothing under the threat model that motivated anchoring in the first
+place. The same applies to `GET /api/v1/audit/integrity`: an attacker who rewrites every row
+recomputes a self-consistent chain, which is precisely the gap anchors were added to close.
+
+So the verification has to be done **outside**, on public material, by code that is not ours.
+
+## 2. What the anchor actually is
+
+- A row in `audit_anchor` (migration `V6`), captured hourly by `AuditAnchorService.captureScheduled`.
+- It attests a **checkpoint over the chain head**: `lastEntryId`, `lastRecordHash`,
+  `chainedCount`, `chainStatus`, `signedAt`.
+- `anchorDigest` = SHA-256 over those five fields pipe-joined (`AuditAnchor.digest`).
+- `signature` = that digest signed by an **asymmetric AWS KMS `ECC_NIST_P256` key**
+  (`SigningAlgorithmSpec.ECDSA_SHA_256`, `MessageType.RAW`), under the audit-service Pod Identity,
+  which holds only `Sign` / `Verify` / `GetPublicKey`. The private key never enters the workload.
+- Deployment (`openbank-infra/gitops/components/audit/audit-service.yaml`) sets
+  `AUDIT_ANCHOR_SIGNER=kms` and `AUDIT_ANCHOR_SIGNING_REQUIRED=true` — so a signer failure
+  **aborts capture** rather than storing an unsigned row that would later read as a checkpoint.
+
+## 3. What you need — and where each piece comes from
+
+| Input | Source | Do you have to trust OpenBank for it? |
+|---|---|---|
+| Anchor export | `GET /api/v1/audit/anchors?limit=200` (`ROLE_AUDITOR`) | It is the *evidence under test*; forgery is what the tool detects |
+| Public key (PEM) | **AWS KMS `GetPublicKey` on the key id recorded in the anchor** — or `GET /api/v1/audit/anchors/verification-key?keyId=…` | **No.** Fetch it from KMS yourself; that is the point |
+| Entry export (optional) | `audit_entries` rows for the attested range | It is the *log under test* |
+
+Fetch the key independently whenever you can:
+
+```
+aws kms get-public-key --key-id <keyId recorded on the anchor> \
+  --query PublicKey --output text | base64 -d > kms-pub.der
+openssl pkey -pubin -inform DER -in kms-pub.der -out kms-pub.pem
+```
+
+The anchors record the **immutable KMS key id returned by `Sign`**, not the alias, so the check
+stays correct across key rotation: each anchor names the exact key generation that signed it.
+
+## 4. Run it
+
+```
+python3 .github/scripts/verify-audit-anchors.py \
+    --anchors anchors.json \
+    --public-key kms-pub.pem \
+    --entries  entries.json      # optional but see §6
+```
+
+Requires only Python 3 and the `cryptography` package. It imports **no OpenBank code** — the two
+canonical forms are re-implemented from their specification, so a producer that silently changes
+one is rejected here instead of being mirrored. Both sides are pinned to the same literal test
+vectors by `OfflineVerifierConformanceTest` (Kotlin) and the verifier's `--self-test` (Python);
+change either form and exactly one side goes red.
+
+### Outcomes are four, not two
+
+| Exit | Verdict | Meaning |
+|---|---|---|
+| `0` | `VERIFIED` | Every anchor recomputed to its stored digest and verified under the public key |
+| `2` | `TAMPERED` | Something was rejected; the message names what and where |
+| `3` | `UNVERIFIABLE` | Nothing to verify, or no usable key — **never** report this as a pass |
+| `4` | `INPUT_ERROR` | Bad arguments or a malformed export |
+
+`UNVERIFIABLE` is deliberately its own exit code. An absent anchor set, an unsigned anchor, and an
+HMAC-keyed anchor all land here, because a shared secret cannot by construction be verified by a
+third party. This repo has already paid once for letting a skipped path share a result with a
+successful one (`PushResult.skipped()`, #4348) — do not re-collapse them in a wrapper script.
+
+## 5. What a rejection looks like
+
+The tool names the finding rather than returning a bare status. Its `--self-test` constructs each
+of these and asserts the rejection, so these paths are exercised on every CI run:
+
+| Tampering | Rejection |
+|---|---|
+| Entry field edited in place | `ENTRY ALTERED at position N` |
+| Entry deleted | `CHAIN LINK BROKEN at position N` |
+| Two entries re-ordered | `CHAIN LINK BROKEN at position N` |
+| Range truncated below an anchor | `ATTESTED HEAD IS MISSING FROM THE LOG` / `CHAIN LENGTH GAP` |
+| Anchor row itself edited | `ANCHOR DIGEST MISMATCH` |
+| Signature forged under another key | `INVALID SIGNATURE` |
+| Log re-anchored over a shortened range | `ANCHOR SEQUENCE WENT BACKWARDS` |
+
+Note why the DB rules do not make these impossible: `no_update_audit` / `no_delete_audit` are
+`DO INSTEAD NOTHING` rules, so an `UPDATE` affects zero rows **and reports success**. They stop
+casual mutation; they are not a control, because anything with rights to drop the rule leaves no
+error behind. The chain plus the anchor are what make such a change *detectable*.
+
+## 6. What this does NOT establish — state this in any report
+
+Three gaps are real, and a partial control described as full independence is worse than none:
+
+1. **Absence of an anchor cannot be rejected.** The tool verifies the anchors it is given. A
+   producer that never captured one for a period, or dropped a range before exporting, presents
+   nothing to reject. Cross-check the anchor cadence against `openbank_workflow_last_success_age_seconds`
+   for `audit-anchor-capture` and against the expected hourly interval — a missing hour is a
+   finding, and only the *reader* can raise it.
+2. **`signedAt` is the producer's own claim.** There is no external time source in the loop, so an
+   anchor cannot prove *when* it was signed, only *what* it attests. A backdated history signed
+   with a live key still verifies. Closing this needs an RFC 3161 timestamping authority or a
+   public transparency log — **neither exists in this platform today**.
+3. **Without `--entries`, only the anchors are checked.** A valid signature proves the checkpoint
+   is authentic; it does not prove the *log* still matches it. The tool says so explicitly in its
+   output rather than letting a signature-only run read as a full verification.
+
+Consequently ADR-0031 **D5 remains 🟡 Partial**. The asymmetric signer and this verifier are the
+part that is real; independent *proof of completeness and of time* is not, and the public control
+score must not advance on the strength of this runbook.
+
+## 7. Falsifying the tool itself
+
+```
+python3 .github/scripts/verify-audit-anchors.py --self-test
+```
+
+Ten cases: one clean range that must be **accepted** (ten rejections prove nothing if the tool
+rejects everything), seven distinct tamperings that must be rejected with a naming message, and
+two absence cases that must produce `UNVERIFIABLE` rather than either other verdict. Enforced in
+CI as gate `audit-anchor-offline-verifier-unit-test` with a `min_subjects: 10` floor, so a suite
+that quietly stopped constructing cases cannot read as a pass on the ones left.

--- a/docs/runbooks/0014-independent-audit-anchor-verification.md
+++ b/docs/runbooks/0014-independent-audit-anchor-verification.md
@@ -66,7 +66,8 @@ stays correct across key rotation: each anchor names the exact key generation th
 python3 .github/scripts/verify-audit-anchors.py \
     --anchors anchors.json \
     --public-key kms-pub.pem \
-    --entries  entries.json      # optional but see §6
+    --public-key-id <the keyId recorded on the anchors> \
+    --entries entries.json       # optional but see §6
 ```
 
 Requires only Python 3 and the `cryptography` package. It imports **no OpenBank code** — the two
@@ -81,7 +82,7 @@ change either form and exactly one side goes red.
 |---|---|---|
 | `0` | `VERIFIED` | Every anchor recomputed to its stored digest and verified under the public key |
 | `2` | `TAMPERED` | Something was rejected; the message names what and where |
-| `3` | `UNVERIFIABLE` | Nothing to verify, or no usable key — **never** report this as a pass |
+| `3` | `UNVERIFIABLE` | Nothing to verify, or no usable key for that generation — **never** report this as a pass |
 | `4` | `INPUT_ERROR` | Bad arguments or a malformed export |
 
 `UNVERIFIABLE` is deliberately its own exit code. An absent anchor set, an unsigned anchor, and an
@@ -108,6 +109,30 @@ Note why the DB rules do not make these impossible: `no_update_audit` / `no_dele
 `DO INSTEAD NOTHING` rules, so an `UPDATE` affects zero rows **and reports success**. They stop
 casual mutation; they are not a control, because anything with rights to drop the rule leaves no
 error behind. The chain plus the anchor are what make such a change *detectable*.
+
+## 5a. Two findings you WILL hit on a real export, and what each means
+
+Verified against the live audit database on 2026-08-21 (1212 anchors, read-only):
+
+**Most anchors here are still HMAC-signed, and they are `UNVERIFIABLE`, not verified.** The KMS
+cutover is recent; anchors captured before it carry `keyId=local-hmac-sha256`. A shared secret
+cannot produce a signature a public key can check, so the tool declines to rule on them. It is
+important that it declines rather than rejects: feeding an HMAC tag to an ECDSA verify fails, and
+an earlier cut of this tool consequently reported *the entire pre-cutover history as forged*. A
+false accusation of tampering is the most expensive wrong answer available here, so the key id is
+inspected before any verification is attempted, and a mismatched key **generation** is treated the
+same way. Practical consequence for a reader: **the independently verifiable window starts at the
+KMS cutover**, and anything earlier rests on the operator's custody of the HMAC secret.
+
+**Some anchors attest `chainStatus=BROKEN`.** This is not a forged anchor — the digest recomputes
+and (for KMS anchors) the signature verifies. It is the producer faithfully recording that its own
+`verifyChain()` walk was not intact *at capture time*. On this platform that population is bounded
+(2026-07-09 to 2026-08-05) and corresponds to the pre-#3586 legacy hash segment: rows hashed in a
+canonical form whose digits `timestamptz` truncated, which can never be recomputed (#3505). Those
+rows are unverifiable rather than tampered with, and the walk was later corrected to count them
+separately — which is why the `BROKEN` anchors stop. Do not read a `BROKEN` anchor as proof of
+tampering, and do not read it as noise either: check whether the affected range is the known legacy
+segment (`hash_version IS NULL` on `audit_entries`) before concluding either way.
 
 ## 6. What this does NOT establish — state this in any report
 

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/infrastructure/persistence/OfflineVerifierConformanceTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/infrastructure/persistence/OfflineVerifierConformanceTest.kt
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.audit.infrastructure.persistence
+
+import com.openbank.audit.domain.model.AttributionSource
+import com.openbank.audit.domain.model.AuditAnchor
+import com.openbank.audit.domain.model.AuditEntry
+import com.openbank.audit.domain.model.OccurredAtSource
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Pins the two canonical forms the OFFLINE verifier re-implements (issue #5838).
+ *
+ * `.github/scripts/verify-audit-anchors.py` deliberately does not import a line of this service:
+ * a third party must be able to check the anchors without running the bank's code, and a verifier
+ * that shared the producer's implementation could not detect a producer that changed it. The cost
+ * of that independence is that the two can drift apart silently — and the failure is invisible
+ * from either side alone, because each is self-consistent. A round-trip against your own encoder
+ * cannot see a spec divergence.
+ *
+ * So the literals below are the contract, asserted from BOTH sides: the Python self-test asserts
+ * it produces exactly these, and this test asserts the real Kotlin does too. Change either
+ * canonical form and exactly one side goes red, which is the whole point — the anchors already
+ * signed were signed under the old form, and silently re-defining it retroactively invalidates
+ * every historical attestation.
+ *
+ * The vectors deliberately include the awkward cases: a MICROSECOND timestamp (six fraction
+ * digits) beside a WHOLE-SECOND one (no fraction at all), because `Instant.toString()` prints
+ * fractions in groups of 3/6/9 and omits them when zero, which no naive ISO-8601 formatter
+ * reproduces; and an anchor over a null head, which is what an empty chain attests.
+ */
+class OfflineVerifierConformanceTest {
+
+    private val entry = AuditEntry(
+        id = UUID.fromString("11111111-2222-3333-4444-555555555555"),
+        eventType = "payment.initiated",
+        aggregateType = "Payment",
+        aggregateId = "PMT-1",
+        actorId = "operator-1",
+        actorType = "HUMAN",
+        payload = """{"amount":100}""",
+        sourceService = "openbank-payment-service",
+        correlationId = "corr-1",
+        occurredAt = Instant.parse("2026-08-21T10:00:00.123456Z"),
+        recordedAt = Instant.parse("2026-08-21T10:00:01Z"),
+        occurredAtSource = OccurredAtSource.EVENT,
+        sourceServiceSource = AttributionSource.EVENT,
+    )
+
+    @Test
+    fun `chain hash matches the vector the offline verifier reproduces`() {
+        assertThat(AuditRepository.chainHash("0".repeat(64), entry))
+            .isEqualTo("e00d6b6fe01bfdbd8808f85a89fdc56ef97c5c79f766142c18f0769abdeec0d1")
+    }
+
+    @Test
+    fun `chain hash ignores nanoseconds the database cannot store`() {
+        // Same row, plus nanosecond digits timestamptz truncates. The hash MUST be unchanged, or
+        // the row is unverifiable the moment it is read back (#3505).
+        val withNanos = entry.copy(occurredAt = Instant.parse("2026-08-21T10:00:00.123456789Z"))
+        assertThat(AuditRepository.chainHash("0".repeat(64), withNanos))
+            .isEqualTo(AuditRepository.chainHash("0".repeat(64), entry))
+    }
+
+    @Test
+    fun `anchor digest matches the vector the offline verifier reproduces`() {
+        assertThat(
+            AuditAnchor.digest(
+                lastEntryId = UUID.fromString("11111111-2222-3333-4444-555555555555"),
+                lastRecordHash = "a".repeat(64),
+                chainedCount = 42,
+                chainStatus = "INTACT",
+                signedAt = Instant.parse("2026-08-21T11:00:00.500Z"),
+            ),
+        ).isEqualTo("c60dbd813438ecfc42924eca6a6b3fef33c4f03c9e16c1e2a9e0da184d11bad8")
+    }
+
+    @Test
+    fun `anchor digest over an empty chain head matches the offline verifier`() {
+        assertThat(
+            AuditAnchor.digest(
+                lastEntryId = null,
+                lastRecordHash = null,
+                chainedCount = 0,
+                chainStatus = "INTACT",
+                signedAt = Instant.parse("2026-08-21T11:00:00.500Z"),
+            ),
+        ).isEqualTo("33cea295a63962d8152fcc655b8d7ec6be3abec01e340f39aa183009ffbfbf88")
+    }
+}


### PR DESCRIPTION
## What this changes

`GET /api/v1/audit/anchors/verify` is audit-service checking its own database with its own signer
bean. That is a useful operational control and it is **not independent verification**, for one
structural reason: the component rendering the verdict is the component whose tampering the anchor
exists to detect. Anyone able to rewrite `audit_entries` is equally able to serve a hand-written
`INTACT`.

This PR adds the other half — `.github/scripts/verify-audit-anchors.py`, which an auditor runs on
their own machine, from an anchor export plus a public key they fetch from AWS KMS `GetPublicKey`
themselves. It imports no OpenBank code: both canonical forms (`AuditAnchor.digest`,
`AuditRepository.chainHash`) are re-implemented from their specification, so a producer that
silently changes one is rejected here rather than mirrored.

## What a third party can now verify — and what they must still trust

**Can verify, without trusting the producer:**

- Each anchor row is exactly what was signed (digest recomputation).
- The signature is valid under an asymmetric key the workload does not hold at rest
  (ECC_NIST_P256 / ECDSA_SHA_256, Pod Identity limited to Sign/Verify/GetPublicKey).
- The anchor sequence was not truncated, re-ordered, or re-anchored backwards.
- With `--entries`, that the exported log reproduces every attested chain head.

**Must still trust the producer:**

- **That an anchor exists at all for a period.** The tool verifies the anchors it is handed. A
  period never anchored, or a range dropped before export, presents nothing to reject. Completeness
  rests on reading the capture cadence, not on any signature.
- **`signedAt`.** It is the producer's own claim; there is no external time source in the loop, so
  a backdated history signed with a live key still verifies.

Both gaps need an external RFC 3161 timestamping authority or a public transparency log. **Neither
exists in this platform today**, so this PR does not claim to close them.

## D5 stays 🟡 Partial

Per the issue's own acceptance criterion — D5 is marked built only once deployed evidence is
independently verifiable — the ADR is updated to record what is now real (asymmetric signer,
offline verifier) and to state the two structural gaps above as ⬜ Planned. **The public control
score does not advance.**

Verified read-only against the live audit database: **1186 of 1212 anchors predate the KMS cutover
and are HMAC-signed**, so the independently verifiable window starts at that cutover, not at the
beginning of the log.

## Falsified by what it rejects

A verifier that only ever says "valid" is decoration. Gate
`audit-anchor-offline-verifier-unit-test` (enforced, `min_subjects: 13`) constructs each case from
a throwaway EC key with no infrastructure:

| Case | Outcome |
|---|---|
| Clean range | **accepted** (exit 0) — 7 rejections prove nothing if the tool rejects everything |
| Matching key generation | **accepted** (exit 0) |
| Entry altered in place | `ENTRY ALTERED` (exit 2) |
| Entry deleted | `CHAIN LINK BROKEN` (exit 2) |
| Two entries re-ordered | `CHAIN LINK BROKEN` (exit 2) |
| Chain gap below an anchor | `ATTESTED HEAD IS MISSING FROM THE LOG` (exit 2) |
| Anchor row edited | `ANCHOR DIGEST MISMATCH` (exit 2) |
| Signature forged under another key | `INVALID SIGNATURE` (exit 2) |
| Backwards re-anchor | `ANCHOR SEQUENCE WENT BACKWARDS` (exit 2) |
| No anchors at all | `NO ANCHORS` — **UNVERIFIABLE** (exit 3) |
| Unsigned anchor | `UNSIGNED ANCHOR` — **UNVERIFIABLE** (exit 3) |
| HMAC anchor | `SYMMETRIC (HMAC) ANCHOR` — **UNVERIFIABLE** (exit 3) |
| Wrong key generation | `KEY GENERATION MISMATCH` — **UNVERIFIABLE** (exit 3) |

Outcomes are four, not two. `UNVERIFIABLE` (exit 3) never shares a result with success — the
`PushResult.skipped()` lesson (#4348).

### A real defect the live data caught

The first cut fed HMAC tags to an ECDSA verify, which failed, and reported the platform's entire
pre-cutover history as `INVALID SIGNATURE` / **TAMPERED**. A false accusation of tampering is the
most expensive wrong answer this tool can give, and it would have been levelled at an auditor. The
key id is now inspected *before* verification is attempted, because an HMAC tag and a forgery are
indistinguishable to an ECDSA verify. Three self-test cases pin it, and removing the predicate
turns them red.

## Cross-language drift

Independence means the verifier cannot import the producer's code — which lets the two drift apart
silently, since each is self-consistent (a round-trip against your own encoder cannot see a spec
divergence). `OfflineVerifierConformanceTest` pins the Kotlin side to the same literal vectors the
Python self-test asserts, including the microsecond and whole-second `Instant.toString()` cases no
naive ISO-8601 formatter reproduces. Change either canonical form and exactly one side goes red —
which matters because anchors already signed were signed under the old form.

## Verification

- `:openbank-audit-service:test ktlintCheck detekt quarkusBuild --rerun-tasks` — exit 0, all four
  tasks present in the task list; JUnit XML **150 tests / 0 failures / 0 errors / 0 skipped**.
- Gate shards in the foreground: security 15/15, lint 20/20, registry 26/26, data 21/21,
  kotlin 19/19, supplychain 23 pass + 1 pre-existing advisory warning.
- `check-adr-registry.sh`, `check-gate-lifecycle-metadata.py`, `check-gate-selftest-declaration.py`,
  `check-threat-model-diff.py` — all exit 0.
- Negative controls (each read from `$?` after redirecting to a file): disabling the entry-hash
  check, the signature check, the `UNVERIFIABLE` classification, the HMAC predicate, and lowering
  the `SUBJECTS` count each turn the suite red. A one-microsecond change to the Kotlin vector
  reddens the conformance test.
- End-to-end against live data (read-only): 26 real KMS anchors verify (exit 0) against a public
  key fetched straight from KMS; 20 real HMAC anchors report UNVERIFIABLE (exit 3); one real anchor
  with `chainedCount` bumped by 1 reports `ANCHOR DIGEST MISMATCH` (exit 2).

Not verified: the `--entries` path against a production entry export (not exported — it is
customer audit data), and behaviour across an actual KMS key rotation.

Closes #5838
Refs ADR-0031 D5
