### PR TITLE
fix(admin-ui): expose readiness refresh state

### DIFF
--- a/openbank-admin-ui/src/app/system/readiness/page.tsx
+++ b/openbank-admin-ui/src/app/system/readiness/page.tsx
@@ -67,12 +67,18 @@ export default function ReadinessPage() {
           'Derived maturity matrix per service × 9 technical/operational dimensions (C1–C9). Generated in CI by prod-readiness-collector.py from the repo + TTL attestations — never hand-edited. Gate: money-path needs all ≥ Verified, critical (Code/Backup/Security) = Bank-grade.',
         )}
         actions={
-          <button onClick={load} style={{
+          <button
+            type="button"
+            onClick={load}
+            disabled={loading}
+            aria-busy={loading}
+            aria-label={t('Obnovit připravenost na produkci', 'Refresh production readiness')}
+            style={{
             display: 'flex', alignItems: 'center', gap: '6px', padding: '8px 14px', cursor: 'pointer',
             background: 'var(--card-bg)', border: '1px solid var(--border)', borderRadius: '8px',
             color: 'var(--text-secondary)', fontSize: '13px', fontWeight: 600,
           }}>
-            <RefreshCw size={15} /> {t('Obnovit', 'Refresh')}
+            <RefreshCw size={15} aria-hidden="true" /> {t('Obnovit', 'Refresh')}
           </button>
         }
       />

--- a/openbank-admin-ui/src/test/prod-readiness-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/prod-readiness-refresh.guard.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache-2.0 license.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('production readiness refresh contract', () => {
+  it('exposes localized busy semantics and preserves the readiness endpoint', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/system/readiness/page.tsx'), 'utf8')
+
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit připravenost na produkci', 'Refresh production readiness')}")
+    expect(source).toContain('<RefreshCw size={15} aria-hidden="true" />')
+    expect(source).toContain("fetch('/api/prod-readiness'")
+  })
+})


### PR DESCRIPTION
## Summary
- prevent overlapping Production Readiness refresh requests while loading
- expose localized accessible naming and busy state
- hide the decorative refresh icon and add a focused source guard

## Verification
- git diff --check

Refs #6190