### PR TITLE
fix(ci): stop a string-literal semicolon from truncating a Kotlin enum's constants

### DIFF
--- a/.github/scripts/check-openapi-enum-vs-domain.py
+++ b/.github/scripts/check-openapi-enum-vs-domain.py
@@ -120,10 +120,14 @@ SPEC_ENUM_BLOCK = re.compile(r"enum:[ \t]*\n((?:[ \t]*-[ \t]*\S+[ \t]*\n)+)")
 KOTLIN_ENUM = re.compile(r"enum\s+class\s+(\w+)\s*(?::[^{]*)?\{([^}]*)\}")
 BLOCK_ITEM = re.compile(r"^[ \t]*-[ \t]*[\"\']?([A-Za-z0-9_]+)[\"\']?[ \t]*$", re.M)
 # A constant is the leading identifier of a member; the rest of a member may be a constructor
-# call (`ACTIVE("active")`) or an override block, and must not be mined for tokens.
-MEMBER = re.compile(r"^\s*([A-Z][A-Z0-9_]*)\s*(?:\(|$)")
+# call (`ACTIVE("active")`) or an override block, and must not be mined for tokens. A member may
+# also carry its own annotation (`@Deprecated("...") LEGACY,`) before the identifier — skipped
+# here, not matched as part of it, run AFTER string literals are blanked so an annotation's
+# `(...)` argument list can't itself hide a stray `)` that would break the skip.
+MEMBER = re.compile(r"^\s*(?:@\w+(?:\([^)]*\))?\s*)*([A-Z][A-Z0-9_]*)\s*(?:\(|$)")
 LINE_COMMENT = re.compile(r"//[^\n]*")
 BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.S)
+STRING_LITERAL = re.compile(r'"(?:[^"\\]|\\.)*"')
 VALUE = re.compile(r"[A-Z][A-Z0-9_]*")
 
 
@@ -145,7 +149,16 @@ def _kotlin_values(body: str) -> frozenset[str]:
     out of doc comments. A drift gate whose findings are mostly noise gets baselined wholesale
     and then protects nothing, so this is load-bearing, not tidiness.
     Only the part before a `;` is constants; anything after it is ordinary class body.
+
+    String literals are blanked before that `;` split, too — a `@Deprecated("...; ...")`
+    message containing a semicolon otherwise truncates the constant list right there, silently
+    dropping every member after it. That is exactly how this gate went blind to
+    `SettlementStatus.LEDGER_REVERSED` (issue #6208): the deprecation message read "Never
+    produced; the stub...", the real `;` inside it looked like the constants/methods boundary,
+    and the enum's actual last member never got extracted — reported as "the code does not
+    have" a value the code plainly declares.
     """
+    body = STRING_LITERAL.sub('""', body)
     body = LINE_COMMENT.sub("", BLOCK_COMMENT.sub("", body))
     constants = body.split(";", 1)[0]
     out = set()
@@ -275,6 +288,10 @@ def self_test() -> int:
          _kotlin_values('SEPA("sepa"), SWIFT("swift")'), frozenset({"SEPA", "SWIFT"})),
         ("members after the `;` are not constants",
          _kotlin_values("OPEN, CLOSED;\n    fun isOPEN() = this == OPEN"),
+         frozenset({"OPEN", "CLOSED"})),
+        ("a `;` inside a string literal (e.g. a @Deprecated message) does not truncate the "
+         "constant list — issue #6208",
+         _kotlin_values('OPEN,\n    @Deprecated("Never produced; see OPEN instead")\n    CLOSED,'),
          frozenset({"OPEN", "CLOSED"})),
         ("lowercase tokens are not constants", _kotlin_values("identity, address"), frozenset()),
         ("an inline spec enum", _spec_values("IDENTITY, ADDRESS"),


### PR DESCRIPTION
## What

\`check-openapi-enum-vs-domain.py\`'s \`_kotlin_values()\` split an enum body on the first
literal \`;\` to separate constants from companion-object/method code. \`Settlement.kt\`'s
\`SettlementStatus.LEDGER_REVERSED\` carries
\`@Deprecated("Never produced; the stub that wrote it reversed nothing...")\` — the \`;\`
inside that message string looked like the constants/methods boundary, silently dropping
\`LEDGER_REVERSED\` from the extracted set.

The gate then reported the spec "advertises a value the code does not have" for a value
the code plainly declares — enforced (\`--enforce\`), and failing \`gates (api)\` fleet-wide
on every open PR (found while investigating unrelated CI failures on #6009, #5979, and
others, all with unrelated diffs, all failing on the identical error).

## Fix

Blank string literals before the \`;\` split. That surfaced a second bug on the same enum:
\`MEMBER\` didn't match an identifier preceded by its own annotation
(\`@Deprecated(...) LEGACY,\`), so the member still wasn't found even once the
string-inside-\`;\` truncation was gone. \`MEMBER\` now skips a leading \`@Annotation(...)\`
before requiring the identifier.

## Verification

Both bugs fixed via a self-test case proven to fail without the fix:

\`\`\`
$ python3 .github/scripts/check-openapi-enum-vs-domain.py --self-test
  ok    a \`;\` inside a string literal (e.g. a @Deprecated message) does not truncate the constant list — issue #6208
self-test: passed

$ python3 .github/scripts/check-openapi-enum-vs-domain.py --enforce
SUBJECTS=149  # spec-enum/domain-enum pairing(s)
openapi-enum-domain-drift: 18 paired enum(s) drift, all 18 baselined; no new drift.
\`\`\`