### PR TITLE
fix(agent): run the oversight sweep off the event loop — enforcement was degrading

### DIFF
--- a/openbank-agent-service/CLAUDE.md
+++ b/openbank-agent-service/CLAUDE.md
@@ -47,6 +47,23 @@ JAVA_HOME=$(/usr/libexec/java_home -v 25) ./gradlew :openbank-agent-service:test
 
 ## Config gotchas
 
+- **`suspend` on a `@Scheduled` method buys a VERT.X context — which is the fix for reactive Panache
+  and the BUG when your collaborators are blocking.** This service has no reactive datasource
+  (jdbc-postgresql + narayana) and its sweep calls blocking REST clients, so on the event loop each
+  one throws `BlockingNotAllowedException`. Measured on the sandbox 2026-08-21, every scheduled
+  oversight sweep logged `BlockedThreadChecker: blocked for 19s`, `Tool call failed:
+  sanctions_list_pending: BlockingNotAllowedException`, and then the line that matters —
+  `agent policy BLOCK but PDP errored — falling back to ADVISORY`: the OPA query failed for reasons
+  that have nothing to do with OPA, so **enforcement silently downgraded on every sweep** while the
+  run still reported "oversight sweep done" and the liveness heartbeat still recorded success. Wrap
+  the scheduled body in `withContext(Dispatchers.IO)`. Only the scheduled path needs it — HTTP and
+  Kafka triggers already arrive on a worker thread. Note what this means for the fleet rule: "make
+  it a suspend fun" is right for a reactive service and insufficient here; the question is which
+  thread YOUR clients need, not which annotation is fashionable.
+  **A unit test cannot see this** — calling the method directly runs it on a test thread where
+  blocking is allowed, so it passes against the broken code. The only witnesses are a real
+  scheduled run's logs or a `@TestProfile` that re-enables the scheduler with a shrunken cron.
+
 - **A reasoning model spends `max_tokens` on REASONING before it emits any answer, so a low cap
   returns an EMPTY `content` field — not a short answer.** Measured on `openai/gpt-oss-120b`
   through the gateway: `max_tokens=40` gives `content=''` with `finish_reason=length` (the whole

--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt
@@ -12,12 +12,12 @@ import com.openbank.agent.domain.policy.AgentIdentity
 import com.openbank.libs.observability.DomainMetrics
 import com.openbank.libs.observability.WorkflowLivenessRecorder
 import io.quarkus.runtime.StartupEvent
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.event.Observes
 import jakarta.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.time.Duration

--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt
@@ -12,6 +12,8 @@ import com.openbank.agent.domain.policy.AgentIdentity
 import com.openbank.libs.observability.DomainMetrics
 import com.openbank.libs.observability.WorkflowLivenessRecorder
 import io.quarkus.runtime.StartupEvent
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.event.Observes
@@ -60,7 +62,24 @@ class OversightService {
     @Scheduled(cron = "{agent.oversight.cron}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     suspend fun scheduledSweep() {
         if (!enabled) return
-        sweep(trigger = "scheduled")
+        // withContext(Dispatchers.IO), and the reason is the opposite of the usual one in this
+        // fleet. A `suspend` @Scheduled method is dispatched on a duplicated VERT.X context — which
+        // is exactly right for reactive Panache, and exactly wrong here: this service has no
+        // reactive datasource (jdbc-postgresql + narayana), and the sweep's collaborators are
+        // BLOCKING REST clients. On the event loop each of them throws
+        // `BlockingNotAllowedException`, so measured on the sandbox 2026-08-21 every scheduled
+        // sweep did this:
+        //   BlockedThreadChecker: event-loop-thread-0 blocked for 19s
+        //   Tool call failed: sanctions_list_pending: BlockingNotAllowedException
+        //   OPA decision query failed ... failing closed: BlockingNotAllowedException
+        //   agent policy BLOCK but PDP errored — falling back to ADVISORY
+        // The last line is the damage: the PDP is unreachable for reasons that have nothing to do
+        // with OPA, so ENFORCEMENT SILENTLY DOWNGRADES on every sweep while the run still reports
+        // "oversight sweep done" and the liveness heartbeat still records success.
+        //
+        // Only the SCHEDULED path needs this. A sweep triggered over HTTP or Kafka already arrives
+        // on a worker thread; wrapping there would add a hop for nothing.
+        withContext(Dispatchers.IO) { sweep(trigger = "scheduled") }
         liveness?.recordSuccess()
     }
 


### PR DESCRIPTION
Found while measuring something else. **Every** scheduled oversight sweep on the sandbox logs:

```
BlockedThreadChecker: vert.x-eventloop-thread-0 blocked for 19s
Tool call failed: sanctions_list_pending: BlockingNotAllowedException
OPA decision query failed for tool=query.compliance.readonly agent=compliance-officer;
  failing closed: BlockingNotAllowedException
agent policy BLOCK but PDP errored — falling back to ADVISORY
```

The last line is the damage: the PDP is unreachable for a reason that has **nothing to do with
OPA**, so `AGENT_POLICY_ENFORCEMENT=block` silently degrades to advisory on every sweep — while the
run still reports "oversight sweep done" and the ADR-0237 liveness heartbeat still records success.
A control that announces its own downgrade in a WARN nobody reads is not a control.

## Cause — the inverse of this fleet's usual scheduler bug

A `suspend` `@Scheduled` method is dispatched on a duplicated **Vert.x** context. That is exactly
right for reactive Panache (the #2148/#2187 family) and exactly **wrong** here: agent-service has no
reactive datasource (`jdbc-postgresql` + narayana) and the sweep's collaborators are blocking REST
clients, so the event loop rejects each one.

`withContext(Dispatchers.IO)` puts the body where those clients may block. Only the scheduled path
needs it — HTTP and Kafka triggers already arrive on a worker thread.

The generalisation is recorded in `openbank-agent-service/CLAUDE.md`: "make it a `suspend fun`" is
right for a reactive service and insufficient here. The question is which thread **your** clients
need.

## What proves it, and what does not

The unit tests pass and **do not prove this fix** — calling a `@Scheduled` method directly runs it
on a test thread where blocking is allowed, so they pass against the broken code too. That is stated
in the KDoc rather than implied away. Verification is the next real sweep on the sandbox: absence of
`BlockingNotAllowedException` and of the advisory fallback in the logs. I will check it after deploy.

## Linked issues

N/A — found during ADR-0265 E2E verification, unrelated to that delivery.
