### PR TITLE
docs(account): cite ADR-0267, the ADR that actually decided this

### DIFF
--- a/openbank-account-service/src/main/resources/application.yaml
+++ b/openbank-account-service/src/main/resources/application.yaml
@@ -180,7 +180,7 @@ mp:
         key:
           serializer: org.apache.kafka.common.serialization.StringSerializer
     incoming:
-      # Onboarding account lifecycle (ADR-0266): open a PENDING_ACTIVATION account on
+      # Onboarding account lifecycle (ADR-0267): open a PENDING_ACTIVATION account on
       # PARTY_CREATED and activate it when the party clears KYC + AML.
       party-events-in:
         connector: smallrye-kafka


### PR DESCRIPTION
## What

`openbank-account-service/src/main/resources/application.yaml:183` cites **ADR-0266** in a comment
that describes the event-driven onboarding account lifecycle. That decision is **ADR-0267**;
ADR-0266 on `main` is *"MGM Fixed-Reward Growth Incentives"*, an unrelated ADR.

```
docs/adr/0266-mgm-fixed-reward-growth-incentives.md
docs/adr/0267-event-driven-onboarding-account-lifecycle.md
```

## Why it was left behind

The commit that renumbered this ADR from 0266 to 0267 rewrote `.kt` and `.md` citations and **not
YAML**. So the reference stayed pointing at the number, which a different ADR then took — the
citation is not merely stale, it now names the wrong decision.

It reached `main` via #5784. Verified as the **last one**: no other file tracked on `main` still
cites `ADR-0266` from a YAML file.

## Scope

Comment only. No shipped behaviour changes, no config key touched. Commit type `docs`, so this
does not trigger a release — correct for a comment fix.

## How this was found

Fell out of resolving the conflicting ADR-citation PRs (#5826 / #5829 / #5830), which each carried
the same class of leftover in their own trees. Those fix their branches; this one is already on
`main` and was outside their scope.

Refs #5785
