### PR TITLE
fix(admin-ui): export BFF traces by preloading the OTel SDK

### DIFF
--- a/openbank-admin-ui/CLAUDE.md
+++ b/openbank-admin-ui/CLAUDE.md
@@ -307,6 +307,32 @@ npx eslint .            # lint
   exist. Verifying tracing end-to-end needs a real operator session; the synthetic journey does
   not help either, it only GETs `/`.
 
+- **`instrumentation.ts` is TOO LATE to start an OpenTelemetry SDK that patches `node:http`, and
+  the failure is silent in every direction you would check.** `@opentelemetry/instrumentation-http`
+  works by monkey-patching `node:http` at require time; by the moment Next.js calls `register()`
+  the standalone server has already loaded it and created its listener, so the patch lands on
+  nothing. Measured 2026-08-21 against the standalone build: the SDK **starts** (its `start()`
+  frame is in the `OTEL_LOG_LEVEL=debug` output, resolved out of `node_modules`), the process is
+  healthy, requests are served — and **zero** spans are exported. `NEXT_OTEL_VERBOSE=1` changed
+  nothing, and Next.js's own `BaseServer.handleRequest` span did not appear either. So "the SDK
+  failed to start" is the wrong diagnosis and will send you hunting the wrong thing; the right one
+  is load order. Fix: preload it with `NODE_OPTIONS=--require /app/otel-bootstrap.cjs` (baked in
+  the Dockerfile). Two consequences worth knowing: a `--require` preload is invisible to Next.js
+  file tracing, so the OTel packages reach `.next/standalone/node_modules` only because
+  `src/lib/telemetry/tracing.ts` imports them — delete that seemingly-unused module and the
+  container dies on MODULE_NOT_FOUND; and the preloaded file cannot be TypeScript, which is why
+  the scrub rules live in a plain `otel-scrub.cjs` the tests import directly rather than in a TS
+  copy that would drift.
+- **Scrub PII at the EXPORTER, not in per-instrumentation hooks — Next.js emits spans no hook of
+  yours will ever see.** `applyCustomAttributesOnSpan` / `requestHook` only run for spans that
+  instrumentation created. Next.js calls the OpenTelemetry API directly for
+  `BaseServer.handleRequest`, so with hooks alone a request to `/privacy?token=SECRET123` still
+  put the token on the wire. Also grep the attribute names before believing a scrub works: the
+  first version covered `url.full` and `http.url`, **neither of which the inbound HTTP
+  instrumentation sets** — the leak was in `http.target` and `url.query`, so the scrub ran, found
+  nothing to do, and reported success. Wrap `exporter.export` instead; it is the one place that
+  sees every span whatever created it (`otel-scrub.cjs: scrubSpans`).
+
 <!-- BEGIN:nextjs-agent-rules -->
 
 # This is NOT the Next.js you know

--- a/openbank-admin-ui/Dockerfile
+++ b/openbank-admin-ui/Dockerfile
@@ -281,6 +281,11 @@ RUN addgroup -S openbank && adduser -S openbank -G openbank
 COPY --from=build /app/public ./public
 COPY --from=build /app/.next/standalone ./
 COPY --from=build /app/.next/static ./.next/static
+# OpenTelemetry preload. Both files sit at the package root rather than inside the standalone
+# bundle because Next.js only emits application code there; a --require preload is invisible to
+# its file tracing. See otel-bootstrap.cjs for why the SDK cannot be started from
+# instrumentation.ts (instrumentation-http patches node:http too late to catch the server).
+COPY --from=build /app/otel-bootstrap.cjs /app/otel-scrub.cjs ./
 COPY --from=docs-collector /docs-bundle ./docs-bundle
 COPY --from=sbom-collector /sbom-bundle ./sbom-bundle
 COPY --from=openapi-collector /openapi-bundle ./openapi-bundle
@@ -396,4 +401,10 @@ ENV OPENBANK_GOVERNANCE_DOCS=/app/governance-bundle
 ENV OPENBANK_SECURITY_GRAPH=/app/security-graph.json
 ENV OPENBANK_INFRA_LIFECYCLE=/app/infra-lifecycle.json
 ENV OPENBANK_INFRA_VULNS=/app/infra-vulns.json
+# Preload the OpenTelemetry SDK before the application so instrumentation-http can patch
+# node:http before the server loads it. Self-gating: without OTEL_EXPORTER_OTLP_ENDPOINT the
+# bootstrap starts no SDK and costs one require (ADR-0075 inv. 2). Baked here rather than left to
+# the manifest so an environment that sets the endpoint cannot get tracing that silently exports
+# nothing — the exact failure this replaced.
+ENV NODE_OPTIONS="--require /app/otel-bootstrap.cjs"
 CMD ["node", "server.js"]

--- a/openbank-admin-ui/eslint.config.mjs
+++ b/openbank-admin-ui/eslint.config.mjs
@@ -9,6 +9,13 @@ const eslintConfig = [
   },
   ...nextCoreWebVitals,
   {
+    // Scoped to the file types eslint-config-next defines the react-hooks plugin for. Without
+    // `files` this block applies to EVERY linted file, including plain CommonJS at the package
+    // root (otel-bootstrap.cjs, otel-scrub.cjs) — and for a file the Next preset does not match,
+    // the plugin is undefined while the rule reference remains, so eslint aborts the whole run
+    // with "could not find plugin react-hooks". That is a config-resolution error, not a lint
+    // finding: it takes down `npm run lint` entirely, including for every pre-existing file.
+    files: ['**/*.{js,jsx,mjs,ts,tsx}'],
     // eslint-plugin-react-hooks@7 (pulled in by eslint-config-next 16) adds
     // React-Compiler-era rules that flag long-standing, working patterns in
     // this codebase (fetch-on-mount setState, components declared in render).

--- a/openbank-admin-ui/next.config.mjs
+++ b/openbank-admin-ui/next.config.mjs
@@ -44,6 +44,7 @@ const nextConfig = {
     '@opentelemetry/sdk-node',
     '@opentelemetry/exporter-trace-otlp-proto',
     '@opentelemetry/instrumentation-undici',
+    '@opentelemetry/instrumentation-http',
     '@opentelemetry/resources',
     '@opentelemetry/semantic-conventions',
     '@opentelemetry/api',

--- a/openbank-admin-ui/otel-bootstrap.cjs
+++ b/openbank-admin-ui/otel-bootstrap.cjs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+/**
+ * Server-side OpenTelemetry bootstrap for the admin console's BFF (issue #5735 follow-up).
+ *
+ * ### Why this is a `--require` preload and NOT `instrumentation.ts`
+ *
+ * Next.js documents `instrumentation.ts` as the place to start an OTel SDK, and for the Next.js
+ * native spans that works. For `@opentelemetry/instrumentation-http` it does not: that
+ * instrumentation works by monkey-patching `node:http` at require time, and by the moment
+ * Next.js calls `register()` the standalone server has already loaded `node:http` and created
+ * its listener. The patch then lands on nothing.
+ *
+ * This failure is silent from every angle you would normally check. Measured 2026-08-21 against
+ * the standalone build: the SDK starts (its `start()` frame is in the debug log, resolved out of
+ * `node_modules`, so the `serverExternalPackages` fix from #6164 is working), the process is
+ * healthy, requests are served — and **zero** spans are exported. `NEXT_OTEL_VERBOSE=1` made no
+ * difference. Only preloading the SDK before the application, via
+ * `NODE_OPTIONS=--require ./otel-bootstrap.cjs`, produced spans; the same build without the
+ * preload exported nothing, which is the falsification that makes this file load-bearing rather
+ * than decorative.
+ *
+ * ### What it traces, and what it deliberately is not
+ *
+ * Inbound requests to the console, plus the outbound BFF calls those handlers make. It is
+ * **not** browser RUM. ADR-0088 D4 rejected Grafana Faro for this surface — "web/JS RUM on an
+ * internal operator console (~2 users) is near-zero value" — and that judgement stands and is
+ * not reopened here. Nothing in this file runs in a browser.
+ *
+ * Inbound is what makes the console observable at all. Every route except `/auth`, `/privacy`
+ * and `/.well-known/` answers 307 before any handler runs (`src/proxy.ts`, ADR-0080 P0), so an
+ * unauthenticated request makes no outbound call and therefore produced no span. Outbound-only
+ * tracing left admin-ui invisible in Tempo from any traffic a probe — or the synthetic journey,
+ * which only GETs `/` — can generate.
+ *
+ * ### Why this needs no new infrastructure
+ *
+ * Spans go to the OTLP collector already deployed in-cluster, so they land in Tempo beside the
+ * 39 backend services and flow through the existing span-metrics connector — which means
+ * `traces_spanmetrics_calls_total{service="openbank-admin-ui"}` starts existing as a
+ * side-effect, closing the metrics gap without a `/metrics` endpoint. It is server-to-collector
+ * inside the cluster, needing none of the hardened public OTLP ingest, CORS or consent
+ * machinery that ADR-0088 correctly identifies as the expensive part of *browser* RUM.
+ *
+ * ### Gating (mirrors ADR-0075 inv. 2, as GlitchTip does with a blank DSN)
+ *
+ * No `OTEL_EXPORTER_OTLP_ENDPOINT` means no SDK is started at all, so a developer running
+ * `next dev` and every test export nothing and pay nothing.
+ *
+ * ### PII (mirrors ADR-0075 inv. 3)
+ *
+ * See `otel-scrub.cjs`: this is a bank operator console, and request targets carry tokens and
+ * customer ids in query strings.
+ */
+
+const { UNTRACED_PATH, scrubSpans } = require('./otel-scrub.cjs')
+
+/** OTLP exporter that strips query strings from every span in the batch before sending. */
+function scrubbingExporter() {
+  const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-proto')
+  const exporter = new OTLPTraceExporter()
+  const send = exporter.export.bind(exporter)
+  exporter.export = (spans, resultCallback) => send(scrubSpans(spans), resultCallback)
+  return exporter
+}
+
+function startTracing() {
+  if (!process.env.OTEL_EXPORTER_OTLP_ENDPOINT) return false
+
+  const { NodeSDK } = require('@opentelemetry/sdk-node')
+  const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http')
+  const { UndiciInstrumentation } = require('@opentelemetry/instrumentation-undici')
+  const { resourceFromAttributes } = require('@opentelemetry/resources')
+  const {
+    ATTR_SERVICE_NAME,
+    ATTR_SERVICE_VERSION,
+  } = require('@opentelemetry/semantic-conventions')
+
+  const version = process.env.NEXT_PUBLIC_GLITCHTIP_RELEASE
+
+  const sdk = new NodeSDK({
+    resource: resourceFromAttributes({
+      [ATTR_SERVICE_NAME]: process.env.OTEL_SERVICE_NAME || 'openbank-admin-ui',
+      ...(version ? { [ATTR_SERVICE_VERSION]: version } : {}),
+    }),
+    // Scrubbing happens HERE, wrapping the exporter, and not in per-instrumentation hooks.
+    // Measured 2026-08-21: with hooks alone the token still reached the wire, because Next.js
+    // emits `BaseServer.handleRequest` through the OpenTelemetry API directly and no hook of
+    // ours runs for it. The exporter is the one place that sees every span whatever created it.
+    traceExporter: scrubbingExporter(),
+    instrumentations: [
+      new HttpInstrumentation({
+        ignoreIncomingRequestHook: (req) => UNTRACED_PATH.test((req && req.url) || ''),
+      }),
+      // Next.js 16 issues its outbound BFF calls through undici's fetch. This is what injects
+      // W3C `traceparent` on the way out, which is the entire point: without it the console
+      // would produce its own orphan traces instead of joining the backend's.
+      new UndiciInstrumentation(),
+    ],
+  })
+  sdk.start()
+  return true
+}
+
+module.exports = { startTracing }
+
+// Preloaded via NODE_OPTIONS, so requiring this file IS the instruction to start.
+startTracing()

--- a/openbank-admin-ui/otel-scrub.cjs
+++ b/openbank-admin-ui/otel-scrub.cjs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+/**
+ * PII scrubbing and path filtering for the admin console's server-side spans.
+ *
+ * Plain CommonJS on purpose, and at the package root rather than under `src/`, because it has
+ * two consumers that cannot share a TypeScript module: `otel-bootstrap.cjs`, which Node loads
+ * via `--require` before any application code exists, and the Next.js build, which type-checks
+ * and tests it. Duplicating the rules into the bootstrap instead would let the exported spans
+ * and the tested behaviour drift apart with nothing to notice.
+ */
+
+/**
+ * Paths that must not become spans. Next.js serves its own build output from `/_next/`, and a
+ * console page pulls dozens of chunks per navigation — tracing them would bury the handful of
+ * spans that describe what the operator actually did, and inflate span-metrics cardinality with
+ * content-hashed filenames. Health probes are excluded for the same reason: kubelet hits them
+ * every few seconds forever and they say nothing an availability alert does not already say.
+ */
+const UNTRACED_PATH = /^\/(_next\/|favicon\.ico|robots\.txt|healthz$|api\/health$)/
+
+/**
+ * Span attributes that can carry a query string, on both the current and the legacy semconv
+ * names. `http.target` and `url.query` are the two that made this a real leak rather than a
+ * theoretical one: measured 2026-08-21 against the standalone build, a request to
+ * `/privacy?token=SECRET123` exported `http.target = "/privacy?token=SECRET123"` and
+ * `url.query = "token=SECRET123"` verbatim. An earlier version of this scrub covered only
+ * `url.full`/`http.url` — neither of which the inbound HTTP instrumentation sets — so it was a
+ * scrub that ran, reported nothing to do, and let the token through.
+ */
+const URL_ATTRS = ['url.full', 'http.url', 'http.target']
+
+/** Attributes whose entire value IS the query string, and which are therefore dropped. */
+const QUERY_ATTRS = ['url.query']
+
+/**
+ * Drop the query string from a URL or a request target, keeping scheme/host/path.
+ *
+ * Returns the input unchanged if it does not parse — a value this function cannot understand is
+ * a value it must not half-rewrite into something that looks scrubbed and is not.
+ */
+function stripQuery(value) {
+  try {
+    const u = new URL(value)
+    u.search = ''
+    u.hash = ''
+    return u.toString()
+  } catch {
+    // Relative target (`/privacy?token=…`) or malformed: cut at the first `?` or `#` rather
+    // than guess a base.
+    const cut = [value.indexOf('?'), value.indexOf('#')].filter((i) => i !== -1)
+    return cut.length ? value.slice(0, Math.min(...cut)) : value
+  }
+}
+
+/**
+ * Scrubs a plain attribute bag in place. This is the core: it takes the attributes rather than a
+ * span so it can be applied at export time, which is the only place that sees EVERY span.
+ *
+ * Per-instrumentation hooks (`applyCustomAttributesOnSpan`, `requestHook`) are not sufficient and
+ * were measured not to be: with those hooks alone a request to `/privacy?token=SECRET123` still
+ * exported the token, because Next.js emits its own `BaseServer.handleRequest` span through the
+ * OpenTelemetry API directly and no instrumentation hook of ours ever touches it.
+ */
+function scrubAttributes(attrs) {
+  if (!attrs) return
+  for (const key of URL_ATTRS) {
+    const v = attrs[key]
+    if (typeof v === 'string' && v !== '') attrs[key] = stripQuery(v)
+  }
+  for (const key of QUERY_ATTRS) {
+    if (typeof attrs[key] === 'string' && attrs[key] !== '') attrs[key] = ''
+  }
+}
+
+/** Applies [scrubAttributes] to every span in an export batch, in place. */
+function scrubSpans(spans) {
+  for (const span of spans || []) scrubAttributes(span && span.attributes)
+  return spans
+}
+
+/**
+ * Span-object form, kept for the unit test's stand-in and for any caller holding a live Span.
+ * Routes through `setAttribute` because a live span's attributes must not be mutated directly.
+ */
+function scrubSpanUrls(span) {
+  const attrs = span && span.attributes
+  if (!attrs) return
+  for (const key of URL_ATTRS) {
+    const v = attrs[key]
+    if (typeof v === 'string' && v !== '') span.setAttribute(key, stripQuery(v))
+  }
+  for (const key of QUERY_ATTRS) {
+    if (typeof attrs[key] === 'string' && attrs[key] !== '') span.setAttribute(key, '')
+  }
+}
+
+module.exports = {
+  UNTRACED_PATH,
+  URL_ATTRS,
+  QUERY_ATTRS,
+  stripQuery,
+  scrubAttributes,
+  scrubSpans,
+  scrubSpanUrls,
+}

--- a/openbank-admin-ui/package-lock.json
+++ b/openbank-admin-ui/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "openbank-admin-ui",
-  "version": "0.183.5",
+  "version": "0.184.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openbank-admin-ui",
-      "version": "0.183.5",
+      "version": "0.184.3",
       "dependencies": {
         "@hookform/resolvers": "5.8.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.221.0",
+        "@opentelemetry/instrumentation-http": "^0.221.0",
         "@opentelemetry/instrumentation-undici": "^0.31.0",
         "@opentelemetry/resources": "^2.10.0",
         "@opentelemetry/sdk-node": "^0.221.0",
@@ -2192,6 +2193,53 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.221.0.tgz",
+      "integrity": "sha512-oIP91CPIANuYr09tGFElPFKAh6JUar+awJf1kBRYlaeo9b0gDwZHEB2zBfFlvdNFHm0wAVutMZODVi5smKT30g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/instrumentation": "0.221.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
+        "forwarded-parse": "2.1.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/api-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.221.0.tgz",
+      "integrity": "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
         "import-in-the-middle": "^3.0.0",
         "require-in-the-middle": "^8.0.0"
       },
@@ -9003,6 +9051,12 @@
       "engines": {
         "node": ">=0.4.x"
       }
+    },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "license": "MIT"
     },
     "node_modules/fraction.js": {
       "version": "5.3.4",

--- a/openbank-admin-ui/package.json
+++ b/openbank-admin-ui/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@hookform/resolvers": "5.8.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.221.0",
+    "@opentelemetry/instrumentation-http": "^0.221.0",
     "@opentelemetry/instrumentation-undici": "^0.31.0",
     "@opentelemetry/resources": "^2.10.0",
     "@opentelemetry/sdk-node": "^0.221.0",

--- a/openbank-admin-ui/src/instrumentation.ts
+++ b/openbank-admin-ui/src/instrumentation.ts
@@ -12,14 +12,15 @@ export async function register() {
     Sentry.init(buildSentryOptions('server'))
   }
 
-  // BFF tracing. `nodejs` ONLY, and imported dynamically: the OpenTelemetry NodeSDK pulls in
-  // node:async_hooks and other Node built-ins that the edge runtime does not provide, so a
-  // static import would break the edge bundle even though the call is guarded. Also a no-op
-  // without OTEL_EXPORTER_OTLP_ENDPOINT — see lib/telemetry/tracing.ts for the gating and the
-  // reason this is server-side tracing rather than the browser RUM ADR-0088 D4 rejected.
+  // BFF tracing. The SDK itself is NOT started here: `@opentelemetry/instrumentation-http`
+  // patches `node:http` at require time, and by the time Next.js calls register() the standalone
+  // server has already loaded it — measured 2026-08-21 as zero exported spans. It is started by
+  // otel-bootstrap.cjs, preloaded via NODE_OPTIONS=--require. This import exists so Next.js file
+  // tracing copies the OpenTelemetry packages into the standalone output, which is what makes
+  // that preload resolvable at runtime. `nodejs` only and dynamic: the NodeSDK pulls in
+  // node:async_hooks and other built-ins the edge runtime does not provide.
   if (process.env.NEXT_RUNTIME === 'nodejs') {
-    const { startTracing } = await import('@/lib/telemetry/tracing')
-    startTracing()
+    await import('@/lib/telemetry/tracing')
   }
 }
 

--- a/openbank-admin-ui/src/lib/telemetry/tracing.ts
+++ b/openbank-admin-ui/src/lib/telemetry/tracing.ts
@@ -5,123 +5,36 @@
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto'
 import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici'
+import { HttpInstrumentation } from '@opentelemetry/instrumentation-http'
 import { resourceFromAttributes } from '@opentelemetry/resources'
-import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions'
-import type { Span } from '@opentelemetry/api'
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
 
 /**
- * Server-side OpenTelemetry tracing for the admin console's BFF (issue #5735 follow-up).
+ * Keeps the OpenTelemetry packages inside the Next.js standalone output.
  *
- * ### What this is, and what it deliberately is not
+ * **This module starts nothing.** The SDK is started by `otel-bootstrap.cjs`, preloaded through
+ * `NODE_OPTIONS=--require`, because `@opentelemetry/instrumentation-http` has to patch
+ * `node:http` before the server loads it and `instrumentation.ts` runs too late for that — see
+ * that file for the measurement.
  *
- * This traces the ~40 `/api/*` App-Router route handlers that proxy operator actions to the
- * backend services. It is **not** browser RUM. ADR-0088 D4 rejected Grafana Faro for this
- * surface — "web/JS RUM on an internal operator console (~2 users) is near-zero value" — and
- * that judgement stands and is not reopened here. Nothing in this file runs in a browser.
+ * What the preload cannot do is put the packages in the image. Next.js copies a dependency into
+ * `.next/standalone/node_modules` only when its file tracing sees an application module import
+ * it, and a `--require` preload is invisible to that analysis. So these imports are the thing
+ * that makes the bootstrap resolvable at runtime, and they must be real references rather than
+ * bare side-effect imports, which the bundler is free to drop.
  *
- * The gap it does close is a different one. Before this, admin-ui had exactly two signals:
- * GlitchTip said an exception was thrown, and the blackbox prober said the pod answered.
- * Measured 2026-08-21: **zero** Prometheus scrape targets in the `admin-ui` namespace and zero
- * spans in Tempo. So when an operator hit a failure on, say, `/api/approvals/pending` — a
- * money-path four-eyes queue — the backend's own trace existed and nothing connected it to the
- * request the human actually made. Every other service in the fleet is traced; the console
- * they are operated from was the blind spot.
- *
- * ### Why this needs no new infrastructure
- *
- * Spans go to the OTLP collector already deployed in-cluster, so they land in Tempo beside the
- * 39 backend services and flow through the existing span-metrics connector — which means
- * `traces_spanmetrics_calls_total{service="openbank-admin-ui"}` starts existing as a
- * side-effect, closing the metrics gap without a second change or a `/metrics` endpoint.
- *
- * This is server-to-collector inside the cluster. It needs none of the hardened public OTLP
- * ingest, CORS or consent machinery that ADR-0088 correctly identifies as the expensive part
- * of *browser* RUM.
- *
- * ### Gating (mirrors ADR-0075 inv. 2, as GlitchTip does with a blank DSN)
- *
- * No `OTEL_EXPORTER_OTLP_ENDPOINT` means no SDK is started at all. A developer running
- * `next dev`, and every test, therefore exports nothing and pays nothing — the feature is off
- * unless an environment deliberately turns it on.
- *
- * ### PII (mirrors ADR-0075 inv. 3)
- *
- * This is a bank operator console: request URLs carry bearer tokens, customer ids and account
- * numbers in path segments and query strings. `[scrub]` strips the query string from every
- * span's URL attributes before export, for the same reason `glitchtip.ts` strips it from every
- * event. The path is kept — knowing WHICH route failed is the whole point — but a path segment
- * that looks like an id is not, on its own, something this layer can safely reason about, so
- * route-level aggregation is left to the span-metrics connector and the raw path is retained
- * only in the trace.
+ * The failure mode if this drops out is a container that crashes on `--require` with
+ * MODULE_NOT_FOUND. `bff-tracing.test.ts` asserts against the built standalone output when one
+ * is present, so a local `NEXT_STANDALONE=true npm run build` catches it; there is no cheap
+ * assertion that catches it without a build.
  */
-
-const ENDPOINT = process.env.OTEL_EXPORTER_OTLP_ENDPOINT || ''
-const SERVICE_NAME = process.env.OTEL_SERVICE_NAME || 'openbank-admin-ui'
-const SERVICE_VERSION = process.env.NEXT_PUBLIC_GLITCHTIP_RELEASE || undefined
-
-/** URL attributes carrying a full URL, on both the current and the legacy semconv names. */
-const URL_ATTRS = ['url.full', 'http.url'] as const
-
-/**
- * Drop the query string from a URL, keeping scheme/host/path.
- *
- * Returns the input unchanged if it does not parse — a value this function cannot understand
- * is a value it must not half-rewrite into something that looks scrubbed and is not.
- */
-export function stripQuery(value: string): string {
-  try {
-    const u = new URL(value)
-    u.search = ''
-    u.hash = ''
-    return u.toString()
-  } catch {
-    // Relative or malformed: cut at the first `?` rather than guess a base.
-    const q = value.indexOf('?')
-    return q === -1 ? value : value.slice(0, q)
-  }
-}
-
-/** Applies [scrub] to a span's URL attributes in place. Exported for the unit test. */
-export function scrubSpanUrls(span: Span): void {
-  // `attributes` is not on the public Span interface (only ReadableSpan), but the SDK's
-  // concrete span exposes it and this hook runs inside the SDK, so it is present. Typed
-  // narrowly rather than `any` so a future SDK change fails the build instead of silently
-  // scrubbing nothing.
-  const attrs = (span as unknown as { attributes?: Record<string, unknown> }).attributes
-  if (!attrs) return
-  for (const key of URL_ATTRS) {
-    const v = attrs[key]
-    if (typeof v === 'string') span.setAttribute(key, stripQuery(v))
-  }
-}
-
-let sdk: NodeSDK | undefined
-
-/**
- * Starts tracing. Safe to call more than once; a no-op when unconfigured.
- *
- * Returns whether the SDK was started, so the caller (and the test) can distinguish
- * "deliberately off" from "tried and failed" — the distinction this repo keeps finding it
- * needs, most recently where a disabled adapter reported success.
- */
-export function startTracing(): boolean {
-  if (sdk || !ENDPOINT) return false
-
-  sdk = new NodeSDK({
-    resource: resourceFromAttributes({
-      [ATTR_SERVICE_NAME]: SERVICE_NAME,
-      ...(SERVICE_VERSION ? { [ATTR_SERVICE_VERSION]: SERVICE_VERSION } : {}),
-    }),
-    traceExporter: new OTLPTraceExporter(),
-    instrumentations: [
-      // Next.js 16 issues its outbound BFF calls through undici's fetch. This instrumentation
-      // is what injects W3C `traceparent` on the way out, which is the entire point: without
-      // it the console would produce its own orphan traces instead of joining the backend's.
-      new UndiciInstrumentation({
-        requestHook: (span) => scrubSpanUrls(span),
-      }),
-    ],
-  })
-  sdk.start()
-  return true
+export function otelPackagesBundled(): string[] {
+  return [
+    NodeSDK.name,
+    OTLPTraceExporter.name,
+    UndiciInstrumentation.name,
+    HttpInstrumentation.name,
+    resourceFromAttributes.name,
+    ATTR_SERVICE_NAME,
+  ]
 }

--- a/openbank-admin-ui/src/test/bff-tracing.test.ts
+++ b/openbank-admin-ui/src/test/bff-tracing.test.ts
@@ -2,77 +2,129 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, expect, it } from 'vitest'
+import { existsSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
 
-/**
- * Cover for the BFF tracing setup (admin-ui had zero spans and zero scrape targets before it).
- *
- * The assertions are on the two properties that can fail SILENTLY in production:
- *
- *  - the PII scrub, because a span carrying a bearer token or an account number in a query
- *    string exports successfully and looks exactly like a clean one; and
- *  - the gating, because "off because unconfigured" and "on but exporting nowhere" are the
- *    same from the outside, which is the shape this repo keeps finding (a disabled adapter
- *    reporting success).
- */
-describe('BFF tracing', () => {
-  const ORIGINAL = process.env.OTEL_EXPORTER_OTLP_ENDPOINT
+// The scrub rules are plain CommonJS at the package root, not a TS module under src/, because
+// `otel-bootstrap.cjs` is loaded by Node via --require before any application code exists and
+// cannot import TypeScript. Testing that exact file — rather than a TS copy of it — is the
+// point: a copy would let the exported spans and the tested behaviour drift apart.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const scrub = require('../../otel-scrub.cjs') as {
+  UNTRACED_PATH: RegExp
+  stripQuery: (v: string) => string
+  scrubSpans: (spans: unknown[]) => unknown[]
+  scrubSpanUrls: (span: unknown) => void
+}
 
-  beforeEach(() => {
-    vi.resetModules()
-  })
-  afterEach(() => {
-    if (ORIGINAL === undefined) delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT
-    else process.env.OTEL_EXPORTER_OTLP_ENDPOINT = ORIGINAL
-  })
+/** Minimal stand-in for the SDK's concrete span: reads and writes the same attribute bag. */
+function fakeSpan(attributes: Record<string, unknown>) {
+  return {
+    attributes,
+    setAttribute(key: string, value: unknown) {
+      this.attributes[key] = value
+    },
+  }
+}
 
-  it('strips the query string, which is where tokens and customer ids live', async () => {
-    const { stripQuery } = await import('@/lib/telemetry/tracing')
-
-    // The realistic case: an operator opening a customer record through the BFF.
-    expect(stripQuery('https://svc/api/v1/parties/7f3?access_token=eyJhbGciOi&partyId=123'))
-      .toBe('https://svc/api/v1/parties/7f3')
-    // The PATH survives — knowing which route failed is the entire point of the span.
-    expect(stripQuery('https://svc/api/v1/approvals/pending')).toBe('https://svc/api/v1/approvals/pending')
-    // Fragments too: they are not sent to servers but they are exported on the span.
-    expect(stripQuery('https://svc/a?b=1#tok')).toBe('https://svc/a')
+describe('stripQuery', () => {
+  it('drops the query and fragment from an absolute URL', () => {
+    expect(scrub.stripQuery('https://h/api/x?token=SECRET#frag')).toBe('https://h/api/x')
   })
 
-  it('does not half-rewrite a value it cannot parse', async () => {
-    const { stripQuery } = await import('@/lib/telemetry/tracing')
-    // Relative URLs do not parse as absolute; cut at `?` rather than invent a base.
-    expect(stripQuery('/api/svc/ledger/accounts?token=abc')).toBe('/api/svc/ledger/accounts')
-    // No query, nothing to do — and crucially, unchanged rather than mangled.
-    expect(stripQuery('not a url at all')).toBe('not a url at all')
+  it('drops the query from a relative request target', () => {
+    // This is the shape `http.target` actually carries; an absolute-URL-only scrub let it through.
+    expect(scrub.stripQuery('/privacy?token=SECRET')).toBe('/privacy')
   })
 
-  it('scrubs both the current and the legacy URL attribute names', async () => {
-    const { scrubSpanUrls } = await import('@/lib/telemetry/tracing')
-    const set = vi.fn()
-    const span = {
-      attributes: {
-        'url.full': 'https://svc/x?tok=1',
-        'http.url': 'https://svc/y?tok=2',
-        'http.method': 'GET',
-      },
-      setAttribute: set,
+  it('leaves a value with no query untouched', () => {
+    expect(scrub.stripQuery('/api/approvals/pending')).toBe('/api/approvals/pending')
+  })
+})
+
+describe('scrubSpanUrls', () => {
+  it('removes a token from every attribute that can carry a query string', () => {
+    // Measured against the standalone build on 2026-08-21: a request to
+    // `/privacy?token=SECRET123` exported these three attributes verbatim.
+    const span = fakeSpan({
+      'http.target': '/privacy?token=SECRET123',
+      'url.query': 'token=SECRET123',
+      'url.full': 'https://admin/privacy?token=SECRET123',
+      'http.url': 'https://admin/privacy?token=SECRET123',
+      'url.path': '/privacy',
+    })
+
+    scrub.scrubSpanUrls(span)
+
+    expect(JSON.stringify(span.attributes)).not.toContain('SECRET123')
+    expect(span.attributes['http.target']).toBe('/privacy')
+    expect(span.attributes['url.query']).toBe('')
+    // The path is deliberately kept — knowing WHICH route failed is the whole point.
+    expect(span.attributes['url.path']).toBe('/privacy')
+  })
+
+  it('does not throw on a span with no attributes', () => {
+    expect(() => scrub.scrubSpanUrls({})).not.toThrow()
+  })
+})
+
+describe('scrubSpans (the exporter path)', () => {
+  it('scrubs a span no instrumentation hook of ours ever touches', () => {
+    // This is the case that made exporter-level scrubbing necessary: Next.js emits
+    // `BaseServer.handleRequest` through the OpenTelemetry API directly, so with
+    // per-instrumentation hooks alone the token reached the wire. Measured 2026-08-21.
+    const spans = [
+      { name: 'BaseServer.handleRequest', attributes: { 'http.target': '/privacy?token=SECRET123' } },
+      { name: 'GET', attributes: { 'url.query': 'token=SECRET123', 'url.path': '/privacy' } },
+    ]
+
+    scrub.scrubSpans(spans)
+
+    expect(JSON.stringify(spans)).not.toContain('SECRET123')
+    expect(spans[0].attributes['http.target']).toBe('/privacy')
+    expect(spans[1].attributes['url.path']).toBe('/privacy')
+  })
+
+  it('tolerates an empty batch and a span with no attributes', () => {
+    expect(() => scrub.scrubSpans([])).not.toThrow()
+    expect(() => scrub.scrubSpans([{}])).not.toThrow()
+  })
+})
+
+describe('UNTRACED_PATH', () => {
+  it('excludes build output and health probes', () => {
+    for (const p of ['/_next/static/chunk.js', '/favicon.ico', '/healthz', '/api/health']) {
+      expect(scrub.UNTRACED_PATH.test(p), p).toBe(true)
     }
-    scrubSpanUrls(span as never)
-
-    // Falsifying detail: a scrub that only knows `url.full` leaves the legacy attribute
-    // carrying the token, and the span still exports cleanly. Both must be rewritten.
-    expect(set).toHaveBeenCalledWith('url.full', 'https://svc/x')
-    expect(set).toHaveBeenCalledWith('http.url', 'https://svc/y')
-    // Non-URL attributes are left alone.
-    expect(set).not.toHaveBeenCalledWith('http.method', expect.anything())
   })
 
-  it('is a no-op when no OTLP endpoint is configured', async () => {
-    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT
-    const { startTracing } = await import('@/lib/telemetry/tracing')
-
-    // Returns false rather than throwing or silently pretending: a developer running
-    // `next dev`, and every test in this suite, must export nothing and pay nothing.
-    expect(startTracing()).toBe(false)
+  it('still traces the operator routes this exists to make visible', () => {
+    // The other half of the assertion: an over-broad exclusion would silently trace nothing,
+    // which is the failure this whole change was made to fix.
+    for (const p of ['/api/approvals/pending', '/api/svc/ledger/accounts', '/', '/privacy']) {
+      expect(scrub.UNTRACED_PATH.test(p), p).toBe(false)
+    }
   })
+})
+
+describe('standalone output', () => {
+  const modules = join(process.cwd(), '.next', 'standalone', 'node_modules', '@opentelemetry')
+
+  it.runIf(existsSync(modules))(
+    'carries the OpenTelemetry packages otel-bootstrap.cjs requires',
+    () => {
+      // Without these the container crashes on `--require` with MODULE_NOT_FOUND. They are in
+      // the image only because src/lib/telemetry/tracing.ts references them; see that file.
+      const present = readdirSync(modules)
+      for (const pkg of [
+        'sdk-node',
+        'exporter-trace-otlp-proto',
+        'instrumentation-http',
+        'instrumentation-undici',
+      ]) {
+        expect(present, pkg).toContain(pkg)
+      }
+    },
+  )
 })

--- a/openbank-admin-ui/src/test/bff-tracing.test.ts
+++ b/openbank-admin-ui/src/test/bff-tracing.test.ts
@@ -10,7 +10,6 @@ import { join } from 'node:path'
 // `otel-bootstrap.cjs` is loaded by Node via --require before any application code exists and
 // cannot import TypeScript. Testing that exact file — rather than a TS copy of it — is the
 // point: a copy would let the exported spans and the tested behaviour drift apart.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const scrub = require('../../otel-scrub.cjs') as {
   UNTRACED_PATH: RegExp
   stripQuery: (v: string) => string


### PR DESCRIPTION
## What

admin-ui BFF tracing was merged (#6153, #6164) and **exported zero spans**. This makes it work, and fixes a token leak the first version shipped with.

## Why it produced nothing

Not a startup failure — that is the wrong diagnosis and sends you hunting the wrong thing. Measured against the standalone build on 2026-08-21:

- the SDK **starts**: its `start()` frame is in the `OTEL_LOG_LEVEL=debug` output, resolved out of `node_modules`, so the `serverExternalPackages` fix from #6164 is working
- the process is healthy and requests are served
- **zero** spans exported. `NEXT_OTEL_VERBOSE=1` changed nothing, and Next.js's own `BaseServer.handleRequest` span did not appear either

The cause is **load order**. `@opentelemetry/instrumentation-http` patches `node:http` at require time; by the moment Next.js calls `register()` the standalone server has already loaded it and created its listener, so the patch lands on nothing.

Fix: preload the SDK before the application, `NODE_OPTIONS=--require /app/otel-bootstrap.cjs`, baked into the Dockerfile.

## Falsification

Same build, same request, one variable:

| preload | spans exported |
|---|---|
| absent | **0** |
| present | spans, including `BaseServer.handleRequest` |

The OTLP sink was itself checked against a known-positive POST before either run, because a sink that silently records nothing would have produced exactly the negative result I was hoping to see.

## The token leak

The first version scrubbed `url.full` and `http.url` — **neither of which the inbound HTTP instrumentation sets**. So the scrub ran, found nothing to do, and reported success while `/privacy?token=SECRET123` went onto the wire verbatim in `http.target` and `url.query`.

Scrubbing now wraps `exporter.export` rather than using `applyCustomAttributesOnSpan` / `requestHook`. Hooks only fire for spans instrumentation created, and Next.js emits `BaseServer.handleRequest` through the OTel API directly — with hooks alone the token still reached the wire. The exporter is the one place that sees every span whatever created it.

End-to-end verified: spans exported, `/privacy` path **retained** (knowing which route failed is the point), `/_next/` excluded by `ignoreIncomingRequestHook`, `SECRET123` absent from the exported payload.

## Structure, and why it looks odd

- `otel-bootstrap.cjs` / `otel-scrub.cjs` are plain CommonJS at the package root: a `--require` preload cannot be TypeScript. The tests import `otel-scrub.cjs` **directly**, so the tested behaviour and what actually runs cannot drift.
- `src/lib/telemetry/tracing.ts` now starts nothing. It exists because a `--require` preload is invisible to Next.js file tracing — those imports are the only reason the OTel packages reach `.next/standalone/node_modules`. Delete it and the container dies on `MODULE_NOT_FOUND`. It says so in place.

## Tests

10 in `src/test/bff-tracing.test.ts`, all falsifying — reverting the attribute list to the old `url.full`/`http.url` pair reddens the leak test (verified). `UNTRACED_PATH` is asserted **both ways**: an over-broad exclusion would silently trace nothing, which is the failure this change exists to fix.

## Not browser RUM

ADR-0088 D4 rejected Grafana Faro for this surface and that judgement is not reopened. This is server-to-collector inside the cluster; nothing here runs in a browser.

## Linked issues

Refs #5735
