### PR TITLE
fix(admin-ui): prevent overlapping party refreshes

### DIFF
--- a/openbank-admin-ui/src/app/parties/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/parties/[id]/page.tsx
@@ -123,7 +123,16 @@ function PartyDetailPage() {
         subtitle={<span style={{ fontFamily: 'var(--font-mono)', fontSize: '12px' }}>{party.id}</span>}
         breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><Link href="/parties" style={{ color: 'var(--text-secondary)', textDecoration: 'none' }}>{t('Subjekty', 'Parties')}</Link><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{party.legalName}</span></div>}
         actions={<div style={{ display: 'flex', gap: '8px' }}>
-          <button className="btn btn-secondary" onClick={load}><RefreshCw size={13} aria-hidden="true" /> {t('Obnovit', 'Refresh')}</button>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={load}
+            disabled={loading}
+            aria-busy={loading}
+            aria-label={t('Obnovit detail subjektu', 'Refresh party detail')}
+          >
+            <RefreshCw size={13} aria-hidden="true" /> {t('Obnovit', 'Refresh')}
+          </button>
           <Link href="/parties" className="btn btn-secondary" style={{ textDecoration: 'none', display: 'flex', alignItems: 'center', gap: '6px' }}>
             <ArrowLeft size={13} aria-hidden="true" /> {t('Zpět', 'Back')}
           </Link>

--- a/openbank-admin-ui/src/test/party-detail-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/party-detail-refresh.guard.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('party detail refresh contract', () => {
+  it('prevents overlapping PII/KYC refreshes and exposes localized busy semantics', () => {
+    const source = readFileSync(
+      path.resolve(__dirname, '../app/parties/[id]/page.tsx'),
+      'utf8',
+    )
+
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit detail subjektu', 'Refresh party detail')}")
+    expect(source).toContain("svcUrl('party-service'")
+    expect(source).toContain("svcUrl('kyc-service'")
+  })
+})


### PR DESCRIPTION
## Summary
- prevent overlapping party/KYC detail refresh requests while loading
- expose localized busy semantics and accessible refresh label
- add focused source guard

Preserves existing party/KYC endpoints and RBAC.

Refs #6148