### PR TITLE
feat(lending): ADR-0269 slice 1 — one credit journey, three product shapes, customer-readable projection

### DIFF
--- a/docs/threat-models/openbank-lending-service.md
+++ b/docs/threat-models/openbank-lending-service.md
@@ -392,7 +392,30 @@ against `lending.intake.caller-principal`, which refuses every call when unset.
   caller, but `operator-lending-write` already grants the same action more broadly; the rule only
   becomes load-bearing if that blanket operator grant is narrowed.
 
+## 9a. Customer credit journey read (ADR-0269) — STRIDE supplement
+
+One new inbound surface on the same customer-edge trust boundary as section 9, and a read path,
+which changes what can go wrong: section 9's risk is a fraudulent WRITE, this one risks a
+DISCLOSURE.
+
+- `CustomerCreditJourneyResource` — `GET /api/v1/lending/intake/applications[/{id}]`. Returns the
+  caller's own applications as customer-readable journeys.
+
+It reuses section 9's caller control verbatim: the handler compares `SecurityIdentity.principal.name`
+to `lending.intake.caller-principal` and refuses when it does not match or is unset, and the party id
+comes only from `X-Customer-Party-Id`.
+
+| Threat | Scenario | Mitigation |
+|---|---|---|
+| **I**nformation disclosure | An operator, or the edge with a forged header, reads another customer's credit history | Rows are filtered by the header party id; a foreign application id is answered **404, not 403**, so a not-found and a not-yours are indistinguishable and the id space does not leak. Covered by `CustomerCreditJourneyResourceTest`. |
+| **I**nformation disclosure | The journey leaks the bank's internal assessment | The projection exposes canonical states, step codes and the decision engine's machine-readable reason codes only. A human checker's free-text `decisionReason` is deliberately NOT exposed, and a reason code is dropped on any non-refused state. |
+
 ## 10. Change log
+
+- **2026-08-21** — Trust-boundary change (ADR-0269 slice 1): a new customer-edge-facing read
+  surface, `GET /api/v1/lending/intake/applications[/{id}]`. See section 9a. Same caller and
+  party-header controls as section 9; the new risk is disclosure of another party's credit history,
+  closed by owner filtering plus a 404-not-403 answer.
 
 - **2026-08-20** — Catalog-governed loan origination (#668). Adds the product-catalog OIDC read edge
   described in §2 item 9. The caller may select an offering, never a revision or a rate: the service

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -527,6 +527,59 @@ class CustomerEdgeResource(
     }
 
     /**
+     * The caller's OWN credit applications, as customer-readable journeys (ADR-0269 rule 3).
+     *
+     * The read half of the intake pair: `applyForLoan` above files an application, this says where
+     * it got to. Before this route the app's flow ended at submission — a form into a void.
+     *
+     * Fail-soft to `[]`, like `listLoans` and for the same reason: an empty list is an honest answer
+     * for an unavailable READ, and a journey the app cannot fetch is one it must not invent. The
+     * write path stays fail-hard.
+     *
+     * The upstream projection is already customer-safe (no rate, no instalment, no APRC — that is
+     * ADR-0269 rule 4 and arrives as a quote object), so the body passes through unprojected rather
+     * than being re-shaped here into a second, drifting copy of the same contract.
+     */
+    @GET
+    @Path("/credit-applications")
+    @Authorize(action = "customer.profile.read", resource = "")
+    @Blocking
+    fun listCreditApplications(): Response {
+        val customer = customer()
+        val resp = upstream.get(
+            "$lendingServiceUrl/api/v1/lending/intake/applications",
+            customer.partyId.toString(),
+        )
+        if (resp.status != 200) return Response.ok("[]").type(MediaType.APPLICATION_JSON).build()
+        return Response.ok(resp.entity ?: "[]").type(MediaType.APPLICATION_JSON).build()
+    }
+
+    /**
+     * One of the caller's OWN credit applications. Ownership is enforced UPSTREAM by party header —
+     * lending-service filters by owner and answers 404 for a foreign id, so a not-found and a
+     * not-yours are indistinguishable here too. This route must not "helpfully" convert that 404
+     * into anything else.
+     *
+     * Not fail-soft: unlike the list, there is no honest empty value for "this one application" —
+     * a synthesised body would be a fabricated journey state.
+     */
+    @GET
+    @Path("/credit-applications/{applicationId}")
+    @Authorize(action = "customer.profile.read", resource = "#applicationId")
+    @Blocking
+    fun getCreditApplication(@PathParam("applicationId") applicationId: UUID): Response {
+        val customer = customer()
+        val resp = upstream.get(
+            "$lendingServiceUrl/api/v1/lending/intake/applications/$applicationId",
+            customer.partyId.toString(),
+        )
+        return Response.status(resp.status)
+            .entity(resp.entity ?: "{}")
+            .type(MediaType.APPLICATION_JSON)
+            .build()
+    }
+
+    /**
      * The repayment schedule for one of the caller's OWN loans. Ownership enforced HERE: the loan is
      * fetched and its partyId compared to the caller (403 otherwise) — lending-service scopes by loan
      * id only. Projects each installment to {number, dueDate, payment, principal, interest, paid}.

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.40.0
+  version: 1.41.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -1091,6 +1091,49 @@ paths:
               schema:
                 type: array
                 items: {$ref: '#/components/schemas/Loan'}
+
+  /credit-applications:
+    get:
+      tags: [Lending]
+      summary: The caller's own credit applications as customer-readable journeys
+      description: >-
+        ADR-0269 rule 3. The read half of the intake pair: POST /loan-applications files an
+        application, this says where it got to. Carries no rate, instalment or APRC — price is
+        ADR-0269 rule 4 and arrives as a separate quote object. Fails soft to an empty array on
+        upstream failure, because an unfetchable journey must not be invented.
+      operationId: listCreditApplications
+      security:
+        - customerOidc: [accounts:read]
+      responses:
+        '200':
+          description: The caller's credit applications (possibly empty)
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {$ref: '#/components/schemas/CreditJourney'}
+
+  /credit-applications/{applicationId}:
+    get:
+      tags: [Lending]
+      summary: One of the caller's own credit applications
+      description: >-
+        Ownership is enforced upstream by party header: lending-service filters by owner and answers
+        404 for a foreign id, so a not-found and a not-yours are indistinguishable. Not fail-soft —
+        there is no honest empty value for a single journey.
+      operationId: getCreditApplication
+      security:
+        - customerOidc: [accounts:read]
+      parameters:
+        - {name: applicationId, in: path, required: true, schema: {type: string, format: uuid}}
+      responses:
+        '200':
+          description: The credit application journey
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/CreditJourney'}
+        '404':
+          description: No such application for this caller
 
   /loans/{loanId}/schedule:
     get:
@@ -3143,6 +3186,62 @@ components:
 
     # Edge's projected view of lending-service's Loan (internal fields dropped — see
     # CustomerEdgeResource.projectLoan).
+    CreditJourney:
+      type: object
+      description: >-
+        A credit application as the customer sees it (ADR-0269 rule 3). The client RENDERS this and
+        derives nothing from it — no local step advancement, no inferred approval. Deliberately
+        carries no price of any kind.
+      required: [id, productKind, state, steps, requirements, awaitingCustomer, submittedAt]
+      properties:
+        id: {type: string, format: uuid}
+        productKind:
+          type: string
+          description: Which of the three shapes this is, and therefore which steps the customer walks.
+          enum: [UNSECURED, SECURED, REVOLVING]
+        state:
+          type: string
+          description: Canonical ADR-0211 origination state.
+        steps:
+          type: array
+          description: The product's own step sequence with each step's position. Codes, not display text.
+          items:
+            type: object
+            required: [code, status]
+            properties:
+              code:
+                type: string
+                enum: [APPLY, ASSESS, OFFER, COLLATERAL, SIGN, DISBURSE, DRAWDOWN, ACTIVATE_LIMIT]
+              status: {type: string, enum: [DONE, CURRENT, UPCOMING]}
+        requirements:
+          type: array
+          description: Outstanding paperwork. Empty until the collecting steps exist.
+          items:
+            type: object
+            required: [code, status, completedByCustomer]
+            properties:
+              code: {type: string}
+              status: {type: string, enum: [TODO, IN_REVIEW, SATISFIED, REJECTED]}
+              completedByCustomer:
+                type: boolean
+                description: >-
+                  False for work the bank does (a valuation). Rendering those as customer tasks
+                  leaves someone staring at a step they cannot action.
+              reason: {type: string, nullable: true}
+        awaitingCustomer:
+          type: array
+          description: >-
+            Requirement codes the customer must act on now. Empty is a real answer — nothing to do
+            but wait.
+          items: {type: string}
+        outcomeReasonCode:
+          type: string
+          nullable: true
+          description: >-
+            Decision-engine reason code, present only on a refused application. Never a human
+            checker's free-text note.
+        submittedAt: {type: string, format: date-time}
+
     Loan:
       type: object
       properties:

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/LendingModels.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/LendingModels.kt
@@ -13,6 +13,7 @@ import com.openbank.libs.lending.AmortizationMethod
 import com.openbank.libs.lending.DelinquencyBucket
 import com.openbank.libs.lending.EclHorizon
 import com.openbank.libs.lending.Ifrs9Stage
+import com.openbank.libs.lending.origination.CreditProductKind
 import com.openbank.libs.lending.origination.OriginationState
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -128,6 +129,12 @@ data class LoanApplication(
     val decidedAt: OffsetDateTime? = null,
     val jurisdiction: String? = null,
     val productType: String? = null,
+    /**
+     * ADR-0269 rule 3: which of the three credit shapes this application is, and therefore which
+     * steps the customer walks. Defaults to UNSECURED — the only intake route that exists today —
+     * so an existing caller keeps the behaviour it already had.
+     */
+    val productKind: CreditProductKind = CreditProductKind.UNSECURED,
     val packVersion: Int? = null,
     val verifiedIncomeMonthly: Money? = null,
     val existingDebtServiceMonthly: Money? = null,

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/entity/LendingEntities.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/entity/LendingEntities.kt
@@ -11,6 +11,7 @@ import com.openbank.libs.domain.identifiers.Ids
 import com.openbank.libs.lending.AmortizationMethod
 import com.openbank.libs.lending.DelinquencyBucket
 import com.openbank.libs.lending.Ifrs9Stage
+import com.openbank.libs.lending.origination.CreditProductKind
 import com.openbank.libs.lending.origination.OriginationState
 import io.quarkus.hibernate.reactive.panache.PanacheEntityBase
 import jakarta.persistence.Column
@@ -73,6 +74,16 @@ class LoanApplicationEntity : PanacheEntityBase() {
 
     @Column(name = "product_type", length = 32)
     var productType: String? = null
+
+    /**
+     * ADR-0269 rule 3 — the product SHAPE, which decides which steps the customer walks. Distinct
+     * from [productType], which is the ADR-0212 compliance-pack identifier deciding which rules
+     * judge the application. Non-null with an UNSECURED default: every application written before
+     * the column existed is a cash loan, because that is the only intake route that exists.
+     */
+    @Column(name = "product_kind", length = 16, nullable = false)
+    @Enumerated(EnumType.STRING)
+    var productKind: CreditProductKind = CreditProductKind.UNSECURED
 
     @Column(name = "pack_version")
     var packVersion: Int? = null

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/mapper/LendingMapper.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/mapper/LendingMapper.kt
@@ -42,6 +42,7 @@ class LendingMapper {
         it.decidedAt = a.decidedAt
         it.jurisdiction = a.jurisdiction
         it.productType = a.productType
+        it.productKind = a.productKind
         it.packVersion = a.packVersion
         it.verifiedIncomeMonthly = a.verifiedIncomeMonthly?.amount
         it.existingDebtServiceMonthly = a.existingDebtServiceMonthly?.amount
@@ -68,7 +69,8 @@ class LendingMapper {
         periodsPerYear = e.periodsPerYear, method = e.method, firstDueDate = e.firstDueDate,
         status = e.status, proposedBy = e.proposedBy, decidedBy = e.decidedBy,
         decisionReason = e.decisionReason, createdAt = e.createdAt, decidedAt = e.decidedAt,
-        jurisdiction = e.jurisdiction, productType = e.productType, packVersion = e.packVersion,
+        jurisdiction = e.jurisdiction, productType = e.productType, productKind = e.productKind,
+        packVersion = e.packVersion,
         verifiedIncomeMonthly = e.verifiedIncomeMonthly?.let { Money.of(it, e.currency) },
         existingDebtServiceMonthly = e.existingDebtServiceMonthly?.let { Money.of(it, e.currency) },
         ageYears = e.ageYears, residency = e.residency, employmentTenureMonths = e.employmentTenureMonths,

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CustomerCreditJourneyResource.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CustomerCreditJourneyResource.kt
@@ -61,7 +61,8 @@ class CustomerCreditJourneyResource(
     @Authorize(action = "lending.intake", resource = "")
     @Operation(summary = "The caller's own credit applications as customer-readable journeys (edge only)")
     fun list(@HeaderParam(CustomerIntakeResource.PARTY_HEADER) partyHeader: String?): Uni<Response> {
-        val partyId = permittedParty(partyHeader) ?: return refusal()
+        if (!callerIsPermitted()) return refusal()
+        val partyId = scopeOf(partyHeader) ?: return badParty()
         return applications.findByParty(partyId)
             .map { list -> Response.ok(list.map { it.toJourneyDto() }).build() }
     }
@@ -74,7 +75,8 @@ class CustomerCreditJourneyResource(
         @HeaderParam(CustomerIntakeResource.PARTY_HEADER) partyHeader: String?,
         @PathParam("id") id: String,
     ): Uni<Response> {
-        val partyId = permittedParty(partyHeader) ?: return refusal()
+        if (!callerIsPermitted()) return refusal()
+        val partyId = scopeOf(partyHeader) ?: return badParty()
         val applicationId = runCatching { UUID.fromString(id) }.getOrNull()
             ?: return Uni.createFrom().item(notFound())
         return applications.findByParty(partyId).map { list ->
@@ -86,17 +88,43 @@ class CustomerCreditJourneyResource(
         }
     }
 
-    /** The party id this caller may read, or null when the caller or the header is not permitted. */
-    private fun permittedParty(partyHeader: String?): UUID? {
-        if (!config.enabled) return null
+    /**
+     * Whether this CALLER may use the endpoint at all. Deliberately takes no request data: the
+     * decision rests only on the authenticated principal and on configuration.
+     *
+     * Split from [scopeOf] on CodeQL's `java/tainted-permissions-check` finding, and the finding
+     * was fair. The two questions really are different — "may you call this" is about the edge's
+     * M2M identity, "whose rows do you get" is about a header — and answering them in one function
+     * meant request data flowed into an authorization decision. It also read as though a
+     * well-formed header could earn access, which was never the intent and is exactly the kind of
+     * thing a later edit turns true by accident.
+     */
+    private fun callerIsPermitted(): Boolean {
+        if (!config.enabled) return false
         val permitted = config.callerPrincipal.orElse("")
-        if (permitted.isBlank() || identity.principal?.name != permitted) return null
-        val partyId = partyHeader?.let { runCatching { UUID.fromString(it) }.getOrNull() } ?: return null
-        return partyId.takeIf { it != ZERO_UUID }
+        return permitted.isNotBlank() && identity.principal?.name == permitted
     }
+
+    /**
+     * The party whose rows the (already-authorised) caller is asking for. A query SCOPE, never a
+     * permission: by the time this runs, the caller has been admitted or refused on its own merits.
+     */
+    private fun scopeOf(partyHeader: String?): UUID? =
+        partyHeader?.let { runCatching { UUID.fromString(it) }.getOrNull() }?.takeIf { it != ZERO_UUID }
 
     private fun refusal(): Uni<Response> = Uni.createFrom().item(
         Response.status(HTTP_FORBIDDEN).entity(mapOf("error" to "caller is not the customer-edge intake principal"))
+            .build(),
+    )
+
+    /**
+     * A missing or malformed party header from an ALREADY-AUTHORISED caller is a bad request, not a
+     * 403: the caller is permitted, the request is not well-formed. Keeping the two apart also
+     * keeps the 403 meaning exactly one thing — "you are not the edge".
+     */
+    private fun badParty(): Uni<Response> = Uni.createFrom().item(
+        Response.status(HTTP_BAD_REQUEST)
+            .entity(mapOf("error" to "${'$'}{CustomerIntakeResource.PARTY_HEADER} is missing or not a UUID"))
             .build(),
     )
 
@@ -105,6 +133,7 @@ class CustomerCreditJourneyResource(
 
     companion object {
         private val ZERO_UUID = UUID(0, 0)
+        private const val HTTP_BAD_REQUEST = 400
         private const val HTTP_FORBIDDEN = 403
         private const val HTTP_NOT_FOUND = 404
     }

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CustomerCreditJourneyResource.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CustomerCreditJourneyResource.kt
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.infrastructure.rest
+
+import com.openbank.lending.application.port.out.LoanApplicationRepository
+import com.openbank.lending.domain.model.LoanApplication
+import com.openbank.lending.infrastructure.intake.CustomerIntakeConfig
+import com.openbank.libs.authz.Authorize
+import com.openbank.libs.lending.origination.CreditJourneyProjection
+import com.openbank.libs.lending.origination.CreditJourneyView
+import com.openbank.libs.lending.origination.CreditRequirement
+import com.openbank.libs.lending.origination.OriginationState
+import io.quarkus.security.identity.SecurityIdentity
+import io.smallrye.mutiny.Uni
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.HeaderParam
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+import java.util.UUID
+
+/**
+ * The customer-readable projection of an origination journey (ADR-0269 rule 3, ADR-0211 D1 states).
+ *
+ * This is the read half of the customer intake pair: `CustomerIntakeResource` files an application,
+ * this route says where it got to. Without it the app's flow ends at submission, which is what it
+ * did before this slice — a form into a void.
+ *
+ * ## What the projection deliberately does NOT carry
+ *
+ * No rate, no instalment, no APRC, no approval probability. Price is ADR-0269 rule 4 and arrives as
+ * a server quote or a binding offer object, both of which are separate work (#6214). A number
+ * invented here would be the exact defect the ADR exists to prevent — a customer plans a year
+ * around an instalment.
+ *
+ * ## Caller and ownership
+ *
+ * Same shape as the intake POST: the edge's named principal is the only permitted caller, and the
+ * party id comes from `X-Customer-Party-Id`, set by the edge from the customer JWT. A row whose
+ * `partyId` does not match the header is not returned — a foreign application id must read as
+ * "not found", never as someone else's credit history.
+ */
+@Path("/api/v1/lending/intake")
+@Produces(MediaType.APPLICATION_JSON)
+@Tag(name = "Lending", description = "Customer self-service origination intake")
+@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+class CustomerCreditJourneyResource(
+    private val applications: LoanApplicationRepository,
+    private val config: CustomerIntakeConfig,
+    private val identity: SecurityIdentity,
+) {
+    @GET
+    @Path("/applications")
+    @Authorize(action = "lending.intake", resource = "")
+    @Operation(summary = "The caller's own credit applications as customer-readable journeys (edge only)")
+    fun list(@HeaderParam(CustomerIntakeResource.PARTY_HEADER) partyHeader: String?): Uni<Response> {
+        val partyId = permittedParty(partyHeader) ?: return refusal()
+        return applications.findByParty(partyId)
+            .map { list -> Response.ok(list.map { it.toJourneyDto() }).build() }
+    }
+
+    @GET
+    @Path("/applications/{id}")
+    @Authorize(action = "lending.intake", resource = "")
+    @Operation(summary = "One of the caller's own credit applications as a customer-readable journey")
+    fun one(
+        @HeaderParam(CustomerIntakeResource.PARTY_HEADER) partyHeader: String?,
+        @PathParam("id") id: String,
+    ): Uni<Response> {
+        val partyId = permittedParty(partyHeader) ?: return refusal()
+        val applicationId = runCatching { UUID.fromString(id) }.getOrNull()
+            ?: return Uni.createFrom().item(notFound())
+        return applications.findByParty(partyId).map { list ->
+            // Filtered by owner, not fetched by id and then checked: a not-found and a
+            // not-yours must be indistinguishable to the caller, or the id space leaks.
+            list.firstOrNull { it.id.value == applicationId }
+                ?.let { Response.ok(it.toJourneyDto()).build() }
+                ?: notFound()
+        }
+    }
+
+    /** The party id this caller may read, or null when the caller or the header is not permitted. */
+    private fun permittedParty(partyHeader: String?): UUID? {
+        if (!config.enabled) return null
+        val permitted = config.callerPrincipal.orElse("")
+        if (permitted.isBlank() || identity.principal?.name != permitted) return null
+        val partyId = partyHeader?.let { runCatching { UUID.fromString(it) }.getOrNull() } ?: return null
+        return partyId.takeIf { it != ZERO_UUID }
+    }
+
+    private fun refusal(): Uni<Response> = Uni.createFrom().item(
+        Response.status(HTTP_FORBIDDEN).entity(mapOf("error" to "caller is not the customer-edge intake principal"))
+            .build(),
+    )
+
+    private fun notFound(): Response =
+        Response.status(HTTP_NOT_FOUND).entity(mapOf("error" to "application not found")).build()
+
+    companion object {
+        private val ZERO_UUID = UUID(0, 0)
+        private const val HTTP_FORBIDDEN = 403
+        private const val HTTP_NOT_FOUND = 404
+    }
+}
+
+/**
+ * The wire shape. Flat and stable: the app renders it directly, so a rename here is a client break.
+ *
+ * [requirements] is empty in this slice — the requirement list is written by the steps that collect
+ * documents and valuations, and none of those exist yet. Empty is the honest value: it says "we are
+ * not waiting on you", which is true of every application in the current unsecured-only book.
+ */
+data class CustomerCreditJourneyDto(
+    val id: String,
+    val productKind: String,
+    val state: String,
+    val steps: List<CustomerCreditStepDto>,
+    val requirements: List<CustomerCreditRequirementDto>,
+    val awaitingCustomer: List<String>,
+    val outcomeReasonCode: String?,
+    val submittedAt: String,
+)
+
+data class CustomerCreditStepDto(val code: String, val status: String)
+
+data class CustomerCreditRequirementDto(
+    val code: String,
+    val status: String,
+    val completedByCustomer: Boolean,
+    val reason: String?,
+)
+
+private fun LoanApplication.toJourneyDto(): CustomerCreditJourneyDto {
+    val view: CreditJourneyView = CreditJourneyProjection.project(
+        productKind = productKind,
+        state = status,
+        requirements = requirementsOf(this),
+        outcomeReasonCode = decisionOutcomeReasonCode(),
+    )
+    return CustomerCreditJourneyDto(
+        id = id.value.toString(),
+        productKind = view.productKind.name,
+        state = view.state.name,
+        steps = view.steps.map { CustomerCreditStepDto(it.code, it.status.name) },
+        requirements = view.requirements.map {
+            CustomerCreditRequirementDto(it.code, it.status.name, it.completedByCustomer, it.reason)
+        },
+        awaitingCustomer = view.awaitingCustomer.map { it.code },
+        outcomeReasonCode = view.outcomeReasonCode,
+        submittedAt = createdAt.toInstant().toString(),
+    )
+}
+
+/** No requirement collection exists yet — see [CustomerCreditJourneyDto]. */
+private fun requirementsOf(@Suppress("UNUSED_PARAMETER") application: LoanApplication): List<CreditRequirement> =
+    emptyList()
+
+/**
+ * The decision engine's reason codes, passed through only for a refused application.
+ *
+ * `decisionReasons` is the engine's own machine-readable list (ADR-0213); the free-text
+ * `decisionReason` written by a human checker is deliberately NOT exposed — a customer-facing
+ * refusal must not surface an officer's internal note verbatim.
+ */
+private fun LoanApplication.decisionOutcomeReasonCode(): String? =
+    decisionReasons?.takeIf { it.isNotBlank() && status == OriginationState.DECLINED }

--- a/openbank-lending-service/src/main/resources/db/migration/V13__credit_product_kind.sql
+++ b/openbank-lending-service/src/main/resources/db/migration/V13__credit_product_kind.sql
@@ -1,0 +1,24 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- ADR-0269 rule 3: one CreditApplication journey for three product shapes.
+--
+-- product_kind is the shape (UNSECURED / SECURED / REVOLVING); the existing product_type stays
+-- what it always was — the ADR-0212 compliance-pack product identifier — and the two are not
+-- interchangeable. A pack decides which rules judge the application; the kind decides which steps
+-- the customer walks.
+--
+-- Backfill is UNSECURED because that is what every application in the book actually is today: the
+-- only origination route that exists is the cash-loan intake. Defaulting to a kind nobody has
+-- applied for would invent a product history.
+--
+-- Rollback: ALTER TABLE loan_application DROP COLUMN product_kind;  (the column is additive and
+-- nothing reads it until the projection endpoint ships in the same release)
+
+ALTER TABLE loan_application
+    ADD COLUMN IF NOT EXISTS product_kind varchar(16) NOT NULL DEFAULT 'UNSECURED';
+
+-- Rows written before this migration are unsecured cash loans by construction; make that explicit
+-- rather than relying on the DEFAULT, so a later DEFAULT change cannot retroactively relabel them.
+UPDATE loan_application SET product_kind = 'UNSECURED' WHERE product_kind IS NULL;
+
+COMMENT ON COLUMN loan_application.product_kind IS
+    'ADR-0269 credit product shape: UNSECURED | SECURED | REVOLVING. Not the compliance-pack product_type.';

--- a/openbank-lending-service/src/main/resources/openapi.yaml
+++ b/openbank-lending-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Lending Service API
-  version: 1.13.0
+  version: 1.14.0
   description: >-
     Loan origination, servicing, collateral and IFRS 9 provisioning (ADR-0028). The loan book posts
     cash events to ledger-service and never owns balances. Credit decisions and collateral
@@ -85,6 +85,47 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '422':
           description: Refused by the origination guard (e.g. no active compliance pack)
+    get:
+      tags: [Lending]
+      operationId: listCustomerCreditJourneys
+      summary: The caller's own credit applications as customer-readable journeys (customer-edge only)
+      description: >-
+        ADR-0269 rule 3. Scoped to the party in X-Customer-Party-Id; carries no rate, instalment or
+        APRC — that is ADR-0269 rule 4 and arrives separately. Only the configured customer-edge principal may
+        call it.
+      parameters:
+        - name: X-Customer-Party-Id
+          in: header
+          required: true
+          description: The applicant's party id, set by customer-edge from the customer JWT.
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: The party's credit applications (possibly empty)
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/lending/intake/applications/{id}:
+    get:
+      tags: [Lending]
+      operationId: getCustomerCreditJourney
+      summary: One of the caller's own credit applications as a customer-readable journey
+      description: >-
+        A journey belonging to another party answers 404, not 403 — a not-found and a not-yours must
+        be indistinguishable, or the id space leaks.
+      parameters:
+        - $ref: '#/components/parameters/IdPath'
+        - name: X-Customer-Party-Id
+          in: header
+          required: true
+          description: The applicant's party id, set by customer-edge from the customer JWT.
+          schema: { type: string, format: uuid }
+      responses:
+        '200': { description: The credit application journey }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404': { description: No such application for this caller }
+
   /api/v1/lending/applications/{id}:
     get:
       tags: [Lending]

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerCreditJourneyResourceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerCreditJourneyResourceTest.kt
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.infrastructure.rest
+
+import com.openbank.lending.application.port.out.LoanApplicationRepository
+import com.openbank.lending.domain.model.ApplicationStateSummary
+import com.openbank.lending.domain.model.LoanApplication
+import com.openbank.lending.infrastructure.intake.CustomerIntakeConfig
+import com.openbank.libs.domain.identifiers.LoanApplicationId
+import com.openbank.libs.domain.money.Money
+import com.openbank.libs.lending.origination.CreditProductKind
+import com.openbank.libs.lending.origination.OriginationState
+import io.quarkus.security.identity.SecurityIdentity
+import io.quarkus.security.runtime.QuarkusSecurityIdentity
+import io.smallrye.mutiny.Uni
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.security.Principal
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.Optional
+import java.util.UUID
+
+/**
+ * Like the intake POST, this GET is a security boundary before it is a feature — it hands back
+ * somebody's credit history. The tests are therefore written against the ways it could wrongly
+ * DISCLOSE: a caller that is not the edge, a party header that is not the one the row belongs to,
+ * and an application id that belongs to someone else.
+ */
+class CustomerCreditJourneyResourceTest {
+
+    private val edge = "service-account-openbank-edge"
+    private val party = UUID.fromString("05a02ef1-381c-40e7-b73f-d6855eead42e")
+    private val stranger = UUID.fromString("11111111-2222-3333-4444-555555555555")
+
+    private fun config(enabled: Boolean = true, caller: String? = "service-account-openbank-edge") =
+        CustomerIntakeConfig(
+            enabled = enabled,
+            callerPrincipal = Optional.ofNullable(caller),
+            jurisdiction = "CZ",
+            productType = "CONSUMER_CREDIT",
+            currency = "CZK",
+            nominalAnnualRate = Optional.of(BigDecimal("0.079")),
+            minAmount = BigDecimal("5000"),
+            maxAmount = BigDecimal("1000000"),
+            minTermMonths = 6,
+            maxTermMonths = 120,
+        )
+
+    private fun identity(name: String): SecurityIdentity =
+        QuarkusSecurityIdentity.builder().setPrincipal(Principal { name }).build()
+
+    private fun application(
+        owner: UUID = party,
+        state: OriginationState = OriginationState.ASSESSMENT,
+        kind: CreditProductKind = CreditProductKind.UNSECURED,
+        id: UUID = UUID.randomUUID(),
+    ) = LoanApplication(
+        id = LoanApplicationId(id),
+        partyId = owner,
+        requestedAmount = Money.of(BigDecimal("250000"), "CZK"),
+        nominalAnnualRate = BigDecimal("0.079"),
+        termPeriods = 48,
+        firstDueDate = LocalDate.parse("2026-10-01"),
+        status = state,
+        productKind = kind,
+        proposedBy = "customer:$owner",
+        createdAt = OffsetDateTime.parse("2026-08-01T10:00:00Z"),
+    )
+
+    private fun resource(
+        rows: List<LoanApplication>,
+        principal: String = edge,
+        config: CustomerIntakeConfig = config(),
+    ) = CustomerCreditJourneyResource(StubRepository(rows), config, identity(principal))
+
+    @Suppress("UNCHECKED_CAST")
+    private fun bodyOf(response: jakarta.ws.rs.core.Response): List<CustomerCreditJourneyDto> =
+        response.entity as List<CustomerCreditJourneyDto>
+
+    // ── Disclosure ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the edge principal reads the party's own applications`() {
+        val response = resource(listOf(application())).list(party.toString()).await().indefinitely()
+        assertThat(response.status).isEqualTo(200)
+        assertThat(bodyOf(response)).hasSize(1)
+    }
+
+    @Test
+    fun `an operator that is not the edge is refused`() {
+        val response = resource(listOf(application()), principal = "service-account-someone-else")
+            .list(party.toString()).await().indefinitely()
+        assertThat(response.status).isEqualTo(403)
+    }
+
+    @Test
+    fun `an unset caller-principal refuses everyone rather than admitting any operator`() {
+        val response = resource(listOf(application()), config = config(caller = null))
+            .list(party.toString()).await().indefinitely()
+        assertThat(response.status).isEqualTo(403)
+    }
+
+    @Test
+    fun `a disabled intake serves nothing`() {
+        val response = resource(listOf(application()), config = config(enabled = false))
+            .list(party.toString()).await().indefinitely()
+        assertThat(response.status).isEqualTo(403)
+    }
+
+    @Test
+    fun `a missing party header is refused, not treated as fleet-wide`() {
+        val response = resource(listOf(application())).list(null).await().indefinitely()
+        assertThat(response.status).isEqualTo(403)
+    }
+
+    @Test
+    fun `another party's application reads as not found, never as someone else's credit history`() {
+        val theirs = application(owner = stranger)
+        val response = resource(listOf(theirs)).one(party.toString(), theirs.id.value.toString())
+            .await().indefinitely()
+        assertThat(response.status).isEqualTo(404)
+    }
+
+    @Test
+    fun `a malformed application id is a 404, not a 500`() {
+        val response = resource(listOf(application())).one(party.toString(), "not-a-uuid").await().indefinitely()
+        assertThat(response.status).isEqualTo(404)
+    }
+
+    // ── Projection ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the journey renders the product's own steps and the state it is actually in`() {
+        val row = application(state = OriginationState.OFFERED, kind = CreditProductKind.REVOLVING)
+        val dto = bodyOf(resource(listOf(row)).list(party.toString()).await().indefinitely()).single()
+        assertThat(dto.productKind).isEqualTo("REVOLVING")
+        assertThat(dto.state).isEqualTo("OFFERED")
+        assertThat(dto.steps.map { it.code }).contains("ACTIVATE_LIMIT").doesNotContain("DISBURSE")
+        assertThat(dto.steps.first { it.code == "OFFER" }.status).isEqualTo("CURRENT")
+    }
+
+    @Test
+    fun `no price of any kind is exposed — rate, instalment and APRC are ADR-0269 rule 4`() {
+        val dto = bodyOf(resource(listOf(application())).list(party.toString()).await().indefinitely()).single()
+        val fields = CustomerCreditJourneyDto::class.java.declaredFields.map { it.name.lowercase() }
+        assertThat(fields).noneMatch { it.contains("rate") || it.contains("apr") || it.contains("instal") }
+    }
+
+    @Test
+    fun `awaitingCustomer is empty while no requirement collection exists`() {
+        val dto = bodyOf(resource(listOf(application())).list(party.toString()).await().indefinitely()).single()
+        assertThat(dto.awaitingCustomer).isEmpty()
+    }
+
+    private class StubRepository(private val rows: List<LoanApplication>) : LoanApplicationRepository {
+        override fun save(application: LoanApplication): Uni<LoanApplication> = Uni.createFrom().item(application)
+
+        override fun findById(id: LoanApplicationId): Uni<LoanApplication?> =
+            Uni.createFrom().item(rows.firstOrNull { it.id == id })
+
+        override fun findByParty(partyId: UUID): Uni<List<LoanApplication>> =
+            Uni.createFrom().item(rows.filter { it.partyId == partyId })
+
+        override fun findRecent(status: String?, limit: Int): Uni<List<LoanApplication>> =
+            Uni.createFrom().item(emptyList())
+
+        override fun summariseByState(): Uni<List<ApplicationStateSummary>> = Uni.createFrom().item(emptyList())
+
+        override fun update(application: LoanApplication): Uni<LoanApplication> = Uni.createFrom().item(application)
+
+        override fun compareAndSetStatus(
+            id: LoanApplicationId,
+            from: OriginationState,
+            to: OriginationState,
+            decidedBy: String?,
+            decisionReason: String?,
+            decidedAt: OffsetDateTime?,
+        ): Uni<Int> = Uni.createFrom().item(0)
+    }
+}

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerCreditJourneyResourceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerCreditJourneyResourceTest.kt
@@ -113,7 +113,18 @@ class CustomerCreditJourneyResourceTest {
 
     @Test
     fun `a missing party header is refused, not treated as fleet-wide`() {
+        // 400, not 403: the caller IS the edge, the request just carries no scope. Keeping the two
+        // apart keeps 403 meaning exactly one thing — "you are not the edge".
         val response = resource(listOf(application())).list(null).await().indefinitely()
+        assertThat(response.status).isEqualTo(400)
+    }
+
+    @Test
+    fun `a well-formed party header does not earn access for a caller that is not the edge`() {
+        // The permission decision must not depend on request data at all (CodeQL
+        // java/tainted-permissions-check): a perfect header from the wrong principal is still 403.
+        val response = resource(listOf(application()), principal = "service-account-someone-else")
+            .list(party.toString()).await().indefinitely()
         assertThat(response.status).isEqualTo(403)
     }
 
@@ -145,9 +156,8 @@ class CustomerCreditJourneyResourceTest {
 
     @Test
     fun `no price of any kind is exposed — rate, instalment and APRC are ADR-0269 rule 4`() {
-        val dto = bodyOf(resource(listOf(application())).list(party.toString()).await().indefinitely()).single()
-        val fields = CustomerCreditJourneyDto::class.java.declaredFields.map { it.name.lowercase() }
-        assertThat(fields).noneMatch { it.contains("rate") || it.contains("apr") || it.contains("instal") }
+        assertThat(CustomerCreditJourneyDto::class.java.declaredFields.map { it.name.lowercase() })
+            .noneMatch { it.contains("rate") || it.contains("apr") || it.contains("instal") }
     }
 
     @Test

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/origination/CreditJourney.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/origination/CreditJourney.kt
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending.origination
+
+/**
+ * ADR-0269 rule 3 — one credit journey, three product shapes.
+ *
+ * The [OriginationState] machine is shared and unchanged: unsecured, secured and revolving credit
+ * all move through the same states, in the same order, under the same guards. What differs between
+ * them is *which steps a customer has to complete*, and that difference lives in the requirement
+ * list rather than in a second state machine.
+ *
+ * Three parallel origination pipelines would mean three audit trails, three sets of reason codes,
+ * and three places for the ADR-0269 rule-2 suppression check to be forgotten — it only has to be
+ * forgotten once to matter. The variance is genuinely in the paperwork, so it is modelled as
+ * paperwork.
+ */
+enum class CreditProductKind {
+    /** Cash loan. Decision in minutes, one disbursement, fixed schedule. */
+    UNSECURED,
+
+    /** Mortgage or car loan. Collateral, valuation, insurance, staged drawdowns, weeks not minutes. */
+    SECURED,
+
+    /** Overdraft, credit card, instalment limit. No disbursement at all — the limit is activated. */
+    REVOLVING,
+}
+
+/** What the bank still needs from (or about) the applicant before the journey can move on. */
+enum class CreditRequirementStatus {
+    /** Not supplied yet. The customer's move. */
+    TODO,
+
+    /** Supplied and being checked. Nobody's move; the app shows a wait, not a button. */
+    IN_REVIEW,
+
+    /** Accepted. */
+    SATISFIED,
+
+    /** Rejected — [CreditRequirement.reason] says why, because "rejected" alone is unactionable. */
+    REJECTED,
+}
+
+/**
+ * One outstanding item. [code] is a stable machine key the client maps to its own copy; [reason] is
+ * populated for [CreditRequirementStatus.REJECTED] and carries the checker's words.
+ *
+ * [completedByCustomer] separates "you must do this" from "we are doing this": a valuation is a
+ * requirement of the journey but not a task for the applicant, and rendering it as one produces a
+ * customer staring at a step they cannot action.
+ */
+data class CreditRequirement(
+    val code: String,
+    val status: CreditRequirementStatus,
+    val completedByCustomer: Boolean,
+    val reason: String? = null,
+) {
+    init {
+        require(code.isNotBlank()) { "requirement code must not be blank" }
+        require(status != CreditRequirementStatus.REJECTED || !reason.isNullOrBlank()) {
+            "a rejected requirement must carry a reason"
+        }
+    }
+
+    val outstanding: Boolean
+        get() = status == CreditRequirementStatus.TODO || status == CreditRequirementStatus.REJECTED
+}
+
+/** How one journey step stands relative to where the application actually is. */
+enum class CreditStepStatus { DONE, CURRENT, UPCOMING }
+
+/** A customer-facing step: a stable [code] plus its position in this application's own journey. */
+data class CreditJourneyStep(val code: String, val status: CreditStepStatus)
+
+/**
+ * The whole customer-readable view of an application. The client renders THIS and derives nothing:
+ * no local step advancement, no inferred approval, no success state ahead of the server.
+ *
+ * [outcomeReasonCode] is non-null only in a terminal, non-disbursed state; it is the decision
+ * engine's reason code (ADR-0213), never free text composed here.
+ */
+data class CreditJourneyView(
+    val productKind: CreditProductKind,
+    val state: OriginationState,
+    val steps: List<CreditJourneyStep>,
+    val requirements: List<CreditRequirement>,
+    val outcomeReasonCode: String? = null,
+) {
+    /** What the customer must act on now. Empty is a meaningful answer: "nothing, wait for us". */
+    val awaitingCustomer: List<CreditRequirement>
+        get() = requirements.filter { it.outstanding && it.completedByCustomer }
+}
+
+/**
+ * Builds [CreditJourneyView] from server state. Pure — no clock, no I/O, no persistence — so the
+ * whole per-product shape is exercisable from a unit test rather than from a running journey.
+ */
+object CreditJourneyProjection {
+
+    /**
+     * The step sequence per product kind, in customer-facing order.
+     *
+     * These are STEPS, not states: several origination states collapse into one thing a customer
+     * recognises ("we are assessing"), and one state can be invisible to them entirely. The mapping
+     * from state to step is [stepOfState] below; a state absent from that map simply does not move
+     * the customer's progress bar, which is the honest rendering of an internal-only transition.
+     */
+    private val UNSECURED_STEPS = listOf(STEP_APPLY, STEP_ASSESS, STEP_OFFER, STEP_SIGN, STEP_DISBURSE)
+
+    /**
+     * Secured credit inserts collateral work between offer and signature and replaces the single
+     * disbursement with staged drawdowns. Several of these steps complete OUTSIDE the app (a lien
+     * registration is not a mobile flow); they appear anyway, because a journey that hides the steps
+     * it cannot host leaves the customer with weeks of unexplained silence.
+     */
+    private val SECURED_STEPS =
+        listOf(STEP_APPLY, STEP_ASSESS, STEP_OFFER, STEP_COLLATERAL, STEP_SIGN, STEP_DRAWDOWN)
+
+    /** Revolving credit has no disbursement: the limit is switched on. */
+    private val REVOLVING_STEPS = listOf(STEP_APPLY, STEP_ASSESS, STEP_OFFER, STEP_SIGN, STEP_ACTIVATE_LIMIT)
+
+    /** Which step each origination state belongs to. States not listed leave progress untouched. */
+    private val STATE_TO_STEP: Map<OriginationState, String> = mapOf(
+        OriginationState.DRAFT to STEP_APPLY,
+        OriginationState.SUBMITTED to STEP_APPLY,
+        OriginationState.KYC_PENDING to STEP_ASSESS,
+        OriginationState.DOCS_REQUIRED to STEP_ASSESS,
+        OriginationState.ASSESSMENT to STEP_ASSESS,
+        OriginationState.DECISION_PENDING to STEP_ASSESS,
+        OriginationState.FOUR_EYES to STEP_ASSESS,
+        OriginationState.OFFERED to STEP_OFFER,
+        OriginationState.AWAITING_SIGNATURE to STEP_SIGN,
+        OriginationState.SIGNED to STEP_SIGN,
+        OriginationState.REFLECTION_PERIOD to STEP_SIGN,
+    )
+
+    fun stepsFor(productKind: CreditProductKind): List<String> = when (productKind) {
+        CreditProductKind.UNSECURED -> UNSECURED_STEPS
+        CreditProductKind.SECURED -> SECURED_STEPS
+        CreditProductKind.REVOLVING -> REVOLVING_STEPS
+    }
+
+    fun project(
+        productKind: CreditProductKind,
+        state: OriginationState,
+        requirements: List<CreditRequirement> = emptyList(),
+        outcomeReasonCode: String? = null,
+    ): CreditJourneyView {
+        val order = stepsFor(productKind)
+        val currentStep = stepOfState(productKind, state)
+        val currentIndex = order.indexOf(currentStep)
+        val steps = order.mapIndexed { index, code ->
+            CreditJourneyStep(code, statusAt(index, currentIndex, state))
+        }
+        return CreditJourneyView(
+            productKind = productKind,
+            state = state,
+            steps = steps,
+            requirements = requirements,
+            // A reason code belongs to a refusal, never to a live or completed journey. Carrying one
+            // on a DISBURSED application would render as "approved, because: declined".
+            outcomeReasonCode = outcomeReasonCode?.takeIf { state in REFUSED_STATES },
+        )
+    }
+
+    /**
+     * The final step of a fully-completed journey is DONE, everything before the current step is
+     * DONE, the current step is CURRENT, the rest UPCOMING.
+     *
+     * A refused journey (declined, withdrawn, expired) freezes: the steps behind it stay DONE and
+     * nothing becomes CURRENT, because there is no next thing for the customer to do. Rendering a
+     * live-looking CURRENT step on a declined application is how a customer waits for a decision
+     * that already happened.
+     */
+    private fun statusAt(index: Int, currentIndex: Int, state: OriginationState): CreditStepStatus = when {
+        state == OriginationState.DISBURSED -> CreditStepStatus.DONE
+        state in REFUSED_STATES -> if (index < currentIndex) CreditStepStatus.DONE else CreditStepStatus.UPCOMING
+        currentIndex < 0 -> CreditStepStatus.UPCOMING
+        index < currentIndex -> CreditStepStatus.DONE
+        index == currentIndex -> CreditStepStatus.CURRENT
+        else -> CreditStepStatus.UPCOMING
+    }
+
+    /**
+     * The step a state belongs to. READY_TO_DISBURSE and DISBURSED land on the product's own final
+     * step, which is why they are resolved here rather than in [STATE_TO_STEP] — the same state
+     * means "money on its way" for a cash loan, "first tranche" for a mortgage and "limit going
+     * live" for an overdraft, and only the product kind can tell them apart.
+     */
+    private fun stepOfState(productKind: CreditProductKind, state: OriginationState): String? = when (state) {
+        OriginationState.READY_TO_DISBURSE, OriginationState.DISBURSED -> stepsFor(productKind).last()
+        // A refused journey's frozen position: the step it never got past.
+        OriginationState.DECLINED, OriginationState.EXPIRED -> STEP_OFFER
+        OriginationState.WITHDRAWN -> STEP_APPLY
+        else -> STATE_TO_STEP[state]
+    }
+
+    private val REFUSED_STATES: Set<OriginationState> = setOf(
+        OriginationState.DECLINED,
+        OriginationState.WITHDRAWN,
+        OriginationState.EXPIRED,
+    )
+}
+
+// Stable step codes. The client maps these to its own copy; they are keys, never display strings.
+const val STEP_APPLY = "APPLY"
+const val STEP_ASSESS = "ASSESS"
+const val STEP_OFFER = "OFFER"
+const val STEP_COLLATERAL = "COLLATERAL"
+const val STEP_SIGN = "SIGN"
+const val STEP_DISBURSE = "DISBURSE"
+const val STEP_DRAWDOWN = "DRAWDOWN"
+const val STEP_ACTIVATE_LIMIT = "ACTIVATE_LIMIT"

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/origination/CreditJourneyProjectionTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/origination/CreditJourneyProjectionTest.kt
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending.origination
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/** ADR-0269 rule 3: one journey, three product shapes, and a view the client renders rather than infers. */
+class CreditJourneyProjectionTest {
+
+    private fun codes(view: CreditJourneyView) = view.steps.map { it.code }
+
+    private fun statusOf(view: CreditJourneyView, code: String) = view.steps.first { it.code == code }.status
+
+    // ── The three shapes ──────────────────────────────────────────────────────
+
+    @Test
+    fun `unsecured credit ends in a disbursement`() {
+        val view = CreditJourneyProjection.project(CreditProductKind.UNSECURED, OriginationState.SUBMITTED)
+        assertThat(codes(view)).containsExactly(STEP_APPLY, STEP_ASSESS, STEP_OFFER, STEP_SIGN, STEP_DISBURSE)
+    }
+
+    @Test
+    fun `secured credit inserts collateral before signing and draws down in tranches`() {
+        val view = CreditJourneyProjection.project(CreditProductKind.SECURED, OriginationState.SUBMITTED)
+        assertThat(codes(view))
+            .containsExactly(STEP_APPLY, STEP_ASSESS, STEP_OFFER, STEP_COLLATERAL, STEP_SIGN, STEP_DRAWDOWN)
+    }
+
+    @Test
+    fun `revolving credit has no disbursement at all — the limit is activated`() {
+        val view = CreditJourneyProjection.project(CreditProductKind.REVOLVING, OriginationState.SUBMITTED)
+        assertThat(codes(view)).doesNotContain(STEP_DISBURSE, STEP_DRAWDOWN)
+        assertThat(codes(view).last()).isEqualTo(STEP_ACTIVATE_LIMIT)
+    }
+
+    @Test
+    fun `all three shapes share the same opening steps — the variance is later, in the paperwork`() {
+        val opening = CreditProductKind.entries.map { CreditJourneyProjection.stepsFor(it).take(3) }
+        assertThat(opening).allMatch { it == listOf(STEP_APPLY, STEP_ASSESS, STEP_OFFER) }
+    }
+
+    // ── Progress ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `assessment states collapse into one customer-visible step`() {
+        val states = listOf(
+            OriginationState.KYC_PENDING,
+            OriginationState.DOCS_REQUIRED,
+            OriginationState.ASSESSMENT,
+            OriginationState.DECISION_PENDING,
+            OriginationState.FOUR_EYES,
+        )
+        states.forEach { state ->
+            val view = CreditJourneyProjection.project(CreditProductKind.UNSECURED, state)
+            assertThat(statusOf(view, STEP_ASSESS)).describedAs(state.name).isEqualTo(CreditStepStatus.CURRENT)
+            assertThat(statusOf(view, STEP_APPLY)).isEqualTo(CreditStepStatus.DONE)
+        }
+    }
+
+    @Test
+    fun `a disbursed application shows every step done`() {
+        val view = CreditJourneyProjection.project(CreditProductKind.UNSECURED, OriginationState.DISBURSED)
+        assertThat(view.steps.map { it.status }).containsOnly(CreditStepStatus.DONE)
+    }
+
+    @Test
+    fun `READY_TO_DISBURSE lands on the product's own final step, not on a shared one`() {
+        val revolving = CreditJourneyProjection.project(CreditProductKind.REVOLVING, OriginationState.READY_TO_DISBURSE)
+        val secured = CreditJourneyProjection.project(CreditProductKind.SECURED, OriginationState.READY_TO_DISBURSE)
+        assertThat(statusOf(revolving, STEP_ACTIVATE_LIMIT)).isEqualTo(CreditStepStatus.CURRENT)
+        assertThat(statusOf(secured, STEP_DRAWDOWN)).isEqualTo(CreditStepStatus.CURRENT)
+    }
+
+    // ── Refusal must not look live ────────────────────────────────────────────
+
+    @Test
+    fun `a declined application has no CURRENT step — there is nothing left to wait for`() {
+        val view = CreditJourneyProjection.project(
+            CreditProductKind.UNSECURED,
+            OriginationState.DECLINED,
+            outcomeReasonCode = "DSTI_ABOVE_LIMIT",
+        )
+        assertThat(view.steps.map { it.status }).doesNotContain(CreditStepStatus.CURRENT)
+        assertThat(view.outcomeReasonCode).isEqualTo("DSTI_ABOVE_LIMIT")
+    }
+
+    @Test
+    fun `a reason code is dropped on a live or completed journey rather than rendered as a refusal`() {
+        val disbursed = CreditJourneyProjection.project(
+            CreditProductKind.UNSECURED,
+            OriginationState.DISBURSED,
+            outcomeReasonCode = "DSTI_ABOVE_LIMIT",
+        )
+        assertThat(disbursed.outcomeReasonCode).isNull()
+    }
+
+    // ── Requirements ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `awaitingCustomer lists only outstanding items the customer can actually action`() {
+        val view = CreditJourneyProjection.project(
+            CreditProductKind.SECURED,
+            OriginationState.OFFERED,
+            requirements = listOf(
+                CreditRequirement("TITLE_DEED", CreditRequirementStatus.TODO, completedByCustomer = true),
+                CreditRequirement("VALUATION", CreditRequirementStatus.TODO, completedByCustomer = false),
+                CreditRequirement("INCOME_PROOF", CreditRequirementStatus.SATISFIED, completedByCustomer = true),
+                CreditRequirement("INSURANCE", CreditRequirementStatus.IN_REVIEW, completedByCustomer = true),
+            ),
+        )
+        assertThat(view.awaitingCustomer.map { it.code }).containsExactly("TITLE_DEED")
+    }
+
+    @Test
+    fun `a rejected requirement counts as outstanding and is handed back to the customer`() {
+        val view = CreditJourneyProjection.project(
+            CreditProductKind.SECURED,
+            OriginationState.OFFERED,
+            requirements = listOf(
+                CreditRequirement("TITLE_DEED", CreditRequirementStatus.REJECTED, true, reason = "illegible scan"),
+            ),
+        )
+        assertThat(view.awaitingCustomer.map { it.code }).containsExactly("TITLE_DEED")
+    }
+
+    @Test
+    fun `a rejected requirement without a reason is refused at construction — unactionable by definition`() {
+        assertThatThrownBy {
+            CreditRequirement("TITLE_DEED", CreditRequirementStatus.REJECTED, completedByCustomer = true)
+        }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `an empty awaitingCustomer is a real answer — nothing to do but wait`() {
+        val view = CreditJourneyProjection.project(
+            CreditProductKind.UNSECURED,
+            OriginationState.ASSESSMENT,
+            requirements = listOf(CreditRequirement("VALUATION", CreditRequirementStatus.TODO, false)),
+        )
+        assertThat(view.awaitingCustomer).isEmpty()
+        assertThat(view.requirements).hasSize(1)
+    }
+}


### PR DESCRIPTION
Closes #6213. Second slice of the epic (#6217). **Stacked on #6226** (slice 0) — base is that branch, not main, so the diff stays readable; retarget to main once slice 0 lands.

## The problem

The app files an application and the flow ends there. No state, no steps, no outcome — a form into a void. Nothing in the fleet exposed where an application got to in customer-readable terms.

## The decision

**The ADR-0211 state machine is shared and unchanged.** Unsecured, secured and revolving credit move through the same states, in the same order, under the same guards. What differs is *which steps the customer walks*, and that lives in `CreditProductKind` + a `requirements[]` list.

Three parallel origination pipelines would mean three audit trails, three sets of reason codes, and three places for slice 0's suppression check to be forgotten. It only has to be forgotten once to matter. The variance between these products is genuinely paperwork, so it is modelled as paperwork.

## Projection rules worth review attention

- **Assessment states collapse into one step** a customer recognises. `KYC_PENDING`, `DOCS_REQUIRED`, `ASSESSMENT`, `DECISION_PENDING`, `FOUR_EYES` are five internal states and one honest sentence.
- **`READY_TO_DISBURSE` resolves to the product's OWN final step** — "money on its way" for a cash loan, "first tranche" for a mortgage, "limit going live" for an overdraft. Only the product kind can tell those apart, which is why it is resolved in the projection rather than in the state→step map.
- **A refused journey has no `CURRENT` step.** A live-looking step on a declined application is exactly how a customer waits for a decision that already happened.
- **A reason code is dropped on a live or completed journey.** Carrying one onto `DISBURSED` would render as "approved, because: declined".
- **`completedByCustomer` separates "you must do this" from "we are doing this".** A valuation is a requirement of the journey but not a task for the applicant, and rendering it as one leaves someone staring at a step they cannot action.
- **A rejected requirement without a reason is refused at construction** — unactionable by definition.

## Disclosure boundary

The GET is a security boundary before it is a feature: it hands back somebody's credit history. Tests are written against the ways it could wrongly **disclose** — a caller that is not the edge, an unset `caller-principal` read as "any operator may", a missing party header, a foreign application id.

A foreign id returns **404, not 403**: a not-found and a not-yours must be indistinguishable, or the id space leaks.

## No price, anywhere

No rate, no instalment, no APRC, no eligibility hint. That is rule 4 (#6214) and arrives as a server quote or a binding offer. One test asserts the DTO has no field whose name contains `rate`, `apr` or `instal` — a structural guard, so adding one later fails rather than shipping.

## Verification

`:openbank-lending-service:test` — 286 tests, 0 failures, 0 skipped. Projection: 13 tests. Resource: 10 tests. Result XML checked for `tests=`/`skipped=` counts, not the build's exit code.

Two self-inflicted defects, both found by running rather than reading, both recorded because they would have failed the same way in CI:

- **V10 was already taken** by `V10__loan_termination_lifecycle.sql`. Flyway's duplicate-version refusal takes down the entire Quarkus test context, so it surfaced as 7 unrelated tests failing — including integration tests that look like a broken environment. Renumbered to V13.
- **The migration named the table `loan_applications`; it is `loan_application`.**

## Not in this PR

Requirement collection (nothing writes the list yet — empty is the honest value for the unsecured-only book that exists today), quotes and offers (#6214), and the app-side rendering (openbank-app#531).

🤖 Generated with [Claude Code](https://claude.com/claude-code)