### PR TITLE
fix(ci): supersede deploy PRs by ancestry, and fail a deploy whose auto-merge never armed

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -248,6 +248,22 @@ gates:
   # comparison itself escalates via deploy-drift-watch.yml and never gates a merge.
   # Without this half, a hand-set tag (`latest`, `sandbox-sec1`) would make the
   # scheduled watch blind for that service while the repo reports green.
+  # issue #6231: the supersede script decides which deploy PRs to CLOSE, and it used to decide by
+  # PR creation time. A slower build opens a later PR for an OLDER commit, so on 2026-08-21 it closed
+  # #6222 (`579dda8e`) in favour of #6225 (`a9e9d082`, an ancestor of it) and stranded the newer code
+  # with every job green. It now decides by ancestry and FAILS the step when the surviving PR is the
+  # ancestor. Nothing in CI executes that script — it only runs inside auto-deploy against live PRs —
+  # so its own self-test is the only place its RED is reachable before it acts on real PRs. Case 1 is
+  # the #6231 interleaving and must exit non-zero; case 2 is the ordinary supersede and must still
+  # close the older PR, so a fail-everything script does not satisfy it either.
+  - id: supersede-deploy-prs-ancestry
+    selftest_exempt: "is-a-test-suite — the run: IS supersede-deploy-prs.sh --self-test"
+    name: "supersede-deploy-prs decides by ancestry, not recency (issue #6231)"
+    group: gitops
+    mode: enforced
+    run: |
+      bash .github/scripts/supersede-deploy-prs.sh --self-test
+
   - id: deploy-drift-declaration
     name: "deployed image pins name a commit (issue #3344, enforced)"
     group: gitops

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -261,6 +261,13 @@ gates:
     name: "supersede-deploy-prs decides by ancestry, not recency (issue #6231)"
     group: gitops
     mode: enforced
+    rationale: >-
+      A slower build opens a later deploy PR for an OLDER commit. Deciding which PR to close by
+      creation time instead of ancestry closed #6222 in favour of an ancestor PR on 2026-08-21 and
+      stranded newer code with every job green (issue #6231). This gate is the only place that
+      defect's fix can go red before it acts on a real PR — the script itself only runs inside
+      auto-deploy against live PRs, never in ordinary CI.
+    review_after: "2027-02-19"
     run: |
       bash .github/scripts/supersede-deploy-prs.sh --self-test
 

--- a/.github/scripts/check-gate-subject-floor.py
+++ b/.github/scripts/check-gate-subject-floor.py
@@ -68,6 +68,7 @@ NO_CORPUS = {
     "pact-version-tree-equivalence-unit-test",
     "record-deployment-version-resolver",
     "runtime-conformance-comparators",
+    "supersede-deploy-prs-ancestry",
 }
 
 # Gates that examine a real corpus and do not yet report how much of it they found. This list

--- a/.github/scripts/supersede-deploy-prs.sh
+++ b/.github/scripts/supersede-deploy-prs.sh
@@ -19,6 +19,26 @@
 # per prefix is open at a time, it is always the newest, and it is always based on current main, so
 # the conflict class cannot arise.
 #
+# ANCESTRY, NOT RECENCY (issue #6231)
+# "Newer" was originally read off PR creation time — the PR that opened last kept, every other one
+# closed. That is not what "newer" means here: a deploy PR is created when its BUILD finishes, and
+# builds do not finish in commit order. Measured 2026-08-21: #6222 pinned `579dda8e` (merged to main
+# 14:08:59Z) and #6225 pinned `a9e9d082` (merged 13:58:07Z, an ANCESTOR of it) — but a9e9d082's build
+# ran ~12 min longer, so its PR was created at 14:47:01Z, twelve minutes after #6222's, and this
+# script closed #6222 at 14:47:04Z as "superseded". The survivor rewound copilot-service from
+# sandbox-579dda8e to sandbox-a9e9d082 and left agent-service short of #6204's code, with every job
+# in both runs green. Fail-open, and invisible: check-deploy-drift compares version.txt, which those
+# commits share (release-please bumps in a separate commit), so the drift watch reads "in sync".
+#
+# So the decision is now ancestry, asked of the GitHub compare API (the job's checkout is shallow,
+# `git merge-base --is-ancestor` cannot answer there):
+#   * other is an ancestor of keep (`ahead`/`identical`) -> genuinely superseded, close it.
+#   * keep is an ancestor of other (`behind`)            -> THIS run is the stale one. Close nothing,
+#     ::error, exit 1. The step fails, so the `Enable auto-merge` step that follows it never runs and
+#     the rollback PR cannot merge itself. Loud beats a silent rewind.
+#   * diverged, or a branch name with no parsable sha    -> ::warning, leave it open. Unknown is not
+#     permission to close someone's PR.
+#
 # Deliberately scoped:
 #   * Only the bot prefixes (chore/gitops-auto-deploy-, chore/admin-ui-deploy-). A hand-cut deploy PR
 #     — they exist, see record-deployment-on-merge.yml — is never touched.
@@ -29,80 +49,227 @@
 #
 # Usage: supersede-deploy-prs.sh <branch-prefix> <keep-pr-number>
 #   e.g. supersede-deploy-prs.sh chore/admin-ui-deploy- 2604
+#        supersede-deploy-prs.sh --self-test     # falsify the ancestry decision, no network
 # Requires: gh, jq, GH_TOKEN with pull-requests: write.
 
 set -euo pipefail
 
-PREFIX="${1:?usage: supersede-deploy-prs.sh <branch-prefix> <keep-pr-number>}"
-KEEP="${2:?usage: supersede-deploy-prs.sh <branch-prefix> <keep-pr-number>}"
+# ── ancestry ────────────────────────────────────────────────────────────────────────────────────
+# Extract the 40-hex commit a deploy branch pins. Anything else yields "" and is treated as unknown.
+sha_of_branch() {
+  local sha="${1#"$2"}"
+  # 40 hex characters exactly. A truncated, suffixed or hand-cut branch name yields "" (unknown),
+  # and unknown must never mean "close it" — that was the pre-#6231 behaviour.
+  case "$sha" in
+    *[!0-9a-f]*) printf '' ;;
+    *) if [ "${#sha}" -eq 40 ]; then printf '%s' "$sha"; else printf ''; fi ;;
+  esac
+}
+
+# Ask GitHub how `head` relates to `base`: ahead | behind | identical | diverged.
+# Overridable for the self-test (SUPERSEDE_COMPARE_HOOK), which is the ONLY seam — the classify /
+# act loop below is the same code in both lanes.
+compare_status() {
+  local base="$1" head="$2"
+  if [ -n "${SUPERSEDE_COMPARE_HOOK:-}" ]; then
+    "$SUPERSEDE_COMPARE_HOOK" "$base" "$head"
+    return
+  fi
+  gh api "repos/$REPO/compare/$base...$head" --jq '.status' 2>/dev/null || printf 'unknown'
+}
+
+# CLOSE | STALE_KEEP | SKIP, from (keep sha, other sha). Pure — no I/O, so the self-test exercises
+# the real decision and not a paraphrase of it.
+classify() {
+  local keep_sha="$1" other_sha="$2" status
+  if [ -z "$keep_sha" ] || [ -z "$other_sha" ]; then printf 'SKIP'; return; fi
+  if [ "$keep_sha" = "$other_sha" ]; then printf 'CLOSE'; return; fi
+  status="$(compare_status "$other_sha" "$keep_sha")"
+  case "$status" in
+    ahead|identical) printf 'CLOSE' ;;       # keep contains other — genuinely superseded
+    behind)          printf 'STALE_KEEP' ;;  # keep is an ANCESTOR of other — this run is the stale one
+    *)               printf 'SKIP' ;;        # diverged / unknown — never close on a guess
+  esac
+}
+
+# ── main ────────────────────────────────────────────────────────────────────────────────────────
+run() {
+  local PREFIX="$1" KEEP="$2" KEEP_SHA="$3" PAIRS="$4"
+  local n ref other_sha verdict failed=0 stale_keep=0 closed=0 skipped=0
+
+  if [ -z "$PAIRS" ]; then
+    echo "supersede: no other open '$PREFIX*' PRs besides #$KEEP — nothing to close."
+    return 0
+  fi
+
+  while IFS=$'\t' read -r n ref; do
+    [ -n "$n" ] || continue
+    other_sha="$(sha_of_branch "$ref" "$PREFIX")"
+    verdict="$(classify "$KEEP_SHA" "$other_sha")"
+    case "$verdict" in
+      STALE_KEEP)
+        stale_keep=1
+        echo "::error::supersede: #$KEEP pins ${KEEP_SHA:0:8}, which is an ANCESTOR of #$n's ${other_sha:0:8}." \
+             "This build finished later than a NEWER commit's, so #$KEEP would roll those services BACK." \
+             "Closing nothing and failing the step: #$n stays open, and auto-merge is not armed on #$KEEP." \
+             "Re-dispatch auto-deploy for the current main once #$n has landed (issue #6231)."
+        ;;
+      SKIP)
+        skipped=$((skipped + 1))
+        echo "::warning::supersede: cannot establish that #$KEEP supersedes #$n (keep=${KEEP_SHA:-?} other=${other_sha:-?}, unrelated or unparsable) — leaving #$n OPEN."
+        ;;
+      CLOSE)
+        if [ "${DRY_RUN:-}" = "true" ]; then
+          echo "supersede: DRY_RUN — would close #$n (${other_sha:0:8} is an ancestor of ${KEEP_SHA:0:8})."
+          closed=$((closed + 1))
+          continue
+        fi
+        # Comment first, then close: if the close succeeds but the comment fails, the PR is shut with
+        # no stated reason, which is the outcome this is trying to avoid.
+        if ! gh pr comment "$n" --repo "$REPO" --body \
+"Superseded by #$KEEP and closed automatically.
+
+#$KEEP pins \`${KEEP_SHA:0:8}\`, a **descendant** of this PR's \`${other_sha:0:8}\` — it therefore already
+contains everything this PR would have applied. (Ancestry, not creation time: a slower build can open a
+newer PR for an older commit, which is issue #6231.)
+
+Left open, both PRs edit the same manifest line and whichever merges first leaves the other conflicting,
+which reads as healthy — green checks, auto-merge armed — right up to the point someone tries to merge it.
+
+If you believe otherwise, reopen it and say what it carries that #$KEEP does not.
+
+(\`.github/scripts/supersede-deploy-prs.sh\`)"; then
+          echo "::warning::supersede: could not comment on #$n — leaving it OPEN rather than closing it silently."
+          failed=1
+          continue
+        fi
+        if ! gh pr close "$n" --repo "$REPO" --delete-branch; then
+          echo "::warning::supersede: could not close #$n."
+          failed=1
+        else
+          closed=$((closed + 1))
+        fi
+        ;;
+    esac
+  done <<EOF
+$PAIRS
+EOF
+
+  echo "supersede: #$KEEP (${KEEP_SHA:0:8}) — closed=$closed skipped=$skipped stale_keep=$stale_keep"
+
+  # A stale KEEP is the one condition that must be loud. Everything else is tidiness: the image is
+  # already built and pushed, and a leftover stale PR does not break a deploy.
+  if [ "$stale_keep" -ne 0 ]; then
+    return 1
+  fi
+  if [ "$failed" -ne 0 ]; then
+    echo "::warning::supersede: one or more superseded deploy PRs could not be closed; close them by hand."
+  fi
+  return 0
+}
+
+# ── self-test ───────────────────────────────────────────────────────────────────────────────────
+# Falsification, not decoration: case 1 is the losing interleaving from #6231 (an older commit's PR
+# created LAST) and must fail; case 2 is the ordinary case and must still close the older PR.
+self_test() {
+  local tmp rc out ok=0
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  # Fake compare: OLD..NEW is `ahead`, NEW..OLD is `behind`, anything else `diverged`.
+  cat > "$tmp/compare" <<'HOOK'
+#!/usr/bin/env bash
+base="$1"; head="$2"
+old=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+new=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+if [ "$base" = "$old" ] && [ "$head" = "$new" ]; then echo ahead
+elif [ "$base" = "$new" ] && [ "$head" = "$old" ]; then echo behind
+else echo diverged; fi
+HOOK
+  chmod +x "$tmp/compare"
+  export SUPERSEDE_COMPARE_HOOK="$tmp/compare"
+  export DRY_RUN=true
+  local OLD=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  local NEW=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  local P=chore/gitops-auto-deploy-
+
+  # case 1 — the #6231 interleaving: KEEP is the OLDER commit, the open PR is the NEWER one.
+  out="$(run "$P" 6225 "$OLD" "$(printf '6222\t%s%s' "$P" "$NEW")" 2>&1)" && rc=0 || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "SELF-TEST FAIL case 1: stale KEEP exited 0 (must be non-zero)"; ok=1
+  elif ! printf '%s' "$out" | grep -q '::error::supersede: #6225 pins aaaaaaaa, which is an ANCESTOR'; then
+    echo "SELF-TEST FAIL case 1: no ::error naming the ancestry; got: $out"; ok=1
+  elif printf '%s' "$out" | grep -q 'would close'; then
+    echo "SELF-TEST FAIL case 1: it still closed the newer PR"; ok=1
+  else
+    echo "self-test case 1 OK (stale keep -> rc=$rc, ::error, nothing closed)"
+  fi
+
+  # case 2 — the ordinary case: KEEP is the NEWER commit. The older PR must still be closed.
+  out="$(run "$P" 6222 "$NEW" "$(printf '6225\t%s%s' "$P" "$OLD")" 2>&1)" && rc=0 || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "SELF-TEST FAIL case 2: ordinary supersede exited $rc; got: $out"; ok=1
+  elif ! printf '%s' "$out" | grep -q 'would close #6225'; then
+    echo "SELF-TEST FAIL case 2: the older PR was not closed; got: $out"; ok=1
+  else
+    echo "self-test case 2 OK (ordinary supersede -> rc=$rc, older PR closed)"
+  fi
+
+  # case 3 — unrelated shas must never be closed on a guess.
+  out="$(run "$P" 1 cccccccccccccccccccccccccccccccccccccccc "$(printf '2\t%s%s' "$P" "$OLD")" 2>&1)" && rc=0 || rc=$?
+  if [ "$rc" -ne 0 ] || printf '%s' "$out" | grep -q 'would close'; then
+    echo "SELF-TEST FAIL case 3: diverged pair was closed or failed; got: $out"; ok=1
+  else
+    echo "self-test case 3 OK (diverged -> warning, left open)"
+  fi
+
+  # case 4 — an unparsable branch name is unknown, not permission.
+  out="$(run "$P" 1 "$NEW" "$(printf '2\t%snot-a-sha' "$P")" 2>&1)" && rc=0 || rc=$?
+  if [ "$rc" -ne 0 ] || printf '%s' "$out" | grep -q 'would close'; then
+    echo "SELF-TEST FAIL case 4: unparsable branch was closed or failed; got: $out"; ok=1
+  else
+    echo "self-test case 4 OK (unparsable sha -> warning, left open)"
+  fi
+
+  if [ "$ok" -ne 0 ]; then
+    echo "self-test: FAILED"
+    return 1
+  fi
+  echo "self-test: all 4 cases OK"
+  return 0
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  self_test
+  exit $?
+fi
+
+PREFIX="${1:?usage: supersede-deploy-prs.sh <branch-prefix> <keep-pr-number> | --self-test}"
+KEEP="${2:?usage: supersede-deploy-prs.sh <branch-prefix> <keep-pr-number> | --self-test}"
 REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+
+# The sha THIS run's deploy PR pins. Without it nothing can be classified, and "cannot classify"
+# must mean "close nothing" — never "close everything", which is the pre-#6231 behaviour.
+KEEP_SHA="$(sha_of_branch "$(gh pr view "$KEEP" --repo "$REPO" --json headRefName --jq '.headRefName')" "$PREFIX")"
+if [ -z "$KEEP_SHA" ]; then
+  echo "::warning::supersede: could not read a commit sha off #$KEEP's branch — closing nothing."
+  exit 0
+fi
 
 # `gh pr list` caps at 30 by default; a backlog can exceed that, and a cap that silently truncates
 # would leave the oldest — the very ones most likely to be conflicting — untouched.
 #
-# Read with `while read`, NOT `mapfile`: mapfile is a bash-4 builtin, absent from macOS's system
+# Read into a single variable, NOT `mapfile`: mapfile is a bash-4 builtin, absent from macOS's system
 # bash 3.2 and from zsh, where it fails with "command not found" and leaves the array EMPTY. The
 # script would then print "nothing to close" and exit 0 — a broken probe reporting a clean result,
-# which is the failure mode this repo has been bitten by repeatedly. `while read` runs everywhere,
-# so the same command can be dry-run locally as it behaves in CI.
-STALE=""
-STALE_COUNT=0
-while IFS= read -r n; do
-  [ -n "$n" ] || continue
-  STALE="$STALE $n"
-  STALE_COUNT=$((STALE_COUNT + 1))
-done <<EOF
-$(gh pr list --repo "$REPO" --state open --limit 200 \
+# which is the failure mode this repo has been bitten by repeatedly.
+PAIRS="$(gh pr list --repo "$REPO" --state open --limit 200 \
     --json number,headRefName,headRepositoryOwner,createdAt \
     --jq "[.[]
            | select(.headRefName | startswith(\"$PREFIX\"))
            | select(.number != ($KEEP | tonumber))
            | select(.headRepositoryOwner.login == \"${REPO%%/*}\")]
           | sort_by(.createdAt)
-          | .[].number")
-EOF
+          | .[] | \"\(.number)\t\(.headRefName)\"")"
 
-if [ "$STALE_COUNT" -eq 0 ]; then
-  echo "supersede: no older open '$PREFIX*' PRs besides #$KEEP — nothing to close."
-  exit 0
-fi
-
-echo "supersede: #$KEEP is the current deploy PR; closing $STALE_COUNT superseded:$STALE"
-
-if [ "${DRY_RUN:-}" = "true" ]; then
-  echo "supersede: DRY_RUN — would close:$STALE"
-  exit 0
-fi
-
-failed=0
-for n in $STALE; do
-  # Comment first, then close: if the close succeeds but the comment fails, the PR is shut with no
-  # stated reason, which is the outcome this is trying to avoid.
-  if ! gh pr comment "$n" --repo "$REPO" --body \
-"Superseded by #$KEEP and closed automatically.
-
-A deploy PR rewrites an image tag to the newest build, so two of them are never additive — #$KEEP
-already contains everything this PR would have applied. Left open, both edit the same manifest line
-and whichever merges first leaves the other conflicting, which reads as healthy (green checks,
-auto-merge armed) right up to the point someone tries to merge it.
-
-Nothing is lost by this close: the tag this PR carried is older than the one in #$KEEP. If you
-believe otherwise, reopen it and say what it carries that #$KEEP does not.
-
-(\`.github/scripts/supersede-deploy-prs.sh\`)"; then
-    echo "::warning::supersede: could not comment on #$n — leaving it OPEN rather than closing it silently."
-    failed=1
-    continue
-  fi
-  if ! gh pr close "$n" --repo "$REPO" --delete-branch; then
-    echo "::warning::supersede: could not close #$n."
-    failed=1
-  fi
-done
-
-# A failure here must not fail the deploy — the image is already built and pushed, and a leftover
-# stale PR is a tidiness problem, not a broken deploy. Warn loudly instead.
-if [ "$failed" -ne 0 ]; then
-  echo "::warning::supersede: one or more superseded deploy PRs could not be closed; close them by hand."
-fi
-exit 0
+run "$PREFIX" "$KEEP" "$KEEP_SHA" "$PAIRS"
+exit $?

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -611,7 +611,15 @@ jobs:
                 await new Promise(r => setTimeout(r, 12000));
               }
             }
-            core.notice('could not enable auto-merge after retries — check the App token (GITOPS_APP_ID/GITOPS_APP_PRIVATE_KEY) / branch protection');
+            // setFailed, NOT notice (issue #6231): a deploy PR with auto-merge unarmed never
+            // merges, so the deploy silently does not happen while every job stays green and
+            // the only evidence is one notice line in a job nobody opens. Same change as
+            // auto-deploy.yml — the two share this step verbatim.
+            core.setFailed(
+              `auto-merge could not be enabled on PR #${pull_number} after 8 attempts, so this deploy ` +
+              `will NOT land on its own — the PR stays open until someone merges it. Check the App ` +
+              `token (GITOPS_APP_ID/GITOPS_APP_PRIVATE_KEY) and branch protection.`
+            );
 
       # The failure this guards against is silent by construction: create-pull-request logs
       # "Commit verified: false; reason: unsigned" and exits 0, the PR opens with every check

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -1186,7 +1186,16 @@ jobs:
                 await new Promise(r => setTimeout(r, 12000));
               }
             }
-            core.notice('could not enable auto-merge after retries — check the App token (GITOPS_APP_ID/GITOPS_APP_PRIVATE_KEY) / branch protection');
+            // setFailed, NOT notice (issue #6231): a deploy PR with auto-merge unarmed never
+            // merges, so the deploy silently does not happen — and a notice leaves the job, the
+            // workflow and `Deploy signal` all green, with the only evidence one line in a job
+            // nobody opens. That is the repo's "green run that deployed nothing" shape. The PR
+            // itself is left open and rescuable; what changes is that the run now says so.
+            core.setFailed(
+              `auto-merge could not be enabled on PR #${pull_number} after 8 attempts, so this deploy ` +
+              `will NOT land on its own — the PR stays open until someone merges it. Check the App ` +
+              `token (GITOPS_APP_ID/GITOPS_APP_PRIVATE_KEY) and branch protection.`
+            );
 
       # The failure this guards against is silent by construction: create-pull-request logs
       # "Commit verified: false; reason: unsigned" and exits 0, the PR opens with every check


### PR DESCRIPTION
## The interleaving

A deploy PR is created when its **build** finishes. Builds do not finish in commit order, so
"the PR that opened last" is not "the newest commit" — and that is what
`supersede-deploy-prs.sh` was deciding on (`sort_by(.createdAt)`, then close every other open
PR with the prefix, unconditionally).

Measured on 2026-08-21, live in this repo:

| deploy PR | pins | that commit merged to main | PR created | fate |
|---|---|---|---|---|
| #6222 | `579dda8e` (#5972) | 14:08:59Z | 14:35:04Z | **closed 14:47:04Z as "superseded by #6225"** |
| #6225 | `a9e9d082` (#5995) | 13:58:07Z | 14:47:01Z | open |

`git merge-base --is-ancestor a9e9d082 579dda8e` → true. The survivor pins the **ancestor**.
Its diff rewinds `openbank-copilot-service` from `sandbox-579dda8e` to `sandbox-a9e9d082`, and
pins `openbank-agent-service` to `a9e9d082`, i.e. short of #6204's `13a21b58` (also an ancestor
of `579dda8e`). The same run had already closed #6219 the same way one link earlier in the chain.

## Direction of failure: FAIL-OPEN

The newer artifact silently does not ship. Nothing goes red: `Gitops PR` succeeded,
`Deploy signal` succeeded, run 32490399407 concluded `success`, and the closing comment on the
losing PR asserts — wrongly — that nothing is lost.

## Would anything notice today? No.

`check-deploy-drift.py` ("Deployed == main watch") reports DRIFT on a **version.txt mismatch
older than 7 days**. `a9e9d082`, `13a21b58` and `579dda8e` all carry `agent 1.20.2` /
`copilot 0.13.3` — release-please bumps in a separate later commit — and `a9e9d082` is an
ancestor of main, so all three of its conditions pass and it reads **in sync**. The stranding is
invisible to the only control aimed at it. (Not changed here; noted so it is not assumed.)

## What now happens instead

`supersede-deploy-prs.sh` decides by **ancestry**, asked of the GitHub compare API (the
`gitops-pr` job checkout is shallow, so `git merge-base` cannot answer there):

* survivor is a **descendant** (`ahead`/`identical`) → close the older PR, as before;
* survivor is an **ancestor** (`behind`) → close nothing, `::error` naming both shas, **exit 1**.
  The step fails, so the `Enable auto-merge` step after it is skipped and the rollback PR cannot
  merge itself. The newer PR stays open and still merges;
* `diverged`, or a branch name with no parsable 40-hex sha → `::warning`, PR left open. Unknown
  is not permission to close someone's PR. Unreadable keep-sha → close nothing.

Defect 2: the failed-auto-merge `core.notice` becomes `core.setFailed` in **both**
`auto-deploy.yml` and `admin-ui-deploy.yml` (they carry the step verbatim). An unarmed deploy PR
never merges; a notice left the job, the workflow and `Deploy signal` all green.

## Proof by what it prevents

`bash .github/scripts/supersede-deploy-prs.sh --self-test` — no network, the compare call is the
only seam; the classify/act loop is the same code both lanes run.

Negative control — the one-line pre-fix behaviour restored (`behind` → `CLOSE`), self-test run
redirected to a file, exit code read from `$?`:

```
EXIT=1
SELF-TEST FAIL case 1: stale KEEP exited 0 (must be non-zero)
self-test case 2 OK (ordinary supersede -> rc=0, older PR closed)
self-test case 3 OK (diverged -> warning, left open)
self-test case 4 OK (unparsable sha -> warning, left open)
self-test: FAILED
```

With the fix:

```
EXIT=0
self-test case 1 OK (stale keep -> rc=1, ::error, nothing closed)
self-test case 2 OK (ordinary supersede -> rc=0, older PR closed)
self-test case 3 OK (diverged -> warning, left open)
self-test case 4 OK (unparsable sha -> warning, left open)
self-test: all 4 cases OK
```

Case 2 passes in **both** runs, so a fail-everything script does not satisfy the harness either.

Registered as the enforced gate `supersede-deploy-prs-ancestry` (group `gitops`,
`selftest_exempt: is-a-test-suite`) — nothing else in CI ever executes this script, so its
self-test is the only place its RED is reachable before it acts on real PRs.
Verified locally: `run-gates.py --group gitops` shows
`PASS [gitops] supersede-deploy-prs decides by ancestry, not recency (issue #6231)`.

## Not done here (needs a decision)

Fully serialising deploys — one auto-deploy run at a time per ref — would remove the race rather
than detect it, at the cost of turning a busy merge hour into a queue and re-introducing the
over-cancellation #1332/#1336 removed. This PR delivers the loud-failure half: the losing
interleaving now fails visibly and cannot roll anything back. Recovery is still the documented
one — `gh workflow run auto-deploy.yml -f services=<svc>` once the newer PR has landed.

Closes #6231
