### PR TITLE
feat(lending): ADR-0269 platform — quotes, credit profile, AI levels, consent surface, financial health, funnel

### DIFF
--- a/.github/event-contract-baseline.txt
+++ b/.github/event-contract-baseline.txt
@@ -16,9 +16,6 @@ openbank-balance-service:openbank.balance.events
 openbank-card-issuance-service:openbank.cards.events
 openbank-clearing-service:openbank.clearing.batch.event
 openbank-consent-service:openbank.consent.events
-openbank-customer-edge:openbank.customer.audit
-openbank-customer-edge:openbank.feedback.events
-openbank-customer-edge:openbank.onboarding.funnel.events
 openbank-dispute-service:openbank.dispute.events
 openbank-document-service:openbank.documents.document.event
 openbank-domestic-payment:openbank.domestic.payment.events

--- a/docs/threat-models/openbank-lending-service.md
+++ b/docs/threat-models/openbank-lending-service.md
@@ -392,16 +392,18 @@ against `lending.intake.caller-principal`, which refuses every call when unset.
   caller, but `operator-lending-write` already grants the same action more broadly; the rule only
   becomes load-bearing if that blanket operator grant is narrowed.
 
-## 9a. Customer credit journey read (ADR-0269) — STRIDE supplement
+## 9a. Customer credit journey read and indicative quotes (ADR-0269) — STRIDE supplement
 
-One new inbound surface on the same customer-edge trust boundary as section 9, and a read path,
-which changes what can go wrong: section 9's risk is a fraudulent WRITE, this one risks a
-DISCLOSURE.
+Two new inbound surfaces on the same customer-edge trust boundary as section 9, and both are read
+paths, which changes what can go wrong: section 9's risk is a fraudulent WRITE, these risk a
+DISCLOSURE and a MIS-DISCLOSURE.
 
 - `CustomerCreditJourneyResource` — `GET /api/v1/lending/intake/applications[/{id}]`. Returns the
   caller's own applications as customer-readable journeys.
+- `CustomerQuoteResource` — `POST /api/v1/lending/intake/quotes`. Returns an indicative,
+  non-binding price. Persists nothing.
 
-It reuses section 9's caller control verbatim: the handler compares `SecurityIdentity.principal.name`
+Both reuse section 9's caller control verbatim: the handler compares `SecurityIdentity.principal.name`
 to `lending.intake.caller-principal` and refuses when it does not match or is unset, and the party id
 comes only from `X-Customer-Party-Id`.
 
@@ -409,15 +411,27 @@ comes only from `X-Customer-Party-Id`.
 |---|---|---|
 | **I**nformation disclosure | An operator, or the edge with a forged header, reads another customer's credit history | Rows are filtered by the header party id; a foreign application id is answered **404, not 403**, so a not-found and a not-yours are indistinguishable and the id space does not leak. Covered by `CustomerCreditJourneyResourceTest`. |
 | **I**nformation disclosure | The journey leaks the bank's internal assessment | The projection exposes canonical states, step codes and the decision engine's machine-readable reason codes only. A human checker's free-text `decisionReason` is deliberately NOT exposed, and a reason code is dropped on any non-refused state. |
+| **T**ampering | A caller prices their own loan by supplying a rate | The quote body carries only amount and term. Rate, currency, bounds and product all come from `CustomerIntakeConfig`; an unconfigured rate refuses the call rather than quoting zero interest. |
+| **R**epudiation / mis-disclosure | The customer is shown an instalment or APRC that the contract later contradicts | The instalment comes from the shared `Amortization` schedule the loan would actually be booked against, and the APRC from `Aprc`, the single implementation permitted to compute it (ADR-0269 rule 4). No client, campaign template or model may compute either. |
+| **I**nformation disclosure | A customer in financial distress is handed a tailored instalment | The ADR-0269 rule-2 distress floor gates pricing as well as offers: a suppressed quote is a **409 with a reason code and no price fields**, never a 200 with empty numbers (which a client renders as "0"). |
+| **D**oS | An app floods the quote endpoint | Pricing is pure computation with no persistence and no upstream call beyond the eligibility read; throttling is customer-edge's `RateLimitFilter`, as in section 9. The same per-party gap noted there applies. |
+| **E**oP | A quote becomes a commitment | Structurally prevented: `CustomerQuote` has no id and no accept path, and the wire DTO carries `binding: false` explicitly. A binding offer is a separate object from the decision engine and does not exist yet (#6214 follow-on). |
+
+**Deliberate asymmetry worth recording:** the quote endpoint does NOT require `credit_offers`
+consent, while the pre-approved read will. ADR-0269's rule is that the bank must not *initiate*;
+refusing to answer a price question the customer just asked would be the same dark pattern pointing
+the other way. The distress floor applies to both, because there the answer itself is the harm.
 
 ## 10. Change log
 
 - **2026-08-24** — Synthetic-journey taint now propagates over this service's existing internal REST clients through `SyntheticTaintClientFilter` (ADR-0252, #4348). This adds no caller, endpoint, network-policy edge, privilege or credit-control bypass. It preserves the marker before a downstream persistence/event boundary; a fleet gate requires every new client to choose propagation or a reasoned external boundary.
 
-- **2026-08-21** — Trust-boundary change (ADR-0269 slice 1): a new customer-edge-facing read
-  surface, `GET /api/v1/lending/intake/applications[/{id}]`. See section 9a. Same caller and
-  party-header controls as section 9; the new risk is disclosure of another party's credit history,
-  closed by owner filtering plus a 404-not-403 answer.
+- **2026-08-21** — Trust-boundary change (ADR-0269 slices 1-2): two new customer-edge-facing read
+  surfaces, `GET /api/v1/lending/intake/applications[/{id}]` and `POST /api/v1/lending/intake/quotes`.
+  See section 9a. Same caller and party-header controls as section 9; new risks are disclosure of
+  another party's credit history (closed by owner filtering plus a 404-not-403 answer) and
+  mis-disclosure of price (closed by server-only pricing through `Amortization`/`Aprc` and a
+  reason-coded 409 when the distress floor suppresses).
 
 - **2026-08-20** — Catalog-governed loan origination (#668). Adds the product-catalog OIDC read edge
   described in §2 item 9. The caller may select an offering, never a revision or a rate: the service

--- a/docs/threat-models/openbank-lending-service.md
+++ b/docs/threat-models/openbank-lending-service.md
@@ -442,9 +442,28 @@ unknown, because permanent `complete = false` would suppress every offer forever
 indistinguishable from the feature being switched off. This is the first thing an operational-risk
 review of this gate should challenge.
 
+## 9c. Customer financial health (ADR-0269 rule 5) — STRIDE supplement
+
+`GET /api/v1/lending/intake/financial-health` — a third read on the section 9 trust boundary, with
+the same caller and party-header controls. It composes the ADR-0269 credit profile with the loan
+book, so it concentrates in one response things that until now lived in separate services.
+
+| Threat | Scenario | Mitigation |
+|---|---|---|
+| **I**nformation disclosure | The route becomes a convenient summary of another customer's finances | Party comes only from the header the edge sets from the JWT; the loan read and the profile read are both scoped by it. Same 403/400 split as section 9a — an authorised caller with no scope is a bad request, not a forbidden one. |
+| **I**nformation disclosure | The view leaks the bank's assessment of the customer | It carries zones and the working behind them, never a score, a rating, an eligibility or a reason code. The credit decision remains the ADR-0213 engine's and is not reachable from here. |
+| **T**ampering / misleading | An unavailable upstream produces a flattering view | Every pillar can answer UNKNOWN and does so independently: a failed profile read greys out cashflow and obligations while the loan-derived pillars stand. Nothing is approximated — in particular the reserve is left UNKNOWN rather than inferred from unspent cashflow, which would show a customer a buffer they do not have. |
+| **T**ampering / misleading | No live loans reads as a healthy debt ratio | An empty loan book gives debt service 0; an *unreadable* one gives null, and null makes the obligations pillar UNKNOWN. The two are not collapsed, because only one of them means "this customer has no debts". |
+| **D**oS | The route fans out to two upstreams per call | Both reads are best-effort with the service's existing timeouts; a slow upstream costs a greyed-out pillar, never a hung request. |
+
 ## 10. Change log
 
 - **2026-08-24** — Synthetic-journey taint now propagates over this service's existing internal REST clients through `SyntheticTaintClientFilter` (ADR-0252, #4348). This adds no caller, endpoint, network-policy edge, privilege or credit-control bypass. It preserves the marker before a downstream persistence/event boundary; a fleet gate requires every new client to choose propagation or a reasoned external boundary.
+
+- **2026-08-21** — Trust-boundary change (ADR-0269 rule 5): `GET /api/v1/lending/intake/financial-health`,
+  a customer-facing read that composes the credit profile with the loan book. See section 9c. No
+  score and no eligibility; every pillar degrades to UNKNOWN independently, and an unreadable loan
+  book is deliberately distinguished from a customer with no loans.
 
 - **2026-08-21** — Trust-boundary change (ADR-0269 slice 3, #6215): two new outbound client edges
   from the credit-offer gate — consent-service (`CREDIT_OFFERS`) and analytics-sink (the 360 credit

--- a/docs/threat-models/openbank-lending-service.md
+++ b/docs/threat-models/openbank-lending-service.md
@@ -422,9 +422,34 @@ consent, while the pre-approved read will. ADR-0269's rule is that the bank must
 refusing to answer a price question the customer just asked would be the same dark pattern pointing
 the other way. The distress floor applies to both, because there the answer itself is the harm.
 
+## 9b. The credit-offer gate's own dependencies (ADR-0269 #6215) — STRIDE supplement
+
+The gate that decides whether a customer may be offered or quoted credit now reaches two services
+outbound: consent-service for `CREDIT_OFFERS`, and analytics-sink for the 360 credit profile
+(`gold_party_credit_profile`). Both are new outbound client edges from a money-path service.
+
+| Threat | Scenario | Mitigation |
+|---|---|---|
+| **T**ampering / **E**oP | A compromised or misconfigured upstream answers "consent granted" or "healthy cash flow" for everyone | Neither answer can *grant* anything on its own: consent only unlocks the PUSH surface, and the profile only relaxes thresholds the hard-fact rules (arrears, hardship) apply independently from lending's own book. A single upstream cannot manufacture an offer. |
+| **D**oS / availability | consent-service or analytics-sink is slow or down | Both reads fail CLOSED with a 2s timeout: an unreadable consent yields `SIGNALS_UNAVAILABLE`, an unreadable profile yields `complete = false` and a refusal. The cost of an outage is a suppressed offer, never an unconsented or unassessed one. |
+| **I**nformation disclosure | The credit profile leaks another party's finances into a decision | The profile is fetched by party id on an internal, OIDC-authenticated route restricted to operator/auditor/admin roles; the party id comes from the same trusted header the rest of section 9 uses, never from a request body. |
+| **R**epudiation | The bank cannot show what a creditworthiness decision was based on | The profile is a query over the ADR-0023 tamper-evident bronze layer, so the inputs can be recomputed as at a date; `monthsObserved` records how much history actually existed. |
+| **S**poofing | An unauthenticated caller reads a customer's cash-flow profile from analytics-sink | The route is `@RolesAllowed(OPERATOR, AUDITOR, ADMIN)`; the party id is parsed as a UUID *before* interpolation, which is also the injection boundary — ClickHouse's HTTP interface has no bound-parameter path. |
+
+**Known gap, stated rather than modelled away:** enforcement orders and insolvency proceedings have
+no source in this deployment — no service ingests a court register. They are reported as absent, not
+unknown, because permanent `complete = false` would suppress every offer forever and be
+indistinguishable from the feature being switched off. This is the first thing an operational-risk
+review of this gate should challenge.
+
 ## 10. Change log
 
 - **2026-08-24** — Synthetic-journey taint now propagates over this service's existing internal REST clients through `SyntheticTaintClientFilter` (ADR-0252, #4348). This adds no caller, endpoint, network-policy edge, privilege or credit-control bypass. It preserves the marker before a downstream persistence/event boundary; a fleet gate requires every new client to choose propagation or a reasoned external boundary.
+
+- **2026-08-21** — Trust-boundary change (ADR-0269 slice 3, #6215): two new outbound client edges
+  from the credit-offer gate — consent-service (`CREDIT_OFFERS`) and analytics-sink (the 360 credit
+  profile) — plus their `rest-client` configuration. See section 9b. Both fail closed on timeout or
+  error; neither can grant an offer on its own, because the hard-fact rules read lending's own book.
 
 - **2026-08-21** — Trust-boundary change (ADR-0269 slices 1-2): two new customer-edge-facing read
   surfaces, `GET /api/v1/lending/intake/applications[/{id}]` and `POST /api/v1/lending/intake/quotes`.

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/rest/CreditProfileResource.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/rest/CreditProfileResource.kt
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.analytics.infrastructure.rest
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.analytics.infrastructure.clickhouse.ClickHouseClient
+import com.openbank.libs.security.Roles
+import jakarta.annotation.security.RolesAllowed
+import jakarta.inject.Inject
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import java.util.UUID
+
+/**
+ * The ADR-0269 credit profile for one party (issue #6215).
+ *
+ * Reads `gold_party_credit_profile` — the single definition of these numbers (see V9). Three
+ * consumers need them and each would otherwise derive its own: the creditworthiness assessment, the
+ * customer's financial-health view, and the AI advisor.
+ *
+ * ## What this returns and what it refuses to
+ *
+ * Observable quantities only: median monthly in, median monthly out, net, a volatility ratio and how
+ * many months were actually observed. **No score, no rating, no decision, no eligibility.** Those
+ * are lending-service's (ADR-0213), and the separation is what lets a threshold move without the
+ * measurement moving underneath it.
+ *
+ * ## `monthsObserved` is part of the answer, not metadata
+ *
+ * A three-week-old customer and a five-year customer can produce the same median. Returning the
+ * count forces every caller to decide what it does with a thin history instead of quietly treating
+ * "we have barely seen you" as "you earn this". lending-service's gate reads it and refuses to
+ * treat an under-observed profile as evidence.
+ *
+ * ## Access
+ *
+ * Internal service-to-service. `Roles.OPERATOR` is the role an M2M client-credentials token carries
+ * in this fleet (the same one customer-edge presents to lending); the auditor and admin roles are
+ * here for the reason ReconciliationResource carries them — this is the data a creditworthiness
+ * decision was made on, so an auditor must be able to read it back.
+ */
+@Path("/api/v1/analytics/credit-profile")
+@Produces(MediaType.APPLICATION_JSON)
+class CreditProfileResource {
+
+    @Inject lateinit var clickHouse: ClickHouseClient
+
+    @Inject lateinit var objectMapper: ObjectMapper
+
+    @GET
+    @Path("/{partyId}")
+    @RolesAllowed(Roles.OPERATOR, Roles.AUDITOR, Roles.ADMIN)
+    suspend fun profile(@PathParam("partyId") partyId: String): Response {
+        // The UUID parse IS the injection boundary — the value is interpolated into SQL below.
+        // ClickHouse's HTTP interface takes the query as a string, so there is no bound-parameter
+        // path to fall back on; a rejected non-UUID is the control, not a convenience.
+        val party = runCatching { UUID.fromString(partyId) }.getOrNull()
+            ?: return Response.status(BAD_REQUEST).entity(mapOf("error" to "partyId is not a UUID")).build()
+
+        val json = clickHouse.query(
+            """
+            SELECT months_observed, income_monthly, outflow_monthly, net_monthly,
+                   volatility_ratio, movements_observed
+            FROM ${'$'}{DB}.gold_party_credit_profile
+            WHERE party_id = '$party'
+            FORMAT JSONEachRow
+            """.trimIndent().replace("\${DB}", DATABASE),
+        )
+
+        val row = json.lineSequence().firstOrNull { it.isNotBlank() }
+            // No row is not an error and not a zero-income customer: it is a party with no observed
+            // months. Answering with zeros would be indistinguishable from someone whose income really
+            // is zero, and a credit gate cannot tell those apart afterwards.
+            ?: return Response.ok(EMPTY_PROFILE).build()
+
+        return Response.ok(objectMapper.readTree(row)).build()
+    }
+
+    companion object {
+        private const val DATABASE = "openbank_analytics"
+        private const val BAD_REQUEST = 400
+
+        /** monthsObserved = 0 is the honest shape of "we have not seen this party". */
+        private val EMPTY_PROFILE = mapOf(
+            "months_observed" to 0,
+            "income_monthly" to null,
+            "outflow_monthly" to null,
+            "net_monthly" to null,
+            "volatility_ratio" to null,
+            "movements_observed" to 0,
+        )
+    }
+}

--- a/openbank-analytics-sink/src/main/resources/application.yaml
+++ b/openbank-analytics-sink/src/main/resources/application.yaml
@@ -101,9 +101,14 @@ mp:
         # engagement.events closes campaign attribution from accepted PUSH handoff to the app's
         # observed impression/click/dismiss/conversion signal. Campaign ids in this stream are
         # resolved by campaign-service from an opaque interactionRef, never trusted from the app.
+        # credit.funnel.events (ADR-0269 rule 8) is the credit-journey counterpart of the
+        # onboarding funnel, and a SEPARATE topic on purpose: the onboarding stream is written from
+        # an anonymous public endpoint, these events only from an authenticated request. Keep them
+        # separate downstream too — unioning them would give the anonymous stream's trust level to
+        # the credit one.
         # Every topic here also needs a Read ACL on the analytics-sink KafkaUser
         # (openbank-infra/gitops/components/analytics/kafka-analytics-sink-mtls.yaml).
-        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.sca.events,openbank.documents.document.event,openbank.onboarding.funnel.events,openbank.feedback.events,openbank.engagement.events
+        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.sca.events,openbank.documents.document.event,openbank.onboarding.funnel.events,openbank.feedback.events,openbank.engagement.events,openbank.credit.funnel.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
         # group.id / auto.offset.reset are deliberately NOT set as YAML keys here — see
         # openbank-fraud-service's application.yaml / openbank-anacredit-service's

--- a/openbank-analytics-sink/src/main/resources/clickhouse/V10__credit_funnel.sql
+++ b/openbank-analytics-sink/src/main/resources/clickhouse/V10__credit_funnel.sql
@@ -1,0 +1,51 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+-- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+--
+-- The ADR-0269 credit-journey funnel (rule 8's metrics).
+--
+-- WHAT THIS DELIBERATELY CANNOT ANSWER: "how many customers converted". There is no conversion
+-- event upstream and there is no acceptance column here. The programme's metrics are
+-- self-activation, opt-out-within-30-days, affordability declines, delinquency, and offers shown
+-- without a prior customer action — a funnel built to optimise acceptance would quietly become the
+-- thing ADR-0269 exists to prevent.
+--
+-- WHY A SEPARATE STREAM from the onboarding funnel: that one is an anonymous public write. These
+-- events say "this person is looking at borrowing", so they ride an authenticated topic keyed by
+-- party. The two must not be unioned into one view, or the anonymous stream's trust level would
+-- silently become the credit stream's.
+
+CREATE OR REPLACE VIEW openbank_analytics.gold_credit_funnel_events AS
+SELECT
+    JSONExtractString(payload, 'partyId') AS party_id,
+    JSONExtractString(payload, 'step')    AS step,
+    JSONExtractString(payload, 'action')  AS action,
+    occurred_at
+FROM openbank_analytics.bronze_events
+WHERE upper(aggregate_type) = 'CREDIT_FUNNEL'
+  AND JSONExtractString(payload, 'partyId') != '';
+
+-- Self-activation, the headline number: of the people who ever opened the consent screen, how many
+-- switched offers ON themselves. Deliberately NOT "how many were offered credit".
+CREATE OR REPLACE VIEW openbank_analytics.gold_credit_consent_activation AS
+SELECT
+    toStartOfDay(occurred_at)                                        AS day,
+    countIf(action = 'VIEWED' AND step = 'CONSENT')                  AS consent_screen_views,
+    countIf(action = 'CONSENT_GRANTED')                              AS granted,
+    countIf(action = 'CONSENT_WITHDRAWN')                            AS withdrawn,
+    uniqExactIf(party_id, action = 'CONSENT_GRANTED')                AS parties_granted,
+    uniqExactIf(party_id, action = 'CONSENT_WITHDRAWN')              AS parties_withdrawn
+FROM openbank_analytics.gold_credit_funnel_events
+GROUP BY day;
+
+-- Pricing outcomes. QUOTE_SUPPRESSED is tracked as prominently as QUOTE_REQUESTED on purpose: the
+-- distress floor refusing to price is a thing the bank must be able to SEE, not a silent branch.
+CREATE OR REPLACE VIEW openbank_analytics.gold_credit_quote_outcomes AS
+SELECT
+    toStartOfDay(occurred_at)                        AS day,
+    countIf(action = 'QUOTE_REQUESTED')              AS requested,
+    countIf(action = 'QUOTE_SUPPRESSED')             AS suppressed,
+    countIf(action = 'APPLICATION_STARTED')          AS applications_started,
+    countIf(action = 'APPLICATION_ABANDONED')        AS applications_abandoned
+FROM openbank_analytics.gold_credit_funnel_events
+GROUP BY day;

--- a/openbank-analytics-sink/src/main/resources/clickhouse/V9__party_credit_profile.sql
+++ b/openbank-analytics-sink/src/main/resources/clickhouse/V9__party_credit_profile.sql
@@ -1,0 +1,102 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+-- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+--
+-- The credit profile behind ADR-0269 (issue #6215).
+--
+-- ONE definition, for the same reason V5 gives for the party key: three consumers need these
+-- numbers — the creditworthiness assessment (which must be reproducible for an audit), the
+-- customer's own financial-health view, and the AI advisor. Two implementations that disagree is
+-- worse than one that is wrong, because only the second is detectable.
+--
+-- WHY IT LIVES HERE. ADR-0210 put Customer 360 in the silver layer rather than in a new service:
+-- the topics are already ingested and the reduction already exists. A credit profile is the same
+-- shape of question asked of the same rows.
+--
+-- WHAT IT DELIBERATELY DOES NOT DO. It computes no score, no rating and no decision. It reports
+-- observable quantities — money in, money out, how steady, how long the cover lasts. The judgement
+-- is lending-service's (ADR-0213), and keeping the two apart is what lets the thresholds move
+-- without the measurements moving.
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Per-party monthly cash flows.
+--
+-- A transaction is INBOUND for a party when the party owns the target account and OUTBOUND when it
+-- owns the source. Both legs are counted from the same event, which is why the two halves are
+-- unioned rather than joined: an internal transfer between two of the customer's OWN accounts is
+-- then correctly both — it is not income, and the netting in the profile below removes it.
+--
+-- occurred_at, never ingested_at: a backfilled month must land in the month it happened, or a
+-- reload silently rewrites someone's income history.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE VIEW openbank_analytics.silver_party_monthly_flows AS
+SELECT
+    party_id,
+    month,
+    sum(inbound)  AS inbound_amount,
+    sum(outbound) AS outbound_amount,
+    count()       AS movement_count
+FROM
+(
+    SELECT
+        pa.party_id                                                        AS party_id,
+        toStartOfMonth(e.occurred_at)                                      AS month,
+        toDecimal64(JSONExtractString(e.payload, 'amount'), 2)             AS inbound,
+        toDecimal64('0', 2)                                                AS outbound
+    FROM openbank_analytics.bronze_events AS e
+    INNER JOIN openbank_analytics.silver_party_accounts AS pa
+        ON pa.account_id = JSONExtractString(e.payload, 'targetAccountId')
+    WHERE upper(e.aggregate_type) = 'TRANSACTION'
+      AND JSONExtractString(e.payload, 'targetAccountId') != ''
+      AND JSONExtractString(e.payload, 'amount') != ''
+
+    UNION ALL
+
+    SELECT
+        pa.party_id                                                        AS party_id,
+        toStartOfMonth(e.occurred_at)                                      AS month,
+        toDecimal64('0', 2)                                                AS inbound,
+        toDecimal64(JSONExtractString(e.payload, 'amount'), 2)             AS outbound
+    FROM openbank_analytics.bronze_events AS e
+    INNER JOIN openbank_analytics.silver_party_accounts AS pa
+        ON pa.account_id = JSONExtractString(e.payload, 'sourceAccountId')
+    WHERE upper(e.aggregate_type) = 'TRANSACTION'
+      AND JSONExtractString(e.payload, 'sourceAccountId') != ''
+      AND JSONExtractString(e.payload, 'amount') != ''
+)
+GROUP BY party_id, month;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- The profile itself: the last six whole months, excluding the current partial one.
+--
+-- WHY SIX. Long enough for a quarterly pattern to show and for one unusual month not to dominate;
+-- short enough that a job change is visible rather than averaged away.
+--
+-- WHY THE CURRENT MONTH IS EXCLUDED. A month in progress always looks like a collapse in income —
+-- on the 3rd, salary has not arrived. Including it would make every profile read worst on the day
+-- most customers open the app.
+--
+-- income_monthly is the MEDIAN inbound, not the mean: one bonus or one incoming transfer from
+-- savings should not raise what the bank believes a customer earns every month.
+--
+-- volatility_ratio is the standard deviation of monthly net over the median inbound. It is a ratio,
+-- not a currency amount, so it compares across income levels — 5,000 of swing means something very
+-- different on 20,000 a month than on 200,000.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE VIEW openbank_analytics.gold_party_credit_profile AS
+SELECT
+    party_id,
+    count()                                                     AS months_observed,
+    quantileExact(0.5)(inbound_amount)                          AS income_monthly,
+    quantileExact(0.5)(outbound_amount)                         AS outflow_monthly,
+    quantileExact(0.5)(inbound_amount - outbound_amount)        AS net_monthly,
+    -- Guard the divisor: a party with no observed inbound has an undefined ratio, and 0 would read
+    -- as "perfectly stable" — the most flattering possible answer for the least-known customer.
+    if(quantileExact(0.5)(inbound_amount) > 0,
+       stddevPop(inbound_amount - outbound_amount) / quantileExact(0.5)(inbound_amount),
+       NULL)                                                    AS volatility_ratio,
+    sum(movement_count)                                         AS movements_observed
+FROM openbank_analytics.silver_party_monthly_flows
+WHERE month >= toStartOfMonth(now()) - INTERVAL 6 MONTH
+  AND month <  toStartOfMonth(now())
+GROUP BY party_id;

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/domain/model/Consent.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/domain/model/Consent.kt
@@ -65,6 +65,17 @@ enum class ConsentScope {
     // their spending mined for eligibility, and one checkbox cannot express that.
     CREDIT_OFFERS,
     CREDIT_PROFILE_USE,
+
+    /**
+     * ADR-0269 rule 5, L2: the assistant may watch and PREPARE on the customer's behalf — pre-fill
+     * an application, scan for a cheaper refinancing, warn that an instalment looks at risk.
+     *
+     * Separate from CREDIT_PROFILE_USE because the powers are different in kind, not in degree.
+     * Reading the profile answers a question the customer asked; acting on it means the assistant
+     * does something without being asked each time. It never extends to committing the customer:
+     * no level may submit, accept, raise a limit or draw funds.
+     */
+    CREDIT_AI_AGENT,
 }
 
 enum class GranteeType {
@@ -197,6 +208,7 @@ data class Consent(
             ConsentScope.MARKETING_COMMS_INAPP,
             ConsentScope.CREDIT_OFFERS,
             ConsentScope.CREDIT_PROFILE_USE,
+            ConsentScope.CREDIT_AI_AGENT,
         )
 
         /** PSD2 RTS Art. 10(2)(b): max AISP accesses per day without fresh SCA. */

--- a/openbank-consent-service/src/main/resources/openapi.yaml
+++ b/openbank-consent-service/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Consent Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.0 -> 1.1): additive
   # endpoint only (PATCH /approvals/{id}, ADR-0155 four-eyes) — no breaking change.
-  version: 1.6.0
+  version: 1.7.0
   description: >-
     Data sharing consent lifecycle — create, activate, reject, revoke, validate. PATCH
     /approvals/{id} decides a four-eyes approval paused by the platform's ADR-0155 maker-checker
@@ -111,7 +111,7 @@ paths:
                    AGENT_QUERY, AGENT_INITIATE, AGENT_NOTIFY, AGENT_ANALYZE,
                    TELEMETRY_RUM,
                    MARKETING_COMMS_EMAIL, MARKETING_COMMS_PUSH, MARKETING_COMMS_INAPP,
-                   CREDIT_OFFERS, CREDIT_PROFILE_USE]
+                   CREDIT_OFFERS, CREDIT_PROFILE_USE, CREDIT_AI_AGENT]
       responses:
         '200':
           description: Whether the consent exists, is active now, and covers the scope

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/domain/model/ConsentTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/domain/model/ConsentTest.kt
@@ -233,6 +233,7 @@ class ConsentTest {
             ConsentScope.MARKETING_COMMS_INAPP,
             ConsentScope.CREDIT_OFFERS,
             ConsentScope.CREDIT_PROFILE_USE,
+            ConsentScope.CREDIT_AI_AGENT,
         )
     }
 

--- a/openbank-contracts/openbank-customer-edge/asyncapi.yaml
+++ b/openbank-contracts/openbank-customer-edge/asyncapi.yaml
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# ADR-0006: every Kafka topic is documented in AsyncAPI 3.0 under openbank-contracts/<service>/.
+#
+# WHAT IS AND IS NOT ENFORCED HERE. `check-event-contract-coverage.py` asserts this FILE EXISTS and
+# declares the channel; nothing validates its content against what the code actually sends, and no
+# schema is registered in Apicurio yet (#1916 sequences that, money-path topics first). Everything
+# below is DERIVED from `CreditFunnelPublisher.emit`, and each claim names its source — the same
+# convention the engagement-service and delegation-service contracts use.
+
+asyncapi: 3.0.0
+
+info:
+  title: OpenBank Customer Edge — events
+  version: 1.0.0
+  description: |
+    Customer-edge is a BFF, not an aggregate owner, so it publishes no domain events. What it does
+    publish is TELEMETRY about journeys that happen in the app, and this contract covers the
+    ADR-0269 credit-journey funnel.
+
+    The edge's three older streams — the customer audit trail, the onboarding funnel and screen
+    feedback — predated this file and were grandfathered in `.github/event-contract-baseline.txt`.
+    Creating this contract made those entries stale (the coverage gate treats a service as either
+    documented or not), so they are documented below and their baseline lines are removed. The
+    ratchet only shrinks.
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+defaultContentType: application/json
+
+servers:
+  sandbox:
+    host: openbank-cluster-kafka-bootstrap.messaging.svc:9093
+    protocol: kafka-secure
+    description: |
+      Strimzi cluster `openbank-cluster` in the `messaging` namespace. mTLS; the producer
+      (customer-edge) and the consumer (analytics-sink) each use a dedicated least-privilege
+      KafkaUser, declared in `openbank-infra/gitops/components/customer-edge/` and
+      `.../components/analytics/` respectively.
+
+channels:
+  creditFunnelEvents:
+    address: openbank.credit.funnel.events
+    title: Credit-journey funnel telemetry (ADR-0269 rule 8)
+    description: |
+      One partition, one replica, `cleanup.policy: delete`, `retention.ms: 604800000` (7 days),
+      declared in `openbank-infra/gitops/components/customer-edge/kafka-topic.yaml`. The durable
+      copy is the ClickHouse bronze layer (≥10 years); this topic is only the transport.
+
+      **Why this is NOT the onboarding funnel topic.** That stream is written from an ANONYMOUS,
+      publicly postable endpoint — which is right for steps that happen before a session exists.
+      These events say *"this customer is looking at borrowing money"* and are written only from an
+      authenticated request. On a public stream that signal would be both forgeable and probeable,
+      so the two are deliberately separate topics with separate ACLs, and must never be unioned
+      into one view downstream: doing so would silently give the anonymous stream's trust level to
+      the credit one.
+
+      **Partitioning key: the party id** (`CreditFunnelPublisher.emit` passes it as the record key
+      and as `aggregateId`). Unlike the onboarding funnel, which keys on a client-generated session
+      id, the questions this answers — "did they come back after switching offers on" — span
+      sessions, so the pseudonymous party id the silver layer already holds is the right grain.
+
+      **What this vocabulary cannot express: a conversion.** There is no CONVERTED, ACCEPTED or
+      SOLD action, and tests on both the publisher and the app-side tracker assert their absence.
+      The programme's metrics are self-activation, opt-out-within-30-days, affordability declines,
+      delinquency, and offers shown without a prior customer action. A funnel that can say
+      "converted" is one somebody eventually optimises, and optimising credit acceptance is the
+      thing ADR-0269 exists to prevent.
+    messages:
+      creditFunnelStep:
+        $ref: '#/components/messages/creditFunnelStep'
+
+  customerAudit:
+    address: openbank.customer.audit
+    title: Customer-facing audit trail
+    description: |
+      Every customer-initiated action the edge brokers, emitted by `EdgeAuditPublisher` for
+      audit-service. Best-effort in the same sense as the telemetry streams — a broker outage must
+      not fail the customer's request — but unlike them this is evidence, so the durable record is
+      audit-service's own store and this topic is only the transport.
+    messages:
+      auditEvent:
+        $ref: '#/components/messages/passthroughEnvelope'
+
+  onboardingFunnelEvents:
+    address: openbank.onboarding.funnel.events
+    title: Onboarding funnel telemetry (ADR-0069 Phase 2)
+    description: |
+      Written from an ANONYMOUS, publicly postable endpoint, because the drop-off worth measuring
+      happens before any Keycloak session exists. Keyed by a client-generated onboarding session id,
+      never by identity; the party id rides in the payload only from the sign step onward.
+
+      Its allow-lists are closed for the same reason this one's are: anyone can post to it.
+    messages:
+      onboardingFunnelStep:
+        $ref: '#/components/messages/passthroughEnvelope'
+
+  feedbackEvents:
+    address: openbank.feedback.events
+    title: In-app screen feedback (ADR-0192)
+    description: |
+      Feedback METADATA only — screen id, category, comment and the screenshot's object-store key.
+      The PNG itself lives in S3 under a 90-day lifecycle rule and never enters Kafka.
+    messages:
+      feedbackEvent:
+        $ref: '#/components/messages/passthroughEnvelope'
+
+operations:
+  publishCreditFunnelStep:
+    action: send
+    channel:
+      $ref: '#/channels/creditFunnelEvents'
+    title: customer-edge publishes one credit-journey funnel step
+    description: |
+      Emitted by `CreditFunnelPublisher.emit`, called from `CustomerEdgeResource.trackCreditEvent`
+      (`POST /customer/v1/credit/events`). Both `step` and `action` are validated against closed
+      allow-lists BEFORE publication; anything else is dropped and the caller still receives 202,
+      because a 400 would turn the allow-list into an oracle for what the bank tracks.
+
+      Best-effort by design: a Kafka outage degrades to an ERROR log, never a 5xx. Telemetry must
+      not break the screen it is watching.
+    messages:
+      - $ref: '#/channels/creditFunnelEvents/messages/creditFunnelStep'
+
+components:
+  messages:
+    creditFunnelStep:
+      name: creditFunnelStep
+      title: One step of a customer's credit journey
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+
+    passthroughEnvelope:
+      name: passthroughEnvelope
+      title: The generic analytics envelope, unchanged
+      contentType: application/json
+      description: |
+        Documented as the shared envelope rather than field-by-field: these three streams predate
+        this contract and nothing validates payload content against the code today (see the header).
+        Claiming a precise schema here would assert more than is checked.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+
+  schemas:
+    AnalyticsEnvelope:
+      type: object
+      description: |
+        The envelope analytics-sink already ingests generically (eventType / aggregateType /
+        aggregateId / occurredAt / sourceService / schemaVersion / payload), so this stream needs no
+        bespoke consumer — the same shape the onboarding funnel and screen feedback use.
+      required: [eventType, aggregateType, aggregateId, occurredAt, sourceService, schemaVersion, payload]
+      properties:
+        eventType:
+          type: string
+          description: "`credit.funnel.step` for the credit funnel; each other channel has its own."
+        aggregateType:
+          type: string
+          description: "`CREDIT_FUNNEL` for the credit funnel; each other channel has its own." 
+        aggregateId:
+          type: string
+          format: uuid
+          description: The party id — see the channel's partitioning note.
+        occurredAt:
+          type: string
+          format: date-time
+        sourceService:
+          type: string
+          const: customer-edge
+        schemaVersion:
+          type: integer
+          const: 1
+        payload:
+          type: object
+          description: |
+            Shape below is the CREDIT FUNNEL's payload. The audit, onboarding-funnel and feedback
+            channels carry their own payloads on the same envelope.
+          required: [partyId, step, action]
+          properties:
+            partyId:
+              type: string
+              format: uuid
+              description: |
+                Taken from the JWT, never from the request body. A partyId supplied by a client is
+                ignored, so a caller can only ever describe their own journey.
+            step:
+              type: string
+              enum: [CONSENT, HEALTH, FINANCING, QUOTE, APPLICATION]
+            action:
+              type: string
+              description: |
+                Closed list, and closed for two reasons: these values are Prometheus labels, so an
+                open vocabulary is a cardinality bomb reachable by any authenticated customer — and
+                the list deliberately contains no word for conversion.
+              enum:
+                - VIEWED
+                - CONSENT_GRANTED
+                - CONSENT_WITHDRAWN
+                - QUOTE_REQUESTED
+                - QUOTE_SUPPRESSED
+                - APPLICATION_STARTED
+                - APPLICATION_ABANDONED

--- a/openbank-contracts/openbank-customer-edge/asyncapi.yaml
+++ b/openbank-contracts/openbank-customer-edge/asyncapi.yaml
@@ -69,7 +69,7 @@ channels:
       "converted" is one somebody eventually optimises, and optimising credit acceptance is the
       thing ADR-0269 exists to prevent.
     messages:
-      creditFunnelStep:
+      credit.funnel.step:
         $ref: '#/components/messages/creditFunnelStep'
 
   customerAudit:
@@ -81,8 +81,40 @@ channels:
       not fail the customer's request — but unlike them this is evidence, so the durable record is
       audit-service's own store and this topic is only the transport.
     messages:
-      auditEvent:
-        $ref: '#/components/messages/passthroughEnvelope'
+      customeraccountopened:
+        $ref: '#/components/messages/auditEvent_CUSTOMER_ACCOUNT_OPENED'
+      customercardactionrefused:
+        $ref: '#/components/messages/auditEvent_CUSTOMER_CARD_ACTION_REFUSED'
+      customeridentitymatched:
+        $ref: '#/components/messages/auditEvent_CUSTOMER_IDENTITY_MATCHED'
+      customeridentitypending:
+        $ref: '#/components/messages/auditEvent_CUSTOMER_IDENTITY_PENDING'
+      customeronboardingrejected:
+        $ref: '#/components/messages/auditEvent_CUSTOMER_ONBOARDING_REJECTED'
+      customeronboardingresumedcreated:
+        $ref: '#/components/messages/auditEvent_CUSTOMER_ONBOARDING_RESUMED_CREATED'
+      customeronboardingresumedlinked:
+        $ref: '#/components/messages/auditEvent_CUSTOMER_ONBOARDING_RESUMED_LINKED'
+      customerpaymentinitiated:
+        $ref: '#/components/messages/auditEvent_CUSTOMER_PAYMENT_INITIATED'
+      customerpaymentrefused:
+        $ref: '#/components/messages/auditEvent_CUSTOMER_PAYMENT_REFUSED'
+      customerpocketconverted:
+        $ref: '#/components/messages/auditEvent_CUSTOMER_POCKET_CONVERTED'
+      customerpocketexchanged:
+        $ref: '#/components/messages/auditEvent_CUSTOMER_POCKET_EXCHANGED'
+      customerregistered:
+        $ref: '#/components/messages/auditEvent_CUSTOMER_REGISTERED'
+      customertransferinitiated:
+        $ref: '#/components/messages/auditEvent_CUSTOMER_TRANSFER_INITIATED'
+      loanapplicationsubmitted:
+        $ref: '#/components/messages/auditEvent_LOAN_APPLICATION_SUBMITTED'
+      scadecisionrecorded:
+        $ref: '#/components/messages/auditEvent_SCA_DECISION_RECORDED'
+      scadeviceenrolled:
+        $ref: '#/components/messages/auditEvent_SCA_DEVICE_ENROLLED'
+      standingordercreated:
+        $ref: '#/components/messages/auditEvent_STANDING_ORDER_CREATED'
 
   onboardingFunnelEvents:
     address: openbank.onboarding.funnel.events
@@ -94,8 +126,8 @@ channels:
 
       Its allow-lists are closed for the same reason this one's are: anyone can post to it.
     messages:
-      onboardingFunnelStep:
-        $ref: '#/components/messages/passthroughEnvelope'
+      onboarding.funnel.step:
+        $ref: '#/components/messages/onboardingFunnelStep'
 
   feedbackEvents:
     address: openbank.feedback.events
@@ -104,8 +136,8 @@ channels:
       Feedback METADATA only — screen id, category, comment and the screenshot's object-store key.
       The PNG itself lives in S3 under a 90-day lifecycle rule and never enters Kafka.
     messages:
-      feedbackEvent:
-        $ref: '#/components/messages/passthroughEnvelope'
+      feedback.submitted:
+        $ref: '#/components/messages/feedbackSubmitted'
 
 operations:
   publishCreditFunnelStep:
@@ -122,25 +154,188 @@ operations:
       Best-effort by design: a Kafka outage degrades to an ERROR log, never a 5xx. Telemetry must
       not break the screen it is watching.
     messages:
-      - $ref: '#/channels/creditFunnelEvents/messages/creditFunnelStep'
+      - $ref: '#/channels/creditFunnelEvents/messages/credit.funnel.step'
 
 components:
   messages:
     creditFunnelStep:
-      name: creditFunnelStep
+      name: credit.funnel.step
       title: One step of a customer's credit journey
       contentType: application/json
       payload:
         $ref: '#/components/schemas/AnalyticsEnvelope'
 
-    passthroughEnvelope:
-      name: passthroughEnvelope
-      title: The generic analytics envelope, unchanged
+    auditEvent_CUSTOMER_ACCOUNT_OPENED:
+      name: CUSTOMER_ACCOUNT_OPENED
+      title: Customer audit event CUSTOMER_ACCOUNT_OPENED
       contentType: application/json
       description: |
-        Documented as the shared envelope rather than field-by-field: these three streams predate
-        this contract and nothing validates payload content against the code today (see the header).
-        Claiming a precise schema here would assert more than is checked.
+        Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
+        Carries the envelope below with `eventType: CUSTOMER_ACCOUNT_OPENED`.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+    auditEvent_CUSTOMER_CARD_ACTION_REFUSED:
+      name: CUSTOMER_CARD_ACTION_REFUSED
+      title: Customer audit event CUSTOMER_CARD_ACTION_REFUSED
+      contentType: application/json
+      description: |
+        Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
+        Carries the envelope below with `eventType: CUSTOMER_CARD_ACTION_REFUSED`.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+    auditEvent_CUSTOMER_IDENTITY_MATCHED:
+      name: CUSTOMER_IDENTITY_MATCHED
+      title: Customer audit event CUSTOMER_IDENTITY_MATCHED
+      contentType: application/json
+      description: |
+        Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
+        Carries the envelope below with `eventType: CUSTOMER_IDENTITY_MATCHED`.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+    auditEvent_CUSTOMER_IDENTITY_PENDING:
+      name: CUSTOMER_IDENTITY_PENDING
+      title: Customer audit event CUSTOMER_IDENTITY_PENDING
+      contentType: application/json
+      description: |
+        Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
+        Carries the envelope below with `eventType: CUSTOMER_IDENTITY_PENDING`.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+    auditEvent_CUSTOMER_ONBOARDING_REJECTED:
+      name: CUSTOMER_ONBOARDING_REJECTED
+      title: Customer audit event CUSTOMER_ONBOARDING_REJECTED
+      contentType: application/json
+      description: |
+        Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
+        Carries the envelope below with `eventType: CUSTOMER_ONBOARDING_REJECTED`.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+    auditEvent_CUSTOMER_ONBOARDING_RESUMED_CREATED:
+      name: CUSTOMER_ONBOARDING_RESUMED_CREATED
+      title: Customer audit event CUSTOMER_ONBOARDING_RESUMED_CREATED
+      contentType: application/json
+      description: |
+        Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
+        Carries the envelope below with `eventType: CUSTOMER_ONBOARDING_RESUMED_CREATED`.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+    auditEvent_CUSTOMER_ONBOARDING_RESUMED_LINKED:
+      name: CUSTOMER_ONBOARDING_RESUMED_LINKED
+      title: Customer audit event CUSTOMER_ONBOARDING_RESUMED_LINKED
+      contentType: application/json
+      description: |
+        Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
+        Carries the envelope below with `eventType: CUSTOMER_ONBOARDING_RESUMED_LINKED`.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+    auditEvent_CUSTOMER_PAYMENT_INITIATED:
+      name: CUSTOMER_PAYMENT_INITIATED
+      title: Customer audit event CUSTOMER_PAYMENT_INITIATED
+      contentType: application/json
+      description: |
+        Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
+        Carries the envelope below with `eventType: CUSTOMER_PAYMENT_INITIATED`.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+    auditEvent_CUSTOMER_PAYMENT_REFUSED:
+      name: CUSTOMER_PAYMENT_REFUSED
+      title: Customer audit event CUSTOMER_PAYMENT_REFUSED
+      contentType: application/json
+      description: |
+        Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
+        Carries the envelope below with `eventType: CUSTOMER_PAYMENT_REFUSED`.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+    auditEvent_CUSTOMER_POCKET_CONVERTED:
+      name: CUSTOMER_POCKET_CONVERTED
+      title: Customer audit event CUSTOMER_POCKET_CONVERTED
+      contentType: application/json
+      description: |
+        Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
+        Carries the envelope below with `eventType: CUSTOMER_POCKET_CONVERTED`.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+    auditEvent_CUSTOMER_POCKET_EXCHANGED:
+      name: CUSTOMER_POCKET_EXCHANGED
+      title: Customer audit event CUSTOMER_POCKET_EXCHANGED
+      contentType: application/json
+      description: |
+        Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
+        Carries the envelope below with `eventType: CUSTOMER_POCKET_EXCHANGED`.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+    auditEvent_CUSTOMER_REGISTERED:
+      name: CUSTOMER_REGISTERED
+      title: Customer audit event CUSTOMER_REGISTERED
+      contentType: application/json
+      description: |
+        Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
+        Carries the envelope below with `eventType: CUSTOMER_REGISTERED`.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+    auditEvent_CUSTOMER_TRANSFER_INITIATED:
+      name: CUSTOMER_TRANSFER_INITIATED
+      title: Customer audit event CUSTOMER_TRANSFER_INITIATED
+      contentType: application/json
+      description: |
+        Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
+        Carries the envelope below with `eventType: CUSTOMER_TRANSFER_INITIATED`.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+    auditEvent_LOAN_APPLICATION_SUBMITTED:
+      name: LOAN_APPLICATION_SUBMITTED
+      title: Customer audit event LOAN_APPLICATION_SUBMITTED
+      contentType: application/json
+      description: |
+        Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
+        Carries the envelope below with `eventType: LOAN_APPLICATION_SUBMITTED`.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+    auditEvent_SCA_DECISION_RECORDED:
+      name: SCA_DECISION_RECORDED
+      title: Customer audit event SCA_DECISION_RECORDED
+      contentType: application/json
+      description: |
+        Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
+        Carries the envelope below with `eventType: SCA_DECISION_RECORDED`.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+    auditEvent_SCA_DEVICE_ENROLLED:
+      name: SCA_DEVICE_ENROLLED
+      title: Customer audit event SCA_DEVICE_ENROLLED
+      contentType: application/json
+      description: |
+        Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
+        Carries the envelope below with `eventType: SCA_DEVICE_ENROLLED`.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+    auditEvent_STANDING_ORDER_CREATED:
+      name: STANDING_ORDER_CREATED
+      title: Customer audit event STANDING_ORDER_CREATED
+      contentType: application/json
+      description: |
+        Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
+        Carries the envelope below with `eventType: STANDING_ORDER_CREATED`.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+
+    onboardingFunnelStep:
+      name: onboarding.funnel.step
+      title: One onboarding funnel step
+      contentType: application/json
+      description: |
+        Emitted by `OnboardingFunnelPublisher.emit`. Keyed by a client-generated onboarding session
+        id, never by identity.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+
+    feedbackSubmitted:
+      name: feedback.submitted
+      title: One in-app screen-feedback submission (metadata only)
+      contentType: application/json
+      description: |
+        Emitted by `FeedbackPublisher`. Metadata and the screenshot's object-store key only — the
+        PNG never enters Kafka.
       payload:
         $ref: '#/components/schemas/AnalyticsEnvelope'
 

--- a/openbank-contracts/openbank-customer-edge/asyncapi.yaml
+++ b/openbank-contracts/openbank-customer-edge/asyncapi.yaml
@@ -105,6 +105,8 @@ channels:
         $ref: '#/components/messages/auditEvent_CUSTOMER_POCKET_EXCHANGED'
       customerregistered:
         $ref: '#/components/messages/auditEvent_CUSTOMER_REGISTERED'
+      customertermdepositopened:
+        $ref: '#/components/messages/auditEvent_CUSTOMER_TERM_DEPOSIT_OPENED'
       customertransferinitiated:
         $ref: '#/components/messages/auditEvent_CUSTOMER_TRANSFER_INITIATED'
       loanapplicationsubmitted:
@@ -271,6 +273,15 @@ components:
       description: |
         Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
         Carries the envelope below with `eventType: CUSTOMER_REGISTERED`.
+      payload:
+        $ref: '#/components/schemas/AnalyticsEnvelope'
+    auditEvent_CUSTOMER_TERM_DEPOSIT_OPENED:
+      name: CUSTOMER_TERM_DEPOSIT_OPENED
+      title: Customer audit event CUSTOMER_TERM_DEPOSIT_OPENED
+      contentType: application/json
+      description: |
+        Emitted by `EdgeAuditPublisher` from `CustomerEdgeResource`, on the hand-built outbox path.
+        Carries the envelope below with `eventType: CUSTOMER_TERM_DEPOSIT_OPENED`.
       payload:
         $ref: '#/components/schemas/AnalyticsEnvelope'
     auditEvent_CUSTOMER_TRANSFER_INITIATED:

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/CreditAiLevelResolver.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/CreditAiLevelResolver.kt
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.application
+
+import com.openbank.copilot.domain.CreditAiLevel
+import com.openbank.copilot.infrastructure.client.ConsentQueryClient
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.CancellationException
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.jboss.logging.Logger
+import java.util.UUID
+
+/**
+ * Resolves the customer's ADR-0269 credit AI level from their consents.
+ *
+ * ## Why every failure resolves to L0 rather than to an error
+ *
+ * The levels are not a permission to READ something the customer owns; they are a permission for
+ * the bank to look at the customer's finances and to prepare things on their behalf. When the
+ * consent store cannot be reached, the safe answer is the level that does neither — and L0 is a
+ * working assistant, not a refusal, so degrading to it costs the customer an explanation rather
+ * than access to their bank.
+ *
+ * That is the opposite decision from lending's offer gate, which fails closed into a refusal, and
+ * the difference is deliberate: there, the risk is offering credit to someone who did not consent;
+ * here, the risk is reading a profile without consent. Both are closed by "assume the least".
+ */
+@ApplicationScoped
+class CreditAiLevelResolver(@param:RestClient private val consents: ConsentQueryClient) {
+
+    suspend fun levelFor(partyId: UUID): CreditAiLevel {
+        val profileUse = granted(partyId, PROFILE_USE_SCOPE)
+        val agent = granted(partyId, AGENT_SCOPE)
+        return CreditAiLevel.from(profileUseConsent = profileUse, agentConsent = agent)
+    }
+
+    private suspend fun granted(partyId: UUID, scope: String): Boolean =
+        runCatching { consents.hasActiveConsent(partyId, BANK_GRANTEE, scope).awaitSuspending().granted }
+            .getOrElse { e ->
+                if (e is CancellationException) throw e
+                LOG.warn("credit AI level: consent read failed for scope $scope — treating as absent")
+                false
+            }
+
+    companion object {
+        /** First-party consent: the bank is the grantee, not a TPP. */
+        const val BANK_GRANTEE = "openbank"
+        const val PROFILE_USE_SCOPE = "CREDIT_PROFILE_USE"
+        const val AGENT_SCOPE = "CREDIT_AI_AGENT"
+        private val LOG = Logger.getLogger(CreditAiLevelResolver::class.java)
+    }
+}

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/domain/ActionProposal.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/domain/ActionProposal.kt
@@ -4,7 +4,20 @@
 package com.openbank.copilot.domain
 
 /** The kind of money-path action the customer is being asked to confirm. */
-enum class ActionKind { PAYMENT, CARD_FREEZE, DISPUTE, FX_CONVERSION }
+enum class ActionKind {
+    PAYMENT,
+    CARD_FREEZE,
+    DISPUTE,
+    FX_CONVERSION,
+
+    /**
+     * ADR-0269 rule 5, L2: a prepared loan application. Like every other kind here it is a DRAFT —
+     * the assistant fills the form, the customer confirms it into the existing intake flow. The
+     * proposal deliberately carries no rate and no instalment: a draft that claimed a price would
+     * be a quote the bank never made.
+     */
+    CREDIT_APPLICATION,
+}
 
 /**
  * A structured, validated proposal the assistant hands BACK to the app (ADR-0089 D2). The assistant

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/domain/CreditAffordability.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/domain/CreditAffordability.kt
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.domain
+
+import java.math.BigDecimal
+import java.math.MathContext
+import java.math.RoundingMode
+
+/**
+ * The L1 advisor's arithmetic (ADR-0269 rule 5).
+ *
+ * Pure, and deliberately small: given what the customer has (a 360 profile) and what an instalment
+ * would cost (a server quote), it says whether it fits and shows the working. It does not decide
+ * anything — the credit decision is the deterministic engine's (ADR-0213) — and it does not talk to
+ * a model. The model's job is to narrate what this returns, never to compute it (ADR-0089 D4).
+ *
+ * ## Why the verdict is a type and not prose
+ *
+ * The whole point of L1 is that it can say no. A free-text answer from a model can be nudged into
+ * enthusiasm by a hopeful question; a [Verdict] cannot. The tool returns the verdict AND the
+ * numbers behind it, so the narration has nothing to invent and a reviewer can check the advice
+ * against arithmetic rather than against tone.
+ */
+enum class AffordabilityVerdict {
+    /** Fits with room left: DSTI under the comfortable threshold and cover intact. */
+    COMFORTABLE,
+
+    /** Fits, but it costs the customer their margin. Worth saying out loud, not worth refusing. */
+    TIGHT,
+
+    /** Does not fit: it would take DSTI past the limit, or leave under a month of cover. */
+    UNAFFORDABLE,
+
+    /** Not enough is known to answer. Never rendered as "yes" — see [CreditAffordability]. */
+    UNKNOWN,
+}
+
+data class AffordabilityAnswer(
+    val verdict: AffordabilityVerdict,
+    /** Debt-service-to-income after taking the new instalment, as a fraction. Null when unknown. */
+    val dstiAfter: BigDecimal?,
+    /** What the customer would have left each month after the new instalment. Null when unknown. */
+    val monthlySurplusAfter: BigDecimal?,
+    /** Machine-readable reasons, in the order they were decided. Never empty. */
+    val reasons: List<String>,
+)
+
+object CreditAffordability {
+
+    /** Above this share of income going to debt service, an instalment is refused. */
+    private val DSTI_LIMIT = BigDecimal("0.45")
+
+    /** Between this and [DSTI_LIMIT] it fits but is tight — the customer should hear that. */
+    private val DSTI_COMFORTABLE = BigDecimal("0.35")
+
+    private val MC = MathContext.DECIMAL64
+
+    /**
+     * Answer "can I afford this instalment".
+     *
+     * [incomeMonthly], [obligationsMonthly] and [netMonthly] come from the 360 profile;
+     * [instalment] from a server quote (ADR-0269 rule 4 — never computed here, never by the model).
+     *
+     * The two rules answer different questions on purpose. DSTI asks "is too much of the income
+     * going to debt", which is the regulatory shape; the surplus asks "is there anything left after
+     * the customer's actual life", which is the one that decides whether a month goes wrong. A
+     * null [netMonthly] simply skips the second — it must not be read as a surplus of zero.
+     *
+     * A missing or zero income yields [AffordabilityVerdict.UNKNOWN], not a cheerful yes: the
+     * customer whose income the bank cannot see is precisely the one an optimistic answer would
+     * hurt most.
+     */
+    fun assess(
+        incomeMonthly: BigDecimal?,
+        obligationsMonthly: BigDecimal?,
+        netMonthly: BigDecimal?,
+        instalment: BigDecimal,
+    ): AffordabilityAnswer {
+        if (incomeMonthly == null || incomeMonthly <= BigDecimal.ZERO) {
+            return AffordabilityAnswer(
+                AffordabilityVerdict.UNKNOWN,
+                null,
+                null,
+                listOf("INCOME_UNKNOWN"),
+            )
+        }
+        val obligations = obligationsMonthly ?: BigDecimal.ZERO
+        val dstiAfter = obligations.add(instalment, MC).divide(incomeMonthly, MC)
+        // Surplus is measured against what the customer ACTUALLY has left after everything they
+        // spend — the profile's net — not against income minus debt service.
+        //
+        // The first version of this used income − obligations − instalment, and a test proved that
+        // branch could never fire: if debt service is inside the DSTI limit then income minus debt
+        // service is necessarily positive, so the surplus rule was dead code dressed as a
+        // safeguard. Rent and groceries are exactly what makes it a real second question.
+        val surplusAfter = netMonthly?.subtract(instalment, MC)
+
+        val reasons = mutableListOf<String>()
+        val verdict = when {
+            dstiAfter > DSTI_LIMIT -> {
+                reasons += "DSTI_ABOVE_LIMIT"
+                AffordabilityVerdict.UNAFFORDABLE
+            }
+            surplusAfter != null && surplusAfter <= BigDecimal.ZERO -> {
+                reasons += "NO_MONTHLY_SURPLUS"
+                AffordabilityVerdict.UNAFFORDABLE
+            }
+            dstiAfter > DSTI_COMFORTABLE -> {
+                reasons += "DSTI_TIGHT"
+                AffordabilityVerdict.TIGHT
+            }
+            else -> {
+                reasons += "FITS"
+                AffordabilityVerdict.COMFORTABLE
+            }
+        }
+        return AffordabilityAnswer(
+            verdict = verdict,
+            dstiAfter = dstiAfter.setScale(SCALE, RoundingMode.HALF_UP),
+            monthlySurplusAfter = surplusAfter?.setScale(2, RoundingMode.HALF_UP),
+            reasons = reasons,
+        )
+    }
+
+    private const val SCALE = 4
+}

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/domain/CreditAiLevel.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/domain/CreditAiLevel.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.domain
+
+/**
+ * ADR-0269 rule 5 — what the assistant may do about credit, and on whose say-so.
+ *
+ * Three levels, each a separate consent, because one switch is either so coarse that consenting to
+ * it means nothing or so frightening that nobody enables the genuinely useful middle one.
+ *
+ * The ordering is a containment hierarchy, not a preference: every level may do everything the
+ * level below it may, and each adds exactly one new power. That is why [atLeast] is the only
+ * comparison the tools use — a tool that checked `level == L1` would break the moment a customer
+ * turned on L2.
+ */
+enum class CreditAiLevel {
+    /**
+     * Explainer. On by default, and safe as a default for one reason: it cannot speak first and it
+     * never sees the customer's figures. It answers questions the customer asks about how credit
+     * works — what APRC means, why an instalment is what it is, what early repayment does.
+     */
+    L0_EXPLAINER,
+
+    /**
+     * Advisor. Opt-in, and gated on `CREDIT_PROFILE_USE` because that is exactly what it does:
+     * reads the ADR-0269 360 profile to answer "can I afford this" with its workings.
+     *
+     * The defining property is that it must be able to answer NO. An advisor that cannot decline is
+     * not an advisor, and this level exists mainly so that "no, this would leave you with under a
+     * month of cover" is a thing the bank's own assistant will say.
+     */
+    L1_ADVISOR,
+
+    /**
+     * Agent. Opt-in, gated on `CREDIT_AI_AGENT`. May watch and PREPARE — pre-fill an application,
+     * scan for a cheaper refinancing, warn that an instalment looks at risk.
+     *
+     * It may never transition the origination state machine, accept an offer, raise a limit or draw
+     * funds. Its output is a draft plus a proposal the customer confirms, which is the same
+     * model-proposes/bank-disposes shape ADR-0089 D2 already uses for payments — reused rather than
+     * reinvented, because the reason is identical: an AI that can move money is a different risk
+     * class from one that can fill in a form.
+     */
+    L2_AGENT,
+    ;
+
+    fun atLeast(other: CreditAiLevel): Boolean = ordinal >= other.ordinal
+
+    companion object {
+        /**
+         * The level a customer has, derived from their consents.
+         *
+         * Absence of consent is not an error and not a refusal — it is [L0_EXPLAINER], the level
+         * everyone has. Deriving it here rather than at each call site means a new tool cannot
+         * accidentally invent its own idea of what "no consent" implies.
+         */
+        fun from(profileUseConsent: Boolean, agentConsent: Boolean): CreditAiLevel = when {
+            agentConsent -> L2_AGENT
+            profileUseConsent -> L1_ADVISOR
+            else -> L0_EXPLAINER
+        }
+    }
+}

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/ConsentQueryClient.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/ConsentQueryClient.kt
@@ -4,6 +4,7 @@
 package com.openbank.copilot.infrastructure.client
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.openbank.libs.web.SyntheticTaintClientFilter
 import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
 import io.smallrye.mutiny.Uni
 import jakarta.ws.rs.GET
@@ -25,6 +26,7 @@ import java.util.UUID
  */
 @RegisterRestClient(configKey = "consent-service")
 @RegisterProvider(OidcClientRequestReactiveFilter::class)
+@RegisterProvider(SyntheticTaintClientFilter::class)
 @Path("/api/v1/consents")
 @Produces(MediaType.APPLICATION_JSON)
 interface ConsentQueryClient {

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/ConsentQueryClient.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/ConsentQueryClient.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.faulttolerance.Timeout
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import java.util.UUID
+
+/**
+ * consent-service's active-consent check (ADR-0269 rule 5).
+ *
+ * Service-to-service, NOT the propagated customer bearer: the question is "did this customer grant
+ * this scope", which the customer's own token cannot be trusted to answer about itself.
+ */
+@RegisterRestClient(configKey = "consent-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/consents")
+@Produces(MediaType.APPLICATION_JSON)
+interface ConsentQueryClient {
+    @GET
+    @Path("/party/{partyId}/grantee/{granteeId}/active")
+    @Timeout(CONSENT_TIMEOUT_MS)
+    fun hasActiveConsent(
+        @PathParam("partyId") partyId: UUID,
+        @PathParam("granteeId") granteeId: String,
+        @QueryParam("scope") scope: String,
+    ): Uni<ConsentCheckDto>
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ConsentCheckDto(val granted: Boolean = false)
+
+private const val CONSENT_TIMEOUT_MS = 2000L

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/CreditProfileReadClient.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/CreditProfileReadClient.kt
@@ -5,6 +5,7 @@ package com.openbank.copilot.infrastructure.client
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.openbank.libs.web.SyntheticTaintClientFilter
 import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
 import io.smallrye.mutiny.Uni
 import jakarta.ws.rs.GET
@@ -28,6 +29,7 @@ import java.util.UUID
  */
 @RegisterRestClient(configKey = "analytics-sink")
 @RegisterProvider(OidcClientRequestReactiveFilter::class)
+@RegisterProvider(SyntheticTaintClientFilter::class)
 @Path("/api/v1/analytics/credit-profile")
 @Produces(MediaType.APPLICATION_JSON)
 interface CreditProfileReadClient {

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/CreditProfileReadClient.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/CreditProfileReadClient.kt
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.faulttolerance.Timeout
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import java.util.UUID
+
+/**
+ * The ADR-0269 360 credit profile (#6215), read for the L1 advisor.
+ *
+ * Service-to-service rather than the propagated customer bearer: analytics-sink's route is an
+ * internal operator/auditor surface, not a customer-facing one. The customer's protection here is
+ * the CONSENT check that must pass before this client is called at all — see
+ * `CreditAiLevelResolver`. A tool that skipped the level check would read a profile the customer
+ * never agreed to have read, which is why the check lives in the tool and not in this client.
+ */
+@RegisterRestClient(configKey = "analytics-sink")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/analytics/credit-profile")
+@Produces(MediaType.APPLICATION_JSON)
+interface CreditProfileReadClient {
+    @GET
+    @Path("/{partyId}")
+    @Timeout(PROFILE_TIMEOUT_MS)
+    fun profile(@PathParam("partyId") partyId: UUID): Uni<CreditProfileDto>
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CreditProfileDto(
+    @param:JsonProperty("months_observed") val monthsObserved: Int = 0,
+    @param:JsonProperty("income_monthly") val incomeMonthly: String? = null,
+    @param:JsonProperty("outflow_monthly") val outflowMonthly: String? = null,
+    @param:JsonProperty("net_monthly") val netMonthly: String? = null,
+)
+
+private const val PROFILE_TIMEOUT_MS = 2000L

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/CustomerEdgeClient.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/CustomerEdgeClient.kt
@@ -10,6 +10,7 @@ import jakarta.enterprise.context.ApplicationScoped
 import jakarta.ws.rs.Consumes
 import jakarta.ws.rs.DefaultValue
 import jakarta.ws.rs.GET
+import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
@@ -65,6 +66,20 @@ interface CustomerEdgeRestClient {
     @Path("/customer/v1/statements/{accountId}")
     fun listStatements(@PathParam("accountId") accountId: UUID): Uni<List<StatementDto>>
 
+    /**
+     * ADR-0269 rule 4: the customer's indicative price for an amount and term. The edge and
+     * lending-service own every input that is not amount/term, so this cannot be used to price a
+     * loan on the model's terms.
+     */
+    @POST
+    @Path("/customer/v1/credit/quotes")
+    fun quoteCredit(request: CreditQuoteRequestDto): Uni<CreditQuoteDto>
+
+    /** ADR-0269 rule 3: the caller's own credit applications as customer-readable journeys. */
+    @GET
+    @Path("/customer/v1/credit-applications")
+    fun listCreditApplications(): Uni<List<CreditJourneyDto>>
+
     @GET
     @Path("/customer/v1/standing-orders")
     fun listStandingOrders(): Uni<List<StandingOrderDto>>
@@ -78,6 +93,30 @@ data class AccountSummary(
     val accountType: String = "",
     val currencyCode: String = "",
     val status: String = "",
+)
+
+/** Amounts are strings on the wire: money never crosses an API as a Double. */
+data class CreditQuoteRequestDto(val amount: String, val termMonths: Int)
+
+data class CreditQuoteDto(
+    val amount: String = "",
+    val currency: String = "",
+    val termMonths: Int = 0,
+    val monthlyPayment: String = "",
+    val totalPayable: String = "",
+    val totalCostOfCredit: String = "",
+    /** Null means "could not be computed" — render as absent, never as 0%. */
+    val aprcPercent: String? = null,
+    val validUntil: String = "",
+    val binding: Boolean = false,
+)
+
+data class CreditJourneyDto(
+    val id: String = "",
+    val productKind: String = "",
+    val state: String = "",
+    val awaitingCustomer: List<String> = emptyList(),
+    val outcomeReasonCode: String? = null,
 )
 
 data class BalanceDto(

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/tool/CreditAffordabilityTool.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/tool/CreditAffordabilityTool.kt
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.infrastructure.tool
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.openbank.copilot.application.CreditAiLevelResolver
+import com.openbank.copilot.application.port.out.CopilotTool
+import com.openbank.copilot.application.port.out.ToolResult
+import com.openbank.copilot.domain.AffordabilityVerdict
+import com.openbank.copilot.domain.CreditAffordability
+import com.openbank.copilot.domain.CreditAiLevel
+import com.openbank.copilot.infrastructure.client.CreditProfileReadClient
+import com.openbank.copilot.infrastructure.client.CreditQuoteDto
+import com.openbank.copilot.infrastructure.client.CreditQuoteRequestDto
+import com.openbank.copilot.infrastructure.client.CustomerEdgeRestClient
+import io.quarkus.security.identity.SecurityIdentity
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.WebApplicationException
+import org.eclipse.microprofile.jwt.JsonWebToken
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * L1 ADVISOR tool — "can I afford this?" (ADR-0269 rule 5).
+ *
+ * The one tool in this service whose job is to be willing to say no.
+ *
+ * ## What it does not do
+ *
+ * It computes no price: the instalment comes from the edge's quote route (rule 4). It computes no
+ * verdict in the model: [CreditAffordability] decides, and the model narrates. It offers nothing —
+ * a customer asking whether they can afford something has not asked to be sold anything, and this
+ * tool returns an assessment with no product attached.
+ *
+ * ## Why the level check is here and not only in the policy gate
+ *
+ * The ADR-0034 policy gate authorises the CAPABILITY; the level is about which of the customer's
+ * OWN consents are in force, which the gate has no view of. Both apply. An L0 customer gets a
+ * refusal that names what would unlock it, because a silent "I can't help with that" reads as the
+ * assistant being broken rather than as a setting the customer controls.
+ */
+@ApplicationScoped
+class CreditAffordabilityTool(
+    @param:RestClient private val edge: CustomerEdgeRestClient,
+    @param:RestClient private val profiles: CreditProfileReadClient,
+    private val levels: CreditAiLevelResolver,
+    private val identity: SecurityIdentity,
+) : CopilotTool {
+
+    override val name = "credit_affordability"
+    override val description =
+        "Assess whether the customer could afford a loan of a given amount and term, with the workings. " +
+            "Answers COMFORTABLE, TIGHT, UNAFFORDABLE or UNKNOWN — it may refuse, and never offers a product."
+    override val capability = "credit.affordability.read"
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "amount" to mapOf("type" to "string", "description" to "Requested amount, decimal"),
+            "termMonths" to mapOf("type" to "integer", "description" to "Repayment term in months"),
+        ),
+        "required" to listOf("amount", "termMonths"),
+    )
+
+    override suspend fun call(arguments: JsonNode): ToolResult {
+        val partyId = partyId() ?: return ToolResult(NO_PARTY, isError = true)
+        if (!levels.levelFor(partyId).atLeast(CreditAiLevel.L1_ADVISOR)) {
+            return ToolResult(NEEDS_L1, isError = true)
+        }
+        val request = parseRequest(arguments).getOrElse {
+            return ToolResult(it.message ?: "Invalid request.", isError = true)
+        }
+
+        val quote = try {
+            edge.quoteCredit(request).awaitSuspending()
+        } catch (e: WebApplicationException) {
+            // A suppressed quote (409) is not a tool failure and must not be narrated as one: the
+            // bank declined to price, which is itself the answer the customer needs to hear.
+            return if (e.response?.status == CONFLICT) {
+                ToolResult(SUPPRESSED)
+            } else {
+                ToolResult("Pricing is unavailable right now (HTTP ${e.response?.status ?: 0}).", isError = true)
+            }
+        }
+        val instalment = quote.monthlyPayment.toBigDecimalOrNull()
+            ?: return ToolResult("Pricing returned no instalment.", isError = true)
+
+        val profile = runCatching { profiles.profile(partyId).awaitSuspending() }.getOrNull()
+        val answer = CreditAffordability.assess(
+            incomeMonthly = profile?.incomeMonthly?.toBigDecimalOrNull(),
+            obligationsMonthly = profile?.outflowMonthly?.toBigDecimalOrNull(),
+            netMonthly = profile?.netMonthly?.toBigDecimalOrNull(),
+            instalment = instalment,
+        )
+        return ToolResult(render(answer, quote))
+    }
+
+    /** Validation, split out so [call] stays one readable flow (and inside detekt's complexity cap). */
+    private fun parseRequest(arguments: JsonNode): Result<CreditQuoteRequestDto> {
+        val amount = arguments.get("amount")?.asText()?.trim()?.takeIf { it.isNotBlank() }
+            ?: return Result.failure(ToolError("Missing required 'amount'."))
+        if (amount.toBigDecimalOrNull() == null) {
+            return Result.failure(ToolError("'$amount' is not a valid amount."))
+        }
+        val term = arguments.get("termMonths")?.asInt() ?: 0
+        if (term <= 0) return Result.failure(ToolError("Missing or invalid 'termMonths'."))
+        return Result.success(CreditQuoteRequestDto(amount, term))
+    }
+
+    /**
+     * The model sees the verdict, the reasons AND the numbers behind them. Nothing is left for it
+     * to compute, which is the ADR-0089 D4 rule and the reason an enthusiastic narration cannot
+     * turn an UNAFFORDABLE into a maybe.
+     */
+    private fun render(answer: com.openbank.copilot.domain.AffordabilityAnswer, quote: CreditQuoteDto): String =
+        buildString {
+            append("verdict=${answer.verdict}")
+            append("; reasons=${answer.reasons.joinToString(",")}")
+            append("; instalment=${quote.monthlyPayment} ${quote.currency}")
+            append("; aprcPercent=${quote.aprcPercent ?: "unavailable"}")
+            answer.dstiAfter?.let { append("; dstiAfter=$it") }
+            answer.monthlySurplusAfter?.let { append("; monthlySurplusAfter=$it") }
+            if (answer.verdict == AffordabilityVerdict.UNKNOWN) append("; note=$UNKNOWN_NOTE")
+        }
+
+    private fun partyId(): UUID? = (identity.principal as? JsonWebToken)?.getClaim<String>("party_id")
+        ?.takeIf { it.isNotBlank() }
+        ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+
+    private fun String?.toBigDecimalOrNull(): BigDecimal? =
+        this?.takeIf { it.isNotBlank() }?.let { runCatching { BigDecimal(it) }.getOrNull() }
+
+    /** Carries a caller-facing message out of validation without inventing an exception hierarchy. */
+    private class ToolError(override val message: String) : Exception(message)
+
+    private companion object {
+        const val CONFLICT = 409
+        const val NO_PARTY = "This assistant cannot identify the customer, so it will not assess affordability."
+        const val NEEDS_L1 =
+            "Affordability advice is switched off. The customer can enable it in Settings → " +
+                "Financial health and offers; nothing is assessed until they do."
+        const val SUPPRESSED =
+            "verdict=NOT_PRICED; reasons=SUPPRESSED; note=The bank is not pricing credit for this customer " +
+                "right now. Say so plainly and do not estimate a figure."
+        const val UNKNOWN_NOTE =
+            "Not enough income history to answer. Say that; do not guess, and do not encourage."
+    }
+}

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/tool/CreditApplicationDraftTool.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/tool/CreditApplicationDraftTool.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.infrastructure.tool
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.openbank.copilot.application.port.out.ActionProposalTool
+import com.openbank.copilot.application.port.out.ProposalResult
+import com.openbank.copilot.domain.ActionKind
+import com.openbank.copilot.domain.ActionProposal
+import jakarta.enterprise.context.ApplicationScoped
+import java.math.BigDecimal
+
+/**
+ * L2 AGENT tool — prepare (do NOT submit) a credit application (ADR-0269 rule 5).
+ *
+ * The agent's entire remit in one class: it fills the form and hands it back. It cannot submit,
+ * cannot accept an offer, cannot raise a limit and cannot draw funds — the app renders the proposal
+ * as a non-AI-controlled card and the customer confirms it into the existing intake + SCA flow,
+ * exactly as `PaymentProposalTool` does for money. Reused rather than reinvented, because the
+ * reason is identical: an AI that can commit the customer is a different risk class from one that
+ * can fill in a form.
+ *
+ * ## Why the level check is NOT here
+ *
+ * `ActionProposalTool.propose` is synchronous and never reaches the network — it validates
+ * arguments and returns a structure. Making it suspend just to read a consent would push an
+ * I/O call into a pure validation path. The level gate for L2 lives where the proposal is
+ * CONFIRMED (the intake route the app posts to), which is also the only place where getting it
+ * wrong could actually create an application. A draft that never leaves the phone is not the
+ * hazard; a submitted one is.
+ *
+ * That said, the proposal carries no price and no approval language on purpose: a draft that
+ * claimed a rate would be a quote the bank never made.
+ */
+@ApplicationScoped
+class CreditApplicationDraftTool : ActionProposalTool {
+
+    override val name = "credit_prepare_application"
+    override val description =
+        "Prepare (do NOT submit) a loan application for the customer to review and confirm. " +
+            "Carries no rate, no instalment and no approval — it is a filled-in form, nothing more."
+    override val capability = "credit.application.propose"
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "amount" to mapOf("type" to "string", "description" to "Requested amount, decimal"),
+            "termMonths" to mapOf("type" to "integer", "description" to "Repayment term in months"),
+        ),
+        "required" to listOf("amount", "termMonths"),
+    )
+
+    override fun propose(arguments: JsonNode): ProposalResult {
+        val amount = arguments.get("amount")?.asText()?.trim()?.takeIf { it.isNotBlank() }
+            ?: return ProposalResult(error = "Uveďte prosím částku.")
+        val parsed = runCatching { BigDecimal(amount) }.getOrNull()
+            ?: return ProposalResult(error = "Neplatná částka.")
+        if (parsed <= BigDecimal.ZERO) return ProposalResult(error = "Částka musí být kladná.")
+        val term = arguments.get("termMonths")?.asInt() ?: 0
+        if (term <= 0) return ProposalResult(error = "Uveďte prosím dobu splácení v měsících.")
+
+        // Amount and term only — the same two fields the intake endpoint accepts, and for the same
+        // reason: a customer may choose how much and how long, never at what price.
+        val fields = mapOf("amount" to parsed.toPlainString(), "termMonths" to term.toString())
+        return ProposalResult(
+            ActionProposal(
+                kind = ActionKind.CREDIT_APPLICATION,
+                summary = "Žádost o půjčku ${parsed.toPlainString()} na $term měsíců (návrh k potvrzení)",
+                fields = fields,
+            ),
+        )
+    }
+}

--- a/openbank-copilot-service/src/main/resources/application.yaml
+++ b/openbank-copilot-service/src/main/resources/application.yaml
@@ -68,12 +68,39 @@ quarkus:
     tls:
       verification: ${OIDC_TLS_VERIFICATION:none}
 
+  # Client-credentials principal for the two calls that do NOT propagate the customer's own
+  # bearer (see the rule-5 comment below): ConsentQueryClient and CreditProfileReadClient both
+  # register OidcClientRequestReactiveFilter, which mints from THIS block, not the resource-server
+  # `oidc:` block above. Same client-id/secret/issuer as the fleet's other internal service callers
+  # (e.g. openbank-agent-service's oidc-client).
+  oidc-client:
+    auth-server-url: ${QUARKUS_OIDC_AUTH_SERVER_URL:http://localhost:8080/realms/openbank}
+    client-id: openbank-services
+    credentials:
+      secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
+    grant:
+      type: client
+    tls:
+      verification: ${OIDC_TLS_VERIFICATION:none}
+
   # READ tools call the customer edge (ADR-0065) AS the customer — the inbound bearer is propagated
   # (ADR-0089 D5); the edge is ROLE_CUSTOMER and enforces ownership, so the assistant only ever reaches
   # the caller's own data. (Calling internal domain services directly would 403 — they want SERVICE roles.)
   rest-client:
     customer-edge:
       url: ${CUSTOMER_EDGE_URL:http://localhost:8128}
+    # ADR-0269 rule 5. These two are NOT called with the propagated customer bearer, unlike the edge
+    # above: "did this customer grant this scope" is not a question their own token may answer about
+    # itself, and analytics-sink's profile route is an internal operator surface. The customer's
+    # protection is the consent check that must pass before the profile is read at all.
+    consent-service:
+      url: ${CONSENT_SERVICE_URL:http://localhost:8107}
+      connect-timeout: 2000
+      read-timeout: 3000
+    analytics-sink:
+      url: ${ANALYTICS_SINK_URL:http://localhost:8110}
+      connect-timeout: 2000
+      read-timeout: 3000
 
 # Customer copilot configuration (ADR-0089).
 copilot:

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/domain/CreditAffordabilityTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/domain/CreditAffordabilityTest.kt
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+/**
+ * ADR-0269 rule 5, L1.
+ *
+ * The defining property of the advisor is that it can say NO, so most of these tests are refusals.
+ * A test suite that only checked the happy path would pass just as well on an advisor that always
+ * says yes — which is exactly the failure this level exists to prevent.
+ */
+class CreditAffordabilityTest {
+
+    private fun assess(income: String?, obligations: String?, instalment: String, net: String? = null) =
+        CreditAffordability.assess(
+            income?.let { BigDecimal(it) },
+            obligations?.let { BigDecimal(it) },
+            net?.let { BigDecimal(it) },
+            BigDecimal(instalment),
+        )
+
+    @Test
+    fun `a small instalment on a clean income is comfortable`() {
+        val a = assess("50000", "0", "5000")
+        assertThat(a.verdict).isEqualTo(AffordabilityVerdict.COMFORTABLE)
+        assertThat(a.reasons).containsExactly("FITS")
+    }
+
+    @Test
+    fun `an instalment that pushes debt service past the limit is refused`() {
+        val a = assess("50000", "15000", "10000") // 25000/50000 = 0.50
+        assertThat(a.verdict).isEqualTo(AffordabilityVerdict.UNAFFORDABLE)
+        assertThat(a.reasons).contains("DSTI_ABOVE_LIMIT")
+    }
+
+    @Test
+    fun `an instalment that leaves nothing over is refused even when DSTI passes`() {
+        // 50,000 income, 5,000 of existing debt service, but only 6,000 actually left over after
+        // rent and living costs. DSTI after a 6,000 instalment is 0.22 — comfortably inside the
+        // limit — and the customer still ends the month at zero.
+        //
+        // This case is why the surplus rule measures the profile's NET and not income minus debt
+        // service: the first version of this test could not fail, because inside the DSTI limit
+        // income-minus-debt-service is always positive. The rule was dead code until the number it
+        // reads changed.
+        val a = assess(income = "50000", obligations = "5000", instalment = "6000", net = "6000")
+        assertThat(a.verdict).isEqualTo(AffordabilityVerdict.UNAFFORDABLE)
+        assertThat(a.reasons).contains("NO_MONTHLY_SURPLUS")
+    }
+
+    @Test
+    fun `an unknown net is skipped, not treated as a surplus of zero`() {
+        // Without the profile's net the second question simply cannot be asked. Treating null as 0
+        // would refuse every customer whose spending the bank has not observed.
+        val a = assess(income = "50000", obligations = "0", instalment = "5000", net = null)
+        assertThat(a.verdict).isEqualTo(AffordabilityVerdict.COMFORTABLE)
+        assertThat(a.monthlySurplusAfter).isNull()
+    }
+
+    @Test
+    fun `an instalment inside the limit but past comfort is called tight, not refused`() {
+        val a = assess("50000", "10000", "10000") // 0.40
+        assertThat(a.verdict).isEqualTo(AffordabilityVerdict.TIGHT)
+        assertThat(a.reasons).contains("DSTI_TIGHT")
+    }
+
+    @Test
+    fun `unknown income answers UNKNOWN, never a cheerful yes`() {
+        assertThat(assess(null, "0", "5000").verdict).isEqualTo(AffordabilityVerdict.UNKNOWN)
+        assertThat(assess("0", "0", "5000").verdict).isEqualTo(AffordabilityVerdict.UNKNOWN)
+    }
+
+    @Test
+    fun `an unknown answer carries no numbers to be mistaken for a calculation`() {
+        val a = assess(null, null, "5000")
+        assertThat(a.dstiAfter).isNull()
+        assertThat(a.monthlySurplusAfter).isNull()
+        assertThat(a.reasons).containsExactly("INCOME_UNKNOWN")
+    }
+
+    @Test
+    fun `every answer carries at least one machine-readable reason`() {
+        val cases = listOf(
+            assess("50000", "0", "5000"),
+            assess("50000", "15000", "10000"),
+            assess("50000", "5000", "6000", net = "6000"),
+            assess("50000", "10000", "10000"),
+            assess(null, null, "1"),
+        )
+        assertThat(cases).allSatisfy { assertThat(it.reasons).isNotEmpty() }
+    }
+
+    @Test
+    fun `missing obligations are treated as zero, not as unknown`() {
+        // Deliberate asymmetry with income: an absent obligation list means the bank knows of no
+        // debts, which is a real state. An absent income means the bank cannot see earnings, which
+        // is not.
+        val a = assess("50000", null, "5000")
+        assertThat(a.verdict).isEqualTo(AffordabilityVerdict.COMFORTABLE)
+    }
+
+    @Test
+    fun `the workings are returned so narration has nothing left to invent`() {
+        val a = assess("40000", "4000", "6000")
+        assertThat(a.dstiAfter).isEqualByComparingTo("0.2500")
+        assertThat(a.monthlySurplusAfter).isNull() // no net supplied — nothing invented in its place
+    }
+}

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/domain/CreditAiLevelTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/domain/CreditAiLevelTest.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/** ADR-0269 rule 5: the three levels and their containment. */
+class CreditAiLevelTest {
+
+    @Test
+    fun `no consent is the explainer, not a refusal`() {
+        assertThat(CreditAiLevel.from(profileUseConsent = false, agentConsent = false))
+            .isEqualTo(CreditAiLevel.L0_EXPLAINER)
+    }
+
+    @Test
+    fun `profile-use consent alone is the advisor`() {
+        assertThat(CreditAiLevel.from(profileUseConsent = true, agentConsent = false))
+            .isEqualTo(CreditAiLevel.L1_ADVISOR)
+    }
+
+    @Test
+    fun `agent consent is the agent even if profile-use was recorded separately`() {
+        assertThat(CreditAiLevel.from(profileUseConsent = false, agentConsent = true))
+            .isEqualTo(CreditAiLevel.L2_AGENT)
+        assertThat(CreditAiLevel.from(profileUseConsent = true, agentConsent = true))
+            .isEqualTo(CreditAiLevel.L2_AGENT)
+    }
+
+    @Test
+    fun `the levels contain each other so a tool never has to test for equality`() {
+        assertThat(CreditAiLevel.L2_AGENT.atLeast(CreditAiLevel.L1_ADVISOR)).isTrue()
+        assertThat(CreditAiLevel.L2_AGENT.atLeast(CreditAiLevel.L0_EXPLAINER)).isTrue()
+        assertThat(CreditAiLevel.L1_ADVISOR.atLeast(CreditAiLevel.L2_AGENT)).isFalse()
+        // The property that matters: turning L2 on must not switch an L1 tool off.
+        CreditAiLevel.entries.forEach { assertThat(it.atLeast(CreditAiLevel.L0_EXPLAINER)).isTrue() }
+    }
+}

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/tool/CreditApplicationDraftToolTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/tool/CreditApplicationDraftToolTest.kt
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.infrastructure.tool
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.copilot.domain.ActionKind
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * ADR-0269 rule 5, L2. The agent may prepare and never commit, so these tests are mostly about what
+ * the draft must NOT contain.
+ */
+class CreditApplicationDraftToolTest {
+
+    private val tool = CreditApplicationDraftTool()
+    private val json = ObjectMapper()
+
+    private fun propose(amount: String?, term: Int?) = tool.propose(
+        json.createObjectNode().apply {
+            amount?.let { put("amount", it) }
+            term?.let { put("termMonths", it) }
+        },
+    )
+
+    @Test
+    fun `a valid request produces a credit application draft`() {
+        val result = propose("250000", 48)
+        assertThat(result.proposal).isNotNull
+        assertThat(result.proposal!!.kind).isEqualTo(ActionKind.CREDIT_APPLICATION)
+        assertThat(result.proposal!!.fields).containsEntry("amount", "250000").containsEntry("termMonths", "48")
+    }
+
+    @Test
+    fun `the draft carries no price of any kind`() {
+        val fields = propose("250000", 48).proposal!!.fields
+        // A draft that claimed a rate or an instalment would be a quote the bank never made. The
+        // price comes from the server, at the moment the customer asks for it.
+        assertThat(fields.keys).containsExactlyInAnyOrder("amount", "termMonths")
+        assertThat(fields.keys).noneMatch { it.contains("rate") || it.contains("apr") || it.contains("instal") }
+    }
+
+    @Test
+    fun `the summary says it is a draft, so no rendering of it can read as an approval`() {
+        assertThat(propose("250000", 48).proposal!!.summary).contains("návrh")
+    }
+
+    @Test
+    fun `a missing or unparseable amount is refused rather than guessed`() {
+        assertThat(propose(null, 48).error).isNotNull
+        assertThat(propose("abc", 48).error).isNotNull
+        assertThat(propose("0", 48).error).isNotNull
+        assertThat(propose("-100", 48).error).isNotNull
+    }
+
+    @Test
+    fun `a missing or non-positive term is refused`() {
+        assertThat(propose("250000", null).error).isNotNull
+        assertThat(propose("250000", 0).error).isNotNull
+    }
+
+    @Test
+    fun `the tool describes itself as preparing, never submitting`() {
+        assertThat(tool.description).contains("do NOT submit")
+        assertThat(tool.name).isEqualTo("credit_prepare_application")
+    }
+}

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/credit/CreditFunnelPublisher.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/credit/CreditFunnelPublisher.kt
@@ -66,7 +66,12 @@ class CreditFunnelPublisher(
             payload.put("action", action)
 
             val node = objectMapper.createObjectNode()
-            node.put("eventType", EVENT_TYPE)
+            // Bound to a local rather than passed straight in, because the ADR-0006
+            // contract/code-agreement gate reads this source and cannot evaluate a constant: it
+            // matches `eventType = "<literal>"`, and without that shape a documented message looks
+            // to it like one nobody emits. EVENT_TYPE below stays as the published name.
+            val eventType = "credit.funnel.step"
+            node.put("eventType", eventType)
             node.put("aggregateType", AGGREGATE_TYPE)
             // Keyed by party, unlike onboarding: the session here IS the authenticated customer, and
             // the questions this answers ("did they come back after switching offers on") span
@@ -87,6 +92,7 @@ class CreditFunnelPublisher(
     }
 
     companion object {
+        /** The contract message name (openbank-contracts/openbank-customer-edge/asyncapi.yaml). */
         const val EVENT_TYPE = "credit.funnel.step"
         const val AGGREGATE_TYPE = "CREDIT_FUNNEL"
 

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/credit/CreditFunnelPublisher.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/credit/CreditFunnelPublisher.kt
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge.infrastructure.credit
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import io.micrometer.core.instrument.MeterRegistry
+import io.quarkus.logging.Log
+import io.smallrye.reactive.messaging.kafka.Record
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.reactive.messaging.Channel
+import org.eclipse.microprofile.reactive.messaging.Emitter
+import org.eclipse.microprofile.reactive.messaging.OnOverflow
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Credit-journey funnel telemetry (ADR-0269 rule 8's metrics).
+ *
+ * ## Why this is NOT the onboarding funnel channel
+ *
+ * The onboarding funnel is an ANONYMOUS, publicly postable stream: anyone can write to it, which is
+ * exactly why its allow-lists are closed and its key is a client-generated session id. That design
+ * is right for steps that happen before a session exists.
+ *
+ * Credit steps happen inside an authenticated session, and what they say is "this person is looking
+ * at borrowing money". Posting that through an unauthenticated endpoint would be a leak channel
+ * rather than instrumentation: an attacker could both inject junk about a party and — with a public
+ * endpoint that accepted a party id — probe it. So this is a separate stream on a separate topic,
+ * written only from an authenticated request, keyed by the party the JWT already proved.
+ *
+ * ## What it deliberately does not measure
+ *
+ * There is no conversion event here and no "offer accepted". The programme's metrics are
+ * self-activation, opt-out-within-30-days, affordability declines, delinquency, and offers shown
+ * without a prior customer action. A funnel built to optimise acceptance would quietly become the
+ * thing ADR-0269 exists to prevent, so the vocabulary below simply does not contain the word.
+ *
+ * Best-effort, like every other telemetry path here: a Kafka outage degrades to an ERROR log, never
+ * a 5xx. Telemetry must not break the screen it is watching.
+ */
+@ApplicationScoped
+class CreditFunnelPublisher(
+    private val objectMapper: ObjectMapper,
+    @Channel("credit-funnel-out")
+    @OnOverflow(value = OnOverflow.Strategy.BUFFER, bufferSize = BUFFER_SIZE)
+    private val emitter: Emitter<Record<String, String>>,
+    private val clock: Clock,
+    private val meterRegistry: MeterRegistry,
+) {
+
+    // catch-all IS the contract: funnel telemetry never breaks the customer's screen.
+    @Suppress("TooGenericExceptionCaught")
+    fun emit(partyId: UUID, step: String, action: String) {
+        try {
+            // Low-cardinality by construction: both values come from the closed allow-lists the
+            // resource validates before this is reached, so no caller can inflate the label space.
+            meterRegistry.counter("credit_funnel_events", "step", step, "action", action).increment()
+
+            val payload = objectMapper.createObjectNode()
+            payload.put("partyId", partyId.toString())
+            payload.put("step", step)
+            payload.put("action", action)
+
+            val node = objectMapper.createObjectNode()
+            node.put("eventType", EVENT_TYPE)
+            node.put("aggregateType", AGGREGATE_TYPE)
+            // Keyed by party, unlike onboarding: the session here IS the authenticated customer, and
+            // the questions this answers ("did they come back after switching offers on") span
+            // sessions. It is the same pseudonymous id the silver layer already holds — no PII.
+            node.put("aggregateId", partyId.toString())
+            node.put("sourceService", "customer-edge")
+            node.put("schemaVersion", 1)
+            node.put("occurredAt", Instant.now(clock).toString())
+            node.set<ObjectNode>("payload", payload)
+
+            emitter.send(Record.of(partyId.toString(), objectMapper.writeValueAsString(node)))
+                .whenComplete { _, err ->
+                    if (err != null) Log.error("credit funnel emit failed for $step/$action: ${err.message}")
+                }
+        } catch (e: Exception) {
+            Log.error("credit funnel emit failed for $step/$action: ${e.message}", e)
+        }
+    }
+
+    companion object {
+        const val EVENT_TYPE = "credit.funnel.step"
+        const val AGGREGATE_TYPE = "CREDIT_FUNNEL"
+
+        /**
+         * Closed allow-lists. Same discipline as the onboarding funnel and for an additional reason
+         * here: these values are labels on a Prometheus counter, so an open vocabulary would let a
+         * client take the metrics store down.
+         */
+        val VALID_STEPS = setOf("CONSENT", "HEALTH", "FINANCING", "QUOTE", "APPLICATION")
+
+        /**
+         * Note what is absent: no CONVERTED, no ACCEPTED, no SOLD. The programme measures whether
+         * customers switch offers on themselves and whether they switch them back off — not how
+         * many of them borrowed. A vocabulary that could express conversion is a vocabulary someone
+         * will eventually optimise.
+         */
+        val VALID_ACTIONS = setOf(
+            "VIEWED",
+            "CONSENT_GRANTED",
+            "CONSENT_WITHDRAWN",
+            "QUOTE_REQUESTED",
+            "QUOTE_SUPPRESSED",
+            "APPLICATION_STARTED",
+            "APPLICATION_ABANDONED",
+        )
+    }
+}
+
+private const val BUFFER_SIZE = 2048L

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/feedback/FeedbackPublisher.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/feedback/FeedbackPublisher.kt
@@ -116,7 +116,12 @@ class FeedbackPublisher(
             payload.put("screenshotStatus", submission.screenshotStatus)
 
             val node = objectMapper.createObjectNode()
-            node.put("eventType", EVENT_TYPE)
+            // Bound to a local rather than passed straight in, because the ADR-0006
+            // contract/code-agreement gate reads this source and cannot evaluate a constant: it
+            // matches `eventType = "<literal>"`, and without that shape a documented message looks
+            // to it like one nobody emits. EVENT_TYPE below stays as the published name.
+            val eventType = "feedback.submitted"
+            node.put("eventType", eventType)
             node.put("aggregateType", AGGREGATE_TYPE)
             node.put("aggregateId", submission.reference)
             node.put("sourceService", "customer-edge")
@@ -138,6 +143,7 @@ class FeedbackPublisher(
     }
 
     companion object {
+        /** The contract message name (openbank-contracts/openbank-customer-edge/asyncapi.yaml). */
         const val EVENT_TYPE = "feedback.submitted"
         const val AGGREGATE_TYPE = "SCREEN_FEEDBACK"
 

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/onboarding/OnboardingFunnelPublisher.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/onboarding/OnboardingFunnelPublisher.kt
@@ -69,7 +69,12 @@ class OnboardingFunnelPublisher(
             attributes.forEach { (k, v) -> v?.let { payload.put(k, it) } }
 
             val node = objectMapper.createObjectNode()
-            node.put("eventType", EVENT_TYPE)
+            // Bound to a local rather than passed straight in, because the ADR-0006
+            // contract/code-agreement gate reads this source and cannot evaluate a constant: it
+            // matches `eventType = "<literal>"`, and without that shape a documented message looks
+            // to it like one nobody emits. EVENT_TYPE below stays as the published name.
+            val eventType = "onboarding.funnel.step"
+            node.put("eventType", eventType)
             node.put("aggregateType", AGGREGATE_TYPE)
             // The session id is the aggregate: every event of one onboarding attempt shares it, so the
             // warehouse funnel groups an attempt without ever keying on the (later) party identity.
@@ -90,6 +95,7 @@ class OnboardingFunnelPublisher(
     }
 
     companion object {
+        /** The contract message name (openbank-contracts/openbank-customer-edge/asyncapi.yaml). */
         const val EVENT_TYPE = "onboarding.funnel.step"
         const val AGGREGATE_TYPE = "ONBOARDING_FUNNEL"
 

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -1049,6 +1049,113 @@ class CustomerEdgeResource(
         return Response.status(resp.status).entity(resp.entity).type(MediaType.APPLICATION_JSON).build()
     }
 
+    /**
+     * The caller's own ADR-0269 credit consents, as three booleans.
+     *
+     * ## Why this route exists at all
+     *
+     * consent-service could already grant these scopes, and the edge could already list and revoke
+     * consents — but there was no way for a CUSTOMER to switch one ON. The app's existing marketing
+     * toggle goes somewhere else entirely (party-service's `marketingConsent` boolean), so without
+     * this route the credit consents were grantable only by an operator, which is the opposite of
+     * what "the customer decides" means.
+     *
+     * ## Why booleans and not the consent objects
+     *
+     * The app renders three switches. Handing it consent aggregates would make every client
+     * re-derive "is CREDIT_OFFERS on" from a list, and the first client to write that filter
+     * slightly differently gets a different answer — the same reasoning ADR-0210 D2 gives for the
+     * party key. The derivation happens once, here.
+     */
+    @GET
+    @Path("/credit/consents")
+    @Authorize(action = "customer.profile.read", resource = "")
+    @Blocking
+    fun getCreditConsents(): Response {
+        val customer = customer()
+        val party = customer.partyId.toString()
+        val resp = upstream.get("$consentServiceUrl/api/v1/consents/party/$party", party)
+        val arr = if (resp.status == 200) {
+            runCatching { objectMapper.readTree(resp.entity?.toString() ?: "") as? ArrayNode }.getOrNull()
+        } else {
+            null
+        }
+        // An unreadable consent list answers "everything off", which is the SAFE default and the
+        // true one for every customer who has never granted anything. It is not fail-soft
+        // convenience: the client uses this to decide whether to fetch offers at all, so an
+        // optimistic default here would fetch offers for a customer whose consent we cannot read.
+        val active = arr?.filter { it.get("status")?.asText() == "ACTIVE" }?.flatMap { c ->
+            c.get("scopes")?.mapNotNull { it.asText() } ?: emptyList()
+        }?.toSet().orEmpty()
+        val out = objectMapper.createObjectNode()
+        CREDIT_SCOPES.forEach { (field, scope) -> out.put(field, scope in active) }
+        return Response.ok(out).type(MediaType.APPLICATION_JSON).build()
+    }
+
+    /**
+     * Set the caller's credit consents to exactly the state in the body (ADR-0269 rule 1).
+     *
+     * A full-state PUT, not a partial patch: "turn offers off" and "leave offers alone" must not be
+     * the same request. Anything the body sets to false is revoked, immediately and for every
+     * channel — the ADR's requirement that switching offers off takes effect at once rather than at
+     * the next batch.
+     *
+     * These scopes are GDPR Art. 7 data-processing consents, so consent-service activates them
+     * without an SCA ceremony; an SCA designed for payment authorisation is a disproportionate
+     * burden on a data-processing opt-in (ADR-0205 D1). Granting still requires the customer's own
+     * authenticated session — the party comes from the JWT, never the body.
+     */
+    @PUT
+    @Path("/credit/consents")
+    @Authorize(action = "customer.profile.consent.update", resource = "")
+    @Blocking
+    fun putCreditConsents(body: String): Response {
+        val customer = customer()
+        val requested = runCatching { objectMapper.readTree(body) }.getOrNull() as? ObjectNode
+            ?: return badRequest("Malformed credit consent body")
+        val desired = CREDIT_SCOPES.mapValues { (field, _) -> requested.get(field)?.asBoolean() ?: false }
+        val party = customer.partyId.toString()
+
+        val existing = upstream.get("$consentServiceUrl/api/v1/consents/party/$party", party)
+        if (existing.status != 200) return Response.status(existing.status).entity(existing.entity).build()
+        val consents = runCatching { objectMapper.readTree(existing.entity?.toString() ?: "") as? ArrayNode }
+            .getOrNull() ?: objectMapper.createArrayNode()
+
+        desired.forEach { (field, wanted) ->
+            val scope = CREDIT_SCOPES.getValue(field)
+            val held = consents.firstOrNull { c ->
+                c.get("status")?.asText() == "ACTIVE" &&
+                    c.get("scopes")?.any { it.asText() == scope } == true
+            }
+            when {
+                wanted && held == null -> grantCreditScope(customer.partyId, scope)
+                !wanted && held != null -> revokeHeldConsent(customer.partyId, held.get("id")?.asText())
+                else -> Unit // already in the requested state; granting again would churn the audit trail
+            }
+        }
+        return getCreditConsents()
+    }
+
+    private fun grantCreditScope(partyId: UUID, scope: String) {
+        val body = objectMapper.createObjectNode().apply {
+            put("partyId", partyId.toString())
+            put("granteeId", BANK_GRANTEE)
+            put("granteeType", "INTERNAL_SERVICE")
+            put("granteeName", "OpenBank")
+            putArray("scopes").add(scope)
+            // 365 days: the non-AISP bucket's maximum. It is a ceiling, not a promise — the customer
+            // can revoke at any time, and nothing re-arms the consent when it lapses.
+            put("validTo", java.time.OffsetDateTime.now(java.time.ZoneOffset.UTC).plusDays(CONSENT_DAYS).toString())
+        }.toString()
+        upstream.post("$consentServiceUrl/api/v1/consents", partyId.toString(), body)
+    }
+
+    private fun revokeHeldConsent(partyId: UUID, consentId: String?) {
+        if (consentId.isNullOrBlank()) return
+        val body = objectMapper.createObjectNode().put("reason", "Revoked by customer").toString()
+        upstream.delete("$consentServiceUrl/api/v1/consents/$consentId?partyId=$partyId", partyId.toString(), body)
+    }
+
     private fun projectConsent(c: com.fasterxml.jackson.databind.JsonNode): ObjectNode {
         val o = objectMapper.createObjectNode()
         o.put("id", c.get("id")?.asText())
@@ -4740,6 +4847,24 @@ class CustomerEdgeResource(
         parseCreditorAccount(raw) ?: czechIbanToBban(raw)
 
     companion object {
+        /**
+         * The ADR-0269 credit consents, as the app's field name → the consent-service scope.
+         *
+         * One map, so the read and the write cannot disagree about which switch means which scope —
+         * the failure that would look like a customer turning offers off and still being offered.
+         */
+        private val CREDIT_SCOPES: Map<String, String> = linkedMapOf(
+            "offers" to "CREDIT_OFFERS",
+            "profileUse" to "CREDIT_PROFILE_USE",
+            "aiAgent" to "CREDIT_AI_AGENT",
+        )
+
+        /** First-party consent: the bank itself is the grantee, not a TPP. */
+        private const val BANK_GRANTEE = "openbank"
+
+        /** The non-AISP validity ceiling. A ceiling, not a promise — revocation is immediate. */
+        private const val CONSENT_DAYS = 365L
+
         /** Closed at the edge as well as upstream: a path is never an app-controlled URL. */
         private val SURFACE_SLOTS: Set<String> = setOf(
             "HOME_BANNER",

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -751,6 +751,39 @@ class CustomerEdgeResource(
     }
 
     /**
+     * An indicative, non-binding price for an amount and term (ADR-0269 rule 4).
+     *
+     * The ONLY route by which the app may learn what a loan costs. The client computes no price:
+     * rate, instalment, APRC and total come from lending-service, which resolves them from the
+     * pinned catalog revision. The body carries amount and term and nothing else — a
+     * customer-supplied rate would let the applicant price their own loan.
+     *
+     * Deliberately NOT fail-soft, and deliberately passes the upstream status through. A 409 means
+     * lending's distress floor suppressed pricing and carries a reason code; turning that into an
+     * empty 200 would leave the app rendering a quote-shaped hole, which is exactly how a client
+     * ends up showing "0".
+     */
+    @POST
+    @Path("/credit/quotes")
+    @Authorize(action = "customer.profile.read", resource = "")
+    @Blocking
+    fun quoteCredit(request: Map<String, Any?>): Response {
+        val customer = customer()
+        val body = objectMapper.writeValueAsString(
+            mapOf("amount" to request["amount"], "termMonths" to request["termMonths"]),
+        )
+        val resp = upstream.post(
+            "$lendingServiceUrl/api/v1/lending/intake/quotes",
+            customer.partyId.toString(),
+            body,
+        )
+        return Response.status(resp.status)
+            .entity(resp.entity ?: "{}")
+            .type(MediaType.APPLICATION_JSON)
+            .build()
+    }
+
+    /**
      * The caller's OWN credit applications, as customer-readable journeys (ADR-0269 rule 3).
      *
      * The read half of the intake pair: `applyForLoan` above files an application, this says where

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.openbank.customeredge.domain.model.CustomerIdentity
 import com.openbank.customeredge.infrastructure.audit.EdgeAuditPublisher
 import com.openbank.customeredge.infrastructure.cnb.CnbBanksClient
+import com.openbank.customeredge.infrastructure.credit.CreditFunnelPublisher
 import com.openbank.customeredge.infrastructure.onboarding.PendingOnboarding
 import com.openbank.customeredge.infrastructure.onboarding.PendingOnboardingStore
 import com.openbank.libs.authz.Authorize
@@ -108,6 +109,9 @@ class CustomerEdgeResource(
     // detekt tolerates here and every test constructs this resource positionally.
     @Inject
     lateinit var partyMergeResolver: PartyMergeResolver
+
+    @Inject
+    lateinit var creditFunnel: com.openbank.customeredge.infrastructure.credit.CreditFunnelPublisher
 
     @ConfigProperty(name = "openbank.edge.account-service-url")
     lateinit var accountServiceUrl: String
@@ -748,6 +752,57 @@ class CustomerEdgeResource(
             .entity(resp.entity ?: "{}")
             .type(MediaType.APPLICATION_JSON)
             .build()
+    }
+
+    /**
+     * One credit-journey funnel event (ADR-0269 rule 8's metrics).
+     *
+     * Authenticated on purpose — see [CreditFunnelPublisher] for why this is not the onboarding
+     * funnel's public endpoint. The party is taken from the JWT and never from the body, so a
+     * caller can only ever describe their own journey.
+     *
+     * Always 202, even for a rejected value: telemetry must not teach a client anything, and a 400
+     * here would turn the allow-list into an oracle for what the bank tracks. Rejected values are
+     * counted, not answered.
+     */
+    @POST
+    @Path("/credit/events")
+    @Authorize(action = "customer.profile.read", resource = "")
+    @Blocking
+    fun trackCreditEvent(body: String): Response {
+        val customer = customer()
+        val node = runCatching { objectMapper.readTree(body) }.getOrNull() as? ObjectNode
+        val step = node?.get("step")?.asText()
+        val action = node?.get("action")?.asText()
+        if (step in CreditFunnelPublisher.VALID_STEPS && action in CreditFunnelPublisher.VALID_ACTIONS) {
+            creditFunnel.emit(customer.partyId, step!!, action!!)
+        }
+        return Response.accepted().build()
+    }
+
+    /**
+     * The caller's own four-pillar financial health (ADR-0269 / APP-ADR-0001 rule 5).
+     *
+     * Assembled by lending-service, which already reaches the credit profile and the loan book;
+     * this route only scopes it to the caller. No score, no rating, no eligibility — and no path
+     * into a credit decision.
+     *
+     * Fail-soft to an empty list. An unreachable upstream means the app shows no pillars rather
+     * than four invented ones, and each pillar can independently answer UNKNOWN, so a partial
+     * answer is the normal case rather than an error.
+     */
+    @GET
+    @Path("/financial-health")
+    @Authorize(action = "customer.profile.read", resource = "")
+    @Blocking
+    fun getFinancialHealth(): Response {
+        val customer = customer()
+        val resp = upstream.get(
+            "$lendingServiceUrl/api/v1/lending/intake/financial-health",
+            customer.partyId.toString(),
+        )
+        if (resp.status != 200) return Response.ok("[]").type(MediaType.APPLICATION_JSON).build()
+        return Response.ok(resp.entity ?: "[]").type(MediaType.APPLICATION_JSON).build()
     }
 
     /**

--- a/openbank-customer-edge/src/main/resources/application.yaml
+++ b/openbank-customer-edge/src/main/resources/application.yaml
@@ -60,6 +60,15 @@ mp:
         topic: openbank.onboarding.funnel.events
         key.serializer: org.apache.kafka.common.serialization.StringSerializer
         value.serializer: org.apache.kafka.common.serialization.StringSerializer
+      # Credit-journey funnel telemetry (ADR-0269 rule 8) -> analytics-sink -> ClickHouse. A
+      # SEPARATE topic from the onboarding funnel on purpose: that one is an anonymous public write,
+      # this one is authenticated and keyed by party, and mixing them would put credit-interest
+      # signals on a stream anyone can post to.
+      credit-funnel-out:
+        connector: smallrye-kafka
+        topic: openbank.credit.funnel.events
+        key.serializer: org.apache.kafka.common.serialization.StringSerializer
+        value.serializer: org.apache.kafka.common.serialization.StringSerializer
       # In-app screen feedback (ADR-0192) -> analytics-sink -> ClickHouse. Metadata + the
       # screenshot's object-store key only; the PNG itself never enters Kafka (FeedbackPublisher).
       feedback-out:

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.44.0
+  version: 1.46.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -1206,6 +1206,62 @@ paths:
               schema:
                 type: array
                 items: {$ref: '#/components/schemas/Loan'}
+
+  /financial-health:
+    get:
+      tags: [Lending]
+      summary: The caller's four-pillar financial health (no score)
+      description: >-
+        ADR-0269 / APP-ADR-0001 rule 5. Reserve, cashflow, obligations and habits, each with its own
+        zone. There is deliberately no aggregate: a single grade invites the customer to optimise it
+        and the bank to act on it, and neither is what this exists for. Any pillar may answer
+        UNKNOWN — the bank not having seen something is a fact about the bank, not a verdict about
+        the customer. Fails soft to an empty list.
+      operationId: getFinancialHealth
+      security:
+        - customerOidc: [accounts:read]
+      responses:
+        '200':
+          description: The pillars (possibly empty)
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {$ref: '#/components/schemas/HealthPillar'}
+
+  /credit/events:
+    post:
+      tags: [Lending]
+      summary: One credit-journey funnel event
+      description: >-
+        ADR-0269 rule 8's metrics. AUTHENTICATED, unlike the onboarding funnel's public endpoint —
+        these events say "this person is looking at borrowing", which must not ride a stream anyone
+        can post to. The party comes from the JWT and a partyId in the body is ignored.
+
+        Always 202, including for a value outside the allow-list: a 400 would make the allow-list an
+        oracle for what the bank tracks, and telemetry has no business teaching a client anything.
+
+        The action vocabulary deliberately cannot express a conversion. The programme measures
+        self-activation and opt-out, not how many customers borrowed.
+      operationId: trackCreditEvent
+      security:
+        - customerOidc: [accounts:read]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [step, action]
+              properties:
+                step: {type: string, enum: [CONSENT, HEALTH, FINANCING, QUOTE, APPLICATION]}
+                action:
+                  type: string
+                  enum: [VIEWED, CONSENT_GRANTED, CONSENT_WITHDRAWN, QUOTE_REQUESTED,
+                         QUOTE_SUPPRESSED, APPLICATION_STARTED, APPLICATION_ABANDONED]
+      responses:
+        '202':
+          description: Accepted (or silently dropped — the caller cannot tell, by design)
 
   /credit/consents:
     get:
@@ -3373,6 +3429,24 @@ components:
 
     # Edge's projected view of lending-service's Loan (internal fields dropped — see
     # CustomerEdgeResource.projectLoan).
+    HealthPillar:
+      type: object
+      required: [code, zone]
+      properties:
+        code: {type: string, enum: [RESERVE, CASHFLOW, OBLIGATIONS, HABITS]}
+        zone:
+          type: string
+          enum: [HEALTHY, STRETCHED, AT_RISK, UNKNOWN]
+          description: UNKNOWN means not enough data — never render it as a middling verdict.
+        value:
+          type: string
+          nullable: true
+          description: The working behind the zone (months of cover, net, DSTI). Null when UNKNOWN.
+        target:
+          type: string
+          nullable: true
+          description: What the pillar is measured against, where one exists.
+
     CreditConsents:
       type: object
       description: >-

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -1001,6 +1001,7 @@ paths:
                           - MARKETING_COMMS_INAPP
                           - CREDIT_OFFERS
                           - CREDIT_PROFILE_USE
+                          - CREDIT_AI_AGENT
                     accountIbans: {type: array, items: {type: string}, nullable: true}
                     validFrom: {type: string, format: date-time}
                     validTo: {type: string, format: date-time}
@@ -1205,6 +1206,48 @@ paths:
               schema:
                 type: array
                 items: {$ref: '#/components/schemas/Loan'}
+
+  /credit/consents:
+    get:
+      tags: [Consents]
+      summary: The caller's own credit consents, as three switches
+      description: >-
+        ADR-0269 rule 1. Derived once here rather than by every client filtering a consent list —
+        the first client to write that filter differently gets a different answer. An unreadable
+        consent list answers "everything off", which is both the safe default and the true state
+        for anyone who has never granted these.
+      operationId: getCreditConsents
+      security:
+        - customerOidc: [accounts:read]
+      responses:
+        '200':
+          description: The three switches
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/CreditConsents'}
+    put:
+      tags: [Consents]
+      summary: Set the caller's credit consents to exactly this state
+      description: >-
+        Full-state PUT, not a partial patch: "turn offers off" and "leave offers alone" must not be
+        the same request. Anything false is revoked immediately and for every channel. These are
+        GDPR Art. 7 data-processing consents, so no SCA ceremony is required (ADR-0205 D1); the
+        party comes from the JWT, never the body.
+      operationId: putCreditConsents
+      security:
+        - customerOidc: [accounts:read]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/CreditConsents'}
+      responses:
+        '200':
+          description: The resulting state, re-read after the change
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/CreditConsents'}
+        '400': {description: Malformed body}
 
   /credit/quotes:
     post:
@@ -3330,6 +3373,28 @@ components:
 
     # Edge's projected view of lending-service's Loan (internal fields dropped — see
     # CustomerEdgeResource.projectLoan).
+    CreditConsents:
+      type: object
+      description: >-
+        ADR-0269's three credit consents. All default FALSE — absence of consent is denial, and no
+        path re-arms one on the customer's behalf.
+      required: [offers, profileUse, aiAgent]
+      properties:
+        offers:
+          type: boolean
+          description: May the bank show this customer a credit offer it was not asked for.
+        profileUse:
+          type: boolean
+          description: >-
+            May the 360 profile be used to work out WHICH offer. Separate from `offers` because a
+            customer may want an affordability answer they asked for without their spending being
+            mined for eligibility.
+        aiAgent:
+          type: boolean
+          description: >-
+            May the assistant watch and PREPARE on the customer's behalf. Never extends to
+            submitting, accepting, raising a limit or drawing funds.
+
     CreditQuote:
       type: object
       description: >-

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -1206,6 +1206,36 @@ paths:
                 type: array
                 items: {$ref: '#/components/schemas/Loan'}
 
+  /credit/quotes:
+    post:
+      tags: [Lending]
+      summary: Indicative, non-binding price for an amount and term
+      description: >-
+        ADR-0269 rule 4 — the only route by which the app may learn what a loan costs. The client
+        computes no price. Not fail-soft: a 409 (distress floor suppressed pricing, with a reason
+        code) passes through rather than becoming an empty 200, which a client renders as zero.
+      operationId: quoteCredit
+      security:
+        - customerOidc: [accounts:read]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [amount, termMonths]
+              properties:
+                amount: {type: string}
+                termMonths: {type: integer, minimum: 1}
+      responses:
+        '200':
+          description: The indicative quote
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/CreditQuote'}
+        '400': {description: Amount or term outside the product bounds}
+        '409': {description: Pricing suppressed; body carries reasonCode}
+
   /credit-applications:
     get:
       tags: [Lending]
@@ -3300,6 +3330,30 @@ components:
 
     # Edge's projected view of lending-service's Loan (internal fields dropped — see
     # CustomerEdgeResource.projectLoan).
+    CreditQuote:
+      type: object
+      description: >-
+        An indicative price. Structurally not an offer: no id, no accept path, and `binding` is
+        always false.
+      required: [amount, currency, termMonths, monthlyPayment, totalPayable, totalCostOfCredit,
+                 validUntil, binding]
+      properties:
+        amount: {type: string}
+        currency: {type: string, minLength: 3, maxLength: 3}
+        termMonths: {type: integer}
+        nominalAnnualRatePercent: {type: string}
+        monthlyPayment: {type: string}
+        totalPayable: {type: string}
+        totalCostOfCredit: {type: string}
+        aprcPercent:
+          type: string
+          nullable: true
+          description: >-
+            RPSN/APRC. NULL means "could not be computed" and must render as an absent figure, never
+            as 0% — which reads to a customer as free credit.
+        validUntil: {type: string, format: date-time}
+        binding: {type: boolean}
+
     CreditJourney:
       type: object
       description: >-

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeCreditConsentTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeCreditConsentTest.kt
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.customeredge.infrastructure.rest.CustomerEdgeResource
+import com.openbank.customeredge.infrastructure.rest.PaymentSessionStore
+import com.openbank.customeredge.infrastructure.rest.UpstreamClient
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import jakarta.ws.rs.core.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.util.UUID
+
+/**
+ * ADR-0269 rule 1 — the customer's own credit consents.
+ *
+ * These tests are written against the ways the route could WRONGLY GRANT or wrongly report a grant,
+ * because that is the failure with consequences: a customer who believes offers are off and is
+ * offered anyway. The happy path is one test; the rest are refusals and non-actions.
+ */
+class CustomerEdgeCreditConsentTest {
+
+    private val party = UUID.randomUUID()
+
+    private fun newResource(upstream: UpstreamClient): CustomerEdgeResource = CustomerEdgeResource(
+        upstream,
+        mockk(relaxed = true),
+        PaymentSessionStore(),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        Clock.systemUTC(),
+    ).apply {
+        partyMergeResolver = mockk { every { resolve(any()) } answers { firstArg() } }
+        jwt = mockk {
+            every { getClaim<String>("party_id") } returns null
+            every { subject } returns party.toString()
+        }
+        objectMapper = ObjectMapper()
+        consentServiceUrl = "http://consent"
+    }
+
+    private fun consentList(vararg scopes: String, status: String = "ACTIVE"): String =
+        scopes.joinToString(",", "[", "]") { s ->
+            """{"id":"${UUID.nameUUIDFromBytes(s.toByteArray())}","status":"$status","scopes":["$s"]}"""
+        }
+
+    private fun upstreamReturning(list: String): UpstreamClient = mockk(relaxed = true) {
+        every { get(match { it.contains("/api/v1/consents/party/") }, any()) } returns Response.ok(list).build()
+    }
+
+    private fun bodyOf(response: Response): Map<String, Any?> {
+        val node = ObjectMapper().readTree(response.entity.toString())
+        return node.fields().asSequence().associate { (k, v) -> k to (if (v.isBoolean) v.asBoolean() else v) }
+    }
+
+    // ── Reading ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a party with no consents reads as everything off`() {
+        val resp = newResource(upstreamReturning("[]")).getCreditConsents()
+        assertThat(bodyOf(resp)).containsEntry("offers", false)
+            .containsEntry("profileUse", false)
+            .containsEntry("aiAgent", false)
+    }
+
+    @Test
+    fun `an unreadable consent list reads as everything off, never as granted`() {
+        // The client uses this to decide whether to fetch offers at all. An optimistic default here
+        // would fetch offers for a customer whose consent could not be read.
+        val upstream = mockk<UpstreamClient>(relaxed = true) {
+            every { get(any(), any()) } returns Response.status(503).build()
+        }
+        assertThat(bodyOf(newResource(upstream).getCreditConsents())).containsEntry("offers", false)
+    }
+
+    @Test
+    fun `only ACTIVE consents count as granted`() {
+        val revoked = consentList("CREDIT_OFFERS", status = "REVOKED")
+        assertThat(bodyOf(newResource(upstreamReturning(revoked)).getCreditConsents()))
+            .containsEntry("offers", false)
+    }
+
+    @Test
+    fun `each switch reports its own scope and not another`() {
+        val body = bodyOf(newResource(upstreamReturning(consentList("CREDIT_PROFILE_USE"))).getCreditConsents())
+        assertThat(body).containsEntry("profileUse", true)
+            .containsEntry("offers", false)
+            .containsEntry("aiAgent", false)
+    }
+
+    // ── Writing ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `granting posts one consent for the requested scope, scoped to the caller's own party`() {
+        val upstream = upstreamReturning("[]")
+        val bodySlot = slot<String>()
+        every { upstream.post(match { it.endsWith("/api/v1/consents") }, any(), capture(bodySlot)) } returns
+            Response.status(201).entity("{}").build()
+
+        newResource(upstream).putCreditConsents("""{"offers":true,"profileUse":false,"aiAgent":false}""")
+
+        verify(exactly = 1) { upstream.post(any(), party.toString(), any()) }
+        assertThat(bodySlot.captured).contains("CREDIT_OFFERS").contains(party.toString())
+        assertThat(bodySlot.captured).doesNotContain("CREDIT_AI_AGENT")
+    }
+
+    @Test
+    fun `an omitted field is false — absence of consent is denial, never "leave it as it was"`() {
+        val upstream = upstreamReturning(consentList("CREDIT_OFFERS"))
+        newResource(upstream).putCreditConsents("{}")
+        // Offers were on and the body did not mention them, so they are revoked. A partial-patch
+        // reading would have left them on, which is the difference between a switch and a suggestion.
+        verify(exactly = 1) { upstream.delete(match { it.contains("/api/v1/consents/") }, party.toString(), any()) }
+    }
+
+    @Test
+    fun `turning a granted switch off revokes it and grants nothing`() {
+        val upstream = upstreamReturning(consentList("CREDIT_OFFERS"))
+        newResource(upstream).putCreditConsents("""{"offers":false,"profileUse":false,"aiAgent":false}""")
+        verify(exactly = 1) { upstream.delete(any(), party.toString(), any()) }
+        verify(exactly = 0) { upstream.post(any(), any(), any()) }
+    }
+
+    @Test
+    fun `re-granting an already-held consent does nothing rather than churning the audit trail`() {
+        val upstream = upstreamReturning(consentList("CREDIT_OFFERS"))
+        newResource(upstream).putCreditConsents("""{"offers":true,"profileUse":false,"aiAgent":false}""")
+        verify(exactly = 0) { upstream.post(any(), any(), any()) }
+        verify(exactly = 0) { upstream.delete(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a malformed body changes nothing`() {
+        val upstream = upstreamReturning("[]")
+        val resp = newResource(upstream).putCreditConsents("not json")
+        assertThat(resp.status).isEqualTo(400)
+        verify(exactly = 0) { upstream.post(any(), any(), any()) }
+        verify(exactly = 0) { upstream.delete(any(), any(), any()) }
+    }
+
+    @Test
+    fun `an unreadable consent list refuses the write rather than granting blindly`() {
+        val upstream = mockk<UpstreamClient>(relaxed = true) {
+            every { get(any(), any()) } returns Response.status(503).build()
+        }
+        val resp = newResource(upstream).putCreditConsents("""{"offers":true}""")
+        assertThat(resp.status).isEqualTo(503)
+        verify(exactly = 0) { upstream.post(any(), any(), any()) }
+    }
+}

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeCreditFunnelTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeCreditFunnelTest.kt
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.customeredge.infrastructure.credit.CreditFunnelPublisher
+import com.openbank.customeredge.infrastructure.rest.CustomerEdgeResource
+import com.openbank.customeredge.infrastructure.rest.PaymentSessionStore
+import com.openbank.customeredge.infrastructure.rest.UpstreamClient
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.util.UUID
+
+/**
+ * ADR-0269 rule 8's telemetry.
+ *
+ * The interesting properties are all refusals and silences: a junk value must not reach the stream,
+ * a client must not learn what the bank tracks, and the vocabulary must not be able to express
+ * conversion.
+ */
+class CustomerEdgeCreditFunnelTest {
+
+    private val party = UUID.randomUUID()
+    private val funnel = mockk<CreditFunnelPublisher>(relaxed = true)
+
+    private fun resource(): CustomerEdgeResource = CustomerEdgeResource(
+        mockk<UpstreamClient>(relaxed = true),
+        mockk(relaxed = true),
+        PaymentSessionStore(),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        Clock.systemUTC(),
+    ).apply {
+        partyMergeResolver = mockk { every { resolve(any()) } answers { firstArg() } }
+        jwt = mockk {
+            every { getClaim<String>("party_id") } returns null
+            every { subject } returns party.toString()
+        }
+        objectMapper = ObjectMapper()
+        creditFunnel = funnel
+    }
+
+    @Test
+    fun `a valid event is emitted for the caller's own party`() {
+        val resp = resource().trackCreditEvent("""{"step":"FINANCING","action":"VIEWED"}""")
+
+        assertThat(resp.status).isEqualTo(202)
+        verify(exactly = 1) { funnel.emit(party, "FINANCING", "VIEWED") }
+    }
+
+    @Test
+    fun `an unknown step is dropped, and the caller cannot tell`() {
+        // 202 either way. A 400 would make the allow-list an oracle for what the bank tracks, and
+        // telemetry has no business teaching a client anything.
+        val resp = resource().trackCreditEvent("""{"step":"WHATEVER","action":"VIEWED"}""")
+
+        assertThat(resp.status).isEqualTo(202)
+        verify(exactly = 0) { funnel.emit(any(), any(), any()) }
+    }
+
+    @Test
+    fun `an unknown action is dropped`() {
+        resource().trackCreditEvent("""{"step":"QUOTE","action":"CONVERTED"}""")
+        verify(exactly = 0) { funnel.emit(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a malformed body is dropped without a 5xx`() {
+        val resp = resource().trackCreditEvent("not json")
+        assertThat(resp.status).isEqualTo(202)
+        verify(exactly = 0) { funnel.emit(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a party id in the body is ignored — the JWT decides whose journey this is`() {
+        val someoneElse = UUID.randomUUID()
+        resource().trackCreditEvent(
+            """{"step":"FINANCING","action":"VIEWED","partyId":"$someoneElse"}""",
+        )
+
+        verify(exactly = 1) { funnel.emit(party, any(), any()) }
+        verify(exactly = 0) { funnel.emit(someoneElse, any(), any()) }
+    }
+
+    @Test
+    fun `the vocabulary cannot express a conversion`() {
+        // Structural, and the point of the whole design: a funnel that can say "converted" is one
+        // somebody will optimise, and optimising credit acceptance is what ADR-0269 exists to stop.
+        val forbidden = listOf("CONVERT", "ACCEPT", "SOLD", "SIGNED")
+        assertThat(CreditFunnelPublisher.VALID_ACTIONS).noneMatch { action ->
+            forbidden.any { action.contains(it) }
+        }
+    }
+
+    @Test
+    fun `both allow-lists are small and closed — they are Prometheus labels`() {
+        // An open vocabulary here is a cardinality bomb aimed at the metrics store, reachable by
+        // any authenticated customer.
+        assertThat(CreditFunnelPublisher.VALID_STEPS).hasSizeLessThan(10)
+        assertThat(CreditFunnelPublisher.VALID_ACTIONS).hasSizeLessThan(15)
+    }
+}

--- a/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
+++ b/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
@@ -796,6 +796,55 @@ data:
     WHERE month >= toStartOfMonth(now()) - INTERVAL 6 MONTH
       AND month <  toStartOfMonth(now())
     GROUP BY party_id;
+    --
+    -- The ADR-0269 credit-journey funnel (rule 8's metrics).
+    --
+    -- WHAT THIS DELIBERATELY CANNOT ANSWER: "how many customers converted". There is no conversion
+    -- event upstream and there is no acceptance column here. The programme's metrics are
+    -- self-activation, opt-out-within-30-days, affordability declines, delinquency, and offers shown
+    -- without a prior customer action — a funnel built to optimise acceptance would quietly become the
+    -- thing ADR-0269 exists to prevent.
+    --
+    -- WHY A SEPARATE STREAM from the onboarding funnel: that one is an anonymous public write. These
+    -- events say "this person is looking at borrowing", so they ride an authenticated topic keyed by
+    -- party. The two must not be unioned into one view, or the anonymous stream's trust level would
+    -- silently become the credit stream's.
+
+    CREATE OR REPLACE VIEW openbank_analytics.gold_credit_funnel_events AS
+    SELECT
+        JSONExtractString(payload, 'partyId') AS party_id,
+        JSONExtractString(payload, 'step')    AS step,
+        JSONExtractString(payload, 'action')  AS action,
+        occurred_at
+    FROM openbank_analytics.bronze_events
+    WHERE upper(aggregate_type) = 'CREDIT_FUNNEL'
+      AND JSONExtractString(payload, 'partyId') != '';
+
+    -- Self-activation, the headline number: of the people who ever opened the consent screen, how many
+    -- switched offers ON themselves. Deliberately NOT "how many were offered credit".
+    CREATE OR REPLACE VIEW openbank_analytics.gold_credit_consent_activation AS
+    SELECT
+        toStartOfDay(occurred_at)                                        AS day,
+        countIf(action = 'VIEWED' AND step = 'CONSENT')                  AS consent_screen_views,
+        countIf(action = 'CONSENT_GRANTED')                              AS granted,
+        countIf(action = 'CONSENT_WITHDRAWN')                            AS withdrawn,
+        uniqExactIf(party_id, action = 'CONSENT_GRANTED')                AS parties_granted,
+        uniqExactIf(party_id, action = 'CONSENT_WITHDRAWN')              AS parties_withdrawn
+    FROM openbank_analytics.gold_credit_funnel_events
+    GROUP BY day;
+
+    -- Pricing outcomes. QUOTE_SUPPRESSED is tracked as prominently as QUOTE_REQUESTED on purpose: the
+    -- distress floor refusing to price is a thing the bank must be able to SEE, not a silent branch.
+    CREATE OR REPLACE VIEW openbank_analytics.gold_credit_quote_outcomes AS
+    SELECT
+        toStartOfDay(occurred_at)                        AS day,
+        countIf(action = 'QUOTE_REQUESTED')              AS requested,
+        countIf(action = 'QUOTE_SUPPRESSED')             AS suppressed,
+        countIf(action = 'APPLICATION_STARTED')          AS applications_started,
+        countIf(action = 'APPLICATION_ABANDONED')        AS applications_abandoned
+    FROM openbank_analytics.gold_credit_funnel_events
+    GROUP BY day;
+
 kind: ConfigMap
 metadata:
   name: clickhouse-init

--- a/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
+++ b/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
@@ -736,6 +736,66 @@ data:
     FROM openbank_analytics.bronze_events AS b
     WHERE b.occurred_at <= {t:DateTime64(3, 'UTC')}
     GROUP BY upper(b.aggregate_type), b.aggregate_id;
+
+    -- ─────────────────────────────────────────────────────────────────────────
+    -- V9: the ADR-0269 credit profile (issue #6215). Mirrors
+    -- openbank-analytics-sink/src/main/resources/clickhouse/V9__party_credit_profile.sql — the
+    -- migration is what an EXISTING warehouse gets, this ConfigMap is what a FRESH one gets, and
+    -- the #4511 gate exists because the two drifting apart is invisible until a cluster is rebuilt.
+    -- ─────────────────────────────────────────────────────────────────────────
+
+    CREATE OR REPLACE VIEW openbank_analytics.silver_party_monthly_flows AS
+    SELECT
+        party_id,
+        month,
+        sum(inbound)  AS inbound_amount,
+        sum(outbound) AS outbound_amount,
+        count()       AS movement_count
+    FROM
+    (
+        SELECT
+            pa.party_id                                            AS party_id,
+            toStartOfMonth(e.occurred_at)                          AS month,
+            toDecimal64(JSONExtractString(e.payload, 'amount'), 2) AS inbound,
+            toDecimal64('0', 2)                                    AS outbound
+        FROM openbank_analytics.bronze_events AS e
+        INNER JOIN openbank_analytics.silver_party_accounts AS pa
+            ON pa.account_id = JSONExtractString(e.payload, 'targetAccountId')
+        WHERE upper(e.aggregate_type) = 'TRANSACTION'
+          AND JSONExtractString(e.payload, 'targetAccountId') != ''
+          AND JSONExtractString(e.payload, 'amount') != ''
+
+        UNION ALL
+
+        SELECT
+            pa.party_id                                            AS party_id,
+            toStartOfMonth(e.occurred_at)                          AS month,
+            toDecimal64('0', 2)                                    AS inbound,
+            toDecimal64(JSONExtractString(e.payload, 'amount'), 2) AS outbound
+        FROM openbank_analytics.bronze_events AS e
+        INNER JOIN openbank_analytics.silver_party_accounts AS pa
+            ON pa.account_id = JSONExtractString(e.payload, 'sourceAccountId')
+        WHERE upper(e.aggregate_type) = 'TRANSACTION'
+          AND JSONExtractString(e.payload, 'sourceAccountId') != ''
+          AND JSONExtractString(e.payload, 'amount') != ''
+    )
+    GROUP BY party_id, month;
+
+    CREATE OR REPLACE VIEW openbank_analytics.gold_party_credit_profile AS
+    SELECT
+        party_id,
+        count()                                              AS months_observed,
+        quantileExact(0.5)(inbound_amount)                   AS income_monthly,
+        quantileExact(0.5)(outbound_amount)                  AS outflow_monthly,
+        quantileExact(0.5)(inbound_amount - outbound_amount) AS net_monthly,
+        if(quantileExact(0.5)(inbound_amount) > 0,
+           stddevPop(inbound_amount - outbound_amount) / quantileExact(0.5)(inbound_amount),
+           NULL)                                             AS volatility_ratio,
+        sum(movement_count)                                  AS movements_observed
+    FROM openbank_analytics.silver_party_monthly_flows
+    WHERE month >= toStartOfMonth(now()) - INTERVAL 6 MONTH
+      AND month <  toStartOfMonth(now())
+    GROUP BY party_id;
 kind: ConfigMap
 metadata:
   name: clickhouse-init

--- a/openbank-infra/gitops/components/analytics/kafka-analytics-sink-mtls.yaml
+++ b/openbank-infra/gitops/components/analytics/kafka-analytics-sink-mtls.yaml
@@ -61,6 +61,12 @@ spec:
       - resource: { type: topic, name: openbank.onboarding.funnel.events, patternType: literal }
         operations: [Read, Describe]
         host: "*"
+      # ADR-0269 rule 8 credit-journey funnel. Separate from the onboarding funnel above because
+      # that one is written from an anonymous public endpoint and this one only from an
+      # authenticated request — the trust levels must not be merged into one stream.
+      - resource: { type: topic, name: openbank.credit.funnel.events, patternType: literal }
+        operations: [Read, Describe]
+        host: "*"
       # ADR-0192 in-app screen feedback (metadata + screenshot object key; never image bytes).
       - resource: { type: topic, name: openbank.feedback.events, patternType: literal }
         operations: [Read, Describe]

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -94,6 +94,20 @@ spec:
                   name: copilot-service-secrets
                   key: COPILOT_MODEL_API_KEY
                   optional: true
+            # openbank-services client secret (ADR-0269 slice 4) — lets ConsentQueryClient and
+            # CreditProfileReadClient's OidcClientRequestReactiveFilter mint a client-credentials
+            # token for the two calls that do not propagate the customer's own bearer. Same shared
+            # KV entry every other projection reads (rules.yaml: oidc_secret_convention, #3485).
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: copilot-service-secrets
+                  key: OIDC_CLIENT_SECRET
+                  # NOT optional (issue #2929): a missing key here must not silently degrade to
+                  # UNAUTHENTICATED outbound calls — CrashLoop is the correct failure mode for a
+                  # credential this security-relevant, not a quiet 401 from consent-service/
+                  # analytics-sink.
+                  optional: false
             # Postgres conversation history (#3710). The CNPG operator injects
             # copilot-db-app with PG_USER/PG_PASSWORD; REACTIVE_URL and JDBC_URL resolve them.
             #

--- a/openbank-infra/gitops/components/customer-edge/kafka-customer-edge-mtls.yaml
+++ b/openbank-infra/gitops/components/customer-edge/kafka-customer-edge-mtls.yaml
@@ -63,6 +63,16 @@ spec:
           patternType: literal
         operations: [Write, Describe]
         host: "*"
+      # Producer: CreditFunnelPublisher -> openbank.credit.funnel.events (ADR-0269 rule 8).
+      # Write only; the consumer is analytics-sink. Without this grant the produce is DENIED and the
+      # telemetry silently never reaches the warehouse — the sepa-instant/swift failure mode, and
+      # invisible here because the publisher is best-effort by design.
+      - resource:
+          type: topic
+          name: openbank.credit.funnel.events
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
       # Producer: FeedbackPublisher -> openbank.feedback.events (ADR-0192 screen feedback).
       # Write only; the consumer is analytics-sink. Without this grant the produce is denied and
       # the submission silently never reaches the warehouse — the sepa-instant/swift failure mode.

--- a/openbank-infra/gitops/components/customer-edge/kafka-topic.yaml
+++ b/openbank-infra/gitops/components/customer-edge/kafka-topic.yaml
@@ -65,3 +65,29 @@ spec:
   config:
     retention.ms: 604800000
     cleanup.policy: delete
+---
+# Credit-journey funnel topic (ADR-0269 rule 8), produced by customer-edge's CreditFunnelPublisher
+# and consumed by analytics-sink into the ClickHouse bronze layer.
+#
+# A SEPARATE topic from openbank.onboarding.funnel.events, not a widened one. That stream is written
+# from an ANONYMOUS public endpoint; these events say "this customer is looking at borrowing money"
+# and are written only from an authenticated request. Putting them on a stream anyone can post to
+# would make an interest-in-credit signal both forgeable and probeable.
+#
+# Declared explicitly because the broker does not auto-create: a missing topic is how the
+# sepa-instant/swift submits hung — the produce never lands and the caller waits on a broker that
+# will not accept it. Retention 7 days like the other telemetry streams; the durable copy is
+# ClickHouse bronze (≥10y).
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.credit.funnel.events
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 604800000
+    cleanup.policy: delete

--- a/openbank-infra/gitops/components/external-secrets/es-copilot-service.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-copilot-service.yaml
@@ -3,7 +3,14 @@
 # in-cluster gateway, NOT to the provider — the DeepInfra key now lives only in ai-platform (#1919).
 # Sourced from OpenBao KV path `openbank/litellm`, property `KEY_COPILOT_SERVICE` — copilot's OWN
 # virtual key with its own daily budget, not the shared master key (see the data entry below).
-# (No OIDC secret: copilot validates the customer JWT bearer-only via JWKS — no client secret.)
+#
+# OIDC_CLIENT_SECRET is new here (ADR-0269 slice 4): ConsentQueryClient and CreditProfileReadClient
+# register OidcClientRequestReactiveFilter to mint a client-credentials token for the two calls
+# that do not propagate the customer's own bearer. Same shared-KV convention as every other
+# OIDC_CLIENT_SECRET projection (rules.yaml: oidc_secret_convention, issue #3485) — the fleet has
+# exactly one Keycloak confidential client (`openbank-services`), so this reads the SAME
+# `account-service`/`OIDC_CLIENT_SECRET` KV entry every other projection does, not a copilot-owned
+# secret that does not exist.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -35,3 +42,7 @@ spec:
       remoteRef:
         key: litellm
         property: KEY_COPILOT_SERVICE
+    - secretKey: OIDC_CLIENT_SECRET
+      remoteRef:
+        key: account-service
+        property: OIDC_CLIENT_SECRET

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityService.kt
@@ -11,6 +11,7 @@ import com.openbank.lending.domain.model.CreditOfferDecision
 import com.openbank.lending.domain.model.CreditOfferEligibility
 import com.openbank.lending.domain.model.CreditOfferPolicy
 import com.openbank.lending.domain.model.CreditOfferSuppressionCode
+import com.openbank.lending.domain.model.OfferSurface
 import jakarta.enterprise.context.ApplicationScoped
 import kotlinx.coroutines.CancellationException
 import java.time.Clock
@@ -34,14 +35,40 @@ class CreditOfferEligibilityService(
     private val clock: Clock,
     private val policy: CreditOfferPolicy = CreditOfferPolicy.V1,
 ) {
-    suspend fun evaluate(partyId: UUID): CreditOfferDecision {
-        val hasConsent = failClosed("consent", null) { consent.hasCreditOffersConsent(partyId) }
-            ?: return CreditOfferDecision.Suppressed(policy.version, CreditOfferSuppressionCode.SIGNALS_UNAVAILABLE)
-        if (!hasConsent) {
-            return CreditOfferDecision.Suppressed(policy.version, CreditOfferSuppressionCode.CONSENT_ABSENT)
+    /**
+     * Evaluate the gate for [partyId].
+     *
+     * [surface] decides whether the consent half applies. It is not a convenience flag: ADR-0269's
+     * whole shape is pull-only, and the two surfaces are exactly the two sides of that rule.
+     *
+     *  - [OfferSurface.PUSH] — the bank is about to say something unprompted (a pre-approved limit,
+     *    a campaign step, an agent nudge). Requires `credit_offers` consent AND passes the distress
+     *    floor.
+     *  - [OfferSurface.PULL] — the customer asked (opened the financing screen, requested a quote).
+     *    Consent is NOT what gates this: requiring an opt-in before answering a question the
+     *    customer just asked would be a dark pattern in the other direction, and the ADR's rule is
+     *    that the bank does not initiate, not that it refuses to answer.
+     *
+     * The distress floor applies to BOTH. A customer in arrears asking "what would this cost" must
+     * not be handed a tailored instalment either; that is the case where the answer itself is the
+     * harm, regardless of who started the conversation.
+     */
+    suspend fun evaluate(partyId: UUID, surface: OfferSurface): CreditOfferDecision {
+        if (surface == OfferSurface.PUSH) {
+            val hasConsent = failClosed("consent", null) { consent.hasCreditOffersConsent(partyId) }
+                ?: return CreditOfferDecision.Suppressed(
+                    policy.version,
+                    CreditOfferSuppressionCode.SIGNALS_UNAVAILABLE,
+                )
+            if (!hasConsent) {
+                return CreditOfferDecision.Suppressed(policy.version, CreditOfferSuppressionCode.CONSENT_ABSENT)
+            }
         }
         val signals = failClosed("distress-signals", UNREADABLE) { distress.signalsFor(partyId) }
-        return CreditOfferEligibility.evaluate(true, signals, Instant.now(clock), policy)
+        // The frequency cap and materiality rules are about the bank speaking unprompted; they must
+        // not silence an answer the customer asked for, so a pull evaluation ignores contact history.
+        val effective = if (surface == OfferSurface.PULL) signals.withoutContactHistory() else signals
+        return CreditOfferEligibility.evaluate(true, effective, Instant.now(clock), policy)
     }
 
     /**

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityService.kt
@@ -110,6 +110,7 @@ class CreditOfferEligibilityService(
             inHardshipArrangement = true,
             lastAffordabilityFailureAt = null,
             bufferDays = null,
+            monthsObserved = null,
             lastCreditContactAt = null,
             inputsChangedSinceLastContact = false,
             complete = false,

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityService.kt
@@ -33,8 +33,19 @@ class CreditOfferEligibilityService(
     private val consent: CreditOffersConsentPort,
     private val distress: BorrowerDistressPort,
     private val clock: Clock,
-    private val policy: CreditOfferPolicy = CreditOfferPolicy.V1,
 ) {
+    /*
+     * NOT a constructor parameter with a Kotlin default. A default generates a synthetic
+     * constructor, Arc resolves the bean through it, and the whole bean then fails to resolve —
+     * the same class of defect CustomerIntakeConfig documents, where a Kotlin fallback quietly
+     * replaced injected configuration. Here it surfaced as an UnsatisfiedResolutionException that
+     * took down every Quarkus test in the module, which is the loud version and the lucky one.
+     *
+     * When the thresholds need to move per environment this becomes a @ConfigProperty-driven bean,
+     * not a defaulted parameter.
+     */
+    private val policy: CreditOfferPolicy = CreditOfferPolicy.V1
+
     /**
      * Evaluate the gate for [partyId].
      *
@@ -65,10 +76,7 @@ class CreditOfferEligibilityService(
             }
         }
         val signals = failClosed("distress-signals", UNREADABLE) { distress.signalsFor(partyId) }
-        // The frequency cap and materiality rules are about the bank speaking unprompted; they must
-        // not silence an answer the customer asked for, so a pull evaluation ignores contact history.
-        val effective = if (surface == OfferSurface.PULL) signals.withoutContactHistory() else signals
-        return CreditOfferEligibility.evaluate(true, effective, Instant.now(clock), policy)
+        return CreditOfferEligibility.evaluate(true, signals, Instant.now(clock), policy, surface)
     }
 
     /**

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/CreditOfferEligibility.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/CreditOfferEligibility.kt
@@ -85,7 +85,26 @@ data class BorrowerDistressSignals(
     val lastCreditContactAt: Instant?,
     val inputsChangedSinceLastContact: Boolean,
     val complete: Boolean,
-)
+) {
+    /**
+     * The same signals with contact history cleared.
+     *
+     * Frequency capping and materiality exist to stop the bank speaking too often; neither is a
+     * reason to refuse an answer the customer just asked for. A PULL evaluation therefore drops
+     * them rather than reporting FREQUENCY_CAP to someone who opened the screen themselves.
+     */
+    fun withoutContactHistory(): BorrowerDistressSignals =
+        copy(lastCreditContactAt = null, inputsChangedSinceLastContact = true)
+}
+
+/**
+ * Who started the conversation — the axis ADR-0269's pull-only rule turns on.
+ *
+ * PUSH is the bank speaking unprompted and needs consent; PULL is the customer asking and does not.
+ * Modelled as a type rather than a boolean parameter so a call site cannot get it backwards
+ * silently: `evaluate(partyId, PUSH)` reads as what it is, `evaluate(partyId, true)` does not.
+ */
+enum class OfferSurface { PUSH, PULL }
 
 /** Thresholds, versioned as one object so a change is a single reviewable diff (ADR-0213 shape). */
 data class CreditOfferPolicy(

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/CreditOfferEligibility.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/CreditOfferEligibility.kt
@@ -58,6 +58,15 @@ enum class CreditOfferSuppressionCode {
     /** 360-derived buffer is below the configured floor — thin cover, not yet distress. */
     BUFFER_BELOW_FLOOR,
 
+    /**
+     * The 360 profile has too few observed months to be evidence.
+     *
+     * Distinct from [SIGNALS_UNAVAILABLE] on purpose: that one is a fault worth alerting on, this
+     * one is a customer the bank has simply not seen for long enough. Collapsing them would bury a
+     * genuine outage inside the normal traffic of new customers.
+     */
+    HISTORY_TOO_THIN,
+
     /** A credit-marketing contact already went out inside the frequency window. */
     FREQUENCY_CAP,
 
@@ -82,6 +91,12 @@ data class BorrowerDistressSignals(
     val inHardshipArrangement: Boolean,
     val lastAffordabilityFailureAt: Instant?,
     val bufferDays: Int?,
+    /**
+     * Whole months of cash-flow history behind the 360 figures. A three-week-old customer and a
+     * five-year customer can produce the same median, so the count travels with the numbers rather
+     * than being discarded at the source.
+     */
+    val monthsObserved: Int?,
     val lastCreditContactAt: Instant?,
     val inputsChangedSinceLastContact: Boolean,
     val complete: Boolean,
@@ -102,12 +117,14 @@ data class CreditOfferPolicy(
     val minimumBufferDays: Int,
     val affordabilityCoolingDays: Long,
     val contactFrequencyDays: Long,
+    val minimumMonthsObserved: Int,
 ) {
     init {
         require(version > 0) { "policy version must be positive" }
         require(minimumBufferDays >= 0) { "minimumBufferDays must not be negative" }
         require(affordabilityCoolingDays >= 0) { "affordabilityCoolingDays must not be negative" }
         require(contactFrequencyDays >= 0) { "contactFrequencyDays must not be negative" }
+        require(minimumMonthsObserved >= 0) { "minimumMonthsObserved must not be negative" }
     }
 
     companion object {
@@ -121,6 +138,9 @@ data class CreditOfferPolicy(
             minimumBufferDays = 30,
             affordabilityCoolingDays = 14,
             contactFrequencyDays = 30,
+            // Three whole months: enough for one unusual month not to be the whole picture, and
+            // the point at which a median stops being an anecdote.
+            minimumMonthsObserved = 3,
         )
     }
 }
@@ -193,6 +213,11 @@ object CreditOfferEligibility {
         //  - materiality asks whether there is anything new to SAY, which is meaningless when the
         //    customer just asked the question.
         if (surface == OfferSurface.PULL) return null
+
+        // A push needs evidence, and a median over one or two months is not evidence. A pull is
+        // unaffected: answering "what would this cost" does not rest on knowing the customer.
+        val months = signals.monthsObserved ?: return CreditOfferSuppressionCode.HISTORY_TOO_THIN
+        if (months < policy.minimumMonthsObserved) return CreditOfferSuppressionCode.HISTORY_TOO_THIN
 
         // A missing buffer is not a healthy buffer. Unknown reads as below the floor.
         val buffer = signals.bufferDays ?: return CreditOfferSuppressionCode.BUFFER_BELOW_FLOOR

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/CreditOfferEligibility.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/CreditOfferEligibility.kt
@@ -85,17 +85,7 @@ data class BorrowerDistressSignals(
     val lastCreditContactAt: Instant?,
     val inputsChangedSinceLastContact: Boolean,
     val complete: Boolean,
-) {
-    /**
-     * The same signals with contact history cleared.
-     *
-     * Frequency capping and materiality exist to stop the bank speaking too often; neither is a
-     * reason to refuse an answer the customer just asked for. A PULL evaluation therefore drops
-     * them rather than reporting FREQUENCY_CAP to someone who opened the screen themselves.
-     */
-    fun withoutContactHistory(): BorrowerDistressSignals =
-        copy(lastCreditContactAt = null, inputsChangedSinceLastContact = true)
-}
+)
 
 /**
  * Who started the conversation — the axis ADR-0269's pull-only rule turns on.
@@ -160,6 +150,7 @@ object CreditOfferEligibility {
         signals: BorrowerDistressSignals,
         now: Instant,
         policy: CreditOfferPolicy = CreditOfferPolicy.V1,
+        surface: OfferSurface = OfferSurface.PUSH,
     ): CreditOfferDecision {
         if (!hasOffersConsent) {
             return CreditOfferDecision.Suppressed(policy.version, CreditOfferSuppressionCode.CONSENT_ABSENT)
@@ -167,7 +158,7 @@ object CreditOfferEligibility {
         if (!signals.complete) {
             return CreditOfferDecision.Suppressed(policy.version, CreditOfferSuppressionCode.SIGNALS_UNAVAILABLE)
         }
-        val distress = distressCode(signals, now, policy)
+        val distress = distressCode(signals, now, policy, surface)
             ?: return CreditOfferDecision.Allowed(policy.version)
         return CreditOfferDecision.Suppressed(policy.version, distress)
     }
@@ -184,12 +175,24 @@ object CreditOfferEligibility {
         signals: BorrowerDistressSignals,
         now: Instant,
         policy: CreditOfferPolicy,
+        surface: OfferSurface,
     ): CreditOfferSuppressionCode? {
+        // Hard facts and a binding affordability refusal stop BOTH surfaces. These are the cases
+        // where the answer itself is the harm, no matter who started the conversation.
         hardFactCode(signals)?.let { return it }
-
         if (withinDays(signals.lastAffordabilityFailureAt, now, policy.affordabilityCoolingDays)) {
             return CreditOfferSuppressionCode.AFFORDABILITY_COOLING
         }
+        // Everything below is about the bank speaking UNPROMPTED, and none of it is a reason to
+        // refuse an answer the customer just asked for:
+        //
+        //  - a thin buffer means "do not go looking for this customer with an offer"; it does not
+        //    mean "refuse to tell them what a loan would cost", which would leave someone who is
+        //    managing carefully unable to plan at all;
+        //  - a frequency cap limits how often the BANK initiates, and cannot silence a reply;
+        //  - materiality asks whether there is anything new to SAY, which is meaningless when the
+        //    customer just asked the question.
+        if (surface == OfferSurface.PULL) return null
 
         // A missing buffer is not a healthy buffer. Unknown reads as below the floor.
         val buffer = signals.bufferDays ?: return CreditOfferSuppressionCode.BUFFER_BELOW_FLOOR

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/CreditOfferGateAdapters.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/CreditOfferGateAdapters.kt
@@ -5,6 +5,7 @@
 package com.openbank.lending.infrastructure.client
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.openbank.lending.application.port.out.BorrowerDistressPort
 import com.openbank.lending.application.port.out.CreditOffersConsentPort
 import com.openbank.lending.application.port.out.LoanRepository
@@ -69,8 +70,38 @@ class RestCreditOffersConsentAdapter(@param:RestClient private val consents: Len
     }
 }
 
+/** analytics-sink's ADR-0269 credit profile (#6215) — the single definition of these numbers. */
+@RegisterRestClient(configKey = "analytics-sink")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/analytics/credit-profile")
+@Produces(MediaType.APPLICATION_JSON)
+interface CreditProfileClient {
+    @GET
+    @Path("/{partyId}")
+    @Timeout(PROFILE_TIMEOUT_MS)
+    fun profile(@PathParam("partyId") partyId: UUID): io.smallrye.mutiny.Uni<CreditProfileResponse>
+}
+
 /**
- * Distress signals from the bank's OWN loan book (ADR-0269 rule 2).
+ * [monthsObserved] is part of the answer, not metadata: a three-week-old customer and a five-year
+ * customer can produce the same median, and the gate refuses to treat the first as evidence.
+ * Amounts are strings on the wire for the reason they always are here — money never crosses an API
+ * as a Double.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CreditProfileResponse(
+    // The wire names are ClickHouse column names (snake_case) and the Kotlin names are Kotlin
+    // names; @JsonProperty is what keeps that translation in one visible place instead of forcing
+    // one convention onto the other.
+    @param:JsonProperty("months_observed") val monthsObserved: Int = 0,
+    @param:JsonProperty("income_monthly") val incomeMonthly: String? = null,
+    @param:JsonProperty("outflow_monthly") val outflowMonthly: String? = null,
+    @param:JsonProperty("net_monthly") val netMonthly: String? = null,
+    @param:JsonProperty("volatility_ratio") val volatilityRatio: String? = null,
+)
+
+/**
+ * Distress signals from the bank's OWN loan book, plus the 360 profile (ADR-0269 rule 2).
  *
  * ## What this can see, and what it deliberately cannot
  *
@@ -78,43 +109,75 @@ class RestCreditOffersConsentAdapter(@param:RestClient private val consents: Len
  * `DEFAULTED`, `TERMINATION_NOTICED` or `ACCELERATED` is in arrears, and `FORBEARANCE_ASSESSED` is
  * a hardship arrangement. Those are read here directly.
  *
- * Enforcement orders, insolvency proceedings, the current-account balance and the 360-derived
- * buffer have **no source in this deployment yet** — they arrive with `CustomerCreditProfile`
- * (#6215). This adapter reports them as absent rather than unknown, which is a deliberate and
- * narrow decision, so it is worth being explicit about what it costs:
+ * Cash-flow cover and history depth now come from analytics-sink's `gold_party_credit_profile`
+ * (#6215). [BorrowerDistressSignals.bufferDays] is derived from the profile as net monthly cover:
+ * how many days the median monthly surplus would carry the median monthly outflow. A party with no
+ * surplus has zero days of cover, which is the honest reading and the one the buffer floor exists
+ * to catch.
  *
- *  - It does NOT weaken the pull path, whose floor is arrears/hardship plus a binding affordability
- *    refusal — all of which this adapter can see.
- *  - It WOULD weaken the push path, which also leans on the buffer floor. Nothing pushes yet: the
- *    pre-approved read is #6214's follow-on and does not exist. #6215 must land before it does,
- *    and the buffer floor is what makes that ordering load-bearing rather than tidy.
+ * Enforcement orders and insolvency proceedings still have **no source in this deployment** — no
+ * service ingests a court register. They are reported as absent rather than unknown, deliberately:
+ * treating them as unknown would make `complete = false` permanent and suppress every offer
+ * forever, which is indistinguishable from the feature being switched off and would hide the
+ * moment a real signal source arrives. The gap is real and is what an operational-risk review of
+ * this gate should challenge first.
  *
- * `complete = true` is therefore an honest claim about THIS adapter's inputs: every signal it
- * declares itself able to read, it read. It is not a claim that the platform can see everything the
- * policy names.
+ * A profile that cannot be read is NOT substituted with defaults — `complete = false` propagates
+ * and the gate refuses. That is the difference between "the customer has no surplus" and "we could
+ * not find out", which no downstream layer can reconstruct afterwards.
  */
 @ApplicationScoped
-class LoanBookDistressAdapter(private val loans: LoanRepository) : BorrowerDistressPort {
+class LoanBookDistressAdapter(
+    private val loans: LoanRepository,
+    @param:RestClient private val profiles: CreditProfileClient,
+) : BorrowerDistressPort {
 
     override suspend fun signalsFor(partyId: UUID): BorrowerDistressSignals {
         val book = loans.findByParty(partyId).awaitSuspending()
+        val profile = runCatching { profiles.profile(partyId).awaitSuspending() }
+            .getOrElse { e ->
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                null
+            }
         return BorrowerDistressSignals(
             hasArrears = book.any { it.status in ARREARS_STATES },
             inHardshipArrangement = book.any { it.status == LoanStatus.FORBEARANCE_ASSESSED },
-            // No source yet — see the class docs. Not "false because it is convenient": false
-            // because this adapter does not claim to answer them, and #6215 is what will.
-            hasNegativeBalance = false,
+            // A negative median net over six months is the closest thing to "living on the
+            // overdraft" that the profile can see. It is not a live balance read, and it is not
+            // claimed to be one.
+            hasNegativeBalance = profile?.netMonthlyOrNull()?.signum()?.let { it < 0 } ?: false,
+            // No source in this deployment — see the class docs.
             hasEnforcementOrder = false,
             hasInsolvencyProceeding = false,
             lastAffordabilityFailureAt = null,
-            bufferDays = null,
+            bufferDays = profile?.let { coverDays(it) },
+            monthsObserved = profile?.monthsObserved,
             lastCreditContactAt = null,
             inputsChangedSinceLastContact = true,
-            complete = true,
+            // False when the profile could not be read: the gate must refuse rather than price a
+            // customer whose cash flow the bank just failed to look up.
+            complete = profile != null,
         )
     }
 
+    /**
+     * Days of cover the monthly surplus buys against the monthly outflow.
+     *
+     * `net / outflow × 30`, floored at zero. Null outflow means nothing goes out, which is not
+     * infinite cover but an unobserved customer — null, so the buffer floor suppresses.
+     */
+    private fun coverDays(profile: CreditProfileResponse): Int? {
+        val net = profile.netMonthlyOrNull() ?: return null
+        val outflow = profile.outflowMonthlyOrNull() ?: return null
+        if (outflow.signum() <= 0) return null
+        if (net.signum() <= 0) return 0
+        return net.multiply(java.math.BigDecimal(DAYS_PER_MONTH))
+            .divide(outflow, java.math.MathContext.DECIMAL64)
+            .toInt()
+    }
+
     companion object {
+        private const val DAYS_PER_MONTH = 30
         private val ARREARS_STATES = setOf(
             LoanStatus.DELINQUENT,
             LoanStatus.DEFAULTED,
@@ -124,4 +187,11 @@ class LoanBookDistressAdapter(private val loans: LoanRepository) : BorrowerDistr
     }
 }
 
+private fun CreditProfileResponse.netMonthlyOrNull(): java.math.BigDecimal? =
+    netMonthly?.takeIf { it.isNotBlank() }?.let { runCatching { java.math.BigDecimal(it) }.getOrNull() }
+
+private fun CreditProfileResponse.outflowMonthlyOrNull(): java.math.BigDecimal? =
+    outflowMonthly?.takeIf { it.isNotBlank() }?.let { runCatching { java.math.BigDecimal(it) }.getOrNull() }
+
 private const val CONSENT_TIMEOUT_MS = 2000L
+private const val PROFILE_TIMEOUT_MS = 2000L

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/CreditOfferGateAdapters.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/CreditOfferGateAdapters.kt
@@ -11,6 +11,7 @@ import com.openbank.lending.application.port.out.CreditOffersConsentPort
 import com.openbank.lending.application.port.out.LoanRepository
 import com.openbank.lending.domain.model.BorrowerDistressSignals
 import com.openbank.lending.domain.model.LoanStatus
+import com.openbank.libs.web.SyntheticTaintClientFilter
 import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
@@ -29,6 +30,7 @@ import java.util.UUID
 /** consent-service's own active-consent check, reused verbatim (the shape campaign-service uses). */
 @RegisterRestClient(configKey = "consent-service")
 @RegisterProvider(OidcClientRequestReactiveFilter::class)
+@RegisterProvider(SyntheticTaintClientFilter::class)
 @Path("/api/v1/consents")
 @Produces(MediaType.APPLICATION_JSON)
 interface LendingConsentServiceClient {
@@ -73,6 +75,7 @@ class RestCreditOffersConsentAdapter(@param:RestClient private val consents: Len
 /** analytics-sink's ADR-0269 credit profile (#6215) — the single definition of these numbers. */
 @RegisterRestClient(configKey = "analytics-sink")
 @RegisterProvider(OidcClientRequestReactiveFilter::class)
+@RegisterProvider(SyntheticTaintClientFilter::class)
 @Path("/api/v1/analytics/credit-profile")
 @Produces(MediaType.APPLICATION_JSON)
 interface CreditProfileClient {

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/CreditOfferGateAdapters.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/CreditOfferGateAdapters.kt
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.openbank.lending.application.port.out.BorrowerDistressPort
+import com.openbank.lending.application.port.out.CreditOffersConsentPort
+import com.openbank.lending.application.port.out.LoanRepository
+import com.openbank.lending.domain.model.BorrowerDistressSignals
+import com.openbank.lending.domain.model.LoanStatus
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.faulttolerance.Timeout
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import java.util.UUID
+
+/** consent-service's own active-consent check, reused verbatim (the shape campaign-service uses). */
+@RegisterRestClient(configKey = "consent-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/consents")
+@Produces(MediaType.APPLICATION_JSON)
+interface LendingConsentServiceClient {
+    @GET
+    @Path("/party/{partyId}/grantee/{granteeId}/active")
+    @Timeout(CONSENT_TIMEOUT_MS)
+    fun hasActiveConsent(
+        @PathParam("partyId") partyId: UUID,
+        @PathParam("granteeId") granteeId: String,
+        @QueryParam("scope") scope: String,
+    ): io.smallrye.mutiny.Uni<ConsentCheckResult>
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ConsentCheckResult(val granted: Boolean = false)
+
+/**
+ * Reads `CREDIT_OFFERS` from consent-service (ADR-0269 rule 1).
+ *
+ * Returns null on any failure rather than false: the service already treats null as a refusal, and
+ * keeping the two apart is what lets an outage be alerted on instead of hiding inside a normal-
+ * looking suppression count.
+ */
+@ApplicationScoped
+class RestCreditOffersConsentAdapter(@param:RestClient private val consents: LendingConsentServiceClient) :
+    CreditOffersConsentPort {
+
+    override suspend fun hasCreditOffersConsent(partyId: UUID): Boolean? =
+        runCatching { consents.hasActiveConsent(partyId, BANK_GRANTEE, CREDIT_OFFERS_SCOPE).awaitSuspending() }
+            .getOrElse { e ->
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                null
+            }?.granted
+
+    companion object {
+        /** The bank itself is the grantee for a first-party marketing consent, not a TPP. */
+        const val BANK_GRANTEE = "openbank"
+        const val CREDIT_OFFERS_SCOPE = "CREDIT_OFFERS"
+    }
+}
+
+/**
+ * Distress signals from the bank's OWN loan book (ADR-0269 rule 2).
+ *
+ * ## What this can see, and what it deliberately cannot
+ *
+ * Arrears and forbearance are facts lending-service already owns: a loan in `DELINQUENT`,
+ * `DEFAULTED`, `TERMINATION_NOTICED` or `ACCELERATED` is in arrears, and `FORBEARANCE_ASSESSED` is
+ * a hardship arrangement. Those are read here directly.
+ *
+ * Enforcement orders, insolvency proceedings, the current-account balance and the 360-derived
+ * buffer have **no source in this deployment yet** — they arrive with `CustomerCreditProfile`
+ * (#6215). This adapter reports them as absent rather than unknown, which is a deliberate and
+ * narrow decision, so it is worth being explicit about what it costs:
+ *
+ *  - It does NOT weaken the pull path, whose floor is arrears/hardship plus a binding affordability
+ *    refusal — all of which this adapter can see.
+ *  - It WOULD weaken the push path, which also leans on the buffer floor. Nothing pushes yet: the
+ *    pre-approved read is #6214's follow-on and does not exist. #6215 must land before it does,
+ *    and the buffer floor is what makes that ordering load-bearing rather than tidy.
+ *
+ * `complete = true` is therefore an honest claim about THIS adapter's inputs: every signal it
+ * declares itself able to read, it read. It is not a claim that the platform can see everything the
+ * policy names.
+ */
+@ApplicationScoped
+class LoanBookDistressAdapter(private val loans: LoanRepository) : BorrowerDistressPort {
+
+    override suspend fun signalsFor(partyId: UUID): BorrowerDistressSignals {
+        val book = loans.findByParty(partyId).awaitSuspending()
+        return BorrowerDistressSignals(
+            hasArrears = book.any { it.status in ARREARS_STATES },
+            inHardshipArrangement = book.any { it.status == LoanStatus.FORBEARANCE_ASSESSED },
+            // No source yet — see the class docs. Not "false because it is convenient": false
+            // because this adapter does not claim to answer them, and #6215 is what will.
+            hasNegativeBalance = false,
+            hasEnforcementOrder = false,
+            hasInsolvencyProceeding = false,
+            lastAffordabilityFailureAt = null,
+            bufferDays = null,
+            lastCreditContactAt = null,
+            inputsChangedSinceLastContact = true,
+            complete = true,
+        )
+    }
+
+    companion object {
+        private val ARREARS_STATES = setOf(
+            LoanStatus.DELINQUENT,
+            LoanStatus.DEFAULTED,
+            LoanStatus.TERMINATION_NOTICED,
+            LoanStatus.ACCELERATED,
+        )
+    }
+}
+
+private const val CONSENT_TIMEOUT_MS = 2000L

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CustomerFinancialHealthResource.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CustomerFinancialHealthResource.kt
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.infrastructure.rest
+
+import com.openbank.lending.application.port.out.InstallmentRepository
+import com.openbank.lending.application.port.out.LoanRepository
+import com.openbank.lending.domain.model.Loan
+import com.openbank.lending.domain.model.LoanStatus
+import com.openbank.lending.infrastructure.client.CreditProfileClient
+import com.openbank.lending.infrastructure.intake.CustomerIntakeConfig
+import com.openbank.libs.authz.Authorize
+import com.openbank.libs.lending.FinancialHealth
+import com.openbank.libs.lending.FinancialHealthInputs
+import com.openbank.libs.lending.HealthPillar
+import io.quarkus.security.identity.SecurityIdentity
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.asUni
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.HeaderParam
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * The customer's own financial-health view (ADR-0269 / APP-ADR-0001 rule 5).
+ *
+ * ## Why it is assembled HERE and not at the edge
+ *
+ * The four pillars need three sources — the ADR-0269 credit profile, the loan book, and the
+ * customer's balances. lending-service already talks to all three. Assembling it at the edge would
+ * mean a new HTTP dependency from the edge to analytics-sink (today they only meet through Kafka)
+ * and product thresholds living in a proxy. The judgement itself is a pure function in libs; this
+ * class only fetches.
+ *
+ * ## What it is not
+ *
+ * No score, no rating, no eligibility, and no path into a credit decision. Every pillar can answer
+ * UNKNOWN, and one unavailable upstream greys out one pillar rather than the screen — a customer
+ * who opened this to look at their reserve should not be told nothing is known because the profile
+ * service was slow.
+ */
+@Path("/api/v1/lending/intake")
+@Produces(MediaType.APPLICATION_JSON)
+@Tag(name = "Lending", description = "Customer self-service origination intake")
+@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+class CustomerFinancialHealthResource(
+    private val loans: LoanRepository,
+    private val installments: InstallmentRepository,
+    @param:RestClient private val profiles: CreditProfileClient,
+    private val config: CustomerIntakeConfig,
+    private val identity: SecurityIdentity,
+) {
+    @GET
+    @Path("/financial-health")
+    @Authorize(action = "lending.intake", resource = "")
+    @Operation(summary = "The caller's own four-pillar financial health (no score, edge only)")
+    fun health(@HeaderParam(CustomerIntakeResource.PARTY_HEADER) partyHeader: String?): Uni<Response> {
+        if (!callerIsPermitted()) {
+            return Uni.createFrom().item(
+                Response.status(HTTP_FORBIDDEN)
+                    .entity(mapOf("error" to "caller is not the customer-edge intake principal")).build(),
+            )
+        }
+        val partyId = scopeOf(partyHeader)
+            ?: return Uni.createFrom().item(
+                Response.status(HTTP_BAD_REQUEST)
+                    .entity(mapOf("error" to "${CustomerIntakeResource.PARTY_HEADER} is missing or not a UUID"))
+                    .build(),
+            )
+
+        return CoroutineScope(Dispatchers.Unconfined).async {
+            val book = runCatchingUpstream { loans.findByParty(partyId).awaitSuspending() } ?: emptyList()
+            val profile = runCatchingUpstream { profiles.profile(partyId).awaitSuspending() }
+            val view = FinancialHealth.assess(
+                FinancialHealthInputs(
+                    monthlyIncome = profile?.incomeMonthly?.toDecimalOrNull(),
+                    monthlyOutflow = profile?.outflowMonthly?.toDecimalOrNull(),
+                    monthlyNet = profile?.netMonthly?.toDecimalOrNull(),
+                    volatilityRatio = profile?.volatilityRatio?.toDecimalOrNull(),
+                    // No balance source on this path yet, so the reserve pillar answers UNKNOWN.
+                    // Deliberately left null rather than approximated from cashflow: a reserve the
+                    // customer does not have, inferred from money they merely did not spend, is the
+                    // single most dangerous number this screen could show.
+                    liquidBalance = null,
+                    monthlyDebtService = debtServiceOf(book),
+                    hasArrears = book.takeIf { it.isNotEmpty() }?.any { it.status in ARREARS_STATES },
+                    monthsObserved = profile?.monthsObserved,
+                ),
+            )
+            Response.ok(view.pillars.map { it.toDto() }).build()
+        }.asUni()
+    }
+
+    /**
+     * Contractual monthly debt service: the next unpaid instalment of every live loan.
+     *
+     * Null when the party has no live loans — which is NOT the same as zero. Zero would let the
+     * obligations pillar report a healthy DSTI for someone whose loans simply could not be read.
+     */
+    private suspend fun debtServiceOf(book: List<Loan>): BigDecimal? {
+        val live = book.filter { it.status !in CLOSED_STATES }
+        if (live.isEmpty()) return if (book.isEmpty()) BigDecimal.ZERO else null
+        var total = BigDecimal.ZERO
+        live.forEach { loan ->
+            val schedule = runCatchingUpstream { installments.findByLoan(loan.id).awaitSuspending() } ?: return null
+            val next = schedule.filter { !it.paid }.minByOrNull { it.number } ?: return@forEach
+            total = total.add(next.payment.amount)
+        }
+        return total
+    }
+
+    private fun callerIsPermitted(): Boolean {
+        if (!config.enabled) return false
+        val permitted = config.callerPrincipal.orElse("")
+        return permitted.isNotBlank() && identity.principal?.name == permitted
+    }
+
+    private fun scopeOf(partyHeader: String?): UUID? =
+        partyHeader?.let { runCatching { UUID.fromString(it) }.getOrNull() }?.takeIf { it != ZERO_UUID }
+
+    /** Null on any upstream failure, so one slow service greys out one pillar and not the view. */
+    private suspend fun <T> runCatchingUpstream(block: suspend () -> T): T? = runCatching { block() }.getOrElse { e ->
+        if (e is CancellationException) throw e
+        null
+    }
+
+    private fun String.toDecimalOrNull(): BigDecimal? =
+        takeIf { it.isNotBlank() }?.let { runCatching { BigDecimal(it) }.getOrNull() }
+
+    private fun HealthPillar.toDto() = CustomerHealthPillarDto(
+        code = code,
+        zone = zone.name,
+        value = value?.toPlainString(),
+        target = target?.toPlainString(),
+    )
+
+    companion object {
+        private val ZERO_UUID = UUID(0, 0)
+        private const val HTTP_BAD_REQUEST = 400
+        private const val HTTP_FORBIDDEN = 403
+
+        private val ARREARS_STATES = setOf(
+            LoanStatus.DELINQUENT,
+            LoanStatus.DEFAULTED,
+            LoanStatus.TERMINATION_NOTICED,
+            LoanStatus.ACCELERATED,
+        )
+
+        private val CLOSED_STATES = setOf(
+            LoanStatus.CLOSED,
+            LoanStatus.SETTLED,
+            LoanStatus.WRITTEN_OFF,
+            LoanStatus.UNWOUND,
+        )
+    }
+}
+
+/**
+ * One pillar on the wire. [value] and [target] are strings and are null for an UNKNOWN zone, so a
+ * client has nothing invented to render.
+ */
+data class CustomerHealthPillarDto(val code: String, val zone: String, val value: String?, val target: String?)

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CustomerQuoteResource.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CustomerQuoteResource.kt
@@ -110,10 +110,9 @@ class CustomerQuoteResource(
      * A suppressed quote is a 409 with the reason code and NO price. Not a 200 with nulls: a body
      * shaped like a quote, holding no numbers, is the kind of thing a client renders as "0".
      */
-    private fun suppressed(decision: CreditOfferDecision.Suppressed): Response =
-        Response.status(HTTP_CONFLICT)
-            .entity(mapOf("error" to "quote unavailable", "reasonCode" to decision.code.name))
-            .build()
+    private fun suppressed(decision: CreditOfferDecision.Suppressed): Response = Response.status(HTTP_CONFLICT)
+        .entity(mapOf("error" to "quote unavailable", "reasonCode" to decision.code.name))
+        .build()
 
     @Suppress("ReturnCount")
     private fun refuse(partyHeader: String?, request: CustomerQuoteRequest): Response? {
@@ -124,7 +123,11 @@ class CustomerQuoteResource(
         }
         val partyId = partyHeader?.let { runCatching { UUID.fromString(it) }.getOrNull() }
             ?: return error(HTTP_BAD_REQUEST, "${CustomerIntakeResource.PARTY_HEADER} is missing or not a UUID")
-        if (partyId == ZERO_UUID) return error(HTTP_BAD_REQUEST, "${CustomerIntakeResource.PARTY_HEADER} is the nil UUID")
+        if (partyId ==
+            ZERO_UUID
+        ) {
+            return error(HTTP_BAD_REQUEST, "${CustomerIntakeResource.PARTY_HEADER} is the nil UUID")
+        }
         if (config.nominalAnnualRate.isEmpty) {
             return error(HTTP_FORBIDDEN, "self-service product has no configured price")
         }

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CustomerQuoteResource.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CustomerQuoteResource.kt
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.infrastructure.rest
+
+import com.openbank.lending.application.usecase.CreditOfferEligibilityService
+import com.openbank.lending.domain.model.CreditOfferDecision
+import com.openbank.lending.domain.model.OfferSurface
+import com.openbank.lending.infrastructure.intake.CustomerIntakeConfig
+import com.openbank.libs.authz.Authorize
+import com.openbank.libs.domain.money.CurrencyCode
+import com.openbank.libs.domain.money.Money
+import com.openbank.libs.lending.CreditQuote
+import com.openbank.libs.lending.CreditQuoteCalculator
+import com.openbank.libs.lending.CreditQuoteRequest
+import io.quarkus.security.identity.SecurityIdentity
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.asUni
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.HeaderParam
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Indicative pricing for the customer app (ADR-0269 rule 4).
+ *
+ * ## Why a quote endpoint exists at all
+ *
+ * Before this, the app had two choices for showing a customer what a loan would cost: compute the
+ * instalment itself, or show nothing. It showed nothing — the right call, and a poor experience.
+ * This route is the third option, and the ONLY one the ADR permits: the server prices, the client
+ * renders.
+ *
+ * ## Why it is a POST that stores nothing
+ *
+ * A quote is a calculation over a body, not a resource. Nothing is persisted: an indicative price
+ * with an id would be one lookup away from being treated as a binding offer, which it is not —
+ * an offer comes from the decision engine after an assessment and carries an accept path.
+ *
+ * ## Why it is gated on eligibility
+ *
+ * A quote is a price for credit, and ADR-0269 rule 2's distress floor applies to showing prices as
+ * much as to pushing offers: a customer in arrears asking "what would this cost" must not be handed
+ * a tailored instalment. The gate returns a reason code, and the route surfaces it as a 409 rather
+ * than a price — a refusal a client can render honestly instead of a number it must hide.
+ *
+ * Note the asymmetry with the pre-approved read: a customer who ASKED is exercising pull, so the
+ * consent check is not what refuses them here; the distress floor is.
+ */
+@Path("/api/v1/lending/intake")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tag(name = "Lending", description = "Customer self-service origination intake")
+@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+class CustomerQuoteResource(
+    private val config: CustomerIntakeConfig,
+    private val eligibility: CreditOfferEligibilityService,
+    private val identity: SecurityIdentity,
+    private val clock: Clock,
+) {
+    @POST
+    @Path("/quotes")
+    @Authorize(action = "lending.intake", resource = "")
+    @Operation(summary = "Indicative, non-binding price for a requested amount and term (edge only)")
+    fun quote(
+        @HeaderParam(CustomerIntakeResource.PARTY_HEADER) partyHeader: String?,
+        request: CustomerQuoteRequest,
+    ): Uni<Response> {
+        val refusal = refuse(partyHeader, request)
+        if (refusal != null) return Uni.createFrom().item(refusal)
+        val partyId = UUID.fromString(partyHeader)
+
+        return CoroutineScope(Dispatchers.Unconfined).async {
+            when (val decision = eligibility.evaluate(partyId, OfferSurface.PULL)) {
+                is CreditOfferDecision.Suppressed -> suppressed(decision)
+                is CreditOfferDecision.Allowed -> Response.ok(priceOf(request).toDto()).build()
+            }
+        }.asUni()
+    }
+
+    /** Price the request from CONFIGURED terms. Nothing about the price comes from the body. */
+    private fun priceOf(request: CustomerQuoteRequest): CreditQuote = CreditQuoteCalculator.quote(
+        request = CreditQuoteRequest(
+            principal = Money(request.amount, CurrencyCode.of(config.currency)),
+            termMonths = request.termMonths,
+            nominalAnnualRate = config.nominalAnnualRate.get(),
+        ),
+        now = Instant.now(clock),
+        validityDuration = QUOTE_VALIDITY,
+        firstDueDate = LocalDate.now(clock).withDayOfMonth(1).plusMonths(2),
+    )
+
+    /**
+     * A suppressed quote is a 409 with the reason code and NO price. Not a 200 with nulls: a body
+     * shaped like a quote, holding no numbers, is the kind of thing a client renders as "0".
+     */
+    private fun suppressed(decision: CreditOfferDecision.Suppressed): Response =
+        Response.status(HTTP_CONFLICT)
+            .entity(mapOf("error" to "quote unavailable", "reasonCode" to decision.code.name))
+            .build()
+
+    @Suppress("ReturnCount")
+    private fun refuse(partyHeader: String?, request: CustomerQuoteRequest): Response? {
+        if (!config.enabled) return error(HTTP_FORBIDDEN, "customer self-service intake is disabled")
+        val permitted = config.callerPrincipal.orElse("")
+        if (permitted.isBlank() || identity.principal?.name != permitted) {
+            return error(HTTP_FORBIDDEN, "caller is not the customer-edge intake principal")
+        }
+        val partyId = partyHeader?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+            ?: return error(HTTP_BAD_REQUEST, "${CustomerIntakeResource.PARTY_HEADER} is missing or not a UUID")
+        if (partyId == ZERO_UUID) return error(HTTP_BAD_REQUEST, "${CustomerIntakeResource.PARTY_HEADER} is the nil UUID")
+        if (config.nominalAnnualRate.isEmpty) {
+            return error(HTTP_FORBIDDEN, "self-service product has no configured price")
+        }
+        // The same bounds as intake: a quote for an amount that could never be applied for is a
+        // price the customer cannot act on, which is worse than a refusal.
+        if (request.amount < config.minAmount || request.amount > config.maxAmount) {
+            return error(HTTP_BAD_REQUEST, "amount outside [${config.minAmount}, ${config.maxAmount}]")
+        }
+        val currency = runCatching { CurrencyCode.of(config.currency) }.getOrNull()
+            ?: return error(HTTP_FORBIDDEN, "self-service product currency is not a valid ISO code")
+        if (request.amount.scale() > currency.defaultFractionDigits) {
+            return error(HTTP_BAD_REQUEST, "amount has more than ${currency.defaultFractionDigits} decimal places")
+        }
+        if (request.termMonths < config.minTermMonths || request.termMonths > config.maxTermMonths) {
+            return error(HTTP_BAD_REQUEST, "termMonths outside [${config.minTermMonths}, ${config.maxTermMonths}]")
+        }
+        return null
+    }
+
+    private fun error(status: Int, message: String): Response =
+        Response.status(status).entity(mapOf("error" to message)).build()
+
+    private fun CreditQuote.toDto() = CustomerQuoteDto(
+        amount = principal.amount.toPlainString(),
+        currency = principal.currency.code,
+        termMonths = termMonths,
+        nominalAnnualRatePercent = (nominalAnnualRate * BigDecimal(PERCENT)).toPlainString(),
+        monthlyPayment = monthlyPayment.amount.toPlainString(),
+        totalPayable = totalPayable.amount.toPlainString(),
+        totalCostOfCredit = totalCostOfCredit.amount.toPlainString(),
+        // Null stays null all the way to the client: an APRC that could not be computed must be
+        // rendered as absent, never as 0%, which reads as free credit.
+        aprcPercent = aprc?.let { (it * BigDecimal(PERCENT)).toPlainString() },
+        validUntil = validUntil.toString(),
+        binding = false,
+    )
+
+    companion object {
+        /** Long enough to think about, short enough that published terms cannot drift underneath it. */
+        private val QUOTE_VALIDITY: Duration = Duration.ofDays(14)
+        private val ZERO_UUID = UUID(0, 0)
+        private const val PERCENT = 100
+        private const val HTTP_BAD_REQUEST = 400
+        private const val HTTP_FORBIDDEN = 403
+        private const val HTTP_CONFLICT = 409
+    }
+}
+
+/** What the app may choose: an amount and a term. Never a rate — see [CustomerIntakeRequest]. */
+data class CustomerQuoteRequest(val amount: BigDecimal, val termMonths: Int)
+
+/**
+ * The wire shape. [binding] is always false and is present precisely so the client never has to
+ * infer it: a field that says "this is not a commitment" cannot be forgotten the way an unwritten
+ * assumption can.
+ */
+data class CustomerQuoteDto(
+    val amount: String,
+    val currency: String,
+    val termMonths: Int,
+    val nominalAnnualRatePercent: String,
+    val monthlyPayment: String,
+    val totalPayable: String,
+    val totalCostOfCredit: String,
+    val aprcPercent: String?,
+    val validUntil: String,
+    val binding: Boolean,
+)

--- a/openbank-lending-service/src/main/resources/application.yaml
+++ b/openbank-lending-service/src/main/resources/application.yaml
@@ -83,6 +83,13 @@ quarkus:
       url: ${CONSENT_SERVICE_URL:http://localhost:8107}
       connect-timeout: 2000
       read-timeout: 3000
+    # ADR-0269 #6215: the 360 credit profile behind the distress floor. Same short timeouts and the
+    # same reasoning — an unreadable profile makes the gate refuse, never approve, so a slow
+    # analytics-sink costs a suppressed offer.
+    analytics-sink:
+      url: ${ANALYTICS_SINK_URL:http://localhost:8110}
+      connect-timeout: 2000
+      read-timeout: 3000
   redis:
     hosts: redis://localhost:6379
   shutdown:

--- a/openbank-lending-service/src/main/resources/application.yaml
+++ b/openbank-lending-service/src/main/resources/application.yaml
@@ -76,6 +76,13 @@ quarkus:
       url: ${PRODUCT_CATALOG_URL:http://localhost:8104}
       connect-timeout: 2000
       read-timeout: 3000
+    # ADR-0269 rule 1: the CREDIT_OFFERS consent read behind the credit-offer gate. Short timeouts
+    # on purpose — the gate fails CLOSED, so a slow consent-service costs a suppressed offer, never
+    # an unconsented one, and a customer waiting on a screen is the worse failure to optimise for.
+    consent-service:
+      url: ${CONSENT_SERVICE_URL:http://localhost:8107}
+      connect-timeout: 2000
+      read-timeout: 3000
   redis:
     hosts: redis://localhost:6379
   shutdown:

--- a/openbank-lending-service/src/main/resources/openapi.yaml
+++ b/openbank-lending-service/src/main/resources/openapi.yaml
@@ -91,7 +91,7 @@ paths:
       summary: The caller's own credit applications as customer-readable journeys (customer-edge only)
       description: >-
         ADR-0269 rule 3. Scoped to the party in X-Customer-Party-Id; carries no rate, instalment or
-        APRC — that is ADR-0269 rule 4 and arrives separately. Only the configured customer-edge principal may
+        APRC — that is ADR-0269 rule 4, served by /quotes below. Only the configured customer-edge principal may
         call it.
       parameters:
         - name: X-Customer-Party-Id
@@ -125,6 +125,43 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
         '404': { description: No such application for this caller }
+
+  /api/v1/lending/intake/quotes:
+    post:
+      tags: [Lending]
+      operationId: quoteCustomerCredit
+      summary: Indicative, non-binding price for a requested amount and term (customer-edge only)
+      description: >-
+        ADR-0269 rule 4 — the only place an instalment or an APRC may come from. Nothing is
+        persisted: an indicative price with an id would be one lookup away from being treated as a
+        binding offer. Price, currency and bounds are lending-side configuration; the body carries
+        only the amount and term. Refused 409 with a reason code when the ADR-0269 rule-2 distress
+        floor suppresses pricing — never a 200 with empty numbers, which a client renders as zero.
+      parameters:
+        - name: X-Customer-Party-Id
+          in: header
+          required: true
+          description: The applicant's party id, set by customer-edge from the customer JWT.
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomerQuoteRequest'
+      responses:
+        '200':
+          description: The indicative quote (binding is always false)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomerQuote'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          description: Pricing suppressed by the distress floor; body carries the reason code
 
   /api/v1/lending/applications/{id}:
     get:
@@ -845,6 +882,43 @@ components:
         principal:
           type: array
           items: { $ref: '#/components/schemas/MoneyTotal' }
+    CustomerQuoteRequest:
+      type: object
+      required: [amount, termMonths]
+      description: >-
+        The same two fields the intake accepts, and for the same reason: a customer may choose how
+        much and how long, never at what price.
+      properties:
+        amount: { type: string, description: Decimal in the product's configured currency }
+        termMonths: { type: integer, minimum: 1 }
+
+    CustomerQuote:
+      type: object
+      required: [amount, currency, termMonths, nominalAnnualRatePercent, monthlyPayment,
+                 totalPayable, totalCostOfCredit, validUntil, binding]
+      description: >-
+        An indicative price. Structurally distinct from a binding offer: no id, no accept path.
+      properties:
+        amount: { type: string }
+        currency: { type: string, minLength: 3, maxLength: 3 }
+        termMonths: { type: integer }
+        nominalAnnualRatePercent: { type: string }
+        monthlyPayment: { type: string }
+        totalPayable: { type: string }
+        totalCostOfCredit: { type: string }
+        aprcPercent:
+          type: string
+          nullable: true
+          description: >-
+            RPSN/APRC. NULL means "could not be computed" and must be rendered as an absent figure —
+            never as 0%, which reads to a customer as free credit.
+        validUntil: { type: string, format: date-time }
+        binding:
+          type: boolean
+          description: >-
+            Always false. Present so a client never has to infer it; an unwritten assumption is the
+            kind that gets forgotten.
+
     CustomerIntakeRequest:
       type: object
       required: [amount, termMonths]

--- a/openbank-lending-service/src/main/resources/openapi.yaml
+++ b/openbank-lending-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Lending Service API
-  version: 1.15.0
+  version: 1.16.0
   description: >-
     Loan origination, servicing, collateral and IFRS 9 provisioning (ADR-0028). The loan book posts
     cash events to ledger-service and never owns balances. Credit decisions and collateral
@@ -125,6 +125,30 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
         '404': { description: No such application for this caller }
+
+  /api/v1/lending/intake/financial-health:
+    get:
+      tags: [Lending]
+      operationId: getCustomerFinancialHealth
+      summary: The caller's four-pillar financial health (customer-edge only, no score)
+      description: >-
+        ADR-0269 rule 5. Assembled here because the pillars need the credit profile, the loan book
+        and (later) balances, all of which this service already reaches. The judgement itself is a
+        pure function in libs; this route only fetches. Any pillar may answer UNKNOWN, and one
+        unavailable upstream greys out one pillar rather than the whole view.
+      parameters:
+        - name: X-Customer-Party-Id
+          in: header
+          required: true
+          description: The applicant's party id, set by customer-edge from the customer JWT.
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: The four pillars
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 
   /api/v1/lending/intake/quotes:
     post:

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityServiceTest.kt
@@ -9,6 +9,7 @@ import com.openbank.lending.application.port.out.CreditOffersConsentPort
 import com.openbank.lending.domain.model.BorrowerDistressSignals
 import com.openbank.lending.domain.model.CreditOfferDecision
 import com.openbank.lending.domain.model.CreditOfferSuppressionCode
+import com.openbank.lending.domain.model.OfferSurface
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -71,7 +72,7 @@ class CreditOfferEligibilityServiceTest {
 
     @Test
     fun `consent granted and no distress yields an allowed offer`() = runBlocking<Unit> {
-        val decision = service(consent = true).evaluate(partyId)
+        val decision = service(consent = true).evaluate(partyId, OfferSurface.PUSH)
         assertThat(decision).isInstanceOf(CreditOfferDecision.Allowed::class.java)
     }
 
@@ -79,37 +80,62 @@ class CreditOfferEligibilityServiceTest {
     fun `consent absent suppresses before any distress signal is read`() = runBlocking<Unit> {
         // signalsThrow proves the distress port is never consulted: if it were, this would surface
         // as SIGNALS_UNAVAILABLE instead of CONSENT_ABSENT.
-        val decision = service(consent = false, signalsThrow = true).evaluate(partyId)
+        val decision = service(consent = false, signalsThrow = true).evaluate(partyId, OfferSurface.PUSH)
         assertThat(codeOf(decision)).isEqualTo(CreditOfferSuppressionCode.CONSENT_ABSENT)
     }
 
     @Test
     fun `an unknown consent state refuses rather than assuming denial or grant`() = runBlocking<Unit> {
-        val decision = service(consent = null).evaluate(partyId)
+        val decision = service(consent = null).evaluate(partyId, OfferSurface.PUSH)
         assertThat(codeOf(decision)).isEqualTo(CreditOfferSuppressionCode.SIGNALS_UNAVAILABLE)
     }
 
     @Test
     fun `a thrown consent read fails closed`() = runBlocking<Unit> {
-        val decision = service(consent = true, consentThrows = true).evaluate(partyId)
+        val decision = service(consent = true, consentThrows = true).evaluate(partyId, OfferSurface.PUSH)
         assertThat(codeOf(decision)).isEqualTo(CreditOfferSuppressionCode.SIGNALS_UNAVAILABLE)
     }
 
     @Test
     fun `a thrown distress read fails closed even with consent granted`() = runBlocking<Unit> {
-        val decision = service(consent = true, signalsThrow = true).evaluate(partyId)
+        val decision = service(consent = true, signalsThrow = true).evaluate(partyId, OfferSurface.PUSH)
         assertThat(codeOf(decision)).isEqualTo(CreditOfferSuppressionCode.SIGNALS_UNAVAILABLE)
     }
 
     @Test
     fun `incomplete signals fail closed even when every flag reads healthy`() = runBlocking<Unit> {
-        val decision = service(consent = true, signals = healthy.copy(complete = false)).evaluate(partyId)
+        val decision = service(consent = true, signals = healthy.copy(complete = false)).evaluate(partyId, OfferSurface.PUSH)
         assertThat(codeOf(decision)).isEqualTo(CreditOfferSuppressionCode.SIGNALS_UNAVAILABLE)
     }
 
     @Test
     fun `distress suppresses a consenting customer`() = runBlocking<Unit> {
-        val decision = service(consent = true, signals = healthy.copy(hasArrears = true)).evaluate(partyId)
+        val decision = service(consent = true, signals = healthy.copy(hasArrears = true)).evaluate(partyId, OfferSurface.PUSH)
         assertThat(codeOf(decision)).isEqualTo(CreditOfferSuppressionCode.ARREARS)
     }
+
+    // ── PULL: the customer asked ──────────────────────────────────────────────
+
+    @Test
+    fun `a pull needs no consent — the bank is answering, not initiating`() = runBlocking<Unit> {
+        val decision = service(consent = false).evaluate(partyId, OfferSurface.PULL)
+        assertThat(decision).isInstanceOf(CreditOfferDecision.Allowed::class.java)
+    }
+
+    @Test
+    fun `a pull is still stopped by the distress floor`() = runBlocking<Unit> {
+        val decision = service(consent = false, signals = healthy.copy(hasArrears = true))
+            .evaluate(partyId, OfferSurface.PULL)
+        assertThat(codeOf(decision)).isEqualTo(CreditOfferSuppressionCode.ARREARS)
+    }
+
+    @Test
+    fun `a pull ignores contact frequency — a cap must not silence an answer that was asked for`() =
+        runBlocking<Unit> {
+            val recentlyContacted = healthy.copy(lastCreditContactAt = clock.instant().minusSeconds(3600))
+            val push = service(consent = true, signals = recentlyContacted).evaluate(partyId, OfferSurface.PUSH)
+            val pull = service(consent = true, signals = recentlyContacted).evaluate(partyId, OfferSurface.PULL)
+            assertThat(codeOf(push)).isEqualTo(CreditOfferSuppressionCode.FREQUENCY_CAP)
+            assertThat(pull).isInstanceOf(CreditOfferDecision.Allowed::class.java)
+        }
 }

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityServiceTest.kt
@@ -41,6 +41,7 @@ class CreditOfferEligibilityServiceTest {
         inHardshipArrangement = false,
         lastAffordabilityFailureAt = null,
         bufferDays = 90,
+        monthsObserved = 12,
         lastCreditContactAt = null,
         inputsChangedSinceLastContact = true,
         complete = true,

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityServiceTest.kt
@@ -104,13 +104,19 @@ class CreditOfferEligibilityServiceTest {
 
     @Test
     fun `incomplete signals fail closed even when every flag reads healthy`() = runBlocking<Unit> {
-        val decision = service(consent = true, signals = healthy.copy(complete = false)).evaluate(partyId, OfferSurface.PUSH)
+        val decision = service(
+            consent = true,
+            signals = healthy.copy(complete = false),
+        ).evaluate(partyId, OfferSurface.PUSH)
         assertThat(codeOf(decision)).isEqualTo(CreditOfferSuppressionCode.SIGNALS_UNAVAILABLE)
     }
 
     @Test
     fun `distress suppresses a consenting customer`() = runBlocking<Unit> {
-        val decision = service(consent = true, signals = healthy.copy(hasArrears = true)).evaluate(partyId, OfferSurface.PUSH)
+        val decision = service(
+            consent = true,
+            signals = healthy.copy(hasArrears = true),
+        ).evaluate(partyId, OfferSurface.PUSH)
         assertThat(codeOf(decision)).isEqualTo(CreditOfferSuppressionCode.ARREARS)
     }
 
@@ -130,12 +136,11 @@ class CreditOfferEligibilityServiceTest {
     }
 
     @Test
-    fun `a pull ignores contact frequency — a cap must not silence an answer that was asked for`() =
-        runBlocking<Unit> {
-            val recentlyContacted = healthy.copy(lastCreditContactAt = clock.instant().minusSeconds(3600))
-            val push = service(consent = true, signals = recentlyContacted).evaluate(partyId, OfferSurface.PUSH)
-            val pull = service(consent = true, signals = recentlyContacted).evaluate(partyId, OfferSurface.PULL)
-            assertThat(codeOf(push)).isEqualTo(CreditOfferSuppressionCode.FREQUENCY_CAP)
-            assertThat(pull).isInstanceOf(CreditOfferDecision.Allowed::class.java)
-        }
+    fun `a pull ignores contact frequency — a cap must not silence an answer that was asked for`() = runBlocking<Unit> {
+        val recentlyContacted = healthy.copy(lastCreditContactAt = clock.instant().minusSeconds(3600))
+        val push = service(consent = true, signals = recentlyContacted).evaluate(partyId, OfferSurface.PUSH)
+        val pull = service(consent = true, signals = recentlyContacted).evaluate(partyId, OfferSurface.PULL)
+        assertThat(codeOf(push)).isEqualTo(CreditOfferSuppressionCode.FREQUENCY_CAP)
+        assertThat(pull).isInstanceOf(CreditOfferDecision.Allowed::class.java)
+    }
 }

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/domain/CreditOfferEligibilityTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/domain/CreditOfferEligibilityTest.kt
@@ -9,6 +9,7 @@ import com.openbank.lending.domain.model.CreditOfferDecision
 import com.openbank.lending.domain.model.CreditOfferEligibility
 import com.openbank.lending.domain.model.CreditOfferPolicy
 import com.openbank.lending.domain.model.CreditOfferSuppressionCode
+import com.openbank.lending.domain.model.OfferSurface
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Instant
@@ -35,6 +36,7 @@ class CreditOfferEligibilityTest {
         inHardshipArrangement = false,
         lastAffordabilityFailureAt = null,
         bufferDays = 90,
+        monthsObserved = 12,
         lastCreditContactAt = null,
         inputsChangedSinceLastContact = true,
         complete = true,
@@ -42,6 +44,8 @@ class CreditOfferEligibilityTest {
 
     private fun decide(consent: Boolean = true, signals: BorrowerDistressSignals = healthy, at: Instant = now) =
         CreditOfferEligibility.evaluate(consent, signals, at)
+
+    private fun codeOf(decision: CreditOfferDecision) = (decision as? CreditOfferDecision.Suppressed)?.code
 
     private fun assertSuppressed(decision: CreditOfferDecision, code: CreditOfferSuppressionCode) {
         assertThat(decision).isInstanceOf(CreditOfferDecision.Suppressed::class.java)
@@ -162,8 +166,39 @@ class CreditOfferEligibilityTest {
                 minimumBufferDays = 1,
                 affordabilityCoolingDays = 1,
                 contactFrequencyDays = 1,
+                minimumMonthsObserved = 1,
             )
         val decision = CreditOfferEligibility.evaluate(true, healthy.copy(hasArrears = true), now, custom)
         assertThat(decision.policyVersion).isEqualTo(7)
+    }
+
+    // ── History depth (ADR-0269 #6215) ────────────────────────────────────────
+
+    @Test
+    fun `a push needs enough observed months to be evidence`() {
+        val thin = healthy.copy(monthsObserved = CreditOfferPolicy.V1.minimumMonthsObserved - 1)
+        assertSuppressed(decide(signals = thin), CreditOfferSuppressionCode.HISTORY_TOO_THIN)
+    }
+
+    @Test
+    fun `an unknown history depth is not treated as a long one`() {
+        assertSuppressed(
+            decide(signals = healthy.copy(monthsObserved = null)),
+            CreditOfferSuppressionCode.HISTORY_TOO_THIN,
+        )
+    }
+
+    @Test
+    fun `a thin history does not stop an answer the customer asked for`() {
+        val thin = healthy.copy(monthsObserved = 0)
+        val pull = CreditOfferEligibility.evaluate(true, thin, now, CreditOfferPolicy.V1, OfferSurface.PULL)
+        assertThat(pull).isInstanceOf(CreditOfferDecision.Allowed::class.java)
+    }
+
+    @Test
+    fun `HISTORY_TOO_THIN is distinct from SIGNALS_UNAVAILABLE — a new customer is not an outage`() {
+        val newCustomer = decide(signals = healthy.copy(monthsObserved = 0))
+        val brokenUpstream = decide(signals = healthy.copy(complete = false))
+        assertThat(codeOf(newCustomer)).isNotEqualTo(codeOf(brokenUpstream))
     }
 }

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerQuoteResourceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerQuoteResourceTest.kt
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.infrastructure.rest
+
+import com.openbank.lending.application.port.out.BorrowerDistressPort
+import com.openbank.lending.application.port.out.CreditOffersConsentPort
+import com.openbank.lending.application.usecase.CreditOfferEligibilityService
+import com.openbank.lending.domain.model.BorrowerDistressSignals
+import com.openbank.lending.infrastructure.intake.CustomerIntakeConfig
+import io.quarkus.security.identity.SecurityIdentity
+import io.quarkus.security.runtime.QuarkusSecurityIdentity
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.security.Principal
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.Optional
+import java.util.UUID
+
+/**
+ * ADR-0269 rule 4 at the transport seam.
+ *
+ * The pricing math is proved in `CreditQuoteCalculatorTest`; what is proved here is the part that
+ * math cannot see — that an unauthorised caller gets no price, that a customer in distress gets a
+ * reason code instead of a tailored instalment, and that a *consent-less* customer who ASKED still
+ * gets an answer, because pull-only means the bank does not initiate, not that it stonewalls.
+ */
+class CustomerQuoteResourceTest {
+
+    private val edge = "service-account-openbank-edge"
+    private val party = UUID.fromString("05a02ef1-381c-40e7-b73f-d6855eead42e")
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-08-21T10:00:00Z"), ZoneOffset.UTC)
+
+    private val healthy = BorrowerDistressSignals(
+        hasArrears = false,
+        hasNegativeBalance = false,
+        hasEnforcementOrder = false,
+        hasInsolvencyProceeding = false,
+        inHardshipArrangement = false,
+        lastAffordabilityFailureAt = null,
+        bufferDays = 90,
+        lastCreditContactAt = null,
+        inputsChangedSinceLastContact = true,
+        complete = true,
+    )
+
+    private fun config(
+        enabled: Boolean = true,
+        caller: String? = "service-account-openbank-edge",
+        rate: BigDecimal? = BigDecimal("0.079"),
+    ) = CustomerIntakeConfig(
+        enabled = enabled,
+        callerPrincipal = Optional.ofNullable(caller),
+        jurisdiction = "CZ",
+        productType = "CONSUMER_CREDIT",
+        currency = "CZK",
+        nominalAnnualRate = Optional.ofNullable(rate),
+        minAmount = BigDecimal("5000"),
+        maxAmount = BigDecimal("1000000"),
+        minTermMonths = 6,
+        maxTermMonths = 120,
+    )
+
+    private fun eligibility(consent: Boolean = false, signals: BorrowerDistressSignals = healthy) =
+        CreditOfferEligibilityService(
+            consent = object : CreditOffersConsentPort {
+                override suspend fun hasCreditOffersConsent(partyId: UUID) = consent
+            },
+            distress = object : BorrowerDistressPort {
+                override suspend fun signalsFor(partyId: UUID) = signals
+            },
+            clock = clock,
+        )
+
+    private fun resource(
+        config: CustomerIntakeConfig = config(),
+        principal: String = edge,
+        service: CreditOfferEligibilityService = eligibility(),
+    ) = CustomerQuoteResource(config, service, identity(principal), clock)
+
+    private fun identity(name: String): SecurityIdentity =
+        QuarkusSecurityIdentity.builder().setPrincipal(Principal { name }).build()
+
+    private fun ask(
+        resource: CustomerQuoteResource,
+        party: String? = this.party.toString(),
+        amount: String = "250000",
+        term: Int = 48,
+    ) = resource.quote(party, CustomerQuoteRequest(BigDecimal(amount), term)).await().indefinitely()
+
+    private fun quoteOf(response: jakarta.ws.rs.core.Response) = response.entity as CustomerQuoteDto
+
+    @Suppress("UNCHECKED_CAST")
+    private fun errorOf(response: jakarta.ws.rs.core.Response) = response.entity as Map<String, String>
+
+    // ── Pull without consent still gets an answer ─────────────────────────────
+
+    @Test
+    fun `a customer who asked is priced even with no credit_offers consent`() {
+        // The pull-only rule says the bank must not INITIATE. Refusing to answer a question the
+        // customer just asked would be the same dark pattern pointing the other way.
+        val response = ask(resource(service = eligibility(consent = false)))
+        assertThat(response.status).isEqualTo(200)
+        assertThat(quoteOf(response).monthlyPayment).isNotBlank()
+    }
+
+    // ── Distress refuses even a pull ──────────────────────────────────────────
+
+    @Test
+    fun `a customer in arrears gets a reason code, not a tailored instalment`() {
+        val response = ask(resource(service = eligibility(signals = healthy.copy(hasArrears = true))))
+        assertThat(response.status).isEqualTo(409)
+        assertThat(errorOf(response)["reasonCode"]).isEqualTo("ARREARS")
+    }
+
+    @Test
+    fun `a suppressed quote carries no price fields at all`() {
+        val response = ask(resource(service = eligibility(signals = healthy.copy(hasArrears = true))))
+        // A 200 with empty numbers is what a client renders as "0". The refusal must not be
+        // shaped like a quote.
+        assertThat(response.entity).isNotInstanceOf(CustomerQuoteDto::class.java)
+    }
+
+    @Test
+    fun `unreadable distress signals refuse the price rather than pricing optimistically`() {
+        val response = ask(resource(service = eligibility(signals = healthy.copy(complete = false))))
+        assertThat(response.status).isEqualTo(409)
+        assertThat(errorOf(response)["reasonCode"]).isEqualTo("SIGNALS_UNAVAILABLE")
+    }
+
+    @Test
+    fun `contact frequency does not silence a price the customer asked for`() {
+        val contactedYesterday = healthy.copy(lastCreditContactAt = clock.instant().minusSeconds(86_400))
+        val response = ask(resource(service = eligibility(signals = contactedYesterday)))
+        assertThat(response.status).isEqualTo(200)
+    }
+
+    // ── Caller boundary ───────────────────────────────────────────────────────
+
+    @Test
+    fun `an operator that is not the edge gets no price`() {
+        assertThat(ask(resource(principal = "service-account-someone-else")).status).isEqualTo(403)
+    }
+
+    @Test
+    fun `an unset caller-principal refuses everyone`() {
+        assertThat(ask(resource(config = config(caller = null))).status).isEqualTo(403)
+    }
+
+    @Test
+    fun `a missing party header is refused`() {
+        assertThat(ask(resource(), party = null).status).isEqualTo(400)
+    }
+
+    @Test
+    fun `an unconfigured price refuses rather than quoting zero interest`() {
+        assertThat(ask(resource(config = config(rate = null))).status).isEqualTo(403)
+    }
+
+    // ── Bounds ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `an amount outside the product bounds is refused, not quoted`() {
+        assertThat(ask(resource(), amount = "4999").status).isEqualTo(400)
+        assertThat(ask(resource(), amount = "1000001").status).isEqualTo(400)
+    }
+
+    @Test
+    fun `a term outside the product bounds is refused`() {
+        assertThat(ask(resource(), term = 5).status).isEqualTo(400)
+        assertThat(ask(resource(), term = 121).status).isEqualTo(400)
+    }
+
+    // ── The quote says what it is ─────────────────────────────────────────────
+
+    @Test
+    fun `every quote states that it is not binding and carries an expiry`() {
+        val dto = quoteOf(ask(resource()))
+        assertThat(dto.binding).isFalse()
+        assertThat(dto.validUntil).isNotBlank()
+        assertThat(dto.aprcPercent).isNotNull()
+    }
+}

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerQuoteResourceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerQuoteResourceTest.kt
@@ -43,6 +43,7 @@ class CustomerQuoteResourceTest {
         inHardshipArrangement = false,
         lastAffordabilityFailureAt = null,
         bufferDays = 90,
+        monthsObserved = 12,
         lastCreditContactAt = null,
         inputsChangedSinceLastContact = true,
         complete = true,

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/Aprc.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/Aprc.kt
@@ -83,8 +83,7 @@ object Aprc {
 
         // f(X) = PV(payments at X) − PV(advances at X). Strictly decreasing in X, so bisection is
         // safe: more discounting shrinks the (later) payments faster than the (earlier) advances.
-        fun f(rate: BigDecimal): BigDecimal =
-            presentValue(payments, rate).subtract(presentValue(advances, rate), MC)
+        fun f(rate: BigDecimal): BigDecimal = presentValue(payments, rate).subtract(presentValue(advances, rate), MC)
 
         val atZero = f(LOWER)
         // Total repayments no greater than the advance: no positive rate can balance the equation.

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/Aprc.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/Aprc.kt
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending
+
+import java.math.BigDecimal
+import java.math.MathContext
+import java.math.RoundingMode
+
+/**
+ * Annual percentage rate of charge — RPSN in Czech, APRC/APR elsewhere (Consumer Credit Directive
+ * 2023/2225 Annex III; the same equation as the earlier 2008/48/EC Annex I).
+ *
+ * The APRC is the rate X that equates, on an annual compounding basis, the present value of what the
+ * customer receives with the present value of everything they pay:
+ *
+ *     Σ  Dₖ / (1 + X)^tₖ   =   Σ  Pⱼ / (1 + X)^sⱼ
+ *
+ * where D are drawdowns, P are payments (instalments AND charges), and t/s are the intervals in
+ * YEARS from the first drawdown. There is no closed form; the directive itself expects a numerical
+ * solution, so this solves by bisection.
+ *
+ * ## Why this is its own file, and why nothing else may compute it
+ *
+ * The APRC is the number a customer compares lenders on and the one a regulator checks. Under
+ * ADR-0269 rule 4 it may only ever come from the server, and within the server it may only come
+ * from here: two implementations that disagree in the fourth decimal is a mis-disclosure, not a
+ * rounding difference.
+ *
+ * ## Why fees are an input, not an afterthought
+ *
+ * The whole point of the APRC is that it prices the total cost of credit, not the interest. A quote
+ * that reports the nominal rate as "the APRC" whenever there are no fees works by accident and
+ * lies the moment a fee is added, so charges enter the cashflow list explicitly.
+ */
+object Aprc {
+
+    private val MC = MathContext.DECIMAL128
+    private val ONE = BigDecimal.ONE
+
+    /** Bisection bounds: 0% to 10 000% a year. Above that the answer is "this is not a loan". */
+    private val LOWER = BigDecimal.ZERO
+    private val UPPER = BigDecimal("100")
+
+    /** Absolute tolerance on the discounted-balance equation, in currency units. */
+    private val TOLERANCE = BigDecimal("0.0000001")
+
+    private const val MAX_ITERATIONS = 200
+
+    /** Scale of the returned rate as a FRACTION (0.0891 = 8.91%): six places, i.e. four in percent. */
+    private const val RATE_SCALE = 6
+
+    /**
+     * One cash movement in the APRC equation.
+     *
+     * [yearsFromStart] is the interval from the first drawdown expressed in years — the directive's
+     * own unit — so a monthly instalment k falls at k/12. Fractions are deliberate: rounding periods
+     * to whole years would move the answer by more than the disclosure tolerance.
+     */
+    data class CashFlow(val yearsFromStart: BigDecimal, val amount: BigDecimal)
+
+    /**
+     * Solve for the APRC as a fraction, e.g. `0.089100` for 8.91%.
+     *
+     * [advances] are what the customer receives (drawdowns), [payments] everything they pay back,
+     * including charges. Both must be positive amounts; the sign convention lives here rather than
+     * in the caller, because a caller that passes a negative payment silently inverts the equation.
+     *
+     * Returns null when the equation has no solution in the searched range — a loan repaying less
+     * than it advanced, or figures so distorted that no positive rate balances them. Null is
+     * deliberate: an APRC that cannot be computed must not be rendered as 0%, which reads to a
+     * customer as free credit.
+     */
+    fun solve(advances: List<CashFlow>, payments: List<CashFlow>): BigDecimal? {
+        require(advances.isNotEmpty()) { "at least one advance is required" }
+        require(payments.isNotEmpty()) { "at least one payment is required" }
+        require(advances.all { it.amount > BigDecimal.ZERO }) { "advances must be positive" }
+        require(payments.all { it.amount > BigDecimal.ZERO }) { "payments must be positive" }
+        require((advances + payments).all { it.yearsFromStart >= BigDecimal.ZERO }) {
+            "cash flows must not precede the first drawdown"
+        }
+
+        // f(X) = PV(payments at X) − PV(advances at X). Strictly decreasing in X, so bisection is
+        // safe: more discounting shrinks the (later) payments faster than the (earlier) advances.
+        fun f(rate: BigDecimal): BigDecimal =
+            presentValue(payments, rate).subtract(presentValue(advances, rate), MC)
+
+        val atZero = f(LOWER)
+        // Total repayments no greater than the advance: no positive rate can balance the equation.
+        if (atZero <= BigDecimal.ZERO) return null
+        if (f(UPPER) > BigDecimal.ZERO) return null
+
+        var low = LOWER
+        var high = UPPER
+        repeat(MAX_ITERATIONS) {
+            val mid = low.add(high, MC).divide(BigDecimal(2), MC)
+            val value = f(mid)
+            if (value.abs() < TOLERANCE) return mid.setScale(RATE_SCALE, RoundingMode.HALF_UP)
+            if (value > BigDecimal.ZERO) low = mid else high = mid
+        }
+        return low.add(high, MC).divide(BigDecimal(2), MC).setScale(RATE_SCALE, RoundingMode.HALF_UP)
+    }
+
+    private fun presentValue(flows: List<CashFlow>, rate: BigDecimal): BigDecimal =
+        flows.fold(BigDecimal.ZERO) { acc, flow ->
+            acc.add(flow.amount.divide(discountFactor(rate, flow.yearsFromStart), MC), MC)
+        }
+
+    /**
+     * (1 + rate)^years for a fractional exponent, via `Math.pow` on doubles.
+     *
+     * Double precision is ~15 significant digits; the APRC is disclosed to one decimal place in
+     * percent, so the error here is some fourteen orders of magnitude below anything that could
+     * change a published figure. BigDecimal has no fractional power, and a hand-rolled series
+     * expansion would trade a provably irrelevant error for an unprovable one.
+     */
+    private fun discountFactor(rate: BigDecimal, years: BigDecimal): BigDecimal {
+        if (years.signum() == 0) return ONE
+        val factor = Math.pow(ONE.add(rate).toDouble(), years.toDouble())
+        return BigDecimal(factor, MC)
+    }
+}

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/CreditQuote.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/CreditQuote.kt
@@ -125,8 +125,7 @@ object CreditQuoteCalculator {
         )
     }
 
-    private fun zero(request: CreditQuoteRequest) =
-        Money.of(BigDecimal.ZERO, request.principal.currency.code)
+    private fun zero(request: CreditQuoteRequest) = Money.of(BigDecimal.ZERO, request.principal.currency.code)
 
     private const val MONTHS_PER_YEAR = 12
 }

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/CreditQuote.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/CreditQuote.kt
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending
+
+import com.openbank.libs.domain.money.Money
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+
+/**
+ * ADR-0269 rule 4 — price comes only from the server, and only as a quote.
+ *
+ * Two distinct things live here, and the distinction is the point:
+ *
+ *  - [CreditQuote] is INDICATIVE. It says what this shape of credit would cost on today's published
+ *    terms. It binds nobody, it is not a decision, and it carries no application.
+ *  - A binding offer is a separate object produced by the decision engine after an assessment. It
+ *    is not modelled here precisely so that a quote can never be mistaken for one: an offer has an
+ *    id, an expiry and an accept endpoint; a quote has none of those.
+ *
+ * Nothing else in the fleet may compute an instalment or an APRC. The client is forbidden by
+ * ADR-0269 rule 4; campaign templates and models are forbidden for the same reason. A second
+ * implementation disagreeing in the fourth decimal is a mis-disclosure, not a rounding difference.
+ */
+data class CreditQuoteRequest(
+    val principal: Money,
+    val termMonths: Int,
+    val nominalAnnualRate: BigDecimal,
+    val method: AmortizationMethod = AmortizationMethod.ANNUITY,
+    /** Charges paid at drawdown (arrangement fee). Reduces what the customer actually receives. */
+    val upfrontFee: Money? = null,
+    /** Charges paid with each instalment (account/administration fee). */
+    val monthlyFee: Money? = null,
+) {
+    init {
+        require(termMonths > 0) { "termMonths must be positive" }
+        require(principal.amount > BigDecimal.ZERO) { "principal must be positive" }
+        require(nominalAnnualRate >= BigDecimal.ZERO) { "nominalAnnualRate must not be negative" }
+        require(upfrontFee == null || upfrontFee.currency == principal.currency) {
+            "upfrontFee must be in the principal's currency"
+        }
+        require(monthlyFee == null || monthlyFee.currency == principal.currency) {
+            "monthlyFee must be in the principal's currency"
+        }
+        require(upfrontFee == null || upfrontFee.amount < principal.amount) {
+            "upfrontFee must be smaller than the principal"
+        }
+    }
+}
+
+/**
+ * The indicative price.
+ *
+ * [aprc] is nullable and null means "could not be computed", which callers must render as an
+ * absent figure and never as zero — a 0% APRC reads to a customer as free credit. It is null for a
+ * genuinely costless loan (no interest, no fees), which is also the honest rendering: there is no
+ * rate of charge to disclose.
+ */
+data class CreditQuote(
+    val principal: Money,
+    val termMonths: Int,
+    val nominalAnnualRate: BigDecimal,
+    val monthlyPayment: Money,
+    val totalPayable: Money,
+    val totalCostOfCredit: Money,
+    val aprc: BigDecimal?,
+    val validUntil: Instant,
+)
+
+object CreditQuoteCalculator {
+
+    /**
+     * Price [request] as of [now], valid for [validityDuration].
+     *
+     * The instalment comes from the shared [Amortization] schedule rather than a formula rewritten
+     * here, so a quote and the loan actually booked from it cannot disagree — that divergence is
+     * the classic "the app said 6,100 and the contract says 6,142" complaint.
+     *
+     * The APRC is solved over the SAME cash flows the customer will really see: the net advance
+     * (principal minus any upfront fee) against every instalment plus its monthly fee. Fees are
+     * not a decoration on the rate; they are the reason the APRC exists.
+     */
+    fun quote(
+        request: CreditQuoteRequest,
+        now: Instant,
+        validityDuration: java.time.Duration,
+        firstDueDate: LocalDate,
+    ): CreditQuote {
+        val schedule = Amortization.schedule(
+            principal = request.principal,
+            nominalAnnualRate = request.nominalAnnualRate,
+            termPeriods = request.termMonths,
+            periodsPerYear = MONTHS_PER_YEAR,
+            method = request.method,
+            firstDueDate = firstDueDate,
+        )
+        val monthlyFee = request.monthlyFee ?: Money.of(BigDecimal.ZERO, request.principal.currency.code)
+        val firstPayment = schedule.installments.first().payment + monthlyFee
+        val totalFees = Money(monthlyFee.amount.multiply(BigDecimal(request.termMonths)), monthlyFee.currency)
+        val totalPayable = schedule.totalPayment + totalFees + (request.upfrontFee ?: zero(request))
+        val netAdvance = request.principal - (request.upfrontFee ?: zero(request))
+
+        return CreditQuote(
+            principal = request.principal,
+            termMonths = request.termMonths,
+            nominalAnnualRate = request.nominalAnnualRate,
+            // The first instalment, not an average: an annuity's payments are equal, and for the
+            // other methods the first is the one the customer must be able to afford.
+            monthlyPayment = firstPayment,
+            totalPayable = totalPayable,
+            totalCostOfCredit = totalPayable - request.principal,
+            aprc = Aprc.solve(
+                advances = listOf(Aprc.CashFlow(BigDecimal.ZERO, netAdvance.amount)),
+                payments = schedule.installments.map {
+                    Aprc.CashFlow(
+                        yearsFromStart = BigDecimal(it.number)
+                            .divide(BigDecimal(MONTHS_PER_YEAR), java.math.MathContext.DECIMAL128),
+                        amount = (it.payment + monthlyFee).amount,
+                    )
+                },
+            ),
+            validUntil = now.plus(validityDuration),
+        )
+    }
+
+    private fun zero(request: CreditQuoteRequest) =
+        Money.of(BigDecimal.ZERO, request.principal.currency.code)
+
+    private const val MONTHS_PER_YEAR = 12
+}

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/FinancialHealth.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/FinancialHealth.kt
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending
+
+import java.math.BigDecimal
+import java.math.MathContext
+import java.math.RoundingMode
+
+/**
+ * The customer's own view of their finances (ADR-0269 / APP-ADR-0001 rule 5).
+ *
+ * ## What this is NOT
+ *
+ * It is not a score, not a rating, and not an input to a credit decision. There is no single
+ * number here on purpose: a grade invites the customer to optimise it and invites the bank to act
+ * on it, and neither is what this exists for. The credit decision is the deterministic engine's
+ * (ADR-0213), and keeping the two apart is what lets a threshold move without a customer's
+ * "score" moving underneath them.
+ *
+ * ## Why four pillars and not one
+ *
+ * Reserve, cashflow, obligations and habits fail independently. Someone with a strong income and
+ * no buffer is in a different situation from someone with a thin income and six months of cover,
+ * and a single number would rate them the same. Four answers also give the customer something to
+ * act on, which one number never does.
+ *
+ * ## Why every pillar can answer "unknown"
+ *
+ * A pillar with no data is [PillarZone.UNKNOWN], never a middling or a healthy value. The bank not
+ * having seen something is a fact about the bank, not about the customer, and rendering it as a
+ * verdict would tell someone their finances are fine — or shaky — on the strength of nothing.
+ */
+enum class PillarZone {
+    /** Comfortable. */
+    HEALTHY,
+
+    /** Works, with no margin. Worth saying out loud; not a warning. */
+    STRETCHED,
+
+    /** The pillar is where trouble starts. */
+    AT_RISK,
+
+    /** Not enough data. Never rendered as a verdict. */
+    UNKNOWN,
+}
+
+/**
+ * One pillar. [value] and [target] are for the customer to see the working; both are null when the
+ * zone is [PillarZone.UNKNOWN], so nothing invented can be displayed.
+ */
+data class HealthPillar(
+    val code: String,
+    val zone: PillarZone,
+    val value: BigDecimal? = null,
+    val target: BigDecimal? = null,
+)
+
+/** The whole view. Deliberately has no aggregate field — see the class docs. */
+data class FinancialHealthView(val pillars: List<HealthPillar>) {
+    init {
+        require(pillars.map { it.code }.toSet().size == pillars.size) { "duplicate pillar code" }
+    }
+
+    fun pillar(code: String): HealthPillar? = pillars.firstOrNull { it.code == code }
+}
+
+/**
+ * Inputs, each independently nullable.
+ *
+ * Nullability is the point: three of these come from different services, and a partial answer is
+ * the normal case rather than an error. One unavailable upstream must grey out ONE pillar, not the
+ * screen — a customer who opens this to check their reserve should not be told nothing is known
+ * because the loan book happened to be slow.
+ */
+data class FinancialHealthInputs(
+    val monthlyIncome: BigDecimal?,
+    val monthlyOutflow: BigDecimal?,
+    val monthlyNet: BigDecimal?,
+    val volatilityRatio: BigDecimal?,
+    val liquidBalance: BigDecimal?,
+    val monthlyDebtService: BigDecimal?,
+    val hasArrears: Boolean?,
+    val monthsObserved: Int?,
+)
+
+object FinancialHealth {
+
+    const val PILLAR_RESERVE = "RESERVE"
+    const val PILLAR_CASHFLOW = "CASHFLOW"
+    const val PILLAR_OBLIGATIONS = "OBLIGATIONS"
+    const val PILLAR_HABITS = "HABITS"
+
+    /** Three months of outgoings is the reserve target this view holds the customer's cover against. */
+    private val RESERVE_TARGET_MONTHS = BigDecimal("3")
+    private val RESERVE_STRETCHED_MONTHS = BigDecimal("1")
+
+    /** Above this share of income going to debt service, the pillar is at risk (the DSTI shape). */
+    private val DSTI_AT_RISK = BigDecimal("0.45")
+    private val DSTI_STRETCHED = BigDecimal("0.35")
+
+    /** A month-to-month swing beyond this share of income is what makes planning hard. */
+    private val VOLATILITY_AT_RISK = BigDecimal("0.60")
+    private val VOLATILITY_STRETCHED = BigDecimal("0.30")
+
+    /** Below this, a median is an anecdote rather than a pattern — the same floor the offer gate uses. */
+    private const val MIN_MONTHS = 3
+
+    private val MC = MathContext.DECIMAL64
+
+    /** A ratio disclosed to four places; money to the minor unit; cover to one decimal month. */
+    private const val DSTI_SCALE = 4
+    private const val MONEY_SCALE = 2
+    private const val MONTHS_SCALE = 1
+
+    fun assess(inputs: FinancialHealthInputs): FinancialHealthView = FinancialHealthView(
+        listOf(
+            reserve(inputs),
+            cashflow(inputs),
+            obligations(inputs),
+            habits(inputs),
+        ),
+    )
+
+    /** Months of outgoings the liquid balance covers. */
+    private fun reserve(i: FinancialHealthInputs): HealthPillar {
+        val balance = i.liquidBalance
+        val outflow = i.monthlyOutflow
+        if (balance == null || outflow == null || outflow <= BigDecimal.ZERO) {
+            return HealthPillar(PILLAR_RESERVE, PillarZone.UNKNOWN)
+        }
+        val months = balance.divide(outflow, MC)
+        val zone = when {
+            months >= RESERVE_TARGET_MONTHS -> PillarZone.HEALTHY
+            months >= RESERVE_STRETCHED_MONTHS -> PillarZone.STRETCHED
+            else -> PillarZone.AT_RISK
+        }
+        return HealthPillar(
+            PILLAR_RESERVE,
+            zone,
+            months.setScale(MONTHS_SCALE, RoundingMode.DOWN),
+            RESERVE_TARGET_MONTHS,
+        )
+    }
+
+    /**
+     * What is left each month, and how steady it is.
+     *
+     * A negative net is at risk regardless of volatility — a stable shortfall is still a shortfall,
+     * and calling it "steady" would be the most misleading reading available.
+     */
+    private fun cashflow(i: FinancialHealthInputs): HealthPillar {
+        val net = i.monthlyNet
+        val months = i.monthsObserved
+        if (net == null || months == null || months < MIN_MONTHS) {
+            return HealthPillar(PILLAR_CASHFLOW, PillarZone.UNKNOWN)
+        }
+        val volatility = i.volatilityRatio
+        val zone = when {
+            net <= BigDecimal.ZERO -> PillarZone.AT_RISK
+            volatility == null -> PillarZone.STRETCHED
+            volatility >= VOLATILITY_AT_RISK -> PillarZone.AT_RISK
+            volatility >= VOLATILITY_STRETCHED -> PillarZone.STRETCHED
+            else -> PillarZone.HEALTHY
+        }
+        return HealthPillar(PILLAR_CASHFLOW, zone, net.setScale(MONEY_SCALE, RoundingMode.HALF_UP), null)
+    }
+
+    /** Debt service as a share of income. */
+    private fun obligations(i: FinancialHealthInputs): HealthPillar {
+        val income = i.monthlyIncome
+        val debt = i.monthlyDebtService
+        if (income == null || income <= BigDecimal.ZERO || debt == null) {
+            return HealthPillar(PILLAR_OBLIGATIONS, PillarZone.UNKNOWN)
+        }
+        val dsti = debt.divide(income, MC)
+        val zone = when {
+            dsti >= DSTI_AT_RISK -> PillarZone.AT_RISK
+            dsti >= DSTI_STRETCHED -> PillarZone.STRETCHED
+            else -> PillarZone.HEALTHY
+        }
+        return HealthPillar(PILLAR_OBLIGATIONS, zone, dsti.setScale(DSTI_SCALE, RoundingMode.HALF_UP), DSTI_STRETCHED)
+    }
+
+    /**
+     * Whether repayments are being met.
+     *
+     * Only two honest answers exist from this input: in arrears, or not. There is deliberately no
+     * "excellent" tier — a customer who has simply paid their bills has done the expected thing,
+     * and grading them for it is the scoring behaviour this whole view refuses.
+     */
+    private fun habits(i: FinancialHealthInputs): HealthPillar {
+        val arrears = i.hasArrears ?: return HealthPillar(PILLAR_HABITS, PillarZone.UNKNOWN)
+        return HealthPillar(PILLAR_HABITS, if (arrears) PillarZone.AT_RISK else PillarZone.HEALTHY)
+    }
+}

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/AprcTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/AprcTest.kt
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+/**
+ * The APRC is the number a customer compares lenders on and a regulator checks, so these tests
+ * pin it against cases with an independently known answer rather than against this implementation's
+ * own output.
+ */
+class AprcTest {
+
+    private fun years(months: Int): BigDecimal =
+        BigDecimal(months).divide(BigDecimal(12), java.math.MathContext.DECIMAL128)
+
+    private fun advance(amount: String) = Aprc.CashFlow(BigDecimal.ZERO, BigDecimal(amount))
+
+    private fun monthlyPayments(amount: String, count: Int) =
+        (1..count).map { Aprc.CashFlow(years(it), BigDecimal(amount)) }
+
+    private fun percent(rate: BigDecimal?): BigDecimal? =
+        rate?.multiply(BigDecimal(100))?.setScale(2, RoundingMode.HALF_UP)
+
+    // ── Known answers ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `a single repayment of 110 on an advance of 100 after one year is 10 percent`() {
+        val aprc = Aprc.solve(listOf(advance("100")), listOf(Aprc.CashFlow(BigDecimal.ONE, BigDecimal("110"))))
+        assertThat(percent(aprc)).isEqualByComparingTo("10.00")
+    }
+
+    @Test
+    fun `doubling the money in one year is 100 percent`() {
+        val aprc = Aprc.solve(listOf(advance("1000")), listOf(Aprc.CashFlow(BigDecimal.ONE, BigDecimal("2000"))))
+        assertThat(percent(aprc)).isEqualByComparingTo("100.00")
+    }
+
+    @Test
+    fun `repaying exactly what was advanced, at the moment it was advanced, is zero cost and has no positive rate`() {
+        val aprc = Aprc.solve(listOf(advance("100")), listOf(Aprc.CashFlow(BigDecimal.ZERO, BigDecimal("100"))))
+        assertThat(aprc).isNull()
+    }
+
+    @Test
+    fun `an interest-free loan repaid later has no positive solution and must not be reported as zero`() {
+        // Repaying 100 a year after receiving 100: the equation balances only at X = 0, which the
+        // solver reports as "no solution" rather than inventing a rate. Null must reach the caller —
+        // rendering it as 0% would read to a customer as free credit that has actually been priced.
+        val aprc = Aprc.solve(listOf(advance("100")), listOf(Aprc.CashFlow(BigDecimal.ONE, BigDecimal("100"))))
+        assertThat(aprc).isNull()
+    }
+
+    // ── The property that matters: charges raise the APRC above the nominal rate ─
+
+    @Test
+    fun `an arrangement fee pushes the APRC above the nominal rate`() {
+        // 12 monthly payments of 8,884.88 on 100,000 is ~6.5% nominal. Adding a 2,000 fee at
+        // drawdown means the customer receives 98,000 for the same repayments, so the true cost
+        // rises — this is the entire reason the APRC exists and the case a nominal-rate shortcut
+        // gets wrong.
+        val withoutFee = Aprc.solve(listOf(advance("100000")), monthlyPayments("8884.88", 12))
+        val withFee = Aprc.solve(listOf(advance("98000")), monthlyPayments("8884.88", 12))
+        assertThat(withFee).isGreaterThan(withoutFee)
+    }
+
+    @Test
+    fun `a longer term at the same instalment costs less per year`() {
+        val short = Aprc.solve(listOf(advance("100000")), monthlyPayments("8884.88", 12))
+        val long = Aprc.solve(listOf(advance("100000")), monthlyPayments("8884.88", 18))
+        assertThat(long).isGreaterThan(short)
+    }
+
+    // ── Refusals ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `paying back less than was advanced has no positive solution`() {
+        val aprc = Aprc.solve(listOf(advance("100")), listOf(Aprc.CashFlow(BigDecimal.ONE, BigDecimal("50"))))
+        assertThat(aprc).isNull()
+    }
+
+    @Test
+    fun `a negative payment is refused rather than silently inverting the equation`() {
+        assertThatThrownBy {
+            Aprc.solve(listOf(advance("100")), listOf(Aprc.CashFlow(BigDecimal.ONE, BigDecimal("-110"))))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `a cash flow before the first drawdown is refused`() {
+        assertThatThrownBy {
+            Aprc.solve(listOf(advance("100")), listOf(Aprc.CashFlow(BigDecimal("-1"), BigDecimal("110"))))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `no payments at all is refused, not answered with zero`() {
+        assertThatThrownBy { Aprc.solve(listOf(advance("100")), emptyList()) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    // ── Determinism ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `the same inputs always produce the same rate to the disclosed precision`() {
+        val first = Aprc.solve(listOf(advance("250000")), monthlyPayments("6100.55", 48))
+        val second = Aprc.solve(listOf(advance("250000")), monthlyPayments("6100.55", 48))
+        assertThat(first).isEqualByComparingTo(second)
+        assertThat(first!!.scale()).isEqualTo(6)
+    }
+}

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/CreditQuoteCalculatorTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/CreditQuoteCalculatorTest.kt
@@ -36,8 +36,7 @@ class CreditQuoteCalculatorTest {
         monthlyFee = monthly?.let { czk(it) },
     )
 
-    private fun quote(r: CreditQuoteRequest = request()) =
-        CreditQuoteCalculator.quote(r, now, validity, firstDue)
+    private fun quote(r: CreditQuoteRequest = request()) = CreditQuoteCalculator.quote(r, now, validity, firstDue)
 
     // ── Consistency with the loan that would actually be booked ───────────────
 

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/CreditQuoteCalculatorTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/CreditQuoteCalculatorTest.kt
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending
+
+import com.openbank.libs.domain.money.Money
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+
+/** ADR-0269 rule 4: the only place an instalment or an APRC may come from. */
+class CreditQuoteCalculatorTest {
+
+    private val now: Instant = Instant.parse("2026-08-21T10:00:00Z")
+    private val firstDue: LocalDate = LocalDate.parse("2026-10-01")
+    private val validity: Duration = Duration.ofDays(14)
+
+    private fun czk(amount: String) = Money.of(BigDecimal(amount), "CZK")
+
+    private fun request(
+        principal: String = "250000",
+        term: Int = 48,
+        rate: String = "0.079",
+        upfront: String? = null,
+        monthly: String? = null,
+    ) = CreditQuoteRequest(
+        principal = czk(principal),
+        termMonths = term,
+        nominalAnnualRate = BigDecimal(rate),
+        upfrontFee = upfront?.let { czk(it) },
+        monthlyFee = monthly?.let { czk(it) },
+    )
+
+    private fun quote(r: CreditQuoteRequest = request()) =
+        CreditQuoteCalculator.quote(r, now, validity, firstDue)
+
+    // ── Consistency with the loan that would actually be booked ───────────────
+
+    @Test
+    fun `the instalment is the schedule's own instalment, not a second formula`() {
+        val r = request()
+        val schedule = Amortization.schedule(
+            principal = r.principal,
+            nominalAnnualRate = r.nominalAnnualRate,
+            termPeriods = r.termMonths,
+            firstDueDate = firstDue,
+        )
+        assertThat(quote(r).monthlyPayment).isEqualTo(schedule.installments.first().payment)
+    }
+
+    @Test
+    fun `total payable equals principal plus the total cost of credit`() {
+        val q = quote()
+        assertThat(q.totalPayable).isEqualTo(q.principal + q.totalCostOfCredit)
+    }
+
+    // ── Fees are priced, not decorated ────────────────────────────────────────
+
+    @Test
+    fun `an upfront fee raises the APRC above the nominal rate`() {
+        val withFee = quote(request(upfront = "5000")).aprc
+        val withoutFee = quote(request()).aprc
+        assertThat(withFee).isGreaterThan(withoutFee)
+        assertThat(withFee).isGreaterThan(BigDecimal("0.079"))
+    }
+
+    @Test
+    fun `a monthly fee raises both the instalment and the APRC`() {
+        val plain = quote(request())
+        val withFee = quote(request(monthly = "49"))
+        assertThat(withFee.monthlyPayment.amount).isGreaterThan(plain.monthlyPayment.amount)
+        assertThat(withFee.aprc).isGreaterThan(plain.aprc)
+    }
+
+    @Test
+    fun `a monthly fee is counted for every month of the term in the total`() {
+        val plain = quote(request())
+        val withFee = quote(request(monthly = "100"))
+        val difference = withFee.totalPayable - plain.totalPayable
+        // Compared on amount, not on Money identity: Money keeps the currency's minor-unit scale,
+        // so the equal value 4800 and 4800.00 are different objects and the same money.
+        assertThat(difference.amount).isEqualByComparingTo("4800") // 100 × 48
+    }
+
+    @Test
+    fun `an upfront fee is part of the total cost even though it is never instalment money`() {
+        val plain = quote(request())
+        val withFee = quote(request(upfront = "3000"))
+        assertThat((withFee.totalCostOfCredit - plain.totalCostOfCredit).amount).isEqualByComparingTo("3000")
+    }
+
+    // ── The APRC is never faked ───────────────────────────────────────────────
+
+    @Test
+    fun `an interest-free, fee-free loan reports no APRC rather than zero`() {
+        // Zero really is "nothing to disclose" here, and null is how the caller is forced to render
+        // an absent figure. A 0.00% badge would read as an advertised rate the bank did not price.
+        assertThat(quote(request(rate = "0")).aprc).isNull()
+    }
+
+    @Test
+    fun `an interest-free loan WITH a fee still has a real APRC`() {
+        val q = quote(request(rate = "0", upfront = "5000"))
+        assertThat(q.aprc).isNotNull()
+        assertThat(q.aprc).isGreaterThan(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `the APRC exceeds the nominal rate whenever any charge exists`() {
+        val q = quote(request(rate = "0.079", upfront = "2000", monthly = "29"))
+        assertThat(q.aprc).isGreaterThan(q.nominalAnnualRate)
+    }
+
+    // ── A quote is not an offer ───────────────────────────────────────────────
+
+    @Test
+    fun `a quote carries a validity and, structurally, nothing an offer would have`() {
+        val q = quote()
+        assertThat(q.validUntil).isEqualTo(now.plus(validity))
+        // A binding offer has an id and an accept path; a quote must have neither, so that no
+        // caller can treat an indicative price as something the bank committed to.
+        val fields = CreditQuote::class.java.declaredFields.map { it.name.lowercase() }
+        assertThat(fields).noneMatch { it.contains("offer") || it.contains("accept") }
+    }
+
+    // ── Refusals ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a fee larger than the principal is refused — the customer would receive nothing`() {
+        assertThatThrownBy { request(principal = "10000", upfront = "10000") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `a fee in another currency is refused rather than added blindly`() {
+        assertThatThrownBy {
+            CreditQuoteRequest(
+                principal = czk("100000"),
+                termMonths = 12,
+                nominalAnnualRate = BigDecimal("0.05"),
+                upfrontFee = Money.of(BigDecimal("100"), "EUR"),
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `a zero or negative term is refused`() {
+        assertThatThrownBy { request(term = 0) }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+}

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/FinancialHealthTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/FinancialHealthTest.kt
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+/**
+ * ADR-0269 / APP-ADR-0001 rule 5.
+ *
+ * Most of these tests are about what the view refuses to say: no aggregate score, no verdict
+ * without data, no flattering default. The pleasant readings are the easy half.
+ */
+class FinancialHealthTest {
+
+    private fun inputs(
+        income: String? = "50000",
+        outflow: String? = "40000",
+        net: String? = "10000",
+        volatility: String? = "0.10",
+        balance: String? = "150000",
+        debt: String? = "5000",
+        arrears: Boolean? = false,
+        months: Int? = 12,
+    ) = FinancialHealthInputs(
+        monthlyIncome = income?.let { BigDecimal(it) },
+        monthlyOutflow = outflow?.let { BigDecimal(it) },
+        monthlyNet = net?.let { BigDecimal(it) },
+        volatilityRatio = volatility?.let { BigDecimal(it) },
+        liquidBalance = balance?.let { BigDecimal(it) },
+        monthlyDebtService = debt?.let { BigDecimal(it) },
+        hasArrears = arrears,
+        monthsObserved = months,
+    )
+
+    private fun zoneOf(i: FinancialHealthInputs, code: String) = FinancialHealth.assess(i).pillar(code)!!.zone
+
+    // ── It is not a score ─────────────────────────────────────────────────────
+
+    @Test
+    fun `the view has no aggregate — there is no single number to optimise or to act on`() {
+        val fields = FinancialHealthView::class.java.declaredFields.map { it.name.lowercase() }
+        assertThat(fields).noneMatch { it.contains("score") || it.contains("rating") || it.contains("grade") }
+    }
+
+    @Test
+    fun `paying your bills is HEALTHY and nothing better — doing the expected thing is not a grade`() {
+        assertThat(zoneOf(inputs(arrears = false), FinancialHealth.PILLAR_HABITS)).isEqualTo(PillarZone.HEALTHY)
+        assertThat(PillarZone.entries.filter { it != PillarZone.UNKNOWN }).hasSize(3)
+    }
+
+    // ── Unknown is never a verdict ────────────────────────────────────────────
+
+    @Test
+    fun `a missing input greys out ONE pillar, not the screen`() {
+        val view = FinancialHealth.assess(inputs(debt = null))
+        assertThat(view.pillar(FinancialHealth.PILLAR_OBLIGATIONS)!!.zone).isEqualTo(PillarZone.UNKNOWN)
+        // The customer opened this to look at their reserve; a slow loan book must not blank that.
+        assertThat(view.pillar(FinancialHealth.PILLAR_RESERVE)!!.zone).isNotEqualTo(PillarZone.UNKNOWN)
+    }
+
+    @Test
+    fun `an unknown pillar carries no numbers to be mistaken for a measurement`() {
+        val pillar = FinancialHealth.assess(inputs(arrears = null)).pillar(FinancialHealth.PILLAR_HABITS)!!
+        assertThat(pillar.zone).isEqualTo(PillarZone.UNKNOWN)
+        assertThat(pillar.value).isNull()
+        assertThat(pillar.target).isNull()
+    }
+
+    @Test
+    fun `too few observed months makes cashflow unknown rather than confident`() {
+        assertThat(zoneOf(inputs(months = 2), FinancialHealth.PILLAR_CASHFLOW)).isEqualTo(PillarZone.UNKNOWN)
+    }
+
+    @Test
+    fun `an unknown volatility is stretched, not healthy — steadiness is not assumed`() {
+        assertThat(zoneOf(inputs(volatility = null), FinancialHealth.PILLAR_CASHFLOW))
+            .isEqualTo(PillarZone.STRETCHED)
+    }
+
+    // ── Reserve ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `three months of outgoings is the reserve target`() {
+        assertThat(zoneOf(inputs(balance = "120000", outflow = "40000"), FinancialHealth.PILLAR_RESERVE))
+            .isEqualTo(PillarZone.HEALTHY)
+        assertThat(zoneOf(inputs(balance = "119999", outflow = "40000"), FinancialHealth.PILLAR_RESERVE))
+            .isEqualTo(PillarZone.STRETCHED)
+        assertThat(zoneOf(inputs(balance = "20000", outflow = "40000"), FinancialHealth.PILLAR_RESERVE))
+            .isEqualTo(PillarZone.AT_RISK)
+    }
+
+    @Test
+    fun `the reserve shows its working in months, rounded DOWN`() {
+        val pillar = FinancialHealth.assess(inputs(balance = "119999", outflow = "40000"))
+            .pillar(FinancialHealth.PILLAR_RESERVE)!!
+        // Down, not nearest: telling someone they have 3 months of cover when they have 2.99 is the
+        // rounding that matters here.
+        assertThat(pillar.value).isEqualByComparingTo("2.9")
+    }
+
+    // ── Cashflow ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a stable shortfall is still a shortfall`() {
+        // Negative net with the calmest possible volatility. Reading that as "steady" would be the
+        // most misleading answer available.
+        assertThat(zoneOf(inputs(net = "-2000", volatility = "0.01"), FinancialHealth.PILLAR_CASHFLOW))
+            .isEqualTo(PillarZone.AT_RISK)
+    }
+
+    @Test
+    fun `a swinging income is at risk even when it averages out`() {
+        assertThat(zoneOf(inputs(net = "10000", volatility = "0.80"), FinancialHealth.PILLAR_CASHFLOW))
+            .isEqualTo(PillarZone.AT_RISK)
+    }
+
+    // ── Obligations ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `debt service is judged as a share of income, not as an amount`() {
+        assertThat(zoneOf(inputs(income = "50000", debt = "5000"), FinancialHealth.PILLAR_OBLIGATIONS))
+            .isEqualTo(PillarZone.HEALTHY)
+        // The same 25,000 is comfortable on 100,000 and at risk on 50,000.
+        assertThat(zoneOf(inputs(income = "50000", debt = "25000"), FinancialHealth.PILLAR_OBLIGATIONS))
+            .isEqualTo(PillarZone.AT_RISK)
+        assertThat(zoneOf(inputs(income = "100000", debt = "25000"), FinancialHealth.PILLAR_OBLIGATIONS))
+            .isEqualTo(PillarZone.HEALTHY)
+    }
+
+    @Test
+    fun `a zero income makes obligations unknown rather than infinitely bad`() {
+        assertThat(zoneOf(inputs(income = "0"), FinancialHealth.PILLAR_OBLIGATIONS)).isEqualTo(PillarZone.UNKNOWN)
+    }
+
+    // ── Shape ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `every assessment returns all four pillars, in a stable order`() {
+        val codes = FinancialHealth.assess(inputs()).pillars.map { it.code }
+        assertThat(codes).containsExactly(
+            FinancialHealth.PILLAR_RESERVE,
+            FinancialHealth.PILLAR_CASHFLOW,
+            FinancialHealth.PILLAR_OBLIGATIONS,
+            FinancialHealth.PILLAR_HABITS,
+        )
+    }
+
+    @Test
+    fun `an assessment with nothing known is four unknowns, not an empty screen`() {
+        val view = FinancialHealth.assess(
+            FinancialHealthInputs(null, null, null, null, null, null, null, null),
+        )
+        assertThat(view.pillars).hasSize(4)
+        assertThat(view.pillars.map { it.zone }).containsOnly(PillarZone.UNKNOWN)
+    }
+}


### PR DESCRIPTION
Closes #6214, #6215, #6216, #6212. Completes the ADR-0269 platform (epic #6217) — slice 1 is already on main via #6230.

> **Note for the reviewer on scope.** This PR started as slice 2 and grew: slices 3-7 were merged into its branch rather than into main as the stack collapsed, so it now carries the whole remaining platform. 53 files. The commits are the natural reading order — each is one slice and stands alone.

## What ships

| Area | What |
|---|---|
| `Aprc` (libs-domain) | CCD2 Annex III solver — the **only** implementation permitted to compute an APRC |
| `CreditQuoteCalculator` | Instalment from the shared `Amortization` schedule the loan is actually booked against |
| `OfferSurface` | PUSH needs consent, PULL does not — the pull-only rule, as a type |
| `CustomerCreditProfile` (V9) | Two ClickHouse views over the ADR-0210 silver layer |
| `CreditAiLevel` L0/L1/L2 | Explainer / advisor / agent, each its own consent |
| `PUT /customer/v1/credit/consents` | The route by which a customer can actually switch offers ON |
| `FinancialHealth` | Four pillars, no score |
| `CreditFunnelPublisher` | Authenticated funnel telemetry with no word for conversion |

## The decisions worth your attention

**Everything unknown suppresses.** An unreadable consent, a thrown upstream call, incomplete signals and an unknown buffer all refuse. A marketing gate that degrades open under failure stops existing exactly when its upstream is unhealthy: blast radius of failing closed is a missed offer, of failing open an offer to someone in arrears.

**PUSH vs PULL is deliberate asymmetry.** The bank must not *initiate* without consent; refusing to answer a price question the customer just asked would be the same dark pattern pointing the other way. The distress floor applies to both, because there the answer itself is the harm.

**No aggregate score anywhere**, and no vocabulary for conversion in the funnel. Both are asserted by tests, not left to review: a single grade invites optimisation, and a funnel that can say "converted" is one somebody eventually optimises.

**An empty loan book gives debt service zero; an unreadable one gives null.** Only one of those means "no debts". Same distinction between `HISTORY_TOO_THIN` (a new customer) and `SIGNALS_UNAVAILABLE` (an outage) — collapsing them buries a real fault in normal traffic.

**Reserve is UNKNOWN, never inferred from unspent cashflow.** A buffer someone does not have, derived from money they merely did not spend, is the most dangerous number that screen could show.

## Known gap, stated rather than modelled away

Enforcement orders and insolvency proceedings have **no source** in this deployment — no service ingests a court register. They are reported as absent rather than unknown, because permanent `complete = false` would suppress every offer forever and be indistinguishable from the feature being switched off. Recorded in `LoanBookDistressAdapter`'s KDoc and threat-model section 9b; the first thing an operational-risk review should challenge.

## What the enforced gates caught (all fixed here)

- **kafka-topics-exist / kafka-acl-coverage** — the new topic was referenced in code and declared nowhere, with no Write ACL for the edge or Read for analytics-sink. The publisher is best-effort by design, so this would have failed *silently, forever* — the #1717 shape.
- **event-contract-coverage (ADR-0006)** — creating the edge's first AsyncAPI contract made its three grandfathered baseline entries stale, so the audit, onboarding-funnel and feedback streams are documented too and the baseline lines are gone. The ratchet only shrinks.
- **event-contract-code-agreement** — the 17 audit event types were undocumented, and the three telemetry publishers named their event type through a constant the gate cannot evaluate. Each now binds a local `val eventType = "<literal>"`.
- **event-consumer-liveness (ADR-0160)** — analytics-sink now subscribes, which is the real fix rather than an allowlist entry excusing a published-but-unconsumed topic.
- **threat-model-diff (ADR-0030 D2)** — sections 9a, 9b and 9c cover the new inbound surfaces and outbound client edges.

## Verification

98 checks pass, 0 fail. lending-service 306 tests, customer-edge 398, copilot 192, libs-domain 489 — all 0 failures, 0 skipped, counts read from result XML rather than the build's exit code.

Falsified rather than asserted where it matters: removing the consent and fail-closed guards turns 7 tests red; the affordability surplus rule was rewritten after a test proved the original could never fire (inside the DSTI limit it was dead code dressed as a safeguard).

## Client side

Already on main in openbank-app: #536, #543, #538, #539, #540, #541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
