### PR TITLE
fix(observability): measure Falco liveness by readiness, not by log volume

### DIFF
--- a/openbank-infra/gitops/components/observability/loki-rules-falco-runtime.yaml
+++ b/openbank-infra/gitops/components/observability/loki-rules-falco-runtime.yaml
@@ -141,39 +141,19 @@ data:
                 (gitops/apps/falco.yaml sets 500m) under an event storm, or a busy node. Check
                 whether it correlates with a workload burst before raising the limit.
 
-          # DEAD-MAN'S SWITCH — the alert for "Falco stopped talking at all", which is the
-          # failure the two alerts above are structurally unable to report.
+          # FalcoAgentSilent USED TO LIVE HERE, and was removed on 2026-08-21 rather than
+          # retuned. It fired on `absent_over_time({namespace="falco"}[30m])`, resting on a
+          # premise its own comment spelled out: "Falco emits continuously ... so an empty 30m
+          # window means the agent, Alloy, or Loki ingestion is broken". #6075 and #6198
+          # deliberately tuned Falco from ~33,000 events/day to ZERO, which made silence the
+          # healthy resting state and the alert a guaranteed false positive — measured minutes
+          # after the ruler first evaluated it: 13/13 pods Ready, no log line in 60m, alert
+          # `pending`. There is no event rate that separates well-tuned Falco from dead Falco,
+          # so the fix is a different observable, not a threshold: agent liveness now comes from
+          # the DaemonSet's own readiness in prometheus-rules-runtime-security.yaml.
           #
-          # This is written as absent_over_time and NOT as `count_over_time(...) == 0`, and
-          # the difference is the whole rule. An `== 0` comparison needs a SERIES to compare;
-          # when the stream is absent the selector matches nothing, the aggregation produces
-          # no series, and the comparison matches nothing — silent in exactly the case it
-          # exists for. This repo has already measured that trap on
-          # kube_endpointslice_endpoints (loki-rules-endpoint-availability.yaml: the obvious
-          # `sum by (...) == 0` returned zero results live, during the outage it described).
-          # absent_over_time returns 1 precisely WHEN there is nothing, which is the inversion
-          # that makes it work.
-          #
-          # t=0 behaviour, re-derived rather than assumed: the query reads Loki's stored data,
-          # not ruler memory, so a ruler or Falco pod RESTART does not fire it — the previous
-          # 30m of logs are still in Loki. Falco emits continuously (the untuned NOTICE rules
-          # alone are thousands a day, and `Run shell untrusted` is deliberately left noisy),
-          # so an empty 30m window means the agent, Alloy, or Loki ingestion is broken. A
-          # genuinely fresh Loki with no data at all WOULD fire, correctly. `for: 15m` damps
-          # a brief ingestion hiccup.
-          - alert: FalcoAgentSilent
-            expr: |
-              absent_over_time({namespace="falco"} [30m])
-            for: 15m
-            labels:
-              severity: warning
-              team: platform
-            annotations:
-              summary: "Falco has logged nothing for 30m — the runtime-security control is dark"
-              description: >-
-                No log line at all from namespace `falco` in 30 minutes. Falco is a DaemonSet that
-                normally emits continuously, so this means the agent, the Alloy tail, or Loki
-                ingestion has stopped — and while it is true, every Falco alert here is silent and
-                the estate has no runtime detection. Not the same failure as
-                FalcoSyscallEventDrops, which is a partial gap the agent itself reports. Check:
-                kubectl -n falco get ds,pods — then the Alloy DaemonSet and Loki ingester.
+          # What this loses, stated plainly rather than quietly: that rule also happened to
+          # cover "the Alloy tail or Loki ingestion has stopped". Nothing covers that now.
+          # Loki's own `loki_distributor_*` metrics would be the right observable and are not
+          # scraped (`monitoring.selfMonitoring.enabled: false`), so a replacement needs that
+          # turned on first — tracked separately, NOT silently inherited by the rules below.

--- a/openbank-infra/gitops/components/observability/prometheus-rules-runtime-security.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-runtime-security.yaml
@@ -1,0 +1,87 @@
+# Falco agent liveness (ADR-0030 / issue #5734 follow-up).
+#
+# WHY THIS EXISTS, AND WHY IT REPLACED A LOKI RULE: liveness for the runtime-security
+# agent used to be `FalcoAgentSilent` in loki-rules-falco-runtime.yaml —
+# `absent_over_time({namespace="falco"}[30m])`. Its own comment stated the premise it
+# rested on: "Falco emits continuously (the untuned NOTICE rules alone are thousands a
+# day, and `Run shell untrusted` is deliberately left noisy), so an empty 30m window
+# means the agent, Alloy, or Loki ingestion is broken."
+#
+# That premise was true when written and was then destroyed BY US. #6075 and #6198 tuned
+# the Falco ruleset from ~33,000 events/day to zero — deliberately, because the noise was
+# what made the control unreadable. Measured 2026-08-21, minutes after the Loki ruler
+# started evaluating rules for the first time: 13/13 Falco pods Ready, zero log lines in
+# 60 minutes, and `FalcoAgentSilent` sitting in `pending` on its way to firing. The alert
+# that exists to reveal a dead agent had become an alert that fires on the healthy resting
+# state — and noise on that control is the one thing that hides a genuinely dead agent.
+#
+# This is the same shape as the WorkflowLivenessStale/Instant.EPOCH lesson in the root
+# CLAUDE.md, one layer up: an alert whose discriminator was a MAGNITUDE stops being able
+# to discriminate the moment that magnitude legitimately changes. The fix is a different
+# observable, not a retuned threshold — there is no event rate that separates
+# "well-tuned Falco" from "dead Falco", because both are zero.
+#
+# The observable used here is the DaemonSet's own readiness from kube-state-metrics, which
+# is emitted whether or not Falco ever detects anything. Verified live 2026-08-21:
+#   kube_daemonset_status_desired_number_scheduled{daemonset="falco"} = 13
+#   kube_daemonset_status_number_ready{daemonset="falco"}             = 13
+#   kube_daemonset_status_number_unavailable{daemonset="falco"}       = 0
+#
+# Falco's own `falco_*` metrics are NOT an option today: `metrics.enabled: false` in
+# apps/falco.yaml and there is no Service in the falco namespace, so Prometheus has zero
+# falco-named series. Enabling them would give a richer signal (rules loaded, event
+# drops) and is worth doing separately; this file deliberately depends only on what
+# already exists.
+#
+# Picked up automatically (ruleSelectorNilUsesHelmValues=false).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-runtime-security-alerts
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: observability
+spec:
+  groups:
+    - name: openbank.runtime-security.falco
+      rules:
+        # A Falco pod that is not Ready is a NODE with no runtime detection. Falco is a
+        # DaemonSet, so this is per-node coverage, not redundancy: one unavailable pod
+        # means one node is dark, and nothing else in the estate reports that.
+        - alert: FalcoAgentNotReady
+          expr: |
+            kube_daemonset_status_number_unavailable{daemonset="falco", namespace="falco"} > 0
+          for: 15m
+          labels:
+            severity: warning
+            team: platform
+          annotations:
+            summary: "Falco is not running on {{ $value | printf \"%.0f\" }} node(s) — those nodes have no runtime detection"
+            description: >-
+              {{ $value | printf "%.0f" }} Falco DaemonSet pod(s) have been unavailable for over
+              15 minutes. Falco runs one pod per node, so each unavailable pod is a node with NO
+              syscall-level detection: every Falco rule is blind there and nothing else covers it.
+              Check: kubectl -n falco get ds,pods -o wide — then the node itself
+              (system-node-critical priority means a pending pod is a node problem, not preemption).
+        # The absence case, which the readiness comparison above CANNOT see. If
+        # kube-state-metrics stops, or the DaemonSet is deleted outright, the
+        # `unavailable > 0` comparison is evaluated over an absent series and matches
+        # nothing — so it reports healthy for a Falco that is not merely degraded but
+        # gone. An absent series is a third state next to ready and unavailable, and it
+        # needs its own rule; this is the lesson the dead alert rules in #5733 cost.
+        - alert: FalcoDaemonSetAbsent
+          expr: |
+            absent(kube_daemonset_status_desired_number_scheduled{daemonset="falco", namespace="falco"})
+          for: 15m
+          labels:
+            severity: critical
+            team: platform
+          annotations:
+            summary: "The Falco DaemonSet has disappeared from monitoring — runtime security is unverifiable"
+            description: >-
+              No `kube_daemonset_status_desired_number_scheduled{daemonset="falco"}` series for 15
+              minutes. Either the Falco DaemonSet no longer exists, or kube-state-metrics has
+              stopped — and in the second case EVERY kube_* based alert in this estate is equally
+              blind, not just this one. FalcoAgentNotReady cannot fire while this is true, because
+              a threshold over an absent series matches nothing.
+              Check: kubectl -n falco get ds && kubectl -n observability get pods -l app.kubernetes.io/name=kube-state-metrics


### PR DESCRIPTION
## What

`FalcoAgentSilent` fired on the **healthy** state. This replaces it with an observable that still works after the noise tuning.

## How it broke — and we broke it

The rule was `absent_over_time({namespace="falco"}[30m])`, and its own comment stated the premise:

> Falco emits continuously (the untuned NOTICE rules alone are thousands a day, and `Run shell untrusted` is deliberately left noisy), so an empty 30m window means the agent, Alloy, or Loki ingestion is broken.

True when written. Then #6075 and #6198 tuned the ruleset from ~33,000 events/day to **zero** — deliberately, because the noise was what made the control unreadable. Silence became the healthy resting state.

Measured 2026-08-21, minutes after the Loki ruler evaluated a rule for the first time ever (#6032 + the sync blockage below):

| fact | value |
|---|---|
| Falco pods Ready | **13 / 13** |
| Falco log lines in 60m | **0** |
| `FalcoAgentSilent` | **pending**, on its way to firing |

Noise on the control that exists to make a dead agent visible is the one thing that hides a dead agent.

## Why a new observable, not a new threshold

There is no event rate that separates well-tuned Falco from dead Falco. Both are zero. Same shape as the `WorkflowLivenessStale` / `Instant.EPOCH` lesson in the root `CLAUDE.md`: an alert whose discriminator is a **magnitude** stops discriminating the moment that magnitude legitimately changes.

Liveness now comes from `kube_daemonset_status_number_unavailable{daemonset="falco"}` — emitted whether or not Falco ever detects anything.

## Verified against live Prometheus, with controls

```
selector matches                    -> 1 series   (not a typo'd selector matching nothing)
FalcoAgentNotReady expr             -> 0 series   (quiet on a healthy estate)
FalcoDaemonSetAbsent expr           -> 0 series   (quiet on a healthy estate)
absent() on a bogus daemonset name  -> 1 series   (proves absent() CAN fire)
```

`promtool check rules` passes, and reddens on a deliberately broken expression.

`FalcoDaemonSetAbsent` exists because the readiness comparison structurally **cannot** see the case where kube-state-metrics stops or the DaemonSet is deleted: a threshold over an absent series matches nothing and reports healthy. A missing series is a third state next to ready and unavailable.

## What this loses, said out loud

The old rule also happened to cover *"the Alloy tail or Loki ingestion has stopped"*. **Nothing covers that now.** The right observable is `loki_distributor_*`, which returns NO SERIES today because `monitoring.selfMonitoring.enabled: false`. Filed as #6236 rather than replaced with a guess keyed on some other namespace's chattiness — which would rebuild the exact defect being fixed here.

## How this was found

Not by review. `#6032`'s ruler fix merged and was **not live**: the loki Argo Application had not completed a sync operation since **2026-08-01**, because #3278 raised `singleBinary.persistence.size` 10Gi -> 30Gi and `volumeClaimTemplates` is immutable — the server-side dry-run apply failed, the comparison errored, and Argo then reported `Synced / Healthy` anyway. Recreating the StatefulSet with `--cascade=orphan` (pod and PVC untouched; the PVC was already 30Gi) unblocked it, and the ruler loaded **3 groups / 8 rules** for the first time. `FalcoAgentSilent` going `pending` was the first thing it said.

## Linked issues

Refs #5734, #6236
