### PR TITLE
fix(copilot): default the model route to the LiteLLM gateway, not an unverified NVIDIA id

### DIFF
--- a/.github/scripts/check-external-feeds.py
+++ b/.github/scripts/check-external-feeds.py
@@ -173,7 +173,6 @@ FEEDS = [
 NOT_PROBED = [
     ("https://api.github.com", "authenticated API, not a data feed; failure is loud at call time"),
     ("https://api.deepinfra.com/v1/openai", "authenticated LLM gateway; needs a key"),
-    ("https://integrate.api.nvidia.com/v1", "authenticated LLM gateway; needs a key"),
     ("https://s3.eu-north-1.amazonaws.com", "AWS endpoint, reached with SigV4 credentials"),
     ("https://kc.open-bank.tech/realms/openbank-customers", "our own Keycloak realm, covered by its own probes"),
     ("https://pid.open-bank.tech", "our own PID issuer, covered by its own probes"),

--- a/openbank-copilot-service/src/main/resources/application.yaml
+++ b/openbank-copilot-service/src/main/resources/application.yaml
@@ -109,15 +109,31 @@ copilot:
       - id: mock-echo
         provider: mock
         sensitivity: hosted
-      # OpenAI-compatible backend (NVIDIA NIM, Groq, vLLM, …). id is sent verbatim as the upstream
-      # model name and is env-driven (COPILOT_MODEL_ID) so the served model can be swapped without an
-      # image rebuild — set COPILOT_MODEL_ID and COPILOT_DEFAULT_MODEL to the SAME value.
-      # Endpoint is also env-driven (COPILOT_MODEL_ENDPOINT) so the backend can be swapped without a
-      # rebuild — e.g. switch between NVIDIA NIM and Groq by updating GitOps env vars only.
+      # OpenAI-compatible backend. `id` is sent verbatim as the upstream model name and is the
+      # CALLER-FACING id: reached through the gateway it is a litellm-config `model_name`, never a
+      # provider's own id. Both id and endpoint are env-driven (COPILOT_MODEL_ID /
+      # COPILOT_MODEL_ENDPOINT) so the backend can be swapped without an image rebuild — set
+      # COPILOT_MODEL_ID and COPILOT_DEFAULT_MODEL to the SAME value.
+      #
+      # ADR-0174/0175 (#1919): the in-cluster LiteLLM gateway is the single pod allowed to egress to
+      # a hosted LLM provider, so the provider key never lands in this pod. Endpoint and id therefore
+      # DEFAULT to exactly what the deployment sets in
+      # openbank-infra/gitops/components/copilot/copilot-service.yaml — one route, exercised by both
+      # local dev and prod, instead of two of which only one is ever used. Same shape as the
+      # content-safety and embedding endpoints above/below, which already go through this gateway.
+      #
+      # It used to default to `https://integrate.api.nvidia.com/v1` + `mistralai/mistral-nemotron`.
+      # NVIDIA does still serve that id, but the gateway does NOT (#6077): a provider base-URL
+      # hard-coded next to a caller-facing id asserts a mapping this file cannot see and nothing
+      # validates — the defect class of #5736/#6076. To go direct to a provider instead, override
+      # BOTH env vars together; changing one alone is the bug.
+      #
       # HOSTED (off-cluster) — sandbox/synthetic data only; production must pin to in-cluster/EU (D6).
-      - id: ${COPILOT_MODEL_ID:mistralai/mistral-nemotron}
+      # Local dev: `kubectl port-forward -n ai-platform svc/litellm 4000:4000`, or override
+      # COPILOT_MODEL_ENDPOINT. Neither the build nor the tests need it — they run on `mock-echo`.
+      - id: ${COPILOT_MODEL_ID:deepseek-ai/DeepSeek-V3.2}
         provider: openai-compat
-        endpoint: ${COPILOT_MODEL_ENDPOINT:https://integrate.api.nvidia.com/v1}
+        endpoint: ${COPILOT_MODEL_ENDPOINT:http://litellm.ai-platform.svc:4000/v1}
         sensitivity: hosted
       # Production (deferred): register a self-hosted/EU model and flip COPILOT_DEFAULT_MODEL to it.
       # - id: vllm-cs


### PR DESCRIPTION
Closes #6077 · Refs #5736, #6076

The in-repo tail of the #6076 sweep, one service over.

## Re-verified on live `origin/main` — the finding stands, and it is ONE entry, not several

- `openbank-copilot-service/src/main/resources/application.yaml:118-120` does still default to
  `mistralai/mistral-nemotron` on `https://integrate.api.nvidia.com/v1`. Confirmed.
- `openbank-infra/gitops/components/copilot/copilot-service.yaml` does set
  `COPILOT_MODEL_ENDPOINT=http://litellm.ai-platform.svc:4000/v1` and both
  `COPILOT_MODEL_ID`/`COPILOT_DEFAULT_MODEL` to `deepseek-ai/DeepSeek-V3.2`. Confirmed.
- Unlike agent-service, this really is a **single** `openai-compat` entry. The only other model
  registered is `mock-echo`. Checked, because #6076's report understated its own case at three.

## Whether NVIDIA still serves the id — ANSWERED, and the answer is yes

#6077 filed this as unknown ("no NVIDIA key, no read-only catalogue endpoint was available").
There is one: `GET https://integrate.api.nvidia.com/v1/models` answers **200 unauthenticated**,
102 ids, no credential involved.

```
mistralai/mistral-nemotron    present
meta/llama-3.1-70b-instruct   present   (the id holmesgpt uses on the same base URL)
```

So this is **not** a second decommissioned id. The route as committed would work for someone
holding an NVIDIA key. That narrows the defect but does not remove it, and it is worth recording
that the probe exists — the same call is now the cheap way to falsify any NVIDIA id in this repo.

## The actual defect, and the default I chose

The defect is the shape, not the id: **a provider base-URL hard-coded next to a caller-facing id.**
The `id` here is sent verbatim upstream, and the environment that actually runs reaches a LiteLLM
gateway, where it is a `model_name` — so the file asserts a mapping it cannot see, and changing one
of the two env vars without the other is silently wrong.

New default: `http://litellm.ai-platform.svc:4000/v1` + `deepseek-ai/DeepSeek-V3.2`.

- It is **exactly** what the deployment already sets, so local dev and prod traverse one route
  instead of two of which only one is exercised.
- **Fleet convention** (established in #6076): six services default to the gateway, three default
  direct-to-DeepInfra with a provider id the gateway also serves, and none default to a provider
  the gateway does not serve. This service was the last exception.
- ADR-0174/0175: the provider key never needs to exist in this pod.
- It matches the three sibling endpoints in this very file — `content-safety.endpoint` and
  `retrieval.embedding-endpoint` are also gateway routes in the deployment. (Their defaults stay
  **empty**, deliberately: both features default to `enabled: false`, so an empty endpoint is
  coherent rather than a third convention. #6077 flagged them; leaving them is the decision, not
  an oversight.)

**Cost, stated plainly:** a dev with no cluster now gets connection-refused instead of a reply.
That is a real cost and it is the right trade — a refused connection names its own cause, and the
alternative default only worked for whoever held an NVIDIA key. Reach it with
`kubectl port-forward -n ai-platform svc/litellm 4000:4000`, or override `COPILOT_MODEL_ENDPOINT`.
Nothing here affects the build or the tests, which run on `mock-echo` (`default-model` untouched).

## Evidence the new id is currently served — read from the RUNNING gateway

Not taken from the committed litellm-config. Read the running LiteLLM pod's own on-disk config
(`/etc/litellm/config.yaml`), read-only, no credential involved:

| gateway `model_name` | resolves to |
|---|---|
| `deepseek-ai/DeepSeek-V3.2` | `deepinfra/deepseek-ai/DeepSeek-V3.2` |
| `llama-3.3-70b-versatile` | `deepinfra/meta-llama/Llama-3.3-70B-Instruct-Turbo` |
| `meta-llama/llama-guard-4-12b` | `deepinfra/meta-llama/Llama-Guard-4-12B` |
| `BAAI/bge-m3` | `openai/BAAI/bge-m3` |
| `openai/gpt-oss-120b` | `deepinfra/openai/gpt-oss-120b` |
| `deepseek-ai/DeepSeek-V4-Pro` | `deepinfra/deepseek-ai/DeepSeek-V4-Pro` |

Six `model_name`s, `mistralai/mistral-nemotron` is not among them, and the id this PR adopts is.
The pod is serving the post-#6041 mapping, which independently confirms that roll landed.

## Sweep — the tail is clean

Every `openbank-*/src/main/resources/application.yaml` with a hard-coded provider base URL:

| service | endpoint default | id default | verdict |
|---|---|---|---|
| `copilot-service` | NVIDIA | `mistralai/mistral-nemotron` | **fixed here** |
| `case-coordinator-agent` | DeepInfra | `deepseek-ai/DeepSeek-V3.2` | not a defect |
| `control-liveness-sentinel` | DeepInfra | `deepseek-ai/DeepSeek-V3.2` | not a defect |
| `devops-agent` | DeepInfra | `deepseek-ai/DeepSeek-V3.2` | not a defect |

The three DeepInfra ones pair a provider URL with an id that provider serves under its own name,
and the gateway serves the same `model_name`, so either route resolves. Same conclusion #6076
reached; re-derived, not copied. No new issue needed — the tail is three entries and all three
are consistent.

## The external-feeds gate fired, and it is mine

Removing the last `integrate.api.nvidia.com` from a scanned YAML made `check-external-feeds.py`
fail with `DRIFT stale NOT_PROBED entry`. Negative control before touching the declaration: the
same script on the **unmodified** tree exits `0`. So it is this diff, not an always-red gate.
Declaration dropped; gate back to `0`.

**Worth someone's attention, not fixed here:** the gate's scan scope is
`openbank-*/src/main/resources/application.yaml` only, so `openbank-infra/gitops/apps/holmesgpt.yaml`
— a live NVIDIA egress on that same base URL — was never in scope and is now undeclared anywhere.
Out of scope for this PR; say the word and I will file it.

## Verified

- `:openbank-copilot-service:test :quarkusBuild --rerun-tasks` → BUILD SUCCESSFUL, exit read from
  `$?` on redirected output, task list read (both tasks present, `32 executed`). JUnit XML across
  **35** result files: `tests=172 failures=0 errors=0 skipped=0` — skipped read explicitly.
  `quarkus-app/` populated (fast-jar), so no `SRCFG00040` and no CDI/config regression.
- `:ktlintCheck :detekt --rerun-tasks` → exit 0.
- YAML parses (`yaml.safe_load`).
- Gates per shard, foreground, `PR_DIFF_BASE=origin/main`, exit from `$?`:
  **lint 20/20 · data 21/21 · registry 26/26 · kotlin 19/19 · security 14/14**, all exit 0.
  (Two advisory `::warning::` lines — an expired `consent.pentest` attestation and Keycloak
  dev/CI realm parity — are pre-existing and unrelated to this diff.)

## Not verified

- **The new default was not exercised end-to-end.** That means actually calling the gateway, which
  needs a virtual key. What is established: the gateway serves this `model_name` right now, and the
  deployed pod already uses this exact URL with this exact id.
- The `supplychain`, `gitops` and `api-contract` shards were not run locally. This diff touches no
  gitops file and no `openapi.yaml`; CI is the reading there.
- NVIDIA's catalogue was read at one point in time. It is a claim about someone else's inventory
  and can change tomorrow — which is precisely why the default no longer depends on it.
