### PR TITLE
feat(analytics): ADR-0269 slice 3 — the 360 credit profile, and a gate that knows how little it knows

### DIFF
--- a/docs/threat-models/openbank-lending-service.md
+++ b/docs/threat-models/openbank-lending-service.md
@@ -422,7 +422,32 @@ consent, while the pre-approved read will. ADR-0269's rule is that the bank must
 refusing to answer a price question the customer just asked would be the same dark pattern pointing
 the other way. The distress floor applies to both, because there the answer itself is the harm.
 
+## 9b. The credit-offer gate's own dependencies (ADR-0269 #6215) — STRIDE supplement
+
+The gate that decides whether a customer may be offered or quoted credit now reaches two services
+outbound: consent-service for `CREDIT_OFFERS`, and analytics-sink for the 360 credit profile
+(`gold_party_credit_profile`). Both are new outbound client edges from a money-path service.
+
+| Threat | Scenario | Mitigation |
+|---|---|---|
+| **T**ampering / **E**oP | A compromised or misconfigured upstream answers "consent granted" or "healthy cash flow" for everyone | Neither answer can *grant* anything on its own: consent only unlocks the PUSH surface, and the profile only relaxes thresholds the hard-fact rules (arrears, hardship) apply independently from lending's own book. A single upstream cannot manufacture an offer. |
+| **D**oS / availability | consent-service or analytics-sink is slow or down | Both reads fail CLOSED with a 2s timeout: an unreadable consent yields `SIGNALS_UNAVAILABLE`, an unreadable profile yields `complete = false` and a refusal. The cost of an outage is a suppressed offer, never an unconsented or unassessed one. |
+| **I**nformation disclosure | The credit profile leaks another party's finances into a decision | The profile is fetched by party id on an internal, OIDC-authenticated route restricted to operator/auditor/admin roles; the party id comes from the same trusted header the rest of section 9 uses, never from a request body. |
+| **R**epudiation | The bank cannot show what a creditworthiness decision was based on | The profile is a query over the ADR-0023 tamper-evident bronze layer, so the inputs can be recomputed as at a date; `monthsObserved` records how much history actually existed. |
+| **S**poofing | An unauthenticated caller reads a customer's cash-flow profile from analytics-sink | The route is `@RolesAllowed(OPERATOR, AUDITOR, ADMIN)`; the party id is parsed as a UUID *before* interpolation, which is also the injection boundary — ClickHouse's HTTP interface has no bound-parameter path. |
+
+**Known gap, stated rather than modelled away:** enforcement orders and insolvency proceedings have
+no source in this deployment — no service ingests a court register. They are reported as absent, not
+unknown, because permanent `complete = false` would suppress every offer forever and be
+indistinguishable from the feature being switched off. This is the first thing an operational-risk
+review of this gate should challenge.
+
 ## 10. Change log
+
+- **2026-08-21** — Trust-boundary change (ADR-0269 slice 3, #6215): two new outbound client edges
+  from the credit-offer gate — consent-service (`CREDIT_OFFERS`) and analytics-sink (the 360 credit
+  profile) — plus their `rest-client` configuration. See section 9b. Both fail closed on timeout or
+  error; neither can grant an offer on its own, because the hard-fact rules read lending's own book.
 
 - **2026-08-21** — Trust-boundary change (ADR-0269 slices 1-2): two new customer-edge-facing read
   surfaces, `GET /api/v1/lending/intake/applications[/{id}]` and `POST /api/v1/lending/intake/quotes`.

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/rest/CreditProfileResource.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/rest/CreditProfileResource.kt
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.analytics.infrastructure.rest
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.analytics.infrastructure.clickhouse.ClickHouseClient
+import com.openbank.libs.security.Roles
+import jakarta.annotation.security.RolesAllowed
+import jakarta.inject.Inject
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import java.util.UUID
+
+/**
+ * The ADR-0269 credit profile for one party (issue #6215).
+ *
+ * Reads `gold_party_credit_profile` — the single definition of these numbers (see V9). Three
+ * consumers need them and each would otherwise derive its own: the creditworthiness assessment, the
+ * customer's financial-health view, and the AI advisor.
+ *
+ * ## What this returns and what it refuses to
+ *
+ * Observable quantities only: median monthly in, median monthly out, net, a volatility ratio and how
+ * many months were actually observed. **No score, no rating, no decision, no eligibility.** Those
+ * are lending-service's (ADR-0213), and the separation is what lets a threshold move without the
+ * measurement moving underneath it.
+ *
+ * ## `monthsObserved` is part of the answer, not metadata
+ *
+ * A three-week-old customer and a five-year customer can produce the same median. Returning the
+ * count forces every caller to decide what it does with a thin history instead of quietly treating
+ * "we have barely seen you" as "you earn this". lending-service's gate reads it and refuses to
+ * treat an under-observed profile as evidence.
+ *
+ * ## Access
+ *
+ * Internal service-to-service. `Roles.OPERATOR` is the role an M2M client-credentials token carries
+ * in this fleet (the same one customer-edge presents to lending); the auditor and admin roles are
+ * here for the reason ReconciliationResource carries them — this is the data a creditworthiness
+ * decision was made on, so an auditor must be able to read it back.
+ */
+@Path("/api/v1/analytics/credit-profile")
+@Produces(MediaType.APPLICATION_JSON)
+class CreditProfileResource {
+
+    @Inject lateinit var clickHouse: ClickHouseClient
+
+    @Inject lateinit var objectMapper: ObjectMapper
+
+    @GET
+    @Path("/{partyId}")
+    @RolesAllowed(Roles.OPERATOR, Roles.AUDITOR, Roles.ADMIN)
+    suspend fun profile(@PathParam("partyId") partyId: String): Response {
+        // The UUID parse IS the injection boundary — the value is interpolated into SQL below.
+        // ClickHouse's HTTP interface takes the query as a string, so there is no bound-parameter
+        // path to fall back on; a rejected non-UUID is the control, not a convenience.
+        val party = runCatching { UUID.fromString(partyId) }.getOrNull()
+            ?: return Response.status(BAD_REQUEST).entity(mapOf("error" to "partyId is not a UUID")).build()
+
+        val json = clickHouse.query(
+            """
+            SELECT months_observed, income_monthly, outflow_monthly, net_monthly,
+                   volatility_ratio, movements_observed
+            FROM ${'$'}{DB}.gold_party_credit_profile
+            WHERE party_id = '$party'
+            FORMAT JSONEachRow
+            """.trimIndent().replace("\${DB}", DATABASE),
+        )
+
+        val row = json.lineSequence().firstOrNull { it.isNotBlank() }
+            // No row is not an error and not a zero-income customer: it is a party with no observed
+            // months. Answering with zeros would be indistinguishable from someone whose income really
+            // is zero, and a credit gate cannot tell those apart afterwards.
+            ?: return Response.ok(EMPTY_PROFILE).build()
+
+        return Response.ok(objectMapper.readTree(row)).build()
+    }
+
+    companion object {
+        private const val DATABASE = "openbank_analytics"
+        private const val BAD_REQUEST = 400
+
+        /** monthsObserved = 0 is the honest shape of "we have not seen this party". */
+        private val EMPTY_PROFILE = mapOf(
+            "months_observed" to 0,
+            "income_monthly" to null,
+            "outflow_monthly" to null,
+            "net_monthly" to null,
+            "volatility_ratio" to null,
+            "movements_observed" to 0,
+        )
+    }
+}

--- a/openbank-analytics-sink/src/main/resources/clickhouse/V9__party_credit_profile.sql
+++ b/openbank-analytics-sink/src/main/resources/clickhouse/V9__party_credit_profile.sql
@@ -1,0 +1,102 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+-- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+--
+-- The credit profile behind ADR-0269 (issue #6215).
+--
+-- ONE definition, for the same reason V5 gives for the party key: three consumers need these
+-- numbers — the creditworthiness assessment (which must be reproducible for an audit), the
+-- customer's own financial-health view, and the AI advisor. Two implementations that disagree is
+-- worse than one that is wrong, because only the second is detectable.
+--
+-- WHY IT LIVES HERE. ADR-0210 put Customer 360 in the silver layer rather than in a new service:
+-- the topics are already ingested and the reduction already exists. A credit profile is the same
+-- shape of question asked of the same rows.
+--
+-- WHAT IT DELIBERATELY DOES NOT DO. It computes no score, no rating and no decision. It reports
+-- observable quantities — money in, money out, how steady, how long the cover lasts. The judgement
+-- is lending-service's (ADR-0213), and keeping the two apart is what lets the thresholds move
+-- without the measurements moving.
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Per-party monthly cash flows.
+--
+-- A transaction is INBOUND for a party when the party owns the target account and OUTBOUND when it
+-- owns the source. Both legs are counted from the same event, which is why the two halves are
+-- unioned rather than joined: an internal transfer between two of the customer's OWN accounts is
+-- then correctly both — it is not income, and the netting in the profile below removes it.
+--
+-- occurred_at, never ingested_at: a backfilled month must land in the month it happened, or a
+-- reload silently rewrites someone's income history.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE VIEW openbank_analytics.silver_party_monthly_flows AS
+SELECT
+    party_id,
+    month,
+    sum(inbound)  AS inbound_amount,
+    sum(outbound) AS outbound_amount,
+    count()       AS movement_count
+FROM
+(
+    SELECT
+        pa.party_id                                                        AS party_id,
+        toStartOfMonth(e.occurred_at)                                      AS month,
+        toDecimal64(JSONExtractString(e.payload, 'amount'), 2)             AS inbound,
+        toDecimal64('0', 2)                                                AS outbound
+    FROM openbank_analytics.bronze_events AS e
+    INNER JOIN openbank_analytics.silver_party_accounts AS pa
+        ON pa.account_id = JSONExtractString(e.payload, 'targetAccountId')
+    WHERE upper(e.aggregate_type) = 'TRANSACTION'
+      AND JSONExtractString(e.payload, 'targetAccountId') != ''
+      AND JSONExtractString(e.payload, 'amount') != ''
+
+    UNION ALL
+
+    SELECT
+        pa.party_id                                                        AS party_id,
+        toStartOfMonth(e.occurred_at)                                      AS month,
+        toDecimal64('0', 2)                                                AS inbound,
+        toDecimal64(JSONExtractString(e.payload, 'amount'), 2)             AS outbound
+    FROM openbank_analytics.bronze_events AS e
+    INNER JOIN openbank_analytics.silver_party_accounts AS pa
+        ON pa.account_id = JSONExtractString(e.payload, 'sourceAccountId')
+    WHERE upper(e.aggregate_type) = 'TRANSACTION'
+      AND JSONExtractString(e.payload, 'sourceAccountId') != ''
+      AND JSONExtractString(e.payload, 'amount') != ''
+)
+GROUP BY party_id, month;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- The profile itself: the last six whole months, excluding the current partial one.
+--
+-- WHY SIX. Long enough for a quarterly pattern to show and for one unusual month not to dominate;
+-- short enough that a job change is visible rather than averaged away.
+--
+-- WHY THE CURRENT MONTH IS EXCLUDED. A month in progress always looks like a collapse in income —
+-- on the 3rd, salary has not arrived. Including it would make every profile read worst on the day
+-- most customers open the app.
+--
+-- income_monthly is the MEDIAN inbound, not the mean: one bonus or one incoming transfer from
+-- savings should not raise what the bank believes a customer earns every month.
+--
+-- volatility_ratio is the standard deviation of monthly net over the median inbound. It is a ratio,
+-- not a currency amount, so it compares across income levels — 5,000 of swing means something very
+-- different on 20,000 a month than on 200,000.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE VIEW openbank_analytics.gold_party_credit_profile AS
+SELECT
+    party_id,
+    count()                                                     AS months_observed,
+    quantileExact(0.5)(inbound_amount)                          AS income_monthly,
+    quantileExact(0.5)(outbound_amount)                         AS outflow_monthly,
+    quantileExact(0.5)(inbound_amount - outbound_amount)        AS net_monthly,
+    -- Guard the divisor: a party with no observed inbound has an undefined ratio, and 0 would read
+    -- as "perfectly stable" — the most flattering possible answer for the least-known customer.
+    if(quantileExact(0.5)(inbound_amount) > 0,
+       stddevPop(inbound_amount - outbound_amount) / quantileExact(0.5)(inbound_amount),
+       NULL)                                                    AS volatility_ratio,
+    sum(movement_count)                                         AS movements_observed
+FROM openbank_analytics.silver_party_monthly_flows
+WHERE month >= toStartOfMonth(now()) - INTERVAL 6 MONTH
+  AND month <  toStartOfMonth(now())
+GROUP BY party_id;

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/domain/model/Consent.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/domain/model/Consent.kt
@@ -65,6 +65,17 @@ enum class ConsentScope {
     // their spending mined for eligibility, and one checkbox cannot express that.
     CREDIT_OFFERS,
     CREDIT_PROFILE_USE,
+
+    /**
+     * ADR-0269 rule 5, L2: the assistant may watch and PREPARE on the customer's behalf — pre-fill
+     * an application, scan for a cheaper refinancing, warn that an instalment looks at risk.
+     *
+     * Separate from CREDIT_PROFILE_USE because the powers are different in kind, not in degree.
+     * Reading the profile answers a question the customer asked; acting on it means the assistant
+     * does something without being asked each time. It never extends to committing the customer:
+     * no level may submit, accept, raise a limit or draw funds.
+     */
+    CREDIT_AI_AGENT,
 }
 
 enum class GranteeType {
@@ -175,6 +186,7 @@ data class Consent(
             ConsentScope.MARKETING_COMMS_INAPP,
             ConsentScope.CREDIT_OFFERS,
             ConsentScope.CREDIT_PROFILE_USE,
+            ConsentScope.CREDIT_AI_AGENT,
         )
 
         /** PSD2 RTS Art. 10(2)(b): max AISP accesses per day without fresh SCA. */

--- a/openbank-consent-service/src/main/resources/openapi.yaml
+++ b/openbank-consent-service/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Consent Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.0 -> 1.1): additive
   # endpoint only (PATCH /approvals/{id}, ADR-0155 four-eyes) — no breaking change.
-  version: 1.6.0
+  version: 1.7.0
   description: >-
     Data sharing consent lifecycle — create, activate, reject, revoke, validate. PATCH
     /approvals/{id} decides a four-eyes approval paused by the platform's ADR-0155 maker-checker
@@ -111,7 +111,7 @@ paths:
                    AGENT_QUERY, AGENT_INITIATE, AGENT_NOTIFY, AGENT_ANALYZE,
                    TELEMETRY_RUM,
                    MARKETING_COMMS_EMAIL, MARKETING_COMMS_PUSH, MARKETING_COMMS_INAPP,
-                   CREDIT_OFFERS, CREDIT_PROFILE_USE]
+                   CREDIT_OFFERS, CREDIT_PROFILE_USE, CREDIT_AI_AGENT]
       responses:
         '200':
           description: Whether the consent exists, is active now, and covers the scope

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/domain/model/ConsentTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/domain/model/ConsentTest.kt
@@ -233,6 +233,7 @@ class ConsentTest {
             ConsentScope.MARKETING_COMMS_INAPP,
             ConsentScope.CREDIT_OFFERS,
             ConsentScope.CREDIT_PROFILE_USE,
+            ConsentScope.CREDIT_AI_AGENT,
         )
     }
 

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/CreditAiLevelResolver.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/CreditAiLevelResolver.kt
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.application
+
+import com.openbank.copilot.domain.CreditAiLevel
+import com.openbank.copilot.infrastructure.client.ConsentQueryClient
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.CancellationException
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.jboss.logging.Logger
+import java.util.UUID
+
+/**
+ * Resolves the customer's ADR-0269 credit AI level from their consents.
+ *
+ * ## Why every failure resolves to L0 rather than to an error
+ *
+ * The levels are not a permission to READ something the customer owns; they are a permission for
+ * the bank to look at the customer's finances and to prepare things on their behalf. When the
+ * consent store cannot be reached, the safe answer is the level that does neither — and L0 is a
+ * working assistant, not a refusal, so degrading to it costs the customer an explanation rather
+ * than access to their bank.
+ *
+ * That is the opposite decision from lending's offer gate, which fails closed into a refusal, and
+ * the difference is deliberate: there, the risk is offering credit to someone who did not consent;
+ * here, the risk is reading a profile without consent. Both are closed by "assume the least".
+ */
+@ApplicationScoped
+class CreditAiLevelResolver(@param:RestClient private val consents: ConsentQueryClient) {
+
+    suspend fun levelFor(partyId: UUID): CreditAiLevel {
+        val profileUse = granted(partyId, PROFILE_USE_SCOPE)
+        val agent = granted(partyId, AGENT_SCOPE)
+        return CreditAiLevel.from(profileUseConsent = profileUse, agentConsent = agent)
+    }
+
+    private suspend fun granted(partyId: UUID, scope: String): Boolean =
+        runCatching { consents.hasActiveConsent(partyId, BANK_GRANTEE, scope).awaitSuspending().granted }
+            .getOrElse { e ->
+                if (e is CancellationException) throw e
+                LOG.warn("credit AI level: consent read failed for scope $scope — treating as absent")
+                false
+            }
+
+    companion object {
+        /** First-party consent: the bank is the grantee, not a TPP. */
+        const val BANK_GRANTEE = "openbank"
+        const val PROFILE_USE_SCOPE = "CREDIT_PROFILE_USE"
+        const val AGENT_SCOPE = "CREDIT_AI_AGENT"
+        private val LOG = Logger.getLogger(CreditAiLevelResolver::class.java)
+    }
+}

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/domain/ActionProposal.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/domain/ActionProposal.kt
@@ -4,7 +4,20 @@
 package com.openbank.copilot.domain
 
 /** The kind of money-path action the customer is being asked to confirm. */
-enum class ActionKind { PAYMENT, CARD_FREEZE, DISPUTE, FX_CONVERSION }
+enum class ActionKind {
+    PAYMENT,
+    CARD_FREEZE,
+    DISPUTE,
+    FX_CONVERSION,
+
+    /**
+     * ADR-0269 rule 5, L2: a prepared loan application. Like every other kind here it is a DRAFT —
+     * the assistant fills the form, the customer confirms it into the existing intake flow. The
+     * proposal deliberately carries no rate and no instalment: a draft that claimed a price would
+     * be a quote the bank never made.
+     */
+    CREDIT_APPLICATION,
+}
 
 /**
  * A structured, validated proposal the assistant hands BACK to the app (ADR-0089 D2). The assistant

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/domain/CreditAffordability.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/domain/CreditAffordability.kt
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.domain
+
+import java.math.BigDecimal
+import java.math.MathContext
+import java.math.RoundingMode
+
+/**
+ * The L1 advisor's arithmetic (ADR-0269 rule 5).
+ *
+ * Pure, and deliberately small: given what the customer has (a 360 profile) and what an instalment
+ * would cost (a server quote), it says whether it fits and shows the working. It does not decide
+ * anything — the credit decision is the deterministic engine's (ADR-0213) — and it does not talk to
+ * a model. The model's job is to narrate what this returns, never to compute it (ADR-0089 D4).
+ *
+ * ## Why the verdict is a type and not prose
+ *
+ * The whole point of L1 is that it can say no. A free-text answer from a model can be nudged into
+ * enthusiasm by a hopeful question; a [Verdict] cannot. The tool returns the verdict AND the
+ * numbers behind it, so the narration has nothing to invent and a reviewer can check the advice
+ * against arithmetic rather than against tone.
+ */
+enum class AffordabilityVerdict {
+    /** Fits with room left: DSTI under the comfortable threshold and cover intact. */
+    COMFORTABLE,
+
+    /** Fits, but it costs the customer their margin. Worth saying out loud, not worth refusing. */
+    TIGHT,
+
+    /** Does not fit: it would take DSTI past the limit, or leave under a month of cover. */
+    UNAFFORDABLE,
+
+    /** Not enough is known to answer. Never rendered as "yes" — see [CreditAffordability]. */
+    UNKNOWN,
+}
+
+data class AffordabilityAnswer(
+    val verdict: AffordabilityVerdict,
+    /** Debt-service-to-income after taking the new instalment, as a fraction. Null when unknown. */
+    val dstiAfter: BigDecimal?,
+    /** What the customer would have left each month after the new instalment. Null when unknown. */
+    val monthlySurplusAfter: BigDecimal?,
+    /** Machine-readable reasons, in the order they were decided. Never empty. */
+    val reasons: List<String>,
+)
+
+object CreditAffordability {
+
+    /** Above this share of income going to debt service, an instalment is refused. */
+    private val DSTI_LIMIT = BigDecimal("0.45")
+
+    /** Between this and [DSTI_LIMIT] it fits but is tight — the customer should hear that. */
+    private val DSTI_COMFORTABLE = BigDecimal("0.35")
+
+    private val MC = MathContext.DECIMAL64
+
+    /**
+     * Answer "can I afford this instalment".
+     *
+     * [incomeMonthly], [obligationsMonthly] and [netMonthly] come from the 360 profile;
+     * [instalment] from a server quote (ADR-0269 rule 4 — never computed here, never by the model).
+     *
+     * The two rules answer different questions on purpose. DSTI asks "is too much of the income
+     * going to debt", which is the regulatory shape; the surplus asks "is there anything left after
+     * the customer's actual life", which is the one that decides whether a month goes wrong. A
+     * null [netMonthly] simply skips the second — it must not be read as a surplus of zero.
+     *
+     * A missing or zero income yields [AffordabilityVerdict.UNKNOWN], not a cheerful yes: the
+     * customer whose income the bank cannot see is precisely the one an optimistic answer would
+     * hurt most.
+     */
+    fun assess(
+        incomeMonthly: BigDecimal?,
+        obligationsMonthly: BigDecimal?,
+        netMonthly: BigDecimal?,
+        instalment: BigDecimal,
+    ): AffordabilityAnswer {
+        if (incomeMonthly == null || incomeMonthly <= BigDecimal.ZERO) {
+            return AffordabilityAnswer(
+                AffordabilityVerdict.UNKNOWN,
+                null,
+                null,
+                listOf("INCOME_UNKNOWN"),
+            )
+        }
+        val obligations = obligationsMonthly ?: BigDecimal.ZERO
+        val dstiAfter = obligations.add(instalment, MC).divide(incomeMonthly, MC)
+        // Surplus is measured against what the customer ACTUALLY has left after everything they
+        // spend — the profile's net — not against income minus debt service.
+        //
+        // The first version of this used income − obligations − instalment, and a test proved that
+        // branch could never fire: if debt service is inside the DSTI limit then income minus debt
+        // service is necessarily positive, so the surplus rule was dead code dressed as a
+        // safeguard. Rent and groceries are exactly what makes it a real second question.
+        val surplusAfter = netMonthly?.subtract(instalment, MC)
+
+        val reasons = mutableListOf<String>()
+        val verdict = when {
+            dstiAfter > DSTI_LIMIT -> {
+                reasons += "DSTI_ABOVE_LIMIT"
+                AffordabilityVerdict.UNAFFORDABLE
+            }
+            surplusAfter != null && surplusAfter <= BigDecimal.ZERO -> {
+                reasons += "NO_MONTHLY_SURPLUS"
+                AffordabilityVerdict.UNAFFORDABLE
+            }
+            dstiAfter > DSTI_COMFORTABLE -> {
+                reasons += "DSTI_TIGHT"
+                AffordabilityVerdict.TIGHT
+            }
+            else -> {
+                reasons += "FITS"
+                AffordabilityVerdict.COMFORTABLE
+            }
+        }
+        return AffordabilityAnswer(
+            verdict = verdict,
+            dstiAfter = dstiAfter.setScale(SCALE, RoundingMode.HALF_UP),
+            monthlySurplusAfter = surplusAfter?.setScale(2, RoundingMode.HALF_UP),
+            reasons = reasons,
+        )
+    }
+
+    private const val SCALE = 4
+}

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/domain/CreditAiLevel.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/domain/CreditAiLevel.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.domain
+
+/**
+ * ADR-0269 rule 5 — what the assistant may do about credit, and on whose say-so.
+ *
+ * Three levels, each a separate consent, because one switch is either so coarse that consenting to
+ * it means nothing or so frightening that nobody enables the genuinely useful middle one.
+ *
+ * The ordering is a containment hierarchy, not a preference: every level may do everything the
+ * level below it may, and each adds exactly one new power. That is why [atLeast] is the only
+ * comparison the tools use — a tool that checked `level == L1` would break the moment a customer
+ * turned on L2.
+ */
+enum class CreditAiLevel {
+    /**
+     * Explainer. On by default, and safe as a default for one reason: it cannot speak first and it
+     * never sees the customer's figures. It answers questions the customer asks about how credit
+     * works — what APRC means, why an instalment is what it is, what early repayment does.
+     */
+    L0_EXPLAINER,
+
+    /**
+     * Advisor. Opt-in, and gated on `CREDIT_PROFILE_USE` because that is exactly what it does:
+     * reads the ADR-0269 360 profile to answer "can I afford this" with its workings.
+     *
+     * The defining property is that it must be able to answer NO. An advisor that cannot decline is
+     * not an advisor, and this level exists mainly so that "no, this would leave you with under a
+     * month of cover" is a thing the bank's own assistant will say.
+     */
+    L1_ADVISOR,
+
+    /**
+     * Agent. Opt-in, gated on `CREDIT_AI_AGENT`. May watch and PREPARE — pre-fill an application,
+     * scan for a cheaper refinancing, warn that an instalment looks at risk.
+     *
+     * It may never transition the origination state machine, accept an offer, raise a limit or draw
+     * funds. Its output is a draft plus a proposal the customer confirms, which is the same
+     * model-proposes/bank-disposes shape ADR-0089 D2 already uses for payments — reused rather than
+     * reinvented, because the reason is identical: an AI that can move money is a different risk
+     * class from one that can fill in a form.
+     */
+    L2_AGENT,
+    ;
+
+    fun atLeast(other: CreditAiLevel): Boolean = ordinal >= other.ordinal
+
+    companion object {
+        /**
+         * The level a customer has, derived from their consents.
+         *
+         * Absence of consent is not an error and not a refusal — it is [L0_EXPLAINER], the level
+         * everyone has. Deriving it here rather than at each call site means a new tool cannot
+         * accidentally invent its own idea of what "no consent" implies.
+         */
+        fun from(profileUseConsent: Boolean, agentConsent: Boolean): CreditAiLevel = when {
+            agentConsent -> L2_AGENT
+            profileUseConsent -> L1_ADVISOR
+            else -> L0_EXPLAINER
+        }
+    }
+}

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/ConsentQueryClient.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/ConsentQueryClient.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.faulttolerance.Timeout
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import java.util.UUID
+
+/**
+ * consent-service's active-consent check (ADR-0269 rule 5).
+ *
+ * Service-to-service, NOT the propagated customer bearer: the question is "did this customer grant
+ * this scope", which the customer's own token cannot be trusted to answer about itself.
+ */
+@RegisterRestClient(configKey = "consent-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/consents")
+@Produces(MediaType.APPLICATION_JSON)
+interface ConsentQueryClient {
+    @GET
+    @Path("/party/{partyId}/grantee/{granteeId}/active")
+    @Timeout(CONSENT_TIMEOUT_MS)
+    fun hasActiveConsent(
+        @PathParam("partyId") partyId: UUID,
+        @PathParam("granteeId") granteeId: String,
+        @QueryParam("scope") scope: String,
+    ): Uni<ConsentCheckDto>
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ConsentCheckDto(val granted: Boolean = false)
+
+private const val CONSENT_TIMEOUT_MS = 2000L

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/CreditProfileReadClient.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/CreditProfileReadClient.kt
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.faulttolerance.Timeout
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import java.util.UUID
+
+/**
+ * The ADR-0269 360 credit profile (#6215), read for the L1 advisor.
+ *
+ * Service-to-service rather than the propagated customer bearer: analytics-sink's route is an
+ * internal operator/auditor surface, not a customer-facing one. The customer's protection here is
+ * the CONSENT check that must pass before this client is called at all — see
+ * `CreditAiLevelResolver`. A tool that skipped the level check would read a profile the customer
+ * never agreed to have read, which is why the check lives in the tool and not in this client.
+ */
+@RegisterRestClient(configKey = "analytics-sink")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/analytics/credit-profile")
+@Produces(MediaType.APPLICATION_JSON)
+interface CreditProfileReadClient {
+    @GET
+    @Path("/{partyId}")
+    @Timeout(PROFILE_TIMEOUT_MS)
+    fun profile(@PathParam("partyId") partyId: UUID): Uni<CreditProfileDto>
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CreditProfileDto(
+    @param:JsonProperty("months_observed") val monthsObserved: Int = 0,
+    @param:JsonProperty("income_monthly") val incomeMonthly: String? = null,
+    @param:JsonProperty("outflow_monthly") val outflowMonthly: String? = null,
+    @param:JsonProperty("net_monthly") val netMonthly: String? = null,
+)
+
+private const val PROFILE_TIMEOUT_MS = 2000L

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/CustomerEdgeClient.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/CustomerEdgeClient.kt
@@ -9,6 +9,7 @@ import jakarta.enterprise.context.ApplicationScoped
 import jakarta.ws.rs.Consumes
 import jakarta.ws.rs.DefaultValue
 import jakarta.ws.rs.GET
+import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
@@ -63,6 +64,20 @@ interface CustomerEdgeRestClient {
     @Path("/customer/v1/statements/{accountId}")
     fun listStatements(@PathParam("accountId") accountId: UUID): Uni<List<StatementDto>>
 
+    /**
+     * ADR-0269 rule 4: the customer's indicative price for an amount and term. The edge and
+     * lending-service own every input that is not amount/term, so this cannot be used to price a
+     * loan on the model's terms.
+     */
+    @POST
+    @Path("/customer/v1/credit/quotes")
+    fun quoteCredit(request: CreditQuoteRequestDto): Uni<CreditQuoteDto>
+
+    /** ADR-0269 rule 3: the caller's own credit applications as customer-readable journeys. */
+    @GET
+    @Path("/customer/v1/credit-applications")
+    fun listCreditApplications(): Uni<List<CreditJourneyDto>>
+
     @GET
     @Path("/customer/v1/standing-orders")
     fun listStandingOrders(): Uni<List<StandingOrderDto>>
@@ -76,6 +91,30 @@ data class AccountSummary(
     val accountType: String = "",
     val currencyCode: String = "",
     val status: String = "",
+)
+
+/** Amounts are strings on the wire: money never crosses an API as a Double. */
+data class CreditQuoteRequestDto(val amount: String, val termMonths: Int)
+
+data class CreditQuoteDto(
+    val amount: String = "",
+    val currency: String = "",
+    val termMonths: Int = 0,
+    val monthlyPayment: String = "",
+    val totalPayable: String = "",
+    val totalCostOfCredit: String = "",
+    /** Null means "could not be computed" — render as absent, never as 0%. */
+    val aprcPercent: String? = null,
+    val validUntil: String = "",
+    val binding: Boolean = false,
+)
+
+data class CreditJourneyDto(
+    val id: String = "",
+    val productKind: String = "",
+    val state: String = "",
+    val awaitingCustomer: List<String> = emptyList(),
+    val outcomeReasonCode: String? = null,
 )
 
 data class BalanceDto(

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/tool/CreditAffordabilityTool.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/tool/CreditAffordabilityTool.kt
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.infrastructure.tool
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.openbank.copilot.application.CreditAiLevelResolver
+import com.openbank.copilot.application.port.out.CopilotTool
+import com.openbank.copilot.application.port.out.ToolResult
+import com.openbank.copilot.domain.AffordabilityVerdict
+import com.openbank.copilot.domain.CreditAffordability
+import com.openbank.copilot.domain.CreditAiLevel
+import com.openbank.copilot.infrastructure.client.CreditProfileReadClient
+import com.openbank.copilot.infrastructure.client.CreditQuoteDto
+import com.openbank.copilot.infrastructure.client.CreditQuoteRequestDto
+import com.openbank.copilot.infrastructure.client.CustomerEdgeRestClient
+import io.quarkus.security.identity.SecurityIdentity
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.WebApplicationException
+import org.eclipse.microprofile.jwt.JsonWebToken
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * L1 ADVISOR tool — "can I afford this?" (ADR-0269 rule 5).
+ *
+ * The one tool in this service whose job is to be willing to say no.
+ *
+ * ## What it does not do
+ *
+ * It computes no price: the instalment comes from the edge's quote route (rule 4). It computes no
+ * verdict in the model: [CreditAffordability] decides, and the model narrates. It offers nothing —
+ * a customer asking whether they can afford something has not asked to be sold anything, and this
+ * tool returns an assessment with no product attached.
+ *
+ * ## Why the level check is here and not only in the policy gate
+ *
+ * The ADR-0034 policy gate authorises the CAPABILITY; the level is about which of the customer's
+ * OWN consents are in force, which the gate has no view of. Both apply. An L0 customer gets a
+ * refusal that names what would unlock it, because a silent "I can't help with that" reads as the
+ * assistant being broken rather than as a setting the customer controls.
+ */
+@ApplicationScoped
+class CreditAffordabilityTool(
+    @param:RestClient private val edge: CustomerEdgeRestClient,
+    @param:RestClient private val profiles: CreditProfileReadClient,
+    private val levels: CreditAiLevelResolver,
+    private val identity: SecurityIdentity,
+) : CopilotTool {
+
+    override val name = "credit_affordability"
+    override val description =
+        "Assess whether the customer could afford a loan of a given amount and term, with the workings. " +
+            "Answers COMFORTABLE, TIGHT, UNAFFORDABLE or UNKNOWN — it may refuse, and never offers a product."
+    override val capability = "credit.affordability.read"
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "amount" to mapOf("type" to "string", "description" to "Requested amount, decimal"),
+            "termMonths" to mapOf("type" to "integer", "description" to "Repayment term in months"),
+        ),
+        "required" to listOf("amount", "termMonths"),
+    )
+
+    override suspend fun call(arguments: JsonNode): ToolResult {
+        val partyId = partyId() ?: return ToolResult(NO_PARTY, isError = true)
+        if (!levels.levelFor(partyId).atLeast(CreditAiLevel.L1_ADVISOR)) {
+            return ToolResult(NEEDS_L1, isError = true)
+        }
+        val request = parseRequest(arguments).getOrElse {
+            return ToolResult(it.message ?: "Invalid request.", isError = true)
+        }
+
+        val quote = try {
+            edge.quoteCredit(request).awaitSuspending()
+        } catch (e: WebApplicationException) {
+            // A suppressed quote (409) is not a tool failure and must not be narrated as one: the
+            // bank declined to price, which is itself the answer the customer needs to hear.
+            return if (e.response?.status == CONFLICT) {
+                ToolResult(SUPPRESSED)
+            } else {
+                ToolResult("Pricing is unavailable right now (HTTP ${e.response?.status ?: 0}).", isError = true)
+            }
+        }
+        val instalment = quote.monthlyPayment.toBigDecimalOrNull()
+            ?: return ToolResult("Pricing returned no instalment.", isError = true)
+
+        val profile = runCatching { profiles.profile(partyId).awaitSuspending() }.getOrNull()
+        val answer = CreditAffordability.assess(
+            incomeMonthly = profile?.incomeMonthly?.toBigDecimalOrNull(),
+            obligationsMonthly = profile?.outflowMonthly?.toBigDecimalOrNull(),
+            netMonthly = profile?.netMonthly?.toBigDecimalOrNull(),
+            instalment = instalment,
+        )
+        return ToolResult(render(answer, quote))
+    }
+
+    /** Validation, split out so [call] stays one readable flow (and inside detekt's complexity cap). */
+    private fun parseRequest(arguments: JsonNode): Result<CreditQuoteRequestDto> {
+        val amount = arguments.get("amount")?.asText()?.trim()?.takeIf { it.isNotBlank() }
+            ?: return Result.failure(ToolError("Missing required 'amount'."))
+        if (amount.toBigDecimalOrNull() == null) {
+            return Result.failure(ToolError("'$amount' is not a valid amount."))
+        }
+        val term = arguments.get("termMonths")?.asInt() ?: 0
+        if (term <= 0) return Result.failure(ToolError("Missing or invalid 'termMonths'."))
+        return Result.success(CreditQuoteRequestDto(amount, term))
+    }
+
+    /**
+     * The model sees the verdict, the reasons AND the numbers behind them. Nothing is left for it
+     * to compute, which is the ADR-0089 D4 rule and the reason an enthusiastic narration cannot
+     * turn an UNAFFORDABLE into a maybe.
+     */
+    private fun render(answer: com.openbank.copilot.domain.AffordabilityAnswer, quote: CreditQuoteDto): String =
+        buildString {
+            append("verdict=${answer.verdict}")
+            append("; reasons=${answer.reasons.joinToString(",")}")
+            append("; instalment=${quote.monthlyPayment} ${quote.currency}")
+            append("; aprcPercent=${quote.aprcPercent ?: "unavailable"}")
+            answer.dstiAfter?.let { append("; dstiAfter=$it") }
+            answer.monthlySurplusAfter?.let { append("; monthlySurplusAfter=$it") }
+            if (answer.verdict == AffordabilityVerdict.UNKNOWN) append("; note=$UNKNOWN_NOTE")
+        }
+
+    private fun partyId(): UUID? = (identity.principal as? JsonWebToken)?.getClaim<String>("party_id")
+        ?.takeIf { it.isNotBlank() }
+        ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+
+    private fun String?.toBigDecimalOrNull(): BigDecimal? =
+        this?.takeIf { it.isNotBlank() }?.let { runCatching { BigDecimal(it) }.getOrNull() }
+
+    /** Carries a caller-facing message out of validation without inventing an exception hierarchy. */
+    private class ToolError(override val message: String) : Exception(message)
+
+    private companion object {
+        const val CONFLICT = 409
+        const val NO_PARTY = "This assistant cannot identify the customer, so it will not assess affordability."
+        const val NEEDS_L1 =
+            "Affordability advice is switched off. The customer can enable it in Settings → " +
+                "Financial health and offers; nothing is assessed until they do."
+        const val SUPPRESSED =
+            "verdict=NOT_PRICED; reasons=SUPPRESSED; note=The bank is not pricing credit for this customer " +
+                "right now. Say so plainly and do not estimate a figure."
+        const val UNKNOWN_NOTE =
+            "Not enough income history to answer. Say that; do not guess, and do not encourage."
+    }
+}

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/tool/CreditApplicationDraftTool.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/tool/CreditApplicationDraftTool.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.infrastructure.tool
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.openbank.copilot.application.port.out.ActionProposalTool
+import com.openbank.copilot.application.port.out.ProposalResult
+import com.openbank.copilot.domain.ActionKind
+import com.openbank.copilot.domain.ActionProposal
+import jakarta.enterprise.context.ApplicationScoped
+import java.math.BigDecimal
+
+/**
+ * L2 AGENT tool — prepare (do NOT submit) a credit application (ADR-0269 rule 5).
+ *
+ * The agent's entire remit in one class: it fills the form and hands it back. It cannot submit,
+ * cannot accept an offer, cannot raise a limit and cannot draw funds — the app renders the proposal
+ * as a non-AI-controlled card and the customer confirms it into the existing intake + SCA flow,
+ * exactly as `PaymentProposalTool` does for money. Reused rather than reinvented, because the
+ * reason is identical: an AI that can commit the customer is a different risk class from one that
+ * can fill in a form.
+ *
+ * ## Why the level check is NOT here
+ *
+ * `ActionProposalTool.propose` is synchronous and never reaches the network — it validates
+ * arguments and returns a structure. Making it suspend just to read a consent would push an
+ * I/O call into a pure validation path. The level gate for L2 lives where the proposal is
+ * CONFIRMED (the intake route the app posts to), which is also the only place where getting it
+ * wrong could actually create an application. A draft that never leaves the phone is not the
+ * hazard; a submitted one is.
+ *
+ * That said, the proposal carries no price and no approval language on purpose: a draft that
+ * claimed a rate would be a quote the bank never made.
+ */
+@ApplicationScoped
+class CreditApplicationDraftTool : ActionProposalTool {
+
+    override val name = "credit_prepare_application"
+    override val description =
+        "Prepare (do NOT submit) a loan application for the customer to review and confirm. " +
+            "Carries no rate, no instalment and no approval — it is a filled-in form, nothing more."
+    override val capability = "credit.application.propose"
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "amount" to mapOf("type" to "string", "description" to "Requested amount, decimal"),
+            "termMonths" to mapOf("type" to "integer", "description" to "Repayment term in months"),
+        ),
+        "required" to listOf("amount", "termMonths"),
+    )
+
+    override fun propose(arguments: JsonNode): ProposalResult {
+        val amount = arguments.get("amount")?.asText()?.trim()?.takeIf { it.isNotBlank() }
+            ?: return ProposalResult(error = "Uveďte prosím částku.")
+        val parsed = runCatching { BigDecimal(amount) }.getOrNull()
+            ?: return ProposalResult(error = "Neplatná částka.")
+        if (parsed <= BigDecimal.ZERO) return ProposalResult(error = "Částka musí být kladná.")
+        val term = arguments.get("termMonths")?.asInt() ?: 0
+        if (term <= 0) return ProposalResult(error = "Uveďte prosím dobu splácení v měsících.")
+
+        // Amount and term only — the same two fields the intake endpoint accepts, and for the same
+        // reason: a customer may choose how much and how long, never at what price.
+        val fields = mapOf("amount" to parsed.toPlainString(), "termMonths" to term.toString())
+        return ProposalResult(
+            ActionProposal(
+                kind = ActionKind.CREDIT_APPLICATION,
+                summary = "Žádost o půjčku ${parsed.toPlainString()} na $term měsíců (návrh k potvrzení)",
+                fields = fields,
+            ),
+        )
+    }
+}

--- a/openbank-copilot-service/src/main/resources/application.yaml
+++ b/openbank-copilot-service/src/main/resources/application.yaml
@@ -68,12 +68,39 @@ quarkus:
     tls:
       verification: ${OIDC_TLS_VERIFICATION:none}
 
+  # Client-credentials principal for the two calls that do NOT propagate the customer's own
+  # bearer (see the rule-5 comment below): ConsentQueryClient and CreditProfileReadClient both
+  # register OidcClientRequestReactiveFilter, which mints from THIS block, not the resource-server
+  # `oidc:` block above. Same client-id/secret/issuer as the fleet's other internal service callers
+  # (e.g. openbank-agent-service's oidc-client).
+  oidc-client:
+    auth-server-url: ${QUARKUS_OIDC_AUTH_SERVER_URL:http://localhost:8080/realms/openbank}
+    client-id: openbank-services
+    credentials:
+      secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
+    grant:
+      type: client
+    tls:
+      verification: ${OIDC_TLS_VERIFICATION:none}
+
   # READ tools call the customer edge (ADR-0065) AS the customer — the inbound bearer is propagated
   # (ADR-0089 D5); the edge is ROLE_CUSTOMER and enforces ownership, so the assistant only ever reaches
   # the caller's own data. (Calling internal domain services directly would 403 — they want SERVICE roles.)
   rest-client:
     customer-edge:
       url: ${CUSTOMER_EDGE_URL:http://localhost:8128}
+    # ADR-0269 rule 5. These two are NOT called with the propagated customer bearer, unlike the edge
+    # above: "did this customer grant this scope" is not a question their own token may answer about
+    # itself, and analytics-sink's profile route is an internal operator surface. The customer's
+    # protection is the consent check that must pass before the profile is read at all.
+    consent-service:
+      url: ${CONSENT_SERVICE_URL:http://localhost:8107}
+      connect-timeout: 2000
+      read-timeout: 3000
+    analytics-sink:
+      url: ${ANALYTICS_SINK_URL:http://localhost:8110}
+      connect-timeout: 2000
+      read-timeout: 3000
 
 # Customer copilot configuration (ADR-0089).
 copilot:

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/domain/CreditAffordabilityTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/domain/CreditAffordabilityTest.kt
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+/**
+ * ADR-0269 rule 5, L1.
+ *
+ * The defining property of the advisor is that it can say NO, so most of these tests are refusals.
+ * A test suite that only checked the happy path would pass just as well on an advisor that always
+ * says yes — which is exactly the failure this level exists to prevent.
+ */
+class CreditAffordabilityTest {
+
+    private fun assess(income: String?, obligations: String?, instalment: String, net: String? = null) =
+        CreditAffordability.assess(
+            income?.let { BigDecimal(it) },
+            obligations?.let { BigDecimal(it) },
+            net?.let { BigDecimal(it) },
+            BigDecimal(instalment),
+        )
+
+    @Test
+    fun `a small instalment on a clean income is comfortable`() {
+        val a = assess("50000", "0", "5000")
+        assertThat(a.verdict).isEqualTo(AffordabilityVerdict.COMFORTABLE)
+        assertThat(a.reasons).containsExactly("FITS")
+    }
+
+    @Test
+    fun `an instalment that pushes debt service past the limit is refused`() {
+        val a = assess("50000", "15000", "10000") // 25000/50000 = 0.50
+        assertThat(a.verdict).isEqualTo(AffordabilityVerdict.UNAFFORDABLE)
+        assertThat(a.reasons).contains("DSTI_ABOVE_LIMIT")
+    }
+
+    @Test
+    fun `an instalment that leaves nothing over is refused even when DSTI passes`() {
+        // 50,000 income, 5,000 of existing debt service, but only 6,000 actually left over after
+        // rent and living costs. DSTI after a 6,000 instalment is 0.22 — comfortably inside the
+        // limit — and the customer still ends the month at zero.
+        //
+        // This case is why the surplus rule measures the profile's NET and not income minus debt
+        // service: the first version of this test could not fail, because inside the DSTI limit
+        // income-minus-debt-service is always positive. The rule was dead code until the number it
+        // reads changed.
+        val a = assess(income = "50000", obligations = "5000", instalment = "6000", net = "6000")
+        assertThat(a.verdict).isEqualTo(AffordabilityVerdict.UNAFFORDABLE)
+        assertThat(a.reasons).contains("NO_MONTHLY_SURPLUS")
+    }
+
+    @Test
+    fun `an unknown net is skipped, not treated as a surplus of zero`() {
+        // Without the profile's net the second question simply cannot be asked. Treating null as 0
+        // would refuse every customer whose spending the bank has not observed.
+        val a = assess(income = "50000", obligations = "0", instalment = "5000", net = null)
+        assertThat(a.verdict).isEqualTo(AffordabilityVerdict.COMFORTABLE)
+        assertThat(a.monthlySurplusAfter).isNull()
+    }
+
+    @Test
+    fun `an instalment inside the limit but past comfort is called tight, not refused`() {
+        val a = assess("50000", "10000", "10000") // 0.40
+        assertThat(a.verdict).isEqualTo(AffordabilityVerdict.TIGHT)
+        assertThat(a.reasons).contains("DSTI_TIGHT")
+    }
+
+    @Test
+    fun `unknown income answers UNKNOWN, never a cheerful yes`() {
+        assertThat(assess(null, "0", "5000").verdict).isEqualTo(AffordabilityVerdict.UNKNOWN)
+        assertThat(assess("0", "0", "5000").verdict).isEqualTo(AffordabilityVerdict.UNKNOWN)
+    }
+
+    @Test
+    fun `an unknown answer carries no numbers to be mistaken for a calculation`() {
+        val a = assess(null, null, "5000")
+        assertThat(a.dstiAfter).isNull()
+        assertThat(a.monthlySurplusAfter).isNull()
+        assertThat(a.reasons).containsExactly("INCOME_UNKNOWN")
+    }
+
+    @Test
+    fun `every answer carries at least one machine-readable reason`() {
+        val cases = listOf(
+            assess("50000", "0", "5000"),
+            assess("50000", "15000", "10000"),
+            assess("50000", "5000", "6000", net = "6000"),
+            assess("50000", "10000", "10000"),
+            assess(null, null, "1"),
+        )
+        assertThat(cases).allSatisfy { assertThat(it.reasons).isNotEmpty() }
+    }
+
+    @Test
+    fun `missing obligations are treated as zero, not as unknown`() {
+        // Deliberate asymmetry with income: an absent obligation list means the bank knows of no
+        // debts, which is a real state. An absent income means the bank cannot see earnings, which
+        // is not.
+        val a = assess("50000", null, "5000")
+        assertThat(a.verdict).isEqualTo(AffordabilityVerdict.COMFORTABLE)
+    }
+
+    @Test
+    fun `the workings are returned so narration has nothing left to invent`() {
+        val a = assess("40000", "4000", "6000")
+        assertThat(a.dstiAfter).isEqualByComparingTo("0.2500")
+        assertThat(a.monthlySurplusAfter).isNull() // no net supplied — nothing invented in its place
+    }
+}

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/domain/CreditAiLevelTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/domain/CreditAiLevelTest.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/** ADR-0269 rule 5: the three levels and their containment. */
+class CreditAiLevelTest {
+
+    @Test
+    fun `no consent is the explainer, not a refusal`() {
+        assertThat(CreditAiLevel.from(profileUseConsent = false, agentConsent = false))
+            .isEqualTo(CreditAiLevel.L0_EXPLAINER)
+    }
+
+    @Test
+    fun `profile-use consent alone is the advisor`() {
+        assertThat(CreditAiLevel.from(profileUseConsent = true, agentConsent = false))
+            .isEqualTo(CreditAiLevel.L1_ADVISOR)
+    }
+
+    @Test
+    fun `agent consent is the agent even if profile-use was recorded separately`() {
+        assertThat(CreditAiLevel.from(profileUseConsent = false, agentConsent = true))
+            .isEqualTo(CreditAiLevel.L2_AGENT)
+        assertThat(CreditAiLevel.from(profileUseConsent = true, agentConsent = true))
+            .isEqualTo(CreditAiLevel.L2_AGENT)
+    }
+
+    @Test
+    fun `the levels contain each other so a tool never has to test for equality`() {
+        assertThat(CreditAiLevel.L2_AGENT.atLeast(CreditAiLevel.L1_ADVISOR)).isTrue()
+        assertThat(CreditAiLevel.L2_AGENT.atLeast(CreditAiLevel.L0_EXPLAINER)).isTrue()
+        assertThat(CreditAiLevel.L1_ADVISOR.atLeast(CreditAiLevel.L2_AGENT)).isFalse()
+        // The property that matters: turning L2 on must not switch an L1 tool off.
+        CreditAiLevel.entries.forEach { assertThat(it.atLeast(CreditAiLevel.L0_EXPLAINER)).isTrue() }
+    }
+}

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/tool/CreditApplicationDraftToolTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/tool/CreditApplicationDraftToolTest.kt
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.infrastructure.tool
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.copilot.domain.ActionKind
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * ADR-0269 rule 5, L2. The agent may prepare and never commit, so these tests are mostly about what
+ * the draft must NOT contain.
+ */
+class CreditApplicationDraftToolTest {
+
+    private val tool = CreditApplicationDraftTool()
+    private val json = ObjectMapper()
+
+    private fun propose(amount: String?, term: Int?) = tool.propose(
+        json.createObjectNode().apply {
+            amount?.let { put("amount", it) }
+            term?.let { put("termMonths", it) }
+        },
+    )
+
+    @Test
+    fun `a valid request produces a credit application draft`() {
+        val result = propose("250000", 48)
+        assertThat(result.proposal).isNotNull
+        assertThat(result.proposal!!.kind).isEqualTo(ActionKind.CREDIT_APPLICATION)
+        assertThat(result.proposal!!.fields).containsEntry("amount", "250000").containsEntry("termMonths", "48")
+    }
+
+    @Test
+    fun `the draft carries no price of any kind`() {
+        val fields = propose("250000", 48).proposal!!.fields
+        // A draft that claimed a rate or an instalment would be a quote the bank never made. The
+        // price comes from the server, at the moment the customer asks for it.
+        assertThat(fields.keys).containsExactlyInAnyOrder("amount", "termMonths")
+        assertThat(fields.keys).noneMatch { it.contains("rate") || it.contains("apr") || it.contains("instal") }
+    }
+
+    @Test
+    fun `the summary says it is a draft, so no rendering of it can read as an approval`() {
+        assertThat(propose("250000", 48).proposal!!.summary).contains("návrh")
+    }
+
+    @Test
+    fun `a missing or unparseable amount is refused rather than guessed`() {
+        assertThat(propose(null, 48).error).isNotNull
+        assertThat(propose("abc", 48).error).isNotNull
+        assertThat(propose("0", 48).error).isNotNull
+        assertThat(propose("-100", 48).error).isNotNull
+    }
+
+    @Test
+    fun `a missing or non-positive term is refused`() {
+        assertThat(propose("250000", null).error).isNotNull
+        assertThat(propose("250000", 0).error).isNotNull
+    }
+
+    @Test
+    fun `the tool describes itself as preparing, never submitting`() {
+        assertThat(tool.description).contains("do NOT submit")
+        assertThat(tool.name).isEqualTo("credit_prepare_application")
+    }
+}

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -825,6 +825,113 @@ class CustomerEdgeResource(
         return Response.status(resp.status).entity(resp.entity).type(MediaType.APPLICATION_JSON).build()
     }
 
+    /**
+     * The caller's own ADR-0269 credit consents, as three booleans.
+     *
+     * ## Why this route exists at all
+     *
+     * consent-service could already grant these scopes, and the edge could already list and revoke
+     * consents — but there was no way for a CUSTOMER to switch one ON. The app's existing marketing
+     * toggle goes somewhere else entirely (party-service's `marketingConsent` boolean), so without
+     * this route the credit consents were grantable only by an operator, which is the opposite of
+     * what "the customer decides" means.
+     *
+     * ## Why booleans and not the consent objects
+     *
+     * The app renders three switches. Handing it consent aggregates would make every client
+     * re-derive "is CREDIT_OFFERS on" from a list, and the first client to write that filter
+     * slightly differently gets a different answer — the same reasoning ADR-0210 D2 gives for the
+     * party key. The derivation happens once, here.
+     */
+    @GET
+    @Path("/credit/consents")
+    @Authorize(action = "customer.profile.read", resource = "")
+    @Blocking
+    fun getCreditConsents(): Response {
+        val customer = customer()
+        val party = customer.partyId.toString()
+        val resp = upstream.get("$consentServiceUrl/api/v1/consents/party/$party", party)
+        val arr = if (resp.status == 200) {
+            runCatching { objectMapper.readTree(resp.entity?.toString() ?: "") as? ArrayNode }.getOrNull()
+        } else {
+            null
+        }
+        // An unreadable consent list answers "everything off", which is the SAFE default and the
+        // true one for every customer who has never granted anything. It is not fail-soft
+        // convenience: the client uses this to decide whether to fetch offers at all, so an
+        // optimistic default here would fetch offers for a customer whose consent we cannot read.
+        val active = arr?.filter { it.get("status")?.asText() == "ACTIVE" }?.flatMap { c ->
+            c.get("scopes")?.mapNotNull { it.asText() } ?: emptyList()
+        }?.toSet().orEmpty()
+        val out = objectMapper.createObjectNode()
+        CREDIT_SCOPES.forEach { (field, scope) -> out.put(field, scope in active) }
+        return Response.ok(out).type(MediaType.APPLICATION_JSON).build()
+    }
+
+    /**
+     * Set the caller's credit consents to exactly the state in the body (ADR-0269 rule 1).
+     *
+     * A full-state PUT, not a partial patch: "turn offers off" and "leave offers alone" must not be
+     * the same request. Anything the body sets to false is revoked, immediately and for every
+     * channel — the ADR's requirement that switching offers off takes effect at once rather than at
+     * the next batch.
+     *
+     * These scopes are GDPR Art. 7 data-processing consents, so consent-service activates them
+     * without an SCA ceremony; an SCA designed for payment authorisation is a disproportionate
+     * burden on a data-processing opt-in (ADR-0205 D1). Granting still requires the customer's own
+     * authenticated session — the party comes from the JWT, never the body.
+     */
+    @PUT
+    @Path("/credit/consents")
+    @Authorize(action = "customer.profile.consent.update", resource = "")
+    @Blocking
+    fun putCreditConsents(body: String): Response {
+        val customer = customer()
+        val requested = runCatching { objectMapper.readTree(body) }.getOrNull() as? ObjectNode
+            ?: return badRequest("Malformed credit consent body")
+        val desired = CREDIT_SCOPES.mapValues { (field, _) -> requested.get(field)?.asBoolean() ?: false }
+        val party = customer.partyId.toString()
+
+        val existing = upstream.get("$consentServiceUrl/api/v1/consents/party/$party", party)
+        if (existing.status != 200) return Response.status(existing.status).entity(existing.entity).build()
+        val consents = runCatching { objectMapper.readTree(existing.entity?.toString() ?: "") as? ArrayNode }
+            .getOrNull() ?: objectMapper.createArrayNode()
+
+        desired.forEach { (field, wanted) ->
+            val scope = CREDIT_SCOPES.getValue(field)
+            val held = consents.firstOrNull { c ->
+                c.get("status")?.asText() == "ACTIVE" &&
+                    c.get("scopes")?.any { it.asText() == scope } == true
+            }
+            when {
+                wanted && held == null -> grantCreditScope(customer.partyId, scope)
+                !wanted && held != null -> revokeHeldConsent(customer.partyId, held.get("id")?.asText())
+                else -> Unit // already in the requested state; granting again would churn the audit trail
+            }
+        }
+        return getCreditConsents()
+    }
+
+    private fun grantCreditScope(partyId: UUID, scope: String) {
+        val body = objectMapper.createObjectNode().apply {
+            put("partyId", partyId.toString())
+            put("granteeId", BANK_GRANTEE)
+            put("granteeType", "INTERNAL_SERVICE")
+            put("granteeName", "OpenBank")
+            putArray("scopes").add(scope)
+            // 365 days: the non-AISP bucket's maximum. It is a ceiling, not a promise — the customer
+            // can revoke at any time, and nothing re-arms the consent when it lapses.
+            put("validTo", java.time.OffsetDateTime.now(java.time.ZoneOffset.UTC).plusDays(CONSENT_DAYS).toString())
+        }.toString()
+        upstream.post("$consentServiceUrl/api/v1/consents", partyId.toString(), body)
+    }
+
+    private fun revokeHeldConsent(partyId: UUID, consentId: String?) {
+        if (consentId.isNullOrBlank()) return
+        val body = objectMapper.createObjectNode().put("reason", "Revoked by customer").toString()
+        upstream.delete("$consentServiceUrl/api/v1/consents/$consentId?partyId=$partyId", partyId.toString(), body)
+    }
+
     private fun projectConsent(c: com.fasterxml.jackson.databind.JsonNode): ObjectNode {
         val o = objectMapper.createObjectNode()
         o.put("id", c.get("id")?.asText())
@@ -4416,6 +4523,24 @@ class CustomerEdgeResource(
         parseCreditorAccount(raw) ?: czechIbanToBban(raw)
 
     companion object {
+        /**
+         * The ADR-0269 credit consents, as the app's field name → the consent-service scope.
+         *
+         * One map, so the read and the write cannot disagree about which switch means which scope —
+         * the failure that would look like a customer turning offers off and still being offered.
+         */
+        private val CREDIT_SCOPES: Map<String, String> = linkedMapOf(
+            "offers" to "CREDIT_OFFERS",
+            "profileUse" to "CREDIT_PROFILE_USE",
+            "aiAgent" to "CREDIT_AI_AGENT",
+        )
+
+        /** First-party consent: the bank itself is the grantee, not a TPP. */
+        private const val BANK_GRANTEE = "openbank"
+
+        /** The non-AISP validity ceiling. A ceiling, not a promise — revocation is immediate. */
+        private const val CONSENT_DAYS = 365L
+
         /** Closed at the edge as well as upstream: a path is never an app-controlled URL. */
         private val SURFACE_SLOTS: Set<String> = setOf(
             "HOME_BANNER",

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.42.0
+  version: 1.43.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -887,6 +887,7 @@ paths:
                           - MARKETING_COMMS_INAPP
                           - CREDIT_OFFERS
                           - CREDIT_PROFILE_USE
+                          - CREDIT_AI_AGENT
                     accountIbans: {type: array, items: {type: string}, nullable: true}
                     validFrom: {type: string, format: date-time}
                     validTo: {type: string, format: date-time}

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.43.0
+  version: 1.44.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -1092,6 +1092,48 @@ paths:
               schema:
                 type: array
                 items: {$ref: '#/components/schemas/Loan'}
+
+  /credit/consents:
+    get:
+      tags: [Consents]
+      summary: The caller's own credit consents, as three switches
+      description: >-
+        ADR-0269 rule 1. Derived once here rather than by every client filtering a consent list —
+        the first client to write that filter differently gets a different answer. An unreadable
+        consent list answers "everything off", which is both the safe default and the true state
+        for anyone who has never granted these.
+      operationId: getCreditConsents
+      security:
+        - customerOidc: [accounts:read]
+      responses:
+        '200':
+          description: The three switches
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/CreditConsents'}
+    put:
+      tags: [Consents]
+      summary: Set the caller's credit consents to exactly this state
+      description: >-
+        Full-state PUT, not a partial patch: "turn offers off" and "leave offers alone" must not be
+        the same request. Anything false is revoked immediately and for every channel. These are
+        GDPR Art. 7 data-processing consents, so no SCA ceremony is required (ADR-0205 D1); the
+        party comes from the JWT, never the body.
+      operationId: putCreditConsents
+      security:
+        - customerOidc: [accounts:read]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/CreditConsents'}
+      responses:
+        '200':
+          description: The resulting state, re-read after the change
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/CreditConsents'}
+        '400': {description: Malformed body}
 
   /credit/quotes:
     post:
@@ -3217,6 +3259,28 @@ components:
 
     # Edge's projected view of lending-service's Loan (internal fields dropped — see
     # CustomerEdgeResource.projectLoan).
+    CreditConsents:
+      type: object
+      description: >-
+        ADR-0269's three credit consents. All default FALSE — absence of consent is denial, and no
+        path re-arms one on the customer's behalf.
+      required: [offers, profileUse, aiAgent]
+      properties:
+        offers:
+          type: boolean
+          description: May the bank show this customer a credit offer it was not asked for.
+        profileUse:
+          type: boolean
+          description: >-
+            May the 360 profile be used to work out WHICH offer. Separate from `offers` because a
+            customer may want an affordability answer they asked for without their spending being
+            mined for eligibility.
+        aiAgent:
+          type: boolean
+          description: >-
+            May the assistant watch and PREPARE on the customer's behalf. Never extends to
+            submitting, accepting, raising a limit or drawing funds.
+
     CreditQuote:
       type: object
       description: >-

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeCreditConsentTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeCreditConsentTest.kt
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.customeredge.infrastructure.rest.CustomerEdgeResource
+import com.openbank.customeredge.infrastructure.rest.PaymentSessionStore
+import com.openbank.customeredge.infrastructure.rest.UpstreamClient
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import jakarta.ws.rs.core.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.util.UUID
+
+/**
+ * ADR-0269 rule 1 — the customer's own credit consents.
+ *
+ * These tests are written against the ways the route could WRONGLY GRANT or wrongly report a grant,
+ * because that is the failure with consequences: a customer who believes offers are off and is
+ * offered anyway. The happy path is one test; the rest are refusals and non-actions.
+ */
+class CustomerEdgeCreditConsentTest {
+
+    private val party = UUID.randomUUID()
+
+    private fun newResource(upstream: UpstreamClient): CustomerEdgeResource = CustomerEdgeResource(
+        upstream,
+        mockk(relaxed = true),
+        PaymentSessionStore(),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        Clock.systemUTC(),
+    ).apply {
+        partyMergeResolver = mockk { every { resolve(any()) } answers { firstArg() } }
+        jwt = mockk {
+            every { getClaim<String>("party_id") } returns null
+            every { subject } returns party.toString()
+        }
+        objectMapper = ObjectMapper()
+        consentServiceUrl = "http://consent"
+    }
+
+    private fun consentList(vararg scopes: String, status: String = "ACTIVE"): String =
+        scopes.joinToString(",", "[", "]") { s ->
+            """{"id":"${UUID.nameUUIDFromBytes(s.toByteArray())}","status":"$status","scopes":["$s"]}"""
+        }
+
+    private fun upstreamReturning(list: String): UpstreamClient = mockk(relaxed = true) {
+        every { get(match { it.contains("/api/v1/consents/party/") }, any()) } returns Response.ok(list).build()
+    }
+
+    private fun bodyOf(response: Response): Map<String, Any?> {
+        val node = ObjectMapper().readTree(response.entity.toString())
+        return node.fields().asSequence().associate { (k, v) -> k to (if (v.isBoolean) v.asBoolean() else v) }
+    }
+
+    // ── Reading ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a party with no consents reads as everything off`() {
+        val resp = newResource(upstreamReturning("[]")).getCreditConsents()
+        assertThat(bodyOf(resp)).containsEntry("offers", false)
+            .containsEntry("profileUse", false)
+            .containsEntry("aiAgent", false)
+    }
+
+    @Test
+    fun `an unreadable consent list reads as everything off, never as granted`() {
+        // The client uses this to decide whether to fetch offers at all. An optimistic default here
+        // would fetch offers for a customer whose consent could not be read.
+        val upstream = mockk<UpstreamClient>(relaxed = true) {
+            every { get(any(), any()) } returns Response.status(503).build()
+        }
+        assertThat(bodyOf(newResource(upstream).getCreditConsents())).containsEntry("offers", false)
+    }
+
+    @Test
+    fun `only ACTIVE consents count as granted`() {
+        val revoked = consentList("CREDIT_OFFERS", status = "REVOKED")
+        assertThat(bodyOf(newResource(upstreamReturning(revoked)).getCreditConsents()))
+            .containsEntry("offers", false)
+    }
+
+    @Test
+    fun `each switch reports its own scope and not another`() {
+        val body = bodyOf(newResource(upstreamReturning(consentList("CREDIT_PROFILE_USE"))).getCreditConsents())
+        assertThat(body).containsEntry("profileUse", true)
+            .containsEntry("offers", false)
+            .containsEntry("aiAgent", false)
+    }
+
+    // ── Writing ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `granting posts one consent for the requested scope, scoped to the caller's own party`() {
+        val upstream = upstreamReturning("[]")
+        val bodySlot = slot<String>()
+        every { upstream.post(match { it.endsWith("/api/v1/consents") }, any(), capture(bodySlot)) } returns
+            Response.status(201).entity("{}").build()
+
+        newResource(upstream).putCreditConsents("""{"offers":true,"profileUse":false,"aiAgent":false}""")
+
+        verify(exactly = 1) { upstream.post(any(), party.toString(), any()) }
+        assertThat(bodySlot.captured).contains("CREDIT_OFFERS").contains(party.toString())
+        assertThat(bodySlot.captured).doesNotContain("CREDIT_AI_AGENT")
+    }
+
+    @Test
+    fun `an omitted field is false — absence of consent is denial, never "leave it as it was"`() {
+        val upstream = upstreamReturning(consentList("CREDIT_OFFERS"))
+        newResource(upstream).putCreditConsents("{}")
+        // Offers were on and the body did not mention them, so they are revoked. A partial-patch
+        // reading would have left them on, which is the difference between a switch and a suggestion.
+        verify(exactly = 1) { upstream.delete(match { it.contains("/api/v1/consents/") }, party.toString(), any()) }
+    }
+
+    @Test
+    fun `turning a granted switch off revokes it and grants nothing`() {
+        val upstream = upstreamReturning(consentList("CREDIT_OFFERS"))
+        newResource(upstream).putCreditConsents("""{"offers":false,"profileUse":false,"aiAgent":false}""")
+        verify(exactly = 1) { upstream.delete(any(), party.toString(), any()) }
+        verify(exactly = 0) { upstream.post(any(), any(), any()) }
+    }
+
+    @Test
+    fun `re-granting an already-held consent does nothing rather than churning the audit trail`() {
+        val upstream = upstreamReturning(consentList("CREDIT_OFFERS"))
+        newResource(upstream).putCreditConsents("""{"offers":true,"profileUse":false,"aiAgent":false}""")
+        verify(exactly = 0) { upstream.post(any(), any(), any()) }
+        verify(exactly = 0) { upstream.delete(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a malformed body changes nothing`() {
+        val upstream = upstreamReturning("[]")
+        val resp = newResource(upstream).putCreditConsents("not json")
+        assertThat(resp.status).isEqualTo(400)
+        verify(exactly = 0) { upstream.post(any(), any(), any()) }
+        verify(exactly = 0) { upstream.delete(any(), any(), any()) }
+    }
+
+    @Test
+    fun `an unreadable consent list refuses the write rather than granting blindly`() {
+        val upstream = mockk<UpstreamClient>(relaxed = true) {
+            every { get(any(), any()) } returns Response.status(503).build()
+        }
+        val resp = newResource(upstream).putCreditConsents("""{"offers":true}""")
+        assertThat(resp.status).isEqualTo(503)
+        verify(exactly = 0) { upstream.post(any(), any(), any()) }
+    }
+}

--- a/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
+++ b/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
@@ -736,6 +736,66 @@ data:
     FROM openbank_analytics.bronze_events AS b
     WHERE b.occurred_at <= {t:DateTime64(3, 'UTC')}
     GROUP BY upper(b.aggregate_type), b.aggregate_id;
+
+    -- ─────────────────────────────────────────────────────────────────────────
+    -- V9: the ADR-0269 credit profile (issue #6215). Mirrors
+    -- openbank-analytics-sink/src/main/resources/clickhouse/V9__party_credit_profile.sql — the
+    -- migration is what an EXISTING warehouse gets, this ConfigMap is what a FRESH one gets, and
+    -- the #4511 gate exists because the two drifting apart is invisible until a cluster is rebuilt.
+    -- ─────────────────────────────────────────────────────────────────────────
+
+    CREATE OR REPLACE VIEW openbank_analytics.silver_party_monthly_flows AS
+    SELECT
+        party_id,
+        month,
+        sum(inbound)  AS inbound_amount,
+        sum(outbound) AS outbound_amount,
+        count()       AS movement_count
+    FROM
+    (
+        SELECT
+            pa.party_id                                            AS party_id,
+            toStartOfMonth(e.occurred_at)                          AS month,
+            toDecimal64(JSONExtractString(e.payload, 'amount'), 2) AS inbound,
+            toDecimal64('0', 2)                                    AS outbound
+        FROM openbank_analytics.bronze_events AS e
+        INNER JOIN openbank_analytics.silver_party_accounts AS pa
+            ON pa.account_id = JSONExtractString(e.payload, 'targetAccountId')
+        WHERE upper(e.aggregate_type) = 'TRANSACTION'
+          AND JSONExtractString(e.payload, 'targetAccountId') != ''
+          AND JSONExtractString(e.payload, 'amount') != ''
+
+        UNION ALL
+
+        SELECT
+            pa.party_id                                            AS party_id,
+            toStartOfMonth(e.occurred_at)                          AS month,
+            toDecimal64('0', 2)                                    AS inbound,
+            toDecimal64(JSONExtractString(e.payload, 'amount'), 2) AS outbound
+        FROM openbank_analytics.bronze_events AS e
+        INNER JOIN openbank_analytics.silver_party_accounts AS pa
+            ON pa.account_id = JSONExtractString(e.payload, 'sourceAccountId')
+        WHERE upper(e.aggregate_type) = 'TRANSACTION'
+          AND JSONExtractString(e.payload, 'sourceAccountId') != ''
+          AND JSONExtractString(e.payload, 'amount') != ''
+    )
+    GROUP BY party_id, month;
+
+    CREATE OR REPLACE VIEW openbank_analytics.gold_party_credit_profile AS
+    SELECT
+        party_id,
+        count()                                              AS months_observed,
+        quantileExact(0.5)(inbound_amount)                   AS income_monthly,
+        quantileExact(0.5)(outbound_amount)                  AS outflow_monthly,
+        quantileExact(0.5)(inbound_amount - outbound_amount) AS net_monthly,
+        if(quantileExact(0.5)(inbound_amount) > 0,
+           stddevPop(inbound_amount - outbound_amount) / quantileExact(0.5)(inbound_amount),
+           NULL)                                             AS volatility_ratio,
+        sum(movement_count)                                  AS movements_observed
+    FROM openbank_analytics.silver_party_monthly_flows
+    WHERE month >= toStartOfMonth(now()) - INTERVAL 6 MONTH
+      AND month <  toStartOfMonth(now())
+    GROUP BY party_id;
 kind: ConfigMap
 metadata:
   name: clickhouse-init

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -94,6 +94,20 @@ spec:
                   name: copilot-service-secrets
                   key: COPILOT_MODEL_API_KEY
                   optional: true
+            # openbank-services client secret (ADR-0269 slice 4) — lets ConsentQueryClient and
+            # CreditProfileReadClient's OidcClientRequestReactiveFilter mint a client-credentials
+            # token for the two calls that do not propagate the customer's own bearer. Same shared
+            # KV entry every other projection reads (rules.yaml: oidc_secret_convention, #3485).
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: copilot-service-secrets
+                  key: OIDC_CLIENT_SECRET
+                  # NOT optional (issue #2929): a missing key here must not silently degrade to
+                  # UNAUTHENTICATED outbound calls — CrashLoop is the correct failure mode for a
+                  # credential this security-relevant, not a quiet 401 from consent-service/
+                  # analytics-sink.
+                  optional: false
             # Postgres conversation history (#3710). The CNPG operator injects
             # copilot-db-app with PG_USER/PG_PASSWORD; REACTIVE_URL and JDBC_URL resolve them.
             #

--- a/openbank-infra/gitops/components/external-secrets/es-copilot-service.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-copilot-service.yaml
@@ -3,7 +3,14 @@
 # in-cluster gateway, NOT to the provider — the DeepInfra key now lives only in ai-platform (#1919).
 # Sourced from OpenBao KV path `openbank/litellm`, property `KEY_COPILOT_SERVICE` — copilot's OWN
 # virtual key with its own daily budget, not the shared master key (see the data entry below).
-# (No OIDC secret: copilot validates the customer JWT bearer-only via JWKS — no client secret.)
+#
+# OIDC_CLIENT_SECRET is new here (ADR-0269 slice 4): ConsentQueryClient and CreditProfileReadClient
+# register OidcClientRequestReactiveFilter to mint a client-credentials token for the two calls
+# that do not propagate the customer's own bearer. Same shared-KV convention as every other
+# OIDC_CLIENT_SECRET projection (rules.yaml: oidc_secret_convention, issue #3485) — the fleet has
+# exactly one Keycloak confidential client (`openbank-services`), so this reads the SAME
+# `account-service`/`OIDC_CLIENT_SECRET` KV entry every other projection does, not a copilot-owned
+# secret that does not exist.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -35,3 +42,7 @@ spec:
       remoteRef:
         key: litellm
         property: KEY_COPILOT_SERVICE
+    - secretKey: OIDC_CLIENT_SECRET
+      remoteRef:
+        key: account-service
+        property: OIDC_CLIENT_SECRET

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityService.kt
@@ -110,6 +110,7 @@ class CreditOfferEligibilityService(
             inHardshipArrangement = true,
             lastAffordabilityFailureAt = null,
             bufferDays = null,
+            monthsObserved = null,
             lastCreditContactAt = null,
             inputsChangedSinceLastContact = false,
             complete = false,

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/CreditOfferEligibility.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/CreditOfferEligibility.kt
@@ -58,6 +58,15 @@ enum class CreditOfferSuppressionCode {
     /** 360-derived buffer is below the configured floor — thin cover, not yet distress. */
     BUFFER_BELOW_FLOOR,
 
+    /**
+     * The 360 profile has too few observed months to be evidence.
+     *
+     * Distinct from [SIGNALS_UNAVAILABLE] on purpose: that one is a fault worth alerting on, this
+     * one is a customer the bank has simply not seen for long enough. Collapsing them would bury a
+     * genuine outage inside the normal traffic of new customers.
+     */
+    HISTORY_TOO_THIN,
+
     /** A credit-marketing contact already went out inside the frequency window. */
     FREQUENCY_CAP,
 
@@ -82,6 +91,12 @@ data class BorrowerDistressSignals(
     val inHardshipArrangement: Boolean,
     val lastAffordabilityFailureAt: Instant?,
     val bufferDays: Int?,
+    /**
+     * Whole months of cash-flow history behind the 360 figures. A three-week-old customer and a
+     * five-year customer can produce the same median, so the count travels with the numbers rather
+     * than being discarded at the source.
+     */
+    val monthsObserved: Int?,
     val lastCreditContactAt: Instant?,
     val inputsChangedSinceLastContact: Boolean,
     val complete: Boolean,
@@ -102,12 +117,14 @@ data class CreditOfferPolicy(
     val minimumBufferDays: Int,
     val affordabilityCoolingDays: Long,
     val contactFrequencyDays: Long,
+    val minimumMonthsObserved: Int,
 ) {
     init {
         require(version > 0) { "policy version must be positive" }
         require(minimumBufferDays >= 0) { "minimumBufferDays must not be negative" }
         require(affordabilityCoolingDays >= 0) { "affordabilityCoolingDays must not be negative" }
         require(contactFrequencyDays >= 0) { "contactFrequencyDays must not be negative" }
+        require(minimumMonthsObserved >= 0) { "minimumMonthsObserved must not be negative" }
     }
 
     companion object {
@@ -121,6 +138,9 @@ data class CreditOfferPolicy(
             minimumBufferDays = 30,
             affordabilityCoolingDays = 14,
             contactFrequencyDays = 30,
+            // Three whole months: enough for one unusual month not to be the whole picture, and
+            // the point at which a median stops being an anecdote.
+            minimumMonthsObserved = 3,
         )
     }
 }
@@ -193,6 +213,11 @@ object CreditOfferEligibility {
         //  - materiality asks whether there is anything new to SAY, which is meaningless when the
         //    customer just asked the question.
         if (surface == OfferSurface.PULL) return null
+
+        // A push needs evidence, and a median over one or two months is not evidence. A pull is
+        // unaffected: answering "what would this cost" does not rest on knowing the customer.
+        val months = signals.monthsObserved ?: return CreditOfferSuppressionCode.HISTORY_TOO_THIN
+        if (months < policy.minimumMonthsObserved) return CreditOfferSuppressionCode.HISTORY_TOO_THIN
 
         // A missing buffer is not a healthy buffer. Unknown reads as below the floor.
         val buffer = signals.bufferDays ?: return CreditOfferSuppressionCode.BUFFER_BELOW_FLOOR

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/CreditOfferGateAdapters.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/CreditOfferGateAdapters.kt
@@ -5,6 +5,7 @@
 package com.openbank.lending.infrastructure.client
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.openbank.lending.application.port.out.BorrowerDistressPort
 import com.openbank.lending.application.port.out.CreditOffersConsentPort
 import com.openbank.lending.application.port.out.LoanRepository
@@ -69,8 +70,38 @@ class RestCreditOffersConsentAdapter(@param:RestClient private val consents: Len
     }
 }
 
+/** analytics-sink's ADR-0269 credit profile (#6215) — the single definition of these numbers. */
+@RegisterRestClient(configKey = "analytics-sink")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/analytics/credit-profile")
+@Produces(MediaType.APPLICATION_JSON)
+interface CreditProfileClient {
+    @GET
+    @Path("/{partyId}")
+    @Timeout(PROFILE_TIMEOUT_MS)
+    fun profile(@PathParam("partyId") partyId: UUID): io.smallrye.mutiny.Uni<CreditProfileResponse>
+}
+
 /**
- * Distress signals from the bank's OWN loan book (ADR-0269 rule 2).
+ * [monthsObserved] is part of the answer, not metadata: a three-week-old customer and a five-year
+ * customer can produce the same median, and the gate refuses to treat the first as evidence.
+ * Amounts are strings on the wire for the reason they always are here — money never crosses an API
+ * as a Double.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CreditProfileResponse(
+    // The wire names are ClickHouse column names (snake_case) and the Kotlin names are Kotlin
+    // names; @JsonProperty is what keeps that translation in one visible place instead of forcing
+    // one convention onto the other.
+    @param:JsonProperty("months_observed") val monthsObserved: Int = 0,
+    @param:JsonProperty("income_monthly") val incomeMonthly: String? = null,
+    @param:JsonProperty("outflow_monthly") val outflowMonthly: String? = null,
+    @param:JsonProperty("net_monthly") val netMonthly: String? = null,
+    @param:JsonProperty("volatility_ratio") val volatilityRatio: String? = null,
+)
+
+/**
+ * Distress signals from the bank's OWN loan book, plus the 360 profile (ADR-0269 rule 2).
  *
  * ## What this can see, and what it deliberately cannot
  *
@@ -78,43 +109,75 @@ class RestCreditOffersConsentAdapter(@param:RestClient private val consents: Len
  * `DEFAULTED`, `TERMINATION_NOTICED` or `ACCELERATED` is in arrears, and `FORBEARANCE_ASSESSED` is
  * a hardship arrangement. Those are read here directly.
  *
- * Enforcement orders, insolvency proceedings, the current-account balance and the 360-derived
- * buffer have **no source in this deployment yet** — they arrive with `CustomerCreditProfile`
- * (#6215). This adapter reports them as absent rather than unknown, which is a deliberate and
- * narrow decision, so it is worth being explicit about what it costs:
+ * Cash-flow cover and history depth now come from analytics-sink's `gold_party_credit_profile`
+ * (#6215). [BorrowerDistressSignals.bufferDays] is derived from the profile as net monthly cover:
+ * how many days the median monthly surplus would carry the median monthly outflow. A party with no
+ * surplus has zero days of cover, which is the honest reading and the one the buffer floor exists
+ * to catch.
  *
- *  - It does NOT weaken the pull path, whose floor is arrears/hardship plus a binding affordability
- *    refusal — all of which this adapter can see.
- *  - It WOULD weaken the push path, which also leans on the buffer floor. Nothing pushes yet: the
- *    pre-approved read is #6214's follow-on and does not exist. #6215 must land before it does,
- *    and the buffer floor is what makes that ordering load-bearing rather than tidy.
+ * Enforcement orders and insolvency proceedings still have **no source in this deployment** — no
+ * service ingests a court register. They are reported as absent rather than unknown, deliberately:
+ * treating them as unknown would make `complete = false` permanent and suppress every offer
+ * forever, which is indistinguishable from the feature being switched off and would hide the
+ * moment a real signal source arrives. The gap is real and is what an operational-risk review of
+ * this gate should challenge first.
  *
- * `complete = true` is therefore an honest claim about THIS adapter's inputs: every signal it
- * declares itself able to read, it read. It is not a claim that the platform can see everything the
- * policy names.
+ * A profile that cannot be read is NOT substituted with defaults — `complete = false` propagates
+ * and the gate refuses. That is the difference between "the customer has no surplus" and "we could
+ * not find out", which no downstream layer can reconstruct afterwards.
  */
 @ApplicationScoped
-class LoanBookDistressAdapter(private val loans: LoanRepository) : BorrowerDistressPort {
+class LoanBookDistressAdapter(
+    private val loans: LoanRepository,
+    @param:RestClient private val profiles: CreditProfileClient,
+) : BorrowerDistressPort {
 
     override suspend fun signalsFor(partyId: UUID): BorrowerDistressSignals {
         val book = loans.findByParty(partyId).awaitSuspending()
+        val profile = runCatching { profiles.profile(partyId).awaitSuspending() }
+            .getOrElse { e ->
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                null
+            }
         return BorrowerDistressSignals(
             hasArrears = book.any { it.status in ARREARS_STATES },
             inHardshipArrangement = book.any { it.status == LoanStatus.FORBEARANCE_ASSESSED },
-            // No source yet — see the class docs. Not "false because it is convenient": false
-            // because this adapter does not claim to answer them, and #6215 is what will.
-            hasNegativeBalance = false,
+            // A negative median net over six months is the closest thing to "living on the
+            // overdraft" that the profile can see. It is not a live balance read, and it is not
+            // claimed to be one.
+            hasNegativeBalance = profile?.netMonthlyOrNull()?.signum()?.let { it < 0 } ?: false,
+            // No source in this deployment — see the class docs.
             hasEnforcementOrder = false,
             hasInsolvencyProceeding = false,
             lastAffordabilityFailureAt = null,
-            bufferDays = null,
+            bufferDays = profile?.let { coverDays(it) },
+            monthsObserved = profile?.monthsObserved,
             lastCreditContactAt = null,
             inputsChangedSinceLastContact = true,
-            complete = true,
+            // False when the profile could not be read: the gate must refuse rather than price a
+            // customer whose cash flow the bank just failed to look up.
+            complete = profile != null,
         )
     }
 
+    /**
+     * Days of cover the monthly surplus buys against the monthly outflow.
+     *
+     * `net / outflow × 30`, floored at zero. Null outflow means nothing goes out, which is not
+     * infinite cover but an unobserved customer — null, so the buffer floor suppresses.
+     */
+    private fun coverDays(profile: CreditProfileResponse): Int? {
+        val net = profile.netMonthlyOrNull() ?: return null
+        val outflow = profile.outflowMonthlyOrNull() ?: return null
+        if (outflow.signum() <= 0) return null
+        if (net.signum() <= 0) return 0
+        return net.multiply(java.math.BigDecimal(DAYS_PER_MONTH))
+            .divide(outflow, java.math.MathContext.DECIMAL64)
+            .toInt()
+    }
+
     companion object {
+        private const val DAYS_PER_MONTH = 30
         private val ARREARS_STATES = setOf(
             LoanStatus.DELINQUENT,
             LoanStatus.DEFAULTED,
@@ -124,4 +187,11 @@ class LoanBookDistressAdapter(private val loans: LoanRepository) : BorrowerDistr
     }
 }
 
+private fun CreditProfileResponse.netMonthlyOrNull(): java.math.BigDecimal? =
+    netMonthly?.takeIf { it.isNotBlank() }?.let { runCatching { java.math.BigDecimal(it) }.getOrNull() }
+
+private fun CreditProfileResponse.outflowMonthlyOrNull(): java.math.BigDecimal? =
+    outflowMonthly?.takeIf { it.isNotBlank() }?.let { runCatching { java.math.BigDecimal(it) }.getOrNull() }
+
 private const val CONSENT_TIMEOUT_MS = 2000L
+private const val PROFILE_TIMEOUT_MS = 2000L

--- a/openbank-lending-service/src/main/resources/application.yaml
+++ b/openbank-lending-service/src/main/resources/application.yaml
@@ -83,6 +83,13 @@ quarkus:
       url: ${CONSENT_SERVICE_URL:http://localhost:8107}
       connect-timeout: 2000
       read-timeout: 3000
+    # ADR-0269 #6215: the 360 credit profile behind the distress floor. Same short timeouts and the
+    # same reasoning — an unreadable profile makes the gate refuse, never approve, so a slow
+    # analytics-sink costs a suppressed offer.
+    analytics-sink:
+      url: ${ANALYTICS_SINK_URL:http://localhost:8110}
+      connect-timeout: 2000
+      read-timeout: 3000
   redis:
     hosts: redis://localhost:6379
   shutdown:

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityServiceTest.kt
@@ -41,6 +41,7 @@ class CreditOfferEligibilityServiceTest {
         inHardshipArrangement = false,
         lastAffordabilityFailureAt = null,
         bufferDays = 90,
+        monthsObserved = 12,
         lastCreditContactAt = null,
         inputsChangedSinceLastContact = true,
         complete = true,

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/domain/CreditOfferEligibilityTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/domain/CreditOfferEligibilityTest.kt
@@ -9,6 +9,7 @@ import com.openbank.lending.domain.model.CreditOfferDecision
 import com.openbank.lending.domain.model.CreditOfferEligibility
 import com.openbank.lending.domain.model.CreditOfferPolicy
 import com.openbank.lending.domain.model.CreditOfferSuppressionCode
+import com.openbank.lending.domain.model.OfferSurface
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Instant
@@ -35,6 +36,7 @@ class CreditOfferEligibilityTest {
         inHardshipArrangement = false,
         lastAffordabilityFailureAt = null,
         bufferDays = 90,
+        monthsObserved = 12,
         lastCreditContactAt = null,
         inputsChangedSinceLastContact = true,
         complete = true,
@@ -42,6 +44,8 @@ class CreditOfferEligibilityTest {
 
     private fun decide(consent: Boolean = true, signals: BorrowerDistressSignals = healthy, at: Instant = now) =
         CreditOfferEligibility.evaluate(consent, signals, at)
+
+    private fun codeOf(decision: CreditOfferDecision) = (decision as? CreditOfferDecision.Suppressed)?.code
 
     private fun assertSuppressed(decision: CreditOfferDecision, code: CreditOfferSuppressionCode) {
         assertThat(decision).isInstanceOf(CreditOfferDecision.Suppressed::class.java)
@@ -162,8 +166,39 @@ class CreditOfferEligibilityTest {
                 minimumBufferDays = 1,
                 affordabilityCoolingDays = 1,
                 contactFrequencyDays = 1,
+                minimumMonthsObserved = 1,
             )
         val decision = CreditOfferEligibility.evaluate(true, healthy.copy(hasArrears = true), now, custom)
         assertThat(decision.policyVersion).isEqualTo(7)
+    }
+
+    // ── History depth (ADR-0269 #6215) ────────────────────────────────────────
+
+    @Test
+    fun `a push needs enough observed months to be evidence`() {
+        val thin = healthy.copy(monthsObserved = CreditOfferPolicy.V1.minimumMonthsObserved - 1)
+        assertSuppressed(decide(signals = thin), CreditOfferSuppressionCode.HISTORY_TOO_THIN)
+    }
+
+    @Test
+    fun `an unknown history depth is not treated as a long one`() {
+        assertSuppressed(
+            decide(signals = healthy.copy(monthsObserved = null)),
+            CreditOfferSuppressionCode.HISTORY_TOO_THIN,
+        )
+    }
+
+    @Test
+    fun `a thin history does not stop an answer the customer asked for`() {
+        val thin = healthy.copy(monthsObserved = 0)
+        val pull = CreditOfferEligibility.evaluate(true, thin, now, CreditOfferPolicy.V1, OfferSurface.PULL)
+        assertThat(pull).isInstanceOf(CreditOfferDecision.Allowed::class.java)
+    }
+
+    @Test
+    fun `HISTORY_TOO_THIN is distinct from SIGNALS_UNAVAILABLE — a new customer is not an outage`() {
+        val newCustomer = decide(signals = healthy.copy(monthsObserved = 0))
+        val brokenUpstream = decide(signals = healthy.copy(complete = false))
+        assertThat(codeOf(newCustomer)).isNotEqualTo(codeOf(brokenUpstream))
     }
 }

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerQuoteResourceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerQuoteResourceTest.kt
@@ -43,6 +43,7 @@ class CustomerQuoteResourceTest {
         inHardshipArrangement = false,
         lastAffordabilityFailureAt = null,
         bufferDays = 90,
+        monthsObserved = 12,
         lastCreditContactAt = null,
         inputsChangedSinceLastContact = true,
         complete = true,


### PR DESCRIPTION
Closes #6215. Fourth slice of the epic (#6217). **Stacked on #6235** (slice 2).

## Why this had to come before anything pushes

Slice 2 shipped the distress floor with a hole in it: the buffer rule had no data source, and the adapter could see only lending's own loan book. That is safe *while nothing initiates* — the pull path's floor is arrears and hardship, which lending owns — and unsafe the moment a pre-approved offer exists. This slice fills it.

## V9 — two ClickHouse views on the ADR-0210 silver layer

One definition, for the reason V5 gives for the party key: three consumers need these numbers (creditworthiness assessment, the customer's financial-health view, the AI advisor) and each would otherwise derive its own. Two implementations that disagree is worse than one that is wrong, because only the second is detectable.

Decisions worth reading in the SQL:

- **Income is the median inbound, not the mean.** One bonus or one transfer from savings should not raise what the bank believes a customer earns every month.
- **The current month is excluded.** A month in progress always looks like a collapse in income — on the 3rd, salary has not arrived. Including it would make every profile read worst on the day most customers open the app.
- **Volatility is a ratio** over median income, because 5,000 of swing means something very different on 20,000 a month than on 200,000.
- **A party with no observed inbound gets NULL volatility, not 0.** Zero would read as perfectly stable — the most flattering possible answer for the least-known customer.
- **`occurred_at`, never `ingested_at`.** A backfilled month must land in the month it happened, or a reload silently rewrites someone's income history.
- Both legs of a transaction are counted from the same event, so an internal transfer between the customer's own accounts is both inbound and outbound and nets to nothing — rather than reading as income.

## `HISTORY_TOO_THIN` — a new customer is not an outage

`monthsObserved` travels with the numbers instead of being discarded at the source: a three-week-old customer and a five-year customer can produce the same median.

The new suppression code is deliberately distinct from `SIGNALS_UNAVAILABLE`. One is a customer the bank has not seen for long enough; the other is a fault worth alerting on. Collapsing them would bury a genuine outage inside the normal traffic of new customers.

It gates **PUSH only**. A push needs evidence; answering "what would this cost" does not rest on knowing the customer.

## Failing closed, precisely

An unreadable profile propagates `complete = false` and the gate refuses. It is not substituted with defaults: "the customer has no surplus" and "we could not find out" are different facts, and no downstream layer can tell them apart afterwards.

## Known gap, stated rather than modelled away

Enforcement orders and insolvency proceedings still have **no source** — no service in this fleet ingests a court register. They are reported as absent rather than unknown, because permanent `complete = false` would suppress every offer forever and be indistinguishable from the feature being switched off. It is recorded in the adapter's KDoc and in threat-model section 9b as the first thing an operational-risk review should challenge.

## Also

- `CreditProfileResource` on analytics-sink: observable quantities only — no score, no rating, no eligibility. The UUID parse is the injection boundary (ClickHouse's HTTP interface has no bound-parameter path). A party with no rows returns `monthsObserved: 0`, not zeros — answering with zeros is indistinguishable from someone whose income really is zero.
- Threat-model section 9b for the two new outbound client edges from a money-path service.

## Verification

lending-service: 305 tests, 0 failures, 0 skipped. Gates run locally: `check-threat-model-diff --enforce` OK against the real base, route-conformance clean, ktlint/detekt clean.

Detekt caught the DTO's snake_case constructor parameters; the wire names now sit behind `@JsonProperty` so the ClickHouse column names and the Kotlin names each keep their own convention in one visible place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)