### PR TITLE
fix(observability): give the Loki ruler Alertmanager's route prefix

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -541,6 +541,29 @@ gates:
     run: |
       python3 .github/scripts/check-alert-window-vs-subject-period.py --enforce
 
+  # A route prefix moves Alertmanager's WHOLE HTTP surface, /api/v2/alerts included, so a
+  # hand-configured client pointed at the bare service URL posts every notification into a 404
+  # and drops it. ENFORCED.
+  - id: alertmanager-url-route-prefix
+    name: "Alertmanager URL carries the route prefix it serves under (enforced)"
+    group: gitops
+    mode: enforced
+    rationale: >-
+      Measured live 2026-08-21, the first time a Loki rule ever fired in this estate: the ruler
+      reported `state: firing` while Alertmanager held zero such alerts, and
+      loki_prometheus_notifications_errors_total equalled sent_total exactly — 10 of 10 dropped.
+      A firing rule that 404s at delivery is indistinguishable from a rule that never fired on
+      every dashboard here. A comment was not enough: apps/kube-prometheus-stack.yaml already
+      said "routePrefix moves the whole HTTP surface, INCLUDING /api/v2/alerts" eleven lines
+      above the value, and the change adding the ruler's URL still wrote the bare one.
+    review_after: "2027-02-21"
+    min_subjects: 1   # only the Loki ruler is hand-configured today; operator-managed
+                      # Prometheus gets its pathPrefix from alertingEndpoints and is not a subject
+    selftest: |
+      python3 .github/scripts/check-alertmanager-url-route-prefix.py --selftest
+    run: |
+      python3 .github/scripts/check-alertmanager-url-route-prefix.py
+
   - id: loki-rule-load-test
     name: "Loki rule load test (enforced)"
     group: gitops

--- a/.github/scripts/check-alertmanager-url-route-prefix.py
+++ b/.github/scripts/check-alertmanager-url-route-prefix.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""
+Assert every hand-written Alertmanager API URL carries the route prefix Alertmanager actually serves.
+
+WHY THIS EXISTS.
+
+`alertmanagerSpec.routePrefix: /tools/alertmanager` (apps/kube-prometheus-stack.yaml) moves the
+WHOLE HTTP surface, `/api/v2/alerts` included, so the bare service URL answers 404 on every API
+path. A component configured with the bare URL therefore posts alerts into a 404 and drops them.
+
+That is not hypothetical. Measured live 2026-08-21, the first time a Loki rule ever fired in this
+estate (the ruler itself had never loaded a rule until that day, #6032):
+
+    loki_prometheus_notifications_sent_total    = 10
+    loki_prometheus_notifications_errors_total  = 10     <- every single one
+    loki_prometheus_notifications_dropped_total = 10
+
+with the ruler reporting `state: firing` and Alertmanager holding zero such alerts. From inside the
+cluster, POST to `…:9093/api/v2/alerts` -> 404, and to `…:9093/tools/alertmanager/api/v2/alerts`
+-> 200.
+
+The reason a gate is warranted rather than a comment: the comment ALREADY EXISTED. Sitting eleven
+lines above the `routePrefix` value, apps/kube-prometheus-stack.yaml says "routePrefix moves the
+whole HTTP surface, INCLUDING /api/v2/alerts, which is how Prometheus delivers alerts" — and the
+change that added the ruler's `alertmanager_url` still wrote the bare URL. Prose in a neighbouring
+file does not survive being read by someone editing a different one.
+
+Prometheus itself is unaffected: prometheus-operator configures its Alertmanager target through
+`prometheusSpec.alertingEndpoints` with an explicit `pathPrefix`. Only hand-configured clients —
+the Loki ruler today — are exposed, which is exactly why this is small and worth keeping small.
+
+Failure shape it catches: an alert that fires, is delivered nowhere, and is indistinguishable from
+an alert that never fired on every dashboard in this estate.
+
+Usage:
+    check-alertmanager-url-route-prefix.py             # scan
+    check-alertmanager-url-route-prefix.py --selftest  # prove the gate can fail
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+GITOPS = REPO / "openbank-infra" / "gitops"
+STACK = GITOPS / "apps" / "kube-prometheus-stack.yaml"
+
+# `alertmanager_url: http://host:9093[/prefix]` — the Loki ruler's key. Matched textually rather
+# than by parsing YAML because these files are Argo Application manifests carrying a chart's
+# valuesObject, and the key lives at a different depth in each.
+URL_RE = re.compile(r"^\s*alertmanager_url:\s*(?P<url>\S+)\s*$", re.MULTILINE)
+ROUTE_PREFIX_RE = re.compile(r"^\s*routePrefix:\s*(?P<prefix>\S+)\s*$", re.MULTILINE)
+
+# A blank value is a DIFFERENT defect (the ruler then notifies nothing at all) and is already
+# covered by the Loki manifest's own comment; this gate is about a URL that looks configured.
+IGNORED_VALUES = {"", '""', "''"}
+
+
+def route_prefix(text: str) -> str | None:
+    """The prefix Alertmanager serves under, read from the chart values that set it."""
+    m = ROUTE_PREFIX_RE.search(text)
+    if not m:
+        return None
+    return m.group("prefix").strip().strip("\"'").rstrip("/")
+
+
+def scan(gitops: Path, prefix: str) -> tuple[list[str], int]:
+    """Returns (violations, number of URLs examined)."""
+    violations, subjects = [], 0
+    for path in sorted(gitops.rglob("*.yaml")):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for m in URL_RE.finditer(text):
+            url = m.group("url").strip().strip("\"'")
+            if url in IGNORED_VALUES:
+                continue
+            subjects += 1
+            if url.rstrip("/").endswith(prefix):
+                continue
+            line = text[: m.start()].count("\n") + 1
+            rel = path.relative_to(REPO)
+            violations.append(
+                f"{rel}:{line}: alertmanager_url {url!r} does not end with the route prefix "
+                f"{prefix!r} that Alertmanager serves under — every notification posted to it "
+                f"404s and is dropped"
+            )
+    return violations, subjects
+
+
+def selftest() -> int:
+    """Prove the gate can fail: the real corpus with the prefix stripped must be reported."""
+    text = STACK.read_text(encoding="utf-8")
+    prefix = route_prefix(text)
+    if not prefix:
+        print("SELFTEST FAIL: no routePrefix found in", STACK.relative_to(REPO))
+        return 1
+
+    good, subjects = scan(GITOPS, prefix)
+    if subjects == 0:
+        print("SELFTEST FAIL: scanned zero alertmanager_url values — the gate has no subject")
+        return 1
+    if good:
+        print("SELFTEST FAIL: the committed tree is not clean, so a negative control proves nothing")
+        for v in good:
+            print("   ", v)
+        return 1
+
+    # Negative control: ask the same corpus for a prefix it demonstrably does not carry. Every
+    # subject must then be reported. This is the half that fails if the matcher silently matches
+    # nothing — a gate that examines no files reports clean exactly like a gate that passes.
+    bad, bad_subjects = scan(GITOPS, "/definitely-not-the-prefix")
+    if bad_subjects != subjects:
+        print(f"SELFTEST FAIL: subject count moved with the prefix ({subjects} -> {bad_subjects})")
+        return 1
+    if len(bad) != subjects:
+        print(f"SELFTEST FAIL: negative control flagged {len(bad)} of {subjects} subject(s)")
+        return 1
+
+    print(
+        f"check-alertmanager-url-route-prefix --selftest: OK — {subjects} subject(s) clean against "
+        f"{prefix!r}, all {len(bad)} reported against a wrong prefix."
+    )
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--selftest", "--self-test", dest="selftest", action="store_true")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
+
+    if not STACK.exists():
+        print(f"check-alertmanager-url-route-prefix: {STACK.relative_to(REPO)} is missing")
+        return 1
+    prefix = route_prefix(STACK.read_text(encoding="utf-8"))
+    if not prefix:
+        # No prefix configured means the bare URL is correct and there is nothing to assert.
+        print("check-alertmanager-url-route-prefix: Alertmanager sets no routePrefix — nothing to check.")
+        return 0
+
+    violations, subjects = scan(GITOPS, prefix)
+    print(f"SUBJECTS={subjects}  # alertmanager_url value(s) scanned")
+    if violations:
+        print(f"check-alertmanager-url-route-prefix: {len(violations)} violation(s):")
+        for v in violations:
+            print("  ", v)
+        return 1
+    print(
+        f"check-alertmanager-url-route-prefix: {subjects} alertmanager_url value(s) all carry "
+        f"{prefix!r} — clean."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-infra/gitops/apps/loki.yaml
+++ b/openbank-infra/gitops/apps/loki.yaml
@@ -144,7 +144,26 @@ spec:
               kvstore:
                 store: inmemory
             # The missing half. Without this a rule evaluates, fires, and is delivered nowhere.
-            alertmanager_url: http://kube-prometheus-stack-alertmanager.observability.svc:9093
+            #
+            # THE `/tools/alertmanager` SUFFIX IS LOAD-BEARING. This Alertmanager runs behind a
+            # route prefix (`--web.route-prefix=/tools/alertmanager`, from
+            # `alertmanagerSpec.routePrefix` so it can be served under admin.open-bank.tech/tools),
+            # so the bare service URL answers 404 on every API path. The ruler appends
+            # `/api/v2/alerts` to whatever it is given, posts it, gets a 404, and DROPS the
+            # notification — with no error surfaced anywhere a human looks. Measured live
+            # 2026-08-21, the first time a Loki rule ever fired in this estate:
+            #   loki_prometheus_notifications_sent_total   = 10
+            #   loki_prometheus_notifications_errors_total = 10   <- every single one
+            #   loki_prometheus_notifications_dropped_total = 10
+            # and the ruler reporting `state: firing` while Alertmanager held zero such alerts.
+            # From inside the cluster:
+            #   POST …:9093/api/v2/alerts                    -> 404
+            #   POST …:9093/tools/alertmanager/api/v2/alerts -> 200
+            # Prometheus itself is unaffected because prometheus-operator configures its
+            # Alertmanager target with `pathPrefix`; this ruler is hand-configured and had no
+            # such help. A firing rule that is dropped at delivery is indistinguishable, from
+            # every dashboard in this estate, from a rule that never fired.
+            alertmanager_url: http://kube-prometheus-stack-alertmanager.observability.svc:9093/tools/alertmanager
             enable_alertmanager_v2: true
             # The SAME half again, for recording rules — and it is a separate switch. An alerting
             # rule needs alertmanager_url; a RECORDING rule needs remote_write, and without it the


### PR DESCRIPTION
## What

The Loki ruler fires and **delivers nothing**. This gives it the path Alertmanager actually serves.

## Measured, not inferred

2026-08-21 — the first time a Loki rule ever fired in this estate (the ruler had never loaded a rule until that day, #6032, and its Argo app had not synced since 2026-08-01):

```
loki_prometheus_notifications_sent_total    = 10
loki_prometheus_notifications_errors_total  = 10     <- every single one
loki_prometheus_notifications_dropped_total = 10
```

Ruler said `state: firing`. Alertmanager held **zero** such alerts.

From inside the cluster:

| POST target | result |
|---|---|
| `…:9093/api/v2/alerts` | **404** |
| `…:9093/tools/alertmanager/api/v2/alerts` | **200** |

`alertmanagerSpec.routePrefix: /tools/alertmanager` moves the whole HTTP surface, `/api/v2/alerts` included. The ruler appends `/api/v2/alerts` to whatever URL it is given, posts into a 404, and drops the notification — surfacing nothing anywhere a human looks.

Prometheus itself is unaffected: prometheus-operator configures its target through `prometheusSpec.alertingEndpoints` with an explicit `pathPrefix`. Only hand-configured clients are exposed, and the Loki ruler is the only one today.

## Why this also adds a gate

**The comment already existed.** `apps/kube-prometheus-stack.yaml` says, eleven lines above the value:

> routePrefix moves the whole HTTP surface, INCLUDING /api/v2/alerts, which is how Prometheus delivers alerts

and the change that added the ruler's `alertmanager_url` still wrote the bare URL. Prose in a neighbouring file does not survive being read by someone editing a different one.

`check-alertmanager-url-route-prefix.py` derives the prefix from the chart values — not a hand-kept constant — and asserts every hand-written `alertmanager_url` carries it.

Verified three ways:

1. **clean** on the fixed tree (1 subject)
2. **red on the exact pre-fix URL**, with the real message: `alertmanager_url '…:9093' does not end with the route prefix '/tools/alertmanager'`
3. **self-test** re-scans the same corpus against a deliberately wrong prefix and requires *every* subject to be reported — so a matcher that silently matches nothing cannot pass as clean, and the subject count is asserted not to move

`min_subjects: 1`, stated with its reason rather than left implicit.

## Blast radius this closes

A firing rule that 404s at delivery is indistinguishable, from every dashboard in this estate, from a rule that never fired. That is the same class as #5733 (dead alert rules) and #6032 (a ruler that had never loaded a rule) — and it is the last leg of the chain those two fixed.

## Linked issues

Refs #5734
