### PR TITLE
fix(ci): widen three gates whose scope was narrower than their subject

### DIFF
--- a/.github/scripts/check-authz-pdp-parity.py
+++ b/.github/scripts/check-authz-pdp-parity.py
@@ -70,7 +70,26 @@ import yaml
 
 import gatelib
 
-IMAGE_SVC = re.compile(r"openbank-([a-z0-9-]+-service)\b")
+# The app container's module, taken from its image. This used to require a literal `-service`
+# suffix (`openbank-([a-z0-9-]+-service)`), which is a NAMING CONVENTION standing in for the set
+# of deployed modules — and five modules do not follow it. Three of those are money-path
+# (openbank-sepa-payment, openbank-domestic-payment, openbank-sepa-instant, plus
+# openbank-customer-edge and openbank-product-catalog), and every one carries @Authorize in
+# src/main. A workload the regex did not match hit `continue`, so it was neither checked NOR
+# listed as skipped: measured on origin/main, deleting the whole `opa` sidecar from the
+# openbank-sepa-payment Rollout left the gate printing "40 workload(s) checked … 0
+# enforce-without-PDP violation(s)" and exiting 0 — the exact #1797 defect, on a money-path
+# service, invisible. The set is now DERIVED: any `openbank-<name>` image whose `<name>` is a
+# real module directory in this repo. An unmatched workload is reported, never dropped.
+IMAGE_SVC = re.compile(r"openbank-([a-z0-9][a-z0-9-]*)\b")
+
+# An `openbank-*` image that is deliberately NOT a module in this repo. Declared with a reason,
+# and stale in BOTH directions: an entry no longer seen in any workload is an error, so this
+# cannot quietly become the place unmatched workloads go to die.
+NON_MODULE_IMAGES = {
+    "openbank-keycloak": "our own Keycloak build (upstream image + realm), not a Quarkus module; "
+                         "it has no src/main and therefore no @Authorize surface",
+}
 WORKLOAD_KINDS = {"Deployment", "Rollout"}
 
 # `@Authorize` as an annotation use-site: the identifier must not be part of a longer word
@@ -304,16 +323,33 @@ def main() -> int:
     violations: list[tuple[str, str, str]] = []
     checked = 0
     unannotated: list[str] = []
+    unresolved: list[tuple[str, str]] = []
+    seen_non_module: set[str] = set()
 
     for path, workload in iter_workloads(components):
         containers = pod_containers(workload)
         if not containers:
             continue
-        # The app container is the one running an openbank-<svc>-service image.
-        app = next((c for c in containers if IMAGE_SVC.search(str(c.get("image", "")))), None)
+        # The app container is the one whose image names a module directory that exists here.
+        app, svc_full = None, None
+        for c in containers:
+            m = IMAGE_SVC.search(str(c.get("image", "")))
+            if m and (root / f"openbank-{m.group(1)}").is_dir():
+                app, svc_full = c, m.group(1)
+                break
         if app is None:
+            # Not a repo-module workload (an upstream image, a sidecar-only pod). Record any
+            # `openbank-*` image we could not resolve, so a renamed or new module surfaces as an
+            # UNRESOLVED line rather than vanishing the way the five above did.
+            for c in containers:
+                m = IMAGE_SVC.search(str(c.get("image", "")))
+                if m:
+                    image = f"openbank-{m.group(1)}"
+                    if image in NON_MODULE_IMAGES:
+                        seen_non_module.add(image)
+                    else:
+                        unresolved.append((image, str(path.relative_to(root))))
             continue
-        svc_full = IMAGE_SVC.search(str(app.get("image", ""))).group(1)  # e.g. "kyc-service"
         service_dir = f"openbank-{svc_full}"
         checked += 1
 
@@ -347,13 +383,38 @@ def main() -> int:
 
     # Print the skipped set, so "0 violations" is never mistaken for "everything was examined" —
     # the reader can see exactly which workloads the annotation predicate took out of scope.
+    # An `openbank-*` image with no module directory is a THIRD state next to checked and
+    # skipped. It is not silently dropped, because that is exactly how five modules — three of
+    # them money-path — stayed outside this gate while it printed a clean count.
+    # The staleness half only means anything over the REAL tree. `--root` is also pointed at
+    # synthetic fixture trees by check_authz_pdp_parity_test.py, where every declared entry is
+    # legitimately absent; reporting it there turns the falsification suite red about nothing.
+    # `openbank-libs` is the marker: no fixture builds one.
+    real_tree = (root / "openbank-libs").is_dir()
+    stale_declared = sorted(set(NON_MODULE_IMAGES) - seen_non_module) if real_tree else []
+    for image in stale_declared:
+        print(
+            f"::{'error' if args.enforce else 'warning'}::authz-pdp-parity: NON_MODULE_IMAGES "
+            f"declares `{image}` ({NON_MODULE_IMAGES[image]}) but no workload runs it any more — "
+            f"remove the entry, or the exclusion outlives the thing it excused."
+        )
+
+    for image, rel in sorted(set(unresolved)):
+        print(
+            f"::{'error' if args.enforce else 'warning'} file={rel}::authz-pdp-parity: workload runs image `{image}` but no such "
+            f"module directory exists in this repo, so its @Authorize surface cannot be read. "
+            f"Rename the module or the image so the two agree."
+        )
+
     print(
         f"check-authz-pdp-parity: {checked} workload(s) checked; "
         f"{len(unannotated)} skipped (no @Authorize in src/main: "
         f"{', '.join(sorted(set(unannotated))) or 'none'}); "
+        f"{len(set(unresolved))} unresolved image(s); "
+        f"{len(stale_declared)} stale NON_MODULE_IMAGES entr(ies); "
         f"{len(violations)} enforce-without-PDP violation(s)."
     )
-    return 1 if (violations and args.enforce) else 0
+    return 1 if ((violations or unresolved or stale_declared) and args.enforce) else 0
 
 
 if __name__ == "__main__":

--- a/.github/scripts/check-external-feeds.py
+++ b/.github/scripts/check-external-feeds.py
@@ -177,15 +177,69 @@ NOT_PROBED = [
     ("https://s3.eu-north-1.amazonaws.com", "AWS endpoint, reached with SigV4 credentials"),
     ("https://kc.open-bank.tech/realms/openbank-customers", "our own Keycloak realm, covered by its own probes"),
     ("https://pid.open-bank.tech", "our own PID issuer, covered by its own probes"),
-    (
-        "https://campaign-service.campaign.svc:8443",
-        "private in-cluster ownership validator; protected by mTLS and the campaign network policy",
-    ),
+    # --- gitops corpus (#6242). Everything below became visible when CORPUS_GLOBS gained
+    # `openbank-infra/gitops/**/*.yaml`. Each entry is stale-checked in BOTH directions by
+    # check_drift: an entry whose URL leaves the tree fails just as loudly as an undeclared URL.
+    #
+    # (1) IDENTIFIERS, not fetch targets. A URL-shaped string nothing dereferences.
+    ("https://www.apache.org/licenses/LICENSE-2.0", "SPDX licence identifier in an embedded SQL header; never fetched"),
+    ("https://cyclonedx.org/bom", "CycloneDX schema URI in a Kyverno SBOM policy; an identifier the policy matches on"),
+    ("https://git.k8s.io", "upstream source link in a vendored CRD's description text; never fetched"),
+    ("https://github.com/thanos-io/thanos/blob", "upstream doc link in a vendored CRD's description text; never fetched"),
+    ("https://github.com/kubernetes-sigs/controller-tools/issues", "upstream issue link in a vendored CRD comment; never fetched"),
+    ("https://github.com/JiRaska/open-bank-oss/blob", "runbook deep-link in an alert annotation; read by a human, not by a workload"),
+    ("https://open-bank.tech/", "OAuth redirect/claimed-HTTPS identifier in a Keycloak client; not a feed"),
+    ("https://flagd.dev", "flagd JSON-schema URI in a feature-flag ConfigMap; an identifier"),
+    ("https://go.temporal.io", "Go module path in a Temporal chart value; not an HTTP fetch"),
+    #
+    # (2) DEPLOY-TIME sources. Resolved by Argo CD / the registry cache, not by a running
+    # service. A failure blocks the sync or the pull loudly — it cannot go silent the way a
+    # 404 on a data feed did (#2204), which is exactly why they are declared and not probed.
+    ("https://github.com/JiRaska/open-bank-oss.git", "this repo, cloned by the realm-drift and tier-classifier CronJobs; a clone failure is loud"),
+    ("https://gitlab.com", "upstream source repo pinned by the GlitchTip chart; deploy-time"),
+    ("https://grafana.github.io", "Helm chart repository; deploy-time, a failure blocks the Argo CD sync"),
+    ("https://open-telemetry.github.io", "Helm chart repository; deploy-time"),
+    ("https://prometheus-community.github.io", "Helm chart repository; deploy-time"),
+    ("https://argoproj.github.io", "Helm chart repository; deploy-time"),
+    ("https://charts.external-secrets.io", "Helm chart repository; deploy-time"),
+    ("https://charts.fairwinds.com", "Helm chart repository; deploy-time"),
+    ("https://falcosecurity.github.io", "Helm chart repository; deploy-time"),
+    ("https://kubernetes.github.io", "Helm chart repository; deploy-time"),
+    ("https://kubernetes-sigs.github.io", "Helm chart repository; deploy-time"),
+    ("https://kyverno.github.io", "Helm chart repository; deploy-time"),
+    ("https://openbao.github.io", "Helm chart repository; deploy-time"),
+    ("https://strimzi.io", "Helm chart repository; deploy-time"),
+    ("https://robusta-charts.storage.googleapis.com", "Helm chart repository; deploy-time"),
+    #
+    # (3) REGISTRY / BUILD-ARTEFACT upstreams behind our own caches. Real third-party egress,
+    # but each has an in-cluster cache whose own liveness is the signal, and none serves a
+    # data feed a money-path job reads.
+    ("https://registry-1.docker.io", "upstream mirrored by the in-cluster registry cache"),
+    ("https://quay.io", "upstream mirrored by the in-cluster registry cache"),
+    ("https://ghcr.io", "upstream mirrored by the in-cluster registry cache"),
+    ("https://repo1.maven.org", "Maven Central, mirrored by Reposilite"),
+    ("https://plugins.gradle.org", "Gradle plugin portal, mirrored by Reposilite"),
+    ("https://dl.google.com", "Google Maven, mirrored by Reposilite"),
+    #
+    # (4) ACME. Real egress; a failure surfaces as an un-renewed Certificate, which cert-manager
+    # reports and the certificate-expiry alert covers.
+    ("https://acme-v02.api.letsencrypt.org", "ACME directory; failure surfaces as a cert-manager Certificate condition"),
+    ("https://acme-staging-v02.api.letsencrypt.org", "ACME staging directory; non-production issuer"),
+    #
+    # (5) OUR OWN public hostnames, each covered by its own probe or journey CronJob.
+    ("https://admin.open-bank.tech", "our own admin-ui ingress; covered by the public-edge journey probe"),
+    ("https://api.open-bank.tech", "our own API ingress; covered by the public-edge journey probe"),
+    ("https://customer.open-bank.tech", "our own customer ingress; covered by the public-edge journey probe"),
+    ("https://kc.open-bank.tech", "our own Keycloak ingress; covered by its own probes"),
+    ("https://glitchtip.open-bank.tech", "our own GlitchTip ingress"),
+    ("https://langfuse.open-bank.tech", "our own Langfuse ingress"),
+    ("https://pact.open-bank.tech", "our own Pact Broker ingress"),
 ]
 
 URL_IN_TEXT = re.compile(r"https?://[^\s\"'}\)>,]+")
 _LOOPBACK = re.compile(r"^https?://(localhost|127\.0\.0\.1|0\.0\.0\.0)(:\d+)?(/|$)")
 _PLAINTEXT = re.compile(r"^http://(?P<host>[^/:]+)(?P<port>:\d+)?")
+_ANY_SCHEME = re.compile(r"^https?://(?P<host>[^/:]+)")
 
 
 def is_internal(url):
@@ -200,15 +254,41 @@ def is_internal(url):
     """
     if _LOOPBACK.match(url):
         return True
+    m = _ANY_SCHEME.match(url)
+    host = m.group("host") if m else ""
+    # A Kubernetes DNS suffix is in-cluster under ANY scheme. This used to be tested only on
+    # the `http://` branch, so `https://campaign-service.campaign.svc:8443` fell through to
+    # "external by definition" and needed a NOT_PROBED entry to excuse an in-cluster mTLS call.
+    # Widening the corpus to gitops (#6242) makes that shape the norm, not the exception.
+    if host.endswith((".svc", ".cluster.local")) or ".svc." in host:
+        return True
     m = _PLAINTEXT.match(url)
     if not m:
         return False  # https:// — external by definition
     host, port = m.group("host"), m.group("port")
-    return "." not in host or bool(port) or host.endswith((".svc", ".cluster.local"))
+    return "." not in host or bool(port)
+
+
+# The corpus. DERIVED from the artifacts, not hand-kept: every service config plus every
+# deployed manifest. It used to be the first glob alone, which is why a live LLM egress
+# declared only in `openbank-infra/gitops/apps/holmesgpt.yaml` was outside this gate's reach
+# and declared nowhere — the gate reported "every external URL accounted for" and exited 0
+# while a workload that receives cluster diagnostics called a third party (#6242). A gate
+# whose SCOPE is narrower than the subject it claims to govern reads as PASSING, never as
+# UNCHECKED; adding a source here is the only way to change that, so it is one list, in code,
+# next to the check that consumes it.
+CORPUS_GLOBS = (
+    "openbank-*/src/main/resources/application.yaml",
+    "openbank-infra/gitops/**/*.yaml",
+)
 
 
 def scanned_yamls(root):
-    return sorted(pathlib.Path(root).glob("openbank-*/src/main/resources/application.yaml"))
+    base = pathlib.Path(root)
+    out = set()
+    for pattern in CORPUS_GLOBS:
+        out.update(base.glob(pattern))
+    return sorted(out)
 
 
 def external_urls_in(path):
@@ -275,7 +355,13 @@ def check_drift(root, resolved):
         for lineno, url in external_urls_in(path):
             if url in probed:
                 continue
-            match = next((e for e in excused if url.startswith(e)), None)
+            # LONGEST matching prefix, not any. `excused` is a set, so `next(...)` picked an
+            # arbitrary one; with overlapping entries (a host and a path under it) that made
+            # which entry got marked seen — and therefore which one was reported stale —
+            # depend on hash order. Longest-prefix is deterministic and keeps a specific
+            # entry meaningful next to a broader one covering the same host.
+            candidates = [e for e in excused if url.startswith(e)]
+            match = max(candidates, key=len) if candidates else None
             if match:
                 seen_excused.add(match)
                 continue

--- a/.github/scripts/check-model-residency-claims.py
+++ b/.github/scripts/check-model-residency-claims.py
@@ -39,6 +39,16 @@ THE RULES
       placeholder. A public FQDN is rejected. An env placeholder with NO default is rejected
       too: a residency claim whose target is supplied entirely at runtime cannot be verified
       from the repo, which is the same as unverified.
+  R4  The DEPLOYED value wins. R2's `${VAR:default}` is only what the service falls back to; the
+      value that reaches the pod is whatever `openbank-infra/gitops/**` sets for that env name.
+      This gate used to read `openbank-*/src/main/resources/application.yaml` and nothing else,
+      so a self-hosted entry with an in-cluster DEFAULT passed while gitops overrode the same
+      variable to a hosted US endpoint — measured: the gate printed "no self-hosted model entry
+      points off-cluster" and exited 0 for exactly that construction. The corpus now includes the
+      gitops env, and EVERY committed value of the variable must be in-cluster, not just the
+      default. A `valueFrom:` override (no literal in the repo) is reported for the same reason
+      R2 rejects a default-less placeholder: unverifiable from this repo is unverified.
+
   R3  `agents.yaml: model_gateway_as_built.routing` and the registered tiers must agree, in
       BOTH directions. `routing: none` while a self-hosted entry exists understates a live
       control; anything other than `none` while no self-hosted entry exists is the machine-
@@ -73,6 +83,41 @@ IN_CLUSTER = re.compile(
 ENV_PLACEHOLDER = re.compile(r"^\$\{([A-Za-z_][A-Za-z0-9_]*)(?::(.*))?\}$")
 
 
+# The deployed half of the corpus. DERIVED by walking every gitops manifest for container env
+# entries, so a new component is in scope the day it is committed — no hand-kept service list.
+GITOPS_ROOT = REPO / "openbank-infra" / "gitops"
+
+
+def _walk_env(node, path, out):
+    """Collect every container env entry anywhere in a manifest tree."""
+    if isinstance(node, dict):
+        env = node.get("env")
+        if isinstance(env, list):
+            for item in env:
+                if isinstance(item, dict) and isinstance(item.get("name"), str):
+                    out.setdefault(item["name"], []).append((path, item))
+        for v in node.values():
+            _walk_env(v, path, out)
+    elif isinstance(node, list):
+        for v in node:
+            _walk_env(v, path, out)
+
+
+def gitops_env_overrides() -> dict:
+    """{ENV_NAME: [(relpath, env_entry_dict), ...]} across every committed gitops manifest."""
+    out = {}
+    if not GITOPS_ROOT.is_dir():
+        return out
+    for src in sorted(GITOPS_ROOT.rglob("*.yaml")):
+        try:
+            docs = list(yaml.safe_load_all(src.read_text(encoding="utf-8")))
+        except yaml.YAMLError:
+            continue  # a Helm-templated or otherwise unparseable manifest sets no literal env
+        for doc in docs:
+            _walk_env(doc, str(src.relative_to(REPO)), out)
+    return out
+
+
 def is_self_hosted(raw) -> bool:
     return isinstance(raw, str) and raw.strip().lower() in SELF_HOSTED_SPELLINGS
 
@@ -87,34 +132,64 @@ def host_of(url: str) -> str | None:
     return authority.rsplit(":", 1)[0].strip("[]").lower() if ":" in authority else authority.lower()
 
 
-def endpoint_findings(entry_id: str, endpoint, where: str) -> list[str]:
-    """R1 + R2 for one entry. Returns one message per distinct problem."""
+def endpoint_findings(entry_id: str, endpoint, where: str, env_index: dict | None = None) -> list[str]:
+    """R1 + R2 + R4 for one entry. Returns one message per distinct problem."""
     if endpoint is None or (isinstance(endpoint, str) and not endpoint.strip()):
         return [f"{where}: model '{entry_id}' declares sensitivity self-hosted but has NO endpoint "
                 f"— the residency claim rests on nothing (R1)."]
     if not isinstance(endpoint, str):
         return [f"{where}: model '{entry_id}' has a non-string endpoint ({endpoint!r}) (R1)."]
 
+    findings: list[str] = []
     target = endpoint.strip()
     placeholder = ENV_PLACEHOLDER.match(target)
     if placeholder:
         var, default = placeholder.group(1), placeholder.group(2)
+        findings.extend(_deployed_findings(entry_id, var, where, env_index or {}))
         if default is None or not default.strip():
-            return [f"{where}: model '{entry_id}' is self-hosted but its endpoint is ${{{var}}} "
-                    f"with no default — the residency target is supplied entirely at runtime and "
-                    f"cannot be verified from this repo (R2)."]
+            findings.append(
+                f"{where}: model '{entry_id}' is self-hosted but its endpoint is ${{{var}}} "
+                f"with no default — the residency target is supplied entirely at runtime and "
+                f"cannot be verified from this repo (R2).")
+            return findings
         target = default.strip()
 
     host = host_of(target)
     if host is None:
-        return [f"{where}: model '{entry_id}' is self-hosted but its endpoint '{target}' is not a "
-                f"URL this gate can resolve to a host (R2)."]
+        findings.append(f"{where}: model '{entry_id}' is self-hosted but its endpoint '{target}' is not a "
+                        f"URL this gate can resolve to a host (R2).")
+        return findings
     if not IN_CLUSTER.match(host):
-        return [f"{where}: model '{entry_id}' declares sensitivity self-hosted but its endpoint "
-                f"resolves to '{host}', which is NOT in-cluster. Sensitive-context prompts routed "
-                f"to it leave the cluster — and every layer above still reports the residency "
-                f"control as working (R2)."]
-    return []
+        findings.append(f"{where}: model '{entry_id}' declares sensitivity self-hosted but its endpoint "
+                        f"resolves to '{host}', which is NOT in-cluster. Sensitive-context prompts routed "
+                        f"to it leave the cluster — and every layer above still reports the residency "
+                        f"control as working (R2).")
+        return findings
+    return findings
+
+
+def _deployed_findings(entry_id: str, var: str, where: str, env_index: dict) -> list[str]:
+    """R4 — every committed gitops value of `var` must also be in-cluster."""
+    out = []
+    for relpath, item in env_index.get(var, []):
+        if "value" in item:
+            value = item["value"]
+            if not isinstance(value, str) or not value.strip():
+                continue
+            host = host_of(value.strip())
+            if host is None or IN_CLUSTER.match(host):
+                continue
+            out.append(
+                f"{where}: model '{entry_id}' is self-hosted and its endpoint falls back to an "
+                f"in-cluster default, but {relpath} sets {var}={value.strip()} — the DEPLOYED "
+                f"target resolves to '{host}', which is NOT in-cluster. The default is not what "
+                f"reaches the pod (R4).")
+        elif "valueFrom" in item:
+            out.append(
+                f"{where}: model '{entry_id}' is self-hosted and {relpath} supplies {var} via "
+                f"valueFrom — the deployed residency target is not committed anywhere in this "
+                f"repo, so it cannot be verified (R4).")
+    return out
 
 
 def walk_model_gateways(node, where: str, path: str = "") -> list[tuple[str, list]]:
@@ -134,14 +209,16 @@ def walk_model_gateways(node, where: str, path: str = "") -> list[tuple[str, lis
     return found
 
 
-def audit_models(models: list, where: str) -> tuple[list[str], int]:
-    """R1+R2 over one models list. Returns (findings, self_hosted_count)."""
+def audit_models(models: list, where: str, env_index: dict | None = None) -> tuple[list[str], int]:
+    """R1+R2+R4 over one models list. Returns (findings, self_hosted_count)."""
     findings, count = [], 0
     for entry in models or []:
         if not isinstance(entry, dict) or not is_self_hosted(entry.get("sensitivity")):
             continue
         count += 1
-        findings.extend(endpoint_findings(str(entry.get("id", "<unnamed>")), entry.get("endpoint"), where))
+        findings.extend(
+            endpoint_findings(str(entry.get("id", "<unnamed>")), entry.get("endpoint"), where, env_index)
+        )
     return findings, count
 
 
@@ -163,6 +240,7 @@ def audit_routing_record(routing, self_hosted_total: int) -> list[str]:
 def audit() -> list[str]:
     findings, self_hosted_total = [], 0
     sources = sorted(REPO.glob("openbank-*/src/main/resources/application.yaml"))
+    env_index = gitops_env_overrides()
     for src in sources:
         try:
             data = yaml.safe_load(src.read_text()) or {}
@@ -170,7 +248,7 @@ def audit() -> list[str]:
             findings.append(f"{src.relative_to(REPO)}: unparseable YAML ({exc.__class__.__name__}).")
             continue
         for where, models in walk_model_gateways(data, str(src.relative_to(REPO))):
-            f, n = audit_models(models, where)
+            f, n = audit_models(models, where, env_index)
             findings.extend(f)
             self_hosted_total += n
 
@@ -220,6 +298,33 @@ def self_test() -> int:
         ("a non-dict entry does not crash the walk", ["nonsense"], 0),
         ("an empty list is clean", [], 0),
     ]
+    # R4 — the deployed value wins over the default. Each case carries its own env index, so the
+    # rule is falsified against a synthetic gitops override rather than against today's tree
+    # (which registers no self-hosted tier at all, and would make every case vacuously green).
+    deployed_cases = [
+        ("an in-cluster default overridden by gitops to a US host is REJECTED",
+         [{"id": "v", "sensitivity": "self-hosted", "endpoint": "${EU_EP:http://vllm.ai-platform.svc:8000}"}],
+         {"EU_EP": [("gitops/x.yaml", {"name": "EU_EP", "value": "https://api.us.example.com/v1"})]}, 1),
+        ("an in-cluster default overridden by gitops to another in-cluster host passes",
+         [{"id": "v", "sensitivity": "self-hosted", "endpoint": "${EU_EP:http://vllm.ai-platform.svc:8000}"}],
+         {"EU_EP": [("gitops/x.yaml", {"name": "EU_EP", "value": "http://vllm.copilot.svc:8000"})]}, 0),
+        ("a gitops valueFrom override is REJECTED — the deployed target is not in this repo",
+         [{"id": "v", "sensitivity": "self-hosted", "endpoint": "${EU_EP:http://vllm.ai-platform.svc:8000}"}],
+         {"EU_EP": [("gitops/x.yaml", {"name": "EU_EP", "valueFrom": {"secretKeyRef": {"name": "s"}}})]}, 1),
+        ("an override of a DIFFERENT variable is not attributed to this entry",
+         [{"id": "v", "sensitivity": "self-hosted", "endpoint": "${EU_EP:http://vllm.ai-platform.svc:8000}"}],
+         {"OTHER_EP": [("gitops/x.yaml", {"name": "OTHER_EP", "value": "https://api.us.example.com/v1"})]}, 0),
+        ("a literal (non-placeholder) endpoint is unaffected by any gitops env",
+         [{"id": "v", "sensitivity": "self-hosted", "endpoint": "http://vllm.ai-platform.svc:8000"}],
+         {"EU_EP": [("gitops/x.yaml", {"name": "EU_EP", "value": "https://api.us.example.com/v1"})]}, 0),
+        ("two overrides, one off-cluster, reports the off-cluster one",
+         [{"id": "v", "sensitivity": "self-hosted", "endpoint": "${EU_EP:http://vllm.ai-platform.svc:8000}"}],
+         {"EU_EP": [("gitops/a.yaml", {"name": "EU_EP", "value": "http://vllm.copilot.svc:8000"}),
+                    ("gitops/b.yaml", {"name": "EU_EP", "value": "https://api.us.example.com/v1"})]}, 1),
+        ("the real gitops walk finds the agent-service endpoint variable at all",
+         None, None, None),
+    ]
+
     routing_cases = [
         ("routing 'none' with no tier is today's honest state", "none", 0, 0),
         ("routing 'none' while a tier IS registered is record drift", "none", 1, 1),
@@ -237,6 +342,20 @@ def self_test() -> int:
     ]
 
     failed = 0
+    for name, models, env_index, expected in deployed_cases:
+        if models is None:
+            # Not a rule case: a floor on the CORPUS itself. A walk that finds no env at all
+            # would make every case above vacuous against the real tree, and print nothing.
+            idx = gitops_env_overrides()
+            got, expected_desc = len(idx), ">0 env names across gitops"
+            ok = got > 0
+            print(f"  {'PASS' if ok else 'FAIL'}  {name} (expected {expected_desc}, got {got})")
+        else:
+            got = len(audit_models(models, "test", env_index)[0])
+            ok = got == expected
+            print(f"  {'PASS' if ok else 'FAIL'}  {name} (expected {expected}, got {got})")
+        failed += 0 if ok else 1
+
     for name, models, expected in model_cases:
         got = len(audit_models(models, "test")[0])
         ok = got == expected
@@ -253,7 +372,7 @@ def self_test() -> int:
         failed += not ok
         print(f"  {'PASS' if ok else 'FAIL'}  {name} (expected {expected}, got {got})")
 
-    total = len(model_cases) + len(routing_cases) + len(walk_cases)
+    total = len(model_cases) + len(routing_cases) + len(walk_cases) + len(deployed_cases)
     print(f"self-test: {total - failed}/{total} passed")
     return 1 if failed else 0
 


### PR DESCRIPTION
## The defect class

**A gate whose SCOPE is narrower than the subject it claims to govern reads as PASSING, never as UNCHECKED.**

Five unrelated instances were found today (#6242, #6032, #5962, #6059, and `pact-drift-check.yml`'s old hand-kept module list). This PR audits the **entire registered gate set** for that class and fixes the three whose blind spot could hide a money-path or security defect.

## Enumeration — two methods, both 166

| method | command | count |
|---|---|---|
| the runner | `python3 .github/scripts/run-gates.py --list` | **166** gates, 8 groups, 145 with a self-test |
| direct parse | `yaml.safe_load('.github/gates/gates.yaml')['gates']` | **166** |

They agree exactly. A third probe — checker scripts on disk vs scripts referenced by a `run:`/`selftest:` — found **9** `check-*`/`verify-*` scripts under `.github/scripts/` that `gates.yaml` does not name. None is dead: 6 run from other workflows (`_service-ci.yml`, `incident-gate-coverage.yml`, `verification-metadata-drift.yml`, `services-ci.yml`, `upstream-unblock-watch.yml`, `ghcr-publish.yml`/`auto-deploy.yml`) and 3 (`check-realm-*-parity.py`) run **in-cluster** from the `keycloak-realm-drift` CronJob. So `gates.yaml` is a complete census of *registered* gates but **not** of enforcement in this repo — which is itself an instance of the class, and is why `gate-invocation-reachability` (below) matters.

## The split

| class | count | share |
|---|---:|---:|
| **(a)** scope DERIVED from the artifacts it governs | **106** | 64% |
| **(b)** scope HAND-KEPT | **21** | 13% |
| **(c)** scope NARROWER than its stated subject | **39** | 23% |
| **(d)** undeterminable without running it | **0** | — |

**The honest headline: two thirds of the fleet is in the healthy shape.** Most (b) gates are fixture suites for shell helpers (`can-i-deploy-*`, `pact-version-*`), where a hand-kept case list is the correct shape; the ones worth watching are those where a stale entry fails in only one direction — `gitops-ref-integrity-guard`'s `IGNORED_NAMES` (no stale detection at all), `scheduler-exercised-in-tests` (`::warning` only), `readiness-attestation-format`'s `KNOWN_KEYS`, `libs-change-dependents`' `LIBS_MODULES`.

## The three fixed — each proven BY EFFECT

Every exit code below was read from `$?` on a redirected run, never off a pipeline.

### 1. `external-feed-declaration-drift` — corpus was YAML in `openbank-*/src/main/resources` only

The gate's own header argues the derived-scope rule. Its corpus was one glob.

| | |
|---|---|
| **blind spot** | inject a brand-new third-party host as HolmesGPT's LLM `api_base` in `openbank-infra/gitops/apps/holmesgpt.yaml:47` — the workload that receives cluster diagnostics |
| **before** | `EXIT=0`, printing `drift: OK — 1 declared feed(s), every external URL accounted for.` |
| **after** | `EXIT=1`, `DRIFT undeclared external URL openbank-infra/gitops/apps/holmesgpt.yaml:47 -> https://evil-exfil.example.net/v1` |
| **restored** | `EXIT=0` |

`CORPUS_GLOBS` now also covers `openbank-infra/gitops/**/*.yaml`. **36 hosts** became visible and are declared with reasons in five argued groups (identifiers that nothing dereferences, deploy-time chart/clone sources, registry upstreams behind our own caches, ACME, our own ingresses) — every one stale-checked in **both** directions by the existing `check_drift`. Two supporting fixes: `is_internal` now honours a `.svc`/`.cluster.local` suffix under **any** scheme (it tested that only on the `http://` branch, which is why an in-cluster mTLS call needed a `NOT_PROBED` excuse), and `NOT_PROBED` matching takes the **longest** prefix — it was `next(...)` over a **set**, so with overlapping entries which one got marked seen, and therefore which was reported stale, depended on hash order. Self-test: 20/20.

### 2. `model-residency-claims` — validated the default, not what reaches the pod (GDPR Chapter V)

R2 checked the `${VAR:default}` committed in `application.yaml`. The value that actually reaches the container is whatever gitops sets.

| | |
|---|---|
| **blind spot** | a `sensitivity: self-hosted` entry with an in-cluster default, while `openbank-infra/gitops/components/agent/agent-service.yaml:108` sets `AGENT_MODEL_ENDPOINT` to a hosted US host |
| **before** | `EXIT=0`, printing `OK — no self-hosted model entry points off-cluster` |
| **after** | `EXIT=1`, naming the file, the variable and the resolved host, under a new **R4** |
| **restored** | `EXIT=0` |

That is a residency control reporting green while class-1/2 prompt content leaves the cluster: `ModelGateway.resolve()` trusts the label, the fail-closed unit test still passes, and `gen-eu-ai-act.py` renders it as a control. Note the same variable's gitops value **equals** its default today — the property held by accident, with nothing asserting the agreement.

R4 derives the deployed value by walking every container `env` in `openbank-infra/gitops/**` (403 env names — no hand-kept service list, a new component is in scope the day it is committed). A `valueFrom:` override is reported for the same reason R2 rejects a default-less placeholder. **7 new self-test cases (24 → 31)**, one of which is a floor on the env corpus itself, so the rule cannot go vacuous the way the gate's live subject already has (the repo registers no self-hosted tier at all today).

### 3. `authz-enforce-pdp-sidecar-parity` — a naming convention standing in for the set of deployed modules

The app container was selected by `openbank-([a-z0-9-]+-service)`. Five modules do not carry that suffix, **three of them money-path**, and every one carries `@Authorize` in `src/main`:

| module | money-path | `@Authorize` files |
|---|---|---:|
| `openbank-sepa-payment` | yes | 8 |
| `openbank-domestic-payment` | yes | 10 |
| `openbank-sepa-instant` | yes | 12 |
| `openbank-customer-edge` | — | 3 |
| `openbank-product-catalog` | — | 7 |

An unmatched workload hit `continue`, so it was neither checked **nor** listed as skipped — invisible in both directions of the output.

| | |
|---|---|
| **blind spot** | delete the entire `opa` sidecar from the `openbank-sepa-payment` Rollout in `openbank-infra/gitops/components/payments/payments-services.yaml` |
| **before** | `EXIT=0`, `40 workload(s) checked; 4 skipped; 0 enforce-without-PDP violation(s).` |
| **after** | `EXIT=1`, `sepa-payment enforces authz (env) but its workload declares no 'opa' PDP sidecar` |
| **restored** | `EXIT=0`, `60 workload(s) checked; 19 skipped; 0 unresolved image(s); 0 stale NON_MODULE_IMAGES entr(ies); 0 violation(s).` |

That is the exact #1797 defect — every `@Authorize` endpoint on a money-path SEPA service failing closed with 503/422 — on the gate written to prevent it. The module set is now **derived**: any `openbank-<name>` image whose `<name>` is a real module directory. **40 workloads checked becomes 60.** An unresolvable `openbank-*` image is a reported **third state**, never a drop. The one legitimate non-module image (`openbank-keycloak`) carries its reason in `NON_MODULE_IMAGES`, which fails stale:

| | |
|---|---|
| **stale-entry control** | add `"openbank-gone"` to `NON_MODULE_IMAGES` |
| **result** | `EXIT=1`, `...but no workload runs it any more — remove the entry, or the exclusion outlives the thing it excused.` |

The staleness half is scoped to the real tree, because `check_authz_pdp_parity_test.py` also drives `--root` at synthetic fixtures. **That regression was caught by the existing falsification suite, not by me** — `governance-script-unit-tests` went red (3 failures) on the first attempt, which is the suite doing its job.

## Why NOT a generic meta-gate

The brief asked me to argue this with evidence rather than assume it, and the evidence is already in the tree: **`gate-subject-floor` IS the generic meta-gate, and its own docstring says it cannot see this class.** It enforces `min_subjects:` and states plainly that it "catches COLLAPSE, not drift… a floor is not a ratchet on coverage". None of the three defects here is a collapse — each gate found a healthy-looking corpus (1 feed, 119 configs, 40 workloads) and cleared any floor comfortably. A meta-gate cannot know that `openbank-sepa-payment` *should* have been among those 40, because that is a fact about what the gate *means* to govern. Two further data points: **51 of 166** gates declare a floor at all (99 sit in a DEBT list, 17 in `NO_CORPUS`), and `gate-invocation-reachability` — a meta-gate scoped to one literal workflow path — is itself class (c). A second generic layer would add coverage-shaped reassurance over the same blind spot.

## Verification

Shards run individually in the **foreground** (`run-gates.py --all` block-buffers, #6068), with `PR_DIFF_BASE` set to the real merge-base:

| shard | result |
|---|---|
| `data` | **PASS 21/21** |
| `security` | **PASS 14/14** |
| `kotlin` | **PASS 19/19** |
| `registry` | **PASS 26/26** |
| `lint` | **PASS 20/20** |
| `supplychain` | PASS 23, WARN 1 (advisory) |
| `gitops` | PASS 33, `loki-rule-load-test` UNFALSIFIED |
| `api` | PASS 7, `api-contract-gate` FAIL |

The last two were baselined on a **pristine `origin/main` worktree** and fail identically there (`EXIT=1` both) — local-environment, not this change. Meta-gates run individually and green: `gate-subject-floor`, `gate-selftest-declaration`, `gate-lifecycle-metadata`, `advisory-gate-registration`, `gates-not-deregistered`, `gate-script-registration`, `python-lint`, `stale-comment-references`, `governance-script-unit-tests`.

## Not fixed here

The remaining **36 (c) gates** are in one issue rather than one each — including one this PR *creates*: the widened `external-feed-declaration-drift` corpus is still YAML-only, and `FcmPushSender.kt` hardcodes `https://fcm.googleapis.com/...`. Fixing a corpus does not make it complete, and saying so is cheaper than discovering it later.

Refs #6242
