### PR TITLE
fix(libs): ignore unknown fields inside the chat message, or every call throws

### DIFF
--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClient.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClient.kt
@@ -186,6 +186,22 @@ internal data class ChatRequest(
 @JsonInclude(JsonInclude.Include.NON_NULL)
 internal data class ChatMetadata(@JsonProperty("trace_id") val traceId: String)
 
+// ignoreUnknown, like every other wire type here — and it is NOT cosmetic. Providers return extra
+// fields INSIDE the message object: `tool_calls` and `function_call` (null on a plain answer, but
+// present), and `reasoning_content` from every reasoning model. Without this annotation Jackson
+// throws on the whole response:
+//
+//   Unrecognized field "tool_calls" (class ...ChatMessage), not marked as ignorable
+//
+// Measured live on 2026-08-21: EVERY content-safety classification came back `unavailable` with
+// reason=transport because of this line, so the guardrail was deployed, enabled, and classifying
+// nothing. The shared gateway client parses through the same type, so the defect was not confined
+// to the guardrail — it was one provider response shape away from silencing every LLM caller that
+// routes through here.
+//
+// It surfaced only because the verdict is three-valued: had `unavailable` been folded into `safe`,
+// a guardrail answering nothing would have looked exactly like a guardrail seeing nothing wrong.
+@JsonIgnoreProperties(ignoreUnknown = true)
 internal data class ChatMessage(val role: String, val content: String)
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/llm/LlamaGuardContentSafetyAdapterTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/llm/LlamaGuardContentSafetyAdapterTest.kt
@@ -157,6 +157,26 @@ class LlamaGuardContentSafetyAdapterTest {
     }
 
     @Test
+    fun `a message carrying provider extras still parses`(): Unit = runBlocking {
+        // The live failure on 2026-08-21: DeepInfra returns `tool_calls`, `function_call` and
+        // `reasoning_content` INSIDE the message object, and the wire type did not ignore unknown
+        // fields — so Jackson threw and EVERY classification came back `unavailable`. The verdict
+        // was visible; the cause was one annotation.
+        val url = startStub(
+            200,
+            """{"choices":[{"message":{"role":"assistant","content":"unsafe\nS2",
+               |"tool_calls":null,"function_call":null,"reasoning_content":"the user asks..."}}],
+               |"usage":{"prompt_tokens":9,"completion_tokens":3}}
+            """.trimMargin(),
+        )
+
+        val verdict = adapter(url).classify(ContentSafetyPort.SafetyRole.USER, "…")
+
+        assertThat(verdict.decision).isEqualTo(ContentSafetyPort.Decision.UNSAFE)
+        assertThat(verdict.categories).containsExactly("S2")
+    }
+
+    @Test
     fun `disabled port classifies nothing and says so`(): Unit = runBlocking {
         val verdict = ContentSafetyPort.DISABLED.classify(ContentSafetyPort.SafetyRole.USER, "anything")
 


### PR DESCRIPTION
Measured on the sandbox minutes after the guardrail went live: **every** content-safety
classification returned `unavailable`, and the log said why:

```
content-safety call failed: Unrecognized field "tool_calls"
  (class com.openbank.libs.llm.ChatMessage), not marked as ignorable
  (2 known properties: "content", "role")
```

Providers put extra fields **inside the message object** — `tool_calls` and `function_call` (null on
a plain answer, but present) and `reasoning_content` from every reasoning model, which is what both
models in the assistant picker now are. `ChatResponse`, `ChatChoice` and `ChatUsage` all carry
`@JsonIgnoreProperties(ignoreUnknown = true)`; `ChatMessage` did not, so Jackson threw on the whole
response.

## Not confined to the guardrail

The shared `LlmGatewayPort` client parses through the same type. Any caller whose provider includes
one of those fields degrades to its deterministic fallback with a single warn line — the fleet's
documented "no model available" path, entered for a **parsing bug** rather than an outage. That is
the quiet failure this repo keeps finding months late.

## Why it was caught in minutes instead

Because the verdict is three-valued. Had `unavailable` been folded into `safe`, a guardrail
answering nothing would have looked exactly like a guardrail seeing nothing wrong — deployed,
enabled, green, and inert. The metric read:

```
openbank_guardrail_classifications_total{decision="unavailable",role="user",blocked="false"} 2
openbank_llm_requests_total{model="meta-llama/llama-guard-4-12b",outcome="exception"} 1
```

That is the first time the third state paid for itself.

## Verification

New test feeds a response carrying all three extras and asserts the verdict parses (`unsafe` + `S2`).
**Falsified**: removing the annotation turns it red. `:openbank-libs-runtime:test` + ktlint + detekt
green.

## Linked issues

Refs #5671
