### PR TITLE
perf(ci): consolidate the 8 gate shards into 3 buckets (#6252)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
   # refuses a selection that matches no gates rather than reporting a green about no work.
   # ---------------------------------------------------------------------------
   gates:
-    name: gates (${{ matrix.group }})
+    name: gates (${{ matrix.slug }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -251,7 +251,32 @@ jobs:
       # gets a one-gate-at-a-time debugging loop instead of the whole picture in one run.
       fail-fast: false
       matrix:
-        group: [lint, gitops, supplychain, registry, kotlin, api, data, security]
+        # THREE buckets, not eight. Each entry is a SPACE-SEPARATED set of manifest groups;
+        # `--group` is repeatable, so the taxonomy in gates.yaml is untouched and
+        # `run-gates.py --group lint` still works locally exactly as before.
+        #
+        # WHY (#6252, measured over 6 PR runs): 93% of a CI job's elapsed time is runner
+        # QUEUE, not work. The eight shards are created in the same instant and admitted
+        # over a ~7 min stagger, so they spend 11.3 min wall-clock doing 5.6 min of work
+        # while holding eight hosted-runner slots. Sharding was the right call when
+        # #4340-#4346 measured it (62s -> 26s of CPU on the slowest shard); the binding
+        # constraint has since moved from CPU to slots, and eight-way parallelism the pool
+        # cannot supply now costs more than it buys — including 8x14s of duplicated
+        # checkout/setup-node/PyYAML per run.
+        #
+        # Balanced on measured gate work, not gate count: gitops alone is ~1.4 min, more
+        # than the other seven together in some runs, so it anchors its own bucket.
+        # `include:` rather than a bare list because each bucket needs TWO values: the set of
+        # manifest groups to pass to --group, and a filesystem/artifact-safe slug. There is no
+        # string-replace function in GitHub expressions (actionlint rejects `replace(...)`), so
+        # the slug is written out rather than derived.
+        include:
+          - slug: gitops-api
+            groups: gitops api
+          - slug: lint-supplychain-security
+            groups: lint supplychain security
+          - slug: registry-kotlin-data
+            groups: registry kotlin data
     env:
       # ${{ }} expressions cannot be expanded outside the workflow, so the two gate inputs
       # that need them are set here rather than in the manifest.
@@ -355,11 +380,12 @@ jobs:
             || python3 -c "import yaml" 2>/dev/null \
             || { echo "::error::pyyaml unavailable — add it to the runner base image"; exit 1; }
 
-      # yamllint is not on the hosted image (shellcheck is), and only the `lint` shard
-      # needs it — installing it in all eight would pay an apt-get eight times over.
-      # ADR-0040: direct CLI invocation, not a Docker container action.
+      # yamllint is not on the hosted image (shellcheck is), and only the bucket CONTAINING
+      # the `lint` group needs it — installing it in every bucket would pay an apt-get three
+      # times over. `contains(...)` on the space-separated set, since the bucket is no longer
+      # a single group name. ADR-0040: direct CLI invocation, not a Docker container action.
       - name: Install lint tools
-        if: matrix.group == 'lint'
+        if: contains(matrix.groups, 'lint')
         run: |
           command -v yamllint >/dev/null 2>&1 || {
             sudo apt-get update -q
@@ -389,8 +415,14 @@ jobs:
 
       - name: Run gates
         run: |
-          python3 .github/scripts/run-gates.py --group "${{ matrix.group }}" \
-            --json "${RUNNER_TEMP}/gate-results-${{ matrix.group }}.json"
+          # matrix.group is a space-separated SET of manifest groups; --group is repeatable.
+          # Unquoted on purpose so the shell word-splits it — the one place in this file where
+          # that is wanted rather than a bug.
+          FLAGS=""
+          for g in ${{ matrix.groups }}; do FLAGS="$FLAGS --group $g"; done
+          # shellcheck disable=SC2086  # deliberate word-splitting of the flag list built above
+          python3 .github/scripts/run-gates.py $FLAGS \
+            --json "${RUNNER_TEMP}/gate-results-${{ matrix.slug }}.json"
 
       # ADR-0255. A structured record per gate, not another log for something to re-parse —
       # CLAUDE.md documents at length why scraping a job's own printed log is fragile (the log
@@ -403,8 +435,10 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: gate-results-${{ matrix.group }}
-          path: ${{ runner.temp }}/gate-results-${{ matrix.group }}.json
+          # matrix.slug, not matrix.groups: a space is not valid in an artifact name, and
+          # this must match the --json path above exactly or the upload finds no file.
+          name: gate-results-${{ matrix.slug }}
+          path: ${{ runner.temp }}/gate-results-${{ matrix.slug }}.json
           if-no-files-found: warn
           retention-days: 90
 


### PR DESCRIPTION
Implements option 1 from #6252.

## Why

93% of a CI job's elapsed time is runner **queue**, not work — queue p50 6.6 min against run p50
0.4 min, measured over 6 PR runs / 78 jobs. The eight shards are created in the same instant and
admitted over a ~7 min stagger, so they spend **11.3 min of wall-clock doing 5.6 min of work** while
holding eight hosted-runner slots.

**The earlier sharding was not wrong.** #4340–#4346 measured CPU (62 s → 26 s on the slowest shard)
and were right at the time. The binding constraint has since moved from CPU to runner slots, so
eight-way parallelism the pool cannot supply now costs more than it buys — including 8 × 14 s of
duplicated `checkout` / `setup-node` / PyYAML per run.

## What changed

Only `ci.yml`. **The manifest taxonomy is untouched** — `--group` is repeatable, so each bucket
passes several, and `run-gates.py --group lint` still works locally exactly as before.

Balanced on measured gate *work*, not gate count (gitops alone is ~1.4 min, so it anchors its own
bucket):

| bucket | groups | gates |
|---|---|---|
| `gitops-api` | gitops, api | 42 |
| `lint-supplychain-security` | lint, supplychain, security | 58 |
| `registry-kotlin-data` | registry, kotlin, data | 66 |

## Verification

- **166/166 gates still reachable.** No manifest group orphaned, none in the matrix the manifest
  lacks — asserted by parsing both files, not by eye.
- `gate-invocation-reachability`, `gate-script-registration`, `advisory-gate-registration`,
  `yamllint`, `gate-subject-floor` — all pass on the branch.
- Each bucket run locally; the only failures are gates that classify a PR diff
  (`api-contract`, `threat-model-diff`, `db-migration`, `release-scope`, `litellm-config-revision`)
  and **they fail identically on unmodified `main`** — confirmed by stashing the change and
  re-running, not assumed.
- `actionlint` clean.

## Two bugs actionlint caught before CI could

Worth recording, because both would have been quiet failures rather than loud ones:

1. **`replace()` is not a GitHub expression function.** I assumed it was and used it for the
   artifact slug. The slug is now written out explicitly in an `include:` entry.
2. A conditional step keyed on `matrix.group == 'lint'` had to become
   `contains(matrix.groups, 'lint')` — otherwise `yamllint` silently stops being installed for the
   bucket that needs it, and the yamllint gate fails for a reason unrelated to its subject.

Also unified the `--json` write path and the artifact upload path onto one slug: they had drifted
apart in my first draft, and a mismatch there uploads nothing while both steps still report success.

## How to falsify this

**Not** "did a shard get faster" — it will not, each bucket does more work per job. The measurement
is **wall-clock from the run's `created_at` to the last gate job's `completed_at`**, against the
11.3 min median recorded in #6252, on the same pinned query:

```
gh api "repos/JiRaska/open-bank-oss/actions/runs/<id>/jobs?per_page=100"
```

If it does not beat 11.3 min, this should be reverted — it is one line of matrix and trivially
reversible, and under low contention the eight-way split is the better design again.

Refs #6252
