### PR TITLE
fix(onboarding): stop counting a dropped projection as a success

### DIFF
--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/application/usecase/OnboardingProjectionService.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/application/usecase/OnboardingProjectionService.kt
@@ -11,6 +11,7 @@ import com.openbank.onboarding.domain.model.KycStage
 import com.openbank.onboarding.domain.model.OnboardingEvent
 import com.openbank.onboarding.domain.model.OnboardingRecord
 import com.openbank.onboarding.domain.model.PartyStage
+import com.openbank.onboarding.domain.model.ProjectionResult
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import java.util.UUID
@@ -51,82 +52,21 @@ class OnboardingProjectionService : OnboardingUseCase {
 
     // ── Event projection ─────────────────────────────────────────────────────
 
-    suspend fun applyEvent(event: OnboardingEvent) {
-        when (event) {
-            is OnboardingEvent.PartyCreated -> {
-                val now = event.occurredAt
-                val record = OnboardingRecord(
-                    partyId = event.partyId,
-                    legalName = event.legalName,
-                    email = event.email,
-                    partyStatus = PartyStage.PENDING_KYC,
-                    kycCaseId = null,
-                    kycStatus = null,
-                    scaEnrolled = false,
-                    deviceCount = 0,
-                    funnelStage = FunnelStage.REGISTERED,
-                    blockedReason = null,
-                    createdAt = now,
-                    updatedAt = now,
-                )
-                repo.upsert(record)
-            }
-
-            is OnboardingEvent.PartyStatusChanged -> {
-                val existing = repo.findByPartyId(event.partyId) ?: return
-                val updated = existing.copy(
-                    partyStatus = event.newStatus,
-                    funnelStage = FunnelStage.derive(event.newStatus, existing.kycStatus, existing.scaEnrolled),
-                    blockedReason = if (event.newStatus == PartyStage.SUSPENDED ||
-                        event.newStatus == PartyStage.CLOSED
-                    ) {
-                        "Party ${event.newStatus.name.lowercase()}"
-                    } else {
-                        null
-                    },
-                    updatedAt = event.occurredAt,
-                )
-                repo.upsert(updated)
-            }
-
-            is OnboardingEvent.KycCaseOpened -> {
-                val existing = repo.findByPartyId(event.partyId) ?: return
-                val updated = existing.copy(
-                    kycCaseId = event.kycCaseId,
-                    kycStatus = KycStage.OPEN,
-                    funnelStage = FunnelStage.derive(existing.partyStatus, KycStage.OPEN, existing.scaEnrolled),
-                    updatedAt = event.occurredAt,
-                )
-                repo.upsert(updated)
-            }
-
-            is OnboardingEvent.KycStatusChanged -> {
-                val existing = repo.findByPartyId(event.partyId) ?: return
-                val updated = existing.copy(
-                    kycStatus = event.newStatus,
-                    funnelStage = FunnelStage.derive(existing.partyStatus, event.newStatus, existing.scaEnrolled),
-                    blockedReason = when (event.newStatus) {
-                        KycStage.REJECTED -> "KYC rejected"
-                        KycStage.EXPIRED -> "KYC expired"
-                        else -> null
-                    },
-                    updatedAt = event.occurredAt,
-                )
-                repo.upsert(updated)
-            }
-
-            is OnboardingEvent.DeviceEnrolled -> {
-                val existing = repo.findByPartyId(event.partyId) ?: return
-                val newCount = existing.deviceCount + 1
-                val updated = existing.copy(
-                    scaEnrolled = true,
-                    deviceCount = newCount,
-                    funnelStage = FunnelStage.derive(existing.partyStatus, existing.kycStatus, true),
-                    updatedAt = event.occurredAt,
-                )
-                repo.upsert(updated)
-            }
-        }
+    /**
+     * Applies one event to the read model and reports what it did.
+     *
+     * Returns [ProjectionResult.SKIPPED_UNKNOWN_PARTY] rather than throwing when the event names
+     * a party with no row: the three source topics are independent consumer groups with no
+     * ordering between them, so this is an expected race, not a fault. The caller must record it
+     * as its own outcome and never as a success — see [ProjectionResult] for what folding the two
+     * together cost (#6248).
+     */
+    suspend fun applyEvent(event: OnboardingEvent): ProjectionResult = when (event) {
+        is OnboardingEvent.PartyCreated -> repo.applyPartyCreated(event)
+        is OnboardingEvent.PartyStatusChanged -> repo.applyPartyStatusChanged(event)
+        is OnboardingEvent.KycCaseOpened -> repo.applyKycCaseOpened(event)
+        is OnboardingEvent.KycStatusChanged -> repo.applyKycStatusChanged(event)
+        is OnboardingEvent.DeviceEnrolled -> repo.applyDeviceEnrolled(event)
     }
 
     // ── GDPR erasure ─────────────────────────────────────────────────────────
@@ -156,4 +96,98 @@ class OnboardingProjectionService : OnboardingUseCase {
         "createdAt" to createdAt.toString(),
         "updatedAt" to updatedAt.toString(),
     )
+}
+
+// ── Per-event projection ────────────────────────────────────────────────────
+//
+// File-private extensions on the repository rather than methods on the service: they need
+// nothing else from it, and keeping them off the class holds it under detekt's TooManyFunctions
+// threshold, which fires AT 11 and not above it.
+
+/** The only branch that creates a row, and so the only one that cannot skip. */
+private suspend fun OnboardingRepository.applyPartyCreated(event: OnboardingEvent.PartyCreated): ProjectionResult {
+    val now = event.occurredAt
+    upsert(
+        OnboardingRecord(
+            partyId = event.partyId,
+            legalName = event.legalName,
+            email = event.email,
+            partyStatus = PartyStage.PENDING_KYC,
+            kycCaseId = null,
+            kycStatus = null,
+            scaEnrolled = false,
+            deviceCount = 0,
+            funnelStage = FunnelStage.REGISTERED,
+            blockedReason = null,
+            createdAt = now,
+            updatedAt = now,
+        ),
+    )
+    return ProjectionResult.APPLIED
+}
+
+private suspend fun OnboardingRepository.applyPartyStatusChanged(
+    event: OnboardingEvent.PartyStatusChanged,
+): ProjectionResult {
+    val existing = findByPartyId(event.partyId) ?: return ProjectionResult.SKIPPED_UNKNOWN_PARTY
+    upsert(
+        existing.copy(
+            partyStatus = event.newStatus,
+            funnelStage = FunnelStage.derive(event.newStatus, existing.kycStatus, existing.scaEnrolled),
+            blockedReason = if (event.newStatus == PartyStage.SUSPENDED ||
+                event.newStatus == PartyStage.CLOSED
+            ) {
+                "Party ${event.newStatus.name.lowercase()}"
+            } else {
+                null
+            },
+            updatedAt = event.occurredAt,
+        ),
+    )
+    return ProjectionResult.APPLIED
+}
+
+private suspend fun OnboardingRepository.applyKycCaseOpened(event: OnboardingEvent.KycCaseOpened): ProjectionResult {
+    val existing = findByPartyId(event.partyId) ?: return ProjectionResult.SKIPPED_UNKNOWN_PARTY
+    upsert(
+        existing.copy(
+            kycCaseId = event.kycCaseId,
+            kycStatus = KycStage.OPEN,
+            funnelStage = FunnelStage.derive(existing.partyStatus, KycStage.OPEN, existing.scaEnrolled),
+            updatedAt = event.occurredAt,
+        ),
+    )
+    return ProjectionResult.APPLIED
+}
+
+private suspend fun OnboardingRepository.applyKycStatusChanged(
+    event: OnboardingEvent.KycStatusChanged,
+): ProjectionResult {
+    val existing = findByPartyId(event.partyId) ?: return ProjectionResult.SKIPPED_UNKNOWN_PARTY
+    upsert(
+        existing.copy(
+            kycStatus = event.newStatus,
+            funnelStage = FunnelStage.derive(existing.partyStatus, event.newStatus, existing.scaEnrolled),
+            blockedReason = when (event.newStatus) {
+                KycStage.REJECTED -> "KYC rejected"
+                KycStage.EXPIRED -> "KYC expired"
+                else -> null
+            },
+            updatedAt = event.occurredAt,
+        ),
+    )
+    return ProjectionResult.APPLIED
+}
+
+private suspend fun OnboardingRepository.applyDeviceEnrolled(event: OnboardingEvent.DeviceEnrolled): ProjectionResult {
+    val existing = findByPartyId(event.partyId) ?: return ProjectionResult.SKIPPED_UNKNOWN_PARTY
+    upsert(
+        existing.copy(
+            scaEnrolled = true,
+            deviceCount = existing.deviceCount + 1,
+            funnelStage = FunnelStage.derive(existing.partyStatus, existing.kycStatus, true),
+            updatedAt = event.occurredAt,
+        ),
+    )
+    return ProjectionResult.APPLIED
 }

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/domain/model/ProjectionResult.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/domain/model/ProjectionResult.kt
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.onboarding.domain.model
+
+/**
+ * What the projection actually did with an event it was handed (#6248).
+ *
+ * Every branch of the projection except `PartyCreated` needs an existing row to update, and
+ * guards with `repo.findByPartyId(...) ?: return`. That guard is correct — the three source
+ * topics are three independent consumer groups with no ordering between them, so an event can
+ * legitimately arrive before the party row exists, and throwing would wedge the group. What was
+ * wrong is that the guard returned normally and the caller could not tell it apart from work
+ * done: a dropped event was counted as `PROJECTED`.
+ *
+ * That cost the platform a real defect. All 15 `DEVICE_ENROLLED` events in the sandbox were
+ * consumed with zero lag and none reached `onboarding_records`, and the alert built for exactly
+ * this class of failure (`UNRECOGNISED > 0 and PROJECTED == 0`, #4353) was structurally unable
+ * to fire, because the drop was landing in the success bucket it compares against.
+ *
+ * So the skip gets its own value, never a flag shared with success — the same rule as
+ * `PushSendOutcome.SKIPPED` (ADR-0252 phase 0), and the same rule the sibling
+ * `ProjectionOutcomeMetrics.Outcome.UNRECOGNISED` already follows one layer up.
+ */
+enum class ProjectionResult {
+    /** The read model was updated. */
+    APPLIED,
+
+    /**
+     * The event named a party that has no row yet, so there was nothing to update and the event
+     * was discarded. Not an error and not a success — this is the state in which enrolments,
+     * KYC transitions and status changes are silently lost.
+     */
+    SKIPPED_UNKNOWN_PARTY,
+}

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumer.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumer.kt
@@ -11,6 +11,7 @@ import com.openbank.onboarding.application.usecase.OnboardingProjectionService
 import com.openbank.onboarding.domain.model.KycStage
 import com.openbank.onboarding.domain.model.OnboardingEvent
 import com.openbank.onboarding.domain.model.PartyStage
+import com.openbank.onboarding.domain.model.ProjectionResult
 import com.openbank.onboarding.infrastructure.observability.ProjectionOutcomeMetrics
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
@@ -215,7 +216,7 @@ class OnboardingEventConsumer(private val clock: Clock) {
 
     @Suppress("TooGenericExceptionCaught")
     private suspend fun project(event: OnboardingEvent, topic: String) {
-        try {
+        val result = try {
             EventRetry.withRetry(log, "[$topic] Projection of ${event::class.simpleName}", partyIdOf(event)) {
                 projection.applyEvent(event)
             }
@@ -225,7 +226,25 @@ class OnboardingEventConsumer(private val clock: Clock) {
             metrics.record(topic, ProjectionOutcomeMetrics.Outcome.FAILED)
             throw e
         }
-        metrics.record(topic, ProjectionOutcomeMetrics.Outcome.PROJECTED)
+        // A skip is NOT a success (#6248). Recording both as PROJECTED is what let 15 DEVICE_ENROLLED
+        // events be consumed with zero lag, reach no row, and leave every alert reading healthy.
+        when (result) {
+            ProjectionResult.APPLIED ->
+                metrics.record(topic, ProjectionOutcomeMetrics.Outcome.PROJECTED)
+
+            ProjectionResult.SKIPPED_UNKNOWN_PARTY -> {
+                // WARN, not ERROR: an out-of-order arrival is expected across independent consumer
+                // groups. It is logged at all because the drop is otherwise invisible per-party —
+                // the metric says how many, only this line says which.
+                log.warnf(
+                    "[%s] Dropped %s for party %s: no onboarding record exists yet",
+                    topic,
+                    event::class.simpleName,
+                    partyIdOf(event),
+                )
+                metrics.record(topic, ProjectionOutcomeMetrics.Outcome.SKIPPED_UNKNOWN_PARTY)
+            }
+        }
     }
 
     // ── JSON helpers ─────────────────────────────────────────────────────────

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/observability/ProjectionOutcomeMetrics.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/observability/ProjectionOutcomeMetrics.kt
@@ -27,11 +27,18 @@ import jakarta.inject.Inject
  * [Outcome.UNRECOGNISED] is its own value rather than being folded into a generic "handled",
  * the same reason `PushSendOutcome.SKIPPED` is not a flag shared with success.
  *
- * Suggested rule (per topic, over a window in which the topic delivered anything at all):
+ * Suggested rules (per topic, over a window in which the topic delivered anything at all).
+ * Producer and consumer disagree about the wire format:
  *   sum by (topic) (rate(...{outcome="UNRECOGNISED"}[1h])) > 0
  *     and sum by (topic) (rate(...{outcome="PROJECTED"}[1h])) == 0
+ * Events are arriving for parties the read model does not have, i.e. cross-topic ordering is
+ * losing them (#6248):
+ *   sum by (topic) (rate(...{outcome="SKIPPED_UNKNOWN_PARTY"}[1h])) > 0
  *
- * Cardinality is bounded: three topics, three outcomes.
+ * The second rule needs no PROJECTED == 0 companion: unlike an unrecognised payload, a skip is
+ * per-party, so a steady trickle among healthy traffic is exactly the shape to alert on.
+ *
+ * Cardinality is bounded: three topics, four outcomes.
  *
  * Service-local [MeterRegistry], null-safe via [Instance] — same shape as
  * [OnboardingFunnelGauge] and notification-service's `PushMetricsAdapter` (ADR-0085 §2).
@@ -57,6 +64,18 @@ class ProjectionOutcomeMetrics(private val registry: MeterRegistry?) {
          * both report healthy.
          */
         UNRECOGNISED,
+
+        /**
+         * Parsed and recognised, but the projection had nothing to update: the event names a
+         * party with no row yet. Its own value rather than part of [PROJECTED], because the two
+         * are opposite states — one means the read model advanced, the other means an enrolment
+         * or a KYC transition was discarded.
+         *
+         * This is the outcome that was missing when this class was written, and its absence is
+         * why the rule below could not fire for #6248: the drops were being counted as
+         * [PROJECTED], the very series the rule requires to be zero.
+         */
+        SKIPPED_UNKNOWN_PARTY,
 
         /** Malformed payload, or the projection itself threw. Already logged at ERROR. */
         FAILED,

--- a/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/application/usecase/OnboardingProjectionServiceTest.kt
+++ b/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/application/usecase/OnboardingProjectionServiceTest.kt
@@ -10,6 +10,7 @@ import com.openbank.onboarding.domain.model.KycStage
 import com.openbank.onboarding.domain.model.OnboardingEvent
 import com.openbank.onboarding.domain.model.OnboardingRecord
 import com.openbank.onboarding.domain.model.PartyStage
+import com.openbank.onboarding.domain.model.ProjectionResult
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.just
@@ -180,6 +181,55 @@ class OnboardingProjectionServiceTest {
             assertThat(deviceCount).isEqualTo(1)
             assertThat(funnelStage).isEqualTo(FunnelStage.ACTIVE)
         }
+    }
+
+    // ── applyEvent: the party row does not exist yet (#6248) ──────────────────
+
+    /**
+     * Every branch that needs an existing row must report the skip rather than returning the same
+     * value as work done. Parameterised over all four so a branch added later cannot quietly opt
+     * out — `DeviceEnrolled` is the one that was measured losing events, but the other three lose
+     * KYC and status transitions the same way.
+     */
+    @Test
+    fun `applyEvent returns SKIPPED_UNKNOWN_PARTY on every branch that needs an existing row`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        val at = Instant.parse("2026-08-19T12:56:36Z")
+        val events = listOf(
+            OnboardingEvent.DeviceEnrolled(partyId, "cred-abc", at),
+            OnboardingEvent.PartyStatusChanged(partyId, PartyStage.ACTIVE, at),
+            OnboardingEvent.KycCaseOpened(partyId, UUID.randomUUID(), at),
+            OnboardingEvent.KycStatusChanged(partyId, UUID.randomUUID(), KycStage.APPROVED, at),
+        )
+        coEvery { repo.findByPartyId(partyId) } returns null
+
+        assertThat(events.map { service.applyEvent(it) })
+            .describedAs("all four branches report the skip")
+            .containsOnly(ProjectionResult.SKIPPED_UNKNOWN_PARTY)
+
+        coVerify(exactly = 0) { repo.upsert(any()) }
+    }
+
+    /**
+     * The other half of the contract: a real update must NOT report a skip. Without this the
+     * assertion above passes against a projection that returns SKIPPED_UNKNOWN_PARTY
+     * unconditionally.
+     */
+    @Test
+    fun `applyEvent returns APPLIED when the row exists`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        coEvery { repo.findByPartyId(partyId) } returns sampleRecord(
+            partyId,
+            funnelStage = FunnelStage.SCA_PENDING,
+            kycStatus = KycStage.APPROVED,
+        )
+        coEvery { repo.upsert(any()) } just runs
+
+        val result = service.applyEvent(
+            OnboardingEvent.DeviceEnrolled(partyId, "cred-abc", Instant.parse("2026-08-19T12:56:36Z")),
+        )
+
+        assertThat(result).isEqualTo(ProjectionResult.APPLIED)
     }
 
     // ── getRecord not found ───────────────────────────────────────────────────

--- a/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumerTest.kt
+++ b/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumerTest.kt
@@ -10,6 +10,7 @@ import com.openbank.onboarding.application.usecase.OnboardingProjectionService
 import com.openbank.onboarding.domain.model.KycStage
 import com.openbank.onboarding.domain.model.OnboardingEvent
 import com.openbank.onboarding.domain.model.PartyStage
+import com.openbank.onboarding.domain.model.ProjectionResult
 import com.openbank.onboarding.infrastructure.observability.ProjectionOutcomeMetrics
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -64,7 +65,7 @@ class OnboardingEventConsumerTest {
             """"partyId":"$partyId",""" +
             """"credentialId":"e2e-1c0a4767-aed7-4e9a-9f91-ea8ba3e0493e",""" +
             """"algorithm":"ES256","occurredAt":"2026-08-08T03:20:23.835301445Z"}"""
-        coEvery { projection.applyEvent(any()) } just runs
+        coEvery { projection.applyEvent(any()) } returns ProjectionResult.APPLIED
 
         consumer.consumeScaEvent(payload)
 
@@ -74,6 +75,50 @@ class OnboardingEventConsumerTest {
             )
         }
         verify(exactly = 1) { metrics.record("sca-events-in", ProjectionOutcomeMetrics.Outcome.PROJECTED) }
+    }
+
+    /**
+     * The defect this outcome exists for (#6248). A DEVICE_ENROLLED whose party has no row yet is
+     * consumed successfully and dropped; before the fourth outcome existed it was recorded as
+     * PROJECTED, so the alert built for exactly this class of loss compared against a series the
+     * drops were inflating.
+     *
+     * The `exactly = 0` on PROJECTED is the assertion that matters. Without it this test passes
+     * unchanged against the old code, which recorded PROJECTED and nothing else — it would be
+     * measuring that a counter was touched, not which bucket it landed in.
+     */
+    @Test
+    fun `a skipped projection is recorded as SKIPPED_UNKNOWN_PARTY and never as PROJECTED`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        coEvery { projection.applyEvent(any()) } returns ProjectionResult.SKIPPED_UNKNOWN_PARTY
+
+        consumer.consumeScaEvent(
+            """{"eventType":"DEVICE_ENROLLED","partyId":"$partyId","credentialId":"c1"}""",
+        )
+
+        verify(exactly = 1) {
+            metrics.record("sca-events-in", ProjectionOutcomeMetrics.Outcome.SKIPPED_UNKNOWN_PARTY)
+        }
+        verify(exactly = 0) { metrics.record("sca-events-in", ProjectionOutcomeMetrics.Outcome.PROJECTED) }
+        verify(exactly = 0) { metrics.record("sca-events-in", ProjectionOutcomeMetrics.Outcome.FAILED) }
+    }
+
+    /**
+     * A skip must stay acked. Nacking it would wedge the consumer group on an ordering race that
+     * resolves itself, which is the failure mode the original `?: return` was right to avoid —
+     * only its reporting was wrong.
+     */
+    @Test
+    fun `a skipped projection does not throw`() {
+        coEvery { projection.applyEvent(any()) } returns ProjectionResult.SKIPPED_UNKNOWN_PARTY
+
+        assertThatCode {
+            runBlocking {
+                consumer.consumeScaEvent(
+                    """{"eventType":"DEVICE_ENROLLED","partyId":"${UUID.randomUUID()}","credentialId":"c1"}""",
+                )
+            }
+        }.doesNotThrowAnyException()
     }
 
     /**
@@ -132,7 +177,7 @@ class OnboardingEventConsumerTest {
         val partyId = UUID.randomUUID()
         val payload = """{"eventType":"PARTY_CREATED","partyId":"$partyId",""" +
             """"legalName":"Alice","email":"a@b.com","occurredAt":"2026-06-01T10:00:00Z"}"""
-        coEvery { projection.applyEvent(any()) } just runs
+        coEvery { projection.applyEvent(any()) } returns ProjectionResult.APPLIED
 
         consumer.consumePartyEvent(payload)
 
@@ -148,7 +193,7 @@ class OnboardingEventConsumerTest {
         val partyId = UUID.randomUUID()
         val payload = """{"eventType":"KYC_STATUS_CHANGED","partyId":"$partyId",""" +
             """"status":"ACTIVE","occurredAt":"2026-06-01T10:00:00Z"}"""
-        coEvery { projection.applyEvent(any()) } just runs
+        coEvery { projection.applyEvent(any()) } returns ProjectionResult.APPLIED
 
         consumer.consumePartyEvent(payload)
 
@@ -174,7 +219,7 @@ class OnboardingEventConsumerTest {
             val caseId = UUID.randomUUID()
             val payload = """{"eventType":"KYC_CASE_STATUS_CHANGED","partyId":"$partyId","kycCaseId":"$caseId",""" +
                 """"status":"UNDER_REVIEW","occurredAt":"2026-06-01T10:00:00Z"}"""
-            coEvery { projection.applyEvent(any()) } just runs
+            coEvery { projection.applyEvent(any()) } returns ProjectionResult.APPLIED
 
             consumer.consumeKycEvent(payload)
 
@@ -258,6 +303,7 @@ class OnboardingEventConsumerTest {
         coEvery { projection.applyEvent(any()) } answers {
             attempts++
             if (attempts < EventRetry.DEFAULT_MAX_ATTEMPTS) throw DownstreamDown("connection reset")
+            ProjectionResult.APPLIED
         }
 
         consumer.consumeScaEvent("""{"eventType":"DEVICE_ENROLLED","partyId":"$partyId","credentialId":"c1"}""")


### PR DESCRIPTION
## Summary

`OnboardingProjectionService.applyEvent` guards every branch except `PartyCreated` with `repo.findByPartyId(event.partyId) ?: return`. That guard is correct — the three source topics are independent consumer groups with no ordering between them, so an event can legitimately arrive before the party row exists, and throwing would wedge the group on a race that resolves itself. What was wrong is that it returned *normally*, so `project()` fell through to `metrics.record(topic, PROJECTED)` and the caller could not distinguish a dropped event from work done.

`applyEvent` now returns a `ProjectionResult`, and the consumer records the new `Outcome.SKIPPED_UNKNOWN_PARTY` for a skip, plus a WARN naming the party. The skip stays acked.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #6248

## Why this matters more than the counter

Measured on the sandbox while investigating #6248: all 15 `DEVICE_ENROLLED` events were consumed with zero lag and none reached `onboarding_records`. Every check anyone would run came back clean — the wire was correct (read off the broker at offset 13), `kafka_consumergroup_lag` was 0, the handler and both sides' unit tests were green.

The alert built for exactly this class of loss — `UNRECOGNISED > 0 and PROJECTED == 0`, added by #4353 — was **structurally unable to fire**, because the drops were inflating the very series it requires to be zero. Four real outcomes, three enum values, and the missing one folded into success. Same shape as `PushResult.skipped()` carrying `success = true`, one layer up.

This PR does not fix the loss itself. It makes the loss *visible*, which is the prerequisite for the rest of #6248 — without it there is no signal that distinguishes a fix from a regression.

## Changes

- **New** `domain/model/ProjectionResult.kt` — `APPLIED` / `SKIPPED_UNKNOWN_PARTY`. In the domain layer, no framework imports.
- `OnboardingProjectionService.applyEvent` returns `ProjectionResult`; all four guards report the skip.
- `ProjectionOutcomeMetrics.Outcome` gains `SKIPPED_UNKNOWN_PARTY`, and the KDoc gains the second alert rule it enables (`rate(...{outcome="SKIPPED_UNKNOWN_PARTY"}[1h]) > 0`, with a note on why that one needs no `PROJECTED == 0` companion — a skip is per-party, so a trickle among healthy traffic is the shape to alert on).
- `OnboardingEventConsumer.project` branches on the result; a skip logs WARN (not ERROR — an out-of-order arrival is expected) and is not rethrown.
- The five `when` branches moved out of `applyEvent` into file-private extensions on `OnboardingRepository`. Not gratuitous: the added `return` pushed `applyEvent` over detekt's `LongMethod` (74 > 60) and onto `CyclomaticComplexMethod` (15, which fires *at* the threshold), and hanging them off the class instead would have hit `TooManyFunctions` (11, likewise at-threshold). Behaviour is unchanged; the existing branch tests cover it.

## Verification — including the negative case

`./gradlew :openbank-onboarding-service:test ktlintCheck detekt koverVerify quarkusBuild` all green. Verdict read from the JUnit XML, not the console: **46 tests, 0 failures, 0 skipped**.

The tests were then checked against the mutations they exist to catch, since a test that cannot detect the absence of what it tests is decoration:

| Sabotage | Expected red | Result |
|---|---|---|
| consumer records `PROJECTED` for a skip | `a skipped projection is recorded as SKIPPED_UNKNOWN_PARTY and never as PROJECTED` | RED, 1 failure |
| `applyDeviceEnrolled` returns `APPLIED` instead of the skip (one branch only) | `applyEvent returns SKIPPED_UNKNOWN_PARTY on every branch that needs an existing row` | RED, 1 failure |

Both restored to green afterwards, and the second sabotage was re-run **after** the extract-function refactor, since the first run measured a shape the code no longer has.

Two details that made the difference: the `verify(exactly = 0) { ... PROJECTED }` assertion is the one that matters — without it the consumer test passes unchanged against the old code, measuring that a counter was touched rather than which bucket it landed in. And `applyEvent returns APPLIED when the row exists` is there so the four-branch assertion cannot be satisfied by a projection that returns `SKIPPED_UNKNOWN_PARTY` unconditionally.

## Definition of Done

- [x] Hexagonal layering preserved — `ProjectionResult` is in `domain/model` with no framework imports.
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated — not in this PR. Proving the end-to-end path needs a real enrolment against a real projection, which is a separate acceptance item on #6248 and cannot be met by a mocked repo.
- [x] Contract tests updated (if public API changed) — N/A, no API change.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes (module-scoped).
- [x] No new lint warnings — the two detekt findings the change introduced were fixed structurally, not suppressed.
- [x] OpenAPI regenerated — N/A.
- [x] Flyway migration — N/A, no schema change.
- [x] Avro schema — N/A. The metric gains a label *value*, not a new series name; existing dashboards and the #4353 rule keep working unchanged.
- [x] Docs updated — the KDoc on all three touched files carries the reasoning; `ProjectionResult` documents why the skip is not a flag shared with success.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. The new WARN logs a party UUID, matching what `EventRetry` already logs on the same path.
- [x] No new `@Suppress`.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? — no.
- [x] PII path changed? — no.
- [x] Cardholder data path changed? — no.

## Compliance impact

- [x] None. A read-model observability fix; no money path, no personal data, no regulatory surface.

## Review note

The judgement call worth checking is that a skip stays **acked**. Nacking would turn an ordering race into a wedged consumer group, which is the failure the original `?: return` was right to avoid — only its reporting was wrong. If reviewers would rather buffer-and-retry, that is the next item on #6248 and deliberately not this PR; that decision needs this counter in place first to tell whether it worked.
