### PR TITLE
test(audit): prove an agent audit envelope reaches audit_entries end to end

### DIFF
--- a/docs/threat-models/openbank-agent-service.md
+++ b/docs/threat-models/openbank-agent-service.md
@@ -35,11 +35,26 @@ takes a state-changing money-path action. The surfaces that accept external inpu
 operator ──bearer──▶ admin-ui BFF ──bearer + X-Agent-Id──▶ /mcp ──▶ AgentPolicyGate ──▶ OPA sidecar
                                                               │                         (agents.rego)
                                                               ├──▶ McpToolRegistry ──▶ downstream svc REST
-                                                              └──▶ AuditEventPublisher ──▶ Kafka audit-events-out
+                                                              └──▶ AuditEventPublisher
+                                                                     (DurableAgentAuditPublisher)
+                                                                        │
+                                                                        ▼
+                                                              agent_audit_outbox (local Postgres,
+                                                              same tx as the audited operation)
+                                                                        │  AgentAuditOutboxDispatcher
+                                                                        ▼  (@Scheduled, gated off)
+                                                              Kafka openbank.agent.audit.events
+                                                                        │  AgentAuditConsumer
+                                                                        ▼
+                                                              audit-service → audit_entries
+                                                              (append-only, hash-chained)
 ```
 
 Trust boundaries: (a) browser→BFF (NextAuth session), (b) BFF→agent-service (Keycloak bearer),
-(c) agent-service→downstream services (service bearer), (d) agent-service→OPA (localhost sidecar).
+(c) agent-service→downstream services (service bearer), (d) agent-service→OPA (localhost sidecar),
+(e) agent-service→Kafka (mTLS, KafkaUser `agent-service`, `Write, Describe` on
+`openbank.agent.audit.events` and deliberately no `Read` — a component may append to the trail
+about itself and may not read it back; `openbank-infra/gitops/components/agent/kafka-agent-mtls.yaml`).
 
 ## 2. STRIDE
 
@@ -82,9 +97,33 @@ Trust boundaries: (a) browser→BFF (NextAuth session), (b) BFF→agent-service 
 
 ### Repudiation
 
-- **T-R1.** Every decision (ALLOW/DENY), tool execution, model completion and now identity rejection
+- **T-R1.** Every decision (ALLOW/DENY), tool execution, model completion and identity rejection
   is audited with an attributable actor (AI_AGENT for agent actions, the OIDC subject for operator
   actions). Kill-switch flips record the OIDC subject, never a body field.
+- **T-R2 (issue #6191, ADR-0031 D5).** Those events reach a durable record and not only a log line.
+  Until #6209 the fleet's only `AuditEventPublisher` implementation was the log-only fallback, so
+  the DFD arrow above credited a Kafka delivery that no code performed — the evidence for every AI
+  action was a log line written by the same process whose behaviour a dispute would put in question.
+  `DurableAgentAuditPublisher` (an `@Alternative`) now enqueues into `agent_audit_outbox` inside the
+  audited operation's own transaction, so an audit call returns only after the source database has
+  acknowledged the row; `AgentAuditOutboxDispatcher` drains it and marks a row published only on
+  Kafka ack, leaving a failed send claimed for retry with `last_error` recorded.
+  `AgentAuditConsumer` acks the Kafka offset only after `audit_entries` has committed, and the
+  producer's `eventId` is the row's `entry_id`, so an at-least-once redelivery de-duplicates rather
+  than double-chaining (`AgentAuditRedeliveryIT`).
+  **Residual, stated rather than implied:**
+  - **The transport is off by default.** `AGENT_AUDIT_KAFKA_ENABLED` defaults to `false` (#6209's
+    deliberate rollout choice), and the gitops `group.id`/`auto.offset.reset` override that
+    audit-service needs is deliberately not added yet. Until both land, AI provenance is durable in
+    agent-service's *local* outbox and has not reached the tamper-evident trail — the outbox grows
+    unbounded and no `audit_entries` row exists. This is a rollout state, not a design gap, but it
+    is the state today and no green test contradicts it.
+  - **`aggregate_id` degrades to the `unknown` sentinel.** The envelope spells the acted-on
+    resource `aggregateId`; `AuditConsumer.inferAggregateId` derives that column from a fixed chain
+    of business id field names and cannot see it. The row is therefore attributable to the actor
+    but not joinable to the resource, and `audit_entries` is append-only so it can never be
+    corrected. Measured by `AgentAuditEventPersistenceIT`, which asserts the sentinel rather than
+    agreeing with it silently.
 
 ### Information disclosure
 

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/AgentAuditEventPersistenceIT.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/AgentAuditEventPersistenceIT.kt
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.audit.integration
+
+import com.openbank.audit.application.AgentAuditConsumer
+import com.openbank.audit.domain.model.AttributionSource
+import com.openbank.audit.domain.model.OccurredAtSource
+import com.openbank.audit.it.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.config.ConfigProvider
+import org.eclipse.microprofile.reactive.messaging.Message
+import org.junit.jupiter.api.Test
+import java.sql.DriverManager
+import java.time.Instant
+
+/**
+ * Issue #6191 — the half of the D5 provenance path neither existing test reaches: an
+ * `AgentAuditEventEnvelope` as agent-service actually puts it on the wire becomes a ROW in the
+ * append-only, hash-chained `audit_entries`.
+ *
+ * **Why this is not covered already.** `DurableAgentAuditPublisherTest` (agent-service) verifies
+ * the producer against a MOCKED `AgentAuditOutbox` — a mock cannot establish that anything was
+ * stored. `AgentAuditOutboxIT` (agent-service) proves the outbox row survives the real V4 schema
+ * but stops at the local table. `AgentAuditRedeliveryIT` (this module) hand-builds an
+ * `AuditEntry` and calls `AuditRepository.save` twice — it never parses a producer payload, so it
+ * cannot see a field the producer spells one way and the consumer reads another. Between them the
+ * two modules were each self-consistent and untested against each other, which is exactly how a
+ * producer/consumer pair drifts in silence.
+ *
+ * **Why the row is read over plain JDBC.** Reading it back through the same reactive
+ * `AuditRepository` that wrote it asks the code under test whether it did its job. This opens its
+ * own connection to the Testcontainers Postgres and selects the row.
+ *
+ * **What this does and does not drive.** There is no Kafka Testcontainer in this repo, so this is
+ * not a literal broker round trip: it is the real CDI-managed [AgentAuditConsumer] — including its
+ * ack-after-persist ordering — and the real database write. The transport itself (topic, mTLS,
+ * ACLs) is manifest, verified by review of `openbank-infra/gitops/components/agent/` rather than
+ * executed here. Stated plainly rather than implied by a green test.
+ *
+ * **The transport flag is not touched.** `AGENT_AUDIT_KAFKA_ENABLED` stays `false`, #6209's
+ * deliberate rollout choice. Nothing here needs it: the consumer is driven directly with the
+ * payload the dispatcher would have sent, so this test is about the wire shape, not the rollout.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class AgentAuditEventPersistenceIT {
+
+    @Inject
+    lateinit var consumer: AgentAuditConsumer
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    private fun jdbc() = DriverManager.getConnection(
+        ConfigProvider.getConfig().getValue("quarkus.datasource.jdbc.url", String::class.java),
+        "openbank",
+        "openbank_secret",
+    )
+
+    /**
+     * The flat JSON `DurableAgentAuditPublisher.publish` produces: the caller's free-form
+     * `AuditEvent.payload` merged UNDER the fixed `AgentAuditEventEnvelope` fields (`Map +`
+     * semantics — the envelope wins a key collision). Every key and spelling below is read off
+     * `AgentAuditEventEnvelope` in `JdbcAgentAuditOutbox.kt`, not invented here; the two modules
+     * cannot share code, so rename a field on either side and this goes red.
+     */
+    private fun agentAuditEnvelope(eventId: String, actorId: String, occurredAt: Instant) = """
+        {
+          "tool": "get_account",
+          "policy_decision": "DENY",
+          "eventId": "$eventId",
+          "eventType": "agent.mcp.tool_call",
+          "aggregateType": "mcp.tool",
+          "aggregateId": "acc-42",
+          "actorId": "$actorId",
+          "actorType": "AI_AGENT",
+          "sourceService": "agent-service",
+          "correlationId": "trace-$eventId",
+          "occurredAt": "$occurredAt",
+          "channel": "mcp",
+          "actChain": [],
+          "sessionId": "sess-$eventId",
+          "result": "DENIED"
+        }
+    """.trimIndent()
+
+    @Test
+    fun `an agent audit envelope lands in audit_entries attributed to agent-service`() {
+        val eventId = "9f1d0b9a-3c2e-4d51-8a77-${System.nanoTime().toString().takeLast(12).padStart(12, '0')}"
+        val actorId = "agent:rca-${System.nanoTime()}"
+        val occurredAt = Instant.parse("2026-08-21T12:34:56Z")
+
+        onEventLoop {
+            consumer.consume(Message.of(agentAuditEnvelope(eventId, actorId, occurredAt)))
+        }
+
+        jdbc().use { c ->
+            c.prepareStatement(
+                """
+                select entry_id, event_type, aggregate_type, aggregate_id, actor_id, actor_type,
+                       source_service, source_service_source, correlation_id, session_id,
+                       occurred_at, occurred_at_source
+                  from audit_entries where actor_id = ?
+                """.trimIndent(),
+            ).use { st ->
+                st.setString(1, actorId)
+                st.executeQuery().use { rs ->
+                    assertThat(rs.next()).describedAs("a row for the agent action must exist").isTrue()
+                    // The producer's event id IS the row id — that is what makes an at-least-once
+                    // Kafka redelivery idempotent (AgentAuditRedeliveryIT proves the second write
+                    // is a no-op; this proves the id it de-duplicates on is the producer's).
+                    assertThat(rs.getString("entry_id")).isEqualTo(eventId)
+                    assertThat(rs.getString("event_type")).isEqualTo("agent.mcp.tool_call")
+                    // Uppercased by AuditConsumer on purpose (#4553): the column records which
+                    // resolution path fired, and a producer's verbatim spelling would split the
+                    // series. The envelope sends AuditEvent.resourceType here.
+                    assertThat(rs.getString("aggregate_type")).isEqualTo("MCP.TOOL")
+                    assertThat(rs.getString("actor_type")).isEqualTo("AI_AGENT")
+                    // The producing service's own claim, not a topic-derived guess — and note
+                    // AgentAuditConsumer passes EventAddress.NONE, so there is no topic to fall
+                    // back to: if the producer ever stopped sending `sourceService` this row
+                    // would be the "unknown" sentinel. The value is chain-hashed into
+                    // record_hash and audit_entries is append-only at the DB (no_update_audit is
+                    // DO INSTEAD NOTHING — an UPDATE affects zero rows and reports success), so
+                    // it can never be corrected afterwards.
+                    assertThat(rs.getString("source_service")).isEqualTo("agent-service")
+                    assertThat(rs.getString("source_service_source")).isEqualTo(AttributionSource.EVENT.name)
+                    assertThat(rs.getString("correlation_id")).isEqualTo("trace-$eventId")
+                    assertThat(rs.getString("session_id")).isEqualTo("sess-$eventId")
+                    // Business time, not ingest time. Asserted as an exact instant rather than
+                    // non-nullity: Instant.EPOCH passes isNotNull(), and an INGEST fallback would
+                    // pass any recency window a fast test could write.
+                    assertThat(rs.getTimestamp("occurred_at").toInstant()).isEqualTo(occurredAt)
+                    assertThat(rs.getString("occurred_at_source")).isEqualTo(OccurredAtSource.EVENT.name)
+                    assertThat(rs.next()).describedAs("exactly one row for one event").isFalse()
+                }
+            }
+        }
+    }
+
+    /**
+     * `aggregate_id` is the one envelope field the consumer does NOT read back, and this test
+     * pins the consequence rather than the intent.
+     *
+     * `AuditConsumer` takes `aggregateType` from the producer verbatim but derives `aggregateId`
+     * through `inferAggregateId`, a fixed (field name -> aggregate type) chain of business ids
+     * (`accountId`, `partyId`, …). The agent envelope carries none of those — it spells the
+     * resource `aggregateId` — so the chain falls through to the `"unknown"` sentinel and the row
+     * is not joinable to the resource the agent acted on. Every other consumed producer happens to
+     * send a field the chain knows, which is why nothing has noticed.
+     *
+     * Asserting the sentinel is deliberate: audit_entries is append-only, so a row written this
+     * way can never be corrected, and a green test that quietly agreed with `"unknown"` would let
+     * the gap persist unnamed. Fixing it is a consumer change with its own blast radius across all
+     * 21 subscribed topics — filed rather than smuggled in here.
+     */
+    @Test
+    fun `the envelope aggregateId does not reach the row - it degrades to the unknown sentinel`() {
+        val eventId = "3ab7c410-55de-4e0a-9b12-${System.nanoTime().toString().takeLast(12).padStart(12, '0')}"
+        val actorId = "agent:aggid-${System.nanoTime()}"
+
+        onEventLoop {
+            consumer.consume(Message.of(agentAuditEnvelope(eventId, actorId, Instant.parse("2026-08-21T12:34:56Z"))))
+        }
+
+        jdbc().use { c ->
+            c.prepareStatement("select aggregate_id from audit_entries where actor_id = ?").use { st ->
+                st.setString(1, actorId)
+                st.executeQuery().use { rs ->
+                    assertThat(rs.next()).isTrue()
+                    assertThat(rs.getString("aggregate_id"))
+                        .describedAs("the envelope sends aggregateId=acc-42; inferAggregateId cannot see it")
+                        .isEqualTo("unknown")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Rebuilt on top of #6209, which merged the competing (and surviving) design for the same feature. This branch no longer implements AI audit delivery — #6209 does — it adds the two things `main` still lacks.

**1. `AgentAuditEventPersistenceIT`** — the end-to-end proof. `main` tests the producer against a mocked outbox, the outbox against the real schema, and the repository against a hand-built `AuditEntry`; nothing joins a producer payload to a row in `audit_entries`. This drives the real `AgentAuditConsumer` with the flat JSON `DurableAgentAuditPublisher.publish` actually emits and reads the row back over plain JDBC.

Negative control run before trusting the green: renaming the consumer's `eventType` lookup reddens this test and nothing else.

It pins a real gap — `AuditConsumer` derives `aggregate_id` through `inferAggregateId`, which cannot see the envelope's `aggregateId`, so every AI audit row lands with the `"unknown"` sentinel and is not joinable to the resource the agent acted on. `audit_entries` is append-only, so it can never be corrected. Asserted rather than silently agreed with; the consumer fix touches all 21 subscribed topics and needs its own PR.

**2. Threat model** — `main`'s DFD still credited a `Kafka audit-events-out` channel that does not exist and named no durable trail. Now shows the real outbox path, adds the agent-service→Kafka mTLS trust boundary, and adds T-R2 with two residuals stated plainly: `AGENT_AUDIT_KAFKA_ENABLED` is still `false` so nothing has yet reached the tamper-evident trail, and the `aggregate_id` degradation above.

`AGENT_AUDIT_KAFKA_ENABLED` is untouched, including in the test profile — the IT needs no transport.

The full keep/drop rationale, verification output and follow-ups are in the [analysis comment](https://github.com/JiRaska/open-bank-oss/pull/6260#issuecomment-5375245636).

```
openbank-audit-service: tests=157 failures/errors=0 skipped=0
ktlintCheck + detekt: exit 0
check-threat-model-claims.py: SUBJECTS=23, OK
```

Refs #6191
