### PR TITLE
fix(admin-ui): clarify DevOps refresh state

### DIFF
--- a/openbank-admin-ui/src/app/devops/page.tsx
+++ b/openbank-admin-ui/src/app/devops/page.tsx
@@ -348,13 +348,16 @@ function DevOpsContent() {
             </span>
           )}
           <button
+            type="button"
             onClick={load}
             disabled={loading}
+            aria-busy={loading}
+            aria-label={t('Obnovit DevOps metriky', 'Refresh DevOps metrics')}
             style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '7px 14px',
               borderRadius: '8px', border: '1px solid var(--border)', background: 'var(--surface)',
               color: 'var(--text-secondary)', fontSize: '12px', cursor: loading ? 'wait' : 'pointer' }}
           >
-            <RefreshCw size={13} style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
+            <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
         </div>}

--- a/openbank-admin-ui/src/test/devops-metrics-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/devops-metrics-refresh.guard.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('DevOps metrics refresh contract', () => {
+  it('exposes busy semantics without changing the metrics loader', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/devops/page.tsx'), 'utf8')
+
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit DevOps metriky', 'Refresh DevOps metrics')}")
+    expect(source).toContain('<RefreshCw size={13} aria-hidden="true"')
+    expect(source).toContain('const load = useCallback')
+  })
+})


### PR DESCRIPTION
## Summary
- add explicit busy semantics and accessible label to DevOps metrics refresh
- hide decorative refresh icon
- add focused source guard

Preserves DORA metric fetches, parallel loading, and DevOps HITL/RBAC flows.

Refs #6148