### PR TITLE
fix(admin-ui): clarify FinOps refresh state

### DIFF
--- a/openbank-admin-ui/src/app/finops/page.tsx
+++ b/openbank-admin-ui/src/app/finops/page.tsx
@@ -429,8 +429,11 @@ function FinOpsContent() {
             {t('Rozpad nákladů', 'Cost allocation')}
           </Link>
           <button
+            type="button"
             onClick={load}
             disabled={loading}
+            aria-busy={loading}
+            aria-label={t('Obnovit FinOps náklady', 'Refresh FinOps costs')}
             style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '7px 14px',
               borderRadius: '8px', border: '1px solid var(--border)', background: 'var(--surface)',
               color: 'var(--text-secondary)', fontSize: '12px', cursor: loading ? 'wait' : 'pointer' }}

--- a/openbank-admin-ui/src/test/finops-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/finops-refresh.guard.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache-2.0 license.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('FinOps refresh contract', () => {
+  it('exposes localized busy semantics without changing the cost loader', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/finops/page.tsx'), 'utf8')
+
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit FinOps náklady', 'Refresh FinOps costs')}")
+    expect(source).toContain('<RefreshCw size={13} aria-hidden="true"')
+    expect(source).toContain('const load = useCallback')
+  })
+})


### PR DESCRIPTION
## Summary
- expose FinOps refresh busy state to assistive technology
- add localized accessible label and explicit button type
- preserve existing FinOps fetch, timeout/fallback, and RBAC behavior

## Verification
- `git diff --check` passed
- focused Vitest/type-check were attempted but did not produce output in the local environment (native/tooling runner hang)

Refs: admin UI UX/a11y audit

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.
