### PR TITLE
fix(admin-ui): clarify Temporal refresh state

### DIFF
--- a/openbank-admin-ui/src/app/temporal/page.tsx
+++ b/openbank-admin-ui/src/app/temporal/page.tsx
@@ -325,8 +325,11 @@ export default function TemporalPage() {
                 </div>
               )}
               <button
+                type="button"
                 onClick={load}
                 disabled={loading}
+                aria-busy={loading}
+                aria-label={t('Obnovit stav Temporal', 'Refresh Temporal status')}
                 style={{
                   display: 'flex', alignItems: 'center', gap: '6px',
                   padding: '8px 14px', borderRadius: '8px',
@@ -334,7 +337,7 @@ export default function TemporalPage() {
                   color: 'var(--text)', fontSize: '13px', fontWeight: 600, cursor: loading ? 'wait' : 'pointer',
                 }}
               >
-                <RefreshCw size={14} style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
+                <RefreshCw size={14} aria-hidden="true" style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
                 {t('Obnovit', 'Refresh')}
               </button>
           </div>}

--- a/openbank-admin-ui/src/test/temporal-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/temporal-refresh.guard.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache-2.0 license.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('Temporal status refresh contract', () => {
+  it('exposes localized busy semantics without changing the status loader', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/temporal/page.tsx'), 'utf8')
+
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit stav Temporal', 'Refresh Temporal status')}")
+    expect(source).toContain('<RefreshCw size={14} aria-hidden="true"')
+    expect(source).toContain("fetch('/api/temporal/status')")
+  })
+})


### PR DESCRIPTION
## Summary
- expose Temporal status refresh busy state to assistive technology
- add localized accessible label and explicit button type
- preserve `/api/temporal/status` and `system:view` RBAC behavior

## Verification
- `git diff --check` passed
- focused Vitest attempted but local runner hung without output; CI is authoritative

Refs: admin UI UX/a11y audit

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.
