### PR TITLE
fix(admin-ui): clarify cost allocation refresh

### DIFF
--- a/openbank-admin-ui/src/app/finops/allocation/page.tsx
+++ b/openbank-admin-ui/src/app/finops/allocation/page.tsx
@@ -144,11 +144,11 @@ function AllocationContent() {
             color: 'var(--text-secondary)', fontSize: '12px', textDecoration: 'none' }}>
             <ArrowLeft size={13} /> {t('Zpět na FinOps', 'Back to FinOps')}
           </Link>
-          <button onClick={load} disabled={loading} aria-label={t('Obnovit', 'Refresh')}
+          <button type="button" onClick={load} disabled={loading} aria-busy={loading} aria-label={t('Obnovit rozpad nákladů', 'Refresh cost allocation')}
             style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '7px 14px', borderRadius: '8px',
               border: '1px solid var(--border)', background: 'var(--surface)', color: 'var(--text-secondary)',
               fontSize: '12px', cursor: loading ? 'wait' : 'pointer' }}>
-            <RefreshCw size={13} style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
+            <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
         </div>}

--- a/openbank-admin-ui/src/test/finops-allocation-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/finops-allocation-refresh.guard.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache-2.0 license.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('FinOps cost allocation refresh contract', () => {
+  it('exposes localized busy semantics without changing the allocation loader', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/finops/allocation/page.tsx'), 'utf8')
+
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit rozpad nákladů', 'Refresh cost allocation')}")
+    expect(source).toContain('<RefreshCw size={13} aria-hidden="true"')
+    expect(source).toContain("fetch('/api/finops/allocation'")
+  })
+})


### PR DESCRIPTION
## Summary
- expose Cost Allocation refresh busy state to assistive technology
- add localized accessible label and explicit button type
- preserve `/api/finops/allocation` and `system:view` behavior

## Verification
- `git diff --check` passed
- focused Vitest attempted but local runner hung without output; CI is authoritative

Refs: admin UI UX/a11y audit

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.
