### PR TITLE
fix(admin-ui): clarify Temporal Flow controls

### DIFF
--- a/openbank-admin-ui/src/app/temporal/flow/page.tsx
+++ b/openbank-admin-ui/src/app/temporal/flow/page.tsx
@@ -82,17 +82,17 @@ export default function TemporalFlowPage() {
       />
       {/* Controls */}
       <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', marginBottom: '14px', gap: '8px' }}>
-        <button onClick={() => setFlow(v => !v)} aria-pressed={flow} title={t('Přepnout tok', 'Toggle flow')}
+        <button type="button" onClick={() => setFlow(v => !v)} aria-pressed={flow} aria-label={t(flow ? 'Pozastavit tok workflow' : 'Spustit tok workflow', flow ? 'Pause workflow flow' : 'Start workflow flow')} title={t('Přepnout tok', 'Toggle flow')}
           style={{
             display: 'flex', alignItems: 'center', gap: '5px', padding: '5px 10px', fontSize: '12px', fontWeight: 600,
             borderRadius: '20px', cursor: 'pointer', fontFamily: 'inherit',
             border: `1px solid ${flow ? 'var(--accent)' : 'var(--border)'}`,
             background: flow ? 'var(--accent)' : 'var(--surface)', color: flow ? '#fff' : 'var(--text-secondary)',
           }}>
-          {flow ? <Pause size={13} /> : <Play size={13} />}{t('Tok', 'Flow')}
+          {flow ? <Pause size={13} aria-hidden="true" /> : <Play size={13} aria-hidden="true" />}{t('Tok', 'Flow')}
         </button>
-        <button onClick={load} disabled={isChecking} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px' }}>
-          <RefreshCw size={14} className={isChecking ? 'animate-spin' : ''} />
+        <button type="button" onClick={load} disabled={isChecking} aria-busy={isChecking} aria-label={t('Obnovit stav Temporal', 'Refresh Temporal status')} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px' }}>
+          <RefreshCw size={14} aria-hidden="true" className={isChecking ? 'animate-spin' : ''} />
           {isChecking ? t('Načítám…', 'Loading...') : t('Obnovit', 'Refresh')}
         </button>
       </div>

--- a/openbank-admin-ui/src/test/temporal-flow-controls.guard.test.ts
+++ b/openbank-admin-ui/src/test/temporal-flow-controls.guard.test.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache-2.0 license.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('Temporal Flow controls contract', () => {
+  it('exposes localized control semantics without changing the status loader', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/temporal/flow/page.tsx'), 'utf8')
+
+    expect(source).toContain('type="button"')
+    expect(source).toContain('aria-pressed={flow}')
+    expect(source).toContain("aria-label={t(flow ? 'Pozastavit tok workflow' : 'Spustit tok workflow'")
+    expect(source).toContain('aria-busy={isChecking}')
+    expect(source).toContain("aria-label={t('Obnovit stav Temporal', 'Refresh Temporal status')}")
+    expect(source).toContain('<RefreshCw size={14} aria-hidden="true"')
+    expect(source).toContain("fetch('/api/temporal/status'")
+  })
+})


### PR DESCRIPTION
## Summary
- add explicit keyboard/control semantics to Temporal Flow toggle and refresh
- expose localized labels and busy state, hide decorative icons
- preserve `/api/temporal/status` and existing workflow animation

## Verification
- `git diff --check` passed
- focused Vitest attempted but local runner hung without output; CI is authoritative

Refs: admin UI UX/a11y audit

## Linked issues
N/A — presentation-only accessibility refinement; no product issue exists.

