### PR TITLE
fix(settlement): watch REVERSAL_FAILED and LEDGER_REVERSAL_UNSUPPORTED in the stranded gauge

### DIFF
--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGauge.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGauge.kt
@@ -61,10 +61,15 @@ import java.util.concurrent.atomic.AtomicLong
  * ### Which states are published
  *
  * Terminal states ([SettlementStatus.BOOKED], [SettlementStatus.REJECTED]) are not published:
- * their age only grows and would alert forever. Everything else is published, including the three
+ * their age only grows and would alert forever. Everything else is published, including the
  * compensation states — `SettlementWorkflowImpl` always calls `rejectSettlement` after
- * compensating, so a row parked in `REVERSED` / `CREDITED_REVERSED` / `LEDGER_REVERSED` means the
- * unwinding ran and the record never reached its terminal state.
+ * compensating, so a row parked in `REVERSED` / `CREDITED_REVERSED` / `REVERSAL_FAILED` /
+ * `LEDGER_REVERSAL_UNSUPPORTED` means the unwinding ran (or could not) and the record never
+ * reached its terminal state. `LEDGER_REVERSED` is included too even though #6037 made it
+ * unreachable (dead status kept for backward compatibility, see its own KDoc) — publishing an
+ * always-zero series for it costs nothing and a status this gauge silently stopped watching is
+ * exactly the failure mode #6037 introduced `REVERSAL_FAILED`/`LEDGER_REVERSAL_UNSUPPORTED` to
+ * replace, so watching the whole non-terminal set rather than hand-picking members is the point.
  *
  * ### t=0 on a cold pod
  *
@@ -178,6 +183,8 @@ class SettlementStrandedGauge(
             SettlementStatus.CREDITED,
             SettlementStatus.REVERSED,
             SettlementStatus.CREDITED_REVERSED,
+            SettlementStatus.REVERSAL_FAILED,
+            SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED,
             SettlementStatus.LEDGER_REVERSED,
         )
     }

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGaugeTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGaugeTest.kt
@@ -123,6 +123,8 @@ class SettlementStrandedGaugeTest {
             "CREDITED",
             "REVERSED",
             "CREDITED_REVERSED",
+            "REVERSAL_FAILED",
+            "LEDGER_REVERSAL_UNSUPPORTED",
             "LEDGER_REVERSED",
         )
         assertThat(published).doesNotContain("BOOKED", "REJECTED")


### PR DESCRIPTION
## What

\`SettlementStrandedGauge.NON_TERMINAL\` predates #6037, which added two new
non-terminal settlement statuses (\`REVERSAL_FAILED\`, \`LEDGER_REVERSAL_UNSUPPORTED\`)
but never updated this gauge's watch list. A settlement stuck in either state (money
moved, unwind failed or unimplemented) had no age metric and was invisible to the
\`openbank_settlement_non_terminal_oldest_age_seconds\` alert — exactly the monitoring
gap #5705 built this gauge to close.

## How found

Found while investigating an unrelated PR's CI failure: \`SettlementStrandedGaugeTest\`'s
own derived assertion (every \`SettlementStatus\` value minus the two terminal ones) was
already failing on \`main\` directly. The test was correct — it caught real drift; the
gauge's hand-kept status list was stale. Fixed the list, not the test.

## Verification

\`\`\`
$ ./gradlew :openbank-settlement-service:test :openbank-settlement-service:ktlintCheck :openbank-settlement-service:detekt
BUILD SUCCESSFUL
\`\`\`

Refs #6037, #5705