### PR TITLE
fix(admin-ui): clarify cards refresh state

### DIFF
--- a/openbank-admin-ui/src/app/cards/page.tsx
+++ b/openbank-admin-ui/src/app/cards/page.tsx
@@ -128,8 +128,8 @@ export default function CardsPage() {
                 <Plus size={13} aria-hidden="true" /> {t('Vydat kartu', 'Issue a card')}
               </button>
             )}
-            <button className="btn btn-ghost btn-sm" onClick={reload} disabled={loading}>
-              <RefreshCw size={13} /> {t('Obnovit', 'Refresh')}
+            <button type="button" className="btn btn-ghost btn-sm" onClick={reload} disabled={loading} aria-busy={loading} aria-label={t('Obnovit karty', 'Refresh cards')}>
+              <RefreshCw size={13} aria-hidden="true" /> {t('Obnovit', 'Refresh')}
             </button>
           </div>}
         />

--- a/openbank-admin-ui/src/test/cards-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/cards-refresh.guard.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache-2.0 license.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('Cards refresh contract', () => {
+  it('exposes localized busy semantics without changing card loading', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/cards/page.tsx'), 'utf8')
+
+    expect(source).toContain('type="button"')
+    expect(source).toContain('onClick={reload}')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit karty', 'Refresh cards')}")
+    expect(source).toContain('<RefreshCw size={13} aria-hidden="true"')
+  })
+})


### PR DESCRIPTION
## Summary
- expose Cards refresh busy state to assistive technology
- add localized label, explicit type, and decorative icon semantics
- preserve card fetch, lifecycle/issuance controls, PCI handling, and cards:view RBAC

## Verification
- `git diff --check` passed
- focused Vitest not run locally (native runner queue/hang); CI authoritative

Refs: admin UI UX/a11y audit

## Linked issues
N/A — presentation-only accessibility refinement; no product issue exists.
