### PR TITLE
fix(admin-ui): clarify infrastructure refresh

### DIFF
--- a/openbank-admin-ui/src/app/infrastructure/page.tsx
+++ b/openbank-admin-ui/src/app/infrastructure/page.tsx
@@ -200,8 +200,8 @@ export default function InfrastructurePage() {
               {upgradable} {t('k aktualizaci', 'upgradable')}
             </span>
           )}
-          <button onClick={load} disabled={loading} className="btn btn-secondary btn-sm">
-            <RefreshCw size={13} style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
+          <button type="button" onClick={load} disabled={loading} aria-busy={loading} aria-label={t('Obnovit stav infrastruktury', 'Refresh infrastructure status')} className="btn btn-secondary btn-sm">
+            <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
         </div>}

--- a/openbank-admin-ui/src/test/infrastructure-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/infrastructure-refresh.guard.test.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache-2.0 license.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('Infrastructure refresh contract', () => {
+  it('exposes localized busy semantics without changing read-only loaders', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/infrastructure/page.tsx'), 'utf8')
+
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit stav infrastruktury', 'Refresh infrastructure status')}")
+    expect(source).toContain('<RefreshCw size={13} aria-hidden="true"')
+    expect(source).toContain("fetch('/api/infra/lifecycle'")
+    expect(source).toContain("fetch('/api/infra/kafka-topics'")
+    expect(source).toContain("fetch('/api/infra/status'")
+  })
+})


### PR DESCRIPTION
## Summary
- expose infrastructure refresh busy state to assistive technology
- add localized label, explicit button type, and decorative icon semantics
- preserve lifecycle, Kafka, and status read-only fetches plus RBAC

## Verification
- `git diff --check` passed
- focused Vitest not run locally (native runner queue/hang); CI authoritative

Refs: admin UI UX/a11y audit

## Linked issues
N/A — presentation-only accessibility refinement; no product issue exists.
