### PR TITLE
fix(admin-ui): clarify system health refresh

### DIFF
--- a/openbank-admin-ui/src/app/system/health/page.tsx
+++ b/openbank-admin-ui/src/app/system/health/page.tsx
@@ -92,8 +92,8 @@ export default function SystemHealthPage() {
               <Clock size={12} aria-hidden="true" /> {lastRefreshed.toLocaleTimeString(dateLocale)}
             </span>
           )}
-          <button className="btn btn-secondary" onClick={() => refresh(true)} disabled={refreshing}>
-            <RefreshCw size={13} className={cn(refreshing && 'animate-spin')} />
+          <button type="button" className="btn btn-secondary" onClick={() => refresh(true)} disabled={refreshing} aria-busy={refreshing} aria-label={t('Obnovit zdraví systému', 'Refresh system health')}>
+            <RefreshCw size={13} aria-hidden="true" className={cn(refreshing && 'animate-spin')} />
             {t('Obnovit', 'Refresh')}
           </button>
         </div>}

--- a/openbank-admin-ui/src/test/system-health-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/system-health-refresh.guard.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache-2.0 license.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('System Health refresh contract', () => {
+  it('exposes localized busy semantics without changing health checks', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/system/health/page.tsx'), 'utf8')
+
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={refreshing}')
+    expect(source).toContain('aria-busy={refreshing}')
+    expect(source).toContain("aria-label={t('Obnovit zdraví systému', 'Refresh system health')}")
+    expect(source).toContain('<RefreshCw size={13} aria-hidden="true"')
+    expect(source).toContain('refresh(true)')
+  })
+})


### PR DESCRIPTION
## Summary
- expose System Health refresh busy state to assistive technology
- add localized label, explicit button type, and decorative icon semantics
- preserve existing health probes, service status data, and system:view RBAC

## Verification
- `git diff --check` passed
- focused Vitest not run locally (native runner queue/hang); CI authoritative

Refs: admin UI UX/a11y audit

## Linked issues
N/A — presentation-only accessibility refinement; no product issue exists.
