### PR TITLE
fix(settlement): publish stranded-age gauges for every non-terminal status

### DIFF
--- a/docs/threat-models/openbank-settlement-service.md
+++ b/docs/threat-models/openbank-settlement-service.md
@@ -175,6 +175,16 @@ replacing the former in-memory stub), so settlement state is durable across rest
    Recovering those funds is a collections/dispute process, not an API call — this is a real
    property of the world, and the design records it rather than smoothing it into a success.
 
+   Recording it is not the same as seeing it, and for a time it was only recorded:
+   `SettlementStrandedGauge` published a **hand-kept** list of non-terminal statuses written before
+   #6037, so `REVERSAL_FAILED` and `LEDGER_REVERSAL_UNSUPPORTED` had no age series at all and
+   neither `SettlementStrandedMidSaga` nor `SettlementStuckAfterCompensation` could fire for them —
+   the two states meaning *the money did not come back* were the two nothing could observe. The
+   list is now derived from `SettlementStatus`, `LEDGER_REVERSAL_UNSUPPORTED` joins the
+   `SettlementStuckAfterCompensation` warning, and `REVERSAL_FAILED` has its own **critical**
+   `SettlementReversalFailed` rule — separated because the other rule's premise ("funds are safe,
+   only the record is wrong") is false here.
+
 7. **A debit applied by balance-service but not observed by settlement-service is not compensated
    (pre-existing, not addressed by #6037).** `SettlementWorkflowImpl` registers the `reverseDebit`
    compensation only *after* `debitPayer` returns, so a debit that balance-service applied while the

--- a/openbank-infra/gitops/components/payments/prometheus-rules.yaml
+++ b/openbank-infra/gitops/components/payments/prometheus-rules.yaml
@@ -341,10 +341,16 @@ spec:
               was never booked to the general ledger. Check whether the Temporal worker for task
               queue `openbank-settlement` is polling and whether a run exists for `settlement-<id>`.
         - alert: SettlementStuckAfterCompensation
-          # The three *_REVERSED states mean the saga already unwound: money was moved and moved
-          # back. SettlementWorkflowImpl always calls rejectSettlement after compensating, so these
-          # states are transient by construction and a row parked in one has a workflow that died
-          # between the compensation and the terminal write — funds are safe, the record is not.
+          # The *_REVERSED states mean the saga already unwound: money was moved and moved back.
+          # LEDGER_REVERSAL_UNSUPPORTED joins them (#6037): the two balance reversals succeeded and
+          # only the general-ledger posting was left standing, so no customer money is in limbo —
+          # the GL needs a manual correcting entry, which is the same class of record-vs-ledger
+          # disagreement. SettlementWorkflowImpl always calls rejectSettlement after compensating,
+          # so these states are transient by construction and a row parked in one has a workflow
+          # that died between the compensation and the terminal write.
+          #
+          # REVERSAL_FAILED is deliberately NOT in this rule — there the money did not come back,
+          # so it is critical, not warning. See SettlementReversalFailed below.
           #
           # 8h, again from the code: the longest legitimate compensation chain starts at
           # LEDGER_REVERSED and still owes reverseCredit + reverseDebit + rejectSettlement, three
@@ -353,7 +359,8 @@ spec:
           expr: |
             max by (status) (
               openbank_settlement_non_terminal_oldest_age_seconds{
-                service="settlement", status=~"REVERSED|CREDITED_REVERSED|LEDGER_REVERSED"
+                service="settlement",
+                status=~"REVERSED|CREDITED_REVERSED|LEDGER_REVERSED|LEDGER_REVERSAL_UNSUPPORTED"
               }
             ) > 28800
           for: 30m
@@ -367,3 +374,35 @@ spec:
               Its compensations ran but it never reached REJECTED, so the settlements table now
               disagrees with the ledger about a settlement that was unwound. Reconcile before the
               next accounting-day close.
+        - alert: SettlementReversalFailed
+          # REVERSAL_FAILED is written by SettlementActivitiesImpl.compensate when a balance
+          # reversal was ATTEMPTED AND REFUSED — the common cause is a payee who already spent the
+          # credited funds, which balance-service answers 422 and no retry resolves. So unlike every
+          # other state in this group the money has left an account and has NOT been returned, and
+          # recovery is a collections/dispute process rather than a workflow that will finish.
+          #
+          # It is separated from SettlementStuckAfterCompensation because that rule's premise —
+          # "funds are safe, only the record is wrong" — is false here. Same 8h threshold (a later
+          # retry can still succeed and overwrite the status, and the remaining compensation chain
+          # is the same 2h-per-activity ceiling), critical severity.
+          #
+          # This state published no series at all until SettlementStrandedGauge stopped hand-keeping
+          # its NON_TERMINAL list: it was written before #6037 added this value, so the one money-path
+          # state meaning "the money did not come back" was the one nothing could see.
+          expr: |
+            max by (status) (
+              openbank_settlement_non_terminal_oldest_age_seconds{
+                service="settlement", status="REVERSAL_FAILED"
+              }
+            ) > 28800
+          for: 15m
+          labels:
+            severity: critical
+            service: settlement
+          annotations:
+            summary: "Settlement reversal FAILED and the money has not been returned"
+            description: >-
+              The oldest settlement in REVERSAL_FAILED is {{ $value | humanizeDuration }} old. A
+              balance compensation was attempted and refused, so funds moved and were not returned —
+              this does not resolve itself. Identify the settlement, confirm which leg is
+              outstanding, and start the collections/dispute path.

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGauge.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGauge.kt
@@ -61,10 +61,16 @@ import java.util.concurrent.atomic.AtomicLong
  * ### Which states are published
  *
  * Terminal states ([SettlementStatus.BOOKED], [SettlementStatus.REJECTED]) are not published:
- * their age only grows and would alert forever. Everything else is published, including the three
- * compensation states — `SettlementWorkflowImpl` always calls `rejectSettlement` after
- * compensating, so a row parked in `REVERSED` / `CREDITED_REVERSED` / `LEDGER_REVERSED` means the
- * unwinding ran and the record never reached its terminal state.
+ * their age only grows and would alert forever. Everything else is published, including all five
+ * compensation outcomes — `SettlementWorkflowImpl` always calls `rejectSettlement` after
+ * compensating, so a row parked in `REVERSED` / `CREDITED_REVERSED` / `LEDGER_REVERSED` /
+ * `REVERSAL_FAILED` / `LEDGER_REVERSAL_UNSUPPORTED` means the unwinding ran (or refused) and the
+ * record never reached its terminal state.
+ *
+ * The set is DERIVED from [SettlementStatus] rather than listed, because it was listed once and
+ * went stale: #6037 split the compensation outcomes into their own values and `REVERSAL_FAILED` /
+ * `LEDGER_REVERSAL_UNSUPPORTED` were left unpublished, so the two states that mean *the money did
+ * not come back* were the only two the stranded-settlement rules could never see.
  *
  * ### t=0 on a cold pod
  *
@@ -167,18 +173,18 @@ class SettlementStrandedGauge(
         private const val WORKFLOW_NAME = "settlement-stranded-gauge"
         private const val REFRESH_INTERVAL_SECONDS = 30L
 
+        /** The only two states a settlement is allowed to rest in. */
+        val TERMINAL: Set<SettlementStatus> = setOf(SettlementStatus.BOOKED, SettlementStatus.REJECTED)
+
         /**
-         * States a settlement must move out of. Everything except the two terminal states
-         * ([SettlementStatus.BOOKED], [SettlementStatus.REJECTED]) — a settlement in any of these
-         * has been accepted and is still owed an outcome, so its age is meaningful.
+         * States a settlement must move out of: everything except [TERMINAL] — a settlement in any
+         * of these has been accepted and is still owed an outcome, so its age is meaningful.
+         *
+         * Derived from the enum on purpose. A hand-kept list is silently wrong the day a status is
+         * added, and the failure mode is a state nobody watches rather than a compile error.
+         * [SettlementStatus.LEDGER_REVERSED] is deprecated and no longer written, but rows written
+         * before #6037 still carry it, so it stays published until they are migrated out.
          */
-        val NON_TERMINAL: List<SettlementStatus> = listOf(
-            SettlementStatus.PENDING,
-            SettlementStatus.DEBITED,
-            SettlementStatus.CREDITED,
-            SettlementStatus.REVERSED,
-            SettlementStatus.CREDITED_REVERSED,
-            SettlementStatus.LEDGER_REVERSED,
-        )
+        val NON_TERMINAL: List<SettlementStatus> = SettlementStatus.entries.filterNot { it in TERMINAL }
     }
 }

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGaugeTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGaugeTest.kt
@@ -124,6 +124,10 @@ class SettlementStrandedGaugeTest {
             "REVERSED",
             "CREDITED_REVERSED",
             "LEDGER_REVERSED",
+            // #6037's two new outcomes. REVERSAL_FAILED is the one that matters: the money moved
+            // and did NOT come back, and it was the only money-path state with no age series.
+            "REVERSAL_FAILED",
+            "LEDGER_REVERSAL_UNSUPPORTED",
         )
         assertThat(published).doesNotContain("BOOKED", "REJECTED")
         // The published set must be exactly "every status minus the two terminal ones", derived


### PR DESCRIPTION
## Problem

`:openbank-settlement-service:test` is **red on `origin/main`** (verified on a clean detached worktree, not caused by any open PR):

```
SettlementStrandedGaugeTest > terminal states are not published and every compensation state is() FAILED
```

`SettlementStrandedGauge.NON_TERMINAL` was a hand-kept list of six statuses. #6037 split the compensation outcomes and added `REVERSAL_FAILED` and `LEDGER_REVERSAL_UNSUPPORTED`; neither was added to the list.

The red test is the smaller half. The real defect: those two statuses had **no `openbank_settlement_non_terminal*` series at all**, so `SettlementStrandedMidSaga` and `SettlementStuckAfterCompensation` could never fire for them. `REVERSAL_FAILED` is written by `SettlementActivitiesImpl.compensate` when a balance reversal was *attempted and refused* (payee already spent the credited funds, 422, no retry resolves it) — money moved and did **not** come back. The one state most worth seeing was the one nothing could observe, and nothing else sees it either: the originating request answered 2xx, the pod is healthy, and a workflow that stopped advancing throws nothing on the request path.

## Change

- **`SettlementStrandedGauge`** — `NON_TERMINAL` is now `SettlementStatus.entries - TERMINAL` (`BOOKED`, `REJECTED`), which is exactly what the test already asserted. A hand-kept list is silently wrong the day a status is added, and the failure mode is an unwatched state rather than a compile error.
- **`LEDGER_REVERSED` stays published.** Deprecated and never written since #6037, but rows written before it still carry the value.
- **`SettlementStuckAfterCompensation`** gains `LEDGER_REVERSAL_UNSUPPORTED`: both balance reversals succeeded and only the GL posting stands, so no customer money is in limbo — same "record disagrees with ledger" class, same 8h threshold, warning.
- **New `SettlementReversalFailed`**, `severity: critical`, `> 28800`, `for: 15m`, scoped to `REVERSAL_FAILED` alone. Deliberately separate: `SettlementStuckAfterCompensation`'s premise — *"funds are safe, only the record is wrong"* — is false there.
- **Threat model** — residual-risk item 6 records that the state was recorded but not observable, and what covers it now.

Both compensation-failure states are transient by construction (`SettlementWorkflowImpl` always calls `rejectSettlement` after compensating), so a row parked in one has a workflow that died between the compensation and the terminal write — the same premise the existing rules rest on. 8h clears the 2h-per-activity `scheduleToClose` ceiling of the remaining chain, and a later successful retry overwrites the status, so a working-but-slow unwind cannot trip either rule.

## Verification

- `./gradlew :openbank-settlement-service:test :openbank-settlement-service:ktlintCheck :openbank-settlement-service:detekt` — **BUILD SUCCESSFUL** (was 5 completed / 1 failed).
- `promtool check rules` over all six documents in `payments/prometheus-rules.yaml` — SUCCESS, settlement group now 3 rules.
- `check-alert-metric-emitted.py` (127 rules, 0 dead), `check-alert-window-vs-subject-period.py` (no findings), `check-critical-alert-egress.py` (critical reaches `slack-alerts`) — all clean.

The gauge test asserts the published set derived from the enum, so it stays a real gate: the next added status fails it rather than going unwatched.

## Out of scope

`rejectSettlement` runs after the compensations regardless, so a settlement whose reversal failed is eventually overwritten to `REJECTED` while the money is still out — the terminal status then asserts an unwind that did not complete. That is a saga-shape question, not an observability one — filed as #6286, which also notes that it blunts the `SettlementReversalFailed` rule added here (the row only rests in `REVERSAL_FAILED` when the workflow itself dies before the terminal write).

Refs #6037

🤖 Generated with [Claude Code](https://claude.com/claude-code)

