### PR TITLE
fix(admin-ui): clarify payments refresh state

### DIFF
--- a/openbank-admin-ui/src/app/payments/page.tsx
+++ b/openbank-admin-ui/src/app/payments/page.tsx
@@ -471,8 +471,15 @@ function PaymentsContent() {
         icon={<Banknote size={18} aria-hidden="true" />}
         breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Platby', 'Payments')}</span></div>}
         actions={activeTab !== 'sct-inst' ? (
-          <button className="btn btn-secondary" onClick={load} disabled={loading}>
-            <RefreshCw size={13} style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
+          <button
+            className="btn btn-secondary"
+            type="button"
+            onClick={load}
+            disabled={loading}
+            aria-busy={loading}
+            aria-label={t('Obnovit platby', 'Refresh payments')}
+          >
+            <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
         ) : undefined}

--- a/openbank-admin-ui/src/test/payments-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/payments-refresh.guard.test.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('Payments refresh contract', () => {
+  it('exposes localized busy semantics without changing payment loaders', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/payments/page.tsx'), 'utf8')
+
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit platby', 'Refresh payments')}")
+    expect(source).toContain('<RefreshCw size={13} aria-hidden="true"')
+    expect(source).toContain('onClick={load}')
+  })
+})


### PR DESCRIPTION
## Summary
- make the Payments refresh action an explicit non-submit button
- expose localized accessible name and loading state while preserving the existing loader
- hide the decorative refresh glyph from assistive technology

## Verification
- `git diff --check` passes
- focused Vitest could not run in the clean worktree because admin-ui dependencies are not installed

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.