### PR TITLE
feat(edge): ADR-0269 — let the customer actually switch the credit consents on and off

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -825,6 +825,113 @@ class CustomerEdgeResource(
         return Response.status(resp.status).entity(resp.entity).type(MediaType.APPLICATION_JSON).build()
     }
 
+    /**
+     * The caller's own ADR-0269 credit consents, as three booleans.
+     *
+     * ## Why this route exists at all
+     *
+     * consent-service could already grant these scopes, and the edge could already list and revoke
+     * consents — but there was no way for a CUSTOMER to switch one ON. The app's existing marketing
+     * toggle goes somewhere else entirely (party-service's `marketingConsent` boolean), so without
+     * this route the credit consents were grantable only by an operator, which is the opposite of
+     * what "the customer decides" means.
+     *
+     * ## Why booleans and not the consent objects
+     *
+     * The app renders three switches. Handing it consent aggregates would make every client
+     * re-derive "is CREDIT_OFFERS on" from a list, and the first client to write that filter
+     * slightly differently gets a different answer — the same reasoning ADR-0210 D2 gives for the
+     * party key. The derivation happens once, here.
+     */
+    @GET
+    @Path("/credit/consents")
+    @Authorize(action = "customer.profile.read", resource = "")
+    @Blocking
+    fun getCreditConsents(): Response {
+        val customer = customer()
+        val party = customer.partyId.toString()
+        val resp = upstream.get("$consentServiceUrl/api/v1/consents/party/$party", party)
+        val arr = if (resp.status == 200) {
+            runCatching { objectMapper.readTree(resp.entity?.toString() ?: "") as? ArrayNode }.getOrNull()
+        } else {
+            null
+        }
+        // An unreadable consent list answers "everything off", which is the SAFE default and the
+        // true one for every customer who has never granted anything. It is not fail-soft
+        // convenience: the client uses this to decide whether to fetch offers at all, so an
+        // optimistic default here would fetch offers for a customer whose consent we cannot read.
+        val active = arr?.filter { it.get("status")?.asText() == "ACTIVE" }?.flatMap { c ->
+            c.get("scopes")?.mapNotNull { it.asText() } ?: emptyList()
+        }?.toSet().orEmpty()
+        val out = objectMapper.createObjectNode()
+        CREDIT_SCOPES.forEach { (field, scope) -> out.put(field, scope in active) }
+        return Response.ok(out).type(MediaType.APPLICATION_JSON).build()
+    }
+
+    /**
+     * Set the caller's credit consents to exactly the state in the body (ADR-0269 rule 1).
+     *
+     * A full-state PUT, not a partial patch: "turn offers off" and "leave offers alone" must not be
+     * the same request. Anything the body sets to false is revoked, immediately and for every
+     * channel — the ADR's requirement that switching offers off takes effect at once rather than at
+     * the next batch.
+     *
+     * These scopes are GDPR Art. 7 data-processing consents, so consent-service activates them
+     * without an SCA ceremony; an SCA designed for payment authorisation is a disproportionate
+     * burden on a data-processing opt-in (ADR-0205 D1). Granting still requires the customer's own
+     * authenticated session — the party comes from the JWT, never the body.
+     */
+    @PUT
+    @Path("/credit/consents")
+    @Authorize(action = "customer.profile.consent.update", resource = "")
+    @Blocking
+    fun putCreditConsents(body: String): Response {
+        val customer = customer()
+        val requested = runCatching { objectMapper.readTree(body) }.getOrNull() as? ObjectNode
+            ?: return badRequest("Malformed credit consent body")
+        val desired = CREDIT_SCOPES.mapValues { (field, _) -> requested.get(field)?.asBoolean() ?: false }
+        val party = customer.partyId.toString()
+
+        val existing = upstream.get("$consentServiceUrl/api/v1/consents/party/$party", party)
+        if (existing.status != 200) return Response.status(existing.status).entity(existing.entity).build()
+        val consents = runCatching { objectMapper.readTree(existing.entity?.toString() ?: "") as? ArrayNode }
+            .getOrNull() ?: objectMapper.createArrayNode()
+
+        desired.forEach { (field, wanted) ->
+            val scope = CREDIT_SCOPES.getValue(field)
+            val held = consents.firstOrNull { c ->
+                c.get("status")?.asText() == "ACTIVE" &&
+                    c.get("scopes")?.any { it.asText() == scope } == true
+            }
+            when {
+                wanted && held == null -> grantCreditScope(customer.partyId, scope)
+                !wanted && held != null -> revokeHeldConsent(customer.partyId, held.get("id")?.asText())
+                else -> Unit // already in the requested state; granting again would churn the audit trail
+            }
+        }
+        return getCreditConsents()
+    }
+
+    private fun grantCreditScope(partyId: UUID, scope: String) {
+        val body = objectMapper.createObjectNode().apply {
+            put("partyId", partyId.toString())
+            put("granteeId", BANK_GRANTEE)
+            put("granteeType", "INTERNAL_SERVICE")
+            put("granteeName", "OpenBank")
+            putArray("scopes").add(scope)
+            // 365 days: the non-AISP bucket's maximum. It is a ceiling, not a promise — the customer
+            // can revoke at any time, and nothing re-arms the consent when it lapses.
+            put("validTo", java.time.OffsetDateTime.now(java.time.ZoneOffset.UTC).plusDays(CONSENT_DAYS).toString())
+        }.toString()
+        upstream.post("$consentServiceUrl/api/v1/consents", partyId.toString(), body)
+    }
+
+    private fun revokeHeldConsent(partyId: UUID, consentId: String?) {
+        if (consentId.isNullOrBlank()) return
+        val body = objectMapper.createObjectNode().put("reason", "Revoked by customer").toString()
+        upstream.delete("$consentServiceUrl/api/v1/consents/$consentId?partyId=$partyId", partyId.toString(), body)
+    }
+
     private fun projectConsent(c: com.fasterxml.jackson.databind.JsonNode): ObjectNode {
         val o = objectMapper.createObjectNode()
         o.put("id", c.get("id")?.asText())
@@ -4416,6 +4523,24 @@ class CustomerEdgeResource(
         parseCreditorAccount(raw) ?: czechIbanToBban(raw)
 
     companion object {
+        /**
+         * The ADR-0269 credit consents, as the app's field name → the consent-service scope.
+         *
+         * One map, so the read and the write cannot disagree about which switch means which scope —
+         * the failure that would look like a customer turning offers off and still being offered.
+         */
+        private val CREDIT_SCOPES: Map<String, String> = linkedMapOf(
+            "offers" to "CREDIT_OFFERS",
+            "profileUse" to "CREDIT_PROFILE_USE",
+            "aiAgent" to "CREDIT_AI_AGENT",
+        )
+
+        /** First-party consent: the bank itself is the grantee, not a TPP. */
+        private const val BANK_GRANTEE = "openbank"
+
+        /** The non-AISP validity ceiling. A ceiling, not a promise — revocation is immediate. */
+        private const val CONSENT_DAYS = 365L
+
         /** Closed at the edge as well as upstream: a path is never an app-controlled URL. */
         private val SURFACE_SLOTS: Set<String> = setOf(
             "HOME_BANNER",

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.43.0
+  version: 1.44.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -1092,6 +1092,48 @@ paths:
               schema:
                 type: array
                 items: {$ref: '#/components/schemas/Loan'}
+
+  /credit/consents:
+    get:
+      tags: [Consents]
+      summary: The caller's own credit consents, as three switches
+      description: >-
+        ADR-0269 rule 1. Derived once here rather than by every client filtering a consent list —
+        the first client to write that filter differently gets a different answer. An unreadable
+        consent list answers "everything off", which is both the safe default and the true state
+        for anyone who has never granted these.
+      operationId: getCreditConsents
+      security:
+        - customerOidc: [accounts:read]
+      responses:
+        '200':
+          description: The three switches
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/CreditConsents'}
+    put:
+      tags: [Consents]
+      summary: Set the caller's credit consents to exactly this state
+      description: >-
+        Full-state PUT, not a partial patch: "turn offers off" and "leave offers alone" must not be
+        the same request. Anything false is revoked immediately and for every channel. These are
+        GDPR Art. 7 data-processing consents, so no SCA ceremony is required (ADR-0205 D1); the
+        party comes from the JWT, never the body.
+      operationId: putCreditConsents
+      security:
+        - customerOidc: [accounts:read]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/CreditConsents'}
+      responses:
+        '200':
+          description: The resulting state, re-read after the change
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/CreditConsents'}
+        '400': {description: Malformed body}
 
   /credit/quotes:
     post:
@@ -3217,6 +3259,28 @@ components:
 
     # Edge's projected view of lending-service's Loan (internal fields dropped — see
     # CustomerEdgeResource.projectLoan).
+    CreditConsents:
+      type: object
+      description: >-
+        ADR-0269's three credit consents. All default FALSE — absence of consent is denial, and no
+        path re-arms one on the customer's behalf.
+      required: [offers, profileUse, aiAgent]
+      properties:
+        offers:
+          type: boolean
+          description: May the bank show this customer a credit offer it was not asked for.
+        profileUse:
+          type: boolean
+          description: >-
+            May the 360 profile be used to work out WHICH offer. Separate from `offers` because a
+            customer may want an affordability answer they asked for without their spending being
+            mined for eligibility.
+        aiAgent:
+          type: boolean
+          description: >-
+            May the assistant watch and PREPARE on the customer's behalf. Never extends to
+            submitting, accepting, raising a limit or drawing funds.
+
     CreditQuote:
       type: object
       description: >-

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeCreditConsentTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeCreditConsentTest.kt
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.customeredge.infrastructure.rest.CustomerEdgeResource
+import com.openbank.customeredge.infrastructure.rest.PaymentSessionStore
+import com.openbank.customeredge.infrastructure.rest.UpstreamClient
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import jakarta.ws.rs.core.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.util.UUID
+
+/**
+ * ADR-0269 rule 1 — the customer's own credit consents.
+ *
+ * These tests are written against the ways the route could WRONGLY GRANT or wrongly report a grant,
+ * because that is the failure with consequences: a customer who believes offers are off and is
+ * offered anyway. The happy path is one test; the rest are refusals and non-actions.
+ */
+class CustomerEdgeCreditConsentTest {
+
+    private val party = UUID.randomUUID()
+
+    private fun newResource(upstream: UpstreamClient): CustomerEdgeResource = CustomerEdgeResource(
+        upstream,
+        mockk(relaxed = true),
+        PaymentSessionStore(),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        Clock.systemUTC(),
+    ).apply {
+        partyMergeResolver = mockk { every { resolve(any()) } answers { firstArg() } }
+        jwt = mockk {
+            every { getClaim<String>("party_id") } returns null
+            every { subject } returns party.toString()
+        }
+        objectMapper = ObjectMapper()
+        consentServiceUrl = "http://consent"
+    }
+
+    private fun consentList(vararg scopes: String, status: String = "ACTIVE"): String =
+        scopes.joinToString(",", "[", "]") { s ->
+            """{"id":"${UUID.nameUUIDFromBytes(s.toByteArray())}","status":"$status","scopes":["$s"]}"""
+        }
+
+    private fun upstreamReturning(list: String): UpstreamClient = mockk(relaxed = true) {
+        every { get(match { it.contains("/api/v1/consents/party/") }, any()) } returns Response.ok(list).build()
+    }
+
+    private fun bodyOf(response: Response): Map<String, Any?> {
+        val node = ObjectMapper().readTree(response.entity.toString())
+        return node.fields().asSequence().associate { (k, v) -> k to (if (v.isBoolean) v.asBoolean() else v) }
+    }
+
+    // ── Reading ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a party with no consents reads as everything off`() {
+        val resp = newResource(upstreamReturning("[]")).getCreditConsents()
+        assertThat(bodyOf(resp)).containsEntry("offers", false)
+            .containsEntry("profileUse", false)
+            .containsEntry("aiAgent", false)
+    }
+
+    @Test
+    fun `an unreadable consent list reads as everything off, never as granted`() {
+        // The client uses this to decide whether to fetch offers at all. An optimistic default here
+        // would fetch offers for a customer whose consent could not be read.
+        val upstream = mockk<UpstreamClient>(relaxed = true) {
+            every { get(any(), any()) } returns Response.status(503).build()
+        }
+        assertThat(bodyOf(newResource(upstream).getCreditConsents())).containsEntry("offers", false)
+    }
+
+    @Test
+    fun `only ACTIVE consents count as granted`() {
+        val revoked = consentList("CREDIT_OFFERS", status = "REVOKED")
+        assertThat(bodyOf(newResource(upstreamReturning(revoked)).getCreditConsents()))
+            .containsEntry("offers", false)
+    }
+
+    @Test
+    fun `each switch reports its own scope and not another`() {
+        val body = bodyOf(newResource(upstreamReturning(consentList("CREDIT_PROFILE_USE"))).getCreditConsents())
+        assertThat(body).containsEntry("profileUse", true)
+            .containsEntry("offers", false)
+            .containsEntry("aiAgent", false)
+    }
+
+    // ── Writing ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `granting posts one consent for the requested scope, scoped to the caller's own party`() {
+        val upstream = upstreamReturning("[]")
+        val bodySlot = slot<String>()
+        every { upstream.post(match { it.endsWith("/api/v1/consents") }, any(), capture(bodySlot)) } returns
+            Response.status(201).entity("{}").build()
+
+        newResource(upstream).putCreditConsents("""{"offers":true,"profileUse":false,"aiAgent":false}""")
+
+        verify(exactly = 1) { upstream.post(any(), party.toString(), any()) }
+        assertThat(bodySlot.captured).contains("CREDIT_OFFERS").contains(party.toString())
+        assertThat(bodySlot.captured).doesNotContain("CREDIT_AI_AGENT")
+    }
+
+    @Test
+    fun `an omitted field is false — absence of consent is denial, never "leave it as it was"`() {
+        val upstream = upstreamReturning(consentList("CREDIT_OFFERS"))
+        newResource(upstream).putCreditConsents("{}")
+        // Offers were on and the body did not mention them, so they are revoked. A partial-patch
+        // reading would have left them on, which is the difference between a switch and a suggestion.
+        verify(exactly = 1) { upstream.delete(match { it.contains("/api/v1/consents/") }, party.toString(), any()) }
+    }
+
+    @Test
+    fun `turning a granted switch off revokes it and grants nothing`() {
+        val upstream = upstreamReturning(consentList("CREDIT_OFFERS"))
+        newResource(upstream).putCreditConsents("""{"offers":false,"profileUse":false,"aiAgent":false}""")
+        verify(exactly = 1) { upstream.delete(any(), party.toString(), any()) }
+        verify(exactly = 0) { upstream.post(any(), any(), any()) }
+    }
+
+    @Test
+    fun `re-granting an already-held consent does nothing rather than churning the audit trail`() {
+        val upstream = upstreamReturning(consentList("CREDIT_OFFERS"))
+        newResource(upstream).putCreditConsents("""{"offers":true,"profileUse":false,"aiAgent":false}""")
+        verify(exactly = 0) { upstream.post(any(), any(), any()) }
+        verify(exactly = 0) { upstream.delete(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a malformed body changes nothing`() {
+        val upstream = upstreamReturning("[]")
+        val resp = newResource(upstream).putCreditConsents("not json")
+        assertThat(resp.status).isEqualTo(400)
+        verify(exactly = 0) { upstream.post(any(), any(), any()) }
+        verify(exactly = 0) { upstream.delete(any(), any(), any()) }
+    }
+
+    @Test
+    fun `an unreadable consent list refuses the write rather than granting blindly`() {
+        val upstream = mockk<UpstreamClient>(relaxed = true) {
+            every { get(any(), any()) } returns Response.status(503).build()
+        }
+        val resp = newResource(upstream).putCreditConsents("""{"offers":true}""")
+        assertThat(resp.status).isEqualTo(503)
+        verify(exactly = 0) { upstream.post(any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
Part of #6212. Stacked on #6264 (slice 4).

## How this was found

I started the app-side consent screen (openbank-app#530) and could not build it honestly: **there was no route by which a customer could grant these consents.**

- consent-service can create them (they are GDPR-only scopes, so they activate without SCA).
- The edge could already *list* and *revoke* consents.
- But nothing exposed a grant, and the app's existing marketing toggle goes somewhere else entirely — `PATCH /profile/consent` → party-service's `marketingConsent` boolean, which is not a `ConsentScope` at all.

So `CREDIT_OFFERS` was operator-grantable only. For a consent model whose entire premise is "the customer decides", that is the wrong way round — and it would not have shown up until someone tried to render the switch.

## The route

`GET /customer/v1/credit/consents` → `{offers, profileUse, aiAgent}`
`PUT /customer/v1/credit/consents` — full desired state.

**Three booleans, not consent objects.** The app renders three switches; handing it aggregates would make every client re-derive "is CREDIT_OFFERS on" from a list, and the first client to write that filter differently is the one that shows an offer to someone who switched them off. Same reasoning ADR-0210 D2 gives for the party key: one definition.

**Full-state PUT, not a partial patch.** "Turn offers off" and "leave offers alone" must not be the same request, so an omitted field is `false`. A test covers exactly that: offers on, body `{}`, expect a revoke.

**Idempotent by intent.** Re-granting something already held does nothing rather than churning the audit trail.

## Both failure directions resolve to OFF

An unreadable consent list reads as everything-off, and an unreadable list on the write path **refuses the write** rather than granting blind.

That is not fail-soft convenience: the client uses the GET to decide whether to fetch offers at all, so an optimistic default here would fetch offers for a customer whose consent could not be read — the exact outcome ADR-0269 rule 1 exists to prevent.

## Tests

10 tests, 0 failures, 0 skipped — written against the ways the route could **wrongly grant** or wrongly report a grant, since that is the failure with consequences. Only `ACTIVE` consents count; each switch reports its own scope and not a neighbour's; a malformed body changes nothing.

api-contract, route-conformance and threat-model gates run locally and clean (edge OpenAPI 1.43.0 → 1.44.0).

## Next

openbank-app#530 builds on this: the settings destination, and the rule that with `offers = false` the app makes **zero** requests to the pre-approved route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)