### PR TITLE
fix(admin-ui): clarify SCT refresh state

### DIFF
--- a/openbank-admin-ui/src/app/payments/page.tsx
+++ b/openbank-admin-ui/src/app/payments/page.tsx
@@ -536,8 +536,15 @@ function PaymentsContent() {
                   style={{ width: '100%', paddingLeft: '30px', paddingRight: '12px', height: '32px', borderRadius: '6px',
                     border: '1px solid var(--border)', fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)', outline: 'none' }} />
               </div>
-              <button aria-label={t('Obnovit SCT platby', 'Refresh SCT payments')} className="btn btn-secondary btn-sm" onClick={loadSct} disabled={sctLoading}>
-                <RefreshCw size={12} style={{ animation: sctLoading ? 'spin 0.8s linear infinite' : 'none' }} />
+              <button
+                aria-label={t('Obnovit SCT platby', 'Refresh SCT payments')}
+                className="btn btn-secondary btn-sm"
+                type="button"
+                onClick={loadSct}
+                disabled={sctLoading}
+                aria-busy={sctLoading}
+              >
+                <RefreshCw size={12} aria-hidden="true" style={{ animation: sctLoading ? 'spin 0.8s linear infinite' : 'none' }} />
               </button>
             </div>
             {sctLoading && !sctPayments.length ? (

--- a/openbank-admin-ui/src/test/payments-sct-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/payments-sct-refresh.guard.test.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('SCT Inst refresh contract', () => {
+  it('exposes localized busy semantics without changing the SCT loader', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/payments/page.tsx'), 'utf8')
+
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={sctLoading}')
+    expect(source).toContain('aria-busy={sctLoading}')
+    expect(source).toContain("aria-label={t('Obnovit SCT platby', 'Refresh SCT payments')}")
+    expect(source).toContain('<RefreshCw size={12} aria-hidden="true"')
+    expect(source).toContain('onClick={loadSct}')
+  })
+})


### PR DESCRIPTION
## Summary
- make the SCT Inst refresh action an explicit non-submit button
- expose localized accessible name and busy state while preserving the existing SCT loader
- hide the decorative refresh glyph from assistive technology

## Verification
- `git diff --check` passes
- focused Vitest unavailable in the clean worktree because admin-ui dependencies are not installed

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.