### PR TITLE
fix(admin-ui): clarify notifications refresh state

### DIFF
--- a/openbank-admin-ui/src/app/notifications/page.tsx
+++ b/openbank-admin-ui/src/app/notifications/page.tsx
@@ -75,7 +75,14 @@ function NotificationsContent() {
         icon={<Bell size={18} aria-hidden="true" />}
         title={t('Oznámení', 'Notifications')}
         subtitle={t('Odchozí oznámení — e-maily, upozornění, webhooky', 'Outbound notification log — emails, alerts, webhooks')}
-        actions={<button className="btn btn-secondary" onClick={load} disabled={loading}>
+        actions={<button
+          className="btn btn-secondary"
+          type="button"
+          onClick={load}
+          disabled={loading}
+          aria-busy={loading}
+          aria-label={t('Obnovit oznámení', 'Refresh notifications')}
+        >
           <RefreshCw aria-hidden="true" size={13} style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
           {t('Obnovit', 'Refresh')}
         </button>}

--- a/openbank-admin-ui/src/test/notifications-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/notifications-refresh.guard.test.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('Notifications refresh contract', () => {
+  it('exposes localized busy semantics without changing notification loading', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/notifications/page.tsx'), 'utf8')
+
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit oznámení', 'Refresh notifications')}")
+    expect(source).toContain('<RefreshCw aria-hidden="true"')
+    expect(source).toContain('onClick={load}')
+  })
+})


### PR DESCRIPTION
## Summary
- make the Notifications refresh action an explicit non-submit button
- expose localized accessible name and busy state while preserving the existing notification loader
- retain the decorative refresh icon as hidden from assistive technology

## Verification
- `git diff --check` passes
- focused Vitest unavailable in the clean worktree because admin-ui dependencies are not installed

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.