### PR TITLE
fix(ci): render an unreachable rulesets API as UNRESOLVED, not a gate failure

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -43,6 +43,24 @@
   plain red while having silently left half the fleet unlinted — 455 actionable findings against a
   true 920 (#2177). Feed every new gate an input it MUST flag, and read what it *prints*, not just
   its exit code.
+- **"I could not READ the corpus" is a third state, and a gate that renders it as a failure
+  turns someone else's rate limit into your red PR.** On 2026-08-21 ~18:25 UTC one installation
+  rate limit hit two gates in the same run and they disagreed:
+  `check-stale-comment-references.py` printed `::notice:: … UNRESOLVED … Not a pass and not a
+  failure` and stayed green, while `ruleset-context-parity` exited 1 and reddened #5896 — a PR
+  touching only admin-ui, `openbank-infra/scripts`, docs and a `CLAUDE.md`. "The ruleset requires
+  X and no job emits X" and "the rulesets API did not answer" are different facts; only the first
+  is a finding. The pattern to copy is the notice + exit 0, with the transient family named
+  explicitly (rate limit, secondary rate limit, timeout, DNS/connection, 5xx) so a NON-transient
+  failure still goes red — on GitHub a rate limit and a permission denial are both HTTP 403 and
+  are told apart only by the message text (`API rate limit exceeded` vs `Resource not accessible
+  by integration` / `Must have admin rights`), so distinguish on that, and where a probe cannot
+  tell them apart, say so rather than degrading both. **The floor undoes this one layer up if you
+  let it**: `min_subjects:` sees 0 subjects and fails a run that examined nothing by definition,
+  so the gate prints `SUBJECTS=UNRESOLVED` (`gatelib.subjects_unresolved`) and run-gates.py skips
+  the floor for that run only, saying so in the output — a silent pass there is indistinguishable
+  from a gate that really looked.
+
 - **An advisory gate's "these findings are all benign" note is an unverified claim, and advisory
   mode is what removes the pressure to check it.** The repo already knows a gate that has only ever
   passed is unfalsified; the sharper form is that a gate can fire CORRECTLY and have its *triage* be

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -3626,7 +3626,10 @@ gates:
     mode: enforced
     selftest: python3 .github/scripts/check-ruleset-context-parity.py --self-test
     selftest_expect: pass
-    min_subjects: 3   # 5 required contexts today (2026-08-09)
+    # 5 required contexts today (2026-08-21). Not applied to a run that could not READ the
+    # ruleset: the gate prints `SUBJECTS=UNRESOLVED` there and run-gates.py skips the floor,
+    # because 0 contexts from a rate-limited API means "not measured", not "corpus collapsed".
+    min_subjects: 3
     run: |
       python3 .github/scripts/check-ruleset-context-parity.py --enforce --repo "${GITHUB_REPOSITORY:-JiRaska/open-bank-oss}"
 

--- a/.github/scripts/check-ruleset-context-parity.py
+++ b/.github/scripts/check-ruleset-context-parity.py
@@ -82,22 +82,75 @@ import gatelib  # noqa: E402
 WORKFLOWS_DIR = ".github/workflows"
 
 
+class Unreachable(RuntimeError):
+    """The rulesets API could not be READ. Not a finding — a third state.
+
+    "the ruleset requires X and no job emits X" and "I could not reach the rulesets API"
+    are different facts and must not render as the same verdict. On 2026-08-21 ~18:25 UTC a
+    shared installation rate limit hit two gates in one run: `check-stale-comment-references.py`
+    printed `::notice:: ... UNRESOLVED ... Not a pass and not a failure` and stayed green, while
+    this gate exited 1 and turned PR #5896 red on a diff that touches no workflow and no
+    ruleset. This class carries the transient half so `main()` can degrade the same way.
+
+    RATE LIMIT vs GENUINE PERMISSION DENIAL — distinguishable, because `gh` prints the reason.
+    A quota exhaustion says `API rate limit exceeded` (HTTP 403 with `x-ratelimit-remaining: 0`)
+    and a permission denial says `Resource not accessible by integration` / `Must have admin
+    rights` (HTTP 403 with quota left). Only the transient family degrades to UNRESOLVED; a
+    permission denial stays a hard error, because it is a persistent misconfiguration of the
+    gate itself that no amount of waiting fixes, and silently downgrading it would leave the
+    gate permanently unresolved with nothing to notice.
+    """
+
+
+TRANSIENT_MARKERS = (
+    "api rate limit exceeded",
+    "secondary rate limit",
+    "you have exceeded a secondary rate limit",
+    "was submitted too quickly",
+    "connection refused",
+    "could not resolve host",
+    "network is unreachable",
+    "timeout",
+    "timed out",
+    "eof",
+    "bad gateway",
+    "service unavailable",
+    "server error",
+    "(http 429)",
+    "(http 500)",
+    "(http 502)",
+    "(http 503)",
+    "(http 504)",
+)
+
+
+def is_transient(message: str) -> bool:
+    """True when a `gh api` failure is about REACHABILITY, not about the ruleset's content."""
+    return any(m in message.lower() for m in TRANSIENT_MARKERS)
+
+
 def gh_api(path: str) -> list | dict:
     """`gh api <path>`, returning the parsed JSON.
 
-    Raises `RuntimeError` on any failure — a missing `gh` binary, a network error, an
-    unauthenticated token, or a non-JSON response — so the caller's one `except RuntimeError`
-    catches every way this can go wrong. A caller that only handled a non-zero exit code
-    would let a missing `gh` executable raise a bare `FileNotFoundError` straight out of
-    `main()`, which still exits non-zero but as an unhandled traceback rather than the
-    `::error::` message an operator can act on.
+    Raises on any failure, in one of two flavours the caller renders differently:
+    `Unreachable` (a subclass) when nothing could be READ — missing `gh`, network error,
+    timeout, rate limit, 5xx — and plain `RuntimeError` for everything else, such as a
+    permission denial or a non-JSON response. A caller that only handled a non-zero exit
+    code would let a missing `gh` executable raise a bare `FileNotFoundError` straight out
+    of `main()`, which still exits non-zero but as an unhandled traceback rather than a
+    message an operator can act on.
     """
     try:
         p = subprocess.run(["gh", "api", path], capture_output=True, text=True, timeout=30)
+    except subprocess.TimeoutExpired as exc:
+        raise Unreachable(f"`gh api {path}` timed out: {exc}") from exc
     except (OSError, subprocess.SubprocessError) as exc:
-        raise RuntimeError(f"could not run `gh api {path}`: {exc}") from exc
+        # A missing `gh` binary is not a defect in the ruleset either — nothing was read.
+        raise Unreachable(f"could not run `gh api {path}`: {exc}") from exc
     if p.returncode != 0:
-        raise RuntimeError(f"gh api {path} failed (rc={p.returncode}): {p.stderr.strip()}")
+        err = p.stderr.strip()
+        msg = f"gh api {path} failed (rc={p.returncode}): {err}"
+        raise (Unreachable if is_transient(err) else RuntimeError)(msg)
     try:
         return json.loads(p.stdout)
     except json.JSONDecodeError as exc:
@@ -205,12 +258,92 @@ def self_test() -> int:
     case("matching is exact — no case-folding or fuzzy match",
          ["gitleaks"], {"Gitleaks"}, ["gitleaks"])
 
+    # --- the THIRD STATE: an unreachable API is not a failure, a mismatch still is --------
+    # Both directions, because either one alone is vacuous: a gate that never fails proves
+    # nothing about rate limits, and a gate that always fails hides them.
+    import contextlib
+    import io
+
+    def run_main(argv_extra, raise_exc=None, contexts=None, jobs=frozenset()):
+        """Drive the real main() end to end, stubbing only the network boundary."""
+        orig_rc = globals()["required_contexts"]
+        orig_jn = globals()["pr_triggered_job_names"]
+        orig_argv = sys.argv
+
+        def stub(repo):
+            if raise_exc is not None:
+                raise raise_exc
+            return list(contexts or [])
+
+        globals()["required_contexts"] = stub
+        globals()["pr_triggered_job_names"] = lambda root: set(jobs)
+        sys.argv = ["check-ruleset-context-parity.py", *argv_extra]
+        out, err = io.StringIO(), io.StringIO()
+        try:
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = main()
+        finally:
+            globals()["required_contexts"], globals()["pr_triggered_job_names"] = orig_rc, orig_jn
+            sys.argv = orig_argv
+        return rc, out.getvalue() + err.getvalue()
+
+    rate_limited = Unreachable(
+        "gh api repos/o/r/rulesets failed (rc=1): gh: API rate limit exceeded for "
+        "installation ... (HTTP 403)"
+    )
+    rc, out = run_main(["--enforce"], raise_exc=rate_limited)
+    if rc != 0 or "::notice::" not in out or "UNRESOLVED" not in out:
+        fails.append(f"API rate-limited must be UNRESOLVED, not a failure: rc={rc}, out={out!r}")
+    if "::error::" in out:
+        fails.append(f"API rate-limited must not emit ::error::: {out!r}")
+
+    rc, out = run_main(
+        ["--enforce"],
+        contexts=["Validate manifests", "Gitleaks", "OPA policy gate", "adr-registry"],
+        jobs={"Validate manifests", "Gitleaks", "OPA policy gate"},
+    )
+    if rc != 1 or "adr-registry" not in out:
+        fails.append(f"a genuine mismatch must STILL fail: rc={rc}, out={out!r}")
+
+    # A NON-transient 403 (a permission denial) is a different fact from a rate limit and
+    # stays red — see Unreachable's docstring.
+    denied = RuntimeError(
+        "gh api repos/o/r/rulesets failed (rc=1): gh: Resource not accessible by "
+        "integration (HTTP 403)"
+    )
+    rc, out = run_main(["--enforce"], raise_exc=denied)
+    if rc != 1 or "::error::" not in out:
+        fails.append(f"a permission denial must stay a hard failure: rc={rc}, out={out!r}")
+
+    for msg, want in [
+        ("gh: API rate limit exceeded for installation ... (HTTP 403)", True),
+        ("You have exceeded a secondary rate limit", True),
+        ("dial tcp: connection refused", True),
+        ("Resource not accessible by integration (HTTP 403)", False),
+        ("Must have admin rights to Repository. (HTTP 403)", False),
+        ("Not Found (HTTP 404)", False),
+    ]:
+        if is_transient(msg) is not want:
+            fails.append(f"is_transient({msg!r}): want {want}, got {not want}")
+
+    # The corpus floor lives in main(), so an UNRESOLVED run is not failed by it while a
+    # ruleset that really lost its protection still is.
+    # The UNRESOLVED run must ALSO tell run-gates.py not to apply `min_subjects:` to it —
+    # otherwise the manifest floor (3) fails a run that examined nothing by definition, and
+    # the third state is undone one layer up. A resolved run still prints a real count.
+    _, out = run_main(["--enforce"], raise_exc=rate_limited)
+    if "SUBJECTS=UNRESOLVED" not in out:
+        fails.append(f"UNRESOLVED run must print SUBJECTS=UNRESOLVED: {out!r}")
+    _, out = run_main(["--enforce"], contexts=["Gitleaks"], jobs={"Gitleaks"})
+    if "SUBJECTS=1" not in out:
+        fails.append(f"a resolved run must print its real subject count: {out!r}")
+
     if fails:
         for f in fails:
             sys.stderr.write(f"::error::self-test: {f}\n")
         sys.stderr.write(f"self-test FAILED ({len(fails)} case(s))\n")
         return 1
-    print("self-test ok: ruleset-context-parity is falsifiable (7 cases)")
+    print("self-test ok: ruleset-context-parity is falsifiable (20 cases)")
     return 0
 
 
@@ -227,13 +360,25 @@ def main() -> int:
     root = pathlib.Path(args.root)
     try:
         missing, contexts, n = findings(root, args.repo)
+    except Unreachable as exc:
+        # THIRD STATE. Not a pass (nothing was compared) and not a failure (the PR's diff
+        # cannot cause this). Same shape as check-stale-comment-references.py's repo rule.
+        gatelib.subjects_unresolved(f"rulesets API unreachable: {exc}")
+        print(
+            f"::notice::ruleset-context-parity: UNRESOLVED for {args.repo} — {exc}. "
+            f"The rulesets API could not be read, so no context was compared against any "
+            f"job. Not a pass and not a failure."
+        )
+        return 0
     except RuntimeError as exc:
-        # A gate that cannot reach the API must not report a silent pass — a missing `gh`
-        # binary, a rate limit, or the API being unreachable is a tool failure, not "no
-        # violations found".
+        # A NON-transient failure — a permission denial, an unparseable response — is a real
+        # defect in the gate's own wiring and stays red. See Unreachable's docstring for why
+        # the two 403s are not the same fact.
         sys.stderr.write(f"::error::ruleset-context-parity: {exc}\n")
         return 1
 
+    # The corpus floor stays in gates.yaml (`min_subjects: 3`) — run-gates.py applies it to a
+    # run that printed a count, and skips it for a run that printed UNRESOLVED above.
     gatelib.subjects(n, "required status-check contexts")
     for c in missing:
         print(

--- a/.github/scripts/gatelib.py
+++ b/.github/scripts/gatelib.py
@@ -204,6 +204,26 @@ def subjects(count: int, label: str = "") -> None:
     print(f"{SUBJECTS_PREFIX}{int(count)}" + (f"  # {label}" if label else ""))
 
 
+SUBJECTS_UNRESOLVED = "UNRESOLVED"
+
+
+def subjects_unresolved(reason: str) -> None:
+    """Declare that the corpus could not be READ at all — a third state, not a count of zero.
+
+    A gate whose corpus lives behind a network API has three outcomes, not two: it compared
+    and found nothing wrong, it compared and found a violation, or it could not compare. The
+    third must render as neither a pass nor a failure — see check-stale-comment-references.py's
+    repo rule, and check-ruleset-context-parity.py, which on 2026-08-21 exited 1 on a shared
+    installation rate limit and reddened a PR whose diff could not have caused it.
+
+    `min_subjects:` exists to catch a gate that silently lost its corpus, and 0 subjects is
+    exactly what an unreachable API produces — so without this line the manifest floor would
+    convert the third state straight back into a red one layer up. run-gates.py reads this and
+    skips the floor for that run only; a run that DID read its corpus is still held to it.
+    """
+    print(f"{SUBJECTS_PREFIX}{SUBJECTS_UNRESOLVED}  # {reason}")
+
+
 def clear() -> None:
     """Drop the in-process parse cache. For tests."""
     _parse_cache.clear()

--- a/.github/scripts/run-gates.py
+++ b/.github/scripts/run-gates.py
@@ -77,6 +77,7 @@ MANIFEST = ".github/gates/gates.yaml"
 # the manifest even where a checker's dependencies are missing, and the string is the contract.
 PARSE_CACHE_ENV = "GATE_PARSE_CACHE"
 SUBJECTS_PREFIX = "SUBJECTS="  # must match gatelib.SUBJECTS_PREFIX
+SUBJECTS_UNRESOLVED = "UNRESOLVED"  # must match gatelib.SUBJECTS_UNRESOLVED
 VALID_MODES = {"enforced", "advisory"}
 VALID_WHEN = {"always", "pull_request"}
 VALID_EXPECT = {"pass", "fail"}
@@ -337,9 +338,11 @@ def last_subject_count(out: str):
     for line in out.splitlines():
         line = line.strip()
         if line.startswith(SUBJECTS_PREFIX):
-            digits = line[len(SUBJECTS_PREFIX):].split("#")[0].strip()
-            if digits.isdigit():
-                found = int(digits)
+            value = line[len(SUBJECTS_PREFIX):].split("#")[0].strip()
+            if value.isdigit():
+                found = int(value)
+            elif value == SUBJECTS_UNRESOLVED:
+                found = SUBJECTS_UNRESOLVED
     return found
 
 
@@ -397,7 +400,16 @@ def execute(gate, root: pathlib.Path, is_pr: bool, timeout: int, index=None) -> 
     floor = gate.get("min_subjects")
     if floor is not None and rc == 0:
         found = last_subject_count(out)
-        if found is None:
+        if found == SUBJECTS_UNRESOLVED:
+            # THIRD STATE. The gate says it could not read its corpus at all (a rate-limited
+            # or unreachable API), so the floor has nothing to hold: 0 subjects here means
+            # "not measured", not "corpus collapsed". Enforcing it would turn every transient
+            # outage into a red PR — exactly what gatelib.subjects_unresolved exists to stop.
+            buf.append(
+                "\n[run-gates] this gate reported its corpus UNRESOLVED; min_subjects "
+                f"({floor}) not applied to this run. Not a pass and not a failure.\n"
+            )
+        elif found is None:
             rc = 1
             buf.append(
                 f"\n[run-gates] this gate declares min_subjects: {floor} but printed no "
@@ -680,6 +692,11 @@ gates:
     group: t
     min_subjects: 3
     run: "echo checked nothing; echo SUBJECTS=0"
+  - id: floor-unresolved
+    name: "a gate whose corpus could not be READ is not held to its floor"
+    group: t
+    min_subjects: 3
+    run: "echo 'SUBJECTS=UNRESOLVED  # rate limited'"
   - id: floor-unreported
     name: "a gate that declares a floor and never prints a count"
     group: t
@@ -713,6 +730,7 @@ EXPECTED = {
     "passing": "ok",
     "floor-met": "ok",
     "floor-missed": "failed",
+    "floor-unresolved": "ok",
     "floor-unreported": "failed",
     "floor-last-wins": "ok",
     "over-budget": "failed",
@@ -751,6 +769,11 @@ def self_test():
                 bad.append("over-budget: failed, but not for the budget reason")
             if r.id == "floor-missed" and "below its declared floor" not in r.output:
                 bad.append("floor-missed: failed, but not for the floor reason")
+            # The third state, both halves: an UNRESOLVED corpus must pass DESPITE the floor,
+            # and must say out loud that the floor was not applied — a silent pass here is
+            # indistinguishable from a gate that really checked 3 subjects.
+            if r.id == "floor-unresolved" and "min_subjects (3) not applied" not in r.output:
+                bad.append("floor-unresolved: passed without saying the floor was skipped")
             # ADR-0255's json_records() must round-trip through json.dumps (a Result carrying
             # something non-serialisable would crash the whole run at the very end, after
             # every gate had already finished) and preserve the SUBJECTS= count this record


### PR DESCRIPTION
## What

`ruleset-context-parity` turned PR #5896 red on 2026-08-21 (~18:25 UTC) because the GitHub rulesets API answered `gh: API rate limit exceeded for installation ... (HTTP 403)`. That PR touches only admin-ui, `openbank-infra/scripts`, `docs/runbooks` and a `CLAUDE.md` — no workflow, no ruleset.

The same rate limit hit `check-stale-comment-references.py` in the same run, and that gate handled it correctly:

```
::notice::stale-comment-references: repo rule UNRESOLVED for JiRaska/open-bank-oss, JiRaska/openbank-app
  — gh: API rate limit exceeded for installation. ... Not a pass and not a failure.
```

"the ruleset requires X and no job emits X" is a finding. "I could not reach the rulesets API" is not the same fact. This copies the existing third-state pattern rather than inventing a new one.

## Changes

- `gh_api()` raises `Unreachable` (a `RuntimeError` subclass) for the transient family — rate limit, secondary rate limit, timeout, DNS/connection failure, 5xx, missing `gh` binary — and plain `RuntimeError` for everything else. `main()` degrades the first to a `::notice::` + exit 0; the second stays red.
- **403 vs 403.** A rate limit and a permission denial are both HTTP 403 here, and `gh` does distinguish them in the message text (`API rate limit exceeded` vs `Resource not accessible by integration` / `Must have admin rights`), so the script matches on that. Only the transient family degrades; a permission denial is a persistent misconfiguration of the gate itself that no amount of waiting fixes, and silently downgrading it would leave the gate permanently unresolved with nothing to notice.
- **The real check is not weakened.** A successfully-fetched ruleset whose contexts match no job still fails under `--enforce`.
- **`min_subjects` would have undone this one layer up.** An unreachable API yields 0 subjects, which the manifest floor reads as "corpus collapsed" and fails. So the gate prints `SUBJECTS=UNRESOLVED` (new `gatelib.subjects_unresolved()`) and `run-gates.py` skips the floor for that run only — and says so in the output, because a silent pass there is indistinguishable from a gate that really looked. A run that DID read the ruleset is still held to the floor.

## Verification (actual local output)

Self-test extended from 7 to 20 cases:

```
$ python3 .github/scripts/check-ruleset-context-parity.py --self-test
self-test ok: ruleset-context-parity is falsifiable (20 cases)
```

Both directions falsified, not assumed. Reverting the degradation (`except Unreachable` re-raising) fails 3 cases:

```
::error::self-test: API rate-limited must be UNRESOLVED, not a failure: rc=1, ...
::error::self-test: API rate-limited must not emit ::error::: ...
::error::self-test: UNRESOLVED run must print SUBJECTS=UNRESOLVED: ...
self-test FAILED (3 case(s))
```

Stubbing out the mismatch comparison (`missing = []`) fails 4, including the new one:

```
::error::self-test: a genuine mismatch must STILL fail: rc=0, ...
self-test FAILED (4 case(s))
```

End to end through `run-gates.py` with `gh` stubbed on `PATH`. Rate limit:

```
::group::PASS [lint] every required status-check context matches a job some workflow emits (ADR-0254, enforced)
SUBJECTS=UNRESOLVED  # rulesets API unreachable: ... gh: API rate limit exceeded for installation ... (HTTP 403)
::notice::ruleset-context-parity: UNRESOLVED for JiRaska/open-bank-oss — ... Not a pass and not a failure.
[run-gates] this gate reported its corpus UNRESOLVED; min_subjects (3) not applied to this run.
1 gates  PASS=1
```

Permission denial (same HTTP 403, different message) still red:

```
::error::ruleset-context-parity: gh api repos/JiRaska/open-bank-oss/rulesets failed (rc=1): gh: Resource not accessible by integration (HTTP 403)
1 gates  FAIL=1
```

Real run against the live API:

```
SUBJECTS=5  # required status-check contexts
ruleset-context-parity: 5 required context(s) checked, 0 orphaned.
```

`run-gates.py --self-test` passes with the new `floor-unresolved` fixture; removing the branch it covers makes the self-test blow up rather than pass, so the case is not vacuous.

`run-gates.py --all`: `171 gates PASS=164 FAIL=6 UNFALSIFIED=1`. All seven are the documented environmental set — six diff-scoped gates printing `PR_DIFF_BASE is empty but this gate requires it` (`api-contract`, `release-scope-mismatch`, `db-migration`, `schema-compat`, `threat-model-updated-on-trust-boundary-change`, `litellm-config-revision`) and `loki-rule-load-test` on `BASE_REF`. Both variables are set only by CI.

## Linked issues

Refs #5896 — the PR this reddened. N/A for a dedicated issue: this is a one-file gate correction with the war-story captured in `.github/CLAUDE.md`.
