### PR TITLE
fix(admin-ui): clarify security refresh state

### DIFF
--- a/openbank-admin-ui/src/app/security/page.tsx
+++ b/openbank-admin-ui/src/app/security/page.tsx
@@ -152,8 +152,15 @@ export default function SecurityPage() {
                 <Shield size={12} /> {platformGrade} · {avgScore}/100
               </span>
             )}
-            <button onClick={load} disabled={loading} className="btn btn-secondary btn-sm">
-              <RefreshCw size={13} style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
+            <button
+              onClick={load}
+              disabled={loading}
+              type="button"
+              aria-busy={loading}
+              aria-label={t('Obnovit bezpečnostní sken', 'Refresh security scan')}
+              className="btn btn-secondary btn-sm"
+            >
+              <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
               {t('Obnovit', 'Refresh')}
             </button>
           </div>}

--- a/openbank-admin-ui/src/test/security-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/security-refresh.guard.test.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('Security refresh contract', () => {
+  it('exposes localized busy semantics without changing the scan loader', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/security/page.tsx'), 'utf8')
+
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit bezpečnostní sken', 'Refresh security scan')}")
+    expect(source).toContain('<RefreshCw size={13} aria-hidden="true"')
+    expect(source).toContain('onClick={load}')
+  })
+})


### PR DESCRIPTION
## Summary
- make the Security posture refresh action an explicit non-submit button
- expose localized accessible name and busy state while preserving the existing read-only loader
- hide the decorative refresh icon from assistive technology

## Verification
- `git diff --check` passes
- focused Vitest unavailable in the clean worktree because admin-ui dependencies are not installed

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.