### PR TITLE
fix(admin-ui): clarify onboarding analytics refresh

### DIFF
--- a/openbank-admin-ui/src/app/onboarding/analytics/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/analytics/page.tsx
@@ -129,7 +129,14 @@ export default function OnboardingAnalyticsPage() {
             <input type="date" value={to} min={from} max={isoDay(new Date())} onChange={e => setTo(e.target.value)}
               className="input" style={{ padding: '5px 8px', fontSize: '12px' }} />
           </label>
-          <button className="btn btn-secondary" onClick={load} disabled={loading}>
+          <button
+            className="btn btn-secondary"
+            type="button"
+            onClick={load}
+            disabled={loading}
+            aria-busy={loading}
+            aria-label={t('Obnovit analytiku onboardingu', 'Refresh onboarding analytics')}
+          >
             <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>

--- a/openbank-admin-ui/src/test/onboarding-analytics-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/onboarding-analytics-refresh.guard.test.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('Onboarding analytics refresh contract', () => {
+  it('exposes localized busy semantics without changing analytics loading', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/onboarding/analytics/page.tsx'), 'utf8')
+
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit analytiku onboardingu', 'Refresh onboarding analytics')}")
+    expect(source).toContain('<RefreshCw size={13} aria-hidden="true"')
+    expect(source).toContain('onClick={load}')
+  })
+})


### PR DESCRIPTION
## Summary
- make the onboarding analytics refresh action an explicit non-submit button
- expose localized accessible name and busy state while preserving the existing analytics loader

## Verification
- `git diff --check` passes
- focused Vitest unavailable in the clean worktree because admin-ui dependencies are not installed

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.