### PR TITLE
fix(admin-ui): clarify SDD refresh state

### DIFF
--- a/openbank-admin-ui/src/app/sdd/page.tsx
+++ b/openbank-admin-ui/src/app/sdd/page.tsx
@@ -68,8 +68,15 @@ export default function SddPage() {
           'Read-only mandate view including the B2B confirmation queue. Lifecycle changes belong to governed flows.',
         )}
         icon={<Repeat size={20} style={{ color: 'var(--accent)' }} />}
-        actions={<button onClick={load} disabled={loading} className="btn btn-secondary btn-sm">
-          <RefreshCw size={14} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
+        actions={<button
+          onClick={load}
+          disabled={loading}
+          type="button"
+          aria-busy={loading}
+          aria-label={t('Obnovit mandáty inkas', 'Refresh direct debit mandates')}
+          className="btn btn-secondary btn-sm"
+        >
+          <RefreshCw size={14} aria-hidden="true" className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
         </button>}
       />
 

--- a/openbank-admin-ui/src/test/sdd-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/sdd-refresh.guard.test.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('SDD refresh contract', () => {
+  it('exposes localized busy semantics without changing mandate loading', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/sdd/page.tsx'), 'utf8')
+
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit mandáty inkas', 'Refresh direct debit mandates')}")
+    expect(source).toContain('<RefreshCw size={14} aria-hidden="true"')
+    expect(source).toContain('onClick={load}')
+  })
+})


### PR DESCRIPTION
## Summary
- make the direct-debit mandates refresh action an explicit non-submit button
- expose localized accessible name and busy state while preserving the existing read-only loader
- hide the decorative refresh icon from assistive technology

## Verification
- `git diff --check` passes
- focused Vitest unavailable in the clean worktree because admin-ui dependencies are not installed

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.