### PR TITLE
fix(admin-ui): clarify PID refresh state

### DIFF
--- a/openbank-admin-ui/src/app/pid/page.tsx
+++ b/openbank-admin-ui/src/app/pid/page.tsx
@@ -198,7 +198,14 @@ export default function PidPage() {
           breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">PID</span></div>}
           actions={<div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: '4px' }}>
             <div style={{ display: 'flex', gap: '8px' }}>
-              <button className="btn btn-secondary" onClick={load} disabled={loading}>
+              <button
+                className="btn btn-secondary"
+                type="button"
+                onClick={load}
+                disabled={loading}
+                aria-busy={loading}
+                aria-label={t('Obnovit PID záznamy', 'Refresh PID records')}
+              >
                 <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
                 {t('Obnovit', 'Refresh')}
               </button>

--- a/openbank-admin-ui/src/test/pid-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/pid-refresh.guard.test.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('PID refresh contract', () => {
+  it('exposes localized busy semantics without changing PID loading', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/pid/page.tsx'), 'utf8')
+
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit PID záznamy', 'Refresh PID records')}")
+    expect(source).toContain('<RefreshCw size={13} aria-hidden="true"')
+    expect(source).toContain('onClick={load}')
+  })
+})


### PR DESCRIPTION
## Summary
- make the PID records refresh action an explicit non-submit button
- expose localized accessible name and busy state while preserving the existing read-only loader

## Verification
- `git diff --check` passes
- focused Vitest unavailable in the clean worktree because admin-ui dependencies are not installed

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.