### PR TITLE
feat(observability): scrape Loki and alert when the log pipeline stops

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-log-ingestion.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-log-ingestion.yaml
@@ -1,0 +1,71 @@
+# Log-pipeline liveness (issue #6236, the tail of #5734).
+#
+# WHY THIS EXISTS. `FalcoAgentSilent` used to cover this by accident: it fired when namespace
+# `falco` produced no logs for 30m, which was also true when Alloy stopped tailing or Loki stopped
+# ingesting. #6237 removed it, because tuning Falco to zero events (#6075, #6198) made silence the
+# healthy resting state and the rule a guaranteed false positive. That fix was correct and it left
+# a real gap, recorded rather than quietly inherited: nothing alerted on the log pipeline itself.
+#
+# The gap matters because of what it hides. Every rule in loki-rules-*.yaml is a LogQL query, and a
+# query over a stream that has stopped arriving returns nothing and looks exactly like a healthy
+# estate. So a dead pipeline silently disables every log-based alert at once — the runtime-security
+# rules, the silent-failure detectors, the endpoint-availability recording rule — while every
+# dashboard stays green. This estate has already paid for that shape twice (#5733, #6032).
+#
+# Measured live 2026-08-21 before this landed: ~445 log lines/second steady-state ingest, and ZERO
+# `loki_*` series in Prometheus. The metric was always there on the pod; nothing scraped it. See
+# servicemonitor-loki.yaml.
+#
+# Picked up automatically (ruleSelectorNilUsesHelmValues=false).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-log-ingestion-alerts
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: observability
+spec:
+  groups:
+    - name: openbank.observability.log-ingestion
+      rules:
+        # Zero is used rather than a percentage drop because zero is the only threshold that needs
+        # no assumption about how chatty the estate happens to be — the assumption that made
+        # FalcoAgentSilent wrong. At ~445 lines/s steady state, a 10m window reading exactly zero
+        # is not a quiet period.
+        - alert: LokiLogIngestionStalled
+          expr: |
+            sum(rate(loki_distributor_lines_received_total[10m])) == 0
+          for: 15m
+          labels:
+            severity: critical
+            team: platform
+          annotations:
+            summary: "Loki has ingested no log lines for 10m — every log-based alert is blind"
+            description: >-
+              Loki's distributor has accepted zero log lines over 10 minutes, sustained for 15. This
+              is not one alert failing: EVERY rule in loki-rules-*.yaml is a LogQL query, so while
+              this is true they all evaluate over an empty window and report healthy. Runtime
+              security, the silent-failure detectors and endpoint availability are all dark.
+              Check the Alloy DaemonSet first (it does the tailing), then Loki's own ingester:
+              kubectl -n observability get pods -l app.kubernetes.io/name=alloy && kubectl -n observability logs loki-0 -c loki | tail
+        # The absence case, which the comparison above structurally CANNOT see: `== 0` over an
+        # absent series matches nothing, so if Loki stops exporting — pod gone, ServiceMonitor
+        # deleted, scrape failing — the stall alert reports healthy precisely when it should not.
+        # A missing series is a third state next to ingesting and stalled, and the reason this
+        # file's own subject was invisible until #6236: not zero, absent.
+        - alert: LokiMetricsAbsent
+          expr: |
+            absent(loki_distributor_lines_received_total)
+          for: 15m
+          labels:
+            severity: critical
+            team: platform
+          annotations:
+            summary: "Loki is not reporting ingestion metrics — pipeline health is unverifiable"
+            description: >-
+              No `loki_distributor_lines_received_total` series for 15 minutes. Loki is down, or its
+              scrape is broken (see servicemonitor-loki.yaml). LokiLogIngestionStalled cannot fire
+              while this is true, because a comparison over an absent series matches nothing — so
+              this is the alert that means "the log pipeline's health is unknown", which is worse
+              than knowing it is stalled.
+              Check: kubectl -n observability get pods,servicemonitor -l app.kubernetes.io/name=loki

--- a/openbank-infra/gitops/components/observability/prometheus-rules-log-ingestion.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-log-ingestion.yaml
@@ -40,6 +40,11 @@ spec:
             severity: critical
             team: platform
           annotations:
+            # Subject: real log traffic from every workload in the estate, not a scheduled job —
+            # measured at ~445 lines/second steady state on 2026-08-21. There is no invocation
+            # period for the 10m window to span, so `continuous` is the honest declaration rather
+            # than a duration invented to satisfy the gate.
+            subject_period: continuous
             summary: "Loki has ingested no log lines for 10m — every log-based alert is blind"
             description: >-
               Loki's distributor has accepted zero log lines over 10 minutes, sustained for 15. This

--- a/openbank-infra/gitops/components/observability/servicemonitor-loki.yaml
+++ b/openbank-infra/gitops/components/observability/servicemonitor-loki.yaml
@@ -1,0 +1,49 @@
+# Scrape Loki's own Prometheus metrics (issue #6236).
+#
+# WHY THIS EXISTS: Loki exported NOTHING to Prometheus — measured 2026-08-21, zero series matching
+# `loki_*` in the cluster Prometheus — because the chart's `monitoring.selfMonitoring` is disabled
+# and nothing else scraped it. So the log pipeline was the one part of the observability stack that
+# could not be observed by the observability stack, and "Alloy stopped tailing" or "Loki stopped
+# ingesting" had no signal at all. Every log-based rule in loki-rules-*.yaml would then evaluate
+# over an empty window and report healthy — the exact shape of #5733 (dead alert rules) and #6032
+# (a ruler that had never loaded a rule).
+#
+# This is a ServiceMonitor rather than `monitoring.selfMonitoring.enabled: true` deliberately: that
+# chart flag installs the Grafana Agent operator and a second collection path alongside the Alloy
+# DaemonSet this estate already runs. The metrics are already served on the existing `loki` Service
+# (port `http-metrics`:3100, verified live) — nothing needed to be turned on, only scraped.
+#
+# Selector precision matters here, because the chart ships three Services under identical
+# name/instance labels and a sloppy selector produces duplicate series:
+#   loki             http-metrics, grpc   <- the one target
+#   loki-headless    http-metrics         <- carries prometheus.io/service-monitor: "false"
+#   loki-memberlist  tcp                  <- no http-metrics port, so no endpoint matches
+# The NotIn expression honours the chart's own opt-out label rather than hard-coding a name.
+# Verified: this selector resolves to `loki` and `loki-memberlist`, and only `loki` has the port.
+#
+# The cluster Prometheus has empty ServiceMonitor selectors, so this is picked up automatically.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: loki
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: observability
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - observability
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/instance: loki
+    matchExpressions:
+      - key: prometheus.io/service-monitor
+        operator: NotIn
+        values: ["false"]
+  endpoints:
+    - port: http-metrics
+      interval: 30s
+      path: /metrics
+      honorLabels: true


### PR DESCRIPTION
## What

Loki exported **nothing** to Prometheus. This scrapes it and alerts when the log pipeline stops.

## Measured

2026-08-21, against the live cluster:

| | |
|---|---|
| `loki_*` series in Prometheus | **0** |
| log lines/second Loki was actually ingesting | **~445** |

The metric was always served on the pod. Nothing scraped it. So the log pipeline was the one part of the observability stack that the observability stack could not see.

## Why the gap matters

Every rule in `loki-rules-*.yaml` is a LogQL query, and a query over a stream that has stopped arriving returns nothing — which looks exactly like a healthy estate. A dead pipeline therefore disables **every log-based alert at once**: runtime security, the silent-failure detectors, endpoint availability. Dashboards stay green throughout.

This estate has paid for that shape twice already (#5733 dead alert rules, #6032 a ruler that had never loaded a rule).

`FalcoAgentSilent` used to cover this **by accident**, until #6237 removed it — tuning Falco to zero events made silence the healthy resting state and that rule a guaranteed false positive. Removing it was right, and it left this gap, which was filed as #6236 rather than quietly inherited.

## A ServiceMonitor, not `selfMonitoring.enabled`

That chart flag installs the Grafana Agent operator and a second collection path beside the Alloy DaemonSet already running here. Nothing needed turning on — only scraping.

Selector precision is load-bearing: the chart ships three Services under identical name/instance labels.

```
loki             http-metrics, grpc   <- the one target
loki-headless    http-metrics         <- carries prometheus.io/service-monitor: "false"
loki-memberlist  tcp                  <- no http-metrics port, no endpoint matches
```

The `NotIn` expression honours the chart's own opt-out label instead of hard-coding a name. Verified against the live cluster: resolves to exactly one scrape target.

## Why zero, and why the second rule is not padding

Zero is the threshold rather than a percentage drop because zero needs **no assumption about how chatty the estate happens to be** — and that assumption is exactly what made `FalcoAgentSilent` wrong.

The paired `absent()` rule earns its place, evaluated against live Prometheus **before** this lands:

```
loki_distributor_lines_received_total                  -> 0 series
sum(rate(loki_distributor_lines_received_total[10m])) == 0  -> 0 series   <- CANNOT fire
absent(loki_distributor_lines_received_total)          -> 1 series   <- correctly true
```

The stall alert is structurally incapable of reporting the case where Loki stops exporting altogether — a comparison over an absent series matches nothing. That is precisely the state this issue was filed about, so it needs its own rule. A missing series is a third state next to ingesting and stalled.

After this deploys the pair should flip: metric present, both alerts quiet. That is the verification, and it will be run.

`promtool check rules` passes.

## Not in scope

The issue's third suggestion — enabling `falco_*` metrics — is a change to a different app with its own risk, and `FalcoAgentNotReady` (#6237) covers agent liveness meanwhile. Left for a separate PR rather than bundled.

## Linked issues

Closes #6236
