### PR TITLE
fix(admin-ui): clarify SWIFT refresh state

### DIFF
--- a/openbank-admin-ui/src/app/swift/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/swift/[id]/page.tsx
@@ -75,7 +75,14 @@ export default function SwiftDetailPage() {
         actions={<div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
           {message?.status && <span className="pill" style={{ background: `${STATUS_COLOR[message.status] ?? 'var(--text-muted)'}22`, color: STATUS_COLOR[message.status] ?? 'var(--text-muted)' }}>{message.status}</span>}
           <Link href="/swift" className="btn btn-secondary"><ArrowLeft size={13} aria-hidden="true" /> {t('Zpět', 'Back')}</Link>
-          <button className="btn btn-secondary" onClick={load} disabled={loading}>
+          <button
+            className="btn btn-secondary"
+            type="button"
+            onClick={load}
+            disabled={loading}
+            aria-busy={loading}
+            aria-label={t('Obnovit SWIFT zprávu', 'Refresh SWIFT message')}
+          >
             <RefreshCw size={13} aria-hidden="true" className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
           </button>
         </div>}

--- a/openbank-admin-ui/src/test/swift-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/swift-refresh.guard.test.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('SWIFT detail refresh contract', () => {
+  it('exposes localized busy semantics without changing message loading', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/swift/[id]/page.tsx'), 'utf8')
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit SWIFT zprávu', 'Refresh SWIFT message')}")
+    expect(source).toContain('<RefreshCw size={13} aria-hidden="true"')
+    expect(source).toContain('onClick={load}')
+  })
+})


### PR DESCRIPTION
## Summary
- make the SWIFT detail refresh action an explicit non-submit button
- expose localized accessible name and busy state while preserving the existing message loader

## Verification
- `git diff --check` passes
- focused Vitest unavailable in the clean worktree because admin-ui dependencies are not installed

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.