### PR TITLE
feat(falco): export Falco's own metrics to Prometheus

### DIFF
--- a/openbank-infra/gitops/apps/falco.yaml
+++ b/openbank-infra/gitops/apps/falco.yaml
@@ -382,6 +382,45 @@ spec:
         falcosidekick:
           enabled: false
 
+        # Falco's own Prometheus metrics (issue #6236, follow-up to #6237).
+        #
+        # Before this, Prometheus held ZERO `falco_*` series — measured 2026-08-21 — so the only
+        # thing the estate knew about the runtime-security agent was whether its pods were Ready.
+        # `FalcoAgentNotReady` (prometheus-rules-runtime-security.yaml) is built on exactly that
+        # DaemonSet-readiness proxy, and it was chosen because it was the only observable available,
+        # not because it was the best one. A Ready pod with a ruleset that failed to load, or one
+        # dropping syscalls, is indistinguishable from a healthy one through that proxy.
+        #
+        # `metrics.enabled` is the only switch needed: the chart derives
+        # `webserver.prometheus_metrics_enabled` from it (verified by rendering 9.1.0 — the
+        # rendered falco.yaml carries `prometheus_metrics_enabled: true`). Two separate keys that
+        # must agree is the shape that produces a configured-looking, inert feature, so it is worth
+        # stating that the chart, not this file, keeps them in step.
+        metrics:
+          enabled: true
+          # THE DEFAULT IS 1h AND WOULD HAVE MADE THIS INERT-LOOKING-BUT-STALE. `interval` is how
+          # often Falco RECOMPUTES its metrics snapshot, not how often Prometheus reads it. Left at
+          # the chart default, a 30s scrape would return the same hour-old numbers 120 times, every
+          # gauge lagging reality by up to an hour — and nothing would look broken. This estate has
+          # already shipped that exact defect once, in the LLM price book recording rules, where an
+          # `interval: 1h` rule was resolvable for 5 minutes in every 60 against Prometheus's 5m
+          # lookback (#6063 merged inert, fixed by #6151).
+          interval: 1m
+          # Per-CPU kernel counters multiply every counter by the core count on every node. Left off
+          # (the chart default) deliberately: 13 nodes is already the multiplier that matters, and
+          # per-rule counters below are the signal worth paying for.
+          kernelEventCountersPerCPUEnabled: false
+
+        serviceMonitor:
+          create: true
+          # 30s against a 1m recompute rather than the chart's 15s: scraping four times per refresh
+          # buys nothing but samples, and scraping exactly once per refresh risks aliasing past an
+          # update. The Service and the `type: falco-metrics` label the selector needs are both
+          # created by the chart when metrics.enabled is set.
+          interval: 30s
+          labels:
+            release: kube-prometheus-stack
+
         # Node-agent priority (same class as CNI/kube-proxy): sandbox nodes
         # run at the max-pods (ENI IP) limit, where a default-priority DS pod
         # finds "Too many pods" and no preemption victim — the security agent


### PR DESCRIPTION
## What

Prometheus held **zero `falco_*` series**. This turns Falco's own metrics on and scrapes them.

## Why it matters

The only thing this estate knew about the runtime-security agent was whether its pods were Ready. `FalcoAgentNotReady` (#6237) is built on exactly that DaemonSet-readiness proxy — and it was chosen because it was the only observable available, not because it was the best one.

Through that proxy, a Ready pod whose ruleset failed to load, or one silently dropping syscalls, is indistinguishable from a healthy one.

## One switch, and the chart keeps the second in step

`metrics.enabled` is all that is needed: the chart derives `webserver.prometheus_metrics_enabled` from it. Verified by rendering 9.1.0 — the emitted `falco.yaml` carries `prometheus_metrics_enabled: true`.

Two keys that must agree is precisely the shape that produces a configured-looking, inert feature, so the comment records that the **chart** keeps them in step, not this file.

## The interval is the substance, not a detail

`metrics.interval` is how often Falco **recomputes** its snapshot — not how often Prometheus reads it. Left at the chart default of **1h**, a 30s scrape returns the same hour-old numbers 120 times, every gauge lagging reality by up to an hour, and **nothing looks broken**.

This estate has already shipped that exact defect once: the LLM price-book recording rules merged with `interval: 1h` against Prometheus's 5m lookback, resolvable for 5 minutes in every 60 (#6063 merged inert, fixed by #6151).

Set to `1m`, with the ServiceMonitor at `30s` — scraping four times per refresh (the chart's 15s) buys nothing but samples, and scraping exactly once per refresh risks aliasing past an update.

Per-CPU kernel counters stay off: 13 nodes is already the multiplier that matters.

## Verified by rendering, with a control

With the committed values:

```
prometheus_metrics_enabled : True
metrics.enabled / interval : True / 1m
per-CPU counters           : False
metrics Service            : falco-metrics [('metrics', 8765)]  (carries type: falco-metrics)
ServiceMonitor             : falco, interval 30s, release: kube-prometheus-stack
  selector matches the Service's type label
```

Control render with the block removed:

```
prometheus_metrics_enabled : False
metrics section            : ABSENT
metrics Service            : NONE
ServiceMonitor             : NONE
```

So the change is what produces them — not a chart default that happened to agree.

## Deliberately no alerts here

A metric name is an unverified claim about someone else's build until it is observed. The series will be read off the running agent first, and alerts written against what is actually there — rather than guessing names now and shipping rules that match nothing, which is the failure #5733 was about.

## Linked issues

Refs #6236
