### PR TITLE
fix(admin-ui): clarify observability refresh

### DIFF
--- a/openbank-admin-ui/src/app/observability/page.tsx
+++ b/openbank-admin-ui/src/app/observability/page.tsx
@@ -158,8 +158,9 @@ export default function ObservabilityPage() {
             <GitBranch size={13} />
             {t('Trace Explorer', 'Trace Explorer')}
           </Link>
-          <button onClick={load} disabled={loading} className="btn btn-secondary btn-sm">
-            <RefreshCw size={13} style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
+          <button onClick={load} disabled={loading} type="button" aria-busy={loading}
+            aria-label={t('Obnovit observabilitu', 'Refresh observability')} className="btn btn-secondary btn-sm">
+            <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
         </div>

--- a/openbank-admin-ui/src/test/observability-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/observability-refresh.guard.test.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('Observability refresh contract', () => {
+  it('exposes localized busy semantics without changing metrics loading', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/observability/page.tsx'), 'utf8')
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit observabilitu', 'Refresh observability')}")
+    expect(source).toContain('<RefreshCw size={13} aria-hidden="true"')
+    expect(source).toContain('onClick={load}')
+  })
+})


### PR DESCRIPTION
## Summary
- make the Observability refresh action an explicit non-submit button
- expose localized accessible name and busy state while preserving metrics loading

## Verification
- `git diff --check` passes
- focused Vitest unavailable in the clean worktree because admin-ui dependencies are not installed

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.