### PR TITLE
fix(admin-ui): clarify parties refresh state

### DIFF
--- a/openbank-admin-ui/src/app/parties/page.tsx
+++ b/openbank-admin-ui/src/app/parties/page.tsx
@@ -153,7 +153,8 @@ export default function PartiesPage() {
         subtitle={t('Zákazníci a společnosti registrované v platformě', 'Customers and companies registered in the platform')}
         breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Subjekty', 'Parties')}</span></div>}
         actions={<div style={{ display: 'flex', gap: '8px' }}>
-          <button className="btn btn-secondary" onClick={load} disabled={loading || inSearchMode}>
+          <button className="btn btn-secondary" type="button" onClick={load} disabled={loading || inSearchMode}
+            aria-busy={loading} aria-label={t('Obnovit subjekty', 'Refresh parties')}>
             <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>

--- a/openbank-admin-ui/src/test/parties-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/parties-refresh.guard.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('Parties refresh contract', () => {
+  it('exposes localized busy semantics without changing party loading', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/parties/page.tsx'), 'utf8')
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading || inSearchMode}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit subjekty', 'Refresh parties')}")
+    expect(source).toContain('onClick={load}')
+  })
+})


### PR DESCRIPTION
## Summary
- make the Parties refresh action an explicit non-submit button
- expose localized accessible name and busy state while preserving search-mode behavior

## Verification
- `git diff --check` passes
- focused Vitest unavailable in the clean worktree because admin-ui dependencies are not installed

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.