### PR TITLE
fix(admin-ui): name approval queue refresh

### DIFF
--- a/openbank-admin-ui/src/app/approvals/page.tsx
+++ b/openbank-admin-ui/src/app/approvals/page.tsx
@@ -127,7 +127,8 @@ export default function ApprovalsPage() {
         icon={<ClipboardCheck size={18} aria-hidden="true" />}
         title={t('Fronta schvalování (AI agent)', 'Approval queue (AI agent)')}
         subtitle={t('Agent navrhuje, governance rozhoduje (ADR-0031 D4). Návrhy nemají žádný efekt, dokud je člověk neschválí. Schválení musí udělat někdo jiný než autor.', 'Agents propose, governance disposes (ADR-0031 D4). Proposals have no effect until a human approves them. The approver must differ from the author.')}
-        actions={<button type="button" onClick={load} disabled={loading} aria-busy={loading} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
+        actions={<button type="button" onClick={load} disabled={loading} aria-busy={loading}
+          aria-label={t('Obnovit schvalovací frontu', 'Refresh approval queue')} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
           <RefreshCw aria-hidden="true" size={14} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
         </button>}
       />

--- a/openbank-admin-ui/src/test/approvals-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/approvals-refresh.guard.test.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('Approval queue refresh contract', () => {
+  it('exposes a localized refresh name without changing approval loading', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/approvals/page.tsx'), 'utf8')
+    expect(source).toContain("aria-label={t('Obnovit schvalovací frontu', 'Refresh approval queue')}")
+    expect(source).toContain('onClick={load}')
+    expect(source).toContain('aria-busy={loading}')
+  })
+})


### PR DESCRIPTION
## Summary
- give the Approval Inbox refresh control a localized accessible name
- preserve existing type, busy, disabled, loader, and maker-checker flows

## Verification
- `git diff --check` passes
- focused Vitest unavailable in the clean worktree because admin-ui dependencies are not installed

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.