### PR TITLE
fix(admin-ui): clarify lending refresh state

### DIFF
--- a/openbank-admin-ui/src/app/lending/page.tsx
+++ b/openbank-admin-ui/src/app/lending/page.tsx
@@ -198,8 +198,9 @@ export default function LendingPage() {
         )}
         icon={<TrendingUp size={18} style={{ color: 'var(--accent)' }} />}
         actions={
-          <button onClick={load} disabled={loading} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
-            <RefreshCw size={14} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
+          <button onClick={load} disabled={loading} type="button" aria-busy={loading}
+            aria-label={t('Obnovit lending', 'Refresh lending')} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
+            <RefreshCw size={14} aria-hidden="true" className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
           </button>
         }
       />

--- a/openbank-admin-ui/src/test/lending-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/lending-refresh.guard.test.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('Lending refresh contract', () => {
+  it('exposes localized busy semantics without changing lending loading', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/lending/page.tsx'), 'utf8')
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit lending', 'Refresh lending')}")
+    expect(source).toContain('<RefreshCw size={14} aria-hidden="true"')
+    expect(source).toContain('onClick={load}')
+  })
+})


### PR DESCRIPTION
## Summary
- make the Lending refresh action an explicit non-submit button
- expose localized accessible name and busy state while preserving lending loading

## Verification
- `git diff --check` passes
- focused Vitest unavailable in the clean worktree because admin-ui dependencies are not installed

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.