### PR TITLE
fix(admin-ui): name system tests refresh

### DIFF
--- a/openbank-admin-ui/src/app/system/tests/page.tsx
+++ b/openbank-admin-ui/src/app/system/tests/page.tsx
@@ -587,7 +587,8 @@ export default function TestCoveragePage() {
               {t('Aktualizováno', 'Updated')} {lastRefresh.toLocaleTimeString(dateLocale)}
             </span>
           )}
-          <button type="button" onClick={load} disabled={testLoading || qualityLoading} aria-busy={testLoading || qualityLoading} className="btn btn-secondary btn-sm">
+          <button type="button" onClick={load} disabled={testLoading || qualityLoading} aria-busy={testLoading || qualityLoading}
+            aria-label={t('Obnovit systémové testy', 'Refresh system tests')} className="btn btn-secondary btn-sm">
             <RefreshCw size={13} aria-hidden="true" style={{ animation: (testLoading || qualityLoading) ? 'spin 0.8s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>

--- a/openbank-admin-ui/src/test/system-tests-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/system-tests-refresh.guard.test.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('System tests refresh contract', () => {
+  it('exposes a localized refresh name without changing test loading', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/system/tests/page.tsx'), 'utf8')
+    expect(source).toContain("aria-label={t('Obnovit systémové testy', 'Refresh system tests')}")
+    expect(source).toContain('onClick={load}')
+    expect(source).toContain('aria-busy={testLoading || qualityLoading}')
+  })
+})


### PR DESCRIPTION
## Summary
- give the System Tests refresh control a localized accessible name
- preserve existing type, busy, disabled, loaders, and system test flows

## Verification
- `git diff --check` passes
- focused Vitest unavailable in the clean worktree because admin-ui dependencies are not installed

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.