### PR TITLE
fix(admin-ui): clarify template refresh state

### DIFF
--- a/openbank-admin-ui/src/app/document-templates/page.tsx
+++ b/openbank-admin-ui/src/app/document-templates/page.tsx
@@ -452,8 +452,9 @@ export default function DocumentTemplatesPage() {
                 <Plus size={14} /> {t('Nová šablona', 'New Template')}
               </button>
             )}
-            <button className="btn btn-secondary" onClick={load} disabled={loading}>
-              <RefreshCw size={13} style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
+            <button className="btn btn-secondary" type="button" onClick={load} disabled={loading}
+              aria-busy={loading} aria-label={t('Obnovit šablony dokumentů', 'Refresh document templates')}>
+              <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
               {t('Obnovit', 'Refresh')}
             </button>
           </div>} />

--- a/openbank-admin-ui/src/test/document-templates-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/document-templates-refresh.guard.test.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('Document templates refresh contract', () => {
+  it('exposes localized busy semantics without changing template loading', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/document-templates/page.tsx'), 'utf8')
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit šablony dokumentů', 'Refresh document templates')}")
+    expect(source).toContain('<RefreshCw size={13} aria-hidden="true"')
+    expect(source).toContain('onClick={load}')
+  })
+})


### PR DESCRIPTION
## Summary
- make the Document Templates refresh action an explicit non-submit button
- expose localized accessible name and busy state while preserving BFF and maker-checker flows

## Verification
- `git diff --check` passes
- focused Vitest unavailable in the clean worktree because admin-ui dependencies are not installed

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.