### PR TITLE
fix(admin-ui): clarify catalog refresh state

### DIFF
--- a/openbank-admin-ui/src/app/product-catalog/page.tsx
+++ b/openbank-admin-ui/src/app/product-catalog/page.tsx
@@ -569,7 +569,8 @@ export default function ProductCatalogPage() {
               <button className="btn btn-primary" onClick={openCreateModal} disabled={loading}>
                 <Plus size={14} aria-hidden="true" /> {t('Nový produkt', 'New Product')}
               </button>
-              <button className="btn btn-secondary" onClick={load} disabled={loading}>
+              <button className="btn btn-secondary" type="button" onClick={load} disabled={loading}
+                aria-busy={loading} aria-label={t('Obnovit katalog produktů', 'Refresh product catalog')}>
                 <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
                 {t('Obnovit', 'Refresh')}
               </button>

--- a/openbank-admin-ui/src/test/product-catalog-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/product-catalog-refresh.guard.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('Product catalog refresh contract', () => {
+  it('exposes localized busy semantics without changing catalog loading', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/product-catalog/page.tsx'), 'utf8')
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit katalog produktů', 'Refresh product catalog')}")
+    expect(source).toContain('onClick={load}')
+  })
+})


### PR DESCRIPTION
## Summary
- make the Product Catalog refresh action an explicit non-submit button
- expose localized accessible name and busy state while preserving catalog BFF/lifecycle flows

## Verification
- `git diff --check` passes
- focused Vitest unavailable in the clean worktree because admin-ui dependencies are not installed

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.