### PR TITLE
fix(admin-ui): clarify onboarding refresh state

### DIFF
--- a/openbank-admin-ui/src/app/onboarding/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/page.tsx
@@ -172,8 +172,9 @@ export default function OnboardingPage() {
             <TrendingUp size={13} style={{ color: 'var(--accent)' }} />
             {t('Konverze', 'Conversion')}
           </Link>
-          <button className="btn btn-secondary" onClick={refresh} disabled={loading}>
-            <RefreshCw size={13} style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
+          <button className="btn btn-secondary" type="button" onClick={refresh} disabled={loading}
+            aria-busy={loading} aria-label={t('Obnovit onboarding', 'Refresh onboarding')}>
+            <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
         </div>}

--- a/openbank-admin-ui/src/test/onboarding-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/onboarding-refresh.guard.test.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('Onboarding refresh contract', () => {
+  it('exposes localized busy semantics without changing onboarding loading', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/onboarding/page.tsx'), 'utf8')
+    expect(source).toContain('type="button"')
+    expect(source).toContain('disabled={loading}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit onboarding', 'Refresh onboarding')}")
+    expect(source).toContain('<RefreshCw size={13} aria-hidden="true"')
+    expect(source).toContain('onClick={refresh}')
+  })
+})


### PR DESCRIPTION
## Summary
- make the Onboarding refresh action an explicit non-submit button
- expose localized accessible name and busy state while preserving onboarding fetches and actions

## Verification
- `git diff --check` passes
- focused Vitest unavailable in the clean worktree because admin-ui dependencies are not installed

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.