### PR TITLE
feat(lending): ADR-0269 rule 5 — four-pillar financial health, assembled server-side

### DIFF
--- a/docs/threat-models/openbank-lending-service.md
+++ b/docs/threat-models/openbank-lending-service.md
@@ -442,7 +442,26 @@ unknown, because permanent `complete = false` would suppress every offer forever
 indistinguishable from the feature being switched off. This is the first thing an operational-risk
 review of this gate should challenge.
 
+## 9c. Customer financial health (ADR-0269 rule 5) — STRIDE supplement
+
+`GET /api/v1/lending/intake/financial-health` — a third read on the section 9 trust boundary, with
+the same caller and party-header controls. It composes the ADR-0269 credit profile with the loan
+book, so it concentrates in one response things that until now lived in separate services.
+
+| Threat | Scenario | Mitigation |
+|---|---|---|
+| **I**nformation disclosure | The route becomes a convenient summary of another customer's finances | Party comes only from the header the edge sets from the JWT; the loan read and the profile read are both scoped by it. Same 403/400 split as section 9a — an authorised caller with no scope is a bad request, not a forbidden one. |
+| **I**nformation disclosure | The view leaks the bank's assessment of the customer | It carries zones and the working behind them, never a score, a rating, an eligibility or a reason code. The credit decision remains the ADR-0213 engine's and is not reachable from here. |
+| **T**ampering / misleading | An unavailable upstream produces a flattering view | Every pillar can answer UNKNOWN and does so independently: a failed profile read greys out cashflow and obligations while the loan-derived pillars stand. Nothing is approximated — in particular the reserve is left UNKNOWN rather than inferred from unspent cashflow, which would show a customer a buffer they do not have. |
+| **T**ampering / misleading | No live loans reads as a healthy debt ratio | An empty loan book gives debt service 0; an *unreadable* one gives null, and null makes the obligations pillar UNKNOWN. The two are not collapsed, because only one of them means "this customer has no debts". |
+| **D**oS | The route fans out to two upstreams per call | Both reads are best-effort with the service's existing timeouts; a slow upstream costs a greyed-out pillar, never a hung request. |
+
 ## 10. Change log
+
+- **2026-08-21** — Trust-boundary change (ADR-0269 rule 5): `GET /api/v1/lending/intake/financial-health`,
+  a customer-facing read that composes the credit profile with the loan book. See section 9c. No
+  score and no eligibility; every pillar degrades to UNKNOWN independently, and an unreadable loan
+  book is deliberately distinguished from a customer with no loans.
 
 - **2026-08-21** — Trust-boundary change (ADR-0269 slice 3, #6215): two new outbound client edges
   from the credit-offer gate — consent-service (`CREDIT_OFFERS`) and analytics-sink (the 360 credit

--- a/openbank-analytics-sink/src/main/resources/clickhouse/V10__credit_funnel.sql
+++ b/openbank-analytics-sink/src/main/resources/clickhouse/V10__credit_funnel.sql
@@ -1,0 +1,51 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+-- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+--
+-- The ADR-0269 credit-journey funnel (rule 8's metrics).
+--
+-- WHAT THIS DELIBERATELY CANNOT ANSWER: "how many customers converted". There is no conversion
+-- event upstream and there is no acceptance column here. The programme's metrics are
+-- self-activation, opt-out-within-30-days, affordability declines, delinquency, and offers shown
+-- without a prior customer action — a funnel built to optimise acceptance would quietly become the
+-- thing ADR-0269 exists to prevent.
+--
+-- WHY A SEPARATE STREAM from the onboarding funnel: that one is an anonymous public write. These
+-- events say "this person is looking at borrowing", so they ride an authenticated topic keyed by
+-- party. The two must not be unioned into one view, or the anonymous stream's trust level would
+-- silently become the credit stream's.
+
+CREATE OR REPLACE VIEW openbank_analytics.gold_credit_funnel_events AS
+SELECT
+    JSONExtractString(payload, 'partyId') AS party_id,
+    JSONExtractString(payload, 'step')    AS step,
+    JSONExtractString(payload, 'action')  AS action,
+    occurred_at
+FROM openbank_analytics.bronze_events
+WHERE upper(aggregate_type) = 'CREDIT_FUNNEL'
+  AND JSONExtractString(payload, 'partyId') != '';
+
+-- Self-activation, the headline number: of the people who ever opened the consent screen, how many
+-- switched offers ON themselves. Deliberately NOT "how many were offered credit".
+CREATE OR REPLACE VIEW openbank_analytics.gold_credit_consent_activation AS
+SELECT
+    toStartOfDay(occurred_at)                                        AS day,
+    countIf(action = 'VIEWED' AND step = 'CONSENT')                  AS consent_screen_views,
+    countIf(action = 'CONSENT_GRANTED')                              AS granted,
+    countIf(action = 'CONSENT_WITHDRAWN')                            AS withdrawn,
+    uniqExactIf(party_id, action = 'CONSENT_GRANTED')                AS parties_granted,
+    uniqExactIf(party_id, action = 'CONSENT_WITHDRAWN')              AS parties_withdrawn
+FROM openbank_analytics.gold_credit_funnel_events
+GROUP BY day;
+
+-- Pricing outcomes. QUOTE_SUPPRESSED is tracked as prominently as QUOTE_REQUESTED on purpose: the
+-- distress floor refusing to price is a thing the bank must be able to SEE, not a silent branch.
+CREATE OR REPLACE VIEW openbank_analytics.gold_credit_quote_outcomes AS
+SELECT
+    toStartOfDay(occurred_at)                        AS day,
+    countIf(action = 'QUOTE_REQUESTED')              AS requested,
+    countIf(action = 'QUOTE_SUPPRESSED')             AS suppressed,
+    countIf(action = 'APPLICATION_STARTED')          AS applications_started,
+    countIf(action = 'APPLICATION_ABANDONED')        AS applications_abandoned
+FROM openbank_analytics.gold_credit_funnel_events
+GROUP BY day;

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/credit/CreditFunnelPublisher.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/credit/CreditFunnelPublisher.kt
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge.infrastructure.credit
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import io.micrometer.core.instrument.MeterRegistry
+import io.quarkus.logging.Log
+import io.smallrye.reactive.messaging.kafka.Record
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.reactive.messaging.Channel
+import org.eclipse.microprofile.reactive.messaging.Emitter
+import org.eclipse.microprofile.reactive.messaging.OnOverflow
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Credit-journey funnel telemetry (ADR-0269 rule 8's metrics).
+ *
+ * ## Why this is NOT the onboarding funnel channel
+ *
+ * The onboarding funnel is an ANONYMOUS, publicly postable stream: anyone can write to it, which is
+ * exactly why its allow-lists are closed and its key is a client-generated session id. That design
+ * is right for steps that happen before a session exists.
+ *
+ * Credit steps happen inside an authenticated session, and what they say is "this person is looking
+ * at borrowing money". Posting that through an unauthenticated endpoint would be a leak channel
+ * rather than instrumentation: an attacker could both inject junk about a party and — with a public
+ * endpoint that accepted a party id — probe it. So this is a separate stream on a separate topic,
+ * written only from an authenticated request, keyed by the party the JWT already proved.
+ *
+ * ## What it deliberately does not measure
+ *
+ * There is no conversion event here and no "offer accepted". The programme's metrics are
+ * self-activation, opt-out-within-30-days, affordability declines, delinquency, and offers shown
+ * without a prior customer action. A funnel built to optimise acceptance would quietly become the
+ * thing ADR-0269 exists to prevent, so the vocabulary below simply does not contain the word.
+ *
+ * Best-effort, like every other telemetry path here: a Kafka outage degrades to an ERROR log, never
+ * a 5xx. Telemetry must not break the screen it is watching.
+ */
+@ApplicationScoped
+class CreditFunnelPublisher(
+    private val objectMapper: ObjectMapper,
+    @Channel("credit-funnel-out")
+    @OnOverflow(value = OnOverflow.Strategy.BUFFER, bufferSize = BUFFER_SIZE)
+    private val emitter: Emitter<Record<String, String>>,
+    private val clock: Clock,
+    private val meterRegistry: MeterRegistry,
+) {
+
+    // catch-all IS the contract: funnel telemetry never breaks the customer's screen.
+    @Suppress("TooGenericExceptionCaught")
+    fun emit(partyId: UUID, step: String, action: String) {
+        try {
+            // Low-cardinality by construction: both values come from the closed allow-lists the
+            // resource validates before this is reached, so no caller can inflate the label space.
+            meterRegistry.counter("credit_funnel_events", "step", step, "action", action).increment()
+
+            val payload = objectMapper.createObjectNode()
+            payload.put("partyId", partyId.toString())
+            payload.put("step", step)
+            payload.put("action", action)
+
+            val node = objectMapper.createObjectNode()
+            node.put("eventType", EVENT_TYPE)
+            node.put("aggregateType", AGGREGATE_TYPE)
+            // Keyed by party, unlike onboarding: the session here IS the authenticated customer, and
+            // the questions this answers ("did they come back after switching offers on") span
+            // sessions. It is the same pseudonymous id the silver layer already holds — no PII.
+            node.put("aggregateId", partyId.toString())
+            node.put("sourceService", "customer-edge")
+            node.put("schemaVersion", 1)
+            node.put("occurredAt", Instant.now(clock).toString())
+            node.set<ObjectNode>("payload", payload)
+
+            emitter.send(Record.of(partyId.toString(), objectMapper.writeValueAsString(node)))
+                .whenComplete { _, err ->
+                    if (err != null) Log.error("credit funnel emit failed for $step/$action: ${err.message}")
+                }
+        } catch (e: Exception) {
+            Log.error("credit funnel emit failed for $step/$action: ${e.message}", e)
+        }
+    }
+
+    companion object {
+        const val EVENT_TYPE = "credit.funnel.step"
+        const val AGGREGATE_TYPE = "CREDIT_FUNNEL"
+
+        /**
+         * Closed allow-lists. Same discipline as the onboarding funnel and for an additional reason
+         * here: these values are labels on a Prometheus counter, so an open vocabulary would let a
+         * client take the metrics store down.
+         */
+        val VALID_STEPS = setOf("CONSENT", "HEALTH", "FINANCING", "QUOTE", "APPLICATION")
+
+        /**
+         * Note what is absent: no CONVERTED, no ACCEPTED, no SOLD. The programme measures whether
+         * customers switch offers on themselves and whether they switch them back off — not how
+         * many of them borrowed. A vocabulary that could express conversion is a vocabulary someone
+         * will eventually optimise.
+         */
+        val VALID_ACTIONS = setOf(
+            "VIEWED",
+            "CONSENT_GRANTED",
+            "CONSENT_WITHDRAWN",
+            "QUOTE_REQUESTED",
+            "QUOTE_SUPPRESSED",
+            "APPLICATION_STARTED",
+            "APPLICATION_ABANDONED",
+        )
+    }
+}
+
+private const val BUFFER_SIZE = 2048L

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -527,6 +527,31 @@ class CustomerEdgeResource(
     }
 
     /**
+     * The caller's own four-pillar financial health (ADR-0269 / APP-ADR-0001 rule 5).
+     *
+     * Assembled by lending-service, which already reaches the credit profile and the loan book;
+     * this route only scopes it to the caller. No score, no rating, no eligibility — and no path
+     * into a credit decision.
+     *
+     * Fail-soft to an empty list. An unreachable upstream means the app shows no pillars rather
+     * than four invented ones, and each pillar can independently answer UNKNOWN, so a partial
+     * answer is the normal case rather than an error.
+     */
+    @GET
+    @Path("/financial-health")
+    @Authorize(action = "customer.profile.read", resource = "")
+    @Blocking
+    fun getFinancialHealth(): Response {
+        val customer = customer()
+        val resp = upstream.get(
+            "$lendingServiceUrl/api/v1/lending/intake/financial-health",
+            customer.partyId.toString(),
+        )
+        if (resp.status != 200) return Response.ok("[]").type(MediaType.APPLICATION_JSON).build()
+        return Response.ok(resp.entity ?: "[]").type(MediaType.APPLICATION_JSON).build()
+    }
+
+    /**
      * An indicative, non-binding price for an amount and term (ADR-0269 rule 4).
      *
      * The ONLY route by which the app may learn what a loan costs. The client computes no price:

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.openbank.customeredge.domain.model.CustomerIdentity
 import com.openbank.customeredge.infrastructure.audit.EdgeAuditPublisher
 import com.openbank.customeredge.infrastructure.cnb.CnbBanksClient
+import com.openbank.customeredge.infrastructure.credit.CreditFunnelPublisher
 import com.openbank.customeredge.infrastructure.onboarding.PendingOnboarding
 import com.openbank.customeredge.infrastructure.onboarding.PendingOnboardingStore
 import com.openbank.libs.authz.Authorize
@@ -107,6 +108,9 @@ class CustomerEdgeResource(
     // detekt tolerates here and every test constructs this resource positionally.
     @Inject
     lateinit var partyMergeResolver: PartyMergeResolver
+
+    @Inject
+    lateinit var creditFunnel: com.openbank.customeredge.infrastructure.credit.CreditFunnelPublisher
 
     @ConfigProperty(name = "openbank.edge.account-service-url")
     lateinit var accountServiceUrl: String
@@ -524,6 +528,32 @@ class CustomerEdgeResource(
             .entity(resp.entity ?: "{}")
             .type(MediaType.APPLICATION_JSON)
             .build()
+    }
+
+    /**
+     * One credit-journey funnel event (ADR-0269 rule 8's metrics).
+     *
+     * Authenticated on purpose — see [CreditFunnelPublisher] for why this is not the onboarding
+     * funnel's public endpoint. The party is taken from the JWT and never from the body, so a
+     * caller can only ever describe their own journey.
+     *
+     * Always 202, even for a rejected value: telemetry must not teach a client anything, and a 400
+     * here would turn the allow-list into an oracle for what the bank tracks. Rejected values are
+     * counted, not answered.
+     */
+    @POST
+    @Path("/credit/events")
+    @Authorize(action = "customer.profile.read", resource = "")
+    @Blocking
+    fun trackCreditEvent(body: String): Response {
+        val customer = customer()
+        val node = runCatching { objectMapper.readTree(body) }.getOrNull() as? ObjectNode
+        val step = node?.get("step")?.asText()
+        val action = node?.get("action")?.asText()
+        if (step in CreditFunnelPublisher.VALID_STEPS && action in CreditFunnelPublisher.VALID_ACTIONS) {
+            creditFunnel.emit(customer.partyId, step!!, action!!)
+        }
+        return Response.accepted().build()
     }
 
     /**

--- a/openbank-customer-edge/src/main/resources/application.yaml
+++ b/openbank-customer-edge/src/main/resources/application.yaml
@@ -60,6 +60,15 @@ mp:
         topic: openbank.onboarding.funnel.events
         key.serializer: org.apache.kafka.common.serialization.StringSerializer
         value.serializer: org.apache.kafka.common.serialization.StringSerializer
+      # Credit-journey funnel telemetry (ADR-0269 rule 8) -> analytics-sink -> ClickHouse. A
+      # SEPARATE topic from the onboarding funnel on purpose: that one is an anonymous public write,
+      # this one is authenticated and keyed by party, and mixing them would put credit-interest
+      # signals on a stream anyone can post to.
+      credit-funnel-out:
+        connector: smallrye-kafka
+        topic: openbank.credit.funnel.events
+        key.serializer: org.apache.kafka.common.serialization.StringSerializer
+        value.serializer: org.apache.kafka.common.serialization.StringSerializer
       # In-app screen feedback (ADR-0192) -> analytics-sink -> ClickHouse. Metadata + the
       # screenshot's object-store key only; the PNG itself never enters Kafka (FeedbackPublisher).
       feedback-out:

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.45.0
+  version: 1.46.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -1114,6 +1114,40 @@ paths:
               schema:
                 type: array
                 items: {$ref: '#/components/schemas/HealthPillar'}
+
+  /credit/events:
+    post:
+      tags: [Lending]
+      summary: One credit-journey funnel event
+      description: >-
+        ADR-0269 rule 8's metrics. AUTHENTICATED, unlike the onboarding funnel's public endpoint —
+        these events say "this person is looking at borrowing", which must not ride a stream anyone
+        can post to. The party comes from the JWT and a partyId in the body is ignored.
+
+        Always 202, including for a value outside the allow-list: a 400 would make the allow-list an
+        oracle for what the bank tracks, and telemetry has no business teaching a client anything.
+
+        The action vocabulary deliberately cannot express a conversion. The programme measures
+        self-activation and opt-out, not how many customers borrowed.
+      operationId: trackCreditEvent
+      security:
+        - customerOidc: [accounts:read]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [step, action]
+              properties:
+                step: {type: string, enum: [CONSENT, HEALTH, FINANCING, QUOTE, APPLICATION]}
+                action:
+                  type: string
+                  enum: [VIEWED, CONSENT_GRANTED, CONSENT_WITHDRAWN, QUOTE_REQUESTED,
+                         QUOTE_SUPPRESSED, APPLICATION_STARTED, APPLICATION_ABANDONED]
+      responses:
+        '202':
+          description: Accepted (or silently dropped — the caller cannot tell, by design)
 
   /credit/consents:
     get:

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.44.0
+  version: 1.45.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -1092,6 +1092,28 @@ paths:
               schema:
                 type: array
                 items: {$ref: '#/components/schemas/Loan'}
+
+  /financial-health:
+    get:
+      tags: [Lending]
+      summary: The caller's four-pillar financial health (no score)
+      description: >-
+        ADR-0269 / APP-ADR-0001 rule 5. Reserve, cashflow, obligations and habits, each with its own
+        zone. There is deliberately no aggregate: a single grade invites the customer to optimise it
+        and the bank to act on it, and neither is what this exists for. Any pillar may answer
+        UNKNOWN — the bank not having seen something is a fact about the bank, not a verdict about
+        the customer. Fails soft to an empty list.
+      operationId: getFinancialHealth
+      security:
+        - customerOidc: [accounts:read]
+      responses:
+        '200':
+          description: The pillars (possibly empty)
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {$ref: '#/components/schemas/HealthPillar'}
 
   /credit/consents:
     get:
@@ -3259,6 +3281,24 @@ components:
 
     # Edge's projected view of lending-service's Loan (internal fields dropped — see
     # CustomerEdgeResource.projectLoan).
+    HealthPillar:
+      type: object
+      required: [code, zone]
+      properties:
+        code: {type: string, enum: [RESERVE, CASHFLOW, OBLIGATIONS, HABITS]}
+        zone:
+          type: string
+          enum: [HEALTHY, STRETCHED, AT_RISK, UNKNOWN]
+          description: UNKNOWN means not enough data — never render it as a middling verdict.
+        value:
+          type: string
+          nullable: true
+          description: The working behind the zone (months of cover, net, DSTI). Null when UNKNOWN.
+        target:
+          type: string
+          nullable: true
+          description: What the pillar is measured against, where one exists.
+
     CreditConsents:
       type: object
       description: >-

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeCreditFunnelTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeCreditFunnelTest.kt
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.customeredge.infrastructure.credit.CreditFunnelPublisher
+import com.openbank.customeredge.infrastructure.rest.CustomerEdgeResource
+import com.openbank.customeredge.infrastructure.rest.PaymentSessionStore
+import com.openbank.customeredge.infrastructure.rest.UpstreamClient
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.util.UUID
+
+/**
+ * ADR-0269 rule 8's telemetry.
+ *
+ * The interesting properties are all refusals and silences: a junk value must not reach the stream,
+ * a client must not learn what the bank tracks, and the vocabulary must not be able to express
+ * conversion.
+ */
+class CustomerEdgeCreditFunnelTest {
+
+    private val party = UUID.randomUUID()
+    private val funnel = mockk<CreditFunnelPublisher>(relaxed = true)
+
+    private fun resource(): CustomerEdgeResource = CustomerEdgeResource(
+        mockk<UpstreamClient>(relaxed = true),
+        mockk(relaxed = true),
+        PaymentSessionStore(),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        Clock.systemUTC(),
+    ).apply {
+        partyMergeResolver = mockk { every { resolve(any()) } answers { firstArg() } }
+        jwt = mockk {
+            every { getClaim<String>("party_id") } returns null
+            every { subject } returns party.toString()
+        }
+        objectMapper = ObjectMapper()
+        creditFunnel = funnel
+    }
+
+    @Test
+    fun `a valid event is emitted for the caller's own party`() {
+        val resp = resource().trackCreditEvent("""{"step":"FINANCING","action":"VIEWED"}""")
+
+        assertThat(resp.status).isEqualTo(202)
+        verify(exactly = 1) { funnel.emit(party, "FINANCING", "VIEWED") }
+    }
+
+    @Test
+    fun `an unknown step is dropped, and the caller cannot tell`() {
+        // 202 either way. A 400 would make the allow-list an oracle for what the bank tracks, and
+        // telemetry has no business teaching a client anything.
+        val resp = resource().trackCreditEvent("""{"step":"WHATEVER","action":"VIEWED"}""")
+
+        assertThat(resp.status).isEqualTo(202)
+        verify(exactly = 0) { funnel.emit(any(), any(), any()) }
+    }
+
+    @Test
+    fun `an unknown action is dropped`() {
+        resource().trackCreditEvent("""{"step":"QUOTE","action":"CONVERTED"}""")
+        verify(exactly = 0) { funnel.emit(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a malformed body is dropped without a 5xx`() {
+        val resp = resource().trackCreditEvent("not json")
+        assertThat(resp.status).isEqualTo(202)
+        verify(exactly = 0) { funnel.emit(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a party id in the body is ignored — the JWT decides whose journey this is`() {
+        val someoneElse = UUID.randomUUID()
+        resource().trackCreditEvent(
+            """{"step":"FINANCING","action":"VIEWED","partyId":"$someoneElse"}""",
+        )
+
+        verify(exactly = 1) { funnel.emit(party, any(), any()) }
+        verify(exactly = 0) { funnel.emit(someoneElse, any(), any()) }
+    }
+
+    @Test
+    fun `the vocabulary cannot express a conversion`() {
+        // Structural, and the point of the whole design: a funnel that can say "converted" is one
+        // somebody will optimise, and optimising credit acceptance is what ADR-0269 exists to stop.
+        val forbidden = listOf("CONVERT", "ACCEPT", "SOLD", "SIGNED")
+        assertThat(CreditFunnelPublisher.VALID_ACTIONS).noneMatch { action ->
+            forbidden.any { action.contains(it) }
+        }
+    }
+
+    @Test
+    fun `both allow-lists are small and closed — they are Prometheus labels`() {
+        // An open vocabulary here is a cardinality bomb aimed at the metrics store, reachable by
+        // any authenticated customer.
+        assertThat(CreditFunnelPublisher.VALID_STEPS).hasSizeLessThan(10)
+        assertThat(CreditFunnelPublisher.VALID_ACTIONS).hasSizeLessThan(15)
+    }
+}

--- a/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
+++ b/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
@@ -796,6 +796,55 @@ data:
     WHERE month >= toStartOfMonth(now()) - INTERVAL 6 MONTH
       AND month <  toStartOfMonth(now())
     GROUP BY party_id;
+    --
+    -- The ADR-0269 credit-journey funnel (rule 8's metrics).
+    --
+    -- WHAT THIS DELIBERATELY CANNOT ANSWER: "how many customers converted". There is no conversion
+    -- event upstream and there is no acceptance column here. The programme's metrics are
+    -- self-activation, opt-out-within-30-days, affordability declines, delinquency, and offers shown
+    -- without a prior customer action — a funnel built to optimise acceptance would quietly become the
+    -- thing ADR-0269 exists to prevent.
+    --
+    -- WHY A SEPARATE STREAM from the onboarding funnel: that one is an anonymous public write. These
+    -- events say "this person is looking at borrowing", so they ride an authenticated topic keyed by
+    -- party. The two must not be unioned into one view, or the anonymous stream's trust level would
+    -- silently become the credit stream's.
+
+    CREATE OR REPLACE VIEW openbank_analytics.gold_credit_funnel_events AS
+    SELECT
+        JSONExtractString(payload, 'partyId') AS party_id,
+        JSONExtractString(payload, 'step')    AS step,
+        JSONExtractString(payload, 'action')  AS action,
+        occurred_at
+    FROM openbank_analytics.bronze_events
+    WHERE upper(aggregate_type) = 'CREDIT_FUNNEL'
+      AND JSONExtractString(payload, 'partyId') != '';
+
+    -- Self-activation, the headline number: of the people who ever opened the consent screen, how many
+    -- switched offers ON themselves. Deliberately NOT "how many were offered credit".
+    CREATE OR REPLACE VIEW openbank_analytics.gold_credit_consent_activation AS
+    SELECT
+        toStartOfDay(occurred_at)                                        AS day,
+        countIf(action = 'VIEWED' AND step = 'CONSENT')                  AS consent_screen_views,
+        countIf(action = 'CONSENT_GRANTED')                              AS granted,
+        countIf(action = 'CONSENT_WITHDRAWN')                            AS withdrawn,
+        uniqExactIf(party_id, action = 'CONSENT_GRANTED')                AS parties_granted,
+        uniqExactIf(party_id, action = 'CONSENT_WITHDRAWN')              AS parties_withdrawn
+    FROM openbank_analytics.gold_credit_funnel_events
+    GROUP BY day;
+
+    -- Pricing outcomes. QUOTE_SUPPRESSED is tracked as prominently as QUOTE_REQUESTED on purpose: the
+    -- distress floor refusing to price is a thing the bank must be able to SEE, not a silent branch.
+    CREATE OR REPLACE VIEW openbank_analytics.gold_credit_quote_outcomes AS
+    SELECT
+        toStartOfDay(occurred_at)                        AS day,
+        countIf(action = 'QUOTE_REQUESTED')              AS requested,
+        countIf(action = 'QUOTE_SUPPRESSED')             AS suppressed,
+        countIf(action = 'APPLICATION_STARTED')          AS applications_started,
+        countIf(action = 'APPLICATION_ABANDONED')        AS applications_abandoned
+    FROM openbank_analytics.gold_credit_funnel_events
+    GROUP BY day;
+
 kind: ConfigMap
 metadata:
   name: clickhouse-init

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CustomerFinancialHealthResource.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CustomerFinancialHealthResource.kt
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.infrastructure.rest
+
+import com.openbank.lending.application.port.out.InstallmentRepository
+import com.openbank.lending.application.port.out.LoanRepository
+import com.openbank.lending.domain.model.Loan
+import com.openbank.lending.domain.model.LoanStatus
+import com.openbank.lending.infrastructure.client.CreditProfileClient
+import com.openbank.lending.infrastructure.intake.CustomerIntakeConfig
+import com.openbank.libs.authz.Authorize
+import com.openbank.libs.lending.FinancialHealth
+import com.openbank.libs.lending.FinancialHealthInputs
+import com.openbank.libs.lending.HealthPillar
+import io.quarkus.security.identity.SecurityIdentity
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.asUni
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.HeaderParam
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * The customer's own financial-health view (ADR-0269 / APP-ADR-0001 rule 5).
+ *
+ * ## Why it is assembled HERE and not at the edge
+ *
+ * The four pillars need three sources — the ADR-0269 credit profile, the loan book, and the
+ * customer's balances. lending-service already talks to all three. Assembling it at the edge would
+ * mean a new HTTP dependency from the edge to analytics-sink (today they only meet through Kafka)
+ * and product thresholds living in a proxy. The judgement itself is a pure function in libs; this
+ * class only fetches.
+ *
+ * ## What it is not
+ *
+ * No score, no rating, no eligibility, and no path into a credit decision. Every pillar can answer
+ * UNKNOWN, and one unavailable upstream greys out one pillar rather than the screen — a customer
+ * who opened this to look at their reserve should not be told nothing is known because the profile
+ * service was slow.
+ */
+@Path("/api/v1/lending/intake")
+@Produces(MediaType.APPLICATION_JSON)
+@Tag(name = "Lending", description = "Customer self-service origination intake")
+@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+class CustomerFinancialHealthResource(
+    private val loans: LoanRepository,
+    private val installments: InstallmentRepository,
+    @param:RestClient private val profiles: CreditProfileClient,
+    private val config: CustomerIntakeConfig,
+    private val identity: SecurityIdentity,
+) {
+    @GET
+    @Path("/financial-health")
+    @Authorize(action = "lending.intake", resource = "")
+    @Operation(summary = "The caller's own four-pillar financial health (no score, edge only)")
+    fun health(@HeaderParam(CustomerIntakeResource.PARTY_HEADER) partyHeader: String?): Uni<Response> {
+        if (!callerIsPermitted()) {
+            return Uni.createFrom().item(
+                Response.status(HTTP_FORBIDDEN)
+                    .entity(mapOf("error" to "caller is not the customer-edge intake principal")).build(),
+            )
+        }
+        val partyId = scopeOf(partyHeader)
+            ?: return Uni.createFrom().item(
+                Response.status(HTTP_BAD_REQUEST)
+                    .entity(mapOf("error" to "${CustomerIntakeResource.PARTY_HEADER} is missing or not a UUID"))
+                    .build(),
+            )
+
+        return CoroutineScope(Dispatchers.Unconfined).async {
+            val book = runCatchingUpstream { loans.findByParty(partyId).awaitSuspending() } ?: emptyList()
+            val profile = runCatchingUpstream { profiles.profile(partyId).awaitSuspending() }
+            val view = FinancialHealth.assess(
+                FinancialHealthInputs(
+                    monthlyIncome = profile?.incomeMonthly?.toDecimalOrNull(),
+                    monthlyOutflow = profile?.outflowMonthly?.toDecimalOrNull(),
+                    monthlyNet = profile?.netMonthly?.toDecimalOrNull(),
+                    volatilityRatio = profile?.volatilityRatio?.toDecimalOrNull(),
+                    // No balance source on this path yet, so the reserve pillar answers UNKNOWN.
+                    // Deliberately left null rather than approximated from cashflow: a reserve the
+                    // customer does not have, inferred from money they merely did not spend, is the
+                    // single most dangerous number this screen could show.
+                    liquidBalance = null,
+                    monthlyDebtService = debtServiceOf(book),
+                    hasArrears = book.takeIf { it.isNotEmpty() }?.any { it.status in ARREARS_STATES },
+                    monthsObserved = profile?.monthsObserved,
+                ),
+            )
+            Response.ok(view.pillars.map { it.toDto() }).build()
+        }.asUni()
+    }
+
+    /**
+     * Contractual monthly debt service: the next unpaid instalment of every live loan.
+     *
+     * Null when the party has no live loans — which is NOT the same as zero. Zero would let the
+     * obligations pillar report a healthy DSTI for someone whose loans simply could not be read.
+     */
+    private suspend fun debtServiceOf(book: List<Loan>): BigDecimal? {
+        val live = book.filter { it.status !in CLOSED_STATES }
+        if (live.isEmpty()) return if (book.isEmpty()) BigDecimal.ZERO else null
+        var total = BigDecimal.ZERO
+        live.forEach { loan ->
+            val schedule = runCatchingUpstream { installments.findByLoan(loan.id).awaitSuspending() } ?: return null
+            val next = schedule.filter { !it.paid }.minByOrNull { it.number } ?: return@forEach
+            total = total.add(next.payment.amount)
+        }
+        return total
+    }
+
+    private fun callerIsPermitted(): Boolean {
+        if (!config.enabled) return false
+        val permitted = config.callerPrincipal.orElse("")
+        return permitted.isNotBlank() && identity.principal?.name == permitted
+    }
+
+    private fun scopeOf(partyHeader: String?): UUID? =
+        partyHeader?.let { runCatching { UUID.fromString(it) }.getOrNull() }?.takeIf { it != ZERO_UUID }
+
+    /** Null on any upstream failure, so one slow service greys out one pillar and not the view. */
+    private suspend fun <T> runCatchingUpstream(block: suspend () -> T): T? = runCatching { block() }.getOrElse { e ->
+        if (e is CancellationException) throw e
+        null
+    }
+
+    private fun String.toDecimalOrNull(): BigDecimal? =
+        takeIf { it.isNotBlank() }?.let { runCatching { BigDecimal(it) }.getOrNull() }
+
+    private fun HealthPillar.toDto() = CustomerHealthPillarDto(
+        code = code,
+        zone = zone.name,
+        value = value?.toPlainString(),
+        target = target?.toPlainString(),
+    )
+
+    companion object {
+        private val ZERO_UUID = UUID(0, 0)
+        private const val HTTP_BAD_REQUEST = 400
+        private const val HTTP_FORBIDDEN = 403
+
+        private val ARREARS_STATES = setOf(
+            LoanStatus.DELINQUENT,
+            LoanStatus.DEFAULTED,
+            LoanStatus.TERMINATION_NOTICED,
+            LoanStatus.ACCELERATED,
+        )
+
+        private val CLOSED_STATES = setOf(
+            LoanStatus.CLOSED,
+            LoanStatus.SETTLED,
+            LoanStatus.WRITTEN_OFF,
+            LoanStatus.UNWOUND,
+        )
+    }
+}
+
+/**
+ * One pillar on the wire. [value] and [target] are strings and are null for an UNKNOWN zone, so a
+ * client has nothing invented to render.
+ */
+data class CustomerHealthPillarDto(val code: String, val zone: String, val value: String?, val target: String?)

--- a/openbank-lending-service/src/main/resources/openapi.yaml
+++ b/openbank-lending-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Lending Service API
-  version: 1.15.0
+  version: 1.16.0
   description: >-
     Loan origination, servicing, collateral and IFRS 9 provisioning (ADR-0028). The loan book posts
     cash events to ledger-service and never owns balances. Credit decisions and collateral
@@ -125,6 +125,30 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
         '404': { description: No such application for this caller }
+
+  /api/v1/lending/intake/financial-health:
+    get:
+      tags: [Lending]
+      operationId: getCustomerFinancialHealth
+      summary: The caller's four-pillar financial health (customer-edge only, no score)
+      description: >-
+        ADR-0269 rule 5. Assembled here because the pillars need the credit profile, the loan book
+        and (later) balances, all of which this service already reaches. The judgement itself is a
+        pure function in libs; this route only fetches. Any pillar may answer UNKNOWN, and one
+        unavailable upstream greys out one pillar rather than the whole view.
+      parameters:
+        - name: X-Customer-Party-Id
+          in: header
+          required: true
+          description: The applicant's party id, set by customer-edge from the customer JWT.
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: The four pillars
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 
   /api/v1/lending/intake/quotes:
     post:

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/FinancialHealth.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/FinancialHealth.kt
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending
+
+import java.math.BigDecimal
+import java.math.MathContext
+import java.math.RoundingMode
+
+/**
+ * The customer's own view of their finances (ADR-0269 / APP-ADR-0001 rule 5).
+ *
+ * ## What this is NOT
+ *
+ * It is not a score, not a rating, and not an input to a credit decision. There is no single
+ * number here on purpose: a grade invites the customer to optimise it and invites the bank to act
+ * on it, and neither is what this exists for. The credit decision is the deterministic engine's
+ * (ADR-0213), and keeping the two apart is what lets a threshold move without a customer's
+ * "score" moving underneath them.
+ *
+ * ## Why four pillars and not one
+ *
+ * Reserve, cashflow, obligations and habits fail independently. Someone with a strong income and
+ * no buffer is in a different situation from someone with a thin income and six months of cover,
+ * and a single number would rate them the same. Four answers also give the customer something to
+ * act on, which one number never does.
+ *
+ * ## Why every pillar can answer "unknown"
+ *
+ * A pillar with no data is [PillarZone.UNKNOWN], never a middling or a healthy value. The bank not
+ * having seen something is a fact about the bank, not about the customer, and rendering it as a
+ * verdict would tell someone their finances are fine — or shaky — on the strength of nothing.
+ */
+enum class PillarZone {
+    /** Comfortable. */
+    HEALTHY,
+
+    /** Works, with no margin. Worth saying out loud; not a warning. */
+    STRETCHED,
+
+    /** The pillar is where trouble starts. */
+    AT_RISK,
+
+    /** Not enough data. Never rendered as a verdict. */
+    UNKNOWN,
+}
+
+/**
+ * One pillar. [value] and [target] are for the customer to see the working; both are null when the
+ * zone is [PillarZone.UNKNOWN], so nothing invented can be displayed.
+ */
+data class HealthPillar(
+    val code: String,
+    val zone: PillarZone,
+    val value: BigDecimal? = null,
+    val target: BigDecimal? = null,
+)
+
+/** The whole view. Deliberately has no aggregate field — see the class docs. */
+data class FinancialHealthView(val pillars: List<HealthPillar>) {
+    init {
+        require(pillars.map { it.code }.toSet().size == pillars.size) { "duplicate pillar code" }
+    }
+
+    fun pillar(code: String): HealthPillar? = pillars.firstOrNull { it.code == code }
+}
+
+/**
+ * Inputs, each independently nullable.
+ *
+ * Nullability is the point: three of these come from different services, and a partial answer is
+ * the normal case rather than an error. One unavailable upstream must grey out ONE pillar, not the
+ * screen — a customer who opens this to check their reserve should not be told nothing is known
+ * because the loan book happened to be slow.
+ */
+data class FinancialHealthInputs(
+    val monthlyIncome: BigDecimal?,
+    val monthlyOutflow: BigDecimal?,
+    val monthlyNet: BigDecimal?,
+    val volatilityRatio: BigDecimal?,
+    val liquidBalance: BigDecimal?,
+    val monthlyDebtService: BigDecimal?,
+    val hasArrears: Boolean?,
+    val monthsObserved: Int?,
+)
+
+object FinancialHealth {
+
+    const val PILLAR_RESERVE = "RESERVE"
+    const val PILLAR_CASHFLOW = "CASHFLOW"
+    const val PILLAR_OBLIGATIONS = "OBLIGATIONS"
+    const val PILLAR_HABITS = "HABITS"
+
+    /** Three months of outgoings is the reserve target this view holds the customer's cover against. */
+    private val RESERVE_TARGET_MONTHS = BigDecimal("3")
+    private val RESERVE_STRETCHED_MONTHS = BigDecimal("1")
+
+    /** Above this share of income going to debt service, the pillar is at risk (the DSTI shape). */
+    private val DSTI_AT_RISK = BigDecimal("0.45")
+    private val DSTI_STRETCHED = BigDecimal("0.35")
+
+    /** A month-to-month swing beyond this share of income is what makes planning hard. */
+    private val VOLATILITY_AT_RISK = BigDecimal("0.60")
+    private val VOLATILITY_STRETCHED = BigDecimal("0.30")
+
+    /** Below this, a median is an anecdote rather than a pattern — the same floor the offer gate uses. */
+    private const val MIN_MONTHS = 3
+
+    private val MC = MathContext.DECIMAL64
+
+    /** A ratio disclosed to four places; money to the minor unit; cover to one decimal month. */
+    private const val DSTI_SCALE = 4
+    private const val MONEY_SCALE = 2
+    private const val MONTHS_SCALE = 1
+
+    fun assess(inputs: FinancialHealthInputs): FinancialHealthView = FinancialHealthView(
+        listOf(
+            reserve(inputs),
+            cashflow(inputs),
+            obligations(inputs),
+            habits(inputs),
+        ),
+    )
+
+    /** Months of outgoings the liquid balance covers. */
+    private fun reserve(i: FinancialHealthInputs): HealthPillar {
+        val balance = i.liquidBalance
+        val outflow = i.monthlyOutflow
+        if (balance == null || outflow == null || outflow <= BigDecimal.ZERO) {
+            return HealthPillar(PILLAR_RESERVE, PillarZone.UNKNOWN)
+        }
+        val months = balance.divide(outflow, MC)
+        val zone = when {
+            months >= RESERVE_TARGET_MONTHS -> PillarZone.HEALTHY
+            months >= RESERVE_STRETCHED_MONTHS -> PillarZone.STRETCHED
+            else -> PillarZone.AT_RISK
+        }
+        return HealthPillar(
+            PILLAR_RESERVE,
+            zone,
+            months.setScale(MONTHS_SCALE, RoundingMode.DOWN),
+            RESERVE_TARGET_MONTHS,
+        )
+    }
+
+    /**
+     * What is left each month, and how steady it is.
+     *
+     * A negative net is at risk regardless of volatility — a stable shortfall is still a shortfall,
+     * and calling it "steady" would be the most misleading reading available.
+     */
+    private fun cashflow(i: FinancialHealthInputs): HealthPillar {
+        val net = i.monthlyNet
+        val months = i.monthsObserved
+        if (net == null || months == null || months < MIN_MONTHS) {
+            return HealthPillar(PILLAR_CASHFLOW, PillarZone.UNKNOWN)
+        }
+        val volatility = i.volatilityRatio
+        val zone = when {
+            net <= BigDecimal.ZERO -> PillarZone.AT_RISK
+            volatility == null -> PillarZone.STRETCHED
+            volatility >= VOLATILITY_AT_RISK -> PillarZone.AT_RISK
+            volatility >= VOLATILITY_STRETCHED -> PillarZone.STRETCHED
+            else -> PillarZone.HEALTHY
+        }
+        return HealthPillar(PILLAR_CASHFLOW, zone, net.setScale(MONEY_SCALE, RoundingMode.HALF_UP), null)
+    }
+
+    /** Debt service as a share of income. */
+    private fun obligations(i: FinancialHealthInputs): HealthPillar {
+        val income = i.monthlyIncome
+        val debt = i.monthlyDebtService
+        if (income == null || income <= BigDecimal.ZERO || debt == null) {
+            return HealthPillar(PILLAR_OBLIGATIONS, PillarZone.UNKNOWN)
+        }
+        val dsti = debt.divide(income, MC)
+        val zone = when {
+            dsti >= DSTI_AT_RISK -> PillarZone.AT_RISK
+            dsti >= DSTI_STRETCHED -> PillarZone.STRETCHED
+            else -> PillarZone.HEALTHY
+        }
+        return HealthPillar(PILLAR_OBLIGATIONS, zone, dsti.setScale(DSTI_SCALE, RoundingMode.HALF_UP), DSTI_STRETCHED)
+    }
+
+    /**
+     * Whether repayments are being met.
+     *
+     * Only two honest answers exist from this input: in arrears, or not. There is deliberately no
+     * "excellent" tier — a customer who has simply paid their bills has done the expected thing,
+     * and grading them for it is the scoring behaviour this whole view refuses.
+     */
+    private fun habits(i: FinancialHealthInputs): HealthPillar {
+        val arrears = i.hasArrears ?: return HealthPillar(PILLAR_HABITS, PillarZone.UNKNOWN)
+        return HealthPillar(PILLAR_HABITS, if (arrears) PillarZone.AT_RISK else PillarZone.HEALTHY)
+    }
+}

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/FinancialHealthTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/FinancialHealthTest.kt
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+/**
+ * ADR-0269 / APP-ADR-0001 rule 5.
+ *
+ * Most of these tests are about what the view refuses to say: no aggregate score, no verdict
+ * without data, no flattering default. The pleasant readings are the easy half.
+ */
+class FinancialHealthTest {
+
+    private fun inputs(
+        income: String? = "50000",
+        outflow: String? = "40000",
+        net: String? = "10000",
+        volatility: String? = "0.10",
+        balance: String? = "150000",
+        debt: String? = "5000",
+        arrears: Boolean? = false,
+        months: Int? = 12,
+    ) = FinancialHealthInputs(
+        monthlyIncome = income?.let { BigDecimal(it) },
+        monthlyOutflow = outflow?.let { BigDecimal(it) },
+        monthlyNet = net?.let { BigDecimal(it) },
+        volatilityRatio = volatility?.let { BigDecimal(it) },
+        liquidBalance = balance?.let { BigDecimal(it) },
+        monthlyDebtService = debt?.let { BigDecimal(it) },
+        hasArrears = arrears,
+        monthsObserved = months,
+    )
+
+    private fun zoneOf(i: FinancialHealthInputs, code: String) = FinancialHealth.assess(i).pillar(code)!!.zone
+
+    // ── It is not a score ─────────────────────────────────────────────────────
+
+    @Test
+    fun `the view has no aggregate — there is no single number to optimise or to act on`() {
+        val fields = FinancialHealthView::class.java.declaredFields.map { it.name.lowercase() }
+        assertThat(fields).noneMatch { it.contains("score") || it.contains("rating") || it.contains("grade") }
+    }
+
+    @Test
+    fun `paying your bills is HEALTHY and nothing better — doing the expected thing is not a grade`() {
+        assertThat(zoneOf(inputs(arrears = false), FinancialHealth.PILLAR_HABITS)).isEqualTo(PillarZone.HEALTHY)
+        assertThat(PillarZone.entries.filter { it != PillarZone.UNKNOWN }).hasSize(3)
+    }
+
+    // ── Unknown is never a verdict ────────────────────────────────────────────
+
+    @Test
+    fun `a missing input greys out ONE pillar, not the screen`() {
+        val view = FinancialHealth.assess(inputs(debt = null))
+        assertThat(view.pillar(FinancialHealth.PILLAR_OBLIGATIONS)!!.zone).isEqualTo(PillarZone.UNKNOWN)
+        // The customer opened this to look at their reserve; a slow loan book must not blank that.
+        assertThat(view.pillar(FinancialHealth.PILLAR_RESERVE)!!.zone).isNotEqualTo(PillarZone.UNKNOWN)
+    }
+
+    @Test
+    fun `an unknown pillar carries no numbers to be mistaken for a measurement`() {
+        val pillar = FinancialHealth.assess(inputs(arrears = null)).pillar(FinancialHealth.PILLAR_HABITS)!!
+        assertThat(pillar.zone).isEqualTo(PillarZone.UNKNOWN)
+        assertThat(pillar.value).isNull()
+        assertThat(pillar.target).isNull()
+    }
+
+    @Test
+    fun `too few observed months makes cashflow unknown rather than confident`() {
+        assertThat(zoneOf(inputs(months = 2), FinancialHealth.PILLAR_CASHFLOW)).isEqualTo(PillarZone.UNKNOWN)
+    }
+
+    @Test
+    fun `an unknown volatility is stretched, not healthy — steadiness is not assumed`() {
+        assertThat(zoneOf(inputs(volatility = null), FinancialHealth.PILLAR_CASHFLOW))
+            .isEqualTo(PillarZone.STRETCHED)
+    }
+
+    // ── Reserve ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `three months of outgoings is the reserve target`() {
+        assertThat(zoneOf(inputs(balance = "120000", outflow = "40000"), FinancialHealth.PILLAR_RESERVE))
+            .isEqualTo(PillarZone.HEALTHY)
+        assertThat(zoneOf(inputs(balance = "119999", outflow = "40000"), FinancialHealth.PILLAR_RESERVE))
+            .isEqualTo(PillarZone.STRETCHED)
+        assertThat(zoneOf(inputs(balance = "20000", outflow = "40000"), FinancialHealth.PILLAR_RESERVE))
+            .isEqualTo(PillarZone.AT_RISK)
+    }
+
+    @Test
+    fun `the reserve shows its working in months, rounded DOWN`() {
+        val pillar = FinancialHealth.assess(inputs(balance = "119999", outflow = "40000"))
+            .pillar(FinancialHealth.PILLAR_RESERVE)!!
+        // Down, not nearest: telling someone they have 3 months of cover when they have 2.99 is the
+        // rounding that matters here.
+        assertThat(pillar.value).isEqualByComparingTo("2.9")
+    }
+
+    // ── Cashflow ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a stable shortfall is still a shortfall`() {
+        // Negative net with the calmest possible volatility. Reading that as "steady" would be the
+        // most misleading answer available.
+        assertThat(zoneOf(inputs(net = "-2000", volatility = "0.01"), FinancialHealth.PILLAR_CASHFLOW))
+            .isEqualTo(PillarZone.AT_RISK)
+    }
+
+    @Test
+    fun `a swinging income is at risk even when it averages out`() {
+        assertThat(zoneOf(inputs(net = "10000", volatility = "0.80"), FinancialHealth.PILLAR_CASHFLOW))
+            .isEqualTo(PillarZone.AT_RISK)
+    }
+
+    // ── Obligations ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `debt service is judged as a share of income, not as an amount`() {
+        assertThat(zoneOf(inputs(income = "50000", debt = "5000"), FinancialHealth.PILLAR_OBLIGATIONS))
+            .isEqualTo(PillarZone.HEALTHY)
+        // The same 25,000 is comfortable on 100,000 and at risk on 50,000.
+        assertThat(zoneOf(inputs(income = "50000", debt = "25000"), FinancialHealth.PILLAR_OBLIGATIONS))
+            .isEqualTo(PillarZone.AT_RISK)
+        assertThat(zoneOf(inputs(income = "100000", debt = "25000"), FinancialHealth.PILLAR_OBLIGATIONS))
+            .isEqualTo(PillarZone.HEALTHY)
+    }
+
+    @Test
+    fun `a zero income makes obligations unknown rather than infinitely bad`() {
+        assertThat(zoneOf(inputs(income = "0"), FinancialHealth.PILLAR_OBLIGATIONS)).isEqualTo(PillarZone.UNKNOWN)
+    }
+
+    // ── Shape ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `every assessment returns all four pillars, in a stable order`() {
+        val codes = FinancialHealth.assess(inputs()).pillars.map { it.code }
+        assertThat(codes).containsExactly(
+            FinancialHealth.PILLAR_RESERVE,
+            FinancialHealth.PILLAR_CASHFLOW,
+            FinancialHealth.PILLAR_OBLIGATIONS,
+            FinancialHealth.PILLAR_HABITS,
+        )
+    }
+
+    @Test
+    fun `an assessment with nothing known is four unknowns, not an empty screen`() {
+        val view = FinancialHealth.assess(
+            FinancialHealthInputs(null, null, null, null, null, null, null, null),
+        )
+        assertThat(view.pillars).hasSize(4)
+        assertThat(view.pillars.map { it.zone }).containsOnly(PillarZone.UNKNOWN)
+    }
+}


### PR DESCRIPTION
Part of #6215 / ADR-0269 rule 5. Replaces #6294, which GitHub auto-closed when its base branch was deleted as #6299 merged — **not reviewed, not merged**. Content unchanged; rebased onto the current slice-3 branch (which now carries slices 3, 4 and 5).

> Third time this has happened in this chain (#6287, #6294, and app#537). Merging a stacked PR with `--delete-branch` closes the child. Worth knowing before the next one.

## Why lending-service and not the edge

The pillars need the ADR-0269 credit profile, the loan book, and (later) balances — lending-service already reaches all three. Assembling at the edge would have meant a new HTTP dependency from customer-edge to analytics-sink (today they meet only through Kafka) and product thresholds living in a proxy. The judgement itself is a **pure function in libs**; the resource only fetches.

## Four pillars, no aggregate

Reserve, cashflow, obligations, habits. There is deliberately **no score**: a single grade invites the customer to optimise it and the bank to act on it, and neither is what this exists for. A test asserts the view has no field whose name contains `score`, `rating` or `grade`.

## Every pillar can answer UNKNOWN

A missing input greys out **one** pillar, not the screen. Two distinctions that matter:

- **The reserve is UNKNOWN, not inferred from unspent cashflow.** A buffer someone does not have, derived from money they merely did not spend, is the most dangerous number this screen could show.
- **An empty loan book gives debt service zero; an unreadable one gives null**, which makes the obligations pillar UNKNOWN. Only one of those means "this customer has no debts".

## Habits has no tier above HEALTHY

A customer who has paid their bills has done the expected thing. Grading them for it is the scoring behaviour this view refuses.

## Verification

`FinancialHealthTest`: 14 tests, 0 failures, 0 skipped — most about what the view declines to say. ktlint/detekt clean; api-contract and route-conformance clean; threat model section 9c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)