### PR TITLE
fix(admin-ui): clarify service inventory refresh state

### DIFF
--- a/openbank-admin-ui/src/app/system/inventory/page.tsx
+++ b/openbank-admin-ui/src/app/system/inventory/page.tsx
@@ -178,15 +178,18 @@ export default function TechInventoryPage() {
             </span>
           )}
           <button
+            type="button"
             onClick={() => refresh(true)}
             disabled={refreshing}
+            aria-busy={refreshing}
+            aria-label={t('Obnovit inventář služeb', 'Refresh service inventory')}
             style={{
               padding: '6px 12px', fontSize: '12px', display: 'flex', alignItems: 'center', gap: '6px',
               background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 'var(--r-md)',
               cursor: refreshing ? 'wait' : 'pointer', color: 'var(--text-secondary)',
             }}
           >
-            <RefreshCw size={12} style={{ animation: refreshing ? 'spin 1s linear infinite' : undefined }} />
+            <RefreshCw size={12} aria-hidden="true" style={{ animation: refreshing ? 'spin 1s linear infinite' : undefined }} />
             {t('Obnovit', 'Refresh')}
           </button>
         </div>}

--- a/openbank-admin-ui/src/test/inventory-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/inventory-refresh.guard.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('service inventory refresh contract', () => {
+  it('keeps refresh action explicit and exposes busy semantics', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/system/inventory/page.tsx'), 'utf8')
+    expect(source).toContain('type="button"')
+    expect(source).toContain('aria-busy={refreshing}')
+    expect(source).toContain("aria-label={t('Obnovit inventář služeb', 'Refresh service inventory')}")
+    expect(source).toContain('<RefreshCw size={12} aria-hidden="true"')
+    expect(source).toContain('refresh(true)')
+  })
+})


### PR DESCRIPTION
## Summary
- make Tech Inventory refresh an explicit button action
- expose localized accessible name and loading state
- hide decorative refresh icon from assistive technology

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.