### PR TITLE
fix(admin-ui): announce clearing loading

### DIFF
--- a/openbank-admin-ui/src/app/clearing/page.tsx
+++ b/openbank-admin-ui/src/app/clearing/page.tsx
@@ -81,8 +81,8 @@ export default function ClearingPage() {
             </div>
           </div>
           {loading ? (
-            <div style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
-              <RefreshCw size={20} style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} /><div>{t('Načítám…', 'Loading…')}</div>
+            <div role="status" aria-live="polite" style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
+              <RefreshCw size={20} aria-hidden="true" style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} /><div>{t('Načítám…', 'Loading…')}</div>
             </div>
           ) : unavailable ? (
             <DataUnavailable kind={unavailable.kind} service={t('Clearing-service', 'Clearing-service')} feature={t('Clearing dávky', 'Clearing batches')} lang={language} />

--- a/openbank-admin-ui/src/test/clearing-loading.guard.test.ts
+++ b/openbank-admin-ui/src/test/clearing-loading.guard.test.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('clearing loading contract', () => {
+  it('announces the existing loading state without changing batch data flow', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/clearing/page.tsx'), 'utf8')
+    expect(source).toContain('<div role="status" aria-live="polite"')
+    expect(source).toContain('<RefreshCw size={20} aria-hidden="true"')
+    expect(source).toContain("t('Načítám…', 'Loading…')")
+  })
+})


### PR DESCRIPTION
## Summary
- expose the existing Clearing loading state as a polite status
- hide the decorative spinner from assistive technology
- preserve existing batch fetch/filter and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.