### PR TITLE
fix(admin-ui): clarify fee refresh state

### DIFF
--- a/openbank-admin-ui/src/app/fees/page.tsx
+++ b/openbank-admin-ui/src/app/fees/page.tsx
@@ -113,7 +113,7 @@ export default function FeesPage() {
           title={t('Ceník poplatků', 'Fee Schedule')}
           subtitle={t('Ceník poplatků ze service product-catalog', 'Fee schedule served by the product-catalog service')}
           actions={<div className="flex gap-2">
-            <button className="btn btn-secondary" onClick={() => void load()} disabled={loading}>
+            <button type="button" className="btn btn-secondary" onClick={() => void load()} disabled={loading} aria-busy={loading} aria-label={t('Obnovit ceník poplatků', 'Refresh fee schedule')}>
               <RefreshCw size={14} aria-hidden="true" style={loading ? { animation: 'spin 1s linear infinite' } : undefined} />
               {t('Obnovit', 'Refresh')}
             </button>

--- a/openbank-admin-ui/src/test/fees-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/fees-refresh.guard.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('fees refresh contract', () => {
+  it('exposes localized busy semantics without changing fee loading', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/fees/page.tsx'), 'utf8')
+    expect(source).toContain('type="button"')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit ceník poplatků', 'Refresh fee schedule')}")
+    expect(source).toContain('onClick={() => void load()}')
+    expect(source).toContain('<RefreshCw size={14} aria-hidden="true"')
+  })
+})


### PR DESCRIPTION
## Summary
- add explicit button semantics and localized busy/name state to fee refresh
- preserve product-catalog fee loading and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.