### PR TITLE
fix(admin-ui): clarify fraud refresh state

### DIFF
--- a/openbank-admin-ui/src/app/fraud/page.tsx
+++ b/openbank-admin-ui/src/app/fraud/page.tsx
@@ -73,7 +73,7 @@ export default function FraudPage() {
           'Payments flagged REVIEW by the engine. Resolution remains in the four-eyes compliance flow.',
         )}
         icon={<ShieldAlert size={20} aria-hidden="true" style={{ color: 'var(--accent)' }} />}
-        actions={<button onClick={load} disabled={loading} className="btn btn-secondary btn-sm">
+        actions={<button type="button" onClick={load} disabled={loading} aria-busy={loading} aria-label={t('Obnovit frontu podvodů', 'Refresh fraud queue')} className="btn btn-secondary btn-sm">
           <RefreshCw size={14} aria-hidden="true" className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
         </button>}
       />

--- a/openbank-admin-ui/src/test/fraud-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/fraud-refresh.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('fraud refresh contract', () => {
+  it('exposes localized busy semantics without changing fraud queue loading', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/fraud/page.tsx'), 'utf8')
+    expect(source).toContain('type="button"')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit frontu podvodů', 'Refresh fraud queue')}")
+    expect(source).toContain('onClick={load}')
+  })
+})


### PR DESCRIPTION
## Summary
- add explicit button semantics and localized busy/name state to fraud queue refresh
- preserve existing fraud queue fetch, four-eyes read flow, and RBAC

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.