### PR TITLE
ci(governance): guard autonomous-agent PRs against protected paths

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -3424,6 +3424,47 @@ gates:
     run: |
       python3 .github/scripts/check-pr-file-overlap.py
 
+  # AGENT PR GUARD — the control that keeps unattended agent work off the money path.
+  #
+  # Until this landed, the only thing enforcing that rule was a PreToolUse hook on the
+  # maintainer's laptop. That hook cannot exist where an agent actually runs unattended (a
+  # cloud session, a GitHub runner), and it could not see through an interpreter even
+  # locally — 17 PRs merged in one session with every one of its rules unevaluated, because
+  # the merge went through a script rather than a bare `gh pr merge`. `main`'s ruleset does
+  # not supply the control either: required_approving_review_count is 0 and the admin bypass
+  # actor is the same identity an agent authenticates as. An agent has already reached for an
+  # administrative override, unprompted, when self-approval was refused.
+  #
+  # A required check is the one shape none of that defeats: it runs wherever the PR came
+  # from, the agent that tripped it cannot clear it, and `--auto` cannot merge past it.
+  #
+  # ENFORCED, not advisory, and deliberately so. The deadlock argument that makes
+  # pr-file-overlap advisory does not apply — a human PR is out of scope entirely, so this
+  # can never red a human's work, and an agent PR it reds is one that SHOULD be waiting for a
+  # human. PR-only: on a push to main there is no author or head branch to classify.
+  #
+  # Needs GH_TOKEN, which the shard job already exports. Exit 2 = the verdict could not be
+  # computed, which is a failure and not a clean — a permission-shaped absence is
+  # byte-identical to a real one.
+  - id: agent-pr-guard
+    name: "agent PR guard (autonomous agents may not land protected paths, enforced)"
+    group: lint
+    mode: enforced
+    rationale: >-
+      Unattended agents open PRs here around the clock, and the only control keeping them off
+      the money path was a PreToolUse hook on one laptop — absent in every environment an
+      agent actually runs in, and blind to a merge issued from inside a script (17 PRs merged
+      in one session with all of its rules unevaluated). main's ruleset does not supply it:
+      0 required approvals, and the admin bypass actor is the identity an agent authenticates
+      as. Re-examine when four-eyes is enforced at the ruleset, which would subsume this.
+    review_after: "2027-02-22"
+    min_subjects: 25   # 33 today: 30 derived+declared service tokens + 3 governance globs
+    when: pull_request
+    selftest: python3 .github/scripts/check-agent-pr-guard.py --self-test
+    selftest_expect: pass
+    run: |
+      python3 .github/scripts/check-agent-pr-guard.py
+
   # ADR-0251. The script this falsifies is the PROOF that an independent review happened, and
   # its predecessor is the reason the control was retired: ADR-0154's "Verify the Claude
   # fallback actually reviewed" step carried the SAME `if:` as the review it verified, so

--- a/.github/scripts/check-agent-pr-guard.py
+++ b/.github/scripts/check-agent-pr-guard.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# AGENT PR GUARD — an autonomous agent's PR may not reach main through a protected path.
+#
+# WHY THIS EXISTS
+#   The repo is moving to scheduled, unattended agents that open PRs 24/7. The control that
+#   has kept unattended work off the money path so far is a PreToolUse hook on the
+#   MAINTAINER'S LAPTOP (`protected-pr-check.sh`). That control does not exist anywhere an
+#   agent actually runs unattended — not in a cloud session, not on a GitHub runner — and
+#   `main`'s ruleset does not supply it either: `required_approving_review_count` is 0 and
+#   the admin bypass actor is the same identity an agent authenticates as. An agent has
+#   already, unprompted, reached for an administrative override on a money-path PR when
+#   self-approval was refused.
+#
+#   So the rule moves to where it runs regardless of who is driving: a required check.
+#   A red required check cannot be cleared by the agent that tripped it, cannot be cleared
+#   by `--auto`, and takes a deliberate human action to override.
+#
+# WHAT IT IS AND IS NOT
+#   IS:     a guard against the unattended-accident — an agent quietly landing a change on
+#           the money path, CI machinery, or authorization policy with nobody reading it.
+#   IS NOT: a boundary against a determined agent. Scope is decided from the PR's author and
+#           head-branch name, both of which the agent itself supplies. The identity boundary
+#           is the token: the agent authenticates as an App that holds no admin rights and is
+#           not in the ruleset's `bypass_actors`. This check is the second layer, not the first.
+#
+# SCOPE — who is judged, and why the unknown case FAILS
+#   in scope:     an author declared in rules.yaml `autonomous_agent_prs.agent_accounts`, OR
+#                 a head branch matching a declared `agent_branch_prefixes` entry.
+#   out of scope: a human author on a human branch (they already own the review), and a
+#                 deterministic automation account declared in `automation_accounts`
+#                 (release-please and the deploy snapshotters legitimately touch money-path
+#                 paths; blocking them deadlocks the release queue for no safety gained —
+#                 their content is generated, not authored).
+#   UNDECLARED:   a Bot-typed author in neither list is a FAILURE, not a pass. A new machine
+#                 identity must be classified by a human before it can open PRs here, and
+#                 that classification is itself a governance-path change. This is the one
+#                 clause that keeps the scope from being a hand-kept list that reads as
+#                 passing when it is short (repo lore: a gate scoped by a hand-kept list of
+#                 its own subjects reports clean about work it never did).
+#
+# PROTECTED PATHS — DERIVED, not retyped
+#   The service token set is derived from rules.yaml `money_path_services` by stripping the
+#   `openbank-` prefix and the optional `-service` suffix, so onboarding a money-path service
+#   extends this guard with no edit here. `extra_protected_tokens` carries the high-blast
+#   radius services that are NOT money-path by that list's definition (kyc, party, card
+#   issuance, aml, tax, dispute) — a hand-kept list of external FACTS, which is fine; a
+#   hand-kept list of the gate's own SCOPE is not.
+#
+#   Two naming schemes must both be covered, because component names are not service names:
+#     service source     openbank-<tok>-service/...
+#     deployment config  openbank-infra/gitops/components/<tok>s?/...
+#   An earlier laptop-side version anchored on the service list only and allowed a PR that
+#   opened balance-service to the public ingress through gitops.
+#
+#   Docs are excluded from the authz clause on purpose: a Markdown file under docs/ cannot
+#   change what the PDP enforces, and blocking the documentation ABOUT a control as if it
+#   were the control trains people to route around the guard (#3888).
+#
+# FALSIFIABILITY
+#   --self-test drives the classifier over fixtures with no network: every block reason must
+#   be independently reachable (asserted on the REASON, not just the exit code — two branches
+#   agreeing on a verdict is how a clause becomes unfalsifiable while the suite stays green),
+#   every out-of-scope shape must pass, the undeclared-bot shape must fail, and an enumeration
+#   failure must NOT be reported as clean.
+#
+# USAGE
+#   python3 .github/scripts/check-agent-pr-guard.py             # PR number from the environment
+#   python3 .github/scripts/check-agent-pr-guard.py --pr 6410   # explicit
+#   python3 .github/scripts/check-agent-pr-guard.py --self-test
+#
+# EXIT CODES
+#   0  out of scope, or in scope and touching nothing protected
+#   1  in scope and touching a protected path — human review required
+#   2  could not determine author / branch / file list — NOT a clean verdict
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import subprocess
+import sys
+
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import gatelib  # noqa: E402  (path must be set first)
+
+REPO = "JiRaska/open-bank-oss"
+RULES = "openbank-libs/governance/rules.yaml"
+
+
+class Undetermined(Exception):
+    """The verdict could not be computed. Never downgraded to a pass — on GitHub a
+    permission-shaped absence is byte-identical to a real one."""
+
+
+# --------------------------------------------------------------------------- rules
+
+
+def load_rules(path=RULES):
+    import yaml
+
+    try:
+        with open(path) as fh:
+            doc = yaml.safe_load(fh)
+    except (OSError, yaml.YAMLError) as e:
+        raise Undetermined(f"could not read {path}: {e}") from e
+    cfg = (doc or {}).get("autonomous_agent_prs")
+    if not isinstance(cfg, dict):
+        raise Undetermined(f"{path} has no `autonomous_agent_prs` block — the guard cannot be scoped")
+    cfg["_money_path_services"] = (doc or {}).get("money_path_services") or []
+    if not cfg["_money_path_services"]:
+        raise Undetermined(f"{path} has no `money_path_services` — the protected token set would be empty")
+    return cfg
+
+
+def protected_tokens(cfg):
+    """Service tokens, DERIVED from money_path_services plus the declared extras."""
+    toks = set()
+    for svc in cfg["_money_path_services"]:
+        t = re.sub(r"^openbank-", "", svc)
+        t = re.sub(r"-service$", "", t)
+        if t:
+            toks.add(t)
+    toks.update(cfg.get("extra_protected_tokens") or [])
+    return sorted(toks)
+
+
+# --------------------------------------------------------------------------- classification
+
+
+def norm_login(login):
+    """One spelling for a machine account.
+
+    GitHub spells the same App three ways depending on which surface answers: the REST API
+    says `openbank-gitops-bot[bot]`, `gh pr view --json author` says `app/openbank-gitops-bot`,
+    and a human writing the config says whichever they last saw. A declaration that matches
+    only one of those silently classifies the account as UNDECLARED — which this gate treats
+    as a failure, so the defect is loud rather than silent, but it is still a defect. Measured
+    on PR #6403, where the declared `openbank-gitops-bot[bot]` did not match the `app/...`
+    form the gate actually received."""
+    login = login.strip()
+    if login.startswith("app/"):
+        login = login[len("app/"):]
+    if login.endswith("[bot]"):
+        login = login[: -len("[bot]")]
+    return login
+
+
+def in_scope(author, is_bot, branch, cfg):
+    """(bool in_scope, str why). Raises Undetermined for an undeclared machine account."""
+    agents = {norm_login(a) for a in (cfg.get("agent_accounts") or [])}
+    automation = {norm_login(a) for a in (cfg.get("automation_accounts") or [])}
+    prefixes = cfg.get("agent_branch_prefixes") or []
+    author_key = norm_login(author)
+
+    if author_key in agents:
+        return True, f"author `{author}` is a declared autonomous agent account"
+    for p in prefixes:
+        if branch.startswith(p):
+            return True, f"head branch `{branch}` uses the agent prefix `{p}`"
+    if author_key in automation:
+        return False, f"author `{author}` is declared deterministic automation (generated content)"
+    if is_bot:
+        raise Undetermined(
+            f"author `{author}` is a machine account declared in NEITHER "
+            f"`autonomous_agent_prs.agent_accounts` NOR `automation_accounts`. A new machine "
+            f"identity must be classified by a human before it opens pull requests here. "
+            f"Refusing to guess — an unclassified bot is not an out-of-scope one."
+        )
+    return False, f"author `{author}` is a human account on a non-agent branch"
+
+
+def protected_reasons(files, cfg):
+    """Every protected-path clause this file list trips, as (clause, matched paths).
+
+    Returns ALL of them rather than the first: a reason list that stops at the first hit
+    cannot show that its later clauses are reachable, which is what the self-test asserts."""
+    toks = "|".join(re.escape(t) for t in protected_tokens(cfg))
+    out = []
+
+    ci = [f for f in files if re.match(r"^\.github/(workflows|actions)/", f)]
+    if ci:
+        out.append(("ci-definitions", ci))
+
+    svc_re = re.compile(
+        rf"^openbank-({toks})s?(-service)?/|^openbank-infra/gitops/components/({toks})s?(-service)?/"
+    )
+    svc = [f for f in files if svc_re.match(f)]
+    if svc:
+        out.append(("money-path", svc))
+
+    # A Markdown file under docs/ cannot change what the PDP enforces (#3888).
+    authz = [
+        f
+        for f in files
+        if not re.match(r"^docs/.*\.md$", f)
+        and re.search(r"(\.rego$|/opa/|authz|rbac|networkpolicy)", f)
+    ]
+    if authz:
+        out.append(("authz-policy", authz))
+
+    gov_globs = cfg.get("governance_path_globs") or []
+    gov = [f for f in files if any(fnmatch.fnmatch(f, g) for g in gov_globs)]
+    if gov:
+        out.append(("governance-and-gates", gov))
+
+    return out
+
+
+REASON_TEXT = {
+    "ci-definitions": (
+        "changes .github/workflows or .github/actions. Merging that to main changes what "
+        "executes on the self-hosted runners."
+    ),
+    "money-path": (
+        "touches money-path / high-blast-radius service or gitops paths, regardless of the "
+        "PR title's scope."
+    ),
+    "authz-policy": "changes authorization policy (rego / OPA / RBAC / NetworkPolicy).",
+    "governance-and-gates": (
+        "changes governance sources or CI gate machinery — these decide what the whole fleet "
+        "enforces."
+    ),
+}
+
+
+def verdict(author, is_bot, branch, files, cfg):
+    """(exit_code, message). Raises Undetermined when it cannot decide."""
+    scoped, why = in_scope(author, is_bot, branch, cfg)
+    if not scoped:
+        return 0, f"out of scope: {why}"
+    if not files:
+        raise Undetermined(
+            "the changed-file list is empty — an agent PR that changes nothing is not a clean verdict"
+        )
+    hits = protected_reasons(files, cfg)
+    if not hits:
+        return 0, f"in scope ({why}) and touches no protected path — {len(files)} file(s) checked"
+    lines = [f"BLOCKED: this PR is agent-authored ({why}) and:"]
+    for clause, matched in hits:
+        lines.append(f"  * {REASON_TEXT[clause]}")
+        lines.append(f"    matched: {' '.join(sorted(matched)[:3])}")
+    lines.append("")
+    lines.append(
+        "An autonomous agent does not land these paths unattended. Hand this PR to a human "
+        "reviewer; do NOT reach for an administrative override flag — a refusal here is the "
+        "correct final state."
+    )
+    return 1, "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- enumeration
+
+
+def _gh(args):
+    cmd = ["gh"] + args
+    if args and args[0] != "api":
+        cmd += ["-R", REPO]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise Undetermined(f"gh {' '.join(args)} failed (rc={proc.returncode}): {proc.stderr.strip()}")
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        raise Undetermined(f"gh {' '.join(args)} returned non-JSON: {e}") from e
+
+
+def fetch_pr(n):
+    pr = _gh(["pr", "view", str(n), "--json", "author,headRefName"])
+    author = (pr.get("author") or {}).get("login") or ""
+    is_bot = bool((pr.get("author") or {}).get("is_bot"))
+    branch = pr.get("headRefName") or ""
+    if not author or not branch:
+        raise Undetermined(f"PR #{n}: could not read author/headRefName")
+    pages = _gh(["api", f"repos/{REPO}/pulls/{n}/files?per_page=100", "--paginate", "--slurp"])
+    files = [f["filename"] for page in pages for f in page]
+    return author, is_bot, branch, files
+
+
+def resolve_pr_number(explicit):
+    if explicit:
+        return int(explicit)
+    for var in ("PR_NUMBER", "GITHUB_PR_NUMBER"):
+        if os.environ.get(var, "").strip().isdigit():
+            return int(os.environ[var])
+    m = re.match(r"refs/pull/(\d+)/", os.environ.get("GITHUB_REF", ""))
+    if m:
+        return int(m.group(1))
+    ev = os.environ.get("GITHUB_EVENT_PATH", "")
+    if ev and os.path.exists(ev):
+        try:
+            with open(ev) as fh:
+                n = (json.load(fh).get("pull_request") or {}).get("number")
+            if n:
+                return int(n)
+        except (OSError, ValueError, json.JSONDecodeError):
+            pass
+    return None
+
+
+# --------------------------------------------------------------------------- self-test
+
+FIXTURE = {
+    "agent_accounts": ["openbank-agent-bot[bot]"],
+    "automation_accounts": ["release-please[bot]", "openbank-gitops-bot[bot]"],
+    "agent_branch_prefixes": ["agent/"],
+    "extra_protected_tokens": ["kyc", "party"],
+    "governance_path_globs": [
+        "openbank-libs/governance/*",
+        ".github/gates/*",
+        ".github/scripts/*",
+    ],
+    "_money_path_services": ["openbank-ledger-service", "openbank-balance-service"],
+}
+
+
+def self_test():
+    cases = [
+        # (name, author, is_bot, branch, files, expect_code, expect_substring)
+        (
+            "agent account + money-path service source is blocked",
+            "openbank-agent-bot[bot]", True, "fix/ledger-rounding",
+            ["openbank-ledger-service/src/main/kotlin/A.kt"], 1, "money-path",
+        ),
+        (
+            "agent BRANCH under the human account is still blocked",
+            "JiRaska", False, "agent/fix-ledger",
+            ["openbank-ledger-service/src/main/kotlin/A.kt"], 1, "money-path",
+        ),
+        (
+            "gitops component path counts as money-path (plural component name)",
+            "openbank-agent-bot[bot]", True, "agent/x",
+            ["openbank-infra/gitops/components/balances/ingress.yaml"], 1, "money-path",
+        ),
+        (
+            "workflow change is blocked on its own clause",
+            "openbank-agent-bot[bot]", True, "agent/x",
+            [".github/workflows/ci.yml"], 1, "self-hosted runners",
+        ),
+        (
+            "rego change is blocked on its own clause",
+            "openbank-agent-bot[bot]", True, "agent/x",
+            ["openbank-infra/gitops/base/policy/rest.rego"], 1, "authorization policy",
+        ),
+        (
+            "governance source is blocked on its own clause",
+            "openbank-agent-bot[bot]", True, "agent/x",
+            ["openbank-libs/governance/rules.yaml"], 1, "governance sources",
+        ),
+        (
+            "a gate script is governance machinery too",
+            "openbank-agent-bot[bot]", True, "agent/x",
+            [".github/scripts/check-something.py"], 1, "governance sources",
+        ),
+        (
+            "docs ABOUT authz are NOT the control (#3888)",
+            "openbank-agent-bot[bot]", True, "agent/x",
+            ["docs/adr/0034-authz.md"], 0, "touches no protected path",
+        ),
+        (
+            "an ordinary agent PR passes",
+            "openbank-agent-bot[bot]", True, "agent/x",
+            ["openbank-admin-ui/app/page.tsx"], 0, "touches no protected path",
+        ),
+        (
+            "a human on a human branch is out of scope even on the money path",
+            "JiRaska", False, "fix/ledger-rounding",
+            ["openbank-ledger-service/src/main/kotlin/A.kt"], 0, "out of scope",
+        ),
+        (
+            "declared automation is out of scope on the money path",
+            "release-please[bot]", True, "release-please--branches--main",
+            ["openbank-ledger-service/version.txt"], 0, "deterministic automation",
+        ),
+        (
+            "the `app/...` spelling of a declared automation account still matches (#6403)",
+            "app/openbank-gitops-bot", True, "deploy/snapshot",
+            ["openbank-infra/gitops/components/balances/kustomization.yaml"], 0,
+            "deterministic automation",
+        ),
+        (
+            "the bare spelling of a declared agent account still matches",
+            "openbank-agent-bot", True, "chore/x",
+            ["openbank-ledger-service/src/main/kotlin/A.kt"], 1, "money-path",
+        ),
+        (
+            "extra_protected_tokens are covered (kyc is not in money_path_services)",
+            "openbank-agent-bot[bot]", True, "agent/x",
+            ["openbank-kyc-service/src/main/kotlin/A.kt"], 1, "money-path",
+        ),
+    ]
+
+    failures = []
+    for name, author, is_bot, branch, files, want_code, want_sub in cases:
+        try:
+            code, msg = verdict(author, is_bot, branch, files, dict(FIXTURE))
+        except Undetermined as e:
+            failures.append(f"{name}: raised Undetermined ({e})")
+            continue
+        if code != want_code:
+            failures.append(f"{name}: exit {code}, expected {want_code} — {msg}")
+        elif want_sub not in msg:
+            failures.append(f"{name}: message missing {want_sub!r} — {msg}")
+
+    # The undeclared-bot clause: absence of a classification must FAIL, not pass.
+    try:
+        verdict("some-new-bot[bot]", True, "chore/whatever", ["README.md"], dict(FIXTURE))
+        failures.append("an UNDECLARED bot account was treated as out of scope — it must be undetermined")
+    except Undetermined as e:
+        if "NEITHER" not in str(e):
+            failures.append(f"undeclared-bot raised the wrong Undetermined: {e}")
+
+    # An empty file list for an in-scope PR is an enumeration failure, not a clean.
+    try:
+        verdict("openbank-agent-bot[bot]", True, "agent/x", [], dict(FIXTURE))
+        failures.append("an EMPTY file list was reported as clean — that is the enumeration-failure shape")
+    except Undetermined:
+        pass
+
+    # A rules file with no autonomous_agent_prs block must be undetermined, not a pass.
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as fh:
+        fh.write("money_path_services: [openbank-ledger-service]\n")
+        empty = fh.name
+    try:
+        load_rules(empty)
+        failures.append("rules.yaml without `autonomous_agent_prs` loaded cleanly — it must be undetermined")
+    except Undetermined:
+        pass
+    finally:
+        os.unlink(empty)
+
+    # And the real rules.yaml must actually carry the block — a self-test that only ever
+    # exercises its own fixture cannot notice the config being deleted from under it.
+    if os.path.exists(RULES):
+        try:
+            live = load_rules()
+        except Undetermined as e:
+            failures.append(f"the live {RULES} does not satisfy the guard: {e}")
+        else:
+            for required in ("agent_accounts", "automation_accounts", "agent_branch_prefixes", "governance_path_globs"):
+                if required not in live:
+                    failures.append(f"live {RULES}: `autonomous_agent_prs.{required}` is missing")
+            toks = protected_tokens(live)
+            if len(toks) < 20:
+                failures.append(f"live rules.yaml yields only {len(toks)} protected tokens — the derivation is broken")
+
+    if failures:
+        print("SELF-TEST FAILED — the guard is not falsifiable as written:")
+        for f in failures:
+            print(f"  x {f}")
+        return 1
+    print(
+        f"self-test OK — {len(cases)} classifier cases + 4 undetermined cases, "
+        f"every block clause independently reached"
+    )
+    return 0
+
+
+# --------------------------------------------------------------------------- main
+
+
+def main():
+    ap = argparse.ArgumentParser(description="agent PR guard")
+    ap.add_argument("--pr")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    try:
+        cfg = load_rules()
+        # The SUBJECT corpus is the RULE SET, not the PR. A PR-scoped gate examines one PR by
+        # definition, so counting PRs could never distinguish a working gate from a broken
+        # one. What CAN silently collapse is the derivation: if money_path_services stops
+        # being readable, or the glob list empties, every clause matches nothing and the gate
+        # passes everything while still exiting 0 on a real PR. That is the exact failure
+        # `min_subjects:` exists for, so the floor is placed on the derived rules.
+        n_rules = len(protected_tokens(cfg)) + len(cfg.get("governance_path_globs") or [])
+        gatelib.subjects(n_rules, "protected service tokens + governance globs")
+        n = resolve_pr_number(args.pr)
+        if n is None:
+            print("agent-pr-guard: no pull request in context — nothing to judge")
+            return 0
+        author, is_bot, branch, files = fetch_pr(n)
+        code, msg = verdict(author, is_bot, branch, files, cfg)
+    except Undetermined as e:
+        # Third state: the verdict could not be computed. The floor must not then convert an
+        # unreachable API into a lost-corpus red one layer up.
+        gatelib.subjects_unresolved(str(e))
+        print(f"::error::agent-pr-guard could not reach a verdict: {e}")
+        return 2
+    print(f"agent-pr-guard: {msg}" if code == 0 else msg)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -2997,3 +2997,63 @@ pr_file_overlap:
     - ".github/workflows/ci.yml"
     - ".github/workflows/auto-deploy.yml"
     - "openbank-infra/gitops/"
+
+# ---------------------------------------------------------------------------
+# AUTONOMOUS AGENT PULL REQUESTS (gate: agent-pr-guard, enforced)
+#
+# The repo runs scheduled, unattended agents that open PRs around the clock. Until now the
+# only thing keeping unattended work off the money path was a PreToolUse hook on the
+# maintainer's laptop — which does not exist in a cloud session or on a runner, and which a
+# command-string matcher cannot see through anyway. `main`'s ruleset does not supply the
+# control either: required_approving_review_count is 0 and the admin bypass actor is the
+# same identity an agent authenticates as.
+#
+# So the rule lives here and is enforced as a required check. A red required check cannot be
+# cleared by the agent that tripped it and cannot be cleared by `--auto`.
+#
+# The PROTECTED SERVICE SET IS DERIVED from money_path_services above (prefix/suffix
+# stripped), so onboarding a money-path service extends the guard with no edit here.
+# `extra_protected_tokens` is a hand-kept list of external FACTS — services that are high
+# blast radius without being money-path by that list's definition. The gate's SCOPE is not
+# hand-kept: an undeclared machine account fails the check rather than passing it.
+autonomous_agent_prs:
+  detect:
+    - 'any pull_request whose author is a declared agent account, or whose head branch carries a declared agent prefix'
+  require:
+    - an agent-authored PR that touches a protected path fails the check and waits for a human
+    - a machine account in neither agent_accounts nor automation_accounts fails the check — it must be classified first
+    - an unreadable author, branch or file list is exit 2 (undetermined), never a pass
+  gate: agent-pr-guard
+  enforced: block
+  ci_producer: .github/scripts/check-agent-pr-guard.py
+  # Autonomous coding agents. Adding a login here is a governance-path change, which this
+  # very guard blocks an agent from making.
+  agent_accounts:
+    - openbank-agent-bot[bot]
+  # Deterministic automation. These legitimately touch money-path paths and their content is
+  # generated rather than authored; blocking them deadlocks the release queue for no safety.
+  automation_accounts:
+    - release-please[bot]
+    - openbank-gitops-bot[bot]
+    - dependabot[bot]
+    - github-actions[bot]
+  # Coverage for an agent running under a HUMAN account, which is the state today — every
+  # open PR in this repo is authored by the maintainer's login. Without this an identity-only
+  # scope would cover nothing at all.
+  agent_branch_prefixes:
+    - agent/
+  # High blast radius, not money-path by the list above.
+  extra_protected_tokens:
+    - payment
+    - kyc
+    - party
+    - card-issuance
+    - aml
+    - tax
+    - dispute
+  # Governance sources and gate machinery: a gate can be defanged by editing its script
+  # without touching any YAML, so the scripts directory is in scope alongside the manifests.
+  governance_path_globs:
+    - openbank-libs/governance/*
+    - .github/gates/*
+    - .github/scripts/*


### PR DESCRIPTION
Closes #6412

## What

Adds **`agent-pr-guard`** — an enforced, PR-only gate that fails when an **agent-authored** PR
touches a protected path: CI definitions, money-path / high-blast-radius service or gitops
paths, authorization policy, or governance and gate machinery.

This is the prerequisite for running scheduled unattended agents at all. See #6412 for the
rest of the programme.

## Why a required check, and not the existing hook

The rule exists today only as `protected-pr-check.sh`, a PreToolUse hook on the maintainer's
laptop. That control:

- does not exist in a cloud session or on a GitHub runner — i.e. anywhere an agent runs
  unattended;
- is blind to a merge issued from inside a script even locally (17 PRs merged in one session
  with all of its rules unevaluated);
- is not backstopped by the ruleset: `required_approving_review_count` is 0, and the admin
  bypass actor is the same identity an agent authenticates as.

A required check is the one shape none of that defeats: it runs wherever the PR came from, the
agent that tripped it cannot clear it, and `--auto` cannot merge past it.

## Design decisions worth reviewing

**The head-branch clause is load-bearing.** Every open PR in this repo today is authored by
`JiRaska` — an identity-only scope would cover *nothing* until the bot App exists. So scope is
`declared agent account` **OR** `declared head-branch prefix` (`agent/`).

**An undeclared machine account FAILS.** A Bot-typed author in neither `agent_accounts` nor
`automation_accounts` is exit 2, not a pass. This is what keeps the scope from being a
hand-kept list of the gate's own subjects — the shape that reads as clean when it is short.

**Deterministic automation stays out of scope.** release-please and the deploy snapshotters
legitimately touch money-path paths; their content is generated, not authored, and blocking
them would deadlock the release queue for no safety gained.

**The protected service set is derived**, not retyped: `money_path_services` with the
`openbank-` prefix and `-service` suffix stripped, plus a short declared list of extras that
are high blast radius without being money-path by that list's definition (kyc, party, card
issuance, aml, tax, dispute). Onboarding a money-path service extends this guard with no edit
to the checker.

**Enforced, not advisory.** The deadlock argument that makes `pr-file-overlap` advisory does
not apply here: a human PR is out of scope entirely, so this can never red a human's work, and
an agent PR it reds is one that *should* be waiting for a human.

## Falsifiability

`--self-test` drives 14 classifier cases plus 4 undetermined cases, asserting on the **reason**
rather than the exit code — two branches agreeing on a verdict is how a clause becomes
unfalsifiable while the suite stays green.

Verified by mutation rather than by inspection: **11 mutations, each defanging exactly one
clause, and every one of them kills the self-test.** Two of those mutations initially
*survived* and turned out to be defects in the mutation harness, not in the gate — which is
the point of running the negative case at all.

Live-PR run found a real defect in the first draft: `gh pr view --json author` spells an App
author `app/openbank-gitops-bot` while the REST API spells it `openbank-gitops-bot[bot]`, so
the declaration matched neither and every deploy PR classified as an undeclared bot. Logins
are now normalised across both spellings, with a self-test case per spelling.

## Verification

- `python3 .github/scripts/check-agent-pr-guard.py --self-test` — 14 + 4 cases green
- mutation sweep — 11/11 killed
- `run-gates.py --group lint` — 21/21 PASS, including the two meta-gates that demand
  `rationale:` / `review_after:` / `min_subjects:`
- run against live PRs #6403, #6402, #6400 — all correctly out of scope as declared automation

`SUBJECTS` is the **rule** corpus (33 = 30 service tokens + 3 governance globs), not the PR:
a PR-scoped gate examines one PR by definition, so counting PRs could never distinguish a
working gate from a broken one. What can silently collapse is the derivation, and the floor is
placed there.

## Note for the reviewer

This PR touches `.github/scripts/`, `.github/gates/` and `openbank-libs/governance/` — three
of the paths the guard itself protects. That is expected: a change to the gate machinery needs
a human by rule, and this is one.
