### PR TITLE
test(ledger): negative control — agent-pr-guard must refuse this PR (DO NOT MERGE)

### DIFF
--- a/openbank-ledger-service/docs/GUARD-NEGATIVE-CONTROL.md
+++ b/openbank-ledger-service/docs/GUARD-NEGATIVE-CONTROL.md
@@ -1,0 +1,11 @@
+# Negative control for `agent-pr-guard` — DO NOT MERGE
+
+This file exists to prove one thing: that `agent-pr-guard`'s RED is reachable in real CI, and
+not only inside its own self-test. A gate that has only ever passed is unfalsified.
+
+It sits under `openbank-ledger-service/` (a money-path service) on a branch named
+`agent/guard-negative-control` (the declared agent prefix), which is exactly the combination
+the guard must refuse. `Validate manifests` is expected to FAIL on this PR.
+
+The PR carrying it is closed as soon as that failure is observed, and this file never reaches
+`main`.


### PR DESCRIPTION
Refs #6412 · negative control for #6413 · **DO NOT MERGE — closed as soon as the red is observed**

## Purpose

`agent-pr-guard` (#6413) is green in its own self-test and in `run-gates.py`. That is not
proof: a gate that has only ever passed is unfalsified, and the self-test only exercises the
checker's own fixtures — it cannot show that the gate is actually **wired into CI** and
reaches a verdict on a real pull request.

This PR is the known-positive. It adds one file under `openbank-ledger-service/` (a money-path
service) on a branch named `agent/guard-negative-control` (the declared agent prefix). That is
precisely the combination the guard must refuse.

**Expected result: `Validate manifests` FAILS**, with `agent-pr-guard` reporting the
`money-path` clause.

If this PR goes green, the guard is not doing its job and #6413 should not have merged.

## Why it is stacked on #6413's branch

Its base is `feat/agent-pr-guard`, not `main`, so the gate exists in this checkout and CI runs
it. That means the control can be observed before #6413 merges rather than after — which is
the right order for a check whose whole purpose is to gate merges.

## Cleanup

Closed once the failure is recorded here. The branch is a leaf, so deleting it closes nothing
else. The file never reaches `main`.
