### PR TITLE
fix(admin-ui): clarify transaction search state

### DIFF
--- a/openbank-admin-ui/src/app/transactions/page.tsx
+++ b/openbank-admin-ui/src/app/transactions/page.tsx
@@ -156,8 +156,8 @@ export default function TransactionsPage() {
             <Filter size={13} />
             {hasFilters ? <span style={{ color: 'var(--accent)' }}>{t('Filtry', 'Filters')} ({[iban,bban,referenceNumber,endToEndId,counterparty,status,type,dateFrom,dateTo,amountMin,amountMax,channel].filter(Boolean).length})</span> : t('Filtry', 'Filters')}
           </button>
-          <button className="btn btn-primary" onClick={() => search()} disabled={loading}>
-            {loading ? <RefreshCw size={13} className="animate-spin" /> : <Search size={13} />}
+          <button type="button" className="btn btn-primary" onClick={() => search()} disabled={loading} aria-busy={loading} aria-label={loading ? t('Vyhledávání transakcí', 'Searching transactions') : t('Vyhledat transakce', 'Search transactions')}>
+            {loading ? <RefreshCw size={13} aria-hidden="true" className="animate-spin" /> : <Search size={13} aria-hidden="true" />}
             {loading ? t('Hledám…', 'Searching…') : t('Hledat', 'Search')}
           </button>
         </div>

--- a/openbank-admin-ui/src/test/transactions-search.guard.test.ts
+++ b/openbank-admin-ui/src/test/transactions-search.guard.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('transactions search contract', () => {
+  it('exposes localized busy semantics without changing search flow', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/transactions/page.tsx'), 'utf8')
+    expect(source).toContain('type="button"')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("t('Vyhledávání transakcí', 'Searching transactions')")
+    expect(source).toContain("t('Vyhledat transakce', 'Search transactions')")
+    expect(source).toContain('onClick={() => search()}')
+  })
+})


### PR DESCRIPTION
## Summary
- add explicit button semantics and localized busy/name state to transaction search
- preserve existing transaction query, pagination, BFF and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.