### PR TITLE
feat(admin-ui): add evidence-backed Agent Control Room

### DIFF
--- a/docs/adr/0246-admin-ui-swarm-thread-view-over-temporal-case-history.md
+++ b/docs/adr/0246-admin-ui-swarm-thread-view-over-temporal-case-history.md
@@ -2,7 +2,7 @@
 date: 2026-08-05
 decision-status: proposed
 delivery-status: partial
-followup: "#5708 — the backend read model and REST surface are live; the admin-ui half of the thread view is the remainder"
+followup: "#5708 — backend read model is live; the read-only Control Room UI and evidence provenance are in delivery"
 authors: [Jiri Raska]
 supersedes: []
 superseded-by: []
@@ -14,6 +14,15 @@ summary: "The admin-ui swarm thread view is a read-only projection of Temporal c
 # ADR-0246 — Admin-ui swarm thread view over Temporal case history
 
 **Delivery note (2026-08-19).** The backend half is live on `main` while this ADR read `delivery-status: planned`: `CaseThread` (*"Read model for the ADR-0246 swarm thread view (Phase 2, #4185)"*), `CaseThreadProjection` (*"Pure projection from persistence rows to the ADR-0246 thread view"*) and `CaseCoordinatorResource`'s ADR-0246 thread endpoint, in `openbank-case-coordinator-agent`. The admin-ui rendering this ADR is named for is the remaining half, which is why this is `partial` and not `shipped`. Found by the code->ADR evidence read described in #5708.
+
+**Delivery clarification (2026-08-22).** `agents.yaml` is a charter registry, not
+runtime proof. A solid topology edge may be rendered only from an observed durable
+record: a consumed contribution, an event published by the transactional outbox,
+a Temporal-history observation, or an OPA allow decision. The current projection
+exposes the first two with source, evidence id, correlation id, observation time
+and precise stage. An outbox `SENT` status proves publication to the broker, not
+consumption by the HITL inbox. Declared-only relationships remain non-runtime
+claims and never become solid edges.
 
 
 ## Context
@@ -50,20 +59,20 @@ Constraints inherited from the estate:
 
 ## Decision
 
-**D1 — The thread view is a read-only projection of Temporal workflow history.**
-The swarm thread page renders the case workflow's history — case opened,
+**D1 — The thread view is a read-only projection of durable case runtime evidence.**
+The swarm thread page renders the case workflow's persisted read model and
+transactional-outbox evidence — case opened,
 contribution accepted/rejected (with contributor principal id and type), step
 pre-empted (`superseded-by-evidence`), budget state, synthesis, outcome — mapped
-one-to-one from history events. No new data model, no new write path, no second
-store to drift from the authoritative history.
+one-to-one from observed records. A later Temporal-history adapter may add another
+evidence source, but absence of that adapter is shown honestly. No new write path
+or second orchestration store is introduced.
 
-**D2 — Rendering is a chronological thread, not a graph.** The v1 surface is a
-chat-like timeline with per-agent attribution (avatar/charter, contribution type,
-timestamp, cited contribution ids per ADR-0244 D6 merge semantics). Temporal
-history is an ordered event log, so a thread maps onto it exactly, while a DAG
-would need a graph library (a new dependency) to render structure the history does
-not inherently have. An interactive flow explainer in the spirit of ADR-0208 may
-follow as a later enhancement; it is not the v1.
+**D2 — Rendering offers a thread, evidence timeline and minimal topology.** The
+thread remains the canonical chronological view with per-agent attribution. The
+topology is a dependency-free list of observed edges, not a workflow designer or
+a second control plane. Solid edges require runtime evidence; charter-only claims
+are never promoted to facts. Each observation has expandable provenance.
 
 **D3 — The view lives under `/iaops` and reuses the BFF path.** The page sits in
 the agent-ops information architecture (`/iaops/cases`, drill-down
@@ -106,9 +115,9 @@ as three different states.
 
 ## Consequences
 
-- Operators gain visibility into swarm orchestration with zero new data
-  infrastructure: the projection reads Temporal history the platform already
-  writes.
+- Operators gain visibility into swarm orchestration with zero new orchestration
+  infrastructure: the projection exposes durable records the case coordinator
+  already writes.
 - v1 needs one read port serving the history projection to the BFF — the only new
   server-side surface, read-only by construction.
 - The thread view becomes the natural link target for proposals in the ADR-0227

--- a/docs/adr/0246-admin-ui-swarm-thread-view-over-temporal-case-history.md
+++ b/docs/adr/0246-admin-ui-swarm-thread-view-over-temporal-case-history.md
@@ -17,10 +17,11 @@ summary: "The admin-ui swarm thread view is a read-only projection of Temporal c
 
 **Delivery clarification (2026-08-22).** `agents.yaml` is a charter registry, not
 runtime proof. A solid topology edge may be rendered only from an observed durable
-record: a consumed contribution, an event published by the transactional outbox,
+record: a persisted contribution, an event published by the transactional outbox,
 a Temporal-history observation, or an OPA allow decision. The current projection
 exposes the first two with source, evidence id, correlation id, observation time
-and precise stage. An outbox `SENT` status proves publication to the broker, not
+and precise stage. Persistence is not mislabeled as a separately observed Temporal
+consumption event. An outbox `SENT` status proves publication to the broker, not
 consumption by the HITL inbox. Declared-only relationships remain non-runtime
 claims and never become solid edges.
 

--- a/openbank-admin-ui/src/app/api/finops/ai-costs/route.ts
+++ b/openbank-admin-ui/src/app/api/finops/ai-costs/route.ts
@@ -13,7 +13,7 @@ export interface AgentCostEntry {
   agentId: string
   model: string
   tokensLast24h: number
-  tokensLast7d: number
+  tokensLast7d: number | null
   costLast24hUsd: number
   costLast7dUsd: number
   budgetMonthlyUsd: number | null
@@ -26,10 +26,38 @@ export interface AiCostsData {
   available: boolean
   collectedAt: string
   totalCostLast7dUsd: number
-  totalCostLast30dUsd: number
-  selfHostedPct: number   // % of cost on self-hosted vLLM vs. Anthropic API
+  totalCostLast30dUsd: number | null
+  selfHostedPct: number | null
+  coverage: MetricsCoverage
   agents: AgentCostEntry[]
   anomalies: FinOpsAnomaly[]
+}
+
+export interface MetricsCoverage {
+  source: 'prometheus'
+  retentionHours: number
+  dataFrom: string
+  dataTo: string
+  lastSuccessfulLoad: string | null
+  windows: Record<'24h' | '7d' | '30d', { requestedHours: number; availableHours: number; partial: boolean }>
+}
+
+function metricsCoverage(now: Date, successful: boolean): MetricsCoverage {
+  const configured = Number(process.env.PROMETHEUS_RETENTION_HOURS ?? '12')
+  const retentionHours = Number.isFinite(configured) && configured > 0 ? configured : 12
+  const available = (requestedHours: number) => Math.min(requestedHours, retentionHours)
+  return {
+    source: 'prometheus',
+    retentionHours,
+    dataFrom: new Date(now.getTime() - retentionHours * 60 * 60 * 1000).toISOString(),
+    dataTo: now.toISOString(),
+    lastSuccessfulLoad: successful ? now.toISOString() : null,
+    windows: {
+      '24h': { requestedHours: 24, availableHours: available(24), partial: retentionHours < 24 },
+      '7d': { requestedHours: 168, availableHours: available(168), partial: retentionHours < 168 },
+      '30d': { requestedHours: 720, availableHours: available(720), partial: retentionHours < 720 },
+    },
+  }
 }
 
 export interface FinOpsAnomaly {
@@ -58,6 +86,7 @@ async function fetchFromPrometheus(query: string, prometheusUrl: string): Promis
 }
 
 export async function GET() {
+  const now = new Date()
   const prometheusUrl = process.env.PROMETHEUS_URL ?? 'http://prometheus-operated.observability:9090'
   const langfuseUp = await fetchFromPrometheus('langfuse_up', prometheusUrl)
   const langfuseAvailable = langfuseUp === 1
@@ -66,10 +95,11 @@ export async function GET() {
     // Return illustrative mock data when Langfuse→Prometheus bridge not yet deployed
     const mock: AiCostsData = {
       available: false,
-      collectedAt: new Date().toISOString(),
+      collectedAt: now.toISOString(),
       totalCostLast7dUsd: 0,
-      totalCostLast30dUsd: 0,
-      selfHostedPct: 0,
+      totalCostLast30dUsd: null,
+      selfHostedPct: null,
+      coverage: metricsCoverage(now, false),
       agents: [],
       anomalies: [],
     }
@@ -110,7 +140,7 @@ export async function GET() {
       agentId,
       model: 'mixed',
       tokensLast24h: tokens24h ?? 0,
-      tokensLast7d: 0,
+      tokensLast7d: null,
       costLast24hUsd: cost24h ?? 0,
       costLast7dUsd: cost7d ?? 0,
       budgetMonthlyUsd,
@@ -125,10 +155,12 @@ export async function GET() {
 
   return NextResponse.json({
     available: true,
-    collectedAt: new Date().toISOString(),
+    collectedAt: now.toISOString(),
     totalCostLast7dUsd: totalCost7d,
-    totalCostLast30dUsd: 0,
-    selfHostedPct: 60,
+    totalCostLast30dUsd: null,
+    // The current bridge exports aggregate token/cost series, not provider-placement evidence.
+    selfHostedPct: null,
+    coverage: metricsCoverage(now, true),
     agents,
     anomalies: [],
   } satisfies AiCostsData)

--- a/openbank-admin-ui/src/app/finops/page.tsx
+++ b/openbank-admin-ui/src/app/finops/page.tsx
@@ -118,7 +118,7 @@ interface AgentCostEntry {
   agentId: string
   model: string
   tokensLast24h: number
-  tokensLast7d: number
+  tokensLast7d: number | null
   costLast24hUsd: number
   costLast7dUsd: number
   budgetMonthlyUsd: number | null
@@ -143,8 +143,16 @@ interface AiCostsData {
   available: boolean
   collectedAt: string
   totalCostLast7dUsd: number
-  totalCostLast30dUsd: number
-  selfHostedPct: number
+  totalCostLast30dUsd: number | null
+  selfHostedPct: number | null
+  coverage: {
+    source: 'prometheus'
+    retentionHours: number
+    dataFrom: string
+    dataTo: string
+    lastSuccessfulLoad: string | null
+    windows: Record<'24h' | '7d' | '30d', { requestedHours: number; availableHours: number; partial: boolean }>
+  }
   agents: AgentCostEntry[]
   anomalies: FinOpsAnomaly[]
 }
@@ -965,13 +973,29 @@ function FinOpsContent() {
                       {t('Celkem AI náklady — posledních 7 dní', 'Total AI costs — last 7 days')}
                     </div>
                   </div>
-                  <span style={{ fontSize: '11px', fontWeight: 700, padding: '3px 10px', borderRadius: '20px',
-                    background: '#dcfce7', color: '#16a34a' }}>
-                    {t(`${aiCosts.selfHostedPct}% self-hosted vLLM`, `${aiCosts.selfHostedPct}% self-hosted vLLM`)}
-                  </span>
-                  <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
-                    {t(`${100 - aiCosts.selfHostedPct}% Anthropic API`, `${100 - aiCosts.selfHostedPct}% Anthropic API`)}
-                  </span>
+                  {aiCosts.selfHostedPct == null ? (
+                    <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
+                      {t('Rozdělení podle poskytovatele bridge neexportuje.', 'Provider split is not exported by the bridge.')}
+                    </span>
+                  ) : (
+                    <>
+                      <span style={{ fontSize: '11px', fontWeight: 700, padding: '3px 10px', borderRadius: '20px',
+                        background: '#dcfce7', color: '#16a34a' }}>
+                        {aiCosts.selfHostedPct}% self-hosted vLLM
+                      </span>
+                      <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
+                        {100 - aiCosts.selfHostedPct}% Anthropic API
+                      </span>
+                    </>
+                  )}
+                </div>
+                <div role="status" style={{ fontSize: '11px', color: 'var(--text-tertiary)', margin: '-10px 0 16px' }}>
+                  {t('Pokrytí', 'Coverage')}: {aiCosts.coverage.windows['7d'].availableHours}h / 7d
+                  {' · '}{t('retence', 'retention')} {aiCosts.coverage.retentionHours}h
+                  {' · '}{t('poslední úspěšné načtení', 'last successful load')}:{' '}
+                  {aiCosts.coverage.lastSuccessfulLoad
+                    ? new Date(aiCosts.coverage.lastSuccessfulLoad).toLocaleString(locale)
+                    : t('žádné', 'none')}
                 </div>
 
                 {/* Per-agent rows */}

--- a/openbank-admin-ui/src/app/iaops/cases/[caseId]/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/cases/[caseId]/page.tsx
@@ -15,6 +15,8 @@ import { deriveCaseDecisionBrief } from '@/lib/governance/caseDecisionBrief'
 import { caseStatusPresentation } from '@/lib/governance/caseStatusPresentation'
 import type { CaseStatus } from '@/lib/governance/caseStatusPresentation'
 import { PageHeader } from '@/components/ui/PageHeader'
+import { CaseRuntimeTimeline, CaseRuntimeTopology } from '@/components/agent/CaseRuntimeViews'
+import type { RuntimeEvidenceView } from '@/components/agent/CaseRuntimeViews'
 
 type EntryType = 'CASE_OPENED' | 'CONTRIBUTION' | 'PROPOSAL_EMITTED' | 'SHADOW_RECORDED'
 
@@ -30,6 +32,8 @@ interface ThreadEntry {
   proposalId?: string
   proposalType?: string
   shadow?: boolean
+  tokensUsed?: number
+  runtimeEvidence: RuntimeEvidenceView
 }
 
 interface CaseThread {
@@ -40,6 +44,11 @@ interface CaseThread {
   openedAtEpochMs: number
   deadlineAtEpochMs: number
   contestedRate: number
+  budgetTokens: number
+  budgetContributions: number
+  observedAtEpochMs: number
+  historySource: string
+  retentionPolicy: string
   entries: ThreadEntry[]
 }
 
@@ -69,6 +78,7 @@ export default function IaopsCaseThreadPage() {
   const [thread, setThread] = useState<CaseThread | null>(null)
   const [loading, setLoading] = useState(true)
   const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
+  const [view, setView] = useState<'thread' | 'timeline' | 'topology'>('thread')
 
   const locale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const fmt = useCallback(
@@ -154,7 +164,16 @@ export default function IaopsCaseThreadPage() {
             <span>{t('Otevřeno', 'Opened')}: <strong style={{ color: 'var(--text-secondary)' }}>{fmt(thread.openedAtEpochMs)}</strong></span>
             <span>{t('Deadline', 'Deadline')}: <strong style={{ color: 'var(--text-secondary)' }}>{fmt(thread.deadlineAtEpochMs)}</strong></span>
             <span>{t('Míra sporu', 'Contested rate')}: <strong style={{ color: 'var(--text-secondary)' }}>{Math.round(thread.contestedRate * 100)} %</strong></span>
+            <span>{t('Rozpočet', 'Budget')}: <strong style={{ color: 'var(--text-secondary)' }}>{thread.budgetTokens.toLocaleString(locale)} tokens / {thread.budgetContributions} contributions</strong></span>
           </div>
+
+          <nav aria-label={t('Pohled na case', 'Case view')} style={{ display: 'flex', gap: '6px', marginBottom: '16px' }}>
+            {(['thread', 'timeline', 'topology'] as const).map(candidate => (
+              <button key={candidate} type="button" onClick={() => setView(candidate)} aria-pressed={view === candidate} style={{ padding: '6px 11px', borderRadius: '9px', border: `1px solid ${view === candidate ? 'var(--accent-border)' : 'var(--border)'}`, background: view === candidate ? 'var(--accent-bg)' : 'var(--surface)', color: view === candidate ? 'var(--accent-text)' : 'var(--text-secondary)', fontSize: '11px', fontWeight: 750, cursor: 'pointer', textTransform: 'capitalize' }}>
+                {candidate}
+              </button>
+            ))}
+          </nav>
 
           {(() => {
             const brief = deriveCaseDecisionBrief(thread)
@@ -234,7 +253,9 @@ export default function IaopsCaseThreadPage() {
             </div>
           )}
 
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          {view === 'timeline' && <CaseRuntimeTimeline thread={thread} locale={locale} />}
+          {view === 'topology' && <CaseRuntimeTopology thread={thread} locale={locale} />}
+          {view === 'thread' && <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
             {thread.entries.map((entry, index) => {
               if (entry.type === 'CASE_OPENED') {
                 return (
@@ -321,7 +342,7 @@ export default function IaopsCaseThreadPage() {
                 </div>
               )
             })}
-          </div>
+          </div>}
         </>
       ) : null}
     </div>

--- a/openbank-admin-ui/src/app/iaops/cases/[caseId]/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/cases/[caseId]/page.tsx
@@ -47,6 +47,10 @@ interface CaseThread {
   budgetTokens: number
   budgetContributions: number
   observedAtEpochMs: number
+  dataFromEpochMs: number
+  dataToEpochMs: number
+  lastSuccessfulLoadEpochMs: number
+  coverageStatus: string
   historySource: string
   retentionPolicy: string
   entries: ThreadEntry[]

--- a/openbank-admin-ui/src/app/iaops/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/page.tsx
@@ -57,6 +57,15 @@ interface AgentCostEntry {
   burnRate: 'low' | 'normal' | 'high' | 'exceeded'
 }
 
+interface MetricsCoverage {
+  source: string
+  retentionHours: number
+  dataFrom: string
+  dataTo: string
+  lastSuccessfulLoad: string | null
+  windows: Record<'24h' | '7d' | '30d', { requestedHours: number; availableHours: number; partial: boolean }>
+}
+
 interface FinOpsAnomaly {
   id: string
   detectedAt: string
@@ -153,6 +162,7 @@ function IAOpsContent() {
   const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [data, setData] = useState<GovData | null>(null)
   const [agentCosts, setAgentCosts] = useState<AgentCostEntry[]>([])
+  const [costCoverage, setCostCoverage] = useState<MetricsCoverage | null>(null)
   const [costAnomalies, setCostAnomalies] = useState<FinOpsAnomaly[]>([])
   const [loading, setLoading] = useState(true)
   const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
@@ -175,8 +185,9 @@ function IAOpsContent() {
       if (!govRes.ok) { setUnavailable({ kind: 'error' }); return }
       setData(await govRes.json())
       if (aiCostRes.ok) {
-        const ac = await aiCostRes.json() as { available: boolean; agents?: AgentCostEntry[] }
+        const ac = await aiCostRes.json() as { available: boolean; agents?: AgentCostEntry[]; coverage?: MetricsCoverage }
         setAgentCosts(ac.agents ?? [])
+        setCostCoverage(ac.coverage ?? null)
       }
       if (anomalyRes.ok) {
         const an = await anomalyRes.json() as { anomalies?: FinOpsAnomaly[] }
@@ -244,7 +255,7 @@ function IAOpsContent() {
 
       <PageHeader
         icon={<Bot size={20} aria-hidden="true" />}
-        title={t('IAOps — governance AI', 'IAOps — AI Governance')}
+        title={t('Řídicí centrum agentů', 'Agent Control Room')}
         subtitle={t(
           'Co AI děláme, proč, jak je to řízené a jak jsme compliant — ADR-0031',
           'What AI we run, why, how it is governed, and how we stay compliant — ADR-0031',
@@ -568,11 +579,11 @@ function IAOpsContent() {
                             {t('Náklady / rozpočet', 'Cost / Budget status')}
                           </div>
                           <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
-                            <span style={{ fontSize: '11px', color: 'var(--text-secondary)' }}>
-                              24h: <strong style={{ fontFamily: 'monospace', color: 'var(--text-primary)' }}>${costEntry.costLast24hUsd.toFixed(2)}</strong>
+                            <span title={costCoverage ? `${costCoverage.dataFrom} → ${costCoverage.dataTo}` : undefined} style={{ fontSize: '11px', color: 'var(--text-secondary)' }}>
+                              {costCoverage?.windows['24h'].partial ? `${costCoverage.windows['24h'].availableHours}h / 24h` : '24h'}: <strong style={{ fontFamily: 'monospace', color: 'var(--text-primary)' }}>${costEntry.costLast24hUsd.toFixed(2)}</strong>
                             </span>
-                            <span style={{ fontSize: '11px', color: 'var(--text-secondary)' }}>
-                              7d: <strong style={{ fontFamily: 'monospace', color: 'var(--text-primary)' }}>${costEntry.costLast7dUsd.toFixed(2)}</strong>
+                            <span title={costCoverage ? `${costCoverage.dataFrom} → ${costCoverage.dataTo}` : undefined} style={{ fontSize: '11px', color: 'var(--text-secondary)' }}>
+                              {costCoverage?.windows['7d'].partial ? `${costCoverage.windows['7d'].availableHours}h / 7d` : '7d'}: <strong style={{ fontFamily: 'monospace', color: 'var(--text-primary)' }}>${costEntry.costLast7dUsd.toFixed(2)}</strong>
                             </span>
                             {budgetPct != null && (
                               <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flex: 1, minWidth: '120px' }}>
@@ -590,6 +601,11 @@ function IAOpsContent() {
                               </span>
                             )}
                           </div>
+                          {costCoverage && (
+                            <div role="status" style={{ marginTop: '7px', fontSize: '9px', color: 'var(--text-tertiary)', lineHeight: 1.4 }}>
+                              {costCoverage.source} · retention {costCoverage.retentionHours}h · {costCoverage.dataFrom} → {costCoverage.dataTo} · last successful load {costCoverage.lastSuccessfulLoad ?? 'unavailable'}
+                            </div>
+                          )}
                         </div>
                       )}
 

--- a/openbank-admin-ui/src/components/agent/CaseRuntimeViews.tsx
+++ b/openbank-admin-ui/src/components/agent/CaseRuntimeViews.tsx
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+'use client'
+
+import { ArrowRight, CheckCircle2, CircleDot, Database, ShieldCheck, TriangleAlert } from 'lucide-react'
+
+export type RuntimeStage = 'RECORDED' | 'CONSUMED' | 'EMITTED' | 'PUBLISHED_TO_BROKER' | 'PUBLISH_FAILED' | 'SHADOW_RECORDED'
+
+export interface RuntimeEvidenceView {
+  evidenceId: string
+  source: string
+  stage: RuntimeStage
+  observedAtEpochMs: number
+  correlationId: string
+  detail: string
+}
+
+export interface RuntimeEntryView {
+  type: string
+  atEpochMs: number
+  actor?: string
+  proposalType?: string
+  runtimeEvidence: RuntimeEvidenceView
+}
+
+export interface RuntimeCaseView {
+  caseId: string
+  historySource: string
+  retentionPolicy: string
+  observedAtEpochMs: number
+  entries: RuntimeEntryView[]
+}
+
+function stageTone(stage: RuntimeStage): { color: string; bg: string; Icon: typeof CircleDot } {
+  if (stage === 'PUBLISH_FAILED') return { color: 'var(--danger)', bg: 'var(--danger-bg)', Icon: TriangleAlert }
+  if (stage === 'PUBLISHED_TO_BROKER') return { color: 'var(--success)', bg: 'var(--success-bg)', Icon: CheckCircle2 }
+  return { color: 'var(--accent-text)', bg: 'var(--accent-bg)', Icon: CircleDot }
+}
+
+function EvidenceDetails({ evidence, locale }: { evidence: RuntimeEvidenceView; locale: string }) {
+  const tone = stageTone(evidence.stage)
+  return (
+    <details style={{ marginTop: '8px' }}>
+      <summary style={{ cursor: 'pointer', color: tone.color, fontSize: '10px', fontWeight: 800 }}>
+        {evidence.stage} · {evidence.evidenceId}
+      </summary>
+      <dl style={{ display: 'grid', gridTemplateColumns: 'max-content 1fr', gap: '4px 10px', margin: '8px 0 0', fontSize: '10px' }}>
+        <dt style={{ color: 'var(--text-tertiary)' }}>source</dt><dd style={{ margin: 0, fontFamily: 'var(--font-mono)' }}>{evidence.source}</dd>
+        <dt style={{ color: 'var(--text-tertiary)' }}>observed</dt><dd style={{ margin: 0 }}>{new Date(evidence.observedAtEpochMs).toLocaleString(locale)}</dd>
+        <dt style={{ color: 'var(--text-tertiary)' }}>correlation</dt><dd style={{ margin: 0, fontFamily: 'var(--font-mono)' }}>{evidence.correlationId}</dd>
+        <dt style={{ color: 'var(--text-tertiary)' }}>meaning</dt><dd style={{ margin: 0 }}>{evidence.detail}</dd>
+      </dl>
+    </details>
+  )
+}
+
+export function CaseRuntimeTimeline({ thread, locale }: { thread: RuntimeCaseView; locale: string }) {
+  return (
+    <section aria-label="Runtime evidence timeline" style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+      {thread.entries.map((entry, index) => {
+        const tone = stageTone(entry.runtimeEvidence.stage)
+        const Icon = tone.Icon
+        return (
+          <article key={`${entry.runtimeEvidence.evidenceId}-${index}`} style={{ padding: '12px 14px', borderRadius: '12px', border: '1px solid var(--border)', background: 'var(--surface)' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
+              <Icon size={13} style={{ color: tone.color }} />
+              <strong style={{ fontSize: '11px' }}>{entry.type}</strong>
+              <span style={{ fontSize: '10px', color: 'var(--text-secondary)' }}>{entry.actor ?? 'case-coordinator'}</span>
+              <time style={{ marginLeft: 'auto', fontSize: '10px', color: 'var(--text-tertiary)' }}>{new Date(entry.atEpochMs).toLocaleString(locale)}</time>
+            </div>
+            <EvidenceDetails evidence={entry.runtimeEvidence} locale={locale} />
+          </article>
+        )
+      })}
+    </section>
+  )
+}
+
+interface Edge {
+  from: string
+  to: string
+  evidence: RuntimeEvidenceView
+}
+
+function runtimeEdges(thread: RuntimeCaseView): Edge[] {
+  return thread.entries.flatMap(entry => {
+    if (entry.type === 'CONTRIBUTION' && entry.actor) return [{ from: entry.actor, to: 'case-coordinator', evidence: entry.runtimeEvidence }]
+    if (entry.type === 'PROPOSAL_EMITTED') return [{ from: 'case-coordinator', to: 'proposal event broker', evidence: entry.runtimeEvidence }]
+    if (entry.type === 'SHADOW_RECORDED') return [{ from: 'case-coordinator', to: 'shadow evidence only', evidence: entry.runtimeEvidence }]
+    return []
+  })
+}
+
+export function CaseRuntimeTopology({ thread, locale }: { thread: RuntimeCaseView; locale: string }) {
+  const edges = runtimeEdges(thread)
+  return (
+    <section aria-label="Evidence-backed runtime topology">
+      <div style={{ padding: '10px 12px', marginBottom: '12px', borderRadius: '10px', background: 'var(--info-bg)', border: '1px solid var(--border)', fontSize: '11px', color: 'var(--text-secondary)' }}>
+        <ShieldCheck size={13} style={{ verticalAlign: '-2px', marginRight: '6px', color: 'var(--blue)' }} />
+        Solid edges below exist only because a durable runtime observation is present. Charter declarations alone never create a solid edge.
+      </div>
+      {edges.length === 0 ? (
+        <div style={{ padding: '24px', textAlign: 'center', border: '1px dashed var(--border)', borderRadius: '12px', color: 'var(--text-tertiary)', fontSize: '12px' }}>
+          No observed collaboration edges in this case yet.
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          {edges.map((edge, index) => (
+            <article key={`${edge.evidence.evidenceId}-${index}`} style={{ padding: '13px 15px', borderRadius: '12px', border: '1px solid var(--accent-border)', background: 'var(--surface)' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '9px', flexWrap: 'wrap', fontSize: '12px' }}>
+                <strong style={{ fontFamily: 'var(--font-mono)' }}>{edge.from}</strong>
+                <span style={{ height: '2px', width: '40px', background: 'var(--accent-text)' }} />
+                <ArrowRight size={14} style={{ color: 'var(--accent-text)', marginLeft: '-14px' }} />
+                <strong style={{ fontFamily: 'var(--font-mono)' }}>{edge.to}</strong>
+                <span style={{ marginLeft: 'auto', padding: '2px 7px', borderRadius: '8px', background: 'var(--accent-bg)', color: 'var(--accent-text)', fontSize: '9px', fontWeight: 850 }}>{edge.evidence.stage}</span>
+              </div>
+              <EvidenceDetails evidence={edge.evidence} locale={locale} />
+            </article>
+          ))}
+        </div>
+      )}
+      <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginTop: '12px', fontSize: '10px', color: 'var(--text-tertiary)' }}>
+        <Database size={11} /> {thread.historySource} · retention: {thread.retentionPolicy} · last observed {new Date(thread.observedAtEpochMs).toLocaleString(locale)}
+      </div>
+    </section>
+  )
+}

--- a/openbank-admin-ui/src/components/agent/CaseRuntimeViews.tsx
+++ b/openbank-admin-ui/src/components/agent/CaseRuntimeViews.tsx
@@ -6,7 +6,7 @@
 import { ArrowRight, CheckCircle2, CircleDot, Database, ShieldCheck, TriangleAlert } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 
-export type RuntimeStage = 'RECORDED' | 'CONSUMED' | 'EMITTED' | 'PUBLISHED_TO_BROKER' | 'PUBLISH_FAILED' | 'SHADOW_RECORDED'
+export type RuntimeStage = 'RECORDED' | 'PERSISTED' | 'EMITTED' | 'PUBLISHED_TO_BROKER' | 'PUBLISH_FAILED' | 'SHADOW_RECORDED'
 
 export interface RuntimeEvidenceView {
   evidenceId: string
@@ -30,6 +30,10 @@ export interface RuntimeCaseView {
   historySource: string
   retentionPolicy: string
   observedAtEpochMs: number
+  dataFromEpochMs: number
+  dataToEpochMs: number
+  lastSuccessfulLoadEpochMs: number
+  coverageStatus: string
   entries: RuntimeEntryView[]
 }
 
@@ -128,7 +132,7 @@ export function CaseRuntimeTopology({ thread, locale }: { thread: RuntimeCaseVie
         </div>
       )}
       <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginTop: '12px', fontSize: '10px', color: 'var(--text-tertiary)' }}>
-        <Database size={11} /> {thread.historySource} · {t('retence', 'retention')}: {thread.retentionPolicy} · {t('naposledy pozorováno', 'last observed')} {new Date(thread.observedAtEpochMs).toLocaleString(locale)}
+        <Database size={11} /> {thread.historySource} · {t('retence', 'retention')}: {thread.retentionPolicy} · {t('coverage', 'coverage')}: {thread.coverageStatus.toLowerCase().replaceAll('_', ' ')} · {new Date(thread.dataFromEpochMs).toLocaleString(locale)} → {new Date(thread.dataToEpochMs).toLocaleString(locale)} · {t('poslední úspěšné načtení', 'last successful load')} {new Date(thread.lastSuccessfulLoadEpochMs).toLocaleString(locale)}
       </div>
     </section>
   )

--- a/openbank-admin-ui/src/components/agent/CaseRuntimeViews.tsx
+++ b/openbank-admin-ui/src/components/agent/CaseRuntimeViews.tsx
@@ -4,6 +4,7 @@
 'use client'
 
 import { ArrowRight, CheckCircle2, CircleDot, Database, ShieldCheck, TriangleAlert } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
 
 export type RuntimeStage = 'RECORDED' | 'CONSUMED' | 'EMITTED' | 'PUBLISHED_TO_BROKER' | 'PUBLISH_FAILED' | 'SHADOW_RECORDED'
 
@@ -39,6 +40,7 @@ function stageTone(stage: RuntimeStage): { color: string; bg: string; Icon: type
 }
 
 function EvidenceDetails({ evidence, locale }: { evidence: RuntimeEvidenceView; locale: string }) {
+  const { t } = useLanguage()
   const tone = stageTone(evidence.stage)
   return (
     <details style={{ marginTop: '8px' }}>
@@ -46,18 +48,19 @@ function EvidenceDetails({ evidence, locale }: { evidence: RuntimeEvidenceView; 
         {evidence.stage} · {evidence.evidenceId}
       </summary>
       <dl style={{ display: 'grid', gridTemplateColumns: 'max-content 1fr', gap: '4px 10px', margin: '8px 0 0', fontSize: '10px' }}>
-        <dt style={{ color: 'var(--text-tertiary)' }}>source</dt><dd style={{ margin: 0, fontFamily: 'var(--font-mono)' }}>{evidence.source}</dd>
-        <dt style={{ color: 'var(--text-tertiary)' }}>observed</dt><dd style={{ margin: 0 }}>{new Date(evidence.observedAtEpochMs).toLocaleString(locale)}</dd>
-        <dt style={{ color: 'var(--text-tertiary)' }}>correlation</dt><dd style={{ margin: 0, fontFamily: 'var(--font-mono)' }}>{evidence.correlationId}</dd>
-        <dt style={{ color: 'var(--text-tertiary)' }}>meaning</dt><dd style={{ margin: 0 }}>{evidence.detail}</dd>
+        <dt style={{ color: 'var(--text-tertiary)' }}>{t('Zdroj', 'Source')}</dt><dd style={{ margin: 0, fontFamily: 'var(--font-mono)' }}>{evidence.source}</dd>
+        <dt style={{ color: 'var(--text-tertiary)' }}>{t('Pozorováno', 'Observed')}</dt><dd style={{ margin: 0 }}>{new Date(evidence.observedAtEpochMs).toLocaleString(locale)}</dd>
+        <dt style={{ color: 'var(--text-tertiary)' }}>{t('Korelace', 'Correlation')}</dt><dd style={{ margin: 0, fontFamily: 'var(--font-mono)' }}>{evidence.correlationId}</dd>
+        <dt style={{ color: 'var(--text-tertiary)' }}>{t('Význam', 'Meaning')}</dt><dd style={{ margin: 0 }}>{evidence.detail}</dd>
       </dl>
     </details>
   )
 }
 
 export function CaseRuntimeTimeline({ thread, locale }: { thread: RuntimeCaseView; locale: string }) {
+  const { t } = useLanguage()
   return (
-    <section aria-label="Runtime evidence timeline" style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+    <section aria-label={t('Časová osa runtime důkazů', 'Runtime evidence timeline')} style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
       {thread.entries.map((entry, index) => {
         const tone = stageTone(entry.runtimeEvidence.stage)
         const Icon = tone.Icon
@@ -93,16 +96,20 @@ function runtimeEdges(thread: RuntimeCaseView): Edge[] {
 }
 
 export function CaseRuntimeTopology({ thread, locale }: { thread: RuntimeCaseView; locale: string }) {
+  const { t } = useLanguage()
   const edges = runtimeEdges(thread)
   return (
-    <section aria-label="Evidence-backed runtime topology">
+    <section aria-label={t('Topologie podložená runtime důkazy', 'Evidence-backed runtime topology')}>
       <div style={{ padding: '10px 12px', marginBottom: '12px', borderRadius: '10px', background: 'var(--info-bg)', border: '1px solid var(--border)', fontSize: '11px', color: 'var(--text-secondary)' }}>
         <ShieldCheck size={13} style={{ verticalAlign: '-2px', marginRight: '6px', color: 'var(--blue)' }} />
-        Solid edges below exist only because a durable runtime observation is present. Charter declarations alone never create a solid edge.
+        {t(
+          'Plné hrany níže existují pouze díky trvalému runtime pozorování. Samotná deklarace v charteru plnou hranu nikdy nevytvoří.',
+          'Solid edges below exist only because a durable runtime observation is present. Charter declarations alone never create a solid edge.',
+        )}
       </div>
       {edges.length === 0 ? (
         <div style={{ padding: '24px', textAlign: 'center', border: '1px dashed var(--border)', borderRadius: '12px', color: 'var(--text-tertiary)', fontSize: '12px' }}>
-          No observed collaboration edges in this case yet.
+          {t('V tomto případu zatím nejsou žádné pozorované hrany spolupráce.', 'No observed collaboration edges in this case yet.')}
         </div>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
@@ -121,7 +128,7 @@ export function CaseRuntimeTopology({ thread, locale }: { thread: RuntimeCaseVie
         </div>
       )}
       <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginTop: '12px', fontSize: '10px', color: 'var(--text-tertiary)' }}>
-        <Database size={11} /> {thread.historySource} · retention: {thread.retentionPolicy} · last observed {new Date(thread.observedAtEpochMs).toLocaleString(locale)}
+        <Database size={11} /> {thread.historySource} · {t('retence', 'retention')}: {thread.retentionPolicy} · {t('naposledy pozorováno', 'last observed')} {new Date(thread.observedAtEpochMs).toLocaleString(locale)}
       </div>
     </section>
   )

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -117,7 +117,8 @@ const docsNav: NavItem[] = [
 const platformNav: NavItem[] = [
   { nameCs: 'FinOps',   nameEn: 'FinOps',   href: '/finops',   icon: PiggyBank,  permission: 'system:view' },
   { nameCs: 'DevOps',   nameEn: 'DevOps',   href: '/devops',   icon: GitBranch,  permission: 'system:view' },
-  { nameCs: 'IAOps',    nameEn: 'IAOps',    href: '/iaops',    icon: Bot,        permission: 'system:view' },
+  { nameCs: 'Řídicí centrum agentů', nameEn: 'Agent Control Room', href: '/iaops', icon: Bot, permission: 'system:view' },
+  { nameCs: 'Živé agentní případy', nameEn: 'Live Agent Cases', href: '/iaops/cases', icon: GitBranch, permission: 'system:view' },
   { nameCs: 'Flaky testy', nameEn: 'Flaky Tests', href: '/iaops/flaky-test-hunter', icon: Bug, permission: 'system:view' },
   { nameCs: 'Temporal', nameEn: 'Temporal', href: '/temporal', icon: Zap,        permission: 'system:view' },
   { nameCs: 'Tok workflow', nameEn: 'Workflow Flow', href: '/temporal/flow', icon: Workflow, permission: 'system:view' },

--- a/openbank-admin-ui/src/test/iaops-case-thread-page.test.tsx
+++ b/openbank-admin-ui/src/test/iaops-case-thread-page.test.tsx
@@ -2,7 +2,7 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import IaopsCaseThreadPage from '@/app/iaops/cases/[caseId]/page'
 
@@ -20,10 +20,15 @@ const THREAD = {
   openedAtEpochMs: 1_700_000_000_000,
   deadlineAtEpochMs: 1_700_000_600_000,
   contestedRate: 0,
+  budgetTokens: 200000,
+  budgetContributions: 40,
+  observedAtEpochMs: 1_700_000_200_000,
+  historySource: 'case-coordinator-postgres-read-model',
+  retentionPolicy: 'not-configured',
   entries: [
-    { type: 'CASE_OPENED', atEpochMs: 1_700_000_000_000, actor: 'case-coordinator' },
-    { type: 'CONTRIBUTION', atEpochMs: 1_700_000_100_000, actor: 'aml-agent', evidenceRefs: ['alert-17'] },
-    { type: 'PROPOSAL_EMITTED', atEpochMs: 1_700_000_200_000, proposalType: 'REVIEW' },
+    { type: 'CASE_OPENED', atEpochMs: 1_700_000_000_000, actor: 'case-coordinator', runtimeEvidence: { evidenceId: 'case-17', source: 'case-coordinator-postgres-read-model', stage: 'RECORDED', observedAtEpochMs: 1_700_000_000_000, correlationId: 'case-17', detail: 'Persisted case workflow record' } },
+    { type: 'CONTRIBUTION', atEpochMs: 1_700_000_100_000, actor: 'aml-agent', evidenceRefs: ['alert-17'], runtimeEvidence: { evidenceId: 'contribution-17', source: 'case-coordinator-postgres-read-model', stage: 'CONSUMED', observedAtEpochMs: 1_700_000_100_000, correlationId: 'case-17', detail: 'Contribution consumed into the durable case read model' } },
+    { type: 'PROPOSAL_EMITTED', atEpochMs: 1_700_000_200_000, proposalType: 'REVIEW', runtimeEvidence: { evidenceId: 'proposal-17', source: 'case-coordinator-transactional-outbox', stage: 'PUBLISHED_TO_BROKER', observedAtEpochMs: 1_700_000_200_000, correlationId: 'case-17', detail: 'Proposal outbox status: SENT' } },
   ],
 }
 
@@ -40,5 +45,19 @@ describe('AIOps case thread proposal event', () => {
     expect(screen.getByText('The coordinator created a proposal event. This page does not track delivery or the human decision.')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Browse the HITL queue' })).toHaveAttribute('href', '/approvals')
     expect(screen.queryByText('Open the HITL queue for approval')).not.toBeInTheDocument()
+  })
+
+  it('renders only observed runtime edges as solid topology with expandable provenance', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ available: true, thread: THREAD }) }))
+
+    render(<IaopsCaseThreadPage />)
+    await screen.findByRole('heading', { name: 'Proposal recorded in the thread' })
+    fireEvent.click(screen.getByRole('button', { name: 'topology' }))
+
+    expect(await screen.findByRole('region', { name: 'Evidence-backed runtime topology' })).toBeInTheDocument()
+    expect(screen.getByText('aml-agent')).toBeInTheDocument()
+    expect(screen.getByText('proposal event broker')).toBeInTheDocument()
+    expect(screen.getByText(/Charter declarations alone never create a solid edge/)).toBeInTheDocument()
+    expect(screen.getAllByText(/CONSUMED|PUBLISHED_TO_BROKER/).length).toBeGreaterThan(0)
   })
 })

--- a/openbank-admin-ui/src/test/iaops-case-thread-page.test.tsx
+++ b/openbank-admin-ui/src/test/iaops-case-thread-page.test.tsx
@@ -23,11 +23,15 @@ const THREAD = {
   budgetTokens: 200000,
   budgetContributions: 40,
   observedAtEpochMs: 1_700_000_200_000,
+  dataFromEpochMs: 1_700_000_000_000,
+  dataToEpochMs: 1_700_000_200_000,
+  lastSuccessfulLoadEpochMs: 1_700_000_300_000,
+  coverageStatus: 'UNKNOWN_RETENTION',
   historySource: 'case-coordinator-postgres-read-model',
   retentionPolicy: 'not-configured',
   entries: [
     { type: 'CASE_OPENED', atEpochMs: 1_700_000_000_000, actor: 'case-coordinator', runtimeEvidence: { evidenceId: 'case-17', source: 'case-coordinator-postgres-read-model', stage: 'RECORDED', observedAtEpochMs: 1_700_000_000_000, correlationId: 'case-17', detail: 'Persisted case workflow record' } },
-    { type: 'CONTRIBUTION', atEpochMs: 1_700_000_100_000, actor: 'aml-agent', evidenceRefs: ['alert-17'], runtimeEvidence: { evidenceId: 'contribution-17', source: 'case-coordinator-postgres-read-model', stage: 'CONSUMED', observedAtEpochMs: 1_700_000_100_000, correlationId: 'case-17', detail: 'Contribution consumed into the durable case read model' } },
+    { type: 'CONTRIBUTION', atEpochMs: 1_700_000_100_000, actor: 'aml-agent', evidenceRefs: ['alert-17'], runtimeEvidence: { evidenceId: 'contribution-17', source: 'case-coordinator-postgres-read-model', stage: 'PERSISTED', observedAtEpochMs: 1_700_000_100_000, correlationId: 'case-17', detail: 'Contribution persisted in the durable case read model' } },
     { type: 'PROPOSAL_EMITTED', atEpochMs: 1_700_000_200_000, proposalType: 'REVIEW', runtimeEvidence: { evidenceId: 'proposal-17', source: 'case-coordinator-transactional-outbox', stage: 'PUBLISHED_TO_BROKER', observedAtEpochMs: 1_700_000_200_000, correlationId: 'case-17', detail: 'Proposal outbox status: SENT' } },
   ],
 }
@@ -58,6 +62,7 @@ describe('AIOps case thread proposal event', () => {
     expect(screen.getByText('aml-agent')).toBeInTheDocument()
     expect(screen.getByText('proposal event broker')).toBeInTheDocument()
     expect(screen.getByText(/Charter declarations alone never create a solid edge/)).toBeInTheDocument()
-    expect(screen.getAllByText(/CONSUMED|PUBLISHED_TO_BROKER/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/PERSISTED|PUBLISHED_TO_BROKER/).length).toBeGreaterThan(0)
+    expect(screen.getByText(/unknown retention/)).toBeInTheDocument()
   })
 })

--- a/openbank-admin-ui/src/test/iaops-truthfulness.guard.test.ts
+++ b/openbank-admin-ui/src/test/iaops-truthfulness.guard.test.ts
@@ -26,4 +26,17 @@ describe('IAOps agent capability truthfulness', () => {
     expect(costsRoute).toContain('No monthly USD budget is configured in the current agents.yaml contract.')
     expect(costsRoute).not.toContain('TODO: read from agents.yaml limits.monthly_budget_usd')
   })
+
+  it('labels partial Prometheus windows and does not invent provider placement', () => {
+    const iaops = readFileSync(path.resolve(__dirname, '../app/iaops/page.tsx'), 'utf8')
+    const finops = readFileSync(path.resolve(__dirname, '../app/finops/page.tsx'), 'utf8')
+    const costsRoute = readFileSync(path.resolve(__dirname, '../app/api/finops/ai-costs/route.ts'), 'utf8')
+
+    expect(costsRoute).toContain("PROMETHEUS_RETENTION_HOURS ?? '12'")
+    expect(costsRoute).toContain('selfHostedPct: null')
+    expect(costsRoute).not.toContain('selfHostedPct: 60')
+    expect(iaops).toContain("costCoverage.windows['7d'].availableHours")
+    expect(finops).toContain("aiCosts.coverage.windows['7d'].availableHours")
+    expect(finops).toContain('Provider split is not exported by the bridge.')
+  })
 })

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseThreadProjection.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseThreadProjection.kt
@@ -10,6 +10,8 @@ import com.openbank.casecoordinator.domain.model.CaseSummary
 import com.openbank.casecoordinator.domain.model.CaseThread
 import com.openbank.casecoordinator.domain.model.ContributionRow
 import com.openbank.casecoordinator.domain.model.ProposalEventRow
+import com.openbank.casecoordinator.domain.model.RuntimeEvidence
+import com.openbank.casecoordinator.domain.model.RuntimeEvidenceStage
 import com.openbank.casecoordinator.domain.model.ThreadEntry
 import com.openbank.casecoordinator.domain.model.ThreadEntryType
 
@@ -33,42 +35,9 @@ object CaseThreadProjection {
 
     fun project(case: CaseRow, contributions: List<ContributionRow>, proposals: List<ProposalEventRow>): CaseThread {
         val entries = buildList {
-            add(
-                ThreadEntry(
-                    type = ThreadEntryType.CASE_OPENED,
-                    atEpochMs = case.openedAtEpochMs,
-                    summary = case.dispositionTarget,
-                ),
-            )
-            contributions.forEach { c ->
-                add(
-                    ThreadEntry(
-                        type = ThreadEntryType.CONTRIBUTION,
-                        atEpochMs = c.contributedAtEpochMs,
-                        actor = c.agentId,
-                        summary = c.summary,
-                        evidenceRefs = c.evidenceRefs,
-                        draftVersion = c.draftVersion,
-                        superseded = c.superseded,
-                        contested = c.contested,
-                    ),
-                )
-            }
-            proposals.forEach { p ->
-                add(
-                    ThreadEntry(
-                        type = if (p.status == "SHADOW") {
-                            ThreadEntryType.SHADOW_RECORDED
-                        } else {
-                            ThreadEntryType.PROPOSAL_EMITTED
-                        },
-                        atEpochMs = p.emittedAtEpochMs,
-                        proposalId = p.proposalId,
-                        proposalType = p.proposalType,
-                        shadow = p.status == "SHADOW",
-                    ),
-                )
-            }
+            add(case.openedEntry())
+            contributions.forEach { add(it.threadEntry(case.workflowId)) }
+            proposals.forEach { add(it.threadEntry(case.workflowId)) }
         }.sortedBy { it.atEpochMs }
 
         return CaseThread(
@@ -79,7 +48,73 @@ object CaseThreadProjection {
             openedAtEpochMs = case.openedAtEpochMs,
             deadlineAtEpochMs = case.deadlineAtEpochMs,
             contestedRate = case.contestedRate,
+            budgetTokens = case.budgetTokens,
+            budgetContributions = case.budgetContributions,
+            observedAtEpochMs = entries.maxOfOrNull { it.atEpochMs } ?: case.openedAtEpochMs,
+            historySource = HISTORY_SOURCE,
+            retentionPolicy = RETENTION_POLICY,
             entries = entries,
         )
     }
+
+    private fun CaseRow.openedEntry(): ThreadEntry = ThreadEntry(
+        type = ThreadEntryType.CASE_OPENED,
+        atEpochMs = openedAtEpochMs,
+        summary = dispositionTarget,
+        runtimeEvidence = RuntimeEvidence(
+            evidenceId = workflowId,
+            source = HISTORY_SOURCE,
+            stage = RuntimeEvidenceStage.RECORDED,
+            observedAtEpochMs = openedAtEpochMs,
+            correlationId = workflowId,
+            detail = "Persisted case workflow record",
+        ),
+    )
+
+    private fun ContributionRow.threadEntry(workflowId: String): ThreadEntry = ThreadEntry(
+        type = ThreadEntryType.CONTRIBUTION,
+        atEpochMs = contributedAtEpochMs,
+        actor = agentId,
+        summary = summary,
+        evidenceRefs = evidenceRefs,
+        draftVersion = draftVersion,
+        superseded = superseded,
+        contested = contested,
+        tokensUsed = tokensUsed,
+        runtimeEvidence = RuntimeEvidence(
+            evidenceId = contributionId,
+            source = HISTORY_SOURCE,
+            stage = RuntimeEvidenceStage.CONSUMED,
+            observedAtEpochMs = contributedAtEpochMs,
+            correlationId = workflowId,
+            detail = "Contribution consumed into the durable case read model",
+        ),
+    )
+
+    private fun ProposalEventRow.threadEntry(workflowId: String): ThreadEntry = ThreadEntry(
+        type = if (status == "SHADOW") ThreadEntryType.SHADOW_RECORDED else ThreadEntryType.PROPOSAL_EMITTED,
+        atEpochMs = emittedAtEpochMs,
+        proposalId = proposalId,
+        proposalType = proposalType,
+        shadow = status == "SHADOW",
+        runtimeEvidence = RuntimeEvidence(
+            evidenceId = proposalId,
+            source = OUTBOX_SOURCE,
+            stage = status.toEvidenceStage(),
+            observedAtEpochMs = emittedAtEpochMs,
+            correlationId = workflowId,
+            detail = "Proposal outbox status: $status",
+        ),
+    )
+
+    private fun String.toEvidenceStage(): RuntimeEvidenceStage = when (this) {
+        "SENT" -> RuntimeEvidenceStage.PUBLISHED_TO_BROKER
+        "FAILED", "DEAD" -> RuntimeEvidenceStage.PUBLISH_FAILED
+        "SHADOW" -> RuntimeEvidenceStage.SHADOW_RECORDED
+        else -> RuntimeEvidenceStage.EMITTED
+    }
+
+    private const val HISTORY_SOURCE = "case-coordinator-postgres-read-model"
+    private const val OUTBOX_SOURCE = "case-coordinator-transactional-outbox"
+    private const val RETENTION_POLICY = "not-configured"
 }

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseThreadProjection.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseThreadProjection.kt
@@ -33,7 +33,12 @@ object CaseThreadProjection {
         contributionCount = row.contributionCount,
     )
 
-    fun project(case: CaseRow, contributions: List<ContributionRow>, proposals: List<ProposalEventRow>): CaseThread {
+    fun project(
+        case: CaseRow,
+        contributions: List<ContributionRow>,
+        proposals: List<ProposalEventRow>,
+        loadedAtEpochMs: Long,
+    ): CaseThread {
         val entries = buildList {
             add(case.openedEntry())
             contributions.forEach { add(it.threadEntry(case.workflowId)) }
@@ -51,6 +56,10 @@ object CaseThreadProjection {
             budgetTokens = case.budgetTokens,
             budgetContributions = case.budgetContributions,
             observedAtEpochMs = entries.maxOfOrNull { it.atEpochMs } ?: case.openedAtEpochMs,
+            dataFromEpochMs = entries.minOfOrNull { it.atEpochMs } ?: case.openedAtEpochMs,
+            dataToEpochMs = entries.maxOfOrNull { it.atEpochMs } ?: case.openedAtEpochMs,
+            lastSuccessfulLoadEpochMs = loadedAtEpochMs,
+            coverageStatus = COVERAGE_STATUS,
             historySource = HISTORY_SOURCE,
             retentionPolicy = RETENTION_POLICY,
             entries = entries,
@@ -84,10 +93,10 @@ object CaseThreadProjection {
         runtimeEvidence = RuntimeEvidence(
             evidenceId = contributionId,
             source = HISTORY_SOURCE,
-            stage = RuntimeEvidenceStage.CONSUMED,
+            stage = RuntimeEvidenceStage.PERSISTED,
             observedAtEpochMs = contributedAtEpochMs,
             correlationId = workflowId,
-            detail = "Contribution consumed into the durable case read model",
+            detail = "Contribution persisted in the durable case read model",
         ),
     )
 
@@ -117,4 +126,5 @@ object CaseThreadProjection {
     private const val HISTORY_SOURCE = "case-coordinator-postgres-read-model"
     private const val OUTBOX_SOURCE = "case-coordinator-transactional-outbox"
     private const val RETENTION_POLICY = "not-configured"
+    private const val COVERAGE_STATUS = "UNKNOWN_RETENTION"
 }

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseThreadService.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseThreadService.kt
@@ -24,6 +24,7 @@ class CaseThreadService(private val readRepository: CaseThreadReadRepository) {
             case = case,
             contributions = readRepository.listContributions(caseId),
             proposals = readRepository.listProposalEvents(caseId),
+            loadedAtEpochMs = System.currentTimeMillis(),
         )
     }
 }

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/domain/model/CaseThread.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/domain/model/CaseThread.kt
@@ -47,7 +47,7 @@ data class ProposalEventRow(
 
 enum class RuntimeEvidenceStage {
     RECORDED,
-    CONSUMED,
+    PERSISTED,
     EMITTED,
     PUBLISHED_TO_BROKER,
     PUBLISH_FAILED,
@@ -112,6 +112,10 @@ data class CaseThread(
     val budgetTokens: Int,
     val budgetContributions: Int,
     val observedAtEpochMs: Long,
+    val dataFromEpochMs: Long,
+    val dataToEpochMs: Long,
+    val lastSuccessfulLoadEpochMs: Long,
+    val coverageStatus: String,
     val historySource: String,
     val retentionPolicy: String,
     val entries: List<ThreadEntry>,

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/domain/model/CaseThread.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/domain/model/CaseThread.kt
@@ -20,10 +20,13 @@ data class CaseRow(
     val deadlineAtEpochMs: Long,
     val contestedRate: Double,
     val contributionCount: Int,
+    val budgetTokens: Int,
+    val budgetContributions: Int,
 )
 
 /** Raw `case_contribution` row (V1 + V3 columns). */
 data class ContributionRow(
+    val contributionId: String,
     val agentId: String,
     val contributedAtEpochMs: Long,
     val summary: String?,
@@ -31,6 +34,7 @@ data class ContributionRow(
     val draftVersion: Int?,
     val superseded: Boolean,
     val contested: Boolean,
+    val tokensUsed: Int,
 )
 
 /** Raw terminal proposal row projected from `case_outbox` (ADR-0244 D7). */
@@ -39,6 +43,25 @@ data class ProposalEventRow(
     val proposalType: String,
     val status: String,
     val emittedAtEpochMs: Long,
+)
+
+enum class RuntimeEvidenceStage {
+    RECORDED,
+    CONSUMED,
+    EMITTED,
+    PUBLISHED_TO_BROKER,
+    PUBLISH_FAILED,
+    SHADOW_RECORDED,
+}
+
+/** Runtime observation backing one rendered case edge. A charter never creates this object. */
+data class RuntimeEvidence(
+    val evidenceId: String,
+    val source: String,
+    val stage: RuntimeEvidenceStage,
+    val observedAtEpochMs: Long,
+    val correlationId: String,
+    val detail: String,
 )
 
 enum class ThreadEntryType {
@@ -61,6 +84,8 @@ data class ThreadEntry(
     val proposalId: String? = null,
     val proposalType: String? = null,
     val shadow: Boolean = false,
+    val runtimeEvidence: RuntimeEvidence,
+    val tokensUsed: Int? = null,
 )
 
 /** Case list item — `GET /api/v1/case-coordinator/cases`. */
@@ -84,5 +109,10 @@ data class CaseThread(
     val openedAtEpochMs: Long,
     val deadlineAtEpochMs: Long,
     val contestedRate: Double,
+    val budgetTokens: Int,
+    val budgetContributions: Int,
+    val observedAtEpochMs: Long,
+    val historySource: String,
+    val retentionPolicy: String,
     val entries: List<ThreadEntry>,
 )

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/persistence/CaseThreadReadRepository.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/persistence/CaseThreadReadRepository.kt
@@ -45,8 +45,8 @@ class CaseThreadReadRepository(private val dataSource: DataSource, private val o
 
     fun listContributions(workflowId: String): List<ContributionRow> = query(
         """
-        SELECT c.agent_id, c.contributed_at, c.summary, c.evidence_refs,
-               c.draft_version, c.preemption_vote, c.contested
+        SELECT c.id, c.agent_id, c.contributed_at, c.summary, c.evidence_refs,
+               c.draft_version, c.preemption_vote, c.contested, c.tokens_used
         FROM case_contribution c
         JOIN case_workflow w ON w.id = c.case_id
         WHERE w.workflow_id = ?
@@ -98,11 +98,14 @@ class CaseThreadReadRepository(private val dataSource: DataSource, private val o
         deadlineAtEpochMs = getTimestamp("deadline_at").toInstant().toEpochMilli(),
         contestedRate = getBigDecimal("contested_rate").toDouble(),
         contributionCount = getInt("contribution_count"),
+        budgetTokens = getInt("budget_tokens"),
+        budgetContributions = getInt("budget_contributions"),
     )
 
     private fun ResultSet.toContributionRow(): ContributionRow {
         val refsJson = getString("evidence_refs")
         return ContributionRow(
+            contributionId = getObject("id", UUID::class.java).toString(),
             agentId = getString("agent_id"),
             contributedAtEpochMs = getTimestamp("contributed_at").toInstant().toEpochMilli(),
             summary = getString("summary"),
@@ -110,6 +113,7 @@ class CaseThreadReadRepository(private val dataSource: DataSource, private val o
             draftVersion = getObject("draft_version") as? Int,
             superseded = getString("preemption_vote") == SUPERSEDED_VOTE,
             contested = getBoolean("contested"),
+            tokensUsed = getInt("tokens_used"),
         )
     }
 
@@ -119,6 +123,7 @@ class CaseThreadReadRepository(private val dataSource: DataSource, private val o
         const val CASE_SELECT = """
             SELECT w.workflow_id, w.case_class, w.disposition_target, w.status,
                    w.opened_at, w.deadline_at, w.contested_rate,
+                   w.budget_tokens, w.budget_contributions,
                    (SELECT COUNT(*) FROM case_contribution c WHERE c.case_id = w.id) AS contribution_count
             FROM case_workflow w
         """

--- a/openbank-case-coordinator-agent/src/main/resources/openapi.yaml
+++ b/openbank-case-coordinator-agent/src/main/resources/openapi.yaml
@@ -363,7 +363,7 @@ components:
           enum: [case-coordinator-postgres-read-model, case-coordinator-transactional-outbox]
         stage:
           type: string
-          enum: [RECORDED, CONSUMED, EMITTED, PUBLISHED_TO_BROKER, PUBLISH_FAILED, SHADOW_RECORDED]
+          enum: [RECORDED, PERSISTED, EMITTED, PUBLISHED_TO_BROKER, PUBLISH_FAILED, SHADOW_RECORDED]
         observedAtEpochMs:
           type: integer
           format: int64
@@ -385,6 +385,10 @@ components:
         - budgetTokens
         - budgetContributions
         - observedAtEpochMs
+        - dataFromEpochMs
+        - dataToEpochMs
+        - lastSuccessfulLoadEpochMs
+        - coverageStatus
         - historySource
         - retentionPolicy
         - entries
@@ -412,6 +416,23 @@ components:
         observedAtEpochMs:
           type: integer
           format: int64
+          description: Timestamp of the newest observed durable evidence, not the load time.
+        dataFromEpochMs:
+          type: integer
+          format: int64
+          description: Oldest timestamp present in this returned case timeline.
+        dataToEpochMs:
+          type: integer
+          format: int64
+          description: Newest timestamp present in this returned case timeline.
+        lastSuccessfulLoadEpochMs:
+          type: integer
+          format: int64
+          description: Server time at which all read-model queries for this response completed successfully.
+        coverageStatus:
+          type: string
+          enum: [UNKNOWN_RETENTION]
+          description: Coverage cannot be claimed complete or partial while the durable read-model retention duration is not configured.
         historySource:
           type: string
           enum: [case-coordinator-postgres-read-model]

--- a/openbank-case-coordinator-agent/src/main/resources/openapi.yaml
+++ b/openbank-case-coordinator-agent/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Case Coordinator Agent API
-  version: 1.3.0
+  version: 1.4.0
   description: >-
     Agent-swarm case coordination (ADR-0244): opens durable Temporal case workflows, accepts
     mid-flight agent signals (join / contribute / supersede / request-synthesis), and projects
@@ -315,7 +315,7 @@ components:
 
     ThreadEntry:
       type: object
-      required: [type, atEpochMs]
+      required: [type, atEpochMs, runtimeEvidence]
       properties:
         type:
           type: string
@@ -345,6 +345,32 @@ components:
         shadow:
           type: boolean
           description: True when this terminal result is recorded for the bounded shadow pilot and was not delivered to HITL.
+        tokensUsed:
+          type: integer
+          minimum: 0
+        runtimeEvidence:
+          $ref: '#/components/schemas/RuntimeEvidence'
+
+    RuntimeEvidence:
+      type: object
+      description: Runtime observation backing the rendered entry. Charter configuration never creates runtime evidence.
+      required: [evidenceId, source, stage, observedAtEpochMs, correlationId, detail]
+      properties:
+        evidenceId:
+          type: string
+        source:
+          type: string
+          enum: [case-coordinator-postgres-read-model, case-coordinator-transactional-outbox]
+        stage:
+          type: string
+          enum: [RECORDED, CONSUMED, EMITTED, PUBLISHED_TO_BROKER, PUBLISH_FAILED, SHADOW_RECORDED]
+        observedAtEpochMs:
+          type: integer
+          format: int64
+        correlationId:
+          type: string
+        detail:
+          type: string
 
     CaseThread:
       type: object
@@ -356,6 +382,11 @@ components:
         - openedAtEpochMs
         - deadlineAtEpochMs
         - contestedRate
+        - budgetTokens
+        - budgetContributions
+        - observedAtEpochMs
+        - historySource
+        - retentionPolicy
         - entries
       properties:
         caseId:
@@ -374,6 +405,19 @@ components:
           format: int64
         contestedRate:
           type: number
+        budgetTokens:
+          type: integer
+        budgetContributions:
+          type: integer
+        observedAtEpochMs:
+          type: integer
+          format: int64
+        historySource:
+          type: string
+          enum: [case-coordinator-postgres-read-model]
+        retentionPolicy:
+          type: string
+          description: Durable read-model retention policy. `not-configured` means the service makes no retention-duration claim.
         entries:
           type: array
           items:

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseThreadProjectionTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseThreadProjectionTest.kt
@@ -38,7 +38,7 @@ class CaseThreadProjectionTest {
 
     @Test
     fun `a case with no contributions projects only the opened entry`() {
-        val thread = CaseThreadProjection.project(caseRow, emptyList(), emptyList())
+        val thread = CaseThreadProjection.project(caseRow, emptyList(), emptyList(), LOADED_AT)
 
         assertThat(thread.entries).hasSize(1)
         assertThat(thread.entries[0].type).isEqualTo(ThreadEntryType.CASE_OPENED)
@@ -65,7 +65,7 @@ class CaseThreadProjectionTest {
             emittedAtEpochMs = T0 + 2 * LATER_MS,
         )
 
-        val thread = CaseThreadProjection.project(caseRow, listOf(contribution), listOf(proposal))
+        val thread = CaseThreadProjection.project(caseRow, listOf(contribution), listOf(proposal), LOADED_AT)
 
         assertThat(thread.entries.map { it.type }).containsExactly(
             ThreadEntryType.CASE_OPENED,
@@ -84,7 +84,7 @@ class CaseThreadProjectionTest {
             emittedAtEpochMs = T0 + LATER_MS,
         )
 
-        val thread = CaseThreadProjection.project(caseRow, emptyList(), listOf(shadow))
+        val thread = CaseThreadProjection.project(caseRow, emptyList(), listOf(shadow), LOADED_AT)
 
         val entry = thread.entries.single { it.type == ThreadEntryType.SHADOW_RECORDED }
         assertThat(entry.shadow).isTrue()
@@ -105,7 +105,7 @@ class CaseThreadProjectionTest {
             tokensUsed = 800,
         )
 
-        val thread = CaseThreadProjection.project(caseRow, listOf(forked), emptyList())
+        val thread = CaseThreadProjection.project(caseRow, listOf(forked), emptyList(), LOADED_AT)
 
         val entry = thread.entries.single { it.type == ThreadEntryType.CONTRIBUTION }
         assertThat(entry.superseded).isTrue()
@@ -127,13 +127,17 @@ class CaseThreadProjectionTest {
             tokensUsed = 600,
         )
 
-        val thread = CaseThreadProjection.project(caseRow, listOf(contribution), emptyList())
+        val thread = CaseThreadProjection.project(caseRow, listOf(contribution), emptyList(), LOADED_AT)
         val entry = thread.entries.single { it.type == ThreadEntryType.CONTRIBUTION }
 
         assertThat(entry.runtimeEvidence.evidenceId).isEqualTo(contribution.contributionId)
-        assertThat(entry.runtimeEvidence.stage.name).isEqualTo("CONSUMED")
+        assertThat(entry.runtimeEvidence.stage.name).isEqualTo("PERSISTED")
         assertThat(entry.runtimeEvidence.correlationId).isEqualTo(caseRow.workflowId)
         assertThat(thread.retentionPolicy).isEqualTo("not-configured")
+        assertThat(thread.coverageStatus).isEqualTo("UNKNOWN_RETENTION")
+        assertThat(thread.dataFromEpochMs).isEqualTo(T0)
+        assertThat(thread.dataToEpochMs).isEqualTo(T0 + LATER_MS)
+        assertThat(thread.lastSuccessfulLoadEpochMs).isEqualTo(LOADED_AT)
         assertThat(thread.budgetTokens).isEqualTo(200_000)
     }
 
@@ -141,6 +145,7 @@ class CaseThreadProjectionTest {
         const val T0 = 1_760_000_000_000L
         const val DEADLINE_MS = 1_200_000L
         const val LATER_MS = 60_000L
+        const val LOADED_AT = T0 + 3 * LATER_MS
         const val CONTESTED_RATE = 0.5
     }
 }

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseThreadProjectionTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseThreadProjectionTest.kt
@@ -23,6 +23,8 @@ class CaseThreadProjectionTest {
         deadlineAtEpochMs = T0 + DEADLINE_MS,
         contestedRate = CONTESTED_RATE,
         contributionCount = 2,
+        budgetTokens = 200_000,
+        budgetContributions = 40,
     )
 
     @Test
@@ -46,6 +48,7 @@ class CaseThreadProjectionTest {
     @Test
     fun `entries are ordered oldest first across all entry kinds`() {
         val contribution = ContributionRow(
+            contributionId = "00000000-0000-0000-0000-000000000001",
             agentId = "fraud-agent",
             contributedAtEpochMs = T0 + LATER_MS,
             summary = "velocity spike",
@@ -53,6 +56,7 @@ class CaseThreadProjectionTest {
             draftVersion = 1,
             superseded = false,
             contested = false,
+            tokensUsed = 1200,
         )
         val proposal = ProposalEventRow(
             proposalId = "prop-1",
@@ -90,6 +94,7 @@ class CaseThreadProjectionTest {
     @Test
     fun `superseded and contested flags survive the projection`() {
         val forked = ContributionRow(
+            contributionId = "00000000-0000-0000-0000-000000000002",
             agentId = "kyc-agent",
             contributedAtEpochMs = T0 + LATER_MS,
             summary = "stale draft",
@@ -97,6 +102,7 @@ class CaseThreadProjectionTest {
             draftVersion = 0,
             superseded = true,
             contested = true,
+            tokensUsed = 800,
         )
 
         val thread = CaseThreadProjection.project(caseRow, listOf(forked), emptyList())
@@ -105,6 +111,30 @@ class CaseThreadProjectionTest {
         assertThat(entry.superseded).isTrue()
         assertThat(entry.contested).isTrue()
         assertThat(entry.draftVersion).isZero()
+    }
+
+    @Test
+    fun `runtime evidence is derived only from persisted rows`() {
+        val contribution = ContributionRow(
+            contributionId = "00000000-0000-0000-0000-000000000003",
+            agentId = "governance-auditor",
+            contributedAtEpochMs = T0 + LATER_MS,
+            summary = "policy evidence",
+            evidenceRefs = listOf("audit-9"),
+            draftVersion = 1,
+            superseded = false,
+            contested = false,
+            tokensUsed = 600,
+        )
+
+        val thread = CaseThreadProjection.project(caseRow, listOf(contribution), emptyList())
+        val entry = thread.entries.single { it.type == ThreadEntryType.CONTRIBUTION }
+
+        assertThat(entry.runtimeEvidence.evidenceId).isEqualTo(contribution.contributionId)
+        assertThat(entry.runtimeEvidence.stage.name).isEqualTo("CONSUMED")
+        assertThat(entry.runtimeEvidence.correlationId).isEqualTo(caseRow.workflowId)
+        assertThat(thread.retentionPolicy).isEqualTo("not-configured")
+        assertThat(thread.budgetTokens).isEqualTo(200_000)
     }
 
     private companion object {

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseThreadServiceTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseThreadServiceTest.kt
@@ -65,6 +65,8 @@ class CaseThreadServiceTest {
         deadlineAtEpochMs = T0 + DEADLINE_MS,
         contestedRate = 0.0,
         contributionCount = 0,
+        budgetTokens = 200_000,
+        budgetContributions = 40,
     )
 
     private companion object {


### PR DESCRIPTION
## Summary

Adds the read-only Agent Control Room over the existing case coordinator projection. Runtime topology edges require durable observed evidence; charter declarations never become runtime facts.

## Type of change

- [x] feat (new functionality)

## Linked issues

Refs #3737

## Changes

- expose contribution, budget, and outbox provenance in the case-thread API
- add Thread, Timeline, and evidence-backed Topology views under IAOps cases
- label Prometheus 12h retention and remove fabricated provider-placement percentages
- clarify ADR-0246 evidence semantics; no case mutation or collaboration grants

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [x] Contract tests updated (if public API changed).
- [x] Relevant Gradle test, detekt, ktlint, and quarkusBuild gates pass.
- [x] No new lint warnings.
- [x] OpenAPI spec updated (REST API changed).
- [x] Docs updated (ADR-0246).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new suppressions.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code unchanged.
- [x] PII path unchanged.
- [x] Cardholder data path unchanged.

## Compliance impact

- [x] None

Read-only visibility strengthens human oversight without changing authorization or processing.

## Rollout / Rollback

- Deployment strategy: rolling
- Rollback plan: revert the two signed commits and redeploy both affected components
- Data migration reversible: N/A

## Screenshots / demo

Local production build completed. In-app visual handoff is unavailable because the browser sandbox cannot reach host localhost; component DOM tests cover all three view modes.

## Reviewer notes

Please verify the evidence boundary: outbox SENT is rendered as published to broker, never as consumed by the HITL inbox. case.join/case.contribute grants and operator mutations are explicitly outside this PR.