### PR TITLE
fix(admin-ui): clarify card detail loading

### DIFF
--- a/openbank-admin-ui/src/app/cards/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/cards/[id]/page.tsx
@@ -171,8 +171,8 @@ export default function CardDetailPage() {
         </div>
 
         {loading ? (
-          <div style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
-            <RefreshCw size={20} style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} />
+          <div role="status" aria-live="polite" style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
+            <RefreshCw size={20} aria-hidden="true" style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} />
             <div>{waking
               ? t('Služba se probouzí…', 'The service is waking up…')
               : t('Načítám kartu…', 'Loading the card…')}</div>
@@ -193,7 +193,7 @@ export default function CardDetailPage() {
               actions={<div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
                 <CardStatusChip status={card.status} current />
                 {(canManage || canBlock) && <CardTransitionButtons card={card} busy={ops.busy} canManage={canManage} canBlock={canBlock} onSelect={onSelectTransition} />}
-                <button className="btn btn-ghost btn-sm" onClick={reload} disabled={ops.busy !== null}>
+                <button type="button" className="btn btn-ghost btn-sm" onClick={reload} disabled={ops.busy !== null} aria-label={t('Obnovit kartu', 'Refresh card')}>
                   <RefreshCw size={12} aria-hidden="true" /> {t('Obnovit', 'Refresh')}
                 </button>
               </div>}

--- a/openbank-admin-ui/src/test/card-detail-loading.guard.test.ts
+++ b/openbank-admin-ui/src/test/card-detail-loading.guard.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('card detail loading contract', () => {
+  it('announces loading and names the refresh action without changing card flows', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/cards/[id]/page.tsx'), 'utf8')
+    expect(source).toContain('<div role="status" aria-live="polite"')
+    expect(source).toContain('<RefreshCw size={20} aria-hidden="true"')
+    expect(source).toContain('type="button" className="btn btn-ghost btn-sm"')
+    expect(source).toContain("aria-label={t('Obnovit kartu', 'Refresh card')}")
+    expect(source).toContain('onClick={reload}')
+  })
+})


### PR DESCRIPTION
## Summary
- expose Card Detail loading as an announced status
- add accessible name/type to the existing refresh action
- preserve card lifecycle, PCI masking, four-eyes and RBAC flows

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.