### PR TITLE
fix(admin-ui): announce account loading

### DIFF
--- a/openbank-admin-ui/src/app/accounts/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/accounts/[id]/page.tsx
@@ -82,8 +82,8 @@ export default function AccountDetailPage() {
   }
 
   if (loading) return (
-    <div style={{ padding: '40px 0', color: 'var(--text-tertiary)', fontSize: '13px', display: 'flex', alignItems: 'center', gap: '8px' }}>
-      <RefreshCw size={14} className="animate-spin" /> {t('Načítám účet…', 'Loading account…')}
+    <div role="status" aria-live="polite" style={{ padding: '40px 0', color: 'var(--text-tertiary)', fontSize: '13px', display: 'flex', alignItems: 'center', gap: '8px' }}>
+      <RefreshCw size={14} aria-hidden="true" className="animate-spin" /> {t('Načítám účet…', 'Loading account…')}
     </div>
   )
 

--- a/openbank-admin-ui/src/test/account-detail-loading.guard.test.ts
+++ b/openbank-admin-ui/src/test/account-detail-loading.guard.test.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('account detail loading contract', () => {
+  it('announces loading without changing account lifecycle flow', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/accounts/[id]/page.tsx'), 'utf8')
+    expect(source).toContain('<div role="status" aria-live="polite"')
+    expect(source).toContain('<RefreshCw size={14} aria-hidden="true"')
+    expect(source).toContain("t('Načítám účet…', 'Loading account…')")
+  })
+})


### PR DESCRIPTION
## Summary
- expose Account Detail loading as a polite status
- hide the decorative spinner from assistive technology
- preserve account lifecycle, idempotency, BFF and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.