### PR TITLE
feat(case-coordinator): trace collaboration signals

### DIFF
--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseSignalAuthorizationService.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseSignalAuthorizationService.kt
@@ -47,7 +47,7 @@ class CaseSignalAuthorizationService(
                 CaseCollaborationPolicyQuery(
                     agentId = agentId,
                     capability = capability,
-                    caseClass = context.caseClass.lowercase().replace('_', '-'),
+                    caseClass = context.caseClass,
                     deliveryMode = context.deliveryMode,
                 ),
             )

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseSignalAuthorizationService.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseSignalAuthorizationService.kt
@@ -16,11 +16,11 @@ import com.openbank.libs.audit.AuditChannel
 import com.openbank.libs.audit.AuditEvent
 import com.openbank.libs.audit.AuditEventPublisher
 import com.openbank.libs.audit.AuditResult
+import com.openbank.libs.domain.identifiers.Ids
 import jakarta.enterprise.context.ApplicationScoped
 import kotlinx.coroutines.runBlocking
 import java.time.Clock
 import java.time.Instant
-import java.util.UUID
 
 sealed interface CaseSignalAuthorizationResult {
     data class Authorized(val signalId: String, val rolloutId: String) : CaseSignalAuthorizationResult
@@ -41,7 +41,7 @@ class CaseSignalAuthorizationService(
     fun authorize(caseId: String, agentId: String, capability: String): CaseSignalAuthorizationResult {
         val context = evidenceRepository.findContext(caseId)
             ?: return CaseSignalAuthorizationResult.UnknownCase
-        val signalId = UUID.randomUUID().toString()
+        val signalId = Ids.randomId().toString()
         val decision = try {
             policy.decide(
                 CaseCollaborationPolicyQuery(

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseSignalAuthorizationService.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseSignalAuthorizationService.kt
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.application
+
+import com.openbank.casecoordinator.application.port.out.CaseCollaborationPolicyDecision
+import com.openbank.casecoordinator.application.port.out.CaseCollaborationPolicyPort
+import com.openbank.casecoordinator.application.port.out.CaseCollaborationPolicyQuery
+import com.openbank.casecoordinator.application.port.out.CaseCollaborationPolicyUnavailable
+import com.openbank.casecoordinator.domain.model.CaseSignalEvidence
+import com.openbank.casecoordinator.domain.model.CaseSignalEvidenceStage
+import com.openbank.casecoordinator.infrastructure.persistence.CaseSignalEvidenceRepository
+import com.openbank.libs.audit.AuditChannel
+import com.openbank.libs.audit.AuditEvent
+import com.openbank.libs.audit.AuditEventPublisher
+import com.openbank.libs.audit.AuditResult
+import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.runBlocking
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+
+sealed interface CaseSignalAuthorizationResult {
+    data class Authorized(val signalId: String, val rolloutId: String) : CaseSignalAuthorizationResult
+    data object Denied : CaseSignalAuthorizationResult
+    data object UnknownCase : CaseSignalAuthorizationResult
+    data object PolicyUnavailable : CaseSignalAuthorizationResult
+}
+
+/** PEP for the two participant capabilities introduced by ADR-0271. */
+@ApplicationScoped
+class CaseSignalAuthorizationService(
+    private val policy: CaseCollaborationPolicyPort,
+    private val localGate: CaseCapabilityGate,
+    private val evidenceRepository: CaseSignalEvidenceRepository,
+    private val auditPublisher: AuditEventPublisher,
+) {
+    private val clock: Clock = Clock.systemUTC()
+    fun authorize(caseId: String, agentId: String, capability: String): CaseSignalAuthorizationResult {
+        val context = evidenceRepository.findContext(caseId)
+            ?: return CaseSignalAuthorizationResult.UnknownCase
+        val signalId = UUID.randomUUID().toString()
+        val decision = try {
+            policy.decide(
+                CaseCollaborationPolicyQuery(
+                    agentId = agentId,
+                    capability = capability,
+                    caseClass = context.caseClass.lowercase().replace('_', '-'),
+                    deliveryMode = context.deliveryMode,
+                ),
+            )
+        } catch (_: CaseCollaborationPolicyUnavailable) {
+            audit(caseId, agentId, capability, AuditResult.FAILURE, signalId, reason = "policy unavailable")
+            return CaseSignalAuthorizationResult.PolicyUnavailable
+        }
+
+        var evaluation = evaluate(agentId, capability, decision)
+        val authorizationEvidence = CaseSignalEvidence(
+            signalId = signalId,
+            caseId = caseId,
+            agentId = agentId,
+            capability = capability,
+            stage = CaseSignalEvidenceStage.AUTHORIZED,
+            observedAtEpochMs = Instant.now(clock).toEpochMilli(),
+            rolloutId = decision.rolloutId,
+            policyDecisionId = decision.decisionId,
+            policyReason = evaluation.reason,
+        )
+        if (evaluation.allowed &&
+            !evidenceRepository.tryRecordAuthorized(authorizationEvidence, decision.maxSignalsPerCase)
+        ) {
+            evaluation = PolicyEvaluation(false, "per-case signal quota exhausted")
+        }
+        return recordDecision(caseId, agentId, capability, signalId, decision, evaluation)
+    }
+
+    private fun recordDecision(
+        caseId: String,
+        agentId: String,
+        capability: String,
+        signalId: String,
+        decision: CaseCollaborationPolicyDecision,
+        evaluation: PolicyEvaluation,
+    ): CaseSignalAuthorizationResult {
+        val stage = if (evaluation.allowed) {
+            CaseSignalEvidenceStage.AUTHORIZED
+        } else {
+            CaseSignalEvidenceStage.DENIED
+        }
+        if (!evaluation.allowed) {
+            evidenceRepository.record(
+                CaseSignalEvidence(
+                    signalId = signalId,
+                    caseId = caseId,
+                    agentId = agentId,
+                    capability = capability,
+                    stage = stage,
+                    observedAtEpochMs = Instant.now(clock).toEpochMilli(),
+                    rolloutId = decision.rolloutId,
+                    policyDecisionId = decision.decisionId,
+                    policyReason = evaluation.reason,
+                ),
+            )
+        }
+        audit(
+            caseId,
+            agentId,
+            capability,
+            if (evaluation.allowed) AuditResult.SUCCESS else AuditResult.DENIED,
+            signalId,
+            decision.decisionId,
+            decision.rolloutId,
+            evaluation.reason,
+        )
+        return if (evaluation.allowed) {
+            CaseSignalAuthorizationResult.Authorized(signalId, decision.rolloutId)
+        } else {
+            CaseSignalAuthorizationResult.Denied
+        }
+    }
+
+    private fun evaluate(
+        agentId: String,
+        capability: String,
+        decision: CaseCollaborationPolicyDecision,
+    ): PolicyEvaluation {
+        val locallyAllowed = when (capability) {
+            "case.join" -> localGate.canJoinCase(agentId)
+            "case.contribute" -> localGate.canContribute(agentId)
+            else -> false
+        }
+        val quotaConfigured = decision.maxSignalsPerCase > 0
+        val reason = when {
+            !decision.allow -> decision.reason
+            !locallyAllowed -> "local charter gate denied"
+            !quotaConfigured -> "signal quota absent from policy decision"
+            else -> decision.reason
+        }
+        return PolicyEvaluation(decision.allow && locallyAllowed && quotaConfigured, reason)
+    }
+
+    fun recordInvoked(
+        caseId: String,
+        agentId: String,
+        capability: String,
+        authorization: CaseSignalAuthorizationResult.Authorized,
+    ) {
+        evidenceRepository.record(
+            CaseSignalEvidence(
+                signalId = authorization.signalId,
+                caseId = caseId,
+                agentId = agentId,
+                capability = capability,
+                stage = CaseSignalEvidenceStage.INVOKED,
+                observedAtEpochMs = Instant.now(clock).toEpochMilli(),
+                rolloutId = authorization.rolloutId,
+            ),
+        )
+    }
+
+    private fun audit(
+        caseId: String,
+        agentId: String,
+        capability: String,
+        result: AuditResult,
+        signalId: String,
+        decisionId: String = "",
+        rolloutId: String = "",
+        reason: String,
+    ) {
+        runBlocking {
+            auditPublisher.publish(
+                AuditEvent(
+                    actorId = agentId,
+                    actorType = "AI_AGENT",
+                    operation = capability,
+                    resourceType = "agent-case",
+                    resourceId = caseId,
+                    timestamp = Instant.now(clock),
+                    result = result,
+                    traceId = caseId,
+                    channel = AuditChannel.API,
+                    payload = mapOf(
+                        "signal_id" to signalId,
+                        "policy_decision_id" to decisionId,
+                        "rollout_id" to rolloutId,
+                        "policy_reason" to reason,
+                    ),
+                ),
+            )
+        }
+    }
+
+    private data class PolicyEvaluation(val allowed: Boolean, val reason: String)
+}

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseThreadProjection.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseThreadProjection.kt
@@ -6,6 +6,7 @@
 package com.openbank.casecoordinator.application
 
 import com.openbank.casecoordinator.domain.model.CaseRow
+import com.openbank.casecoordinator.domain.model.CaseSignalEvidenceRow
 import com.openbank.casecoordinator.domain.model.CaseSummary
 import com.openbank.casecoordinator.domain.model.CaseThread
 import com.openbank.casecoordinator.domain.model.ContributionRow
@@ -38,11 +39,13 @@ object CaseThreadProjection {
         contributions: List<ContributionRow>,
         proposals: List<ProposalEventRow>,
         loadedAtEpochMs: Long,
+        signalEvidence: List<CaseSignalEvidenceRow> = emptyList(),
     ): CaseThread {
         val entries = buildList {
             add(case.openedEntry())
             contributions.forEach { add(it.threadEntry(case.workflowId)) }
             proposals.forEach { add(it.threadEntry(case.workflowId)) }
+            signalEvidence.forEach { add(it.threadEntry(case.workflowId)) }
         }.sortedBy { it.atEpochMs }
 
         return CaseThread(
@@ -123,8 +126,32 @@ object CaseThreadProjection {
         else -> RuntimeEvidenceStage.EMITTED
     }
 
+    private fun CaseSignalEvidenceRow.threadEntry(workflowId: String): ThreadEntry = ThreadEntry(
+        type = when (stage) {
+            "AUTHORIZED", "DENIED" -> ThreadEntryType.POLICY_DECISION
+            "INVOKED" -> ThreadEntryType.SIGNAL_INVOKED
+            "CONSUMED" -> ThreadEntryType.SIGNAL_CONSUMED
+            else -> ThreadEntryType.CONTRIBUTION_PERSISTED
+        },
+        atEpochMs = observedAtEpochMs,
+        actor = agentId,
+        summary = policyReason,
+        signalId = signalId,
+        capability = capability,
+        rolloutId = rolloutId,
+        runtimeEvidence = RuntimeEvidence(
+            evidenceId = policyDecisionId?.takeIf { it.isNotBlank() } ?: "$signalId:$stage",
+            source = SIGNAL_EVIDENCE_SOURCE,
+            stage = RuntimeEvidenceStage.valueOf(stage),
+            observedAtEpochMs = observedAtEpochMs,
+            correlationId = workflowId,
+            detail = "$capability signal $signalId",
+        ),
+    )
+
     private const val HISTORY_SOURCE = "case-coordinator-postgres-read-model"
     private const val OUTBOX_SOURCE = "case-coordinator-transactional-outbox"
+    private const val SIGNAL_EVIDENCE_SOURCE = "case-coordinator-signal-evidence"
     private const val RETENTION_POLICY = "not-configured"
     private const val COVERAGE_STATUS = "UNKNOWN_RETENTION"
 }

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseThreadService.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseThreadService.kt
@@ -25,6 +25,7 @@ class CaseThreadService(private val readRepository: CaseThreadReadRepository) {
             contributions = readRepository.listContributions(caseId),
             proposals = readRepository.listProposalEvents(caseId),
             loadedAtEpochMs = System.currentTimeMillis(),
+            signalEvidence = readRepository.listSignalEvidence(caseId),
         )
     }
 }

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/port/out/CaseCollaborationPolicyPort.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/port/out/CaseCollaborationPolicyPort.kt
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.application.port.out
+
+data class CaseCollaborationPolicyQuery(
+    val agentId: String,
+    val capability: String,
+    val caseClass: String,
+    val deliveryMode: String,
+)
+
+data class CaseCollaborationPolicyDecision(
+    val allow: Boolean,
+    val reason: String,
+    val decisionId: String = "",
+    val rolloutId: String = "",
+    val maxSignalsPerCase: Int = 0,
+)
+
+/** Dedicated ADR-0271 decision port; deliberately separate from the REST/MCP policy namespaces. */
+interface CaseCollaborationPolicyPort {
+    fun decide(query: CaseCollaborationPolicyQuery): CaseCollaborationPolicyDecision
+}
+
+class CaseCollaborationPolicyUnavailable(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflow.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflow.kt
@@ -6,6 +6,7 @@
 package com.openbank.casecoordinator.application.workflow
 
 import com.openbank.casecoordinator.domain.model.CaseOutcome
+import com.openbank.casecoordinator.domain.model.CaseSignalEvidence
 import com.openbank.casecoordinator.domain.model.CaseStart
 import com.openbank.casecoordinator.domain.model.CaseState
 import com.openbank.casecoordinator.domain.model.ContributeSignal
@@ -78,6 +79,8 @@ interface CasePersistenceActivity {
     fun recordCaseOpened(start: CaseStart, openedAtEpochMs: Long)
 
     fun recordContributions(caseId: String, contributions: List<Contribution>)
+
+    fun recordSignalEvidence(evidence: List<CaseSignalEvidence>)
 
     fun recordCaseClosed(caseId: String, status: String, closedAtEpochMs: Long)
 }

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflowImpl.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflowImpl.kt
@@ -7,6 +7,8 @@ package com.openbank.casecoordinator.application.workflow
 
 import com.openbank.casecoordinator.domain.model.CaseClass
 import com.openbank.casecoordinator.domain.model.CaseOutcome
+import com.openbank.casecoordinator.domain.model.CaseSignalEvidence
+import com.openbank.casecoordinator.domain.model.CaseSignalEvidenceStage
 import com.openbank.casecoordinator.domain.model.CaseStart
 import com.openbank.casecoordinator.domain.model.CaseState
 import com.openbank.casecoordinator.domain.model.CaseStatus
@@ -49,6 +51,7 @@ class CaseWorkflowImpl : CaseWorkflow {
     private var status = CaseStatus.OPEN
     private val participants = linkedSetOf<String>()
     private val contributions = mutableListOf<Contribution>()
+    private val consumedSignals = mutableListOf<CaseSignalEvidence>()
     private var contestedCount = 0
     private var draftVersion = 0
     private var synthesisRequested = false
@@ -93,6 +96,14 @@ class CaseWorkflowImpl : CaseWorkflow {
 
     override fun join(signal: JoinSignal) {
         participants += signal.agentId
+        consumedEvidence(
+            Workflow.getInfo().workflowId,
+            signal.signalId,
+            signal.agentId,
+            "case.join",
+            signal.rolloutId,
+            Workflow.currentTimeMillis(),
+        )?.let(consumedSignals::add)
     }
 
     override fun contribute(signal: ContributeSignal) {
@@ -102,7 +113,17 @@ class CaseWorkflowImpl : CaseWorkflow {
             evidenceRefs = signal.evidenceRefs,
             contested = signal.contested,
             draftVersion = draftVersion,
+            signalId = signal.signalId,
+            rolloutId = signal.rolloutId,
         )
+        consumedEvidence(
+            Workflow.getInfo().workflowId,
+            signal.signalId,
+            signal.agentId,
+            "case.contribute",
+            signal.rolloutId,
+            Workflow.currentTimeMillis(),
+        )?.let(consumedSignals::add)
         if (signal.contested) contestedCount++
     }
 
@@ -143,6 +164,11 @@ class CaseWorkflowImpl : CaseWorkflow {
         summary: String,
         contested: Boolean,
     ): CaseOutcome {
+        if (Workflow.getVersion(SIGNAL_EVIDENCE_CHANGE_ID, Workflow.DEFAULT_VERSION, 1) !=
+            Workflow.DEFAULT_VERSION
+        ) {
+            persistence.recordSignalEvidence(consumedSignals)
+        }
         persistence.recordContributions(start.caseId, contributions)
         val proposalId = if (Workflow.getVersion(DELIVERY_MODE_CHANGE_ID, Workflow.DEFAULT_VERSION, 1) ==
             Workflow.DEFAULT_VERSION
@@ -179,5 +205,26 @@ class CaseWorkflowImpl : CaseWorkflow {
 
     private companion object {
         const val DELIVERY_MODE_CHANGE_ID = "case-proposal-delivery-mode-v1"
+        const val SIGNAL_EVIDENCE_CHANGE_ID = "case-signal-evidence-v1"
     }
+}
+
+private fun consumedEvidence(
+    caseId: String,
+    signalId: String,
+    agentId: String,
+    capability: String,
+    rolloutId: String,
+    observedAtEpochMs: Long,
+): CaseSignalEvidence? {
+    if (signalId.isBlank()) return null // Legacy histories predate ADR-0271 correlation ids.
+    return CaseSignalEvidence(
+        signalId = signalId,
+        caseId = caseId,
+        agentId = agentId,
+        capability = capability,
+        stage = CaseSignalEvidenceStage.CONSUMED,
+        observedAtEpochMs = observedAtEpochMs,
+        rolloutId = rolloutId,
+    )
 }

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/domain/model/CaseModels.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/domain/model/CaseModels.kt
@@ -45,13 +45,15 @@ data class CaseStart(
     val deliveryMode: CaseDeliveryMode = CaseDeliveryMode.HITL,
 )
 
-data class JoinSignal(val agentId: String, val role: String)
+data class JoinSignal(val agentId: String, val role: String, val signalId: String = "", val rolloutId: String = "")
 
 data class ContributeSignal(
     val agentId: String,
     val summary: String,
     val evidenceRefs: List<String>,
     val contested: Boolean,
+    val signalId: String = "",
+    val rolloutId: String = "",
 )
 
 /**
@@ -69,6 +71,23 @@ data class Contribution(
     val evidenceRefs: List<String>,
     val contested: Boolean,
     val draftVersion: Int,
+    val signalId: String = "",
+    val rolloutId: String = "",
+)
+
+enum class CaseSignalEvidenceStage { AUTHORIZED, DENIED, INVOKED, CONSUMED, PERSISTED }
+
+/** Metadata-only collaboration evidence; summaries and evidence contents never enter this trail. */
+data class CaseSignalEvidence(
+    val signalId: String,
+    val caseId: String,
+    val agentId: String,
+    val capability: String,
+    val stage: CaseSignalEvidenceStage,
+    val observedAtEpochMs: Long,
+    val rolloutId: String = "",
+    val policyDecisionId: String = "",
+    val policyReason: String = "",
 )
 
 /** Read model exposed via the workflow query method — the Phase 2 API projects this. */

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/domain/model/CaseThread.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/domain/model/CaseThread.kt
@@ -22,6 +22,7 @@ data class CaseRow(
     val contributionCount: Int,
     val budgetTokens: Int,
     val budgetContributions: Int,
+    val deliveryMode: String = "HITL",
 )
 
 /** Raw `case_contribution` row (V1 + V3 columns). */
@@ -45,7 +46,22 @@ data class ProposalEventRow(
     val emittedAtEpochMs: Long,
 )
 
+data class CaseSignalEvidenceRow(
+    val signalId: String,
+    val agentId: String,
+    val capability: String,
+    val stage: String,
+    val observedAtEpochMs: Long,
+    val rolloutId: String?,
+    val policyDecisionId: String?,
+    val policyReason: String?,
+)
+
 enum class RuntimeEvidenceStage {
+    AUTHORIZED,
+    DENIED,
+    INVOKED,
+    CONSUMED,
     RECORDED,
     PERSISTED,
     EMITTED,
@@ -69,6 +85,10 @@ enum class ThreadEntryType {
     CONTRIBUTION,
     PROPOSAL_EMITTED,
     SHADOW_RECORDED,
+    POLICY_DECISION,
+    SIGNAL_INVOKED,
+    SIGNAL_CONSUMED,
+    CONTRIBUTION_PERSISTED,
 }
 
 /** One thread entry in the ADR-0246 timeline, oldest first. */
@@ -86,6 +106,9 @@ data class ThreadEntry(
     val shadow: Boolean = false,
     val runtimeEvidence: RuntimeEvidence,
     val tokensUsed: Int? = null,
+    val signalId: String? = null,
+    val capability: String? = null,
+    val rolloutId: String? = null,
 )
 
 /** Case list item — `GET /api/v1/case-coordinator/cases`. */

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/persistence/CaseSignalEvidenceRepository.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/persistence/CaseSignalEvidenceRepository.kt
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.infrastructure.persistence
+
+import com.openbank.casecoordinator.domain.model.CaseSignalEvidence
+import jakarta.enterprise.context.ApplicationScoped
+import java.nio.charset.StandardCharsets
+import java.sql.Connection
+import java.sql.PreparedStatement
+import java.sql.SQLException
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.UUID
+import javax.sql.DataSource
+
+data class CaseAuthorizationContext(val caseClass: String, val deliveryMode: String)
+
+@ApplicationScoped
+class CaseSignalEvidenceRepository(private val dataSource: DataSource) {
+    fun findContext(caseId: String): CaseAuthorizationContext? =
+        dataSource.connection.use { connection -> findContext(connection, caseId) }
+
+    private fun findContext(connection: Connection, caseId: String): CaseAuthorizationContext? =
+        connection.prepareStatement(
+            "SELECT case_class, delivery_mode FROM case_workflow WHERE workflow_id = ?",
+        ).use { ps ->
+            ps.setString(P1, caseId)
+            readContext(ps)
+        }
+
+    private fun readContext(statement: PreparedStatement): CaseAuthorizationContext? =
+        statement.executeQuery().use { rs ->
+            if (rs.next()) CaseAuthorizationContext(rs.getString(P1), rs.getString(P2)) else null
+        }
+
+    fun record(evidence: CaseSignalEvidence) {
+        dataSource.connection.use { connection -> insert(connection, evidence) }
+    }
+
+    /** Locks the case row so concurrent authorizations cannot cross the policy quota. */
+    fun tryRecordAuthorized(evidence: CaseSignalEvidence, maxSignalsPerCase: Int): Boolean {
+        dataSource.connection.use { connection ->
+            connection.autoCommit = false
+            return try {
+                if (!lockCase(connection, evidence.caseId)) {
+                    connection.rollback()
+                    return false
+                }
+                if (countAuthorized(connection, evidence.caseId, evidence.agentId) >= maxSignalsPerCase) {
+                    connection.rollback()
+                    false
+                } else {
+                    insert(connection, evidence)
+                    connection.commit()
+                    true
+                }
+            } catch (failure: SQLException) {
+                connection.rollback()
+                throw failure
+            }
+        }
+    }
+
+    private fun lockCase(connection: Connection, caseId: String): Boolean =
+        connection.prepareStatement("SELECT id FROM case_workflow WHERE id = ? FOR UPDATE").use { statement ->
+            statement.setObject(P1, caseUuid(caseId))
+            statement.executeQuery().use { it.next() }
+        }
+
+    private fun countAuthorized(connection: Connection, caseId: String, agentId: String): Int =
+        connection.prepareStatement(
+            """
+            SELECT COUNT(*) FROM case_signal_evidence
+            WHERE case_id = ? AND agent_id = ? AND stage = 'AUTHORIZED'
+            """.trimIndent(),
+        ).use { ps ->
+            ps.setObject(P1, caseUuid(caseId))
+            ps.setString(P2, agentId)
+            ps.executeQuery().use { rs ->
+                rs.next()
+                rs.getInt(P1)
+            }
+        }
+
+    private fun insert(connection: Connection, evidence: CaseSignalEvidence) {
+        connection.prepareStatement(
+            """
+            INSERT INTO case_signal_evidence
+                (signal_id, case_id, agent_id, capability, stage, observed_at,
+                 rollout_id, policy_decision_id, policy_reason)
+            VALUES (?, ?, ?, ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''))
+            ON CONFLICT (signal_id, stage) DO NOTHING
+            """.trimIndent(),
+        ).use { ps ->
+            ps.setObject(P1, UUID.fromString(evidence.signalId))
+            ps.setObject(P2, caseUuid(evidence.caseId))
+            ps.setString(P3, evidence.agentId)
+            ps.setString(P4, evidence.capability)
+            ps.setString(P5, evidence.stage.name)
+            ps.setTimestamp(P6, Timestamp.from(Instant.ofEpochMilli(evidence.observedAtEpochMs)))
+            ps.setString(P7, evidence.rolloutId)
+            ps.setString(P8, evidence.policyDecisionId)
+            ps.setString(P9, evidence.policyReason)
+            ps.executeUpdate()
+        }
+    }
+
+    private fun caseUuid(caseId: String): UUID = UUID.nameUUIDFromBytes(caseId.toByteArray(StandardCharsets.UTF_8))
+
+    private companion object {
+        const val P1 = 1
+        const val P2 = 2
+        const val P3 = 3
+        const val P4 = 4
+        const val P5 = 5
+        const val P6 = 6
+        const val P7 = 7
+        const val P8 = 8
+        const val P9 = 9
+    }
+}

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/persistence/CaseThreadReadRepository.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/persistence/CaseThreadReadRepository.kt
@@ -8,6 +8,7 @@ package com.openbank.casecoordinator.infrastructure.persistence
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.openbank.casecoordinator.domain.model.CaseRow
+import com.openbank.casecoordinator.domain.model.CaseSignalEvidenceRow
 import com.openbank.casecoordinator.domain.model.ContributionRow
 import com.openbank.casecoordinator.domain.model.ProposalEventRow
 import jakarta.enterprise.context.ApplicationScoped
@@ -75,6 +76,30 @@ class CaseThreadReadRepository(private val dataSource: DataSource, private val o
         },
     )
 
+    fun listSignalEvidence(workflowId: String): List<CaseSignalEvidenceRow> = query(
+        """
+        SELECT e.signal_id, e.agent_id, e.capability, e.stage, e.observed_at,
+               e.rollout_id, e.policy_decision_id, e.policy_reason
+        FROM case_signal_evidence e
+        JOIN case_workflow w ON w.id = e.case_id
+        WHERE w.workflow_id = ?
+        ORDER BY e.observed_at, e.signal_id, e.stage
+        """.trimIndent(),
+        { ps -> ps.setString(P1, workflowId) },
+        { rs ->
+            CaseSignalEvidenceRow(
+                signalId = rs.getObject("signal_id", UUID::class.java).toString(),
+                agentId = rs.getString("agent_id"),
+                capability = rs.getString("capability"),
+                stage = rs.getString("stage"),
+                observedAtEpochMs = rs.getTimestamp("observed_at").toInstant().toEpochMilli(),
+                rolloutId = rs.getString("rollout_id"),
+                policyDecisionId = rs.getString("policy_decision_id"),
+                policyReason = rs.getString("policy_reason"),
+            )
+        },
+    )
+
     private fun <T> query(sql: String, bind: (PreparedStatement) -> Unit, mapRow: (ResultSet) -> T): List<T> =
         dataSource.connection.use { conn ->
             conn.prepareStatement(sql).use { ps ->
@@ -92,6 +117,7 @@ class CaseThreadReadRepository(private val dataSource: DataSource, private val o
     private fun ResultSet.toCaseRow(): CaseRow = CaseRow(
         workflowId = getString("workflow_id"),
         caseClass = getString("case_class"),
+        deliveryMode = getString("delivery_mode"),
         dispositionTarget = getString("disposition_target"),
         status = getString("status"),
         openedAtEpochMs = getTimestamp("opened_at").toInstant().toEpochMilli(),
@@ -121,7 +147,7 @@ class CaseThreadReadRepository(private val dataSource: DataSource, private val o
         const val P1 = 1
 
         const val CASE_SELECT = """
-            SELECT w.workflow_id, w.case_class, w.disposition_target, w.status,
+            SELECT w.workflow_id, w.case_class, w.delivery_mode, w.disposition_target, w.status,
                    w.opened_at, w.deadline_at, w.contested_rate,
                    w.budget_tokens, w.budget_contributions,
                    (SELECT COUNT(*) FROM case_contribution c WHERE c.case_id = w.id) AS contribution_count

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/policy/OpaCaseCollaborationPolicyAdapter.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/policy/OpaCaseCollaborationPolicyAdapter.kt
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.infrastructure.policy
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.casecoordinator.application.port.out.CaseCollaborationPolicyDecision
+import com.openbank.casecoordinator.application.port.out.CaseCollaborationPolicyPort
+import com.openbank.casecoordinator.application.port.out.CaseCollaborationPolicyQuery
+import com.openbank.casecoordinator.application.port.out.CaseCollaborationPolicyUnavailable
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+
+@ApplicationScoped
+class OpaCaseCollaborationPolicyAdapter(
+    private val mapper: ObjectMapper,
+    @ConfigProperty(name = "opa.url", defaultValue = "http://localhost:8181") private val baseUrl: String,
+    @ConfigProperty(
+        name = "opa.case-collaboration-path",
+        defaultValue = "/v1/data/openbank/case_collaboration/decision",
+    ) private val queryPath: String,
+    @ConfigProperty(name = "opa.timeout-ms", defaultValue = "500") timeoutMs: Long,
+) : CaseCollaborationPolicyPort {
+    private val timeout = Duration.ofMillis(timeoutMs)
+    private val http = HttpClient.newBuilder().connectTimeout(timeout).build()
+
+    override fun decide(query: CaseCollaborationPolicyQuery): CaseCollaborationPolicyDecision {
+        val input = mapOf(
+            "agent" to query.agentId,
+            "capability" to query.capability,
+            "case_class" to query.caseClass,
+            "delivery_mode" to query.deliveryMode,
+        )
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create("$baseUrl$queryPath"))
+            .timeout(timeout)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(mapOf("input" to input))))
+            .build()
+        val response = runCatching { http.send(request, HttpResponse.BodyHandlers.ofString()) }
+            .getOrElse { throw CaseCollaborationPolicyUnavailable("case policy call failed", it) }
+        if (response.statusCode() !in HTTP_OK until HTTP_REDIRECT) {
+            throw CaseCollaborationPolicyUnavailable("case policy returned HTTP ${response.statusCode()}")
+        }
+        val root = runCatching { mapper.readTree(response.body()) }
+            .getOrElse { throw CaseCollaborationPolicyUnavailable("case policy returned invalid JSON", it) }
+        val result = root.path("result")
+        if (!result.isObject) {
+            return CaseCollaborationPolicyDecision(
+                false,
+                "no matching policy rule",
+                root.path("decision_id").asText(""),
+            )
+        }
+        return CaseCollaborationPolicyDecision(
+            allow = result.path("allow").asBoolean(false),
+            reason = result.path("reason").asText("policy denied"),
+            decisionId = root.path("decision_id").asText(""),
+            rolloutId = result.path("rollout_id").asText(""),
+            maxSignalsPerCase = result.path("max_signals_per_case").asInt(0),
+        )
+    }
+
+    private companion object {
+        const val HTTP_OK = 200
+        const val HTTP_REDIRECT = 300
+    }
+}

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseCoordinatorResource.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseCoordinatorResource.kt
@@ -8,6 +8,8 @@ package com.openbank.casecoordinator.infrastructure.rest
 import com.openbank.casecoordinator.application.CaseCapabilityGate
 import com.openbank.casecoordinator.application.CaseOpenResult
 import com.openbank.casecoordinator.application.CaseOpenService
+import com.openbank.casecoordinator.application.CaseSignalAuthorizationResult
+import com.openbank.casecoordinator.application.CaseSignalAuthorizationService
 import com.openbank.casecoordinator.application.CaseThreadService
 import com.openbank.casecoordinator.application.workflow.CaseWorkflow
 import com.openbank.casecoordinator.domain.model.CaseClass
@@ -47,6 +49,7 @@ class CaseCoordinatorResource(
     private val workflowClient: WorkflowClient,
     private val temporalConfig: TemporalConfig,
     private val identity: SecurityIdentity,
+    private val signalAuthorization: CaseSignalAuthorizationService,
 ) {
 
     data class Status(val service: String, val status: String)
@@ -150,6 +153,7 @@ class CaseCoordinatorResource(
 
     @POST
     @Path("/cases/{caseId}/signals")
+    @Blocking
     @RolesAllowed("ROLE_ADMIN", "ROLE_OPERATOR")
     fun signal(@PathParam("caseId") caseId: String?, request: SignalRequest?): Response {
         val id = requireNotNull(caseId) { "caseId path parameter is required" }
@@ -162,8 +166,27 @@ class CaseCoordinatorResource(
         // one the caller proved it may act as, not one it named. Answering 503 first would also
         // make the decision unobservable wherever Temporal is off.
         if (!gate.permitsAssertedIdentity(identity.roles, agentId)) return assertedIdentityDenied()
+        val capability = when (type) {
+            "join" -> "case.join"
+            "contribute" -> "case.contribute"
+            "supersede", "request-synthesis" -> null
+            else -> throw IllegalArgumentException("unknown signal type '$type'")
+        }
+        val collaborationAuthorization = capability?.let {
+            when (val result = signalAuthorization.authorize(id, agentId, it)) {
+                is CaseSignalAuthorizationResult.Authorized -> result
+                CaseSignalAuthorizationResult.Denied -> return Response.status(Response.Status.FORBIDDEN)
+                    .entity(errorBody("signal '$type' denied for the requested agent")).build()
+                CaseSignalAuthorizationResult.UnknownCase -> return Response.status(Response.Status.NOT_FOUND)
+                    .entity(errorBody("no running case with id '$id'")).build()
+                CaseSignalAuthorizationResult.PolicyUnavailable -> return Response.status(
+                    Response.Status.SERVICE_UNAVAILABLE,
+                )
+                    .entity(errorBody("case collaboration policy is unavailable")).build()
+            }
+        }
         if (!temporalConfig.enabled()) return temporalUnavailable()
-        if (!capable(type, agentId)) {
+        if (capability == null && !capable(type, agentId)) {
             return Response.status(Response.Status.FORBIDDEN)
                 // agentId is NOT echoed (#4834), matching the openCase denial. It is free-form
                 // request-body input, and reflecting it verbatim tells the caller nothing it did
@@ -171,7 +194,7 @@ class CaseCoordinatorResource(
                 // it against the four known signal literals, so it is a bounded server-side value.
                 .entity(errorBody("signal '$type' denied for the requested agent")).build()
         }
-        return deliver(id, type, agentId, request)
+        return deliver(id, type, agentId, request, capability, collaborationAuthorization)
     }
 
     private fun capable(type: String, agentId: String): Boolean = when (type) {
@@ -182,17 +205,33 @@ class CaseCoordinatorResource(
         else -> throw IllegalArgumentException("unknown signal type '$type'")
     }
 
-    private fun deliver(id: String, type: String, agentId: String, request: SignalRequest): Response {
+    private fun deliver(
+        id: String,
+        type: String,
+        agentId: String,
+        request: SignalRequest,
+        capability: String?,
+        authorization: CaseSignalAuthorizationResult.Authorized?,
+    ): Response {
         val stub = workflowClient.newWorkflowStub(CaseWorkflow::class.java, id)
         return try {
             when (type) {
-                "join" -> stub.join(JoinSignal(agentId, request.role ?: "participant"))
+                "join" -> stub.join(
+                    JoinSignal(
+                        agentId,
+                        request.role ?: "participant",
+                        requireNotNull(authorization).signalId,
+                        authorization.rolloutId,
+                    ),
+                )
                 "contribute" -> stub.contribute(
                     ContributeSignal(
                         agentId = agentId,
                         summary = requireNotNull(request.summary) { "summary is required for contribute" },
                         evidenceRefs = request.evidenceRefs ?: emptyList(),
                         contested = request.contested ?: false,
+                        signalId = requireNotNull(authorization).signalId,
+                        rolloutId = authorization.rolloutId,
                     ),
                 )
                 "supersede" -> stub.supersede(
@@ -205,6 +244,9 @@ class CaseCoordinatorResource(
                     ),
                 )
                 else -> stub.requestSynthesis(SynthesisRequest(agentId))
+            }
+            if (capability != null && authorization != null) {
+                signalAuthorization.recordInvoked(id, agentId, capability, authorization)
             }
             Response.accepted().build()
         } catch (e: WorkflowNotFoundException) {

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/workflow/CaseActivitiesImpl.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/workflow/CaseActivitiesImpl.kt
@@ -11,6 +11,8 @@ import com.openbank.casecoordinator.application.workflow.CasePersistenceActivity
 import com.openbank.casecoordinator.application.workflow.CaseProposalActivity
 import com.openbank.casecoordinator.application.workflow.CaseProposalDeliveryActivity
 import com.openbank.casecoordinator.application.workflow.CaseSynthesisActivity
+import com.openbank.casecoordinator.domain.model.CaseSignalEvidence
+import com.openbank.casecoordinator.domain.model.CaseSignalEvidenceStage
 import com.openbank.casecoordinator.domain.model.CaseStart
 import com.openbank.casecoordinator.domain.model.Contribution
 import com.openbank.libs.persistence.outbox.OutboxStatus
@@ -108,19 +110,20 @@ class CaseActivitiesImpl(
             conn.prepareStatement(
                 """
                 INSERT INTO case_workflow
-                    (id, workflow_id, case_class, disposition_target, opened_at, deadline_at, status,
+                    (id, workflow_id, case_class, delivery_mode, disposition_target, opened_at, deadline_at, status,
                      budget_tokens, budget_contributions, contested_rate)
-                VALUES (?, ?, ?, ?, ?, ?, 'OPEN', ?, ?, 0.0)
+                VALUES (?, ?, ?, ?, ?, ?, ?, 'OPEN', ?, ?, 0.0)
                 """.trimIndent(),
             ).use { ps ->
                 ps.setObject(P1, caseUuid(start.caseId))
                 ps.setString(P2, start.caseId)
                 ps.setString(P3, start.caseClass.name)
-                ps.setString(P4, start.dispositionTarget)
-                ps.setTimestamp(P5, Timestamp.from(Instant.ofEpochMilli(openedAtEpochMs)))
-                ps.setTimestamp(P6, Timestamp.from(Instant.ofEpochMilli(start.deadlineEpochMs)))
-                ps.setInt(P7, TOKENS_PER_CASE)
-                ps.setInt(P8, start.maxContributions)
+                ps.setString(P4, start.deliveryMode.name)
+                ps.setString(P5, start.dispositionTarget)
+                ps.setTimestamp(P6, Timestamp.from(Instant.ofEpochMilli(openedAtEpochMs)))
+                ps.setTimestamp(P7, Timestamp.from(Instant.ofEpochMilli(start.deadlineEpochMs)))
+                ps.setInt(P8, TOKENS_PER_CASE)
+                ps.setInt(P9, start.maxContributions)
                 ps.executeUpdate()
             }
         }
@@ -155,6 +158,20 @@ class CaseActivitiesImpl(
                 }
                 ps.executeBatch()
             }
+            contributions.filter { it.signalId.isNotBlank() }.forEach { contribution ->
+                recordEvidence(
+                    conn,
+                    CaseSignalEvidence(
+                        signalId = contribution.signalId,
+                        caseId = caseId,
+                        agentId = contribution.agentId,
+                        capability = "case.contribute",
+                        stage = CaseSignalEvidenceStage.PERSISTED,
+                        observedAtEpochMs = now.toInstant().toEpochMilli(),
+                        rolloutId = contribution.rolloutId,
+                    ),
+                )
+            }
             val contested = contributions.count { it.contested }
             conn.prepareStatement(
                 "UPDATE case_workflow SET contested_rate = ? WHERE id = ?",
@@ -163,6 +180,34 @@ class CaseActivitiesImpl(
                 ps.setObject(P2, caseUuid(caseId))
                 ps.executeUpdate()
             }
+        }
+    }
+
+    override fun recordSignalEvidence(evidence: List<CaseSignalEvidence>) {
+        if (evidence.isEmpty()) return
+        dataSource.connection.use { conn -> evidence.forEach { recordEvidence(conn, it) } }
+    }
+
+    private fun recordEvidence(conn: java.sql.Connection, evidence: CaseSignalEvidence) {
+        conn.prepareStatement(
+            """
+            INSERT INTO case_signal_evidence
+                (signal_id, case_id, agent_id, capability, stage, observed_at,
+                 rollout_id, policy_decision_id, policy_reason)
+            VALUES (?, ?, ?, ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''))
+            ON CONFLICT (signal_id, stage) DO NOTHING
+            """.trimIndent(),
+        ).use { ps ->
+            ps.setObject(P1, UUID.fromString(evidence.signalId))
+            ps.setObject(P2, caseUuid(evidence.caseId))
+            ps.setString(P3, evidence.agentId)
+            ps.setString(P4, evidence.capability)
+            ps.setString(P5, evidence.stage.name)
+            ps.setTimestamp(P6, Timestamp.from(Instant.ofEpochMilli(evidence.observedAtEpochMs)))
+            ps.setString(P7, evidence.rolloutId)
+            ps.setString(P8, evidence.policyDecisionId)
+            ps.setString(P9, evidence.policyReason)
+            ps.executeUpdate()
         }
     }
 

--- a/openbank-case-coordinator-agent/src/main/resources/db/migration/V5__case_signal_evidence.sql
+++ b/openbank-case-coordinator-agent/src/main/resources/db/migration/V5__case_signal_evidence.sql
@@ -1,0 +1,27 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+-- A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+-- See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+--
+-- ADR-0271: server-owned delivery mode plus separately observable authorization, invocation,
+-- consumption and persistence stages for case collaboration. Payload content is deliberately absent.
+-- Rollback: DROP TABLE case_signal_evidence; ALTER TABLE case_workflow DROP COLUMN delivery_mode;
+
+ALTER TABLE case_workflow
+    ADD COLUMN delivery_mode VARCHAR(16) NOT NULL DEFAULT 'HITL';
+
+CREATE TABLE case_signal_evidence (
+    signal_id         UUID         NOT NULL,
+    case_id           UUID         NOT NULL REFERENCES case_workflow(id) ON DELETE CASCADE,
+    agent_id          VARCHAR(64)  NOT NULL,
+    capability        VARCHAR(32)  NOT NULL,
+    stage             VARCHAR(16)  NOT NULL,
+    observed_at       TIMESTAMPTZ  NOT NULL,
+    rollout_id        VARCHAR(128),
+    policy_decision_id VARCHAR(128),
+    policy_reason     VARCHAR(255),
+    PRIMARY KEY (signal_id, stage)
+);
+
+CREATE INDEX idx_case_signal_evidence_case_time
+    ON case_signal_evidence (case_id, observed_at);

--- a/openbank-case-coordinator-agent/src/main/resources/openapi.yaml
+++ b/openbank-case-coordinator-agent/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Case Coordinator Agent API
-  version: 1.4.0
+  version: 1.4.1
   description: >-
     Agent-swarm case coordination (ADR-0244): opens durable Temporal case workflows, accepts
     mid-flight agent signals (join / contribute / supersede / request-synthesis), and projects
@@ -155,7 +155,9 @@ paths:
       operationId: signalCase
       description: >-
         Signal ingress for swarm participants: join, contribute, supersede (deterministic
-        pre-emption, D5) or request-synthesis. Each type is capability-gated (D2).
+        pre-emption, D5) or request-synthesis. Join and contribute require the dedicated OPA
+        collaboration decision plus the local charter gate. Authorization, Temporal invocation,
+        workflow consumption and contribution persistence remain separate evidence stages.
       parameters:
         - name: caseId
           in: path
@@ -170,7 +172,9 @@ paths:
               $ref: '#/components/schemas/SignalRequest'
       responses:
         '202':
-          description: Signal accepted by the workflow
+          description: >-
+            Temporal client accepted the signal invocation. This does not assert that the workflow
+            consumed the signal or persisted a contribution.
         '400':
           description: Missing or invalid request field
           content:
@@ -180,7 +184,7 @@ paths:
         '403':
           description: >-
             The authenticated caller may not act as the requested `agentId`, or the signal type is
-            denied for that agent by the capability gate.
+            denied by the OPA collaboration policy or the fail-safe local charter gate.
           content:
             application/json:
               schema:
@@ -192,7 +196,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorBody'
         '503':
-          description: Temporal case workflows disabled
+          description: Temporal case workflows disabled or the OPA collaboration policy unavailable
           content:
             application/json:
               schema:
@@ -319,7 +323,15 @@ components:
       properties:
         type:
           type: string
-          enum: [CASE_OPENED, CONTRIBUTION, PROPOSAL_EMITTED, SHADOW_RECORDED]
+          enum:
+            - CASE_OPENED
+            - CONTRIBUTION
+            - PROPOSAL_EMITTED
+            - SHADOW_RECORDED
+            - POLICY_DECISION
+            - SIGNAL_INVOKED
+            - SIGNAL_CONSUMED
+            - CONTRIBUTION_PERSISTED
         atEpochMs:
           type: integer
           format: int64
@@ -348,6 +360,14 @@ components:
         tokensUsed:
           type: integer
           minimum: 0
+        signalId:
+          type: string
+          format: uuid
+        capability:
+          type: string
+          enum: [case.join, case.contribute]
+        rolloutId:
+          type: string
         runtimeEvidence:
           $ref: '#/components/schemas/RuntimeEvidence'
 
@@ -360,10 +380,23 @@ components:
           type: string
         source:
           type: string
-          enum: [case-coordinator-postgres-read-model, case-coordinator-transactional-outbox]
+          enum:
+            - case-coordinator-postgres-read-model
+            - case-coordinator-transactional-outbox
+            - case-coordinator-signal-evidence
         stage:
           type: string
-          enum: [RECORDED, PERSISTED, EMITTED, PUBLISHED_TO_BROKER, PUBLISH_FAILED, SHADOW_RECORDED]
+          enum:
+            - AUTHORIZED
+            - DENIED
+            - INVOKED
+            - CONSUMED
+            - RECORDED
+            - PERSISTED
+            - EMITTED
+            - PUBLISHED_TO_BROKER
+            - PUBLISH_FAILED
+            - SHADOW_RECORDED
         observedAtEpochMs:
           type: integer
           format: int64

--- a/openbank-case-coordinator-agent/src/main/resources/openapi.yaml
+++ b/openbank-case-coordinator-agent/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Case Coordinator Agent API
-  version: 1.4.1
+  version: 1.5.0
   description: >-
     Agent-swarm case coordination (ADR-0244): opens durable Temporal case workflows, accepts
     mid-flight agent signals (join / contribute / supersede / request-synthesis), and projects

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseSignalAuthorizationServiceTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseSignalAuthorizationServiceTest.kt
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.application
+
+import com.openbank.casecoordinator.application.port.out.CaseCollaborationPolicyDecision
+import com.openbank.casecoordinator.application.port.out.CaseCollaborationPolicyPort
+import com.openbank.casecoordinator.domain.model.CaseSignalEvidence
+import com.openbank.casecoordinator.domain.model.CaseSignalEvidenceStage
+import com.openbank.casecoordinator.infrastructure.persistence.CaseAuthorizationContext
+import com.openbank.casecoordinator.infrastructure.persistence.CaseSignalEvidenceRepository
+import com.openbank.libs.audit.AuditEvent
+import com.openbank.libs.audit.AuditEventPublisher
+import com.openbank.libs.audit.AuditResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CaseSignalAuthorizationServiceTest {
+    private val policy = mockk<CaseCollaborationPolicyPort>()
+    private val localGate = mockk<CaseCapabilityGate>()
+    private val repository = mockk<CaseSignalEvidenceRepository>(relaxed = true)
+    private val audit = mockk<AuditEventPublisher>()
+    private val service = CaseSignalAuthorizationService(policy, localGate, repository, audit)
+
+    @Test
+    fun `allow requires policy local charter and remaining quota and emits correlated audit`() = runBlocking {
+        every { repository.findContext("case-1") } returns CaseAuthorizationContext("INCIDENT_RESPONSE", "SHADOW")
+        every { repository.tryRecordAuthorized(any(), 8) } returns true
+        every { localGate.canContribute("rca-investigator") } returns true
+        every { policy.decide(any()) } returns CaseCollaborationPolicyDecision(
+            allow = true,
+            reason = "allowed by charter and rules matrix",
+            decisionId = "opa-decision-7",
+            rolloutId = "shadow-rca-1",
+            maxSignalsPerCase = 8,
+        )
+        coEvery { audit.publish(any()) } returns Unit
+        val evidence = slot<CaseSignalEvidence>()
+
+        val result = service.authorize("case-1", "rca-investigator", "case.contribute")
+
+        assertThat(result).isInstanceOf(CaseSignalAuthorizationResult.Authorized::class.java)
+        verify { repository.tryRecordAuthorized(capture(evidence), 8) }
+        assertThat(evidence.captured.stage).isEqualTo(CaseSignalEvidenceStage.AUTHORIZED)
+        assertThat(evidence.captured.policyDecisionId).isEqualTo("opa-decision-7")
+        coVerify {
+            audit.publish(
+                match<AuditEvent> {
+                    it.operation == "case.contribute" &&
+                        it.resourceId == "case-1" &&
+                        it.result == AuditResult.SUCCESS &&
+                        it.payload["policy_decision_id"] == "opa-decision-7"
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `policy allow still denies when local charter gate disagrees`() = runBlocking {
+        every { repository.findContext(any()) } returns CaseAuthorizationContext("INCIDENT_RESPONSE", "SHADOW")
+        every { localGate.canJoinCase(any()) } returns false
+        every { policy.decide(any()) } returns CaseCollaborationPolicyDecision(
+            allow = true,
+            reason = "allowed by charter and rules matrix",
+            decisionId = "opa-decision-8",
+            rolloutId = "shadow-rca-1",
+            maxSignalsPerCase = 8,
+        )
+        coEvery { audit.publish(any()) } returns Unit
+
+        val result = service.authorize("case-1", "rca-investigator", "case.join")
+
+        assertThat(result).isEqualTo(CaseSignalAuthorizationResult.Denied)
+        verify {
+            repository.record(
+                match { it.stage == CaseSignalEvidenceStage.DENIED && it.policyReason == "local charter gate denied" },
+            )
+        }
+    }
+}

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseSignalAuthorizationServiceTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseSignalAuthorizationServiceTest.kt
@@ -7,6 +7,7 @@ package com.openbank.casecoordinator.application
 
 import com.openbank.casecoordinator.application.port.out.CaseCollaborationPolicyDecision
 import com.openbank.casecoordinator.application.port.out.CaseCollaborationPolicyPort
+import com.openbank.casecoordinator.application.port.out.CaseCollaborationPolicyQuery
 import com.openbank.casecoordinator.domain.model.CaseSignalEvidence
 import com.openbank.casecoordinator.domain.model.CaseSignalEvidenceStage
 import com.openbank.casecoordinator.infrastructure.persistence.CaseAuthorizationContext
@@ -45,10 +46,14 @@ class CaseSignalAuthorizationServiceTest {
         )
         coEvery { audit.publish(any()) } returns Unit
         val evidence = slot<CaseSignalEvidence>()
+        val query = slot<CaseCollaborationPolicyQuery>()
 
         val result = service.authorize("case-1", "rca-investigator", "case.contribute")
 
         assertThat(result).isInstanceOf(CaseSignalAuthorizationResult.Authorized::class.java)
+        verify { policy.decide(capture(query)) }
+        assertThat(query.captured.caseClass).isEqualTo("INCIDENT_RESPONSE")
+        assertThat(query.captured.deliveryMode).isEqualTo("SHADOW")
         verify { repository.tryRecordAuthorized(capture(evidence), 8) }
         assertThat(evidence.captured.stage).isEqualTo(CaseSignalEvidenceStage.AUTHORIZED)
         assertThat(evidence.captured.policyDecisionId).isEqualTo("opa-decision-7")

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseSignalAuthorizationServiceTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseSignalAuthorizationServiceTest.kt
@@ -32,7 +32,7 @@ class CaseSignalAuthorizationServiceTest {
     private val service = CaseSignalAuthorizationService(policy, localGate, repository, audit)
 
     @Test
-    fun `allow requires policy local charter and remaining quota and emits correlated audit`() = runBlocking {
+    fun `allow requires policy local charter and remaining quota and emits correlated audit`(): Unit = runBlocking {
         every { repository.findContext("case-1") } returns CaseAuthorizationContext("INCIDENT_RESPONSE", "SHADOW")
         every { repository.tryRecordAuthorized(any(), 8) } returns true
         every { localGate.canContribute("rca-investigator") } returns true
@@ -65,7 +65,7 @@ class CaseSignalAuthorizationServiceTest {
     }
 
     @Test
-    fun `policy allow still denies when local charter gate disagrees`() = runBlocking {
+    fun `policy allow still denies when local charter gate disagrees`(): Unit = runBlocking {
         every { repository.findContext(any()) } returns CaseAuthorizationContext("INCIDENT_RESPONSE", "SHADOW")
         every { localGate.canJoinCase(any()) } returns false
         every { policy.decide(any()) } returns CaseCollaborationPolicyDecision(

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseThreadProjectionTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseThreadProjectionTest.kt
@@ -6,8 +6,10 @@
 package com.openbank.casecoordinator.application
 
 import com.openbank.casecoordinator.domain.model.CaseRow
+import com.openbank.casecoordinator.domain.model.CaseSignalEvidenceRow
 import com.openbank.casecoordinator.domain.model.ContributionRow
 import com.openbank.casecoordinator.domain.model.ProposalEventRow
+import com.openbank.casecoordinator.domain.model.RuntimeEvidenceStage
 import com.openbank.casecoordinator.domain.model.ThreadEntryType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -139,6 +141,52 @@ class CaseThreadProjectionTest {
         assertThat(thread.dataToEpochMs).isEqualTo(T0 + LATER_MS)
         assertThat(thread.lastSuccessfulLoadEpochMs).isEqualTo(LOADED_AT)
         assertThat(thread.budgetTokens).isEqualTo(200_000)
+    }
+
+    @Test
+    fun `OPA authorization and Temporal stages retain one signal correlation`() {
+        val evidence = listOf(
+            CaseSignalEvidenceRow(
+                signalId = "11111111-1111-1111-1111-111111111111",
+                agentId = "rca-investigator",
+                capability = "case.contribute",
+                stage = "AUTHORIZED",
+                observedAtEpochMs = T0 + LATER_MS,
+                rolloutId = "shadow-rca-1",
+                policyDecisionId = "opa-decision-7",
+                policyReason = "allowed by charter and rules matrix",
+            ),
+            CaseSignalEvidenceRow(
+                signalId = "11111111-1111-1111-1111-111111111111",
+                agentId = "rca-investigator",
+                capability = "case.contribute",
+                stage = "CONSUMED",
+                observedAtEpochMs = T0 + 2 * LATER_MS,
+                rolloutId = "shadow-rca-1",
+                policyDecisionId = null,
+                policyReason = null,
+            ),
+        )
+
+        val thread = CaseThreadProjection.project(
+            caseRow,
+            emptyList(),
+            emptyList(),
+            LOADED_AT,
+            evidence,
+        )
+
+        val signalEntries = thread.entries.filter { it.signalId != null }
+        assertThat(signalEntries.map { it.type }).containsExactly(
+            ThreadEntryType.POLICY_DECISION,
+            ThreadEntryType.SIGNAL_CONSUMED,
+        )
+        assertThat(signalEntries.map { it.runtimeEvidence.stage }).containsExactly(
+            RuntimeEvidenceStage.AUTHORIZED,
+            RuntimeEvidenceStage.CONSUMED,
+        )
+        assertThat(signalEntries.map { it.runtimeEvidence.correlationId }).containsOnly(caseRow.workflowId)
+        assertThat(signalEntries.first().runtimeEvidence.evidenceId).isEqualTo("opa-decision-7")
     }
 
     private companion object {

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseThreadServiceTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseThreadServiceTest.kt
@@ -48,6 +48,7 @@ class CaseThreadServiceTest {
         every { repository.findCase(WORKFLOW_ID) } returns caseRow()
         every { repository.listContributions(WORKFLOW_ID) } returns emptyList()
         every { repository.listProposalEvents(WORKFLOW_ID) } returns emptyList()
+        every { repository.listSignalEvidence(WORKFLOW_ID) } returns emptyList()
 
         val thread = service.caseThread(WORKFLOW_ID)
 

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflowReplayTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflowReplayTest.kt
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.application.workflow
+
+import com.openbank.casecoordinator.domain.model.CaseClass
+import com.openbank.casecoordinator.domain.model.CaseDeliveryMode
+import com.openbank.casecoordinator.domain.model.CaseOutcome
+import com.openbank.casecoordinator.domain.model.CaseStart
+import com.openbank.casecoordinator.domain.model.CaseState
+import com.openbank.casecoordinator.domain.model.CaseStatus
+import com.openbank.casecoordinator.domain.model.ContributeSignal
+import com.openbank.casecoordinator.domain.model.Contribution
+import com.openbank.casecoordinator.domain.model.JoinSignal
+import com.openbank.casecoordinator.domain.model.SupersedeSignal
+import com.openbank.casecoordinator.domain.model.SynthesisRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.temporal.activity.ActivityOptions
+import io.temporal.client.WorkflowClient
+import io.temporal.client.WorkflowClientOptions
+import io.temporal.client.WorkflowOptions
+import io.temporal.client.WorkflowStub
+import io.temporal.common.RetryOptions
+import io.temporal.testing.TestEnvironmentOptions
+import io.temporal.testing.TestWorkflowEnvironment
+import io.temporal.testing.WorkflowReplayer
+import io.temporal.worker.Worker
+import io.temporal.workflow.Workflow
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+/** Proves the evidence marker can replay a history produced before that marker existed. */
+class CaseWorkflowReplayTest {
+    private lateinit var environment: TestWorkflowEnvironment
+    private lateinit var worker: Worker
+
+    @BeforeEach
+    fun setUp() {
+        environment = replayEnvironment()
+        worker = environment.newWorker(TASK_QUEUE)
+        worker.registerWorkflowImplementationTypes(PreSignalEvidenceCaseWorkflow::class.java)
+        val synthesis = mockk<CaseSynthesisActivity>()
+        val proposals = mockk<CaseProposalActivity>(relaxed = true)
+        val delivery = mockk<CaseProposalDeliveryActivity>()
+        val persistence = mockk<CasePersistenceActivity>(relaxed = true)
+        every { synthesis.synthesize(any(), any(), any()) } returns "legacy synthesis"
+        every { delivery.emitProposalWithDelivery(any(), any(), any(), any(), any()) } returns "proposal-legacy"
+        worker.registerActivitiesImplementations(synthesis, proposals, delivery, persistence)
+        environment.start()
+    }
+
+    @AfterEach
+    fun tearDown() = environment.close()
+
+    @Test
+    fun `pre-evidence history replays against the current workflow`() {
+        val stub = environment.workflowClient.newWorkflowStub(
+            CaseWorkflow::class.java,
+            WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build(),
+        )
+        val execution = WorkflowClient.start(stub::run, caseStart())
+        stub.join(JoinSignal("rca-investigator", "investigator"))
+        stub.contribute(ContributeSignal("rca-investigator", "legacy finding", emptyList(), false))
+        stub.requestSynthesis(SynthesisRequest("case-coordinator"))
+        WorkflowStub.fromTyped(stub).getResult(CaseOutcome::class.java)
+        val history = environment.getWorkflowExecutionHistory(execution)
+
+        replayEnvironment().use { replay ->
+            WorkflowReplayer.replayWorkflowExecution(history, replay, CaseWorkflowImpl::class.java)
+        }
+    }
+
+    private fun replayEnvironment(): TestWorkflowEnvironment = TestWorkflowEnvironment.newInstance(
+        TestEnvironmentOptions.newBuilder()
+            .setWorkflowClientOptions(
+                WorkflowClientOptions.newBuilder()
+                    .setDataConverter(CaseWorkflowTest.kotlinAwareDataConverter())
+                    .build(),
+            )
+            .build(),
+    )
+
+    private fun caseStart() = CaseStart(
+        caseId = CASE_ID,
+        caseClass = CaseClass.INCIDENT_RESPONSE,
+        subjectRef = "masked-incident",
+        openedBy = "case-coordinator",
+        dispositionTarget = "shadow-evaluation",
+        deadlineEpochMs = System.currentTimeMillis() + Duration.ofHours(1).toMillis(),
+        contestedRateThreshold = 0.35,
+        maxContributions = 40,
+        deliveryMode = CaseDeliveryMode.SHADOW,
+    )
+
+    private companion object {
+        const val TASK_QUEUE = "test-pre-signal-evidence-history"
+        const val CASE_ID = "case-pre-signal-evidence"
+    }
+}
+
+/** The production command sequence immediately before ADR-0271 signal evidence was added. */
+class PreSignalEvidenceCaseWorkflow : CaseWorkflow {
+    private val longOptions = ActivityOptions.newBuilder()
+        .setStartToCloseTimeout(Duration.ofMinutes(10))
+        .setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(2).build())
+        .build()
+    private val shortOptions = ActivityOptions.newBuilder()
+        .setStartToCloseTimeout(Duration.ofMinutes(5))
+        .build()
+    private val synthesis = Workflow.newActivityStub(CaseSynthesisActivity::class.java, longOptions)
+    private val proposals = Workflow.newActivityStub(CaseProposalActivity::class.java, shortOptions)
+    private val delivery = Workflow.newActivityStub(CaseProposalDeliveryActivity::class.java, shortOptions)
+    private val persistence = Workflow.newActivityStub(CasePersistenceActivity::class.java, shortOptions)
+    private val participants = linkedSetOf<String>()
+    private val contributions = mutableListOf<Contribution>()
+    private var synthesisRequested = false
+    private lateinit var start: CaseStart
+
+    override fun run(start: CaseStart): CaseOutcome {
+        this.start = start
+        persistence.recordCaseOpened(start, Workflow.currentTimeMillis())
+        val remainingMs = start.deadlineEpochMs - Workflow.currentTimeMillis()
+        Workflow.await(Duration.ofMillis(remainingMs)) { synthesisRequested }
+        val summary = synthesis.synthesize(start.caseId, start.caseClass.name, contributions) ?: "pending"
+        persistence.recordContributions(start.caseId, contributions)
+        val proposalId = if (Workflow.getVersion(DELIVERY_CHANGE_ID, Workflow.DEFAULT_VERSION, 1) ==
+            Workflow.DEFAULT_VERSION
+        ) {
+            proposals.emitProposal(start.caseId, "case-synthesis", summary, false)
+        } else {
+            delivery.emitProposalWithDelivery(start.caseId, "case-synthesis", summary, false, true)
+        }
+        persistence.recordCaseClosed(start.caseId, CaseStatus.SYNTHESIZED.name, Workflow.currentTimeMillis())
+        return CaseOutcome(start.caseId, CaseStatus.SYNTHESIZED, proposalId, summary, contributions.size)
+    }
+
+    override fun join(signal: JoinSignal) {
+        participants += signal.agentId
+    }
+
+    override fun contribute(signal: ContributeSignal) {
+        contributions += Contribution(signal.agentId, signal.summary, signal.evidenceRefs, signal.contested, 0)
+    }
+
+    override fun supersede(signal: SupersedeSignal) = Unit
+
+    override fun requestSynthesis(request: SynthesisRequest) {
+        synthesisRequested = true
+    }
+
+    override fun state() = CaseState(
+        start.caseId,
+        start.caseClass,
+        CaseStatus.OPEN,
+        participants.toList(),
+        contributions.size,
+        contributions.count { it.contested },
+        0,
+        0,
+        start.deadlineEpochMs,
+    )
+
+    private companion object {
+        const val DELIVERY_CHANGE_ID = "case-proposal-delivery-mode-v1"
+    }
+}

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflowTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflowTest.kt
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.openbank.casecoordinator.domain.model.CaseClass
 import com.openbank.casecoordinator.domain.model.CaseDeliveryMode
 import com.openbank.casecoordinator.domain.model.CaseOutcome
+import com.openbank.casecoordinator.domain.model.CaseSignalEvidenceStage
 import com.openbank.casecoordinator.domain.model.CaseStart
 import com.openbank.casecoordinator.domain.model.CaseStatus
 import com.openbank.casecoordinator.domain.model.ContributeSignal
@@ -116,9 +117,23 @@ class CaseWorkflowTest {
     @Test
     fun `join contribute then synthesis emits exactly one proposal`() {
         val stub = start()
-        stub.join(JoinSignal("incident-responder", "investigator"))
+        stub.join(
+            JoinSignal(
+                "incident-responder",
+                "investigator",
+                "11111111-1111-1111-1111-111111111111",
+                "rollout-shadow-1",
+            ),
+        )
         stub.contribute(
-            ContributeSignal("incident-responder", "consumer lag spike after deploy", listOf("grafana/x"), false),
+            ContributeSignal(
+                "incident-responder",
+                "consumer lag spike after deploy",
+                listOf("grafana/x"),
+                false,
+                "22222222-2222-2222-2222-222222222222",
+                "rollout-shadow-1",
+            ),
         )
         stub.requestSynthesis(SynthesisRequest("case-coordinator"))
 
@@ -134,6 +149,18 @@ class CaseWorkflowTest {
                 any(),
                 false,
                 false,
+            )
+        }
+        verify(exactly = 1) {
+            persistence.recordSignalEvidence(
+                match { evidence ->
+                    evidence.size == 2 &&
+                        evidence.all { it.stage == CaseSignalEvidenceStage.CONSUMED } &&
+                        evidence.map { it.signalId }.toSet() == setOf(
+                            "11111111-1111-1111-1111-111111111111",
+                            "22222222-2222-2222-2222-222222222222",
+                        )
+                },
             )
         }
     }

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/infrastructure/persistence/CaseSignalEvidenceQuotaIT.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/infrastructure/persistence/CaseSignalEvidenceQuotaIT.kt
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.infrastructure.persistence
+
+import com.openbank.casecoordinator.PostgresTestResource
+import com.openbank.casecoordinator.domain.model.CaseSignalEvidence
+import com.openbank.casecoordinator.domain.model.CaseSignalEvidenceStage
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import javax.sql.DataSource
+
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class CaseSignalEvidenceQuotaIT {
+    @Inject
+    lateinit var repository: CaseSignalEvidenceRepository
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    @BeforeEach
+    fun seedCase() {
+        dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                """
+                INSERT INTO case_workflow
+                    (id, workflow_id, case_class, disposition_target, opened_at, deadline_at,
+                     status, budget_tokens, budget_contributions, contested_rate)
+                VALUES (?, ?, 'INCIDENT_RESPONSE', 'quota-it', ?, ?, 'OPEN', 200000, 40, 0.0)
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setObject(1, CASE_UUID)
+                statement.setString(2, CASE_ID)
+                statement.setTimestamp(3, NOW)
+                statement.setTimestamp(4, NOW)
+                statement.executeUpdate()
+            }
+        }
+    }
+
+    @AfterEach
+    fun cleanCase() {
+        dataSource.connection.use { connection ->
+            connection.prepareStatement("DELETE FROM case_workflow WHERE id = ?").use { statement ->
+                statement.setObject(1, CASE_UUID)
+                statement.executeUpdate()
+            }
+        }
+    }
+
+    @Test
+    fun `concurrent authorizations cannot exceed the policy quota`() {
+        val executor = Executors.newFixedThreadPool(ATTEMPT_COUNT)
+        val attempts = (1..ATTEMPT_COUNT).map { attempt ->
+            Callable {
+                repository.tryRecordAuthorized(
+                    authorizationEvidence(attempt),
+                    MAX_SIGNALS,
+                )
+            }
+        }
+
+        val accepted = try {
+            executor.invokeAll(attempts).count { it.get() }
+        } finally {
+            executor.shutdownNow()
+        }
+
+        assertThat(accepted).isEqualTo(MAX_SIGNALS)
+        assertThat(storedAuthorizationCount()).isEqualTo(MAX_SIGNALS)
+    }
+
+    private fun authorizationEvidence(attempt: Int) = CaseSignalEvidence(
+        signalId = UUID.nameUUIDFromBytes("signal-$attempt".toByteArray(StandardCharsets.UTF_8)).toString(),
+        caseId = CASE_ID,
+        agentId = "rca-investigator",
+        capability = "case.contribute",
+        stage = CaseSignalEvidenceStage.AUTHORIZED,
+        observedAtEpochMs = NOW.time,
+        rolloutId = "shadow-v1",
+        policyDecisionId = "decision-$attempt",
+        policyReason = "shadow grant",
+    )
+
+    private fun storedAuthorizationCount(): Int = dataSource.connection.use { connection ->
+        connection.prepareStatement(
+            "SELECT COUNT(*) FROM case_signal_evidence WHERE case_id = ? AND stage = 'AUTHORIZED'",
+        ).use { statement ->
+            statement.setObject(1, CASE_UUID)
+            statement.executeQuery().use { result ->
+                result.next()
+                result.getInt(1)
+            }
+        }
+    }
+
+    private companion object {
+        const val CASE_ID = "case-signal-quota-it"
+        const val MAX_SIGNALS = 8
+        const val ATTEMPT_COUNT = 16
+        val CASE_UUID: UUID = UUID.nameUUIDFromBytes(CASE_ID.toByteArray(StandardCharsets.UTF_8))
+        val NOW: Timestamp = Timestamp.from(Instant.parse("2026-08-22T12:00:00Z"))
+    }
+}

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/infrastructure/policy/OpaCaseCollaborationPolicyAdapterTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/infrastructure/policy/OpaCaseCollaborationPolicyAdapterTest.kt
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.infrastructure.policy
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.casecoordinator.application.port.out.CaseCollaborationPolicyQuery
+import com.sun.net.httpserver.HttpServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicReference
+
+class OpaCaseCollaborationPolicyAdapterTest {
+    private var server: HttpServer? = null
+
+    @AfterEach
+    fun stopServer() {
+        server?.stop(0)
+    }
+
+    @Test
+    fun `posts the dedicated flat case decision input and preserves OPA provenance`() {
+        val body = AtomicReference<String>()
+        server = HttpServer.create(InetSocketAddress(0), 0).apply {
+            createContext("/v1/data/openbank/case_collaboration/decision") { exchange ->
+                body.set(exchange.requestBody.bufferedReader().readText())
+                val response = """
+                    {"decision_id":"decision-42","result":{"allow":true,
+                    "reason":"allowed by charter and rules matrix","rollout_id":"shadow-1",
+                    "max_signals_per_case":8}}
+                """.trimIndent().toByteArray()
+                exchange.sendResponseHeaders(200, response.size.toLong())
+                exchange.responseBody.use { it.write(response) }
+            }
+            start()
+        }
+        val adapter = OpaCaseCollaborationPolicyAdapter(
+            mapper = jacksonObjectMapper(),
+            baseUrl = "http://127.0.0.1:${server!!.address.port}",
+            queryPath = "/v1/data/openbank/case_collaboration/decision",
+            timeoutMs = 1_000,
+        )
+
+        val decision = adapter.decide(
+            CaseCollaborationPolicyQuery(
+                "rca-investigator",
+                "case.contribute",
+                "incident-response",
+                "SHADOW",
+            ),
+        )
+
+        assertThat(decision.allow).isTrue()
+        assertThat(decision.decisionId).isEqualTo("decision-42")
+        assertThat(decision.rolloutId).isEqualTo("shadow-1")
+        assertThat(decision.maxSignalsPerCase).isEqualTo(8)
+        val input = jacksonObjectMapper().readTree(body.get()).path("input")
+        assertThat(input.path("agent").asText()).isEqualTo("rca-investigator")
+        assertThat(input.path("case_class").asText()).isEqualTo("incident-response")
+        assertThat(input.path("delivery_mode").asText()).isEqualTo("SHADOW")
+    }
+}

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseAssertedIdentityIT.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseAssertedIdentityIT.kt
@@ -31,10 +31,10 @@ import org.junit.jupiter.api.Test
  * `ROLE_OPERATOR` to only the first, which is precisely the state the config comment says is
  * coming ("swarm join/contribute grants are deliberate follow-up charter work").
  *
- * Read the pairs, not the single status. Temporal is disabled in `%test`, so an authorised call
- * cannot reach 201 — it stops at 503 Unavailable. That is the point of the control in each test:
- * 503 means "every authorisation decision in the path accepted this call", 403 means one refused
- * it. Before the fix BOTH members of each pair answered 503 — the asserted identity was believed.
+ * Read the pairs, not the single status. Temporal is disabled in `%test`. An authorised case-open
+ * stops at 503; an authorised collaboration signal reaches the server-owned case lookup and stops
+ * at 404 because this profile created no case row. Both prove the identity gate passed, while 403
+ * proves it refused the asserted identity before either downstream decision.
  */
 @QuarkusTest
 @QuarkusTestResource(PostgresTestResource::class)
@@ -104,7 +104,7 @@ class CaseAssertedIdentityIT {
     @Test
     @TestSecurity(user = "operator-1", roles = ["ROLE_OPERATOR"])
     fun `signal still accepts the agent identity the caller's role IS bound to`() {
-        signal("case-coordinator").statusCode(503)
+        signal("case-coordinator").statusCode(404)
     }
 
     @Test

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseCoordinatorResourceDenialTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseCoordinatorResourceDenialTest.kt
@@ -7,11 +7,14 @@ package com.openbank.casecoordinator.infrastructure.rest
 
 import com.openbank.casecoordinator.application.CaseCapabilityGate
 import com.openbank.casecoordinator.application.CaseOpenService
+import com.openbank.casecoordinator.application.CaseSignalAuthorizationResult
+import com.openbank.casecoordinator.application.CaseSignalAuthorizationService
 import com.openbank.casecoordinator.application.CaseThreadService
 import com.openbank.libs.temporal.TemporalConfig
 import io.mockk.every
 import io.mockk.mockk
 import io.quarkus.security.identity.SecurityIdentity
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -30,6 +33,7 @@ class CaseCoordinatorResourceDenialTest {
     private val gate = mockk<CaseCapabilityGate>()
     private val temporalConfig = mockk<TemporalConfig>()
     private val identity = mockk<SecurityIdentity>(relaxed = true)
+    private val signalAuthorization = mockk<CaseSignalAuthorizationService>()
 
     private val resource = CaseCoordinatorResource(
         openService,
@@ -38,6 +42,7 @@ class CaseCoordinatorResourceDenialTest {
         mockk(relaxed = true),
         temporalConfig,
         identity,
+        signalAuthorization,
     )
 
     @Test
@@ -48,12 +53,16 @@ class CaseCoordinatorResourceDenialTest {
         // first (#4834) and carries its own, differently-worded body.
         every { gate.permitsAssertedIdentity(any(), any()) } returns true
         every { gate.canContribute(any()) } returns false
+        io.mockk.coEvery { signalAuthorization.authorize(any(), any(), any()) } returns
+            CaseSignalAuthorizationResult.Denied
 
         val marker = "spoofed-agent-DEADBEEF"
-        val response = resource.signal(
-            "case-incident-response-acct-1",
-            CaseCoordinatorResource.SignalRequest(type = "contribute", agentId = marker, summary = "x"),
-        )
+        val response = runBlocking {
+            resource.signal(
+                "case-incident-response-acct-1",
+                CaseCoordinatorResource.SignalRequest(type = "contribute", agentId = marker, summary = "x"),
+            )
+        }
 
         assertThat(response.status).isEqualTo(403)
         val body = response.entity.toString()


### PR DESCRIPTION
## Summary

Adds the fail-closed runtime enforcement and evidence path for the collaboration policy isolated in #6434. This PR does not grant any agent a capability: the policy matrix remains empty and production behavior remains deny-by-default.

## Type of change

- [x] feat (new functionality)

## Linked issues

Refs #6426

## Changes

- Evaluate `case.join` and `case.contribute` through the dedicated OPA decision and the existing local charter gate.
- Persist metadata-only AUTHORIZED, DENIED, INVOKED, CONSUMED, and PERSISTED evidence with a shared signal correlation ID.
- Reserve per-case policy quota transactionally under a case-row lock; a concurrent PostgreSQL IT proves 16 attempts cannot exceed a limit of 8.
- Carry correlation through Temporal with a version marker and replay a real pre-evidence workflow history against the current implementation.
- Expose the evidence in the read-only case thread projection.
- Add Flyway V5 and update OpenAPI 1.5.0 with honest 202/403/503 semantics.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [x] Contract tests updated (if public API changed).
- [x] Module `ktlintCheck`, `detekt`, `test`, and `quarkusBuild` pass locally.
- [x] No new lint warnings.
- [x] OpenAPI spec updated (if REST API changed).
- [x] Flyway migration added + rollback note (if DB changed).
- [x] Avro schema versioned backward-compatibly (N/A; no event change).
- [x] Docs updated through the prerequisite ADR PR #6429.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new suppressions or unsafe casts.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? No.
- [x] PII path changed? No; evidence intentionally excludes signal payloads.
- [x] Cardholder data path changed? No.

## Compliance impact

- [x] DORA

Improves authorization and runtime-evidence traceability while retaining deny-by-default behavior. No money-path grant is introduced.

## Rollout / Rollback

- Deployment strategy: stacked merge after #6429 and #6434; policy remains deny-by-default until a separately approved grant.
- Rollback plan: revert this PR; V5 rollback is documented in the migration header.
- Data migration reversible: yes (drops metadata-only evidence table and `delivery_mode`).

## Reviewer notes

Please verify the evidence semantics: policy authorization is not presented as Temporal invocation, workflow consumption, or persistence. Quota counts authorization reservations conservatively and is serialized per case to prevent concurrent overrun. The replay test captures history with the previous production command sequence, including the existing delivery-mode marker, then replays it against the new implementation.