### PR TITLE
feat(admin-ui): show case signal evidence

### DIFF
--- a/openbank-admin-ui/src/app/iaops/cases/[caseId]/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/cases/[caseId]/page.tsx
@@ -18,7 +18,7 @@ import { PageHeader } from '@/components/ui/PageHeader'
 import { CaseRuntimeTimeline, CaseRuntimeTopology } from '@/components/agent/CaseRuntimeViews'
 import type { RuntimeEvidenceView } from '@/components/agent/CaseRuntimeViews'
 
-type EntryType = 'CASE_OPENED' | 'CONTRIBUTION' | 'PROPOSAL_EMITTED' | 'SHADOW_RECORDED'
+type EntryType = 'CASE_OPENED' | 'CONTRIBUTION' | 'PROPOSAL_EMITTED' | 'SHADOW_RECORDED' | 'POLICY_DECISION' | 'SIGNAL_INVOKED' | 'SIGNAL_CONSUMED' | 'CONTRIBUTION_PERSISTED'
 
 interface ThreadEntry {
   type: EntryType
@@ -33,6 +33,9 @@ interface ThreadEntry {
   proposalType?: string
   shadow?: boolean
   tokensUsed?: number
+  signalId?: string
+  capability?: string
+  rolloutId?: string
   runtimeEvidence: RuntimeEvidenceView
 }
 
@@ -293,6 +296,24 @@ export default function IaopsCaseThreadPage() {
                     {!shadow && <Link href="/approvals" style={{ display: 'inline-flex', alignItems: 'center', gap: '5px', marginTop: '10px', fontSize: '11px', fontWeight: 700, color: 'var(--accent-text)', textDecoration: 'none' }}>
                       {t('Procházet HITL frontu', 'Browse the HITL queue')}
                     </Link>}
+                  </div>
+                )
+              }
+              if (entry.type === 'POLICY_DECISION' || entry.type === 'SIGNAL_INVOKED' || entry.type === 'SIGNAL_CONSUMED' || entry.type === 'CONTRIBUTION_PERSISTED') {
+                const denied = entry.runtimeEvidence.stage === 'DENIED'
+                return (
+                  <div key={index} style={{ padding: '12px 16px', borderRadius: '12px', background: denied ? 'var(--danger-bg)' : 'var(--info-bg)', border: `1px solid ${denied ? 'var(--danger)' : 'var(--border)'}` }}>
+                    <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
+                      {denied ? <TriangleAlert size={13} style={{ color: 'var(--danger)' }} /> : <CircleDot size={13} style={{ color: 'var(--blue)' }} />}
+                      <strong style={{ fontSize: '11px', color: denied ? 'var(--danger)' : 'var(--text-primary)' }}>{entry.type}</strong>
+                      <span style={{ fontFamily: 'var(--font-mono)', fontSize: '10px', color: 'var(--text-secondary)' }}>{entry.actor ?? '—'}</span>
+                      {entry.capability && <span style={{ fontFamily: 'var(--font-mono)', fontSize: '10px', color: 'var(--accent-text)' }}>{entry.capability}</span>}
+                      <span style={{ marginLeft: 'auto', fontSize: '10px', color: 'var(--text-tertiary)' }}>{fmt(entry.atEpochMs)}</span>
+                    </div>
+                    <div style={{ marginTop: '6px', fontFamily: 'var(--font-mono)', fontSize: '9px', color: 'var(--text-tertiary)' }}>
+                      {entry.signalId && <>signal {entry.signalId}</>}{entry.signalId && entry.rolloutId && ' · '}{entry.rolloutId && <>rollout {entry.rolloutId}</>}
+                    </div>
+                    {entry.summary && <p style={{ margin: '6px 0 0', fontSize: '11px', color: 'var(--text-secondary)' }}>{entry.summary}</p>}
                   </div>
                 )
               }

--- a/openbank-admin-ui/src/components/agent/CaseRuntimeViews.tsx
+++ b/openbank-admin-ui/src/components/agent/CaseRuntimeViews.tsx
@@ -6,7 +6,7 @@
 import { ArrowRight, CheckCircle2, CircleDot, Database, ShieldCheck, TriangleAlert } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 
-export type RuntimeStage = 'RECORDED' | 'PERSISTED' | 'EMITTED' | 'PUBLISHED_TO_BROKER' | 'PUBLISH_FAILED' | 'SHADOW_RECORDED'
+export type RuntimeStage = 'AUTHORIZED' | 'DENIED' | 'INVOKED' | 'CONSUMED' | 'RECORDED' | 'PERSISTED' | 'EMITTED' | 'PUBLISHED_TO_BROKER' | 'PUBLISH_FAILED' | 'SHADOW_RECORDED'
 
 export interface RuntimeEvidenceView {
   evidenceId: string
@@ -22,6 +22,9 @@ export interface RuntimeEntryView {
   atEpochMs: number
   actor?: string
   proposalType?: string
+  signalId?: string
+  capability?: string
+  rolloutId?: string
   runtimeEvidence: RuntimeEvidenceView
 }
 
@@ -38,9 +41,19 @@ export interface RuntimeCaseView {
 }
 
 function stageTone(stage: RuntimeStage): { color: string; bg: string; Icon: typeof CircleDot } {
-  if (stage === 'PUBLISH_FAILED') return { color: 'var(--danger)', bg: 'var(--danger-bg)', Icon: TriangleAlert }
+  if (stage === 'PUBLISH_FAILED' || stage === 'DENIED') return { color: 'var(--danger)', bg: 'var(--danger-bg)', Icon: TriangleAlert }
   if (stage === 'PUBLISHED_TO_BROKER') return { color: 'var(--success)', bg: 'var(--success-bg)', Icon: CheckCircle2 }
   return { color: 'var(--accent-text)', bg: 'var(--accent-bg)', Icon: CircleDot }
+}
+
+function evidenceAge(epochMs: number): string {
+  const seconds = Math.max(0, Math.floor((Date.now() - epochMs) / 1000))
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h`
+  return `${Math.floor(hours / 24)}d`
 }
 
 function EvidenceDetails({ evidence, locale }: { evidence: RuntimeEvidenceView; locale: string }) {
@@ -54,6 +67,7 @@ function EvidenceDetails({ evidence, locale }: { evidence: RuntimeEvidenceView; 
       <dl style={{ display: 'grid', gridTemplateColumns: 'max-content 1fr', gap: '4px 10px', margin: '8px 0 0', fontSize: '10px' }}>
         <dt style={{ color: 'var(--text-tertiary)' }}>{t('Zdroj', 'Source')}</dt><dd style={{ margin: 0, fontFamily: 'var(--font-mono)' }}>{evidence.source}</dd>
         <dt style={{ color: 'var(--text-tertiary)' }}>{t('Pozorováno', 'Observed')}</dt><dd style={{ margin: 0 }}>{new Date(evidence.observedAtEpochMs).toLocaleString(locale)}</dd>
+        <dt style={{ color: 'var(--text-tertiary)' }}>{t('Stáří', 'Age')}</dt><dd style={{ margin: 0 }}>{evidenceAge(evidence.observedAtEpochMs)}</dd>
         <dt style={{ color: 'var(--text-tertiary)' }}>{t('Korelace', 'Correlation')}</dt><dd style={{ margin: 0, fontFamily: 'var(--font-mono)' }}>{evidence.correlationId}</dd>
         <dt style={{ color: 'var(--text-tertiary)' }}>{t('Význam', 'Meaning')}</dt><dd style={{ margin: 0 }}>{evidence.detail}</dd>
       </dl>
@@ -74,8 +88,14 @@ export function CaseRuntimeTimeline({ thread, locale }: { thread: RuntimeCaseVie
               <Icon size={13} style={{ color: tone.color }} />
               <strong style={{ fontSize: '11px' }}>{entry.type}</strong>
               <span style={{ fontSize: '10px', color: 'var(--text-secondary)' }}>{entry.actor ?? 'case-coordinator'}</span>
+              {entry.capability && <span style={{ fontFamily: 'var(--font-mono)', fontSize: '10px', color: 'var(--accent-text)' }}>{entry.capability}</span>}
               <time style={{ marginLeft: 'auto', fontSize: '10px', color: 'var(--text-tertiary)' }}>{new Date(entry.atEpochMs).toLocaleString(locale)}</time>
             </div>
+            {(entry.signalId || entry.rolloutId) && (
+              <div style={{ marginTop: '6px', fontFamily: 'var(--font-mono)', fontSize: '9px', color: 'var(--text-tertiary)' }}>
+                {entry.signalId && <>signal {entry.signalId}</>}{entry.signalId && entry.rolloutId && ' · '}{entry.rolloutId && <>rollout {entry.rolloutId}</>}
+              </div>
+            )}
             <EvidenceDetails evidence={entry.runtimeEvidence} locale={locale} />
           </article>
         )
@@ -92,6 +112,10 @@ interface Edge {
 
 function runtimeEdges(thread: RuntimeCaseView): Edge[] {
   return thread.entries.flatMap(entry => {
+    if (entry.type === 'POLICY_DECISION' && entry.actor && entry.runtimeEvidence.stage === 'AUTHORIZED') return [{ from: entry.actor, to: 'OPA case policy', evidence: entry.runtimeEvidence }]
+    if (entry.type === 'SIGNAL_INVOKED' && entry.actor) return [{ from: entry.actor, to: 'Temporal signal client', evidence: entry.runtimeEvidence }]
+    if (entry.type === 'SIGNAL_CONSUMED' && entry.actor) return [{ from: entry.actor, to: 'case workflow', evidence: entry.runtimeEvidence }]
+    if (entry.type === 'CONTRIBUTION_PERSISTED' && entry.actor) return [{ from: entry.actor, to: 'durable case read model', evidence: entry.runtimeEvidence }]
     if (entry.type === 'CONTRIBUTION' && entry.actor) return [{ from: entry.actor, to: 'case-coordinator', evidence: entry.runtimeEvidence }]
     if (entry.type === 'PROPOSAL_EMITTED') return [{ from: 'case-coordinator', to: 'proposal event broker', evidence: entry.runtimeEvidence }]
     if (entry.type === 'SHADOW_RECORDED') return [{ from: 'case-coordinator', to: 'shadow evidence only', evidence: entry.runtimeEvidence }]

--- a/openbank-admin-ui/src/lib/governance/caseDecisionBrief.ts
+++ b/openbank-admin-ui/src/lib/governance/caseDecisionBrief.ts
@@ -2,7 +2,7 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 
 export type CaseStatus = 'OPEN' | 'CONVERGING' | 'CONTESTED' | 'SYNTHESIZED' | 'CLOSED'
-export type CaseEntryType = 'CASE_OPENED' | 'CONTRIBUTION' | 'PROPOSAL_EMITTED' | 'SHADOW_RECORDED'
+export type CaseEntryType = 'CASE_OPENED' | 'CONTRIBUTION' | 'PROPOSAL_EMITTED' | 'SHADOW_RECORDED' | 'POLICY_DECISION' | 'SIGNAL_INVOKED' | 'SIGNAL_CONSUMED' | 'CONTRIBUTION_PERSISTED'
 
 export interface CaseThreadEntry {
   type: CaseEntryType

--- a/openbank-admin-ui/src/test/iaops-case-thread-page.test.tsx
+++ b/openbank-admin-ui/src/test/iaops-case-thread-page.test.tsx
@@ -31,6 +31,11 @@ const THREAD = {
   retentionPolicy: 'not-configured',
   entries: [
     { type: 'CASE_OPENED', atEpochMs: 1_700_000_000_000, actor: 'case-coordinator', runtimeEvidence: { evidenceId: 'case-17', source: 'case-coordinator-postgres-read-model', stage: 'RECORDED', observedAtEpochMs: 1_700_000_000_000, correlationId: 'case-17', detail: 'Persisted case workflow record' } },
+    { type: 'POLICY_DECISION', atEpochMs: 1_700_000_010_000, actor: 'rca-investigator', signalId: 'signal-17', capability: 'case.contribute', rolloutId: 'shadow-rca-1', runtimeEvidence: { evidenceId: 'opa-17', source: 'case-coordinator-signal-evidence', stage: 'AUTHORIZED', observedAtEpochMs: 1_700_000_010_000, correlationId: 'case-17', detail: 'case.contribute signal signal-17' } },
+    { type: 'SIGNAL_INVOKED', atEpochMs: 1_700_000_020_000, actor: 'rca-investigator', signalId: 'signal-17', capability: 'case.contribute', rolloutId: 'shadow-rca-1', runtimeEvidence: { evidenceId: 'signal-17:INVOKED', source: 'case-coordinator-signal-evidence', stage: 'INVOKED', observedAtEpochMs: 1_700_000_020_000, correlationId: 'case-17', detail: 'case.contribute signal signal-17' } },
+    { type: 'SIGNAL_CONSUMED', atEpochMs: 1_700_000_030_000, actor: 'rca-investigator', signalId: 'signal-17', capability: 'case.contribute', rolloutId: 'shadow-rca-1', runtimeEvidence: { evidenceId: 'signal-17:CONSUMED', source: 'case-coordinator-signal-evidence', stage: 'CONSUMED', observedAtEpochMs: 1_700_000_030_000, correlationId: 'case-17', detail: 'case.contribute signal signal-17' } },
+    { type: 'CONTRIBUTION_PERSISTED', atEpochMs: 1_700_000_040_000, actor: 'rca-investigator', signalId: 'signal-17', capability: 'case.contribute', rolloutId: 'shadow-rca-1', runtimeEvidence: { evidenceId: 'signal-17:PERSISTED', source: 'case-coordinator-signal-evidence', stage: 'PERSISTED', observedAtEpochMs: 1_700_000_040_000, correlationId: 'case-17', detail: 'case.contribute signal signal-17' } },
+    { type: 'POLICY_DECISION', atEpochMs: 1_700_000_050_000, actor: 'unknown-agent', signalId: 'signal-denied', capability: 'case.join', runtimeEvidence: { evidenceId: 'opa-denied', source: 'case-coordinator-signal-evidence', stage: 'DENIED', observedAtEpochMs: 1_700_000_050_000, correlationId: 'case-17', detail: 'case.join signal signal-denied' } },
     { type: 'CONTRIBUTION', atEpochMs: 1_700_000_100_000, actor: 'aml-agent', evidenceRefs: ['alert-17'], runtimeEvidence: { evidenceId: 'contribution-17', source: 'case-coordinator-postgres-read-model', stage: 'PERSISTED', observedAtEpochMs: 1_700_000_100_000, correlationId: 'case-17', detail: 'Contribution persisted in the durable case read model' } },
     { type: 'PROPOSAL_EMITTED', atEpochMs: 1_700_000_200_000, proposalType: 'REVIEW', runtimeEvidence: { evidenceId: 'proposal-17', source: 'case-coordinator-transactional-outbox', stage: 'PUBLISHED_TO_BROKER', observedAtEpochMs: 1_700_000_200_000, correlationId: 'case-17', detail: 'Proposal outbox status: SENT' } },
   ],
@@ -60,9 +65,30 @@ describe('AIOps case thread proposal event', () => {
 
     expect(await screen.findByRole('region', { name: 'Evidence-backed runtime topology' })).toBeInTheDocument()
     expect(screen.getByText('aml-agent')).toBeInTheDocument()
+    expect(screen.getByText('OPA case policy')).toBeInTheDocument()
+    expect(screen.getByText('Temporal signal client')).toBeInTheDocument()
+    expect(screen.getByText('case workflow')).toBeInTheDocument()
+    expect(screen.getByText('durable case read model')).toBeInTheDocument()
     expect(screen.getByText('proposal event broker')).toBeInTheDocument()
     expect(screen.getByText(/Charter declarations alone never create a solid edge/)).toBeInTheDocument()
     expect(screen.getAllByText(/PERSISTED|PUBLISHED_TO_BROKER/).length).toBeGreaterThan(0)
     expect(screen.getByText(/unknown retention/)).toBeInTheDocument()
+    expect(screen.queryByText('unknown-agent')).not.toBeInTheDocument()
+  })
+
+  it('keeps authorization invocation consumption persistence and denial visibly distinct', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ available: true, thread: THREAD }) }))
+
+    render(<IaopsCaseThreadPage />)
+    await screen.findByRole('heading', { name: 'Proposal recorded in the thread' })
+    fireEvent.click(screen.getByRole('button', { name: 'timeline' }))
+
+    expect(screen.getAllByText('POLICY_DECISION')).toHaveLength(2)
+    expect(screen.getByText('SIGNAL_INVOKED')).toBeInTheDocument()
+    expect(screen.getByText('SIGNAL_CONSUMED')).toBeInTheDocument()
+    expect(screen.getByText('CONTRIBUTION_PERSISTED')).toBeInTheDocument()
+    expect(screen.getAllByText(/signal signal-17 · rollout shadow-rca-1/)).toHaveLength(4)
+    expect(screen.getAllByText('case.contribute')).toHaveLength(4)
+    expect(screen.getAllByText('Age').length).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## Summary

Adds the read-only Control Room projection for the separately reviewed collaboration evidence introduced by #6446. It does not add a grant, signal ingress, or operator mutation.

## Type of change

- [x] feat (new functionality)

## Linked issues

Refs #6426

## Changes

- Render policy authorization/denial, Temporal invocation, workflow consumption, and durable persistence as distinct timeline events.
- Create solid topology edges only from observed runtime evidence; a denied decision never becomes a collaboration edge.
- Preserve signal id, capability, rollout, source, timestamp, age, correlation id and evidence meaning in expandable provenance.
- Extend the existing case-page tests with the complete stage chain and a denied signal.

## Definition of Done

- [x] Existing Control Room architecture reused.
- [x] Unit/UI tests added: 6 focused tests pass.
- [x] `npm run type-check` passes.
- [x] Focused ESLint has no errors (one pre-existing set-state-in-effect warning remains on the touched page).
- [x] `npm run build` passes.
- [x] No API, DB, event or governance mutation.

## Security checklist

- [x] No secrets, tokens, passwords or PII.
- [x] No new dependency or suppression.
- [x] Denials are visible in the timeline but cannot create solid topology edges.
- [x] Caller-provided signal payload content is not displayed; evidence remains metadata-only.

## Compliance impact

- [x] DORA

Makes the collaboration evidence chain reconstructable without inferring later stages from an earlier one.

## Rollout / Rollback

- Deployment strategy: merge/deploy only after prerequisite #6434 (which now contains merged #6446).
- Rollback plan: revert this UI-only PR.
- Data migration reversible: N/A

## Reviewer notes

The topology intentionally treats an OPA `AUTHORIZED` decision as an observed authorization edge, `INVOKED` as client acceptance, `CONSUMED` as workflow incorporation and `PERSISTED` as durable completion. These are separate edges and labels; none implies the next.