### PR TITLE
fix(ci): declare HolmesGPT's NVIDIA LLM egress — gates (data) is red on main

### DIFF
--- a/.github/scripts/check-external-feeds.py
+++ b/.github/scripts/check-external-feeds.py
@@ -220,6 +220,14 @@ NOT_PROBED = [
     ("https://plugins.gradle.org", "Gradle plugin portal, mirrored by Reposilite"),
     ("https://dl.google.com", "Google Maven, mirrored by Reposilite"),
     #
+    # (3b) AUTHENTICATED LLM EGRESS. Real third-party egress from a running workload, but it
+    # cannot be probed: the endpoint answers 401 without a key, so a probe would assert the
+    # liveness of an error page (the #2204 shape it exists to prevent). HolmesGPT dials this for
+    # its meta/llama-3.1-70b-instruct route; a failure surfaces as a failed investigation, not as
+    # a silently-empty table, and the LLM-failure alerts (#6041) cover the gateway path.
+    # Same category and same reason as api.deepinfra.com above.
+    ("https://integrate.api.nvidia.com/v1", "authenticated LLM endpoint for HolmesGPT; needs a key, so a probe would only measure a 401"),
+    #
     # (4) ACME. Real egress; a failure surfaces as an un-renewed Certificate, which cert-manager
     # reports and the certificate-expiry alert covers.
     ("https://acme-v02.api.letsencrypt.org", "ACME directory; failure surfaces as a cert-manager Certificate condition"),


### PR DESCRIPTION
## Summary
- declare HolmesGPT's `https://integrate.api.nvidia.com/v1` egress in `check-external-feeds.py`'s `NOT_PROBED`
- unblocks `gates (data)`, red on `main` since #6251 merged

## Why

#6251 widened `CORPUS_GLOBS` to `openbank-infra/gitops/**/*.yaml`. That was the point of it — the
script's own comment names the case:

> a live LLM egress declared only in `openbank-infra/gitops/apps/holmesgpt.yaml` was outside this
> gate's reach

The widening landed without a declaration for what it would newly see, so every PR whose
`Validate manifests` completes now fails:

```
DRIFT undeclared external URL openbank-infra/gitops/apps/holmesgpt.yaml:47 -> https://integrate.api.nvidia.com/v1
DRIFT undeclared external URL openbank-infra/gitops/apps/holmesgpt.yaml:53 -> https://integrate.api.nvidia.com/v1
2 drift problem(s).
```

This is the gate working, not a regression — it found a real, previously-undeclared third-party
egress on the first run that could see it.

## Why NOT_PROBED rather than a probed feed

`integrate.api.nvidia.com` answers 401 without a key, so a probe would assert the liveness of an
error page — the exact #2204 shape the gate exists to prevent. Same category and same stated reason
as the existing `api.deepinfra.com/v1/openai` entry. A failure here surfaces as a failed HolmesGPT
investigation, not as a silently-empty table, and the LLM-failure alerts from #6041 cover the
gateway path.

## Verification

```
check-external-feeds.py --self-test  -> 20 passed, 0 failed              rc=0
check-external-feeds.py --offline    -> OK, every external URL accounted rc=0
negative control (entry removed)     -> 2 drift problem(s)               rc=1
```

The negative control matters here: the declaration list is stale-checked in both directions, so an
entry that stops matching anything fails as loudly as an undeclared URL. Removing the entry and
watching it go red is what shows the check is reaching this URL and not passing vacuously.

## Linked issues
Refs #6251, Refs #6242, Refs #2204
