### PR TITLE
fix(ci): declare the HolmesGPT NVIDIA endpoint, unblocking main

### DIFF
--- a/.github/scripts/check-external-feeds.py
+++ b/.github/scripts/check-external-feeds.py
@@ -173,6 +173,7 @@ FEEDS = [
 NOT_PROBED = [
     ("https://api.github.com", "authenticated API, not a data feed; failure is loud at call time"),
     ("https://api.deepinfra.com/v1/openai", "authenticated LLM gateway; needs a key"),
+    ("https://integrate.api.nvidia.com/v1", "authenticated LLM endpoint used by the HolmesGPT deployment (NVIDIA_API_KEY); needs a key, so it cannot be probed anonymously"),
     ("https://s3.eu-north-1.amazonaws.com", "AWS endpoint, reached with SigV4 credentials"),
     ("https://kc.open-bank.tech/realms/openbank-customers", "our own Keycloak realm, covered by its own probes"),
     ("https://pid.open-bank.tech", "our own PID issuer, covered by its own probes"),


### PR DESCRIPTION
## What

`external-feed-declaration-drift` is **failing on `origin/main`**, so every open PR inherits a red
`gates (data)` it did not cause. Confirmed today on #5836 and #5849 — two unrelated diffs failing
the identical gate, which is the signature of a main-side problem rather than a branch defect.

Reproduced on a clean detached worktree of `origin/main`:

```
python3 .github/scripts/check-external-feeds.py --root . --offline
-> exit 1
DRIFT undeclared external URL openbank-infra/gitops/apps/holmesgpt.yaml:47 -> https://integrate.api.nvidia.com/v1
DRIFT undeclared external URL openbank-infra/gitops/apps/holmesgpt.yaml:53 -> https://integrate.api.nvidia.com/v1
```

## Cause

Widening `CORPUS_GLOBS` to `openbank-infra/gitops/**/*.yaml` — the fix for #6242 — brought
HolmesGPT's `OPENAI_API_BASE` and its `modelList` `api_base` into scope for the first time. That
change declared the rest of the newly-visible gitops corpus (the whole `# --- gitops corpus (#6242)`
block) and missed this one.

So the gate is working exactly as intended: a new external dependency in scope with no declaration
is precisely what it exists to catch. The declaration is what was missing, not the gate.

## Why NOT_PROBED and not FEEDS

The endpoint is authenticated with `NVIDIA_API_KEY`, so it cannot be probed anonymously — the same
reason `https://api.deepinfra.com/v1/openai` already sits in `NOT_PROBED`. Declaring it under
`FEEDS` would add a probe that can only ever fail.

## Falsified both ways

On a clean checkout, changing nothing else:

| state | exit | output |
|---|---|---|
| without the entry | **1** | `DRIFT undeclared external URL ... holmesgpt.yaml:47` |
| with the entry | **0** | `drift: OK — every external URL accounted for` |

The gate's stale-entry check runs in the other direction too, so if HolmesGPT ever stops using this
endpoint the entry fails just as loudly as an undeclared URL would.

## Scope

One line. No behaviour change to any workload — this declares a dependency that already exists.

Refs #6242
