### PR TITLE
fix(ci): restore the NOT_PROBED entry for the NVIDIA LLM gateway (#2204)

### DIFF
--- a/.github/scripts/check-external-feeds.py
+++ b/.github/scripts/check-external-feeds.py
@@ -173,6 +173,7 @@ FEEDS = [
 NOT_PROBED = [
     ("https://api.github.com", "authenticated API, not a data feed; failure is loud at call time"),
     ("https://api.deepinfra.com/v1/openai", "authenticated LLM gateway; needs a key"),
+    ("https://integrate.api.nvidia.com/v1", "authenticated LLM gateway; needs a key"),
     ("https://s3.eu-north-1.amazonaws.com", "AWS endpoint, reached with SigV4 credentials"),
     ("https://kc.open-bank.tech/realms/openbank-customers", "our own Keycloak realm, covered by its own probes"),
     ("https://pid.open-bank.tech", "our own PID issuer, covered by its own probes"),


### PR DESCRIPTION
## What this is

`CORPUS_GLOBS` grew to cover `openbank-infra/gitops/**/*.yaml` in #6251 (following #6242), which made `integrate.api.nvidia.com/v1` (used twice in `holmesgpt.yaml`) visible to the `external-feed-declaration-drift` gate (issue #2204). The `NOT_PROBED` entry excusing this URL never got carried over during that refactor — it existed before, it's gone now. Every PR merging main since then fails `gates (data)` on this.

## The fix

Restore the `NOT_PROBED` entry:
```python
("https://integrate.api.nvidia.com/v1", "authenticated LLM gateway; needs a key"),
```

## Verification

\`\`\`
$ python3 .github/scripts/check-external-feeds.py --root . --offline
drift: OK — 1 declared feed(s), every external URL accounted for.

$ python3 .github/scripts/check-external-feeds.py --self-test
self-test: 20 passed, 0 failed
\`\`\`