### PR TITLE
fix(ci): the issue worker could run no commands, and the job went green anyway

### DIFF
--- a/.github/agent-prompts/issue-worker.md
+++ b/.github/agent-prompts/issue-worker.md
@@ -111,7 +111,23 @@ words you meant to write.
 If CI goes red: fix it if it is yours. If it is `agent-pr-guard`, you picked a protected issue —
 say so plainly, leave the draft for a human, and do not route around the gate.
 
-## Step 6 — report
+## Step 6 — report, and state a verdict
 
 Under 200 words: which issue, what you changed, the test that proves it, the PR link, anything a
 reviewer must check by hand, and any branch you left behind.
+
+Then end your output with **exactly one** of these three lines, alone on its own line. The job
+fails if none is present, because otherwise "the session produced prose" and "the session did the
+job" look identical from outside — a previous run spent its whole session discovering it could not
+run a single command, said so clearly, and the workflow still went green.
+
+```
+WORKER-VERDICT: OPENED <pr-url>
+WORKER-VERDICT: NOTHING QUALIFIED
+WORKER-VERDICT: BLOCKED <one-line reason>
+```
+
+Use `BLOCKED` when the runner or the credential could not do what this task needs — a tool you
+were denied, a command that does not exist, a missing permission. That is a defect in the
+workflow, not in the backlog, and it is treated as a job failure so somebody fixes it. Do not use
+`BLOCKED` for an issue you judged out of scope; that is `NOTHING QUALIFIED`.

--- a/.github/workflows/agent-issue-worker.yml
+++ b/.github/workflows/agent-issue-worker.yml
@@ -171,6 +171,19 @@ jobs:
           echo "Merge this workflow, then run it with mode=work (or wait for the schedule)."
 
       # ---- the actual work ----------------------------------------------------------------
+      # `--permission-mode acceptEdits` was the first attempt and it does not work here: it
+      # auto-accepts FILE EDITS only. Every Bash command still asks, and in a non-interactive
+      # run there is nobody to ask, so the tool is denied instantly. The first live run spent
+      # its whole session discovering that `gh`, `python3` and `curl` were all refused — it
+      # could not list issues, could not run the guard's self-test, could not open a PR. It
+      # reported that honestly and the job still went green, which is the second half of the
+      # defect and is fixed by the assertion below.
+      #
+      # `bypassPermissions` is the right mode for this specific context and not a shortcut:
+      # the container is ephemeral and discarded, the token is a job-scoped GITHUB_TOKEN with
+      # the three narrow permissions declared above, and everything the agent can actually
+      # land is still gated by `agent-pr-guard` and by branch protection. The blast radius is
+      # bounded by the credential, not by the prompt.
       - name: Work one issue
         if: steps.mode.outputs.mode == 'work'
         env:
@@ -182,9 +195,40 @@ jobs:
           git config user.email "openbank-issue-worker@users.noreply.github.com"
           claude -p "$(cat .github/agent-prompts/issue-worker.md)" \
             --max-turns 120 \
-            --permission-mode acceptEdits \
+            --permission-mode bypassPermissions \
           | tee /tmp/worker-output.txt
           echo "--- worker output above ---"
+
+      # ---- did it actually run? -----------------------------------------------------------
+      # The run this replaces exited 0 having done nothing at all, because `claude -p` exits 0
+      # when it finishes talking, whatever it managed to accomplish. An exit code is not a
+      # verdict. So the agent must END with one of three explicit lines, and this step fails
+      # the job when none is present: "the session produced prose" and "the session did the
+      # job" are otherwise the same green.
+      - name: Assert the worker reached a verdict
+        if: steps.mode.outputs.mode == 'work'
+        run: |
+          set -uo pipefail
+          if [ ! -s /tmp/worker-output.txt ]; then
+            echo "::error::the worker produced no output at all — it did not run, which is not the same as having nothing to do"
+            exit 1
+          fi
+          verdict=$(grep -oE '^WORKER-VERDICT: (OPENED .*|NOTHING QUALIFIED|BLOCKED .*)$' /tmp/worker-output.txt | tail -1)
+          if [ -z "${verdict}" ]; then
+            echo "::error::the worker never stated a verdict. It talked, but nothing here can tell whether it worked an issue, found nothing to do, or was blocked. Treating as NOT having run."
+            echo "--- last 20 lines of what it did say ---"
+            tail -20 /tmp/worker-output.txt
+            exit 1
+          fi
+          echo "verdict: ${verdict}"
+          # BLOCKED is a real outcome and must be loud: it means the runner or the credential
+          # could not do what the task needs, which is a defect in this workflow, not in the
+          # backlog. NOTHING QUALIFIED is a legitimate, quiet success.
+          case "${verdict}" in
+            "WORKER-VERDICT: BLOCKED"*)
+              echo "::error::${verdict}"
+              exit 1 ;;
+          esac
 
       - name: Summarise
         if: always() && steps.mode.outputs.mode == 'work'


### PR DESCRIPTION
Refs #6412 · follow-up to #6453

## What the first live run found

`mode=work` ran, exited **success**, and did nothing. Its own words:

> **What's being denied (instantly, no prompt shown to work with):** `gh` (any subcommand),
> `curl`, `python3` (even a no-op `-c "print(...)"`), and `printenv`/`env`.

Two defects, both mine.

### 1. `--permission-mode acceptEdits` auto-accepts file EDITS only

Bash commands still ask for permission, and a non-interactive run has nobody to ask, so every
tool call was denied the instant it was made. The worker could not list the backlog (Step 1),
could not run `check-agent-pr-guard.py --self-test` (required before Step 1), could not run
Gradle (Step 4), could not open a PR (Step 5).

It spent the whole session probing the boundary, then reported exactly what it had found. The
behaviour was good; the harness was wrong.

### 2. The job went green over a run that accomplished nothing — and that is the worse half

`claude -p` exits 0 when it finishes talking, whatever it managed to do. So **"the session
produced prose" and "the session did the job" were the same green**, in a workflow whose entire
purpose is to supervise an unattended agent. Left alone, this fails in the direction this
repository keeps rediscovering: a scheduled thing that runs, reports success, and achieves
nothing, for as long as nobody reads the logs.

## Fixes

**`--permission-mode bypassPermissions`.** Right for this context, and worth saying why rather
than waving it through:

- the container is ephemeral and discarded at the end of the job;
- the credential is a job-scoped `GITHUB_TOKEN` carrying exactly `contents: write`,
  `pull-requests: write`, `issues: write`;
- everything the agent can actually land is still gated by `agent-pr-guard` and by branch
  protection on `main`.

The blast radius is bounded by the token, not by the permission prompt. A prompt that nobody can
answer is not a security control — it is just a hang.

**A verdict contract.** The agent must end with exactly one of:

```
WORKER-VERDICT: OPENED <pr-url>
WORKER-VERDICT: NOTHING QUALIFIED
WORKER-VERDICT: BLOCKED <one-line reason>
```

A new step fails the job when no verdict line is present. `BLOCKED` fails **loudly** on purpose:
it means the runner or the credential cannot do what the task needs, which is a defect in this
workflow rather than in the backlog, and it should wake somebody. `NOTHING QUALIFIED` stays a
quiet success — an honest empty run is a good run.

This is the `REVIEW-VERDICT` pattern `agent-review.yml` already uses, for the same reason: assert
on what the model *said*, never on the exit code of the process that said it.

## Verification

- `run-gates.py --group lint` — 22/22 PASS
- The negative case is what this PR is: the previous run is the known-positive, and it went green.
  After this change the same run fails at `Assert the worker reached a verdict`.

## After merge

`workflow_dispatch` with `mode=work` once by hand, and read the verdict line before trusting the
schedule.
