### PR TITLE
chore(admin-ui): drop two unused imports flagged by CodeQL

### DIFF
--- a/openbank-admin-ui/src/app/kyc/page.tsx
+++ b/openbank-admin-ui/src/app/kyc/page.tsx
@@ -11,7 +11,6 @@ import { DataUnavailable, type UnavailableKind } from '@/components/feedback/Dat
 import { ShieldCheck, Search, RefreshCw, ChevronRight } from 'lucide-react'
 import Link from 'next/link'
 import { PageHeader, StatusBadge } from '@/components/ui'
-import { PartyLookup } from '@/components/kyc/PartyLookup'
 import { Can } from '@/components/auth/AuthGuard'
 
 const KYC_SERVICE = '/api/svc/kyc-service'

--- a/openbank-admin-ui/src/test/trace-explorer-states.test.tsx
+++ b/openbank-admin-ui/src/test/trace-explorer-states.test.tsx
@@ -19,7 +19,7 @@
  * them back together.
  */
 
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import TraceExplorerPage from '@/app/observability/traces/page'
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'


### PR DESCRIPTION
## What

Removes two unused imports CodeQL flagged on `main`:

- `PartyLookup` — `openbank-admin-ui/src/app/kyc/page.tsx:14`
- `within` — `openbank-admin-ui/src/test/trace-explorer-states.test.tsx:22`

## Why now

Both CodeQL review threads are attached to #5884, a two-file PR touching only
`.github/scripts/fuzz-services.sh` and `.github/workflows/api-fuzz.yml`. The threads
are `isOutdated=true` and point at files that PR does not contain — but
`main-protection` sets `required_review_thread_resolution: true`, so #5884 sat
`BLOCKED` with **26 green checks and zero failures**. Every required status check
passed; the block came entirely from two unresolved threads about someone else's code.

Resolving them on #5884 without fixing anything would have dismissed a finding that
is genuinely true on `main`. Fixing them here means the threads can be resolved
honestly.

## Verification

- Each identifier occurs exactly once per file — at the import. No JSX or call site.
- `npx tsc --noEmit`: 20 errors before and after, all in `product-studio`, `catalog-*`
  and `OriginationFlow` — none in these two files.
- `npm test -- src/test/trace-explorer-states.test.tsx`: 6/6 pass.
- `npx eslint` on both files: 0 errors (1 pre-existing `set-state-in-effect` warning,
  untouched).

## Release

`chore`, not `fix` — nothing shipped changes behaviour, so this intentionally does not
trigger an admin-ui release.

Refs #5884
