### PR TITLE
fix(party): create the Hibernate id sequences in lower case so inserts can allocate an id

### DIFF
--- a/openbank-party-service/src/main/resources/db/migration/V19__fix_quoted_sequence_names.sql
+++ b/openbank-party-service/src/main/resources/db/migration/V19__fix_quoted_sequence_names.sql
@@ -1,0 +1,42 @@
+-- Fixes two Hibernate id sequences that Postgres and Hibernate spell differently, so every
+-- insert into `party_payees` and `party_marketing_consent` fails at id allocation.
+--
+-- V5 made this exact mistake for parties/party_documents/party_outbox and V6 fixed it the same
+-- way. V16 and V18 reintroduced it. A quoted `"x_SEQ"` keeps its case in Postgres, while the
+-- `select nextval('x_SEQ')` Hibernate emits carries an UNQUOTED identifier inside the literal,
+-- which Postgres folds to lower case — so it looks up `x_seq` and finds nothing:
+--
+--   ERROR: relation "party_payees_seq" does not exist (42P01) [select nextval('party_payees_SEQ')]
+--
+-- Observed live on four party endpoints in the authenticated fuzz lane (#5913). The
+-- `party_marketing_consent` one has the identical shape and was found by grepping for it, not by
+-- the fuzzer — it fails the same way on the first grant the projection consumer records.
+--
+-- Seeded from the table's own max(id) rather than restarting at 1: `id` is BIGSERIAL, so any row
+-- written before this migration got its id from the implicit `party_payees_id_seq`, and a fresh
+-- sequence starting at 1 would collide with it on the first insert.
+--
+-- Rollback:
+--   DROP SEQUENCE IF EXISTS party_payees_seq;
+--   DROP SEQUENCE IF EXISTS party_marketing_consent_seq;
+--   CREATE SEQUENCE IF NOT EXISTS "party_payees_SEQ" INCREMENT BY 50;
+--   CREATE SEQUENCE IF NOT EXISTS "party_marketing_consent_SEQ" INCREMENT BY 50;
+--   (restores the broken state exactly; both endpoints resume answering 500)
+
+DROP SEQUENCE IF EXISTS "party_payees_SEQ";
+DROP SEQUENCE IF EXISTS "party_marketing_consent_SEQ";
+
+DO $$
+DECLARE
+    next_payee  BIGINT;
+    next_consent BIGINT;
+BEGIN
+    SELECT COALESCE(MAX(id), 0) + 50 INTO next_payee   FROM party_payees;
+    SELECT COALESCE(MAX(id), 0) + 50 INTO next_consent FROM party_marketing_consent;
+
+    EXECUTE format('CREATE SEQUENCE IF NOT EXISTS party_payees_seq INCREMENT BY 50 START WITH %s', next_payee);
+    EXECUTE format('CREATE SEQUENCE IF NOT EXISTS party_marketing_consent_seq INCREMENT BY 50 START WITH %s', next_consent);
+END
+$$;
+
+GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO openbank;

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/integration/PartySequenceAllocationIT.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/integration/PartySequenceAllocationIT.kt
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.integration
+
+import com.openbank.party.it.PostgresRedpandaTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Extract
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import javax.sql.DataSource
+
+/**
+ * #5913. `PUT /api/v1/parties/{id}/payees` answered 500 on every call for the life of the
+ * endpoint, and so did the marketing-consent projection's first write:
+ *
+ *   SQLGrammarException: relation "party_payees_seq" does not exist (42P01)
+ *     [select nextval('party_payees_SEQ')]
+ *
+ * V16 and V18 wrote `CREATE SEQUENCE "party_payees_SEQ"` — quoted, so Postgres keeps the case.
+ * Hibernate emits `nextval('party_payees_SEQ')`, where the identifier inside the literal is
+ * UNQUOTED and Postgres folds it to lower case, so it looks for `party_payees_seq`. V6 had
+ * already fixed exactly this for parties/party_documents/party_outbox; V16 and V18 reintroduced
+ * it. V19 is the fix.
+ *
+ * Why this test is an IT and not a unit test: `PartyServicePayeeTest` mocks the repository, so it
+ * passes against a database that cannot allocate an id at all — the mock never touches a
+ * sequence. The defect lives strictly between Hibernate and Postgres, so only a real request
+ * against a real schema can see it. That is the same reason the consent `SuppressionEntity`
+ * column-name defect and the sca `eventType` payload defect both shipped green.
+ *
+ * The assertion is deliberately the ALLOCATED ID, not merely a 200: a 200 would also be
+ * satisfied by an endpoint that stopped persisting, and the claim here is specifically that the
+ * insert reached the table with an id drawn from the sequence Hibernate asks for.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedpandaTestResource::class)
+class PartySequenceAllocationIT {
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    private fun createParty(email: String): UUID {
+        val body = """
+            {"partyType":"INDIVIDUAL","legalName":"Sequence Probe","tradingName":null,
+             "dateOfBirth":"1990-01-01","nationality":"CZ","taxId":null,"registrationNumber":null,
+             "email":"$email","phone":null,"address":null}
+        """.trimIndent()
+        val id = Given {
+            contentType("application/json")
+            header("Idempotency-Key", UUID.randomUUID().toString())
+            body(body)
+        } When {
+            post("/api/v1/parties")
+        } Then {
+            statusCode(201)
+        } Extract {
+            jsonPath().getString("id")
+        }
+        return UUID.fromString(id)
+    }
+
+    private fun payeeRowCount(partyId: UUID): Int = dataSource.connection.use { conn ->
+        val ps = conn.prepareStatement("SELECT count(*) FROM party_payees WHERE party_id = ?")
+        ps.setObject(1, partyId)
+        val rs = ps.executeQuery()
+        if (rs.next()) rs.getInt(1) else 0
+    }
+
+    private fun nextval(sequence: String): Long = dataSource.connection.use { conn ->
+        val rs = conn.createStatement().executeQuery("SELECT nextval('$sequence')")
+        rs.next()
+        rs.getLong(1)
+    }
+
+    @Test
+    @TestSecurity(user = "sequence-it", roles = ["ROLE_ADMIN", "ROLE_OPERATOR"])
+    fun `saving a payee allocates an id and writes the row`() {
+        val partyId = createParty("payee-seq-${UUID.randomUUID()}@example.cz")
+
+        val payeeId = Given {
+            contentType("application/json")
+            body("""{"name":"Sequence Probe Payee","iban":"CZ6508000000192000145399","bic":null}""")
+        } When {
+            put("/api/v1/parties/$partyId/payees")
+        } Then {
+            statusCode(200)
+        } Extract {
+            jsonPath().getString("id")
+        }
+
+        assertThat(payeeId).describedAs("payee id returned by the endpoint").isNotBlank()
+        assertThat(payeeRowCount(partyId)).describedAs("party_payees rows for %s", partyId).isEqualTo(1)
+    }
+
+    /**
+     * The projection consumer's sequence is the same defect, found by grepping the migrations
+     * rather than by a request — nothing in the fuzz lane reaches it. Asserting the sequence
+     * directly keeps the claim honest: this test is about id allocation being possible, and does
+     * not pretend to exercise the consumer.
+     *
+     * `nextval` with the identifier spelled exactly as Hibernate spells it is the whole point —
+     * an assertion against `party_marketing_consent_seq` in lower case would pass against the
+     * broken quoted sequence too, and prove nothing.
+     */
+    @Test
+    fun `both Hibernate-managed sequences resolve under the name Hibernate uses`() {
+        assertThat(nextval("party_payees_SEQ")).isPositive()
+        assertThat(nextval("party_marketing_consent_SEQ")).isPositive()
+    }
+}


### PR DESCRIPTION
## The defect

`PUT /api/v1/parties/{id}/payees` has answered 500 on every call since the endpoint shipped:

```
SQLGrammarException: relation "party_payees_seq" does not exist (42P01)
  [select nextval('party_payees_SEQ')]
```

`V18__party_payees.sql:23` creates the sequence **quoted** — `CREATE SEQUENCE "party_payees_SEQ"` —
so Postgres preserves the case. Hibernate emits `nextval('party_payees_SEQ')`, where the
identifier inside the string literal is **unquoted**; Postgres folds it to lower case and looks
for `party_payees_seq`. Nothing by that name exists.

`V5` made this exact mistake for `parties` / `party_documents` / `party_outbox` and `V6` fixed it
the same way. `V16` and `V18` reintroduced it.

## Second occurrence, not found by the fuzzer

`V16__marketing_consent_tracking.sql:16` has the identical shape:
`CREATE SEQUENCE "party_marketing_consent_SEQ"`. `PartyMarketingConsentEntity` is a
`PanacheEntity`, so the projection consumer's first write fails the same way. Confirmed against a
real Postgres rather than argued from the source:

```
select nextval('party_marketing_consent_SEQ');
ERROR:  relation "party_marketing_consent_seq" does not exist
```

Nothing in the fuzz lane reaches that path — it came out of grepping the migrations for the shape.

## The fix

`V19` drops both quoted sequences and recreates them lower case. `V18` cannot be edited: Flyway
checksums the whole file, and it has been applied.

The new sequences start at `max(id) + 50`, not 1. `id` is `BIGSERIAL`, so any row written before
this migration drew its id from the implicit `<table>_id_seq`; a sequence restarting at 1 would
collide on the first insert. Rollback note is in the migration and restores the broken state
exactly.

## Verification

Against a real Postgres 16, negative control first:

| step | result |
|---|---|
| before V19, `nextval('party_payees_SEQ')` | exit 1, `relation "party_payees_seq" does not exist` |
| apply V19 | exit 0 |
| after V19, same call, table already holding `max(id)=7` | `57` — allocated past the existing rows |
| quoted sequences remaining | none |

`PartySequenceAllocationIT` drives the real endpoint over HTTP against the real schema:

- with `V19` removed — **2 tests, 2 failures**, both with the production error
- with `V19` present — **2 tests, 0 skipped, 0 failures**

`:openbank-party-service:test ktlintCheck detekt` all three ran and passed (checked the task list,
not just the exit code).

The assertion is the allocated id and the row, not merely a 200 — a 200 would also be satisfied by
an endpoint that stopped persisting. The second test calls `nextval` with the identifier spelled
exactly as Hibernate spells it; asserting the lower-case name would pass against the broken
sequence and prove nothing.

## Why a unit test could not have caught this

`PartyServicePayeeTest` mocks the repository, so it passes against a database that cannot allocate
an id at all. The defect lives strictly between Hibernate and Postgres. Same reason the consent
`SuppressionEntity` column-name defect and the sca `eventType` payload defect both shipped green.

## Not included

A CI gate for the shape is the obvious follow-up, and I did not ship one. My first detector —
"every `PanacheEntity` needs a matching `<table>_seq`" — flagged 16 of 24 entities; I checked two
and both were false (balance-service and audit-service do create theirs, in a syntax my regex
missed). A gate whose subject enumeration is wrong is worse than none. Enumerating the subjects
correctly is its own piece of work.

Refs #5913
