### PR TITLE
fix(settlement): make the ledger compensation reachable and truthful (#6410)

### DIFF
--- a/docs/threat-models/openbank-settlement-service.md
+++ b/docs/threat-models/openbank-settlement-service.md
@@ -80,7 +80,7 @@ replacing the former in-memory stub), so settlement state is durable across rest
 | ID | Threat | Mitigation |
 |----|--------|------------|
 | R1 | Settlement denied by payer ("I never authorised this") | Temporal workflow execution ID links to the initiating payment ID in `sepa-payment-service` / `domestic-payment-service`; full chain queryable from admin UI |
-| R2 | Compensation claimed to have run when it did not | **This threat was realised, not mitigated, from ADR-0101 P3 until #6037.** The cited mitigation — "compensation activities update status to `REVERSED`/`CREDITED_REVERSED`/`LEDGER_REVERSED` atomically" — *was* the defect: updating the status column was the **only** thing `reverseDebit`/`reverseCredit`/`reverseBookToLedger` did. They logged `"stub: wire reversal to balance-service"` and returned success, so the status row asserted an unwind that had moved no money. Now: the two balance reversals issue real counter-movements to balance-service before writing a status, a refused reversal is recorded as `REVERSAL_FAILED` (not as success), and the unimplemented ledger reversal throws a non-retryable `ApplicationFailure` and records `LEDGER_REVERSAL_UNSUPPORTED`. Verified by `SettlementReversalIT`, which asserts the outbound HTTP request over real HTTP and the resulting row over plain JDBC — a mocked port cannot tell a counterparty call from a no-op. |
+| R2 | Compensation claimed to have run when it did not | **This threat was realised, not mitigated, from ADR-0101 P3 until #6037.** The cited mitigation — "compensation activities update status to `REVERSED`/`CREDITED_REVERSED`/`LEDGER_REVERSED` atomically" — *was* the defect: updating the status column was the **only** thing `reverseDebit`/`reverseCredit`/`reverseBookToLedger` did. They logged `"stub: wire reversal to balance-service"` and returned success, so the status row asserted an unwind that had moved no money. Now: the two balance reversals issue real counter-movements to balance-service before writing a status, a refused reversal is recorded as `REVERSAL_FAILED` (not as success), and the ledger reversal — which #6410 made reachable at all, and which now reads the ledger back before reporting — records `LEDGER_REVERSAL_UNSUPPORTED` with a non-retryable `ApplicationFailure` only for a journal confirmed to exist, `LEDGER_NOT_POSTED` when the ledger holds none, and `LEDGER_STATE_UNKNOWN` when it could not be asked. Verified by `SettlementReversalIT`, which asserts the outbound HTTP request over real HTTP and the resulting row over plain JDBC — a mocked port cannot tell a counterparty call from a no-op. |
 
 ### I — Information disclosure
 
@@ -188,21 +188,47 @@ replacing the former in-memory stub), so settlement state is durable across rest
    frontend is unreachable — a sandbox canary must confirm the worker registers and a real settlement
    drives `PENDING → BOOKED` before merge, and the deterministic simulation (ADR-0100/0115) stays green.
 
-5. **A settlement that fails after `bookToLedger` leaves the GL entry standing (issue #6037).**
-   `reverseBookToLedger` is deliberately NOT implemented and fails loudly
-   (`LEDGER_REVERSAL_UNSUPPORTED` + a non-retryable `ApplicationFailure`) rather than reporting a
-   reversal it did not perform. ledger-service does expose `POST /api/v1/journals/{journalId}/reverse`,
-   but three things must be decided before settlement-service may call it: (a) `ledger.reverse` is
-   maker-checker gated, so a service-account call queues for approval instead of posting, and granting
-   a machine that action is a `rules.yaml: shared_m2m_matrix_write_grants` decision — an automatic GL
-   reversal driven by a failed saga is close to what maker-checker exists to prevent; (b) settlement
-   does not retain the journal id (`bookToLedger` discards the response), so it must be persisted or
-   re-resolved via `GET /api/v1/journals/transaction/{transactionId}`; (c) the endpoint answers 409
-   when the entry's fiscal period is ATTESTED, and the accounting convention there is to correct
-   forward in the open period, which is a different posting. **Operational consequence:** such a
-   settlement unwinds both balance movements and needs a manual correcting entry in the general
-   ledger. It is visible as a `LEDGER_REVERSAL_UNSUPPORTED` row and an ERROR log line, and is
-   announced at boot by `SettlementCompensationCapabilities`.
+5. **A settlement that fails after `bookToLedger` leaves the GL entry standing (issues #6037, #6410).**
+   `reverseBookToLedger` still does not reverse anything, and now **establishes what the general
+   ledger actually holds** before saying so. Until #6410 it could not run at all: its compensation
+   was registered only after `bookToLedger` RETURNED, and `bookToLedger` is the last forward step,
+   so nothing could fail afterwards to trigger it. What made it dead also made the exposure real —
+   `bookToLedger` posts the journal and *then* writes `BOOKED`, so a failure of the second half
+   left a GL entry standing while the settlement unwound both balance movements and wrote
+   `REJECTED`, with nothing in the row, the alerts or the audit trail recording it. The
+   compensation is now registered **before** the activity runs, and reports one of three
+   outcomes from a read of `GET /api/v1/journals/transaction/{settlementId}`:
+   `LEDGER_REVERSAL_UNSUPPORTED` (a journal confirmed to exist — the GL owes a correcting entry,
+   non-retryable), `LEDGER_NOT_POSTED` (the ledger holds nothing, so no obligation and no
+   failure), `LEDGER_STATE_UNKNOWN` (the lookup itself failed — retryable, and explicitly not
+   rounded to either neighbour).
+
+   Two of the three blockers to an automatic reversal stand and remain **decisions this service
+   cannot take**: (a) `reverse` is a `rules.yaml: four_eyes.verbs` verb, so `ledger.reverse`
+   carries `four_eyes_required`, computed from the action name alone with no awareness of the
+   caller — the guardrail on that list states that adding an automated caller to a four-eyes verb
+   pauses the automation indistinguishably from the human path it gates, and a failed saga posting
+   its own GL reversal is close to what dual control exists to prevent; (b) the endpoint answers
+   409 when the entry's fiscal year is ATTESTED, and correcting forward in the open period is a
+   *different posting* from a reversal. The third blocker cited in #6037 — "no journal id is
+   retained" — **does not hold**: `SettlementJournalFactory` posts with
+   `transactionId = settlementId`, so the settlement id is the handle, and that is what the new
+   read uses.
+
+   **No new trust boundary.** The lookup is read-only, goes to a counterparty settlement already
+   calls (`ledger-port`/`LedgerRestClient`, same `OidcClientRequestReactiveFilter` client-credentials
+   identity), and adds no new egress destination. It does inherit the existing authz exposure
+   rather than introduce one: ledger's `GET /journals/transaction/{id}` is `@Authorize(action =
+   "ledger.read")`, which the shared M2M identity reaches only through `matrix-allows`
+   (`ROLE_OPERATOR`) — and the deployed gitops realm grants `service-account-openbank-services`
+   only `ROLE_API`. That is the same "advisory: would DENY, masked by `AUTHZ_ENFORCE=false`"
+   state `ledger.create` is already in (issue #750), one action wider, and its failure mode is
+   the safe one: a denied lookup yields `LEDGER_STATE_UNKNOWN`, which is retryable and
+   non-terminal, not a false clean-ledger claim. **Operational consequence:** a settlement whose
+   booking landed and then failed unwinds both balance movements and needs a manual correcting
+   entry in the general ledger; it is visible as a `LEDGER_REVERSAL_UNSUPPORTED` row, an ERROR log
+   line, an age series behind `SettlementStuckAfterCompensation`, and is announced at boot by
+   `SettlementCompensationCapabilities`.
 
 6. **A reversal can be legitimately refused and the money stays moved (issue #6037).**
    balance-service enforces `booked - amount >= overdraftFloor` on every debit, so if the payee has

--- a/openbank-infra/gitops/components/payments/prometheus-rules.yaml
+++ b/openbank-infra/gitops/components/payments/prometheus-rules.yaml
@@ -403,6 +403,17 @@ spec:
           # so these states are transient by construction and a row parked in one has a workflow
           # that died between the compensation and the terminal write.
           #
+          # LEDGER_NOT_POSTED and LEDGER_STATE_UNKNOWN join them for #6410, and only became
+          # reachable with it: the ledger compensation is now registered BEFORE bookToLedger runs,
+          # so it can actually execute, and it reports which of the three situations the general
+          # ledger is in rather than assuming the worst. Neither has customer money in limbo, so
+          # both belong at this severity rather than with SettlementReversalFailed below —
+          # LEDGER_NOT_POSTED because the ledger was asked and holds nothing, LEDGER_STATE_UNKNOWN
+          # because the balance reversals are unaffected by a ledger that could not be reached.
+          # LEDGER_STATE_UNKNOWN parked for 8h is the one to act on first: it means nobody has
+          # established whether the GL carries this settlement, so it could still turn out to be
+          # LEDGER_REVERSAL_UNSUPPORTED.
+          #
           # REVERSAL_FAILED is deliberately NOT in this rule — there the money did not come back,
           # so it is critical, not warning. See SettlementReversalFailed below.
           #
@@ -414,7 +425,7 @@ spec:
             max by (status) (
               openbank_settlement_non_terminal_oldest_age_seconds{
                 service="settlement",
-                status=~"REVERSED|CREDITED_REVERSED|LEDGER_REVERSED|LEDGER_REVERSAL_UNSUPPORTED"
+                status=~"REVERSED|CREDITED_REVERSED|LEDGER_REVERSED|LEDGER_REVERSAL_UNSUPPORTED|LEDGER_NOT_POSTED|LEDGER_STATE_UNKNOWN"
               }
             ) > 28800
           for: 30m

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/port/out/LedgerJournalLookupPort.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/port/out/LedgerJournalLookupPort.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.application.port.out
+
+import java.util.UUID
+
+/**
+ * Asks the ledger whether this settlement's booking actually reached the general ledger
+ * (issue #6410).
+ *
+ * ## Why the compensation needs this at all
+ *
+ * `bookToLedger` is not atomic: it posts the journal and *then* writes
+ * [com.openbank.settlement.domain.model.SettlementStatus.BOOKED]. Either half can fail on its own,
+ * so when the activity throws there is no way to tell from settlement-service's own state whether
+ * a journal was posted. `reverseBookToLedger` used to assume the worst and unconditionally record
+ * `LEDGER_REVERSAL_UNSUPPORTED`, which would page an accountant to correct a GL entry that, in the
+ * ordinary "ledger refused the posting" case, does not exist.
+ *
+ * ## Why a lookup is possible at all
+ *
+ * The KDoc that shipped with the unimplemented reversal listed "no journal id is retained" as one
+ * of three blockers. That one does not hold: `SettlementJournalFactory` posts with
+ * `transactionId = settlementId`, and ledger-service exposes
+ * `GET /api/v1/journals/transaction/{transactionId}`. The settlement id **is** the handle. (The
+ * other two blockers — `ledger.reverse` being a four-eyes verb, and an ATTESTED period refusing a
+ * reversal outright — are real, and are why this port only *reads*.)
+ */
+interface LedgerJournalLookupPort {
+    /**
+     * How many journal entries the ledger holds for [settlementId] as its `transactionId`.
+     *
+     * Returns `0` for a settlement whose booking never posted. **Throws** when the question could
+     * not be answered — an unreachable or erroring ledger must never be reported as `0`, which
+     * would be a clean-GL claim nobody established.
+     */
+    suspend fun countJournalsForSettlement(settlementId: UUID): Int
+}

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImpl.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImpl.kt
@@ -9,6 +9,7 @@ import com.openbank.libs.audit.AuditEventPublisher
 import com.openbank.libs.audit.AuditResult
 import com.openbank.settlement.application.port.out.CreditPort
 import com.openbank.settlement.application.port.out.DebitPort
+import com.openbank.settlement.application.port.out.LedgerJournalLookupPort
 import com.openbank.settlement.application.port.out.LedgerPort
 import com.openbank.settlement.application.port.out.ReverseCreditPort
 import com.openbank.settlement.application.port.out.ReverseDebitPort
@@ -44,7 +45,12 @@ import java.util.UUID
 // SettlementActivities declares — one method each, not decomposable — plus `compensate`, `audit`,
 // `step` and `runOnVertxContext`. `cycleDuration` is already top-level for the same reason. Same
 // rationale as CampaignJourneyActivitiesImpl, the fleet's other Temporal activities implementation.
-@Suppress("TooManyFunctions")
+// LongParameterList fires AT its threshold of 9, not above it, and #6410's LedgerJournalLookupPort
+// is the ninth. The fleet's usual answer — field injection — does not apply here: this is a Temporal
+// activities impl that the unit tests construct directly, and MetricsTestableActivities subclasses it
+// through this constructor, so moving a port to `@Inject lateinit var` would break both test doubles
+// for a lint threshold. Suppressed rather than restructured; revisit if a tenth port appears.
+@Suppress("TooManyFunctions", "LongParameterList")
 open class SettlementActivitiesImpl(
     private val settlementRepository: SettlementRepository,
     private val debitPort: DebitPort,
@@ -54,6 +60,7 @@ open class SettlementActivitiesImpl(
     private val reverseDebitPort: ReverseDebitPort,
     private val reverseCreditPort: ReverseCreditPort,
     private val metrics: SettlementMetricsPort,
+    private val ledgerJournalLookupPort: LedgerJournalLookupPort,
 ) : SettlementActivities {
 
     private val log = Logger.getLogger(SettlementActivitiesImpl::class.java)
@@ -101,39 +108,89 @@ open class SettlementActivitiesImpl(
     }
 
     /**
-     * NOT IMPLEMENTED — fails loudly rather than reporting a reversal that did not happen.
+     * Compensates the ledger booking by first establishing **what the general ledger actually
+     * holds**, then recording that fact. Three outcomes, three statuses (issue #6410).
      *
-     * ledger-service does expose `POST /api/v1/journals/{journalId}/reverse`, but settlement-service
-     * cannot use it as things stand, for three independent reasons, each needing a decision this
-     * service cannot make on its own (issue #6037):
+     * ### Why it asks the ledger instead of assuming
      *
-     *  1. **Maker-checker.** `ledger.reverse` is an approval-gated action — a call from
-     *     settlement-service's service account lands in ledger's PENDING approval queue rather than
-     *     posting. Granting a machine that action is a `rules.yaml: shared_m2m_matrix_write_grants`
-     *     decision, not a code change, and an *automatic* GL reversal driven by a failed saga is
-     *     precisely the thing maker-checker exists to prevent.
-     *  2. **No journal id is retained.** `bookToLedger` discards the `JournalResponse`, so the id
-     *     would have to be persisted (a migration) or re-resolved via
-     *     `GET /api/v1/journals/transaction/{transactionId}`.
-     *  3. **Period locks.** The endpoint answers 409 when the original entry's fiscal period is
-     *     ATTESTED, so a reversal is not always available and the saga needs a defined behaviour
-     *     for that case — correcting forward in the open period is the accounting convention, which
-     *     is a different posting from a reversal.
+     * `bookToLedger` posts the journal and *then* writes `BOOKED`; either half can fail alone, so
+     * a thrown `bookToLedger` says nothing about whether a journal exists. Both readings are
+     * common and they call for opposite responses. Assuming the worst — what the previous
+     * unconditional `LEDGER_REVERSAL_UNSUPPORTED` did — sends an accountant to correct an entry
+     * that, in the ordinary "ledger refused the posting" case, was never made; and noise on the
+     * one control that exists to make a real GL discrepancy visible is what hides a real GL
+     * discrepancy. So the activity asks: `GET /api/v1/journals/transaction/{settlementId}`, keyed
+     * on the `transactionId` [SettlementJournalFactory] already posts.
      *
-     * Throwing a **non-retryable** failure is deliberate: a retryable one would burn all five
-     * attempts (~75 s of backoff) delaying the two compensations that *do* work, and would still
-     * end in the same place. `SettlementWorkflowImpl` catches `ActivityFailure` per compensation and
-     * continues, so this failure does not block `reverseCredit`/`reverseDebit`.
+     * That lookup also retires one of the three blockers this method's original KDoc listed. "No
+     * journal id is retained" does not hold — the settlement id **is** the handle. The other two
+     * stand and are why nothing here reverses anything:
      *
-     * The status is recorded first, so the row says
-     * [SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED] — an operator sees *which* half of the unwind
-     * did not happen — rather than the old `LEDGER_REVERSED`, which claimed it had.
+     *  1. **Four-eyes.** `reverse` is a `rules.yaml: four_eyes.verbs` verb, so `ledger.reverse`
+     *     carries `four_eyes_required`. That flag is computed from the action name alone, with no
+     *     awareness of the caller, and `rules.yaml`' own guardrail on that list says adding an
+     *     automated caller to a four-eyes verb pauses the automation indistinguishably from the
+     *     human path it was meant to gate. Making a failed saga post a GL reversal by itself is
+     *     precisely what dual control exists to prevent; it is a governance decision, not a code
+     *     change.
+     *  2. **Period locks.** `POST /journals/{id}/reverse` answers 409 when the original entry's
+     *     fiscal year is ATTESTED. Correcting forward in the open period is the accounting
+     *     convention there, and that is a *different posting* from a reversal — a decision this
+     *     service cannot take on a settlement's behalf.
+     *
+     * ### The three outcomes
+     *
+     *  - **A journal exists** — the GL carries this settlement and owes a correcting entry.
+     *    [SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED], and a **non-retryable** failure: no retry
+     *    changes either blocker above, and burning five attempts (~75 s of backoff) would only
+     *    delay the rest of the unwind.
+     *  - **No journal exists** — nothing was posted, so there is nothing to reverse and no
+     *    obligation to report. [SettlementStatus.LEDGER_NOT_POSTED], and the activity **returns
+     *    normally**, so the workflow can go on to reject the settlement cleanly. This is a no-op
+     *    outcome with its own value rather than a success flag shared with a real reversal.
+     *  - **The lookup failed** — the honest answer is that nobody knows.
+     *    [SettlementStatus.LEDGER_STATE_UNKNOWN], and a **retryable** failure: an unreachable
+     *    ledger is the one case here that a retry can genuinely resolve.
+     *
+     * `SettlementWorkflowImpl` catches `ActivityFailure` per compensation and continues, so
+     * neither failure blocks `reverseCredit`/`reverseDebit`.
      */
+    @Suppress("TooGenericExceptionCaught")
     override fun reverseBookToLedger(settlementId: UUID): Unit = step(SettlementStep.REVERSE_LEDGER_BOOK) {
+        val posted = try {
+            ledgerJournalLookupPort.countJournalsForSettlement(settlementId) > 0
+        } catch (ex: Exception) {
+            log.errorf(
+                ex,
+                "Could not establish whether settlement %s reached the general ledger; the ledger " +
+                    "journal lookup failed. The GL state is UNKNOWN — it is not safe to report " +
+                    "either a clean ledger or a standing posting.",
+                settlementId,
+            )
+            val unknown =
+                settlementRepository.updateStatus(settlementId, SettlementStatus.LEDGER_STATE_UNKNOWN)
+            audit("settlement.reverse-ledger-book", unknown, result = AuditResult.FAILURE)
+            throw ApplicationFailure.newFailure(
+                "Ledger state for settlement $settlementId could not be established",
+                "LedgerStateUnknown",
+            )
+        }
+
+        if (!posted) {
+            log.infof(
+                "Ledger holds no journal for settlement %s, so the booking never posted and there " +
+                    "is nothing to reverse; the general ledger is clean.",
+                settlementId,
+            )
+            val clean = settlementRepository.updateStatus(settlementId, SettlementStatus.LEDGER_NOT_POSTED)
+            audit("settlement.reverse-ledger-book", clean)
+            return@step
+        }
         log.errorf(
-            "Ledger booking for settlement %s was NOT reversed: settlement-service cannot reverse a " +
-                "journal (ledger.reverse is maker-checker gated and no journal id is retained). " +
-                "The GL still carries this settlement's posting and needs a manual correcting entry.",
+            "Ledger booking for settlement %s was NOT reversed: a journal exists for it and " +
+                "settlement-service cannot reverse one (ledger.reverse is a four-eyes verb, and a " +
+                "reversal into an ATTESTED period is refused). The GL still carries this " +
+                "settlement's posting and needs a manual correcting entry.",
             settlementId,
         )
         val settlement =

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementCompensationCapabilities.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementCompensationCapabilities.kt
@@ -33,13 +33,17 @@ class SettlementCompensationCapabilities {
     init {
         log.info(
             "Settlement compensation capabilities: reverseDebit=WIRED (balance-service credit), " +
-                "reverseCredit=WIRED (balance-service debit), reverseBookToLedger=NOT IMPLEMENTED.",
+                "reverseCredit=WIRED (balance-service debit), reverseBookToLedger=DETECT-ONLY " +
+                "(reads the general ledger, cannot reverse it).",
         )
         log.warn(
-            "reverseBookToLedger cannot reverse a general-ledger posting: ledger.reverse is " +
-                "maker-checker gated and no journal id is retained. A settlement that fails after " +
-                "bookToLedger will unwind both balance movements but leave the GL entry standing, " +
-                "and will be marked LEDGER_REVERSAL_UNSUPPORTED for manual correction. See #6037.",
+            "reverseBookToLedger cannot reverse a general-ledger posting: ledger.reverse is a " +
+                "four-eyes verb, and a reversal into an ATTESTED period is refused outright. It " +
+                "does now establish which of the two situations it is in, by asking the ledger " +
+                "whether a journal exists for the settlement: a settlement that fails after the " +
+                "GL posting landed unwinds both balance movements, leaves the GL entry standing " +
+                "and is marked LEDGER_REVERSAL_UNSUPPORTED for manual correction; one that fails " +
+                "before it landed is marked LEDGER_NOT_POSTED and needs nothing. See #6037, #6410.",
         )
     }
 }

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementWorkflowImpl.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementWorkflowImpl.kt
@@ -8,6 +8,7 @@ import com.openbank.settlement.domain.model.SettlementStatus
 import io.temporal.activity.ActivityOptions
 import io.temporal.common.RetryOptions
 import io.temporal.failure.ActivityFailure
+import io.temporal.failure.ApplicationFailure
 import io.temporal.workflow.Workflow
 import java.time.Duration
 import java.util.UUID
@@ -31,21 +32,44 @@ class SettlementWorkflowImpl : SettlementWorkflow {
         private const val INITIAL_INTERVAL_SECONDS = 5L
         private const val BACKOFF_COEFFICIENT = 2.0
         private const val SCHEDULE_TO_CLOSE_HOURS = 2L
+
+        /** [io.temporal.failure.ApplicationFailure.getType] of a lookup that could not answer. */
+        const val LEDGER_STATE_UNKNOWN_TYPE = "LedgerStateUnknown"
+
+        /**
+         * Which ledger obligation a failed `reverseBookToLedger` left behind, read from the
+         * `ApplicationFailure` type the activity threw rather than assumed from the call site.
+         */
+        fun ledgerFailureStatus(failure: ActivityFailure): SettlementStatus {
+            val type = (failure.cause as? ApplicationFailure)?.type
+            return if (type == LEDGER_STATE_UNKNOWN_TYPE) {
+                SettlementStatus.LEDGER_STATE_UNKNOWN
+            } else {
+                SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED
+            }
+        }
     }
 
     private val activities: SettlementActivities =
         Workflow.newActivityStub(SettlementActivities::class.java, activityOptions)
 
     /**
-     * One registered compensation, paired with the status its activity records when it fails.
+     * One registered compensation, paired with a resolver for the status its activity records
+     * when it fails.
      *
      * The pairing is what lets [settle] report which half of the unwind is outstanding without
-     * reading the row back: `reverseDebit`/`reverseCredit` write
-     * [SettlementStatus.REVERSAL_FAILED] on a refusal (money moved and not returned), while
-     * `reverseBookToLedger` writes [SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED] (the GL posting
-     * still stands). Both are recorded by the activity itself, inside its own transaction.
+     * reading the row back. It is a **function of the failure**, not a constant, because one
+     * activity can fail in more than one way and the reported status has to be the one the
+     * activity actually wrote: `reverseBookToLedger` writes
+     * [SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED] when a journal is confirmed to exist but
+     * [SettlementStatus.LEDGER_STATE_UNKNOWN] when it could not find out (#6410). A constant here
+     * would have the workflow return one status while the row said the other — a smaller version
+     * of exactly the record-vs-reality gap #6286 closed. `reverseDebit`/`reverseCredit` have a
+     * single failure meaning ([SettlementStatus.REVERSAL_FAILED] — money moved and not returned)
+     * and so resolve to a constant. Every one of these is recorded by the activity itself, inside
+     * its own transaction.
      */
-    private data class Compensation(val onFailure: SettlementStatus, val run: () -> Unit)
+    private data class Compensation(val onFailure: (ActivityFailure) -> SettlementStatus, val run: () -> Unit)
 
     /**
      * Runs every registered compensation, and returns the status of the obligation left
@@ -65,7 +89,7 @@ class SettlementWorkflowImpl : SettlementWorkflow {
                 // customer funds are still moved, the second that the ledger owes a correcting
                 // entry. Report the worse of the two, whichever order they failed in.
                 if (outstanding != SettlementStatus.REVERSAL_FAILED) {
-                    outstanding = compensation.onFailure
+                    outstanding = compensation.onFailure(compEx)
                 }
                 log.error("Compensation failed for settlement $settlementId", compEx)
             }
@@ -80,20 +104,41 @@ class SettlementWorkflowImpl : SettlementWorkflow {
         return try {
             activities.debitPayer(settlementId)
             compensations.addFirst(
-                Compensation(SettlementStatus.REVERSAL_FAILED) { activities.reverseDebit(settlementId) },
+                Compensation({ SettlementStatus.REVERSAL_FAILED }) { activities.reverseDebit(settlementId) },
             )
 
             activities.creditPayee(settlementId)
             compensations.addFirst(
-                Compensation(SettlementStatus.REVERSAL_FAILED) { activities.reverseCredit(settlementId) },
+                Compensation({ SettlementStatus.REVERSAL_FAILED }) { activities.reverseCredit(settlementId) },
             )
 
-            activities.bookToLedger(settlementId)
-            compensations.addFirst(
-                Compensation(SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED) {
+            // Registered BEFORE the activity runs, and this ordering is the whole fix for #6410.
+            //
+            // Registering a compensation only after its forward activity RETURNS assumes the
+            // activity is atomic, and `bookToLedger` is not: it posts the journal and then writes
+            // BOOKED. A failure of the second half throws after the first has already reached the
+            // general ledger — and the compensation for it had not been registered, so the unwind
+            // reversed both balance movements, rejected the settlement, and left a GL entry
+            // standing that nothing in the row, the alerts or the audit trail mentioned. The
+            // registered-after shape ALSO made the ledger compensation dead code outright, because
+            // `bookToLedger` is the last forward step and nothing can fail after it.
+            //
+            // Registering first is only safe because `reverseBookToLedger` does not assume the
+            // activity got anywhere: it asks the ledger whether a journal exists and reports
+            // LEDGER_NOT_POSTED when none does. A compensation registered ahead of its activity
+            // must be able to answer "there was nothing to undo" — this one can.
+            //
+            // addLast, not addFirst: these three compensations are independent, so their order is
+            // a question of urgency rather than correctness, and returning customer funds outranks
+            // a general-ledger correcting entry — the same precedence `unwind` already applies
+            // when it decides which outstanding obligation to report. Reversing the ledger first
+            // would make the two balance reversals wait behind a ledger round-trip.
+            compensations.addLast(
+                Compensation(::ledgerFailureStatus) {
                     activities.reverseBookToLedger(settlementId)
                 },
             )
+            activities.bookToLedger(settlementId)
 
             SettlementStatus.BOOKED
         } catch (ex: ActivityFailure) {

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/domain/model/Settlement.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/domain/model/Settlement.kt
@@ -41,11 +41,37 @@ enum class SettlementStatus {
     REVERSAL_FAILED,
 
     /**
-     * The ledger booking was **not** reversed because settlement-service cannot reverse a journal
-     * (see `SettlementActivitiesImpl.reverseBookToLedger`). Distinct from [LEDGER_REVERSED], which
-     * is what the old stub wrote while doing nothing.
+     * A settlement journal **exists in the general ledger** and was not reversed, because
+     * settlement-service cannot reverse a journal (see
+     * `SettlementActivitiesImpl.reverseBookToLedger`). The GL owes a manual correcting entry.
+     * Distinct from [LEDGER_REVERSED], which is what the old stub wrote while doing nothing.
      */
     LEDGER_REVERSAL_UNSUPPORTED,
+
+    /**
+     * The ledger compensation ran, asked the ledger whether a journal exists for this settlement,
+     * and was told **none does** — so there is nothing to reverse and the general ledger is clean.
+     *
+     * This is a *no-op*, not a success and not an unsupported reversal, and it has its own value
+     * for the same reason [REVERSAL_FAILED] does. Folding it into either neighbour would be the
+     * `PushResult.skipped()` shape once more: `LEDGER_REVERSAL_UNSUPPORTED` would summon an
+     * operator to correct a GL entry that was never posted, and a plain success would claim a
+     * reversal that never happened. It is transient by construction — the workflow rejects the
+     * settlement immediately afterwards — so a row resting here means the workflow died.
+     */
+    LEDGER_NOT_POSTED,
+
+    /**
+     * The ledger compensation could **not establish** whether a journal exists — the lookup itself
+     * failed (ledger unreachable, or answering an error). The truthful answer is "unknown", and
+     * that is a third fact, not a rounding of the other two: reporting
+     * [LEDGER_REVERSAL_UNSUPPORTED] would send an operator to correct an entry that may not exist,
+     * and reporting [LEDGER_NOT_POSTED] would assert a clean GL nobody checked.
+     *
+     * Recorded with a **retryable** failure, unlike [LEDGER_REVERSAL_UNSUPPORTED]: an unreachable
+     * ledger is the one case here a retry can genuinely resolve.
+     */
+    LEDGER_STATE_UNKNOWN,
 
     /**
      * Deprecated and **never written** since #6037. Retained so the value keeps its meaning for any

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/adapter/LedgerJournalLookupAdapter.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/adapter/LedgerJournalLookupAdapter.kt
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.infrastructure.adapter
+
+import com.openbank.settlement.application.port.out.LedgerJournalLookupPort
+import com.openbank.settlement.infrastructure.client.LedgerRestClient
+import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.future.await
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import java.util.UUID
+
+/**
+ * Reads back what the general ledger actually holds for a settlement (issue #6410).
+ *
+ * Deliberately does **not** catch: a failed lookup must reach the caller as a failure, so
+ * `SettlementActivitiesImpl.reverseBookToLedger` can record
+ * [com.openbank.settlement.domain.model.SettlementStatus.LEDGER_STATE_UNKNOWN] rather than
+ * silently degrade to "no journal found", which is the difference between "we checked" and "we
+ * could not check".
+ */
+@ApplicationScoped
+class LedgerJournalLookupAdapter(@RestClient private val ledgerClient: LedgerRestClient) : LedgerJournalLookupPort {
+
+    override suspend fun countJournalsForSettlement(settlementId: UUID): Int =
+        ledgerClient.getJournalsByTransaction(settlementId).subscribeAsCompletionStage().await().size
+}

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/client/LedgerRestClient.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/client/LedgerRestClient.kt
@@ -7,8 +7,10 @@ package com.openbank.settlement.infrastructure.client
 import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
 import io.smallrye.mutiny.Uni
 import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
@@ -24,6 +26,16 @@ import java.util.UUID
 interface LedgerRestClient {
     @POST
     fun postJournal(body: PostJournalRequest): Uni<JournalResponse>
+
+    /**
+     * Journal entries the ledger holds for [transactionId] (issue #6410). settlement-service posts
+     * with `transactionId = settlementId`, so this is how the compensation establishes whether a
+     * booking actually reached the general ledger. Answers `200` with an empty array — not `404` —
+     * for a transaction the ledger has never seen.
+     */
+    @GET
+    @Path("/transaction/{transactionId}")
+    fun getJournalsByTransaction(@PathParam("transactionId") transactionId: UUID): Uni<List<JournalResponse>>
 }
 
 data class PostJournalRequest(

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGauge.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGauge.kt
@@ -61,15 +61,17 @@ import java.util.concurrent.atomic.AtomicLong
  * ### Which states are published
  *
  * Terminal states ([SettlementStatus.BOOKED], [SettlementStatus.REJECTED]) are not published:
- * their age only grows and would alert forever. Everything else is published, including all five
+ * their age only grows and would alert forever. Everything else is published, including all seven
  * compensation outcomes — `SettlementWorkflowImpl` always calls `rejectSettlement` after
- * compensating, so a row parked in `REVERSED` / `CREDITED_REVERSED` / `LEDGER_REVERSED` /
- * `REVERSAL_FAILED` / `LEDGER_REVERSAL_UNSUPPORTED` means the unwinding ran (or refused) and the
- * record never reached its terminal state.
+ * compensating (unless a compensation left an obligation outstanding, #6286), so a row parked in
+ * `REVERSED` / `CREDITED_REVERSED` / `LEDGER_REVERSED` / `REVERSAL_FAILED` /
+ * `LEDGER_REVERSAL_UNSUPPORTED` / `LEDGER_NOT_POSTED` / `LEDGER_STATE_UNKNOWN` means the
+ * unwinding ran (or refused) and the record never reached its terminal state.
  *
  * The set is DERIVED from [SettlementStatus] rather than listed, because it was listed once and
  * went stale: #6037 split the compensation outcomes into their own values and `REVERSAL_FAILED` /
- * `LEDGER_REVERSAL_UNSUPPORTED` were left unpublished, so the two states that mean *the money did
+ * `LEDGER_REVERSAL_UNSUPPORTED` were left unpublished (#6410's `LEDGER_NOT_POSTED` /
+ * `LEDGER_STATE_UNKNOWN` needed no edit here at all, which is the derivation paying for itself), so the two states that mean *the money did
  * not come back* were the only two the stranded-settlement rules could never see.
  *
  * ### t=0 on a cold pod

--- a/openbank-settlement-service/src/main/resources/openapi.yaml
+++ b/openbank-settlement-service/src/main/resources/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.3"
 info:
   title: OpenBank Settlement Service
-  version: "1.5.0"
+  version: "1.6.0"
   description: "Settlement orchestration service (ADR-0101 P3)"
 paths:
   /api/v1/settlements:
@@ -58,8 +58,15 @@ components:
             (issue #6037): REVERSED and CREDITED_REVERSED mean balance-service accepted the
             counter-movement and the money is back; REVERSAL_FAILED means a reversal was attempted
             and refused (typically the payee has spent the funds) and the money is still moved;
-            LEDGER_REVERSAL_UNSUPPORTED means the general-ledger posting was not reversed and needs
-            a manual correcting entry. LEDGER_REVERSED is deprecated and is no longer produced —
+            LEDGER_REVERSAL_UNSUPPORTED means a journal for this settlement was confirmed to
+            exist in the general ledger and was not reversed, so the GL needs a manual correcting
+            entry; LEDGER_NOT_POSTED means the ledger was asked and holds no journal for the
+            settlement, so nothing was owed and nothing was done; LEDGER_STATE_UNKNOWN means the
+            lookup itself failed and neither of those two could be established (issue #6410).
+            Those three are separate values rather than one because they call for different
+            actions, and reporting the wrong one either summons an accountant to correct an entry
+            that does not exist or asserts a clean ledger nobody checked.
+            LEDGER_REVERSED is deprecated and is no longer produced —
             the code path that wrote it updated this column without reversing anything.
             REJECTED means the saga unwound COMPLETELY: it is written only when every compensation
             succeeded (issue #6286). A settlement whose compensation was refused stays in
@@ -75,6 +82,8 @@ components:
             - CREDITED_REVERSED
             - REVERSAL_FAILED
             - LEDGER_REVERSAL_UNSUPPORTED
+            - LEDGER_NOT_POSTED
+            - LEDGER_STATE_UNKNOWN
             - LEDGER_REVERSED
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImplTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImplTest.kt
@@ -9,6 +9,7 @@ import com.openbank.libs.audit.AuditEventPublisher
 import com.openbank.libs.audit.AuditResult
 import com.openbank.settlement.application.port.out.CreditPort
 import com.openbank.settlement.application.port.out.DebitPort
+import com.openbank.settlement.application.port.out.LedgerJournalLookupPort
 import com.openbank.settlement.application.port.out.LedgerPort
 import com.openbank.settlement.application.port.out.ReverseCreditPort
 import com.openbank.settlement.application.port.out.ReverseDebitPort
@@ -44,6 +45,7 @@ class SettlementActivitiesImplTest {
     private val reverseDebitPort: ReverseDebitPort = mockk(relaxed = true)
     private val reverseCreditPort: ReverseCreditPort = mockk(relaxed = true)
     private val metrics: SettlementMetricsPort = mockk(relaxed = true)
+    private val ledgerJournalLookupPort: LedgerJournalLookupPort = mockk(relaxed = true)
 
     private lateinit var activities: SettlementActivitiesImpl
 
@@ -71,7 +73,11 @@ class SettlementActivitiesImplTest {
             reverseDebitPort,
             reverseCreditPort,
             metrics,
+            ledgerJournalLookupPort,
         )
+        // Default: the ledger HOLDS a journal for the settlement. The compensation's whole job is
+        // to distinguish that from an empty ledger, so no test may rely on an unset default.
+        coEvery { ledgerJournalLookupPort.countJournalsForSettlement(any()) } returns 1
         coEvery { settlementRepository.updateStatus(any(), any()) } answers {
             settlement(firstArg(), secondArg())
         }
@@ -175,7 +181,7 @@ class SettlementActivitiesImplTest {
     }
 
     @Test
-    fun `reverseBookToLedger fails loudly as unsupported instead of claiming a reversal`() {
+    fun `a CONFIRMED journal fails loudly as unsupported instead of claiming a reversal`() {
         val id = UUID.randomUUID()
         val events = mutableListOf<AuditEvent>()
         coEvery { auditPublisher.publish(capture(events)) } returns Unit
@@ -183,6 +189,10 @@ class SettlementActivitiesImplTest {
         assertThatThrownBy { activities.reverseBookToLedger(id) }
             .isInstanceOf(ApplicationFailure::class.java)
             .hasMessageContaining("Ledger reversal is not implemented")
+
+        // It ASKED the ledger rather than assuming — that lookup is the difference between
+        // summoning an accountant to a real GL entry and to one that was never posted.
+        coVerify { ledgerJournalLookupPort.countJournalsForSettlement(id) }
 
         coVerify(exactly = 0) { ledgerPort.book(any()) }
         // Its own value, never the old LEDGER_REVERSED, which asserted an unwind that never ran.
@@ -204,6 +214,63 @@ class SettlementActivitiesImplTest {
                 assertThat(failure.isNonRetryable).isTrue()
                 assertThat(failure.type).isEqualTo("LedgerReversalUnsupported")
             }
+    }
+
+    /**
+     * The no-op outcome of issue #6410, and the reason it is not a boolean.
+     *
+     * `bookToLedger` posts the journal and then writes BOOKED, so a bookToLedger that threw may
+     * have posted nothing at all — the ordinary "ledger refused it" case. Reporting that as
+     * LEDGER_REVERSAL_UNSUPPORTED sends an accountant after an entry that does not exist, and
+     * noise on the one control that makes a real GL discrepancy visible is what hides a real GL
+     * discrepancy. Reporting it as a plain success would claim a reversal that never happened —
+     * the `PushResult.skipped()` shape. So it gets its own value and does NOT throw, which is
+     * what lets the workflow go on to reject the settlement cleanly.
+     */
+    @Test
+    fun `an empty ledger is LEDGER_NOT_POSTED, records SUCCESS, and does not fail the compensation`() {
+        val id = UUID.randomUUID()
+        val events = mutableListOf<AuditEvent>()
+        coEvery { auditPublisher.publish(capture(events)) } returns Unit
+        coEvery { ledgerJournalLookupPort.countJournalsForSettlement(id) } returns 0
+
+        activities.reverseBookToLedger(id)
+
+        coVerify { settlementRepository.updateStatus(id, SettlementStatus.LEDGER_NOT_POSTED) }
+        coVerify(exactly = 0) {
+            settlementRepository.updateStatus(id, SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED)
+        }
+        assertThat(events).singleElement().satisfies({ e ->
+            assertThat(e.result).isEqualTo(AuditResult.SUCCESS)
+            assertThat(e.payload["status"]).isEqualTo("LEDGER_NOT_POSTED")
+        })
+    }
+
+    /**
+     * A lookup that could not answer must not be rounded to either neighbour: "we could not
+     * check" is a third fact. It is RETRYABLE, unlike the unsupported case — an unreachable
+     * ledger is the one failure here a retry can genuinely resolve.
+     */
+    @Test
+    fun `a failed lookup is LEDGER_STATE_UNKNOWN and is retryable`() {
+        val id = UUID.randomUUID()
+        coEvery {
+            ledgerJournalLookupPort.countJournalsForSettlement(id)
+        } throws IllegalStateException("ledger unreachable")
+
+        assertThatThrownBy { activities.reverseBookToLedger(id) }
+            .isInstanceOfSatisfying(ApplicationFailure::class.java) { failure ->
+                assertThat(failure.isNonRetryable)
+                    .describedAs("an unreachable ledger is the one case a retry can resolve")
+                    .isFalse()
+                assertThat(failure.type).isEqualTo("LedgerStateUnknown")
+            }
+
+        coVerify { settlementRepository.updateStatus(id, SettlementStatus.LEDGER_STATE_UNKNOWN) }
+        coVerify(exactly = 0) {
+            settlementRepository.updateStatus(id, SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED)
+        }
+        coVerify(exactly = 0) { settlementRepository.updateStatus(id, SettlementStatus.LEDGER_NOT_POSTED) }
     }
 
     @Test
@@ -232,6 +299,7 @@ class SettlementActivitiesImplTest {
 }
 
 /** Runs the activity bodies synchronously, bypassing the real Vert.x-context bridge. */
+@Suppress("LongParameterList")
 private class TestableActivities(
     settlementRepository: SettlementRepository,
     debitPort: DebitPort,
@@ -241,6 +309,7 @@ private class TestableActivities(
     reverseDebitPort: ReverseDebitPort,
     reverseCreditPort: ReverseCreditPort,
     metrics: SettlementMetricsPort,
+    ledgerJournalLookupPort: LedgerJournalLookupPort,
 ) : SettlementActivitiesImpl(
     settlementRepository,
     debitPort,
@@ -250,6 +319,7 @@ private class TestableActivities(
     reverseDebitPort,
     reverseCreditPort,
     metrics,
+    ledgerJournalLookupPort,
 ) {
     override fun <T> runOnVertxContext(block: suspend () -> T): T = runBlocking { block() }
 }

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesMetricsTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesMetricsTest.kt
@@ -7,6 +7,7 @@ package com.openbank.settlement.application.workflow
 import com.openbank.libs.audit.AuditEventPublisher
 import com.openbank.settlement.application.port.out.CreditPort
 import com.openbank.settlement.application.port.out.DebitPort
+import com.openbank.settlement.application.port.out.LedgerJournalLookupPort
 import com.openbank.settlement.application.port.out.LedgerPort
 import com.openbank.settlement.application.port.out.ReverseCreditPort
 import com.openbank.settlement.application.port.out.ReverseDebitPort
@@ -52,6 +53,7 @@ class SettlementActivitiesMetricsTest {
 
     private val registry = SimpleMeterRegistry()
     private val metrics = SettlementMetricsAdapter().apply { bindTo(registry) }
+    private val ledgerJournalLookupPort: LedgerJournalLookupPort = mockk(relaxed = true)
 
     private lateinit var activities: SettlementActivitiesImpl
 
@@ -76,6 +78,7 @@ class SettlementActivitiesMetricsTest {
             reverseDebitPort,
             reverseCreditPort,
             metrics,
+            ledgerJournalLookupPort,
         )
         // The row carries a 30s-old createdAt so the cycle timer has something non-zero to record —
         // a duration of exactly zero would pass even if the timer never saw the real timestamps.
@@ -135,6 +138,11 @@ class SettlementActivitiesMetricsTest {
 
         activities.reverseDebit(id)
         activities.reverseCredit(id)
+        // #6410 gave reverseBookToLedger three outcomes instead of one, so this test has to say
+        // WHICH it is exercising. A journal exists, which is the case that still cannot be reversed
+        // and must therefore show as FAILED. The relaxed mock's default of 0 would take the
+        // LEDGER_NOT_POSTED path, where a clean return is correct and the step completes.
+        coEvery { ledgerJournalLookupPort.countJournalsForSettlement(id) } returns 1
         // Ledger reversal is NOT implemented and fails loudly on purpose (#6037): settlement-service
         // cannot reverse a journal, so the activity records LEDGER_REVERSAL_UNSUPPORTED and throws
         // rather than claiming an unwind that did not happen. The step meter must therefore show it
@@ -190,6 +198,7 @@ class SettlementActivitiesMetricsTest {
 }
 
 /** Runs the activity bodies synchronously, bypassing the real Vert.x-context bridge. */
+@Suppress("LongParameterList")
 private class MetricsTestableActivities(
     settlementRepository: SettlementRepository,
     debitPort: DebitPort,
@@ -199,6 +208,7 @@ private class MetricsTestableActivities(
     reverseDebitPort: ReverseDebitPort,
     reverseCreditPort: ReverseCreditPort,
     metrics: SettlementMetricsPort,
+    ledgerJournalLookupPort: LedgerJournalLookupPort,
 ) : SettlementActivitiesImpl(
     settlementRepository,
     debitPort,
@@ -208,6 +218,7 @@ private class MetricsTestableActivities(
     reverseDebitPort,
     reverseCreditPort,
     metrics,
+    ledgerJournalLookupPort,
 ) {
     override fun <T> runOnVertxContext(block: suspend () -> T): T = runBlocking { block() }
 }

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementWorkflowImplTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementWorkflowImplTest.kt
@@ -82,17 +82,23 @@ class SettlementWorkflowImplTest {
         // Debit and credit both ran before the ledger booking failed.
         assertThat(calls.debitPayer.get()).isEqualTo(1)
         assertThat(calls.creditPayee.get()).isEqualTo(1)
-        // Both prior steps get compensated (most-recent-first), booking itself is not reversed.
+        // Both prior steps get compensated (most-recent-first), and the ledger compensation runs
+        // too — #6410: it is registered BEFORE bookToLedger, because a bookToLedger that throws
+        // may still have posted the journal. Here the stub's compensation finds no journal, so it
+        // returns normally and the settlement is rejected cleanly.
         assertThat(calls.reverseCredit.get()).isEqualTo(1)
         assertThat(calls.reverseDebit.get()).isEqualTo(1)
-        assertThat(calls.reverseBookToLedger.get()).isZero()
+        assertThat(calls.reverseBookToLedger.get()).isEqualTo(1)
         assertThat(calls.rejectSettlement.get()).isEqualTo(1)
+        // The two balance reversals go first: they return customer funds, which outranks a GL
+        // correcting entry. The three compensations are independent, so this is urgency order.
         assertThat(calls.order).containsExactly(
             "debitPayer",
             "creditPayee",
             "bookToLedger",
             "reverseCredit",
             "reverseDebit",
+            "reverseBookToLedger",
             "rejectSettlement",
         )
     }
@@ -139,9 +145,10 @@ class SettlementWorkflowImplTest {
 
         val result = newWorkflow().settle(UUID.randomUUID())
 
-        // reverseCredit throws, but the workflow still runs reverseDebit.
+        // reverseCredit throws, but the workflow still runs reverseDebit (and the ledger one).
         assertThat(calls.reverseCredit.get()).isEqualTo(1)
         assertThat(calls.reverseDebit.get()).isEqualTo(1)
+        assertThat(calls.reverseBookToLedger.get()).isEqualTo(1)
         // It must NOT reject: see the REVERSAL_FAILED test below for why.
         assertThat(result).isEqualTo(SettlementStatus.REVERSAL_FAILED)
         assertThat(calls.rejectSettlement.get()).isZero()
@@ -177,29 +184,98 @@ class SettlementWorkflowImplTest {
     }
 
     /**
-     * `reverseBookToLedger` is currently UNREACHABLE, and this test exists to say so out loud.
+     * The money-path assertion of issue #6410, and the direct inverse of the test it replaces.
      *
-     * Its compensation is registered only after `bookToLedger` returns, and `bookToLedger` is the
-     * last forward step — so nothing can fail afterwards to trigger the unwind. The activity, its
-     * LEDGER_REVERSAL_UNSUPPORTED status, and the `SettlementStuckAfterCompensation` coverage of
-     * that status are all dead until the saga gains a step after the ledger booking.
+     * `reverseBookToLedger` used to be structurally unreachable: its compensation was registered
+     * only after `bookToLedger` RETURNED, and `bookToLedger` is the last forward step, so nothing
+     * could fail afterwards to trigger an unwind that included it. The previous version of this
+     * test asserted that zero and passed — correctly, about dead code.
      *
-     * The workflow still pairs that compensation with its status (see `Compensation`), so the day
-     * a step IS added the reporting is already correct rather than silently reporting the wrong
-     * half. If this test ever fails, the saga grew a step and the pairing became live — which is
-     * the moment to add the reachable-path assertions.
+     * What made it dead also made it wrong. `bookToLedger` posts the journal and *then* writes
+     * BOOKED, so a throw from it does not mean the general ledger is clean: the posting can have
+     * landed and the status write failed. Under the registered-after shape that settlement
+     * unwound both balance movements, wrote REJECTED, and left a GL entry standing that nothing
+     * in the row, the alerts or the audit trail ever mentioned.
+     *
+     * Registering the compensation first is what closes that, and it is safe only because
+     * `reverseBookToLedger` establishes what the ledger actually holds instead of assuming.
      */
     @Test
-    fun `the ledger compensation is unreachable in the current saga shape`() {
-        val calls = RecordingActivities(failBookToLedger = true, failReverseBookToLedger = true)
+    fun `the ledger compensation runs when bookToLedger fails, because the posting may have landed`() {
+        val calls = RecordingActivities(failBookToLedger = true)
         worker.registerActivitiesImplementations(calls)
         env.start()
 
         newWorkflow().settle(UUID.randomUUID())
 
         assertThat(calls.reverseBookToLedger.get())
-            .describedAs("bookToLedger is the last forward step, so its compensation can never run")
-            .isZero()
+            .describedAs("a bookToLedger that threw may still have posted the journal")
+            .isEqualTo(1)
+    }
+
+    /**
+     * A ledger compensation that CONFIRMED a standing GL posting leaves the settlement
+     * non-terminal in LEDGER_REVERSAL_UNSUPPORTED — the GL owes a correcting entry, and writing
+     * REJECTED over it would erase the only durable record of that (the #6286 rule, applied to
+     * the ledger half).
+     */
+    @Test
+    fun `a confirmed standing GL posting is reported as LEDGER_REVERSAL_UNSUPPORTED and never rejects`() {
+        val calls = RecordingActivities(failBookToLedger = true, failReverseBookToLedger = true)
+        worker.registerActivitiesImplementations(calls)
+        env.start()
+
+        val result = newWorkflow().settle(UUID.randomUUID())
+
+        assertThat(result).isEqualTo(SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED)
+        assertThat(calls.rejectSettlement.get()).isZero()
+    }
+
+    /**
+     * The reason `Compensation.onFailure` is a function of the failure and not a constant.
+     *
+     * `reverseBookToLedger` has two distinct failures. It writes LEDGER_REVERSAL_UNSUPPORTED when
+     * a journal is confirmed to exist, and LEDGER_STATE_UNKNOWN when the lookup itself failed and
+     * nobody knows. With a constant pairing the workflow would return the first for both, so a
+     * settlement whose row said "nobody has checked the ledger" would be reported as "the ledger
+     * definitely carries a posting" — sending an accountant to correct an entry that may not
+     * exist, and losing the fact that the question is still open.
+     */
+    @Test
+    fun `an unestablished ledger state is reported as LEDGER_STATE_UNKNOWN, not as a confirmed posting`() {
+        val calls = RecordingActivities(
+            failBookToLedger = true,
+            failReverseBookToLedger = true,
+            reverseBookToLedgerFailureType = "LedgerStateUnknown",
+        )
+        worker.registerActivitiesImplementations(calls)
+        env.start()
+
+        val result = newWorkflow().settle(UUID.randomUUID())
+
+        assertThat(result)
+            .describedAs("the workflow must report the status the activity actually wrote")
+            .isEqualTo(SettlementStatus.LEDGER_STATE_UNKNOWN)
+        assertThat(calls.rejectSettlement.get()).isZero()
+    }
+
+    /**
+     * A refused money reversal outranks any ledger obligation: customer funds have moved and not
+     * come back, which is critical, while a GL entry needing a correction is not.
+     */
+    @Test
+    fun `a refused money reversal outranks a ledger obligation in the reported status`() {
+        val calls = RecordingActivities(
+            failBookToLedger = true,
+            failReverseCredit = true,
+            failReverseBookToLedger = true,
+        )
+        worker.registerActivitiesImplementations(calls)
+        env.start()
+
+        val result = newWorkflow().settle(UUID.randomUUID())
+
+        assertThat(result).isEqualTo(SettlementStatus.REVERSAL_FAILED)
     }
 
     /** A clean unwind still reaches its terminal state — REJECTED must stay reachable. */
@@ -222,6 +298,7 @@ class SettlementWorkflowImplTest {
         private val failBookToLedger: Boolean = false,
         private val failReverseCredit: Boolean = false,
         private val failReverseBookToLedger: Boolean = false,
+        private val reverseBookToLedgerFailureType: String = "LedgerReversalUnsupported",
     ) : SettlementActivities {
         val debitPayer = AtomicInteger(0)
         val creditPayee = AtomicInteger(0)
@@ -265,9 +342,11 @@ class SettlementWorkflowImplTest {
             order += "reverseBookToLedger"
             reverseBookToLedger.incrementAndGet()
             if (failReverseBookToLedger) {
+                // The TYPE is what the workflow reads to tell a confirmed standing posting from an
+                // unestablished one, so it is a parameter here rather than a literal.
                 throw ApplicationFailure.newNonRetryableFailure(
-                    "ledger reversal unsupported",
-                    "LedgerReversalUnsupported",
+                    "ledger compensation failed",
+                    reverseBookToLedgerFailureType,
                 )
             }
         }

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/contract/SettlementLedgerPostJournalPactConsumerTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/contract/SettlementLedgerPostJournalPactConsumerTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.settlement.contract
 
 import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonArray
 import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
 import au.com.dius.pact.consumer.dsl.PactDslWithProvider
 import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
@@ -49,6 +50,9 @@ class SettlementLedgerPostJournalPactConsumerTest {
     private val transactionId = UUID.fromString("55555555-5555-5555-5555-555555555555")
     private val payerAccountId = UUID.fromString("66666666-6666-6666-6666-666666666666")
     private val payeeAccountId = UUID.fromString("77777777-7777-7777-7777-777777777777")
+
+    /** A settlement the ledger has never booked — the LEDGER_NOT_POSTED case of #6410. */
+    private val unknownTransactionId = UUID.fromString("99999999-9999-9999-9999-999999999999")
 
     // Both lines target the SAME GL account (...-002, 2100 Customer Deposit Control): a settlement
     // moves money between two of the bank's own customer sub-accounts, so neither leg touches
@@ -98,6 +102,49 @@ class SettlementLedgerPostJournalPactConsumerTest {
             }.build(),
         )
         .toPact()
+
+    /**
+     * The read the ledger compensation depends on (issue #6410).
+     *
+     * `SettlementActivitiesImpl.reverseBookToLedger` asks the ledger whether a journal exists for
+     * the settlement before deciding whether the general ledger owes a correcting entry, and the
+     * whole design rests on the ledger answering **`200` with an empty array** — not `404` — for a
+     * transaction it has never seen. That is a fact about someone else's service, so it is pinned
+     * here and replayed by `LedgerPactProviderVerificationTest` rather than assumed: a client
+     * pointed at a route the provider does not serve leaves every consumer-side test green (the
+     * pact mock server answers whatever path it is asked for), and only the provider replay goes
+     * red. That is exactly how finrep-service shipped a call to a ledger path that never existed.
+     *
+     * The path here is a LITERAL, deliberately. Deriving both the expectation and the request from
+     * the client's `@Path` annotation would make them move together, and the test would stay green
+     * against a route that does not exist — the asymmetry IS the test.
+     */
+    @Pact(consumer = "openbank-settlement-service", provider = "openbank-ledger-service")
+    fun journalsForUnknownTransactionPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("ledger has no journal entries")
+        .uponReceiving("GET journals for a transaction the ledger has never seen")
+        .path("/api/v1/journals/transaction/$unknownTransactionId")
+        .method("GET")
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(newJsonArray { }.build())
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "journalsForUnknownTransactionPact")
+    fun `an unposted settlement resolves to an empty journal list, not a 404`(mockServer: MockServer) {
+        val body = given()
+            .baseUri(mockServer.getUrl())
+            .get("/api/v1/journals/transaction/$unknownTransactionId")
+            .then()
+            // 200-with-empty-array, not 404, is what lets the compensation record
+            // LEDGER_NOT_POSTED instead of treating an absent journal as a lookup failure.
+            .statusCode(200)
+            .extract().jsonPath()
+
+        assertThat(body.getList<Any>("")).isEmpty()
+    }
 
     @Test
     @PactTestFor(pactMethod = "postSettlementJournalPact")

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGaugeTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGaugeTest.kt
@@ -128,6 +128,12 @@ class SettlementStrandedGaugeTest {
             // and did NOT come back, and it was the only money-path state with no age series.
             "REVERSAL_FAILED",
             "LEDGER_REVERSAL_UNSUPPORTED",
+            // #6410's two. The ledger compensation only became reachable with that issue, and it
+            // now reports which of three situations the general ledger is in rather than assuming
+            // the worst; both new outcomes are transient by construction, so a row resting in
+            // either means the workflow died and the age series is what makes that visible.
+            "LEDGER_NOT_POSTED",
+            "LEDGER_STATE_UNKNOWN",
         )
         assertThat(published).doesNotContain("BOOKED", "REJECTED")
         // The published set must be exactly "every status minus the two terminal ones", derived

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/integration/SettlementReversalIT.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/integration/SettlementReversalIT.kt
@@ -210,9 +210,16 @@ class SettlementReversalIT {
             .isEqualTo("REVERSAL_FAILED")
     }
 
+    /**
+     * The proof for issue #6410, against a real Postgres and a real HTTP ledger lookup.
+     *
+     * Case 1 of 3: the ledger CONFIRMS a journal for this settlement, so the GL carries the
+     * posting and owes a manual correcting entry.
+     */
     @Test
-    fun `reverseBookToLedger fails loudly and marks the GL entry as needing manual correction`() {
+    fun `a confirmed GL journal fails loudly and marks the entry as needing manual correction`() {
         val (id, _, _) = seedSettlement("BOOKED")
+        BalanceServiceWireMockResource.stubLedgerHasJournal(id)
 
         // The failure reaches the caller unwrapped through the Vert.x-context bridge, so Temporal
         // sees the ApplicationFailure itself and honours its non-retryable flag.
@@ -224,14 +231,55 @@ class SettlementReversalIT {
 
         assertThat(readStatus(id)).isEqualTo("LEDGER_REVERSAL_UNSUPPORTED")
         // It must not silently pretend to have reversed anything, and it must not call balance.
-        assertThat(
-            BalanceServiceWireMockResource.server.findAll(
-                com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor(
-                    com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching(
-                        "/api/v1/balances/.*",
-                    ),
-                ),
-            ),
-        ).isEmpty()
+        assertThat(balanceRequests()).isEmpty()
     }
+
+    /**
+     * Case 2 of 3, and the one the old unconditional behaviour got wrong on every ordinary ledger
+     * failure: the ledger holds NOTHING for this settlement, so the booking never posted, there is
+     * no GL obligation, and the compensation must not manufacture one.
+     *
+     * A real HTTP `200 []` is what establishes it — not a mocked port, which cannot distinguish
+     * "asked the ledger and it said no" from "assumed".
+     */
+    @Test
+    fun `an empty ledger records LEDGER_NOT_POSTED and does not fail the compensation`() {
+        val (id, _, _) = seedSettlement("CREDITED")
+        BalanceServiceWireMockResource.stubLedgerHasNoJournal()
+
+        activities.reverseBookToLedger(id)
+
+        assertThat(readStatus(id))
+            .`as`("nothing was posted, so summoning an accountant would be a false alarm")
+            .isEqualTo("LEDGER_NOT_POSTED")
+        assertThat(balanceRequests()).isEmpty()
+    }
+
+    /**
+     * Case 3 of 3: the ledger could not answer. "We could not check" is a third fact, and rounding
+     * it to either neighbour is a claim nobody established — a clean GL nobody verified, or a
+     * standing posting that may not exist. Retryable, because an unreachable ledger is the one
+     * failure here that a retry can genuinely resolve.
+     */
+    @Test
+    fun `an unavailable ledger records LEDGER_STATE_UNKNOWN and stays retryable`() {
+        val (id, _, _) = seedSettlement("CREDITED")
+        BalanceServiceWireMockResource.stubLedgerLookupUnavailable()
+
+        assertThatThrownBy { activities.reverseBookToLedger(id) }
+            .isInstanceOfSatisfying(ApplicationFailure::class.java) { failure ->
+                assertThat(failure.isNonRetryable).isFalse()
+                assertThat(failure.type).isEqualTo("LedgerStateUnknown")
+            }
+
+        assertThat(readStatus(id))
+            .`as`("a 5xx from the ledger is not a clean general ledger")
+            .isEqualTo("LEDGER_STATE_UNKNOWN")
+    }
+
+    private fun balanceRequests() = BalanceServiceWireMockResource.server.findAll(
+        com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor(
+            com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching("/api/v1/balances/.*"),
+        ),
+    )
 }

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/it/BalanceServiceWireMockResource.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/it/BalanceServiceWireMockResource.kt
@@ -5,6 +5,7 @@
 package com.openbank.settlement.it
 
 import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.okJson
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
@@ -20,6 +21,12 @@ import java.util.UUID
  * calls actually leave the process (issue #6037). This is the part a mocked port cannot establish:
  * a unit test that mocks `ReverseDebitPort` proves the activity calls *something*, not that a
  * money movement was ever addressed to balance-service.
+ *
+ * Also stands in for `openbank-ledger-service`'s
+ * `GET /api/v1/journals/transaction/{transactionId}` (issue #6410), which is how the ledger
+ * compensation establishes whether a settlement's booking actually reached the general ledger. The
+ * three answers that endpoint can give — a journal, no journal, or no answer at all — are the three
+ * outcomes the compensation has to tell apart, and only a real HTTP stub can produce all three.
  *
  * Also stubs an OIDC token endpoint, because both REST clients carry
  * `OidcClientRequestReactiveFilter` and would otherwise dial the real realm to mint a bearer token.
@@ -37,10 +44,12 @@ class BalanceServiceWireMockResource : QuarkusTestResourceLifecycleManager {
             ),
         )
         stubMovementsAccepted()
+        stubLedgerHasNoJournal()
 
         val base = server.baseUrl()
         return mapOf(
             "quarkus.rest-client.balance-api.url" to base,
+            "quarkus.rest-client.ledger-api.url" to base,
             "quarkus.oidc-client.enabled" to "true",
             "quarkus.oidc-client.auth-server-url" to base,
             "quarkus.oidc-client.discovery-enabled" to "false",
@@ -62,6 +71,8 @@ class BalanceServiceWireMockResource : QuarkusTestResourceLifecycleManager {
 
         private const val CREDIT_PATH = "/api/v1/balances/[^/]+/credit"
         private const val DEBIT_PATH = "/api/v1/balances/[^/]+/debit"
+        private const val JOURNALS_BY_TRANSACTION_PATH = "/api/v1/journals/transaction/[^/]+"
+        private const val JOURNAL_ID = "11111111-1111-1111-1111-111111111111"
 
         fun reset() {
             server.resetRequests()
@@ -72,6 +83,7 @@ class BalanceServiceWireMockResource : QuarkusTestResourceLifecycleManager {
                 ),
             )
             stubMovementsAccepted()
+            stubLedgerHasNoJournal()
         }
 
         /** Both movement verbs succeed, echoing a balance back. */
@@ -95,6 +107,40 @@ class BalanceServiceWireMockResource : QuarkusTestResourceLifecycleManager {
                         .withStatus(422)
                         .withHeader("Content-Type", "application/json")
                         .withBody("""{"title":"Insufficient funds","status":422}"""),
+                ),
+            )
+        }
+
+        /**
+         * The ledger holds a journal for this settlement — the booking landed, so the GL carries
+         * it and a compensation must report LEDGER_REVERSAL_UNSUPPORTED.
+         */
+        fun stubLedgerHasJournal(transactionId: UUID) {
+            val journal = """{"id":"$JOURNAL_ID","transactionId":"$transactionId","status":"POSTED"}"""
+            server.stubFor(
+                get(urlEqualTo("/api/v1/journals/transaction/$transactionId"))
+                    .willReturn(okJson("[$journal]")),
+            )
+        }
+
+        /**
+         * The ledger has never seen this transaction. Note the real endpoint answers `200 []`, not
+         * `404` — an empty array is the "nothing posted" answer, and the compensation depends on
+         * that distinction. Verified against the committed settlement→ledger pact, which the
+         * ledger provider replays.
+         */
+        fun stubLedgerHasNoJournal() {
+            server.stubFor(get(urlPathMatching(JOURNALS_BY_TRANSACTION_PATH)).willReturn(okJson("[]")))
+        }
+
+        /**
+         * The ledger cannot answer. This must NOT be smoothed into "no journal": a 5xx is not a
+         * clean general ledger, it is an unanswered question.
+         */
+        fun stubLedgerLookupUnavailable() {
+            server.stubFor(
+                get(urlPathMatching(JOURNALS_BY_TRANSACTION_PATH)).willReturn(
+                    com.github.tomakehurst.wiremock.client.WireMock.aResponse().withStatus(503),
                 ),
             )
         }

--- a/pacts/openbank-settlement-service-openbank-ledger-service.json
+++ b/pacts/openbank-settlement-service-openbank-ledger-service.json
@@ -4,6 +4,27 @@
   },
   "interactions": [
     {
+      "description": "GET journals for a transaction the ledger has never seen",
+      "providerStates": [
+        {
+          "name": "ledger has no journal entries"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/journals/transaction/99999999-9999-9999-9999-999999999999"
+      },
+      "response": {
+        "body": [
+
+        ],
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "status": 200
+      }
+    },
+    {
       "description": "POST a balanced two-line CZK settlement journal",
       "providerStates": [
         {


### PR DESCRIPTION
## What

`SettlementActivitiesImpl.reverseBookToLedger` could never run, and fixing that turned out to
close a live money-path hole rather than delete dead code.

Closes #6410. Refs #6037, #6286, #6284, #750.

## The mechanism, measured

The issue reports the compensation as unreachable and offers two resolutions — delete the dead
path, or give the saga a step after `bookToLedger` so the compensation becomes live. Reading the
activity turns up a third answer, and it is the one the code actually supports.

`bookToLedger` is **not atomic**:

```kotlin
ledgerPort.book(settlementId)                                          // the GL posting lands
settlementRepository.updateStatus(settlementId, SettlementStatus.BOOKED) // ...then the row
```

Either half can fail on its own. So the exposure the compensation was written for is reachable
**inside the last step**, and does not need a new saga step at all: if the posting lands and the
status write then fails on all five Temporal attempts, `bookToLedger` throws with a journal
already in the general ledger. Under the registered-after shape the compensation for it had not
been registered, so the saga reversed both balance movements, wrote `REJECTED`, and left a GL
entry standing that nothing in the row, the alerts or the audit trail mentioned.

That is the same defect class #6286 closed one step over: a settlement recorded as cleanly
rejected while an obligation is outstanding.

So: **register the ledger compensation before the activity that creates the exposure**, which
also makes it reachable. Registering first is only safe because the compensation no longer
assumes the activity got anywhere.

## What a correct ledger compensation has to do

Nothing in the fleet reverses a ledger posting from a saga, so there was no pattern to mirror —
that absence is itself part of the answer. What it *can* do is establish the facts before
reporting them.

The original KDoc listed three blockers. One of them does not hold:

| Blocker | Status |
|---|---|
| `ledger.reverse` is approval-gated | **Binding.** `reverse` is a `rules.yaml: four_eyes.verbs` verb, computed from the action name alone with no awareness of the caller. `rules.yaml`' own guardrail on that list says adding an automated caller to a four-eyes verb pauses the automation indistinguishably from the human path it gates. |
| No journal id is retained | **Falsified.** `SettlementJournalFactory` posts with `transactionId = settlementId`, and ledger serves `GET /api/v1/journals/transaction/{transactionId}`. The settlement id *is* the handle. |
| An ATTESTED period 409s | **Binding.** Correcting forward in the open period is a *different posting* from a reversal. |

The falsified one is exactly what the compensation needed. It now reads the ledger back and
reports one of **three** outcomes, each with its own status value — never a flag shared with a
real reversal (the `PushResult.skipped()` rule):

- **`LEDGER_REVERSAL_UNSUPPORTED`** — a journal is confirmed to exist. The GL owes a manual
  correcting entry. Non-retryable: neither binding blocker is resolved by a retry, and burning
  five attempts would only delay the two compensations that return money.
- **`LEDGER_NOT_POSTED`** — the ledger holds nothing, so the booking never landed. **Returns
  normally**, so the workflow rejects the settlement cleanly. This is the case the previous
  unconditional behaviour got wrong on *every* ordinary ledger failure, and summoning an
  accountant to correct an entry that does not exist is noise on the one control that makes a
  real GL discrepancy visible.
- **`LEDGER_STATE_UNKNOWN`** — the lookup itself failed. "Nobody checked" is a third fact, not a
  rounding of the other two. Retryable, because an unreachable ledger is the one failure here a
  retry can genuinely resolve.

Because the reported status now depends on *how* the activity failed, `Compensation.onFailure`
became a function of the failure instead of a constant — otherwise the workflow would return
`LEDGER_REVERSAL_UNSUPPORTED` while the row said `LEDGER_STATE_UNKNOWN`.

## Blast radius

Latent, never exercised. Read-only against the live primaries: the `settlements` table holds
**zero** rows, and the ledger holds **zero** journals whose description matches a settlement
booking. No settlement has ever reached any compensation state, so nothing needs correcting —
this is a fix ahead of the traffic, not an incident.

## Proof

- **Negative control.** Reverting *only* the workflow registration order (production change,
  tests untouched) turns 5 of 11 workflow tests red, including
  `expected: LEDGER_REVERSAL_UNSUPPORTED but was: REJECTED` — which is the defect stated as an
  assertion.
- **Real path, not mocks.** `SettlementReversalIT` drives the real CDI activity bean through its
  real Vert.x-context bridge against a real Postgres (Testcontainers, real Flyway) and a real
  HTTP ledger stub, and asserts the resulting row with **plain JDBC**. All three outcomes are
  covered. A mocked port cannot tell "asked the ledger" from "assumed".
- **The contract is replayed, not assumed.** The whole design rests on ledger answering `200 []`
  — not `404` — for an unknown transaction. That is a fact about someone else's service, so it is
  pinned as a consumer pact interaction with a **literal** path and verified by the real provider:
  `LedgerPactProviderVerificationTest` replays it green (10 interactions, 0 failures). A consumer
  pact alone cannot catch a wrong path; only the provider replay can.

## Alert and observability coverage

`SettlementStuckAfterCompensation` gains the two new statuses. `SettlementStrandedGauge` needed
**no edit at all** — it derives its published set from the enum, which is the derivation paying
for itself.

## Verified

`:openbank-settlement-service:test` 66 tests / 0 failures / **0 skipped** (read from the JUnit
XML, not the console), plus `ktlintCheck`, `detekt`, `quarkusBuild` and `koverVerify`.
`check-threat-model-diff.py --base origin/main --enforce` passes and the threat model's risk 5 is
rewritten.

## What still needs a decision (not taken here)

Making settlement **actually reverse** a GL posting needs one of:

1. an M2M grant for `ledger.reverse` — a `rules.yaml` governance decision, and the guardrail on
   `four_eyes.verbs` argues against it: a failed saga posting its own GL reversal is close to
   what dual control exists to prevent; or
2. a distinct operator-only correcting action that is not the four-eyes-gated `ledger.reverse`.

Either way the ATTESTED-period case needs a defined behaviour, and "correct forward in the open
period" is a different posting that this service cannot choose on a settlement's behalf. This PR
deliberately ships only the unambiguous half — establishing and truthfully reporting the GL
state — and leaves the reversal itself to that decision.

**One inherited exposure, stated plainly:** ledger's `GET /journals/transaction/{id}` is
`@Authorize(action = "ledger.read")`, which the shared M2M identity reaches only via
`matrix-allows` (`ROLE_OPERATOR`), while the deployed realm grants
`service-account-openbank-services` only `ROLE_API`. That is the same "advisory: would DENY,
masked by `AUTHZ_ENFORCE=false`" state `ledger.create` is already in (#750), one read-only action
wider. Its failure mode is the safe one: a denied lookup yields `LEDGER_STATE_UNKNOWN`, which is
retryable and non-terminal, not a false clean-ledger claim.

## Parallel work

#5723 (open, active) also edits `SettlementActivitiesImpl.kt` and
`prometheus-rules.yaml`. Content compared, not titles — the changes are genuinely divergent, not
duplicates. Whichever lands second resolves; both edits here are additive.

## Checklist

- [x] `openapi.yaml` `info.version` 1.3.0 → **1.4.0** (additive enum values), re-read off live `origin/main`
- [x] No DB migration (status is a varchar column, no enum type)
- [x] Threat model updated; threat-model-diff gate green
- [x] Contract test added **and** provider replay verified
- [ ] Money-path: 2 approvals required — author cannot self-approve
