### PR TITLE
fix(settlement): remove the ledger compensation that could never run

### DIFF
--- a/docs/threat-models/openbank-settlement-service.md
+++ b/docs/threat-models/openbank-settlement-service.md
@@ -80,7 +80,7 @@ replacing the former in-memory stub), so settlement state is durable across rest
 | ID | Threat | Mitigation |
 |----|--------|------------|
 | R1 | Settlement denied by payer ("I never authorised this") | Temporal workflow execution ID links to the initiating payment ID in `sepa-payment-service` / `domestic-payment-service`; full chain queryable from admin UI |
-| R2 | Compensation claimed to have run when it did not | **This threat was realised, not mitigated, from ADR-0101 P3 until #6037.** The cited mitigation — "compensation activities update status to `REVERSED`/`CREDITED_REVERSED`/`LEDGER_REVERSED` atomically" — *was* the defect: updating the status column was the **only** thing `reverseDebit`/`reverseCredit`/`reverseBookToLedger` did. They logged `"stub: wire reversal to balance-service"` and returned success, so the status row asserted an unwind that had moved no money. Now: the two balance reversals issue real counter-movements to balance-service before writing a status, a refused reversal is recorded as `REVERSAL_FAILED` (not as success), and the unimplemented ledger reversal throws a non-retryable `ApplicationFailure` and records `LEDGER_REVERSAL_UNSUPPORTED`. Verified by `SettlementReversalIT`, which asserts the outbound HTTP request over real HTTP and the resulting row over plain JDBC — a mocked port cannot tell a counterparty call from a no-op. |
+| R2 | Compensation claimed to have run when it did not | **This threat was realised, not mitigated, from ADR-0101 P3 until #6037.** The cited mitigation — "compensation activities update status to `REVERSED`/`CREDITED_REVERSED`/`LEDGER_REVERSED` atomically" — *was* the defect: updating the status column was the **only** thing `reverseDebit`/`reverseCredit`/`reverseBookToLedger` did. They logged `"stub: wire reversal to balance-service"` and returned success, so the status row asserted an unwind that had moved no money. Now: the two balance reversals issue real counter-movements to balance-service before writing a status, a refused reversal is recorded as `REVERSAL_FAILED` (not as success), and the ledger reversal — which could never run, since nothing follows `bookToLedger` — was removed rather than left as code describing a recovery that cannot occur (#6410). Verified by `SettlementReversalIT`, which asserts the outbound HTTP request over real HTTP and the resulting row over plain JDBC — a mocked port cannot tell a counterparty call from a no-op. |
 
 ### I — Information disclosure
 
@@ -100,7 +100,7 @@ replacing the former in-memory stub), so settlement state is durable across rest
 
 | ID | Threat | Mitigation |
 |----|--------|------------|
-| E1 | Attacker injects a workflow that calls `reverseBookToLedger` on a legitimate settlement | **Corrected 2026-08-20 (#6055) — no such gate is implemented.** The activity policy file exists in the service's resources but is bundled by no ConfigMap and loaded by nothing, so it is evaluated never; and it does not say what this row said it said — its allow rule is a single membership test over a fixed activity set, with no `compensation` term anywhere in the file, and the reversal activity is an unconditional member. The effective control on this boundary is the Temporal namespace ACL in E2 alone |
+| E1 | Attacker injects a workflow that calls a compensation activity (`reverseCredit`, `reverseDebit`) on a legitimate settlement | **Corrected 2026-08-20 (#6055) — no such gate is implemented.** The activity policy file exists in the service's resources but is bundled by no ConfigMap and loaded by nothing, so it is evaluated never; and it does not say what this row said it said — its allow rule is a single membership test over a fixed activity set, with no `compensation` term anywhere in the file, and the reversal activity is an unconditional member. The effective control on this boundary is the Temporal namespace ACL in E2 alone |
 | E2 | Service account token used to submit arbitrary workflows | Temporal namespace ACL restricts task queue submission to settlement-service service account (SPIFFE `spiffe://openbank/ns/openbank-settlement/sa/settlement-service`) |
 
 ---
@@ -140,11 +140,13 @@ replacing the former in-memory stub), so settlement state is durable across rest
    `openbank.temporal.enabled` dispatch gate is removed and the in-process legacy saga
    (`legacySettle`) is deleted. This closes a compensation gap: the legacy path flipped a mid-flight
    failure straight to `REJECTED` **without reversing an already-moved debit/credit**, whereas
-   `SettlementWorkflow` runs `reverseBookToLedger → reverseCredit → reverseDebit` before rejecting.
+   `SettlementWorkflow` runs `reverseCredit → reverseDebit` before rejecting (it ran
+   `reverseBookToLedger` first until #6410 removed that unreachable activity).
    **Correction (#6037):** that last sentence was true only of the ordering. Until #6037 all three
    compensation activities were stubs, so the Temporal path unwound exactly as much money as the
    legacy path it replaced — none — while recording that it had. The gap is closed for the two
-   balance movements as of #6037; the ledger half remains open, as risk 5 below.
+   balance movements as of #6037; the ledger half is not a gap but a shape — nothing runs after
+   `bookToLedger`, as risk 5 below now states.
    Flip pre-conditions are verified: Temporal server healthy, `openbank-settlement` namespace
    registered, `settlement_activity.rego` present (risk 2). Worker registration is gated on
    `openbank.settlement.worker.enabled` (default true; false in `%test`). **Cutover risk:** with no
@@ -152,10 +154,16 @@ replacing the former in-memory stub), so settlement state is durable across rest
    frontend is unreachable — a sandbox canary must confirm the worker registers and a real settlement
    drives `PENDING → BOOKED` before merge, and the deterministic simulation (ADR-0100/0115) stays green.
 
-5. **A settlement that fails after `bookToLedger` leaves the GL entry standing (issue #6037).**
-   `reverseBookToLedger` is deliberately NOT implemented and fails loudly
-   (`LEDGER_REVERSAL_UNSUPPORTED` + a non-retryable `ApplicationFailure`) rather than reporting a
-   reversal it did not perform. ledger-service does expose `POST /api/v1/journals/{journalId}/reverse`,
+5. **Nothing can fail after `bookToLedger`, so the GL posting has no compensation — and the code
+   that pretended otherwise is gone (issues #6037, #6410).**
+   `bookToLedger` is the last forward step of the saga and writes the terminal `BOOKED` status
+   itself, so no failure can occur afterwards to trigger an unwind of it. `reverseBookToLedger`,
+   its `LEDGER_REVERSAL_UNSUPPORTED` status and that status's alert coverage were therefore
+   unreachable from the day they were written; #6410 removed them, because a status nothing writes
+   and an alert regex matching it read as coverage without being any. `SettlementWorkflowImplTest`
+   pins the shape, so the day a step is added after the ledger booking the assertion goes red.
+   **This is a constraint on future work, not a closed risk:** such a step must answer the GL
+   question before it is added. ledger-service does expose `POST /api/v1/journals/{journalId}/reverse`,
    but three things must be decided before settlement-service may call it: (a) `ledger.reverse` is
    maker-checker gated, so a service-account call queues for approval instead of posting, and granting
    a machine that action is a `rules.yaml: shared_m2m_matrix_write_grants` decision — an automatic GL
@@ -163,10 +171,10 @@ replacing the former in-memory stub), so settlement state is durable across rest
    does not retain the journal id (`bookToLedger` discards the response), so it must be persisted or
    re-resolved via `GET /api/v1/journals/transaction/{transactionId}`; (c) the endpoint answers 409
    when the entry's fiscal period is ATTESTED, and the accounting convention there is to correct
-   forward in the open period, which is a different posting. **Operational consequence:** such a
-   settlement unwinds both balance movements and needs a manual correcting entry in the general
-   ledger. It is visible as a `LEDGER_REVERSAL_UNSUPPORTED` row and an ERROR log line, and is
-   announced at boot by `SettlementCompensationCapabilities`.
+   forward in the open period, which is a different posting. **Operational consequence today:**
+   none — no path reaches it. `SettlementCompensationCapabilities` announces at boot that the GL
+   posting has no compensation and why, so the constraint is visible in a pod log rather than only
+   in this document.
 
 6. **A reversal can be legitimately refused and the money stays moved (issue #6037).**
    balance-service enforces `booked - amount >= overdraftFloor` on every debit, so if the payee has
@@ -177,13 +185,12 @@ replacing the former in-memory stub), so settlement state is durable across rest
 
    Recording it is not the same as seeing it, and for a time it was only recorded:
    `SettlementStrandedGauge` published a **hand-kept** list of non-terminal statuses written before
-   #6037, so `REVERSAL_FAILED` and `LEDGER_REVERSAL_UNSUPPORTED` had no age series at all and
-   neither `SettlementStrandedMidSaga` nor `SettlementStuckAfterCompensation` could fire for them —
-   the two states meaning *the money did not come back* were the two nothing could observe. The
-   list is now derived from `SettlementStatus`, `LEDGER_REVERSAL_UNSUPPORTED` joins the
-   `SettlementStuckAfterCompensation` warning, and `REVERSAL_FAILED` has its own **critical**
-   `SettlementReversalFailed` rule — separated because the other rule's premise ("funds are safe,
-   only the record is wrong") is false here.
+   #6037, so `REVERSAL_FAILED` had no age series at all and neither `SettlementStrandedMidSaga` nor
+   `SettlementStuckAfterCompensation` could fire for it — the one state meaning *the money did not
+   come back* was the one nothing could observe. The list is now derived from `SettlementStatus`,
+   and `REVERSAL_FAILED` has its own **critical** `SettlementReversalFailed` rule — separated from
+   `SettlementStuckAfterCompensation` because that rule's premise ("funds are safe, only the record
+   is wrong") is false here.
 
    Nor was it enough to publish the state: `SettlementWorkflowImpl` called `rejectSettlement`
    unconditionally after the compensation loop, so the row was overwritten to `REJECTED` within

--- a/openbank-infra/gitops/components/payments/prometheus-rules.yaml
+++ b/openbank-infra/gitops/components/payments/prometheus-rules.yaml
@@ -396,12 +396,13 @@ spec:
               queue `openbank-settlement` is polling and whether a run exists for `settlement-<id>`.
         - alert: SettlementStuckAfterCompensation
           # The *_REVERSED states mean the saga already unwound: money was moved and moved back.
-          # LEDGER_REVERSAL_UNSUPPORTED joins them (#6037): the two balance reversals succeeded and
-          # only the general-ledger posting was left standing, so no customer money is in limbo —
-          # the GL needs a manual correcting entry, which is the same class of record-vs-ledger
-          # disagreement. SettlementWorkflowImpl always calls rejectSettlement after compensating,
-          # so these states are transient by construction and a row parked in one has a workflow
-          # that died between the compensation and the terminal write.
+          # A row parked in one has a workflow that died between the compensation and the terminal
+          # write, so funds are safe and only the record is wrong.
+          #
+          # LEDGER_REVERSAL_UNSUPPORTED was in this regex until #6410 removed the status: the
+          # activity that wrote it could never run, because bookToLedger is the last forward step
+          # and nothing can fail after it. Matching a status nothing writes reads as coverage and
+          # is not.
           #
           # REVERSAL_FAILED is deliberately NOT in this rule — there the money did not come back,
           # so it is critical, not warning. See SettlementReversalFailed below.
@@ -414,7 +415,7 @@ spec:
             max by (status) (
               openbank_settlement_non_terminal_oldest_age_seconds{
                 service="settlement",
-                status=~"REVERSED|CREDITED_REVERSED|LEDGER_REVERSED|LEDGER_REVERSAL_UNSUPPORTED"
+                status=~"REVERSED|CREDITED_REVERSED|LEDGER_REVERSED"
               }
             ) > 28800
           for: 30m

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementActivities.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementActivities.kt
@@ -14,6 +14,5 @@ interface SettlementActivities {
     fun bookToLedger(settlementId: UUID)
     fun reverseDebit(settlementId: UUID)
     fun reverseCredit(settlementId: UUID)
-    fun reverseBookToLedger(settlementId: UUID)
     fun rejectSettlement(settlementId: UUID)
 }

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImpl.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImpl.kt
@@ -17,7 +17,6 @@ import com.openbank.settlement.domain.model.Settlement
 import com.openbank.settlement.domain.model.SettlementStatus
 import io.quarkus.vertx.VertxContextSupport
 import io.smallrye.mutiny.coroutines.asUni
-import io.temporal.failure.ApplicationFailure
 import jakarta.enterprise.context.ApplicationScoped
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -64,6 +63,29 @@ open class SettlementActivitiesImpl(
         Unit
     }
 
+    /**
+     * Books the settlement to the general ledger. This is the LAST forward step, and it writes the
+     * terminal [SettlementStatus.BOOKED] itself — so nothing can fail after it and this posting has
+     * no compensation (issue #6410, which removed the `reverseBookToLedger` activity that could
+     * never run).
+     *
+     * Kept here because it is what a future step after this one would have to solve. Reversing a
+     * GL posting from this service is not a code change; three separate decisions block it
+     * (issue #6037):
+     *
+     *  1. **Maker-checker.** `ledger.reverse` is approval-gated — a call from settlement-service's
+     *     service account lands in ledger's PENDING queue rather than posting. Granting a machine
+     *     that action is a `rules.yaml: shared_m2m_matrix_write_grants` decision, and an
+     *     *automatic* GL reversal driven by a failed saga is what maker-checker exists to prevent.
+     *  2. **No journal id is retained.** This method discards the `JournalResponse`, so the id
+     *     would have to be persisted (a migration) or re-resolved via
+     *     `GET /api/v1/journals/transaction/{transactionId}`.
+     *  3. **Period locks.** The endpoint answers 409 when the original entry's fiscal period is
+     *     ATTESTED, so a reversal is not always available; correcting forward in the open period is
+     *     the accounting convention, and that is a different posting.
+     *
+     * So a step added after this one needs an answer for the GL before it is added, not after.
+     */
     override fun bookToLedger(settlementId: UUID): Unit = runOnVertxContext {
         log.infof("Booking settlement %s to ledger", settlementId)
         ledgerPort.book(settlementId)
@@ -86,51 +108,6 @@ open class SettlementActivitiesImpl(
             operation = "settlement.reverse-credit",
             onSuccess = SettlementStatus.CREDITED_REVERSED,
         ) { reverseCreditPort.reverseCredit(settlementId) }
-    }
-
-    /**
-     * NOT IMPLEMENTED — fails loudly rather than reporting a reversal that did not happen.
-     *
-     * ledger-service does expose `POST /api/v1/journals/{journalId}/reverse`, but settlement-service
-     * cannot use it as things stand, for three independent reasons, each needing a decision this
-     * service cannot make on its own (issue #6037):
-     *
-     *  1. **Maker-checker.** `ledger.reverse` is an approval-gated action — a call from
-     *     settlement-service's service account lands in ledger's PENDING approval queue rather than
-     *     posting. Granting a machine that action is a `rules.yaml: shared_m2m_matrix_write_grants`
-     *     decision, not a code change, and an *automatic* GL reversal driven by a failed saga is
-     *     precisely the thing maker-checker exists to prevent.
-     *  2. **No journal id is retained.** `bookToLedger` discards the `JournalResponse`, so the id
-     *     would have to be persisted (a migration) or re-resolved via
-     *     `GET /api/v1/journals/transaction/{transactionId}`.
-     *  3. **Period locks.** The endpoint answers 409 when the original entry's fiscal period is
-     *     ATTESTED, so a reversal is not always available and the saga needs a defined behaviour
-     *     for that case — correcting forward in the open period is the accounting convention, which
-     *     is a different posting from a reversal.
-     *
-     * Throwing a **non-retryable** failure is deliberate: a retryable one would burn all five
-     * attempts (~75 s of backoff) delaying the two compensations that *do* work, and would still
-     * end in the same place. `SettlementWorkflowImpl` catches `ActivityFailure` per compensation and
-     * continues, so this failure does not block `reverseCredit`/`reverseDebit`.
-     *
-     * The status is recorded first, so the row says
-     * [SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED] — an operator sees *which* half of the unwind
-     * did not happen — rather than the old `LEDGER_REVERSED`, which claimed it had.
-     */
-    override fun reverseBookToLedger(settlementId: UUID): Unit = runOnVertxContext {
-        log.errorf(
-            "Ledger booking for settlement %s was NOT reversed: settlement-service cannot reverse a " +
-                "journal (ledger.reverse is maker-checker gated and no journal id is retained). " +
-                "The GL still carries this settlement's posting and needs a manual correcting entry.",
-            settlementId,
-        )
-        val settlement =
-            settlementRepository.updateStatus(settlementId, SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED)
-        audit("settlement.reverse-ledger-book", settlement, result = AuditResult.FAILURE)
-        throw ApplicationFailure.newNonRetryableFailure(
-            "Ledger reversal is not implemented for settlement $settlementId; GL correction required",
-            "LedgerReversalUnsupported",
-        )
     }
 
     /**

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementCompensationCapabilities.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementCompensationCapabilities.kt
@@ -33,13 +33,14 @@ class SettlementCompensationCapabilities {
     init {
         log.info(
             "Settlement compensation capabilities: reverseDebit=WIRED (balance-service credit), " +
-                "reverseCredit=WIRED (balance-service debit), reverseBookToLedger=NOT IMPLEMENTED.",
+                "reverseCredit=WIRED (balance-service debit).",
         )
-        log.warn(
-            "reverseBookToLedger cannot reverse a general-ledger posting: ledger.reverse is " +
-                "maker-checker gated and no journal id is retained. A settlement that fails after " +
-                "bookToLedger will unwind both balance movements but leave the GL entry standing, " +
-                "and will be marked LEDGER_REVERSAL_UNSUPPORTED for manual correction. See #6037.",
+        log.info(
+            "The general-ledger posting has NO compensation, and needs none: bookToLedger is the " +
+                "last forward step and writes the terminal BOOKED status, so no failure can occur " +
+                "after it. A step added after bookToLedger would change that — reversing a GL " +
+                "posting is blocked by maker-checker gating on ledger.reverse, by no journal id " +
+                "being retained, and by fiscal-period locks. See #6037 and #6410.",
         )
     }
 }

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementWorkflowImpl.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementWorkflowImpl.kt
@@ -37,16 +37,15 @@ class SettlementWorkflowImpl : SettlementWorkflow {
         Workflow.newActivityStub(SettlementActivities::class.java, activityOptions)
 
     /**
-     * One registered compensation, paired with the status its activity records when it fails.
+     * Compensations are recorded as plain lambdas: every one of them is a balance-service reversal,
+     * and every balance-service reversal records [SettlementStatus.REVERSAL_FAILED] when it is
+     * refused. The general-ledger posting has no compensation — `bookToLedger` is the last forward
+     * step, so nothing can fail after it (issue #6410).
      *
-     * The pairing is what lets [settle] report which half of the unwind is outstanding without
-     * reading the row back: `reverseDebit`/`reverseCredit` write
-     * [SettlementStatus.REVERSAL_FAILED] on a refusal (money moved and not returned), while
-     * `reverseBookToLedger` writes [SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED] (the GL posting
-     * still stands). Both are recorded by the activity itself, inside its own transaction.
+     * If a step is ever added AFTER `bookToLedger`, its compensation will not share that status,
+     * and the single `REVERSAL_FAILED` below stops being the right answer. That is the moment to
+     * pair each compensation with the status its activity records, not before.
      */
-    private data class Compensation(val onFailure: SettlementStatus, val run: () -> Unit)
-
     /**
      * Runs every registered compensation, and returns the status of the obligation left
      * outstanding — or `null` when the unwind was complete and the settlement may be rejected.
@@ -54,19 +53,16 @@ class SettlementWorkflowImpl : SettlementWorkflow {
      * Every compensation is attempted even after one fails, so a refused credit reversal does not
      * strand the debit reversal that would still have worked.
      */
-    private fun unwind(settlementId: UUID, compensations: Collection<Compensation>): SettlementStatus? {
+    private fun unwind(settlementId: UUID, compensations: Collection<() -> Unit>): SettlementStatus? {
         val log = Workflow.getLogger(SettlementWorkflowImpl::class.java)
         var outstanding: SettlementStatus? = null
-        compensations.forEach { compensation ->
+        compensations.forEach { compensate ->
             try {
-                compensation.run()
+                compensate()
             } catch (compEx: ActivityFailure) {
-                // A refused money reversal outranks an unsupported GL reversal: the first means
-                // customer funds are still moved, the second that the ledger owes a correcting
-                // entry. Report the worse of the two, whichever order they failed in.
-                if (outstanding != SettlementStatus.REVERSAL_FAILED) {
-                    outstanding = compensation.onFailure
-                }
+                // The activity has already recorded REVERSAL_FAILED for this settlement: the money
+                // moved and did not come back.
+                outstanding = SettlementStatus.REVERSAL_FAILED
                 log.error("Compensation failed for settlement $settlementId", compEx)
             }
         }
@@ -75,25 +71,19 @@ class SettlementWorkflowImpl : SettlementWorkflow {
 
     @Suppress("TooGenericExceptionCaught")
     override fun settle(settlementId: UUID): SettlementStatus {
-        val compensations = ArrayDeque<Compensation>()
+        val compensations = ArrayDeque<() -> Unit>()
 
         return try {
             activities.debitPayer(settlementId)
-            compensations.addFirst(
-                Compensation(SettlementStatus.REVERSAL_FAILED) { activities.reverseDebit(settlementId) },
-            )
+            compensations.addFirst { activities.reverseDebit(settlementId) }
 
             activities.creditPayee(settlementId)
-            compensations.addFirst(
-                Compensation(SettlementStatus.REVERSAL_FAILED) { activities.reverseCredit(settlementId) },
-            )
+            compensations.addFirst { activities.reverseCredit(settlementId) }
 
+            // bookToLedger registers no compensation: it is the last forward step and writes the
+            // terminal BOOKED status itself, so nothing can fail afterwards to trigger one. See
+            // SettlementActivitiesImpl.bookToLedger for what a step added after it would owe.
             activities.bookToLedger(settlementId)
-            compensations.addFirst(
-                Compensation(SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED) {
-                    activities.reverseBookToLedger(settlementId)
-                },
-            )
 
             SettlementStatus.BOOKED
         } catch (ex: ActivityFailure) {

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/domain/model/Settlement.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/domain/model/Settlement.kt
@@ -11,7 +11,7 @@ import java.util.UUID
 /**
  * Settlement saga states.
  *
- * The three compensation outcomes below are deliberately **four** values, not one (issue #6037).
+ * The compensation outcomes below are deliberately distinct values, not one (issue #6037).
  * Until this was fixed, `reverseDebit`/`reverseCredit`/`reverseBookToLedger` wrote
  * `REVERSED`/`CREDITED_REVERSED`/`LEDGER_REVERSED` and moved no money at all, so the one thing an
  * operator could observe — the status column — asserted an unwind that had not happened. That is
@@ -41,18 +41,12 @@ enum class SettlementStatus {
     REVERSAL_FAILED,
 
     /**
-     * The ledger booking was **not** reversed because settlement-service cannot reverse a journal
-     * (see `SettlementActivitiesImpl.reverseBookToLedger`). Distinct from [LEDGER_REVERSED], which
-     * is what the old stub wrote while doing nothing.
+     * Deprecated and **never written** since #6037. Retained because rows written before it still
+     * carry the value; the code path that produced it only ever updated this column and never
+     * reversed anything in the general ledger. Nothing reverses a GL posting today either — see
+     * `SettlementActivitiesImpl.bookToLedger` (#6410).
      */
-    LEDGER_REVERSAL_UNSUPPORTED,
-
-    /**
-     * Deprecated and **never written** since #6037. Retained so the value keeps its meaning for any
-     * consumer that pinned the old enum; the code path that produced it only ever updated this
-     * column and never reversed anything in the general ledger.
-     */
-    @Deprecated("Never produced; the stub that wrote it reversed nothing. See LEDGER_REVERSAL_UNSUPPORTED.")
+    @Deprecated("Never produced; the stub that wrote it reversed nothing. The GL is not reversed at all.")
     LEDGER_REVERSED,
 }
 

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGauge.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGauge.kt
@@ -61,16 +61,16 @@ import java.util.concurrent.atomic.AtomicLong
  * ### Which states are published
  *
  * Terminal states ([SettlementStatus.BOOKED], [SettlementStatus.REJECTED]) are not published:
- * their age only grows and would alert forever. Everything else is published, including all five
- * compensation outcomes — `SettlementWorkflowImpl` always calls `rejectSettlement` after
- * compensating, so a row parked in `REVERSED` / `CREDITED_REVERSED` / `LEDGER_REVERSED` /
- * `REVERSAL_FAILED` / `LEDGER_REVERSAL_UNSUPPORTED` means the unwinding ran (or refused) and the
- * record never reached its terminal state.
+ * their age only grows and would alert forever. Everything else is published, including every
+ * compensation outcome — `SettlementWorkflowImpl` calls `rejectSettlement` only when the unwind
+ * completed, so a row parked in `REVERSED` / `CREDITED_REVERSED` / `LEDGER_REVERSED` means the
+ * unwinding ran and the record never reached its terminal state, and one parked in
+ * `REVERSAL_FAILED` means a reversal was refused and the money is still moved (#6286).
  *
  * The set is DERIVED from [SettlementStatus] rather than listed, because it was listed once and
- * went stale: #6037 split the compensation outcomes into their own values and `REVERSAL_FAILED` /
- * `LEDGER_REVERSAL_UNSUPPORTED` were left unpublished, so the two states that mean *the money did
- * not come back* were the only two the stranded-settlement rules could never see.
+ * went stale: #6037 split the compensation outcomes into their own values and `REVERSAL_FAILED`
+ * was left unpublished, so the one state that means *the money did not come back* was the one the
+ * stranded-settlement rules could never see.
  *
  * ### t=0 on a cold pod
  *

--- a/openbank-settlement-service/src/main/resources/opa/settlement_activity.rego
+++ b/openbank-settlement-service/src/main/resources/opa/settlement_activity.rego
@@ -10,7 +10,6 @@ allowed_activities := {
     "bookToLedger",
     "reverseDebit",
     "reverseCredit",
-    "reverseBookToLedger",
     "rejectSettlement",
 }
 

--- a/openbank-settlement-service/src/main/resources/openapi.yaml
+++ b/openbank-settlement-service/src/main/resources/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.3"
 info:
   title: OpenBank Settlement Service
-  version: "1.3.0"
+  version: "1.4.0"
   description: "Settlement orchestration service (ADR-0101 P3)"
 paths:
   /api/v1/settlements:
@@ -57,10 +57,11 @@ components:
             Settlement saga state. The compensation outcomes are distinct values on purpose
             (issue #6037): REVERSED and CREDITED_REVERSED mean balance-service accepted the
             counter-movement and the money is back; REVERSAL_FAILED means a reversal was attempted
-            and refused (typically the payee has spent the funds) and the money is still moved;
-            LEDGER_REVERSAL_UNSUPPORTED means the general-ledger posting was not reversed and needs
-            a manual correcting entry. LEDGER_REVERSED is deprecated and is no longer produced —
-            the code path that wrote it updated this column without reversing anything.
+            and refused (typically the payee has spent the funds) and the money is still moved.
+            The general-ledger posting has no reversal state because it is never reversed: booking
+            to the ledger is the last step of the saga, so nothing can fail after it (issue #6410).
+            LEDGER_REVERSED is deprecated and is no longer produced — the code path that wrote it
+            updated this column without reversing anything.
             REJECTED means the saga unwound COMPLETELY: it is written only when every compensation
             succeeded (issue #6286). A settlement whose compensation was refused stays in
             REVERSAL_FAILED and is never rejected, so REJECTED never has to be read as "possibly
@@ -74,7 +75,6 @@ components:
             - REVERSED
             - CREDITED_REVERSED
             - REVERSAL_FAILED
-            - LEDGER_REVERSAL_UNSUPPORTED
             - LEDGER_REVERSED
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceOriginateTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceOriginateTest.kt
@@ -119,7 +119,6 @@ class SettlementServiceOriginateTest {
         override fun bookToLedger(settlementId: UUID) = Unit
         override fun reverseDebit(settlementId: UUID) = Unit
         override fun reverseCredit(settlementId: UUID) = Unit
-        override fun reverseBookToLedger(settlementId: UUID) = Unit
         override fun rejectSettlement(settlementId: UUID) = Unit
     }
 }

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceTemporalSettleTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceTemporalSettleTest.kt
@@ -104,7 +104,6 @@ class SettlementServiceTemporalSettleTest {
         override fun bookToLedger(settlementId: UUID) = Unit
         override fun reverseDebit(settlementId: UUID) = Unit
         override fun reverseCredit(settlementId: UUID) = Unit
-        override fun reverseBookToLedger(settlementId: UUID) = Unit
         override fun rejectSettlement(settlementId: UUID) = Unit
     }
 }

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImplTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImplTest.kt
@@ -19,7 +19,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.coVerifyOrder
 import io.mockk.mockk
-import io.temporal.failure.ApplicationFailure
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -169,38 +168,6 @@ class SettlementActivitiesImplTest {
             assertThat(e.result).isEqualTo(AuditResult.FAILURE)
             assertThat(e.payload["status"]).isEqualTo("REVERSAL_FAILED")
         })
-    }
-
-    @Test
-    fun `reverseBookToLedger fails loudly as unsupported instead of claiming a reversal`() {
-        val id = UUID.randomUUID()
-        val events = mutableListOf<AuditEvent>()
-        coEvery { auditPublisher.publish(capture(events)) } returns Unit
-
-        assertThatThrownBy { activities.reverseBookToLedger(id) }
-            .isInstanceOf(ApplicationFailure::class.java)
-            .hasMessageContaining("Ledger reversal is not implemented")
-
-        coVerify(exactly = 0) { ledgerPort.book(any()) }
-        // Its own value, never the old LEDGER_REVERSED, which asserted an unwind that never ran.
-        coVerify { settlementRepository.updateStatus(id, SettlementStatus.LEDGER_REVERSAL_UNSUPPORTED) }
-        @Suppress("DEPRECATION")
-        coVerify(exactly = 0) { settlementRepository.updateStatus(id, SettlementStatus.LEDGER_REVERSED) }
-        assertThat(events).singleElement().satisfies({ e ->
-            assertThat(e.result).isEqualTo(AuditResult.FAILURE)
-        })
-    }
-
-    @Test
-    fun `the unsupported ledger reversal is NON-retryable so it cannot delay the balance unwinds`() {
-        // SettlementWorkflowImpl runs compensations LIFO and catches ActivityFailure per step, so a
-        // retryable failure here would burn five attempts of backoff before reverseCredit and
-        // reverseDebit — the two that actually return money — even got to run.
-        assertThatThrownBy { activities.reverseBookToLedger(UUID.randomUUID()) }
-            .isInstanceOfSatisfying(ApplicationFailure::class.java) { failure ->
-                assertThat(failure.isNonRetryable).isTrue()
-                assertThat(failure.type).isEqualTo("LedgerReversalUnsupported")
-            }
     }
 
     @Test

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementWorkflowImplTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementWorkflowImplTest.kt
@@ -66,7 +66,6 @@ class SettlementWorkflowImplTest {
         assertThat(calls.bookToLedger.get()).isEqualTo(1)
         assertThat(calls.reverseDebit.get()).isZero()
         assertThat(calls.reverseCredit.get()).isZero()
-        assertThat(calls.reverseBookToLedger.get()).isZero()
         assertThat(calls.rejectSettlement.get()).isZero()
     }
 
@@ -85,7 +84,6 @@ class SettlementWorkflowImplTest {
         // Both prior steps get compensated (most-recent-first), booking itself is not reversed.
         assertThat(calls.reverseCredit.get()).isEqualTo(1)
         assertThat(calls.reverseDebit.get()).isEqualTo(1)
-        assertThat(calls.reverseBookToLedger.get()).isZero()
         assertThat(calls.rejectSettlement.get()).isEqualTo(1)
         assertThat(calls.order).containsExactly(
             "debitPayer",
@@ -127,7 +125,6 @@ class SettlementWorkflowImplTest {
         assertThat(calls.creditPayee.get()).isZero()
         assertThat(calls.reverseDebit.get()).isZero()
         assertThat(calls.reverseCredit.get()).isZero()
-        assertThat(calls.reverseBookToLedger.get()).isZero()
         assertThat(calls.rejectSettlement.get()).isEqualTo(1)
     }
 
@@ -177,29 +174,27 @@ class SettlementWorkflowImplTest {
     }
 
     /**
-     * `reverseBookToLedger` is currently UNREACHABLE, and this test exists to say so out loud.
+     * The saga shape that makes the ledger posting compensation-free, asserted rather than assumed.
      *
-     * Its compensation is registered only after `bookToLedger` returns, and `bookToLedger` is the
-     * last forward step — so nothing can fail afterwards to trigger the unwind. The activity, its
-     * LEDGER_REVERSAL_UNSUPPORTED status, and the `SettlementStuckAfterCompensation` coverage of
-     * that status are all dead until the saga gains a step after the ledger booking.
-     *
-     * The workflow still pairs that compensation with its status (see `Compensation`), so the day
-     * a step IS added the reporting is already correct rather than silently reporting the wrong
-     * half. If this test ever fails, the saga grew a step and the pairing became live — which is
-     * the moment to add the reachable-path assertions.
+     * `bookToLedger` is the last forward step and writes the terminal BOOKED status itself, so no
+     * failure can occur after it. That is why #6410 could delete `reverseBookToLedger`, its
+     * LEDGER_REVERSAL_UNSUPPORTED status and that status's alert coverage — all three were
+     * unreachable. If a step is ever added after the ledger booking, this test goes red, which is
+     * the signal to answer the GL question (see `SettlementActivitiesImpl.bookToLedger`) before
+     * the new step ships.
      */
     @Test
-    fun `the ledger compensation is unreachable in the current saga shape`() {
-        val calls = RecordingActivities(failBookToLedger = true, failReverseBookToLedger = true)
+    fun `booking to the ledger is the last forward step, so it registers no compensation`() {
+        val calls = RecordingActivities()
         worker.registerActivitiesImplementations(calls)
         env.start()
 
-        newWorkflow().settle(UUID.randomUUID())
+        val result = newWorkflow().settle(UUID.randomUUID())
 
-        assertThat(calls.reverseBookToLedger.get())
-            .describedAs("bookToLedger is the last forward step, so its compensation can never run")
-            .isZero()
+        assertThat(result).isEqualTo(SettlementStatus.BOOKED)
+        assertThat(calls.order)
+            .describedAs("nothing may run after bookToLedger, or the GL posting needs a compensation")
+            .endsWith("bookToLedger")
     }
 
     /** A clean unwind still reaches its terminal state — REJECTED must stay reachable. */
@@ -221,14 +216,12 @@ class SettlementWorkflowImplTest {
         private val failCreditPayee: Boolean = false,
         private val failBookToLedger: Boolean = false,
         private val failReverseCredit: Boolean = false,
-        private val failReverseBookToLedger: Boolean = false,
     ) : SettlementActivities {
         val debitPayer = AtomicInteger(0)
         val creditPayee = AtomicInteger(0)
         val bookToLedger = AtomicInteger(0)
         val reverseDebit = AtomicInteger(0)
         val reverseCredit = AtomicInteger(0)
-        val reverseBookToLedger = AtomicInteger(0)
         val rejectSettlement = AtomicInteger(0)
         val order = mutableListOf<String>()
 
@@ -259,17 +252,6 @@ class SettlementWorkflowImplTest {
             order += "reverseCredit"
             reverseCredit.incrementAndGet()
             if (failReverseCredit) throw ApplicationFailure.newNonRetryableFailure("balance down", "BalanceError")
-        }
-
-        override fun reverseBookToLedger(settlementId: UUID) {
-            order += "reverseBookToLedger"
-            reverseBookToLedger.incrementAndGet()
-            if (failReverseBookToLedger) {
-                throw ApplicationFailure.newNonRetryableFailure(
-                    "ledger reversal unsupported",
-                    "LedgerReversalUnsupported",
-                )
-            }
         }
 
         override fun rejectSettlement(settlementId: UUID) {

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGaugeTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/observability/SettlementStrandedGaugeTest.kt
@@ -124,10 +124,9 @@ class SettlementStrandedGaugeTest {
             "REVERSED",
             "CREDITED_REVERSED",
             "LEDGER_REVERSED",
-            // #6037's two new outcomes. REVERSAL_FAILED is the one that matters: the money moved
-            // and did NOT come back, and it was the only money-path state with no age series.
+            // #6037's outcome that matters: the money moved and did NOT come back, and it was the
+            // only money-path state with no age series.
             "REVERSAL_FAILED",
-            "LEDGER_REVERSAL_UNSUPPORTED",
         )
         assertThat(published).doesNotContain("BOOKED", "REJECTED")
         // The published set must be exactly "every status minus the two terminal ones", derived

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/integration/SettlementReversalIT.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/integration/SettlementReversalIT.kt
@@ -9,7 +9,6 @@ import com.openbank.settlement.it.BalanceServiceWireMockResource
 import com.openbank.settlement.it.PostgresTestResource
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
-import io.temporal.failure.ApplicationFailure
 import jakarta.inject.Inject
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -208,30 +207,5 @@ class SettlementReversalIT {
         assertThat(readStatus(id))
             .`as`("money is still with the payee, so the row must not say CREDITED_REVERSED")
             .isEqualTo("REVERSAL_FAILED")
-    }
-
-    @Test
-    fun `reverseBookToLedger fails loudly and marks the GL entry as needing manual correction`() {
-        val (id, _, _) = seedSettlement("BOOKED")
-
-        // The failure reaches the caller unwrapped through the Vert.x-context bridge, so Temporal
-        // sees the ApplicationFailure itself and honours its non-retryable flag.
-        assertThatThrownBy { activities.reverseBookToLedger(id) }
-            .isInstanceOfSatisfying(ApplicationFailure::class.java) { failure ->
-                assertThat(failure.isNonRetryable).isTrue()
-                assertThat(failure.type).isEqualTo("LedgerReversalUnsupported")
-            }
-
-        assertThat(readStatus(id)).isEqualTo("LEDGER_REVERSAL_UNSUPPORTED")
-        // It must not silently pretend to have reversed anything, and it must not call balance.
-        assertThat(
-            BalanceServiceWireMockResource.server.findAll(
-                com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor(
-                    com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching(
-                        "/api/v1/balances/.*",
-                    ),
-                ),
-            ),
-        ).isEmpty()
     }
 }


### PR DESCRIPTION
Closes #6410.

## What was dead

`reverseBookToLedger` could never run. Its compensation is registered only after `bookToLedger` returns, and `bookToLedger` is the **last** forward step — it writes the terminal `BOOKED` status itself, so nothing can fail afterwards to trigger an unwind that includes it.

Checked against the whole history of `SettlementWorkflowImpl`, not just today's revision: **no step has ever followed the ledger booking**. So `LEDGER_REVERSAL_UNSUPPORTED` has never been written by any path, and no row in any environment can carry it — which is what makes deleting the status safe rather than a migration question.

Removed with it: the activity and its non-retryable `LedgerReversalUnsupported` failure, the status, its entry in the `SettlementStuckAfterCompensation` regex, its share of `SettlementStrandedGauge`'s published series, the `openapi.yaml` enum value, the boot announcement in `SettlementCompensationCapabilities`, and the `settlement_activity.rego` allow-list entry.

The alert entry is the one worth calling out: a rule matching a status nothing writes reads as coverage and is not. Same shape as the defect #6284 fixed, one step further along.

## What was kept, and moved rather than deleted

The three reasons a GL posting cannot be reversed from this service — `ledger.reverse` is maker-checker gated, no journal id is retained, fiscal periods lock — are not obsolete. They are what the **next** step after `bookToLedger` will owe. They now live in the KDoc of `bookToLedger` itself, phrased as a constraint on future work, and `SettlementCompensationCapabilities` announces at boot that the posting has no compensation and why, so the constraint appears in a pod log rather than only in a threat model.

`LEDGER_REVERSED` stays. It is deprecated and never written since #6037, but rows written *before* it still carry the value — unlike `LEDGER_REVERSAL_UNSUPPORTED`, which no row can.

## The shape is now asserted, not assumed

```kotlin
assertThat(calls.order)
    .describedAs("nothing may run after bookToLedger, or the GL posting needs a compensation")
    .endsWith("bookToLedger")
```

`SettlementWorkflowImplTest > booking to the ledger is the last forward step, so it registers no compensation` replaces the "this is unreachable" test added in #6369. Adding a step after the ledger booking turns it red, which is the moment to answer the GL question before the new step ships — rather than discovering it afterwards.

The `Compensation(onFailure, run)` pairing from #6369 goes with the second status: every remaining compensation records `REVERSAL_FAILED`, so the pairing was carrying one value. The comment where it stood says exactly when to bring it back.

## Verification

- `./gradlew :openbank-settlement-service:test :openbank-settlement-service:ktlintCheck :openbank-settlement-service:detekt` — **BUILD SUCCESSFUL**.
- `promtool check rules` — settlement group still 3 rules, `SettlementStuckAfterCompensation` regex now `REVERSED|CREDITED_REVERSED|LEDGER_REVERSED`.
- `run-gates.py --group api` — `api-contract gate: openbank-settlement-service: additive change, info.version 1.3.0 -> 1.4.0 — OK (required >= MINOR)`. Measured beforehand that the enum removal is **not** breaking (`oasdiff breaking` returns `[]` — response enums), so the #2313 trap where a MAJOR is demanded but D2 forbids it does not apply here.
- `run-gates.py --group lint --group registry --group data --group gitops` — 104/109 pass. The 4 failures (`regen-derived-inventory`, `litellm-config-revision`, `db-migration-gate`, `schema-compat-gate`) reproduce **identically on a clean `origin/main` worktree**, so they are local-environment noise (no `PR_DIFF_BASE`), not this change. Control run included rather than assumed.

## Note on scope

#6410 offered two honest resolutions: delete the dead path, or give the saga the step that makes it live. I took the first. The second means deciding that settlement should *do* something after booking to the ledger — publish an outcome event, confirm with a counterparty — which is product scope, not cleanup, and the service has no outbox or outcome event today. If that step is wanted, this PR leaves the constraint documented exactly where it will be read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
