### PR TITLE
fix(ci): register the case-collaboration generator, unblocking main

### DIFF
--- a/.github/scripts/regen-derived.sh
+++ b/.github/scripts/regen-derived.sh
@@ -62,6 +62,7 @@ GENERATORS=(
   "agents-opa-data|python3 .github/scripts/gen-agents-opa-data.py|openbank-libs/governance/agents.yaml"
   "eu-ai-act|python3 .github/scripts/gen-eu-ai-act.py|openbank-libs/governance/agents.yaml"
   "ai-governance-snapshot|python3 .github/scripts/gen-ai-governance-snapshot.py|openbank-libs/governance/agents.yaml prompts/registry.yaml"
+  "case-collaboration-opa-data|python3 .github/scripts/gen-case-collaboration-opa-data.py|openbank-libs/governance/agents.yaml openbank-libs/governance/rules.yaml"
   "adr-index|bash docs/adr/gen-index.sh|docs/adr/"
   "bundles|__BUNDLES__|openbank-libs/governance/rules.yaml openbank-libs/governance/agents.yaml .rego"
 )


### PR DESCRIPTION
## What

`gates (lint)` is **failing on `origin/main`**, so every open PR inherits a red shard it did not
cause. Seen today on **#6477** and **#6478** — two unrelated diffs failing the identical gate, which
is the signature of a main-side problem rather than a branch defect.

Reproduced on a clean detached worktree of `origin/main`, running `regen-derived.sh --selftest`:

```
-> exit 1
[FAIL] generator not named in GENERATORS, so it would never run:
       .github/scripts/gen-case-collaboration-opa-data.py
SELF-TEST FAILED: 1 problem(s).
```

## Cause

`gen-case-collaboration-opa-data.py` arrived with **#6434** and was never added to `GENERATORS` in
`regen-derived.sh`. So the regeneration driver would not run it, and its derived output would drift
from its sources with nothing to notice.

That is precisely what the inventory self-test exists to prevent, and it caught it. The gate is not
at fault — the registration is what was missing.

## The declared inputs match what the script reads

The generator reads `openbank-libs/governance/agents.yaml` (agent ids and `case_capabilities`) and
`openbank-libs/governance/rules.yaml` (`agent_case_capability_matrix`), so both are declared as its
triggers. Getting this wrong in the other direction would be worse than the current state: a
generator registered with the wrong inputs runs on the wrong changes and stays stale on the right
ones, while still reporting as inventoried.

## Falsified both ways

On a clean checkout, changing nothing else:

| state | exit | output |
|---|---|---|
| without the entry | **1** | `[FAIL] generator not named in GENERATORS ... gen-case-collaboration-opa-data.py` |
| with the entry | **0** | `SELF-TEST OK: inventory complete both ways` |

`SUBJECTS=49` in both runs — the inventory reaches the same corpus either way, so the difference is
the finding and not a change in scope.

## Scope

One line. No generator behaviour changes; this makes an existing one reachable.

Refs #6434
