### PR TITLE
fix(ci): inventory gen-case-collaboration-opa-data.py in regen-derived.sh

### DIFF
--- a/.github/scripts/regen-derived.sh
+++ b/.github/scripts/regen-derived.sh
@@ -62,6 +62,7 @@ GENERATORS=(
   "agents-opa-data|python3 .github/scripts/gen-agents-opa-data.py|openbank-libs/governance/agents.yaml"
   "eu-ai-act|python3 .github/scripts/gen-eu-ai-act.py|openbank-libs/governance/agents.yaml"
   "ai-governance-snapshot|python3 .github/scripts/gen-ai-governance-snapshot.py|openbank-libs/governance/agents.yaml prompts/registry.yaml"
+  "case-collaboration-opa-data|python3 .github/scripts/gen-case-collaboration-opa-data.py|openbank-libs/governance/agents.yaml openbank-libs/governance/rules.yaml"
   "adr-index|bash docs/adr/gen-index.sh|docs/adr/"
   "bundles|__BUNDLES__|openbank-libs/governance/rules.yaml openbank-libs/governance/agents.yaml .rego"
 )


### PR DESCRIPTION
## Main is red, and it is the new gate working

`gen-case-collaboration-opa-data.py` (ADR-0271) landed on main while #6469 was in flight, so `regen-derived.sh`'s inventory does not name it:

```
[FAIL] generator not named in GENERATORS, so it would never run:
       .github/scripts/gen-case-collaboration-opa-data.py
SELF-TEST FAILED: 1 problem(s).
```

That is precisely the case the gate exists for — a generator that exists and is not inventoried would never be run by the single entrypoint, which is how #3771 red-gated main in the first place. It caught it within hours of merging, on the first generator added after it landed.

## The fix

The generator reads `agents.yaml` + `rules.yaml` and writes `case-collaboration-opa-data.yaml`, which `case_collaboration.rego` consumes. So it is a derived-**data** step and must run *before* the bundle expansion — placed next to the other two `*-opa-data` generators.

## Verification

- `regen-derived.sh --selftest` — green, both directions, `SUBJECTS=49`.
- `regen-derived.sh --all` — the working tree is byte-identical afterwards apart from this one-line edit, so the added step is idempotent and its position in the order is right.
- `run-gates.py --only regen-derived-inventory --only shellcheck --only gate-subject-floor` — all pass.

Refs #3771

🤖 Generated with [Claude Code](https://claude.com/claude-code)
