### PR TITLE
fix(ci): inventory gen-case-collaboration-opa-data.py so regen-derived runs it (main is red)

### DIFF
--- a/.github/scripts/regen-derived.sh
+++ b/.github/scripts/regen-derived.sh
@@ -60,6 +60,7 @@ esac
 GENERATORS=(
   "rules-opa-data|python3 .github/scripts/gen-rules-opa-data.py|openbank-libs/governance/rules.yaml"
   "agents-opa-data|python3 .github/scripts/gen-agents-opa-data.py|openbank-libs/governance/agents.yaml"
+  "case-collaboration-opa-data|python3 .github/scripts/gen-case-collaboration-opa-data.py|openbank-libs/governance/agents.yaml openbank-libs/governance/rules.yaml"
   "eu-ai-act|python3 .github/scripts/gen-eu-ai-act.py|openbank-libs/governance/agents.yaml"
   "ai-governance-snapshot|python3 .github/scripts/gen-ai-governance-snapshot.py|openbank-libs/governance/agents.yaml prompts/registry.yaml"
   "adr-index|bash docs/adr/gen-index.sh|docs/adr/"


### PR DESCRIPTION
## main is red, and not because of anything in flight

Every PR's `gates (lint)` shard is failing on:

```
[FAIL] generator not named in GENERATORS, so it would never run:
       .github/scripts/gen-case-collaboration-opa-data.py
```

Reproduced on a **clean detached `origin/main` worktree**, so this is main's state, not a branch's — it blocks every open PR that runs the lint shard. Found while triaging a red check on #6484, which turned out to be inheriting it.

#6434 added the generator and its committed output, but not the entry in `regen-derived.sh`'s `GENERATORS` inventory. That is precisely the failure mode the inventory self-test exists to catch: a generator nothing invokes, whose output goes stale the first time `agents.yaml` or `rules.yaml` moves — discovered later as a drift gate failing on content nobody wrote.

## The fix

One inventory line:

```bash
"case-collaboration-opa-data|python3 .github/scripts/gen-case-collaboration-opa-data.py|openbank-libs/governance/agents.yaml openbank-libs/governance/rules.yaml"
```

Sources are the two the generator actually reads (ADR-0271: agent ids + `case_capabilities` from `agents.yaml`, `agent_case_capability_matrix` from `rules.yaml`), so a change to either re-runs it. Placed **before** `bundles`, because it writes a derived data file the bundle scripts embed — the ordering the script's own header calls out as non-cosmetic.

## Verified by effect

Not just "the self-test is green now":

```
regen-derived.sh --selftest  →  SELF-TEST OK: inventory complete both ways  (49 subjects; was "1 problem")
regen-derived.sh --all       →  run   case-collaboration-opa-data
                                wrote openbank-libs/governance/case-collaboration-opa-data.yaml
                                      (453 bytes; 408 decisions identical)
```

The generator now actually runs through the entrypoint, and its regenerated output is **byte-identical** to what is committed (`git status` clean apart from my one-line edit). So this is the inventory gap alone — no derived artefact had gone stale yet. Negative control: the gate fails without this line, on clean `origin/main`.

Refs #6434

🤖 Generated with [Claude Code](https://claude.com/claude-code)
