### PR TITLE
docs(tpp-registry): stop claiming lifecycle transitions no code implements

### DIFF
--- a/openbank-tpp-registry-service/src/main/resources/diagrams/03-tpp-lifecycle.mmd
+++ b/openbank-tpp-registry-service/src/main/resources/diagrams/03-tpp-lifecycle.mmd
@@ -1,9 +1,23 @@
 %% title: TPP Lifecycle
+%%
+%% The first block is implemented. Every edge labelled PLANNED has no code path today (#6489):
+%% nothing writes SUSPENDED or REVOKED, and the EBA register sync is a stub that reports
+%% "EBA sync not yet implemented — manual registration only" rather than syncing.
+%% checkAuthorization denies every status that is not ACTIVE, so the check is already correct
+%% for all four states — what is missing is a way to reach two of them.
 stateDiagram-v2
-    [*] --> ACTIVE : EBA sync — new TPP\nor manual registration
-    ACTIVE --> ACTIVE : EBA sync update\n(roles/certs refreshed)
-    ACTIVE --> SUSPENDED : NCA suspension\nor cert expired
+    [*] --> ACTIVE : manual registration\n(POST /api/v1/tpp-registry)
     ACTIVE --> BLACKLISTED : fraud / regulatory action\n(blacklisted_at set)
-    SUSPENDED --> ACTIVE : NCA reinstatement
-    SUSPENDED --> BLACKLISTED : escalation
     BLACKLISTED --> [*] : permanent — cannot be reactivated
+
+    [*] --> ACTIVE : PLANNED — EBA sync, new TPP
+    ACTIVE --> ACTIVE : PLANNED — EBA sync update\n(roles/certs refreshed)
+    ACTIVE --> SUSPENDED : PLANNED — NCA suspension\nor cert expired
+    SUSPENDED --> ACTIVE : PLANNED — NCA reinstatement
+    SUSPENDED --> BLACKLISTED : PLANNED — escalation
+
+    note right of SUSPENDED
+        No writer today (#6489).
+        A withdrawn authorisation is
+        currently recorded as BLACKLISTED.
+    end note

--- a/openbank-tpp-registry-service/src/main/resources/docs/02-architecture.cs.md
+++ b/openbank-tpp-registry-service/src/main/resources/docs/02-architecture.cs.md
@@ -35,7 +35,7 @@ Služba dodržuje hexagonální architekturu OpenBank (ADR-0002): doména bez fr
 
 - `TppEntry` — agregát (id, tppId, name, countryCode, nca, roles, status, Subject DN + expirace QWAC/QSeal, časová razítka, pole blacklistu).
 - enum `TppRole` — `AISP`, `PISP`, `PIISP`, `ASPSP`.
-- enum `TppStatus` — `ACTIVE`, `SUSPENDED`, `REVOKED`, `BLACKLISTED`.
+- enum `TppStatus` — `ACTIVE`, `SUSPENDED`, `REVOKED`, `BLACKLISTED`. Zapisují se pouze `ACTIVE` (registrace) a `BLACKLISTED` (blacklist API); zbylé dva dnes nemají zapisovatele (#6489). `checkAuthorization` odmítá každý stav jiný než `ACTIVE`, takže kontrola je správná pro všechny čtyři.
 - `TppAuthorizationResult` — read model vracený kontrolou autorizace.
 - `EbaRegisterSyncState` — value object evidence syncu.
 

--- a/openbank-tpp-registry-service/src/main/resources/docs/02-architecture.en.md
+++ b/openbank-tpp-registry-service/src/main/resources/docs/02-architecture.en.md
@@ -35,7 +35,7 @@ Pure Kotlin, no framework imports:
 
 - `TppEntry` — the aggregate (id, tppId, name, countryCode, nca, roles, status, QWAC/QSeal Subject DN + expiry, timestamps, blacklist fields).
 - `TppRole` enum — `AISP`, `PISP`, `PIISP`, `ASPSP`.
-- `TppStatus` enum — `ACTIVE`, `SUSPENDED`, `REVOKED`, `BLACKLISTED`.
+- `TppStatus` enum — `ACTIVE`, `SUSPENDED`, `REVOKED`, `BLACKLISTED`. Only `ACTIVE` (register) and `BLACKLISTED` (blacklist API) are written; the other two have no writer today (#6489). `checkAuthorization` denies every status that is not `ACTIVE`, so the check is already correct for all four.
 - `TppAuthorizationResult` — the read model returned by the authorization check.
 - `EbaRegisterSyncState` — sync bookkeeping value object.
 

--- a/openbank-tpp-registry-service/src/main/resources/docs/04-data.cs.md
+++ b/openbank-tpp-registry-service/src/main/resources/docs/04-data.cs.md
@@ -18,7 +18,7 @@
 | `country_code` | CHAR(2) NOT NULL | ISO 3166-1 alpha-2 |
 | `nca` | VARCHAR(20) NOT NULL | národní příslušný orgán (`CNB`, `BaFin`, …) |
 | `roles` | VARCHAR(100) NOT NULL | čárkou spojená množina `TppRole` (`AISP,PISP`) |
-| `status` | VARCHAR(20) NOT NULL DEFAULT `ACTIVE` | ACTIVE / SUSPENDED / REVOKED / BLACKLISTED |
+| `status` | VARCHAR(20) NOT NULL DEFAULT `ACTIVE` | doména sloupce: ACTIVE / SUSPENDED / REVOKED / BLACKLISTED. Zapisují se pouze ACTIVE a BLACKLISTED (#6489) |
 | `qwac_subject_dn` | TEXT | Subject DN eIDAS QWAC certifikátu |
 | `qseal_subject_dn` | TEXT | Subject DN eIDAS QSeal certifikátu |
 | `qwac_expires_at` | DATE | expirace QWAC (kontrolováno při autorizaci) |
@@ -93,7 +93,7 @@ Tři sandbox/test TPP jsou vloženy pro local/dev: `CZ-CNB-SANDBOX-001` (AISP,PI
 
 ## Retence
 
-`governance.yaml: retentionPolicy: 5 years`. Záznamy registrace a blacklistu TPP se uchovávají **5 let**, v souladu s PSD2 / povinnostmi vedení záznamů pro důkaz autorizace. Záznamy se při deautorizaci tvrdě nemažou — přechody stavu na `REVOKED`/`BLACKLISTED` zachovávají auditní historii.
+`governance.yaml: retentionPolicy: 5 years`. Záznamy registrace a blacklistu TPP se uchovávají **5 let**, v souladu s PSD2 / povinnostmi vedení záznamů pro důkaz autorizace. Záznamy se při deautorizaci tvrdě nemažou — přechod stavu na `BLACKLISTED` zachovává auditní historii. (`REVOKED` a `SUSPENDED` jsou v enumu deklarovány, ale dnes je nic nezapisuje — viz #6489.)
 
 ## Datová lineage
 

--- a/openbank-tpp-registry-service/src/main/resources/docs/04-data.en.md
+++ b/openbank-tpp-registry-service/src/main/resources/docs/04-data.en.md
@@ -18,7 +18,7 @@
 | `country_code` | CHAR(2) NOT NULL | ISO 3166-1 alpha-2 |
 | `nca` | VARCHAR(20) NOT NULL | National Competent Authority (`CNB`, `BaFin`, …) |
 | `roles` | VARCHAR(100) NOT NULL | comma-joined `TppRole` set (`AISP,PISP`) |
-| `status` | VARCHAR(20) NOT NULL DEFAULT `ACTIVE` | ACTIVE / SUSPENDED / REVOKED / BLACKLISTED |
+| `status` | VARCHAR(20) NOT NULL DEFAULT `ACTIVE` | column domain: ACTIVE / SUSPENDED / REVOKED / BLACKLISTED. Only ACTIVE and BLACKLISTED are ever written (#6489) |
 | `qwac_subject_dn` | TEXT | eIDAS QWAC certificate Subject DN |
 | `qseal_subject_dn` | TEXT | eIDAS QSeal certificate Subject DN |
 | `qwac_expires_at` | DATE | QWAC expiry (checked in authorization) |
@@ -93,7 +93,7 @@ No customer PII (no party-id, IBAN, name of a natural person) is stored here. Th
 
 ## Retention
 
-`governance.yaml: retentionPolicy: 5 years`. TPP registration and blacklist records are retained for **5 years**, aligning with PSD2 / record-keeping obligations for authorisation evidence. Entries are not hard-deleted on de-authorisation — status transitions to `REVOKED`/`BLACKLISTED` preserve the audit history.
+`governance.yaml: retentionPolicy: 5 years`. TPP registration and blacklist records are retained for **5 years**, aligning with PSD2 / record-keeping obligations for authorisation evidence. Entries are not hard-deleted on de-authorisation — the status transition to `BLACKLISTED` preserves the audit history. (`REVOKED` and `SUSPENDED` are declared in the enum but written by nothing today — see #6489.)
 
 ## Data lineage
 

--- a/openbank-tpp-registry-service/src/main/resources/docs/06-compliance.cs.md
+++ b/openbank-tpp-registry-service/src/main/resources/docs/06-compliance.cs.md
@@ -11,7 +11,7 @@
 | **GDPR** | Registr drží data právnických osob (TPP), ne zákaznické PII | `dataClassification: internal`; žádné party-id/IBAN/data fyzické osoby |
 | **DORA** (Reg. (EU) 2022/2554) | Provozní odolnost control-plane služby | health probes, fault tolerance, OTel, runbooky, BuildInfo |
 | **NIS2** | Síťová a informační bezpečnost | mTLS v clusteru, bezpečnostní hlavičky, OPA authz, audit přes outbox (čeká) |
-| **AMLD** (nepřímo) | Screening onboardingu TPP / blacklist jako kontrola | blacklist API; lifecycle stavu ACTIVE→REVOKED/BLACKLISTED |
+| **AMLD** (nepřímo) | Screening onboardingu TPP / blacklist jako kontrola | blacklist API (`ACTIVE→BLACKLISTED`); `checkAuthorization` odmítá jakýkoli stav jiný než ACTIVE |
 | **Autorizační registr CNB** | Pohled národního příslušného orgánu | `nca` + `tpp_id` klíčovány na identifikátor CNB/EBA |
 
 ## PSD2 — autorizační brána
@@ -52,7 +52,7 @@ Obecně **nepoužitelná** na firemní data registru. Jediné pole, které by mo
 Žádná data neopouštějí region EU/EHP.
 
 ### Retence (čl. 5(1)(e))
-`governance.yaml: retentionPolicy: 5 years`. Záznamy registrace a blacklistu uchovávány 5 let; deautorizace je přechod stavu (`REVOKED`/`BLACKLISTED`), ne tvrdé smazání, čímž zachovává autorizační auditní stopu.
+`governance.yaml: retentionPolicy: 5 years`. Záznamy registrace a blacklistu uchovávány 5 let; deautorizace je přechod stavu (`BLACKLISTED`), ne tvrdé smazání, čímž zachovává autorizační auditní stopu. `REVOKED` a `SUSPENDED` v enumu existují, ale dnes je nic nezapisuje (#6489), takže odejmutá autorizace se zaznamenává jako blacklisting.
 
 ## Mapování DORA (Reg. (EU) 2022/2554)
 

--- a/openbank-tpp-registry-service/src/main/resources/docs/06-compliance.en.md
+++ b/openbank-tpp-registry-service/src/main/resources/docs/06-compliance.en.md
@@ -11,7 +11,7 @@
 | **GDPR** | Registry holds legal-entity (TPP) data, not customer PII | `dataClassification: internal`; no party-id/IBAN/natural-person data stored |
 | **DORA** (Reg. (EU) 2022/2554) | Operational resilience of a control-plane service | health probes, fault tolerance, OTel, runbooks, BuildInfo |
 | **NIS2** | Network & info security | mTLS in-cluster, security headers, OPA authz, audit via outbox (pending) |
-| **AMLD** (indirect) | TPP onboarding screening / blacklist as a control | blacklist API; status lifecycle ACTIVE→REVOKED/BLACKLISTED |
+| **AMLD** (indirect) | TPP onboarding screening / blacklist as a control | blacklist API (`ACTIVE→BLACKLISTED`); `checkAuthorization` denies any status other than ACTIVE |
 | **CNB authorisation register** | National competent authority view | `nca` + `tpp_id` keyed to the CNB/EBA identifier |
 
 ## PSD2 — the authorisation gate
@@ -52,7 +52,7 @@ Generally **not applicable** to corporate registry data. The only field that cou
 No data leaves the EU/EEA region.
 
 ### Retention (Art. 5(1)(e))
-`governance.yaml: retentionPolicy: 5 years`. Registration and blacklist records retained 5 years; de-authorisation is a status transition (`REVOKED`/`BLACKLISTED`), not a hard delete, preserving the authorisation audit trail.
+`governance.yaml: retentionPolicy: 5 years`. Registration and blacklist records retained 5 years; de-authorisation is a status transition (`BLACKLISTED`), not a hard delete, preserving the authorisation audit trail. `REVOKED` and `SUSPENDED` exist in the enum but nothing writes them today (#6489), so a withdrawn authorisation is currently recorded as a blacklisting.
 
 ## DORA mapping (Reg. (EU) 2022/2554)
 


### PR DESCRIPTION
Closes #6489.

## What was wrong

`TppStatus.SUSPENDED` and `REVOKED` are never written — only `ACTIVE` (`registerTpp`) and `BLACKLISTED` (`blacklistTpp`) are — and the EBA register sync is a stub. The docs described the whole lifecycle as working.

## Corrected, in both `en` and `cs`

| file | was | now |
|---|---|---|
| `06-compliance` AMLD row | control column cited *"status lifecycle ACTIVE→REVOKED/BLACKLISTED"* | names `ACTIVE→BLACKLISTED` and the `checkAuthorization` deny — both real |
| `06-compliance` + `04-data` retention | *"de-authorisation is a status transition (`REVOKED`/`BLACKLISTED`)"* | only `BLACKLISTED` is reachable, and says so plus why that is a different fact from a withdrawn authorisation |
| `04-data` status row | bare value list | marked as the column **domain**, with which values are actually written |
| `02-architecture` enum line | bare enum list | which two have writers, plus: `checkAuthorization` denies every non-`ACTIVE` status, so the check is already correct for all four — what is missing is a way to reach two of them |
| `03-tpp-lifecycle.mmd` | 7 edges, all undifferentiated | the 3 implemented edges stand alone; the 4 with no code path are labelled `PLANNED` and carry a note |

The compliance row is the one that mattered most: a compliance table is read as an assertion about *implemented* controls, and half of the cited control did not exist.

## Deliberately not changed

`01-overview` and `02-architecture` already state plainly that the EBA sync is a stub, and `attemptEbaSync` returns `errorMessage = "EBA sync not yet implemented — manual registration only"` with `lastSuccessAt` null rather than a false success. That is the *opposite* of the failure mode this sweep looked for, and it is already documented honestly — nothing to fix.

No code changes. Enforcement was already correct for every status; only the description was wrong.

## Verification

Parsed the edited diagram with the same mermaid the admin-ui renders with (11.16.1 + jsdom + `mermaid.parse`): **PARSE OK**. Negative control: a deliberately broken state diagram through the same probe is *correctly rejected* (`Parse error on line 2`), so the check can fail.

One thing found while doing that, not fixed here: `check-mermaid-parses.sh` scans only ```mermaid blocks inside `.md` files (`e.name.endsWith('.md')`), so **standalone `.mmd` files are outside its scope** — this diagram included. That is the "gate scoped narrower than its subject" shape; say the word and I will file it.

Refs #6410, #6487

🤖 Generated with [Claude Code](https://claude.com/claude-code)
