### PR TITLE
fix(docs): repair the 7 .mmd diagrams that do not parse

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -3677,14 +3677,14 @@ gates:
   # NOT an admin-ui vitest test: `ui-build` fires on openbank-admin-ui/ paths, and a broken
   # diagram arrives in a DOCS-only PR that touches none of them — the #4083 absent-job shape.
   - id: mermaid-parses
-    name: "every mermaid block parses in the renderer admin-ui uses (enforced)"
+    name: "every mermaid diagram parses in the renderer admin-ui uses — .md blocks and .mmd files (enforced)"
     group: lint
     mode: enforced
     rationale: "A mermaid block that does not parse renders as a red error box in the admin-ui Service Docs page and nothing else in CI looks at that page — 40 of 248 blocks across 21 services were broken when this was written, found only because a human opened one."
     review_after: "2027-02-19"
     selftest: bash .github/scripts/check-mermaid-parses.sh --self-test
     selftest_expect: pass
-    min_subjects: 150   # 248 mermaid blocks today (2026-08-19)
+    min_subjects: 220   # 362 diagrams today (2026-08-22): 248 ```mermaid blocks + 114 .mmd files (#6495)
     run: |
       bash .github/scripts/check-mermaid-parses.sh
 

--- a/.github/scripts/check-mermaid-parses.sh
+++ b/.github/scripts/check-mermaid-parses.sh
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 #
-# Every ```mermaid block in the tree must PARSE with the mermaid the admin-ui renders with.
+# Every mermaid diagram in the tree must PARSE with the mermaid the admin-ui renders with:
+# both ```mermaid blocks inside .md files AND standalone .mmd files.
 #
 # WHY THIS EXISTS
 #   The Service Docs viewer renders the per-service docs client-side with mermaid. A block
@@ -91,7 +92,7 @@ const files = [];
 (function walk(dir) {
   for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
     if (e.isDirectory()) { if (!SKIP.has(e.name)) walk(path.join(dir, e.name)); }
-    else if (e.isFile() && e.name.endsWith('.md')) files.push(path.join(dir, e.name));
+    else if (e.isFile() && (e.name.endsWith('.md') || e.name.endsWith('.mmd'))) files.push(path.join(dir, e.name));
   }
 })(scanRoot);
 
@@ -99,12 +100,16 @@ let blocks = 0;
 const failures = [];
 for (const f of files.sort()) {
   const src = fs.readFileSync(f, 'utf8');
-  // Fenced mermaid blocks only. An indented or ~~~-fenced block is not what the viewer
-  // renders, so widening this would flag text the page never parses.
-  for (const [i, m] of [...src.matchAll(/```mermaid\r?\n([\s\S]*?)```/g)].entries()) {
+  // A .mmd file IS one diagram — the whole file, no fence to strip. A .md file contributes
+  // its fenced ```mermaid blocks only: an indented or ~~~-fenced block is not what the viewer
+  // renders, so widening THAT would flag text the page never parses.
+  const found = f.endsWith('.mmd')
+    ? [src]
+    : [...src.matchAll(/```mermaid\r?\n([\s\S]*?)```/g)].map((m) => m[1]);
+  for (const [i, body] of found.entries()) {
     blocks++;
     try {
-      await mermaid.parse(m[1]);
+      await mermaid.parse(body);
     } catch (e) {
       const [first, second = ''] = String(e?.message ?? e).split('\n');
       failures.push({ file: path.relative(scanRoot, f), block: i, msg: `${first} ${second}`.trim() });
@@ -115,21 +120,27 @@ for (const f of files.sort()) {
 // A gate whose subject set is empty must not read as a pass: no mermaid blocks means the
 // walk is broken or pointed at the wrong tree, not that every diagram is fine (#2165).
 if (blocks === 0) {
-  console.error(`::error::[mermaid-parses] found NO mermaid blocks under ${scanRoot} — the scan, not the tree, is what this proves.`);
+  console.error(`::error::[mermaid-parses] found NO mermaid diagrams under ${scanRoot} — the scan, not the tree, is what this proves.`);
   process.exit(1);
 }
 
 for (const f of failures) {
   console.error(`::error file=${f.file}::[mermaid-parses] block #${f.block} does not parse: ${f.msg}`);
 }
-console.log(`[mermaid-parses] mermaid ${mermaidPkg.version}: ${failures.length} failing / ${blocks} blocks in ${files.length} markdown files`);
+const mmdCount = files.filter((f) => f.endsWith('.mmd')).length;
+console.log(`[mermaid-parses] mermaid ${mermaidPkg.version}: ${failures.length} failing / ${blocks} diagram(s) in ${files.length} file(s) (${mmdCount} standalone .mmd)`);
 // The subject count run-gates.py checks against min_subjects: a gate that examined nothing
 // passes everything (#4339).
 console.log(`SUBJECTS=${blocks}`);
 if (failures.length > 0) {
   console.error('[mermaid-parses] These render as a red "Mermaid render failed" box in admin-ui Service Docs.');
   console.error('[mermaid-parses] Common causes: a bare `@` in an unquoted node label (quote the label);');
-  console.error('[mermaid-parses] a literal `;` in a sequenceDiagram message or Note (write `#59;`).');
+  console.error('[mermaid-parses] a literal `;` in a sequenceDiagram message or Note (write `#59;`);');
+  console.error('[mermaid-parses] an HTML entity such as &lt; in a message (write `#lt;`); a participant');
+  console.error('[mermaid-parses] alias that is a keyword (PAR lexes as `par`); a bare `%%` comment line');
+  console.error('[mermaid-parses] with no content; a key marker like PK_FK (write `PK,FK`) — see #6496.');
+  console.error('[mermaid-parses] The caret in a parse error points at the END of the construct, not the');
+  console.error('[mermaid-parses] offending token: bisect by mutating the file, not by reading the column.');
   process.exit(1);
 }
 NODE
@@ -150,6 +161,10 @@ if [ "${1:-}" = "--self-test" ]; then
 
   write_doc() {  # $1 filename, $2 body of the mermaid block
     { echo '```mermaid'; printf '%s\n' "$2"; echo '```'; } > "$tmp/$1"
+  }
+
+  write_mmd() {  # $1 filename, $2 whole-file diagram — no fence, that IS the difference
+    printf '%s\n' "$2" > "$tmp/$1"
   }
 
   probe() {  # $1 label, $2 expected rc, $3 must-appear substring ("" = none)
@@ -188,13 +203,38 @@ if [ "${1:-}" = "--self-test" ]; then
   A->>B: status=ACTIVE; outbox written'
   probe "a literal ; in a sequence message is flagged, by file" 1 "good.md"
 
+  # --- standalone .mmd coverage (#6495) ---------------------------------------------------
+  # 114 .mmd files were outside this gate's walk until #6495, and 7 of them did not parse
+  # (#6496). The extension list is the whole subject set here, so it needs a fixture in BOTH
+  # directions — a gate that only ever sees .md fixtures cannot notice that .mmd was dropped
+  # from the walk again.
   rm -f "$tmp"/*.md
-  probe "an empty tree FAILS rather than reporting a vacuous pass" 1 "found NO mermaid blocks"
+  write_mmd good.mmd 'graph TB
+  a[Sink]
+  b[Source]
+  b --> a'
+  probe "a standalone .mmd is scanned and parses" 0 ""
+
+  write_mmd good.mmd 'sequenceDiagram
+  participant PAR as party-service
+  PAR->>K: party.events'
+  probe "a broken .mmd is flagged, by file" 1 "good.mmd"
+
+  # The whole file is the diagram: a .mmd wrapped in a fence is NOT valid, and treating it
+  # like a .md would silently skip it (no fence match => zero blocks => vacuous pass).
+  write_mmd fenced.mmd '```mermaid
+  graph TB
+  a --> b
+  ```'
+  probe "a .mmd is read whole, not searched for fences" 1 "fenced.mmd"
+
+  rm -f "$tmp"/*.md "$tmp"/*.mmd
+  probe "an empty tree FAILS rather than reporting a vacuous pass" 1 "found NO mermaid diagrams"
 
   if [ "$fails" -ne 0 ]; then
     echo "[mermaid-parses] SELF-TEST FAILED ($fails)"; exit 1
   fi
-  echo "[mermaid-parses] self-test passed: both defect shapes are detected and the empty case fails closed."
+  echo "[mermaid-parses] self-test passed: both defect shapes are detected, .mmd files are in scope, and the empty case fails closed."
   exit 0
 fi
 

--- a/openbank-account-service/src/main/resources/diagrams/02-er-schema.mmd
+++ b/openbank-account-service/src/main/resources/diagrams/02-er-schema.mmd
@@ -51,7 +51,7 @@ erDiagram
     }
 
     account_balances {
-        UUID account_id PK_FK
+        UUID account_id PK,FK
         NUMERIC available_balance
         NUMERIC current_balance
         NUMERIC reserved_balance

--- a/openbank-api-gateway/src/main/resources/diagrams/01-gateway-routing-flow.mmd
+++ b/openbank-api-gateway/src/main/resources/diagrams/01-gateway-routing-flow.mmd
@@ -6,17 +6,17 @@ sequenceDiagram
     participant KC as Keycloak :8080
     participant US as Upstream Service<br/>host.docker.internal:81xx
 
-    C->>K: HTTP request<br/>Authorization: Bearer &lt;jwt&gt;<br/>X-Request-Id, X-Correlation-Id
+    C->>K: HTTP request<br/>Authorization: Bearer #lt;jwt#gt;<br/>X-Request-Id, X-Correlation-Id
 
     note over K: Route match (kong/kong.yml)<br/>strip_path: false → full path forwarded<br/>No JWT inspection (passthrough mode)
 
-    alt path matches /api/v1/<resource>
+    alt path matches /api/v1/#lt;resource#gt;
         K->>US: Proxy request verbatim<br/>retries: 2, connect: 5s, r/w: 30s
         US->>KC: OIDC token validation<br/>(Quarkus SmallRye JWT)
         KC-->>US: 200 OK / 401 Unauthorized
         US-->>K: Upstream response
         K-->>C: Response (status, headers, body)
-    else path matches /health/<service>/*
+    else path matches /health/#lt;service#gt;/*
         note over K: strip_path: true<br/>/health/account/ready → /q/health/ready
         K->>US: GET /q/health/ready
         US-->>K: 200 OK {"status":"UP"}

--- a/openbank-audit-service/src/main/resources/diagrams/01-audit-event-flow.mmd
+++ b/openbank-audit-service/src/main/resources/diagrams/01-audit-event-flow.mmd
@@ -3,7 +3,7 @@ sequenceDiagram
   participant ACC as account-service
   participant TXN as transaction-service
   participant BAL as balance-service
-  participant PAR as party-service
+  participant PTY as party-service
   participant KYC as kyc-service
   participant CON as consent-service
   participant K as Kafka<br/>(multiple topics)
@@ -14,7 +14,7 @@ sequenceDiagram
   ACC->>K: account.created / account.frozen / …
   TXN->>K: transaction.initiated / …
   BAL->>K: balance.events
-  PAR->>K: party.events
+  PTY->>K: party.events
   KYC->>K: kyc.events
   CON->>K: consent.events
 

--- a/openbank-customer-edge/src/main/resources/diagrams/01-customer-api-flow.mmd
+++ b/openbank-customer-edge/src/main/resources/diagrams/01-customer-api-flow.mmd
@@ -7,7 +7,7 @@ sequenceDiagram
     participant KC as Keycloak
     participant Up as upstream service
 
-    App->>Nginx: HTTPS  Authorization: Bearer &lt;customer JWT&gt;
+    App->>Nginx: HTTPS  Authorization: Bearer #lt;customer JWT#gt;
     Nginx->>Edge: /customer/v1/*  (rate-limit passed)
 
     Edge->>Edge: Quarkus OIDC validates JWT<br/>(openbank-customers realm, issuer pinned)
@@ -18,9 +18,9 @@ sequenceDiagram
     end
 
     alt ownership check required (account/balance/tx/statement/payment)
-        Edge->>KC: GET /realms/openbank/protocol/openid-connect/token<br/>grant_type=client_credentials  [if M2M token expired or &lt;60 s left]
+        Edge->>KC: GET /realms/openbank/protocol/openid-connect/token<br/>grant_type=client_credentials  [if M2M token expired or <60 s left]
         KC-->>Edge: access_token + expires_in
-        Edge->>Up: GET .../accounts/{accountId}<br/>Authorization: Bearer &lt;M2M token&gt;<br/>X-Customer-Party-Id: &lt;partyId&gt;
+        Edge->>Up: GET .../accounts/{accountId}<br/>Authorization: Bearer #lt;M2M token#gt;<br/>X-Customer-Party-Id: #lt;partyId#gt;
         Up-->>Edge: account (partyId field)
         Edge->>Edge: ownsAccount? account.partyId == JWT partyId
         alt does NOT own account
@@ -33,7 +33,7 @@ sequenceDiagram
         KC-->>Edge: access_token
     end
 
-    Edge->>Up: proxied request<br/>Authorization: Bearer &lt;M2M token&gt;<br/>X-Customer-Party-Id: &lt;partyId&gt;
+    Edge->>Up: proxied request<br/>Authorization: Bearer #lt;M2M token#gt;<br/>X-Customer-Party-Id: #lt;partyId#gt;
     Up-->>Edge: 200 / 4xx / 5xx
 
     alt transport error

--- a/openbank-domestic-payment/src/main/resources/diagrams/01-payment-flow.mmd
+++ b/openbank-domestic-payment/src/main/resources/diagrams/01-payment-flow.mmd
@@ -12,7 +12,7 @@ sequenceDiagram
     participant LS as ledger-service
 
     CH->>DP: POST /api/v1/domestic-payments<br/>(Idempotency-Key, Bearer token)
-    note over CH,DP: SCA already done upstream;<br/>sca_reference in request body
+    note over CH,DP: SCA already done upstream#59;<br/>sca_reference in request body
 
     DP->>DB: INSERT domestic_payment (status=RECEIVED)<br/>+ outbox event
     DP->>SAP: POST /api/v1/sanctions/screen<br/>(debtor name + creditor name)

--- a/openbank-standing-order-service/src/main/resources/diagrams/03-standing-order-lifecycle.mmd
+++ b/openbank-standing-order-service/src/main/resources/diagrams/03-standing-order-lifecycle.mmd
@@ -15,7 +15,7 @@ stateDiagram-v2
     COMPLETED --> [*]
     FAILED --> [*]
 
-    note on join ACTIVE
+    note right of ACTIVE
         Each execution: next_execution_date advances by frequency,
         execution_count++, last_execution_date updated.
         Actual payment triggered downstream (transaction-service).

--- a/openbank-vop-service/src/main/resources/diagrams/02-er-schema.mmd
+++ b/openbank-vop-service/src/main/resources/diagrams/02-er-schema.mmd
@@ -11,26 +11,26 @@ erDiagram
     }
 
 %% One table, and that is the whole point.
-%%
+
 %% What is NOT here matters more than what is:
-%%
+
 %%   * No payee name, no IBAN in plaintext. Proving the control ran (IPR Art. 5c)
 %%     does not require retaining every name typed into a payment form
 %%     (GDPR Art. 5(1)(c)). The hashes still answer the only question a fraud
 %%     claim asks — "did we check this name against this IBAN, and what did we
 %%     say?" — because the claimant supplies the inputs.
-%%
+
 %%   * No account-holder name cache. The authoritative name lives in
 %%     party-service (parties.legal_name / trading_name) and is resolved live on
 %%     every request. A local copy would be a second place for it to go stale —
 %%     precisely the drift party-service exists to prevent.
-%%
+
 %%   * No foreign keys. vop-service owns no account or party; it reads both over
 %%     REST with an M2M token and stores nothing about them.
-%%
+
 %% Retention: 13 months (the fraud-claim window), NOT the 7-year accounting
 %% default — a VoP record is evidence a control ran, not an accounting record.
-%%
+
 %% Indexes:
 %%   ix_vop_verification_lookup      (iban_hash, supplied_name_hash, verified_at DESC)
 %%       the fraud-claim query: "what did we answer for this IBAN + name?"


### PR DESCRIPTION
Fixes the 7 broken diagrams measured in #6495. All **114** standalone `.mmd` files now parse with the mermaid the admin-ui renders with (11.16.1 + jsdom + `mermaid.parse`).

## Seven files, seven different causes — and none was what its error said

The parse error's caret lands on the **last line of the construct**, not the offending token, so every one of these was found by mutating the real file and re-parsing, never by reading the message. (The gate's own header warns about exactly this; it cost a few rounds anyway.)

| service | broken | fixed | why |
|---|---|---|---|
| account | `UUID account_id PK_FK` | `PK,FK` | `PK_FK` is not a key marker. Reported **8 lines later**, on the closing brace |
| api-gateway | `&lt;jwt&gt;` | `#lt;jwt#gt;` | an HTML entity in a sequence message is a parse error |
| customer-edge | `&lt;customer JWT&gt;` | `#lt;customer JWT#gt;` | same |
| audit | `participant PAR` | `PTY` | `par` is the sequenceDiagram **parallel-block keyword**, so `PAR->>K:` lexes as a block opener |
| domestic-payment | `upstream;<br/>` | `upstream#59;<br/>` | a literal `;` separates statements in a note |
| standing-order | `note on join ACTIVE` | `note right of ACTIVE` | `note on join` is not mermaid syntax |
| vop | bare `%%` lines | blank lines | a comment marker with **no content after it** is a parse error — `%% text` and even `%% ` are fine |

## One judgement call worth flagging

Plain `<jwt>` *parses*. I did not use it: mermaid may then read it as markup and drop the label text, which is the "green check, wrong output" failure — the diagram would render, just without the thing it was documenting. The `#lt;`/`#gt;` escapes cannot be read as a tag.

I could not confirm this by rendering: `mermaid.render` needs `CSSStyleSheet`, which jsdom does not provide, so no local render is possible. **That is precisely why I picked the encoding that cannot be misread over the one I could only prove parses.** If someone has a browser-backed render handy, the `<jwt>` question is worth settling — but the committed form is safe either way.

## Verification

```
before: scanned 114 .mmd files, 7 fail to parse
after:  scanned 114 .mmd files, 0 fail to parse
```

The probe was falsified first against a deliberately broken state diagram (correctly rejected, `Parse error on line 2`), so 114 passes is not a probe that cannot fail.

All edits are semantic-preserving — no diagram content changed beyond the token that broke the parser. Diff is 16 lines across 7 files.

## This will rot again

`check-mermaid-parses.sh` walks only `.md` files, so **nothing in CI keeps these parsing**. That is #6495, and this PR deliberately does not fix it: widening the gate's scope is a change to the gate plus a self-test fixture, and it belongs in its own PR where the scope change is the subject rather than a rider on 7 content fixes.

Closes #6495 — the gate-scope fix (#6497) merged into this branch rather than into `main`, so its own
`Closes` keyword never fired. This PR now carries both halves: the 7 repaired diagrams and the widened gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

