### PR TITLE
fix(admin-ui): announce customer app loading

### DIFF
--- a/openbank-admin-ui/src/app/docs/customer-app/page.tsx
+++ b/openbank-admin-ui/src/app/docs/customer-app/page.tsx
@@ -129,7 +129,7 @@ export default function CustomerAppDossierPage() {
         icon={<Smartphone aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
       />
 
-      {loading && <div className="card" style={{ padding: 24, color: 'var(--text-secondary)' }}>{t('Načítám…', 'Loading…')}</div>}
+      {loading && <div role="status" aria-live="polite" className="card" style={{ padding: 24, color: 'var(--text-secondary)' }}>{t('Načítám…', 'Loading…')}</div>}
 
       {!loading && data?.available === false && (
         <div className="card" style={{ padding: 24, borderTop: '3px solid #d97706' }}>

--- a/openbank-admin-ui/src/test/customer-app-loading.guard.test.ts
+++ b/openbank-admin-ui/src/test/customer-app-loading.guard.test.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('customer app dossier loading contract', () => {
+  it('announces the existing status fetch loading state', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/docs/customer-app/page.tsx'), 'utf8')
+    expect(source).toContain('{loading && <div role="status" aria-live="polite"')
+    expect(source).toContain("t('Načítám…', 'Loading…')")
+    expect(source).toContain("fetch('/api/app-status'")
+  })
+})


### PR DESCRIPTION
## Summary
- expose Customer App dossier status loading as a polite status
- preserve /api/app-status truthfulness and existing docs flow

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.