### PR TITLE
fix(consent): supersede the consent a new grant replaces

### DIFF
--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/application/port/out/ConsentPorts.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/application/port/out/ConsentPorts.kt
@@ -23,7 +23,22 @@ interface ConsentRepository {
      * at-least-once — closing the direct-Kafka dual-write that silently dropped the event on a
      * crash between the DB commit and the send.
      */
-    suspend fun save(consent: Consent, event: DomainEvent): Consent
+    suspend fun save(consent: Consent, event: DomainEvent): Consent = saveSuperseding(consent, event, emptyList())
+
+    /**
+     * Persist [consent] with [event], AND every aggregate in [superseded] with its own event, in a
+     * SINGLE transaction (issue #6487).
+     *
+     * Atomicity is the whole point: an activation that commits without its supersedes leaves two
+     * ACTIVE consents for the same grantee and scopes, each independently sufficient to grant
+     * access — which is the defect this exists to prevent. Two sequential [save] calls cannot give
+     * that guarantee.
+     */
+    suspend fun saveSuperseding(
+        consent: Consent,
+        event: DomainEvent,
+        superseded: List<Pair<Consent, DomainEvent>>,
+    ): Consent
 
     suspend fun findById(id: UUID): Consent?
 

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/application/usecase/ConsentService.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/application/usecase/ConsentService.kt
@@ -18,6 +18,7 @@ import com.openbank.consent.application.port.out.ScaChallengeClient
 import com.openbank.consent.domain.event.ConsentGranted
 import com.openbank.consent.domain.event.ConsentRejected
 import com.openbank.consent.domain.event.ConsentRevoked
+import com.openbank.consent.domain.event.ConsentSuperseded
 import com.openbank.consent.domain.model.Consent
 import com.openbank.consent.domain.model.ConsentScope
 import com.openbank.consent.domain.model.ConsentStatus
@@ -110,20 +111,11 @@ class ConsentService(
             updatedAt = now,
         )
 
+        // A GDPR-only consent is born ACTIVE (ADR-0205 D1), so it supersedes on creation — the
+        // PENDING_SCA reasoning in persistActivation does not apply where there is no SCA to wait
+        // for. Every other consent supersedes at activateConsent, not here.
         return if (allGdprOnly) {
-            consentRepository.save(
-                consent,
-                ConsentGranted(
-                    aggregateId = consent.id,
-                    partyId = consent.partyId,
-                    granteeId = consent.granteeId,
-                    granteeType = consent.granteeType,
-                    scopes = consent.scopes,
-                    validTo = consent.validTo,
-                    occurredAt = clock.instant(),
-                    sourceService = "consent-service",
-                ),
-            )
+            persistActivation(consent, now)
         } else {
             consentRepository.save(consent)
         }
@@ -153,20 +145,53 @@ class ConsentService(
             throw ConsentScaNotCompletedException(consentId, scaSessionId)
         }
 
-        val activated = consent.activate(scaSessionId, OffsetDateTime.now(clock))
-        return consentRepository.save(
-            activated,
-            ConsentGranted(
-                aggregateId = activated.id,
-                partyId = activated.partyId,
-                granteeId = activated.granteeId,
-                granteeType = activated.granteeType,
-                scopes = activated.scopes,
-                validTo = activated.validTo,
-                occurredAt = clock.instant(),
-                sourceService = "consent-service",
-            ),
+        val now = OffsetDateTime.now(clock)
+        val activated = consent.activate(scaSessionId, now)
+        return persistActivation(activated, now)
+    }
+
+    /**
+     * Commits an activation together with the retirement of every consent it replaces (#6487).
+     *
+     * Superseding happens HERE and not at creation, and the difference matters: a new consent is
+     * born PENDING_SCA, so retiring the old one at creation would end the customer's access before
+     * the replacement had been confirmed — and if the SCA then failed or was abandoned, they would
+     * be left with no consent at all. The old grant stands until the new one is genuinely ACTIVE.
+     *
+     * Without this, `createConsent` never looked for an existing grant, the table has no unique
+     * constraint, `revokeConsent` revokes one row by id, and `hasActiveConsent` answers over a
+     * LIST — so duplicates accumulated and withdrawing access left the older ones granting it.
+     */
+    private suspend fun persistActivation(activated: Consent, now: OffsetDateTime): Consent {
+        val granted = ConsentGranted(
+            aggregateId = activated.id,
+            partyId = activated.partyId,
+            granteeId = activated.granteeId,
+            granteeType = activated.granteeType,
+            scopes = activated.scopes,
+            validTo = activated.validTo,
+            occurredAt = clock.instant(),
+            sourceService = "consent-service",
         )
+
+        val superseded = consentRepository
+            .findActiveByGranteeAndParty(activated.granteeId, activated.partyId)
+            .filter { activated.supersedes(it) }
+            .map { old ->
+                old.supersede(now) to ConsentSuperseded(
+                    aggregateId = old.id,
+                    partyId = old.partyId,
+                    granteeId = old.granteeId,
+                    scopes = old.scopes,
+                    supersededBy = activated.id,
+                    occurredAt = clock.instant(),
+                    sourceService = "consent-service",
+                )
+            }
+
+        // No log line here on purpose: this class logs nothing, and the durable record is the
+        // ConsentSuperseded outbox event, which is queryable long after a log line has aged out.
+        return consentRepository.saveSuperseding(activated, granted, superseded)
     }
 
     override suspend fun rejectConsent(consentId: UUID, reason: String): Consent {

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/domain/event/ConsentEvents.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/domain/event/ConsentEvents.kt
@@ -62,6 +62,28 @@ data class ConsentRevoked(
     override val version = 1L
 }
 
+/**
+ * A consent was replaced by a newer one for the same grantee and the same scopes (#6487).
+ *
+ * Carries `supersededBy` so a consumer can tell this apart from a withdrawal: access continues
+ * under the named consent, and a journey keyed to the old id should follow it rather than stop.
+ * That is the opposite of [ConsentRevoked], which means access ended.
+ */
+data class ConsentSuperseded(
+    override val aggregateId: UUID,
+    val partyId: UUID,
+    val granteeId: String,
+    val scopes: Set<ConsentScope>,
+    val supersededBy: UUID,
+    override val occurredAt: Instant,
+    /** See [ConsentGranted.sourceService] (#3994/#5256). */
+    val sourceService: String = "consent-service",
+) : DomainEvent(occurredAt) {
+    override val aggregateType = "Consent"
+    override val eventType = "ConsentSuperseded"
+    override val version = 1L
+}
+
 data class ConsentExpired(
     override val aggregateId: UUID,
     val partyId: UUID,

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/domain/model/Consent.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/domain/model/Consent.kt
@@ -142,6 +142,28 @@ data class Consent(
     )
 
     /**
+     * Replaced by a newer consent covering the same grantee and the same scopes (issue #6487).
+     *
+     * Distinct from [revoke]: the customer did not withdraw anything, so recording this as REVOKED
+     * would put a withdrawal in the audit trail that never happened. It is the *bank* retiring a
+     * row the customer replaced.
+     */
+    fun supersede(now: OffsetDateTime): Consent = copy(
+        status = ConsentStatus.SUPERSEDED,
+        updatedAt = now,
+    )
+
+    /**
+     * True when [other] grants the same grantee exactly the same scope set.
+     *
+     * Set EQUALITY, not overlap: a consent for {ACCOUNTS} and one for {ACCOUNTS, PAYMENTS} are
+     * different grants, and superseding the narrower one would silently widen what the customer
+     * agreed to. Overlap is a different question that needs a customer-facing decision, not a
+     * comparison operator.
+     */
+    fun supersedes(other: Consent): Boolean = other.id != id && other.granteeId == granteeId && other.scopes == scopes
+
+    /**
      * PSD2 RTS Art. 10(2)(b) access-frequency cap for this consent's scopes: an AISP may read the
      * account data at most [AISP_MAX_ACCESSES_PER_DAY] times per day without fresh SCA. Returned by
      * `/validate` so a resource server can cache within that window. null when no AISP scope applies

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/persistence/repository/ConsentRepositoryImpl.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/persistence/repository/ConsentRepositoryImpl.kt
@@ -32,11 +32,27 @@ class ConsentRepositoryImpl(
     override suspend fun save(consent: Consent): Consent =
         Panache.withTransaction { mergeConsent(consent) }.awaitSuspending().toDomain()
 
-    override suspend fun save(consent: Consent, event: DomainEvent): Consent = Panache.withTransaction {
-        // Aggregate state change + outbox row in ONE transaction: the bare persist() inside
-        // persistInTransaction joins this @WithTransaction session (transactional outbox, ADR-0126 §D3).
-        mergeConsent(consent).flatMap { merged ->
-            outboxRepository.persistInTransaction(outboxMessage(event)).replaceWith(merged)
+    // Aggregate state change + outbox row in ONE transaction: the bare persist() inside
+    // persistInTransaction joins this @WithTransaction session (transactional outbox, ADR-0126 §D3).
+    // The single-aggregate save(consent, event) is the empty-supersede case of this, defaulted on
+    // the port rather than written twice.
+    override suspend fun saveSuperseding(
+        consent: Consent,
+        event: DomainEvent,
+        superseded: List<Pair<Consent, DomainEvent>>,
+    ): Consent = Panache.withTransaction {
+        // Every merge and every outbox row joins THIS transaction, so the activation and the
+        // retirement of the rows it replaces commit together or not at all (#6487).
+        superseded.fold(Uni.createFrom().voidItem()) { chain, (old, oldEvent) ->
+            chain.flatMap {
+                mergeConsent(old).flatMap {
+                    outboxRepository.persistInTransaction(outboxMessage(oldEvent))
+                }
+            }.replaceWithVoid()
+        }.flatMap {
+            mergeConsent(consent).flatMap { merged ->
+                outboxRepository.persistInTransaction(outboxMessage(event)).replaceWith(merged)
+            }
         }
     }.awaitSuspending().toDomain()
 

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/application/usecase/ConsentServiceTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/application/usecase/ConsentServiceTest.kt
@@ -14,6 +14,7 @@ import com.openbank.consent.application.port.out.ScaChallengeSnapshot
 import com.openbank.consent.domain.event.ConsentGranted
 import com.openbank.consent.domain.event.ConsentRejected
 import com.openbank.consent.domain.event.ConsentRevoked
+import com.openbank.consent.domain.event.ConsentSuperseded
 import com.openbank.consent.domain.model.Consent
 import com.openbank.consent.domain.model.ConsentScope
 import com.openbank.consent.domain.model.ConsentStatus
@@ -82,7 +83,11 @@ class ConsentServiceTest {
     fun `createConsent auto-activates and emits ConsentGranted for a GDPR-only scope, no SCA`(): Unit = runBlocking {
         val savedConsent = slot<Consent>()
         val savedEvent = slot<ConsentGranted>()
-        coEvery { consentRepository.save(capture(savedConsent), capture(savedEvent)) } answers { firstArg() }
+        // GDPR-only consents are born ACTIVE, so they now take the superseding write path (#6487).
+        coEvery { consentRepository.findActiveByGranteeAndParty(any(), any()) } returns emptyList()
+        coEvery {
+            consentRepository.saveSuperseding(capture(savedConsent), capture(savedEvent), any())
+        } answers { firstArg() }
 
         val command = CreateConsentCommand(
             partyId = partyId,
@@ -112,7 +117,11 @@ class ConsentServiceTest {
     fun `createConsent stays PENDING_SCA for a single GDPR-only scope too`(): Unit = runBlocking {
         val savedConsent = slot<Consent>()
         val savedEvent = slot<ConsentGranted>()
-        coEvery { consentRepository.save(capture(savedConsent), capture(savedEvent)) } answers { firstArg() }
+        // GDPR-only consents are born ACTIVE, so they now take the superseding write path (#6487).
+        coEvery { consentRepository.findActiveByGranteeAndParty(any(), any()) } returns emptyList()
+        coEvery {
+            consentRepository.saveSuperseding(capture(savedConsent), capture(savedEvent), any())
+        } answers { firstArg() }
 
         val command = CreateConsentCommand(
             partyId = partyId,
@@ -492,16 +501,18 @@ class ConsentServiceTest {
         coEvery { consentRepository.findById(consentId) } returns consent(status = ConsentStatus.PENDING_SCA)
         coEvery { scaChallengeClient.getChallenge(scaSessionId) } returns
             ScaChallengeSnapshot(scaSessionId, partyId, "CONSENT_GRANT", "COMPLETED")
-        coEvery { consentRepository.save(capture(saved), any()) } answers { firstArg() }
+        coEvery { consentRepository.findActiveByGranteeAndParty(granteeId, partyId) } returns emptyList()
+        coEvery { consentRepository.saveSuperseding(capture(saved), any(), any()) } answers { firstArg() }
 
         val result = service.activateConsent(consentId, scaSessionId)
 
         assertThat(result.status).isEqualTo(ConsentStatus.ACTIVE)
         assertThat(saved.captured.scaSessionId).isEqualTo(scaSessionId)
         coVerify(exactly = 1) {
-            consentRepository.save(
+            consentRepository.saveSuperseding(
                 match<Consent> { it.status == ConsentStatus.ACTIVE },
                 match<ConsentGranted> { it.aggregateId == consentId && it.partyId == partyId },
+                match<List<Pair<Consent, ConsentSuperseded>>> { it.isEmpty() },
             )
         }
     }
@@ -596,8 +607,9 @@ class ConsentServiceTest {
         granteeId: String = this.granteeId,
         status: ConsentStatus = ConsentStatus.ACTIVE,
         scopes: Set<ConsentScope> = setOf(ConsentScope.ACCOUNTS_READ),
+        id: UUID = this.consentId,
     ): Consent = Consent(
-        id = consentId,
+        id = id,
         partyId = partyId,
         granteeId = granteeId,
         granteeType = GranteeType.TPP,

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/application/usecase/ConsentSupersedeTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/application/usecase/ConsentSupersedeTest.kt
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.consent.application.usecase
+
+import com.openbank.consent.application.port.`in`.CreateConsentCommand
+import com.openbank.consent.application.port.out.ConsentRepository
+import com.openbank.consent.application.port.out.ScaChallengeClient
+import com.openbank.consent.application.port.out.ScaChallengeSnapshot
+import com.openbank.consent.domain.event.ConsentSuperseded
+import com.openbank.consent.domain.model.Consent
+import com.openbank.consent.domain.model.ConsentScope
+import com.openbank.consent.domain.model.ConsentStatus
+import com.openbank.consent.domain.model.GranteeType
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * Issue #6487 — duplicate ACTIVE consents for the same grantee and scopes.
+ *
+ * Nothing ever wrote SUPERSEDED, `createConsent` never looked for an existing grant, the table has
+ * no unique constraint, `revokeConsent` revokes ONE row by id, and `hasActiveConsent` answers over
+ * a LIST. So duplicates accumulated, each independently sufficient to grant access, and a customer
+ * withdrawing a TPP's access left the older ones granting it.
+ *
+ * Split out of ConsentServiceTest, which detekt already considers a LargeClass.
+ */
+class ConsentSupersedeTest {
+
+    private val consentRepository = mockk<ConsentRepository>()
+    private val scaChallengeClient = mockk<ScaChallengeClient>()
+    private val fixedClock = Clock.fixed(Instant.parse("2024-01-15T10:00:00Z"), ZoneOffset.UTC)
+    private val service = ConsentService(consentRepository, scaChallengeClient, fixedClock)
+
+    private val partyId = UUID.randomUUID()
+    private val consentId = UUID.randomUUID()
+    private val granteeId = "tpp-123"
+    private val now = OffsetDateTime.now().plusMinutes(1)
+
+    @Test
+    fun `activation supersedes an existing ACTIVE consent for the same grantee and scopes`(): Unit = runBlocking {
+        val scaSessionId = UUID.randomUUID()
+        val olderId = UUID.randomUUID()
+        val superseded = slot<List<Pair<Consent, ConsentSuperseded>>>()
+        coEvery { consentRepository.findById(consentId) } returns consent(status = ConsentStatus.PENDING_SCA)
+        coEvery { scaChallengeClient.getChallenge(scaSessionId) } returns
+            ScaChallengeSnapshot(scaSessionId, partyId, "CONSENT_GRANT", "COMPLETED")
+        coEvery { consentRepository.findActiveByGranteeAndParty(granteeId, partyId) } returns
+            listOf(consent(status = ConsentStatus.ACTIVE, id = olderId))
+        coEvery { consentRepository.saveSuperseding(any(), any(), capture(superseded)) } answers { firstArg() }
+
+        service.activateConsent(consentId, scaSessionId)
+
+        assertThat(superseded.captured).hasSize(1)
+        val (old, event) = superseded.captured.single()
+        assertThat(old.id).isEqualTo(olderId)
+        assertThat(old.status)
+            .describedAs("SUPERSEDED, not REVOKED — the customer withdrew nothing")
+            .isEqualTo(ConsentStatus.SUPERSEDED)
+        assertThat(event.supersededBy).isEqualTo(consentId)
+        assertThat(event.aggregateId).isEqualTo(olderId)
+    }
+
+    @Test
+    fun `activation does NOT supersede a consent whose scope set merely overlaps`(): Unit = runBlocking {
+        val scaSessionId = UUID.randomUUID()
+        val superseded = slot<List<Pair<Consent, ConsentSuperseded>>>()
+        coEvery { consentRepository.findById(consentId) } returns
+            consent(status = ConsentStatus.PENDING_SCA, scopes = setOf(ConsentScope.ACCOUNTS_READ))
+        coEvery { scaChallengeClient.getChallenge(scaSessionId) } returns
+            ScaChallengeSnapshot(scaSessionId, partyId, "CONSENT_GRANT", "COMPLETED")
+        // A WIDER grant. Retiring it because the scopes intersect would silently narrow what the
+        // customer agreed to, which is a different decision from replacing a like-for-like grant.
+        coEvery { consentRepository.findActiveByGranteeAndParty(granteeId, partyId) } returns listOf(
+            consent(
+                status = ConsentStatus.ACTIVE,
+                scopes = setOf(ConsentScope.ACCOUNTS_READ, ConsentScope.BALANCES_READ),
+                id = UUID.randomUUID(),
+            ),
+        )
+        coEvery { consentRepository.saveSuperseding(any(), any(), capture(superseded)) } answers { firstArg() }
+
+        service.activateConsent(consentId, scaSessionId)
+
+        assertThat(superseded.captured).isEmpty()
+    }
+
+    @Test
+    fun `creating an SCA-gated consent supersedes nothing — the old grant stands until the new one is ACTIVE`(): Unit =
+        runBlocking {
+            // The whole reason superseding lives in activation: a new consent is born PENDING_SCA, and
+            // retiring the old one here would end access before the replacement was confirmed. If the
+            // SCA then failed or was abandoned, the customer would be left with no consent at all.
+            coEvery { consentRepository.save(any<Consent>()) } answers { firstArg() }
+
+            val result = service.createConsent(
+                CreateConsentCommand(
+                    partyId = partyId,
+                    granteeId = granteeId,
+                    granteeType = GranteeType.TPP,
+                    granteeName = "Test TPP",
+                    scopes = setOf(ConsentScope.ACCOUNTS_READ),
+                    accountIbans = null,
+                    validTo = now.plusDays(30),
+                    redirectUri = "https://example.com/redirect",
+                    tppTransactionId = "txn-1",
+                    ipAddress = "127.0.0.1",
+                    userAgent = "JUnit",
+                ),
+            )
+
+            assertThat(result.status).isEqualTo(ConsentStatus.PENDING_SCA)
+            coVerify(exactly = 0) { consentRepository.saveSuperseding(any(), any(), any()) }
+            coVerify(exactly = 0) { consentRepository.findActiveByGranteeAndParty(any(), any()) }
+        }
+
+    private fun consent(
+        granteeId: String = this.granteeId,
+        status: ConsentStatus = ConsentStatus.ACTIVE,
+        scopes: Set<ConsentScope> = setOf(ConsentScope.ACCOUNTS_READ),
+        id: UUID = this.consentId,
+    ): Consent = Consent(
+        id = id,
+        partyId = partyId,
+        granteeId = granteeId,
+        granteeType = GranteeType.TPP,
+        granteeName = "Test TPP",
+        scopes = scopes,
+        accountIbans = listOf("CZ6508000000192000145399"),
+        status = status,
+        validFrom = now,
+        validTo = now.plusDays(1),
+        scaSessionId = UUID.randomUUID(),
+        redirectUri = "https://example.com/redirect",
+        tppTransactionId = "txn-1",
+        ipAddress = "127.0.0.1",
+        userAgent = "JUnit",
+        createdAt = OffsetDateTime.now(),
+        updatedAt = OffsetDateTime.now(),
+    )
+}


### PR DESCRIPTION
Closes #6487.

## The defect

`ConsentStatus.SUPERSEDED` — comment: *"Replaced by a newer consent for same grantee+scopes"* — was written by **nothing**. Not dead code: it was the mitigation for a live behaviour.

- `createConsent` never looked for an existing grant
- no unique constraint on the table (the only `UNIQUE` in the service's migrations is `event_id` on the outbox)
- `revokeConsent` revokes **one** row by id
- `hasActiveConsent` answers over a **list**: `findActiveByGranteeAndParty(...).any { it.isActive(now) && it.hasScope(...) }`

So N consents for the same TPP and the same scopes could be ACTIVE at once, each independently sufficient. A customer withdrawing that TPP's access revoked the one they were shown; an older duplicate kept `hasActiveConsent` answering **true**. The UI, the audit event and the row all said "revoked" and were each individually correct — what was wrong was the assumption that there was one.

## Superseding happens at ACTIVATION, not creation

The load-bearing choice in this PR, and the reason it is not a two-line change in `createConsent`:

A new consent is born `PENDING_SCA`. Retiring the old one at creation would end the customer's access **before the replacement was confirmed** — and if the SCA then failed or was abandoned, they would be left with no consent at all. So the old grant stands until the new one is genuinely ACTIVE.

GDPR-only consents are born ACTIVE (ADR-0205 D1), so they supersede on creation — there is no SCA to wait for. Both paths go through one `persistActivation`.

## Scope-set equality, not overlap

`{ACCOUNTS_READ}` and `{ACCOUNTS_READ, BALANCES_READ}` are different grants. Retiring the wider one because the sets intersect would silently narrow what the customer agreed to — a customer-facing decision, not a comparison operator. Asserted by `activation does NOT supersede a consent whose scope set merely overlaps`.

## SUPERSEDED, never REVOKED

The customer withdrew nothing. Recording a withdrawal that did not happen would put a false event in an audit trail that exists to prove exactly that. The new `ConsentSuperseded` carries `supersededBy`, so a consumer can tell the two apart: access **continues** under the named consent, rather than ending — the opposite of `ConsentRevoked`. Existing consumers filtering on `ConsentRevoked` (campaign-service's journey termination, ADR-0200 D2) are unaffected by construction.

## Atomicity

`saveSuperseding` commits the activation and every supersede in **one** transaction, with their outbox rows. Two sequential `save` calls cannot give that guarantee, and a half-applied activation leaves precisely the duplicate state this fixes. The single-aggregate `save(consent, event)` is now the empty-supersede case, defaulted on the port rather than written twice.

## Verification

- `./gradlew :openbank-consent-service:test :ktlintCheck :detekt` — **BUILD SUCCESSFUL**.
- **Negative control**: with superseding disabled and the new tests kept, `activation supersedes an existing ACTIVE consent for the same grantee and scopes` **fails**. It can detect the absence of what it tests.
- The three new tests are in `ConsentSupersedeTest`; the JUnit XML confirms `tests="3" skipped="0" failures="0"` — they ran, rather than being silently skipped.
- Two existing GDPR-only tests were updated: that path now takes the superseding write. Flagging it because those are assertion changes, not new assertions.

`ConsentServiceTest` is already a detekt `LargeClass`, so the new tests went into their own class rather than pushing it over; `ConsentRepositoryImpl` hit `TooManyFunctions` **at** the threshold (11 of 11), fixed structurally by the port default rather than by a baseline entry.

## Not in scope

**Revocation still covers the row, not the grantee.** #6487 raises this as the second half: arguably a customer withdrawing a TPP's access means every ACTIVE consent for that `(partyId, granteeId)`, not the one row. With this PR duplicates should no longer accumulate, so the exposure is much smaller — but a consent created *before* this lands still has its twin, and revoking one will still leave the other. That is an API-semantics decision and needs its own PR.

**No backfill.** Existing duplicates in any environment are untouched. Worth running before closing this out:

```sql
SELECT party_id, grantee_id, count(*) FROM consents
WHERE status = 'ACTIVE' GROUP BY party_id, grantee_id HAVING count(*) > 1;
```

**No DB constraint.** A partial unique index (`WHERE status = 'ACTIVE'`) would enforce this below the application, but scopes are a set — the index shape needs deciding first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
