### PR TITLE
fix(ci): stop the agents backgrounding commands and abandoning claimed issues

### DIFF
--- a/.github/agent-prompts/issue-worker.md
+++ b/.github/agent-prompts/issue-worker.md
@@ -37,6 +37,24 @@ Check this BEFORE writing code, not after: run
 and read `openbank-libs/governance/rules.yaml` key `autonomous_agent_prs` for the exact
 protected set. Picking a protected issue wastes the entire run.
 
+## You are ONE non-interactive invocation — never background a command
+
+This is `claude -p`, a single shot. There is **no loop to deliver a background-task
+notification**, and no user to wake you. If you start a command in the background and end your
+turn saying "waiting for the run to complete", the session simply ends there: the work is
+abandoned mid-flight, and if you had already pushed a claim branch it stays on the remote and
+hides that issue from every future run.
+
+That is not hypothetical — it is exactly how the run of 2026-08-22 15:14 died, having claimed an
+issue and produced nothing. It ended with the line *"Waiting for the background test run to
+complete — will proceed once notified."*
+
+So: **run every command in the FOREGROUND**, with an explicit `timeout` so a hang cannot eat the
+job. A Gradle module build here takes minutes, not hours; wrap it in `timeout 900 ./gradlew ...`
+and read the output when it returns. Do not use background execution, do not poll for a file to
+appear, do not wait for a notification. If a command genuinely cannot finish inside the job's
+45-minute budget, the issue is too big for one run — abandon it and say so.
+
 ## Step 1 — pick one issue you can actually finish and verify
 
 List open issues with `gh issue list`. Discard, in this order:
@@ -76,6 +94,19 @@ which is what this run was: a successful run that opened no PR.
 Create and push `agent/<type>-<slug>-<issue-number>` before writing code. Runs are serialized by
 the workflow's concurrency group, but a human may be working the same issue, and the pushed
 branch is what makes your claim visible.
+
+**A claim you abandon is worse than no claim.** Step 1 discards any issue that already has an
+`agent/` branch naming it, so an orphaned claim hides that issue from every future run —
+permanently, and with nothing to explain why it is never picked. If you abandon the issue for
+any reason after claiming it, **delete the branch before you finish**:
+
+```
+git push origin --delete agent/<the-branch-you-pushed>
+```
+
+That works on this runner (it did not in the cloud sandbox this worker used to run in, which is
+why older instructions said to leave it). If the delete fails, name the branch in your report so
+a human removes it — never leave it unmentioned.
 
 ## Step 3 — understand before you edit
 

--- a/.github/agent-prompts/pr-steward.md
+++ b/.github/agent-prompts/pr-steward.md
@@ -33,6 +33,24 @@ the one thing you must never do.
 Likewise, do not "fix" a red check by deleting or weakening the test that is failing, or by
 adding an exclusion. If the honest fix is not available to you, say so.
 
+## You are ONE non-interactive invocation — never background a command
+
+This is `claude -p`, a single shot. There is **no loop to deliver a background-task
+notification**, and no user to wake you. If you start a command in the background and end your
+turn saying "waiting for the run to complete", the session simply ends there: the work is
+abandoned mid-flight, and if you had already pushed a claim branch it stays on the remote and
+hides that issue from every future run.
+
+That is not hypothetical — it is exactly how the run of 2026-08-22 15:14 died, having claimed an
+issue and produced nothing. It ended with the line *"Waiting for the background test run to
+complete — will proceed once notified."*
+
+So: **run every command in the FOREGROUND**, with an explicit `timeout` so a hang cannot eat the
+job. A Gradle module build here takes minutes, not hours; wrap it in `timeout 900 ./gradlew ...`
+and read the output when it returns. Do not use background execution, do not poll for a file to
+appear, do not wait for a notification. If a command genuinely cannot finish inside the job's
+45-minute budget, the issue is too big for one run — abandon it and say so.
+
 ## Step 1 — find the one PR to tend
 
 List open PRs whose head branch starts with `agent/`. For each, get its mergeable state and its


### PR DESCRIPTION
Refs #6412 · follow-up to #6462 and #6504

## What happened

The 15:14 issue-worker run claimed #6479, pushed its claim branch, started a Gradle test run in the background, and ended its turn with:

> Waiting for the background test run to complete — will proceed once notified.

**That notification never arrives.** `claude -p` is a single non-interactive invocation — there is no loop to deliver a background-task event and no user to wake it. The session ended there, mid-flight, having produced nothing.

## What worked, and what it could not prevent

The verdict assertion from #6462 **caught it**: the job went red instead of reporting the silent success this exact class of failure used to produce. That is the control doing its job on its first real test.

What it could not prevent is the mess left behind: an orphaned `agent/` claim branch. Step 1 treats an `agent/` branch naming an issue as *already claimed*, so that orphan would have hidden #6479 from **every future run** — permanently, and with nothing anywhere to explain why it was never picked.

## Fixes

**Foreground only.** Every command runs in the foreground with an explicit `timeout`. No background execution, no polling for a file to appear, no waiting for a notification. If a command cannot finish inside the job's 45-minute budget, the issue is too big for one run — abandon and say so. Applied to the **steward** as well: same shape, same trap, it just had not hit it yet.

**Clean up an abandoned claim.** `git push origin --delete agent/<branch>` before finishing. That works on an Actions runner — it did *not* in the cloud sandbox the worker originally ran in, which is why the older wording told it to leave the branch and report it. If the delete fails, name the branch so a human removes it.

## Cleanup already done

The orphan from that run is deleted. No work was lost — the branch carried no commits beyond `main`, having been pushed at the claim step before any code was written. `agent/` branch count is back to 0.

## Verification

- `run-gates.py --group lint` — 24/24 PASS
- The known-positive is the 15:14 run itself: it failed at `Assert the worker reached a verdict`, which is what a run that abandons mid-flight should now always do.