### PR TITLE
ci(governance): make every required context report on merge_group (ADR-0272 step 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
+  # ADR-0272. `Validate manifests` is a required status check, so the gate shards it aggregates
+  # must run on the queue's event too -- and they are the shards that catch the defect the queue
+  # exists for: 19 of 20 main breakages measured on 2026-08-22 came from PRs that were themselves
+  # green, failing in `gates (data)` / `gates (supplychain)` only once merged.
+  merge_group:
 
 permissions:
   contents: read
@@ -17,8 +22,8 @@ concurrency:
   # PR pushes keep the superseding behaviour, which is what that setting is for.
   # The key stays O(1) — a sha, never a list: interpolating a fleet-sized value here
   # stops the job being created at all (#3082).
-  group: ci-${{ github.ref }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci' }}
-  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+  group: ci-${{ github.ref }}-${{ ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group') && github.sha || 'ci' }}
+  cancel-in-progress: ${{ !((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group') }}
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -257,7 +262,10 @@ jobs:
       # that need them are set here rather than in the manifest.
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_BODY: ${{ github.event.pull_request.body }}
-      BASE_REF: ${{ github.base_ref || github.ref_name }}
+      # On merge_group, github.base_ref is empty and github.ref_name is the queue's own ref, so
+      # the fallback would name a ref that is not the target branch. The queue always targets the
+      # default branch, and merge_group carries it explicitly.
+      BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref || github.ref_name }}
       # `gh` needs GH_TOKEN; the job-level `permissions: contents: read` above is what
       # scopes it. check-msg-channel-image-parity.py reads a file at an arbitrary historical
       # commit (the sha an image tag names) through the contents API, because CI checks out
@@ -386,6 +394,35 @@ jobs:
           fi
           echo "PR diff base: ${base} (event base.sha: ${EVENT_BASE_SHA})"
           echo "PR_DIFF_BASE=${base}" >> "$GITHUB_ENV"
+
+      # ADR-0272. The diff-classifying gates (api-contract, db-migration, schema-compat,
+      # release-scope-mismatch, threat-model-on-trust-boundary-change) need a base or run-gates.py
+      # fails them rather than running them vacuously. In a merge group the honest base is where
+      # the BATCH branched from the target branch, which merge_group carries as base_sha -- so the
+      # whole batch classifies against main, in one comparison.
+      #
+      # That is not merely "good enough in the absence of a PR": it is the comparison ADR-0048
+      # says cannot be made on the pull_request event. A PR whose last CI run predates a competing
+      # spec merge is invisible to ANY base resolved at PR time, because the classification is only
+      # as fresh as the run. Here the base is resolved after the batch is assembled, so two entries
+      # claiming the same openapi info.version are compared against each other, not just against
+      # their own stale bases.
+      - name: resolve merge-group diff base (the batch's branch point)
+        if: github.event_name == 'merge_group'
+        env:
+          MG_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MG_BASE_SHA}" ]; then
+            # Never fall through to an empty base: run-gates.py would fail the needs_base gates,
+            # which reads as "the change is bad" when the truth is "the harness lost its base".
+            echo "::error::merge_group payload carried no base_sha — refusing to classify against" \
+                 "an undefined base."
+            exit 1
+          fi
+          git fetch --depth=1 origin "${MG_BASE_SHA}" 2>/dev/null || true
+          echo "merge-group diff base: ${MG_BASE_SHA}"
+          echo "PR_DIFF_BASE=${MG_BASE_SHA}" >> "$GITHUB_ENV"
 
       - name: Run gates
         run: |

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -19,13 +19,22 @@ name: Issue hygiene
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
+  # ADR-0272. `issue-hygiene` is a required status check and is PR-SCOPED: it asserts that the
+  # pull request links an issue, and a merge group has no pull request. It still has to REPORT
+  # on this event -- a required context that does not report blocks the queue with zero
+  # failures -- so it runs and succeeds as an explicit no-op. The property it asserts was
+  # already established on the PR, before the entry was ever queued.
+  merge_group:
 
 permissions:
   contents: read
 
 concurrency:
-  group: issue-hygiene-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # github.event.pull_request.number is empty on merge_group, so keying on it alone would put
+  # every queue entry in ONE group and let them cancel each other -- and a cancelled run leaves
+  # the required context absent, which stalls the queue. github.ref is unique per entry.
+  group: issue-hygiene-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   issue-hygiene:
@@ -34,7 +43,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10  # measured max 6s
     steps:
+      # Reported, not skipped: `if:` on the step would leave the JOB green either way, but being
+      # explicit here keeps the no-op visible in the log rather than looking like a check that
+      # quietly did nothing.
+      - name: No pull request in a merge group — nothing to lint
+        if: github.event_name == 'merge_group'
+        run: |
+          echo "::notice title=issue-hygiene::merge_group carries no pull request; the linked-issue" \
+               "requirement was enforced on each entry's own PR before it was queued (ADR-0272)."
+
       - name: Lint PR "Linked issues"
+        if: github.event_name != 'merge_group'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/opa-policy.yml
+++ b/.github/workflows/opa-policy.yml
@@ -21,6 +21,11 @@ on:
   push:
     branches: [main]
   pull_request:
+  # ADR-0272. A merge queue only merges an entry once every required status check reports on
+  # `merge_group`. A context that never reports there does not fail the queue -- it STALLS it,
+  # forever, with zero failures. `OPA policy gate` is one of the five required contexts, so it
+  # must be reachable from this event before the queue is enabled.
+  merge_group:
 
 permissions:
   contents: read
@@ -34,8 +39,12 @@ concurrency:
   # PR pushes keep the superseding behaviour, which is what that setting is for.
   # The key stays O(1) — a sha, never a list: interpolating a fleet-sized value here
   # stops the job being created at all (#3082).
-  group: opa-policy-${{ github.ref }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci' }}
-  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+  # A merge_group run gets its own lane and is never cancelled, for the same reason a main
+  # push is not: a cancelled run leaves its required context ABSENT, and absent is not a third
+  # state the queue can act on -- it waits. github.ref is unique per queue entry, so the sha
+  # suffix is what keeps two entries on the same ref from cancelling each other.
+  group: opa-policy-${{ github.ref }}-${{ ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group') && github.sha || 'ci' }}
+  cancel-in-progress: ${{ !((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group') }}
 
 jobs:
   changes:
@@ -75,8 +84,14 @@ jobs:
             PATTERN="${PATTERN}|^${dir//./\\.}/"
           done < <(find openbank-infra/gitops/components -name 'gen-*opa-bundle*.sh' -exec dirname {} \; | sort -u)
 
-          if [ "${{ github.event_name }}" = "push" ]; then
-            echo "Event push -> always verify (post-merge; keeps the deployed-bundle check current)."
+          # merge_group is grouped with push, not with pull_request, and the reason is not
+          # convenience. A path-based skip needs a base to diff against, and in a queue the
+          # entry under test is a BATCH whose contents were each green against a different
+          # base -- which is the exact staleness the queue exists to remove. Verifying
+          # unconditionally costs a few minutes per batch and cannot be wrong; skipping on a
+          # mis-derived diff can. `push` already takes this branch for the same reason.
+          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "Event ${{ github.event_name }} -> always verify."
             echo "relevant=true" >> "$GITHUB_OUTPUT"
           else
             BASE="origin/${{ github.base_ref }}"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  # ADR-0272. `Gitleaks` is a required status check, so it must report on the queue's event or
+  # the queue stalls on it forever (never reports, never fails).
+  merge_group:
   schedule:
     - cron: "0 4 * * 1"  # weekly Monday 04:00 UTC
 
@@ -22,8 +25,10 @@ concurrency:
   # PR pushes keep the superseding behaviour, which is what that setting is for.
   # The key stays O(1) — a sha, never a list: interpolating a fleet-sized value here
   # stops the job being created at all (#3082).
-  group: secret-scan-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci' }}
-  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+  # A merge_group run is never cancelled: a cancelled run leaves its required context ABSENT,
+  # and the queue cannot act on absent -- it waits (ADR-0272).
+  group: secret-scan-${{ github.event_name }}-${{ github.ref }}-${{ ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group') && github.sha || 'ci' }}
+  cancel-in-progress: ${{ !((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group') }}
 
 jobs:
   gitleaks:
@@ -71,6 +76,8 @@ jobs:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PUSH_BEFORE_SHA: ${{ github.event.before }}
           PUSH_AFTER_SHA: ${{ github.sha }}
+          MG_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
         run: |
           set -euo pipefail
           LOG_OPTS=""
@@ -80,6 +87,20 @@ jobs:
             # github.event.before is all-zeroes for the first push of a branch.
             if [ -n "${PUSH_BEFORE_SHA}" ] && [ "${PUSH_BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]; then
               LOG_OPTS="--log-opts=--no-merges ${PUSH_BEFORE_SHA}..${PUSH_AFTER_SHA}"
+            fi
+          elif [ "${{ github.event_name }}" = "merge_group" ]; then
+            # The queued BATCH: base_sha is where the batch branched from main, head_sha its tip.
+            # Scoping to that range matters in both directions -- an unscoped run would rescan the
+            # whole history on every batch (slow, and it re-surfaces findings the baseline already
+            # settled), while scoping to the wrong range would scan nothing and report clean, which
+            # is the failure mode a secret scanner must never have.
+            if [ -n "${MG_BASE_SHA}" ] && [ -n "${MG_HEAD_SHA}" ]; then
+              LOG_OPTS="--log-opts=--no-merges ${MG_BASE_SHA}..${MG_HEAD_SHA}"
+            else
+              # Refuse to silently degrade into "scanned nothing, found nothing".
+              echo "::error::merge_group payload carried no base/head sha — refusing to report a" \
+                   "clean scan that examined an undefined range."
+              exit 1
             fi
           fi
           gitleaks detect --source . --config .gitleaks.toml \

--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -37,6 +37,10 @@ on:
   push:
     branches: [main]
   pull_request:
+  # ADR-0272. `all-green` is a required status check; without this trigger the queue waits on it
+  # forever. It aggregates the per-service builds, so this is also where the queue actually pays
+  # for itself -- the batch is compiled and tested as the tree it will become.
+  merge_group:
   # Nightly full-fleet health build. PRs are path-scoped (only changed services build),
   # so a PR that breaks a service it does NOT touch ships green and the breakage only
   # surfaces post-merge — where nobody watches. (account-service did not compile on main
@@ -62,8 +66,10 @@ concurrency:
   # (issue #846). Key push-to-main by SHA so every commit gets its own lane and is never
   # cancelled; PR pushes keep the superseding behavior (a new push to the same branch
   # should cancel the old run).
-  group: services-ci-${{ github.ref }}-${{ github.event_name == 'schedule' && 'nightly' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci') }}
-  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+  # A merge_group run gets its own lane and is never cancelled: a cancelled run leaves the
+  # required context ABSENT, and the queue treats absent as "still waiting", not as a verdict.
+  group: services-ci-${{ github.ref }}-${{ github.event_name == 'schedule' && 'nightly' || (((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group') && github.sha || 'ci') }}
+  cancel-in-progress: ${{ !((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group') }}
 
 jobs:
   changes:
@@ -98,7 +104,8 @@ jobs:
              || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "Event ${{ github.event_name }} -> build all modules (full-fleet)."
             CHANGED="$ALL"
-          elif [ "${{ github.event_name }}" = "push" ]; then
+          elif [ "${{ github.event_name }}" = "push" ] \
+               || [ "${{ github.event_name }}" = "merge_group" ]; then
             # A push to main normally re-runs the WHOLE fleet so every provider
             # re-verifies every consumer's current contract (Pact matrix completeness,
             # ADR-0092) and publishes fresh results the SHA's auto-deploy gates on (#846).
@@ -114,8 +121,28 @@ jobs:
             # safe direction is over-build, never under-build (an under-build would leave a
             # stale/missing Pact verification). fetch-depth:0 above guarantees HEAD~1
             # exists (main is squash-merged => each push is a single commit).
-            FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
-            echo "Push changed files:"; echo "$FILES"
+            # HEAD~1 is right for a squash-merged main push (each push is one commit) but wrong
+            # for a queue entry, whose parent is the previous entry in the same batch, not the
+            # branch point. merge_group carries base_sha for exactly this.
+            if [ "${{ github.event_name }}" = "merge_group" ]; then
+              DIFF_BASE="${{ github.event.merge_group.base_sha }}"
+              if [ -z "$DIFF_BASE" ] || ! git cat-file -e "${DIFF_BASE}^{commit}" 2>/dev/null; then
+                # Building nothing here would report all-green over an empty matrix -- a pass that
+                # examined no service. Fall back to the full fleet: over-build is recoverable,
+                # under-build ships an unbuilt module (#1001).
+                echo "::warning::merge_group base_sha missing or unfetchable -> full-fleet build."
+                DIFF_BASE=""
+              fi
+            else
+              DIFF_BASE="HEAD~1"
+            fi
+            if [ -z "$DIFF_BASE" ]; then
+              FILES="$(git ls-files)"
+            else
+              FILES=$(git diff --name-only "$DIFF_BASE" HEAD 2>/dev/null || true)
+            fi
+            echo "Changed files (${{ github.event_name }}, base ${DIFF_BASE:-<full-fleet>}):"
+            echo "$FILES"
             # Inert = provably cannot change a compile input or a contract. Anchored so a
             # service's own src/ (or ANY build.gradle.kts, openbank-libs, gradle/, contracts
             # under pacts/) is NEVER matched here and thus never treated as inert. Feed grep


### PR DESCRIPTION
**ADR-0272 step 2.** Every required status check now reports on `merge_group`. **The queue is not enabled** — step 3 is validation against a real payload on a canary branch.

## Why this had to come first

A merge queue merges an entry only once every required check reports on `merge_group`. A context that never reports there does not **fail** the queue — it **stalls** it, forever, with zero failures. All five were in that state.

The readiness check from #6499, before and after:

```
before:  5 required context(s) checked, 0 orphaned, 5 not merge_group-ready
after:   5 required context(s) checked, 0 orphaned, 0 not merge_group-ready
```

## Two categories, not interchangeable

Conflating them is how the queue goes permanently **red** instead of permanently stalled.

### State-scoped — validate the resulting tree

**`ci.yml` → `Validate manifests`.** This is where the measured defect lands: 19 of 20 main breakages came from green PRs, failing in `gates (data)` / `gates (supplychain)` only once merged.

New `resolve merge-group diff base` step. The honest base is where the **batch** branched from the target branch, which `merge_group` carries as `base_sha` — so the whole batch classifies against `main` in one comparison. That is not a fallback for the missing PR: it is the comparison ADR-0048 says **cannot** be made at PR time, because a PR whose last run predates a competing spec merge is invisible to any base resolved then.

`BASE_REF` also learns the event — `github.base_ref` is empty on `merge_group` and `github.ref_name` is the *queue's* ref, not the target branch.

**`services-ci.yml` → `all-green`.** Where the queue pays for itself: the batch is compiled and tested as the tree it will become. Routed through the existing **push** path — already "diff a range, attribute files to modules, fall back to full fleet when a path is not cleanly attributable" — with only the range differing. `HEAD~1` is right for a squash-merged push and wrong for a queue entry, whose parent is the previous entry in the batch.

A missing `base_sha` falls back to full-fleet, never to an empty matrix: `all-green` over nothing is a pass that examined no service (#1001).

**`secret-scan.yml` → `Gitleaks`.** Scans `base_sha..head_sha`. Scope matters in both directions — unscoped rescans all history every batch; mis-scoped scans nothing and reports clean, which a secret scanner must never do. An absent payload is an explicit error, not a silent full-history pass.

**`opa-policy.yml` → `OPA policy gate`.** Grouped with `push`, not `pull_request`. A path-based skip needs a base, and in a queue the entry is a batch whose members were each green against a *different* base — the exact staleness the queue removes. Verifying unconditionally cannot be wrong; skipping on a mis-derived diff can.

### PR-scoped — validate the change as authored

**`issue-hygiene.yml`.** It asserts the PR links an issue, and a merge group has no PR. It still has to **report**, so it runs and succeeds as an explicit no-op step. The property was established on each entry's own PR before it was queued.

## Concurrency — the subtle half

In all five: a `merge_group` run gets its own sha-keyed lane and is **never cancelled**. A cancelled run leaves its required context **absent**, and absent is not a verdict the queue can act on — it waits.

`issue-hygiene` needed this most: its group was keyed on `github.event.pull_request.number`, which is empty on `merge_group`, so **every queue entry would have shared one group and cancelled the others**.

## Verification

- `actionlint` clean on all five. The two shellcheck findings in `services-ci.yml` are byte-identical on `origin/main` — verified by stashing and re-running, not assumed.
- `run-gates.py --all`: no new failure.
- YAML parses; triggers confirmed per file.

**What is not verified, and cannot be yet:** none of this executes until a `merge_group` event exists. That is step 3 — a canary branch with its own queue — and it is deliberately not folded into this PR.

Refs #4339
