### PR TITLE
fix(admin-ui): clarify agent loading state

### DIFF
--- a/openbank-admin-ui/src/app/system/agent/page.tsx
+++ b/openbank-admin-ui/src/app/system/agent/page.tsx
@@ -89,8 +89,8 @@ export default function AgentPage() {
         title={t('Agent služba', 'Agent Service')}
         subtitle={t('MCP server zpřístupňující nástroje OpenBank AI agentům · JSON-RPC 2.0 přes HTTP', 'MCP server exposing OpenBank tools to AI agents · JSON-RPC 2.0 over HTTP')}
         icon={<Bot aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
-        actions={<button type="button" className="btn btn-secondary" onClick={loadTools} disabled={loading}>
-          <RefreshCw size={13} className={cn(loading && 'animate-spin')} />
+        actions={<button type="button" className="btn btn-secondary" onClick={loadTools} disabled={loading} aria-busy={loading} aria-label={t('Obnovit nástroje agenta', 'Refresh agent tools')}>
+          <RefreshCw size={13} aria-hidden="true" className={cn(loading && 'animate-spin')} />
           {t('Obnovit', 'Refresh')}
         </button>}
       />
@@ -170,8 +170,8 @@ export default function AgentPage() {
 
       {/* Loading */}
       {loading && !error && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '40px 0', color: 'var(--text-tertiary)', fontSize: '13px' }}>
-          <RefreshCw size={15} className="animate-spin" style={{ color: 'var(--accent)' }} />
+        <div role="status" aria-live="polite" style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '40px 0', color: 'var(--text-tertiary)', fontSize: '13px' }}>
+          <RefreshCw size={15} aria-hidden="true" className="animate-spin" style={{ color: 'var(--accent)' }} />
           {t('Připojování k MCP serveru…', 'Connecting to MCP server…')}
         </div>
       )}

--- a/openbank-admin-ui/src/test/agent-loading.guard.test.ts
+++ b/openbank-admin-ui/src/test/agent-loading.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('agent tools loading contract', () => {
+  it('announces loading and names refresh without changing MCP flow', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/system/agent/page.tsx'), 'utf8')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit nástroje agenta', 'Refresh agent tools')}")
+    expect(source).toContain('<div role="status" aria-live="polite"')
+    expect(source).toContain('onClick={loadTools}')
+  })
+})


### PR DESCRIPTION
## Summary
- add localized accessible name and busy semantics to Agent tools refresh
- announce MCP tool loading and hide decorative spinners
- preserve JSON-RPC fetch, agent execution and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.