### PR TITLE
fix(governance): the agent guard did not cover the agents' own prompts

### DIFF
--- a/.github/scripts/check-agent-pr-guard.py
+++ b/.github/scripts/check-agent-pr-guard.py
@@ -313,6 +313,7 @@ FIXTURE = {
         "openbank-libs/governance/*",
         ".github/gates/*",
         ".github/scripts/*",
+        ".github/agent-prompts/*",
     ],
     "_money_path_services": ["openbank-ledger-service", "openbank-balance-service"],
 }
@@ -355,6 +356,11 @@ def self_test():
             "a gate script is governance machinery too",
             "openbank-agent-bot[bot]", True, "agent/x",
             [".github/scripts/check-something.py"], 1, "governance sources",
+        ),
+        (
+            "an agent's own PROMPT is its program — it may not edit its mandate",
+            "openbank-agent-bot[bot]", True, "agent/x",
+            [".github/agent-prompts/issue-worker.md"], 1, "governance sources",
         ),
         (
             "docs ABOUT authz are NOT the control (#3888)",

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -3093,3 +3093,13 @@ autonomous_agent_prs:
     - openbank-libs/governance/*
     - .github/gates/*
     - .github/scripts/*
+    # An agent's PROMPT is its program. `.github/agent-prompts/` holds the instructions the
+    # scheduled issue worker and PR steward actually execute — "never merge", "never close an
+    # issue", "run the guard's self-test before picking". An agent able to edit these could
+    # delete its own restraints in a diff that looks like a docs tweak.
+    #
+    # This was MISSING and asserted to be present: #6453 and runbook 0015 both claimed the
+    # prompts were protected "so the worker cannot edit its own mandate". Nobody had run the
+    # guard against those paths, and it tripped no clause at all (measured 2026-08-22 on #6512,
+    # a PR touching only this directory, which the guard waved through).
+    - .github/agent-prompts/*


### PR DESCRIPTION
Refs #6412

## The gap

`.github/agent-prompts/` holds the instructions the scheduled agents **actually execute** — the
issue worker's and the PR steward's. Those files contain the restraints:

- *never merge, approve, or enable auto-merge*
- *never close an issue*
- *run `check-agent-pr-guard.py --self-test` before picking an issue*
- *a PR red because of `agent-pr-guard` must wait for a human*

An agent able to edit that directory can delete its own restraints, in a diff that reads as a
documentation tweak.

**`agent-pr-guard` did not protect it.** It matched `.github/workflows|actions`,
`.github/scripts`, `.github/gates`, `openbank-libs/governance`, money-path service paths, and
authorization policy. Not the prompts.

## Worse than the gap: it was asserted closed

PR #6453 says, in its own body:

> Both files this PR adds are themselves protected paths — `.github/workflows/` and
> `.github/agent-prompts/` under `.github/` — so the worker cannot edit its own mandate.

Runbook 0015 repeats it. **Nobody ran the guard against those paths.** The claim was inferred
from the directory sitting under `.github/`, which is not how the checker matches.

Measured today on **#6512**, a PR touching only `.github/agent-prompts/`: the guard tripped no
clause at all and the local merge hook allowed it. That is how this surfaced — not by review, but
by a merge that should have been refused and was not.

## The fix

`.github/agent-prompts/*` joins `autonomous_agent_prs.governance_path_globs`, with a comment in
`rules.yaml` recording why and how it was missed.

A self-test case is added: *"an agent's own PROMPT is its program — it may not edit its mandate"*.

## Verification

- self-test: **15** classifier cases + 4 undetermined, every block clause independently reached
- **negative control**: removing the new glob makes that case fail with
  `exit 0, expected 1 — ... touches no protected path`. The clause is doing the work, not
  passing incidentally.
- `run-gates.py --group lint` — 24/24 PASS

## Consequence for the agents

They can no longer submit a change to their own prompts. A human must. That is the intended
shape, and it is now true rather than claimed.
