### PR TITLE
fix(admin-ui): announce IAOPS case loading

### DIFF
--- a/openbank-admin-ui/src/app/iaops/cases/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/cases/page.tsx
@@ -149,8 +149,8 @@ export default function IaopsCasesPage() {
       </div>
 
       {loading ? (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '40px', color: 'var(--text-tertiary)' }}>
-          <RefreshCw size={16} style={{ animation: 'spin 0.8s linear infinite' }} />
+        <div role="status" aria-live="polite" style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '40px', color: 'var(--text-tertiary)' }}>
+          <RefreshCw size={16} aria-hidden="true" style={{ animation: 'spin 0.8s linear infinite' }} />
           <span style={{ fontSize: '13px' }}>{t('Načítám case…', 'Loading cases…')}</span>
         </div>
       ) : cases.length === 0 ? (
@@ -219,6 +219,7 @@ export default function IaopsCasesPage() {
           </div>
           {cases.length >= limit && limit < MAX_LIMIT && (
             <button
+              type="button"
               onClick={() => setLimit(Math.min(limit + PAGE_SIZE, MAX_LIMIT))}
               style={{
                 marginTop: '14px', fontSize: '12px', fontWeight: 700, padding: '8px 18px', borderRadius: '10px',

--- a/openbank-admin-ui/src/test/iaops-cases-loading.guard.test.ts
+++ b/openbank-admin-ui/src/test/iaops-cases-loading.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('IAOPS cases loading contract', () => {
+  it('announces loading and keeps pagination controls explicit', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/iaops/cases/page.tsx'), 'utf8')
+    expect(source).toContain('<div role="status" aria-live="polite"')
+    expect(source).toContain('<RefreshCw size={16} aria-hidden="true"')
+    expect(source).toContain("t('Načítám case…', 'Loading cases…')")
+    expect(source).toContain('type="button"')
+  })
+})


### PR DESCRIPTION
## Summary
- expose IAOPS cases loading as a polite status
- hide decorative spinner and make pagination action explicit
- preserve governance fetch/filter/pagination and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.