### PR TITLE
fix(admin-ui): clarify flaky hunter loading

### DIFF
--- a/openbank-admin-ui/src/app/iaops/flaky-test-hunter/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/flaky-test-hunter/page.tsx
@@ -113,8 +113,8 @@ function FlakyTestHunterContent() {
         breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><Link href="/iaops" className="breadcrumb-current" style={{ textDecoration: 'none' }}>{t('IAOps', 'IAOps')}</Link><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Flaky testy', 'Flaky tests')}</span></div>}
         actions={
           <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-            <button className="btn btn-secondary" onClick={() => void load()} disabled={loading}>
-              <RefreshCw size={13} className={loading ? 'animate-spin' : undefined} />
+            <button type="button" className="btn btn-secondary" onClick={() => void load()} disabled={loading} aria-busy={loading} aria-label={t('Obnovit flaky testy', 'Refresh flaky tests')}>
+              <RefreshCw size={13} aria-hidden="true" className={loading ? 'animate-spin' : undefined} />
               {t('Obnovit', 'Refresh')}
             </button>
             {canTrigger && (
@@ -168,8 +168,8 @@ function FlakyTestHunterContent() {
 
       <div className="card">
         {loading ? (
-          <div style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
-            <RefreshCw size={20} className="animate-spin" style={{ marginBottom: '8px', margin: '0 auto', display: 'block' }} />
+          <div role="status" aria-live="polite" style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
+            <RefreshCw size={20} aria-hidden="true" className="animate-spin" style={{ marginBottom: '8px', margin: '0 auto', display: 'block' }} />
             <div>{t('Načítám…', 'Loading…')}</div>
           </div>
         ) : findings.length === 0 ? (

--- a/openbank-admin-ui/src/test/flaky-hunter-loading.guard.test.ts
+++ b/openbank-admin-ui/src/test/flaky-hunter-loading.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('flaky test hunter loading contract', () => {
+  it('announces loading and names refresh without changing governance flow', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/iaops/flaky-test-hunter/page.tsx'), 'utf8')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit flaky testy', 'Refresh flaky tests')}")
+    expect(source).toContain('<div role="status" aria-live="polite"')
+    expect(source).toContain('onClick={() => void load()}')
+  })
+})


### PR DESCRIPTION
## Summary
- add localized accessible name and busy semantics to Flaky Test Hunter refresh
- announce findings loading and hide decorative spinners
- preserve findings fetch, trigger HITL flow, governance and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.