### PR TITLE
fix(admin-ui): announce IAOPS agent loading

### DIFF
--- a/openbank-admin-ui/src/app/iaops/agents/[agentId]/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/agents/[agentId]/page.tsx
@@ -225,8 +225,8 @@ function AgentDetailContent() {
       />
 
       {loading && !data ? (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '40px', color: 'var(--text-tertiary)' }}>
-          <RefreshCw size={16} style={{ animation: 'spin 0.8s linear infinite' }} />
+        <div role="status" aria-live="polite" style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '40px', color: 'var(--text-tertiary)' }}>
+          <RefreshCw size={16} aria-hidden="true" style={{ animation: 'spin 0.8s linear infinite' }} />
           <span style={{ fontSize: '13px' }}>{t('Načítám agenta…', 'Loading agent…')}</span>
         </div>
       ) : data ? (

--- a/openbank-admin-ui/src/test/iaops-agent-loading.guard.test.ts
+++ b/openbank-admin-ui/src/test/iaops-agent-loading.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('IAOPS agent loading contract', () => {
+  it('announces agent detail loading without changing probe flow', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/iaops/agents/[agentId]/page.tsx'), 'utf8')
+    expect(source).toContain('<div role="status" aria-live="polite"')
+    expect(source).toContain('<RefreshCw size={16} aria-hidden="true"')
+    expect(source).toContain("t('Načítám agenta…', 'Loading agent…')")
+    expect(source).toContain('triggerBoundedCheck')
+  })
+})


### PR DESCRIPTION
## Summary
- expose IAOPS agent detail loading as a polite status
- hide decorative spinner from assistive technology
- preserve agent probe, bounded check and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.