### PR TITLE
fix(admin-ui): announce flaky finding loading

### DIFF
--- a/openbank-admin-ui/src/app/iaops/flaky-test-hunter/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/flaky-test-hunter/[id]/page.tsx
@@ -57,8 +57,8 @@ function FlakyTestFindingDetailContent() {
       />
 
       {loading ? (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '40px', color: 'var(--text-tertiary)' }}>
-          <RefreshCw size={16} style={{ animation: 'spin 0.8s linear infinite' }} />
+        <div role="status" aria-live="polite" style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '40px', color: 'var(--text-tertiary)' }}>
+          <RefreshCw size={16} aria-hidden="true" style={{ animation: 'spin 0.8s linear infinite' }} />
           <span style={{ fontSize: '13px' }}>{t('Načítám nález…', 'Loading finding…')}</span>
         </div>
       ) : unavailable ? (

--- a/openbank-admin-ui/src/test/flaky-hunter-detail-loading.guard.test.ts
+++ b/openbank-admin-ui/src/test/flaky-hunter-detail-loading.guard.test.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('flaky finding detail loading contract', () => {
+  it('announces detail loading without changing finding fetch flow', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/iaops/flaky-test-hunter/[id]/page.tsx'), 'utf8')
+    expect(source).toContain('<div role="status" aria-live="polite"')
+    expect(source).toContain('<RefreshCw size={16} aria-hidden="true"')
+    expect(source).toContain("t('Načítám nález…', 'Loading finding…')")
+  })
+})


### PR DESCRIPTION
## Summary
- expose flaky finding detail loading as a polite status
- hide the decorative spinner from assistive technology
- preserve finding fetch, governance truthfulness and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.