### PR TITLE
fix(ci): release agent claim branches that carry no work

### DIFF
--- a/.github/workflows/agent-issue-worker.yml
+++ b/.github/workflows/agent-issue-worker.yml
@@ -230,6 +230,44 @@ jobs:
               exit 1 ;;
           esac
 
+      # ---- reclaim abandoned claims ---------------------------------------------------------
+      # The prompt tells the agent to delete its claim branch when it gives up. That only covers
+      # the case where it gives up ON PURPOSE. A run that DIES mid-flight — hit its turn limit,
+      # ended a turn waiting for a background task that never reports, timed out — cannot clean
+      # up after itself, and the claim it already pushed is then permanent.
+      #
+      # That is not a tidiness problem. STEP 1 discards any issue that already has an `agent/`
+      # branch naming it, so an orphan silently removes that issue from the backlog forever,
+      # with nothing anywhere to explain why it is never picked. Two runs died that way on
+      # 2026-08-22 (15:14 and the 18:17 schedule), each leaving one.
+      #
+      # An EMPTY claim is unambiguous: a branch under `agent/` with no open PR and no commit of
+      # its own beyond origin/main is a ref that was pushed at the claim step and never built
+      # on. Deleting exactly that set can never destroy work — a branch carrying a single
+      # commit is left alone and reported instead.
+      - name: Release claim branches that carry no work
+        if: always() && steps.mode.outputs.mode == 'work'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          git fetch origin main --quiet
+          released=0; kept=0
+          for ref in $(git ls-remote --heads origin 'refs/heads/agent/*' | awk '{print $2}' | sed 's|refs/heads/||'); do
+            if [ -n "$(gh pr list -R "${GITHUB_REPOSITORY}" --head "$ref" --state all --json number --jq '.[0].number // empty')" ]; then
+              continue                                  # has a PR: it is real work, leave it
+            fi
+            git fetch origin "refs/heads/${ref}" --quiet
+            ahead=$(git rev-list --count origin/main..FETCH_HEAD)
+            if [ "$ahead" -eq 0 ]; then
+              git push origin --delete "$ref" && echo "released empty claim: $ref" && released=$((released+1))
+            else
+              echo "::warning::branch ${ref} has ${ahead} commit(s) and no PR — a human should decide; not deleting it"
+              kept=$((kept+1))
+            fi
+          done
+          echo "claim gc: ${released} released, ${kept} left for a human"
+
       - name: Summarise
         if: always() && steps.mode.outputs.mode == 'work'
         run: |


### PR DESCRIPTION
Refs #6412

## The residual gap

The prompt tells the worker to delete its claim branch when it gives up. That covers giving up **on purpose**. A run that **dies** mid-flight — turn limit, a turn ended waiting on a background task that never reports, a timeout — cannot clean up after itself.

And an orphaned claim is not clutter. STEP 1 discards any issue that already has an `agent/` branch naming it, so the orphan **silently removes that issue from the backlog forever**, with nothing anywhere to explain why it is never picked again.

Two runs died that way today — the 15:14 dispatch and the 18:17 schedule — each leaving a claim on #6479. Both were found by hand. The third time nobody would be looking.

## The fix

An `if: always()` step that releases exactly the unambiguous case:

- a branch under `agent/`
- **and** no PR of any state referencing it as head
- **and** `git rev-list --count origin/main..<branch>` is **0**

That is a ref pushed at the claim step and never built on. Deleting it cannot destroy work.

A branch carrying even **one** commit is left alone and reported as a `::warning::` for a human — the same asymmetry the worktree-cleanup rule uses: rescue-then-verify, never verify-then-maybe-rescue.

It runs on every `work` invocation regardless of outcome, so **the run that dies is cleaned up by the next one** rather than by whoever happens to notice.

## Verification

- `run-gates.py --group lint` — 24/24 PASS
- The known-positive is today's two orphans: both had `ahead == 0`, and both were deleted by hand after being found. This step would have released them on the following run.
- The negative case is #6547's branch (`agent/fix-notification-approval-inbox-5679`): it has a PR, so the first condition excludes it before the commit count is even consulted.