### PR TITLE
fix(case-coordinator): correct case UI claim

### DIFF
--- a/docs/agents/case-coordinator.md
+++ b/docs/agents/case-coordinator.md
@@ -67,6 +67,7 @@ The `openbank-case-coordinator-agent` module now runs the case lifecycle:
 - **The capability gate is not yet OPA-backed.** Phase 1 checks `agents.yaml` directly (fail-closed);
   routing the decision through the per-service OPA bundle, and shipping the coordinator's GitOps
   deployment (CNPG database, `openbank.temporal.enabled=true`, network policies), is Phase 4.
-- **There is no read API or visualization yet.** Case history projection (Phase 2) and the admin-ui
-  swarm thread view (Phase 3, ADR-0246) are follow-up work; until then a case is observable only
-  through Temporal's own tooling.
+- **The read-only case index is live, but durable history remains incomplete.** `/iaops/cases`
+  truthfully shows opened coordination cases (and an explicit empty state when none exist). A
+  durable history projection and a per-case evidence/thread view remain follow-up work; Temporal
+  is still the authoritative source for workflow history.


### PR DESCRIPTION
## Summary

Corrects the case-coordinator narrative shown in the deployed Agent Control Room: `/iaops/cases` is a live read-only case index and must not be described as having no visualization.

## Linked issue

Refs #6426

## Scope

- Corrects only the stale factual claim in `docs/agents/case-coordinator.md`.
- Keeps the remaining limitation explicit: durable history and per-case evidence/thread views still require runtime evidence; Temporal remains authoritative.
- No charter capability, OPA grant, Temporal signal ingress, API, data, or operator-mutation change.

## Verification

- `git diff --check`
- `bash .github/scripts/check-agent-charter-registry.sh openbank-libs/governance/agents.yaml docs/agents` — 16/16 parity
- Authenticated production audit: `/iaops/cases` renders an explicit "No cases have been opened yet" state, while the profile had claimed no visualization existed.

## Compliance impact

Truthful operator-facing status; no change to authority or data handling.
