### PR TITLE
fix(admin-ui): clarify BCP refresh state

### DIFF
--- a/openbank-admin-ui/src/app/docs/bcp/page.tsx
+++ b/openbank-admin-ui/src/app/docs/bcp/page.tsx
@@ -323,9 +323,12 @@ export default function BcpPage() {
           )}
           <PrintDocumentButton />
           <button
+            type="button"
             className="btn"
             onClick={fetchHealth}
             disabled={loading}
+            aria-busy={loading}
+            aria-label={t('Obnovit stav BCP', 'Refresh BCP status')}
             style={{
               display: 'flex', alignItems: 'center', gap: '6px',
               padding: '8px 14px', borderRadius: '8px', border: '1px solid var(--border)',
@@ -333,7 +336,7 @@ export default function BcpPage() {
               color: 'var(--text-primary)',
             }}
           >
-            <RefreshCw size={13} style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
+            <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
         </div>}

--- a/openbank-admin-ui/src/test/bcp-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/bcp-refresh.guard.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('BCP refresh contract', () => {
+  it('exposes localized busy semantics without changing health probes', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/docs/bcp/page.tsx'), 'utf8')
+    expect(source).toContain('type="button"')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit stav BCP', 'Refresh BCP status')}")
+    expect(source).toContain('onClick={fetchHealth}')
+    expect(source).toContain('<RefreshCw size={13} aria-hidden="true"')
+  })
+})


### PR DESCRIPTION
## Summary
- add explicit button semantics and localized busy/name state to BCP health refresh
- preserve service/infrastructure health probes, truthfulness and docs flow

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.