### PR TITLE
fix(ci): open agent PRs as openbank-agent-bot, so their checks actually run

### DIFF
--- a/.github/workflows/agent-issue-worker.yml
+++ b/.github/workflows/agent-issue-worker.yml
@@ -95,10 +95,62 @@ jobs:
       contents: write        # push an agent/ branch — never main, enforced by branch rules
       pull-requests: write   # open a draft PR
       issues: write          # comment on the issue it worked
+    env:
+      AGENT_APP_ID: ${{ secrets.AGENT_APP_ID }}
     steps:
+      # ---- identity ------------------------------------------------------------------------
+      # A PR opened with the workflow's own GITHUB_TOKEN does not get its checks run. Measured
+      # on #6547: all NINE workflow runs on its head sat at `conclusion: action_required`,
+      # waiting for a maintainer to click "Approve and run". Nothing had failed — nothing had
+      # STARTED. That is GitHub refusing to let a token trigger further automation, and it
+      # stalls this loop at its first step: the steward has no verdict to act on, the PR sits,
+      # and a human has to click before any of it moves.
+      #
+      # An App token is not subject to that. `auto-deploy.yml` learned the same lesson for a
+      # second reason worth keeping in view: GitHub signs API-created commits only for Apps and
+      # the web UI, never for a user PAT — an assumption that was wrong for five days and
+      # stranded seven deploy PRs (#1269).
+      #
+      # It must be `openbank-agent-bot`, NOT the gitops App. `openbank-gitops-bot` is declared
+      # in `rules.yaml: autonomous_agent_prs.automation_accounts`, so `agent-pr-guard` treats
+      # its PRs as out of scope by design — borrowing that identity here would silently switch
+      # the guard OFF for every agent PR. `openbank-agent-bot` is in `agent_accounts`, which is
+      # what keeps the guard pointed at this work.
+      - name: Mint the agent App token
+        id: apptoken
+        if: env.AGENT_APP_ID != ''
+        env:
+          AGENT_APP_ID: ${{ secrets.AGENT_APP_ID }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AGENT_APP_ID }}
+          private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+
+      # Fall back rather than fail: without the secrets this still works, it just produces PRs
+      # whose checks need a manual "Approve and run". Say so loudly instead of leaving somebody
+      # to rediscover it from a PR that looks stuck for no reason.
+      - name: Resolve the token to use
+        id: token
+        env:
+          APP_TOKEN: ${{ steps.apptoken.outputs.token }}
+          FALLBACK: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "${APP_TOKEN:-}" ]; then
+            echo "identity: openbank-agent-bot (App token)"
+            echo "token=${APP_TOKEN}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::AGENT_APP_ID/AGENT_APP_PRIVATE_KEY are not set — falling back to GITHUB_TOKEN. Any PR opened by this run will have its checks stuck at 'action_required' until a maintainer approves them by hand."
+            echo "identity: github-actions (GITHUB_TOKEN fallback)"
+            echo "token=${FALLBACK}" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          # actions/checkout persists whatever token it is given as the git credential.
+          # Without this, `git push` would go out as GITHUB_TOKEN no matter what the
+          # steps below mint, and the PR's checks would sit at `action_required` again.
+          token: ${{ steps.token.outputs.token }}
 
       - name: Decide mode
         id: mode
@@ -188,7 +240,7 @@ jobs:
         if: steps.mode.outputs.mode == 'work'
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           set -uo pipefail
           git config user.name  "openbank-issue-worker"

--- a/.github/workflows/agent-pr-steward.yml
+++ b/.github/workflows/agent-pr-steward.yml
@@ -70,10 +70,62 @@ jobs:
       pull-requests: write   # comment on the PR it tended
       checks: read
       actions: read
+    env:
+      AGENT_APP_ID: ${{ secrets.AGENT_APP_ID }}
     steps:
+      # ---- identity ------------------------------------------------------------------------
+      # A PR opened with the workflow's own GITHUB_TOKEN does not get its checks run. Measured
+      # on #6547: all NINE workflow runs on its head sat at `conclusion: action_required`,
+      # waiting for a maintainer to click "Approve and run". Nothing had failed — nothing had
+      # STARTED. That is GitHub refusing to let a token trigger further automation, and it
+      # stalls this loop at its first step: the steward has no verdict to act on, the PR sits,
+      # and a human has to click before any of it moves.
+      #
+      # An App token is not subject to that. `auto-deploy.yml` learned the same lesson for a
+      # second reason worth keeping in view: GitHub signs API-created commits only for Apps and
+      # the web UI, never for a user PAT — an assumption that was wrong for five days and
+      # stranded seven deploy PRs (#1269).
+      #
+      # It must be `openbank-agent-bot`, NOT the gitops App. `openbank-gitops-bot` is declared
+      # in `rules.yaml: autonomous_agent_prs.automation_accounts`, so `agent-pr-guard` treats
+      # its PRs as out of scope by design — borrowing that identity here would silently switch
+      # the guard OFF for every agent PR. `openbank-agent-bot` is in `agent_accounts`, which is
+      # what keeps the guard pointed at this work.
+      - name: Mint the agent App token
+        id: apptoken
+        if: env.AGENT_APP_ID != ''
+        env:
+          AGENT_APP_ID: ${{ secrets.AGENT_APP_ID }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AGENT_APP_ID }}
+          private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+
+      # Fall back rather than fail: without the secrets this still works, it just produces PRs
+      # whose checks need a manual "Approve and run". Say so loudly instead of leaving somebody
+      # to rediscover it from a PR that looks stuck for no reason.
+      - name: Resolve the token to use
+        id: token
+        env:
+          APP_TOKEN: ${{ steps.apptoken.outputs.token }}
+          FALLBACK: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "${APP_TOKEN:-}" ]; then
+            echo "identity: openbank-agent-bot (App token)"
+            echo "token=${APP_TOKEN}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::AGENT_APP_ID/AGENT_APP_PRIVATE_KEY are not set — falling back to GITHUB_TOKEN. Any PR opened by this run will have its checks stuck at 'action_required' until a maintainer approves them by hand."
+            echo "identity: github-actions (GITHUB_TOKEN fallback)"
+            echo "token=${FALLBACK}" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          # actions/checkout persists whatever token it is given as the git credential.
+          # Without this, `git push` would go out as GITHUB_TOKEN no matter what the
+          # steps below mint, and the PR's checks would sit at `action_required` again.
+          token: ${{ steps.token.outputs.token }}
 
       - name: Decide mode
         id: mode
@@ -111,7 +163,7 @@ jobs:
       - name: Tend
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.token.outputs.token }}
           STEWARD_MODE: ${{ steps.mode.outputs.mode }}
         run: |
           set -uo pipefail


### PR DESCRIPTION
Refs #6412

## The blocker

A PR opened with the workflow's own `GITHUB_TOKEN` **does not get its checks run.**

Measured on #6547, the first real PR the worker produced: all **nine** workflow runs on its head sat at `conclusion: action_required`, waiting for a maintainer to click *Approve and run*. Nothing had failed — nothing had **started**.

That stalls the loop at its first step. The steward looked at #6547, correctly found there was no verdict to act on, and reported `NOTHING TO TEND`. It also verified it could not unblock it itself (`403 Resource not accessible by integration` on the approve endpoint) — which is right: that gate is maintainer-only by design.

**An agent pipeline whose every output needs a click is not unattended.**

## The fix

Both workflows mint an installation token for the **`openbank-agent-bot`** App and use it for checkout, `git push`, and `gh`.

**Order matters and is the subtle part.** `actions/checkout` persists whatever token it is given as the git credential, so the mint runs **before** checkout and the token is passed into it. Without that, pushes go out as `GITHUB_TOKEN` no matter what was minted — the bug survives a change that looks like it fixed it.

## Why not the gitops App

`openbank-gitops-bot` already has App credentials in this repo and would have been the quick answer. It is declared in `rules.yaml: autonomous_agent_prs.automation_accounts`, so **`agent-pr-guard` treats its PRs as out of scope by design**. Borrowing that identity would have switched the guard **off** for every agent PR while looking like a fix.

`openbank-agent-bot` is in `agent_accounts`, which is what keeps the guard pointed at this work.

## A second reason, from a real incident

`auto-deploy.yml` documents it in place: GitHub signs API-created commits only for **Apps and the web UI**, never for a user PAT. That assumption was wrong for five days and stranded seven deploy PRs with green checks and auto-merge armed (#1269).

## Fallback

Missing secrets do **not** fail the run — it falls back to `GITHUB_TOKEN` and emits a `::warning::` naming the consequence, so nobody rediscovers "the PR looks stuck for no reason" from scratch.

## What you need to add

| secret | value |
|---|---|
| `AGENT_APP_ID` | `4680922` |
| `AGENT_APP_PRIVATE_KEY` | the `.pem` contents |

`Settings → Secrets and variables → Actions`.

## Verification

- `run-gates.py --group lint` — 24/24 PASS
- step order asserted on the parsed YAML: `Mint → Resolve → checkout → …` in both workflows
- The known-positive is #6547 itself: nine runs at `action_required`. The next agent PR after this merges should show real check conclusions instead.