### PR TITLE
fix(admin-ui): hide day-end clock icons

### DIFF
--- a/openbank-admin-ui/src/app/day-end/page.tsx
+++ b/openbank-admin-ui/src/app/day-end/page.tsx
@@ -192,7 +192,7 @@ function EodPanel() {
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
           {lastRefreshed && (
             <span style={{ fontSize: '12px', color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: '5px' }}>
-              <Clock size={12} /> {lastRefreshed.toLocaleTimeString(locale)}
+              <Clock size={12} aria-hidden="true" /> {lastRefreshed.toLocaleTimeString(locale)}
             </span>
           )}
           <button type="button" className="btn btn-secondary" aria-busy={refreshing} aria-label={t('Obnovit denní závěrku', 'Refresh day-end close')} onClick={() => refresh(true)} disabled={refreshing}>
@@ -599,7 +599,7 @@ function EomPanel() {
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
           {lastRefreshed && (
             <span style={{ fontSize: '12px', color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: '5px' }}>
-              <Clock size={12} /> {lastRefreshed.toLocaleTimeString(locale)}
+              <Clock size={12} aria-hidden="true" /> {lastRefreshed.toLocaleTimeString(locale)}
             </span>
           )}
           <button type="button" className="btn btn-secondary" aria-busy={refreshing} aria-label={t('Obnovit měsíční závěrku', 'Refresh month-end close')} onClick={() => load(true)} disabled={refreshing}>

--- a/openbank-admin-ui/src/test/day-end-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/day-end-refresh.guard.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('day-end refresh contract', () => {
+  it('keeps both refresh controls accessible and closing actions intact', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/day-end/page.tsx'), 'utf8')
+    expect(source).toContain("aria-label={t('Obnovit denní závěrku', 'Refresh day-end close')}")
+    expect(source).toContain("aria-label={t('Obnovit měsíční závěrku', 'Refresh month-end close')}")
+    expect(source).toContain('onClick={() => refresh(true)}')
+    expect(source).toContain('onClick={() => load(true)}')
+    expect(source).toContain('<Clock size={12} aria-hidden="true"')
+  })
+})


### PR DESCRIPTION
## Summary
- hide decorative Day-end/Month-end clock icons from assistive technology
- add a source guard for both existing refresh controls
- preserve closing refresh, run, idempotency and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.