### PR TITLE
fix(admin-ui): clarify parties pagination

### DIFF
--- a/openbank-admin-ui/src/app/parties/page.tsx
+++ b/openbank-admin-ui/src/app/parties/page.tsx
@@ -275,10 +275,12 @@ export default function PartiesPage() {
           {inSearchMode && searchPagi?.hasNextPage && !loadingMore && (
             <div style={{ padding: '12px 20px', borderTop: '1px solid var(--border)' }}>
               <button
+                type="button"
                 className="btn btn-secondary"
                 onClick={() => runSearch(debouncedQ, searchPagi.nextCursor)}
+                aria-label={t('Načíst další subjekty', 'Load more parties')}
               >
-                <ChevronDown size={13} />
+                <ChevronDown size={13} aria-hidden="true" />
                 {t('Načíst další', 'Load more')}
               </button>
             </div>

--- a/openbank-admin-ui/src/test/parties-pagination.guard.test.ts
+++ b/openbank-admin-ui/src/test/parties-pagination.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('parties pagination contract', () => {
+  it('keeps cursor pagination explicit and accessible', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/parties/page.tsx'), 'utf8')
+    expect(source).toContain('type="button"')
+    expect(source).toContain("aria-label={t('Načíst další subjekty', 'Load more parties')}")
+    expect(source).toContain('<ChevronDown size={13} aria-hidden="true" />')
+    expect(source).toContain('runSearch(debouncedQ, searchPagi.nextCursor)')
+  })
+})


### PR DESCRIPTION
## Summary
- make Parties cursor pagination action an explicit accessible button
- preserve cursor query, search, party-service BFF and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.