### PR TITLE
fix(admin-ui): announce SWIFT detail loading

### DIFF
--- a/openbank-admin-ui/src/app/swift/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/swift/[id]/page.tsx
@@ -89,8 +89,8 @@ export default function SwiftDetailPage() {
       />
 
       {loading && !message ? (
-        <div style={{ padding: '40px 0', color: 'var(--text-tertiary)', fontSize: '13px', display: 'flex', alignItems: 'center', gap: '8px' }}>
-          <RefreshCw size={14} className="animate-spin" /> {t('Načítám zprávu…', 'Loading message…')}
+        <div role="status" aria-live="polite" style={{ padding: '40px 0', color: 'var(--text-tertiary)', fontSize: '13px', display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <RefreshCw size={14} aria-hidden="true" className="animate-spin" /> {t('Načítám zprávu…', 'Loading message…')}
         </div>
       ) : !message && unavailable ? (
         <div className="card"><DataUnavailable kind={unavailable.kind} service={t('SWIFT-service', 'SWIFT-service')} feature={t('SWIFT zpráva', 'SWIFT message')} lang={language} /></div>

--- a/openbank-admin-ui/src/test/swift-detail-loading.guard.test.ts
+++ b/openbank-admin-ui/src/test/swift-detail-loading.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('SWIFT detail loading contract', () => {
+  it('announces loading without changing list-source refresh or RBAC', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/swift/[id]/page.tsx'), 'utf8')
+    expect(source).toContain('<div role="status" aria-live="polite"')
+    expect(source).toContain('<RefreshCw size={14} aria-hidden="true"')
+    expect(source).toContain("t('Načítám zprávu…', 'Loading message…')")
+    expect(source).toContain('aria-label={t(\'Obnovit SWIFT zprávu\', \'Refresh SWIFT message\')}')
+  })
+})


### PR DESCRIPTION
## Summary
- expose SWIFT detail loading as a polite status
- hide the decorative spinner from assistive technology
- preserve list-source refresh, raw message state and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.