### PR TITLE
fix(admin-ui): clarify PID quick create

### DIFF
--- a/openbank-admin-ui/src/app/pid/page.tsx
+++ b/openbank-admin-ui/src/app/pid/page.tsx
@@ -209,7 +209,7 @@ export default function PidPage() {
                 <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
                 {t('Obnovit', 'Refresh')}
               </button>
-              <button className="btn btn-secondary" onClick={() => setShowNewForm(true)}>
+              <button type="button" className="btn btn-secondary" onClick={() => setShowNewForm(true)} aria-label={t('Otevřít rychlé vytvoření PID záznamu', 'Open PID quick create')}>
                 {t('Rychlé vytvoření', 'Quick Create')}
               </button>
               <Can permission="parties:create">

--- a/openbank-admin-ui/src/test/pid-quick-create.guard.test.ts
+++ b/openbank-admin-ui/src/test/pid-quick-create.guard.test.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('PID quick-create contract', () => {
+  it('keeps the entry action explicit and localized', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/pid/page.tsx'), 'utf8')
+    expect(source).toContain('type="button" className="btn btn-secondary" onClick={() => setShowNewForm(true)}')
+    expect(source).toContain("aria-label={t('Otevřít rychlé vytvoření PID záznamu', 'Open PID quick create')}")
+    expect(source).toContain('setShowNewForm(true)')
+  })
+})


### PR DESCRIPTION
## Summary
- make PID Quick Create an explicit localized button
- preserve PID list loading, create payload, BFF/four-eyes and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.