### PR TITLE
fix(admin-ui): announce onboarding analytics loading

### DIFF
--- a/openbank-admin-ui/src/app/onboarding/analytics/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/analytics/page.tsx
@@ -156,8 +156,8 @@ export default function OnboardingAnalyticsPage() {
             feature={t('Konverze onboardingu', 'Onboarding conversion')} lang={language} />
         </div>
       ) : loading && !data ? (
-        <div className="card" style={{ padding: '48px', textAlign: 'center', color: 'var(--text-muted)' }}>
-          <RefreshCw size={20} style={{ animation: 'spin 1s linear infinite' }} />
+        <div role="status" aria-live="polite" className="card" style={{ padding: '48px', textAlign: 'center', color: 'var(--text-muted)' }}>
+          <RefreshCw size={20} aria-hidden="true" style={{ animation: 'spin 1s linear infinite' }} />
         </div>
       ) : !data || data.available === false ? (
         <div className="card" style={{ padding: 0 }}>

--- a/openbank-admin-ui/src/test/onboarding-analytics-loading.guard.test.ts
+++ b/openbank-admin-ui/src/test/onboarding-analytics-loading.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('onboarding analytics loading contract', () => {
+  it('announces loading without changing analytics filters or fetch flow', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/onboarding/analytics/page.tsx'), 'utf8')
+    expect(source).toContain('<div role="status" aria-live="polite"')
+    expect(source).toContain('<RefreshCw size={20} aria-hidden="true"')
+    expect(source).toContain('aria-label={t(\'Obnovit analytiku onboardingu\', \'Refresh onboarding analytics\')}')
+    expect(source).toContain('onClick={load}')
+  })
+})


### PR DESCRIPTION
## Summary
- expose Onboarding Analytics loading as a polite status
- hide decorative spinner from assistive technology
- preserve date filters, analytics fetch, and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.