### PR TITLE
fix(admin-ui): mark onboarding table busy

### DIFF
--- a/openbank-admin-ui/src/app/onboarding/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/page.tsx
@@ -241,7 +241,7 @@ export default function OnboardingPage() {
           <DataUnavailable kind={listUnavail.kind} service={t('Onboarding-service', 'Onboarding-service')} feature={t('Onboarding záznamy', 'Onboarding records')} lang={language} dense />
         </div>
       ) : (
-        <div className="card" style={{ overflow: 'hidden' }}>
+        <div className="card" aria-busy={loading} style={{ overflow: 'hidden' }}>
           <table className="data-table">
             <thead>
               <tr>

--- a/openbank-admin-ui/src/test/onboarding-loading.guard.test.ts
+++ b/openbank-admin-ui/src/test/onboarding-loading.guard.test.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('onboarding list loading contract', () => {
+  it('marks the existing records table busy during refresh', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/onboarding/page.tsx'), 'utf8')
+    expect(source).toContain('<div className="card" aria-busy={loading}')
+    expect(source).toContain('aria-label={t(\'Obnovit onboarding\', \'Refresh onboarding\')}')
+    expect(source).toContain('setLoading(true)')
+  })
+})


### PR DESCRIPTION
## Summary
- expose the existing Onboarding records refresh state through aria-busy on the table card
- preserve funnel filters, records fetch and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.