### PR TITLE
fix(admin-ui): clarify delegation refresh

### DIFF
--- a/openbank-admin-ui/src/app/delegations/page.tsx
+++ b/openbank-admin-ui/src/app/delegations/page.tsx
@@ -126,8 +126,8 @@ export default function DelegationsPage() {
         title={t('Delegovaný přístup', 'Delegated Access')}
         subtitle={t('Kdo komu udělil práva k účtu, kartě nebo spoření (ADR-0232). Konzole je pouze pro čtení.', 'Who granted whom rights over an account, card or savings goal (ADR-0232). This console is read-only.')}
         actions={party && (
-          <button className="btn btn-secondary" onClick={() => loadGrants(party)} disabled={loading}>
-            <RefreshCw size={14} />
+          <button type="button" className="btn btn-secondary" onClick={() => loadGrants(party)} disabled={loading} aria-busy={loading} aria-label={t('Obnovit delegovaný přístup', 'Refresh delegated access')}>
+            <RefreshCw size={14} aria-hidden="true" />
             {t('Obnovit', 'Refresh')}
           </button>
         )}

--- a/openbank-admin-ui/src/test/delegations-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/delegations-refresh.guard.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('delegations refresh contract', () => {
+  it('keeps the read-only refresh action explicit and accessible', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/delegations/page.tsx'), 'utf8')
+    expect(source).toContain('type="button"')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit delegovaný přístup', 'Refresh delegated access')}")
+    expect(source).toContain('loadGrants(party)')
+    expect(source).toContain('<RefreshCw size={14} aria-hidden="true" />')
+  })
+})


### PR DESCRIPTION
## Summary
- add explicit button semantics and localized busy/name state to Delegated Access refresh
- preserve read-only grants/projection fetches and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.