### PR TITLE
fix(admin-ui): clarify FX refresh controls

### DIFF
--- a/openbank-admin-ui/src/app/fx/page.tsx
+++ b/openbank-admin-ui/src/app/fx/page.tsx
@@ -312,9 +312,9 @@ export default function FxPage() {
           title={t('Devizové operace', 'Foreign Exchange')}
           subtitle={t('CNB, ECB & Bankovní kurzovní lístek', 'CNB, ECB & bank rate sheet')}
           actions={<div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-            <button onClick={loadData} disabled={loading} className="btn btn-secondary btn-sm"><RefreshCw size={13} style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />{t('Obnovit', 'Refresh')}</button>
-            <button onClick={() => manualRefresh('all')} disabled={!!refreshing || loading} className="btn btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px' }}>
-              <Download size={13} style={{ animation: refreshing === 'all' ? 'spin 1s linear infinite' : 'none' }} />
+            <button type="button" onClick={loadData} disabled={loading} aria-busy={loading} aria-label={t('Obnovit kurzy FX', 'Refresh FX rates')} className="btn btn-secondary btn-sm"><RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />{t('Obnovit', 'Refresh')}</button>
+            <button type="button" onClick={() => manualRefresh('all')} disabled={!!refreshing || loading} aria-busy={refreshing === 'all'} aria-label={t('Stáhnout všechny kurzy FX', 'Fetch all FX rates')} className="btn btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px' }}>
+              <Download size={13} aria-hidden="true" style={{ animation: refreshing === 'all' ? 'spin 1s linear infinite' : 'none' }} />
               {t('Stáhnout vše', 'Fetch All')}
             </button>
             {(() => {

--- a/openbank-admin-ui/src/test/fx-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/fx-refresh.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('FX refresh contract', () => {
+  it('keeps rate refresh controls explicit and localized', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/fx/page.tsx'), 'utf8')
+    expect(source).toContain("aria-label={t('Obnovit kurzy FX', 'Refresh FX rates')}")
+    expect(source).toContain("aria-label={t('Stáhnout všechny kurzy FX', 'Fetch all FX rates')}")
+    expect(source).toContain('aria-busy={refreshing === \'all\'}')
+    expect(source).toContain('manualRefresh(\'all\')')
+  })
+})


### PR DESCRIPTION
## Summary
- add explicit type, localized names and busy semantics to FX rate refresh controls
- preserve CNB/ECB reads, manual refresh endpoints, preview-only truthfulness and RBAC

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.