### PR TITLE
fix(admin-ui): surface Test Intelligence

### DIFF
--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -115,6 +115,9 @@ const docsNav: NavItem[] = [
 ]
 
 const platformNav: NavItem[] = [
+  // Test evidence is a first-class platform capability. Keeping the only link
+  // near the bottom of System made an implemented route effectively invisible.
+  { nameCs: 'Test Intelligence', nameEn: 'Test Intelligence', href: '/system/tests', icon: FlaskConical, permission: 'system:view', badge: 'LIVE' },
   { nameCs: 'FinOps',   nameEn: 'FinOps',   href: '/finops',   icon: PiggyBank,  permission: 'system:view' },
   { nameCs: 'DevOps',   nameEn: 'DevOps',   href: '/devops',   icon: GitBranch,  permission: 'system:view' },
   { nameCs: 'Řídicí centrum agentů', nameEn: 'Agent Control Room', href: '/iaops', icon: Bot, permission: 'system:view' },
@@ -143,7 +146,6 @@ const sysNav: NavItem[] = [
   { nameCs: 'Tech Inventory',   nameEn: 'Tech Inventory',  href: '/system/inventory', icon: Package,           permission: 'system:view' },
   { nameCs: 'Infrastruktura',   nameEn: 'Infrastructure',  href: '/infrastructure',   icon: Server,            permission: 'system:view' },
   { nameCs: 'Topologie infra',  nameEn: 'Infra Topology',  href: '/infrastructure/topology', icon: Network,     permission: 'system:view' },
-  { nameCs: 'Test Coverage',    nameEn: 'Test Coverage',   href: '/system/tests',     icon: FlaskConical,      permission: 'system:view' },
   { nameCs: 'Připravenost prod',nameEn: 'Prod Readiness',  href: '/system/readiness', icon: ClipboardCheck,    permission: 'system:view' },
   { nameCs: 'Konfigurace',      nameEn: 'Configuration',   href: '/system/config',    icon: SlidersHorizontal, permission: 'system:config' },
   { nameCs: 'Agent (MCP)',      nameEn: 'Agent (MCP)',     href: '/system/agent',     icon: Bot,               permission: 'agent:view' },

--- a/openbank-admin-ui/src/lib/auth/persona.ts
+++ b/openbank-admin-ui/src/lib/auth/persona.ts
@@ -43,10 +43,10 @@ const WORKSPACES: Record<Persona, WorkspaceLink[]> = {
     { href: '/audit', nameCs: 'Audit', nameEn: 'Audit', permission: 'audit:view' },
   ],
   platform: [
+    { href: '/system/tests', nameCs: 'Test Intelligence', nameEn: 'Test Intelligence', permission: 'system:view' },
     { href: '/system/health', nameCs: 'Zdraví systému', nameEn: 'System Health', permission: 'system:view' },
     { href: '/devops', nameCs: 'DevOps', nameEn: 'DevOps', permission: 'system:view' },
     { href: '/observability', nameCs: 'Observability', nameEn: 'Observability', permission: 'system:view' },
-    { href: '/services', nameCs: 'Služby', nameEn: 'Services', permission: 'docs:view' },
   ],
 }
 

--- a/openbank-admin-ui/src/test/test-intelligence-navigation.guard.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-navigation.guard.test.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+import { readFileSync } from 'fs'
+import { describe, expect, it } from 'vitest'
+
+describe('Test Intelligence discoverability', () => {
+  it('is a primary platform destination and a platform workspace shortcut', () => {
+    const sidebar = readFileSync('src/components/layout/Sidebar.tsx', 'utf8')
+    const persona = readFileSync('src/lib/auth/persona.ts', 'utf8')
+    const platform = sidebar.slice(sidebar.indexOf('const platformNav'), sidebar.indexOf('const toolsNav'))
+
+    expect(platform.indexOf("href: '/system/tests'")).toBeGreaterThan(-1)
+    expect(platform.indexOf("href: '/system/tests'")).toBeLessThan(platform.indexOf("href: '/finops'"))
+    expect(sidebar.match(/href: '\/system\/tests'/g)).toHaveLength(1)
+    expect(persona).toContain("href: '/system/tests', nameCs: 'Test Intelligence'")
+  })
+})


### PR DESCRIPTION
## Summary
- promote Test Intelligence to the first Platform navigation destination
- pin it in the platform persona workspace
- add a guard proving the route is unique and discoverable

## Verification
- `npm test -- --run src/test/test-intelligence-navigation.guard.test.ts`

Refs #4348