### PR TITLE
fix(infra): detect ArgoCD apps reporting Synced while applying nothing (#6371)

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -4401,3 +4401,31 @@ gates:
     min_subjects: 1600   # 1628 raw hex colour literals today (2026-08-31)
     run: |
       python3 .github/scripts/check-raw-colour-literal-ratchet.py
+
+  # ArgoCD applied NOTHING to the `loki` app for three weeks and reported `Synced / Healthy`
+  # throughout (#6371). With `ServerSideApply=true` the controller diffs by a server-side dry-run
+  # apply; a rejected dry-run makes the COMPARISON error, and the Application then keeps serving
+  # its last known status instead of going OutOfSync. The state is recorded as
+  # `.status.conditions[].type == ComparisonError` and NO ArgoCD metric exposes it —
+  # `argocd_app_info` carries `sync_status` and `health_status` only — so both rules in
+  # prometheus-rules-argocd.yaml were quiet BY CONSTRUCTION, keying on Degraded and Unknown
+  # against an app that was Healthy.
+  #
+  # The live observation cannot happen here: no PR runner holds cluster credentials. It happens
+  # in the `argocd-sync-verifier` CronJob, six-hourly, publishing a report ConfigMap and then
+  # FAILING the Job so KubeJobFailed carries it. What this gate holds is the other half — that
+  # the comparison logic still classifies correctly, and that the in-cluster detector is still
+  # wired to THAT script rather than deleted, unregistered, or replaced by an inline copy that
+  # can drift. A detector that runs nowhere reports nothing, which reads exactly like a detector
+  # reporting no findings.
+  - id: argocd-sync-integrity-unit-test
+    name: "the ArgoCD Synced-but-applying-nothing detector still classifies, and is still wired (#6371, enforced)"
+    group: gitops
+    mode: enforced
+    rationale: "ArgoCD reported Synced/Healthy on an app it had applied nothing to for three weeks, and no metric exposes the condition that recorded it; the replacement detector runs in-cluster, so only this gate can notice it being unwired or its comparison being broken."
+    review_after: "2027-02-23"
+    selftest: python3 .github/scripts/check-argocd-sync-integrity.py --self-test
+    selftest_expect: pass
+    run: |
+      python3 -m unittest openbank-infra/scripts/check_argocd_sync_integrity_test.py
+      python3 .github/scripts/check-argocd-sync-integrity.py --check-wiring

--- a/.github/scripts/check-argocd-sync-integrity.py
+++ b/.github/scripts/check-argocd-sync-integrity.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""Detect ArgoCD Applications that report Synced/Healthy while applying nothing (issue #6371).
+
+THE GAP
+    With `ServerSideApply=true` the application-controller computes its diff by a server-side
+    dry-run apply. If that dry-run is REJECTED the comparison errors, and the Application keeps
+    serving its LAST KNOWN status instead of going OutOfSync. It reports `Synced / Healthy` and
+    applies nothing, for as long as the rejection lasts — measured at three weeks on the `loki`
+    app (2026-08-21: `singleBinary.persistence.size` 10Gi -> 30Gi, and a StatefulSet's
+    `volumeClaimTemplates` is immutable). Every values change merged in that window was silently
+    dropped, including #6032's Loki ruler fix, which is why that fix appeared to have landed
+    while the ruler had still never loaded a rule.
+
+    The state IS recorded, in `.status.conditions[].type == ComparisonError`. It is exposed by
+    NO ArgoCD metric: `argocd_app_info` carries `sync_status` and `health_status` only. So both
+    rules in `prometheus-rules-argocd.yaml` are quiet BY CONSTRUCTION, not by accident —
+    `ArgoCDAppDegraded` keys on health `Degraded` and `ArgoCDAppHealthUnknown` on `Unknown`,
+    and this app was `Healthy`. `argocd_app_sync_total` is not a substitute either: an app that
+    legitimately needs no sync looks identical to one that CANNOT sync.
+
+WHY NOT A kube-state-metrics customResourceState
+    That was the first proposal (#6371) and it is not free: a malformed CRS config takes down the
+    kube-state-metrics pod and with it every `kube_*` series in the estate — a far larger blast
+    radius than the gap being closed — and KSM parses the config only AFTER connecting to an
+    apiserver, so a deliberately broken config and a good one produce byte-identical startup logs
+    offline. A probe that cannot tell those apart is not validation. This detector reads the same
+    field with no shared failure domain, and is falsifiable offline against fixtures.
+
+WHAT IT REJECTS
+    ERROR_CONDITION            any `.status.conditions[].type` ending in `Error` — the class the
+                               metrics cannot see. This is the #6371 mechanism itself.
+    SYNCED_MASKING_FAILED_OP   `.status.sync.status == Synced` while the last sync operation
+                               finished `Failed`/`Error` AT THE VERY REVISION now being reported
+                               as Synced. That is the "a failed sync self-heals to Synced"
+                               mechanism: the app claims Synced at a revision nothing ever
+                               successfully applied.
+                               The revision equality is load-bearing, not a refinement. Measured
+                               against the live cluster 2026-08-23, `keycloak` had a Failed
+                               operation from 2026-08-07 (its theme ConfigMap exceeded the 256KB
+                               `last-applied-configuration` annotation limit) while reporting
+                               Synced at today's revision — and it is genuinely converged: an
+                               unmanaged probe (`kubectl get cm` vs the manifest in git) found the
+                               three theme keys byte-identical. Without the revision test this
+                               detector is red on that app from the day it lands, which is the
+                               one thing that reliably stops anyone reading it.
+    UNVERIFIABLE_REVISION      (--repo) an app sourced from this repo whose `.status.sync.revision`
+                               is not a commit reachable from `origin/main`. ANCESTRY, not an
+                               image tag: a tag can be moved or reused, ancestry cannot (#6234,
+                               where an older commit's PR closed a newer one and every
+                               version-equality check stayed green).
+
+WHAT IT DELIBERATELY DOES NOT DO
+    It does not treat an old `.status.operationState.finishedAt` as a finding on its own. Most of
+    this estate's Applications track a pinned upstream chart version and legitimately have not
+    synced since May; measured 2026-08-23, 15 of 93 last synced more than a month ago and every
+    one was correct. A detector that fires on all of them is one nobody reads by week two.
+
+USAGE
+    python3 .github/scripts/check-argocd-sync-integrity.py --capture apps.json [--repo .]
+        where apps.json is `kubectl -n argocd get applications -o json`.
+    python3 .github/scripts/check-argocd-sync-integrity.py --self-test
+    python3 .github/scripts/check-argocd-sync-integrity.py --check-wiring
+
+Exit 0 = no findings. Exit 1 = findings (or a broken/absent capture). Exit 2 = usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+# Substring that identifies an Application sourced from THIS repo. Both the SSH and HTTPS
+# spellings appear in gitops/apps, so match on the repo name rather than a full URL.
+OWN_REPO_MARKER = "open-bank-oss"
+
+FAILED_OPERATION_PHASES = {"Failed", "Error"}
+
+# The wiring the CI half asserts still exists. A detector that runs nowhere reports nothing,
+# which reads exactly like a detector reporting no findings.
+CRONJOB_MANIFEST = (
+    REPO / "openbank-infra/gitops/components/argocd-sync-verifier/argocd-sync-verifier.yaml"
+)
+APP_MANIFEST = REPO / "openbank-infra/gitops/apps/argocd-sync-verifier.yaml"
+SCRIPT_REL = ".github/scripts/check-argocd-sync-integrity.py"
+
+
+class Finding:
+    def __init__(self, kind: str, app: str, detail: str):
+        self.kind = kind
+        self.app = app
+        self.detail = detail
+
+    def __str__(self) -> str:
+        return f"{self.kind}  {self.app}: {self.detail}"
+
+
+def _source_urls(spec: dict) -> list:
+    srcs = spec.get("sources") or []
+    if spec.get("source"):
+        srcs = [spec["source"]] + list(srcs)
+    return [s.get("repoURL") or "" for s in srcs]
+
+
+def evaluate(apps: list, git_check=None) -> list:
+    """Classify every Application. `git_check(rev) -> str|None` returns a reason or None."""
+    findings = []
+    for app in apps:
+        name = app.get("metadata", {}).get("name", "<unnamed>")
+        status = app.get("status") or {}
+        sync = status.get("sync") or {}
+        sync_status = sync.get("status")
+        health = (status.get("health") or {}).get("status")
+
+        for cond in status.get("conditions") or []:
+            ctype = cond.get("type") or ""
+            # `*Error` is the whole class the metrics cannot express: ComparisonError,
+            # SyncError, InvalidSpecError, UnknownError. Matching the suffix rather than a
+            # hard-coded list means a new ArgoCD condition type is covered on the day it
+            # appears, not on the day someone notices it.
+            if ctype.endswith("Error"):
+                msg = " ".join((cond.get("message") or "").split())[:300]
+                findings.append(
+                    Finding(
+                        "ERROR_CONDITION",
+                        name,
+                        f"condition {ctype} while sync={sync_status} health={health}. "
+                        f"No ArgoCD metric exposes this. message: {msg}",
+                    )
+                )
+
+        op = status.get("operationState") or {}
+        phase = op.get("phase")
+        op_rev = ((op.get("operation") or {}).get("sync") or {}).get("revision")
+        # Only when the FAILED operation is the one that would have produced the revision now
+        # being claimed. A failure at an older revision that the app has since been compared
+        # against and found Synced is convergence, not masking — see the module docstring.
+        if (
+            sync_status == "Synced"
+            and phase in FAILED_OPERATION_PHASES
+            and op_rev
+            and op_rev == sync.get("revision")
+        ):
+            findings.append(
+                Finding(
+                    "SYNCED_MASKING_FAILED_OP",
+                    name,
+                    f"reports sync=Synced at revision {str(sync.get('revision'))[:8]}, but the "
+                    f"only sync operation at that revision finished phase={phase} at "
+                    f"{op.get('finishedAt')}. Nothing ever successfully applied it.",
+                )
+            )
+
+        if git_check is not None and any(OWN_REPO_MARKER in u for u in _source_urls(app.get("spec") or {})):
+            reason = git_check(sync.get("revision") or "")
+            if reason:
+                findings.append(
+                    Finding(
+                        "UNVERIFIABLE_REVISION",
+                        name,
+                        f"{reason}. A deploy is verified by commit ANCESTRY, never by a tag "
+                        f"or a version string (#6234).",
+                    )
+                )
+    return findings
+
+
+def make_git_check(repo: pathlib.Path, base_ref: str):
+    """Return a git_check closure, or None if the repo cannot answer (never silently pass)."""
+
+    def check(rev: str):
+        if len(rev) != 40 or any(c not in "0123456789abcdef" for c in rev.lower()):
+            return f"sync.revision {rev!r} is not a commit sha"
+        known = subprocess.run(
+            ["git", "-C", str(repo), "cat-file", "-e", rev + "^{commit}"],
+            capture_output=True,
+        )
+        if known.returncode != 0:
+            return f"sync.revision {rev[:8]} is not a commit in this repository"
+        anc = subprocess.run(
+            ["git", "-C", str(repo), "merge-base", "--is-ancestor", rev, base_ref],
+            capture_output=True,
+        )
+        if anc.returncode != 0:
+            return f"sync.revision {rev[:8]} is not an ancestor of {base_ref}"
+        return None
+
+    return check
+
+
+def load_capture(path: pathlib.Path) -> list:
+    doc = json.loads(path.read_text())
+    if isinstance(doc, dict) and doc.get("kind") == "List" or "items" in (doc if isinstance(doc, dict) else {}):
+        return doc["items"]
+    if isinstance(doc, list):
+        return doc
+    if isinstance(doc, dict) and doc.get("kind") == "Application":
+        return [doc]
+    raise ValueError("capture is neither an Application, a list, nor a kubectl List")
+
+
+# ─── wiring check (the CI half) ──────────────────────────────────────────────
+def check_wiring() -> list:
+    """The live detector runs in-cluster; assert it is still wired, in the repo, at PR time.
+
+    An in-cluster detector that is deleted, unregistered or pointed at a different script stops
+    producing findings — which is indistinguishable from producing none.
+    """
+    problems = []
+    if not CRONJOB_MANIFEST.exists():
+        problems.append(f"missing {CRONJOB_MANIFEST.relative_to(REPO)} — the in-cluster detector")
+    else:
+        text = CRONJOB_MANIFEST.read_text()
+        if "kind: CronJob" not in text:
+            problems.append(f"{CRONJOB_MANIFEST.relative_to(REPO)} declares no CronJob")
+        if SCRIPT_REL not in text:
+            problems.append(
+                f"{CRONJOB_MANIFEST.relative_to(REPO)} does not invoke {SCRIPT_REL} — the "
+                f"comparison must be the committed, unit-tested one, never a second inline copy"
+            )
+        # Reading Applications is the whole point; without the verb the job captures nothing
+        # and exits 0.
+        if "applications" not in text or "argoproj.io" not in text:
+            problems.append(
+                f"{CRONJOB_MANIFEST.relative_to(REPO)} grants no read on argoproj.io/applications"
+            )
+        if "exit 1" not in text:
+            problems.append(
+                f"{CRONJOB_MANIFEST.relative_to(REPO)} never fails the Job — a finding that only "
+                f"lands in a ConfigMap is a finding nobody acts on"
+            )
+    if not APP_MANIFEST.exists():
+        problems.append(
+            f"missing {APP_MANIFEST.relative_to(REPO)} — the detector is not registered with ArgoCD"
+        )
+    return problems
+
+
+# ─── self-test ───────────────────────────────────────────────────────────────
+def _app(name, sync="Synced", health="Healthy", conditions=None, phase=None, revision=None, op_revision=None, own=True):
+    spec = {"source": {"repoURL": ("git@github.com:JiRaska/open-bank-oss.git" if own else "https://grafana.github.io/helm-charts")}}
+    status = {"sync": {"status": sync}, "health": {"status": health}}
+    if conditions:
+        status["conditions"] = conditions
+    if phase:
+        status["operationState"] = {
+            "phase": phase,
+            "finishedAt": "2026-08-21T17:25:22Z",
+            "operation": {"sync": {"revision": op_revision if op_revision is not None else revision}},
+        }
+    if revision is not None:
+        status["sync"]["revision"] = revision
+    return {"metadata": {"name": name}, "spec": spec, "status": status}
+
+
+LOKI_COMPARISON_ERROR = (
+    "Failed to compare desired state to live state: failed to calculate diff: error calculating "
+    "server side diff: serverSideDiff error: error running server side apply in dryrun mode for "
+    'resource StatefulSet/loki: StatefulSet.apps "loki" is invalid: spec: Forbidden: updates to '
+    "statefulset spec for fields other than 'replicas' are forbidden"
+)
+
+
+def self_test() -> int:
+    """Feed the detector states it MUST classify, in both directions. A detector that has only
+    ever seen healthy input is unfalsified."""
+    cases = []
+
+    # 1. THE REAL 2026-08-21 STATE, verbatim: Synced AND Healthy AND ComparisonError.
+    #    This is the state that existed for three weeks and that nothing in the estate could see.
+    cases.append((
+        "loki as it really was on 2026-08-21 (Synced/Healthy + ComparisonError)",
+        [_app("loki", conditions=[{"type": "ComparisonError", "message": LOKI_COMPARISON_ERROR}])],
+        ["ERROR_CONDITION"],
+    ))
+
+    # 2. Negative control: the SAME app with the condition removed — today's real state.
+    #    If this fires, the detector is keying on Synced/Healthy and is useless.
+    cases.append(("loki as it is today (no condition)", [_app("loki")], []))
+
+    # 3. Any other *Error condition is the same class, not a special case.
+    for ctype in ("SyncError", "InvalidSpecError", "UnknownError"):
+        cases.append((
+            f"{ctype} is caught by the suffix rule",
+            [_app("x", conditions=[{"type": ctype, "message": "m"}])],
+            ["ERROR_CONDITION"],
+        ))
+
+    # 4. Non-error conditions must NOT fire. SharedResourceWarning is live on `agent` today;
+    #    a detector that reddens on it is red from the day it lands.
+    cases.append((
+        "SharedResourceWarning does not fire",
+        [_app("agent", sync="OutOfSync", conditions=[{"type": "SharedResourceWarning", "message": "m"}])],
+        [],
+    ))
+
+    # 5. A failed sync operation masked behind sync=Synced.
+    cases.append((
+        "Synced at the very revision whose only sync operation Failed",
+        [_app("y", phase="Failed", revision="c" * 40)],
+        ["SYNCED_MASKING_FAILED_OP"],
+    ))
+    cases.append((
+        "Synced with a Succeeded operation",
+        [_app("y", phase="Succeeded", revision="c" * 40)],
+        [],
+    ))
+    # OutOfSync + Failed is honest reporting, not masking — the status already says so.
+    cases.append((
+        "OutOfSync while the last operation Failed",
+        [_app("y", sync="OutOfSync", phase="Failed", revision="c" * 40)],
+        [],
+    ))
+    # THE REAL keycloak STATE, 2026-08-23: a Failed operation at ba578499 while Synced at
+    # a13b85d3. Verified converged by an unmanaged probe (live ConfigMap == the manifest in
+    # git, three keys byte-identical), so this MUST NOT fire. It is the negative control that
+    # keeps this rule from being the resting state.
+    cases.append((
+        "keycloak: Failed operation at an OLDER revision, since converged",
+        [_app("keycloak", phase="Failed", revision="a" * 40, op_revision="b" * 40)],
+        [],
+    ))
+
+    # 6. Ancestry. The checker is handed a stub so the case is deterministic offline.
+    def stub_git(rev):
+        return None if rev == "a" * 40 else f"sync.revision {rev[:8]} is not an ancestor of origin/main"
+
+    cases_git = [
+        ("revision on main", [_app("z", revision="a" * 40)], []),
+        ("revision NOT reachable from main", [_app("z", revision="b" * 40)], ["UNVERIFIABLE_REVISION"]),
+        # An upstream-chart app carries a chart version, not a sha — it must be exempt, or the
+        # detector is red on 22 of 93 apps forever.
+        ("upstream chart app is exempt from ancestry", [_app("loki", revision="6.55.0", own=False)], []),
+    ]
+
+    failures = 0
+    for label, apps, expect in cases:
+        got = sorted(f.kind for f in evaluate(apps))
+        if got != sorted(expect):
+            print(f"SELF-TEST FAIL: {label}: expected {sorted(expect)}, got {got}")
+            failures += 1
+        else:
+            print(f"  ok  {label} -> {got or 'no findings'}")
+    for label, apps, expect in cases_git:
+        got = sorted(f.kind for f in evaluate(apps, git_check=stub_git))
+        if got != sorted(expect):
+            print(f"SELF-TEST FAIL: {label}: expected {sorted(expect)}, got {got}")
+            failures += 1
+        else:
+            print(f"  ok  {label} -> {got or 'no findings'}")
+
+    # 7. The wiring half must be able to fail too: point it at a repo where the manifest is gone.
+    global CRONJOB_MANIFEST
+    saved = CRONJOB_MANIFEST
+    CRONJOB_MANIFEST = REPO / "openbank-infra/gitops/components/argocd-sync-verifier/does-not-exist.yaml"
+    if not check_wiring():
+        print("SELF-TEST FAIL: wiring check passed with the detector manifest absent")
+        failures += 1
+    else:
+        print("  ok  wiring check fails when the in-cluster detector is missing")
+    CRONJOB_MANIFEST = saved
+    if check_wiring():
+        print(f"SELF-TEST FAIL: wiring check red on the real repo: {check_wiring()}")
+        failures += 1
+    else:
+        print("  ok  wiring check green on the real repo")
+
+    print(f"\nself-test: {failures} failure(s)")
+    return 1 if failures else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--capture", help="kubectl -n argocd get applications -o json")
+    ap.add_argument("--repo", help="repo checkout, enables the ancestry check")
+    ap.add_argument("--base-ref", default="origin/main")
+    ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--check-wiring", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if args.check_wiring:
+        problems = check_wiring()
+        if problems:
+            print("FAIL: the in-cluster ArgoCD sync verifier is not wired (#6371):")
+            for p in problems:
+                print(f"  - {p}")
+            return 1
+        print("OK: the in-cluster ArgoCD sync verifier is wired and invokes the committed checker.")
+        return 0
+
+    if not args.capture:
+        ap.error("one of --capture, --self-test or --check-wiring is required")
+
+    path = pathlib.Path(args.capture)
+    if not path.exists():
+        # An absent capture is a FAILED capture, never "no findings".
+        print(f"FAIL: capture {path} does not exist — the detector observed nothing.")
+        return 1
+    try:
+        apps = load_capture(path)
+    except Exception as exc:  # noqa: BLE001 - any parse problem is a failed capture
+        print(f"FAIL: capture {path} is unreadable ({exc}) — the detector observed nothing.")
+        return 1
+    if not apps:
+        print(f"FAIL: capture {path} holds zero Applications — the detector observed nothing.")
+        return 1
+
+    git_check = make_git_check(pathlib.Path(args.repo), args.base_ref) if args.repo else None
+    findings = evaluate(apps, git_check=git_check)
+
+    print(f"ArgoCD sync integrity — {len(apps)} Application(s) examined (#6371).")
+    if not findings:
+        print("OK: no Application is reporting a status it cannot back up.")
+        return 0
+    print(f"FAIL: {len(findings)} finding(s):")
+    for f in findings:
+        print(f"  - {f}")
+    print(
+        "\nA `ComparisonError` app keeps serving its LAST status — `Synced/Healthy` is not "
+        "evidence anything was applied. Read .status.operationState.finishedAt, and confirm by "
+        "rendering the chart from the app's own live valuesObject and diffing the live object."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check-gate-subject-floor.py
+++ b/.github/scripts/check-gate-subject-floor.py
@@ -58,6 +58,7 @@ NO_CORPUS = {
     # `gh`/`aws`/`curl` stub them inside the self-test (ensure-ecr-repository.sh even validates its
     # own stub first). No repo corpus to floor.
     "agent-review-proof-falsifiable",
+    "argocd-sync-integrity-unit-test",
     "agent-review-scope-falsifiable",
     "auto-deploy-reconcile-probe-unit-test",
     "blocking-counterpart-probe-unit-test",

--- a/openbank-infra/CLAUDE.md
+++ b/openbank-infra/CLAUDE.md
@@ -27,6 +27,18 @@ out of it (they are path-scoped, not less important — several are live-inciden
   is the only thing missing". Fix without downtime: `kubectl delete sts <n> --cascade=orphan` leaves
   the pod and the PVC running and lets Argo recreate the object with the new template; the PVC keeps
   whatever size it was expanded to separately.
+  **Now held by the `argocd-sync-verifier` CronJob** (#6371): six-hourly it captures
+  `kubectl -n argocd get applications -o json`, runs the committed
+  `.github/scripts/check-argocd-sync-integrity.py`, publishes a report ConfigMap and then FAILS the
+  Job so `KubeJobFailed` carries it. It rejects three states — any `*Error` condition (the class no
+  metric exposes), an app reporting `Synced` at the very revision whose only sync operation
+  *Failed*, and a repo-sourced app whose `sync.revision` is not an ancestor of `origin/main`
+  (ancestry, never a tag — #6234). It deliberately does NOT fire on a stale `finishedAt`: 15 of 93
+  apps last synced over a month ago and every one was correct. The kube-state-metrics
+  `customResourceState` route was rejected on blast radius — a malformed CRS config takes down the
+  pod serving every `kube_*` series, and KSM parses that config only after connecting to an
+  apiserver, so it cannot be falsified offline. Exposing the condition as a metric is still the
+  better long-run answer and needs a *dedicated* KSM instance.
 - **`realm-template.json` is read ONLY on Keycloak's cold start (`--import-realm`), so editing it
   changes nothing on a running realm — and ArgoCD reports `Synced/Healthy` throughout.** ArgoCD
   manages the ConfigMap, and the ConfigMap does match the repo; the drift is one layer below what it

--- a/openbank-infra/gitops/apps/argocd-sync-verifier.yaml
+++ b/openbank-infra/gitops/apps/argocd-sync-verifier.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Issue #6371: ArgoCD applied nothing to `loki` for three weeks while reporting Synced/Healthy,
+# and no ArgoCD metric exposes the `ComparisonError` condition that recorded it. Its own
+# Application rather than folding into the observability component, so the detector can be
+# synced, suspended or rolled back without touching the monitoring stack it would otherwise
+# share a failure domain with.
+# See gitops/components/argocd-sync-verifier/ for the design rationale.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-sync-verifier
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:JiRaska/open-bank-oss.git
+    targetRevision: main
+    path: openbank-infra/gitops/components/argocd-sync-verifier
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+      - ServerSideApply=true

--- a/openbank-infra/gitops/components/argocd-sync-verifier/argocd-sync-verifier.yaml
+++ b/openbank-infra/gitops/components/argocd-sync-verifier/argocd-sync-verifier.yaml
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# ---------------------------------------------------------------------------
+# ArgoCD sync-integrity verifier (issue #6371).
+#
+# THE GAP THIS CLOSES
+#   ArgoCD applied NOTHING to the `loki` app for three weeks and reported `Synced / Healthy`
+#   the entire time. With `ServerSideApply=true` the controller diffs by a server-side dry-run
+#   apply; when that dry-run is rejected the comparison ERRORS and the Application keeps serving
+#   its LAST KNOWN status rather than going OutOfSync. The trigger on 2026-08-21 was
+#   `singleBinary.persistence.size` 10Gi -> 30Gi (#3278) against an immutable StatefulSet
+#   `volumeClaimTemplates`. Every values change merged after that date was silently not applied,
+#   including #6032's Loki ruler fix — which is why that fix appeared to have "landed" while the
+#   ruler had still never loaded a rule.
+#
+#   The state IS recorded, as `.status.conditions[].type == ComparisonError`, and NO ArgoCD
+#   metric exposes it: `argocd_app_info` carries `sync_status` and `health_status` only. So both
+#   rules in observability/prometheus-rules-argocd.yaml were quiet BY CONSTRUCTION —
+#   `ArgoCDAppDegraded` keys on `Degraded`, `ArgoCDAppHealthUnknown` on `Unknown`, and this app
+#   was `Healthy`. Nothing in the estate could have detected it.
+#
+# WHY THIS AND NOT kube-state-metrics customResourceState
+#   That was #6371's first proposal and it is not free. A malformed CRS config takes down the
+#   kube-state-metrics pod, and with it EVERY `kube_*` series in the estate — including the ones
+#   `FalcoAgentNotReady` and much of the existing alert set depend on. That is a far larger blast
+#   radius than the gap being closed. Worse, it cannot be falsified offline: KSM parses
+#   `--custom-resource-state-config-file` only AFTER connecting to an apiserver, so a deliberately
+#   broken config and a good one produce byte-identical startup logs. A probe that cannot tell the
+#   two apart is not validation. This job reads the same field with no shared failure domain, and
+#   its comparison is falsifiable offline against fixtures (`--self-test`). Exposing the condition
+#   as a metric remains the better long-run answer and is NOT closed by this — it needs a
+#   dedicated KSM instance validated against a real apiserver first, per #6371's own step 1-2.
+#
+# WHY A CronJob AND NOT A CI GATE
+#   The observation is of LIVE controller status; no PR runner holds cluster credentials. So the
+#   CAPTURE happens here and the COMPARISON is ordinary repo code —
+#   `.github/scripts/check-argocd-sync-integrity.py`, unit-tested in both directions by
+#   `openbank-infra/scripts/check_argocd_sync_integrity_test.py` and self-tested against the real
+#   2026-08-21 loki condition. This pod holds no logic worth testing; it holds a network path and
+#   a read verb. The repo half of the control (`--check-wiring`, gate `argocd-sync-integrity`)
+#   asserts this file still exists and still invokes that script — a detector that runs nowhere
+#   reports nothing, which reads exactly like a detector reporting no findings.
+#
+# WHY IT FAILS THE JOB RATHER THAN JUST WRITING A REPORT
+#   The sbom-drift-scanner lesson (2026-07-12): a finding that only lands in a ConfigMap is a
+#   finding nobody acts on. The report is published FIRST, then the Job fails, so KubeJobFailed
+#   carries it with the detail already readable.
+#
+# WHAT IT DELIBERATELY DOES NOT DO
+#   It does not treat a stale `.status.operationState.finishedAt` as a finding. Measured
+#   2026-08-23, 15 of 93 Applications last synced more than a month ago and every one was correct
+#   — they track a pinned upstream chart version and legitimately need no sync. A detector that
+#   fires on all of them is one nobody reads by week two.
+#   It reads only; it never syncs, patches or deletes. Remediating a ComparisonError means
+#   recreating an immutable object (`kubectl delete sts <n> --cascade=orphan` keeps the pod and
+#   the PVC), which is a human's decision, not a CronJob's.
+#
+# NAMESPACE: `argocd`, so the reader is co-located with what it reads and needs no NetworkPolicy
+# edge — it talks to the apiserver, not to ArgoCD.
+# ---------------------------------------------------------------------------
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argocd-sync-verifier
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-sync-verifier
+    app.kubernetes.io/part-of: argocd
+
+---
+# ─── RBAC: read Application status cluster-wide, write one report ConfigMap ──
+# `get/list` on applications only. No `patch` and no `update`: this job must never be able to
+# change the thing it observes, or a future edit turns a detector into an actor with no review.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-sync-verifier-read
+  labels:
+    app.kubernetes.io/name: argocd-sync-verifier
+rules:
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-sync-verifier-read
+  labels:
+    app.kubernetes.io/name: argocd-sync-verifier
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argocd-sync-verifier-read
+subjects:
+  - kind: ServiceAccount
+    name: argocd-sync-verifier
+    namespace: argocd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-sync-verifier-configmap
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-sync-verifier
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["argocd-sync-verifier"]
+    verbs: ["get", "patch", "update"]
+  # create: resourceNames cannot gate create — needed for the first run only.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-sync-verifier-configmap
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-sync-verifier
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-sync-verifier-configmap
+subjects:
+  - kind: ServiceAccount
+    name: argocd-sync-verifier
+    namespace: argocd
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: argocd-sync-verifier
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-sync-verifier
+    app.kubernetes.io/part-of: argocd
+spec:
+  # Every 6h, not daily: the failure this detects is a deploy that silently did not happen, and
+  # the cost of finding out is proportional to how long people keep merging into it. Daily was
+  # the wrong granularity for a three-week outage only because nothing ran at all; six hours
+  # bounds the window at one working session.
+  schedule: "25 */6 * * *"
+  timeZone: "UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  # failedJobsHistoryLimit: 1 — keep the LATEST failure for triage, not an archive.
+  # kube-prometheus-stack's KubeJobFailed fires per surviving failed Job OBJECT, so a higher
+  # limit turns one recurring failure into several permanent alerts whose pods are already
+  # garbage-collected (measured 2026-08-02: 11 of 37 firing alerts, 8 with pods=0).
+  failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      # 48h self-delete so a failed Job cannot become a permanent KubeJobFailed tombstone.
+      ttlSecondsAfterFinished: 172800
+      activeDeadlineSeconds: 900
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: argocd-sync-verifier
+        spec:
+          serviceAccountName: argocd-sync-verifier
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          initContainers:
+            # Phase 1 — capture the live Application status and run the COMMITTED comparison.
+            # The logic is deliberately not inlined here: it lives in the repo, where it is
+            # reviewable and unit-tested, and the CI wiring check asserts this container still
+            # calls it rather than a second copy that can drift.
+            - name: capture-and-compare
+              image: docker.io/alpine/k8s:1.34.1
+              command: ["/bin/sh", "-ec"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              env:
+                - name: HOME
+                  value: /tmp
+              args:
+                - |
+                  set -eu
+                  # --filter=blob:none, NOT --depth 1: the ancestry check needs the full commit
+                  # graph to answer `merge-base --is-ancestor`, and a shallow clone answers it
+                  # wrongly rather than erroring. Blobless keeps the clone small anyway.
+                  echo "Cloning openbank-oss (public repo, unauthenticated, blobless)..."
+                  git clone --filter=blob:none --single-branch --branch main --quiet \
+                    https://github.com/JiRaska/open-bank-oss.git /tmp/repo
+
+                  echo "Capturing Application status from the apiserver..."
+                  # A capture that fails must NOT leave an empty file that the checker reads as
+                  # "no Applications, no findings" — the checker rejects an absent, unparseable
+                  # or empty capture as a FAILED capture, and this `||` keeps the failure loud
+                  # here too rather than substituting an empty document.
+                  kubectl -n argocd get applications -o json > /work/applications.json
+
+                  cd /tmp/repo
+                  python3 .github/scripts/check-argocd-sync-integrity.py \
+                    --capture /work/applications.json \
+                    --repo /tmp/repo \
+                    --base-ref origin/main \
+                    > /work/report.txt 2>&1 \
+                    || echo findings > /work/findings
+                  cat /work/report.txt
+              volumeMounts:
+                - name: work
+                  mountPath: /work
+                - name: tmp
+                  mountPath: /tmp
+          containers:
+            # Phase 2 — publish the report, THEN fail. Order is load-bearing: the alert must fire
+            # with the detail already readable, not with a promise of it.
+            - name: publish
+              image: docker.io/alpine/k8s:1.34.1
+              command: ["/bin/sh", "-ec"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              env:
+                - name: HOME
+                  value: /tmp
+              args:
+                - |
+                  set -eu
+                  kubectl -n argocd create configmap argocd-sync-verifier \
+                    --from-file=report.txt=/work/report.txt \
+                    --dry-run=client -o yaml | kubectl apply -f -
+
+                  if [ -f /work/findings ]; then
+                    echo "FINDINGS PRESENT — failing the Job so KubeJobFailed carries it (#6371)."
+                    echo "An Application reporting Synced/Healthy that cannot compute a diff"
+                    echo "applies NOTHING. Read the report above, then"
+                    echo "kubectl -n argocd get configmap argocd-sync-verifier -o yaml"
+                    exit 1
+                  fi
+                  echo "No findings: every Application can back up the status it reports."
+              volumeMounts:
+                - name: work
+                  mountPath: /work
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: work
+              emptyDir: {}
+            - name: tmp
+              emptyDir: {}

--- a/openbank-infra/scripts/check_argocd_sync_integrity_test.py
+++ b/openbank-infra/scripts/check_argocd_sync_integrity_test.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""Falsification suite for .github/scripts/check-argocd-sync-integrity.py (issue #6371).
+
+A gate that has only ever passed is unfalsified. Every case below drives the SCRIPT — as a
+subprocess, through the same CLI the in-cluster CronJob uses — with an input it MUST classify a
+particular way, in BOTH directions. The negative cases carry as much weight as the positive
+ones: this detector's whole value is that it distinguishes an app that CANNOT sync from the 93
+that are simply not syncing because nothing changed, and a detector that cannot tell those
+apart is one nobody reads by week two.
+
+Run: python3 -m unittest openbank-infra/scripts/check_argocd_sync_integrity_test.py
+"""
+
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = REPO / ".github" / "scripts" / "check-argocd-sync-integrity.py"
+
+# The message ArgoCD actually served for three weeks, verbatim from #6371.
+LOKI_MSG = (
+    "Failed to compare desired state to live state: failed to calculate diff: error calculating "
+    "server side diff: serverSideDiff error: error running server side apply in dryrun mode for "
+    'resource StatefulSet/loki: StatefulSet.apps "loki" is invalid: spec: Forbidden: updates to '
+    "statefulset spec for fields other than 'replicas' are forbidden"
+)
+
+OWN = "git@github.com:JiRaska/open-bank-oss.git"
+UPSTREAM = "https://grafana.github.io/helm-charts"
+
+
+def app(name, *, sync="Synced", health="Healthy", conditions=None, phase=None,
+        revision=None, op_revision=None, repo=OWN):
+    status = {"sync": {"status": sync}, "health": {"status": health}}
+    if revision is not None:
+        status["sync"]["revision"] = revision
+    if conditions is not None:
+        status["conditions"] = conditions
+    if phase is not None:
+        status["operationState"] = {
+            "phase": phase,
+            "finishedAt": "2026-08-07T14:47:51Z",
+            "operation": {"sync": {"revision": op_revision if op_revision is not None else revision}},
+        }
+    return {"metadata": {"name": name}, "spec": {"source": {"repoURL": repo}}, "status": status}
+
+
+def run(apps, *, repo=None):
+    """Run the real script over a synthetic capture. Returns (exit_code, output)."""
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+        json.dump({"apiVersion": "v1", "kind": "List", "items": apps}, fh)
+        path = fh.name
+    argv = [sys.executable, str(SCRIPT), "--capture", path]
+    if repo:
+        argv += ["--repo", repo, "--base-ref", "origin/main"]
+    proc = subprocess.run(argv, capture_output=True, text=True)
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+class TheMechanismItself(unittest.TestCase):
+    """`ComparisonError` under Synced/Healthy — the state nothing in the estate could see."""
+
+    def test_the_real_2026_08_21_loki_state_is_rejected(self):
+        rc, out = run([app("loki", conditions=[{"type": "ComparisonError", "message": LOKI_MSG}])])
+        self.assertEqual(rc, 1, out)
+        self.assertIn("ERROR_CONDITION", out)
+        self.assertIn("loki", out)
+
+    def test_the_same_app_without_the_condition_passes(self):
+        """The negative control. If this fails, the detector is keying on Synced/Healthy —
+        which every healthy app in the estate also reports — and is worthless."""
+        rc, out = run([app("loki", conditions=[])])
+        self.assertEqual(rc, 0, out)
+
+    def test_every_error_suffixed_condition_is_the_same_class(self):
+        for ctype in ("SyncError", "InvalidSpecError", "UnknownError", "SomeFutureError"):
+            with self.subTest(ctype=ctype):
+                rc, out = run([app("x", conditions=[{"type": ctype, "message": "m"}])])
+                self.assertEqual(rc, 1, out)
+
+    def test_a_non_error_condition_does_not_fire(self):
+        """`agent` carries SharedResourceWarning on the live cluster today. A detector that
+        reddens on it is red from the day it lands."""
+        rc, out = run([app("agent", sync="OutOfSync",
+                           conditions=[{"type": "SharedResourceWarning", "message": "m"}])])
+        self.assertEqual(rc, 0, out)
+
+
+class FailedOperationMaskedBySynced(unittest.TestCase):
+    def test_synced_at_the_revision_whose_only_sync_failed(self):
+        rc, out = run([app("y", phase="Failed", revision="c" * 40)])
+        self.assertEqual(rc, 1, out)
+        self.assertIn("SYNCED_MASKING_FAILED_OP", out)
+
+    def test_a_failure_at_an_older_revision_since_converged_does_not_fire(self):
+        """The real `keycloak` state, 2026-08-23: a Failed operation from 2026-08-07 (its theme
+        ConfigMap exceeded the 256KB last-applied-configuration annotation limit) while the app
+        reports Synced at today's revision. An unmanaged probe — `kubectl get cm
+        keycloak-theme-openbank` against the manifest in git — found all three keys
+        byte-identical, so the app is genuinely converged and this must stay quiet. This test is
+        what stops the rule being the estate's resting state."""
+        rc, out = run([app("keycloak", phase="Failed", revision="a" * 40, op_revision="b" * 40)])
+        self.assertEqual(rc, 0, out)
+
+    def test_a_succeeded_operation_does_not_fire(self):
+        rc, out = run([app("y", phase="Succeeded", revision="c" * 40)])
+        self.assertEqual(rc, 0, out)
+
+    def test_outofsync_with_a_failed_operation_is_honest_reporting(self):
+        rc, out = run([app("y", sync="OutOfSync", phase="Failed", revision="c" * 40)])
+        self.assertEqual(rc, 0, out)
+
+
+class RevisionAncestry(unittest.TestCase):
+    """A deploy is verified by commit ANCESTRY, never by a tag or a version string (#6234)."""
+
+    def setUp(self):
+        self.head = subprocess.run(
+            ["git", "-C", str(REPO), "rev-parse", "origin/main"],
+            capture_output=True, text=True,
+        ).stdout.strip()
+        if len(self.head) != 40:
+            self.skipTest("origin/main is not resolvable in this checkout")
+
+    def test_a_revision_on_main_passes(self):
+        rc, out = run([app("z", revision=self.head)], repo=str(REPO))
+        self.assertEqual(rc, 0, out)
+
+    def test_a_revision_no_commit_in_this_repo_is_rejected(self):
+        rc, out = run([app("z", revision="b" * 40)], repo=str(REPO))
+        self.assertEqual(rc, 1, out)
+        self.assertIn("UNVERIFIABLE_REVISION", out)
+
+    def test_a_chart_version_string_is_rejected_for_a_repo_sourced_app(self):
+        """An app sourced from THIS repo must be at a commit. `6.55.0` is not one."""
+        rc, out = run([app("z", revision="6.55.0")], repo=str(REPO))
+        self.assertEqual(rc, 1, out)
+
+    def test_an_upstream_chart_app_is_exempt(self):
+        """22 of the 93 live Applications track a pinned upstream chart and carry a chart
+        version, not a sha. Ancestry is meaningless for them and must not fire."""
+        rc, out = run([app("loki", revision="6.55.0", repo=UPSTREAM)], repo=str(REPO))
+        self.assertEqual(rc, 0, out)
+
+    def test_ancestry_is_not_checked_when_no_repo_is_given(self):
+        rc, out = run([app("z", revision="6.55.0")])
+        self.assertEqual(rc, 0, out)
+
+
+class AFailedCaptureIsNeverNoFindings(unittest.TestCase):
+    """The defining failure of this repo's controls: a probe that observed nothing reporting
+    that it found nothing. Every way the capture can fail must exit non-zero."""
+
+    def test_absent_capture(self):
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--capture", "/nonexistent/apps.json"],
+            capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 1, proc.stdout)
+
+    def test_empty_capture(self):
+        rc, out = run([])
+        self.assertEqual(rc, 1, out)
+
+    def test_unparseable_capture(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+            fh.write("this is not json")
+            path = fh.name
+        proc = subprocess.run([sys.executable, str(SCRIPT), "--capture", path],
+                              capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 1, proc.stdout)
+
+
+class WiringCannotBeSilentlyRemoved(unittest.TestCase):
+    """The live half runs in-cluster. If its manifest is deleted, unregistered, or pointed at
+    an inline copy of the comparison, it stops producing findings — which is indistinguishable
+    from producing none. This is the repo half that notices."""
+
+    def test_the_real_repo_is_wired(self):
+        proc = subprocess.run([sys.executable, str(SCRIPT), "--check-wiring"],
+                              capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+
+    def test_the_cronjob_manifest_invokes_the_committed_checker(self):
+        manifest = (REPO / "openbank-infra/gitops/components/argocd-sync-verifier"
+                    / "argocd-sync-verifier.yaml").read_text()
+        self.assertIn(".github/scripts/check-argocd-sync-integrity.py", manifest)
+        self.assertIn("exit 1", manifest)
+
+    def test_the_selftest_passes(self):
+        proc = subprocess.run([sys.executable, str(SCRIPT), "--self-test"],
+                              capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #6371

## Does the claim reproduce?

**Not the original instance — it has been remediated.** Measured against the sandbox on 2026-08-23: 93 Applications, **zero** carrying a `ComparisonError`. `loki` reports `Synced/Healthy` with no conditions, its live StatefulSet `volumeClaimTemplates` is at 30Gi, and #6032's ruler block is present in the live ConfigMap.

Confirmed by an **unmanaged probe** — the one thing ArgoCD does not manage and cannot influence: the chart rendered locally from the Application's *own live* `valuesObject` (`kubectl get application loki -o jsonpath='{.spec.source.helm.valuesObject}'` → `helm template grafana/loki --version 6.55.0`), diffed against the live `ConfigMap/loki`. **Byte-identical, `diff` exit 0.** Asking ArgoCD whether ArgoCD applied something is asking the suspect about itself; this does not.

## The mechanism — measured, not inferred

The detector was run against the real 93-app capture *before* it was tuned, and it found a live instance of a **second** state in the same family:

`keycloak` reports `sync=Synced / health=Healthy` while its last sync **operation** finished `phase=Failed` on 2026-08-07 — 16 days earlier — with `ConfigMap "keycloak-theme-openbank" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes (retried 5 times)`.

The candidate mechanisms in this class have **opposite** fixes, so this had to be measured rather than assumed. The unmanaged probe settles it: the live `keycloak-theme-openbank` and the manifest in git agree on all three keys, byte for byte. The failed operation was at revision `ba578499`; the app now reports Synced at `a13b85d3`, having been compared and found converged at a *newer* revision. **That is convergence, not masking** — and shipping a rule that fires on it would have made this detector the estate's resting state from day one, which is the single most reliable way to ensure nobody reads it.

So `SYNCED_MASKING_FAILED_OP` only fires when the failed operation's revision **equals** the revision now being claimed Synced — i.e. nothing ever successfully applied what the app says it applied. That narrowing is a measurement, and the real keycloak state is a permanent negative-control test case.

## What is shipped

`argocd-sync-verifier` — a six-hourly in-cluster CronJob (`argocd` namespace, `get`/`list` on `argoproj.io/applications` only; no `patch`, no `update`, so a future edit cannot turn a detector into an actor). It captures Application status, runs the **committed** `.github/scripts/check-argocd-sync-integrity.py`, publishes a report ConfigMap and **then fails the Job**, so `KubeJobFailed` carries it with the detail already readable.

Three rejected states:

| finding | what it catches |
|---|---|
| `ERROR_CONDITION` | any `.status.conditions[].type` ending in `Error` — the #6371 mechanism itself, the class no metric exposes |
| `SYNCED_MASKING_FAILED_OP` | `Synced` at the very revision whose only sync operation `Failed` |
| `UNVERIFIABLE_REVISION` | a repo-sourced app whose `sync.revision` is not an ancestor of `origin/main` — **ancestry, never a tag or a version string** (#6234, where an older commit's PR closed a newer one and every version-equality check stayed green) |

It deliberately does **not** fire on a stale `finishedAt`: 15 of 93 apps last synced over a month ago and every one was correct, tracking a pinned upstream chart.

## Why not the kube-state-metrics `customResourceState` the issue proposed

The issue's own steps 1–2 are the blocker, and they hold. A malformed CRS config takes down the KSM pod and with it **every `kube_*` series in the estate** — a far larger blast radius than the gap being closed — and KSM parses `--custom-resource-state-config-file` only *after* connecting to an apiserver, so a deliberately broken config and a good one produce byte-identical startup logs offline. A probe that cannot tell those apart is not validation, and validating it needs a cluster mutation this PR will not make.

This detector shares **no failure domain** with the metrics pipeline and is falsifiable offline. Exposing the condition as a metric is still the better long-run answer; it needs a *dedicated* KSM instance and is not closed by this.

## Prevent-proof — exit codes read from `$?`, output redirected to files

The negative case was written first. Every command below redirects to a file; none is piped, so no exit code is `tail`'s.

**End-to-end, against the real 93-app cluster capture:**

```
$ ... --capture <live 93-app capture> --repo . --base-ref origin/main > /tmp/live2.out 2>&1
LIVE_EXIT=0     # OK: no Application is reporting a status it cannot back up.

# the SAME capture with the real 2026-08-21 loki ComparisonError message re-injected,
# loki still reporting Synced/Healthy exactly as it did for three weeks:
$ ... --capture <same capture + the real condition> --repo . > /tmp/broken2.out 2>&1
BROKEN_EXIT=1
  - ERROR_CONDITION  loki: condition ComparisonError while sync=Synced health=Healthy.
```

**A failed capture is never "no findings"** — the defining failure of a control in this repo:

```
ABSENT_EXIT=1        capture does not exist — the detector observed nothing.
EMPTY_EXIT=1         capture holds zero Applications — the detector observed nothing.
UNPARSEABLE_EXIT=1   capture is unreadable — the detector observed nothing.
```

**The falsification suite detects the control being removed.** Replacing the one line that detects `*Error` conditions with `if False:`:

```
SABOTAGED_UNITTEST_EXIT=1                      (FAILED, failures=6 of 19)
SABOTAGED_DETECTOR_ON_REAL_DEFECT_EXIT=0       # the sabotaged detector calls the real defect clean
RESTORED_EXIT=0
```

That middle line is the point: with the tests removed, a broken detector reports the three-week outage as healthy and nothing else in CI disagrees.

**A detector that runs nowhere reports nothing, which reads exactly like one reporting no findings.** `--check-wiring` (gate `argocd-sync-integrity-unit-test`) asserts the CronJob manifest exists, is registered as an Application, grants the read verb, invokes *this* script rather than an inline copy, and contains the `exit 1`. Proven falsifiable: pointed at an absent manifest it goes red; on the real repo, `WIRING_EXIT=0`.

## Verified

- `run-gates.py --only argocd-sync-integrity-unit-test` → **PASS** (19 unit tests + 14 self-test cases + wiring)
- `run-gates.py --group lint` → exit **0**; `--group gitops` → the new gate PASS
- meta-gates `gate-subject-floor`, `gate-selftest-declaration`, `gate-lifecycle-metadata`, `gate-invocation-reachability` → all exit **0**
- `ruff --select E9,F,B` → exit 0 · `yamllint` (CI config) → exit 0 · `kubeconform -strict` → 6 valid / 0 invalid (Application CRD skipped, no schema) · `trivy config` → 0 misconfigurations
- `gen-network-policies-drift-gate` failed only until the new manifests were `git add`ed — the documented untracked-file trap in `openbank-infra/CLAUDE.md`, not drift. It passes staged.

## NOT verified

- **The CronJob has never run.** No cluster mutation was made, per the task's read-only constraint. The comparison logic is proven against the real capture; the pod, its RBAC and the clone step are proven only by schema validation and by their identity with the `keycloak-realm-drift` job they are modelled on.
- The KSM `customResourceState` config from the issue is untested and not included.
- No claim that the estate is free of this defect class *beyond* what `.status` reports — an app whose controller never recorded a condition is invisible to this and to ArgoCD alike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
