### PR TITLE
fix(onboarding): SCA enrolments are seeded, not dropped, and device_count is derived

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-onboarding.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-onboarding.yaml
@@ -97,6 +97,45 @@ spec:
           annotations:
             summary: "{{ $value }} party(ies) have no KYC case at all"
             description: "openbank_kyc_orphaned_parties is {{ $value }} — that many parties, all past the detection grace period, have NO kyc_cases row. Each is a customer permanently stuck: PENDING_KYC party, accounts stuck in PENDING_ACTIVATION, no welcome bonus, and nothing retries because the PARTY_CREATED event was acked and dropped (#5698). Not self-healing — the event is gone, so it needs a replay per party. The stranded party ids are logged by kyc-service under `[orphan-detection]`; openbank_kyc_orphaned_parties_oldest_age_seconds says how long the worst one has been waiting."
+        - alert: OnboardingProjectionWireFormatMismatch
+          # #4353/#4692/#6248. sca-service published DEVICE_ENROLLED without the discriminator in
+          # the payload body; onboarding's parser fell through to `?: return`, and 15 enrolments
+          # were consumed, acked and discarded with no lag, no error and no log. The alertable
+          # state is therefore the SUCCESS state, not an error rate: a topic delivering messages
+          # of which NONE are projected. `ProjectionOutcomeMetrics` was added for exactly this
+          # and this rule was written only as prose in its KDoc — so when #6248 asked why the
+          # alert had not fired, the answer was that it had never been created. A suggested rule
+          # in a comment is documentation, not a control.
+          expr: |
+            sum by (topic) (rate(openbank_onboarding_projection_events_total{outcome="UNRECOGNISED"}[1h])) > 0
+            and
+            sum by (topic) (rate(openbank_onboarding_projection_events_total{outcome="PROJECTED"}[1h])) == 0
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            # continuous: the subject is inbound event traffic, not a periodic job, so the 1h
+            # window is bounded by the `and PROJECTED == 0` clause rather than by a period.
+            subject_period: continuous
+            summary: "onboarding-service recognises nothing on {{ $labels.topic }}"
+            description: "Every message onboarding-service consumed from `{{ $labels.topic }}` in the last hour parsed as JSON and matched no known event type, and none was projected. The producer and this consumer disagree about the wire format — typically a missing or renamed `eventType` discriminator in the payload body. The funnel is silently frozen for this topic: no lag, no errors, no log lines. Compare a real message on the topic against the parser in `OnboardingEventConsumer`."
+        - alert: OnboardingProjectionSeedingBackwards
+          # Events arriving for parties whose row does not exist yet. Since #6248 the row is
+          # seeded from the event rather than dropped, so this is no longer data loss — but a
+          # topic where seeding DOMINATES means party-events is chronically behind its siblings,
+          # and every such row carries no legal name or email until PARTY_CREATED lands.
+          # A steady trickle is normal across three independent consumer groups; the ratio is not.
+          expr: |
+            sum by (topic) (rate(openbank_onboarding_projection_events_total{outcome="SEEDED_UNKNOWN_PARTY"}[1h]))
+            >
+            sum by (topic) (rate(openbank_onboarding_projection_events_total{outcome="PROJECTED"}[1h]))
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            subject_period: continuous
+            summary: "onboarding-service is assembling records backwards on {{ $labels.topic }}"
+            description: "More events on `{{ $labels.topic }}` created a placeholder onboarding record than updated an existing one, for 30 minutes. party-events-in is running behind the KYC/SCA topics, so rows are being built from the wrong end and will show no legal name or email until PARTY_CREATED arrives. Check the `onboarding-service-party` consumer group's lag."
         - alert: KafkaConsumerGroupLagStuck
           # General event-bus safety net — the config comment on the Kafka Exporter calls
           # consumer-group lag "the single most useful event-bus health signal" and until now NO

--- a/openbank-onboarding-service/build.gradle.kts
+++ b/openbank-onboarding-service/build.gradle.kts
@@ -41,6 +41,12 @@ dependencies {
     // Consumer-driven contracts for party-service (REST + Kafka) and kyc-service (Kafka)
     // (ADR-0063, issue #468).
     testImplementation(libs.pact.consumer)
+    // Drives the real @Incoming handler without a broker (#6248): the projection defect is only
+    // observable as a row that does not change, so the test must go through the real channel.
+    testImplementation(libs.smallrye.reactive.messaging.inmemory)
+    testImplementation(libs.testcontainers)
+    testImplementation(libs.testcontainers.junit)
+    testImplementation(libs.testcontainers.postgresql)
 }
 
 // Pact: write the generated consumer contracts to pacts/ and forward broker config, matching

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/application/port/out/OnboardingRepository.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/application/port/out/OnboardingRepository.kt
@@ -16,6 +16,17 @@ interface OnboardingRepository {
 
     suspend fun upsert(record: OnboardingRecord)
 
+    /**
+     * Records that [credentialId] is enrolled for [partyId] and returns the party's resulting
+     * total number of distinct enrolled credentials.
+     *
+     * **Idempotent by construction (#6248).** Re-recording a credential already present is a
+     * no-op and returns the unchanged total, so a replayed `DEVICE_ENROLLED` converges instead
+     * of inflating `deviceCount`. This is what makes any backfill of the enrolments lost to
+     * #4353 safe to run more than once — the previous `deviceCount + 1` did not.
+     */
+    suspend fun recordDeviceEnrolment(partyId: UUID, credentialId: String, enrolledAt: java.time.Instant): Int
+
     suspend fun findByPartyId(partyId: UUID): OnboardingRecord?
 
     suspend fun listByStage(stage: FunnelStage, page: Int, size: Int): List<OnboardingRecord>

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/application/usecase/OnboardingProjectionService.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/application/usecase/OnboardingProjectionService.kt
@@ -14,6 +14,7 @@ import com.openbank.onboarding.domain.model.PartyStage
 import com.openbank.onboarding.domain.model.ProjectionResult
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
+import java.time.Instant
 import java.util.UUID
 
 class OnboardingRecordNotFoundException(partyId: UUID) :
@@ -55,11 +56,12 @@ class OnboardingProjectionService : OnboardingUseCase {
     /**
      * Applies one event to the read model and reports what it did.
      *
-     * Returns [ProjectionResult.SKIPPED_UNKNOWN_PARTY] rather than throwing when the event names
-     * a party with no row: the three source topics are independent consumer groups with no
-     * ordering between them, so this is an expected race, not a fault. The caller must record it
-     * as its own outcome and never as a success — see [ProjectionResult] for what folding the two
-     * together cost (#6248).
+     * No branch drops an event any more. The three source topics are independent consumer
+     * groups with no ordering between them, so an SCA or KYC event legitimately arrives before
+     * `PARTY_CREATED` has created the row. That used to `return` without writing anything, and
+     * nothing ever replayed it — so the enrolment was lost permanently. The row is now seeded
+     * from the event instead, and [ProjectionResult.APPLIED_TO_SEEDED_RECORD] says so, because
+     * an out-of-order arrival is still worth seeing (#6248).
      */
     suspend fun applyEvent(event: OnboardingEvent): ProjectionResult = when (event) {
         is OnboardingEvent.PartyCreated -> repo.applyPartyCreated(event)
@@ -104,23 +106,78 @@ class OnboardingProjectionService : OnboardingUseCase {
 // nothing else from it, and keeping them off the class holds it under detekt's TooManyFunctions
 // threshold, which fires AT 11 and not above it.
 
-/** The only branch that creates a row, and so the only one that cannot skip. */
+/**
+ * The row this event applies to, creating a placeholder if the party has none yet (#6248).
+ *
+ * Returns the record and whether it had to be seeded. A seeded row carries only what is known
+ * without `PARTY_CREATED` — the party id and the event time. No PII, because none is available,
+ * and none is invented.
+ */
+private suspend fun OnboardingRepository.recordFor(
+    partyId: UUID,
+    occurredAt: Instant,
+): Pair<OnboardingRecord, Boolean> {
+    val existing = findByPartyId(partyId)
+    if (existing != null) return existing to false
+    val seeded = OnboardingRecord(
+        partyId = partyId,
+        legalName = null,
+        email = null,
+        partyStatus = PartyStage.PENDING_KYC,
+        kycCaseId = null,
+        kycStatus = null,
+        scaEnrolled = false,
+        deviceCount = 0,
+        funnelStage = FunnelStage.REGISTERED,
+        blockedReason = null,
+        createdAt = occurredAt,
+        updatedAt = occurredAt,
+    )
+    return seeded to true
+}
+
+private fun result(seeded: Boolean) =
+    if (seeded) ProjectionResult.APPLIED_TO_SEEDED_RECORD else ProjectionResult.APPLIED
+
+/**
+ * `PARTY_CREATED` fills in identity; it must never reset progress.
+ *
+ * It used to write a fixed `scaEnrolled = false, deviceCount = 0, kycStatus = null,
+ * funnelStage = REGISTERED` over whatever the row held. That is destructive on exactly the two
+ * occasions it now matters: when the row was seeded by an out-of-order SCA/KYC event, and when
+ * `PARTY_CREATED` is replayed. Preserve the projected state and re-derive the stage from it.
+ */
 private suspend fun OnboardingRepository.applyPartyCreated(event: OnboardingEvent.PartyCreated): ProjectionResult {
-    val now = event.occurredAt
+    val existing = findByPartyId(event.partyId)
+    val base = existing ?: OnboardingRecord(
+        partyId = event.partyId,
+        legalName = null,
+        email = null,
+        partyStatus = PartyStage.PENDING_KYC,
+        kycCaseId = null,
+        kycStatus = null,
+        scaEnrolled = false,
+        deviceCount = 0,
+        funnelStage = FunnelStage.REGISTERED,
+        blockedReason = null,
+        createdAt = event.occurredAt,
+        updatedAt = event.occurredAt,
+    )
+    // Re-derive ONLY where there is progress to preserve. A brand-new party has none, and
+    // `derive(PENDING_KYC, null, false)` answers KYC_OPEN — so deriving unconditionally would
+    // push every new registration a stage down the funnel, and push it there again on replay.
+    val hasProgress = base.scaEnrolled || base.kycStatus != null || base.partyStatus != PartyStage.PENDING_KYC
     upsert(
-        OnboardingRecord(
-            partyId = event.partyId,
+        base.copy(
             legalName = event.legalName,
             email = event.email,
-            partyStatus = PartyStage.PENDING_KYC,
-            kycCaseId = null,
-            kycStatus = null,
-            scaEnrolled = false,
-            deviceCount = 0,
-            funnelStage = FunnelStage.REGISTERED,
-            blockedReason = null,
-            createdAt = now,
-            updatedAt = now,
+            funnelStage = if (hasProgress) {
+                FunnelStage.derive(base.partyStatus, base.kycStatus, base.scaEnrolled)
+            } else {
+                base.funnelStage
+            },
+            createdAt = event.occurredAt,
+            updatedAt = maxOf(base.updatedAt, event.occurredAt),
         ),
     )
     return ProjectionResult.APPLIED
@@ -129,7 +186,7 @@ private suspend fun OnboardingRepository.applyPartyCreated(event: OnboardingEven
 private suspend fun OnboardingRepository.applyPartyStatusChanged(
     event: OnboardingEvent.PartyStatusChanged,
 ): ProjectionResult {
-    val existing = findByPartyId(event.partyId) ?: return ProjectionResult.SKIPPED_UNKNOWN_PARTY
+    val (existing, seeded) = recordFor(event.partyId, event.occurredAt)
     upsert(
         existing.copy(
             partyStatus = event.newStatus,
@@ -144,11 +201,11 @@ private suspend fun OnboardingRepository.applyPartyStatusChanged(
             updatedAt = event.occurredAt,
         ),
     )
-    return ProjectionResult.APPLIED
+    return result(seeded)
 }
 
 private suspend fun OnboardingRepository.applyKycCaseOpened(event: OnboardingEvent.KycCaseOpened): ProjectionResult {
-    val existing = findByPartyId(event.partyId) ?: return ProjectionResult.SKIPPED_UNKNOWN_PARTY
+    val (existing, seeded) = recordFor(event.partyId, event.occurredAt)
     upsert(
         existing.copy(
             kycCaseId = event.kycCaseId,
@@ -157,13 +214,13 @@ private suspend fun OnboardingRepository.applyKycCaseOpened(event: OnboardingEve
             updatedAt = event.occurredAt,
         ),
     )
-    return ProjectionResult.APPLIED
+    return result(seeded)
 }
 
 private suspend fun OnboardingRepository.applyKycStatusChanged(
     event: OnboardingEvent.KycStatusChanged,
 ): ProjectionResult {
-    val existing = findByPartyId(event.partyId) ?: return ProjectionResult.SKIPPED_UNKNOWN_PARTY
+    val (existing, seeded) = recordFor(event.partyId, event.occurredAt)
     upsert(
         existing.copy(
             kycStatus = event.newStatus,
@@ -176,18 +233,28 @@ private suspend fun OnboardingRepository.applyKycStatusChanged(
             updatedAt = event.occurredAt,
         ),
     )
-    return ProjectionResult.APPLIED
+    return result(seeded)
 }
 
+/**
+ * `deviceCount` is DERIVED from the credential ledger, never incremented (#6248).
+ *
+ * `deviceCount + 1` cannot be replayed: re-consuming an event the read model has already seen
+ * inflates the count instead of converging on it. That matters because replay is the only way
+ * back for the enrolments lost to #4353 — the Kafka topic's retention dropped the originals long
+ * ago, so any recovery necessarily re-publishes from `sca_enrolled_devices`, and a backfill you
+ * cannot run twice is a backfill nobody dares run once.
+ */
 private suspend fun OnboardingRepository.applyDeviceEnrolled(event: OnboardingEvent.DeviceEnrolled): ProjectionResult {
-    val existing = findByPartyId(event.partyId) ?: return ProjectionResult.SKIPPED_UNKNOWN_PARTY
+    val (existing, seeded) = recordFor(event.partyId, event.occurredAt)
+    val total = recordDeviceEnrolment(event.partyId, event.credentialId, event.occurredAt)
     upsert(
         existing.copy(
-            scaEnrolled = true,
-            deviceCount = existing.deviceCount + 1,
-            funnelStage = FunnelStage.derive(existing.partyStatus, existing.kycStatus, true),
+            scaEnrolled = total > 0,
+            deviceCount = total,
+            funnelStage = FunnelStage.derive(existing.partyStatus, existing.kycStatus, total > 0),
             updatedAt = event.occurredAt,
         ),
     )
-    return ProjectionResult.APPLIED
+    return result(seeded)
 }

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/domain/model/ProjectionResult.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/domain/model/ProjectionResult.kt
@@ -6,30 +6,27 @@ package com.openbank.onboarding.domain.model
 /**
  * What the projection actually did with an event it was handed (#6248).
  *
- * Every branch of the projection except `PartyCreated` needs an existing row to update, and
- * guards with `repo.findByPartyId(...) ?: return`. That guard is correct — the three source
- * topics are three independent consumer groups with no ordering between them, so an event can
- * legitimately arrive before the party row exists, and throwing would wedge the group. What was
- * wrong is that the guard returned normally and the caller could not tell it apart from work
- * done: a dropped event was counted as `PROJECTED`.
+ * History, because it explains why an out-of-order arrival gets its own value rather than being
+ * silently normal. Every branch except `PartyCreated` used to guard with
+ * `repo.findByPartyId(...) ?: return`: an event naming a party with no row was discarded, the
+ * caller could not tell that apart from work done, and it was counted as a success. Nothing
+ * replays this read model — the consumer's own KDoc said it "can be replayed" and no such job
+ * exists — so the discarded event was gone for good. #6258 made the drop visible; this change
+ * stops it happening. The row is seeded from the event instead.
  *
- * That cost the platform a real defect. All 15 `DEVICE_ENROLLED` events in the sandbox were
- * consumed with zero lag and none reached `onboarding_records`, and the alert built for exactly
- * this class of failure (`UNRECOGNISED > 0 and PROJECTED == 0`, #4353) was structurally unable
- * to fire, because the drop was landing in the success bucket it compares against.
- *
- * So the skip gets its own value, never a flag shared with success — the same rule as
- * `PushSendOutcome.SKIPPED` (ADR-0252 phase 0), and the same rule the sibling
- * `ProjectionOutcomeMetrics.Outcome.UNRECOGNISED` already follows one layer up.
+ * The seeded case still needs its own value. It means the read model is being assembled
+ * backwards, which is legal but is also the shape that precedes a real ordering problem, and a
+ * quiet path that reports as an ordinary success is exactly what cost the platform 15 enrolments.
  */
 enum class ProjectionResult {
-    /** The read model was updated. */
+    /** The event was applied to a row that already existed. */
     APPLIED,
 
     /**
-     * The event named a party that has no row yet, so there was nothing to update and the event
-     * was discarded. Not an error and not a success — this is the state in which enrolments,
-     * KYC transitions and status changes are silently lost.
+     * The event named a party with no row, so a placeholder was created from the event and the
+     * event applied to it. Not a loss — but not an ordinary success either: it says an SCA or KYC
+     * event overtook `PARTY_CREATED`, and the row will carry no legal name or email until that
+     * event arrives.
      */
-    SKIPPED_UNKNOWN_PARTY,
+    APPLIED_TO_SEEDED_RECORD,
 }

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumer.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumer.kt
@@ -182,7 +182,12 @@ class OnboardingEventConsumer(private val clock: Clock) {
         return when (type) {
             "DEVICE_ENROLLED" -> OnboardingEvent.DeviceEnrolled(
                 partyId = partyId,
-                credentialId = node.path("credentialId").asText(""),
+                // sca-service sends both; `credentialId` is the stable identity of the key
+                // material and `deviceId` the row id. Fall back rather than default to "",
+                // because an empty credential id collapses every one of a party's devices onto
+                // the same ledger key and silently caps device_count at 1.
+                credentialId = node.path("credentialId").asText("").takeIf { it.isNotBlank() }
+                    ?: node.path("deviceId").asText(""),
                 occurredAt = occurredAt,
             )
             else -> null
@@ -226,23 +231,25 @@ class OnboardingEventConsumer(private val clock: Clock) {
             metrics.record(topic, ProjectionOutcomeMetrics.Outcome.FAILED)
             throw e
         }
-        // A skip is NOT a success (#6248). Recording both as PROJECTED is what let 15 DEVICE_ENROLLED
-        // events be consumed with zero lag, reach no row, and leave every alert reading healthy.
+        // A seed is NOT an ordinary success (#6248). This used to be a *drop* counted as
+        // PROJECTED, which is how 15 DEVICE_ENROLLED events were consumed with zero lag, reached
+        // no row, and left every alert reading healthy.
         when (result) {
             ProjectionResult.APPLIED ->
                 metrics.record(topic, ProjectionOutcomeMetrics.Outcome.PROJECTED)
 
-            ProjectionResult.SKIPPED_UNKNOWN_PARTY -> {
-                // WARN, not ERROR: an out-of-order arrival is expected across independent consumer
-                // groups. It is logged at all because the drop is otherwise invisible per-party —
-                // the metric says how many, only this line says which.
-                log.warnf(
-                    "[%s] Dropped %s for party %s: no onboarding record exists yet",
+            ProjectionResult.APPLIED_TO_SEEDED_RECORD -> {
+                // INFO, not WARN: nothing is lost any more. It is logged at all because the
+                // ordering is otherwise invisible per-party — the metric says how many, only
+                // this line says which, and a row with no legal name is a question an operator
+                // will eventually ask about.
+                log.infof(
+                    "[%s] Seeded onboarding record for party %s from %s: PARTY_CREATED has not arrived yet",
                     topic,
-                    event::class.simpleName,
                     partyIdOf(event),
+                    event::class.simpleName,
                 )
-                metrics.record(topic, ProjectionOutcomeMetrics.Outcome.SKIPPED_UNKNOWN_PARTY)
+                metrics.record(topic, ProjectionOutcomeMetrics.Outcome.SEEDED_UNKNOWN_PARTY)
             }
         }
     }

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/observability/ProjectionOutcomeMetrics.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/observability/ProjectionOutcomeMetrics.kt
@@ -31,12 +31,15 @@ import jakarta.inject.Inject
  * Producer and consumer disagree about the wire format:
  *   sum by (topic) (rate(...{outcome="UNRECOGNISED"}[1h])) > 0
  *     and sum by (topic) (rate(...{outcome="PROJECTED"}[1h])) == 0
- * Events are arriving for parties the read model does not have, i.e. cross-topic ordering is
- * losing them (#6248):
- *   sum by (topic) (rate(...{outcome="SKIPPED_UNKNOWN_PARTY"}[1h])) > 0
+ * Events are arriving for parties the read model does not have yet, i.e. cross-topic ordering
+ * is running backwards (#6248):
+ *   sum by (topic) (rate(...{outcome="SEEDED_UNKNOWN_PARTY"}[1h])) > 0
  *
- * The second rule needs no PROJECTED == 0 companion: unlike an unrecognised payload, a skip is
- * per-party, so a steady trickle among healthy traffic is exactly the shape to alert on.
+ * Both rules are DEPLOYED, in
+ * `openbank-infra/gitops/components/observability/prometheus-rules-onboarding.yaml`. They were
+ * written here as prose only and never became a PrometheusRule, so "the alert did not fire"
+ * for #6248 had a simpler explanation than anyone reached for: there was no alert. A suggested
+ * rule in a KDoc is documentation, not a control.
  *
  * Cardinality is bounded: three topics, four outcomes.
  *
@@ -66,16 +69,14 @@ class ProjectionOutcomeMetrics(private val registry: MeterRegistry?) {
         UNRECOGNISED,
 
         /**
-         * Parsed and recognised, but the projection had nothing to update: the event names a
-         * party with no row yet. Its own value rather than part of [PROJECTED], because the two
-         * are opposite states — one means the read model advanced, the other means an enrolment
-         * or a KYC transition was discarded.
-         *
-         * This is the outcome that was missing when this class was written, and its absence is
-         * why the rule below could not fire for #6248: the drops were being counted as
-         * [PROJECTED], the very series the rule requires to be zero.
+         * Parsed, recognised and applied — to a row the projection had to create first, because
+         * the event named a party `PARTY_CREATED` had not reached it for yet. Its own value
+         * rather than part of [PROJECTED]: the event is no longer lost (it was, until #6248),
+         * but the read model is being assembled backwards and the row carries no identity until
+         * `PARTY_CREATED` lands. A steady trickle is normal across independent consumer groups;
+         * a topic where this is the *dominant* outcome is a real ordering problem.
          */
-        SKIPPED_UNKNOWN_PARTY,
+        SEEDED_UNKNOWN_PARTY,
 
         /** Malformed payload, or the projection itself threw. Already logged at ERROR. */
         FAILED,

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/persistence/entity/DeviceEnrolmentEntity.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/persistence/entity/DeviceEnrolmentEntity.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.onboarding.infrastructure.persistence.entity
+
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheCompanion
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * One enrolled SCA credential, as seen by the onboarding read model (#6248).
+ *
+ * Exists so `onboarding_records.device_count` can be *derived* rather than incremented. The
+ * previous `deviceCount + 1` made DEVICE_ENROLLED non-idempotent, which in turn made replay —
+ * the only recovery path for events Kafka retention has already dropped — unusable.
+ */
+@Entity
+@Table(
+    name = "onboarding_device_enrolments",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uq_onboarding_device_enrolment", columnNames = ["party_id", "credential_id"]),
+    ],
+    indexes = [Index(name = "idx_onboarding_device_enrolment_party", columnList = "party_id")],
+)
+class DeviceEnrolmentEntity : PanacheEntity() {
+
+    companion object : PanacheCompanion<DeviceEnrolmentEntity>
+
+    @Column(name = "party_id", nullable = false)
+    lateinit var partyId: UUID
+
+    @Column(name = "credential_id", nullable = false)
+    lateinit var credentialId: String
+
+    @Column(name = "enrolled_at", nullable = false)
+    lateinit var enrolledAt: Instant
+}

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/persistence/repository/OnboardingRepositoryImpl.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/persistence/repository/OnboardingRepositoryImpl.kt
@@ -9,12 +9,14 @@ import com.openbank.onboarding.domain.model.FunnelStage
 import com.openbank.onboarding.domain.model.KycStage
 import com.openbank.onboarding.domain.model.OnboardingRecord
 import com.openbank.onboarding.domain.model.PartyStage
+import com.openbank.onboarding.infrastructure.persistence.entity.DeviceEnrolmentEntity
 import com.openbank.onboarding.infrastructure.persistence.entity.OnboardingEntity
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
 import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
+import java.time.Instant
 import java.util.UUID
 
 @ApplicationScoped
@@ -47,6 +49,34 @@ class OnboardingRepositoryImpl :
             }
         }.awaitSuspending()
     }
+
+    /**
+     * Check-then-insert inside one transaction, so a duplicate is absorbed without ever letting a
+     * constraint violation reach the reactive session (a failed statement poisons it for the rest
+     * of the transaction, and this method must be safe to call on every replayed event). The
+     * UNIQUE index remains the real guarantee under concurrency; this is the common path.
+     */
+    override suspend fun recordDeviceEnrolment(partyId: UUID, credentialId: String, enrolledAt: Instant): Int =
+        Panache.withTransaction {
+            DeviceEnrolmentEntity
+                .find("partyId = ?1 and credentialId = ?2", partyId, credentialId)
+                .firstResult()
+                .flatMap { existing ->
+                    if (existing != null) {
+                        Uni.createFrom().item(Unit)
+                    } else {
+                        val e = DeviceEnrolmentEntity()
+                        e.partyId = partyId
+                        e.credentialId = credentialId
+                        e.enrolledAt = enrolledAt
+                        // replaceWith(Unit), not the bare persist(): Kotlin infers the branch
+                        // type from the `if`, and `Uni<DeviceEnrolmentEntity>` vs `Uni<Void>`
+                        // unifies to a cast that only blows up at runtime.
+                        e.persist<DeviceEnrolmentEntity>().replaceWith(Unit)
+                    }
+                }
+                .flatMap { DeviceEnrolmentEntity.count("partyId", partyId) }
+        }.awaitSuspending().toInt()
 
     override suspend fun findByPartyId(partyId: UUID): OnboardingRecord? =
         Panache.withSession { find("partyId", partyId).firstResult() }.awaitSuspending()?.toDomain()
@@ -83,34 +113,37 @@ class OnboardingRepositoryImpl :
             }
         }.awaitSuspending()
     }
-
-    private fun OnboardingRecord.toEntity() = OnboardingEntity().also {
-        it.partyId = partyId
-        it.legalName = legalName
-        it.email = email
-        it.partyStatus = partyStatus.name
-        it.kycCaseId = kycCaseId
-        it.kycStatus = kycStatus?.name
-        it.scaEnrolled = scaEnrolled
-        it.deviceCount = deviceCount
-        it.funnelStage = funnelStage.name
-        it.blockedReason = blockedReason
-        it.createdAt = createdAt
-        it.updatedAt = updatedAt
-    }
-
-    private fun OnboardingEntity.toDomain() = OnboardingRecord(
-        partyId = partyId,
-        legalName = legalName,
-        email = email,
-        partyStatus = PartyStage.valueOf(partyStatus),
-        kycCaseId = kycCaseId,
-        kycStatus = kycStatus?.let { runCatching { KycStage.valueOf(it) }.getOrNull() },
-        scaEnrolled = scaEnrolled,
-        deviceCount = deviceCount,
-        funnelStage = FunnelStage.valueOf(funnelStage),
-        blockedReason = blockedReason,
-        createdAt = createdAt,
-        updatedAt = updatedAt,
-    )
 }
+
+// Entity <-> domain mapping as file-private top-level extensions rather than methods: they
+// need nothing from the class, and keeping them off it holds it under detekt's
+// TooManyFunctions threshold, which fires AT 11 and not above it.
+private fun OnboardingRecord.toEntity() = OnboardingEntity().also {
+    it.partyId = partyId
+    it.legalName = legalName
+    it.email = email
+    it.partyStatus = partyStatus.name
+    it.kycCaseId = kycCaseId
+    it.kycStatus = kycStatus?.name
+    it.scaEnrolled = scaEnrolled
+    it.deviceCount = deviceCount
+    it.funnelStage = funnelStage.name
+    it.blockedReason = blockedReason
+    it.createdAt = createdAt
+    it.updatedAt = updatedAt
+}
+
+private fun OnboardingEntity.toDomain() = OnboardingRecord(
+    partyId = partyId,
+    legalName = legalName,
+    email = email,
+    partyStatus = PartyStage.valueOf(partyStatus),
+    kycCaseId = kycCaseId,
+    kycStatus = kycStatus?.let { runCatching { KycStage.valueOf(it) }.getOrNull() },
+    scaEnrolled = scaEnrolled,
+    deviceCount = deviceCount,
+    funnelStage = FunnelStage.valueOf(funnelStage),
+    blockedReason = blockedReason,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+)

--- a/openbank-onboarding-service/src/main/resources/db/migration/V3__device_enrolment_ledger.sql
+++ b/openbank-onboarding-service/src/main/resources/db/migration/V3__device_enrolment_ledger.sql
@@ -1,0 +1,35 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors.
+-- Flyway migration V3 (#6248): a per-credential ledger behind onboarding_records.device_count.
+--
+-- `device_count` was maintained as a blind `existing.deviceCount + 1` on every DEVICE_ENROLLED.
+-- That makes the projection non-idempotent: replaying an event — which is the ONLY way the 15
+-- enrolments already lost to #4353/#4692 can ever be recovered, since the Kafka topic's retention
+-- has long since dropped them — inflates the count instead of converging. A read model must be
+-- able to re-consume its own input.
+--
+-- Counting rows in this ledger instead makes DEVICE_ENROLLED idempotent by construction: the
+-- unique key absorbs a duplicate, and `device_count` / `sca_enrolled` are then derived, never
+-- incremented. `credential_id` is the sca-service credential identifier carried in the payload.
+--
+-- Rollback note:
+--   DROP TABLE onboarding_device_enrolments;
+--   DROP SEQUENCE onboarding_device_enrolments_seq;
+-- `onboarding_records.device_count` keeps whatever value it holds, so a rollback degrades to the
+-- previous (non-idempotent) behaviour rather than losing the funnel column.
+
+CREATE TABLE IF NOT EXISTS onboarding_device_enrolments (
+    id            BIGINT      PRIMARY KEY,
+    party_id      UUID        NOT NULL,
+    credential_id TEXT        NOT NULL,
+    enrolled_at   TIMESTAMPTZ NOT NULL,
+    CONSTRAINT uq_onboarding_device_enrolment UNIQUE (party_id, credential_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_onboarding_device_enrolment_party
+    ON onboarding_device_enrolments (party_id);
+
+-- Hibernate (PanacheEntity, ORM 6) allocates ids from `<table>_seq` with a pooled optimizer of
+-- allocationSize 50. V2 records what happens when that sequence is missing: every insert fails
+-- with `relation "..._seq" does not exist` and the read model silently never persists.
+CREATE SEQUENCE IF NOT EXISTS onboarding_device_enrolments_seq START WITH 1 INCREMENT BY 50;

--- a/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/application/usecase/OnboardingProjectionServiceTest.kt
+++ b/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/application/usecase/OnboardingProjectionServiceTest.kt
@@ -75,6 +75,8 @@ class OnboardingProjectionServiceTest {
         val slot = slot<OnboardingRecord>()
         coEvery { repo.upsert(capture(slot)) } just runs
 
+        coEvery { repo.findByPartyId(any()) } returns null
+
         service.applyEvent(
             OnboardingEvent.PartyCreated(
                 partyId = partyId,
@@ -167,6 +169,7 @@ class OnboardingProjectionServiceTest {
         val slot = slot<OnboardingRecord>()
         coEvery { repo.findByPartyId(partyId) } returns existing
         coEvery { repo.upsert(capture(slot)) } just runs
+        coEvery { repo.recordDeviceEnrolment(partyId, "cred-abc", any()) } returns 1
 
         service.applyEvent(
             OnboardingEvent.DeviceEnrolled(
@@ -186,13 +189,12 @@ class OnboardingProjectionServiceTest {
     // ── applyEvent: the party row does not exist yet (#6248) ──────────────────
 
     /**
-     * Every branch that needs an existing row must report the skip rather than returning the same
-     * value as work done. Parameterised over all four so a branch added later cannot quietly opt
-     * out — `DeviceEnrolled` is the one that was measured losing events, but the other three lose
-     * KYC and status transitions the same way.
+     * No branch may drop an event. Parameterised over all four so a branch added later cannot
+     * quietly opt out — `DeviceEnrolled` is the one that was measured losing events, but the
+     * other three lose KYC and status transitions the same way, and nothing replays any of them.
      */
     @Test
-    fun `applyEvent returns SKIPPED_UNKNOWN_PARTY on every branch that needs an existing row`(): Unit = runBlocking {
+    fun `applyEvent seeds a record on every branch that needs one, and never drops the event`(): Unit = runBlocking {
         val partyId = UUID.randomUUID()
         val at = Instant.parse("2026-08-19T12:56:36Z")
         val events = listOf(
@@ -201,18 +203,24 @@ class OnboardingProjectionServiceTest {
             OnboardingEvent.KycCaseOpened(partyId, UUID.randomUUID(), at),
             OnboardingEvent.KycStatusChanged(partyId, UUID.randomUUID(), KycStage.APPROVED, at),
         )
+        val written = mutableListOf<OnboardingRecord>()
         coEvery { repo.findByPartyId(partyId) } returns null
+        coEvery { repo.upsert(capture(written)) } just runs
+        coEvery { repo.recordDeviceEnrolment(partyId, "cred-abc", any()) } returns 1
 
         assertThat(events.map { service.applyEvent(it) })
-            .describedAs("all four branches report the skip")
-            .containsOnly(ProjectionResult.SKIPPED_UNKNOWN_PARTY)
+            .describedAs("all four branches seed rather than drop")
+            .containsOnly(ProjectionResult.APPLIED_TO_SEEDED_RECORD)
 
-        coVerify(exactly = 0) { repo.upsert(any()) }
+        assertThat(written).describedAs("every event wrote a row").hasSize(4)
+        assertThat(written).allSatisfy { assertThat(it.partyId).isEqualTo(partyId) }
+        // The seeded row invents no identity it was not given.
+        assertThat(written).allSatisfy { assertThat(it.legalName).isNull() }
     }
 
     /**
-     * The other half of the contract: a real update must NOT report a skip. Without this the
-     * assertion above passes against a projection that returns SKIPPED_UNKNOWN_PARTY
+     * The other half of the contract: a real update must NOT report a seed. Without this the
+     * assertion above passes against a projection that returns APPLIED_TO_SEEDED_RECORD
      * unconditionally.
      */
     @Test
@@ -224,12 +232,70 @@ class OnboardingProjectionServiceTest {
             kycStatus = KycStage.APPROVED,
         )
         coEvery { repo.upsert(any()) } just runs
+        coEvery { repo.recordDeviceEnrolment(partyId, "cred-abc", any()) } returns 1
 
         val result = service.applyEvent(
             OnboardingEvent.DeviceEnrolled(partyId, "cred-abc", Instant.parse("2026-08-19T12:56:36Z")),
         )
 
         assertThat(result).isEqualTo(ProjectionResult.APPLIED)
+    }
+
+    /**
+     * `deviceCount` is whatever the ledger says, never `existing + 1`. Replaying an event the
+     * read model has already seen must converge, not inflate — that is what makes a backfill of
+     * the enrolments lost to #4353 safe to run more than once.
+     */
+    @Test
+    fun `applyEvent DeviceEnrolled takes deviceCount from the ledger, not from an increment`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        val existing = sampleRecord(partyId, funnelStage = FunnelStage.ACTIVE, kycStatus = KycStage.APPROVED)
+            .copy(scaEnrolled = true, deviceCount = 7)
+        val slot = slot<OnboardingRecord>()
+        coEvery { repo.findByPartyId(partyId) } returns existing
+        coEvery { repo.upsert(capture(slot)) } just runs
+        // The ledger already holds this credential: a replay changes nothing.
+        coEvery { repo.recordDeviceEnrolment(partyId, "cred-abc", any()) } returns 7
+
+        service.applyEvent(
+            OnboardingEvent.DeviceEnrolled(partyId, "cred-abc", Instant.parse("2026-08-19T12:56:36Z")),
+        )
+
+        assertThat(slot.captured.deviceCount)
+            .describedAs("a replayed enrolment must not become an 8th device")
+            .isEqualTo(7)
+    }
+
+    /**
+     * `PARTY_CREATED` arriving after an SCA or KYC event must fill in identity, not reset
+     * progress. The old branch wrote a fixed `scaEnrolled = false, deviceCount = 0,
+     * kycStatus = null, funnelStage = REGISTERED` over whatever the row held.
+     */
+    @Test
+    fun `applyEvent PartyCreated preserves projected state on an existing row`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        val existing = sampleRecord(partyId, funnelStage = FunnelStage.ACTIVE, kycStatus = KycStage.APPROVED)
+            .copy(scaEnrolled = true, deviceCount = 2, partyStatus = PartyStage.ACTIVE)
+        val slot = slot<OnboardingRecord>()
+        coEvery { repo.findByPartyId(partyId) } returns existing
+        coEvery { repo.upsert(capture(slot)) } just runs
+
+        service.applyEvent(
+            OnboardingEvent.PartyCreated(
+                partyId,
+                "Jana Nova",
+                "jana@example.test",
+                Instant.parse("2026-08-19T12:56:12Z"),
+            ),
+        )
+
+        with(slot.captured) {
+            assertThat(legalName).isEqualTo("Jana Nova")
+            assertThat(scaEnrolled).describedAs("SCA state survives a late PARTY_CREATED").isTrue()
+            assertThat(deviceCount).isEqualTo(2)
+            assertThat(kycStatus).isEqualTo(KycStage.APPROVED)
+            assertThat(funnelStage).isEqualTo(FunnelStage.ACTIVE)
+        }
     }
 
     // ── getRecord not found ───────────────────────────────────────────────────

--- a/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumerTest.kt
+++ b/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumerTest.kt
@@ -88,29 +88,29 @@ class OnboardingEventConsumerTest {
      * measuring that a counter was touched, not which bucket it landed in.
      */
     @Test
-    fun `a skipped projection is recorded as SKIPPED_UNKNOWN_PARTY and never as PROJECTED`(): Unit = runBlocking {
+    fun `a seeded projection is recorded as SEEDED_UNKNOWN_PARTY and never as PROJECTED`(): Unit = runBlocking {
         val partyId = UUID.randomUUID()
-        coEvery { projection.applyEvent(any()) } returns ProjectionResult.SKIPPED_UNKNOWN_PARTY
+        coEvery { projection.applyEvent(any()) } returns ProjectionResult.APPLIED_TO_SEEDED_RECORD
 
         consumer.consumeScaEvent(
             """{"eventType":"DEVICE_ENROLLED","partyId":"$partyId","credentialId":"c1"}""",
         )
 
         verify(exactly = 1) {
-            metrics.record("sca-events-in", ProjectionOutcomeMetrics.Outcome.SKIPPED_UNKNOWN_PARTY)
+            metrics.record("sca-events-in", ProjectionOutcomeMetrics.Outcome.SEEDED_UNKNOWN_PARTY)
         }
         verify(exactly = 0) { metrics.record("sca-events-in", ProjectionOutcomeMetrics.Outcome.PROJECTED) }
         verify(exactly = 0) { metrics.record("sca-events-in", ProjectionOutcomeMetrics.Outcome.FAILED) }
     }
 
     /**
-     * A skip must stay acked. Nacking it would wedge the consumer group on an ordering race that
-     * resolves itself, which is the failure mode the original `?: return` was right to avoid —
-     * only its reporting was wrong.
+     * A seed must stay acked. Nacking it would wedge the consumer group on an ordering race
+     * that resolves itself, which is the failure mode the original `?: return` was right to
+     * avoid — what was wrong was discarding the event, and then reporting that as a success.
      */
     @Test
-    fun `a skipped projection does not throw`() {
-        coEvery { projection.applyEvent(any()) } returns ProjectionResult.SKIPPED_UNKNOWN_PARTY
+    fun `a seeded projection does not throw`() {
+        coEvery { projection.applyEvent(any()) } returns ProjectionResult.APPLIED_TO_SEEDED_RECORD
 
         assertThatCode {
             runBlocking {

--- a/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/integration/ScaEnrolmentProjectionIT.kt
+++ b/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/integration/ScaEnrolmentProjectionIT.kt
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.onboarding.integration
+
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import io.smallrye.reactive.messaging.memory.InMemorySource
+import jakarta.enterprise.inject.Any
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.config.ConfigProvider
+import org.eclipse.microprofile.reactive.messaging.Message
+import org.junit.jupiter.api.Test
+import java.sql.Connection
+import java.sql.DriverManager
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.TimeUnit
+import java.util.function.Supplier
+
+/**
+ * The end-to-end proof #6248 asks for: a real `DEVICE_ENROLLED` message, delivered through the
+ * real `@Incoming` handler, landing as a real row read back over plain JDBC.
+ *
+ * Why not a unit test: every unit test on both sides of this defect was green for the whole time
+ * it was live. The producer's tests asserted the payload it built, the consumer's asserted the
+ * parse and the metric, and the projection's asserted the record it handed a **mocked**
+ * repository. None of them could see that no row ever changed — the only observable that was ever
+ * wrong. A mocked repository cannot establish that a row landed.
+ *
+ * The payloads below are the real 2026-08-19 sandbox message shape (`sca_outbox` id 2101), minus
+ * the key material.
+ */
+@QuarkusTest
+@QuarkusTestResource(ScaEnrolmentProjectionIT.InMemoryScaChannels::class)
+@QuarkusTestResource(com.openbank.onboarding.it.OnboardingPostgresTestResource::class)
+class ScaEnrolmentProjectionIT {
+
+    class InMemoryScaChannels : io.quarkus.test.common.QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> =
+            InMemoryConnector.switchIncomingChannelsToInMemory("sca-events-in") +
+                InMemoryConnector.switchIncomingChannelsToInMemory("party-events-in") +
+                InMemoryConnector.switchIncomingChannelsToInMemory("kyc-events-in")
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    @Inject
+    @Any
+    lateinit var connector: InMemoryConnector
+
+    /**
+     * The measured defect, end to end: an enrolment for a party whose row does not exist yet.
+     *
+     * On `origin/main` before this change the projection returned without writing, no row ever
+     * appeared, and the outcome was counted as a skip that nothing replays — so this assertion
+     * fails on `no row for party <id>`.
+     */
+    @Test
+    fun `a DEVICE_ENROLLED for an unknown party is projected, not dropped`() {
+        val partyId = UUID.randomUUID()
+        val before = Instant.now()
+
+        sendSca(partyId, credentialId = "cred-1")
+
+        val row = readRecord(partyId)
+        assertThat(row).describedAs("no row for party %s", partyId).isNotNull
+        assertThat(row!!.scaEnrolled).isTrue()
+        assertThat(row.deviceCount).isEqualTo(1)
+        // Recency, never non-nullity: `updated_at` carries the event time, and an Instant.EPOCH
+        // or a default-constructed value would satisfy isNotNull just as well.
+        assertThat(row.updatedAt).isBetween(before.minusSeconds(60), Instant.now().plusSeconds(60))
+    }
+
+    /**
+     * Idempotence, which is the precondition for backfilling the enrolments already lost: the
+     * originals are long past Kafka's retention, so any recovery re-publishes them, and a
+     * `deviceCount + 1` projection would inflate the count on every run.
+     */
+    @Test
+    fun `replaying the same enrolment does not double-count, and a second device does`() {
+        val partyId = UUID.randomUUID()
+
+        sendSca(partyId, credentialId = "cred-a")
+        sendSca(partyId, credentialId = "cred-a")
+        sendSca(partyId, credentialId = "cred-a")
+
+        assertThat(readRecord(partyId)!!.deviceCount)
+            .describedAs("three deliveries of one credential are one device")
+            .isEqualTo(1)
+
+        sendSca(partyId, credentialId = "cred-b")
+
+        assertThat(readRecord(partyId)!!.deviceCount)
+            .describedAs("a genuinely different credential still counts")
+            .isEqualTo(2)
+    }
+
+    /**
+     * The other half of the ordering race. `PARTY_CREATED` arriving *after* the enrolment must
+     * fill in identity without resetting progress — the old branch wrote a fixed
+     * `sca_enrolled = false, device_count = 0` over whatever the row held, which would have
+     * turned the seeded row straight back into the defect.
+     */
+    @Test
+    fun `a late PARTY_CREATED fills in identity without wiping the enrolment`() {
+        val partyId = UUID.randomUUID()
+
+        sendSca(partyId, credentialId = "cred-late")
+        sendParty(partyId)
+
+        val row = readRecord(partyId)!!
+        assertThat(row.legalName).isEqualTo("Jana Nova")
+        assertThat(row.scaEnrolled).describedAs("PARTY_CREATED must not reset SCA state").isTrue()
+        assertThat(row.deviceCount).isEqualTo(1)
+    }
+
+    // ── Driving the real channel ─────────────────────────────────────────────
+
+    private fun sendSca(partyId: UUID, credentialId: String) = send(
+        "sca-events-in",
+        """{"eventType":"DEVICE_ENROLLED","deviceId":"${UUID.randomUUID()}","partyId":"$partyId",""" +
+            """"credentialId":"$credentialId","algorithm":"ES256",""" +
+            """"occurredAt":"${Instant.now()}","sourceService":"sca-service"}""",
+    )
+
+    private fun sendParty(partyId: UUID) = send(
+        "party-events-in",
+        """{"eventType":"PARTY_CREATED","partyId":"$partyId","legalName":"Jana Nova",""" +
+            """"email":"jana@example.test","occurredAt":"${Instant.now()}"}""",
+    )
+
+    /**
+     * `runOnVertxContext(true)` is load-bearing: a `suspend @Incoming` handler needs the
+     * duplicated context the real Kafka connector supplies, or the reactive Panache transaction
+     * inside the projection fails with `No current Vertx context found`.
+     *
+     * Waiting on the ack rather than polling is what makes the assertion deterministic — the ack
+     * completes only after the handler has run to completion.
+     */
+    private fun send(channel: String, payload: String) {
+        val source: InMemorySource<Message<String>> = connector.source(channel)
+        source.runOnVertxContext(true)
+        val acked = CompletableFuture<Void>()
+        source.send(
+            Message.of(
+                payload,
+                Supplier<CompletionStage<Void>> {
+                    acked.complete(null)
+                    CompletableFuture.completedFuture(null)
+                },
+            ),
+        )
+        acked.get(ACK_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    }
+
+    // ── Reading it back the way a different pod would ────────────────────────
+
+    private data class Row(
+        val scaEnrolled: Boolean,
+        val deviceCount: Int,
+        val updatedAt: Instant,
+        val legalName: String?,
+    )
+
+    private fun readRecord(partyId: UUID): Row? = jdbc().use { conn -> conn.selectRow(partyId) }
+
+    private fun Connection.selectRow(partyId: UUID): Row? = prepareStatement(SELECT_ROW).use { st ->
+        st.setObject(1, partyId)
+        st.executeQuery().use { rs -> if (rs.next()) rs.toRow() else null }
+    }
+
+    private fun java.sql.ResultSet.toRow() = Row(
+        scaEnrolled = getBoolean(1),
+        deviceCount = getInt(2),
+        updatedAt = getTimestamp(3).toInstant(),
+        legalName = getString(4),
+    )
+
+    private fun jdbc(): Connection {
+        val config = ConfigProvider.getConfig()
+        return DriverManager.getConnection(
+            config.getValue("quarkus.datasource.jdbc.url", String::class.java),
+            config.getValue("quarkus.datasource.username", String::class.java),
+            config.getValue("quarkus.datasource.password", String::class.java),
+        )
+    }
+
+    private companion object {
+        const val ACK_TIMEOUT_SECONDS = 30L
+        const val SELECT_ROW =
+            "SELECT sca_enrolled, device_count, updated_at, legal_name FROM onboarding_records WHERE party_id = ?"
+    }
+}

--- a/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/it/OnboardingPostgresTestResource.kt
+++ b/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/it/OnboardingPostgresTestResource.kt
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.onboarding.it
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import org.opentest4j.TestAbortedException
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * A real PostgreSQL for the projection ITs, with Flyway running the service's own migrations.
+ *
+ * A real database is the point, not incidental infra: the defect in #6248 is a row that does not
+ * change, and only a genuine INSERT/UPDATE against a genuine schema can distinguish "the
+ * projection wrote it" from "a mock recorded the call". Ryuk is disabled fleet-wide, so `stop()`
+ * is what tears the container down.
+ */
+class OnboardingPostgresTestResource : QuarkusTestResourceLifecycleManager {
+
+    private var postgres: PostgreSQLContainer<*>? = null
+
+    override fun start(): Map<String, String> {
+        if (!DockerClientFactory.instance().isDockerAvailable) {
+            throw TestAbortedException("Docker not available — skipping Testcontainers IT")
+        }
+        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+            .withUsername("openbank")
+            .withPassword("openbank_secret")
+            .withDatabaseName(DB)
+        pg.start()
+        postgres = pg
+
+        val host = pg.host
+        val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
+        return mapOf(
+            "quarkus.datasource.reactive.url" to "vertx-reactive:postgresql://$host:$port/$DB",
+            "quarkus.datasource.jdbc.url" to "jdbc:postgresql://$host:$port/$DB",
+            "quarkus.datasource.username" to "openbank",
+            "quarkus.datasource.password" to "openbank_secret",
+            "quarkus.flyway.migrate-at-start" to "true",
+            "quarkus.devservices.enabled" to "false",
+        )
+    }
+
+    override fun stop() {
+        postgres?.stop()
+    }
+
+    private companion object {
+        const val DB = "openbank_onboarding_it"
+    }
+}


### PR DESCRIPTION
## What this is

`onboarding_records.sca_enrolled` reads `false` for **every** party in the sandbox, including
parties that provably have an enrolled SCA credential. #4692 fixed the producer half and that fix
is deployed and working — the wire is correct. This is the downstream half.

Closes #6248. Refs #4353, #4692, #6258.

## What the earlier passes concluded, and where this differs

| Pass | Conclusion |
|---|---|
| #4353 / #4692 | The producer omitted `eventType` from the serialized payload body, so `parseScaEvent` fell to `else -> null`. **Correct, fixed, deployed.** |
| #6248 comment | The post-fix event was consumed and then dropped inside the projection at `findByPartyId(...) ?: return`, because `PARTY_CREATED` had not arrived yet. Flagged as *"strong, not proven"*, and offered as the explanation for **all fifteen at once**. |
| #6258 | Gave that drop its own `ProjectionResult`, so it stops being counted as a success. Made the loss visible; did not stop it. |

**What this pass measured that the others did not: the two populations are different defects.**

`onboarding_records.created_at` is event time, which is why the earlier pass could not settle it —
the table cannot say when a row physically appeared. But the **pooled `onboarding_records_seq`**
can: `increment_by 50`, ids drawn only when allocating for a `persist`, so the surviving ids are a
total *insert* order that no timestamp column in the table provides. Cross-referencing that order
against `sca_outbox` splits the enrolments cleanly:

- **Every enrolment published before #4692 landed already had an onboarding row** — in one case a
  row that had existed for two months before the device was enrolled, with `updated_at` still
  frozen at its creation. A missing row cannot explain those. They were lost at the parser, which
  is exactly what #4692 fixed.
- **The single enrolment published after the fix is the one that hit a missing row.** Its
  `PARTY_CREATED` was still ~30 minutes behind on an independent consumer group.

Both mechanisms are real; they are not the same mechanism; only the second is still live. That
matters because the fix for "the row was missing" does nothing for the pre-fix population, and
believing one cause explained all fifteen is what would have made a fourth pass necessary.

## The fix

- **Seed the row from the event instead of returning without writing**, on all four branches that
  need one. Nothing replays this read model — the consumer's own KDoc claimed it *"can be
  replayed"* and no such job exists — so a discarded event was gone for good.
- **`PARTY_CREATED` no longer resets progress.** It wrote a fixed `sca_enrolled = false,
  device_count = 0, kyc_status = null, funnel_stage = REGISTERED` over whatever the row held. That
  would have turned every seeded row straight back into the defect, and it made the event
  destructive on replay. It now fills in identity and re-derives the stage only where there is
  progress to preserve.
- **`device_count` is derived from a new per-credential ledger, never incremented** (migration V3).
  `deviceCount + 1` cannot be replayed, and replay is the only recovery path left: the topic's
  retention dropped the originals long ago, so any backfill necessarily re-publishes from
  `sca_enrolled_devices`. A backfill you cannot run twice is one nobody dares run once.
- **`credentialId` falls back to `deviceId`** rather than defaulting to `""`, which would collapse
  every one of a party's devices onto the same ledger key and silently cap `device_count` at 1.
- `ProjectionResult.SKIPPED_UNKNOWN_PARTY` becomes `APPLIED_TO_SEEDED_RECORD`; the metric outcome
  becomes `SEEDED_UNKNOWN_PARTY`. The event is no longer lost, but the row is still being built
  backwards and that stays its own value — never a flag shared with success.

## The alert did not fire because there was no alert

The acceptance list asks whether the #4353 alert is "actually loaded and evaluating". It is not,
and never was: the rules were written as **prose in a KDoc** — "Suggested rules" — and never became
a `PrometheusRule`. Nothing in the repo and no live rule in the cluster references
`openbank_onboarding_projection_events_total`. Both rules are now deployed in
`prometheus-rules-onboarding.yaml`. A suggested rule in a comment is documentation, not a control.

## Proof

`ScaEnrolmentProjectionIT` — a real `DEVICE_ENROLLED` through the real `@Incoming` handler
(in-memory connector, `runOnVertxContext(true)`), against a real Postgres with the service's own
Flyway migrations, asserted by a **plain JDBC read**. Recency, not non-nullity, on `updated_at`.

Every unit test on both sides of this defect was green for its entire life: the producer's asserted
the payload it built, the consumer's the parse and the metric, and the projection's the record it
handed a **mocked** repository. None could see that no row ever changed — the only observable that
was ever wrong.

**Negative control.** Reverting only the projection change (restoring `?: return` and
`deviceCount + 1`) fails all three, each for the right reason:

```
a DEVICE_ENROLLED for an unknown party is projected, not dropped
  AssertionError: [no row for party 73824792-...] Expecting actual not to be null
a late PARTY_CREATED fills in identity without wiping the enrolment
  AssertionFailedError: [PARTY_CREATED must not reset SCA state] Expecting value to be true but was false
```

The IT also caught a runtime bug the compiler did not: `persist()` unifying to `Uni<Void>` through
an `if` branch, which only fails as a `ClassCastException` under a live session.

## Verified

`test --rerun-tasks`: **51 tests, 0 failures, 0 errors, 0 skipped** (read from the JUnit XML, not
the console) — the IT contributes 3, all executed. `ktlintCheck`, `detekt`, `quarkusBuild` green.
`check-threat-model-diff.py --enforce`, `check-flyway-default-datasource.py`,
`db-migration-gate`, `schema-compat-gate`, `alert-window-vs-subject-period` green.

## Still open on #6248 — deliberately not in this PR

- **Backfilling the existing enrolments.** They cannot come from Kafka (retention has eaten them)
  and onboarding-service cannot read `sca_enrolled_devices` — it belongs to sca-service. The
  backfill is therefore a re-publish from sca-service, a second service and its own change. This
  PR ships the precondition the issue itself names: without an idempotent `device_count`, a
  backfill double-counts on every re-run.
- The 2 `SENT`-but-absent and 1 `DEAD` `sca_outbox` rows, and the `1970-01-01` `created_at` values
  on nine of them (the `Instant.EPOCH` default trap).
