### PR TITLE
fix(admin-ui): clarify dashboard refresh

### DIFF
--- a/openbank-admin-ui/src/app/dashboard/page.tsx
+++ b/openbank-admin-ui/src/app/dashboard/page.tsx
@@ -168,8 +168,8 @@ export default function DashboardPage() {
               {t('Aktualizováno', 'Updated')} {lastRefresh.toLocaleTimeString(dateLocale)}
             </span>
           )}
-          <button onClick={load} disabled={loading} className="btn btn-secondary btn-sm">
-            <RefreshCw size={13} style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
+          <button type="button" onClick={load} disabled={loading} aria-busy={loading} aria-label={t('Obnovit přehled platformy', 'Refresh platform overview')} className="btn btn-secondary btn-sm">
+            <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
           </div>

--- a/openbank-admin-ui/src/test/dashboard-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/dashboard-refresh.guard.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('dashboard refresh contract', () => {
+  it('exposes localized busy semantics without changing parallel health reads', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/dashboard/page.tsx'), 'utf8')
+    expect(source).toContain('type="button"')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit přehled platformy', 'Refresh platform overview')}")
+    expect(source).toContain('Promise.all')
+    expect(source).toContain('onClick={load}')
+  })
+})


### PR DESCRIPTION
## Summary
- add explicit button semantics and localized busy/name state to Platform Overview refresh
- preserve parallel governance/health reads, graceful fallback and RBAC

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.