### PR TITLE
fix(ci): retry the spot-kill DETECTION call, and make it falsifiable

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1811,6 +1811,44 @@ gates:
     run: |
       python3 .github/scripts/check-main-red-watch.py --check-declaration
 
+  # The spot-kill auto-retry is a control with no audience: it is `workflow_run`-triggered, so
+  # its red is addressed to nobody, and its whole design is to act unattended. Until #6255 its
+  # decision logic was a `run:` block, which means GitHub Actions on a real `workflow_run` event
+  # was its ONLY executor — every error path was reachable only by waiting for the rare event
+  # that produces it. What that cost, measured: the detection `gh api` call had no transient
+  # handling while the `gh run rerun` call three lines away had three attempts with backoff, and
+  # one installation rate limit (HTTP 403 — indistinguishable from a permission denial except by
+  # message text) killed the step before it emitted any `decision=` line. Its target, run
+  # 32499371733, had two jobs interrupted mid-flight (22 and 20 recorded steps) and is still at
+  # `run_attempt: 1`. The mirror-image hole on the `failure` branch was worse: `|| echo ""`
+  # rendered the same rate limit as `jobs-unreadable` + exit 0, a GREEN run of the control about
+  # a reclaimed run it never re-ran.
+  #
+  # This gate is that logic's only falsification. It is the pair of prevent-proofs that matter —
+  # a reclaim IS re-run, a deliberate queue cancel is NOT — plus every error class, asserted on
+  # BOTH the exit code and the calls actually issued to a stub `gh`. The call log is the
+  # load-bearing half: an exit code alone cannot tell "declined to re-run" from "re-ran and the
+  # stub happened to succeed", which is exactly the confusion the queue-cancel case exists to
+  # prevent (#3208: a retry that silently undid a queue drain).
+  - id: spot-kill-retry-selftest
+    name: "spot-kill auto-retry decides correctly and survives a rate limit (issue #6255, enforced)"
+    group: registry
+    mode: enforced
+    # The gate IS the harness: its `run:` is the script's own falsification suite, so a separate
+    # `selftest:` would be the same command executed twice for one signal.
+    selftest_exempt: >-
+      is-a-test-suite — the run: below IS the self-test. It drives the real decision function
+      against a stub gh and asserts exit code AND issued calls for all 12 cases, so its red is
+      reachable by construction; falsified in both directions before wiring in (see the
+      rationale and the script header).
+    budget_seconds: 30   # no network, no sleeps (the backoff is 0 in the harness); ~1s observed
+    rationale: "Without it the script's error paths are exercised only when a real spot reclaim coincides with a real API failure — which is how #6255 shipped a detection call with no transient handling at all, stranding a reclaimed run at attempt 1 and telling nobody."
+    review_after: "2027-02-23"
+    # Subjects are assertions, not files: the floor drops the day someone deletes a case.
+    min_subjects: 12
+    run: |
+      bash .github/scripts/spot-kill-retry.sh --self-test
+
   # Nothing in this repo has ever read a merged PR's required contexts: before #4240,
   # `grep -rl 'required_status_checks\|statusCheckRollup' .github/scripts .github/workflows`
   # returned one hit and it was a comment. A ruleset bypass is recorded only in

--- a/.github/scripts/spot-kill-retry.sh
+++ b/.github/scripts/spot-kill-retry.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# Decide whether a completed CI run was killed by a spot reclaim, and if so re-run it once.
+#
+# WHY THIS IS A SCRIPT AND NOT A `run:` BLOCK (issue #6255)
+# This logic used to live inline in `.github/workflows/auto-retry-cancelled.yml`. Inline, its
+# only executor was GitHub Actions on a real `workflow_run` event, so every branch — including
+# the ones that exist precisely for the rare case — was reachable only by waiting for that rare
+# case to happen in production. That is how #6255 shipped: the DETECTION call
+# (`gh api .../jobs`) had no transient handling at all, while the re-run call next to it had
+# three attempts with backoff, and nothing could demonstrate the asymmetry because nothing
+# could run the step. As a script it has a `--self-test` that drives every decision and every
+# error class against a stub `gh`, so the failure paths are exercised on every PR.
+#
+# THE #6255 DEFECT, PRECISELY
+# Run 32502824965: the `cancelled` branch's detection query answered
+#   gh: API rate limit exceeded for installation ... (HTTP 403)
+# and, being a plain command substitution under `set -euo pipefail`, killed the step at once —
+# before any `decide` line was emitted, so the workflow's own evidence contract ("every exit
+# path records ONE line saying what was examined and what was decided") was not honoured on the
+# one path where it mattered. Its target, run 32499371733, had TWO jobs interrupted mid-flight
+# (22 and 20 steps recorded) — an unambiguous reclaim — and is still at `run_attempt: 1` today.
+# The `failure` branch had the mirror-image bug and it is the worse one: its `|| echo ""` turned
+# the same rate limit into `decision=jobs-unreadable` + **exit 0**, i.e. a GREEN run of the
+# control, about a reclaimed run it never re-ran and told nobody about.
+#
+# RATE LIMIT vs PERMISSION DENIAL
+# On GitHub both are HTTP 403 and are told apart only by the message text (`API rate limit
+# exceeded` / `secondary rate limit` vs `Resource not accessible by integration`). The status
+# code alone therefore cannot classify, which is why `is_transient` matches on text.
+#
+# "COULD NOT READ" IS NOT A PASS HERE
+# `.github/CLAUDE.md` records that a gate should render an unreadable corpus as a notice + exit
+# 0 rather than as a finding. That is right for a gate, whose subject is the PR. It is wrong
+# here, and the difference is what happens next: a gate that cannot read simply does not judge,
+# whereas this control not judging leaves a reclaimed CI run sitting red forever with no PR to
+# redden and no commit status anyone reads. So an unreadable jobs API — after the transient
+# retries are spent — exits 1 on purpose, which is what routes it to the `raise-issue` job and
+# puts a named human in the loop. Non-transient (a real permission answer) exits 1 immediately.
+#
+# WHAT THIS CANNOT DO
+# A human who cancels a run WHILE its jobs are running is indistinguishable from a spot reclaim
+# with the data GitHub exposes — both leave `cancelled` jobs carrying recorded steps — and is
+# still re-run once. That is the accepted waste #2330 priced, not an oversight. The only human
+# cancel this can rule out is the queue drain, where no cancelled job ever started a step
+# (#3208); the self-test proves that one is declined.
+#
+# EXIT CODES
+#   0  a decision was reached and acted on (re-run issued, or correctly declined)
+#   1  the control could not do its job — a human must re-run the target by hand
+#
+# ENV (all required except the last three)
+#   GITHUB_REPOSITORY  owner/repo
+#   RUN_ID             the triggering run id
+#   CONCLUSION         its conclusion: `cancelled` or `failure`
+#   RUN_URL            its html_url (for the human-readable notices)
+#   GITHUB_STEP_SUMMARY  optional; the `decide` table is appended here when set
+#   GH_BIN             optional; the `gh` executable (the self-test points it at a stub)
+#   SPOT_KILL_BACKOFF_BASE  optional; seconds multiplier for the backoff (default 15, 0 in tests)
+set -euo pipefail
+
+GH_BIN="${GH_BIN:-gh}"
+BACKOFF_BASE="${SPOT_KILL_BACKOFF_BASE:-15}"
+ATTEMPTS="${SPOT_KILL_ATTEMPTS:-3}"
+RETRY_LAST_ERROR=""
+
+# `-R` ON EVERY CALL IS LOAD-BEARING (issue #2841/#2898). This runs in a job with no
+# actions/checkout, so there is no git repository for `gh` to infer the target repo from and a
+# bare call dies with `failed to determine base repo`. That defect made the auto-retry from
+# #2330 fail 208 times in silence. Do not drop the flag and do not "fix" it with a checkout.
+gh_() { "${GH_BIN}" "$@"; }
+
+# A transient failure is one where trying again can succeed. Matched on TEXT, never on status
+# code — see the header on 403 being both a rate limit and a permission denial.
+is_transient() {
+  case "$1" in
+    *"rate limit"*|*"Rate Limit"*|*"secondary rate"*) return 0 ;;
+    *"HTTP 5"*|*"Server Error"*|*"HTTP 429"*)         return 0 ;;
+    *"connection reset"*|*"EOF"*|*"timeout"*|*"Timeout"*|*"no such host"*|*"TLS handshake"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+decide() { # decide <decision> <human sentence>
+  echo "spot-kill-auto-retry run=${RUN_ID} conclusion=${CONCLUSION} decision=$1"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    echo "| \`${CONCLUSION}\` | [${RUN_ID}](${RUN_URL:-}) | \`$1\` | $2 |" >> "${GITHUB_STEP_SUMMARY}"
+  fi
+}
+
+# Retry wrapper shared by BOTH the detection query and the re-run call. Before #6255 only the
+# re-run had one; the asymmetry was the defect, so there is now exactly one implementation and
+# it cannot drift.
+with_retry() { # with_retry <label> <cmd...>  -> stdout of the successful call
+  local label="$1"; shift
+  local out attempt
+  out=""
+  for (( attempt=1; attempt<=ATTEMPTS; attempt++ )); do
+    if out="$("$@" 2>&1)"; then
+      printf '%s' "${out}"
+      if [ "${attempt}" -gt 1 ]; then
+        echo "${label} succeeded on attempt ${attempt}/${ATTEMPTS} after a transient error" >&2
+      fi
+      return 0
+    fi
+    echo "${label} attempt ${attempt}/${ATTEMPTS} failed: ${out}" >&2
+    # "Already running" is neither transient nor an error: the substance this control exists to
+    # achieve has ALREADY happened (issue #5489, measured on run 32100417490). Matched first so
+    # it can fall into neither branch below.
+    case "${out}" in
+      *"already running"*)
+        echo "${label}: target is already running (race with a prior attempt or GitHub's own mechanism) — nothing to do, treating as success" >&2
+        printf '%s' "${out}"; return 0 ;;
+    esac
+    if ! is_transient "${out}"; then
+      echo "::error title=spot-kill auto-retry::Non-transient error from ${label}; not retrying: ${out}" >&2
+      RETRY_LAST_ERROR="${out}"; return 1
+    fi
+    if [ "${attempt}" -lt "${ATTEMPTS}" ]; then
+      sleep $(( attempt * BACKOFF_BASE ))
+    fi
+  done
+  echo "::error title=spot-kill auto-retry::${label} failed ${ATTEMPTS}/${ATTEMPTS} times on ${RUN_URL:-run ${RUN_ID}} (last: ${out}). Needs a manual re-run." >&2
+  RETRY_LAST_ERROR="${out}"; return 1
+}
+
+# Both branches query attempt 1 explicitly. `/actions/runs/<id>/jobs` returns the LATEST
+# attempt's jobs, so a concurrent manual re-run would make this inspect a different (possibly
+# green) attempt and silently decline.
+jobs_query() { # jobs_query <jq>
+  gh_ api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/attempts/1/jobs?per_page=100" --jq "$1"
+}
+
+main() {
+  : "${GITHUB_REPOSITORY:?}" "${RUN_ID:?}" "${CONCLUSION:?}"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '%s\n' '| triggering conclusion | run | decision | detail |' '|---|---|---|---|' \
+      >> "${GITHUB_STEP_SUMMARY}"
+  fi
+
+  local q count
+  if [ "${CONCLUSION}" = "cancelled" ]; then
+    # A reclaim kills a RUNNING job. So if not one cancelled job ever started a step, nothing
+    # was running and a reclaim is impossible — this was a queue cancel, and re-running it puts
+    # back exactly the load whoever cancelled was removing (#3208, #2039).
+    #
+    # ONE-DIRECTIONAL on purpose: this rules a reclaim OUT, it never claims one happened. See
+    # the WHAT THIS CANNOT DO note in the header.
+    q='[.jobs[] | select(.conclusion == "cancelled") | select((.steps | length) > 0)] | length'
+  else
+    # conclusion == failure: retry ONLY on the partial-spot-kill signature — a failed job with a
+    # cancelled step and no failed step (issue #2841).
+    q='[.jobs[]
+        | select(.conclusion == "failure")
+        | select(([.steps[]? | select(.conclusion == "cancelled")] | length) > 0)
+        | select(([.steps[]? | select(.conclusion == "failure")]  | length) == 0)]
+       | length'
+  fi
+
+  if ! count="$(with_retry "jobs API" jobs_query "${q}")" || [ -z "${count}" ]; then
+    # See the header: for THIS control an unreadable corpus is not a pass. Exiting 1 is what
+    # routes it to raise-issue, because a reclaimed run that nobody re-runs sits red forever.
+    echo "::error title=spot-kill auto-retry::Could not read the jobs of ${RUN_URL:-${RUN_ID}} (last: ${RETRY_LAST_ERROR:-unknown}); NOT re-running. A genuine reclaim here needs a MANUAL re-run." >&2
+    decide jobs-unreadable "the jobs API could not be read after ${ATTEMPTS} attempts — a genuine reclaim here needs a MANUAL re-run"
+    return 1
+  fi
+
+  if [ "${CONCLUSION}" = "cancelled" ]; then
+    if [ "${count}" -eq 0 ]; then
+      echo "::notice title=spot-kill auto-retry::NOT re-running ${RUN_URL:-${RUN_ID}} — no cancelled job had started a step, so no runner was reclaimed. Treating it as a deliberate cancel (#3208)."
+      decide skipped-queue-cancel "0 cancelled jobs had started a step — deliberate cancel, not a reclaim (#3208)"
+      return 0
+    fi
+    echo "Re-running cancelled run ${RUN_URL:-${RUN_ID}} (${count} job(s) interrupted mid-flight; issue #2330)"
+    # `--failed` is a no-op against `cancelled`, so this is always the full re-run.
+    with_retry "gh run rerun" gh_ run rerun -R "${GITHUB_REPOSITORY}" "${RUN_ID}" || return 1
+    echo "::notice title=spot-kill auto-retry::Re-ran cancelled run ${RUN_URL:-${RUN_ID}} (attempt 2 of max 2; a second kill stays for a human)"
+    decide rerun-cancelled "${count} job(s) interrupted mid-flight — full re-run issued (attempt 2 of max 2)"
+    return 0
+  fi
+
+  if [ "${count}" -eq 0 ]; then
+    echo "::notice title=spot-kill auto-retry::${RUN_URL:-${RUN_ID}} failed with no spot-kill signature (no job has a cancelled step and no failed step) — treating it as a real failure and NOT re-running."
+    decide no-spot-kill-signature "no failed job has a cancelled step and no failed step — a real build failure"
+    return 0
+  fi
+  echo "Re-running ${RUN_URL:-${RUN_ID}}: ${count} job(s) killed mid-step by a runner reclaim (issue #2841)"
+  with_retry "gh run rerun" gh_ run rerun -R "${GITHUB_REPOSITORY}" "${RUN_ID}" --failed || return 1
+  echo "::notice title=spot-kill auto-retry::Re-ran ${count} spot-killed job(s) in ${RUN_URL:-${RUN_ID}} (attempt 2 of max 2; a second kill stays for a human)"
+  decide rerun-partial "${count} job(s) carry the spot-kill signature — failed jobs re-run (attempt 2 of max 2)"
+}
+
+# ── SELF-TEST ────────────────────────────────────────────────────────────────────────────────
+# Drives the real `main` against a stub `gh` whose answers are scripted per call, and asserts
+# BOTH the exit code and what was actually invoked. The call log is the load-bearing half: an
+# assertion on the exit code alone cannot tell "declined to re-run" from "re-ran and the stub
+# happened to succeed", which is the exact confusion the queue-cancel case exists to prevent.
+self_test() {
+  local tmp; tmp="$(mktemp -d)"
+  cat > "${tmp}/gh" <<'STUB'
+#!/usr/bin/env bash
+# Scripted stub. STUB_SCRIPT holds one line per expected call: "<exit>|<output>".
+# An output of `@<fixture>` means: run the REAL jq program this call was given against
+# tests/<fixture>.json. That is not a nicety — a stub that returns a canned count exercises the
+# branch logic and NOT the jq predicate, so deleting the `(.steps | length) > 0` clause (the
+# entire queue-cancel guard, #3208) left the suite green. Measured: with canned counts the
+# negative control passed; with the fixtures it reddens the queue-cancel case.
+#
+# The call is flattened to ONE line before logging: the jq programs are multi-line, and a
+# newline inside a logged call would desynchronise the call counter from the script — the exact
+# way this stub was wrong on its first run, which showed up as two cases failing.
+echo "$*" | tr '\n' ' ' >> "${CALL_LOG}"; echo >> "${CALL_LOG}"
+n=$(( $(cat "${CALL_LOG}.n" 2>/dev/null || echo 0) + 1 )); echo "${n}" > "${CALL_LOG}.n"
+line="$(sed -n "${n}p" "${STUB_SCRIPT}")"
+[ -n "${line}" ] || { echo "stub: no scripted answer for call ${n}: $*" >&2; exit 99; }
+out="${line#*|}"
+case "${out}" in
+  @*) prog="${!#}"          # the jq program is the last argument of `api ... --jq <prog>`
+      jq -r "${prog}" "${FIXTURE_DIR}/${out#@}.json" || exit 1
+      exit "${line%%|*}" ;;
+esac
+printf '%s\n' "${out}"
+exit "${line%%|*}"
+STUB
+  chmod +x "${tmp}/gh"
+
+  # Fixtures — real jobs-API shapes, fed to the real jq programs by the stub above.
+  export FIXTURE_DIR="${tmp}"
+  # A spot reclaim: two cancelled jobs that were RUNNING (they carry recorded steps), alongside
+  # queued siblings that never started. Modelled on run 32499371733, the run #6255 stranded.
+  cat > "${tmp}/reclaim.json" <<'FIX'
+{"jobs":[
+ {"name":"build (balance)","conclusion":"cancelled","steps":[{"name":"Set up job","conclusion":"success"},{"name":"Gradle build","conclusion":"cancelled"}]},
+ {"name":"build (billing)","conclusion":"cancelled","steps":[{"name":"Set up job","conclusion":"success"},{"name":"Gradle build","conclusion":"cancelled"}]},
+ {"name":"build (campaign)","conclusion":"cancelled","steps":[]},
+ {"name":"nightly fleet-health alert","conclusion":"cancelled","steps":[]}]}
+FIX
+  # A deliberate cancel of a QUEUE: every cancelled job was still queued, so nothing was running
+  # and no runner can have been reclaimed. Modelled on run 30693441813 (an operator drain).
+  cat > "${tmp}/queue-cancel.json" <<'FIX'
+{"jobs":[
+ {"name":"build (a)","conclusion":"cancelled","steps":[]},
+ {"name":"build (b)","conclusion":"cancelled","steps":[]},
+ {"name":"build (c)","conclusion":"cancelled","steps":[]}]}
+FIX
+  # A PARTIAL reclaim: the run is `failure` because one job died mid-step while a sibling passed.
+  cat > "${tmp}/partial-kill.json" <<'FIX'
+{"jobs":[
+ {"name":"CodeQL java-kotlin","conclusion":"failure","steps":[{"name":"Init","conclusion":"success"},{"name":"Analyze","conclusion":"cancelled"}]},
+ {"name":"Trivy","conclusion":"success","steps":[{"name":"Scan","conclusion":"success"}]}]}
+FIX
+  # An ordinary red build: the failed job has a FAILED step, so it is not a reclaim.
+  cat > "${tmp}/real-failure.json" <<'FIX'
+{"jobs":[
+ {"name":"build (ledger)","conclusion":"failure","steps":[{"name":"Set up job","conclusion":"success"},{"name":"Gradle build","conclusion":"failure"}]},
+ {"name":"build (party)","conclusion":"success","steps":[{"name":"Gradle build","conclusion":"success"}]}]}
+FIX
+
+  # Assign the VARIABLE, not just the env var: `BACKOFF_BASE` is read from the environment at
+  # script startup, which is before this function runs, so exporting `SPOT_KILL_BACKOFF_BASE`
+  # here changes nothing. Measured: the suite took 196 s of pure `sleep` at the default 15 s
+  # backoff, and every case still passed — a self-test can be right about behaviour and wrong
+  # about what it is exercising, and the only tell was 0% CPU.
+  BACKOFF_BASE=0
+  export GH_BIN="${tmp}/gh"
+  export GITHUB_REPOSITORY="owner/repo" RUN_ID=1 RUN_URL="http://x/1"
+  unset GITHUB_STEP_SUMMARY || true
+
+  local pass=0 fail=0 subjects=0
+  local RL="gh: API rate limit exceeded for installation ... (HTTP 403)"
+  local PERM="gh: Resource not accessible by integration (HTTP 403)"
+
+  case_() { # case_ <name> <conclusion> <expect_exit> <expect_rerun_calls> <scripted lines...>
+    local name="$1" concl="$2" want_exit="$3" want_reruns="$4"; shift 4
+    subjects=$(( subjects + 1 ))
+    export CALL_LOG="${tmp}/calls" STUB_SCRIPT="${tmp}/script"
+    : > "${CALL_LOG}"; : > "${CALL_LOG}.n"; printf '%s\n' "$@" > "${STUB_SCRIPT}"
+    local rc reruns
+    # Redirect and read $? — a pipeline would report the LAST command's status, not main's.
+    set +e
+    CONCLUSION="${concl}" main > "${tmp}/out" 2>&1
+    rc=$?
+    set -e
+    reruns=$(grep -c '^run rerun' "${CALL_LOG}" || true)
+    if [ "${rc}" -eq "${want_exit}" ] && [ "${reruns}" -eq "${want_reruns}" ]; then
+      echo "PASS  ${name} (exit=${rc}, rerun calls=${reruns})"; pass=$(( pass + 1 ))
+    else
+      echo "FAIL  ${name}: exit=${rc} (want ${want_exit}), rerun calls=${reruns} (want ${want_reruns})"
+      sed 's/^/        /' "${tmp}/out"
+      fail=$(( fail + 1 ))
+    fi
+  }
+
+  # ── the two prevent-proofs the control exists for ──────────────────────────────────────────
+  # PROVE-RETRY: a reclaim (jobs were running when cancelled) IS re-run.
+  case_ "spot-kill (cancelled, 2 jobs mid-flight) is re-run" cancelled 0 1 "0|@reclaim" "0|ok"
+  # PROVE-NO-RETRY: a deliberate cancel of a QUEUE (no cancelled job ever started a step) is NOT
+  # re-run. This is the only human cancel GitHub's data can distinguish; see the header.
+  case_ "deliberate queue cancel is NOT re-run" cancelled 0 0 "0|@queue-cancel"
+
+  # ── the #6255 regression, in both directions ───────────────────────────────────────────────
+  case_ "rate-limited jobs query recovers and still re-runs" cancelled 0 1 "1|${RL}" "1|${RL}" "0|@reclaim" "0|ok"
+  case_ "jobs query rate-limited 3/3 escalates (exit 1)"     cancelled 1 0 "1|${RL}" "1|${RL}" "1|${RL}"
+  case_ "jobs query permission-denied escalates immediately" cancelled 1 0 "1|${PERM}"
+  # The `failure` branch had the same hole and used to answer exit 0 (green, silent).
+  case_ "rate-limited jobs query on the failure branch escalates" failure 1 0 "1|${RL}" "1|${RL}" "1|${RL}"
+
+  # ── the failure branch's signature ─────────────────────────────────────────────────────────
+  case_ "partial spot-kill (failure) re-runs the failed jobs" failure 0 1 "0|@partial-kill" "0|ok"
+  case_ "a real build failure is NOT re-run"                  failure 0 0 "0|@real-failure"
+
+  # ── the re-run call's own error classes ────────────────────────────────────────────────────
+  case_ "rerun 502 then success"           cancelled 0 2 "0|@reclaim" "1|failed to rerun: HTTP 502: Server Error" "0|ok"
+  case_ "rerun already-running is success" cancelled 0 1 "0|@reclaim" "1|run 1 cannot be rerun; This workflow is already running"
+  case_ "rerun rate-limited 3/3 escalates" cancelled 1 3 "0|@reclaim" "1|${RL}" "1|${RL}" "1|${RL}"
+  case_ "rerun 404 escalates immediately"  cancelled 1 1 "0|@reclaim" "1|HTTP 404: Not Found"
+
+  rm -rf "${tmp}"
+  echo "SUBJECTS=${subjects}"
+  echo "spot-kill-retry self-test: ${pass} passed, ${fail} failed"
+  [ "${fail}" -eq 0 ]
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  self_test
+else
+  main
+fi

--- a/.github/workflows/auto-retry-cancelled.yml
+++ b/.github/workflows/auto-retry-cancelled.yml
@@ -69,9 +69,23 @@
 # back in the queue, so the drain silently needed two passes and the re-added load landed on
 # everyone else's PRs (#3208, capacity itself is #2039).
 #
+# WHERE THE DECISION LIVES (issue #6255)
+# The classify-and-re-run logic is `.github/scripts/spot-kill-retry.sh`, not a `run:` block
+# here. It moved because inline it was unfalsifiable — GitHub Actions on a real `workflow_run`
+# event was its only executor, so the branches that exist for the rare case could only be
+# exercised BY the rare case, and #6255 is what that cost: the detection `gh api` call had no
+# transient handling while the `gh run rerun` call beside it had three attempts with backoff,
+# and one installation rate limit (HTTP 403) killed the step before it emitted any `decision=`
+# line at all. Its target, run 32499371733, had two jobs interrupted mid-flight and is still at
+# `run_attempt: 1`. The script's `--self-test` now drives every decision and every error class
+# against a stub `gh` on every PR (gate `spot-kill-retry-selftest`), including the two
+# prevent-proofs: a reclaim IS re-run, a deliberate queue cancel is NOT.
+#
 # `-R` ON EVERY `gh run rerun` IS LOAD-BEARING (issue #2841 follow-up)
-# This job has no `actions/checkout`, so there is no git repository for `gh` to infer the
-# target repo from, and a bare `gh run rerun <id>` dies with
+# This job used to have no `actions/checkout` at all — it now takes a sparse one for the script
+# above, and `-R` stays regardless, because a checkout that fails must not silently restore the
+# shape below. Without a git repository for `gh` to infer the target repo from, a bare
+# `gh run rerun <id>` dies with
 #   failed to determine base repo: failed to run git: fatal: not a git repository
 # That is not a new hazard: it is how this workflow behaved from the day it was written, so
 # the auto-retry from #2330 had NEVER once succeeded — every invocation exited 1. Nothing
@@ -105,163 +119,42 @@ jobs:
        github.event.workflow_run.conclusion == 'failure') &&
       github.event.workflow_run.run_attempt == 1
     steps:
+      # A SPARSE checkout, added by #6255. The header note above says this job has none, and
+      # that was true and load-bearing while the decision logic lived inline in this file. It
+      # had a price nobody had paid attention to: a `run:` block is executable ONLY by GitHub
+      # Actions on a real `workflow_run` event, so its error paths were unfalsifiable and the
+      # detection call shipped with no transient handling at all (#6255). The logic now lives
+      # in `.github/scripts/spot-kill-retry.sh`, which has a `--self-test` run by the
+      # `spot-kill-retry-selftest` gate on every PR. Fetching one file at depth 1 is not the
+      # "clone the repo to make one API call" waste that note warned about — and `-R` stays on
+      # every `gh` call regardless, because a checkout that fails must not silently restore the
+      # #2898 shape (a bare `gh run rerun` resolving no repo, 208 silent failures).
+      #
+      # No `ref:` on purpose: a `workflow_run` checkout defaults to the DEFAULT BRANCH, which is
+      # what a privileged control should execute. Checking out the triggering branch here would
+      # let any PR author rewrite this script and have it run with `actions: write`.
+      - name: Fetch the decision script (sparse, default branch)
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github/scripts/spot-kill-retry.sh
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: Re-run only if the runner was reclaimed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Belt AND braces with the `-R` on every call (see the header note): this job has no
-          # actions/checkout, so without one of the two `gh` exits 1 with "failed to determine
-          # base repo" — the defect behind 208 silent failures (#2898). `-R` stays because it
-          # is the explicit one; GH_REPO covers any `gh` call added later that forgets it, and
-          # is what check-gh-repo-context.py reads at PR time.
+          # Belt AND braces with the `-R` the script puts on every call: GH_REPO covers any
+          # `gh` call added later that forgets it, and is what check-gh-repo-context.py reads
+          # at PR time.
           GH_REPO: ${{ github.repository }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           CONCLUSION: ${{ github.event.workflow_run.conclusion }}
-        run: |
-          set -euo pipefail
-
-          # ── EVIDENCE (issue #4595) ──────────────────────────────────────────────────
-          # Every exit path records ONE line saying what was examined and what was decided,
-          # into the job summary as well as the log. Before this, a no-op and a success were
-          # both "green with a notice buried in a log nobody opens", so the only observable
-          # difference between "the control ran and correctly declined" and "the control ran
-          # and did nothing because it could not tell" was a log download. `decision=` is the
-          # field to read; it is one of skipped-queue-cancel / rerun-cancelled /
-          # no-spot-kill-signature / jobs-unreadable / rerun-partial.
-          decide() { # decide <decision> <human sentence>
-            echo "spot-kill-auto-retry run=${RUN_ID} conclusion=${CONCLUSION} decision=$1"
-            echo "| \`${CONCLUSION}\` | [${RUN_ID}](${RUN_URL}) | \`$1\` | $2 |" \
-              >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
-          }
-          printf '%s\n' \
-            '| triggering conclusion | run | decision | detail |' \
-            '|---|---|---|---|' >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
-
-          # ── TRANSIENT-FAILURE RETRY (issue #4595) ───────────────────────────────────
-          # The re-run API call itself can fail transiently, and when it does the whole point
-          # of this workflow is lost: the reclaimed run stays red and waits for the human
-          # round-trip #2330 removed. Measured on run 31710803432 — detection was correct
-          # ("1 job(s) interrupted mid-flight"), and `gh run rerun` answered
-          #   failed to rerun: HTTP 502: Server Error
-          # with no retry, so the step exited 1, raise-issue filed #4595, and the target run
-          # (31710216158) only reached attempt 2 seventeen minutes later by a human hand.
-          # Note what that failure was NOT: not "never triggered" and not "never detected" —
-          # 3 of 10 sampled runs the same day issued a real re-run that landed as attempt 2.
-          # Only 5xx / 429 / a transport error are retried. A 403/404/422 is a real answer
-          # (run too old, no permission); retrying those just burns the budget and delays the
-          # alarm, so they fail immediately.
-          #
-          # "ALREADY RUNNING" IS NOT ONE OF THOSE (issue #5489). Measured on run 32100417490:
-          # attempt 1 hit `HTTP 502: Server Error` (a transient loss, retried per the rule
-          # above); by attempt 2 the run had already started re-running — a race with GitHub's
-          # own retry of the first, lost call, or with a duplicate trigger — and `gh` answered
-          #   run 32100417490 cannot be rerun; This workflow is already running
-          # Treating that as a hard failure was wrong: the substance this workflow exists to
-          # achieve (the reclaimed run gets a fresh attempt) had ALREADY happened by the time
-          # attempt 2 asked. Filing #5489 for it escalates a no-op as if it were the #4595
-          # case (the API call losing 3/3), which it structurally cannot be — a losing call
-          # never gets to "already running", it gets HTTP 5xx/429/timeout every time. So this
-          # is matched and returned as a distinct success, not folded into the transient-retry
-          # loop above and not falling to the non-transient catch-all.
-          rerun_with_retry() {
-            # Written with `if ... fi`, never `[ x ] && cmd`, because a trailing AND-list that
-            # evaluates false is a FAILING last command and `set -e` would exit the whole step
-            # from inside the success path — the shape that turns a retry helper into a new
-            # silent failure.
-            local out
-            for attempt in 1 2 3; do
-              if out="$(gh run rerun -R "${GITHUB_REPOSITORY}" "$@" 2>&1)"; then
-                echo "${out}"
-                if [ "${attempt}" -gt 1 ]; then
-                  echo "gh run rerun succeeded on attempt ${attempt}/3 after a transient error"
-                fi
-                return 0
-              fi
-              echo "gh run rerun attempt ${attempt}/3 failed: ${out}"
-              case "${out}" in
-                *"already running"*)
-                  # Not an error to retry and not an error to escalate: the run is already
-                  # retrying, so there is nothing left for this step to do. Matched BEFORE the
-                  # transient-vs-non-transient case below so it can never fall into either —
-                  # it is neither.
-                  echo "gh run rerun attempt ${attempt}/3: ${RUN_URL} is already running (race with a prior attempt or GitHub's own mechanism) — nothing to do, treating as success"
-                  return 0 ;;
-                *"HTTP 5"*|*"HTTP 429"*|*"Server Error"*|*"connection reset"*|*"EOF"*|*"timeout"*) ;;
-                *) echo "::error title=spot-kill auto-retry::Non-transient error from gh run rerun; not retrying: ${out}"
-                   return 1 ;;
-              esac
-              if [ "${attempt}" -lt 3 ]; then
-                sleep $((attempt * 15))
-              fi
-            done
-            echo "::error title=spot-kill auto-retry::gh run rerun failed 3/3 times on ${RUN_URL} (last: ${out}). Needs a manual re-run."
-            return 1
-          }
-
-          if [ "${CONCLUSION}" = "cancelled" ]; then
-            # A reclaim kills a RUNNING job. So if not one cancelled job ever started a step,
-            # nothing was running and a reclaim is impossible — this was a queue cancel, and
-            # re-running it puts back exactly the load whoever cancelled was removing (#3208).
-            #
-            # `steps` is empty for a job that was still queued when the run was cancelled;
-            # a job interrupted mid-flight carries its steps with their conclusions. Verified on
-            # both sides against real runs: 30693441813 (operator drain) has 5 cancelled jobs and
-            # 0 with steps, while contemporaneous cancels that hit running jobs report 1-2 with
-            # steps. Attempt-scoped for the same reason the failure branch below is.
-            #
-            # ONE-DIRECTIONAL on purpose. This only rules a reclaim OUT; it never claims one
-            # happened. A human who cancels while jobs are running still looks exactly like a
-            # reclaim and is still retried once — unchanged, and still the accepted waste the
-            # LOOP SAFETY note describes. What it removes is the case the header never priced:
-            # draining a deep queue, where every cancelled job is one that never started, and the
-            # retry silently undid the drain (#3208, #2039).
-            RUNNING="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/attempts/1/jobs?per_page=100" \
-                        --jq '[.jobs[] | select(.conclusion == "cancelled") | select((.steps | length) > 0)] | length')"
-            if [ "${RUNNING:-0}" -eq 0 ]; then
-              echo "::notice title=spot-kill auto-retry::NOT re-running ${RUN_URL} — no cancelled job had started a step, so no runner was reclaimed. Treating it as a deliberate cancel (#3208)."
-              decide skipped-queue-cancel "0 cancelled jobs had started a step — deliberate cancel, not a reclaim (#3208)"
-              exit 0
-            fi
-
-            # At least one job was interrupted mid-flight: a reclaim is possible, so retry once.
-            # `--failed` is a no-op against `cancelled`, so this is always the full re-run.
-            echo "Re-running cancelled run ${RUN_URL} (${RUNNING} job(s) interrupted mid-flight; issue #2330)"
-            rerun_with_retry "${RUN_ID}"
-            echo "::notice title=spot-kill auto-retry::Re-ran cancelled run ${RUN_URL} (attempt 2 of max 2; a second kill stays for a human)"
-            decide rerun-cancelled "${RUNNING} job(s) interrupted mid-flight — full re-run issued (attempt 2 of max 2)"
-            exit 0
-          fi
-
-          # conclusion == failure: retry ONLY on the partial-spot-kill signature.
-          # ATTEMPT-SCOPED on purpose: /actions/runs/<id>/jobs returns the LATEST attempt's jobs,
-          # so a concurrent manual re-run would make this inspect a different (possibly green)
-          # attempt and silently decline to retry. The `if:` above already pins run_attempt to 1;
-          # this pins the query to match. Caught by running the real script against a fixture run
-          # that had since been re-run by hand — the unscoped query reported "no spot-kill
-          # signature" for a run whose attempt 1 was unambiguously spot-killed.
-          killed="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/attempts/1/jobs?per_page=100" \
-            --jq '[.jobs[]
-                   | select(.conclusion == "failure")
-                   | select(([.steps[]? | select(.conclusion == "cancelled")] | length) > 0)
-                   | select(([.steps[]? | select(.conclusion == "failure")]  | length) == 0)]
-                  | length' 2>/dev/null || echo "")"
-
-          if [ -z "${killed}" ]; then
-            echo "::warning title=spot-kill auto-retry::Could not read jobs for ${RUN_URL}; not re-running. A genuine reclaim will need a manual re-run."
-            decide jobs-unreadable "the jobs API could not be read — a genuine reclaim here needs a MANUAL re-run"
-            exit 0
-          fi
-
-          if [ "${killed}" -eq 0 ]; then
-            echo "::notice title=spot-kill auto-retry::${RUN_URL} failed with no spot-kill signature (no job has a cancelled step and no failed step) — treating it as a real failure and NOT re-running."
-            decide no-spot-kill-signature "no failed job has a cancelled step and no failed step — a real build failure"
-            exit 0
-          fi
-
-          echo "Re-running ${RUN_URL}: ${killed} job(s) killed mid-step by a runner reclaim (issue #2841)"
-          rerun_with_retry "${RUN_ID}" --failed
-          echo "::notice title=spot-kill auto-retry::Re-ran ${killed} spot-killed job(s) in ${RUN_URL} (attempt 2 of max 2; a second kill stays for a human)"
-          decide rerun-partial "${killed} job(s) carry the spot-kill signature — failed jobs re-run (attempt 2 of max 2)"
+        # Exit 0 = a decision was reached (re-run issued, or correctly declined). Exit 1 = the
+        # control could not do its job, which routes to raise-issue below. The script's header
+        # carries the full rationale, including why an unreadable jobs API is NOT a pass here
+        # and why a rate limit must be told from a permission denial by message text.
+        run: bash .github/scripts/spot-kill-retry.sh
 
   # ── The alarm (issue #2901) ───────────────────────────────────────────────────
   # Why this exists: this workflow failed 208 times without anyone noticing. It is


### PR DESCRIPTION
Closes #6255

## Does it run at all?

Yes — and that is the first thing worth establishing, because the sibling case in this repo
(#2330 / #2898) was an auto-retry that had **never once succeeded** while looking configured.
This one is not that. Measured over the last 200 runs of `auto-retry-cancelled.yml`
(2026-08-22T21:44:50Z → 2026-08-23T04:14:34Z): `Counter({'skipped': 198, 'success': 2})` — it
triggers on essentially every completed run of the three watched workflows, and the `if:`
correctly skips the ones that are neither `cancelled` nor `failure`. Over its whole history the
failures cluster into the 208 of 2026-07-31 (the `-R` defect, fixed in #2898) and seven since,
each with a distinct, readable cause.

So the diagnosis is "it fails on a specific call", not "it never ran".

## The defect

Decisive line, read from **after the last `##[endgroup]`** of run `32502824965`:

```
gh: API rate limit exceeded for installation. ... (HTTP 403)
##[error]Process completed with exit code 1.
```

That is the **detection** call — `gh api .../attempts/1/jobs` — not the re-run. The re-run call
three lines away had three attempts with backoff since #4595; the detection call beside it had
none. As a plain command substitution under `set -euo pipefail` it killed the step immediately,
before any `decision=` line was emitted, so the workflow's own evidence contract ("every exit
path records ONE line saying what was examined and what was decided") went unmet on the one path
where it mattered.

Its target is still stranded. `run_attempt: 1`, and attempt 1's jobs API shows two jobs that were
unambiguously running when they were cancelled:

```
build (openbank-balance-service)   cancelled  22 steps
build (openbank-billing-service)   cancelled  20 steps
build (openbank-campaign-service)  cancelled   0 steps   <- queued, never started
```

The `failure` branch had the mirror-image hole and a **worse** rendering: its `|| echo ""` turned
the same rate limit into `decision=jobs-unreadable` + **exit 0** — a green run of the control,
about a reclaimed run it never re-ran and told nobody about. `raise-issue` only fires on
`failure()`, so that path escalated to no one.

## Can it tell a spot-kill from a deliberate cancel?

Partly, and the honest boundary is now written down in the script header rather than implied:

- **Separable:** a queue drain. A reclaim kills a *running* job, so a run whose cancelled jobs
  never started a step cannot have been reclaimed (#3208, #2039). Declined.
- **Not separable:** a human who cancels *while jobs are running*. Both leave `cancelled` jobs
  carrying recorded steps, and GitHub exposes nothing that distinguishes them. It is still
  re-run once — the accepted waste #2330 priced, unchanged by this PR.

Shipping something that claimed more than that would re-run deliberate cancels forever, which is
worse than retrying nothing.

## The change

The decision logic moves to `.github/scripts/spot-kill-retry.sh`, and the reason is the defect
itself: inline, a `run:` block's only executor is GitHub Actions on a real `workflow_run` event,
so every error path was reachable **only by waiting for the rare event that produces it**. That
is how an unretried detection call sat next to a retried re-run call without anyone noticing.

- One `with_retry` wraps **both** calls, so the asymmetry cannot come back.
- `is_transient` classifies on message **text**, never status code: on GitHub a rate limit and a
  permission denial are both HTTP 403 and differ only in the message (`API rate limit exceeded`
  vs `Resource not accessible by integration`).
- An unreadable jobs API exits **1**, on purpose. `.github/CLAUDE.md` records that a *gate*
  should render an unreadable corpus as a notice + exit 0; that is right for a gate, whose
  subject is the PR, and wrong here — this control declining to judge leaves a reclaimed run red
  forever with no PR to redden and no commit status anyone reads. Exit 1 is what routes it to
  `raise-issue` and puts a human in the loop.
- The job takes a **sparse, default-branch** checkout of that one file. No `ref:` on purpose: a
  `workflow_run` checkout of the triggering branch would let any PR author rewrite a script that
  runs with `actions: write`. `-R` stays on every `gh` call regardless, so a failed checkout
  cannot silently restore the #2898 shape.
- Existing behaviour preserved verbatim: the #5489 already-running success, the #2841
  partial-kill signature, the attempt-1 scoping, and the #4595 `decision=` evidence line.

## Prevent-proofs

`bash .github/scripts/spot-kill-retry.sh --self-test` drives the real decision function against a
stub `gh` and asserts **both** the exit code and the calls actually issued. The call log is the
load-bearing half — an exit code alone cannot tell "declined to re-run" from "re-ran and the stub
happened to succeed". The jobs-API answers come from JSON fixtures run through the **real** jq
programs, so the predicates are exercised, not just the branches.

```
PASS  spot-kill (cancelled, 2 jobs mid-flight) is re-run (exit=0, rerun calls=1)
PASS  deliberate queue cancel is NOT re-run (exit=0, rerun calls=0)
PASS  rate-limited jobs query recovers and still re-runs (exit=0, rerun calls=1)
PASS  jobs query rate-limited 3/3 escalates (exit 1) (exit=1, rerun calls=0)
PASS  jobs query permission-denied escalates immediately (exit=1, rerun calls=0)
PASS  rate-limited jobs query on the failure branch escalates (exit=1, rerun calls=0)
PASS  partial spot-kill (failure) re-runs the failed jobs (exit=0, rerun calls=1)
PASS  a real build failure is NOT re-run (exit=0, rerun calls=0)
PASS  rerun 502 then success (exit=0, rerun calls=2)
PASS  rerun already-running is success (exit=0, rerun calls=1)
PASS  rerun rate-limited 3/3 escalates (exit=1, rerun calls=3)
PASS  rerun 404 escalates immediately (exit=1, rerun calls=1)
SUBJECTS=12 — 12 passed, 0 failed  (exit code read from $? after redirecting to a file)
```

**Falsified in four directions** — each mutation applied, suite run, `$?` read from a file, then
reverted and re-confirmed green:

| mutation | exit | reddens |
|---|---|---|
| detection call back to the pre-fix shape (no retry wrapper) | 1 | `rate-limited jobs query recovers and still re-runs` |
| delete the queue-cancel guard (the `steps length > 0` clause) | 1 | **`deliberate queue cancel is NOT re-run`** (it re-runs: 1 call, want 0) |
| drop `rate limit` from `is_transient` | 1 | 2 cases |
| `jobs-unreadable` returns 0 instead of 1 | 1 | 3 cases |

One of those mutations was not hypothetical. The suite's first version fed the stub canned
counts, and deleting the queue-cancel guard left it **green** — the assertions exercised the
branch logic and not the jq predicate. The fixtures exist because of that. A second, same shape:
the harness set `SPOT_KILL_BACKOFF_BASE` after the script had already read it, so the suite spent
196 s in real `sleep` and every case still passed — right about behaviour, wrong about what it was
exercising, and the only tell was 0% CPU.

The suite is wired in as the enforced gate `spot-kill-retry-selftest`
(`registry` shard, `min_subjects: 12`, ~1.2 s).

## Verified / not verified

Verified: `run-gates.py --only spot-kill-retry-selftest` PASS; `--group lint` exit 0 (the
gates-that-check-gates — `gate-lifecycle-metadata`, `gate-subject-floor`,
`gate-selftest-declaration` — all PASS); `--group registry` exit 0; `--all` → 181 gates,
174 PASS, and the 6 FAIL + 1 UNFALSIFIED are exactly the documented environmental set
(`PR_DIFF_BASE is empty` on six diff-scoped gates, `loki-rule-load-test` UNFALSIFIED on an unset
`BASE_REF`). `actionlint` on the workflow, exit 0. YAML parses; the `retry` job has the two
expected steps.

**Not verified:** the workflow end to end on a real spot reclaim — that needs a reclaim to happen,
which is precisely why this logic is now testable without one. Stranded run 32499371733 was
**not** re-run by hand as part of this PR (deliberate: no side effects on other people's CI runs);
it needs one `gh run rerun` from a human, or it can be left to age out.

Also observed and **not** fixed here, worth its own issue: `raise-issue` has `needs: retry` and
`if: failure()`, so when `retry` is skipped and the **`record-flake`** job fails (runs
`32040100832`, `32051255345`), the alarm is skipped too — those failures escalate to nobody, the
same blind spot #2901 exists to close.

Note: workflow PRs cannot auto-merge in this repo. Expected, not a problem to solve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
