### PR TITLE
fix(admin-ui): announce FinOps allocation loading

### DIFF
--- a/openbank-admin-ui/src/app/finops/allocation/page.tsx
+++ b/openbank-admin-ui/src/app/finops/allocation/page.tsx
@@ -155,8 +155,8 @@ function AllocationContent() {
       />
 
       {loading && !data ? (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '40px', color: 'var(--text-tertiary)' }}>
-          <RefreshCw size={16} style={{ animation: 'spin 0.8s linear infinite' }} />
+        <div role="status" aria-live="polite" style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '40px', color: 'var(--text-tertiary)' }}>
+          <RefreshCw size={16} aria-hidden="true" style={{ animation: 'spin 0.8s linear infinite' }} />
           <span style={{ fontSize: '13px' }}>{t('Počítám rozpad nákladů…', 'Computing cost allocation…')}</span>
         </div>
       ) : unavailable ? (

--- a/openbank-admin-ui/src/test/finops-allocation-loading.guard.test.ts
+++ b/openbank-admin-ui/src/test/finops-allocation-loading.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('FinOps allocation loading contract', () => {
+  it('announces cost allocation loading without changing the BFF flow', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/finops/allocation/page.tsx'), 'utf8')
+    expect(source).toContain('<div role="status" aria-live="polite"')
+    expect(source).toContain('<RefreshCw size={16} aria-hidden="true"')
+    expect(source).toContain("t('Počítám rozpad nákladů…', 'Computing cost allocation…')")
+    expect(source).toContain("fetch('/api/finops/allocation'")
+  })
+})


### PR DESCRIPTION
## Summary
- expose FinOps allocation loading as a polite status
- hide decorative spinner from assistive technology
- preserve /api/finops/allocation truthfulness and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.