### PR TITLE
fix(admin-ui): mark KYC table busy

### DIFF
--- a/openbank-admin-ui/src/app/kyc/page.tsx
+++ b/openbank-admin-ui/src/app/kyc/page.tsx
@@ -115,7 +115,7 @@ export default function KycPage() {
         </div>
       )}
 
-      <div className="card" style={{ overflow: 'hidden' }}>
+      <div className="card" aria-busy={loading} style={{ overflow: 'hidden' }}>
         <table className="data-table">
           <thead>
             <tr>

--- a/openbank-admin-ui/src/test/kyc-table-loading.guard.test.ts
+++ b/openbank-admin-ui/src/test/kyc-table-loading.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('KYC table loading contract', () => {
+  it('marks the existing cases table busy during refresh/search', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/kyc/page.tsx'), 'utf8')
+    expect(source).toContain('<div className="card" aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Obnovit KYC případy', 'Refresh KYC cases')}")
+    expect(source).toContain("aria-label={t('Vyhledat KYC případy', 'Search KYC cases')}")
+    expect(source).toContain('setLoading(true)')
+  })
+})


### PR DESCRIPTION
## Summary
- expose existing KYC cases table refresh/search state via aria-busy
- preserve KYC query, 404/405 fallback, BFF and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.