### PR TITLE
fix(ci): a run that dies must still report — provisional verdict, and more turns for the worker

### DIFF
--- a/.github/agent-prompts/issue-worker.md
+++ b/.github/agent-prompts/issue-worker.md
@@ -37,6 +37,27 @@ Check this BEFORE writing code, not after: run
 and read `openbank-libs/governance/rules.yaml` key `autonomous_agent_prs` for the exact
 protected set. Picking a protected issue wastes the entire run.
 
+## Emit a PROVISIONAL verdict before you start, and the real one at the end
+
+The job reads the **last** `WORKER-VERDICT:` line in your output. So the very first thing you do,
+before any tool call, is print exactly this:
+
+```
+WORKER-VERDICT: BLOCKED run ended before reaching its own conclusion
+```
+
+Then do the work, and print the real verdict at the end. It wins, because it comes later.
+
+This exists because a run that **dies** — turn limit, timeout, a turn ended waiting on something
+— cannot report anything, and a session that produced pages of reasoning and no verdict line is
+indistinguishable from one that never started. Both happened on 2026-08-23: the worker hit
+`Reached max turns (120)` at 04:15, and the steward's 06:58 run simply stopped after five
+minutes with no closing line. Neither was a lie, but neither said what had happened.
+
+With the provisional line in place, a death now reports `BLOCKED` and fails the job loudly,
+which is the truth: a run that could not finish is a defect in this harness, not an empty
+backlog. Do not skip it because you expect to finish — the runs that died expected to finish too.
+
 ## You are ONE non-interactive invocation — never background a command
 
 This is `claude -p`, a single shot. There is **no loop to deliver a background-task

--- a/.github/agent-prompts/pr-steward.md
+++ b/.github/agent-prompts/pr-steward.md
@@ -33,6 +33,27 @@ the one thing you must never do.
 Likewise, do not "fix" a red check by deleting or weakening the test that is failing, or by
 adding an exclusion. If the honest fix is not available to you, say so.
 
+## Emit a PROVISIONAL verdict before you start, and the real one at the end
+
+The job reads the **last** `STEWARD-VERDICT:` line in your output. So the very first thing you do,
+before any tool call, is print exactly this:
+
+```
+STEWARD-VERDICT: BLOCKED run ended before reaching its own conclusion
+```
+
+Then do the work, and print the real verdict at the end. It wins, because it comes later.
+
+This exists because a run that **dies** — turn limit, timeout, a turn ended waiting on something
+— cannot report anything, and a session that produced pages of reasoning and no verdict line is
+indistinguishable from one that never started. Both happened on 2026-08-23: the worker hit
+`Reached max turns (120)` at 04:15, and the steward's 06:58 run simply stopped after five
+minutes with no closing line. Neither was a lie, but neither said what had happened.
+
+With the provisional line in place, a death now reports `BLOCKED` and fails the job loudly,
+which is the truth: a run that could not finish is a defect in this harness, not an empty
+backlog. Do not skip it because you expect to finish — the runs that died expected to finish too.
+
 ## You are ONE non-interactive invocation — never background a command
 
 This is `claude -p`, a single shot. There is **no loop to deliver a background-task

--- a/.github/workflows/agent-issue-worker.yml
+++ b/.github/workflows/agent-issue-worker.yml
@@ -246,7 +246,7 @@ jobs:
           git config user.name  "openbank-issue-worker"
           git config user.email "openbank-issue-worker@users.noreply.github.com"
           claude -p "$(cat .github/agent-prompts/issue-worker.md)" \
-            --max-turns 120 \
+            --max-turns 200 \
             --permission-mode bypassPermissions \
           | tee /tmp/worker-output.txt
           echo "--- worker output above ---"


### PR DESCRIPTION
Refs #6412

## What happened today

Two runs died without saying anything:

| run | outcome |
|---|---|
| worker 04:15 | `Reached max turns (120)` after **18 minutes of real work** — it had already opened #6607 |
| steward 06:58 | stopped after five minutes, no closing line, no verdict |

Both failed the verdict assertion, which is correct. But the message — *"never stated a verdict"* — does not distinguish **a session that died mid-flight** from **one that never started**. Those need different responses, and the log could not tell them apart.

## The durable fix

Both prompts now print a **provisional verdict before any tool call**:

```
<KIND>-VERDICT: BLOCKED run ended before reaching its own conclusion
```

and the real verdict at the end. The assertion reads the **last** match, so the real one wins whenever there is one — and when the run dies, the provisional stands and fails the job loudly.

That is the honest reading: **a run that cannot finish is a defect in this harness, not an empty backlog.** The prompt says explicitly not to skip the line because the run expects to finish — the runs that died expected to finish too.

## The band-aid, named as one

The worker's turn budget goes **120 → 200**. Its 04:15 run was not looping — it was doing a genuine build-and-test cycle and ran out, having already produced a PR. The steward stays at 120, which has been enough for what it does.

**Raising a limit only moves where the silence happens.** The provisional line is what makes the silence impossible; the budget change just makes it rarer.

## State this fixes into

The loop closed today without either of these: the worker opened #6607 under the `openbank-agent-bot` identity (real check conclusions, no `action_required`), and at 15:48 the steward **tended #6547** — found it 86 commits behind, merged `main`, verified the scope was still exactly its 5 files, ran the module test and then ktlint/detekt as a separate command, and pushed under the App identity. That PR now shows **8 success / 1 skipped** where it previously had nine runs stuck awaiting approval.

## Verification

- `run-gates.py --group lint` — 24/24 PASS
- The known-positives are the two dead runs above: with this change each would have reported `BLOCKED run ended before reaching its own conclusion` instead of an unexplained assertion failure.