### PR TITLE
fix(admin-ui): clarify lending overview tabs

### DIFF
--- a/openbank-admin-ui/src/app/lending/page.tsx
+++ b/openbank-admin-ui/src/app/lending/page.tsx
@@ -257,7 +257,10 @@ export default function LendingPage() {
         {(['queue', 'portfolio'] as const).map(id => (
           <button
             key={id}
+            type="button"
             onClick={() => setTab(id)}
+            aria-pressed={tab === id}
+            aria-label={id === 'queue' ? t('Zobrazit frontu žádostí', 'Show applications queue') : t('Zobrazit portfolio', 'Show portfolio')}
             style={{
               padding: '6px 12px', fontSize: 12, fontWeight: 600, borderRadius: 6, border: 'none', cursor: 'pointer',
               background: tab === id ? 'var(--accent)' : 'var(--surface-3)',
@@ -268,7 +271,7 @@ export default function LendingPage() {
           </button>
         ))}
         {stage && tab === 'queue' && (
-          <button onClick={() => setStage(null)} className="btn btn-secondary" style={{ fontSize: 11 }} data-testid="clear-stage">
+          <button type="button" onClick={() => setStage(null)} className="btn btn-secondary" style={{ fontSize: 11 }} data-testid="clear-stage" aria-label={t('Zrušit filtr fáze', 'Clear stage filter')}>
             {t('Filtr:', 'Filter:')} {label(stage)} ✕
           </button>
         )}

--- a/openbank-admin-ui/src/test/lending-tabs.guard.test.ts
+++ b/openbank-admin-ui/src/test/lending-tabs.guard.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('lending overview controls contract', () => {
+  it('keeps tabs and stage filter explicit without changing data flow', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/lending/page.tsx'), 'utf8')
+    expect(source).toContain('aria-pressed={tab === id}')
+    expect(source).toContain("t('Zobrazit frontu žádostí', 'Show applications queue')")
+    expect(source).toContain("t('Zobrazit portfolio', 'Show portfolio')")
+    expect(source).toContain("aria-label={t('Zrušit filtr fáze', 'Clear stage filter')}")
+    expect(source).toContain('setTab(id)')
+  })
+})


### PR DESCRIPTION
## Summary
- add explicit type/pressed state and localized names to Lending overview tabs
- make stage filter clear action explicit
- preserve lending queue/portfolio data, maker-checker and RBAC behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.