### PR TITLE
fix(admin-ui): clarify sanctions disclosure

### DIFF
--- a/openbank-admin-ui/src/app/sanctions/page.tsx
+++ b/openbank-admin-ui/src/app/sanctions/page.tsx
@@ -166,9 +166,9 @@ function ListCard({ list, onToggle, onRefresh, onSave }: {
           {t('Stáhnout', 'Download')}
         </button>
         </Can>
-        <button onClick={() => setExpanded(e => !e)}
+        <button type="button" onClick={() => setExpanded(e => !e)} aria-expanded={expanded} aria-label={expanded ? t('Sbalit podrobnosti seznamu', 'Collapse list details') : t('Rozbalit podrobnosti seznamu', 'Expand list details')}
           style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-tertiary)', padding: '4px', display: 'flex' }}>
-          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+          {expanded ? <ChevronUp size={14} aria-hidden="true" /> : <ChevronDown size={14} aria-hidden="true" />}
         </button>
       </div>
       {expanded && (

--- a/openbank-admin-ui/src/test/sanctions-expand.guard.test.ts
+++ b/openbank-admin-ui/src/test/sanctions-expand.guard.test.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('sanctions list disclosure contract', () => {
+  it('keeps list details disclosure explicit and localized', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/sanctions/page.tsx'), 'utf8')
+    expect(source).toContain('<button type="button" onClick={() => setExpanded(e => !e)}')
+    expect(source).toContain('aria-expanded={expanded}')
+    expect(source).toContain("t('Sbalit podrobnosti seznamu', 'Collapse list details')")
+    expect(source).toContain("t('Rozbalit podrobnosti seznamu', 'Expand list details')")
+    expect(source).toContain('setExpanded(e => !e)')
+    expect(source).toContain('<ChevronUp size={14} aria-hidden="true" />')
+    expect(source).toContain('<ChevronDown size={14} aria-hidden="true" />')
+  })
+})


### PR DESCRIPTION
## Summary
- make sanctions list disclosure an explicit accessible button
- preserve screening/list/four-eyes flows and RBAC

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.