### PR TITLE
fix(admin-ui): clarify account controls

### DIFF
--- a/openbank-admin-ui/src/app/accounts/page.tsx
+++ b/openbank-admin-ui/src/app/accounts/page.tsx
@@ -217,7 +217,9 @@ export default function AccountsPage() {
             </select>
             <button
               className="btn btn-primary"
+              type="button"
               aria-label={t('Vyhledat účty', 'Search accounts')}
+              aria-busy={loading}
               onClick={() => void search()}
               disabled={loading || !canSearch}
             >
@@ -226,6 +228,8 @@ export default function AccountsPage() {
             </button>
             <button
               className="btn btn-ghost"
+              type="button"
+              aria-label={t('Vymazat filtry účtů', 'Reset account filters')}
               onClick={resetFilters}
               disabled={loading}
             >
@@ -335,6 +339,8 @@ export default function AccountsPage() {
           <div style={{ padding: '12px 16px', borderTop: '1px solid var(--border)', textAlign: 'center' }}>
             <button
               className="btn btn-secondary"
+              type="button"
+              aria-label={t('Zobrazit další účty', 'Load more accounts')}
               style={{ fontSize: '12px' }}
               onClick={() => setVisibleCount(c => c + PAGE_SIZE)}
             >

--- a/openbank-admin-ui/src/test/accounts-controls-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/accounts-controls-a11y.guard.test.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('accounts controls accessibility contract', () => {
+  it('keeps search, reset and pagination controls explicit', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/accounts/page.tsx'), 'utf8')
+    expect(source).toContain('type="button"')
+    expect(source).toContain("aria-label={t('Vyhledat účty', 'Search accounts')}")
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Vymazat filtry účtů', 'Reset account filters')}")
+    expect(source).toContain("aria-label={t('Zobrazit další účty', 'Load more accounts')}")
+    expect(source).toContain('onClick={() => setVisibleCount(c => c + PAGE_SIZE)}')
+  })
+})


### PR DESCRIPTION
## Summary
- make account search/reset/load-more controls explicit non-submit buttons
- expose search busy state and localized accessible names

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.