### PR TITLE
fix(admin-ui): clarify template controls

### DIFF
--- a/openbank-admin-ui/src/app/document-templates/page.tsx
+++ b/openbank-admin-ui/src/app/document-templates/page.tsx
@@ -448,7 +448,7 @@ export default function DocumentTemplatesPage() {
       <div style={{ padding: '28px 32px', maxWidth: '1400px' }}>
         <PageHeader breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Šablony dokumentů', 'Document Templates')}</span></div>} icon={<FileSignature size={20} aria-hidden="true" />} title={t('Šablony dokumentů', 'Document Templates')} subtitle={t('Správa šablon smluv, formulářů a vygenerovaných dokumentů (openbank-document-service)', 'Manage contract/form templates and generated documents (openbank-document-service)')} actions={<div style={{ display: 'flex', gap: '8px' }}>
             {canEdit && tab === 'templates' && (
-              <button className="btn btn-primary" onClick={openCreateModal} disabled={loading}>
+              <button className="btn btn-primary" type="button" onClick={openCreateModal} disabled={loading}>
                 <Plus size={14} /> {t('Nová šablona', 'New Template')}
               </button>
             )}
@@ -573,7 +573,7 @@ export default function DocumentTemplatesPage() {
               </table>
               {!loading && filtered.length > visibleCount && (
                 <div style={{ padding: '12px', textAlign: 'center', borderTop: '1px solid var(--border)' }}>
-                  <button className="btn btn-secondary btn-sm" onClick={() => setVisibleCount(c => c + PAGE_SIZE)}>
+                  <button className="btn btn-secondary btn-sm" type="button" onClick={() => setVisibleCount(c => c + PAGE_SIZE)}>
                     {t(`Načíst dalších ${Math.min(PAGE_SIZE, filtered.length - visibleCount)}`, `Load ${Math.min(PAGE_SIZE, filtered.length - visibleCount)} more`)}
                   </button>
                 </div>
@@ -798,8 +798,8 @@ export default function DocumentTemplatesPage() {
                 : t('Vyřazená šablona se přestane nabízet pro generování nových dokumentů.', 'A retired template stops being offered for new document generation.')}
             </div>
             <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
-              <button className="btn btn-secondary" onClick={() => setPendingAction(null)} disabled={actioning}>{t('Zrušit', 'Cancel')}</button>
-              <button className="btn btn-primary" onClick={() => runAction(pendingAction.id, pendingAction.kind)} disabled={actioning}>
+              <button className="btn btn-secondary" type="button" onClick={() => setPendingAction(null)} disabled={actioning}>{t('Zrušit', 'Cancel')}</button>
+              <button className="btn btn-primary" type="button" onClick={() => runAction(pendingAction.id, pendingAction.kind)} disabled={actioning} aria-busy={actioning}>
                 {actioning ? t('Provádím…', 'Working…') : t('Potvrdit', 'Confirm')}
               </button>
             </div>
@@ -869,7 +869,7 @@ function DocumentsLookup({ t, language }: { t: (cs: string, en: string) => strin
             onKeyDown={e => { if (e.key === 'Enter') lookup() }}
           />
         </div>
-        <button className="btn btn-primary" onClick={lookup} disabled={loading || idInput.trim().length === 0}>
+        <button className="btn btn-primary" type="button" onClick={lookup} disabled={loading || idInput.trim().length === 0} aria-busy={loading} aria-label={t('Vyhledat dokument podle ID', 'Look up document by ID')}>
           <Search size={13} /> {loading ? t('Hledám…', 'Looking up…') : t('Vyhledat', 'Look up')}
         </button>
       </div>

--- a/openbank-admin-ui/src/test/document-template-controls.guard.test.ts
+++ b/openbank-admin-ui/src/test/document-template-controls.guard.test.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('document template workflow controls contract', () => {
+  it('keeps action and lookup controls explicit and truthful', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/document-templates/page.tsx'), 'utf8')
+    expect(source).toContain('type="button" onClick={openCreateModal} disabled={loading}')
+    expect(source).toContain('type="button" onClick={() => setPendingAction(null)} disabled={actioning}')
+    expect(source).toContain('aria-busy={actioning}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Vyhledat dokument podle ID', 'Look up document by ID')}")
+    expect(source).toContain('type="button" onClick={() => runAction(pendingAction.id, pendingAction.kind)}')
+  })
+})


### PR DESCRIPTION
## Summary
- make template create, pagination, confirmation and lookup controls explicit buttons
- expose action/lookup busy state and localized lookup naming

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.