### PR TITLE
fix(admin-ui): clarify payment creation

### DIFF
--- a/openbank-admin-ui/src/app/payments/page.tsx
+++ b/openbank-admin-ui/src/app/payments/page.tsx
@@ -617,7 +617,7 @@ function PaymentsContent() {
 
           {canCreate && (
             <div style={{ display: 'flex', gap: '10px', marginBottom: '16px', justifyContent: 'flex-end' }}>
-              <button className="btn btn-primary" onClick={() => setShowCreate(showCreate ? null : 'payment-type')}>
+              <button className="btn btn-primary" type="button" aria-expanded={showCreate === 'payment-type'} aria-controls="payment-create-type-panel" aria-label={t('Nová platba', 'New Payment')} onClick={() => setShowCreate(showCreate ? null : 'payment-type')}>
                 <Plus size={14} aria-hidden="true" />
                 {t('Nová platba', 'New Payment')}
               </button>
@@ -626,7 +626,7 @@ function PaymentsContent() {
 
           {/* Payment type selector */}
           {showCreate === 'payment-type' && (
-            <div className="card" style={{ padding: '20px', marginBottom: '20px' }}>
+            <div id="payment-create-type-panel" className="card" style={{ padding: '20px', marginBottom: '20px' }}>
               <h2 style={{ fontSize: '16px', fontWeight: 600, marginBottom: '16px' }}>{t('Vyberte typ platby', 'Select payment type')}</h2>
               <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '12px' }}>
                 {CREATE_OPTIONS.map(opt => {

--- a/openbank-admin-ui/src/test/payment-create-disclosure.guard.test.ts
+++ b/openbank-admin-ui/src/test/payment-create-disclosure.guard.test.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('payment create disclosure contract', () => {
+  it('keeps the create toggle and payment type panel related', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/payments/page.tsx'), 'utf8')
+    expect(source).toContain('type="button" aria-expanded={showCreate === \'payment-type\'} aria-controls="payment-create-type-panel"')
+    expect(source).toContain('id="payment-create-type-panel"')
+    expect(source).toContain("onClick={() => setShowCreate(showCreate ? null : 'payment-type')}")
+  })
+})


### PR DESCRIPTION
## Summary
- relate the New Payment toggle to its type selector with explicit disclosure semantics
- preserve payment create permissions and payload flow

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.