### PR TITLE
fix(admin-ui): clarify catalog status control

### DIFF
--- a/openbank-admin-ui/src/app/product-catalog/page.tsx
+++ b/openbank-admin-ui/src/app/product-catalog/page.tsx
@@ -177,11 +177,11 @@ function ProductDetailPanel({ product, onClose, onEdit, onToggleStatus }: { prod
           >
             <Edit size={12} /> {t('Upravit', 'Edit')}
           </button>
-          <button type="button" onClick={onToggleStatus} aria-label={product.status === 'ACTIVE' ? t('Deaktivovat produkt', 'Deactivate product') : t('Aktivovat produkt', 'Activate product')} style={{ background: sc.bg, border: `1px solid ${sc.border}`, borderRadius: '6px', padding: '5px 10px', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '4px', fontSize: '11px', color: sc.text }}>
-            {product.status === 'ACTIVE' ? <><Square size={11} /> {t('Deaktivovat', 'Deactivate')}</> : <><Play size={11} /> {t('Aktivovat', 'Activate')}</>}
+          <button type="button" aria-pressed={product.status === 'ACTIVE'} onClick={onToggleStatus} aria-label={product.status === 'ACTIVE' ? t('Deaktivovat produkt', 'Deactivate product') : t('Aktivovat produkt', 'Activate product')} style={{ background: sc.bg, border: `1px solid ${sc.border}`, borderRadius: '6px', padding: '5px 10px', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '4px', fontSize: '11px', color: sc.text }}>
+            {product.status === 'ACTIVE' ? <><Square size={11} aria-hidden="true" /> {t('Deaktivovat', 'Deactivate')}</> : <><Play size={11} aria-hidden="true" /> {t('Aktivovat', 'Activate')}</>}
           </button>
           <button type="button" onClick={onClose} aria-label={t('Zavřít detail produktu', 'Close product details')} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-tertiary)', padding: '4px' }}>
-            <X size={18} />
+            <X size={18} aria-hidden="true" />
           </button>
         </div>
       </div>

--- a/openbank-admin-ui/src/test/product-catalog-detail-controls.guard.test.ts
+++ b/openbank-admin-ui/src/test/product-catalog-detail-controls.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('product catalog detail controls contract', () => {
+  it('keeps lifecycle status and close controls explicit', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/product-catalog/page.tsx'), 'utf8')
+    expect(source).toContain('type="button" aria-pressed={product.status === \'ACTIVE\'}')
+    expect(source).toContain('<Square size={11} aria-hidden="true" />')
+    expect(source).toContain('<Play size={11} aria-hidden="true" />')
+    expect(source).toContain('<X size={18} aria-hidden="true" />')
+  })
+})


### PR DESCRIPTION
## Summary
- expose Product Catalog status toggle state to assistive technology
- hide decorative lifecycle/close icons

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.