### PR TITLE
fix(admin-ui): clarify transaction filters

### DIFF
--- a/openbank-admin-ui/src/app/transactions/page.tsx
+++ b/openbank-admin-ui/src/app/transactions/page.tsx
@@ -152,7 +152,7 @@ export default function TransactionsPage() {
               value={bban} onChange={e => setBban(e.target.value)}
               onKeyDown={e => e.key === 'Enter' && search()} />
           </div>
-          <button className="btn btn-secondary" onClick={() => setShowFilters(f => !f)} aria-expanded={showFilters} aria-controls="transaction-search-filters">
+          <button type="button" className="btn btn-secondary" onClick={() => setShowFilters(f => !f)} aria-expanded={showFilters} aria-controls="transaction-search-filters">
             <Filter size={13} />
             {hasFilters ? <span style={{ color: 'var(--accent)' }}>{t('Filtry', 'Filters')} ({[iban,bban,referenceNumber,endToEndId,counterparty,status,type,dateFrom,dateTo,amountMin,amountMax,channel].filter(Boolean).length})</span> : t('Filtry', 'Filters')}
           </button>
@@ -217,7 +217,7 @@ export default function TransactionsPage() {
               </div>
             </div>
             {hasFilters && (
-              <button className="btn btn-secondary" style={{ marginTop: '10px' }} onClick={clearFilters}>
+              <button type="button" className="btn btn-secondary" style={{ marginTop: '10px' }} onClick={clearFilters} aria-label={t('Vymazat filtry transakcí', 'Clear transaction filters')}>
                 <X size={12} /> {t('Vymazat filtry', 'Clear filters')}
               </button>
             )}

--- a/openbank-admin-ui/src/test/transactions-filter-controls.guard.test.ts
+++ b/openbank-admin-ui/src/test/transactions-filter-controls.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('transactions filter controls contract', () => {
+  it('keeps disclosure and clear controls explicit', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/transactions/page.tsx'), 'utf8')
+    expect(source).toContain('type="button" className="btn btn-secondary" onClick={() => setShowFilters(f => !f)}')
+    expect(source).toContain('aria-controls="transaction-search-filters"')
+    expect(source).toContain("aria-label={t('Vymazat filtry transakcí', 'Clear transaction filters')}")
+    expect(source).toContain('onClick={clearFilters}')
+  })
+})


### PR DESCRIPTION
## Summary
- make transaction filter disclosure/clear controls explicit buttons
- add localized clear-filter naming

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.