### PR TITLE
fix(admin-ui): clarify onboarding pagination

### DIFF
--- a/openbank-admin-ui/src/app/onboarding/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/page.tsx
@@ -313,13 +313,13 @@ export default function OnboardingPage() {
           {/* Pagination */}
           {total > 20 && (
             <div style={{ padding: '12px 20px', borderTop: '1px solid var(--border)', display: 'flex', gap: '8px', alignItems: 'center' }}>
-              <button className="btn btn-secondary" disabled={page === 0} onClick={() => setPage(p => p - 1)}>
+              <button type="button" className="btn btn-secondary" aria-label={t('Předchozí strana onboardingu', 'Previous onboarding page')} disabled={page === 0} onClick={() => setPage(p => p - 1)}>
                 {t('← Předchozí', '← Prev')}
               </button>
               <span style={{ fontSize: '12px', color: 'var(--text-muted)' }}>
                 {t(`Strana ${page + 1} z ${Math.ceil(total / 20)}`, `Page ${page + 1} of ${Math.ceil(total / 20)}`)}
               </span>
-              <button className="btn btn-secondary" disabled={(page + 1) * 20 >= total} onClick={() => setPage(p => p + 1)}>
+              <button type="button" className="btn btn-secondary" aria-label={t('Další strana onboardingu', 'Next onboarding page')} disabled={(page + 1) * 20 >= total} onClick={() => setPage(p => p + 1)}>
                 {t('Další →', 'Next →')}
               </button>
             </div>

--- a/openbank-admin-ui/src/test/onboarding-pagination.guard.test.ts
+++ b/openbank-admin-ui/src/test/onboarding-pagination.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('onboarding pagination contract', () => {
+  it('keeps pagination controls explicit and named', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/onboarding/page.tsx'), 'utf8')
+    expect(source).toContain("type=\"button\" className=\"btn btn-secondary\" aria-label={t('Předchozí strana onboardingu', 'Previous onboarding page')}")
+    expect(source).toContain("aria-label={t('Další strana onboardingu', 'Next onboarding page')}")
+    expect(source).toContain('onClick={() => setPage(p => p - 1)}')
+    expect(source).toContain('onClick={() => setPage(p => p + 1)}')
+  })
+})


### PR DESCRIPTION
## Summary
- make onboarding pagination controls explicit buttons
- add localized accessible names for previous/next page actions

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.