### PR TITLE
fix(admin-ui): clarify audit search state

### DIFF
--- a/openbank-admin-ui/src/app/audit/page.tsx
+++ b/openbank-admin-ui/src/app/audit/page.tsx
@@ -82,7 +82,7 @@ export default function AuditPage() {
               onKeyDown={e => e.key === 'Enter' && search()}
             />
           </div>
-          <button className="btn btn-primary" onClick={search} disabled={loading || !aggregateId.trim()}>
+          <button type="button" className="btn btn-primary" onClick={search} disabled={loading || !aggregateId.trim()} aria-busy={loading} aria-label={t('Vyhledat auditní záznam', 'Search audit trail')}>
             {loading ? t('Hledám…', 'Searching…') : t('Hledat', 'Search')}
           </button>
         </div>

--- a/openbank-admin-ui/src/test/audit-search.guard.test.ts
+++ b/openbank-admin-ui/src/test/audit-search.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('audit search contract', () => {
+  it('keeps audit search explicit and truthful while loading', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/audit/page.tsx'), 'utf8')
+    expect(source).toContain('type="button" className="btn btn-primary" onClick={search}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Vyhledat auditní záznam', 'Search audit trail')}")
+    expect(source).toContain('disabled={loading || !aggregateId.trim()}')
+  })
+})


### PR DESCRIPTION
## Summary
- expose audit search loading state to assistive technology
- add explicit button type and localized accessible naming

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.