### PR TITLE
fix(admin-ui): clarify delegations search

### DIFF
--- a/openbank-admin-ui/src/app/delegations/page.tsx
+++ b/openbank-admin-ui/src/app/delegations/page.tsx
@@ -149,8 +149,8 @@ export default function DelegationsPage() {
             placeholder={t('Jméno strany…', 'Party name…')}
             aria-label={t('Hledat stranu', 'Search party')}
           />
-          <button className="btn btn-primary" onClick={search} disabled={term.trim().length < SEARCH_MIN}>
-            <Search size={14} />
+          <button type="button" className="btn btn-primary" onClick={search} disabled={term.trim().length < SEARCH_MIN} aria-busy={loading} aria-label={t('Vyhledat delegující stranu', 'Search delegating party')}>
+            <Search size={14} aria-hidden="true" />
             {t('Vyhledat', 'Search')}
           </button>
         </div>
@@ -175,7 +175,10 @@ export default function DelegationsPage() {
             {results.map(r => (
               <button
                 key={r.id}
+                type="button"
                 className="btn btn-secondary"
+                aria-pressed={party?.id === r.id}
+                aria-label={t(`Vybrat stranu ${r.label}`, `Select party ${r.label}`)}
                 onClick={() => loadGrants(r)}
                 style={{ fontWeight: party?.id === r.id ? 700 : 500 }}
               >

--- a/openbank-admin-ui/src/test/delegations-search.guard.test.ts
+++ b/openbank-admin-ui/src/test/delegations-search.guard.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('delegations search contract', () => {
+  it('keeps party search and selection explicit', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/delegations/page.tsx'), 'utf8')
+    expect(source).toContain('type="button" className="btn btn-primary" onClick={search}')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain("aria-label={t('Vyhledat delegující stranu', 'Search delegating party')}")
+    expect(source).toContain('aria-pressed={party?.id === r.id}')
+    expect(source).toContain('onClick={() => loadGrants(r)}')
+  })
+})


### PR DESCRIPTION
## Summary
- expose Delegations party search loading state and accessible naming
- mark selected party result and explicit result buttons

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.