### PR TITLE
feat(governance): let an agent ASK the guard whether a change is in scope

### DIFF
--- a/.github/agent-prompts/issue-worker.md
+++ b/.github/agent-prompts/issue-worker.md
@@ -90,6 +90,22 @@ List open issues with `gh issue list`. Discard, in this order:
   architecture;
 - any too large for one run: a whole new service, a 30-module sweep, a framework migration.
 
+**Do not reason about whether the fix lands on a protected path — ASK.** Once you know which
+files you would touch, run:
+
+```
+python3 .github/scripts/check-agent-pr-guard.py --paths <file> <file> ...
+```
+
+Exit 1 means the gate will refuse the PR, so the issue is out of scope: pick another and say why.
+Exit 0 means it is in scope.
+
+This exists because reasoning about it failed. On 2026-08-24 the worker picked the
+party-service slice of #5679, having weighed `money_path_services` and overlooked
+`extra_protected_tokens`, where `party` sits. #6607 was red from its first check and could never
+merge — a whole run spent on work the gate was always going to refuse. The rule was in these
+instructions the entire time; applying it by hand is what went wrong. One command answers it.
+
 Then ask the question that decides everything else: **what test would prove this fix, and can I
 run that test on this runner?** Check rather than assume — the job step before you measured
 whether a real database image can be pulled here, and its output is in the run log. If the proof

--- a/.github/scripts/check-agent-pr-guard.py
+++ b/.github/scripts/check-agent-pr-guard.py
@@ -475,10 +475,42 @@ def main():
     ap = argparse.ArgumentParser(description="agent PR guard")
     ap.add_argument("--pr")
     ap.add_argument("--self-test", action="store_true")
+    ap.add_argument(
+        "--paths", nargs="+", metavar="PATH",
+        help="classify a file list directly, with no PR: exit 1 if any path is protected. "
+             "For an agent deciding whether a change is in scope BEFORE writing it.",
+    )
     args = ap.parse_args()
 
     if args.self_test:
         return self_test()
+
+    # --paths: ask the gate instead of reasoning about it.
+    #
+    # The worker's own instructions tell it to discard an issue whose fix would land on a
+    # protected path. On 2026-08-24 it reasoned about that and got it wrong: it picked the
+    # party-service slice of #5679, having weighed `money_path_services` and overlooked
+    # `extra_protected_tokens`, where `party` sits. The PR (#6607) was red from its first
+    # check and could never merge — a whole run spent on work the gate was always going to
+    # refuse.
+    #
+    # A rule an agent must APPLY BY REASONING is a rule it can misread. This makes the same
+    # question answerable by running one command, before any code is written.
+    if args.paths:
+        try:
+            cfg = load_rules()
+        except Undetermined as e:
+            print(f"::error::agent-pr-guard --paths could not read the rules: {e}")
+            return 2
+        hits = protected_reasons(list(args.paths), cfg)
+        if not hits:
+            print(f"in scope: none of the {len(args.paths)} path(s) given are protected")
+            return 0
+        print("PROTECTED — an agent PR touching these will be refused by the gate:")
+        for clause, matched in hits:
+            print(f"  * {REASON_TEXT[clause]}")
+            print(f"    matched: {' '.join(sorted(matched)[:3])}")
+        return 1
 
     try:
         cfg = load_rules()


### PR DESCRIPTION
Refs #6412

## What went wrong

The worker's instructions have always said to discard an issue whose fix would land on a protected path. It applied that rule **by reasoning**, and got it wrong: it picked the **party-service** slice of #5679, having weighed `money_path_services` and overlooked `extra_protected_tokens` — where `party` sits.

#6607 was red from its first check and **can never merge**. A whole run spent on work the gate was always going to refuse.

## What went right, and is worth recording

The steward handled it exactly as intended. From its 01:04 report:

> every red check (`gates (lint)`, `Validate manifests`, `build`, `all-green`) traces to a single root cause: the `agent-pr-guard` gate fails because `openbank-party-service` is listed in `rules.yaml`'s `extra_protected_tokens`. The build/manifest/all-green failures are pure downstream consequences of that one gate (**confirmed by reading each job's log** — "Validate manifests" is just an aggregator over the gate shards). This is exactly the protected-path case I must not try to fix.

It did not see four red checks and start fixing them. It traced the causality to one gate and stopped. **The steward's judgement was sound; the worker's was the error.**

## The fix

A rule an agent must apply **by reasoning** is a rule it can misread. `--paths` makes the same question answerable by running the gate:

```
python3 .github/scripts/check-agent-pr-guard.py --paths <file> ...
```

| exit | meaning |
|---|---|
| 0 | in scope |
| 1 | protected — prints the clause and the matching paths |
| 2 | the rules could not be read — never a clean verdict |

The worker's prompt now runs it as soon as it knows which files it would touch, **before writing code**.

## Measured, on the two real cases

```
$ ... --paths openbank-party-service/src/main/kotlin/X.kt
PROTECTED — an agent PR touching these will be refused by the gate:
  * touches money-path / high-blast-radius service or gitops paths...
    matched: openbank-party-service/src/main/kotlin/X.kt
rc=1

$ ... --paths openbank-notification-service/src/main/kotlin/X.kt
in scope: none of the 1 path(s) given are protected
rc=0
```

That discrimination is exactly what would have saved the #6607 run — `notification` was the slice it *should* have taken, and did take, in #6547.

## Verification

- guard self-test — 15 classifier cases + 4 undetermined, unchanged
- `run-gates.py --group lint` — 24/24 PASS
- `--paths` is a thin CLI over `protected_reasons()`, which the self-test already exercises in both directions; the two invocations above measure the exit-code contract itself.

## What to do about #6607

It cannot merge as an agent PR. Either a human takes the branch over, or it is closed and the party slice of #5679 is done by hand — `party` is protected for a reason.