### PR TITLE
fix(ci): stop the unauthenticated fuzz lane reporting an unfinished boot as a failure

### DIFF
--- a/.github/scripts/fuzz-services.sh
+++ b/.github/scripts/fuzz-services.sh
@@ -87,6 +87,25 @@
 # What pass 2 does NOT test is authorization by design; that property is pass 1's job, which is why
 # both run and both must pass rather than one replacing the other.
 #
+# ── Dev services OFF ──────────────────────────────────────────────────────────────────────────
+# Quarkus dev mode starts a container for anything it believes unconfigured, and on a cold hosted
+# runner the PULL is what blows the readiness window. That is the whole of #6492: every scheduled
+# run from 2026-08-04 to 2026-08-20 failed, 5-11 jobs each, in a different combination every time
+# — and not one of those jobs had failed. They had not finished. Run 32336553304's sca-service was
+# mid-`Extracting 583.8MB/638.7MB` of docker.io/grafana/otel-lgtm at the second the 180s loop gave
+# up, having pulled testcontainers/ryuk and apache/kafka-native first. None of the three is
+# reachable from the fuzzed HTTP surface. The shifting failure set was never a signal about any
+# service; it was which jobs happened to lose the race to Docker Hub that morning.
+#
+# Everything this lane needs is provisioned explicitly above (postgres, redis) and already
+# suppresses its own dev service by config — the boot log says so per component ("Not starting Dev
+# Services for default datasource as it has explicit configuration"). What was left was an
+# observability stack and a Kafka broker, pulled on every one of ~26 jobs, for nothing.
+#
+# The identical fix landed on the AUTHENTICATED lane on 2026-08-14 (#4703, api-fuzz-authenticated.yml)
+# and was never carried across to this one; the two lanes had drifted for eighteen days with the
+# unauthenticated one — the surface reachable without a credential — reporting nothing at all.
+#
 # ── The exception census ───────────────────────────────────────────────────────────────────────
 # schemathesis reports "Server error: N" with a generic INTERNAL_ERROR body, so the count alone
 # cannot distinguish a defect from a dependency this job does not run — three different
@@ -117,6 +136,90 @@
 # 32503175988 printed `Selected: 19/19` for dispute-service and no census at all, while its
 # artifact held 53 ERROR lines).
 set -uo pipefail
+
+# ── Boot-failure classification (see "Dev services OFF" above) ─────────────────────────────────
+# Extracted so it can be exercised directly: `fuzz-services.sh --self-test` feeds it one log that
+# MUST be called a crash and one that MUST NOT be, and checks what it prints. A diagnostic nobody
+# has run against a known-positive is decoration.
+classify_boot_failure () {
+  local svc="$1" label="$2" BOOTLOG="$3" waited="$4"
+  local CRASH
+  CRASH="$(grep -aE 'Failed to start (application|quarkus)|FATAL: |BUILD FAILED' "${BOOTLOG}" 2>/dev/null | head -3 || true)"
+  if [ -n "${CRASH}" ]; then
+    echo "::error::[${svc}] CRASHED during boot (${label}) — the application failed to start; this is a finding about the service, not the harness"
+    printf '%s\n' "${CRASH}"
+    # The cause chain, not the last 50 lines: a boot log's tail is whatever it happened to be
+    # doing, which for years was docker-pull progress.
+    grep -aE 'Caused by:' "${BOOTLOG}" 2>/dev/null | head -5 || true
+  else
+    echo "::error::[${svc}] DID NOT FINISH booting within ${waited}s (${label}) — no terminal failure in the log: this is a TIMEOUT, not a crash, and nothing here is a finding about the service"
+    # Name the environmental cause when the log shows one. An unfinished image pull is the
+    # documented shape (#6492: docker.io/grafana/otel-lgtm, 638 MB, still extracting at the
+    # second the loop gave up) and dev services are now off, so seeing this again means the
+    # switch stopped working rather than that a service is slow.
+    local PULLING
+    PULLING="$(grep -a 'Pulling docker image' "${BOOTLOG}" 2>/dev/null | tail -3 || true)"
+    if [ -n "${PULLING}" ]; then
+      echo "::warning::[${svc}] the boot was pulling container images — dev services should be OFF in this job:"
+      printf '%s\n' "${PULLING}"
+    fi
+    echo "      last lines of the boot log, image-pull progress stripped:"
+    grep -av 'http-outgoing\|PullImageResultCallback\|ProgressDetail' "${BOOTLOG}" 2>/dev/null \
+      | tail -15 | sed 's/^/      /' || true
+  fi
+}
+
+
+# ── Falsifiability harness ────────────────────────────────────────────────────────────────────
+# Two negative controls, because the fix is a CLASSIFICATION and a green run cannot show that a
+# classification is right. Control 1 is a real crash (settlement-service's Flyway
+# password-authentication chain, run 32289597634) and MUST be called a crash with its cause named.
+# Control 2 is a real timeout (sca-service mid-pull of grafana/otel-lgtm, run 32336553304) and
+# MUST NOT be called a crash — that misattribution is what #6492 was. Control 3 asserts the
+# quarkusDev command line still carries the dev-services switch, since the classifier being
+# correct about a pull is worth nothing if the pull is still happening.
+if [ "${1:-}" = "--self-test" ]; then
+  ST_TMP="$(mktemp -d)"; ST_RC=0
+  cat > "${ST_TMP}/crash.log" <<'EOF'
+05:51:56 ERROR [io.qu.ru.Application] Failed to start application: java.lang.RuntimeException: Failed to start quarkus
+Caused by: org.flywaydb.core.internal.exception.sqlExceptions.FlywaySqlUnableToConnectToDbException: Unable to obtain connection from database: FATAL: password authentication failed for user "openbank_settlement"
+Caused by: org.postgresql.util.PSQLException: FATAL: password authentication failed for user "openbank_settlement"
+EOF
+  cat > "${ST_TMP}/timeout.log" <<'EOF'
+05:49:09 INFO  [tc.do.io.24.0] Pulling docker image: docker.io/grafana/otel-lgtm:0.24.0. Please be patient; this may take some time but only needs to be done once.
+05:49:26 DEBUG [co.gi.do.ap.co.PullImageResultCallback] ResponseItem(stream=null, status=Extracting, progressDetail=ResponseItem.ProgressDetail(current=583794688,total=638658233))
+EOF
+  out1="$(classify_boot_failure svc-crash "authz ON" "${ST_TMP}/crash.log" 180 2>&1)"
+  case "${out1}" in
+    *"CRASHED during boot"*) ;;
+    *) echo "SELF-TEST FAIL 1: a real crash was not classified as a crash"; ST_RC=1 ;;
+  esac
+  case "${out1}" in
+    *"password authentication failed"*) ;;
+    *) echo "SELF-TEST FAIL 1b: the crash cause was not printed"; ST_RC=1 ;;
+  esac
+  out2="$(classify_boot_failure svc-timeout "authz OFF" "${ST_TMP}/timeout.log" 180 2>&1)"
+  case "${out2}" in
+    *"CRASHED"*) echo "SELF-TEST FAIL 2: an unfinished image pull was reported as a crash"; ST_RC=1 ;;
+  esac
+  case "${out2}" in
+    *"DID NOT FINISH"*"TIMEOUT, not a crash"*) ;;
+    *) echo "SELF-TEST FAIL 2b: a timeout was not named as one"; ST_RC=1 ;;
+  esac
+  case "${out2}" in
+    *"dev services should be OFF"*) ;;
+    *) echo "SELF-TEST FAIL 2c: the image pull was not named as the environmental cause"; ST_RC=1 ;;
+  esac
+  # Anchored to the CONTINUED command-line form, not the bare string: the string also occurs in
+  # this file's header and in this very check, so an unanchored grep matches itself and the
+  # control can never fail. (It could not, until it was falsified — measured, not assumed.)
+  if ! grep -qE '^[[:space:]]+-Dquarkus\.devservices\.enabled=false \\$' "$0"; then
+    echo "SELF-TEST FAIL 3: quarkusDev no longer disables dev services"; ST_RC=1
+  fi
+  rm -rf "${ST_TMP}"
+  [ "${ST_RC}" = 0 ] && echo "self-test OK (3 controls)" || echo "self-test FAILED"
+  exit "${ST_RC}"
+fi
 
 mkdir -p fuzz-reports
 OVERALL=0
@@ -231,6 +334,7 @@ for svc in $SERVICES; do
       -Dquarkus.datasource.username="${DBUSER}" \
       -Dquarkus.datasource.password="${POSTGRES_PASSWORD}" \
       "${WORKER_FLAGS[@]}" "$@" \
+      -Dquarkus.devservices.enabled=false \
       -Dquarkus.console.basic=true \
       --console=plain --quiet \
       > "fuzz-reports/${svc}-boot${logsuffix}.log" 2>&1 &
@@ -251,8 +355,13 @@ for svc in $SERVICES; do
     done
 
     if [ "$UP" != "1" ]; then
-      echo "::error::[${svc}] failed to boot (${label}) — see ${svc}-boot${logsuffix}.log artifact"
-      tail -50 "fuzz-reports/${svc}-boot${logsuffix}.log" || true
+      # "failed to boot" is TWO states with opposite fixes, and printing one message for both is
+      # how this lane spent eighteen days reporting a broken harness (#6492). A CRASH leaves a
+      # terminal failure in the boot log and needs a code or config fix; a TIMEOUT leaves a JVM
+      # still working — its log ends mid-progress, its ERROR grep prints nothing, and the fix is
+      # time or one less container. Classify from the LOG, never from $DEV_PID (see the wait
+      # comment above for why the PID is not a liveness proxy).
+      classify_boot_failure "${svc}" "${label}" "fuzz-reports/${svc}-boot${logsuffix}.log" "${WAITED}"
       OVERALL=1
     else
       echo "==> [${svc}] answered after ${WAITED}s (${label}); fuzzing http://localhost:${PORT}"

--- a/.github/workflows/api-fuzz.yml
+++ b/.github/workflows/api-fuzz.yml
@@ -67,6 +67,13 @@ jobs:
       # a service that becomes money-path is fuzzed the day rules.yaml says so. A service that
       # cannot be fuzzed is EXCLUDED OUT LOUD with its reason — a silently shortened list reads as
       # "covered" when it is not, which is the failure this whole issue is about.
+      # The harness's boot-failure CLASSIFIER, exercised against a known crash and a known
+      # timeout before the matrix runs. #6492 was eighteen days of a timeout reported as a
+      # failure; a diagnostic that has only ever printed one message cannot be trusted to tell
+      # the two apart, so prove it here rather than assume it. ~0.1s.
+      - name: Self-test the fuzz harness diagnostics
+        run: .github/scripts/fuzz-services.sh --self-test
+
       - name: Derive service list
         id: derive
         env:


### PR DESCRIPTION
Closes #6492

## The runs did not fail. They did not finish.

Six scheduled runs, 2026-08-04 to 2026-08-20, 5–11 red jobs each in a different
combination every time. The decisive line is the same in every failing job I read: the
last thing the script prints is `starting quarkusDev`, and ~180 s later the readiness
loop gives up. What the boot log is doing at that instant is the whole answer.

| run | date | sampled job | decisive evidence | verdict |
|---|---|---|---|---|
| 32336553304 | 08-20 | sca-service | `Extracting 583794688/638658233` of `docker.io/grafana/otel-lgtm` at 05:49:28, the second the loop expired | **timed out** |
| 32336553304 | 08-20 | settlement-service | `FlywaySqlUnableToConnectToDbException: … FATAL: password authentication failed for user "openbank_settlement"` | **failed** (already fixed on main by #5884) |
| 32336553304 | 08-20 | ledger-service | boot artifact 180 bytes — no boot log at all inside the budget | **timed out** |
| 32336553304 | 08-20 | dispute-service | tail is `Removed unused … bean` CDI DEBUG — augmentation still running | **timed out** |
| 32103867665 | 08-18 | consent-service | `Selected: 13/13` … `❌ Server error: 2` | **finished, real finding** |
| 31672218945 | 08-13 | sepa-payment | pull of `…638658233` in the tail | **timed out** |
| 31083072870 | 08-06 | clearing-service / sepa-instant | `otel-lgtm` / `…638658233` in the tail | **timed out** |
| 31462872662 / 30890107900 | 08-11 / 08-04 | domestic-payment, sepa-payment, transaction | `failed to boot` + pull-progress tail, no terminal failure in the log | **timed out** |

The logs are not byte-identical, but the *shape* is: `::error::[svc] failed to boot`
followed by 50 lines of docker-pull progress and no cause. Quarkus dev mode starts a
container for anything it believes unconfigured; on a cold hosted runner the 638 MB
`grafana/otel-lgtm` pull is what blows the window. Nothing in it is reachable from the
fuzzed HTTP surface.

The shifting failure set was never a signal about any service. It was which jobs lost
that morning's race to Docker Hub.

## Harness, not subject — with one exception that proves the cost

Fourteen of the fifteen failing jobs I sampled are the harness. One is not:
**openbank-consent-service, run 32103867665, `Server error: 2` over `Selected: 13/13`** —
a genuine finding about the unauthenticated surface, sitting in a run that reads at a
glance as "the fuzz lane is broken again". That is exactly the conflation this PR
removes: a real finding and a harness timeout were indistinguishable at run level.

## Would a real finding have been visible?

Only by accident. A job that dies before `schemathesis run` produces a 180-byte artifact
and no junit XML, so the only downstream reader — the artifact — is empty and silent.
For the ~18 days in question the answer is: a regression on the unauthenticated surface
of any service that lost the pull race would not have been caught.

## Same defect, already fixed next door

`#4703` (merged 2026-08-14) fixed precisely this on `api-fuzz-authenticated.yml`, citing
the same image and the same misattribution. It was never carried across to this lane.
`#5763` (merged 08-22) and `#5884` (merged 08-23) both post-date every failing scheduled
run, so neither could have fixed them; `#5884` did fix settlement's real password
failure, and `#5763` moved the compile out of the readiness budget — necessary, and not
sufficient, because the pull is what remained inside it. `#5849` is still open and
touches scope/attestations, not boot. Compared by content, not title.

## What changed

- `-Dquarkus.devservices.enabled=false` on both `quarkusDev` passes.
- The readiness diagnostic split into CRASH vs TIMEOUT, classified from the boot log
  (never from `$DEV_PID` — #5763 established the launcher can exit under a healthy
  service). A crash prints its `Caused by:` chain; a timeout says it is a timeout and
  names an in-flight image pull if one is there.
- `fuzz-services.sh --self-test`, run in the workflow's `prepare` job.

## Prove it by what it prevents

Both controls were run by mutating the real script in place and reading `$?` from a
redirected run, not from a pipeline.

```
POSITIVE                                                      RC=0   self-test OK (3 controls)

NEG-A  remove -Dquarkus.devservices.enabled=false from the
       quarkusDev command line                                RC=1
       SELF-TEST FAIL 3: quarkusDev no longer disables dev services

NEG-B  restore the pre-fix diagnostic (one message + tail -50) RC=1
       SELF-TEST FAIL 1:  a real crash was not classified as a crash
       SELF-TEST FAIL 2b: a timeout was not named as one
       SELF-TEST FAIL 2c: the image pull was not named as the environmental cause
```

Control 3 was itself vacuous on first writing — `grep -q 'Dquarkus.devservices.enabled=false'`
matches the header prose and the check's own line, so it passed with the switch deleted
(measured: NEG-A returned 0). It is now anchored to the continued command-line form, and
NEG-A goes red.

## Verified / not verified

- `run-gates.py --all` on the branch: 7 failures, byte-identical id-for-id to a pristine
  `origin/main` control worktree (`litellm-config-revision`, `loki-rule-load-test`,
  `release-scope-mismatch`, `api-contract`, `db-migration`, `schema-compat`,
  `threat-model-updated-on-trust-boundary-change`) — the documented environmental set.
- `actionlint .github/workflows/api-fuzz.yml` → 0. `shellcheck -S warning` → 0. `bash -n` → 0.
- **Not verified:** no live matrix run. The classifier is proven against captured real
  logs; that dev services staying off keeps every service inside the budget can only be
  shown by the next scheduled run (Tue 05:30 UTC) or a dispatch.

## The control nobody was reading

Six consecutive scheduled failures over eighteen days, on the lane that fuzzes the
surface reachable without a credential, and the issue was opened on day nineteen. The
lane is *futile*, not dead: it fires on time, the Actions list looks busy, nothing is
stuck. Nothing anywhere alerts on a scheduled workflow whose last N runs all failed, and
the fuzz artifacts have no reader, so the only detection path was a human scrolling the
Actions tab. Worth a follow-up; deliberately out of scope here.
