### PR TITLE
fix(deploy): stop calling a live provider version "contentless" at can-i-deploy

### DIFF
--- a/.github/scripts/can-i-deploy-gate.sh
+++ b/.github/scripts/can-i-deploy-gate.sh
@@ -74,13 +74,30 @@ if [ ! -x "$CLI" ]; then
 else
   echo "  ✓ pact CLI restored from cache ($CLI)"
 fi
-# Ensure sandbox environment is registered — idempotent, 409 = already exists.
-"$CLI" create-environment --name sandbox --display-name Sandbox --no-production \
-  --broker-base-url "$PACT_BROKER_URL" \
-  --broker-username "$PACT_BROKER_USERNAME" \
-  --broker-password "$PACT_BROKER_PASSWORD" \
-  && echo "  ✓ sandbox environment ready" \
-  || echo "::warning::could not ensure sandbox environment (may already exist — continuing)"
+# Ensure the sandbox environment is registered.
+#
+# This was written as "idempotent, 409 = already exists" and is not: the broker answers a
+# duplicate name with 400 and a validation body, so on every single run after the first this
+# printed
+#   Error making request to <broker>/environments status=400
+#   {"errors":{"name":["name 'sandbox' is already used by an existing environment."]}}
+#   ::warning::could not ensure sandbox environment (may already exist — continuing)
+# — a red-looking error and a warning, in the one log a person reads while a deploy is stuck,
+# describing the NORMAL state (#6568). A real broker outage produces the same two lines, so the
+# noise also costs the signal. Look first, and only create when it is genuinely missing; a
+# failure to LOOK is still a warning, because then the create is the fallback.
+env_auth="${PACT_BROKER_USERNAME}:${PACT_BROKER_PASSWORD}"
+if envs_body="$(curl -sf --max-time 20 -u "$env_auth" "${PACT_BROKER_URL}/environments" 2>/dev/null)" \
+   && printf '%s' "$envs_body" | jq -e '[.._embedded?, .environments?] | flatten | map(select(.name? == "sandbox")) | length > 0' >/dev/null 2>&1; then
+  echo "  ✓ sandbox environment already registered"
+else
+  "$CLI" create-environment --name sandbox --display-name Sandbox --no-production \
+    --broker-base-url "$PACT_BROKER_URL" \
+    --broker-username "$PACT_BROKER_USERNAME" \
+    --broker-password "$PACT_BROKER_PASSWORD" \
+    && echo "  ✓ sandbox environment created" \
+    || echo "::warning::could not ensure sandbox environment (may already exist — continuing)"
+fi
 rc=0
 deployable_list=()
 # Shared wait budget for probe-pact-version.sh (#3082). See that script's header.

--- a/.github/scripts/classify-can-i-deploy-block.sh
+++ b/.github/scripts/classify-can-i-deploy-block.sh
@@ -191,6 +191,21 @@ fi
 #    pacts is unverifiable no matter what the consumer did. Run 31080511057 is the worked
 #    example — PACT_VERSION_PRESENT was `no` for all six blocked services, so every one
 #    reported PENDING_BUILD and promised a reconcile that could not deliver.
+# #6568: a counterpart version that publishes no pacts but DOES carry verification results is
+# a live PROVIDER version, not the #3223 bookkeeping shape. It is still durable — the 3-hourly
+# reconciler asks whether the provider's LATEST MAIN version owes a verification, while
+# can-i-deploy asks about the version currently DEPLOYED IN THE ENVIRONMENT, and a provider that
+# is not itself deploying never gains a new verification at that older sha. But the remedy is the
+# opposite of UNVERIFIABLE's: publish the missing verification AT that sha, which is exactly what
+# verify-provider.yml's `ref` input exists for ("a counterpart's deployed sha"). Telling an
+# operator to redeploy a healthy provider instead is what kept six services (four money-path)
+# blocked for 40 hours on run 32599859753.
+if [ "$CP_STATE" = "provider-live" ]; then
+  cp_svc="${CP_DETAIL%%@*}"; cp_ref="${CP_DETAIL##*@}"; cp_ref="${cp_ref%%,*}"
+  emit PROVIDER_UNVERIFIED "the counterpart version deployed in the environment has published no verification result for this pact — ${CP_DETAIL:-see the verdict}. That version is NOT contentless: it carries verification results for other consumers, so it is a live provider version and this is not the #3223 shape. It is still not self-clearing — the reconciler (pact-verification-reconcile.yml) asks about the provider's LATEST main version, not the version deployed in the environment. Remedy: gh workflow run verify-provider.yml -f service=${cp_svc} -f ref=${cp_ref}"
+  exit 0
+fi
+
 if [ "$CP_STATE" = "contentless" ]; then
   emit UNVERIFIABLE "blocked on counterpart version(s) that carry ZERO pacts — ${CP_DETAIL:-see the verdict}. No verification run targets a version with no pacts, so this will NOT clear on its own and waiting for a reconcile tick cannot help (#3223). The counterpart has to be deployed at a version that actually published pacts, or co-deployed with ${SVC}"
   exit 0

--- a/.github/scripts/derive-codeploy-set.py
+++ b/.github/scripts/derive-codeploy-set.py
@@ -113,7 +113,11 @@ PAIR_LINE = ("There is no verified pact", "The verification for the pact between
 # with one that has pacts. Before this class existed these same blocks arrived as UNVERIFIED
 # (already eligible) or as PENDING_BUILD (excluded, and mislabelled), so the allow-list
 # entry keeps the honest half of today's behaviour rather than widening it.
-CODEPLOY_CLASSES = ("UNVERIFIED", "REGRESSION", "UNVERIFIABLE")
+# PROVIDER_UNVERIFIED (#6568) is eligible for the same reason UNVERIFIABLE is: a co-deploy that
+# includes the provider republishes verifications at the version being deployed, which is exactly
+# what the block is missing. Omitting it would not be neutral — an unlisted class falls through
+# every branch below and the set analysis silently stops mentioning those services at all.
+CODEPLOY_CLASSES = ("UNVERIFIED", "REGRESSION", "UNVERIFIABLE", "PROVIDER_UNVERIFIED")
 TRANSIENT_CLASSES = ("PENDING_BUILD",)
 
 # NOT_ASKED (#3454) is ineligible for a set by construction — CODEPLOY_CLASSES is an

--- a/.github/scripts/probe-blocking-counterparts.sh
+++ b/.github/scripts/probe-blocking-counterparts.sh
@@ -35,6 +35,25 @@
 # helping, is worse than no message: it is the reason four deploy-drift issues sat open
 # while money-path services fell five patch releases behind.
 #
+# WHY "ZERO PACTS" IS NOT BY ITSELF THE #3223 SHAPE (#6568)
+# `pb:pact-versions` counts the pacts a version published AS A CONSUMER. A version that is
+# only ever a PROVIDER in the pairs that block — openbank-product-catalog and
+# openbank-document-service are exactly that — legitimately publishes zero of them, and
+# reporting `contentless` for it is a false positive with an actively wrong remedy: the
+# message told operators to redeploy or co-deploy a counterpart that was already perfectly
+# healthy. Measured on run 32599859753: openbank-product-catalog@af04613a was called
+# "ZERO pacts ... no verification run targets it" for six services, while in the SAME log
+# openbank-card-issuance-service passed against `openbank-product-catalog | af04613... |
+# true` (verification-results/42274). A version that has verified somebody is not a version
+# nothing can verify. Six services (four money-path) sat blocked behind that sentence for
+# 40 hours.
+#
+# So the probe now asks a SECOND question of a zero-pact version: does the broker matrix
+# hold any verification result published at it? If yes it is a live provider version
+# (`provider-live`) whose real remedy is to publish the missing verification at that exact
+# sha — `verify-provider.yml` takes `ref` for precisely this ("a counterpart's deployed
+# sha"). If no, it is the #3223 bookkeeping version and nothing changes.
+#
 # WHAT THIS DOES
 # Reads a can-i-deploy CLI output on stdin, extracts every (counterpart, version) pair the
 # verdict names as currently deployed, and asks the broker one question per pair: does that
@@ -51,6 +70,11 @@
 # Prints ONE tab-separated line: <state>\t<detail>
 #   contentless  at least one named counterpart version carries no pacts at all. Durable:
 #                no reconcile tick can clear it. <detail> lists them as <svc>@<sha8>.
+#   provider-live
+#                at least one named counterpart version publishes NO pacts but DOES carry
+#                verification results — i.e. it is a live PROVIDER version, not a bookkeeping
+#                one. Durable in a different way, with a different remedy (#6568). <detail>
+#                lists them as <svc>@<sha8>.
 #   has-pacts    every named counterpart version has pacts, so the missing piece really is
 #                a verification result and waiting may genuinely help.
 #   none         the output names no counterpart version — nothing to say about it.
@@ -91,14 +115,30 @@ probe_one() { # <service> <sha> -> prints: contentless | has-pacts | unknown
   # probe failure, not an answer.
   n="$(printf '%s' "$body" | jq -r '(._links["pb:pact-versions"] // []) | length' 2>/dev/null)" || { echo unknown; return; }
   case "$n" in
+    ''|*[!0-9]*) echo unknown; return ;;
+    0)           : ;;
+    *)           echo has-pacts; return ;;
+  esac
+  # Zero pacts is ambiguous (#6568): a bookkeeping version and a provider-only version look
+  # identical here. Ask the matrix whether ANY verification result was published at this
+  # version. -g (--globoff) is required: the `q[][pacticipant]` parameter contains brackets,
+  # which curl would otherwise read as a URL glob and refuse.
+  local mbody mcount
+  mbody="$(curl -sfg --max-time 20 -u "$auth" \
+    "${PACT_BROKER_URL:-}/matrix?q[][pacticipant]=${svc}&q[][version]=${sha}&latestby=cvpv" 2>/dev/null)" \
+    || { echo unknown; return; }
+  mcount="$(printf '%s' "$mbody" \
+    | jq -r '[(.matrix // [])[] | select(.verificationResult != null)] | length' 2>/dev/null)" \
+    || { echo unknown; return; }
+  case "$mcount" in
     ''|*[!0-9]*) echo unknown ;;
     0)           echo contentless ;;
-    *)           echo has-pacts ;;
+    *)           echo provider-live ;;
   esac
 }
 
 run() {
-  local out pairs seen_any=0 saw_unknown=0 contentless=()
+  local out pairs seen_any=0 saw_unknown=0 contentless=() provider_live=()
   out="$(cat)"
   # sed -E over grep -oE: we need two capture groups per match, and BSD grep has no -P.
   pairs="$(printf '%s\n' "$out" \
@@ -111,12 +151,21 @@ run() {
     [ -n "${cp:-}" ] || continue
     seen_any=1
     case "$(probe_one "$cp" "$sha")" in
-      contentless) contentless+=("${cp}@${sha:0:8}") ;;
-      unknown)     saw_unknown=1 ;;
+      contentless)   contentless+=("${cp}@${sha:0:8}") ;;
+      provider-live) provider_live+=("${cp}@${sha}") ;;
+      unknown)       saw_unknown=1 ;;
     esac
   done <<< "$pairs"
   if [ "${#contentless[@]}" -gt 0 ]; then
     printf 'contentless\t%s\n' "$(IFS=,; echo "${contentless[*]}")"
+    return
+  fi
+  # provider-live outranks `unknown` and `has-pacts`: it is a definite fact about a definite
+  # counterpart, and its message carries no self-clearing promise, so naming it cannot restore
+  # the false reassurance this script exists to remove. It stays BELOW contentless, which is
+  # the strictly worse state.
+  if [ "${#provider_live[@]}" -gt 0 ]; then
+    printf 'provider-live\t%s\n' "$(IFS=,; echo "${provider_live[*]}")"
     return
   fi
   if [ "$saw_unknown" -eq 1 ] || [ "$seen_any" -eq 0 ]; then
@@ -135,7 +184,17 @@ if [ "${1:-}" = "--self-test" ] || [ "${1:-}" = "--selftest" ]; then
 #!/usr/bin/env bash
 url="${@: -1}"
 case "$url" in
-  *openbank-empty-service/versions/*)  echo '{"_links":{"pb:pact-versions":[]}}' ;;
+  # The matrix probe (#6568) — must be matched BEFORE the version endpoints, since both
+  # carry the service name. `openbank-empty-service` is the #3223 bookkeeping version: no
+  # pacts AND no verification results. `openbank-provider-service` is the shape #6568 was
+  # about: no pacts, but verification results published at that exact version.
+  *matrix*openbank-provider-service*) echo '{"matrix":[{"verificationResult":{"success":true}}]}' ;;
+  *matrix*openbank-empty-service*)    echo '{"matrix":[{"verificationResult":null}]}' ;;
+  *matrix*openbank-matrixless-service*) exit 7 ;;
+  *matrix*)                           echo '{"matrix":[]}' ;;
+  *openbank-empty-service/versions/*)    echo '{"_links":{"pb:pact-versions":[]}}' ;;
+  *openbank-provider-service/versions/*) echo '{"_links":{"pb:pact-versions":[]}}' ;;
+  *openbank-matrixless-service/versions/*) echo '{"_links":{"pb:pact-versions":[]}}' ;;
   *openbank-full-service/versions/*)   echo '{"_links":{"pb:pact-versions":[{"name":"a"}]}}' ;;
   *openbank-broken-service/versions/*) echo 'not json at all' ;;
   *)                                   exit 7 ;;
@@ -164,6 +223,28 @@ STUB
   case_is "mixed contentless + healthy"    contentless "$(line_for openbank-full-service "$S40_A"; line_for openbank-empty-service "$S40_A")"
   case_is "mixed contentless + unknown"    contentless "$(line_for openbank-missing-service "$S40_A"; line_for openbank-empty-service "$S40_A")"
   case_is "healthy + unknown is unknown"   unknown     "$(line_for openbank-full-service "$S40_A"; line_for openbank-missing-service "$S40_A")"
+  # ── #6568 ────────────────────────────────────────────────────────────────────────────
+  # THE NEGATIVE CONTROL FOR THIS CHANGE. A version with no pacts and no verification
+  # results must STILL be `contentless` — the fix must not make #3223 unreportable. That is
+  # the "counterpart with 0 pacts" case above, which now reaches its verdict through the
+  # matrix probe; it is asserted again here next to its twin so the pair reads as one test.
+  case_is "0 pacts + 0 verifications"      contentless   "$(line_for openbank-empty-service "$S40_A")"
+  # ... and a version with no pacts but verification results published AT IT is a live
+  # provider version, not a bookkeeping one. This is the case that mislabelled six services.
+  case_is "0 pacts + verifications"        provider-live "$(line_for openbank-provider-service "$S40_A")"
+  # contentless still DOMINATES provider-live: one genuinely unverifiable counterpart makes
+  # the block durable regardless of a healthy sibling.
+  case_is "contentless beats provider-live" contentless  "$(line_for openbank-provider-service "$S40_A"; line_for openbank-empty-service "$S40_A")"
+  # A matrix probe that fails is a probe failure, not a verdict — it must not degrade to
+  # either `contentless` or `provider-live`.
+  case_is "matrix probe fails is unknown"  unknown       "$(line_for openbank-matrixless-service "$S40_A")"
+  # provider-live outranks a failed probe elsewhere, but carries no self-clearing promise.
+  case_is "provider-live beats unknown"    provider-live "$(line_for openbank-missing-service "$S40_A"; line_for openbank-provider-service "$S40_A")"
+  # The detail must carry the FULL 40-hex sha: the remedy is a verify-provider dispatch at
+  # that exact ref, and a truncated sha is not something an operator can paste.
+  pdetail="$(PATH="$self_tmp:$PATH" bash "$me_abs" <<< "$(line_for openbank-provider-service "$S40_A")" | cut -f2)"
+  if [ "$pdetail" = "openbank-provider-service@${S40_A}" ]; then echo "  ok   provider-live detail carries the full sha"
+  else echo "  FAIL provider-live detail carries the full sha: got '${pdetail}'"; fails=$((fails + 1)); fi
   # A short sha, or a phrasing without one, must not be read as a version to probe.
   case_is "short sha is not a version"     none        "and the version of openbank-empty-service currently in sandbox (a5e5d32a)"
   # The detail field must NAME the unverifiable versions — the whole point is that an

--- a/.github/scripts/test-classify-can-i-deploy-block.sh
+++ b/.github/scripts/test-classify-can-i-deploy-block.sh
@@ -191,6 +191,57 @@ case "$msg_unk" in
   *) echo "  FAIL unprobed counterparts do not qualify the promise: ${msg_unk}"; fails=$((fails + 1)) ;;
 esac
 
+# ── issue #6568: provider-live is a THIRD counterpart state, not a flavour of contentless ──
+# The six services blocked for 40 hours on run 32599859753 all reached UNVERIFIABLE through
+# COUNTERPART_STATE=contentless on a counterpart that was demonstrably verifiable. These cases
+# pin the new state's class, its precedence, and — the load-bearing part — that its message
+# carries a runnable remedy rather than the advice to redeploy a healthy provider.
+PL_DETAIL="openbank-product-catalog@af04613a74c7d2cb27baf1b681448ebd3e3c7c33"
+check_pl() { # <name> <want> <present> [event]
+  local name="$1" want="$2" present="$3" event="${4:-}" got
+  got="$(PACT_VERSION_PRESENT="$present" EVENT_NAME="$event" COUNTERPART_STATE=provider-live \
+    COUNTERPART_DETAIL="$PL_DETAIL" bash "$CLASSIFY" openbank-demo-service <<< "$NO_VERIFIED_PACT" | cut -f1)"
+  if [ "$got" = "$want" ]; then echo "  ok   ${name} → ${got}"
+  else echo "  FAIL ${name}: want ${want}, got ${got}"; fails=$((fails + 1)); fi
+}
+check_pl "provider-live beats PENDING_BUILD" PROVIDER_UNVERIFIED no
+check_pl "provider-live beats UNVERIFIED"    PROVIDER_UNVERIFIED yes
+# It must NOT be UNVERIFIABLE — that is the exact mislabel #6568 is about, and the one a
+# "simplification" back to a single contentless branch would reintroduce.
+got_pl="$(PACT_VERSION_PRESENT=no COUNTERPART_STATE=provider-live COUNTERPART_DETAIL="$PL_DETAIL" \
+  bash "$CLASSIFY" openbank-demo-service <<< "$NO_VERIFIED_PACT" | cut -f1)"
+if [ "$got_pl" = "UNVERIFIABLE" ]; then
+  echo "  FAIL provider-live must not be labelled UNVERIFIABLE (#6568)"; fails=$((fails + 1))
+else
+  echo "  ok   provider-live is not UNVERIFIABLE"
+fi
+# A REGRESSION still outranks it: an observed verification FAILURE is not a missing one.
+got_plr="$(PACT_VERSION_PRESENT=yes COUNTERPART_STATE=provider-live COUNTERPART_DETAIL="$PL_DETAIL" \
+  bash "$CLASSIFY" openbank-demo-service <<< "$VERIFICATION_FAILED" | cut -f1)"
+if [ "$got_plr" = "REGRESSION" ]; then echo "  ok   regression outranks provider-live → REGRESSION"
+else echo "  FAIL regression outranks provider-live: got ${got_plr}"; fails=$((fails + 1)); fi
+# The message is the whole point: it must name a runnable dispatch at the counterpart's exact
+# deployed sha, and must not repeat either self-clearing promise.
+msg_pl="$(PACT_VERSION_PRESENT=no COUNTERPART_STATE=provider-live COUNTERPART_DETAIL="$PL_DETAIL" \
+  bash "$CLASSIFY" openbank-demo-service <<< "$NO_VERIFIED_PACT" | cut -f2-)"
+case "$msg_pl" in
+  *"verify-provider.yml -f service=openbank-product-catalog -f ref=af04613a74c7d2cb27baf1b681448ebd3e3c7c33"*)
+    echo "  ok   PROVIDER_UNVERIFIED names a runnable remedy at the exact sha" ;;
+  *) echo "  FAIL PROVIDER_UNVERIFIED remedy is not runnable: ${msg_pl}"; fails=$((fails + 1)) ;;
+esac
+if grep -qE 'clears within one reconcile|re-drives it automatically' <<< "$msg_pl"; then
+  echo "  FAIL PROVIDER_UNVERIFIED repeats a self-clearing promise: ${msg_pl}"; fails=$((fails + 1))
+else
+  echo "  ok   PROVIDER_UNVERIFIED makes no self-clearing promise"
+fi
+# ...and it must not repeat UNVERIFIABLE's remedy, which is the wrong action for a healthy
+# provider and is what kept #6568 open.
+if grep -q 'deployed at a version that actually published pacts' <<< "$msg_pl"; then
+  echo "  FAIL PROVIDER_UNVERIFIED repeats UNVERIFIABLE's redeploy advice: ${msg_pl}"; fails=$((fails + 1))
+else
+  echo "  ok   PROVIDER_UNVERIFIED does not advise redeploying a healthy provider"
+fi
+
 # 7. Missing argument is a usage error, not a silent classification.
 if PACT_VERSION_PRESENT=no bash "$CLASSIFY" </dev/null >/dev/null 2>&1; then
   echo "  FAIL missing-service-arg: expected non-zero exit"


### PR DESCRIPTION
## The direction of the failure

Fail-**closed**. Nine services were refused a deploy; nothing bad reached sandbox. The block was
live and unchanged 40 hours after it started, so this is not a transient.

Decisive line, run [32599859753](https://github.com/JiRaska/open-bank-oss/actions/runs/32599859753),
repeated verbatim on [32677306449](https://github.com/JiRaska/open-bank-oss/actions/runs/32677306449)
(2026-08-24 00:38Z, `Deployable this run: []`):

```
can-i-deploy: openbank-account-service NOT deployable [UNVERIFIABLE] — blocked on counterpart
version(s) that carry ZERO pacts — openbank-product-catalog@af04613a. No verification run targets
a version with no pacts, so this will NOT clear on its own ... The counterpart has to be deployed
at a version that actually published pacts, or co-deployed with openbank-account-service
```

## The nine are two causes, not one

| services | class | verdict |
|---|---|---|
| account, interest, lending (product-catalog@af04613a) · sepa-payment, domestic-payment, statement (document-service@ee974ea3) | `UNVERIFIABLE` | **wrong** — fixed here |
| billing (product-catalog) · campaign, engagement (consent-service@75720e3) | `REGRESSION` | **correct** — real failed verifications, root cause filed as #6689 |

### Six of them were misdiagnosed

`probe-blocking-counterparts.sh` counts `_links["pb:pact-versions"]` on the counterpart version
and reads `0` as "nothing can ever verify this" (#3223). That link counts pacts published **as a
consumer**. `openbank-product-catalog` and `openbank-document-service` are only ever the
*provider* in these pairs, so they legitimately publish zero — and being a provider is precisely
what makes them verifiable.

The same log disproves the claim it printed. Three lines after account-service was told
product-catalog@af04613a carries zero pacts and nothing can verify it:

```
openbank-card-issuance-service | f41b037... | openbank-product-catalog | af04613... | true | 2
  ✓ openbank-card-issuance-service deployable
```

`verification-results/42274`, published at that exact version. A version that has verified
somebody is not a version nothing can verify.

The cost was not the red — it was the remedy. The message told an operator to redeploy or
co-deploy a healthy provider, which is not a thing anyone would do, so nobody did anything, and
six services (four money-path) sat still for 40 hours.

## The change

A zero-pact counterpart version is now asked a second question: does the broker matrix hold any
verification result published *at that version*?

- **yes** → new state `provider-live` → class `PROVIDER_UNVERIFIED`, whose message says what to
  actually run: `gh workflow run verify-provider.yml -f service=<counterpart> -f ref=<deployed sha>`.
  That `ref` input already documents itself as "a counterpart's deployed sha" — the remedy
  existed, the log just never pointed at it.
- **no** → `contentless` → `UNVERIFIABLE`, exactly as before. #3223 stays reportable.
- **probe fails** → `unknown`. Unchanged safe direction.

`PROVIDER_UNVERIFIED` makes **no** self-clearing promise, and that is deliberate: the 3-hourly
reconciler asks whether the provider's *latest main* version owes a verification, while
`can-i-deploy` asks about the version *deployed in the environment*. A provider that is not
itself deploying never gains a verification at that older sha, so the block is durable — just
durable for a different reason, with a different fix, than the message claimed.

Also: `create-environment --name sandbox` ran unconditionally every run, and the broker answers a
duplicate name with **400**, not the 409 the comment assumed. Every run after the first printed an
`Error making request ... status=400` plus a warning, describing the normal state, in the one log
someone reads while a deploy is stuck. Now it looks first.

## Prove it by what it prevents

This cannot become a fail-open, structurally: the classifier is reachable only from the terminal
`else` of the per-service loop, which sets `rc=1` and never appends to `deployable_list`. All four
`deployable_list+=` sites (lines 231, 270, 278, 291) are upstream of and mutually exclusive with
it. No class value can make anything deployable — the change is diagnosis-only.

Three negative controls, each run with output redirected to a file and `$?` read directly:

| control | what was broken | exit |
|---|---|---|
| baseline, fix in place | — | `0` (16/16 probe cases, whole classifier suite) |
| revert `probe_one` to `0 → contentless` | the fix itself | **`1`** — 4 failures, incl. `0 pacts + verifications: want provider-live, got contentless` |
| collapse `contentless` into `provider-live` | #3223 becomes unreportable | **`1`** — `contentless counterpart beats PENDING_BUILD: want UNVERIFIABLE, got PROVIDER_UNVERIFIED` |
| move `provider-live` above the regression rule | a real contract break gets hidden | **`1`** — `regression outranks provider-live: got PROVIDER_UNVERIFIED` |

So: a genuinely unverifiable counterpart is **still** refused, a genuinely failed verification is
**still** REGRESSION and still fails a scheduled tick, and the only thing that changed is what the
log tells you to do about the third case.

`PROVIDER_UNVERIFIED` is added to `derive-codeploy-set.py`'s `CODEPLOY_CLASSES` on purpose — an
unlisted class falls through every branch there, and the set analysis would silently stop
mentioning those services at all.

## Verified / not verified

Verified: `run-gates.py --all` on this branch — the four `can-i-deploy` unit-test gates,
`shellcheck` and `workflow-run-step-size` all PASS. Seven gates fail; all seven fail **identically**
on a pristine `git worktree add --detach <tmp> origin/main` control (five diff-scoped gates plus
`loki-rule-load-test` want CI-only variables, and `litellm-config-revision` is pre-existing).

**Not** verified: the broker itself. `https://pact.open-bank.tech/` answers `401` from here and I
hold no credential, so every broker interaction is stubbed. The matrix response shape
(`.matrix[].verificationResult`) is asserted against a stub, not against the live broker — that is
the one thing a maintainer should sanity-check on the first real run.

## This does not unblock the deploy by itself

It cannot: the fix corrects what the gate *says*, and the nine services need actions I am not
going to take (they mutate the broker and start builds).

```
gh workflow run verify-provider.yml -f service=openbank-product-catalog  -f ref=af04613a74c7d2cb27baf1b681448ebd3e3c7c33
gh workflow run verify-provider.yml -f service=openbank-document-service -f ref=ee974ea3c2c7f4b37e53bf1603b944c9726b4b12
```

That should clear all six `UNVERIFIABLE`/`PROVIDER_UNVERIFIED` blocks at once. The three
`REGRESSION` blocks need a contract decision — see #6689, which is also why they were not caught
before #6505 merged.

Refs #6568
Refs #6689
