### PR TITLE
fix(admin-ui): clarify swift raw disclosure

### DIFF
--- a/openbank-admin-ui/src/app/swift/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/swift/[id]/page.tsx
@@ -115,13 +115,13 @@ export default function SwiftDetailPage() {
             ]} />
           </div>
           <div className="card" style={{ gridColumn: '1 / -1' }}>
-            <button onClick={() => setShowRaw(s => !s)}
+            <button type="button" aria-expanded={showRaw} aria-controls="swift-raw-payload" aria-label={showRaw ? t('Skrýt surový payload', 'Hide raw payload') : t('Zobrazit surový payload', 'Show raw payload')} onClick={() => setShowRaw(s => !s)}
               style={{ width: '100%', display: 'flex', alignItems: 'center', gap: '6px', padding: '12px 18px', background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)', fontSize: '13px', fontWeight: 600 }}>
-              {showRaw ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+              {showRaw ? <ChevronDown size={14} aria-hidden="true" /> : <ChevronRight size={14} aria-hidden="true" />}
               {t('Surová data (JSON)', 'Raw payload (JSON)')}
             </button>
             {showRaw && (
-              <pre style={{ margin: 0, padding: '0 18px 18px', fontSize: '11px', fontFamily: 'var(--font-mono)', color: 'var(--text-secondary)', overflowX: 'auto' }}>
+              <pre id="swift-raw-payload" style={{ margin: 0, padding: '0 18px 18px', fontSize: '11px', fontFamily: 'var(--font-mono)', color: 'var(--text-secondary)', overflowX: 'auto' }}>
                 {JSON.stringify(message, null, 2)}
               </pre>
             )}

--- a/openbank-admin-ui/src/test/swift-raw-disclosure.guard.test.ts
+++ b/openbank-admin-ui/src/test/swift-raw-disclosure.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('SWIFT raw payload disclosure contract', () => {
+  it('keeps raw payload disclosure related and explicit', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/swift/[id]/page.tsx'), 'utf8')
+    expect(source).toContain('type="button" aria-expanded={showRaw} aria-controls="swift-raw-payload"')
+    expect(source).toContain('id="swift-raw-payload"')
+    expect(source).toContain("aria-label={showRaw ? t('Skrýt surový payload', 'Hide raw payload') : t('Zobrazit surový payload', 'Show raw payload')}")
+    expect(source).toContain('<ChevronDown size={14} aria-hidden="true" />')
+  })
+})


### PR DESCRIPTION
## Summary
- relate SWIFT raw payload disclosure to its panel
- expose truthful show/hide labels and decorative icon semantics

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.