### PR TITLE
fix(admin-ui): clarify onboarding filter reset

### DIFF
--- a/openbank-admin-ui/src/app/onboarding/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/page.tsx
@@ -223,12 +223,12 @@ export default function OnboardingPage() {
           <span style={{ fontSize: '12px', color: 'var(--text-muted)' }}>{t('Filtr:', 'Filter:')}</span>
           <span className="pill" style={{ background: `${STAGE_COLOR[stage]}22`, color: STAGE_COLOR[stage], display: 'flex', alignItems: 'center', gap: '4px' }}>
             {stageLabel(stage)}
-            <button
+            <button type="button"
               onClick={() => handleStageFilter('')}
               style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, display: 'flex', color: 'inherit' }}
               aria-label={t('Zrušit filtr', 'Clear filter')}
             >
-              <X size={11} />
+              <X size={11} aria-hidden="true" />
             </button>
           </span>
           <span style={{ fontSize: '12px', color: 'var(--text-muted)' }}>{t(`${total} záznamů`, `${total} records`)}</span>

--- a/openbank-admin-ui/src/test/onboarding-filter-clear.guard.test.ts
+++ b/openbank-admin-ui/src/test/onboarding-filter-clear.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('onboarding filter clear contract', () => {
+  it('keeps stage filter reset explicit and decorative', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/onboarding/page.tsx'), 'utf8')
+    expect(source).toContain('<button type="button"')
+    expect(source).toContain("onClick={() => handleStageFilter('')}")
+    expect(source).toContain("aria-label={t('Zrušit filtr', 'Clear filter')}")
+    expect(source).toContain('<X size={11} aria-hidden="true" />')
+  })
+})


### PR DESCRIPTION
## Summary
- make onboarding stage filter reset an explicit button
- hide decorative reset icon

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.