### PR TITLE
fix(admin-ui): clarify global error recovery

### DIFF
--- a/openbank-admin-ui/src/app/global-error.tsx
+++ b/openbank-admin-ui/src/app/global-error.tsx
@@ -32,7 +32,7 @@ export default function GlobalError({ error }: { error: Error & { digest?: strin
               An unexpected error occurred. Please reload the page.<br />
               Došlo k neočekávané chybě. Načtěte prosím stránku znovu.
             </p>
-            <button
+            <button type="button" aria-label="Reload admin console / Načíst konzoli"
               onClick={() => window.location.reload()}
               style={{ padding: '8px 16px', borderRadius: 6, border: '1px solid #d1d5db', background: '#fff', cursor: 'pointer' }}
             >

--- a/openbank-admin-ui/src/test/global-error-reload.guard.test.ts
+++ b/openbank-admin-ui/src/test/global-error-reload.guard.test.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('global error recovery contract', () => {
+  it('keeps reload recovery an explicit accessible button', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/global-error.tsx'), 'utf8')
+    expect(source).toContain('<button type="button" aria-label="Reload admin console / Načíst konzoli"')
+    expect(source).toContain('window.location.reload()')
+  })
+})


### PR DESCRIPTION
## Summary
- make global error reload recovery an explicit accessible button
- preserve full-page recovery behavior

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.