### PR TITLE
fix(admin-ui): clarify auth error retry

### DIFF
--- a/openbank-admin-ui/src/app/auth/error/page.tsx
+++ b/openbank-admin-ui/src/app/auth/error/page.tsx
@@ -31,7 +31,7 @@ function ErrorContent() {
         <div style={{ fontSize: "13px", color: "var(--text-secondary)", marginBottom: "24px" }}>
           {messages[error ?? "Default"] ?? messages.Default}
         </div>
-        <button onClick={() => signIn("keycloak")} style={{
+        <button type="button" aria-label="Retry sign-in / Zkusit přihlášení znovu" onClick={() => signIn("keycloak")} style={{
           padding: "10px 24px", borderRadius: "8px", border: "none",
           background: "var(--accent)", color: "#fff", fontSize: "13px",
           fontWeight: 600, cursor: "pointer",

--- a/openbank-admin-ui/src/test/auth-error-retry.guard.test.ts
+++ b/openbank-admin-ui/src/test/auth-error-retry.guard.test.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('auth error recovery contract', () => {
+  it('keeps retry sign-in an explicit accessible button', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/auth/error/page.tsx'), 'utf8')
+    expect(source).toContain('<button type="button" aria-label="Retry sign-in / Zkusit přihlášení znovu"')
+    expect(source).toContain('signIn("keycloak")')
+  })
+})


### PR DESCRIPTION
## Summary
- make auth error retry an explicit accessible button
- preserve Keycloak sign-in recovery flow

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.