### PR TITLE
fix(admin-ui): clarify regulatory preview close

### DIFF
--- a/openbank-admin-ui/src/app/regulatory/page.tsx
+++ b/openbank-admin-ui/src/app/regulatory/page.tsx
@@ -556,8 +556,8 @@ export default function RegulatoryPage() {
                   <div style={{ fontSize: '12px', color: 'var(--text-tertiary)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{preview.name}</div>
                 </div>
               </div>
-              <button className="btn btn-secondary" style={{ padding: '5px', flexShrink: 0 }} onClick={() => setPreview(null)} aria-label={t('Zavřít', 'Close')}>
-                <X size={15} />
+              <button type="button" className="btn btn-secondary" style={{ padding: '5px', flexShrink: 0 }} onClick={() => setPreview(null)} aria-label={t('Zavřít náhled exportu', 'Close export preview')}>
+                <X size={15} aria-hidden="true" />
               </button>
             </div>
 

--- a/openbank-admin-ui/src/test/regulatory-preview-close.guard.test.ts
+++ b/openbank-admin-ui/src/test/regulatory-preview-close.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('regulatory export preview close contract', () => {
+  it('keeps preview close explicit and decorative', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/regulatory/page.tsx'), 'utf8')
+    expect(source).toContain('type="button" className="btn btn-secondary"')
+    expect(source).toContain("aria-label={t('Zavřít náhled exportu', 'Close export preview')}")
+    expect(source).toContain('<X size={15} aria-hidden="true" />')
+    expect(source).toContain('onClick={() => setPreview(null)}')
+  })
+})


### PR DESCRIPTION
## Summary
- make regulatory export preview close an explicit button
- localize its accessible name and hide decorative icon

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.