### PR TITLE
fix(admin-ui): clarify regulatory exports

### DIFF
--- a/openbank-admin-ui/src/app/regulatory/page.tsx
+++ b/openbank-admin-ui/src/app/regulatory/page.tsx
@@ -628,11 +628,11 @@ export default function RegulatoryPage() {
                   : t('FINREP/COREP se při načtení ověřují ve finrep-service nad ledger trial balance; při nedostupnosti se hodnoty nezobrazí. ClickHouse ani ČNB XBRL/SDAT přenos nejsou součástí tohoto náhledu.', 'FINREP/COREP are verified on load from finrep-service over the ledger trial balance; values are not shown when unavailable. ClickHouse and ČNB XBRL/SDAT transmission are not part of this preview.')}
               </div>
               <div style={{ display: 'flex', gap: '8px', flexShrink: 0 }}>
-                <button className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={() => exportCsv(preview)} disabled={!exportReadiness.ok}>
-                  <FileSpreadsheet size={13} /> {t('Export CSV', 'Export CSV')}
+                <button type="button" className="btn btn-secondary" aria-label={t('Exportovat náhled jako CSV', 'Export preview as CSV')} style={{ fontSize: '12px' }} onClick={() => exportCsv(preview)} disabled={!exportReadiness.ok}>
+                  <FileSpreadsheet size={13} aria-hidden="true" /> {t('Export CSV', 'Export CSV')}
                 </button>
-                <button className="btn btn-primary" style={{ fontSize: '12px' }} onClick={() => exportJson(preview)} disabled={!exportReadiness.ok}>
-                  <FileJson size={13} /> {t('Export JSON', 'Export JSON')}
+                <button type="button" className="btn btn-primary" aria-label={t('Exportovat náhled jako JSON', 'Export preview as JSON')} style={{ fontSize: '12px' }} onClick={() => exportJson(preview)} disabled={!exportReadiness.ok}>
+                  <FileJson size={13} aria-hidden="true" /> {t('Export JSON', 'Export JSON')}
                 </button>
               </div>
             </div>

--- a/openbank-admin-ui/src/test/regulatory-export-actions.guard.test.ts
+++ b/openbank-admin-ui/src/test/regulatory-export-actions.guard.test.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('regulatory export actions contract', () => {
+  it('keeps CSV and JSON export actions explicit', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/regulatory/page.tsx'), 'utf8')
+    expect(source).toContain("aria-label={t('Exportovat náhled jako CSV', 'Export preview as CSV')}")
+    expect(source).toContain("aria-label={t('Exportovat náhled jako JSON', 'Export preview as JSON')}")
+    expect(source).toContain('onClick={() => exportCsv(preview)}')
+    expect(source).toContain('onClick={() => exportJson(preview)}')
+  })
+})

--- a/openbank-admin-ui/src/test/regulatory-export-gate.test.tsx
+++ b/openbank-admin-ui/src/test/regulatory-export-gate.test.tsx
@@ -205,8 +205,8 @@ describe('Regulatory export gate — the surface', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('export-blocked')).not.toBeInTheDocument()
     })
-    expect(screen.getByRole('button', { name: /Export JSON/i })).toBeEnabled()
-    expect(screen.getByRole('button', { name: /Export CSV/i })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /JSON/i })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /CSV/i })).toBeEnabled()
   })
 
   it('BLOCKS export, with a named reason, when a cell is a flagged data gap', async () => {
@@ -214,8 +214,8 @@ describe('Regulatory export gate — the surface', () => {
 
     const banner = await screen.findByTestId('export-blocked')
     expect(banner).toHaveAttribute('data-block-reason', 'data_gaps')
-    expect(screen.getByRole('button', { name: /Export JSON/i })).toBeDisabled()
-    expect(screen.getByRole('button', { name: /Export CSV/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /JSON/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /CSV/i })).toBeDisabled()
   })
 
   it('BLOCKS export when the data source is unreachable', async () => {
@@ -223,7 +223,7 @@ describe('Regulatory export gate — the surface', () => {
 
     const banner = await screen.findByTestId('export-blocked')
     expect(banner).toHaveAttribute('data-block-reason', 'source_unavailable')
-    expect(screen.getByRole('button', { name: /Export JSON/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /JSON/i })).toBeDisabled()
   })
 
   it('produces NO file when a blocked export is invoked anyway', async () => {
@@ -233,7 +233,7 @@ describe('Regulatory export gate — the surface', () => {
     await openPreview(async () => template({ cells: [cell({ isDataGap: true })], hasDataGaps: true }))
     await screen.findByTestId('export-blocked')
 
-    const jsonButton = screen.getByRole('button', { name: /Export JSON/i })
+    const jsonButton = screen.getByRole('button', { name: /JSON/i })
     fireEvent.click(jsonButton)
     // Fire the handler directly too, past the disabled attribute.
     jsonButton.removeAttribute('disabled')


### PR DESCRIPTION
## Summary
- make CSV and JSON regulatory export actions explicit accessible buttons
- hide decorative export icons

## Verification
- git diff --check
- focused Vitest unavailable in clean worktree because dependencies are not installed; repository CI is authoritative

## Linked issues
N/A — bounded admin UI accessibility hardening; no separate issue exists.