### PR TITLE
feat(party): classify synthetic canary parties

### DIFF
--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/in/PartyPort.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/in/PartyPort.kt
@@ -54,6 +54,8 @@ data class CreatePartyCommand(
     /** Onboarding consent capture (mobile app "Agreement" step). Null = not asked/answered. */
     val consentGdpr: Boolean? = null,
     val consentMarketing: Boolean? = null,
+    /** Bank-owned canary only; the REST adapter authorizes this transition to ROLE_ADMIN. */
+    val classification: PartyClassification = PartyClassification.CUSTOMER,
 )
 
 /**

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
@@ -85,6 +85,7 @@ class PartyService : PartyUseCase {
             // keycloakSub so sub-keyed lookups (getMyParty, legacy mobile path) agree.
             keycloakSub = cmd.id?.toString(),
             partyType = cmd.partyType,
+            classification = cmd.classification,
             status = PartyStatus.PENDING_KYC,
             legalName = cmd.legalName,
             tradingName = cmd.tradingName,

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/Party.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/Party.kt
@@ -10,6 +10,16 @@ import java.util.UUID
 enum class PartyType { INDIVIDUAL, SOLE_TRADER, COMPANY, TRUST }
 
 /**
+ * Origin classification of a party. Synthetic parties are bank-owned canaries, never an
+ * alternative customer type: they must still traverse the same control paths as customers.
+ *
+ * This is deliberately immutable in [Party]. Turning an existing customer into a synthetic
+ * record (or the reverse) would falsify historical regulatory projections and taint lineage.
+ * ADR-0252.
+ */
+enum class PartyClassification { CUSTOMER, SYNTHETIC }
+
+/**
  * [CLOSED] and [MERGED] are both terminal, and deliberately distinct (ADR-0179): CLOSED is written
  * only by GDPR Art. 17 erasure, which anonymizes PII; MERGED retires a duplicate identity and
  * preserves everything, pointing at the survivor via [Party.mergedIntoPartyId].
@@ -20,6 +30,7 @@ enum class DocumentType { NATIONAL_ID, PASSPORT, DRIVING_LICENCE, COMPANY_REGIST
 data class Party(
     val id: UUID,
     val partyType: PartyType,
+    val classification: PartyClassification = PartyClassification.CUSTOMER,
     val status: PartyStatus,
     val legalName: String,
     val tradingName: String?,

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/PartyEvent.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/PartyEvent.kt
@@ -146,6 +146,7 @@ object PartyEvents {
             "eventType" to eventType,
             "partyId" to party.id,
             "partyType" to party.partyType,
+            "classification" to party.classification,
             "status" to party.status,
             "kycStatus" to party.kycStatus,
             "legalName" to party.legalName,

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/entity/PartyEntity.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/entity/PartyEntity.kt
@@ -18,6 +18,9 @@ class PartyEntity : PanacheEntity() {
     @Column(name = "party_type", nullable = false)
     lateinit var partyType: String
 
+    @Column(name = "classification", nullable = false)
+    lateinit var classification: String
+
     @Column(name = "status", nullable = false)
     lateinit var status: String
 

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyRepositoryImpl.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyRepositoryImpl.kt
@@ -17,6 +17,7 @@ import com.openbank.party.domain.model.AmlStatus
 import com.openbank.party.domain.model.DocumentType
 import com.openbank.party.domain.model.KycStatus
 import com.openbank.party.domain.model.Party
+import com.openbank.party.domain.model.PartyClassification
 import com.openbank.party.domain.model.PartyDocument
 import com.openbank.party.domain.model.PartyDocumentFile
 import com.openbank.party.domain.model.PartyEvent
@@ -222,6 +223,7 @@ class PartyRepositoryImpl(
     private fun Party.toEntity() = PartyEntity().also {
         it.partyId = id
         it.partyType = partyType.name
+        it.classification = classification.name
         it.status = status.name
         it.legalName = legalName
         it.tradingName = tradingName
@@ -253,7 +255,8 @@ class PartyRepositoryImpl(
     }
 
     private fun PartyEntity.toDomain() = Party(
-        id = partyId, partyType = PartyType.valueOf(partyType), status = PartyStatus.valueOf(status),
+        id = partyId, partyType = PartyType.valueOf(partyType),
+        classification = PartyClassification.valueOf(classification), status = PartyStatus.valueOf(status),
         legalName = legalName, tradingName = tradingName, dateOfBirth = dateOfBirth,
         nationality = nationality, taxId = taxId, registrationNumber = registrationNumber,
         email = email, phone = phone, discoverable = discoverable, kycStatus = KycStatus.valueOf(kycStatus),

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
@@ -28,6 +28,7 @@ import com.openbank.party.domain.model.Address
 import com.openbank.party.domain.model.DocumentType
 import com.openbank.party.domain.model.KycStatus
 import com.openbank.party.domain.model.Party
+import com.openbank.party.domain.model.PartyClassification
 import com.openbank.party.domain.model.PartyGdprExport
 import com.openbank.party.domain.model.PartyStatus
 import com.openbank.party.domain.model.PartyType
@@ -135,7 +136,11 @@ class PartyResource {
         @HeaderParam("Idempotency-Key") idempotencyKey: String?,
     ): Response {
         requireNotNull(idempotencyKey) { "header 'Idempotency-Key' is required" }
-        val party = partyUseCase.createParty(req.toCommand(idempotencyKey))
+        val classification = req.classification()
+        require(classification != PartyClassification.SYNTHETIC || securityIdentity.hasRole("ROLE_ADMIN")) {
+            "only ROLE_ADMIN may create a synthetic party"
+        }
+        val party = partyUseCase.createParty(req.toCommand(idempotencyKey, classification))
         return Response.created(URI.create("/api/v1/parties/${party.id}")).entity(party.toResponse()).build()
     }
 
@@ -627,8 +632,14 @@ data class CreatePartyRequest(
     // asked/answered — operator-created parties never send these.
     val consentGdpr: Boolean? = null,
     val consentMarketing: Boolean? = null,
+    /** Explicit only for bank-owned production canaries; omitted stays CUSTOMER. */
+    val classification: String? = null,
 ) {
-    fun toCommand(key: String): CreatePartyCommand {
+    fun classification(): PartyClassification = classification?.let {
+        PartyClassification.valueOf(it.uppercase())
+    } ?: PartyClassification.CUSTOMER
+
+    fun toCommand(key: String, classification: PartyClassification = classification()): CreatePartyCommand {
         require(!email.isNullOrBlank()) { "email is required" }
         return CreatePartyCommand(
             key, PartyType.valueOf(partyType), legalName, tradingName,
@@ -636,6 +647,7 @@ data class CreatePartyRequest(
             id?.takeIf { it.isNotBlank() }?.let { UUID.fromString(it) },
             consentGdpr = consentGdpr,
             consentMarketing = consentMarketing,
+            classification = classification,
         )
     }
 }
@@ -687,6 +699,7 @@ data class AddressRequest(
 fun Party.toSimpleResponse() = mapOf(
     "id" to id,
     "partyType" to partyType,
+    "classification" to classification,
     "status" to status,
     "legalName" to legalName,
     "tradingName" to tradingName,
@@ -696,7 +709,11 @@ fun Party.toSimpleResponse() = mapOf(
 )
 
 fun Party.toResponse() = mapOf(
-    "id" to id, "partyType" to partyType, "status" to status, "legalName" to legalName,
+    "id" to id,
+    "partyType" to partyType,
+    "classification" to classification,
+    "status" to status,
+    "legalName" to legalName,
     "tradingName" to tradingName, "email" to email, "phone" to phone,
     "kycStatus" to kycStatus, "address" to address, "createdAt" to createdAt, "updatedAt" to updatedAt,
     // Onboarding-time consent snapshot (consentGdpr is informational/non-revocable — see
@@ -712,6 +729,7 @@ fun PartyGdprExport.toResponse() = mapOf(
     "subject" to mapOf(
         "id" to party.id,
         "partyType" to party.partyType,
+        "classification" to party.classification,
         "status" to party.status,
         "legalName" to party.legalName,
         "tradingName" to party.tradingName,

--- a/openbank-party-service/src/main/resources/db/migration/V20__party_classification.sql
+++ b/openbank-party-service/src/main/resources/db/migration/V20__party_classification.sql
@@ -1,0 +1,6 @@
+-- ADR-0252: bank-owned synthetic canaries are a distinct, immutable party origin.
+-- Existing parties predate the fleet and are customers by definition.
+-- Rollback: before this migration is applied, DROP COLUMN classification; never edit an applied Flyway migration.
+ALTER TABLE parties
+    ADD COLUMN classification VARCHAR(20) NOT NULL DEFAULT 'CUSTOMER',
+    ADD CONSTRAINT chk_parties_classification CHECK (classification IN ('CUSTOMER', 'SYNTHETIC'));

--- a/openbank-party-service/src/main/resources/openapi.yaml
+++ b/openbank-party-service/src/main/resources/openapi.yaml
@@ -6,7 +6,7 @@ info:
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.8 -> 1.9): additive
   # only — a new PATCH /api/v1/parties/approvals/{id} endpoint and an additional 202 response
   # on POST /{id}/merge (ADR-0155 four-eyes). No existing response or schema changed.
-  version: 1.18.0
+  version: 1.19.0
   description: Legal entity and individual party management with document storage.
   license:
     name: Apache-2.0
@@ -681,6 +681,13 @@ components:
         consentMarketing:
           type: boolean
           description: Optional marketing-communications consent from the same onboarding step.
+        classification:
+          type: string
+          enum: [CUSTOMER, SYNTHETIC]
+          default: CUSTOMER
+          description: >-
+            Bank-owned synthetic canary only. Requires ROLE_ADMIN and is immutable once created;
+            ordinary self-service onboarding always creates CUSTOMER.
 
     UpdatePartyRequest:
       type: object

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyClassificationServiceTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyClassificationServiceTest.kt
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.application.usecase
+
+import com.openbank.party.application.port.`in`.CreatePartyCommand
+import com.openbank.party.domain.model.Party
+import com.openbank.party.domain.model.PartyClassification
+import com.openbank.party.domain.model.PartyType
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.Optional
+
+class PartyClassificationServiceTest {
+
+    @Test
+    fun `createParty preserves an explicitly provisioned synthetic classification`(): Unit = runBlocking {
+        val service = PartyService().apply {
+            partyRepo = mockk()
+            documentRepo = mockk()
+            documentFileRepo = mockk()
+            metrics = mockk(relaxed = true)
+            changeMetrics = mockk(relaxed = true)
+            gdprAggregation = mockk(relaxed = true)
+            rcPepper = Optional.empty()
+            clock = Clock.fixed(Instant.parse("2025-01-01T00:00:00Z"), ZoneOffset.UTC)
+        }
+        val savedPartySlot = slot<Party>()
+        coEvery { service.partyRepo.findByEmail("canary@example.test") } returns null
+        coEvery { service.partyRepo.save(capture(savedPartySlot), any()) } answers { savedPartySlot.captured }
+
+        service.createParty(
+            CreatePartyCommand(
+                idempotencyKey = "synthetic-idem-1",
+                partyType = PartyType.INDIVIDUAL,
+                legalName = "Synthetic Canary",
+                tradingName = null,
+                dateOfBirth = null,
+                nationality = null,
+                taxId = null,
+                registrationNumber = null,
+                email = "canary@example.test",
+                phone = null,
+                address = null,
+                classification = PartyClassification.SYNTHETIC,
+            ),
+        )
+
+        assertThat(savedPartySlot.captured.classification).isEqualTo(PartyClassification.SYNTHETIC)
+    }
+}

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceTest.kt
@@ -16,6 +16,7 @@ import com.openbank.party.domain.model.AmlStatus
 import com.openbank.party.domain.model.DocumentType
 import com.openbank.party.domain.model.KycStatus
 import com.openbank.party.domain.model.Party
+import com.openbank.party.domain.model.PartyClassification
 import com.openbank.party.domain.model.PartyDocument
 import com.openbank.party.domain.model.PartyDocumentFile
 import com.openbank.party.domain.model.PartyEvent
@@ -80,6 +81,7 @@ class PartyServiceTest {
 
         assertThat(savedPartySlot.captured.email).isEqualTo("alice@example.com")
         assertThat(savedPartySlot.captured.status).isEqualTo(PartyStatus.PENDING_KYC)
+        assertThat(savedPartySlot.captured.classification).isEqualTo(PartyClassification.CUSTOMER)
         assertThat(savedPartySlot.captured.kycStatus).isEqualTo(KycStatus.NOT_STARTED)
         assertThat(result).isSameAs(savedPartySlot.captured)
         assertEvent("PARTY_CREATED", result.id)

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/domain/model/PartyEventEnvelopeContractTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/domain/model/PartyEventEnvelopeContractTest.kt
@@ -67,6 +67,7 @@ class PartyEventEnvelopeContractTest {
         assertThat(json.get("partyId").asText()).isEqualTo("11111111-1111-1111-1111-111111111111")
         // account-service gates on partyType; legalName required for OpenAccountCommand (sanctions, ADR-0032 §C)
         assertThat(json.get("partyType").asText()).isEqualTo("INDIVIDUAL")
+        assertThat(json.get("classification").asText()).isEqualTo("CUSTOMER")
         assertThat(json.get("legalName").asText()).isEqualTo("Jan Novák")
         assertThat(json.get("status").asText()).isEqualTo("PENDING_KYC")
         assertThat(json.has("occurredAt")).isTrue()
@@ -91,6 +92,15 @@ class PartyEventEnvelopeContractTest {
         // account-service activates the pending account when it sees status=ACTIVE
         assertThat(json.get("status").asText()).isEqualTo("ACTIVE")
         assertThat(json.get("partyId").asText()).isEqualTo("11111111-1111-1111-1111-111111111111")
+    }
+
+    @Test
+    fun `synthetic classification is preserved in the lifecycle contract`() {
+        val canary = individual().copy(classification = PartyClassification.SYNTHETIC)
+        val event = PartyEvents.created(canary, at, PartyActor.system("canary"))
+        val json = mapper.readTree(mapper.writeValueAsString(event.envelope))
+
+        assertThat(json.get("classification").asText()).isEqualTo("SYNTHETIC")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- persist immutable `CUSTOMER` / `SYNTHETIC` party origin with a Flyway migration
- expose the additive classification in party lifecycle events and operator responses
- allow only `ROLE_ADMIN` to provision a synthetic party; self-service remains `CUSTOMER`

## Safety

This is the identity root for ADR-0252 taint propagation. It does not exempt synthetic parties from sanctions, SCA, VoP, or AML controls, and does not yet claim durable Kafka/outbox taint propagation.

Refs #4348

## Verification

- `./gradlew :openbank-party-service:ktlintCheck :openbank-party-service:test --tests ... --no-daemon`
- `python3 openbank-infra/scripts/check-threat-model-diff.py --base origin/main --enforce`