### PR TITLE
fix(admin-ui): retain latest client evidence by kind

### DIFF
--- a/openbank-admin-ui/scripts/collect-test-intelligence.mjs
+++ b/openbank-admin-ui/scripts/collect-test-intelligence.mjs
@@ -337,16 +337,27 @@ function mobileClientRuns() {
 
 function clientExperiences() {
   const mobileRuns = mobileClientRuns()
-  const latestMobile = mobileRuns.sort((a, b) => Date.parse(b.run?.observedAt ?? 0) - Date.parse(a.run?.observedAt ?? 0))[0]
+  // Mobile lanes complete independently.  Select the latest *execution of each
+  // evidence kind*, rather than treating a later connected-device artifact as a
+  // replacement for the earlier unit/visual artifact from the same app build.
+  // This preserves provenance and prevents an E2E run from visually erasing
+  // passing deterministic checks.
+  const latestMobile = mobileRuns[0]
+  const latestMobileSuites = new Map()
+  for (const run of mobileRuns) {
+    for (const suite of run.suites ?? []) {
+      if (!latestMobileSuites.has(suite.kind)) latestMobileSuites.set(suite.kind, { suite, run })
+    }
+  }
   const appSource = path.join(repo, '.app-src')
   const androidRum = exists(path.join(appSource, 'shared/src/androidMain/kotlin/tech/openbank/app/telemetry/RumMonitor.android.kt'))
   const iosRum = exists(path.join(appSource, 'shared/src/iosMain/kotlin/tech/openbank/app/telemetry/RumMonitor.ios.kt'))
   const webEvidence = runEnvelope('openbank-admin-ui')?.evidence ?? junitEvidence('openbank-admin-ui')
-  const mobileEvidence = (latestMobile?.suites ?? []).map(item => ({
-    kind: item.kind, state: item.state, observedAt: latestMobile.run?.observedAt ?? null,
+  const mobileEvidence = [...latestMobileSuites.values()].map(({ suite: item, run }) => ({
+    kind: item.kind, state: item.state, observedAt: run.run?.observedAt ?? null,
     source: 'openbank-app-test-intelligence:v1', environment: 'ci', durationMs: item.durationMs,
     counts: item.counts, detail: item.detail,
-    ...(latestMobile.run ? { run: latestMobile.run } : {}),
+    ...(run.run ? { run: run.run } : {}),
   }))
   if (!latestMobile) warnings.push('openbank-app execution artifact is not bundled; mobile test verdict is not inferred from source.')
   return [

--- a/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
@@ -130,9 +130,9 @@ journeys:
     expect(app.evidence.find(item => item.kind === 'unit')).toMatchObject({
       kind: 'unit', state: 'passed', run: { id: '9' },
     })
-    expect(app.evidence).toEqual(expect.arrayContaining([
-      expect.objectContaining({ kind: 'e2e', state: 'passed', run: { id: '10' } }),
-    ]))
+    expect(app.evidence.some(item =>
+      item.kind === 'e2e' && item.state === 'passed' && item.run?.id === '10',
+    )).toBe(true)
     expect(app.rum).toMatchObject({ policy: 'consent-gated', state: 'unknown' })
     expect(report.runHistory.filter(item => item.component === 'openbank-app').map(item => item.run.id)).toEqual(['10', '9', '8'])
   })

--- a/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
@@ -127,7 +127,9 @@ journeys:
     execFileSync('node', [SCRIPT, '--repo', repo, '--out', out, '--stale-after-days', '99999'])
     const report = JSON.parse(readFileSync(out, 'utf8')) as TestIntelligenceReport
     const app = report.clientExperiences.find(item => item.id === 'openbank-app')!
-    expect(app.evidence[0]).toMatchObject({ kind: 'unit', state: 'passed', run: { id: '9' } })
+    expect(app.evidence.find(item => item.kind === 'unit')).toMatchObject({
+      kind: 'unit', state: 'passed', run: { id: '9' },
+    })
     expect(app.evidence).toEqual(expect.arrayContaining([
       expect.objectContaining({ kind: 'e2e', state: 'passed', run: { id: '10' } }),
     ]))

--- a/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
@@ -118,12 +118,20 @@ journeys:
       run: { id: '8', attempt: 1, commit: 'older', branch: 'main', workflow: 'app build', url: 'https://example.test/8', observedAt: '2026-08-22T10:00:00Z' },
       suites: [{ kind: 'unit', state: 'failed', durationMs: 100, counts: { discovered: 2, executed: 2, passed: 1, failed: 1, skipped: 0, errors: 0 } }],
     }))
+    write(repo, 'openbank-admin-ui/client-test-evidence/openbank-app-e2e.json', JSON.stringify({
+      schemaVersion: 1, component: 'openbank-app',
+      run: { id: '10', attempt: 1, commit: 'abc', branch: 'main', workflow: 'app build', url: 'https://example.test/10', observedAt: '2026-08-23T11:00:00Z' },
+      suites: [{ kind: 'e2e', state: 'passed', durationMs: 200, counts: { discovered: 2, executed: 2, passed: 2, failed: 0, skipped: 0, errors: 0 } }],
+    }))
     const out = path.join(repo, 'report.json')
     execFileSync('node', [SCRIPT, '--repo', repo, '--out', out, '--stale-after-days', '99999'])
     const report = JSON.parse(readFileSync(out, 'utf8')) as TestIntelligenceReport
     const app = report.clientExperiences.find(item => item.id === 'openbank-app')!
     expect(app.evidence[0]).toMatchObject({ kind: 'unit', state: 'passed', run: { id: '9' } })
+    expect(app.evidence).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'e2e', state: 'passed', run: { id: '10' } }),
+    ]))
     expect(app.rum).toMatchObject({ policy: 'consent-gated', state: 'unknown' })
-    expect(report.runHistory.filter(item => item.component === 'openbank-app').map(item => item.run.id)).toEqual(['9', '8'])
+    expect(report.runHistory.filter(item => item.component === 'openbank-app').map(item => item.run.id)).toEqual(['10', '9', '8'])
   })
 })


### PR DESCRIPTION
## Linked issues

N/A — narrowly corrects the evidence projection introduced by the existing Test Intelligence delivery; no separate backlog item is created for this direct follow-up.

## Why

Mobile CI lanes complete independently. Selecting one newest envelope causes a connected-device E2E artifact to hide the latest unit and visual results in Test Intelligence.

## Change

Select the latest immutable client execution independently for each evidence kind, retaining the run provenance for every displayed result. The collector test proves an E2E artifact from run 10 is combined with unit evidence from run 9 rather than replacing it.

## Verification

- `git diff --check`
- focused Vitest command prepared; local dependency bootstrap was blocked by the repository package-manager policy before Vitest could execute, so CI remains the authoritative test run.