### PR TITLE
fix(admin-ui): bound client evidence staging

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -362,7 +362,13 @@ jobs:
           APP_REPO: JiRaska/openbank-app
         run: |
           set -u
-          api() { curl -sf -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" "$@"; }
+          # Cross-repository evidence is advisory input. A stalled artifact redirect must
+          # never hold the sandbox deployment indefinitely; an unavailable artifact is
+          # represented as absent evidence by the collector instead.
+          api() {
+            curl -sf --connect-timeout 10 --max-time 20 --retry 2 --retry-delay 1 \
+              -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" "$@"
+          }
           mkdir -p openbank-admin-ui/client-test-evidence
           # Only reviewed default-branch evidence may enter a deployed control plane. A newer
           # PR artifact remains visible in GitHub but cannot replace the sandbox verdict.


### PR DESCRIPTION
## Why
The Admin UI deployment can stall in cross-repository customer-app evidence staging. Artifact downloads were best-effort but had no connection or total timeout, so a stalled redirect could block the sandbox deployment indefinitely.

## Change
Adds bounded connection and total timeouts with short retry behavior to the read-only artifact fetch. A failed download remains absent evidence; it never becomes a passing verdict and cannot block deployment forever.

## Verification
- Ruby YAML parse of the deployment workflow
- Test Intelligence ecosystem self-test, including its red path
- Full Test Intelligence ecosystem verifier: SUBJECTS=59