### PR TITLE
fix(ci): bound advisory Kover report

### DIFF
--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -267,7 +267,10 @@ jobs:
       # second invocation of the same, single-shaped `test` task.
       - name: Generate Kover XML report
         continue-on-error: true
-        run: ./gradlew :${{ inputs.service }}:koverXmlReport --build-cache --console=plain
+        # This is advisory evidence, never a second mandatory build.  Keep it daemonless
+        # and bounded so a Gradle/Kover process cannot retain the raw coverage file or
+        # hold a fleet runner after the enforcing build has already completed (#6734).
+        run: timeout --kill-after=10s 180s ./gradlew --no-daemon :${{ inputs.service }}:koverXmlReport --build-cache --console=plain
 
       # The envelope is built even after a failing suite. A missing envelope is not a
       # passing zero: the projection renders it as absent evidence. The collector only


### PR DESCRIPTION
## Summary

Bounds the non-gating Kover XML evidence step and runs it without a Gradle daemon. The enforcing `build` and `koverVerify` path is unchanged.

This prevents an advisory report process from retaining coverage files or fleet runners after successful tests, as observed while validating the Test Intelligence fleet.

Refs #6734

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/_service-ci.yml"); puts "YAML OK"'`\n- `git diff --check`\n- `python3 .github/scripts/check-test-intelligence-ecosystem.py --root . --self-test`