### PR TITLE
feat(testing): retain unmeasured perf provenance

### DIFF
--- a/.github/scripts/collect-test-run-evidence.py
+++ b/.github/scripts/collect-test-run-evidence.py
@@ -212,7 +212,11 @@ def observations(service: Path) -> list[dict]:
     return result
 
 
-def specialized_evidence(performance_summary: str | None, mutation_report: str | None) -> list[dict]:
+def specialized_evidence(
+    performance_summary: str | None,
+    mutation_report: str | None,
+    performance_not_run_detail: str | None = None,
+) -> list[dict]:
     specialized = []
     if performance_summary:
         summary_file = Path(performance_summary)
@@ -222,8 +226,10 @@ def specialized_evidence(performance_summary: str | None, mutation_report: str |
         # k6 summary-export encodes a crossed threshold as bare True (and a passing
         # threshold as False). Accept the older object fixture form too.
         failed = sum(1 for value in thresholds if value is True or (isinstance(value, dict) and value.get("ok") is False))
+        detail = (performance_not_run_detail or "performance summary absent") if summary is None \
+            else f"{len(thresholds)} threshold result(s), {failed} breached"
         specialized.append({"kind": "performance", "state": "not-run" if summary is None else "failed" if failed else "passed",
-                            "source": str(summary_file), "detail": f"{len(thresholds)} threshold result(s), {failed} breached"})
+                            "source": str(summary_file), "detail": detail})
     if mutation_report:
         mutation_file = Path(mutation_report)
         if mutation_file.exists():
@@ -244,6 +250,7 @@ def main() -> None:
     parser.add_argument("--out")
     parser.add_argument("--component")
     parser.add_argument("--performance-summary")
+    parser.add_argument("--performance-not-run-detail")
     parser.add_argument("--mutation-report")
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
@@ -301,6 +308,8 @@ def main() -> None:
             assert [item["lifecycle"] for item in observations(service)] == ["started", "stopped"]
             specialized = specialized_evidence(str(performance), str(mutation))
             assert [(item["kind"], item["state"]) for item in specialized] == [("performance", "failed"), ("mutation", "passed")]
+            absent = specialized_evidence(str(service / "missing-summary.json"), None, "no safe target configured")
+            assert absent == [{"kind": "performance", "state": "not-run", "source": str(service / "missing-summary.json"), "detail": "no safe target configured"}]
             valid = {
                 "schemaVersion": 1,
                 "run": {"id": "1", "attempt": 1, "commit": "1234567", "branch": "main", "workflow": "CI", "url": "", "observedAt": "2026-08-22T00:00:00Z"},
@@ -328,7 +337,11 @@ def main() -> None:
     server = os.getenv("GITHUB_SERVER_URL", "")
     repository = os.getenv("GITHUB_REPOSITORY", "")
     run_id = os.getenv("GITHUB_RUN_ID", "local")
-    specialized = specialized_evidence(args.performance_summary, args.mutation_report)
+    specialized = specialized_evidence(
+        args.performance_summary,
+        args.mutation_report,
+        args.performance_not_run_detail,
+    )
     envelope = {
         "schemaVersion": 1,
         "run": {

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -460,7 +460,9 @@ jobs:
         # The Test Intelligence collector reads k6 summaries only from the deployment-local
         # perf-artifacts directory.  A declared scenario is deliberately not promoted to a
         # result, so bring in only artifacts emitted by the latest successful main run of the
-        # governed performance workflow.  Missing or expired evidence remains `not-run` in the
+        # governed performance workflows.  The money-path baseline may intentionally emit only
+        # a `not-run` envelope when no safe runner target exists; retain that provenance too.
+        # Missing or expired evidence remains `not-run` in the
         # UI; this best-effort staging step must never turn absence into a deployment failure.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -496,6 +498,42 @@ jobs:
           done <<< "${ARTIFACTS}"
           COUNT=$(find openbank-admin-ui/perf-artifacts -name '*-summary.json' | wc -l | tr -d ' ')
           echo "Staged ${COUNT} k6 summary file(s) from ${DOWNLOADED} performance artifact(s), run ${RUN_ID}."
+
+          BASELINE_RUN_ID=$(api \
+            "https://api.github.com/repos/${REPO}/actions/workflows/perf-baseline.yml/runs?branch=main&status=success&per_page=1" \
+            | python3 -c "import json,sys; r=json.load(sys.stdin).get('workflow_runs',[]); print(r[0]['id'] if r else '')" \
+            2>/dev/null || true)
+          if [ -z "${BASELINE_RUN_ID}" ]; then
+            echo "No successful money-path baseline run found — it remains declared but unmeasured."
+            exit 0
+          fi
+          BASELINE_ARTIFACT=$(api \
+            "https://api.github.com/repos/${REPO}/actions/runs/${BASELINE_RUN_ID}/artifacts?per_page=100" \
+            | python3 -c "import json,sys; a=[x for x in json.load(sys.stdin).get('artifacts',[]) if x['name']=='k6-money-path-summary' and not x['expired']]; print(a[0]['id'] if a else '')" \
+            2>/dev/null || true)
+          if [ -z "${BASELINE_ARTIFACT}" ]; then
+            echo "Money-path baseline ${BASELINE_RUN_ID} has no retained evidence artifact."
+            exit 0
+          fi
+          BASELINE_DIR="$(mktemp -d)"
+          if ! api "https://api.github.com/repos/${REPO}/actions/artifacts/${BASELINE_ARTIFACT}/zip" -L -o /tmp/k6-money-path-summary.zip \
+            || ! unzip -q /tmp/k6-money-path-summary.zip -d "${BASELINE_DIR}"; then
+            echo "::warning::Could not stage money-path baseline evidence from run ${BASELINE_RUN_ID}."
+            exit 0
+          fi
+          BASELINE_SUMMARY=$(find "${BASELINE_DIR}" -name 'perf-summary.json' -print -quit)
+          BASELINE_ENVELOPE=$(find "${BASELINE_DIR}" -name 'perf-run.json' -print -quit)
+          SUMMARY_STATUS=no
+          if [ -n "${BASELINE_SUMMARY}" ]; then
+            cp "${BASELINE_SUMMARY}" openbank-admin-ui/perf-artifacts/money-path-smoke-summary.json
+            SUMMARY_STATUS=yes
+          fi
+          ENVELOPE_STATUS=no
+          if [ -n "${BASELINE_ENVELOPE}" ]; then
+            cp "${BASELINE_ENVELOPE}" openbank-admin-ui/perf-artifacts/money-path-smoke-summary.json.run.json
+            ENVELOPE_STATUS=yes
+          fi
+          echo "Staged money-path baseline ${BASELINE_RUN_ID}: summary=${SUMMARY_STATUS} envelope=${ENVELOPE_STATUS}."
 
       - name: Collect production-readiness scorecard
         # Derives C1–C9 maturity scores from the repo and writes

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -51,6 +51,7 @@ jobs:
           if [ -z "$ledger" ] || [ -z "$txn" ]; then
             echo "::notice::PERF_LEDGER_URL / PERF_TXN_URL not configured — skipping the perf baseline (no target to measure)."
             echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "reason=No safe money-path target is configured for this GitHub-hosted runner." >> "$GITHUB_OUTPUT"
           else
             echo "run=true" >> "$GITHUB_OUTPUT"
             echo "ledger=$ledger" >> "$GITHUB_OUTPUT"
@@ -74,7 +75,9 @@ jobs:
         run: |
           python3 .github/scripts/collect-test-run-evidence.py \
             --service perf --component openbank-money-path \
-            --performance-summary perf-summary.json --out perf-run.json
+            --performance-summary perf-summary.json \
+            --performance-not-run-detail "${{ steps.target.outputs.reason }}" \
+            --out perf-run.json
 
       - name: Upload k6 summary and versioned envelope
         if: always()

--- a/openbank-admin-ui/scripts/collect-test-intelligence.mjs
+++ b/openbank-admin-ui/scripts/collect-test-intelligence.mjs
@@ -302,6 +302,9 @@ function performance() {
     definitionsByComponent.set(component, (definitionsByComponent.get(component) ?? 0) + 1)
   }
   const summaries = allFiles(path.join(repo, 'openbank-admin-ui', 'perf-artifacts'), file => file.endsWith('-summary.json'))
+  // A no-target baseline has a versioned envelope but deliberately no k6 summary.
+  // It is still evidence: the UI must distinguish that outcome from a lost artifact.
+  const runSidecars = allFiles(path.join(repo, 'openbank-admin-ui', 'perf-artifacts'), file => file.endsWith('-summary.json.run.json'))
   return definitions.map(file => {
     const raw = fs.readFileSync(file, 'utf8')
     const thresholds = (raw.match(/thresholds\s*:/g) ?? []).length
@@ -309,7 +312,7 @@ function performance() {
     const component = relative[0].startsWith('openbank-') ? relative[0] : null
     const localId = path.basename(file, '.js')
     const id = component ? `${component}-${localId.replace(/^openbank-/, '')}` : localId
-    const summaryFile = summaries.find(candidate => {
+    const matchesScenario = candidate => {
       const name = path.basename(candidate)
       // perf-gate names its artifact after the service, not the script.  That fallback is
       // unambiguous only while the service declares exactly one k6 scenario; otherwise leaving
@@ -318,14 +321,16 @@ function performance() {
         && definitionsByComponent.get(component) === 1
         && name === `${component}-summary.json`
       return name.includes(id) || name.includes(localId) || singleScenarioServiceSummary
-    })
+    }
+    const summaryFile = summaries.find(matchesScenario)
+    const runSidecar = runSidecars.find(matchesScenario)
     const summary = summaryFile ? readJson(summaryFile) : null
     const summaryMeta = summaryFile ? readJson(`${summaryFile}.meta.json`) : null
     // perf-gate writes sibling <service>-summary.json and <service>-run.json files.
     // Keep the former sidecar spelling as a fallback for any older retained artifact.
     const performanceRun = summaryFile
       ? readJson(summaryFile.replace(/-summary\.json$/, '-run.json')) ?? readJson(`${summaryFile}.run.json`)
-      : null
+      : readJson(runSidecar)
     const specialized = performanceRun?.specializedEvidence?.find(item => item.kind === 'performance')
     const thresholdResults = summary
       ? Object.values(summary.metrics ?? {}).flatMap(metric => Object.values(metric?.thresholds ?? {}))

--- a/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
@@ -62,6 +62,14 @@ journeys:
     write(repo, 'openbank-admin-ui/perf-artifacts/breached-summary.json', JSON.stringify({ metrics: {
       checks: { value: 0.9, thresholds: { 'rate==1.0': true } },
     } }))
+    write(repo, 'perf/k6/money-path-smoke.js', 'export const options = { thresholds: { checks: ["rate>0.99"] } }')
+    write(repo, 'openbank-admin-ui/perf-artifacts/money-path-smoke-summary.json.run.json', JSON.stringify({
+      schemaVersion: 1,
+      run: { id: 'baseline-7', attempt: 1, commit: 'fedcba987654', branch: 'main', workflow: 'Perf baseline', url: 'https://example.test/perf/baseline-7', observedAt: '2026-08-25T07:00:00Z' },
+      component: 'openbank-money-path', suites: [], coverage: null,
+      testInfrastructure: { declared: [], observed: [] },
+      specializedEvidence: [{ kind: 'performance', state: 'not-run', source: 'perf-summary.json', detail: 'No safe money-path target is configured for this GitHub-hosted runner.' }],
+    }))
     const out = path.join(repo, 'report.json')
     execFileSync('node', [SCRIPT, '--repo', repo, '--out', out, '--stale-after-days', '99999'])
     const report = JSON.parse(readFileSync(out, 'utf8')) as TestIntelligenceReport
@@ -78,6 +86,9 @@ journeys:
       p95Ms: 321.4, errorRatePercent: 1.25, checkPassRatePercent: 98.75, requests: 80,
     }, run: { id: 'perf-42', workflow: 'Performance gate' } })
     expect(report.performance.find(item => item.id === 'breached')).toMatchObject({ state: 'failed', detail: '1 threshold result(s), 1 breached' })
+    expect(report.performance.find(item => item.id === 'money-path-smoke')).toMatchObject({
+      state: 'not-run', detail: 'No safe money-path target is configured for this GitHub-hosted runner.', run: { id: 'baseline-7', workflow: 'Perf baseline' },
+    })
     expect(report.clientExperiences).toEqual(expect.arrayContaining([
       expect.objectContaining({ id: 'admin-ui', rum: expect.objectContaining({ policy: 'rejected' }) }),
       expect.objectContaining({ id: 'openbank-app', evidence: [], blocker: expect.stringMatching(/artifact/i) }),


### PR DESCRIPTION
## Linked issues

Refs #3348

## Why

The money-path performance baseline correctly records an unmeasured run when no safe runner target is configured, but Admin UI staging previously discarded that envelope because no k6 summary exists. The UI could not distinguish an intentional no-measurement outcome from missing artifacts.

## What

- preserve explicit not-run detail in the performance evidence envelope
- stage the latest retained money-path baseline envelope even without a summary
- project its run provenance and reason into Test Intelligence
- cover the run-only collector path and the collector negative control

## Verification

Focused Test Intelligence collector tests passed (4 tests); TypeScript no-emit passed; Python collector self-test passed; both workflows parsed as YAML; diff check passed.