### PR TITLE
fix(admin-ui): age synthetic job failures

### DIFF
--- a/openbank-admin-ui/src/app/api/test-intelligence/route.ts
+++ b/openbank-admin-ui/src/app/api/test-intelligence/route.ts
@@ -93,7 +93,11 @@ async function attachLiveJourneys(report: TestIntelligenceReport): Promise<TestI
     const [scheduled, successful, failures, recentRuns] = await Promise.all([
       queryPrometheus(base, `max(kube_cronjob_status_last_schedule_time{namespace="observability",cronjob="${cronjob}"})`),
       queryPrometheus(base, `max(kube_cronjob_status_last_successful_time{namespace="observability",cronjob="${cronjob}"})`),
-      queryPrometheus(base, `max(max_over_time(kube_job_status_failed{namespace="observability",job_name=~"${cronjob}.*"}[30m]))`),
+      // kube-state-metrics continues exporting terminal Job status until the Job is garbage
+      // collected. A historical failed Job therefore remains `1` forever; selecting it with
+      // max_over_time makes a later successful schedule look failed. Join on completion time so
+      // only a Job which both failed AND completed inside the window is a current failure.
+      queryPrometheus(base, `max((kube_job_status_failed{namespace="observability",job_name=~"${cronjob}.*"} > 0) and on(namespace,job_name) (time() - kube_job_status_completion_time{namespace="observability",job_name=~"${cronjob}.*"} < 1800))`),
       queryPrometheusRuns(base, cronjob),
     ])
     const observedAt = new Date().toISOString()

--- a/openbank-admin-ui/src/test/test-intelligence-route.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-route.test.ts
@@ -61,4 +61,34 @@ describe('GET /api/test-intelligence', () => {
     })
     expect(body.clientExperiences[0].evidence).toEqual([])
   })
+
+  it('does not treat a retained historical failed Job as a current synthetic failure', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'test-intelligence-synthetic-route-'))
+    dirs.push(dir)
+    const file = path.join(dir, 'report.json')
+    writeFileSync(file, JSON.stringify({
+      schemaVersion: 1, collectedAt: '2026-08-25T00:00:00.000Z', components: [], contracts: [], mutations: [], performance: [], history: [], runHistory: [], testCases: [], clientExperiences: [],
+      syntheticJourneys: [{ id: 'public-edge', title: 'Public edge', status: 'active', state: 'unknown', severity: 'page', schedule: '*/5 * * * *', environment: 'sandbox', covers: [], falsifies: 'Break the edge.', blocker: null }],
+      totals: { components: 0, componentsWithExecutionEvidence: 0, moneyPathComponents: 0, failingEvidence: 0, missingEvidence: 0, staleEvidence: 0 }, warnings: [],
+    }))
+    process.env.OPENBANK_TEST_INTELLIGENCE = file
+    process.env.PROMETHEUS_URL = 'http://prometheus.test'
+    const now = Date.now() / 1000
+    const queries: string[] = []
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL) => {
+      const query = new URL(String(input)).searchParams.get('query') ?? ''
+      queries.push(query)
+      const payload = query.includes('kube_job_status_completion_time')
+        ? { status: 'success', data: { result: [] } }
+        : query.includes('kube_cronjob_status_last_successful_time') || query.includes('kube_cronjob_status_last_schedule_time')
+          ? { status: 'success', data: { result: [{ value: [now, String(now)] }] } }
+          : { status: 'success', data: { result: [] } }
+      return new Response(JSON.stringify(payload), { status: 200 })
+    }))
+    const { GET } = await import('@/app/api/test-intelligence/route')
+    const body = await (await GET()).json()
+    expect(body.syntheticJourneys[0].state).toBe('passed')
+    expect(queries.some(query => query.includes('kube_job_status_completion_time'))).toBe(true)
+    expect(queries.some(query => query.includes('max_over_time(kube_job_status_failed'))).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary

- classify a synthetic failure only when its failed Kubernetes Job completed in the last 30 minutes
- avoid treating retained kube-state-metrics terminal status as a current incident
- add a regression route test with a retained historical failed Job

Refs #4348

## Verification

- live Prometheus probe: a retained failed public-edge Job from 00:15 is excluded by the completion-time predicate
- clean query returns no current failures while recent public-edge runs succeeded
- CI will run the admin-ui route test in a clean dependency environment