### PR TITLE
feat(admin-ui): explain contract verification evidence

### DIFF
--- a/.github/scripts/check-fleet-attestations.sh
+++ b/.github/scripts/check-fleet-attestations.sh
@@ -206,7 +206,12 @@ STUB
       failures=$((failures + 1))
       return
     fi
-    if ! printf '%s' "$out" | grep -qF "$expected_summary"; then
+    # Do not use `printf | grep -q` here: with `pipefail`, grep may exit as
+    # soon as it finds the expected summary and leave printf with SIGPIPE.
+    # That turns a correct, sufficiently large self-test output into a false
+    # failure on a faster CI runner. Feed grep directly so this assertion is
+    # about the summary, not pipe scheduling.
+    if ! grep -qF "$expected_summary" <<< "$out"; then
       printf '  FAIL: %s — exit %s correct, but summary missing\n' "$name" "$code"
       printf '        expected summary: %s\n' "$expected_summary"
       fixture_diagnostics

--- a/.github/scripts/check-test-intelligence-ecosystem.py
+++ b/.github/scripts/check-test-intelligence-ecosystem.py
@@ -47,6 +47,15 @@ def check(root: Path) -> list[str]:
     deploy = text(root / ".github/workflows/admin-ui-deploy.yml")
     if "build/test-intelligence/run.json" not in deploy:
         errors.append("admin deployment does not stage the versioned run envelope")
+    # A staged Pact file is not a provider-verification verdict. The deploy collector
+    # can query the existing read-only Broker credentials and must receive them only
+    # in its build/collection step; without this wiring the UI bakes every Pact as
+    # `unknown` even though main CI has published authoritative results.
+    for needle in ("PACT_BROKER_URL: ${{ vars.PACT_BROKER_URL }}",
+                   "PACT_BROKER_USERNAME: ${{ vars.PACT_BROKER_USERNAME }}",
+                   "PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}"):
+        if needle not in deploy:
+            errors.append(f"admin deployment cannot project Pact Broker verification evidence: {needle}")
     for needle in ("openbank-app-test-intelligence-", ".get('head_branch') == 'main'", "client-test-evidence/openbank-app-${artifact_id}.json"):
         if needle not in deploy:
             errors.append(f"admin deployment lost trusted mobile evidence staging: {needle}")

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -593,6 +593,13 @@ jobs:
       - name: Build, collect, push
         id: build
         env:
+          # The build script's quality collector reads these only to fetch the
+          # Pact Broker's per-Pact provider-verification verdict before the
+          # immutable Test Intelligence snapshot is baked. Docker receives no
+          # build arg for them, so they cannot enter the image or browser bundle.
+          PACT_BROKER_URL: ${{ vars.PACT_BROKER_URL }}
+          PACT_BROKER_USERNAME: ${{ vars.PACT_BROKER_USERNAME }}
+          PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
           # Optional: enables source-map upload to GlitchTip (#3235). Unset = no upload, normal
           # build — the maps are what turn a captured error into a file and a line.
           GLITCHTIP_AUTH_TOKEN: ${{ secrets.GLITCHTIP_AUTH_TOKEN }}

--- a/openbank-admin-ui/playwright.config.ts
+++ b/openbank-admin-ui/playwright.config.ts
@@ -14,7 +14,15 @@ export default defineConfig({
   // Fail fast in CI — one retry on flake
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  // CI retains both the human GitHub/HTML reports and a machine-readable JUnit
+  // report. The latter is consumed by the shared Test Intelligence envelope;
+  // merely exporting PLAYWRIGHT_JUNIT_OUTPUT_FILE in the workflow does nothing
+  // unless the reporter is configured to write it.
+  reporter: process.env.CI ? [
+    ['github'],
+    ['html', { open: 'never' }],
+    ['junit', { outputFile: process.env.PLAYWRIGHT_JUNIT_OUTPUT_FILE ?? 'build/test-results/e2e/playwright.xml' }],
+  ] : 'list',
 
   use: {
     baseURL: 'http://localhost:3001',

--- a/openbank-admin-ui/scripts/collect-test-intelligence.mjs
+++ b/openbank-admin-ui/scripts/collect-test-intelligence.mjs
@@ -252,6 +252,9 @@ function contracts() {
     consumer: item.consumer, provider: item.provider, pactFile: item.pactFile,
     state: item.status === 'pending' ? 'unknown' : item.status,
     observedAt: item.verifiedAt ?? null, interactions: item.interactions?.length ?? 0,
+    verificationDetail: item.status === 'pending'
+      ? 'Pact Broker provider-verification verdict was unavailable when this immutable deployment snapshot was built. This is not a passing result.'
+      : 'Verified by the Pact Broker provider-verification verdict retained in this deployment snapshot.',
   }))
   const dir = path.join(repo, 'pacts')
   if (!exists(dir)) return []
@@ -260,6 +263,7 @@ function contracts() {
     return pact ? [{
       consumer: pact.consumer?.name ?? 'unknown', provider: pact.provider?.name ?? 'unknown',
       pactFile: name, state: 'unknown', observedAt: null, interactions: pact.interactions?.length ?? 0,
+      verificationDetail: 'No Pact Broker verification snapshot was bundled. This is not a passing result.',
     }] : []
   })
 }

--- a/openbank-admin-ui/src/app/system/tests/page.tsx
+++ b/openbank-admin-ui/src/app/system/tests/page.tsx
@@ -222,10 +222,26 @@ function Coverage({ report }: { report: TestIntelligenceReport }) {
 }
 
 function Contracts({ report }: { report: TestIntelligenceReport }) {
-  return <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}><table style={tableStyle}>
-    <thead><tr><th style={thStyle}>Consumer</th><th style={thStyle}>Provider</th><th style={thStyle}>State</th><th style={thStyle}>Interactions</th><th style={thStyle}>Pact</th><th style={thStyle}>Verified</th></tr></thead>
-    <tbody>{report.contracts.map(row => <tr key={row.pactFile}><td style={tdStyle}>{row.consumer}</td><td style={tdStyle}>{row.provider}</td><td style={tdStyle}><StateBadge state={row.state} /></td><td style={tdStyle}>{row.interactions}</td><td style={tdStyle}>{row.pactFile}</td><td style={tdStyle}>{row.observedAt ? formatTimestamp(row.observedAt) : '—'}</td></tr>)}</tbody>
-  </table></div>
+  const { t } = useLanguage()
+  const unknown = report.contracts.filter(row => row.state === 'unknown')
+  const contractSuites = report.runHistory.flatMap(run => Object.entries(run.states)
+    .filter(([kind]) => kind === 'contract')
+    .map(([, state]) => state))
+  const suiteSummary = contractSuites.length === 0
+    ? t('V uchované historii není přibalen žádný contract suite verdict.', 'No contract-suite verdict is bundled in retained run history.')
+    : t(`${contractSuites.filter(state => state === 'passed').length}/${contractSuites.length} uchovaných CI contract suite verdiktů prošlo.`, `${contractSuites.filter(state => state === 'passed').length}/${contractSuites.length} retained CI contract-suite verdicts passed.`)
+  return <div style={{ display: 'grid', gap: 12 }}>
+    <div style={{ padding: 13, border: '1px solid color-mix(in srgb, #64748b 36%, var(--border))', borderRadius: 10, background: 'var(--surface-2)', color: 'var(--text-secondary)', fontSize: 12 }}>
+      <strong style={{ color: 'var(--text-primary)' }}>{t('Dva nezaměnitelné druhy důkazu.', 'Two non-interchangeable evidence types.')}</strong>{' '}
+      {t('Tabulka níže ukazuje per-Pact provider-verification verdikt z Pact Brokeru. Historie běhů ukazuje CI contract suite verdikt. Jeden není náhradou druhého a neznámý broker verdikt se nikdy nevydává za zelený.', 'The table below shows the per-Pact provider-verification verdict from the Pact Broker. Run history shows the CI contract-suite verdict. Neither substitutes for the other, and an unavailable broker verdict is never presented as green.')}
+      <div style={{ marginTop: 7 }}>{suiteSummary}</div>
+      {unknown.length > 0 && <div style={{ marginTop: 7, color: '#64748b' }}>{t(`${unknown.length} Pactů má neznámý broker verdikt v tomto snapshotu; otevři detail řádku pro přesný důvod.`, `${unknown.length} Pacts have an unavailable broker verdict in this snapshot; open a row detail for the precise reason.`)}</div>}
+    </div>
+    <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}><table style={tableStyle}>
+      <thead><tr><th style={thStyle}>Consumer</th><th style={thStyle}>Provider</th><th style={thStyle}>{t('Broker verdict', 'Broker verdict')}</th><th style={thStyle}>Interactions</th><th style={thStyle}>Pact</th><th style={thStyle}>Verified</th><th style={thStyle}>{t('Evidence basis', 'Evidence basis')}</th></tr></thead>
+      <tbody>{report.contracts.map(row => <tr key={row.pactFile}><td style={tdStyle}>{row.consumer}</td><td style={tdStyle}>{row.provider}</td><td style={tdStyle}><StateBadge state={row.state} /></td><td style={tdStyle}>{row.interactions}</td><td style={tdStyle}>{row.pactFile}</td><td style={tdStyle}>{row.observedAt ? formatTimestamp(row.observedAt) : '—'}</td><td style={{ ...tdStyle, minWidth: 300, color: 'var(--text-secondary)', fontSize: 11 }}>{row.verificationDetail ?? t('Snapshot does not provide a verification explanation.', 'Snapshot neposkytuje vysvětlení ověření.')}</td></tr>)}</tbody>
+    </table></div>
+  </div>
 }
 
 function Mutations({ report }: { report: TestIntelligenceReport }) {

--- a/openbank-admin-ui/src/lib/types/test-intelligence.ts
+++ b/openbank-admin-ui/src/lib/types/test-intelligence.ts
@@ -85,6 +85,8 @@ export interface ContractEvidence {
   state: EvidenceState
   observedAt: string | null
   interactions: number
+  /** Why a broker verdict is unavailable, or the authority behind one that is. */
+  verificationDetail?: string
 }
 
 export interface MutationEvidence {

--- a/openbank-admin-ui/src/test/playwright-test-intelligence-evidence.guard.test.ts
+++ b/openbank-admin-ui/src/test/playwright-test-intelligence-evidence.guard.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync } from 'fs'
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+
+const config = () => readFileSync(path.resolve(process.cwd(), 'playwright.config.ts'), 'utf8')
+
+describe('Playwright Test Intelligence evidence', () => {
+  it('writes a JUnit report to the workflow-controlled E2E evidence path', () => {
+    const source = config()
+    expect(source).toContain("['junit', { outputFile: process.env.PLAYWRIGHT_JUNIT_OUTPUT_FILE")
+    expect(source).toContain("'build/test-results/e2e/playwright.xml'")
+  })
+})

--- a/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
@@ -26,6 +26,10 @@ describe('test-intelligence collector', () => {
     write(repo, 'openbank-alpha-service/build/reports/kover/report.xml',
       '<report><counter type="BRANCH" missed="4" covered="6"/><counter type="LINE" missed="20" covered="80"/></report>')
     write(repo, 'openbank-libs/governance/rules.yaml', 'money_path_services:\n  - openbank-alpha-service\n')
+    write(repo, 'openbank-admin-ui/quality-report.json', JSON.stringify({ contracts: [{
+      consumer: 'openbank-alpha-service', provider: 'openbank-provider-not-inventory', pactFile: 'alpha-provider.json',
+      status: 'pending', verifiedAt: null, interactions: [{ description: 'create', status: 'pending' }],
+    }] }))
     write(repo, 'openbank-libs/governance/journeys.yaml', `version: 1
 journeys:
   - id: edge
@@ -80,6 +84,10 @@ journeys:
     expect(report.components[0].coverage.lines.percentage).toBe(80)
     expect(report.components[1].evidence).toEqual([])
     expect(report.totals.missingEvidence).toBe(1)
+    expect(report.contracts).toEqual([expect.objectContaining({
+      pactFile: 'alpha-provider.json', state: 'unknown',
+      verificationDetail: expect.stringMatching(/not a passing result/i),
+    })])
     expect(report.syntheticJourneys[0]).toMatchObject({ id: 'edge', state: 'unknown', schedule: '*/5 * * * *' })
     expect(report.syntheticJourneys[1]).toMatchObject({ id: 'mobile', state: 'blocked', schedule: '0 * * * *', blocker: 'needs canary devices' })
     expect(report.performance.find(item => item.id === 'openbank-alpha-service-alpha-smoke')).toMatchObject({ state: 'passed', metrics: {


### PR DESCRIPTION
## What

- Make unavailable Pact Broker verdicts explicit in Test Intelligence instead of an unexplained unknown state.
- Distinguish immutable per-Pact broker verification from CI contract-suite evidence and show the evidence basis per row.
- Supply the existing read-only Pact Broker credentials only to the Admin-UI snapshot collector, so its immutable deployment snapshot carries authoritative broker verdicts when the broker is available.
- Enforce that projection path through the fleet Test Intelligence ecosystem gate.
- Fix a proven fleet-attestation self-test race: under pipefail, a successful grep -q could SIGPIPE its producer and report a false supply-chain failure.
- Fix a real E2E observability gap discovered from this PR’s published run envelope: Playwright had passed but produced no JUnit XML, so the immutable envelope omitted the E2E suite. CI now explicitly configures the JUnit reporter and guards its evidence path.

No Pact Broker credential is passed as a Docker build argument or exposed to the browser bundle.

## Verification

- Targeted Test Intelligence collector and UI guard tests: 6/6 passed before the E2E evidence finding.
- Playwright evidence guard + collector tests: 5/5 passed after the finding.
- Test Intelligence ecosystem self-test and full fleet gate passed (59 subjects).
- Fleet attestation self-test: 20 consecutive passing runs; Bash syntax check passed.
- Admin-UI deployment workflow YAML parses.
- Targeted ESLint passed.
- git diff --check passed.

Refs #6614