### PR TITLE
feat(testing): add trace contract kit

### DIFF
--- a/openbank-agent-service/build.gradle.kts
+++ b/openbank-agent-service/build.gradle.kts
@@ -52,6 +52,9 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.rest.assured.kotlin)
+    // First fleet adopter of the shared OTel trace-contract kit. It keeps the agent's existing
+    // span test coupled to an evidence-safe assertion surface reusable by E2E/synthetic tests.
+    testImplementation(project(":openbank-libs-testing"))
     // D3b SVID tests build an EC CA + leaf cert at runtime (no committed private keys → gitleaks-clean).
     // Declared directly (not via the shared catalog) so this one-service test dep does not trigger a
     // full-fleet rebuild on the shared libs.versions.toml.

--- a/openbank-agent-service/src/test/kotlin/com/openbank/agent/application/AgentChatServiceTracingTest.kt
+++ b/openbank-agent-service/src/test/kotlin/com/openbank/agent/application/AgentChatServiceTracingTest.kt
@@ -17,6 +17,7 @@ import com.openbank.agent.domain.model.ToolInvocation
 import com.openbank.agent.domain.policy.EnforcementMode
 import com.openbank.agent.domain.policy.GateOutcome
 import com.openbank.agent.domain.policy.PolicyDecision
+import com.openbank.libs.testing.trace.TraceContract
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -126,6 +127,10 @@ class AgentChatServiceTracingTest {
             assertThat(a["openbank.agent.tool_calls"]).isEqualTo(1L)
             assertThat(a["openbank.agent.is_proposal"]).isEqualTo(false)
             assertThat(a["openbank.agent.model_id"]).isEqualTo("mock-echo")
+            TraceContract.from(exported)
+                .requiresSpan("agent.run")
+                .requiresAttribute("agent.run", "openbank.agent.result")
+                .hasNoErrorSpan()
         }
     }
 

--- a/openbank-libs-testing/build.gradle.kts
+++ b/openbank-libs-testing/build.gradle.kts
@@ -38,6 +38,11 @@ dependencies {
     api(libs.junit.jupiter)
     api(libs.assertj)
 
+    // Trace-contract kit exposes SpanData/SpanExporter in its public test API. Keep the
+    // SDK version aligned with the fleet's Quarkus OpenTelemetry line rather than making
+    // every consumer reinvent an in-memory exporter and ad-hoc span assertions.
+    api("io.opentelemetry:opentelemetry-sdk:1.62.0")
+
     // AuditEventTime parses a producer's real outbox payload with the same Jackson the audit
     // consumer uses. jsr310 (not bare databind) because it carries jackson-databind/core
     // transitively at the catalog's pinned `jackson` version, and this module has no Quarkus BOM

--- a/openbank-libs-testing/src/main/kotlin/com/openbank/libs/testing/trace/TraceContract.kt
+++ b/openbank-libs-testing/src/main/kotlin/com/openbank/libs/testing/trace/TraceContract.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.libs.testing.trace
+
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.sdk.trace.export.SpanExporter
+import org.assertj.core.api.Assertions.assertThat
+import java.time.Duration
+import java.util.Collections
+
+/**
+ * Assert the observable distributed-system contract of a test without exporting test data.
+ *
+ * A trace contract deliberately works on the SDK's already-exported [SpanData], so an integration,
+ * E2E or synthetic test proves the same spans that an OTLP exporter would see. Failure messages name
+ * only span names and attribute *keys*: test fixture values, trace ids and request payloads stay out
+ * of CI output and Test Intelligence evidence.
+ */
+class TraceContract private constructor(private val spans: List<SpanData>) {
+    fun requiresSpan(name: String): TraceContract {
+        assertThat(spans.any { it.name == name })
+            .describedAs("expected trace to contain span '%s'; observed span names only: %s", name, spanNames())
+            .isTrue()
+        return this
+    }
+
+    fun requiresAttribute(spanName: String, attributeKey: String): TraceContract {
+        val matching = spans.filter { it.name == spanName }
+        assertThat(matching.isNotEmpty())
+            .describedAs("cannot require attribute key '%s': trace has no span '%s'", attributeKey, spanName)
+            .isTrue()
+        assertThat(matching.any { span -> span.attributes.asMap().keys.any { it.key == attributeKey } })
+            .describedAs("expected span '%s' to carry attribute key '%s'", spanName, attributeKey)
+            .isTrue()
+        return this
+    }
+
+    fun requiresSameTrace(vararg spanNames: String): TraceContract {
+        require(spanNames.isNotEmpty()) { "at least one span name is required" }
+        spanNames.forEach(::requiresSpan)
+        val traceIds = spans.filter { it.name in spanNames }.map { it.spanContext.traceId }.toSet()
+        assertThat(traceIds)
+            .describedAs("expected named spans to share one trace; trace ids are deliberately redacted")
+            .hasSize(1)
+        return this
+    }
+
+    fun hasNoErrorSpan(): TraceContract {
+        val errorSpanNames = spans
+            .filter { it.status.statusCode == StatusCode.ERROR }
+            .map { it.name }
+        assertThat(spans.none { it.status.statusCode == StatusCode.ERROR })
+            .describedAs("expected no error span; error span names only: %s", errorSpanNames)
+            .isTrue()
+        return this
+    }
+
+    fun spanCompletesWithin(name: String, maximum: Duration): TraceContract {
+        require(!maximum.isNegative) { "maximum duration must not be negative" }
+        val matching = spans.filter { it.name == name }
+        assertThat(matching.isNotEmpty()).describedAs("cannot assess duration: trace has no span '%s'", name).isTrue()
+        assertThat(matching.all { Duration.ofNanos(it.endEpochNanos - it.startEpochNanos) <= maximum })
+            .describedAs("expected span '%s' to complete within %s", name, maximum)
+            .isTrue()
+        return this
+    }
+
+    private fun spanNames(): List<String> = spans.map { it.name }.distinct().sorted()
+
+    companion object {
+        fun from(spans: Collection<SpanData>): TraceContract = TraceContract(spans.toList())
+    }
+}
+
+/** Thread-safe in-memory SDK exporter for a test's trace contract. */
+class RecordingSpanExporter : SpanExporter {
+    private val recorded = Collections.synchronizedList(mutableListOf<SpanData>())
+
+    override fun export(spans: Collection<SpanData>): CompletableResultCode {
+        recorded.addAll(spans)
+        return CompletableResultCode.ofSuccess()
+    }
+
+    override fun flush(): CompletableResultCode = CompletableResultCode.ofSuccess()
+
+    override fun shutdown(): CompletableResultCode = CompletableResultCode.ofSuccess()
+
+    fun contract(): TraceContract = synchronized(recorded) { TraceContract.from(recorded) }
+}

--- a/openbank-libs-testing/src/test/kotlin/com/openbank/libs/testing/trace/TraceContractTest.kt
+++ b/openbank-libs-testing/src/test/kotlin/com/openbank/libs/testing/trace/TraceContractTest.kt
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.libs.testing.trace
+
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class TraceContractTest {
+    @Test
+    fun `asserts span topology attributes status and duration without exposing attribute values`() {
+        val exporter = RecordingSpanExporter()
+        val provider = SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+            .build()
+        val parent = provider.get("test").spanBuilder("journey.checkout").startSpan()
+        val child = provider.get("test")
+            .spanBuilder("payment.authorize")
+            .setParent(io.opentelemetry.context.Context.current().with(parent))
+            .startSpan()
+        child.setAllAttributes(
+            Attributes.builder()
+                .put("openbank.journey.id", "customer-fixture-never-in-output")
+                .build(),
+        )
+        child.end()
+        parent.end()
+
+        exporter.contract()
+            .requiresSpan("journey.checkout")
+            .requiresSpan("payment.authorize")
+            .requiresAttribute("payment.authorize", "openbank.journey.id")
+            .requiresSameTrace("journey.checkout", "payment.authorize")
+            .hasNoErrorSpan()
+            .spanCompletesWithin("payment.authorize", Duration.ofSeconds(1))
+
+        provider.close()
+    }
+
+    @Test
+    fun `failure message does not include sensitive attribute value or trace id`() {
+        val exporter = RecordingSpanExporter()
+        val provider = SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+            .build()
+        val span = provider.get("test").spanBuilder("payment.authorize").startSpan()
+        span.setAttribute("openbank.secret-shaped-fixture", "do-not-print-me")
+        span.setStatus(StatusCode.ERROR)
+        span.end()
+
+        assertThatThrownBy { exporter.contract().hasNoErrorSpan() }
+            .hasMessageNotContaining("do-not-print-me")
+            .hasMessageNotContaining(span.spanContext.traceId)
+
+        provider.close()
+    }
+}


### PR DESCRIPTION
## Summary
- adds a shared, evidence-safe OpenTelemetry trace-contract kit for integration, E2E and synthetic tests
- provides span topology, attribute-key, same-trace, error-state and duration assertions
- proves failure output redacts fixture values and trace IDs
- adopts the kit in the existing agent trace test

## Verification
- `./gradlew :openbank-libs-testing:ktlintCheck :openbank-agent-service:ktlintCheck :openbank-libs-testing:test --tests com.openbank.libs.testing.trace.TraceContractTest :openbank-agent-service:test --tests com.openbank.agent.application.AgentChatServiceTracingTest`

Refs #6614