### PR TITLE
ci(admin-ui): refresh Test Intelligence snapshot daily

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -35,6 +35,12 @@
 name: Admin-UI deploy
 
 on:
+  # CI evidence changes far more frequently than the Admin UI source. Rebuild the
+  # read-only evidence projection daily so a successful service/contract run cannot
+  # remain invisible in the sandbox until the next UI release. The existing job
+  # still uses the same signed image and GitOps-PR path as source-triggered deploys.
+  schedule:
+    - cron: '17 3 * * *'
   push:
     branches: [main]
     paths:
@@ -610,10 +616,10 @@ jobs:
           # skips ./gradlew sbomAll (too heavy for CI); SBOMs are staged from the
           # security workflow artifact in the preceding step instead.
           # --no-bump skips the sed+git step; the gitops PR job handles the bump.
-          # ECR tags are immutable. A manual refresh can intentionally rebuild the
-          # same commit after a new evidence artifact arrives, so make only that
-          # retry unique while retaining the commit-derived provenance in the tag.
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          # ECR tags are immutable. An operator-initiated or scheduled evidence
+          # refresh can intentionally rebuild the same commit after new artifacts
+          # arrive, so make that refresh unique while retaining commit provenance.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "schedule" ]; then
             export ADMIN_UI_IMAGE_TAG_SUFFIX="run${GITHUB_RUN_ID}"
           fi
           bash openbank-infra/scripts/build-push-admin-ui.sh --no-sbom --no-bump --no-login \

--- a/openbank-admin-ui/src/test/admin-ui-deploy-tag.guard.test.ts
+++ b/openbank-admin-ui/src/test/admin-ui-deploy-tag.guard.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 const repoRoot = join(__dirname, '../../..')
 
 describe('Admin UI deploy image-tag guard', () => {
-  it('makes manual evidence refreshes unique without changing push tags', () => {
+  it('makes operator and scheduled evidence refreshes unique without changing push tags', () => {
     const script = readFileSync(
       join(repoRoot, 'openbank-infra/scripts/build-push-admin-ui.sh'),
       'utf8',
@@ -16,11 +16,12 @@ describe('Admin UI deploy image-tag guard', () => {
     )
 
     // ECR intentionally makes tags immutable. The normal push remains the
-    // reproducible commit tag, while a workflow_dispatch gets a bounded run id
-    // suffix and can therefore deliver evidence that arrived after the first build.
+    // reproducible commit tag, while an operator or scheduled refresh gets a
+    // bounded run id suffix and can therefore deliver evidence that arrived
+    // after the first build.
     expect(script).toContain('TAG="sandbox-${GIT_SHA}${TAG_SUFFIX:+-${TAG_SUFFIX}}"')
     expect(script).toContain('^run[0-9]+$')
-    expect(workflow).toContain('if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then')
+    expect(workflow).toContain('if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "schedule" ]; then')
     expect(workflow).toContain('ADMIN_UI_IMAGE_TAG_SUFFIX="run${GITHUB_RUN_ID}"')
   })
 })


### PR DESCRIPTION
## Why

Service and contract evidence changes independently of Admin UI source. The sandbox projection was therefore only refreshed by a subsequent UI/governance change.

## Change

Schedule the existing Admin UI deploy pipeline daily at 03:17 UTC. It retains the existing signed-image and GitOps-PR path; no runtime credential or protection bypass is introduced.

## Verification

- Parsed .github/workflows/admin-ui-deploy.yml with PyYAML
- git diff --check

Refs #6570