### PR TITLE
ci(testing): refresh evidence after main CI

### DIFF
--- a/.github/scripts/check-test-intelligence-ecosystem.py
+++ b/.github/scripts/check-test-intelligence-ecosystem.py
@@ -47,9 +47,14 @@ def check(root: Path) -> list[str]:
     deploy = text(root / ".github/workflows/admin-ui-deploy.yml")
     for needle, message in (
         ("build/test-intelligence/run.json", "admin deployment does not stage the versioned run envelope"),
+        ("workflow_run:", "admin deployment does not refresh Test Intelligence after successful Services CI"),
+        ("workflows: [\"Services CI\"]", "admin deployment is not subscribed to the authoritative Services CI workflow"),
+        ("workflow_run.conclusion == 'success'", "admin deployment accepts unsuccessful Services CI evidence"),
+        ("workflow_run.head_branch == 'main'", "admin deployment accepts non-main Services CI evidence"),
         ("schedule:", "admin deployment has no scheduled Test Intelligence snapshot refresh"),
         ("cron: '17 3 * * *'", "admin deployment refresh cadence drifted from the governed daily schedule"),
         ("github.event_name }}\" = \"schedule\"", "scheduled snapshot refresh does not use a unique immutable image tag"),
+        ("github.event_name }}\" = \"workflow_run\"", "event-driven snapshot refresh does not use a unique immutable image tag"),
     ):
         if needle not in deploy:
             errors.append(message)

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -35,10 +35,13 @@
 name: Admin-UI deploy
 
 on:
-  # CI evidence changes far more frequently than the Admin UI source. Rebuild the
-  # read-only evidence projection daily so a successful service/contract run cannot
-  # remain invisible in the sandbox until the next UI release. The existing job
-  # still uses the same signed image and GitOps-PR path as source-triggered deploys.
+  # CI evidence changes far more frequently than the Admin UI source. A successful
+  # main Services CI immediately rebuilds the read-only evidence projection; the
+  # daily run is its recovery path when GitHub suppresses or delays an event. Both
+  # use the same signed image and GitOps-PR path as source-triggered deploys.
+  workflow_run:
+    workflows: ["Services CI"]
+    types: [completed]
   schedule:
     - cron: '17 3 * * *'
   push:
@@ -98,7 +101,14 @@ jobs:
     # scopes the deploy commit to the gitops manifest alone, so the loop can no longer form by
     # that route. This guard is kept as belt-and-braces: it costs nothing and still holds if a
     # future step writes into openbank-admin-ui/** again.
-    if: "!startsWith(github.event.head_commit.message, 'chore(admin-ui): deploy')"
+    # `workflow_run` is trusted only after a successful Services CI on main.  It
+    # executes this default-branch workflow, never unreviewed PR YAML, and only
+    # refreshes a read-only projection from CI artifacts.  Keep the old push
+    # loop-breaker; workflow_run has no head_commit, hence the explicit fallback.
+    if: >-
+      (github.event_name != 'workflow_run' ||
+       (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')) &&
+      !startsWith(github.event.head_commit.message || '', 'chore(admin-ui): deploy')
     # Native arm64 GitHub-hosted runner (free on public repos): the admin-ui image
     # is linux/arm64. ECR push + cosign use the same GitHub-OIDC role as before.
     runs-on: ubuntu-24.04-arm
@@ -619,7 +629,7 @@ jobs:
           # ECR tags are immutable. An operator-initiated or scheduled evidence
           # refresh can intentionally rebuild the same commit after new artifacts
           # arrive, so make that refresh unique while retaining commit provenance.
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "schedule" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_run" ]; then
             export ADMIN_UI_IMAGE_TAG_SUFFIX="run${GITHUB_RUN_ID}"
           fi
           bash openbank-infra/scripts/build-push-admin-ui.sh --no-sbom --no-bump --no-login \


### PR DESCRIPTION
## Linked issues

N/A — closes an evidence freshness gap discovered during the Test Intelligence E2E audit; no separate backlog item exists.

## Why
A successful `Services CI` on `main` produced fresh Test Intelligence envelopes but the sandbox projection refreshed only daily.

## Change
- trigger Admin-UI deploy after a successful main `Services CI` `workflow_run`
- keep daily refresh as recovery path
- use a unique immutable image tag for event-driven rebuilds
- enforce the trigger, main/success guard, and tag handling through the Test Intelligence ecosystem gate

## Verification
- `python3 .github/scripts/check-test-intelligence-ecosystem.py --self-test`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py` (`SUBJECTS=59`)
- YAML parse
- `actionlint .github/workflows/admin-ui-deploy.yml`