### PR TITLE
test(admin-ui): cover event-driven deploy tag

### DIFF
--- a/openbank-admin-ui/src/test/admin-ui-deploy-tag.guard.test.ts
+++ b/openbank-admin-ui/src/test/admin-ui-deploy-tag.guard.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 const repoRoot = join(__dirname, '../../..')
 
 describe('Admin UI deploy image-tag guard', () => {
-  it('makes operator and scheduled evidence refreshes unique without changing push tags', () => {
+  it('makes every non-push evidence refresh unique without changing push tags', () => {
     const script = readFileSync(
       join(repoRoot, 'openbank-infra/scripts/build-push-admin-ui.sh'),
       'utf8',
@@ -21,7 +21,7 @@ describe('Admin UI deploy image-tag guard', () => {
     // after the first build.
     expect(script).toContain('TAG="sandbox-${GIT_SHA}${TAG_SUFFIX:+-${TAG_SUFFIX}}"')
     expect(script).toContain('^run[0-9]+$')
-    expect(workflow).toContain('if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "schedule" ]; then')
+    expect(workflow).toContain('if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_run" ]; then')
     expect(workflow).toContain('ADMIN_UI_IMAGE_TAG_SUFFIX="run${GITHUB_RUN_ID}"')
   })
 })


### PR DESCRIPTION
## Summary

- update the deploy image-tag guard for the successful-main-CI `workflow_run` path
- retain the invariant: every non-push refresh gets a unique immutable ECR tag

## Verification

- `git diff --check`
- static guard contract check (workflow and guard assertion agree)
- full Vitest execution is delegated to required CI; local dependency installation was unavailable because the isolated environment could not resolve the npm registry

Refs #6614