### PR TITLE
fix(ci): refresh evidence after main UI CI

### DIFF
--- a/.github/scripts/check-test-intelligence-ecosystem.py
+++ b/.github/scripts/check-test-intelligence-ecosystem.py
@@ -48,7 +48,7 @@ def check(root: Path) -> list[str]:
     for needle, message in (
         ("build/test-intelligence/run.json", "admin deployment does not stage the versioned run envelope"),
         ("workflow_run:", "admin deployment does not refresh Test Intelligence after successful Services CI"),
-        ("workflows: [\"Services CI\"]", "admin deployment is not subscribed to the authoritative Services CI workflow"),
+        ("workflows: [\"Services CI\", \"CI\"]", "admin deployment is not subscribed to both fleet and Admin UI CI evidence workflows"),
         ("workflow_run.conclusion == 'success'", "admin deployment accepts unsuccessful Services CI evidence"),
         ("workflow_run.head_branch == 'main'", "admin deployment accepts non-main Services CI evidence"),
         ("schedule:", "admin deployment has no scheduled Test Intelligence snapshot refresh"),

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -36,11 +36,14 @@ name: Admin-UI deploy
 
 on:
   # CI evidence changes far more frequently than the Admin UI source. A successful
-  # main Services CI immediately rebuilds the read-only evidence projection; the
+  # main Services CI and CI immediately rebuild the read-only evidence projection; the
   # daily run is its recovery path when GitHub suppresses or delays an event. Both
   # use the same signed image and GitOps-PR path as source-triggered deploys.
   workflow_run:
-    workflows: ["Services CI"]
+    # Services CI produces fleet envelopes; CI produces the Admin UI envelope.  Subscribe
+    # to both: refreshing after Services CI alone can snapshot a stale Admin UI verdict
+    # before the same main commit's UI test artifact is available.
+    workflows: ["Services CI", "CI"]
     types: [completed]
   schedule:
     - cron: '17 3 * * *'


### PR DESCRIPTION
## Summary

- refresh Test Intelligence after both successful main `Services CI` and `CI`
- prevent the Services-CI-first race from projecting a previous failing Admin UI test after its fix has passed on main

## Verification

- `python3 .github/scripts/check-test-intelligence-ecosystem.py --self-test`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py`
- `git diff --check`

Refs #6614