### PR TITLE
fix(admin-ui): stale client test evidence

### DIFF
--- a/openbank-admin-ui/scripts/collect-test-intelligence.mjs
+++ b/openbank-admin-ui/scripts/collect-test-intelligence.mjs
@@ -393,6 +393,16 @@ function mobileClientRuns() {
     .sort((a, b) => Date.parse(b.run?.observedAt ?? 0) - Date.parse(a.run?.observedAt ?? 0))
 }
 
+function clientEvidenceState(suite, observedAt) {
+  // A private-client artifact is immutable CI evidence, but it is still only
+  // useful while it is recent.  Do not turn a recorded failure into "stale":
+  // the failure remains the more important operator verdict.
+  if (suite.state === 'failed') return 'failed'
+  if (!observedAt) return 'not-run'
+  if (collectedAt.getTime() - new Date(observedAt).getTime() > staleAfterMs) return 'stale'
+  return suite.state
+}
+
 async function clientExperiences() {
   const mobileRuns = mobileClientRuns()
   // Mobile lanes complete independently.  Select the latest *execution of each
@@ -412,7 +422,7 @@ async function clientExperiences() {
   const iosRum = exists(path.join(appSource, 'shared/src/iosMain/kotlin/tech/openbank/app/telemetry/RumMonitor.ios.kt'))
   const webEvidence = runEnvelope('openbank-admin-ui')?.evidence ?? await junitEvidence('openbank-admin-ui')
   const mobileEvidence = [...latestMobileSuites.values()].map(({ suite: item, run }) => ({
-    kind: item.kind, state: item.state, observedAt: run.run?.observedAt ?? null,
+    kind: item.kind, state: clientEvidenceState(item, run.run?.observedAt ?? null), observedAt: run.run?.observedAt ?? null,
     source: 'openbank-app-test-intelligence:v1', environment: 'ci', durationMs: item.durationMs,
     counts: item.counts, detail: item.detail,
     ...(run.run ? { run: run.run } : {}),

--- a/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
@@ -194,4 +194,27 @@ journeys:
     expect(app.rum).toMatchObject({ policy: 'consent-gated', state: 'unknown' })
     expect(report.runHistory.filter(item => item.component === 'openbank-app').map(item => item.run.id)).toEqual(['10', '9', '8'])
   })
+
+  it('marks old mobile CI evidence stale without hiding a recorded failure', () => {
+    const repo = mkdtempSync(path.join(tmpdir(), 'test-intelligence-client-freshness-'))
+    dirs.push(repo)
+    write(repo, 'openbank-libs/governance/rules.yaml', 'money_path_services: []\n')
+    write(repo, 'openbank-libs/governance/journeys.yaml', 'version: 1\njourneys: []\n')
+    write(repo, 'openbank-admin-ui/client-test-evidence/openbank-app-unit.json', JSON.stringify({
+      schemaVersion: 1, component: 'openbank-app',
+      run: { id: 'old-pass', attempt: 1, commit: 'abc', branch: 'main', workflow: 'app build', url: 'https://example.test/old-pass', observedAt: '2020-01-01T00:00:00Z' },
+      suites: [{ kind: 'unit', state: 'passed', durationMs: 100, counts: { discovered: 1, executed: 1, passed: 1, failed: 0, skipped: 0, errors: 0 } }],
+    }))
+    write(repo, 'openbank-admin-ui/client-test-evidence/openbank-app-e2e.json', JSON.stringify({
+      schemaVersion: 1, component: 'openbank-app',
+      run: { id: 'old-fail', attempt: 1, commit: 'abc', branch: 'main', workflow: 'app build', url: 'https://example.test/old-fail', observedAt: '2020-01-01T00:00:00Z' },
+      suites: [{ kind: 'e2e', state: 'failed', durationMs: 100, counts: { discovered: 1, executed: 1, passed: 0, failed: 1, skipped: 0, errors: 0 } }],
+    }))
+    const out = path.join(repo, 'report.json')
+    execFileSync('node', [SCRIPT, '--repo', repo, '--out', out, '--stale-after-days', '1'])
+    const report = JSON.parse(readFileSync(out, 'utf8')) as TestIntelligenceReport
+    const app = report.clientExperiences.find(item => item.id === 'openbank-app')!
+    expect(app.evidence.find(item => item.kind === 'unit')).toMatchObject({ state: 'stale', run: { id: 'old-pass' } })
+    expect(app.evidence.find(item => item.kind === 'e2e')).toMatchObject({ state: 'failed', run: { id: 'old-fail' } })
+  })
 })


### PR DESCRIPTION
## Why

A passing private mobile CI artifact was displayed as current indefinitely. The Test Intelligence view could therefore show old mobile evidence as green.

## What

- derive stale state from mobile run provenance using the collector freshness policy
- retain failed state as failed even when the artifact is old
- add a collector regression test for both cases

## Linked issues

Refs #4348

## Verification

- npm test -- --run src/test/test-intelligence-collector.test.ts
- npm run type-check
- git diff --check