### PR TITLE
feat(customer-edge): add term deposit journey

### DIFF
--- a/openbank-account-service/src/main/kotlin/com/openbank/account/domain/model/Account.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/domain/model/Account.kt
@@ -85,6 +85,7 @@ data class Account(
 enum class AccountType {
     CURRENT,
     SAVINGS,
+    TERM_DEPOSIT,
     NOSTRO,
     GL_ASSET,
     GL_LIABILITY,

--- a/openbank-account-service/src/main/resources/db/migration/V22__term_deposit_accounts.sql
+++ b/openbank-account-service/src/main/resources/db/migration/V22__term_deposit_accounts.sql
@@ -1,0 +1,7 @@
+-- Add the account representation of the TERM_DEPOSIT product already supported by product-catalog.
+-- Rollback: first close/migrate TERM_DEPOSIT accounts, then restore the previous check constraint.
+ALTER TABLE accounts DROP CONSTRAINT chk_accounts_type;
+
+ALTER TABLE accounts ADD CONSTRAINT chk_accounts_type CHECK (account_type IN (
+    'CURRENT','SAVINGS','TERM_DEPOSIT','NOSTRO','GL_ASSET','GL_LIABILITY','GL_INCOME','GL_EXPENSE'
+));

--- a/openbank-account-service/src/main/resources/docs/01-overview.cs.md
+++ b/openbank-account-service/src/main/resources/docs/01-overview.cs.md
@@ -4,7 +4,7 @@
 
 `openbank-account-service` je **systém záznamu (system of record) pro definici účtů** v OpenBank platformě. Drží:
 
-- **Account aggregate** — IBAN, měna, vlastník (party-id), typ účtu (CURRENT / SAVINGS / TECHNICAL), stav (ACTIVE / FROZEN / CLOSED).
+- **Account aggregate** — IBAN, měna, vlastník (party-id), typ účtu (CURRENT / SAVINGS / TERM_DEPOSIT / TECHNICAL), stav (ACTIVE / FROZEN / CLOSED).
 - **AccountAuthorization** — kdo má jaké oprávnění k účtu (OWNER / SIGNATORY / VIEWER / TECHNICAL).
 - **AccountBalance** — denormalizovaný "rychlý" zůstatek pro UI; **autoritativní zdroj je `openbank-balance-service`** (event-driven sync).
 

--- a/openbank-account-service/src/main/resources/docs/01-overview.en.md
+++ b/openbank-account-service/src/main/resources/docs/01-overview.en.md
@@ -4,7 +4,7 @@
 
 `openbank-account-service` is the **system of record for account definitions** in the OpenBank platform. It holds:
 
-- **Account aggregate** — IBAN, currency, owner (party-id), account type (CURRENT / SAVINGS / TECHNICAL), state (ACTIVE / FROZEN / CLOSED).
+- **Account aggregate** — IBAN, currency, owner (party-id), account type (CURRENT / SAVINGS / TERM_DEPOSIT / TECHNICAL), state (ACTIVE / FROZEN / CLOSED).
 - **AccountAuthorization** — who has which permissions on the account (OWNER / SIGNATORY / VIEWER / TECHNICAL).
 - **AccountBalance** — a denormalized "fast" balance for the UI; **the authoritative source is `openbank-balance-service`** (event-driven sync).
 

--- a/openbank-account-service/src/main/resources/docs/04-data.cs.md
+++ b/openbank-account-service/src/main/resources/docs/04-data.cs.md
@@ -15,7 +15,7 @@ erDiagram
     text public_id UK "acc-xxxx"
     text iban UK
     text owner_party_id "FK to party-svc, no DB FK"
-    text type "CURRENT|SAVINGS|TECHNICAL"
+    text type "CURRENT|SAVINGS|TERM_DEPOSIT|TECHNICAL"
     text currency "ISO 4217"
     text status "ACTIVE|FROZEN|CLOSED"
     text freeze_reason

--- a/openbank-account-service/src/main/resources/docs/04-data.en.md
+++ b/openbank-account-service/src/main/resources/docs/04-data.en.md
@@ -15,7 +15,7 @@ erDiagram
     text public_id UK "acc-xxxx"
     text iban UK
     text owner_party_id "FK to party-svc, no DB FK"
-    text type "CURRENT|SAVINGS|TECHNICAL"
+    text type "CURRENT|SAVINGS|TERM_DEPOSIT|TECHNICAL"
     text currency "ISO 4217"
     text status "ACTIVE|FROZEN|CLOSED"
     text freeze_reason

--- a/openbank-account-service/src/main/resources/openapi.yaml
+++ b/openbank-account-service/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Account Service API
   # API-contract axis (ADR-0048) — bumps are classified from the OpenAPI diff,
   # independently of the release version in version.txt.
-  version: 1.10.0
+  version: 1.11.0
   description: BIAN-aligned account lifecycle management — open, query, freeze, close accounts.
   contact:
     name: OpenBank Platform
@@ -718,7 +718,7 @@ components:
           type: string
         accountType:
           type: string
-          enum: [CURRENT, SAVINGS, LOAN, ESCROW]
+          enum: [CURRENT, SAVINGS, LOAN, ESCROW, TERM_DEPOSIT]
         currencyCode:
           type: string
           example: CZK

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/contract/TermDepositAccountContractTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/contract/TermDepositAccountContractTest.kt
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.account.contract
+
+import com.openbank.account.domain.model.AccountType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class TermDepositAccountContractTest {
+    @Test
+    fun `term deposit is an account domain type`() {
+        assertThat(AccountType.entries).contains(AccountType.TERM_DEPOSIT)
+    }
+
+    @Test
+    fun `open account contract exposes term deposits`() {
+        val openApi = File("src/main/resources/openapi.yaml").readText()
+
+        assertThat(openApi)
+            .contains("TERM_DEPOSIT")
+    }
+}

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/integration/AccountApiIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/integration/AccountApiIT.kt
@@ -118,6 +118,34 @@ class AccountApiIT {
 
     @Test
     @Order(5)
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `POST accounts persists a term deposit account`() {
+        val payload = """
+            {
+              "partyId": "$partyId",
+              "productId": "00000000-2222-0000-0000-000000000002",
+              "accountType": "TERM_DEPOSIT",
+              "currencyCode": "CZK",
+              "legalName": "Test Customer"
+            }
+        """.trimIndent()
+
+        Given {
+            contentType("application/json")
+            header("Idempotency-Key", UUID.randomUUID().toString())
+            body(payload)
+        } When {
+            post("/api/v1/accounts")
+        } Then {
+            statusCode(201)
+            body("accountType", equalTo("TERM_DEPOSIT"))
+            body("currencyCode", equalTo("CZK"))
+            body("status", equalTo("ACTIVE"))
+        }
+    }
+
+    @Test
+    @Order(5)
     @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_VIEWER"])
     fun `GET accounts by partyId returns list`() {
         val body = (

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/integration/AccountApiIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/integration/AccountApiIT.kt
@@ -125,7 +125,7 @@ class AccountApiIT {
               "partyId": "$partyId",
               "productId": "00000000-2222-0000-0000-000000000002",
               "accountType": "TERM_DEPOSIT",
-              "currencyCode": "CZK",
+              "currencyCode": "EUR",
               "legalName": "Test Customer"
             }
         """.trimIndent()
@@ -139,7 +139,7 @@ class AccountApiIT {
         } Then {
             statusCode(201)
             body("accountType", equalTo("TERM_DEPOSIT"))
-            body("currencyCode", equalTo("CZK"))
+            body("currencyCode", equalTo("EUR"))
             body("status", equalTo("ACTIVE"))
         }
     }

--- a/openbank-admin-ui/e2e/product-lifecycle.spec.ts
+++ b/openbank-admin-ui/e2e/product-lifecycle.spec.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const product = {
+  id: '00000000-2222-0000-0000-000000000002',
+  code: 'TERM_DEPOSIT_6M_CZK',
+  name: 'Term Deposit 6M',
+  type: 'TERM_DEPOSIT',
+  currency: 'CZK',
+  status: 'ACTIVE',
+  isPublic: true,
+  version: '1.0.0',
+  revision: 4,
+  baseRate: 0.058,
+}
+
+test.describe('product lifecycle', () => {
+  test.beforeEach(async ({ context, baseURL }) => {
+    await signInAsOperator(context, baseURL!)
+  })
+
+  test('an operator can deactivate a product and reach governed add-on management', async ({ page }) => {
+    await page.route('**/api/svc/product-catalog/api/v1/products', route => {
+      if (route.request().method() === 'GET') {
+        return route.fulfill({ contentType: 'application/json', body: JSON.stringify([product]) })
+      }
+      return route.fallback()
+    })
+    await page.route(`**/api/svc/product-catalog/api/v1/products/${product.id}/deactivate`, async route => {
+      expect(route.request().method()).toBe('POST')
+      expect(route.request().headers()['if-match']).toBe('"4"')
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ...product, status: 'INACTIVE', revision: 5 }) })
+    })
+
+    await page.goto('/product-catalog')
+    await expect(page.getByText('TERM_DEPOSIT_6M_CZK')).toBeVisible()
+    await expect(page.locator('a.btn[href="/product-studio"]')).toBeVisible()
+
+    page.once('dialog', dialog => dialog.accept())
+    await page.locator('button[title="Deactivate"]').click()
+  })
+})

--- a/openbank-admin-ui/e2e/term-deposit-account-opening.spec.ts
+++ b/openbank-admin-ui/e2e/term-deposit-account-opening.spec.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const partyId = '00000000-1111-0000-0000-000000000001'
+const productId = '00000000-2222-0000-0000-000000000002'
+const accountId = '00000000-3333-0000-0000-000000000003'
+
+test.describe('term-deposit account opening', () => {
+  test.beforeEach(async ({ context, baseURL }) => {
+    await signInAsOperator(context, baseURL!)
+  })
+
+  test('selecting an active term-deposit product fills the account and opens it', async ({ page }) => {
+    await page.route('**/api/svc/product-catalog/api/v1/products?status=ACTIVE', route => route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: productId,
+          code: 'TERM_DEPOSIT_6M_CZK',
+          name: 'Termínovaný vklad 6 měsíců',
+          type: 'TERM_DEPOSIT',
+          currency: 'CZK',
+          status: 'ACTIVE',
+        },
+      ]),
+    }))
+    await page.route('**/api/svc/account-service/api/v1/accounts', async route => {
+      expect(route.request().method()).toBe('POST')
+      expect(route.request().postDataJSON()).toMatchObject({
+        partyId,
+        productId,
+        accountType: 'TERM_DEPOSIT',
+        currencyCode: 'CZK',
+        legalName: 'Test Customer',
+      })
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: accountId }),
+      })
+    })
+
+    await page.goto('/accounts/new')
+    await page.locator('#account-party-id').fill(partyId)
+    await page.locator('#account-product-id').selectOption(productId)
+
+    await expect(page.locator('#account-type')).toHaveValue('TERM_DEPOSIT')
+    await expect(page.locator('#account-currency')).toHaveValue('CZK')
+
+    await page.locator('#account-legal-name').fill('Test Customer')
+    await page.locator('button[type="submit"]').click()
+
+    await expect(page).toHaveURL(`/accounts/${accountId}`)
+  })
+})

--- a/openbank-admin-ui/src/app/accounts/new/page.tsx
+++ b/openbank-admin-ui/src/app/accounts/new/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { ArrowLeft, Save, AlertCircle } from 'lucide-react'
@@ -14,10 +14,21 @@ import { PageHeader } from '@/components/ui/PageHeader'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { PartySearch, type PartyHit } from '@/components/party/PartySearch'
 import { accountPartySelection } from '@/lib/accounts/partySelection'
+import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 
 
-const ACCOUNT_TYPES = ['CURRENT', 'SAVINGS', 'NOSTRO', 'GL_ASSET', 'GL_LIABILITY', 'GL_INCOME', 'GL_EXPENSE']
+const ACCOUNT_TYPES = ['CURRENT', 'SAVINGS', 'TERM_DEPOSIT', 'NOSTRO', 'GL_ASSET', 'GL_LIABILITY', 'GL_INCOME', 'GL_EXPENSE']
+const CUSTOMER_ACCOUNT_TYPES = new Set(['CURRENT', 'SAVINGS', 'TERM_DEPOSIT'])
 const CURRENCIES    = ['CZK', 'EUR', 'USD', 'GBP', 'CHF', 'PLN']
+
+interface CatalogProduct {
+  id: string
+  code: string
+  name: string
+  type: string
+  currency: string
+  status: string
+}
 
 export default function NewAccountPage() {
   const router = useRouter()
@@ -32,6 +43,37 @@ export default function NewAccountPage() {
   const [errors, setErrors]   = useState<Record<string, string>>({})
   const [submitting, setSubmitting] = useState(false)
   const [apiError, setApiError]     = useState<string | null>(null)
+  const [products, setProducts] = useState<CatalogProduct[]>([])
+  const [productsLoading, setProductsLoading] = useState(true)
+  const [productsUnavailable, setProductsUnavailable] = useState(false)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    void fetch(svcUrl('product-catalog', '/api/v1/products?status=ACTIVE'), {
+      cache: 'no-store', signal: controller.signal,
+    }).then(async response => {
+      if (!response.ok) {
+        await classifyBffFailure(response.clone())
+        throw new Error('catalog unavailable')
+      }
+      const body = await response.json() as CatalogProduct[] | { products?: CatalogProduct[]; items?: CatalogProduct[] }
+      const rows = Array.isArray(body) ? body : body.products ?? body.items ?? []
+      setProducts(rows.filter(product => product.status === 'ACTIVE' && CUSTOMER_ACCOUNT_TYPES.has(product.type)))
+    }).catch(error => {
+      if (error instanceof DOMException && error.name === 'AbortError') return
+      setProductsUnavailable(true)
+    }).finally(() => setProductsLoading(false))
+    return () => controller.abort()
+  }, [])
+
+  function selectProduct(productId: string) {
+    const product = products.find(item => item.id === productId)
+    setForm(current => ({
+      ...current,
+      productId,
+      ...(product ? { accountType: product.type, currencyCode: product.currency } : {}),
+    }))
+  }
 
   function validate() {
     const e: Record<string, string> = {}
@@ -131,17 +173,31 @@ export default function NewAccountPage() {
 
               <div className="field">
                 <label htmlFor="account-product-id">{t('Product ID', 'Product ID')} <span aria-hidden="true" style={{ color: 'var(--danger)' }}>*</span></label>
-                <input
+                {!productsUnavailable ? <select
+                  id="account-product-id"
+                  className="input"
+                  required
+                  disabled={productsLoading}
+                  value={form.productId}
+                  onChange={event => selectProduct(event.target.value)}
+                  aria-invalid={Boolean(errors.productId)}
+                  aria-describedby={errors.productId ? 'account-product-id-error' : 'account-product-id-help'}
+                  style={{ borderColor: errors.productId ? 'var(--danger)' : undefined }}
+                >
+                  <option value="">{productsLoading ? t('Načítám produkty…', 'Loading products…') : t('Vyberte aktivní produkt', 'Select an active product')}</option>
+                  {products.map(product => <option key={product.id} value={product.id}>{product.name} ({product.code}) · {product.currency}</option>)}
+                </select> : <input
                   id="account-product-id"
                   className="input"
                   placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
                   value={form.productId}
                   onChange={set('productId')}
                   aria-invalid={Boolean(errors.productId)}
-                  aria-describedby={errors.productId ? 'account-product-id-error' : undefined}
+                  aria-describedby={errors.productId ? 'account-product-id-error' : 'account-product-id-help'}
                   style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '12px', borderColor: errors.productId ? 'var(--danger)' : undefined }}
-                />
+                />}
                 {errors.productId && <span id="account-product-id-error" role="alert" style={{ fontSize: '11px', color: 'var(--danger)' }}>{errors.productId}</span>}
+                {!errors.productId && <span id="account-product-id-help" style={{ fontSize: '11px', color: 'var(--text-muted)' }}>{productsUnavailable ? t('Katalog není dostupný; Product ID lze zadat ručně.', 'Catalog is unavailable; enter the Product ID manually.') : t('Typ účtu a měna se převezmou z produktu.', 'Account type and currency follow the selected product.')}</span>}
               </div>
 
               <div className="field">

--- a/openbank-admin-ui/src/app/accounts/page.tsx
+++ b/openbank-admin-ui/src/app/accounts/page.tsx
@@ -214,6 +214,7 @@ export default function AccountsPage() {
               <option value="">{t('Všechny typy', 'All types')}</option>
               <option value="CURRENT">{t('Běžný', 'Current')}</option>
               <option value="SAVINGS">{t('Spořicí', 'Savings')}</option>
+              <option value="TERM_DEPOSIT">{t('Termínovaný', 'Term deposit')}</option>
             </select>
             <button
               className="btn btn-primary"

--- a/openbank-admin-ui/src/app/product-catalog/page.tsx
+++ b/openbank-admin-ui/src/app/product-catalog/page.tsx
@@ -5,13 +5,14 @@
 'use client'
 
 import { useState, useEffect, useCallback, useMemo } from 'react'
+import Link from 'next/link'
 import {
   Package, Search, RefreshCw, Edit, Play, Square, Plus, X,
   Eye, EyeOff, CreditCard, Globe, TrendingDown,
   Clock, FileText, Tag, Users, ExternalLink, History, CheckCircle2,
   Layers, Banknote, Shield,
 } from 'lucide-react'
-import { AuthGuard } from '@/components/auth/AuthGuard'
+import { AuthGuard, Can } from '@/components/auth/AuthGuard'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { svcUrl, classifyBffFailure, type BffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
@@ -167,6 +168,7 @@ function ProductDetailPanel({ product, onClose, onEdit, onToggleStatus }: { prod
           {product.shortDescription && <div style={{ fontSize: '12px', color: 'var(--text-secondary)', marginTop: '4px' }}>{product.shortDescription}</div>}
         </div>
         <div style={{ display: 'flex', gap: '6px', flexShrink: 0, marginLeft: '12px' }}>
+          <Can permission="catalog:author">
           <button
             type="button"
             onClick={onEdit}
@@ -180,6 +182,7 @@ function ProductDetailPanel({ product, onClose, onEdit, onToggleStatus }: { prod
           <button type="button" aria-pressed={product.status === 'ACTIVE'} onClick={onToggleStatus} aria-label={product.status === 'ACTIVE' ? t('Deaktivovat produkt', 'Deactivate product') : t('Aktivovat produkt', 'Activate product')} style={{ background: sc.bg, border: `1px solid ${sc.border}`, borderRadius: '6px', padding: '5px 10px', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '4px', fontSize: '11px', color: sc.text }}>
             {product.status === 'ACTIVE' ? <><Square size={11} aria-hidden="true" /> {t('Deaktivovat', 'Deactivate')}</> : <><Play size={11} aria-hidden="true" /> {t('Aktivovat', 'Activate')}</>}
           </button>
+          </Can>
           <button type="button" onClick={onClose} aria-label={t('Zavřít detail produktu', 'Close product details')} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-tertiary)', padding: '4px' }}>
             <X size={18} aria-hidden="true" />
           </button>
@@ -542,6 +545,10 @@ export default function ProductCatalogPage() {
 
   const handleToggleStatus = async (p: Product) => {
     if (!p.id) return
+    if (p.status === 'ACTIVE' && !window.confirm(t(
+      `Deaktivovat produkt ${p.name}? Historie zůstane zachována a produkt nebude možné použít pro nové účty.`,
+      `Deactivate ${p.name}? Its history remains available and it cannot be used for new accounts.`,
+    ))) return
     setActionError(null)
     try {
       if (p.revision === undefined) {
@@ -556,7 +563,7 @@ export default function ProductCatalogPage() {
   }
 
   return (
-    <AuthGuard permission="payments:view">
+    <AuthGuard permission="catalog:read">
       <div style={{ display: 'flex', height: '100%' }}>
         <div style={{ flex: 1, minWidth: 0, padding: '28px 32px', overflowY: 'auto' }}>
 
@@ -566,9 +573,14 @@ export default function ProductCatalogPage() {
             subtitle={t('Správa bankovních produktů, sazeb, poplatků a obchodních podmínek', 'Manage banking products, rates, fees and terms')}
             breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Katalog produktů', 'Product Catalog')}</span></div>}
             actions={<div style={{ display: 'flex', gap: '8px' }}>
+              <Can permission="accounts:create"><Link href="/accounts/new" className="btn btn-secondary">
+                <CreditCard size={14} aria-hidden="true" /> {t('Založit účet', 'Open Account')}
+              </Link></Can>
+              <Can permission="catalog:author">
               <button type="button" className="btn btn-primary" onClick={openCreateModal} disabled={loading} aria-label={t('Vytvořit nový produkt', 'Create new product')}>
                 <Plus size={14} aria-hidden="true" /> {t('Nový produkt', 'New Product')}
               </button>
+              </Can>
               <button className="btn btn-secondary" type="button" onClick={load} disabled={loading}
                 aria-busy={loading} aria-label={t('Obnovit katalog produktů', 'Refresh product catalog')}>
                 <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
@@ -576,6 +588,14 @@ export default function ProductCatalogPage() {
               </button>
             </div>}
           />
+
+          <div className="card" style={{ padding: '14px 16px', marginBottom: '16px', display: 'flex', alignItems: 'center', gap: '16px', flexWrap: 'wrap' }}>
+            <div style={{ flex: 1, minWidth: '260px' }}>
+              <div style={{ fontSize: '12px', fontWeight: 700, color: 'var(--text-primary)' }}>{t('Produkty, účty a doplňkové služby', 'Products, accounts and add-on services')}</div>
+              <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginTop: '3px' }}>{t('Produkt zde vytvoříte nebo deaktivujete. Účet otevřete z aktivního produktu a uzavřete v jeho detailu. Doplňkové služby přidáte či odeberete jako vazby nabídky v Produktovém studiu.', 'Create or deactivate products here. Open an account from an active product and close it from its detail. Add or remove add-on services as offering relationships in Product Studio.')}</div>
+            </div>
+            <Can permission="catalog:read"><Link href="/product-studio" className="btn btn-secondary"><Layers size={13} />{t('Spravovat služby', 'Manage services')}</Link></Can>
+          </div>
 
           {unavailable && (
             <div className="card" style={{ padding: 0, marginBottom: '16px' }}>
@@ -689,12 +709,14 @@ export default function ProductCatalogPage() {
                     </td>
                     <td style={{ textAlign: 'right' }} onClick={e => e.stopPropagation()}>
                       <div style={{ display: 'flex', gap: '3px', justifyContent: 'flex-end' }}>
+                        <Can permission="catalog:author">
                         <button type="button" className="btn btn-secondary btn-sm" disabled={p.status === 'ACTIVE'} onClick={() => openEditModal(p)} style={{ padding: '4px' }} title={p.status === 'ACTIVE' ? t('Nejprve deaktivujte', 'Deactivate before editing') : t('Upravit', 'Edit')} aria-label={p.status === 'ACTIVE' ? t('Nejprve deaktivujte produkt před úpravou', 'Deactivate product before editing') : t('Upravit produkt', 'Edit product')}>
                           <Edit size={13} aria-hidden="true" />
                         </button>
                         <button type="button" aria-pressed={p.status === 'ACTIVE'} className="btn btn-secondary btn-sm" onClick={() => handleToggleStatus(p)} style={{ padding: '4px', color: p.status === 'ACTIVE' ? 'var(--warning-text)' : 'var(--success-text)' }} title={p.status === 'ACTIVE' ? t('Deaktivovat', 'Deactivate') : t('Aktivovat', 'Activate')} aria-label={p.status === 'ACTIVE' ? t('Deaktivovat produkt', 'Deactivate product') : t('Aktivovat produkt', 'Activate product')}>
                           {p.status === 'ACTIVE' ? <Square size={13} aria-hidden="true" /> : <Play size={13} aria-hidden="true" />}
                         </button>
+                        </Can>
                       </div>
                     </td>
                   </tr>

--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -73,7 +73,7 @@ export const PERMISSIONS = {
   "cards:block":           [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE],
   // Generic Product Studio. Scope-derived roles make the same UI usable with a provider-neutral
   // standalone OIDC issuer; OpenBank OPERATOR/ADMIN remain compatible personas.
-  "catalog:read":         [ROLES.ADMIN, ROLES.OPERATOR, ROLES.CATALOG_READ, ROLES.CATALOG_AUTHOR, ROLES.CATALOG_PUBLISH],
+  "catalog:read":         [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER, ROLES.PAYMENTS, ROLES.CATALOG_READ, ROLES.CATALOG_AUTHOR, ROLES.CATALOG_PUBLISH],
   "catalog:author":       [ROLES.ADMIN, ROLES.OPERATOR, ROLES.CATALOG_AUTHOR],
   "catalog:publish":      [ROLES.ADMIN, ROLES.OPERATOR, ROLES.CATALOG_PUBLISH],
   // Parties / KYC / Onboarding — party-service's list/search/detail GETs accept

--- a/openbank-admin-ui/src/test/catalog-account-lifecycle.guard.test.ts
+++ b/openbank-admin-ui/src/test/catalog-account-lifecycle.guard.test.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const source = (path: string) => readFileSync(new URL(path, import.meta.url), 'utf8')
+
+describe('catalog and account lifecycle controls', () => {
+  it('offers active term-deposit products when opening an account', () => {
+    const page = source('../app/accounts/new/page.tsx')
+
+    expect(page).toContain("'TERM_DEPOSIT'")
+    expect(page).toContain("/api/v1/products?status=ACTIVE")
+    expect(page).toContain('selectProduct(event.target.value)')
+  })
+
+  it('gates catalog mutations and account closure with their write permissions', () => {
+    const catalog = source('../app/product-catalog/page.tsx')
+    const account = source('../app/accounts/[id]/page.tsx')
+
+    expect(catalog).toContain('<Can permission="catalog:author">')
+    expect(account).toContain('<Can permission="accounts:close">')
+    expect(account).toContain('<Can permission="accounts:freeze">')
+  })
+
+  it('routes add-on service management through governed offering relationships', () => {
+    const catalog = source('../app/product-catalog/page.tsx')
+    const studio = source('../app/product-studio/page.tsx')
+
+    expect(catalog).toContain('href="/product-studio"')
+    expect(studio).toContain('removeOfferingRelationship')
+    expect(studio).toContain('addOfferingRelationship')
+  })
+})

--- a/openbank-admin-ui/src/types/index.ts
+++ b/openbank-admin-ui/src/types/index.ts
@@ -2,7 +2,7 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-export type AccountType = 'CURRENT' | 'SAVINGS' | 'NOSTRO' | 'GL_ASSET' | 'GL_LIABILITY' | 'GL_INCOME' | 'GL_EXPENSE'
+export type AccountType = 'CURRENT' | 'SAVINGS' | 'TERM_DEPOSIT' | 'NOSTRO' | 'GL_ASSET' | 'GL_LIABILITY' | 'GL_INCOME' | 'GL_EXPENSE'
 export type AccountStatus = 'PENDING_ACTIVATION' | 'ACTIVE' | 'DORMANT' | 'FROZEN' | 'CLOSED'
 export type TransactionType = 'DEBIT' | 'CREDIT' | 'TRANSFER' | 'FEE' | 'INTEREST' | 'REVERSAL' | 'ADJUSTMENT'
 export type TransactionStatus = 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED' | 'REVERSED'

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -409,6 +409,93 @@ class CustomerEdgeResource(
         return Response.ok(body).type(MediaType.APPLICATION_JSON).build()
     }
 
+    // --- Term deposits ---
+
+    /**
+     * Customer-safe term-deposit catalogue. The operator catalogue deliberately contains draft,
+     * private and historical products too; none of those must become discoverable merely because
+     * this edge has an M2M credential. This projection is therefore also the single source for
+     * the product eligibility check at [openTermDeposit].
+     */
+    @GET
+    @Path("/products/term-deposits")
+    @Authorize(action = "customer.products.read")
+    @Blocking
+    fun listTermDepositOffers(): Response {
+        val customer = customer()
+        val catalog = upstream.get(
+            "$productCatalogUrl/api/v1/products?type=TERM_DEPOSIT&status=ACTIVE",
+            customer.partyId.toString(),
+        )
+        if (catalog.status != 200) return termDepositCatalogueUnavailable()
+        val products = parseJson(catalog)?.takeIf { it.isArray } ?: return termDepositCatalogueUnavailable()
+        val offers = objectMapper.createArrayNode()
+        products.forEach { product -> termDepositOffer(product)?.let(offers::add) }
+        return Response.ok(objectMapper.createObjectNode().set<ArrayNode>("items", offers)).build()
+    }
+
+    @GET
+    @Path("/products/term-deposits/{productId}")
+    @Authorize(action = "customer.products.read", resource = "#productId")
+    @Blocking
+    fun getTermDepositOffer(@PathParam("productId") productId: UUID): Response =
+        when (val result = resolvePublicTermDeposit(customer(), productId)) {
+            is TermDepositResolution.Found -> Response.ok(result.offer).build()
+            TermDepositResolution.NotFound -> termDepositNotFound()
+            TermDepositResolution.Unavailable -> termDepositCatalogueUnavailable()
+        }
+
+    /**
+     * Opens a term-deposit account selected from [listTermDepositOffers]. The app intentionally
+     * supplies no account type or currency: both are fixed by the public catalogue product, so a
+     * crafted client cannot turn a term-deposit offer into another account kind or currency.
+     * Funding and maturity instructions are outside account-service's account-opening contract;
+     * this operation creates the dedicated account and the app can then present its normal funding
+     * flow.
+     */
+    @POST
+    @Path("/term-deposits")
+    @Authorize(action = "customer.products.open-term-deposit")
+    @Blocking
+    fun openTermDeposit(body: String, @HeaderParam("Idempotency-Key") idempotencyKey: String?): Response {
+        requireNotNull(idempotencyKey) { "Idempotency-Key header is required" }
+        require(idempotencyKey.isNotBlank()) { "Idempotency-Key header must not be blank" }
+        val customer = customer()
+        val productId = extractTextField(objectMapper, body, "productId")
+            ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+            ?: return Response.status(400).entity("{\"error\":\"productId must be a UUID\"}").build()
+        val offer = when (val result = resolvePublicTermDeposit(customer, productId)) {
+            is TermDepositResolution.Found -> result.offer
+            TermDepositResolution.NotFound -> return termDepositNotFound()
+            TermDepositResolution.Unavailable -> return termDepositCatalogueUnavailable()
+        }
+        val party = when (val result = activeParty(customer)) {
+            is ActivePartyResult.Approved -> result
+            is ActivePartyResult.Rejected -> return result.response
+        }
+        val accountBody = objectMapper.createObjectNode()
+            .put("partyId", customer.partyId.toString())
+            .put("productId", productId.toString())
+            .put("accountType", "TERM_DEPOSIT")
+            .put("currencyCode", offer.path("currency").asText())
+            .put("legalName", party.legalName)
+        val response = upstream.post(
+            "$accountServiceUrl/api/v1/accounts",
+            customer.partyId.toString(),
+            objectMapper.writeValueAsString(accountBody),
+            idempotencyKey,
+        )
+        audit.emit(
+            eventType = "CUSTOMER_TERM_DEPOSIT_OPENED",
+            partyId = customer.partyId.toString(),
+            operation = "termDeposits.open",
+            result = if (response.statusInfo.family == Response.Status.Family.SUCCESSFUL) "SUCCESS" else "FAILURE",
+            resourceId = extractTextField(objectMapper, (response.entity as? String).orEmpty(), "id"),
+            details = mapOf("productId" to productId.toString(), "currency" to offer.path("currency").asText()),
+        )
+        return response
+    }
+
     // --- KYC / identity verification status (AML Act §8, ADR-0116) ---
 
     /**
@@ -4377,6 +4464,106 @@ class CustomerEdgeResource(
         // upstream trouble the resolver hands back `claimed` unchanged. See PartyMergeResolver.
         return CustomerIdentity(partyMergeResolver.resolve(claimed))
     }
+
+    private sealed interface ActivePartyResult {
+        data class Approved(val legalName: String) : ActivePartyResult
+        data class Rejected(val response: Response) : ActivePartyResult
+    }
+
+    /** Shared KYC gate for products opened from the authenticated customer surface. */
+    private fun activeParty(customer: CustomerIdentity): ActivePartyResult {
+        val partyResponse = upstream.get(
+            "$partyServiceUrl/api/v1/parties/${customer.partyId}",
+            customer.partyId.toString(),
+        )
+        if (partyResponse.status != 200) {
+            return ActivePartyResult.Rejected(
+                Response.status(404).entity("{\"error\":\"Party not found\"}").type(MediaType.APPLICATION_JSON).build(),
+            )
+        }
+        val partyJson = (partyResponse.entity as? String).orEmpty()
+        val partyStatus = extractTextField(objectMapper, partyJson, "status").orEmpty()
+        if (partyStatus != "ACTIVE") {
+            return ActivePartyResult.Rejected(
+                Response.status(422)
+                    .entity("{\"error\":\"KYC not approved — party status: $partyStatus\"}")
+                    .type(MediaType.APPLICATION_JSON)
+                    .build(),
+            )
+        }
+        val legalName = extractTextField(objectMapper, partyJson, "legalName")
+            ?: return ActivePartyResult.Rejected(
+                Response.status(422).entity("{\"error\":\"Party has no legal name\"}")
+                    .type(MediaType.APPLICATION_JSON).build(),
+            )
+        return ActivePartyResult.Approved(legalName)
+    }
+
+    private sealed interface TermDepositResolution {
+        data class Found(val offer: ObjectNode) : TermDepositResolution
+        data object NotFound : TermDepositResolution
+        data object Unavailable : TermDepositResolution
+    }
+
+    private fun resolvePublicTermDeposit(customer: CustomerIdentity, productId: UUID): TermDepositResolution {
+        val catalog = upstream.get("$productCatalogUrl/api/v1/products/$productId", customer.partyId.toString())
+        if (catalog.status == 404) return TermDepositResolution.NotFound
+        if (catalog.status != 200) return TermDepositResolution.Unavailable
+        return parseJson(catalog)?.let(::termDepositOffer)?.let(TermDepositResolution::Found)
+            ?: TermDepositResolution.NotFound
+    }
+
+    /** Maps the rich operator product into only the terms a retail customer needs to decide. */
+    private fun termDepositOffer(product: JsonNode): ObjectNode? {
+        val today = LocalDate.now(clock)
+        if (!isDiscoverableTermDeposit(product) || !isCurrentlyValid(product, today)) return null
+        val configuration = product.get("termDepositConfig")?.takeIf { it.isObject } ?: return null
+        return objectMapper.createObjectNode().apply {
+            put("id", product.path("id").asText())
+            put("code", product.path("code").asText())
+            put("name", product.path("name").asText())
+            product.get("shortDescription")?.takeIf { !it.isNull }?.let { set<JsonNode>("shortDescription", it) }
+            product.get("description")?.takeIf { !it.isNull }?.let { set<JsonNode>("description", it) }
+            put("currency", product.path("currency").asText())
+            product.get("minBalance")?.takeIf { !it.isNull }?.let { set<JsonNode>("minimumDeposit", it) }
+            product.get("maxBalance")?.takeIf { !it.isNull }?.let { set<JsonNode>("maximumDeposit", it) }
+            put("annualRate", configuration.path("interestRateAnnual").asDouble())
+            set<JsonNode>("term", configuration)
+            set<JsonNode>("termsAndConditions", product.path("termsAndConditions"))
+        }
+    }
+
+    private fun isDiscoverableTermDeposit(product: JsonNode): Boolean =
+        product.path("type").asText() == "TERM_DEPOSIT" &&
+            product.path("status").asText() == "ACTIVE" &&
+            product.path("isPublic").asBoolean(false) &&
+            product.path("id").asText().isNotBlank() &&
+            product.path("currency").asText().isNotBlank()
+
+    private fun isCurrentlyValid(product: JsonNode, today: LocalDate): Boolean {
+        val validFrom = product.optionalDate("validFrom")
+        val validTo = product.optionalDate("validTo")
+        return !(validFrom?.isAfter(today) == true || validTo?.isBefore(today) == true)
+    }
+
+    private fun JsonNode.optionalDate(field: String): LocalDate? =
+        path(field).asText().takeIf { it.isNotBlank() }?.let { value ->
+            runCatching { LocalDate.parse(value) }.getOrNull()
+        }
+
+    private fun parseJson(response: Response): JsonNode? = runCatching {
+        objectMapper.readTree(response.entity?.toString().orEmpty())
+    }.getOrNull()
+
+    private fun termDepositCatalogueUnavailable(): Response = Response.status(Response.Status.BAD_GATEWAY)
+        .entity("{\"error\":\"Term deposit offers are temporarily unavailable\"}")
+        .type(MediaType.APPLICATION_JSON)
+        .build()
+
+    private fun termDepositNotFound(): Response = Response.status(404)
+        .entity("{\"error\":\"Term deposit offer not found\"}")
+        .type(MediaType.APPLICATION_JSON)
+        .build()
 
     /** Accepts "number/bankcode" BBAN or Czech IBAN — contacts store the IBAN form. */
     private fun resolveCreditorBban(raw: String): Pair<String, String>? =

--- a/openbank-customer-edge/src/main/resources/docs/03-api.cs.md
+++ b/openbank-customer-edge/src/main/resources/docs/03-api.cs.md
@@ -54,6 +54,9 @@ Všechny cesty jsou pod `/customer/v1`. Scopy jsou OAuth scopy deklarované v `o
 | `GET /devices` | `accounts:read` | vypsat zařízení (tokeny se nikdy nevrací) |
 | `POST /onboarding/start` | *(anonymní)* | vytvořit party `PENDING_ACTIVATION` |
 | `POST /onboarding/account` | `accounts:read` | otevřít první účet po KYC bráně |
+| `GET /products/term-deposits` | `accounts:read` | zobrazit aktivní veřejné nabídky termínovaných vkladů |
+| `GET /products/term-deposits/{productId}` | `accounts:read` | detail nabídky a podmínek |
+| `POST /term-deposits` | `accounts:read` | založit účet termínovaného vkladu po KYC |
 
 ## Vybrané requesty
 
@@ -97,6 +100,16 @@ Content-Type: application/json
 ### Otevření prvního účtu po KYC
 
 `POST /onboarding/account` vyžaduje `ROLE_CUSTOMER`. Edge načte party z party-service a přepošle na account-service **jen pokud `status == ACTIVE`**, přičemž injektuje `partyId` z JWT.
+
+### Termínované vklady
+
+Aplikace nabídky načte přes `GET /products/term-deposits`; edge z operátorského katalogu propustí
+jen produkty `ACTIVE`, veřejné a platné k dnešnímu dni. Nabídka obsahuje sazbu, pevnou délku,
+limity vkladu, podmínky předčasného výběru a odkazy na podmínky. Pro založení se volá
+`POST /term-deposits` pouze s `{ "productId": "…" }` a hlavičkou `Idempotency-Key`. Edge odvodí
+`TERM_DEPOSIT` i měnu z nabídky, nikoli z klientského JSONu, a použije stejnou KYC bránu `ACTIVE`
+i autoritativní jméno jako u založení účtu. Založení účtu je oddělené od jeho financování: aplikace
+pak použije běžný tok financování účtu.
 
 ## Chybový model
 

--- a/openbank-customer-edge/src/main/resources/docs/03-api.en.md
+++ b/openbank-customer-edge/src/main/resources/docs/03-api.en.md
@@ -58,6 +58,9 @@ All paths are under `/customer/v1`. Scopes are the OAuth scopes declared in `ope
 | `GET /devices` | `accounts:read` | list devices (tokens never returned) |
 | `POST /onboarding/start` | *(anonymous)* | create `PENDING_ACTIVATION` party |
 | `POST /onboarding/account` | `accounts:read` | open first account after KYC gate |
+| `GET /products/term-deposits` | `accounts:read` | discover active public term-deposit offers |
+| `GET /products/term-deposits/{productId}` | `accounts:read` | read one offer and its conditions |
+| `POST /term-deposits` | `accounts:read` | open a term-deposit account after KYC |
 
 ## Selected requests
 
@@ -101,6 +104,16 @@ Content-Type: application/json
 ### Open first account after KYC
 
 `POST /onboarding/account` requires `ROLE_CUSTOMER`. The edge reads the party from party-service and forwards to account-service **only if `status == ACTIVE`**, injecting `partyId` from the JWT.
+
+### Term deposits
+
+The app discovers offers through `GET /products/term-deposits`; the edge filters the operator
+catalogue to products that are `ACTIVE`, public and valid today. Each offer carries its rate, fixed
+term, deposit limits, early-withdrawal conditions and terms links. To open one, call
+`POST /term-deposits` with only `{ "productId": "…" }` and an `Idempotency-Key`. The edge derives
+`TERM_DEPOSIT` and the currency from that offer rather than trusting client-supplied values, then
+applies the same ACTIVE-KYC and authoritative-legal-name gate as account opening. Creating the
+account is separate from funding it: the app follows with its normal account-funding flow.
 
 ## Error model
 

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.41.0
+  version: 1.42.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -24,6 +24,7 @@ servers:
 tags:
   - name: Reference
   - name: Accounts
+  - name: Term deposits
   - name: Balances
   - name: SCA
   - name: Devices
@@ -52,6 +53,82 @@ tags:
   - name: Complaints
 
 paths:
+  /products/term-deposits:
+    get:
+      tags: [Term deposits]
+      summary: List public term-deposit offers available to the signed-in customer
+      description: >-
+        Projects only ACTIVE, public and currently valid TERM_DEPOSIT products from the operator
+        catalogue. The response includes the rate, fixed term, deposit limits, early-withdrawal
+        conditions and linked terms so the app can make the product discoverable before asking the
+        customer to open it.
+      operationId: listTermDepositOffers
+      security:
+        - customerOidc: [accounts:read]
+      responses:
+        '200':
+          description: Current public offers
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TermDepositOfferList'
+        '502':
+          description: Product catalogue unavailable
+
+  /products/term-deposits/{productId}:
+    get:
+      tags: [Term deposits]
+      summary: Read one public term-deposit offer
+      operationId: getTermDepositOffer
+      security:
+        - customerOidc: [accounts:read]
+      parameters:
+        - name: productId
+          in: path
+          required: true
+          schema: {type: string, format: uuid}
+      responses:
+        '200':
+          description: Offer and contractual conditions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TermDepositOffer'
+        '404':
+          description: No active public term-deposit offer with this ID
+
+  /term-deposits:
+    post:
+      tags: [Term deposits]
+      summary: Open a term-deposit account from a public offer
+      description: >-
+        Requires an ACTIVE KYC party. The client submits only the catalogue product ID; the edge
+        derives TERM_DEPOSIT and the product currency server-side. This creates the dedicated
+        account. Initial funding is intentionally a separate normal account-funding flow.
+      operationId: openTermDeposit
+      security:
+        - customerOidc: [accounts:read]
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema: {type: string, minLength: 1, maxLength: 255}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OpenTermDepositRequest'
+      responses:
+        '201':
+          description: Term-deposit account opened
+        '400':
+          description: Missing idempotency key or malformed product ID
+        '404':
+          description: Product is not an active public term-deposit offer, or party is absent
+        '422':
+          description: KYC not approved
+
   /feedback:
     post:
       tags: [Feedback]
@@ -4156,10 +4233,67 @@ components:
           description: Product catalogue ID for the account product
         accountType:
           type: string
-          enum: [CURRENT, SAVINGS]
+          enum: [CURRENT, SAVINGS, TERM_DEPOSIT]
         currencyCode:
           type: string
           example: EUR
+
+    OpenTermDepositRequest:
+      type: object
+      required: [productId]
+      additionalProperties: false
+      properties:
+        productId:
+          type: string
+          format: uuid
+          description: ID returned by /products/term-deposits
+
+    TermDepositOfferList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/TermDepositOffer'
+
+    TermDepositOffer:
+      type: object
+      required: [id, code, name, currency, annualRate, term, termsAndConditions]
+      properties:
+        id: {type: string, format: uuid}
+        code: {type: string, example: TERM_DEPOSIT_12M}
+        name: {type: string}
+        shortDescription: {type: string, nullable: true}
+        description: {type: string, nullable: true}
+        currency: {type: string, example: CZK}
+        minimumDeposit: {type: number, nullable: true}
+        maximumDeposit: {type: number, nullable: true}
+        annualRate: {type: number, format: double, example: 5.8}
+        term:
+          type: object
+          required: [termMonths, interestRateAnnual, payoutFrequency, autoRenewEnabled, earlyWithdrawalPenaltyPct, earlyWithdrawalNoticeDays]
+          properties:
+            termMonths: {type: integer, minimum: 1}
+            minTermMonths: {type: integer, nullable: true}
+            maxTermMonths: {type: integer, nullable: true}
+            interestRateAnnual: {type: number, format: double}
+            payoutFrequency: {type: string, enum: [MONTHLY, QUARTERLY, SEMI_ANNUAL, ANNUAL, AT_MATURITY]}
+            autoRenewEnabled: {type: boolean}
+            earlyWithdrawalPenaltyPct: {type: number, format: double}
+            earlyWithdrawalNoticeDays: {type: integer, minimum: 0}
+        termsAndConditions:
+          type: array
+          items:
+            type: object
+            required: [version, url, effectiveFrom, language]
+            properties:
+              version: {type: string}
+              url: {type: string, format: uri}
+              effectiveFrom: {type: string, format: date}
+              effectiveTo: {type: string, format: date, nullable: true}
+              language: {type: string, example: cs}
+              summary: {type: string, nullable: true}
 
     # --- Cards ---
     # Mirrors openbank-card-issuance-service CardResponse (masked PAN only).

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
@@ -54,6 +54,15 @@ class CustomerEdgeResourceTest {
     private fun accountJson(accountId: UUID, ownerParty: UUID) =
         Response.ok("""{"id":"$accountId","partyId":"$ownerParty"}""").build()
 
+    private fun termDepositProduct(id: UUID, public: Boolean = true, status: String = "ACTIVE"): String = """{
+        "id":"$id", "code":"TERM_DEPOSIT_6M_CZK", "name":"Termínovaný vklad 6 měsíců",
+        "type":"TERM_DEPOSIT", "currency":"CZK", "status":"$status", "isPublic":$public,
+        "minBalance":10000, "termDepositConfig":{"termMonths":6,"interestRateAnnual":5.8,
+        "payoutFrequency":"AT_MATURITY","autoRenewEnabled":true,"earlyWithdrawalPenaltyPct":50.0,
+        "earlyWithdrawalNoticeDays":0}, "termsAndConditions":[]
+    }
+    """.trimIndent()
+
     @Test
     fun `getBalance rejects an account owned by another party and does not proxy (IDOR guard)`() {
         val caller = UUID.randomUUID()
@@ -100,6 +109,52 @@ class CustomerEdgeResourceTest {
         val upstream = mockk<UpstreamClient>()
         every { upstream.get(any(), any()) } returns Response.status(404).build()
         assertThat(resourceFor(upstream, caller).getBalance(acct).status).isEqualTo(403)
+    }
+
+    @Test
+    fun `term deposit catalogue exposes only public active offers`() {
+        val caller = UUID.randomUUID()
+        val visible = UUID.randomUUID()
+        val private = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.contains("type=TERM_DEPOSIT") }, any()) } returns Response.ok(
+            "[${termDepositProduct(visible)},${termDepositProduct(private, public = false)}]",
+        ).build()
+
+        val response = resourceFor(upstream, caller).apply {
+            productCatalogUrl = "http://catalog"
+        }.listTermDepositOffers()
+
+        assertThat(response.status).isEqualTo(200)
+        val items = ObjectMapper().readTree(response.entity.toString()).path("items")
+        assertThat(items).hasSize(1)
+        assertThat(items[0].path("id").asText()).isEqualTo(visible.toString())
+        assertThat(items[0].path("term").path("termMonths").asInt()).isEqualTo(6)
+    }
+
+    @Test
+    fun `term deposit opening derives type and currency from the public offer`() {
+        val caller = UUID.randomUUID()
+        val product = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.endsWith("/products/$product") }, any()) } returns
+            Response.ok(termDepositProduct(product)).build()
+        every { upstream.get(match { it.contains("/parties/$caller") }, any()) } returns
+            Response.ok("""{"status":"ACTIVE","legalName":"Ada Customer"}""").build()
+        val sent = slot<String>()
+        every { upstream.post(match { it.contains("/api/v1/accounts") }, any(), capture(sent), "retry-key") } returns
+            Response.status(201).entity("""{"id":"${UUID.randomUUID()}"}""").build()
+
+        val response = resourceFor(upstream, caller).apply {
+            productCatalogUrl = "http://catalog"
+            partyServiceUrl = "http://party"
+        }.openTermDeposit("""{"productId":"$product","accountType":"CURRENT","currencyCode":"EUR"}""", "retry-key")
+
+        assertThat(response.status).isEqualTo(201)
+        val body = ObjectMapper().readTree(sent.captured)
+        assertThat(body.path("accountType").asText()).isEqualTo("TERM_DEPOSIT")
+        assertThat(body.path("currencyCode").asText()).isEqualTo("CZK")
+        assertThat(body.path("legalName").asText()).isEqualTo("Ada Customer")
     }
 
     // ── party_id claim resolution (B1 fix, ADR-0069 §2) ─────────────────────


### PR DESCRIPTION
## Summary

- add TERM_DEPOSIT to account opening and the database constraint
- add customer-edge catalogue, product detail and safe term-deposit account opening
- add operator account/product controls and focused E2E coverage

## Verification

- account service contract, integration, ktlint and detekt checks passed
- customer-edge focused test, ktlint and detekt checks passed
- admin UI type check, guard tests and focused Playwright E2E checks passed

## Release dependency

Deploy this PR before merging openbank-app PR #550 and uploading the TestFlight build.
