### PR TITLE
fix(ci): retain root test intelligence envelopes

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -420,7 +420,11 @@ jobs:
                 [ -n "${artifact_id}" ] || continue
                 archive="/tmp/${artifact_name}.zip"
                 api "https://api.github.com/repos/${REPO}/actions/artifacts/${artifact_id}/zip" -L -o "${archive}" 2>/dev/null || continue
-                envelope="$(unzip -Z1 "${archive}" | grep 'test-intelligence/run.json$' | head -1 || true)"
+                # actions/upload-artifact strips the uploaded directory prefix, so the
+                # immutable service envelope is normally `run.json` at the zip root.
+                # Keep accepting a nested path for compatibility with an artifact action
+                # layout change, but never require a source-tree path that is not retained.
+                envelope="$(unzip -Z1 "${archive}" | awk '$0 == "run.json" || /\/run\.json$/ { print; exit }' || true)"
                 [ -n "${envelope}" ] || continue
                 unzip -p "${archive}" "${envelope}" > "openbank-admin-ui/test-run-history/${artifact_name}.json"
               done


### PR DESCRIPTION
## Why

The immutable service artifact correctly contained Testcontainers lifecycle evidence, but actions/upload-artifact flattened the file to `run.json`. The deployment extractor only accepted a source-tree path, so it silently skipped every valid service envelope and rendered an empty runtime history.

## What

- accept the retained root `run.json` artifact layout
- retain compatibility with a nested `run.json` layout
- keep the artifact-first main-branch source and bounded download policy

## Linked issues

Refs #4348

## Verification

- extracted the real immutable service artifact and selected `run.json`
- python3 .github/scripts/check-test-intelligence-ecosystem.py --self-test
- python3 .github/scripts/check-test-intelligence-ecosystem.py
- YAML parse
- git diff --check