### PR TITLE
fix(ci): stage root service test envelopes

### DIFF
--- a/.github/scripts/check-test-intelligence-ecosystem.py
+++ b/.github/scripts/check-test-intelligence-ecosystem.py
@@ -47,6 +47,7 @@ def check(root: Path) -> list[str]:
     deploy = text(root / ".github/workflows/admin-ui-deploy.yml")
     for needle, message in (
         ("build/test-intelligence/run.json", "admin deployment does not stage the versioned run envelope"),
+        ("-name 'run.json'", "admin deployment does not accept the root run-envelope artifact layout"),
         ("workflow_run:", "admin deployment does not refresh Test Intelligence after successful Services CI"),
         ("workflows: [\"Services CI\", \"CI\"]", "admin deployment is not subscribed to both fleet and Admin UI CI evidence workflows"),
         ("workflow_run.conclusion == 'success'", "admin deployment accepts unsuccessful Services CI evidence"),

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -345,7 +345,12 @@ jobs:
               TMPDIR_ART="/tmp/${art_name}-extracted"
               rm -rf "${TMPDIR_ART}" && mkdir -p "${TMPDIR_ART}"
               unzip -q "/tmp/${art_name}.zip" -d "${TMPDIR_ART}" 2>/dev/null || true
-              RUN_JSON="$(find "${TMPDIR_ART}" -path '*/test-intelligence/run.json' -print -quit)"
+              # actions/upload-artifact strips the uploaded directory prefix: the
+              # service envelope is therefore normally `run.json` at the archive
+              # root.  Keep accepting the previous nested layout too, so the UI
+              # retains the latest per-service execution evidence across action
+              # layout changes rather than silently falling back to stale JUnit.
+              RUN_JSON="$(find "${TMPDIR_ART}" -type f \( -name 'run.json' -o -path '*/test-intelligence/run.json' \) -print -quit)"
               if [ -n "${RUN_JSON}" ]; then
                 mkdir -p "${svc}/build/test-intelligence"
                 cp "${RUN_JSON}" "${svc}/build/test-intelligence/run.json"


### PR DESCRIPTION
## Summary
- stage per-service Test Intelligence `run.json` from the real root artifact layout while retaining nested-layout compatibility
- ratchet the Test Intelligence ecosystem gate against removal of root-layout support

## Evidence
- `python3 .github/scripts/check-test-intelligence-ecosystem.py --self-test`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py`
- YAML parse
- real `openbank-billing-service` artifact `9568537435`: root `run.json`, schema v1 verified

Refs #4348