### PR TITLE
fix(finrep): select immutable reporting periods

### DIFF
--- a/.github/workflows/pact-drift-check.yml
+++ b/.github/workflows/pact-drift-check.yml
@@ -29,7 +29,10 @@ jobs:
   drift-check:
     name: Regenerate consumer pacts and diff against committed
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # The fleet-wide regeneration reached 18m10s while successful and twice hit the old 20m
+    # ceiling on #7001 before Gradle could finish. Keep the full derived scope and drift proof;
+    # the extra headroom covers cold-cache variance without weakening either assertion below.
+    timeout-minutes: 30
     # This job regenerates EVERY consumer pact in one Gradle invocation, and the scope is derived
     # from the @Pact annotations — so it grows by one module each time anyone adds a pact, while
     # the heap did not grow at all. It set no GRADLE_OPTS, so the daemon ran on Gradle's default,

--- a/docs/design/regulatory-reporting-ai-agents.md
+++ b/docs/design/regulatory-reporting-ai-agents.md
@@ -1,0 +1,75 @@
+# AI agents for regulatory reporting — design proposal
+
+Status: proposal, not an architectural decision. Any implementation requires an ADR, threat model,
+model-risk review, and explicit data-classification approval.
+
+## Boundary that must not move
+
+FINREP/COREP values remain deterministic Kotlin mappings over the ledger's immutable `FROZEN /
+LINES_V1` evidence. An AI model must never calculate or overwrite a cell, create or freeze an
+accounting period, post a journal, approve a close, classify a data gap as resolved, or submit a
+return. A model outage must have zero effect on report generation.
+
+Every AI result is advisory and must cite immutable inputs: close content hash, reporting date,
+template/cell coordinates, source account codes, lineage edges, and the versioned rule/taxonomy
+material used. A result without resolvable citations is rejected before persistence.
+
+## Proposed agents
+
+1. **Evidence-readiness agent** — assembles a pre-render checklist from closed-period status,
+   evidence state, balance verdicts, data-gap flags, lineage freshness and control outcomes. It
+   explains exactly why a period is or is not reportable; it cannot waive a failed gate.
+2. **Variance-investigation agent** — compares two already-rendered periods, ranks material cell
+   movements and traces them back to account groups and source services. It produces hypotheses and
+   investigation queries, never a replacement value.
+3. **Taxonomy-change agent** — monitors versioned EBA/ČNB publications, proposes a machine-readable
+   mapping diff and tests affected templates against frozen fixtures. A human regulatory owner must
+   approve the source document, interpretation and code change.
+4. **Review-pack copilot** — generates an operator narrative from deterministic facts: period/hash,
+   completeness gates, movements, known gaps, controls and approvals. Each sentence carries evidence
+   references; the operator edits and signs the final pack.
+
+The first useful delivery should be agents 1 and 2. They use only internal structured evidence and
+do not require autonomous web access. Taxonomy monitoring is valuable later but has a larger prompt-
+injection, copyright, provenance and change-management surface.
+
+## Runtime shape
+
+```text
+ledger FROZEN evidence ─┐
+finrep rendered cells ──┼─> deterministic evidence snapshot + hash ─> agent read tools
+lineage/control state ──┘                                      │
+                                                               v
+                                            structured findings with citations
+                                                               │
+                                                               v
+                                             human review in Admin UI
+```
+
+- Give agents narrow read-only tools returning typed DTOs; never SQL, arbitrary HTTP, generic MCP,
+  or write-capable service credentials.
+- Snapshot all inputs before inference and bind findings to the snapshot hash. Re-running later is a
+  new analysis, not a mutation of history.
+- Persist prompt/model/tool versions, citations, token cost, latency and reviewer disposition. Do
+  not persist unrestricted chain-of-thought.
+- Redact or aggregate customer-level data before inference. The initial agents need GL/account-group
+  facts, not natural-person PII.
+- Treat retrieved documents as untrusted data. Taxonomy instructions cannot grant tools or alter
+  system policy.
+- Use maker/checker review for any finding promoted into a regulatory work item. Submission remains
+  a separate deterministic workflow with its own authorization.
+
+## Evaluation and release gates
+
+Use a frozen golden set covering normal periods, material movements, unbalanced inputs, missing
+evidence, legacy `HASH_ONLY`, explicit COREP gaps and adversarial retrieved text. Required gates:
+
+- 100% citation validity and zero invented account/cell identifiers;
+- 100% refusal to recommend export/submission when deterministic readiness fails;
+- deterministic arithmetic independently recomputed outside the model;
+- measured precision/recall for material variance ranking, split by template;
+- no PII leakage and no tool call outside the allow-list;
+- shadow mode first, then read-only operator preview; no autonomous actuation phase.
+
+The stop condition for the first increment is an evidence-readiness panel whose every statement can
+be clicked through to a deterministic source, plus a variance report that never changes report data.

--- a/openbank-admin-ui/e2e/operator-cockpit.spec.ts
+++ b/openbank-admin-ui/e2e/operator-cockpit.spec.ts
@@ -108,6 +108,9 @@ test('compliance pack detail exposes exact reviewed content, not a summary only'
 })
 
 test('regulatory preview blocks fiction: it shows real FINREP cells and no submission claim', async ({ page }) => {
+  await json(page, '**/api/svc/finrep-service/api/v1/finrep/periods', {
+    latest: '2026-06-30', periods: ['2026-06-30'],
+  })
   await page.route('**/api/svc/finrep-service/api/v1/finrep/templates/**', route => {
     const path = new URL(route.request().url()).pathname
     const body = path.includes('F01.01')

--- a/openbank-admin-ui/src/app/regulatory/page.tsx
+++ b/openbank-admin-ui/src/app/regulatory/page.tsx
@@ -46,6 +46,7 @@ interface RegulatoryTemplate {
 type PreviewData =
   | { status: 'idle' | 'loading' }
   | { status: 'unavailable'; kind: BffFailure }
+  | { status: 'no-periods' }
   | { status: 'unsupported' }
   | { status: 'ready'; templates: RegulatoryTemplate[] }
 
@@ -66,12 +67,6 @@ const CELL_LABELS: Record<string, string> = {
   'F02.00:r010:c010': 'Celkové výnosy',
   'F02.00:r030:c010': 'Celkové náklady',
   'F02.00:r450:c010': 'Čistý zisk / ztráta',
-}
-
-/** The latest fully completed calendar quarter, never a moving live-date report. */
-function defaultReportingDate(now = new Date()): string {
-  const quarterStart = Math.floor(now.getUTCMonth() / 3) * 3
-  return new Date(Date.UTC(now.getUTCFullYear(), quarterStart, 0)).toISOString().slice(0, 10)
 }
 
 function cellLabel(template: RegulatoryTemplate, cell: RegulatoryCell): string {
@@ -247,9 +242,10 @@ export default function RegulatoryPage() {
   // export is being inspected.
   const [preview, setPreview] = useState<Report | null>(null)
   const [previewData, setPreviewData] = useState<PreviewData>({ status: 'idle' })
-  const [reportingDate, setReportingDate] = useState(() => defaultReportingDate())
+  const [reportingDate, setReportingDate] = useState('')
+  const [reportingPeriods, setReportingPeriods] = useState<string[]>([])
 
-  async function loadPreview(report: Report, asOf = reportingDate) {
+  async function loadPreview(report: Report, requestedAsOf?: string) {
     const paths = TEMPLATE_PATHS[report.id]
     if (!paths) {
       setPreviewData({ status: 'unsupported' })
@@ -257,6 +253,24 @@ export default function RegulatoryPage() {
     }
     setPreviewData({ status: 'loading' })
     try {
+      let asOf = requestedAsOf
+      if (!asOf) {
+        const periodsResponse = await fetch(svcUrl('finrep-service', '/api/v1/finrep/periods'), {
+          cache: 'no-store', signal: AbortSignal.timeout(15_000),
+        })
+        if (!periodsResponse.ok) {
+          setPreviewData({ status: 'unavailable', kind: await classifyBffFailure(periodsResponse) })
+          return
+        }
+        const available = await periodsResponse.json() as { latest: string | null; periods: string[] }
+        setReportingPeriods(available.periods)
+        if (!available.latest) {
+          setPreviewData({ status: 'no-periods' })
+          return
+        }
+        asOf = available.latest
+        setReportingDate(asOf)
+      }
       const results: TemplateLoadResult[] = await Promise.all(paths.map(async (path): Promise<TemplateLoadResult> => {
         const response = await fetch(svcUrl('finrep-service', path, { asOf }), {
           cache: 'no-store', signal: AbortSignal.timeout(15_000),
@@ -565,14 +579,15 @@ export default function RegulatoryPage() {
               <div style={{ padding: '10px 20px', borderBottom: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap', background: 'var(--surface-2)' }}>
                 <label style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '12px', color: 'var(--text-secondary)' }}>
                   {t('Referenční datum', 'Reference date')}
-                  <input
-                    type="date"
+                  <select
                     value={reportingDate}
                     onChange={e => setReportingDate(e.target.value)}
                     style={{ font: 'inherit', color: 'var(--text-primary)', border: '1px solid var(--border)', borderRadius: '4px', padding: '4px 6px', background: 'var(--surface-1)' }}
-                  />
+                  >
+                    {reportingPeriods.map(period => <option key={period} value={period}>{period}</option>)}
+                  </select>
                 </label>
-                <button type="button" className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={() => void loadPreview(preview)} disabled={previewData.status === 'loading'} aria-busy={previewData.status === 'loading'} aria-label={t('Načíst data pro náhled', 'Load preview data')}>
+                <button type="button" className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={() => void loadPreview(preview, reportingDate || undefined)} disabled={previewData.status === 'loading' || !reportingDate} aria-busy={previewData.status === 'loading'} aria-label={t('Načíst data pro náhled', 'Load preview data')}>
                   <RefreshCw size={13} aria-hidden="true" className={previewData.status === 'loading' ? 'animate-spin' : ''} />
                   {t('Načíst data', 'Load data')}
                 </button>
@@ -583,6 +598,10 @@ export default function RegulatoryPage() {
             <div style={{ overflowY: 'auto', padding: '0' }}>
               {previewData.status === 'unavailable' ? (
                 <DataUnavailable kind={previewData.kind} service="FINREP / COREP service" feature={t('regulatorní šablony', 'regulatory templates')} lang="cs" dense />
+              ) : previewData.status === 'no-periods' ? (
+                <div style={{ padding: '20px', color: 'var(--text-secondary)', fontSize: '13px' }}>
+                  {t('Ledger zatím nemá žádné zmrazené měsíční období s neměnnou řádkovou evidencí. Výkaz nelze správně sestavit, dokud operátor nedokončí uzávěrku.', 'The ledger has no frozen monthly period with immutable line evidence yet. A correct report cannot be rendered until an operator completes the close.')}
+                </div>
               ) : (
                 <table className="data-table" style={{ width: '100%' }}>
                   <thead>

--- a/openbank-admin-ui/src/lib/regulatory/exportReadiness.ts
+++ b/openbank-admin-ui/src/lib/regulatory/exportReadiness.ts
@@ -54,6 +54,7 @@
 export type PreviewLike =
   | { status: 'idle' | 'loading' }
   | { status: 'unavailable'; kind: string }
+  | { status: 'no-periods' }
   | { status: 'unsupported' }
   | { status: 'ready'; templates: ReadonlyArray<TemplateLike> }
 
@@ -83,6 +84,8 @@ export type ExportBlockReason =
   | 'no_data_source'
   /** The fetch to finrep-service failed (unreachable, unauthorized, …). */
   | 'source_unavailable'
+  /** Ledger has no immutable frozen month evidence from which a return may be rendered. */
+  | 'no_closed_periods'
   /** A template came back with no cells — malformed against the contract. */
   | 'missing_cells'
   /** At least one cell is a flagged data gap (`isDataGap`). */
@@ -109,6 +112,9 @@ export function evaluateExportReadiness(data: PreviewLike): ExportReadiness {
   }
   if (data.status === 'unavailable') {
     return { ok: false, reason: 'source_unavailable', templateIds: [] }
+  }
+  if (data.status === 'no-periods') {
+    return { ok: false, reason: 'no_closed_periods', templateIds: [] }
   }
   // Everything that is not `ready` is data we do not have: idle or still in flight. Tested via
   // `!== 'ready'` rather than by listing the two so that a future PreviewData variant defaults to
@@ -181,6 +187,10 @@ export function blockReasonCopy(
       return cs
         ? { title: 'Export je zablokován: zdroj dat není dostupný', detail: 'finrep-service neodpověděla, takže hodnoty nelze ověřit. Zkuste načtení zopakovat.' }
         : { title: 'Export blocked: data source unavailable', detail: 'finrep-service did not answer, so the values cannot be verified. Try loading again.' }
+    case 'no_closed_periods':
+      return cs
+        ? { title: 'Export je zablokován: chybí uzavřené období', detail: 'Ledger nemá žádné zmrazené měsíční období s neměnnou řádkovou evidencí (FROZEN / LINES_V1). Dokončete uzávěrku; živá předvaha se pro regulatorní výkaz nikdy nepoužije.' }
+        : { title: 'Export blocked: no closed reporting period', detail: 'The ledger has no frozen monthly period with immutable line evidence (FROZEN / LINES_V1). Complete the close; a live trial balance is never used for a regulatory return.' }
     case 'missing_cells':
       return cs
         ? { title: 'Export je zablokován: šablona je prázdná', detail: `Šablona ${list} se vrátila bez buněk. Podle kontraktu se vykresluje vždy každý řádek, takže jde o vadnou odpověď.` }

--- a/openbank-admin-ui/src/test/regulatory-export-gate.test.tsx
+++ b/openbank-admin-ui/src/test/regulatory-export-gate.test.tsx
@@ -46,6 +46,7 @@ describe('evaluateExportReadiness', () => {
     ['not_loaded', { status: 'idle' as const }],
     ['no_data_source', { status: 'unsupported' as const }],
     ['source_unavailable', { status: 'unavailable' as const, kind: 'unreachable' }],
+    ['no_closed_periods', { status: 'no-periods' as const }],
   ])('blocks with %s when the data was never obtained', (reason, data) => {
     const verdict = evaluateExportReadiness(data)
     expect(verdict.ok).toBe(false)
@@ -187,7 +188,12 @@ describe('blockReasonCopy for the balance verdicts', () => {
 const FINREP_CARD = 'CNB — Finanční výkazy (FINREP)'
 
 async function openPreview(fetchImpl: (url: string) => Promise<Response>) {
-  vi.stubGlobal('fetch', vi.fn(fetchImpl))
+  vi.stubGlobal('fetch', vi.fn((url: string) => url.includes('/api/v1/finrep/periods')
+    ? Promise.resolve(new Response(JSON.stringify({ latest: '2026-06-30', periods: ['2026-06-30'] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }))
+    : fetchImpl(url)))
   render(<LanguageProvider><RegulatoryPage /></LanguageProvider>)
   const card = (await screen.findAllByText(FINREP_CARD))[0].closest('.card')
   if (!card) throw new Error(`no .card ancestor for "${FINREP_CARD}" — the report card markup changed`)

--- a/openbank-admin-ui/src/test/regulatory-preview.guard.test.ts
+++ b/openbank-admin-ui/src/test/regulatory-preview.guard.test.ts
@@ -9,6 +9,6 @@ describe('regulatory preview loading contract', () => {
     expect(source).toContain('type="button"')
     expect(source).toContain("aria-busy={previewData.status === 'loading'}")
     expect(source).toContain("aria-label={t('Načíst data pro náhled', 'Load preview data')}")
-    expect(source).toContain('onClick={() => void loadPreview(preview)}')
+    expect(source).toContain('onClick={() => void loadPreview(preview, reportingDate || undefined)}')
   })
 })

--- a/openbank-admin-ui/src/test/regulatory-report-preview.test.tsx
+++ b/openbank-admin-ui/src/test/regulatory-report-preview.test.tsx
@@ -28,6 +28,12 @@ afterEach(() => vi.unstubAllGlobals())
 describe('Regulatory report preview', () => {
   it('loads the two implemented FINREP templates through the authenticated BFF and renders their real cells', async () => {
     const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/api/v1/finrep/periods')) {
+        return new Response(JSON.stringify({ latest: '2026-06-30', periods: ['2026-06-30', '2026-05-31'] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
       const templateId = url.includes('F01.01') ? 'F01.01' : 'F02.00'
       return new Response(JSON.stringify(finrepResponse(templateId)), {
         status: 200,
@@ -45,15 +51,16 @@ describe('Regulatory report preview', () => {
     expect(finrepCard).not.toBeNull()
     fireEvent.click(within(finrepCard as HTMLElement).getByRole('button', { name: 'Preview export' }))
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
     await waitFor(() => {
       expect(screen.queryByText(/FINREP \/ COREP service/)).not.toBeInTheDocument()
       expect(screen.getByText(/Celková aktiva/)).toBeInTheDocument()
       expect(screen.getByText(/Čistý zisk \/ ztráta/)).toBeInTheDocument()
     })
-    expect(fetchMock).toHaveBeenCalledTimes(2)
-    expect(String(fetchMock.mock.calls[0][0])).toContain('/api/svc/finrep-service/api/v1/finrep/templates/F01.01?asOf=')
-    expect(String(fetchMock.mock.calls[1][0])).toContain('/api/svc/finrep-service/api/v1/finrep/templates/F02.00?asOf=')
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(String(fetchMock.mock.calls[0][0])).toContain('/api/svc/finrep-service/api/v1/finrep/periods')
+    expect(String(fetchMock.mock.calls[1][0])).toContain('/api/svc/finrep-service/api/v1/finrep/templates/F01.01?asOf=2026-06-30')
+    expect(String(fetchMock.mock.calls[2][0])).toContain('/api/svc/finrep-service/api/v1/finrep/templates/F02.00?asOf=2026-06-30')
     expect(screen.getByText('finrep-service ← ledger trial balance (ne ClickHouse)')).toBeInTheDocument()
     expect(screen.getByTestId('export-readiness')).toHaveTextContent(/Ready for internal export/)
     expect(screen.getByRole('button', { name: 'Export preview as JSON' })).toBeEnabled()
@@ -73,17 +80,38 @@ describe('Regulatory report preview', () => {
     expect(finrepCard).not.toBeNull()
     fireEvent.click(within(finrepCard as HTMLElement).getByRole('button', { name: 'Preview export' }))
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
     expect(screen.queryByText('Celková aktiva')).not.toBeInTheDocument()
     expect(screen.queryByText('Živý datový náhled')).not.toBeInTheDocument()
     expect(screen.queryByText('Dostupnost dat')).not.toBeInTheDocument()
   })
 
+  it('explains and blocks export when no immutable closed period exists', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ latest: null, periods: [] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    render(<LanguageProvider><RegulatoryPage /></LanguageProvider>)
+
+    const finrepCard = screen.getByText('CNB — Finanční výkazy (FINREP)').closest('.card')
+    fireEvent.click(within(finrepCard as HTMLElement).getByRole('button', { name: 'Preview export' }))
+
+    expect(await screen.findByText(/A correct report cannot be rendered/i)).toBeInTheDocument()
+    expect(screen.getByTestId('export-blocked')).toHaveAttribute('data-block-reason', 'no_closed_periods')
+    expect(screen.getByRole('button', { name: 'Export preview as JSON' })).toBeDisabled()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('blocks export when COREP honestly reports a data gap', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
-      templateId: 'C_01.00', period: '2026-06-30', hasDataGaps: true,
-      cells: [{ rowRef: 'r010', colRef: 'c010', value: 0, currency: 'CZK', isDataGap: true, gapReason: 'capital accounts unavailable' }],
-    }), { status: 200, headers: { 'content-type': 'application/json' } })))
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => new Response(JSON.stringify(
+      url.includes('/api/v1/finrep/periods')
+        ? { latest: '2026-06-30', periods: ['2026-06-30'] }
+        : {
+            templateId: 'C_01.00', period: '2026-06-30', hasDataGaps: true,
+            cells: [{ rowRef: 'r010', colRef: 'c010', value: 0, currency: 'CZK', isDataGap: true, gapReason: 'capital accounts unavailable' }],
+          },
+    ), { status: 200, headers: { 'content-type': 'application/json' } })))
     render(<LanguageProvider><RegulatoryPage /></LanguageProvider>)
 
     const corepCard = screen.getByText('CNB — Kapitálová přiměřenost (COREP)').closest('.card')

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/inbound/ReportingPeriodPorts.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/inbound/ReportingPeriodPorts.kt
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.finrep.application.port.inbound
+
+import java.time.LocalDate
+
+data class ReportingPeriods(val latest: LocalDate?, val periods: List<LocalDate>)
+
+interface ReportingPeriodUseCase {
+    suspend fun listAvailable(): ReportingPeriods
+}

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/out/FinrepPorts.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/out/FinrepPorts.kt
@@ -40,6 +40,11 @@ data class TrialBalanceLineDto(val code: String, val accountType: String, val ne
  */
 data class TrialBalanceSnapshot(val lines: List<TrialBalanceLineDto>, val ledgerReportsBalanced: Boolean?)
 
+/** Minimal closed-period metadata needed to decide whether a regulatory render is reproducible. */
+data class ClosedPeriodDto(val periodType: String, val to: LocalDate, val status: String, val evidenceState: String)
+
 interface LedgerPort {
     suspend fun getTrialBalance(asOf: LocalDate): TrialBalanceSnapshot
+
+    suspend fun listClosedPeriods(): List<ClosedPeriodDto>
 }

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/ReportingPeriodService.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/ReportingPeriodService.kt
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.finrep.application.usecase
+
+import com.openbank.finrep.application.port.inbound.ReportingPeriodUseCase
+import com.openbank.finrep.application.port.inbound.ReportingPeriods
+import com.openbank.finrep.application.port.out.LedgerPort
+import jakarta.enterprise.context.ApplicationScoped
+
+/** Exposes only immutable month-end evidence that is safe to render into a regulatory return. */
+@ApplicationScoped
+class ReportingPeriodService(private val ledgerPort: LedgerPort) : ReportingPeriodUseCase {
+    override suspend fun listAvailable(): ReportingPeriods {
+        val periods = ledgerPort.listClosedPeriods()
+            .asSequence()
+            .filter { it.periodType == "MONTH" && it.status == "FROZEN" && it.evidenceState == "LINES_V1" }
+            .map { it.to }
+            .distinct()
+            .sortedDescending()
+            .toList()
+        return ReportingPeriods(latest = periods.firstOrNull(), periods = periods)
+    }
+}

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/client/LedgerClient.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/client/LedgerClient.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.finrep.infrastructure.client
 
+import com.openbank.finrep.application.port.out.ClosedPeriodDto
 import com.openbank.finrep.application.port.out.LedgerPort
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
 import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
@@ -17,6 +18,7 @@ import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
@@ -40,14 +42,20 @@ import java.time.LocalDate
 @RegisterRestClient(configKey = "ledger-service")
 @RegisterProvider(SyntheticTaintClientFilter::class)
 @RegisterProvider(OidcClientRequestReactiveFilter::class)
-@Path("/api/v1/ledger/periods/MONTH")
+@Path("/api/v1/ledger/periods")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 interface LedgerRestClient {
 
     @GET
-    @Path("/{asOf}/frozen-trial-balance")
+    @Path("/MONTH/{asOf}/frozen-trial-balance")
     fun getTrialBalance(@PathParam("asOf") asOf: String): Uni<ClosedPeriodTrialBalanceResponse>
+
+    @GET
+    fun listClosedPeriods(
+        @QueryParam("from") from: String,
+        @QueryParam("to") to: String,
+    ): Uni<List<ClosedPeriodResponse>>
 }
 
 data class TrialBalanceLineResponse(val code: String, val type: String, val net: BigDecimal, val currency: String)
@@ -67,6 +75,13 @@ data class ClosedPeriodTrialBalanceResponse(
     val period: String,
     val balanced: Boolean?,
     val lines: List<TrialBalanceLineResponse>,
+)
+
+data class ClosedPeriodResponse(
+    val periodType: String,
+    val to: LocalDate,
+    val status: String,
+    val evidenceState: String,
 )
 
 @ApplicationScoped
@@ -91,5 +106,20 @@ class LedgerAdapter(@RestClient private val client: LedgerRestClient) : LedgerPo
             },
             ledgerReportsBalanced = response.balanced,
         )
+    }
+
+    override suspend fun listClosedPeriods(): List<ClosedPeriodDto> =
+        client.listClosedPeriods(CLOSED_PERIODS_FROM, CLOSED_PERIODS_TO).awaitSuspending().map {
+            ClosedPeriodDto(
+                periodType = it.periodType,
+                to = it.to,
+                status = it.status,
+                evidenceState = it.evidenceState,
+            )
+        }
+
+    private companion object {
+        const val CLOSED_PERIODS_FROM = "1970-01-01"
+        const val CLOSED_PERIODS_TO = "9999-12-31"
     }
 }

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/rest/ReportingPeriodResource.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/rest/ReportingPeriodResource.kt
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.finrep.infrastructure.rest
+
+import com.openbank.finrep.application.port.inbound.ReportingPeriodUseCase
+import com.openbank.finrep.application.port.inbound.ReportingPeriods
+import com.openbank.libs.security.Roles
+import jakarta.annotation.security.RolesAllowed
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+
+@ApplicationScoped
+@Path("/api/v1/finrep/periods")
+@Produces(MediaType.APPLICATION_JSON)
+@RolesAllowed(Roles.ADMIN, Roles.OPERATOR)
+class ReportingPeriodResource(private val reportingPeriods: ReportingPeriodUseCase) {
+    @GET
+    suspend fun list(): ReportingPeriods = reportingPeriods.listAvailable()
+}

--- a/openbank-finrep-service/src/main/resources/openapi.yaml
+++ b/openbank-finrep-service/src/main/resources/openapi.yaml
@@ -20,11 +20,31 @@ info:
 
     Cells are always fully rendered: a value the platform cannot honestly derive is an explicit
     flagged zero (`isDataGap`), never an omitted row, so a regulatory return never has a silent gap.
-  version: 1.2.0
+  version: 1.3.0
 tags:
   - name: FINREP
   - name: COREP
 paths:
+  /api/v1/finrep/periods:
+    get:
+      tags: [FINREP]
+      summary: List reporting dates backed by immutable ledger evidence
+      description: >-
+        Returns only MONTH closes whose status is FROZEN and evidence state is LINES_V1. DRAFT,
+        legacy HASH_ONLY, quarter/year and missing closes are excluded; clients must not guess a
+        reporting date or fall back to a mutable trial balance.
+      operationId: listFinrepReportingPeriods
+      responses:
+        '200':
+          description: Available dates, newest first; latest is null when none are available
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ReportingPeriods' }
+        '401':
+          description: Missing or invalid access token
+        '403':
+          description: Token lacks ROLE_ADMIN or ROLE_OPERATOR
+
   /api/v1/finrep/templates/{templateId}:
     get:
       tags: [FINREP]
@@ -107,6 +127,18 @@ paths:
 
 components:
   schemas:
+    ReportingPeriods:
+      type: object
+      required: [periods]
+      properties:
+        latest:
+          type: string
+          format: date
+          nullable: true
+        periods:
+          type: array
+          items: { type: string, format: date }
+
     FinrepCell:
       type: object
       description: One FINREP template cell — an (row, column) coordinate with its monetary value.

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/ReportingPeriodServiceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/ReportingPeriodServiceTest.kt
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.finrep.application.usecase
+
+import com.openbank.finrep.application.port.out.ClosedPeriodDto
+import com.openbank.finrep.application.port.out.LedgerPort
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class ReportingPeriodServiceTest {
+    private val ledger = mockk<LedgerPort>()
+    private val service = ReportingPeriodService(ledger)
+
+    @Test
+    fun `only immutable frozen month evidence is available newest first`(): Unit = runBlocking {
+        coEvery { ledger.listClosedPeriods() } returns listOf(
+            period("2026-05-31", "MONTH", "FROZEN", "LINES_V1"),
+            period("2026-06-30", "MONTH", "FROZEN", "LINES_V1"),
+            period("2026-07-31", "MONTH", "DRAFT", "LINES_V1"),
+            period("2026-04-30", "MONTH", "FROZEN", "HASH_ONLY"),
+            period("2026-06-30", "QUARTER", "FROZEN", "LINES_V1"),
+        )
+
+        val result = service.listAvailable()
+
+        assertThat(result.latest).isEqualTo(LocalDate.parse("2026-06-30"))
+        assertThat(result.periods).containsExactly(LocalDate.parse("2026-06-30"), LocalDate.parse("2026-05-31"))
+    }
+
+    @Test
+    fun `no qualifying evidence is represented honestly`(): Unit = runBlocking {
+        coEvery { ledger.listClosedPeriods() } returns emptyList()
+
+        val result = service.listAvailable()
+
+        assertThat(result.latest).isNull()
+        assertThat(result.periods).isEmpty()
+    }
+
+    private fun period(to: String, type: String, status: String, evidence: String) = ClosedPeriodDto(
+        periodType = type,
+        to = LocalDate.parse(to),
+        status = status,
+        evidenceState = evidence,
+    )
+}

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/LedgerTrialBalancePactConsumerTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/LedgerTrialBalancePactConsumerTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.finrep.contract
 
 import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonArray
 import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
 import au.com.dius.pact.consumer.dsl.PactDslWithProvider
 import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
@@ -18,10 +19,12 @@ import com.openbank.finrep.application.port.out.TrialBalanceLineDto
 import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
 import com.openbank.finrep.domain.mapper.F0101Mapper
 import com.openbank.finrep.domain.model.BalanceVerdict
+import com.openbank.finrep.infrastructure.client.ClosedPeriodResponse
 import com.openbank.finrep.infrastructure.client.ClosedPeriodTrialBalanceResponse
 import com.openbank.finrep.infrastructure.client.LedgerRestClient
 import io.restassured.RestAssured.given
 import jakarta.ws.rs.Path
+import jakarta.ws.rs.QueryParam
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -81,7 +84,7 @@ import java.time.LocalDate
 @PactTestFor(providerName = "openbank-ledger-service", pactVersion = PactSpecVersion.V3)
 class LedgerTrialBalancePactConsumerTest {
 
-    private val json = jacksonObjectMapper()
+    private val json = jacksonObjectMapper().findAndRegisterModules()
 
     @Pact(consumer = "openbank-finrep-service", provider = "openbank-ledger-service")
     fun trialBalanceWithEntriesPact(builder: PactDslWithProvider): RequestResponsePact = builder
@@ -118,6 +121,29 @@ class LedgerTrialBalancePactConsumerTest {
                     // and no fewer (the client's `currency` is non-nullable, so a provider that
                     // stopped sending it would fail deserialization at runtime, not here).
                     line.stringType("currency", "CZK")
+                }
+            }.build(),
+        )
+        .toPact()
+
+    @Pact(consumer = "openbank-finrep-service", provider = "openbank-ledger-service")
+    fun closedPeriodsPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("ledger has frozen monthly trial balance for the reporting date")
+        .uponReceiving("GET closed periods available for regulatory reporting")
+        .path(LEDGER_PERIODS_PATH)
+        .query("from=$CLOSED_PERIODS_FROM&to=$CLOSED_PERIODS_TO")
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonArray { a ->
+                a.`object` { period ->
+                    period.stringValue("periodType", "MONTH")
+                    period.stringValue("to", REPORTING_DATE)
+                    period.stringValue("status", "FROZEN")
+                    period.stringValue("evidenceState", "LINES_V1")
                 }
             }.build(),
         )
@@ -168,6 +194,30 @@ class LedgerTrialBalancePactConsumerTest {
         assertThat(template.balanceVerdict).isEqualTo(BalanceVerdict.SOURCES_DISAGREE)
     }
 
+    @Test
+    @PactTestFor(pactMethod = "closedPeriodsPact")
+    fun `the ledger client exposes immutable reporting period eligibility`(mockServer: MockServer) {
+        assertThat(ledgerPeriodsPath).isEqualTo(LEDGER_PERIODS_PATH)
+
+        val body = given()
+            .baseUri(mockServer.getUrl())
+            .accept("application/json")
+            .queryParam(closedPeriodsFromParam, CLOSED_PERIODS_FROM)
+            .queryParam(closedPeriodsToParam, CLOSED_PERIODS_TO)
+            .get(ledgerPeriodsPath)
+            .then()
+            .statusCode(200)
+            .extract().body().asString()
+        val periods: List<ClosedPeriodResponse> = json.readValue(body)
+
+        assertThat(periods).hasSize(1)
+        val period = periods.single()
+        assertThat(period.periodType).isEqualTo("MONTH")
+        assertThat(period.to).isEqualTo(LocalDate.parse(REPORTING_DATE))
+        assertThat(period.status).isEqualTo("FROZEN")
+        assertThat(period.evidenceState).isEqualTo("LINES_V1")
+    }
+
     /** Issues the request against the path the production client is annotated with. */
     private fun fetchTrialBalance(mockServer: MockServer, asOf: String): ClosedPeriodTrialBalanceResponse {
         val body = given()
@@ -193,6 +243,9 @@ class LedgerTrialBalancePactConsumerTest {
          * the annotation is measured against.
          */
         const val LEDGER_MONTH_TRIAL_BALANCE_PATH = "/api/v1/ledger/periods/MONTH"
+        const val LEDGER_PERIODS_PATH = "/api/v1/ledger/periods"
+        const val CLOSED_PERIODS_FROM = "1970-01-01"
+        const val CLOSED_PERIODS_TO = "9999-12-31"
 
         /** Ledger's query-parameter name for the as-of date — likewise literal. */
         /** A FINREP quarter-end reference date. */
@@ -200,6 +253,11 @@ class LedgerTrialBalancePactConsumerTest {
 
         private val getTrialBalanceMethod =
             LedgerRestClient::class.java.getDeclaredMethod("getTrialBalance", String::class.java)
+        private val listClosedPeriodsMethod = LedgerRestClient::class.java.getDeclaredMethod(
+            "listClosedPeriods",
+            String::class.java,
+            String::class.java,
+        )
 
         /**
          * `@Path` on the interface + `@Path` on the method, joined the way JAX-RS resolves them.
@@ -209,6 +267,12 @@ class LedgerTrialBalancePactConsumerTest {
             LedgerRestClient::class.java.getAnnotation(Path::class.java).value,
             getTrialBalanceMethod.getAnnotation(Path::class.java).value,
         ).joinToString("/") { it.trim('/') }.let { "/$it" }
+
+        val ledgerPeriodsPath: String = LedgerRestClient::class.java.getAnnotation(Path::class.java).value
+        val closedPeriodsFromParam: String =
+            listClosedPeriodsMethod.parameterAnnotations[0].filterIsInstance<QueryParam>().single().value
+        val closedPeriodsToParam: String =
+            listClosedPeriodsMethod.parameterAnnotations[1].filterIsInstance<QueryParam>().single().value
 
         /** The query-parameter name the production client sends the as-of date under. */
     }

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/TemplateWireFormatTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/TemplateWireFormatTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.finrep.contract
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.finrep.application.port.out.ClosedPeriodDto
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
 import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
 import com.openbank.finrep.infrastructure.client.LedgerAdapter
@@ -104,7 +105,26 @@ class TemplateWireFormatTest {
             // Ledger's own verdict for this fixture, passed explicitly: it ties out (issue #6011).
             ledgerReportsBalanced = true,
         )
+        coEvery { ledger.listClosedPeriods() } returns listOf(
+            ClosedPeriodDto("MONTH", LocalDate.of(2026, 6, 30), "FROZEN", "LINES_V1"),
+            ClosedPeriodDto("MONTH", LocalDate.of(2026, 5, 31), "DRAFT", "LINES_V1"),
+        )
         QuarkusMock.installMockForType(ledger, LedgerAdapter::class.java)
+    }
+
+    @Test
+    fun `reporting periods expose only immutable evidence`() {
+        val body = given()
+            .accept("application/json")
+            .get("/api/v1/finrep/periods")
+            .then()
+            .statusCode(200)
+            .extract().body().asString()
+        val json = mapper.readValue(body, Map::class.java)
+
+        assertThat(json.keys).containsExactlyInAnyOrder("latest", "periods")
+        assertThat(json["latest"]).isEqualTo("2026-06-30")
+        assertThat(json["periods"]).isEqualTo(listOf("2026-06-30"))
     }
 
     private fun getJson(path: String, asOf: LocalDate): Map<*, *> {

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/client/LedgerAdapterTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/client/LedgerAdapterTest.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.finrep.infrastructure.client
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.smallrye.mutiny.Uni
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class LedgerAdapterTest {
+
+    @Test
+    fun `closed periods use the complete date range and preserve ledger evidence`(): Unit = runBlocking {
+        val client = mockk<LedgerRestClient>()
+        every { client.listClosedPeriods("1970-01-01", "9999-12-31") } returns Uni.createFrom().item(
+            listOf(
+                ClosedPeriodResponse(
+                    periodType = "MONTH",
+                    to = LocalDate.parse("2026-06-30"),
+                    status = "FROZEN",
+                    evidenceState = "LINES_V1",
+                ),
+            ),
+        )
+
+        val periods = LedgerAdapter(client).listClosedPeriods()
+
+        assertThat(periods).hasSize(1)
+        val period = periods.single()
+        assertThat(period.periodType).isEqualTo("MONTH")
+        assertThat(period.to).isEqualTo(LocalDate.parse("2026-06-30"))
+        assertThat(period.status).isEqualTo("FROZEN")
+        assertThat(period.evidenceState).isEqualTo("LINES_V1")
+        verify(exactly = 1) { client.listClosedPeriods("1970-01-01", "9999-12-31") }
+    }
+}

--- a/pacts/openbank-finrep-service-openbank-ledger-service.json
+++ b/pacts/openbank-finrep-service-openbank-ledger-service.json
@@ -4,6 +4,43 @@
   },
   "interactions": [
     {
+      "description": "GET closed periods available for regulatory reporting",
+      "providerStates": [
+        {
+          "name": "ledger has frozen monthly trial balance for the reporting date"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/ledger/periods",
+        "query": {
+          "from": [
+            "1970-01-01"
+          ],
+          "to": [
+            "9999-12-31"
+          ]
+        }
+      },
+      "response": {
+        "body": [
+          {
+            "evidenceState": "LINES_V1",
+            "periodType": "MONTH",
+            "status": "FROZEN",
+            "to": "2026-06-30"
+          }
+        ],
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "status": 200
+      }
+    },
+    {
       "description": "GET the GL trial balance for a FINREP reporting date",
       "providerStates": [
         {


### PR DESCRIPTION
## Summary

Stops the regulatory UI from guessing a reporting date and failing generically. FINREP now exposes only ledger periods backed by immutable `MONTH` / `FROZEN` / `LINES_V1` evidence; the UI selects the latest eligible period, constrains the selector to eligible dates, and blocks export with a precise no-close reason.

## Type of change

- [x] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [x] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #7000

## Changes

- Add `GET /api/v1/finrep/periods`, filtering ledger closes fail-closed and returning newest-first eligible dates.
- Replace the admin UI's guessed quarter-end date with eligible-period discovery and an explicit no-period blocking state.
- Extend the FINREP→ledger Pact with the literal list route, required date-range parameters, consumed wire fields, and provider replay.
- Document four advisory, evidence-bound regulatory AI agents and their non-negotiable deterministic boundary.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [x] Contract tests updated (if public API changed).
- [x] Relevant service test, detekt, ktlintCheck and quarkusBuild gates pass.
- [x] No new lint warnings.
- [x] OpenAPI spec updated (additive 1.2.0 → 1.3.0).
- [x] Flyway migration added + rollback note (N/A: no DB change).
- [x] Avro schema versioned backward-compatibly (N/A: no event change).
- [x] Docs updated.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, or `@Suppress`.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code unchanged.
- [x] PII path unchanged.
- [x] Cardholder data path unchanged.

## Compliance impact

- [x] CNB reporting

The change strengthens evidence selection: only immutable ledger closes can feed a regulatory preview or export. AI remains advisory/read-only and cannot calculate, alter, approve, or submit report values.

## Rollout / Rollback

- Deployment strategy: rolling
- Rollback plan: revert the three commits; no persisted data or schema is changed.
- Data migration reversible: N/A

## Screenshots / demo

The sandbox admin endpoint requires an interactive Keycloak session unavailable to the isolated worktree. UI behavior is covered by 28 focused tests and a successful Next.js production build.

## Reviewer notes

Provider replay initially caught a real 400 because ledger requires `from` and `to` on its list endpoint; the final client and Pact both pin those parameters. Please focus review on the fail-closed eligibility predicate and the AI-agent trust boundary.

### Verification

- `./gradlew :openbank-finrep-service:test :openbank-finrep-service:ktlintCheck :openbank-finrep-service:detekt :openbank-finrep-service:quarkusBuild`
- `./gradlew :openbank-ledger-service:test --tests '*LedgerPactProviderVerificationTest*'`
- `npm test -- --run src/test/regulatory-report-preview.test.tsx src/test/regulatory-export-gate.test.tsx`
- `npx eslint ...` on all changed UI/test files
- `npm run build`
- API contract, route conformance, and Pact provider-replay governance scripts
