### PR TITLE
test(standing-order): eliminate scheduler fixture race

### DIFF
--- a/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/integration/StandingOrderExecutionSweepIT.kt
+++ b/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/integration/StandingOrderExecutionSweepIT.kt
@@ -97,7 +97,7 @@ class StandingOrderExecutionSweepIT {
         return dueEventCount(orderId)
     }
 
-    private fun dueOnceOrder(id: UUID, due: LocalDate): StandingOrder {
+    private fun dueDailyOrder(id: UUID, due: LocalDate): StandingOrder {
         val now = Instant.now(clock)
         return StandingOrder(
             id = id,
@@ -111,7 +111,11 @@ class StandingOrderExecutionSweepIT {
             creditorBic = null,
             amountMinorUnits = 4_200,
             currency = "EUR",
-            frequency = Frequency.ONCE,
+            // A ONCE order intentionally stays due until its payment is confirmed. With the
+            // dispatcher disabled and this profile's two-second cron, that fixture can be picked
+            // up again between the outbox assertion and the reload below. DAILY advances beyond
+            // today's sweep while exercising the same scheduler, transaction and outbox path.
+            frequency = Frequency.DAILY,
             paymentType = PaymentType.SEPA_CREDIT,
             remittanceInfo = null,
             startDate = due,
@@ -130,7 +134,7 @@ class StandingOrderExecutionSweepIT {
     fun `the scheduled sweep executes a due order and writes its outbox event`() {
         val id = Ids.newId()
         val today = LocalDate.now(clock)
-        onEventLoop { repository.save(dueOnceOrder(id, today)) }
+        onEventLoop { repository.save(dueDailyOrder(id, today)) }
 
         assertThat(awaitDueEvent(id))
             .describedAs(
@@ -146,16 +150,15 @@ class StandingOrderExecutionSweepIT {
             .isEqualTo(1)
         assertThat(reloaded.status)
             .describedAs(
-                "the sweep only SCHEDULES the attempt — dispatch is off in this profile, so the " +
-                    "payment was never actually confirmed. Staying ACTIVE (not COMPLETED) here is " +
-                    "the fix for the #3931-class defect where a ONCE order completed before its " +
-                    "payment was even attempted, so a failed one-off silently ended up COMPLETED " +
-                    "with zero money moved.",
+                "the recurring order remains active after its due occurrence is scheduled",
             )
             .isEqualTo(StandingOrderStatus.ACTIVE)
         assertThat(reloaded.lastExecutionDate)
             .describedAs("the execution is stamped with the date it was due")
             .isEqualTo(today)
+        assertThat(reloaded.nextExecutionDate)
+            .describedAs("the fixture must advance beyond this sweep so the fast cron cannot reschedule it")
+            .isEqualTo(today.plusDays(1))
     }
 
     private companion object {


### PR DESCRIPTION
## Cause
The cron IT used a due ONCE order while the dispatcher was disabled. ONCE deliberately remains ACTIVE and due until payment confirmation, so the two-second test cron could schedule it again between the outbox poll and entity reload. The recorded line-146 failure was therefore a fixture race, not a lost Vert.x scheduler context.

## Fix
- use a DAILY fixture that advances beyond the current sweep after one scheduling
- keep the real Quarkus cron, reactive Postgres and atomic outbox/update assertions
- explicitly assert the next date advanced, without increasing the timeout
- retain the separate focused ONCE lifecycle tests

## Verification
- cron-driven Testcontainers IT passed three independent runs
- ktlintCheck passed
- detekt passed
- git diff --check passed

Closes #7010