### PR TITLE
fix(admin-ui): expose campaign action state

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -202,7 +202,7 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
   // machine; whether the caller may run them is decided by OPA, and the domain re-asserts
   // maker != checker on activate. The UI renders capability, the policy decides it.
   const [actionError, setActionError] = useState<string | null>(null)
-  const [acting, setActing] = useState(false)
+  const [actingAction, setActingAction] = useState<string | null>(null)
   const [duplicating, setDuplicating] = useState(false)
 
   /**
@@ -233,7 +233,7 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
   }
 
   const runAction = (action: string) => {
-    setActing(true)
+    setActingAction(action)
     setActionError(null)
     fetch(`/api/campaigns/${encodeURIComponent(id ?? '')}/actions`, {
       method: 'POST',
@@ -260,7 +260,7 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
         )
       })
       .catch(() => setActionError(t('Campaign-service neodpovídá.', 'Campaign-service is not responding.')))
-      .finally(() => setActing(false))
+      .finally(() => setActingAction(null))
   }
 
   const actionsFor = (state?: string): string[] => {
@@ -509,7 +509,8 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
               <button
                 type="button"
                 onClick={() => runAction(a)}
-                disabled={acting}
+                disabled={actingAction !== null}
+                aria-busy={actingAction === a}
                 className="rounded-md border px-3 py-1.5 text-sm disabled:opacity-40"
               >
                 {actionLabel(a)}
@@ -542,7 +543,13 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
               </p>
             </div>
             <Can permission="campaign:create" fallback={<span className="text-xs text-muted-foreground">{t('Kopii může vytvořit jen oprávněný operátor', 'Only an authorized operator can create a copy')}</span>}>
-              <button type="button" className="btn btn-secondary" onClick={duplicateAsDraft} disabled={duplicating}>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={duplicateAsDraft}
+                disabled={duplicating}
+                aria-busy={duplicating}
+              >
                 {duplicating ? t('Zakládám koncept…', 'Creating draft…') : t('Vytvořit kopii jako koncept', 'Create draft copy')}
               </button>
             </Can>
@@ -826,15 +833,21 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
                 </span>
                 <span className="flex gap-2">
                   <button
+                    type="button"
                     onClick={() => loadSends(sendPage.page - 1, outcomeFilter)}
                     disabled={sendPage.page === 0 || sendsLoading}
+                    aria-busy={sendsLoading}
+                    aria-label={t('Předchozí stránka logu odeslání', 'Previous send-log page')}
                     className="rounded-md border px-2 py-1 text-xs disabled:opacity-40"
                   >
                     {t('Předchozí', 'Previous')}
                   </button>
                   <button
+                    type="button"
                     onClick={() => loadSends(sendPage.page + 1, outcomeFilter)}
                     disabled={(sendPage.page + 1) * sendPage.size >= sendPage.total || sendsLoading}
+                    aria-busy={sendsLoading}
+                    aria-label={t('Další stránka logu odeslání', 'Next send-log page')}
                     className="rounded-md border px-2 py-1 text-xs disabled:opacity-40"
                   >
                     {t('Další', 'Next')}

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -1017,8 +1017,10 @@ export default function NewCampaignPage() {
         </div>
         <div className="campaign-composer-footer-actions">
         <button
+          type="button"
           onClick={submit}
           disabled={!ready || saving}
+          aria-busy={saving}
           className="btn btn-primary disabled:opacity-40"
         >
           {saving

--- a/openbank-admin-ui/src/app/campaigns/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/page.tsx
@@ -517,7 +517,7 @@ export default function CampaignsPage() {
               className="w-72 rounded-md border bg-transparent px-3 py-1.5 text-sm"
             />
             {stateFilter && (
-              <button className="btn btn-secondary" style={{ fontSize: 11 }} onClick={() => setStateFilter(null)} data-testid="clear-state">
+              <button type="button" className="btn btn-secondary" style={{ fontSize: 11 }} onClick={() => setStateFilter(null)} data-testid="clear-state">
                 {t('Filtr:', 'Filter:')} {label(stateFilter)} ✕
               </button>
             )}

--- a/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
@@ -103,7 +103,7 @@ export function StepEditor({
         <h3 className="text-sm font-semibold">
           {t('Krok', 'Step')} {index + 1}
         </h3>
-        <button onClick={onClose} className="text-xs text-muted-foreground hover:underline">
+        <button type="button" onClick={onClose} className="text-xs text-muted-foreground hover:underline">
           {t('Hotovo', 'Done')}
         </button>
       </div>

--- a/openbank-admin-ui/src/test/campaign-action-state.guard.test.ts
+++ b/openbank-admin-ui/src/test/campaign-action-state.guard.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const read = (path: string) => readFileSync(new URL(path, import.meta.url), 'utf8')
+
+describe('campaign action state accessibility guard', () => {
+  it('exposes truthful progress for draft and detail mutations', () => {
+    const composer = read('../app/campaigns/new/page.tsx')
+    const detail = read('../app/campaigns/[id]/page.tsx')
+
+    expect(composer).toMatch(/type="button"[\s\S]*?onClick=\{submit\}[\s\S]*?aria-busy=\{saving\}/)
+    expect(detail).toContain('const [actingAction, setActingAction] = useState<string | null>(null)')
+    expect(detail).toContain('aria-busy={actingAction === a}')
+    expect(detail).toContain('aria-busy={duplicating}')
+    expect(detail).toContain("aria-label={t('Předchozí stránka logu odeslání', 'Previous send-log page')}")
+    expect(detail).toContain("aria-label={t('Další stránka logu odeslání', 'Next send-log page')}")
+  })
+
+  it('keeps non-submit campaign controls explicit buttons', () => {
+    const portfolio = read('../app/campaigns/page.tsx')
+    const stepEditor = read('../components/campaigns/StepEditor.tsx')
+
+    expect(portfolio).toContain('<button type="button" className="btn btn-secondary"')
+    expect(portfolio).toContain('data-testid="clear-state"')
+    expect(stepEditor).toMatch(/<button type="button" onClick=\{onClose\}/)
+  })
+})


### PR DESCRIPTION
## Summary
- announce the exact in-flight Campaign Studio lifecycle action instead of exposing only a blanket disabled state
- expose draft creation, duplication, and send-log paging progress to assistive technology
- make the remaining campaign reset, paging, composer, and step-editor controls explicit non-submit buttons

## Safety
- campaign payloads, BFF routes, lifecycle transitions, maker-checker enforcement, RBAC, contact policy, and analytics remain unchanged
- this is an isolated accessibility/progress slice of #4476, not completion of the whole Campaign Studio objective

## Verification
- `npx vitest run src/test/campaign-action-state.guard.test.ts src/test/campaign-studio.test.tsx` — 22/22 passed
- `npx playwright test e2e/campaign-entry-authoring.spec.ts --reporter=line` — 1/1 passed
- scoped ESLint — 0 errors; 3 pre-existing `react-hooks/set-state-in-effect` warnings in the composer
- `git diff --check origin/main...HEAD`

Refs #4476