### PR TITLE
feat(governance): reuse synthetic journey evidence

### DIFF
--- a/.github/scripts/check-journey-catalog.py
+++ b/.github/scripts/check-journey-catalog.py
@@ -46,6 +46,7 @@
 #   2 — findings (with --enforce; without it they are ::warning and the exit is 0)
 #
 # Run:  python3 .github/scripts/check-journey-catalog.py --root . [--enforce]
+#       python3 .github/scripts/check-journey-catalog.py --root . --extract public-edge --out /tmp/journey.js
 #       python3 .github/scripts/check-journey-catalog.py --self-test
 
 import argparse
@@ -159,6 +160,35 @@ def cronjob_facts(root: pathlib.Path, rel_path: str, journey_id: str):
             )
         return spec.get("schedule"), defined_configmaps, None
     return None, defined_configmaps, f"{rel_path} defines no CronJob named {CRONJOB_PREFIX}{journey_id}"
+
+
+def extract_script(root: pathlib.Path, journey_id: str) -> str:
+    """Return the exact ConfigMap-mounted k6 program for one active catalog journey.
+
+    The manifest is the runtime artifact applied by Argo CD. CI extracts that same scalar
+    instead of keeping a sibling .js file which can drift from what the CronJob executes.
+    """
+    catalog = yaml.safe_load((root / CATALOG).read_text(encoding="utf-8")) or {}
+    matches = [item for item in catalog.get("journeys", []) if item.get("id") == journey_id]
+    if len(matches) != 1 or matches[0].get("status") != "active":
+        raise ValueError(f"{journey_id}: expected exactly one active catalog entry")
+    rel_path = matches[0].get("cronjob")
+    docs = load_docs(root / rel_path)
+    cronjob_name = f"{CRONJOB_PREFIX}{journey_id}"
+    cronjob = next((d for d in docs if d.get("kind") == "CronJob" and
+                    (d.get("metadata") or {}).get("name") == cronjob_name), None)
+    if cronjob is None:
+        raise ValueError(f"{journey_id}: manifest defines no {cronjob_name} CronJob")
+    pod = (((cronjob.get("spec") or {}).get("jobTemplate") or {}).get("spec") or {}).get("template") or {}
+    pod_spec = pod.get("spec") or {}
+    mounted = {(volume.get("configMap") or {}).get("name") for volume in pod_spec.get("volumes", [])
+               if isinstance(volume, dict) and volume.get("configMap")}
+    scripts = [((doc.get("data") or {}).get("journey.js")) for doc in docs
+               if doc.get("kind") == "ConfigMap" and (doc.get("metadata") or {}).get("name") in mounted]
+    scripts = [script for script in scripts if isinstance(script, str) and script.strip()]
+    if len(scripts) != 1:
+        raise ValueError(f"{journey_id}: expected one mounted non-empty journey.js, found {len(scripts)}")
+    return scripts[0]
 
 
 def alerted_journeys(root: pathlib.Path):
@@ -422,6 +452,18 @@ def self_test():
         SELF_TEST_CRONJOB.replace("name: journey-demo-script\ndata:", "name: some-other-name\ndata:"),
         SELF_TEST_RULES, expect_finding=True)
 
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        write_tree(root, SELF_TEST_CATALOG_OK, SELF_TEST_CRONJOB, SELF_TEST_RULES)
+        extracted = extract_script(root, "demo")
+        cases.append(("control: CI extracts the exact mounted runtime script",
+                      extracted == "export default function () {}", [repr(extracted)]))
+        try:
+            extract_script(root, "later")
+            cases.append(("planned journey cannot be executed", False, []))
+        except ValueError:
+            cases.append(("planned journey cannot be executed", True, []))
+
     run("empty catalog is fatal, not a pass",
         "version: 1\njourneys: []\n", SELF_TEST_CRONJOB, SELF_TEST_RULES, expect_finding=True)
 
@@ -458,12 +500,25 @@ def main():
     parser.add_argument("--root", default=".")
     parser.add_argument("--enforce", action="store_true")
     parser.add_argument("--self-test", action="store_true", dest="selftest")
+    parser.add_argument("--extract", metavar="JOURNEY_ID")
+    parser.add_argument("--out")
     args = parser.parse_args()
 
     if args.selftest:
         return self_test()
 
     root = pathlib.Path(args.root).resolve()
+    if args.extract:
+        if not args.out:
+            parser.error("--extract requires --out")
+        try:
+            script = extract_script(root, args.extract)
+        except (OSError, yaml.YAMLError, ValueError) as exc:
+            print(f"::error::check-journey-catalog: cannot extract {args.extract}: {exc}")
+            return 1
+        pathlib.Path(args.out).write_text(script, encoding="utf-8")
+        print(f"check-journey-catalog: extracted {args.extract} runtime script to {args.out}")
+        return 0
     findings, fatal, subjects = check(root)
     # Printed unconditionally, including on the failure path: a gate that found its corpus and
     # then failed on it must not also be reported as having lost the corpus.

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -60,6 +60,7 @@ on:
       - "openbank-libs/governance/agents.yaml"
       - "openbank-libs/governance/compliance-controls.yaml"
       - "openbank-libs/governance/rules.yaml"
+      - "openbank-libs/governance/journeys.yaml"
       # openbank-libs/docs is the ONLY docs tree baked into the image: the Dockerfile's
       # docs-collector copies /repo/openbank-*/docs, and src/lib/services/docs.ts serves the
       # `libs` service from /app/docs-bundle rather than from a running pod. Every other

--- a/.github/workflows/main-red-watch.yml
+++ b/.github/workflows/main-red-watch.yml
@@ -73,6 +73,7 @@ on:
       - "Pact drift check"
       - "Product Catalog Native Build (T1 enabler smoke test)"
       - "Schema registry apply (document-service pilot)"
+      - "Synthetic journeys"
     types: [completed]
   pull_request:
     paths:

--- a/.github/workflows/synthetic-journeys.yml
+++ b/.github/workflows/synthetic-journeys.yml
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# One executable journey, three call sites (ADR-0252 phase 2, #4348).
+#
+# The k6 program is not copied into this workflow. It is extracted from the ConfigMap that
+# Argo CD applies and the sandbox CronJob mounts. A PR therefore proves the proposed runtime
+# artifact, a GitOps merge proves the newly desired sandbox state, and the CronJob keeps
+# falsifying it every five minutes. The post-merge lane is watched by main-red-watch.
+name: Synthetic journeys
+
+on:
+  pull_request:
+    paths:
+      - ".github/scripts/check-journey-catalog.py"
+      - ".github/workflows/synthetic-journeys.yml"
+      - "openbank-libs/governance/journeys.yaml"
+      - "openbank-infra/gitops/components/observability/cronjob-journey-public-edge.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "openbank-infra/gitops/components/observability/cronjob-journey-public-edge.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: synthetic-public-edge-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  public-edge:
+    name: public-edge / exact runtime artifact
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install PyYAML
+        run: bash .github/scripts/install-pyyaml-hash-pinned.sh
+
+      - name: Validate catalog and extract the mounted k6 program
+        run: |
+          python3 .github/scripts/check-journey-catalog.py --self-test
+          python3 .github/scripts/check-journey-catalog.py --root . --enforce
+          mkdir -p synthetic-evidence
+          python3 .github/scripts/check-journey-catalog.py \
+            --root . --extract public-edge --out synthetic-evidence/journey.js
+
+      - name: Run the exact sandbox journey
+        run: |
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            --volume "$PWD/synthetic-evidence:/evidence" \
+            docker.io/grafana/k6:1.2.0@sha256:5301215b669b3758b1b3b1f43a25a91378c2bbb8cbb6b29d5b4a44be8064dedc \
+            run --quiet --summary-export /evidence/summary.json /evidence/journey.js
+
+      - name: Retain immutable synthetic evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: synthetic-public-edge-${{ github.run_id }}-${{ github.run_attempt }}
+          path: synthetic-evidence/
+          retention-days: 30
+          if-no-files-found: error

--- a/openbank-infra/gitops/components/observability/cronjob-journey-public-edge.yaml
+++ b/openbank-infra/gitops/components/observability/cronjob-journey-public-edge.yaml
@@ -144,7 +144,7 @@ spec:
               # (measured with `docker run grafana/k6:0.58.0 version`), so that pin runs a
               # release candidate in a production monitor while reading as the last stable
               # 0.x. `1.2.0` reports `k6 v1.2.0`.
-              image: docker.io/grafana/k6:1.2.0
+              image: docker.io/grafana/k6:1.2.0@sha256:5301215b669b3758b1b3b1f43a25a91378c2bbb8cbb6b29d5b4a44be8064dedc
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true

--- a/openbank-libs/governance/journeys.yaml
+++ b/openbank-libs/governance/journeys.yaml
@@ -39,9 +39,10 @@
 #   money_moving   true when the journey initiates a real payment or ledger posting.
 #   cronjob        path to the manifest that runs it — the CronJob and the ConfigMap holding
 #                  its k6 script live in that one file (active only). The script is embedded
-#                  rather than kept as a sibling .js so there is no second copy to drift:
-#                  the same reason the external-feed watch reads its URL out of the committed
-#                  config instead of keeping its own.
+#                  rather than kept as a sibling .js so there is no second copy to drift.
+#                  CI extracts this exact ConfigMap scalar for the PR and post-GitOps-merge
+#                  calls; the periodic CronJob mounts it directly. One executable artifact,
+#                  three call sites, enforced by check-journey-catalog.py.
 #   schedule       cron expression, mirrored from the manifest (active only).
 #   target_schedule intended cadence once a planned journey's blocker is removed. It is shown
 #                  in Test Intelligence but never interpreted as proof that a scheduler exists.


### PR DESCRIPTION
## Summary
- execute the exact ConfigMap-mounted public-edge k6 program in PR validation and after its GitOps merge
- keep the sandbox CronJob as the third call site and pin all executions to the same k6 image digest
- retain immutable k6 summaries and route post-merge failures through the existing main-red watch
- rebuild Admin UI when the governed journey catalog changes

## Evidence
- check-journey-catalog self-test: 16/16
- catalog and main-red-watch declarations: clean
- actionlint and YAML parsing: clean
- exact extracted runtime program: 3/3 checks passed against public sandbox edges, p95 71.44 ms

Refs #4348