### PR TITLE
feat(party): expose pending approvals in unified inbox

### DIFF
--- a/openbank-admin-ui/src/app/api/approvals/pending/route.ts
+++ b/openbank-admin-ui/src/app/api/approvals/pending/route.ts
@@ -26,12 +26,11 @@ const NOT_CONFIGURED_SOURCES = {
   balance: 'not-configured',
   billing: 'not-configured',
   consent: 'not-configured',
-  party: 'not-configured',
 } as const satisfies Record<string, SourceState>
 
 type InboxItem = {
   id: string
-  domain: 'lending' | 'sanctions' | 'transaction' | 'domestic-payment' | 'clearing' | 'fx' | 'ledger' | 'swift' | 'sepa-payment' | 'sepa-instant' | 'notification' | 'agent'
+  domain: 'lending' | 'sanctions' | 'transaction' | 'domestic-payment' | 'clearing' | 'fx' | 'ledger' | 'swift' | 'sepa-payment' | 'sepa-instant' | 'notification' | 'party' | 'agent'
   action: string
   resourceId: string | null
   maker: string | null
@@ -95,6 +94,10 @@ type SepaPaymentApproval = LendingApproval
 // an `opsmessage.compose` four-eyes decision parked at 202 was discoverable only by whoever had
 // been handed its id out of band.
 type NotificationApproval = LendingApproval
+
+// party-service serves the same shared PendingApproval shape. This source turns the approval id
+// returned from a parked `party.merge` into a visible checker hand-off before its 24-hour TTL.
+type PartyApproval = LendingApproval
 
 type AgentProposal = {
   id: string
@@ -291,6 +294,21 @@ async function notificationPending(headers: HeadersInit): Promise<SourceResult> 
   }
 }
 
+async function partyPending(headers: HeadersInit): Promise<SourceResult> {
+  const res = await fetch(serverSvcUrl('party-service', 'party', 8111, '/api/v1/parties/approvals', { limit: '50' }), {
+    headers, signal: AbortSignal.timeout(4000), cache: 'no-store',
+  })
+  if (!res.ok) return { items: [], state: stateFor(res.status) }
+  const rows = (await res.json()) as PartyApproval[]
+  return {
+    state: 'ok',
+    items: rows.map(r => ({
+      id: r.id, domain: 'party' as const, action: r.action,
+      resourceId: r.resourceId, maker: r.makerId, proposedAt: r.createdAt,
+    })),
+  }
+}
+
 function agentBase(): string {
   if (process.env.SERVICES_HOST === 'container') return 'http://openbank-agent-service:8109'
   return (process.env.AGENT_SERVICE_URL ?? 'http://localhost:8109/mcp').replace(/\/mcp$/, '')
@@ -318,7 +336,7 @@ export async function GET() {
   }
   const headers = { authorization: `Bearer ${session.user.accessToken}` }
   const unavailable: SourceResult = { items: [], state: 'unavailable' }
-  const [lending, sanctions, transaction, domesticPayment, clearing, fx, ledger, swift, sepaPayment, sepaInstant, notification, agent] = await Promise.all([
+  const [lending, sanctions, transaction, domesticPayment, clearing, fx, ledger, swift, sepaPayment, sepaInstant, notification, party, agent] = await Promise.all([
     lendingPending(headers).catch(() => unavailable),
     sanctionsPending(headers).catch(() => unavailable),
     transactionPending(headers).catch(() => unavailable),
@@ -330,9 +348,10 @@ export async function GET() {
     sepaPaymentPending(headers).catch(() => unavailable),
     sepaInstantPending(headers).catch(() => unavailable),
     notificationPending(headers).catch(() => unavailable),
+    partyPending(headers).catch(() => unavailable),
     agentPending(headers).catch(() => unavailable),
   ])
-  const items = [...lending.items, ...sanctions.items, ...transaction.items, ...domesticPayment.items, ...clearing.items, ...fx.items, ...ledger.items, ...swift.items, ...sepaPayment.items, ...sepaInstant.items, ...notification.items, ...agent.items]
+  const items = [...lending.items, ...sanctions.items, ...transaction.items, ...domesticPayment.items, ...clearing.items, ...fx.items, ...ledger.items, ...swift.items, ...sepaPayment.items, ...sepaInstant.items, ...notification.items, ...party.items, ...agent.items]
     .sort((a, b) => (a.proposedAt ?? '').localeCompare(b.proposedAt ?? ''))
   return NextResponse.json({
     items,
@@ -349,6 +368,7 @@ export async function GET() {
       'sepa-payment': sepaPayment.state,
       'sepa-instant': sepaInstant.state,
       notification: notification.state,
+      party: party.state,
       agent: agent.state,
     },
   })

--- a/openbank-admin-ui/src/test/approvals-inbox.test.ts
+++ b/openbank-admin-ui/src/test/approvals-inbox.test.ts
@@ -127,8 +127,7 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(body.items[10]).toMatchObject({ domain: 'sanctions', action: 'sanctions.clear', maker: 'analyst.c' })
     expect(body.items[11]).toMatchObject({ domain: 'agent', action: 'agent.research' })
     expect(body.items[12]).toMatchObject({ domain: 'transaction', action: 'transaction.reverse', maker: 'teller.d' })
-    expect(body.sources.account).toBe('not-configured')
-    expect(body.sources.balance).toBe('not-configured')
+    expect(body.sources.party).toBe('ok')
   })
 
   // The regression this file exists to prevent, stated as a test for the transaction slice of

--- a/openbank-admin-ui/src/test/approvals-inbox.test.ts
+++ b/openbank-admin-ui/src/test/approvals-inbox.test.ts
@@ -33,7 +33,7 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(res.status).toBe(401)
   })
 
-  it('merges lending, sanctions, transaction, domestic-payment, clearing, fx, ledger, swift, sepaPayment, sepa-instant, notification and agent queues into canonical items, sorted by proposedAt', async () => {
+  it('merges every configured domain queue into canonical items, sorted by proposedAt', async () => {
     const mock = vi.fn().mockImplementation((url: string) => {
       if (url.includes('lending')) {
         return Promise.resolve(new Response(JSON.stringify([
@@ -96,6 +96,11 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
           { id: 'N-1', action: 'opsmessage.compose', resourceId: null, makerId: 'operator.f', createdAt: '2026-07-29T10:30:00Z' },
         ]), { status: 200 }))
       }
+      if (url.includes('parties/approvals') || url.includes('party-service')) {
+        return Promise.resolve(new Response(JSON.stringify([
+          { id: 'PT-1', action: 'party.merge', resourceId: 'party-7', makerId: 'operator.g', createdAt: '2026-07-29T11:45:00Z' },
+        ]), { status: 200 }))
+      }
       return Promise.resolve(new Response(JSON.stringify([
         { id: 'P-1', suggestedAction: 'agent.research', proposedBy: 'ui-assistant', proposedAt: '2026-07-30T08:00:00Z' },
       ]), { status: 200 }))
@@ -108,7 +113,7 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     // sepaPayment); F-1 and I-1 both sit at 11:30 (fx before sepa-instant) — both ties resolved
     // by the stable-sort's concat order in route.ts. N-1 sits at 10:30, between L-1 and the
     // 11:00 tie.
-    expect(body.items.map((i: { id: string }) => i.id)).toEqual(['L-1', 'N-1', 'D-1', 'C-1', 'J-1', 'W-1', 'SP-1', 'F-1', 'I-1', 'S-1', 'P-1', 'T-1', 'L-2'])
+    expect(body.items.map((i: { id: string }) => i.id)).toEqual(['L-1', 'N-1', 'D-1', 'C-1', 'J-1', 'W-1', 'SP-1', 'F-1', 'I-1', 'PT-1', 'S-1', 'P-1', 'T-1', 'L-2'])
     expect(body.items[0]).toMatchObject({ domain: 'lending', action: 'lending.writeoff', maker: 'officer.a' })
     expect(body.items[1]).toMatchObject({ domain: 'notification', action: 'opsmessage.compose', maker: 'operator.f' })
     expect(body.items[2]).toMatchObject({ domain: 'domestic-payment', action: 'domestic-payment.transitionStatus', maker: 'operator.d' })
@@ -118,9 +123,10 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(body.items[6]).toMatchObject({ domain: 'sepa-payment', action: 'sepaPayment.transitionStatus', maker: 'operator.d' })
     expect(body.items[7]).toMatchObject({ domain: 'fx', action: 'fx.convert', maker: 'trader.d' })
     expect(body.items[8]).toMatchObject({ domain: 'sepa-instant', action: 'sctInstPayment.recall', maker: 'operator.e' })
-    expect(body.items[9]).toMatchObject({ domain: 'sanctions', action: 'sanctions.clear', maker: 'analyst.c' })
-    expect(body.items[10]).toMatchObject({ domain: 'agent', action: 'agent.research' })
-    expect(body.items[11]).toMatchObject({ domain: 'transaction', action: 'transaction.reverse', maker: 'teller.d' })
+    expect(body.items[9]).toMatchObject({ domain: 'party', action: 'party.merge', maker: 'operator.g' })
+    expect(body.items[10]).toMatchObject({ domain: 'sanctions', action: 'sanctions.clear', maker: 'analyst.c' })
+    expect(body.items[11]).toMatchObject({ domain: 'agent', action: 'agent.research' })
+    expect(body.items[12]).toMatchObject({ domain: 'transaction', action: 'transaction.reverse', maker: 'teller.d' })
     expect(body.sources.account).toBe('not-configured')
     expect(body.sources.balance).toBe('not-configured')
   })
@@ -291,6 +297,19 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(body.sources.notification).toBe('ok')
   })
 
+  it('reads the party queue at all — an unread source is indistinguishable from an empty one', async () => {
+    const seen: string[] = []
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      seen.push(String(url))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    }))
+
+    const body = await (await (await route()).GET()).json()
+
+    expect(seen.some(u => u.includes('/api/v1/parties/approvals'))).toBe(true)
+    expect(body.sources.party).toBe('ok')
+  })
+
   it('degrades to the working half when one queue is down', async () => {
     const mock = vi.fn().mockImplementation((url: string) => {
       if (url.includes('lending')) return Promise.reject(new Error('lending down'))
@@ -346,6 +365,8 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(body.sources.swift).toBe('ok')
     expect(body.sources['sepa-payment']).toBe('ok')
     expect(body.sources['sepa-instant']).toBe('ok')
+    expect(body.sources.notification).toBe('ok')
+    expect(body.sources.party).toBe('ok')
     expect(body.sources.agent).toBe('ok')
   })
 
@@ -369,6 +390,8 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(body.sources.swift).toBe('unavailable')
     expect(body.sources['sepa-payment']).toBe('unavailable')
     expect(body.sources['sepa-instant']).toBe('unavailable')
+    expect(body.sources.notification).toBe('unavailable')
+    expect(body.sources.party).toBe('unavailable')
     expect(body.sources.agent).toBe('unavailable')
   })
 })

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/ApprovalResource.kt
@@ -10,11 +10,14 @@ import com.openbank.libs.authz.Authorize
 import io.quarkus.security.identity.SecurityIdentity
 import jakarta.annotation.security.RolesAllowed
 import jakarta.inject.Inject
+import jakarta.ws.rs.DefaultValue
+import jakarta.ws.rs.GET
 import jakarta.ws.rs.NotFoundException
 import jakarta.ws.rs.PATCH
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.openapi.annotations.Operation
@@ -48,6 +51,21 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     @Inject
     lateinit var identity: SecurityIdentity
 
+    /**
+     * The checker's queue (issue #5679). Without this read, a parked `party.merge` decision is
+     * visible only to whoever received its approval id out of band, and silently expires after the
+     * shared store's 24-hour TTL. The queue is intentionally readable by the maker too: seeing a
+     * request is not authority to decide it, and [ApprovalStore.decide] still enforces four eyes.
+     */
+    @GET
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "party.approval.read", resource = "")
+    @Operation(summary = "List pending four-eyes approvals, oldest first (ADR-0227 D2)")
+    suspend fun listPending(@QueryParam("limit") @DefaultValue("50") limit: Int): Response {
+        val pending = approvalStore.findPending(limit.coerceIn(1, MAX_PENDING_LIMIT))
+        return Response.ok(pending.map { it.toApprovalResponse() }).build()
+    }
+
     @PATCH
     @Path("/{id}")
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
@@ -71,6 +89,11 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     // their own request. SecurityIdentity (not @Context SecurityContext) since this is a
     // `suspend fun` — mirrors consent-service's ApprovalResource.
     private fun checkerId(): String = identity.principal?.name ?: "anonymous"
+
+    private companion object {
+        /** The store performs a Redis scan; cap the caller-controlled amount like sibling queues. */
+        const val MAX_PENDING_LIMIT = 200
+    }
 }
 
 data class DecideApprovalRequest(val approve: Boolean)
@@ -80,6 +103,8 @@ data class ApprovalResponse(
     val action: String,
     val resourceId: String?,
     val status: String,
+    val makerId: String?,
+    val createdAt: String?,
     val decidedBy: String?,
 )
 
@@ -88,5 +113,7 @@ fun PendingApproval.toApprovalResponse() = ApprovalResponse(
     action = action,
     resourceId = resourceId,
     status = status.name,
+    makerId = makerId,
+    createdAt = createdAt.toString(),
     decidedBy = decidedBy,
 )

--- a/openbank-party-service/src/main/resources/openapi.yaml
+++ b/openbank-party-service/src/main/resources/openapi.yaml
@@ -3,10 +3,10 @@
 openapi: 3.1.0
 info:
   title: Party Service API
-  # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.8 -> 1.9): additive
-  # only — a new PATCH /api/v1/parties/approvals/{id} endpoint and an additional 202 response
-  # on POST /{id}/merge (ADR-0155 four-eyes). No existing response or schema changed.
-  version: 1.19.0
+  # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.19 -> 1.20): additive
+  # only — GET /api/v1/parties/approvals exposes the existing maker-checker queue and
+  # ApprovalResponse gains makerId/createdAt so the checker can understand age and provenance.
+  version: 1.20.0
   description: Legal entity and individual party management with document storage.
   license:
     name: Apache-2.0
@@ -194,6 +194,36 @@ paths:
             A merge precondition failed — already merged, the target is itself merged (chains are
             refused), a party is erased, or the duplicate still owns an open account.
 
+  /api/v1/parties/approvals:
+    get:
+      tags: [Parties]
+      summary: List pending four-eyes approvals, oldest first
+      description: >-
+        PENDING maker-checker approvals on party.merge, oldest first. This is the read side of the
+        unified approval inbox; deciding remains on PATCH /api/v1/parties/approvals/{id}. Requires
+        ROLE_OPERATOR or ROLE_ADMIN.
+      operationId: listPendingApprovals
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+      responses:
+        '200':
+          description: Pending approvals, oldest first
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApprovalResponse'
+        '403':
+          description: Caller lacks ROLE_OPERATOR or ROLE_ADMIN
+
   /api/v1/parties/approvals/{id}:
     patch:
       tags: [Parties]
@@ -223,6 +253,10 @@ paths:
       responses:
         '200':
           description: The decided approval
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApprovalResponse'
         '403':
           description: >-
             The decider is the original maker — segregation of duties (SelfApprovalNotAllowedMapper
@@ -596,6 +630,35 @@ components:
             $ref: '#/components/schemas/ApiError'
 
   schemas:
+    ApprovalResponse:
+      type: object
+      description: >-
+        A four-eyes approval record. makerId identifies who requested the gated action; a different
+        principal must decide it, which is enforced by the shared ApprovalStore.
+      required: [id, action, status]
+      properties:
+        id:
+          type: string
+        action:
+          type: string
+          example: party.merge
+        resourceId:
+          type: string
+          nullable: true
+        status:
+          type: string
+          description: Shared ApprovalStatus value; deliberately not narrowed to the party KYC enum.
+        makerId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+          description: Request time; pending approvals expire after 24 hours.
+        decidedBy:
+          type: string
+          nullable: true
+
     GdprExport:
       type: object
       description: GDPR Art. 15 subject-access export (party-service-direct PII).

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/rest/ApprovalResourceMappingTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/rest/ApprovalResourceMappingTest.kt
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.infrastructure.rest
+
+import com.openbank.libs.approval.ApprovalStatus
+import com.openbank.libs.approval.ApprovalStore
+import com.openbank.libs.approval.PendingApproval
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+
+class ApprovalResourceMappingTest {
+
+    @Test
+    fun `listPending exposes the mapped checker queue`(): Unit = runBlocking {
+        val store = mockk<ApprovalStore>()
+        coEvery { store.findPending(50) } returns listOf(pendingApproval())
+
+        val response = ApprovalResource(store).listPending(50)
+
+        assertThat(response.status).isEqualTo(200)
+        @Suppress("UNCHECKED_CAST")
+        val body = response.entity as List<ApprovalResponse>
+        assertThat(body).hasSize(1)
+        val item = body.single()
+        assertThat(item.id).isEqualTo("appr-1")
+        assertThat(item.makerId).isEqualTo("maker")
+    }
+
+    @Test
+    fun `listPending clamps a caller-controlled limit`(): Unit = runBlocking {
+        val store = mockk<ApprovalStore>()
+        coEvery { store.findPending(200) } returns emptyList()
+
+        ApprovalResource(store).listPending(10_000)
+
+        coVerify(exactly = 1) { store.findPending(200) }
+    }
+
+    @Test
+    fun `queue response preserves maker and request age`() {
+        val approval = pendingApproval()
+
+        val response = approval.toApprovalResponse()
+
+        assertThat(response.id).isEqualTo("appr-1")
+        assertThat(response.action).isEqualTo("party.merge")
+        assertThat(response.resourceId).isEqualTo("party-1")
+        assertThat(response.status).isEqualTo("PENDING")
+        assertThat(response.makerId).isEqualTo("maker")
+        assertThat(response.createdAt).isEqualTo(approval.createdAt.toString())
+        assertThat(response.decidedBy).isNull()
+    }
+
+    @Test
+    fun `decided response remains backward compatible`() {
+        val decidedAt = OffsetDateTime.parse("2026-08-23T01:00:00Z")
+        val approval = PendingApproval(
+            id = "appr-2",
+            action = "party.merge",
+            resourceId = null,
+            makerId = "maker",
+            status = ApprovalStatus.APPROVED,
+            createdAt = decidedAt.minusHours(1),
+            decidedBy = "checker",
+            decidedAt = decidedAt,
+        )
+
+        val response = approval.toApprovalResponse()
+
+        assertThat(response.status).isEqualTo("APPROVED")
+        assertThat(response.resourceId).isNull()
+        assertThat(response.decidedBy).isEqualTo("checker")
+    }
+
+    private fun pendingApproval() = PendingApproval(
+        id = "appr-1",
+        action = "party.merge",
+        resourceId = "party-1",
+        makerId = "maker",
+        status = ApprovalStatus.PENDING,
+        createdAt = OffsetDateTime.parse("2026-08-23T00:00:00Z"),
+    )
+}


### PR DESCRIPTION
## Summary
- add the authenticated, bounded party-service pending-approval read endpoint
- expose maker and request time in the additive approval response contract
- federate party approvals into the Admin UI unified checker inbox with truthful per-source state

## Safety
- deciding approvals remains on the existing PATCH endpoint
- shared ApprovalStore four-eyes and self-approval protections are unchanged
- ROLE_OPERATOR / ROLE_ADMIN and OPA authorization remain enforced
- this closes one real queue-visibility gap; it does not claim the broader Admin UI modernization is complete

## Verification
- `./gradlew :openbank-party-service:test`
- `./gradlew :openbank-party-service:ktlintCheck :openbank-party-service:detekt`
- `./gradlew :openbank-party-service:quarkusBuild`
- `python3 .github/scripts/check-api-contract.py --base origin/main`
- `python3 .github/scripts/check-openapi-route-conformance.py --enforce --service openbank-party-service`
- `npm run type-check`
- `npm test -- --run src/test/approvals-inbox.test.ts` (16/16)
- focused ESLint

Refs #5679