### PR TITLE
feat(admin-ui): retain synthetic run history

### DIFF
--- a/.github/scripts/check-test-intelligence-ecosystem.py
+++ b/.github/scripts/check-test-intelligence-ecosystem.py
@@ -70,6 +70,8 @@ def check(root: Path) -> list[str]:
         ("cron: '17 3 * * *'", "admin deployment refresh cadence drifted from the governed daily schedule"),
         ("github.event_name }}\" = \"schedule\"", "scheduled snapshot refresh does not use a unique immutable image tag"),
         ("github.event_name }}\" = \"workflow_run\"", "event-driven snapshot refresh does not use a unique immutable image tag"),
+        ("github.event.workflow_run.conclusion != 'success'", "ineligible workflow-run events can evict a valid pending Admin UI deploy"),
+        ("github.run_id || 'eligible'", "ineligible Admin UI deploy events do not use an isolated concurrency group"),
     ):
         if needle not in deploy:
             errors.append(message)
@@ -136,6 +138,26 @@ def check(root: Path) -> list[str]:
             errors.append(f"synthetic runtime projection lost its verified Kubernetes signal: {needle}")
     if 'traces_spanmetrics_calls_total{service=~"openbank-app.*"}' not in synthetic_route:
         errors.append("mobile RUM projection lost its live Tempo span-metrics signal")
+    synthetic_workflow = text(root / ".github/workflows/synthetic-journeys.yml")
+    for needle, message in (
+        ("--extract public-edge", "synthetic CI does not execute the ConfigMap-mounted runtime artifact"),
+        ('event_name }}-${{ github.ref }}', "synthetic PR and post-GitOps calls do not have isolated concurrency"),
+        ('branches: [main]', "synthetic workflow has no post-GitOps main call site"),
+        ('cronjob-journey-public-edge.yaml', "synthetic workflow does not run when the runtime artifact changes"),
+        ('--synthetic-summary', "synthetic workflow does not publish compatible Test Intelligence evidence"),
+        ('test-intelligence-run-openbank-platform-', "synthetic run envelope is not retained in immutable history"),
+        ('grafana/k6:1.2.0@sha256:', "synthetic CI image is not pinned to the runtime k6 digest"),
+    ):
+        if needle not in synthetic_workflow:
+            errors.append(message)
+    collector = text(root / "openbank-admin-ui/scripts/collect-test-intelligence.mjs")
+    for needle, message in (
+        ("evidence.kind !== 'synthetic'", "Admin projection ignores retained synthetic run evidence"),
+        ("latestCi.set", "Admin projection cannot select the latest synthetic CI verdict"),
+        ("ci: latestCi.get", "Admin journey rows do not expose the synthetic CI verdict"),
+    ):
+        if needle not in collector:
+            errors.append(message)
     if not (root / "openbank-libs/governance/journeys.yaml").exists():
         errors.append("synthetic journey inventory is missing")
     return errors

--- a/.github/scripts/collect-test-run-evidence.py
+++ b/.github/scripts/collect-test-run-evidence.py
@@ -216,6 +216,8 @@ def specialized_evidence(
     performance_summary: str | None,
     mutation_report: str | None,
     performance_not_run_detail: str | None = None,
+    synthetic_summary: str | None = None,
+    synthetic_journey: str | None = None,
 ) -> list[dict]:
     specialized = []
     if performance_summary:
@@ -241,6 +243,22 @@ def specialized_evidence(
                                 "source": str(mutation_file), "detail": f"{killed}/{len(mutations)} killed ({score if score is not None else 'n/a'}%)"})
         else:
             specialized.append({"kind": "mutation", "state": "not-run", "source": str(mutation_file), "detail": "mutation report absent"})
+    if synthetic_summary:
+        if not synthetic_journey or not re.fullmatch(r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?", synthetic_journey):
+            raise ValueError("--synthetic-summary requires a valid --synthetic-journey id")
+        summary_file = Path(synthetic_summary)
+        summary = json.loads(summary_file.read_text()) if summary_file.exists() else None
+        thresholds = [value for metric in (summary or {}).get("metrics", {}).values()
+                      for value in (metric.get("thresholds") or {}).values()]
+        failed = sum(1 for value in thresholds if value is True or
+                     (isinstance(value, dict) and value.get("ok") is False))
+        specialized.append({
+            "kind": "synthetic",
+            "state": "not-run" if summary is None else "failed" if failed else "passed",
+            "source": f"journey:{synthetic_journey}",
+            "detail": "synthetic summary absent" if summary is None else
+                      f"{len(thresholds)} threshold result(s), {failed} breached",
+        })
     return specialized
 
 
@@ -252,6 +270,8 @@ def main() -> None:
     parser.add_argument("--performance-summary")
     parser.add_argument("--performance-not-run-detail")
     parser.add_argument("--mutation-report")
+    parser.add_argument("--synthetic-summary")
+    parser.add_argument("--synthetic-journey")
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
     if args.self_test:
@@ -310,6 +330,8 @@ def main() -> None:
             assert [(item["kind"], item["state"]) for item in specialized] == [("performance", "failed"), ("mutation", "passed")]
             absent = specialized_evidence(str(service / "missing-summary.json"), None, "no safe target configured")
             assert absent == [{"kind": "performance", "state": "not-run", "source": str(service / "missing-summary.json"), "detail": "no safe target configured"}]
+            synthetic = specialized_evidence(None, None, synthetic_summary=str(performance), synthetic_journey="public-edge")
+            assert synthetic == [{"kind": "synthetic", "state": "failed", "source": "journey:public-edge", "detail": "1 threshold result(s), 1 breached"}]
             valid = {
                 "schemaVersion": 1,
                 "run": {"id": "1", "attempt": 1, "commit": "1234567", "branch": "main", "workflow": "CI", "url": "", "observedAt": "2026-08-22T00:00:00Z"},
@@ -341,6 +363,8 @@ def main() -> None:
         args.performance_summary,
         args.mutation_report,
         args.performance_not_run_detail,
+        args.synthetic_summary,
+        args.synthetic_journey,
     )
     envelope = {
         "schemaVersion": 1,

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -91,7 +91,17 @@ concurrency:
   # later, far from the cause (same hazard auto-deploy.yml documents). Queueing is
   # safe: GitHub keeps only the newest pending run per group, so the latest commit
   # still wins — it just waits for the in-flight deploy to finish signing.
-  group: admin-ui-deploy
+  # Job-level `if:` is evaluated only after concurrency admission. A cancelled CI
+  # workflow_run therefore used to enter this shared queue, evict the valid pending push
+  # deploy, and then skip itself in deploy-source. Observed in runs 32945400498/32945568749
+  # (#7023). Give events that cannot possibly deploy a run-unique group; only eligible
+  # push/dispatch/schedule and successful main workflow_run events share the deploy queue.
+  group: >-
+    admin-ui-deploy-${{
+      github.event_name == 'workflow_run' &&
+      (github.event.workflow_run.conclusion != 'success' || github.event.workflow_run.head_branch != 'main') &&
+      github.run_id || 'eligible'
+    }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/synthetic-journeys.yml
+++ b/.github/workflows/synthetic-journeys.yml
@@ -17,6 +17,11 @@ on:
   push:
     branches: [main]
     paths:
+      # Re-prove and publish main-branch evidence when the executor or envelope producer
+      # changes; manifest merges remain the actual post-GitOps call site.
+      - ".github/scripts/check-journey-catalog.py"
+      - ".github/scripts/collect-test-run-evidence.py"
+      - ".github/workflows/synthetic-journeys.yml"
       - "openbank-infra/gitops/components/observability/cronjob-journey-public-edge.yaml"
   workflow_dispatch:
 
@@ -54,11 +59,30 @@ jobs:
             docker.io/grafana/k6:1.2.0@sha256:5301215b669b3758b1b3b1f43a25a91378c2bbb8cbb6b29d5b4a44be8064dedc \
             run --quiet --summary-export /evidence/summary.json /evidence/journey.js
 
+      - name: Build synthetic Test Intelligence envelope
+        if: always()
+        run: |
+          python3 .github/scripts/collect-test-run-evidence.py \
+            --service synthetic-evidence \
+            --component openbank-platform \
+            --synthetic-summary synthetic-evidence/summary.json \
+            --synthetic-journey public-edge \
+            --out synthetic-evidence/run.json
+
       - name: Retain immutable synthetic evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: synthetic-public-edge-${{ github.run_id }}-${{ github.run_attempt }}
           path: synthetic-evidence/
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Retain immutable Test Intelligence history
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-intelligence-run-openbank-platform-${{ github.run_id }}-a${{ github.run_attempt }}
+          path: synthetic-evidence/run.json
           retention-days: 30
           if-no-files-found: error

--- a/openbank-admin-ui/scripts/collect-test-intelligence.mjs
+++ b/openbank-admin-ui/scripts/collect-test-intelligence.mjs
@@ -385,6 +385,19 @@ function syntheticJourneys() {
   const file = path.join(repo, 'openbank-libs', 'governance', 'journeys.yaml')
   try {
     const raw = parseYaml(fs.readFileSync(file, 'utf8'))
+    const latestCi = new Map()
+    const history = allFiles(path.join(repo, 'openbank-admin-ui', 'test-run-history'), candidate => candidate.endsWith('.json'))
+      .map(readJson).filter(item => item?.schemaVersion === 1 && item?.run)
+      .sort((a, b) => Date.parse(a.run.observedAt) - Date.parse(b.run.observedAt))
+    for (const envelope of history) {
+      for (const evidence of envelope.specializedEvidence ?? []) {
+        if (evidence.kind !== 'synthetic' || !evidence.source?.startsWith('journey:')) continue
+        latestCi.set(evidence.source.slice('journey:'.length), {
+          state: evidence.state, observedAt: envelope.run.observedAt,
+          detail: evidence.detail ?? 'Synthetic run retained without detail.', run: envelope.run,
+        })
+      }
+    }
     return (raw?.journeys ?? []).map(item => ({
       id: item.id, title: item.name ?? item.title ?? item.id, status: item.status,
       capability: item.capability ?? '',
@@ -392,6 +405,7 @@ function syntheticJourneys() {
       schedule: item.schedule ?? item.target_schedule ?? null, environment: item.environment ?? null,
       covers: item.covers ?? item.covered_services ?? [],
       falsifies: item.falsification ?? '', blocker: item.blocked_by ?? null,
+      ...(latestCi.has(item.id) ? { ci: latestCi.get(item.id) } : {}),
     }))
   } catch (error) {
     warnings.push(`synthetic journey catalogue unavailable: ${error.message}`)

--- a/openbank-admin-ui/src/app/system/tests/page.tsx
+++ b/openbank-admin-ui/src/app/system/tests/page.tsx
@@ -295,6 +295,7 @@ function Synthetics({ report }: { report: TestIntelligenceReport }) {
       <div><span style={{ color: 'var(--text-tertiary)' }}>{t('Čerstvost evidence', 'Evidence freshness')}</span><br /><strong>{row.live.freshnessSeconds === null ? 'unknown' : `${Math.round(row.live.freshnessSeconds / 60)} min`}</strong></div>
       <div><span style={{ color: 'var(--text-tertiary)' }}>{t('Poslední Kubernetes běhy', 'Recent Kubernetes runs')}</span><br /><strong>{row.live.recentRuns.length || 'none retained'}</strong></div>
     </div>}
+    {row.ci && <p style={{ fontSize: 11, color: 'var(--text-tertiary)', margin: '10px 0 0' }}><strong>CI / post-deploy:</strong> <StateBadge state={row.ci.state} /> · {row.ci.detail} · <a href={row.ci.run.url} target="_blank" rel="noreferrer">run {row.ci.run.id}</a></p>}
     {row.falsifies && <p style={{ fontSize: 12, color: 'var(--text-secondary)', margin: '10px 0 0' }}><strong>Falsification:</strong> {row.falsifies}</p>}
     {row.blocker && <p style={{ fontSize: 12, color: '#7c3aed', margin: '10px 0 0' }}><strong>Blocker:</strong> {row.blocker}</p>}
   </div>)}</div>

--- a/openbank-admin-ui/src/lib/types/test-intelligence.ts
+++ b/openbank-admin-ui/src/lib/types/test-intelligence.ts
@@ -137,6 +137,12 @@ export interface SyntheticJourneyEvidence {
   covers: string[]
   falsifies: string
   blocker: string | null
+  ci?: {
+    state: EvidenceState
+    observedAt: string
+    detail: string
+    run: TestRunProvenance
+  }
   live?: {
     source: 'prometheus'
     observedAt: string

--- a/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
@@ -89,6 +89,12 @@ scenarios:
       testInfrastructure: { declared: [], observed: [] },
       specializedEvidence: [{ kind: 'performance', state: 'not-run', source: 'perf-summary.json', detail: 'No safe money-path target is configured for this GitHub-hosted runner.' }],
     }))
+    write(repo, 'openbank-admin-ui/test-run-history/synthetic.json', JSON.stringify({
+      schemaVersion: 1,
+      run: { id: 'synthetic-9', attempt: 1, commit: '123456789abc', branch: 'main', workflow: 'Synthetic journeys', url: 'https://example.test/synthetic/9', observedAt: '2026-08-25T08:00:00Z' },
+      component: 'openbank-platform', suites: [], coverage: null, testInfrastructure: { declared: [], observed: [] },
+      specializedEvidence: [{ kind: 'synthetic', state: 'passed', source: 'journey:edge', detail: '2 threshold result(s), 0 breached' }],
+    }))
     const out = path.join(repo, 'report.json')
     execFileSync('node', [SCRIPT, '--repo', repo, '--out', out, '--stale-after-days', '99999'])
     const report = JSON.parse(readFileSync(out, 'utf8')) as TestIntelligenceReport
@@ -103,7 +109,9 @@ scenarios:
       pactFile: 'alpha-provider.json', state: 'unknown',
       verificationDetail: expect.stringMatching(/not a passing result/i),
     })])
-    expect(report.syntheticJourneys[0]).toMatchObject({ id: 'edge', state: 'unknown', schedule: '*/5 * * * *' })
+    expect(report.syntheticJourneys[0]).toMatchObject({ id: 'edge', state: 'unknown', schedule: '*/5 * * * *', ci: {
+      state: 'passed', detail: '2 threshold result(s), 0 breached', run: { id: 'synthetic-9', workflow: 'Synthetic journeys' },
+    } })
     expect(report.syntheticJourneys[1]).toMatchObject({ id: 'mobile', state: 'blocked', schedule: '0 * * * *', blocker: 'needs canary devices' })
     expect(report.journeyCoverage).toMatchObject({ moneyPathTotal: 2, activelyCovered: 1, explicitlyUnwatched: 1 })
     expect(report.journeyCoverage?.services).toEqual([


### PR DESCRIPTION
## Summary
- emit a provenance-complete synthetic v1 Test Intelligence envelope from every PR and post-GitOps k6 run
- retain it through the existing bounded main-branch run-history ingestion
- show the latest CI/post-deploy verdict beside the independent live Prometheus verdict in Admin UI
- isolate ineligible workflow_run events so they cannot evict a valid pending Admin UI deploy

## Evidence
- Test Intelligence collector self-test passed, including a red synthetic threshold control
- focused Admin UI Vitest: 10/10
- TypeScript and actionlint: clean
- ESLint: 0 errors (one pre-existing useEffect warning)
- real extracted public-edge summary produces synthetic passed, 2 thresholds, 0 breached
- deploy race reproduced by runs 32945400498 and 32945568749

Refs #4348
Closes #7023