### PR TITLE
feat(account): expose pending approvals in unified inbox

### DIFF
--- a/.github/openapi-route-conformance-baseline.txt
+++ b/.github/openapi-route-conformance-baseline.txt
@@ -12,14 +12,6 @@
 # closes #2314; the per-service corrections are blocked on the unsatisfiable-bump gap (#2313).
 #
 # Format: <service> <served-not-published|published-not-served> <VERB> <absolute path>
-openbank-account-service served-not-published DELETE /api/v1/accounts/{accountId}/authorizations/{authorizationId}
-openbank-account-service served-not-published DELETE /api/v1/accounts/{accountId}/pockets/{currency}
-openbank-account-service served-not-published GET /api/v1/accounts/{accountId}/authorizations
-openbank-account-service served-not-published GET /api/v1/accounts/{accountId}/authorizations/check
-openbank-account-service served-not-published GET /api/v1/accounts/{accountId}/pockets
-openbank-account-service served-not-published GET /api/v1/accounts/{accountId}/pockets/resolve
-openbank-account-service served-not-published POST /api/v1/accounts/{accountId}/authorizations
-openbank-account-service served-not-published POST /api/v1/accounts/{accountId}/pockets
 openbank-agent-service served-not-published GET /api/v1/admin/agents/halts
 openbank-agent-service served-not-published POST /api/v1/admin/agents/halt
 openbank-agent-service served-not-published POST /api/v1/admin/agents/resume

--- a/.github/scripts/check-openapi-enum-vs-domain.py
+++ b/.github/scripts/check-openapi-enum-vs-domain.py
@@ -62,8 +62,6 @@ MIN_SHARED = 2
 # Spec-vs-domain drift that exists today, each with the issue that owns it.
 # Format: "<service>:<sorted spec values>" -> reason
 BASELINE: dict[str, str] = {
-    "openbank-account-service:ACTIVE,CLOSED,FROZEN,PENDING":
-        "#5962 — AccountStatus: spec-only PENDING; undeclared DORMANT/PENDING_ACTIVATION",
     "openbank-account-service:APPROVED,CANCELLED,PENDING,REJECTED":
         "#5962 — WithdrawalProposalStatus: undeclared EXPIRED",
     "openbank-campaign-service:BANNER,PUSH":
@@ -217,6 +215,11 @@ def best_match(
     best: tuple[str, frozenset[str]] | None = None
     best_n = 0
     for name, vals in domain.items():
+        # An exact vocabulary is authoritative. Without this fast path, declaration order can
+        # make a shorter enum (for example PocketStatus) tie with a longer superset
+        # (AccountStatus) and be reported as drift even though its real domain enum matches.
+        if vals == spec:
+            return name, vals
         n = len(spec & vals)
         if n > best_n:
             best, best_n = (name, vals), n
@@ -262,6 +265,8 @@ def self_test() -> int:
     domain = {
         "CheckType": frozenset({"IDENTITY", "ADDRESS", "PEP_SCREENING", "SANCTIONS_SCREENING", "ADVERSE_MEDIA"}),
         "CaseStatus": frozenset({"OPEN", "UNDER_REVIEW", "APPROVED", "REJECTED"}),
+        "LifecycleStatus": frozenset({"ACTIVE", "DORMANT", "FROZEN", "CLOSED"}),
+        "PocketStatus": frozenset({"ACTIVE", "FROZEN", "CLOSED"}),
     }
     cases: list[tuple[str, frozenset[str], bool]] = [
         # (name, spec values, must be reported as drift)
@@ -279,6 +284,8 @@ def self_test() -> int:
          frozenset({"IDENTITY", "ADDRESS", "AAA", "BBB", "CCC", "DDD", "EEE", "FFF"}), False),
         ("a different domain enum in the same service pairs with ITS OWN match",
          domain["CaseStatus"], False),
+        ("an exact enum wins over an earlier overlapping superset",
+         domain["PocketStatus"], False),
         ("drift in the second enum is still found",
          frozenset({"OPEN", "UNDER_REVIEW", "APPROVED", "DECLINED"}), True),
     ]

--- a/docs/threat-models/openbank-account-service.md
+++ b/docs/threat-models/openbank-account-service.md
@@ -104,6 +104,16 @@ not change any existing request's outcome until explicitly flipped.
   availability assertion, not an access-control bypass: Product Catalog still owns
   request handling, and removing the policy restores fail-closed connection denial.
 
+- **2026-08-26** — The operator approval inbox gains a bounded, read-only
+  `GET /api/v1/accounts/approvals` edge. It exposes only the pending approval id, action,
+  resource id, maker id and creation time to callers already holding `ROLE_OPERATOR` or
+  `ROLE_ADMIN`, with the same OPA policy boundary as the checker decision endpoint. The result is
+  capped at 200 and ordered oldest first; it cannot approve, reject or execute an action. The
+  existing random ids, 24-hour Redis TTL, maker/checker separation and one-time execution checks
+  remain unchanged. **Risk class:** confidentiality (operator workflow metadata) and bounded Redis
+  read load; no new principal, service-to-service edge or money mutation. Rollback: remove the GET
+  route and let the admin UI report the account source unavailable; the decision path is unaffected.
+
 - **2026-08-24** — Synthetic-journey taint now propagates over this service's existing internal REST clients through `SyntheticTaintClientFilter` (ADR-0252, #4348). This adds no caller, endpoint, network-policy edge, privilege or control bypass: sanctions, SCA and all other downstream controls still see the journey. It prevents synthetic activity from becoming indistinguishable before a downstream persistence/event boundary; a separate fleet gate requires every new client to choose propagation or a reasoned external boundary.
 
 - **2026-08-20** — Product-catalog product/currency enforcement (#668). This existing reference-data

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/ApprovalResource.kt
@@ -11,11 +11,14 @@ import com.openbank.libs.security.Roles
 import io.quarkus.security.identity.SecurityIdentity
 import jakarta.annotation.security.RolesAllowed
 import jakarta.inject.Inject
+import jakarta.ws.rs.DefaultValue
+import jakarta.ws.rs.GET
 import jakarta.ws.rs.NotFoundException
 import jakarta.ws.rs.PATCH
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.openapi.annotations.Operation
@@ -35,6 +38,20 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
 
     @Inject
     lateinit var identity: SecurityIdentity
+
+    /**
+     * FIFO checker queue for account lifecycle approvals (issue #5679). The read is deliberately
+     * separate from disposal: deciding still requires the existing endpoint and the shared store's
+     * maker != checker invariant.
+     */
+    @GET
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "account.approval.read", resource = "")
+    @Operation(summary = "List pending account approvals, oldest first (ADR-0227 D2)")
+    suspend fun listPending(@QueryParam("limit") @DefaultValue("50") limit: Int): Response {
+        val pending = approvalStore.findPending(limit.coerceIn(1, MAX_PENDING_LIMIT))
+        return Response.ok(pending.map { it.toResponse() }).build()
+    }
 
     @PATCH
     @Path("/{id}")
@@ -60,6 +77,11 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     // own request. SecurityIdentity (not @Context SecurityContext) because this is
     // a `suspend fun` — see AccountResource.operatorId() for the same workaround.
     private fun checkerId(): String = identity.principal?.name ?: "anonymous"
+
+    private companion object {
+        /** ApprovalStore scans Redis; keep the caller-controlled result bounded. */
+        const val MAX_PENDING_LIMIT = 200
+    }
 }
 
 data class DecideApprovalRequest(val approve: Boolean)
@@ -69,6 +91,8 @@ data class ApprovalResponse(
     val action: String,
     val resourceId: String?,
     val status: String,
+    val makerId: String?,
+    val createdAt: String?,
     val decidedBy: String?,
 )
 
@@ -77,5 +101,7 @@ fun PendingApproval.toResponse() = ApprovalResponse(
     action = action,
     resourceId = resourceId,
     status = status.name,
+    makerId = makerId,
+    createdAt = createdAt.toString(),
     decidedBy = decidedBy,
 )

--- a/openbank-account-service/src/main/resources/openapi.yaml
+++ b/openbank-account-service/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Account Service API
   # API-contract axis (ADR-0048) — bumps are classified from the OpenAPI diff,
   # independently of the release version in version.txt.
-  version: 1.11.0
+  version: 1.12.0
   description: BIAN-aligned account lifecycle management — open, query, freeze, close accounts.
   contact:
     name: OpenBank Platform
@@ -616,6 +616,250 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /api/v1/accounts/{accountId}/authorizations:
+    get:
+      tags: [Accounts]
+      summary: List account authorizations
+      operationId: listAccountAuthorizations
+      security:
+        - bearerAuth: [ROLE_API, ROLE_VIEWER, ROLE_OPERATOR, ROLE_ADMIN]
+      parameters:
+        - $ref: '#/components/parameters/accountId'
+      responses:
+        '200':
+          description: Authorizations granted on the account
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AuthorizationResponse'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    post:
+      tags: [Accounts]
+      summary: Grant an account authorization
+      operationId: grantAccountAuthorization
+      security:
+        - bearerAuth: [ROLE_OPERATOR, ROLE_ADMIN]
+      parameters:
+        - $ref: '#/components/parameters/accountId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GrantAuthorizationRequest'
+      responses:
+        '201':
+          description: Authorization granted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthorizationResponse'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/accounts/{accountId}/authorizations/check:
+    get:
+      tags: [Accounts]
+      summary: Check whether a party holds an active account role
+      operationId: checkAccountAuthorization
+      security:
+        - bearerAuth: [ROLE_API, ROLE_VIEWER, ROLE_OPERATOR, ROLE_ADMIN]
+      parameters:
+        - $ref: '#/components/parameters/accountId'
+        - name: partyId
+          in: query
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: role
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/AuthorizationRole'
+      responses:
+        '200':
+          description: Authorization decision
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [authorized]
+                properties:
+                  authorized:
+                    type: boolean
+        '400':
+          description: partyId or role is missing or malformed
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/accounts/{accountId}/authorizations/{authorizationId}:
+    delete:
+      tags: [Accounts]
+      summary: Revoke an account authorization
+      operationId: revokeAccountAuthorization
+      security:
+        - bearerAuth: [ROLE_OPERATOR, ROLE_ADMIN]
+      parameters:
+        - $ref: '#/components/parameters/accountId'
+        - name: authorizationId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RevokeAuthorizationRequest'
+      responses:
+        '200':
+          description: Revoked authorization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthorizationResponse'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/accounts/{accountId}/pockets:
+    get:
+      tags: [Accounts]
+      summary: List currency pockets of an account
+      operationId: listCurrencyPockets
+      security:
+        - bearerAuth: [ROLE_API, ROLE_VIEWER, ROLE_OPERATOR, ROLE_ADMIN]
+      parameters:
+        - $ref: '#/components/parameters/accountId'
+      responses:
+        '200':
+          description: Active and historical currency pockets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PocketListResponse'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    post:
+      tags: [Accounts]
+      summary: Add a currency pocket to an account
+      operationId: addCurrencyPocket
+      security:
+        - bearerAuth: [ROLE_OPERATOR, ROLE_ADMIN]
+      parameters:
+        - $ref: '#/components/parameters/accountId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddPocketRequest'
+      responses:
+        '201':
+          description: Currency pocket created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PocketResponse'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/accounts/{accountId}/pockets/resolve:
+    get:
+      tags: [Accounts]
+      summary: Resolve the pocket used to settle a payment currency
+      operationId: resolveCurrencyPocket
+      security:
+        - bearerAuth: [ROLE_API, ROLE_VIEWER, ROLE_OPERATOR, ROLE_ADMIN]
+      parameters:
+        - $ref: '#/components/parameters/accountId'
+        - name: currency
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 3
+            maxLength: 3
+        - name: policy
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [REJECT, AUTO_CREATE, CONVERT_TO_PRIMARY]
+            default: CONVERT_TO_PRIMARY
+      responses:
+        '200':
+          description: Pocket routing decision
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PocketResolutionResponse'
+        '400':
+          description: Currency or policy is missing or malformed
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/accounts/{accountId}/pockets/{currency}:
+    delete:
+      tags: [Accounts]
+      summary: Close a non-primary currency pocket
+      operationId: closeCurrencyPocket
+      security:
+        - bearerAuth: [ROLE_OPERATOR, ROLE_ADMIN]
+      parameters:
+        - $ref: '#/components/parameters/accountId'
+        - name: currency
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 3
+            maxLength: 3
+      responses:
+        '200':
+          description: Closed currency pocket
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PocketResponse'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/accounts/approvals:
+    get:
+      tags: [Accounts]
+      summary: List pending account approvals, oldest first
+      description: >-
+        PENDING maker-checker approvals for account lifecycle actions, oldest first. This is the
+        read side consumed by the unified approval inbox; deciding remains on
+        PATCH /api/v1/accounts/approvals/{id}. Requires ROLE_OPERATOR or ROLE_ADMIN.
+      operationId: listPendingApprovals
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+      responses:
+        '200':
+          description: Pending account approvals, oldest first
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApprovalResponse'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
   /api/v1/accounts/approvals/{id}:
     patch:
       tags: [Accounts]
@@ -648,22 +892,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required: [id, action, status]
-                properties:
-                  id:
-                    type: string
-                  action:
-                    type: string
-                    description: The gated action this approval was raised for.
-                  resourceId:
-                    type: string
-                    nullable: true
-                  status:
-                    type: string
-                  decidedBy:
-                    type: string
-                    nullable: true
+                $ref: '#/components/schemas/ApprovalResponse'
         '404':
           $ref: '#/components/responses/NotFound'
 
@@ -707,6 +936,187 @@ components:
             $ref: '#/components/schemas/ApiError'
 
   schemas:
+    AuthorizationRole:
+      type: string
+      enum: [FULL_ACCESS, PAYMENT_ONLY, READ_ONLY, CARD_HOLDER]
+
+    Money:
+      type: object
+      required: [amount, currency]
+      properties:
+        amount:
+          type: number
+        currency:
+          type: string
+          minLength: 3
+          maxLength: 3
+
+    GrantAuthorizationRequest:
+      type: object
+      required: [partyId, role, validFrom, grantedBy]
+      properties:
+        partyId:
+          type: string
+          format: uuid
+        role:
+          $ref: '#/components/schemas/AuthorizationRole'
+        dailyLimit:
+          allOf:
+            - $ref: '#/components/schemas/Money'
+          nullable: true
+        transactionLimit:
+          allOf:
+            - $ref: '#/components/schemas/Money'
+          nullable: true
+        validFrom:
+          type: string
+          format: date
+        validTo:
+          type: string
+          format: date
+          nullable: true
+        grantedBy:
+          type: string
+          format: uuid
+
+    RevokeAuthorizationRequest:
+      type: object
+      required: [revokedBy, reason]
+      properties:
+        revokedBy:
+          type: string
+          format: uuid
+        reason:
+          type: string
+
+    AuthorizationResponse:
+      type: object
+      required: [id, accountId, partyId, role, validFrom, status, grantedBy, grantedAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        accountId:
+          type: string
+          format: uuid
+        partyId:
+          type: string
+          format: uuid
+        role:
+          $ref: '#/components/schemas/AuthorizationRole'
+        dailyLimit:
+          allOf:
+            - $ref: '#/components/schemas/Money'
+          nullable: true
+        transactionLimit:
+          allOf:
+            - $ref: '#/components/schemas/Money'
+          nullable: true
+        validFrom:
+          type: string
+          format: date
+        validTo:
+          type: string
+          format: date
+          nullable: true
+        status:
+          type: string
+          enum: [ACTIVE, SUSPENDED, REVOKED, EXPIRED]
+        grantedBy:
+          type: string
+          format: uuid
+        grantedAt:
+          type: string
+          format: date-time
+
+    AddPocketRequest:
+      type: object
+      required: [currencyCode]
+      properties:
+        currencyCode:
+          type: string
+          minLength: 3
+          maxLength: 3
+
+    PocketResponse:
+      type: object
+      required: [id, accountId, currencyCode, isPrimary, status, openedAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        accountId:
+          type: string
+          format: uuid
+        currencyCode:
+          type: string
+        isPrimary:
+          type: boolean
+        status:
+          type: string
+          enum: [ACTIVE, FROZEN, CLOSED]
+        openedAt:
+          type: string
+          format: date-time
+        closedAt:
+          type: string
+          format: date-time
+          nullable: true
+
+    PocketListResponse:
+      type: object
+      required: [pockets]
+      properties:
+        pockets:
+          type: array
+          items:
+            $ref: '#/components/schemas/PocketResponse'
+
+    PocketResolutionResponse:
+      type: object
+      required: [outcome]
+      properties:
+        outcome:
+          type: string
+          enum: [USE_EXISTING, CREATE_NEW, CONVERT_TO_PRIMARY, REJECTED]
+        pocketCurrency:
+          type: string
+          nullable: true
+        convertFrom:
+          type: string
+          nullable: true
+        reason:
+          type: string
+          nullable: true
+
+    ApprovalResponse:
+      type: object
+      description: >-
+        A four-eyes account approval. makerId identifies who requested the gated action; the
+        shared ApprovalStore requires a different authenticated principal to decide it.
+      required: [id, action, status]
+      properties:
+        id:
+          type: string
+        action:
+          type: string
+          description: The gated account action this approval was raised for.
+        resourceId:
+          type: string
+          nullable: true
+        status:
+          type: string
+        makerId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+          description: Request time; pending approvals expire after 24 hours.
+        decidedBy:
+          type: string
+          nullable: true
+
     OpenAccountRequest:
       type: object
       required: [partyId, productId, accountType, currencyCode, legalName]
@@ -759,7 +1169,7 @@ components:
           type: string
         status:
           type: string
-          enum: [ACTIVE, FROZEN, CLOSED, PENDING]
+          enum: [PENDING_ACTIVATION, ACTIVE, DORMANT, FROZEN, CLOSED]
         openedAt:
           type: string
           format: date-time

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/rest/ApprovalResourceMappingTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/rest/ApprovalResourceMappingTest.kt
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.account.infrastructure.rest
+
+import com.openbank.libs.approval.ApprovalStatus
+import com.openbank.libs.approval.ApprovalStore
+import com.openbank.libs.approval.PendingApproval
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+
+class ApprovalResourceMappingTest {
+
+    @Test
+    fun `listPending exposes the mapped checker queue`(): Unit = runBlocking {
+        val store = mockk<ApprovalStore>()
+        coEvery { store.findPending(50) } returns listOf(pendingApproval())
+
+        val response = ApprovalResource(store).listPending(50)
+
+        assertThat(response.status).isEqualTo(200)
+        @Suppress("UNCHECKED_CAST")
+        val body = response.entity as List<ApprovalResponse>
+        assertThat(body).hasSize(1)
+        assertThat(body.single().makerId).isEqualTo("maker")
+        assertThat(body.single().createdAt).isEqualTo("2026-08-23T00:00Z")
+    }
+
+    @Test
+    fun `listPending clamps a caller-controlled limit`(): Unit = runBlocking {
+        val store = mockk<ApprovalStore>()
+        coEvery { store.findPending(200) } returns emptyList()
+
+        ApprovalResource(store).listPending(10_000)
+
+        coVerify(exactly = 1) { store.findPending(200) }
+    }
+
+    @Test
+    fun `decided response preserves the existing fields and provenance`() {
+        val decidedAt = OffsetDateTime.parse("2026-08-23T01:00:00Z")
+        val approval = PendingApproval(
+            id = "appr-2",
+            action = "account.freeze",
+            resourceId = "account-1",
+            makerId = "maker",
+            status = ApprovalStatus.APPROVED,
+            createdAt = decidedAt.minusHours(1),
+            decidedBy = "checker",
+            decidedAt = decidedAt,
+        )
+
+        val response = approval.toResponse()
+
+        assertThat(response.id).isEqualTo("appr-2")
+        assertThat(response.action).isEqualTo("account.freeze")
+        assertThat(response.resourceId).isEqualTo("account-1")
+        assertThat(response.status).isEqualTo("APPROVED")
+        assertThat(response.makerId).isEqualTo("maker")
+        assertThat(response.createdAt).isEqualTo("2026-08-23T00:00Z")
+        assertThat(response.decidedBy).isEqualTo("checker")
+    }
+
+    private fun pendingApproval() = PendingApproval(
+        id = "appr-1",
+        action = "account.freeze",
+        resourceId = "account-1",
+        makerId = "maker",
+        status = ApprovalStatus.PENDING,
+        createdAt = OffsetDateTime.parse("2026-08-23T00:00:00Z"),
+    )
+}

--- a/openbank-admin-ui/src/app/api/approvals/pending/route.ts
+++ b/openbank-admin-ui/src/app/api/approvals/pending/route.ts
@@ -22,7 +22,6 @@ type SourceState = 'ok' | 'forbidden' | 'unavailable' | 'not-configured'
 // the inbox can distinguish "not wired" from an empty queue. Omitting them would make
 // the most dangerous state look healthy to an operator.
 const NOT_CONFIGURED_SOURCES = {
-  account: 'not-configured',
   balance: 'not-configured',
   billing: 'not-configured',
   consent: 'not-configured',
@@ -30,7 +29,7 @@ const NOT_CONFIGURED_SOURCES = {
 
 type InboxItem = {
   id: string
-  domain: 'lending' | 'sanctions' | 'transaction' | 'domestic-payment' | 'clearing' | 'fx' | 'ledger' | 'swift' | 'sepa-payment' | 'sepa-instant' | 'notification' | 'party' | 'agent'
+  domain: 'lending' | 'sanctions' | 'transaction' | 'domestic-payment' | 'clearing' | 'fx' | 'ledger' | 'swift' | 'sepa-payment' | 'sepa-instant' | 'notification' | 'party' | 'account' | 'agent'
   action: string
   resourceId: string | null
   maker: string | null
@@ -98,6 +97,10 @@ type NotificationApproval = LendingApproval
 // party-service serves the same shared PendingApproval shape. This source turns the approval id
 // returned from a parked `party.merge` into a visible checker hand-off before its 24-hour TTL.
 type PartyApproval = LendingApproval
+
+// account-service serves the shared PendingApproval shape for gated account lifecycle actions.
+// Surfacing it here makes a parked freeze or other protected action discoverable before TTL expiry.
+type AccountApproval = LendingApproval
 
 type AgentProposal = {
   id: string
@@ -309,6 +312,21 @@ async function partyPending(headers: HeadersInit): Promise<SourceResult> {
   }
 }
 
+async function accountPending(headers: HeadersInit): Promise<SourceResult> {
+  const res = await fetch(serverSvcUrl('account-service', 'accounts', 8100, '/api/v1/accounts/approvals', { limit: '50' }), {
+    headers, signal: AbortSignal.timeout(4000), cache: 'no-store',
+  })
+  if (!res.ok) return { items: [], state: stateFor(res.status) }
+  const rows = (await res.json()) as AccountApproval[]
+  return {
+    state: 'ok',
+    items: rows.map(r => ({
+      id: r.id, domain: 'account' as const, action: r.action,
+      resourceId: r.resourceId, maker: r.makerId, proposedAt: r.createdAt,
+    })),
+  }
+}
+
 function agentBase(): string {
   if (process.env.SERVICES_HOST === 'container') return 'http://openbank-agent-service:8109'
   return (process.env.AGENT_SERVICE_URL ?? 'http://localhost:8109/mcp').replace(/\/mcp$/, '')
@@ -336,7 +354,7 @@ export async function GET() {
   }
   const headers = { authorization: `Bearer ${session.user.accessToken}` }
   const unavailable: SourceResult = { items: [], state: 'unavailable' }
-  const [lending, sanctions, transaction, domesticPayment, clearing, fx, ledger, swift, sepaPayment, sepaInstant, notification, party, agent] = await Promise.all([
+  const [lending, sanctions, transaction, domesticPayment, clearing, fx, ledger, swift, sepaPayment, sepaInstant, notification, party, account, agent] = await Promise.all([
     lendingPending(headers).catch(() => unavailable),
     sanctionsPending(headers).catch(() => unavailable),
     transactionPending(headers).catch(() => unavailable),
@@ -349,9 +367,10 @@ export async function GET() {
     sepaInstantPending(headers).catch(() => unavailable),
     notificationPending(headers).catch(() => unavailable),
     partyPending(headers).catch(() => unavailable),
+    accountPending(headers).catch(() => unavailable),
     agentPending(headers).catch(() => unavailable),
   ])
-  const items = [...lending.items, ...sanctions.items, ...transaction.items, ...domesticPayment.items, ...clearing.items, ...fx.items, ...ledger.items, ...swift.items, ...sepaPayment.items, ...sepaInstant.items, ...notification.items, ...party.items, ...agent.items]
+  const items = [...lending.items, ...sanctions.items, ...transaction.items, ...domesticPayment.items, ...clearing.items, ...fx.items, ...ledger.items, ...swift.items, ...sepaPayment.items, ...sepaInstant.items, ...notification.items, ...party.items, ...account.items, ...agent.items]
     .sort((a, b) => (a.proposedAt ?? '').localeCompare(b.proposedAt ?? ''))
   return NextResponse.json({
     items,
@@ -369,6 +388,7 @@ export async function GET() {
       'sepa-instant': sepaInstant.state,
       notification: notification.state,
       party: party.state,
+      account: account.state,
       agent: agent.state,
     },
   })

--- a/openbank-admin-ui/src/test/approvals-inbox.test.ts
+++ b/openbank-admin-ui/src/test/approvals-inbox.test.ts
@@ -101,6 +101,11 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
           { id: 'PT-1', action: 'party.merge', resourceId: 'party-7', makerId: 'operator.g', createdAt: '2026-07-29T11:45:00Z' },
         ]), { status: 200 }))
       }
+      if (url.includes('accounts/approvals') || url.includes('account-service')) {
+        return Promise.resolve(new Response(JSON.stringify([
+          { id: 'A-1', action: 'account.freeze', resourceId: 'account-7', makerId: 'operator.h', createdAt: '2026-07-29T11:50:00Z' },
+        ]), { status: 200 }))
+      }
       return Promise.resolve(new Response(JSON.stringify([
         { id: 'P-1', suggestedAction: 'agent.research', proposedBy: 'ui-assistant', proposedAt: '2026-07-30T08:00:00Z' },
       ]), { status: 200 }))
@@ -113,7 +118,7 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     // sepaPayment); F-1 and I-1 both sit at 11:30 (fx before sepa-instant) — both ties resolved
     // by the stable-sort's concat order in route.ts. N-1 sits at 10:30, between L-1 and the
     // 11:00 tie.
-    expect(body.items.map((i: { id: string }) => i.id)).toEqual(['L-1', 'N-1', 'D-1', 'C-1', 'J-1', 'W-1', 'SP-1', 'F-1', 'I-1', 'PT-1', 'S-1', 'P-1', 'T-1', 'L-2'])
+    expect(body.items.map((i: { id: string }) => i.id)).toEqual(['L-1', 'N-1', 'D-1', 'C-1', 'J-1', 'W-1', 'SP-1', 'F-1', 'I-1', 'PT-1', 'A-1', 'S-1', 'P-1', 'T-1', 'L-2'])
     expect(body.items[0]).toMatchObject({ domain: 'lending', action: 'lending.writeoff', maker: 'officer.a' })
     expect(body.items[1]).toMatchObject({ domain: 'notification', action: 'opsmessage.compose', maker: 'operator.f' })
     expect(body.items[2]).toMatchObject({ domain: 'domestic-payment', action: 'domestic-payment.transitionStatus', maker: 'operator.d' })
@@ -124,10 +129,12 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(body.items[7]).toMatchObject({ domain: 'fx', action: 'fx.convert', maker: 'trader.d' })
     expect(body.items[8]).toMatchObject({ domain: 'sepa-instant', action: 'sctInstPayment.recall', maker: 'operator.e' })
     expect(body.items[9]).toMatchObject({ domain: 'party', action: 'party.merge', maker: 'operator.g' })
-    expect(body.items[10]).toMatchObject({ domain: 'sanctions', action: 'sanctions.clear', maker: 'analyst.c' })
-    expect(body.items[11]).toMatchObject({ domain: 'agent', action: 'agent.research' })
-    expect(body.items[12]).toMatchObject({ domain: 'transaction', action: 'transaction.reverse', maker: 'teller.d' })
+    expect(body.items[10]).toMatchObject({ domain: 'account', action: 'account.freeze', maker: 'operator.h' })
+    expect(body.items[11]).toMatchObject({ domain: 'sanctions', action: 'sanctions.clear', maker: 'analyst.c' })
+    expect(body.items[12]).toMatchObject({ domain: 'agent', action: 'agent.research' })
+    expect(body.items[13]).toMatchObject({ domain: 'transaction', action: 'transaction.reverse', maker: 'teller.d' })
     expect(body.sources.party).toBe('ok')
+    expect(body.sources.account).toBe('ok')
   })
 
   // The regression this file exists to prevent, stated as a test for the transaction slice of
@@ -307,6 +314,19 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
 
     expect(seen.some(u => u.includes('/api/v1/parties/approvals'))).toBe(true)
     expect(body.sources.party).toBe('ok')
+  })
+
+  it('reads the account queue at all — an unread money-path source must never look empty', async () => {
+    const seen: string[] = []
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      seen.push(String(url))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    }))
+
+    const body = await (await (await route()).GET()).json()
+
+    expect(seen.some(u => u.includes('/api/v1/accounts/approvals'))).toBe(true)
+    expect(body.sources.account).toBe('ok')
   })
 
   it('degrades to the working half when one queue is down', async () => {


### PR DESCRIPTION
## Summary

Expose account-service's pending four-eyes queue and federate it into the Admin UI approval inbox so protected account lifecycle actions no longer become invisible until their 24-hour TTL expires. This PR is intentionally stacked on #7020; its diff contains only the account source, an OpenAPI truthfulness repair, and the exact-match enum-gate fix required by that repair.

## Type of change

- [x] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #5679

## Changes

- Add a bounded, oldest-first `GET /api/v1/accounts/approvals` checker queue without changing the existing maker/checker decision path.
- Federate account approvals into the Admin UI inbox with truthful source health, provenance, ordering, and regression coverage.
- Publish the previously served account authorization and currency-pocket routes, correct the AccountStatus vocabulary, and make the enum ratchet prefer an exact match over an overlapping superset.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved).
- [x] Contract tests updated (if public API changed).
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed).
- [x] Flyway migration added + rollback note (if DB changed). N/A — no DB change.
- [x] Avro schema versioned backward-compatibly (if event changed). N/A — no event change.
- [x] Docs updated (README, ADR if architectural). N/A — implements ADR-0227 D2.

Local proof: targeted account tests, ktlint, detekt, Quarkus build, Admin UI type-check, focused ESLint, and 17 focused Vitest tests pass. OpenAPI route/API-version/enum gates pass. The full account test run reached 257 tests; the only 3 failures and 46 skips require Docker/Testcontainers, unavailable in the clean local worktree, so CI remains authoritative for that boundary.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification. The existing-style unchecked cast is test-only and narrows the JAX-RS response entity for assertions.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? Money-path account approval visibility changed; two independent approvals and security review are required before merge.
- [x] PII path changed? No.
- [x] Cardholder data path changed? No.

## Compliance impact

- [ ] PCI DSS
- [x] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

Improves operational visibility of pending four-eyes controls. Existing RBAC, OPA authorization, maker/checker identity separation, payloads, and 24-hour TTL remain unchanged.

## Rollout / Rollback

- Deployment strategy: rolling after normal release-please and GitOps promotion
- Rollback plan: revert the squash commit; the UI already renders unavailable/not-configured sources explicitly
- Data migration reversible: N/A

## Screenshots / demo (if UI change)

No visual layout change; this connects a formerly missing data source to the existing approval inbox.

## Reviewer notes

Stacked on #7020. Review only `codex/party-approval-inbox...codex/account-approval-inbox`. Account-service is money-path: do not merge without two independent approvals, green CI, and the existing `docs/threat-models/openbank-account-service.md` control context.
