### PR TITLE
feat(balance): expose pending approvals in unified inbox

### DIFF
--- a/docs/threat-models/openbank-balance-service.md
+++ b/docs/threat-models/openbank-balance-service.md
@@ -173,6 +173,16 @@ also be deleted (nothing else in balance-service depends on it).
 
 ## 7. Change log
 
+- **2026-08-26** — The operator approval inbox gains a bounded, read-only
+  `GET /api/v1/balances/approvals` edge. It returns pending approval workflow metadata
+  (random id, action, resource id, maker id and creation time) only to `ROLE_OPERATOR` or
+  `ROLE_ADMIN` callers behind the existing OPA boundary. Results are capped at 200 and ordered
+  oldest first; the endpoint cannot decide or execute an approval. Existing maker/checker
+  separation, one-time execution and 24-hour Redis TTL controls remain unchanged. **Risk class:**
+  confidentiality of operator workflow metadata and bounded Redis read load; no new caller,
+  service edge or money mutation. Rollback: remove the GET route and let the admin UI report this
+  source unavailable; balance posting and approval decisions are unaffected.
+
 - **2026-08-24** — Synthetic-journey taint now propagates over this service's existing internal REST clients through `SyntheticTaintClientFilter` (ADR-0252, #4348). This adds no caller, endpoint, network-policy edge, privilege or control bypass: downstream controls still see the journey. It prevents synthetic activity from becoming indistinguishable before a downstream persistence/event boundary; a fleet gate now requires every new client to choose propagation or a reasoned external boundary.
 
 - **2026-08-05** — Prohibit the customer-edge M2M principal from balance writes (#3734). The

--- a/openbank-admin-ui/src/app/api/approvals/pending/route.ts
+++ b/openbank-admin-ui/src/app/api/approvals/pending/route.ts
@@ -22,13 +22,12 @@ type SourceState = 'ok' | 'forbidden' | 'unavailable' | 'not-configured'
 // the inbox can distinguish "not wired" from an empty queue. Omitting them would make
 // the most dangerous state look healthy to an operator.
 const NOT_CONFIGURED_SOURCES = {
-  balance: 'not-configured',
   billing: 'not-configured',
 } as const satisfies Record<string, SourceState>
 
 type InboxItem = {
   id: string
-  domain: 'lending' | 'sanctions' | 'transaction' | 'domestic-payment' | 'clearing' | 'fx' | 'ledger' | 'swift' | 'sepa-payment' | 'sepa-instant' | 'notification' | 'party' | 'account' | 'consent' | 'agent'
+  domain: 'lending' | 'sanctions' | 'transaction' | 'domestic-payment' | 'clearing' | 'fx' | 'ledger' | 'swift' | 'sepa-payment' | 'sepa-instant' | 'notification' | 'party' | 'account' | 'consent' | 'balance' | 'agent'
   action: string
   resourceId: string | null
   maker: string | null
@@ -102,6 +101,9 @@ type PartyApproval = LendingApproval
 type AccountApproval = LendingApproval
 
 type ConsentApproval = LendingApproval
+
+// balance-service serves the shared PendingApproval shape for gated credit/debit actions.
+type BalanceApproval = LendingApproval
 
 type AgentProposal = {
   id: string
@@ -343,6 +345,21 @@ async function consentPending(headers: HeadersInit): Promise<SourceResult> {
   }
 }
 
+async function balancePending(headers: HeadersInit): Promise<SourceResult> {
+  const res = await fetch(serverSvcUrl('balance-service', 'balances', 8103, '/api/v1/balances/approvals', { limit: '50' }), {
+    headers, signal: AbortSignal.timeout(4000), cache: 'no-store',
+  })
+  if (!res.ok) return { items: [], state: stateFor(res.status) }
+  const rows = (await res.json()) as BalanceApproval[]
+  return {
+    state: 'ok',
+    items: rows.map(r => ({
+      id: r.id, domain: 'balance' as const, action: r.action,
+      resourceId: r.resourceId, maker: r.makerId, proposedAt: r.createdAt,
+    })),
+  }
+}
+
 function agentBase(): string {
   if (process.env.SERVICES_HOST === 'container') return 'http://openbank-agent-service:8109'
   return (process.env.AGENT_SERVICE_URL ?? 'http://localhost:8109/mcp').replace(/\/mcp$/, '')
@@ -370,7 +387,7 @@ export async function GET() {
   }
   const headers = { authorization: `Bearer ${session.user.accessToken}` }
   const unavailable: SourceResult = { items: [], state: 'unavailable' }
-  const [lending, sanctions, transaction, domesticPayment, clearing, fx, ledger, swift, sepaPayment, sepaInstant, notification, party, account, consent, agent] = await Promise.all([
+  const [lending, sanctions, transaction, domesticPayment, clearing, fx, ledger, swift, sepaPayment, sepaInstant, notification, party, account, consent, balance, agent] = await Promise.all([
     lendingPending(headers).catch(() => unavailable),
     sanctionsPending(headers).catch(() => unavailable),
     transactionPending(headers).catch(() => unavailable),
@@ -385,9 +402,10 @@ export async function GET() {
     partyPending(headers).catch(() => unavailable),
     accountPending(headers).catch(() => unavailable),
     consentPending(headers).catch(() => unavailable),
+    balancePending(headers).catch(() => unavailable),
     agentPending(headers).catch(() => unavailable),
   ])
-  const items = [...lending.items, ...sanctions.items, ...transaction.items, ...domesticPayment.items, ...clearing.items, ...fx.items, ...ledger.items, ...swift.items, ...sepaPayment.items, ...sepaInstant.items, ...notification.items, ...party.items, ...account.items, ...consent.items, ...agent.items]
+  const items = [...lending.items, ...sanctions.items, ...transaction.items, ...domesticPayment.items, ...clearing.items, ...fx.items, ...ledger.items, ...swift.items, ...sepaPayment.items, ...sepaInstant.items, ...notification.items, ...party.items, ...account.items, ...consent.items, ...balance.items, ...agent.items]
     .sort((a, b) => (a.proposedAt ?? '').localeCompare(b.proposedAt ?? ''))
   return NextResponse.json({
     items,
@@ -407,6 +425,7 @@ export async function GET() {
       party: party.state,
       account: account.state,
       consent: consent.state,
+      balance: balance.state,
       agent: agent.state,
     },
   })

--- a/openbank-admin-ui/src/test/approvals-inbox.test.ts
+++ b/openbank-admin-ui/src/test/approvals-inbox.test.ts
@@ -111,6 +111,11 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
           { id: 'CO-1', action: 'consent.revoke', resourceId: 'consent-7', makerId: 'operator.h', createdAt: '2026-07-29T11:50:00Z' },
         ]), { status: 200 }))
       }
+      if (url.includes('balances/approvals') || url.includes('balance-service')) {
+        return Promise.resolve(new Response(JSON.stringify([
+          { id: 'B-1', action: 'balance.debit', resourceId: 'account-7', makerId: 'operator.i', createdAt: '2026-07-29T11:55:00Z' },
+        ]), { status: 200 }))
+      }
       return Promise.resolve(new Response(JSON.stringify([
         { id: 'P-1', suggestedAction: 'agent.research', proposedBy: 'ui-assistant', proposedAt: '2026-07-30T08:00:00Z' },
       ]), { status: 200 }))
@@ -123,7 +128,7 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     // sepaPayment); F-1 and I-1 both sit at 11:30 (fx before sepa-instant) — both ties resolved
     // by the stable-sort's concat order in route.ts. N-1 sits at 10:30, between L-1 and the
     // 11:00 tie.
-    expect(body.items.map((i: { id: string }) => i.id)).toEqual(['L-1', 'N-1', 'D-1', 'C-1', 'J-1', 'W-1', 'SP-1', 'F-1', 'I-1', 'PT-1', 'A-1', 'CO-1', 'S-1', 'P-1', 'T-1', 'L-2'])
+    expect(body.items.map((i: { id: string }) => i.id)).toEqual(['L-1', 'N-1', 'D-1', 'C-1', 'J-1', 'W-1', 'SP-1', 'F-1', 'I-1', 'PT-1', 'A-1', 'CO-1', 'B-1', 'S-1', 'P-1', 'T-1', 'L-2'])
     expect(body.items[0]).toMatchObject({ domain: 'lending', action: 'lending.writeoff', maker: 'officer.a' })
     expect(body.items[1]).toMatchObject({ domain: 'notification', action: 'opsmessage.compose', maker: 'operator.f' })
     expect(body.items[2]).toMatchObject({ domain: 'domestic-payment', action: 'domestic-payment.transitionStatus', maker: 'operator.d' })
@@ -136,11 +141,13 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(body.items[9]).toMatchObject({ domain: 'party', action: 'party.merge', maker: 'operator.g' })
     expect(body.items[10]).toMatchObject({ domain: 'account', action: 'account.freeze', maker: 'operator.h' })
     expect(body.items[11]).toMatchObject({ domain: 'consent', action: 'consent.revoke', maker: 'operator.h' })
-    expect(body.items[12]).toMatchObject({ domain: 'sanctions', action: 'sanctions.clear', maker: 'analyst.c' })
-    expect(body.items[13]).toMatchObject({ domain: 'agent', action: 'agent.research' })
-    expect(body.items[14]).toMatchObject({ domain: 'transaction', action: 'transaction.reverse', maker: 'teller.d' })
+    expect(body.items[12]).toMatchObject({ domain: 'balance', action: 'balance.debit', maker: 'operator.i' })
+    expect(body.items[13]).toMatchObject({ domain: 'sanctions', action: 'sanctions.clear', maker: 'analyst.c' })
+    expect(body.items[14]).toMatchObject({ domain: 'agent', action: 'agent.research' })
+    expect(body.items[15]).toMatchObject({ domain: 'transaction', action: 'transaction.reverse', maker: 'teller.d' })
     expect(body.sources.party).toBe('ok')
     expect(body.sources.account).toBe('ok')
+    expect(body.sources.balance).toBe('ok')
   })
 
   // The regression this file exists to prevent, stated as a test for the transaction slice of
@@ -346,6 +353,19 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
 
     expect(seen.some(u => u.includes('/api/v1/consents/approvals'))).toBe(true)
     expect(body.sources.consent).toBe('ok')
+  })
+
+  it('reads the balance queue at all — an unread money-path source must never look empty', async () => {
+    const seen: string[] = []
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      seen.push(String(url))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    }))
+
+    const body = await (await (await route()).GET()).json()
+
+    expect(seen.some(u => u.includes('/api/v1/balances/approvals'))).toBe(true)
+    expect(body.sources.balance).toBe('ok')
   })
 
   it('degrades to the working half when one queue is down', async () => {

--- a/openbank-admin-ui/src/test/approvals-source-truth.guard.test.ts
+++ b/openbank-admin-ui/src/test/approvals-source-truth.guard.test.ts
@@ -11,7 +11,9 @@ const pageSource = fs.readFileSync(path.join(process.cwd(), 'src/app/approvals/p
 describe('approval inbox source truthfulness', () => {
   it('exposes known-but-unwired queues instead of treating them as empty', () => {
     expect(routeSource).toContain("'not-configured'")
-    expect(routeSource).toContain("balance: 'not-configured'")
+    expect(routeSource).not.toContain("balance: 'not-configured'")
+    expect(routeSource).toContain("billing: 'not-configured'")
+    expect(routeSource).not.toContain("consent: 'not-configured'")
     expect(routeSource).toContain('...NOT_CONFIGURED_SOURCES')
   })
 

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/rest/ApprovalResource.kt
@@ -11,11 +11,14 @@ import com.openbank.libs.security.Roles
 import io.quarkus.security.identity.SecurityIdentity
 import jakarta.annotation.security.RolesAllowed
 import jakarta.inject.Inject
+import jakarta.ws.rs.DefaultValue
+import jakarta.ws.rs.GET
 import jakarta.ws.rs.NotFoundException
 import jakarta.ws.rs.PATCH
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.openapi.annotations.Operation
@@ -38,6 +41,16 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
 
     @Inject
     lateinit var identity: SecurityIdentity
+
+    /** Read-only checker queue; deciding remains on PATCH and preserves four-eyes separation. */
+    @GET
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "balance.approval.read", resource = "")
+    @Operation(summary = "List pending balance approvals, oldest first (ADR-0227 D2)")
+    suspend fun listPending(@QueryParam("limit") @DefaultValue("50") limit: Int): Response {
+        val pending = approvalStore.findPending(limit.coerceIn(1, MAX_PENDING_LIMIT))
+        return Response.ok(pending.map { it.toResponse() }).build()
+    }
 
     @PATCH
     @Path("/{id}")
@@ -63,6 +76,11 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     // own request. SecurityIdentity (not @Context SecurityContext) because this is
     // a `suspend fun` — see AccountResource.operatorId() for the same workaround.
     private fun checkerId(): String = identity.principal?.name ?: "anonymous"
+
+    private companion object {
+        /** ApprovalStore scans Redis; keep the caller-controlled result bounded. */
+        const val MAX_PENDING_LIMIT = 200
+    }
 }
 
 data class DecideApprovalRequest(val approve: Boolean)
@@ -72,6 +90,8 @@ data class ApprovalResponse(
     val action: String,
     val resourceId: String?,
     val status: String,
+    val makerId: String?,
+    val createdAt: String?,
     val decidedBy: String?,
 )
 
@@ -80,5 +100,7 @@ fun PendingApproval.toResponse() = ApprovalResponse(
     action = action,
     resourceId = resourceId,
     status = status.name,
+    makerId = makerId,
+    createdAt = createdAt.toString(),
     decidedBy = decidedBy,
 )

--- a/openbank-balance-service/src/main/resources/openapi.yaml
+++ b/openbank-balance-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Balance Service API
-  version: 1.8.0
+  version: 1.9.0
   description: >-
     Account balance management — holds, credits, debits, multi-currency. Per ADR-0039 (Phase A) a
     read-only reconciliation ties out, per currency, the ledger deposit-control balance against the
@@ -274,6 +274,36 @@ paths:
         '404':
           description: No reconciliation has been run yet
 
+  /api/v1/balances/approvals:
+    get:
+      tags: [Balances]
+      summary: List pending balance approvals, oldest first
+      description: >-
+        PENDING maker-checker approvals for balance credit/debit actions. This read-only queue is
+        consumed by the unified approval inbox; deciding remains on PATCH
+        /api/v1/balances/approvals/{id}. Requires ROLE_OPERATOR or ROLE_ADMIN.
+      operationId: listPendingApprovals
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+      responses:
+        '200':
+          description: Pending balance approvals, oldest first
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApprovalResponse'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
   /api/v1/balances/approvals/{id}:
     patch:
       tags: [Balances]
@@ -306,22 +336,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required: [id, action, status]
-                properties:
-                  id:
-                    type: string
-                  action:
-                    type: string
-                    description: The gated action this approval was raised for.
-                  resourceId:
-                    type: string
-                    nullable: true
-                  status:
-                    type: string
-                  decidedBy:
-                    type: string
-                    nullable: true
+                $ref: '#/components/schemas/ApprovalResponse'
         '404':
           $ref: '#/components/responses/NotFound'
 
@@ -356,6 +371,34 @@ components:
             $ref: '#/components/schemas/ApiError'
 
   schemas:
+    ApprovalResponse:
+      type: object
+      description: >-
+        A four-eyes balance approval. makerId identifies who requested the money-path action; the
+        shared ApprovalStore requires a different authenticated principal to decide it.
+      required: [id, action, status]
+      properties:
+        id:
+          type: string
+        action:
+          type: string
+          description: The gated balance action this approval was raised for.
+        resourceId:
+          type: string
+          nullable: true
+        status:
+          type: string
+        makerId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+          description: Request time; pending approvals expire after 24 hours.
+        decidedBy:
+          type: string
+          nullable: true
+
     BalanceResponse:
       type: object
       properties:

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/infrastructure/rest/ApprovalResourceMappingTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/infrastructure/rest/ApprovalResourceMappingTest.kt
@@ -5,13 +5,42 @@
 package com.openbank.balance.infrastructure.rest
 
 import com.openbank.libs.approval.ApprovalStatus
+import com.openbank.libs.approval.ApprovalStore
 import com.openbank.libs.approval.PendingApproval
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.OffsetDateTime
 
 /** Unit coverage for the [PendingApproval] -> `ApprovalResponse` mapping (ADR-0155). */
 class ApprovalResourceMappingTest {
+
+    @Test
+    fun `listPending exposes provenance in the checker queue`(): Unit = runBlocking {
+        val store = mockk<ApprovalStore>()
+        coEvery { store.findPending(50) } returns listOf(pendingApproval())
+
+        val response = ApprovalResource(store).listPending(50)
+
+        assertThat(response.status).isEqualTo(200)
+        @Suppress("UNCHECKED_CAST")
+        val body = response.entity as List<ApprovalResponse>
+        assertThat(body.single().makerId).isEqualTo("maker")
+        assertThat(body.single().createdAt).isEqualTo("2026-07-12T00:00Z")
+    }
+
+    @Test
+    fun `listPending clamps a caller-controlled limit`(): Unit = runBlocking {
+        val store = mockk<ApprovalStore>()
+        coEvery { store.findPending(200) } returns emptyList()
+
+        ApprovalResource(store).listPending(10_000)
+
+        coVerify(exactly = 1) { store.findPending(200) }
+    }
 
     @Test
     fun `toResponse maps every field including a decided approval`() {
@@ -33,6 +62,8 @@ class ApprovalResourceMappingTest {
         assertThat(response.action).isEqualTo("balance.credit")
         assertThat(response.resourceId).isEqualTo("acc-1")
         assertThat(response.status).isEqualTo("APPROVED")
+        assertThat(response.makerId).isEqualTo("maker")
+        assertThat(response.createdAt).isEqualTo("2026-07-11T23:00Z")
         assertThat(response.decidedBy).isEqualTo("checker")
     }
 
@@ -53,4 +84,13 @@ class ApprovalResourceMappingTest {
         assertThat(response.status).isEqualTo("PENDING")
         assertThat(response.decidedBy).isNull()
     }
+
+    private fun pendingApproval() = PendingApproval(
+        id = "appr-pending",
+        action = "balance.debit",
+        resourceId = "acc-1",
+        makerId = "maker",
+        status = ApprovalStatus.PENDING,
+        createdAt = OffsetDateTime.parse("2026-07-12T00:00:00Z"),
+    )
 }


### PR DESCRIPTION
## Summary

Expose balance-service's pending four-eyes queue and federate it into the Admin UI approval inbox, so a parked credit/debit decision is visible to checkers before its 24-hour TTL expires. This PR is intentionally stacked on #7028 and contains only the balance source.

## Type of change

- [x] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #5679

## Changes

- Add a bounded, oldest-first `GET /api/v1/balances/approvals` checker queue while preserving the existing PATCH decision path and maker != checker invariant.
- Publish the additive API contract at version 1.9.0 with provenance fields required by the inbox.
- Federate balance approvals with explicit source health, stable ordering, and regression coverage.

## Definition of Done

- [x] Hexagonal layering preserved.
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated. No runtime disposal change; CI remains authoritative for Testcontainers.
- [x] Contract tests updated.
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [x] OpenAPI spec updated.
- [x] Flyway migration added + rollback note. N/A — no DB change.
- [x] Avro schema versioned backward-compatibly. N/A — no event change.
- [x] Docs updated. N/A — implements ADR-0227 D2.

Local proof: targeted balance tests, ktlint, detekt, Quarkus build, Admin UI type-check, focused ESLint, and 18 focused Vitest tests pass. OpenAPI route/API-version/enum gates pass. The full balance suite ran 161 tests; the only 2 failures and 48 skips are Testcontainers boundaries with no local Docker socket, so CI is authoritative there.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No unjustified suppression. The test-only unchecked cast narrows the JAX-RS response entity for assertions.
- [x] No new dependency.
- [x] Auth / crypto / payment code changed? Money-path balance approval visibility changed; two independent approvals and security review are required.
- [x] PII path changed? No.
- [x] Cardholder data path changed? No.

## Compliance impact

- [x] DORA

Improves operational visibility of pending four-eyes money-path controls. Credit/debit payloads, RBAC, OPA decisions, identity separation, and TTL are unchanged.

## Rollout / Rollback

- Deployment strategy: rolling after normal release-please and GitOps promotion
- Rollback plan: revert the squash commit; the UI keeps unavailable/not-configured states explicit
- Data migration reversible: N/A

## Screenshots / demo (if UI change)

No layout change; this connects a formerly missing source to the existing inbox.

## Reviewer notes

Stacked on #7028. Review only `codex/account-approval-inbox...codex/balance-approval-inbox`. Balance-service is money-path: do not merge without two independent approvals, green CI, and `docs/threat-models/openbank-balance-service.md` control context.
