### PR TITLE
feat(billing): expose pending approvals in unified inbox

### DIFF
--- a/docs/threat-models/openbank-billing-service.md
+++ b/docs/threat-models/openbank-billing-service.md
@@ -228,8 +228,9 @@ first departure from "every trust boundary here is OIDC+mTLS REST".
   `GET /api/v1/fees/approvals` edge. It returns pending approval workflow metadata
   (random id, action, resource id, maker id and creation time) only to human `ROLE_OPERATOR` or
   `ROLE_ADMIN` callers behind the existing OPA boundary. The billing policy explicitly vetoes
-  `service-account-openbank-edge` for `billing.approval.read`, even though that client carries
-  `ROLE_OPERATOR`, so customer-facing machine traffic cannot enumerate approval metadata.
+  every `service-account-*` identity for `billing.approval.read`; this includes edge and shared
+  service principals that currently carry `ROLE_OPERATOR` and may be classified as `HUMAN`, so
+  machine traffic cannot enumerate approval metadata.
   Results are capped at 200 and ordered
   oldest first; the endpoint cannot decide, post or reverse a fee. Existing maker/checker
   separation, one-time execution and 24-hour Redis TTL controls remain unchanged. **Risk class:**

--- a/docs/threat-models/openbank-billing-service.md
+++ b/docs/threat-models/openbank-billing-service.md
@@ -224,6 +224,16 @@ first departure from "every trust boundary here is OIDC+mTLS REST".
 
 ## 6. Change log
 
+- **2026-08-26** — The operator approval inbox gains a bounded, read-only
+  `GET /api/v1/fees/approvals` edge. It returns pending approval workflow metadata
+  (random id, action, resource id, maker id and creation time) only to `ROLE_OPERATOR` or
+  `ROLE_ADMIN` callers behind the existing OPA boundary. Results are capped at 200 and ordered
+  oldest first; the endpoint cannot decide, post or reverse a fee. Existing maker/checker
+  separation, one-time execution and 24-hour Redis TTL controls remain unchanged. **Risk class:**
+  confidentiality of operator workflow metadata and bounded Redis read load; no new caller,
+  service edge or money mutation. Rollback: remove the GET route and let the admin UI report this
+  source unavailable; billing decisions and fee flows are unaffected.
+
 - **2026-08-24** — Synthetic-journey taint now propagates over this service's existing internal REST clients through `SyntheticTaintClientFilter` (ADR-0252, #4348). This adds no caller, endpoint, network-policy edge, privilege or control bypass. It preserves the marker before a downstream persistence/event boundary; a fleet gate now requires every new client to choose propagation or a reasoned external boundary.
 
 | Date | Change |

--- a/docs/threat-models/openbank-billing-service.md
+++ b/docs/threat-models/openbank-billing-service.md
@@ -226,8 +226,11 @@ first departure from "every trust boundary here is OIDC+mTLS REST".
 
 - **2026-08-26** — The operator approval inbox gains a bounded, read-only
   `GET /api/v1/fees/approvals` edge. It returns pending approval workflow metadata
-  (random id, action, resource id, maker id and creation time) only to `ROLE_OPERATOR` or
-  `ROLE_ADMIN` callers behind the existing OPA boundary. Results are capped at 200 and ordered
+  (random id, action, resource id, maker id and creation time) only to human `ROLE_OPERATOR` or
+  `ROLE_ADMIN` callers behind the existing OPA boundary. The billing policy explicitly vetoes
+  `service-account-openbank-edge` for `billing.approval.read`, even though that client carries
+  `ROLE_OPERATOR`, so customer-facing machine traffic cannot enumerate approval metadata.
+  Results are capped at 200 and ordered
   oldest first; the endpoint cannot decide, post or reverse a fee. Existing maker/checker
   separation, one-time execution and 24-hour Redis TTL controls remain unchanged. **Risk class:**
   confidentiality of operator workflow metadata and bounded Redis read load; no new caller,

--- a/openbank-admin-ui/src/app/api/approvals/pending/route.ts
+++ b/openbank-admin-ui/src/app/api/approvals/pending/route.ts
@@ -17,17 +17,9 @@ export const dynamic = 'force-dynamic'
 
 type SourceState = 'ok' | 'forbidden' | 'unavailable' | 'not-configured'
 
-// These domains already persist maker-checker decisions, but do not yet expose the
-// pending-list read required by ADR-0227 D2. Keep them in the response explicitly so
-// the inbox can distinguish "not wired" from an empty queue. Omitting them would make
-// the most dangerous state look healthy to an operator.
-const NOT_CONFIGURED_SOURCES = {
-  billing: 'not-configured',
-} as const satisfies Record<string, SourceState>
-
 type InboxItem = {
   id: string
-  domain: 'lending' | 'sanctions' | 'transaction' | 'domestic-payment' | 'clearing' | 'fx' | 'ledger' | 'swift' | 'sepa-payment' | 'sepa-instant' | 'notification' | 'party' | 'account' | 'consent' | 'balance' | 'agent'
+  domain: 'lending' | 'sanctions' | 'transaction' | 'domestic-payment' | 'clearing' | 'fx' | 'ledger' | 'swift' | 'sepa-payment' | 'sepa-instant' | 'notification' | 'party' | 'account' | 'consent' | 'balance' | 'billing' | 'agent'
   action: string
   resourceId: string | null
   maker: string | null
@@ -105,6 +97,9 @@ type ConsentApproval = LendingApproval
 // balance-service serves the shared PendingApproval shape for gated credit/debit actions.
 type BalanceApproval = LendingApproval
 
+// billing-service serves the shared PendingApproval shape for gated fee-posting actions.
+// Listing is read-only; posting and reversal controls remain entirely service-owned.
+type BillingApproval = LendingApproval
 type AgentProposal = {
   id: string
   suggestedAction: string
@@ -360,6 +355,21 @@ async function balancePending(headers: HeadersInit): Promise<SourceResult> {
   }
 }
 
+async function billingPending(headers: HeadersInit): Promise<SourceResult> {
+  const res = await fetch(serverSvcUrl('billing-service', 'billing', 8132, '/api/v1/fees/approvals', { limit: '50' }), {
+    headers, signal: AbortSignal.timeout(4000), cache: 'no-store',
+  })
+  if (!res.ok) return { items: [], state: stateFor(res.status) }
+  const rows = (await res.json()) as BillingApproval[]
+  return {
+    state: 'ok',
+    items: rows.map(r => ({
+      id: r.id, domain: 'billing' as const, action: r.action,
+      resourceId: r.resourceId, maker: r.makerId, proposedAt: r.createdAt,
+    })),
+  }
+}
+
 function agentBase(): string {
   if (process.env.SERVICES_HOST === 'container') return 'http://openbank-agent-service:8109'
   return (process.env.AGENT_SERVICE_URL ?? 'http://localhost:8109/mcp').replace(/\/mcp$/, '')
@@ -387,7 +397,7 @@ export async function GET() {
   }
   const headers = { authorization: `Bearer ${session.user.accessToken}` }
   const unavailable: SourceResult = { items: [], state: 'unavailable' }
-  const [lending, sanctions, transaction, domesticPayment, clearing, fx, ledger, swift, sepaPayment, sepaInstant, notification, party, account, consent, balance, agent] = await Promise.all([
+  const [lending, sanctions, transaction, domesticPayment, clearing, fx, ledger, swift, sepaPayment, sepaInstant, notification, party, account, consent, balance, billing, agent] = await Promise.all([
     lendingPending(headers).catch(() => unavailable),
     sanctionsPending(headers).catch(() => unavailable),
     transactionPending(headers).catch(() => unavailable),
@@ -403,14 +413,14 @@ export async function GET() {
     accountPending(headers).catch(() => unavailable),
     consentPending(headers).catch(() => unavailable),
     balancePending(headers).catch(() => unavailable),
+    billingPending(headers).catch(() => unavailable),
     agentPending(headers).catch(() => unavailable),
   ])
-  const items = [...lending.items, ...sanctions.items, ...transaction.items, ...domesticPayment.items, ...clearing.items, ...fx.items, ...ledger.items, ...swift.items, ...sepaPayment.items, ...sepaInstant.items, ...notification.items, ...party.items, ...account.items, ...consent.items, ...balance.items, ...agent.items]
+  const items = [...lending.items, ...sanctions.items, ...transaction.items, ...domesticPayment.items, ...clearing.items, ...fx.items, ...ledger.items, ...swift.items, ...sepaPayment.items, ...sepaInstant.items, ...notification.items, ...party.items, ...account.items, ...consent.items, ...balance.items, ...billing.items, ...agent.items]
     .sort((a, b) => (a.proposedAt ?? '').localeCompare(b.proposedAt ?? ''))
   return NextResponse.json({
     items,
     sources: {
-      ...NOT_CONFIGURED_SOURCES,
       lending: lending.state,
       sanctions: sanctions.state,
       transaction: transaction.state,
@@ -426,6 +436,7 @@ export async function GET() {
       account: account.state,
       consent: consent.state,
       balance: balance.state,
+      billing: billing.state,
       agent: agent.state,
     },
   })

--- a/openbank-admin-ui/src/test/approvals-inbox.test.ts
+++ b/openbank-admin-ui/src/test/approvals-inbox.test.ts
@@ -116,6 +116,11 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
           { id: 'B-1', action: 'balance.debit', resourceId: 'account-7', makerId: 'operator.i', createdAt: '2026-07-29T11:55:00Z' },
         ]), { status: 200 }))
       }
+      if (url.includes('fees/approvals') || url.includes('billing-service')) {
+        return Promise.resolve(new Response(JSON.stringify([
+          { id: 'BL-1', action: 'billing.post', resourceId: 'fee-7', makerId: 'operator.j', createdAt: '2026-07-29T11:57:00Z' },
+        ]), { status: 200 }))
+      }
       return Promise.resolve(new Response(JSON.stringify([
         { id: 'P-1', suggestedAction: 'agent.research', proposedBy: 'ui-assistant', proposedAt: '2026-07-30T08:00:00Z' },
       ]), { status: 200 }))
@@ -128,7 +133,7 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     // sepaPayment); F-1 and I-1 both sit at 11:30 (fx before sepa-instant) — both ties resolved
     // by the stable-sort's concat order in route.ts. N-1 sits at 10:30, between L-1 and the
     // 11:00 tie.
-    expect(body.items.map((i: { id: string }) => i.id)).toEqual(['L-1', 'N-1', 'D-1', 'C-1', 'J-1', 'W-1', 'SP-1', 'F-1', 'I-1', 'PT-1', 'A-1', 'CO-1', 'B-1', 'S-1', 'P-1', 'T-1', 'L-2'])
+    expect(body.items.map((i: { id: string }) => i.id)).toEqual(['L-1', 'N-1', 'D-1', 'C-1', 'J-1', 'W-1', 'SP-1', 'F-1', 'I-1', 'PT-1', 'A-1', 'CO-1', 'B-1', 'BL-1', 'S-1', 'P-1', 'T-1', 'L-2'])
     expect(body.items[0]).toMatchObject({ domain: 'lending', action: 'lending.writeoff', maker: 'officer.a' })
     expect(body.items[1]).toMatchObject({ domain: 'notification', action: 'opsmessage.compose', maker: 'operator.f' })
     expect(body.items[2]).toMatchObject({ domain: 'domestic-payment', action: 'domestic-payment.transitionStatus', maker: 'operator.d' })
@@ -142,12 +147,14 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(body.items[10]).toMatchObject({ domain: 'account', action: 'account.freeze', maker: 'operator.h' })
     expect(body.items[11]).toMatchObject({ domain: 'consent', action: 'consent.revoke', maker: 'operator.h' })
     expect(body.items[12]).toMatchObject({ domain: 'balance', action: 'balance.debit', maker: 'operator.i' })
-    expect(body.items[13]).toMatchObject({ domain: 'sanctions', action: 'sanctions.clear', maker: 'analyst.c' })
-    expect(body.items[14]).toMatchObject({ domain: 'agent', action: 'agent.research' })
-    expect(body.items[15]).toMatchObject({ domain: 'transaction', action: 'transaction.reverse', maker: 'teller.d' })
+    expect(body.items[13]).toMatchObject({ domain: 'billing', action: 'billing.post', maker: 'operator.j' })
+    expect(body.items[14]).toMatchObject({ domain: 'sanctions', action: 'sanctions.clear', maker: 'analyst.c' })
+    expect(body.items[15]).toMatchObject({ domain: 'agent', action: 'agent.research' })
+    expect(body.items[16]).toMatchObject({ domain: 'transaction', action: 'transaction.reverse', maker: 'teller.d' })
     expect(body.sources.party).toBe('ok')
     expect(body.sources.account).toBe('ok')
     expect(body.sources.balance).toBe('ok')
+    expect(body.sources.billing).toBe('ok')
   })
 
   // The regression this file exists to prevent, stated as a test for the transaction slice of
@@ -366,6 +373,19 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
 
     expect(seen.some(u => u.includes('/api/v1/balances/approvals'))).toBe(true)
     expect(body.sources.balance).toBe('ok')
+  })
+
+  it('reads the billing queue at all — an unread money-path source must never look empty', async () => {
+    const seen: string[] = []
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      seen.push(String(url))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    }))
+
+    const body = await (await (await route()).GET()).json()
+
+    expect(seen.some(u => u.includes('/api/v1/fees/approvals'))).toBe(true)
+    expect(body.sources.billing).toBe('ok')
   })
 
   it('degrades to the working half when one queue is down', async () => {

--- a/openbank-admin-ui/src/test/approvals-source-truth.guard.test.ts
+++ b/openbank-admin-ui/src/test/approvals-source-truth.guard.test.ts
@@ -9,12 +9,14 @@ const routeSource = fs.readFileSync(path.join(process.cwd(), 'src/app/api/approv
 const pageSource = fs.readFileSync(path.join(process.cwd(), 'src/app/approvals/page.tsx'), 'utf8')
 
 describe('approval inbox source truthfulness', () => {
-  it('exposes known-but-unwired queues instead of treating them as empty', () => {
+  it('does not label a wired queue as not configured', () => {
     expect(routeSource).toContain("'not-configured'")
     expect(routeSource).not.toContain("balance: 'not-configured'")
-    expect(routeSource).toContain("billing: 'not-configured'")
     expect(routeSource).not.toContain("consent: 'not-configured'")
-    expect(routeSource).toContain('...NOT_CONFIGURED_SOURCES')
+    expect(routeSource).not.toContain("billing: 'not-configured'")
+    expect(routeSource).not.toContain('NOT_CONFIGURED_SOURCES')
+    expect(routeSource).toContain('balancePending(headers)')
+    expect(routeSource).toContain('billingPending(headers)')
   })
 
   it('does not render an empty-state claim while a source is not configured', () => {

--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/rest/ApprovalResource.kt
@@ -10,11 +10,14 @@ import com.openbank.libs.authz.Authorize
 import io.quarkus.security.identity.SecurityIdentity
 import jakarta.annotation.security.RolesAllowed
 import jakarta.inject.Inject
+import jakarta.ws.rs.DefaultValue
+import jakarta.ws.rs.GET
 import jakarta.ws.rs.NotFoundException
 import jakarta.ws.rs.PATCH
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.openapi.annotations.Operation
@@ -35,6 +38,16 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
 
     @Inject
     lateinit var identity: SecurityIdentity
+
+    /** Read-only checker queue; deciding remains on PATCH and preserves four-eyes separation. */
+    @GET
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "billing.approval.read", resource = "")
+    @Operation(summary = "List pending billing approvals, oldest first (ADR-0227 D2)")
+    suspend fun listPending(@QueryParam("limit") @DefaultValue("50") limit: Int): Response {
+        val pending = approvalStore.findPending(limit.coerceIn(1, MAX_PENDING_LIMIT))
+        return Response.ok(pending.map { it.toResponse() }).build()
+    }
 
     @PATCH
     @Path("/{id}")
@@ -59,6 +72,11 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     // their own request. SecurityIdentity (not @Context SecurityContext) since this is a
     // `suspend fun` — see AccountResource.operatorId() for the same workaround.
     private fun checkerId(): String = identity.principal?.name ?: "anonymous"
+
+    private companion object {
+        /** ApprovalStore scans Redis; keep the caller-controlled result bounded. */
+        const val MAX_PENDING_LIMIT = 200
+    }
 }
 
 data class DecideApprovalRequest(val approve: Boolean)
@@ -68,6 +86,8 @@ data class ApprovalResponse(
     val action: String,
     val resourceId: String?,
     val status: String,
+    val makerId: String?,
+    val createdAt: String?,
     val decidedBy: String?,
 )
 
@@ -76,5 +96,7 @@ fun PendingApproval.toResponse() = ApprovalResponse(
     action = action,
     resourceId = resourceId,
     status = status.name,
+    makerId = makerId,
+    createdAt = createdAt.toString(),
     decidedBy = decidedBy,
 )

--- a/openbank-billing-service/src/main/resources/openapi.yaml
+++ b/openbank-billing-service/src/main/resources/openapi.yaml
@@ -6,7 +6,7 @@ info:
   title: Billing Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.2 -> 1.3): additive
   # endpoint only (POST /fees/reverse) — phase 2e, no breaking change.
-  version: 1.4.0
+  version: 1.5.0
   description: >-
     Runtime product fee assessment, posting and reversal (ADR-0143). POST /api/v1/fees/assess
     computes an account's fee assessment from live account/balance/catalog reads and returns it
@@ -137,6 +137,28 @@ paths:
           description: No assessed fee with that idempotencyKey.
         "409":
           description: The fee exists but was never POSTED (waived, zero, still PENDING, or FAILED) — nothing to reverse.
+  /api/v1/fees/approvals:
+    get:
+      summary: List pending billing approvals, oldest first (ADR-0227 D2).
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, default: 50, minimum: 1, maximum: 200 }
+      responses:
+        "200":
+          description: Pending billing approvals, oldest first.
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/ApprovalResponse' }
+        "401":
+          description: Unauthenticated.
+        "403":
+          description: Authenticated but denied by the OPA authorization policy (ADR-0034).
   /api/v1/fees/approvals/{id}:
     patch:
       summary: Approve or reject a pending four-eyes approval for a fee posting (ADR-0155).
@@ -156,6 +178,9 @@ paths:
       responses:
         "200":
           description: The decided approval.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApprovalResponse' }
         "401":
           description: Unauthenticated.
         "403":
@@ -168,3 +193,23 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+  schemas:
+    ApprovalResponse:
+      type: object
+      description: >-
+        A four-eyes billing approval. makerId identifies who requested the fee action; the shared
+        ApprovalStore requires a different authenticated principal to decide it.
+      required: [id, action, status]
+      properties:
+        id: { type: string }
+        action:
+          type: string
+          description: The gated billing action this approval was raised for.
+        resourceId: { type: string, nullable: true }
+        status: { type: string }
+        makerId: { type: string, nullable: true }
+        createdAt:
+          type: string
+          format: date-time
+          description: Request time; pending approvals expire after 24 hours.
+        decidedBy: { type: string, nullable: true }

--- a/openbank-billing-service/src/test/kotlin/com/openbank/billing/ApprovalResourceMappingTest.kt
+++ b/openbank-billing-service/src/test/kotlin/com/openbank/billing/ApprovalResourceMappingTest.kt
@@ -4,15 +4,46 @@
 
 package com.openbank.billing
 
+import com.openbank.billing.infrastructure.rest.ApprovalResource
+import com.openbank.billing.infrastructure.rest.ApprovalResponse
 import com.openbank.billing.infrastructure.rest.toResponse
 import com.openbank.libs.approval.ApprovalStatus
+import com.openbank.libs.approval.ApprovalStore
 import com.openbank.libs.approval.PendingApproval
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.OffsetDateTime
 
 /** Unit coverage for the [PendingApproval] -> `ApprovalResponse` mapping (ADR-0155). */
 class ApprovalResourceMappingTest {
+
+    @Test
+    fun `listPending exposes provenance in the checker queue`(): Unit = runBlocking {
+        val store = mockk<ApprovalStore>()
+        coEvery { store.findPending(50) } returns listOf(pendingApproval())
+
+        val response = ApprovalResource(store).listPending(50)
+
+        assertThat(response.status).isEqualTo(200)
+        @Suppress("UNCHECKED_CAST")
+        val body = response.entity as List<ApprovalResponse>
+        assertThat(body.single().makerId).isEqualTo("maker")
+        assertThat(body.single().createdAt).isEqualTo("2026-07-08T00:00Z")
+    }
+
+    @Test
+    fun `listPending clamps a caller-controlled limit`(): Unit = runBlocking {
+        val store = mockk<ApprovalStore>()
+        coEvery { store.findPending(200) } returns emptyList()
+
+        ApprovalResource(store).listPending(10_000)
+
+        coVerify(exactly = 1) { store.findPending(200) }
+    }
 
     @Test
     fun `toResponse maps every field including a decided approval`() {
@@ -34,6 +65,8 @@ class ApprovalResourceMappingTest {
         assertThat(response.action).isEqualTo("billing.post")
         assertThat(response.resourceId).isEqualTo("acc-1")
         assertThat(response.status).isEqualTo("APPROVED")
+        assertThat(response.makerId).isEqualTo("maker")
+        assertThat(response.createdAt).isEqualTo("2026-07-07T23:00Z")
         assertThat(response.decidedBy).isEqualTo("checker")
     }
 
@@ -54,4 +87,13 @@ class ApprovalResourceMappingTest {
         assertThat(response.status).isEqualTo("PENDING")
         assertThat(response.decidedBy).isNull()
     }
+
+    private fun pendingApproval() = PendingApproval(
+        id = "appr-pending",
+        action = "billing.post",
+        resourceId = "acc-1",
+        makerId = "maker",
+        status = ApprovalStatus.PENDING,
+        createdAt = OffsetDateTime.parse("2026-07-08T00:00:00Z"),
+    )
 }

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "599399c6a41d74c4"
+    openbank.tech/policy-checksum: "8fe69ed899c89230"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -576,17 +576,19 @@ data:
     # account-service's billing-discovery read is INBOUND from billing, and product-catalog fees are
     # read via catalog, not billing), so there is no identity-scoped grant to preserve: the
     # exclusion closes the role-only path and this veto closes the matrix path for the edge (base
-    # rest.rego gates its allow head on `not prohibited`). billing.read stays reachable to M2M via
-    # base operator-read-any — the fleet-wide M2M read over-grant is tracked separately in #3734.
+    # rest.rego gates its allow head on `not prohibited`). Ordinary billing.read stays reachable to
+    # M2M via base operator-read-any, but billing.approval.read is different: it exposes the maker,
+    # action and resource id of every pending four-eyes decision and therefore gets the same veto as
+    # deciding that approval.
     prohibited if {
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {
+            "billing.approval.read",
     		"billing.post",
     		"billing.reverse",
     		"billing.approval.decide",
     	}
     }
-
   agents.rego: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "8fe69ed899c89230"
+    openbank.tech/policy-checksum: "3deb0b360583661d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -561,11 +561,11 @@ data:
     # console path (re-run an assessment, and the phase 2c-ii posting verbs once
     # they land behind the four-eyes gate).
     allowed_reasons contains "operator-billing-write" if {
-    	input.principal.type == "HUMAN"
-    	not startswith(input.principal.id, "service-account-")
-    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
-    	role in input.principal.roles
-    	startswith(input.action, "billing.")
+        input.principal.type == "HUMAN"
+        not startswith(input.principal.id, "service-account-")
+        some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+        role in input.principal.roles
+        startswith(input.action, "billing.")
     }
 
     # 2026-08-05 (#3734): operator-billing-write was role-only, and rules.yaml's role_action_matrix
@@ -576,18 +576,24 @@ data:
     # account-service's billing-discovery read is INBOUND from billing, and product-catalog fees are
     # read via catalog, not billing), so there is no identity-scoped grant to preserve: the
     # exclusion closes the role-only path and this veto closes the matrix path for the edge (base
-    # rest.rego gates its allow head on `not prohibited`). Ordinary billing.read stays reachable to
-    # M2M via base operator-read-any, but billing.approval.read is different: it exposes the maker,
-    # action and resource id of every pending four-eyes decision and therefore gets the same veto as
-    # deciding that approval.
+    # rest.rego gates its allow head on `not prohibited`).
     prohibited if {
-    	input.principal.id == "service-account-openbank-edge"
-    	input.action in {
-            "billing.approval.read",
-    		"billing.post",
-    		"billing.reverse",
-    		"billing.approval.decide",
-    	}
+        input.principal.id == "service-account-openbank-edge"
+        input.action in {
+            "billing.post",
+            "billing.reverse",
+            "billing.approval.decide",
+        }
+    }
+
+    # Ordinary billing.read stays reachable to M2M via base operator-read-any, but
+    # billing.approval.read is different: it exposes the maker, action and resource id of every
+    # pending four-eyes decision. Deny it to every service account; some client_credentials
+    # principals currently retain type HUMAN and ROLE_OPERATOR, so checking type or role alone is
+    # insufficient to enforce the staff-only boundary.
+    prohibited if {
+        startswith(input.principal.id, "service-account-")
+        input.action == "billing.approval.read"
     }
   agents.rego: |
     # SPDX-License-Identifier: Apache-2.0

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -36,7 +36,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "599399c6a41d74c4"
+        openbank.tech/policy-checksum: "8fe69ed899c89230"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -36,7 +36,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8fe69ed899c89230"
+        openbank.tech/policy-checksum: "3deb0b360583661d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing_rest_ext.rego
+++ b/openbank-infra/gitops/components/billing/billing_rest_ext.rego
@@ -45,14 +45,16 @@ allowed_reasons contains "operator-billing-write" if {
 # account-service's billing-discovery read is INBOUND from billing, and product-catalog fees are
 # read via catalog, not billing), so there is no identity-scoped grant to preserve: the
 # exclusion closes the role-only path and this veto closes the matrix path for the edge (base
-# rest.rego gates its allow head on `not prohibited`). billing.read stays reachable to M2M via
-# base operator-read-any — the fleet-wide M2M read over-grant is tracked separately in #3734.
+# rest.rego gates its allow head on `not prohibited`). Ordinary billing.read stays reachable to
+# M2M via base operator-read-any, but billing.approval.read is different: it exposes the maker,
+# action and resource id of every pending four-eyes decision and therefore gets the same veto as
+# deciding that approval.
 prohibited if {
 	input.principal.id == "service-account-openbank-edge"
 	input.action in {
+        "billing.approval.read",
 		"billing.post",
 		"billing.reverse",
 		"billing.approval.decide",
 	}
 }
-

--- a/openbank-infra/gitops/components/billing/billing_rest_ext.rego
+++ b/openbank-infra/gitops/components/billing/billing_rest_ext.rego
@@ -45,16 +45,22 @@ allowed_reasons contains "operator-billing-write" if {
 # account-service's billing-discovery read is INBOUND from billing, and product-catalog fees are
 # read via catalog, not billing), so there is no identity-scoped grant to preserve: the
 # exclusion closes the role-only path and this veto closes the matrix path for the edge (base
-# rest.rego gates its allow head on `not prohibited`). Ordinary billing.read stays reachable to
-# M2M via base operator-read-any, but billing.approval.read is different: it exposes the maker,
-# action and resource id of every pending four-eyes decision and therefore gets the same veto as
-# deciding that approval.
+# rest.rego gates its allow head on `not prohibited`).
 prohibited if {
 	input.principal.id == "service-account-openbank-edge"
 	input.action in {
-        "billing.approval.read",
 		"billing.post",
 		"billing.reverse",
 		"billing.approval.decide",
 	}
+}
+
+# Ordinary billing.read stays reachable to M2M via base operator-read-any, but
+# billing.approval.read is different: it exposes the maker, action and resource id of every
+# pending four-eyes decision. Deny it to every service account; some client_credentials
+# principals currently retain type HUMAN and ROLE_OPERATOR, so checking type or role alone is
+# insufficient to enforce the staff-only boundary.
+prohibited if {
+	startswith(input.principal.id, "service-account-")
+	input.action == "billing.approval.read"
 }

--- a/openbank-infra/gitops/components/billing/billing_rest_ext_test.rego
+++ b/openbank-infra/gitops/components/billing/billing_rest_ext_test.rego
@@ -75,6 +75,16 @@ test_edge_veto_fires_on_approval_read if {
 		with data.rules as rules_mock
 }
 
+test_shared_denied_approval_read if {
+	not rest.allow with input as {"principal": shared, "action": "billing.approval.read"}
+		with data.rules as rules_mock
+}
+
+test_shared_veto_fires_on_approval_read if {
+	rest.prohibited with input as {"principal": shared, "action": "billing.approval.read"}
+		with data.rules as rules_mock
+}
+
 test_edge_veto_fires_on_post if {
 	rest.prohibited with input as {"principal": edge, "action": "billing.post"}
 		with data.rules as rules_mock

--- a/openbank-infra/gitops/components/billing/billing_rest_ext_test.rego
+++ b/openbank-infra/gitops/components/billing/billing_rest_ext_test.rego
@@ -41,7 +41,12 @@ test_admin_reverses if {
 		with data.rules as rules_mock
 }
 
-# --- edge: no legitimate M2M access exists; all three writes closed on BOTH paths ---
+# --- edge: no legitimate M2M access exists; writes and the sensitive approval read are closed ---
+
+test_operator_reads_pending_approvals if {
+	rest.allow with input as {"principal": operator, "action": "billing.approval.read"}
+		with data.rules as rules_mock
+}
 
 test_edge_denied_post if {
 	not rest.allow with input as {"principal": edge, "action": "billing.post"}
@@ -55,6 +60,18 @@ test_edge_denied_reverse if {
 
 test_edge_denied_approval_decide if {
 	not rest.allow with input as {"principal": edge, "action": "billing.approval.decide"}
+		with data.rules as rules_mock
+}
+
+# billing.approval.read ends in `.read`, so base operator-read-any admits the edge's
+# ROLE_OPERATOR-shaped client_credentials principal unless the billing-specific veto fires.
+test_edge_denied_approval_read if {
+	not rest.allow with input as {"principal": edge, "action": "billing.approval.read"}
+		with data.rules as rules_mock
+}
+
+test_edge_veto_fires_on_approval_read if {
+	rest.prohibited with input as {"principal": edge, "action": "billing.approval.read"}
 		with data.rules as rules_mock
 }
 

--- a/openbank-infra/gitops/components/billing/gen-billing-opa-bundle.sh
+++ b/openbank-infra/gitops/components/billing/gen-billing-opa-bundle.sh
@@ -38,7 +38,7 @@ OUT=$REPO/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
   echo "  rest.rego: |"
   sed 's/^/    /' "$REST_REGO" | sed 's/[[:space:]]*$//'
   echo "  billing_rest_ext.rego: |"
-  sed 's/^/    /' "$EXT_REGO" | sed 's/[[:space:]]*$//'
+  expand -t 4 "$EXT_REGO" | sed 's/^/    /' | sed 's/[[:space:]]*$//'
   echo "  agents.rego: |"
   sed 's/^/    /' "$AGENTS_REGO" | sed 's/[[:space:]]*$//'
   echo "  agents-data.yaml: |"


### PR DESCRIPTION
## Summary
- add a bounded, FIFO read-only billing approval queue with maker and creation provenance
- document the additive API contract and preserve the existing checker-only PATCH decision path
- federate billing into the admin unified approval inbox with explicit source health

## Verification
- targeted billing tests, ktlint, detekt, and quarkusBuild: green
- admin type-check, focused Vitest (19/19), and scoped ESLint: green
- API contract, route conformance, enum drift, and diff checks: green
- full billing suite: 111 tests; 2 failed and 20 skipped only because Docker/Testcontainers is unavailable locally
- both commits signed and verified

## Risk and controls
- money-path change: requires two independent approvals
- existing four-eyes self-approval prevention and decision endpoint remain unchanged
- existing threat model: docs/threat-models/openbank-billing-service.md

Refs #5679