### PR TITLE
feat(consent): expose pending approvals in unified inbox

### DIFF
--- a/docs/threat-models/openbank-consent-service.md
+++ b/docs/threat-models/openbank-consent-service.md
@@ -56,6 +56,16 @@ escalating a consent is a direct path to unauthorized data access or payment ini
 
 ## 6. Change log
 
+- **2026-08-26** — The operator approval inbox gains a bounded, read-only
+  `GET /api/v1/consents/approvals` edge. It returns pending approval workflow metadata
+  (random id, action, resource id, maker id and creation time) only to `ROLE_OPERATOR` or
+  `ROLE_ADMIN` callers behind the existing OPA boundary. Results are capped at 200 and ordered
+  oldest first; the endpoint cannot grant, revoke or decide a consent. Existing maker/checker
+  separation, one-time execution and 24-hour Redis TTL controls remain unchanged. **Risk class:**
+  confidentiality of operator workflow metadata and bounded Redis read load; no new caller,
+  service edge or consent mutation. Rollback: remove the GET route and let the admin UI report this
+  source unavailable; consent decisions and lifecycle flows are unaffected.
+
 - **2026-08-24** — Synthetic-journey taint now propagates over this service's existing internal SCA REST edge through `SyntheticTaintClientFilter` (ADR-0252, #4348). This adds no caller, endpoint, network-policy edge, privilege or SCA bypass: the synthetic journey must still satisfy the same controls. It prevents the marker from being lost before a downstream persistence/event boundary; a fleet gate requires every new client to choose propagation or a reasoned external boundary.
 
 - **2026-08-05** — Trust-boundary change (#3734): `operator-consent-write`'s M2M exclusion widened from `service-account-openbank-services` to the `service-account-` prefix. ADR-0206 D5 closed the backend M2M identity but left `service-account-openbank-edge` admitted to every `consent.*` write. The edge's legitimate consent access ({consent.list, consent.revoke} via base edge-service-consent, the customer's PSD2 consent screen) is preserved; no prohibition clause needed — the role_action_matrix grants no `consent.*` write to ROLE_OPERATOR.

--- a/openbank-admin-ui/src/app/api/approvals/pending/route.ts
+++ b/openbank-admin-ui/src/app/api/approvals/pending/route.ts
@@ -24,12 +24,11 @@ type SourceState = 'ok' | 'forbidden' | 'unavailable' | 'not-configured'
 const NOT_CONFIGURED_SOURCES = {
   balance: 'not-configured',
   billing: 'not-configured',
-  consent: 'not-configured',
 } as const satisfies Record<string, SourceState>
 
 type InboxItem = {
   id: string
-  domain: 'lending' | 'sanctions' | 'transaction' | 'domestic-payment' | 'clearing' | 'fx' | 'ledger' | 'swift' | 'sepa-payment' | 'sepa-instant' | 'notification' | 'party' | 'account' | 'agent'
+  domain: 'lending' | 'sanctions' | 'transaction' | 'domestic-payment' | 'clearing' | 'fx' | 'ledger' | 'swift' | 'sepa-payment' | 'sepa-instant' | 'notification' | 'party' | 'account' | 'consent' | 'agent'
   action: string
   resourceId: string | null
   maker: string | null
@@ -101,6 +100,8 @@ type PartyApproval = LendingApproval
 // account-service serves the shared PendingApproval shape for gated account lifecycle actions.
 // Surfacing it here makes a parked freeze or other protected action discoverable before TTL expiry.
 type AccountApproval = LendingApproval
+
+type ConsentApproval = LendingApproval
 
 type AgentProposal = {
   id: string
@@ -327,6 +328,21 @@ async function accountPending(headers: HeadersInit): Promise<SourceResult> {
   }
 }
 
+async function consentPending(headers: HeadersInit): Promise<SourceResult> {
+  const res = await fetch(serverSvcUrl('consent-service', 'consent', 8106, '/api/v1/consents/approvals', { limit: '50' }), {
+    headers, signal: AbortSignal.timeout(4000), cache: 'no-store',
+  })
+  if (!res.ok) return { items: [], state: stateFor(res.status) }
+  const rows = (await res.json()) as ConsentApproval[]
+  return {
+    state: 'ok',
+    items: rows.map(r => ({
+      id: r.id, domain: 'consent' as const, action: r.action,
+      resourceId: r.resourceId, maker: r.makerId, proposedAt: r.createdAt,
+    })),
+  }
+}
+
 function agentBase(): string {
   if (process.env.SERVICES_HOST === 'container') return 'http://openbank-agent-service:8109'
   return (process.env.AGENT_SERVICE_URL ?? 'http://localhost:8109/mcp').replace(/\/mcp$/, '')
@@ -354,7 +370,7 @@ export async function GET() {
   }
   const headers = { authorization: `Bearer ${session.user.accessToken}` }
   const unavailable: SourceResult = { items: [], state: 'unavailable' }
-  const [lending, sanctions, transaction, domesticPayment, clearing, fx, ledger, swift, sepaPayment, sepaInstant, notification, party, account, agent] = await Promise.all([
+  const [lending, sanctions, transaction, domesticPayment, clearing, fx, ledger, swift, sepaPayment, sepaInstant, notification, party, account, consent, agent] = await Promise.all([
     lendingPending(headers).catch(() => unavailable),
     sanctionsPending(headers).catch(() => unavailable),
     transactionPending(headers).catch(() => unavailable),
@@ -368,9 +384,10 @@ export async function GET() {
     notificationPending(headers).catch(() => unavailable),
     partyPending(headers).catch(() => unavailable),
     accountPending(headers).catch(() => unavailable),
+    consentPending(headers).catch(() => unavailable),
     agentPending(headers).catch(() => unavailable),
   ])
-  const items = [...lending.items, ...sanctions.items, ...transaction.items, ...domesticPayment.items, ...clearing.items, ...fx.items, ...ledger.items, ...swift.items, ...sepaPayment.items, ...sepaInstant.items, ...notification.items, ...party.items, ...account.items, ...agent.items]
+  const items = [...lending.items, ...sanctions.items, ...transaction.items, ...domesticPayment.items, ...clearing.items, ...fx.items, ...ledger.items, ...swift.items, ...sepaPayment.items, ...sepaInstant.items, ...notification.items, ...party.items, ...account.items, ...consent.items, ...agent.items]
     .sort((a, b) => (a.proposedAt ?? '').localeCompare(b.proposedAt ?? ''))
   return NextResponse.json({
     items,
@@ -389,6 +406,7 @@ export async function GET() {
       notification: notification.state,
       party: party.state,
       account: account.state,
+      consent: consent.state,
       agent: agent.state,
     },
   })

--- a/openbank-admin-ui/src/test/approvals-inbox.test.ts
+++ b/openbank-admin-ui/src/test/approvals-inbox.test.ts
@@ -106,6 +106,11 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
           { id: 'A-1', action: 'account.freeze', resourceId: 'account-7', makerId: 'operator.h', createdAt: '2026-07-29T11:50:00Z' },
         ]), { status: 200 }))
       }
+      if (url.includes('consents/approvals') || url.includes('consent-service')) {
+        return Promise.resolve(new Response(JSON.stringify([
+          { id: 'CO-1', action: 'consent.revoke', resourceId: 'consent-7', makerId: 'operator.h', createdAt: '2026-07-29T11:50:00Z' },
+        ]), { status: 200 }))
+      }
       return Promise.resolve(new Response(JSON.stringify([
         { id: 'P-1', suggestedAction: 'agent.research', proposedBy: 'ui-assistant', proposedAt: '2026-07-30T08:00:00Z' },
       ]), { status: 200 }))
@@ -118,7 +123,7 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     // sepaPayment); F-1 and I-1 both sit at 11:30 (fx before sepa-instant) — both ties resolved
     // by the stable-sort's concat order in route.ts. N-1 sits at 10:30, between L-1 and the
     // 11:00 tie.
-    expect(body.items.map((i: { id: string }) => i.id)).toEqual(['L-1', 'N-1', 'D-1', 'C-1', 'J-1', 'W-1', 'SP-1', 'F-1', 'I-1', 'PT-1', 'A-1', 'S-1', 'P-1', 'T-1', 'L-2'])
+    expect(body.items.map((i: { id: string }) => i.id)).toEqual(['L-1', 'N-1', 'D-1', 'C-1', 'J-1', 'W-1', 'SP-1', 'F-1', 'I-1', 'PT-1', 'A-1', 'CO-1', 'S-1', 'P-1', 'T-1', 'L-2'])
     expect(body.items[0]).toMatchObject({ domain: 'lending', action: 'lending.writeoff', maker: 'officer.a' })
     expect(body.items[1]).toMatchObject({ domain: 'notification', action: 'opsmessage.compose', maker: 'operator.f' })
     expect(body.items[2]).toMatchObject({ domain: 'domestic-payment', action: 'domestic-payment.transitionStatus', maker: 'operator.d' })
@@ -130,9 +135,10 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(body.items[8]).toMatchObject({ domain: 'sepa-instant', action: 'sctInstPayment.recall', maker: 'operator.e' })
     expect(body.items[9]).toMatchObject({ domain: 'party', action: 'party.merge', maker: 'operator.g' })
     expect(body.items[10]).toMatchObject({ domain: 'account', action: 'account.freeze', maker: 'operator.h' })
-    expect(body.items[11]).toMatchObject({ domain: 'sanctions', action: 'sanctions.clear', maker: 'analyst.c' })
-    expect(body.items[12]).toMatchObject({ domain: 'agent', action: 'agent.research' })
-    expect(body.items[13]).toMatchObject({ domain: 'transaction', action: 'transaction.reverse', maker: 'teller.d' })
+    expect(body.items[11]).toMatchObject({ domain: 'consent', action: 'consent.revoke', maker: 'operator.h' })
+    expect(body.items[12]).toMatchObject({ domain: 'sanctions', action: 'sanctions.clear', maker: 'analyst.c' })
+    expect(body.items[13]).toMatchObject({ domain: 'agent', action: 'agent.research' })
+    expect(body.items[14]).toMatchObject({ domain: 'transaction', action: 'transaction.reverse', maker: 'teller.d' })
     expect(body.sources.party).toBe('ok')
     expect(body.sources.account).toBe('ok')
   })
@@ -327,6 +333,19 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
 
     expect(seen.some(u => u.includes('/api/v1/accounts/approvals'))).toBe(true)
     expect(body.sources.account).toBe('ok')
+  })
+
+  it('reads the consent queue at all — an unread source is indistinguishable from an empty one', async () => {
+    const seen: string[] = []
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      seen.push(String(url))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    }))
+
+    const body = await (await (await route()).GET()).json()
+
+    expect(seen.some(u => u.includes('/api/v1/consents/approvals'))).toBe(true)
+    expect(body.sources.consent).toBe('ok')
   })
 
   it('degrades to the working half when one queue is down', async () => {

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ApprovalResource.kt
@@ -10,11 +10,14 @@ import com.openbank.libs.authz.Authorize
 import io.quarkus.security.identity.SecurityIdentity
 import jakarta.annotation.security.RolesAllowed
 import jakarta.inject.Inject
+import jakarta.ws.rs.DefaultValue
+import jakarta.ws.rs.GET
 import jakarta.ws.rs.NotFoundException
 import jakarta.ws.rs.PATCH
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.openapi.annotations.Operation
@@ -37,6 +40,16 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
 
     @Inject
     lateinit var identity: SecurityIdentity
+
+    /** Read-only checker queue; deciding remains on PATCH and preserves four-eyes separation. */
+    @GET
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "consent.approval.read", resource = "")
+    @Operation(summary = "List pending consent approvals, oldest first (ADR-0227 D2)")
+    suspend fun listPending(@QueryParam("limit") @DefaultValue("50") limit: Int): Response {
+        val pending = approvalStore.findPending(limit.coerceIn(1, MAX_PENDING_LIMIT))
+        return Response.ok(pending.map { it.toResponse() }).build()
+    }
 
     @PATCH
     @Path("/{id}")
@@ -61,6 +74,11 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     // their own request. SecurityIdentity (not @Context SecurityContext) since this is a
     // `suspend fun` — mirrors billing-service's ApprovalResource.
     private fun checkerId(): String = identity.principal?.name ?: "anonymous"
+
+    private companion object {
+        /** ApprovalStore scans Redis; keep the caller-controlled result bounded. */
+        const val MAX_PENDING_LIMIT = 200
+    }
 }
 
 data class DecideApprovalRequest(val approve: Boolean)
@@ -70,6 +88,8 @@ data class ApprovalResponse(
     val action: String,
     val resourceId: String?,
     val status: String,
+    val makerId: String?,
+    val createdAt: String?,
     val decidedBy: String?,
 )
 
@@ -78,5 +98,7 @@ fun PendingApproval.toResponse() = ApprovalResponse(
     action = action,
     resourceId = resourceId,
     status = status.name,
+    makerId = makerId,
+    createdAt = createdAt.toString(),
     decidedBy = decidedBy,
 )

--- a/openbank-consent-service/src/main/resources/openapi.yaml
+++ b/openbank-consent-service/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Consent Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.0 -> 1.1): additive
   # endpoint only (PATCH /approvals/{id}, ADR-0155 four-eyes) — no breaking change.
-  version: 1.7.0
+  version: 1.8.0
   description: >-
     Data sharing consent lifecycle — create, activate, reject, revoke, validate. GET /approvals
     lists pending four-eyes work for checkers; PATCH /approvals/{id} decides an approval paused by

--- a/openbank-consent-service/src/main/resources/openapi.yaml
+++ b/openbank-consent-service/src/main/resources/openapi.yaml
@@ -7,9 +7,10 @@ info:
   # endpoint only (PATCH /approvals/{id}, ADR-0155 four-eyes) — no breaking change.
   version: 1.7.0
   description: >-
-    Data sharing consent lifecycle — create, activate, reject, revoke, validate. PATCH
-    /approvals/{id} decides a four-eyes approval paused by the platform's ADR-0155 maker-checker
-    gate on `consent.grant` / `consent.revoke` (maker != checker).
+    Data sharing consent lifecycle — create, activate, reject, revoke, validate. GET /approvals
+    lists pending four-eyes work for checkers; PATCH /approvals/{id} decides an approval paused by
+    the platform's ADR-0155 maker-checker gate on `consent.grant` / `consent.revoke`
+    (maker != checker).
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
@@ -253,6 +254,27 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /api/v1/consents/approvals:
+    get:
+      tags: [Consents]
+      summary: List pending consent approvals, oldest first (ADR-0227 D2)
+      operationId: listPendingApprovals
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, default: 50, minimum: 1, maximum: 200 }
+      responses:
+        '200':
+          description: Pending consent approvals, oldest first
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/ApprovalResponse' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
   /api/v1/consents/approvals/{id}:
     patch:
       tags: [Consents]
@@ -278,6 +300,9 @@ paths:
       responses:
         '200':
           description: The decided approval
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApprovalResponse' }
         '404':
           description: No pending approval with that id
         '403':
@@ -387,6 +412,26 @@ components:
             $ref: '#/components/schemas/ApiError'
 
   schemas:
+    ApprovalResponse:
+      type: object
+      description: >-
+        A four-eyes consent approval. makerId identifies who requested the gated action; the
+        shared ApprovalStore requires a different authenticated principal to decide it.
+      required: [id, action, status]
+      properties:
+        id: { type: string }
+        action:
+          type: string
+          description: The gated consent action this approval was raised for.
+        resourceId: { type: string, nullable: true }
+        status: { type: string }
+        makerId: { type: string, nullable: true }
+        createdAt:
+          type: string
+          format: date-time
+          description: Request time; pending approvals expire after 24 hours.
+        decidedBy: { type: string, nullable: true }
+
     CreateConsentRequest:
       type: object
       required: [partyId, granteeId, scopes, expiresAt]

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/ApprovalResourceMappingTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/ApprovalResourceMappingTest.kt
@@ -4,15 +4,46 @@
 
 package com.openbank.consent
 
+import com.openbank.consent.infrastructure.rest.ApprovalResource
+import com.openbank.consent.infrastructure.rest.ApprovalResponse
 import com.openbank.consent.infrastructure.rest.toResponse
 import com.openbank.libs.approval.ApprovalStatus
+import com.openbank.libs.approval.ApprovalStore
 import com.openbank.libs.approval.PendingApproval
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.OffsetDateTime
 
 /** Unit coverage for the [PendingApproval] -> `ApprovalResponse` mapping (ADR-0155). */
 class ApprovalResourceMappingTest {
+
+    @Test
+    fun `listPending exposes provenance in the checker queue`(): Unit = runBlocking {
+        val store = mockk<ApprovalStore>()
+        coEvery { store.findPending(50) } returns listOf(pendingApproval())
+
+        val response = ApprovalResource(store).listPending(50)
+
+        assertThat(response.status).isEqualTo(200)
+        @Suppress("UNCHECKED_CAST")
+        val body = response.entity as List<ApprovalResponse>
+        assertThat(body.single().makerId).isEqualTo("maker")
+        assertThat(body.single().createdAt).isEqualTo("2026-07-13T00:00Z")
+    }
+
+    @Test
+    fun `listPending clamps a caller-controlled limit`(): Unit = runBlocking {
+        val store = mockk<ApprovalStore>()
+        coEvery { store.findPending(200) } returns emptyList()
+
+        ApprovalResource(store).listPending(10_000)
+
+        coVerify(exactly = 1) { store.findPending(200) }
+    }
 
     @Test
     fun `toResponse maps every field including a decided approval`() {
@@ -34,6 +65,8 @@ class ApprovalResourceMappingTest {
         assertThat(response.action).isEqualTo("consent.grant")
         assertThat(response.resourceId).isEqualTo("consent-1")
         assertThat(response.status).isEqualTo("APPROVED")
+        assertThat(response.makerId).isEqualTo("maker")
+        assertThat(response.createdAt).isEqualTo("2026-07-12T23:00Z")
         assertThat(response.decidedBy).isEqualTo("checker")
     }
 
@@ -54,4 +87,13 @@ class ApprovalResourceMappingTest {
         assertThat(response.status).isEqualTo("PENDING")
         assertThat(response.decidedBy).isNull()
     }
+
+    private fun pendingApproval() = PendingApproval(
+        id = "appr-pending",
+        action = "consent.grant",
+        resourceId = "consent-1",
+        makerId = "maker",
+        status = ApprovalStatus.PENDING,
+        createdAt = OffsetDateTime.parse("2026-07-13T00:00:00Z"),
+    )
 }


### PR DESCRIPTION
## Summary
- add a bounded, FIFO read-only consent approval queue with maker and creation provenance
- document the additive API contract and update the money-path threat model
- federate the final previously not-configured source into the Admin UI approval inbox

## Verification
- targeted consent tests, ktlint, detekt, and quarkusBuild: green
- admin type-check, focused Vitest (20/20), and scoped ESLint: green
- API contract, route conformance, enum drift, threat-model diff, and diff checks: green
- both commits signed and verified

## Risk and controls
- money-path change: requires two independent approvals
- existing four-eyes self-approval prevention and decision endpoint remain unchanged
- existing M2M consent policy exceptions are not widened
- threat model updated: docs/threat-models/openbank-consent-service.md

Refs #5679