### PR TITLE
fix(admin-ui): connect notification approvals

### DIFF
--- a/openbank-admin-ui/src/app/approvals/page.tsx
+++ b/openbank-admin-ui/src/app/approvals/page.tsx
@@ -11,6 +11,7 @@
 // author) is enforced by the agent.
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
 import { useSession } from 'next-auth/react'
 import { CheckCircle2, XCircle, Clock, ClipboardCheck, RefreshCw, ShieldCheck, AlertTriangle, Bot, UserRound } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -212,11 +213,22 @@ export default function ApprovalsPage() {
             <div style={{ flex: 1, minWidth: 0 }}>
               <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-primary)', fontFamily: 'var(--font-mono)' }}>{item.action}</div>
               <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 2 }}>
+                <span style={{ fontFamily: 'var(--font-mono)' }}>{item.id}</span>
+                {(item.resourceId || item.maker || item.proposedAt) && <span> · </span>}
                 {item.resourceId && <span style={{ fontFamily: 'var(--font-mono)' }}>{item.resourceId} · </span>}
                 {item.maker && <span>{t('navrhl', 'by')} {item.maker}</span>}
                 {item.proposedAt && <span> · {new Date(item.proposedAt).toLocaleString(dateLocale)}</span>}
               </div>
             </div>
+            {item.domain === 'notification' && (
+              <Link
+                href={`/notifications?approvalId=${encodeURIComponent(item.id)}#message-approvals`}
+                className="btn btn-secondary"
+                style={{ textDecoration: 'none', flexShrink: 0 }}
+              >
+                {t('Otevřít rozhodnutí', 'Open decision')}
+              </Link>
+            )}
             <span style={{ fontSize: 10, fontWeight: 700, color: '#d97706', background: '#fffbeb', border: '1px solid #fcd34d', padding: '2px 7px', borderRadius: 20, textTransform: 'uppercase', flexShrink: 0 }}>
               {t('Čeká', 'Pending')}
             </span>

--- a/openbank-admin-ui/src/app/notifications/page.tsx
+++ b/openbank-admin-ui/src/app/notifications/page.tsx
@@ -4,7 +4,8 @@
 
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { Suspense, useState, useEffect, useCallback } from 'react'
+import { useSearchParams } from 'next/navigation'
 import { Bell, RefreshCw, Mail, AlertTriangle, CheckCircle2, Info, Clock, Check, X } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { useAuth } from '@/lib/auth/useAuth'
@@ -102,7 +103,7 @@ function NotificationsContent() {
         ))}
       </div>
 
-      {canApprove && <OperatorMessageApprovals />}
+      {canApprove && <Suspense fallback={null}><OperatorMessageApprovals /></Suspense>}
 
       {unavailable && (
         <div className="card" style={{ padding: 0, marginBottom: '16px' }}>
@@ -180,14 +181,14 @@ export default function NotificationsPage() {
  * `PATCH /api/v1/notifications/approvals/{id}` endpoint. SelfApprovalNotAllowedException refuses
  * a maker deciding their own request server-side (403).
  *
- * Deliberately NOT an auto-loaded queue: the shipped backend (ApprovalStore) exposes no query to
- * enumerate pending approvals — there is no list endpoint — so the checker acts on the approval
- * id the maker relays out of band (shown on the maker's party-page banner). A backend list
- * endpoint would let this become a real queue; that is remaining ADR-0176 work.
+ * The unified Approval Centre discovers pending notification approvals through the backend list
+ * endpoint and deep-links here with the selected approval id. Direct id entry remains available
+ * for operational recovery and does not weaken the server-side maker-checker boundary.
  */
 function OperatorMessageApprovals() {
   const { t } = useLanguage()
-  const [approvalId, setApprovalId] = useState('')
+  const searchParams = useSearchParams()
+  const [approvalId, setApprovalId] = useState(() => searchParams.get('approvalId')?.trim() ?? '')
   const [busy, setBusy] = useState(false)
   const [result, setResult] = useState<{ ok: boolean; text: string } | null>(null)
 
@@ -212,7 +213,7 @@ function OperatorMessageApprovals() {
   }
 
   return (
-    <div className="card" style={{ overflow: 'hidden', marginBottom: '16px' }}>
+    <div id="message-approvals" className="card" style={{ overflow: 'hidden', marginBottom: '16px', scrollMarginTop: '16px' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '16px 20px', borderBottom: '1px solid var(--border)' }}>
         <Clock aria-hidden="true" size={15} style={{ color: 'var(--yellow)' }} />
         <span style={{ fontWeight: 600, fontSize: '13px' }}>
@@ -222,8 +223,8 @@ function OperatorMessageApprovals() {
       <div style={{ padding: '16px 20px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
         <span style={{ fontSize: '12px', color: 'var(--text-muted)' }}>
           {t(
-            'Zadejte ID schválení, které vám předal operátor odesílající zprávu, a rozhodněte. Vlastní zprávu schválit nelze.',
-            'Enter the approval id the composing operator gave you, then decide. You cannot approve your own message.',
+            'Vyberte čekající notifikaci v Centru schvalování; její ID se zde doplní automaticky. Pro provozní obnovu můžete ID zadat ručně. Vlastní zprávu schválit nelze.',
+            'Select a pending notification in the Approval Centre and its ID will be filled in here. You can enter an ID manually for operational recovery. You cannot approve your own message.',
           )}
         </span>
         <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>

--- a/openbank-admin-ui/src/app/parties/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/parties/[id]/page.tsx
@@ -451,11 +451,13 @@ function MessagesTab({ partyId, partyEmail, roles }: { partyId: string; partyEma
                   <RefreshCw size={13} aria-hidden="true" /> {retrying ? t('Zkouším…', 'Retrying…') : t('Zkusit znovu odeslat', 'Retry send')}
                 </button>
               </div>
-              {/* No backend endpoint lists pending approvals (ApprovalStore has no query), so the
-                  checker cannot discover this from a queue — the maker relays the id out of band. */}
               <div style={{ fontSize: '12px', color: 'var(--text-muted)' }}>
-                {t('Předejte toto ID schválení druhému operátorovi:', 'Give this approval id to a second operator:')}{' '}
+                {t('Žádost se automaticky zobrazí jinému operátorovi v Centru schvalování. ID pro dohledání:', 'The request automatically appears for another operator in the Approval Centre. Tracking ID:')}{' '}
                 <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-secondary)' }}>{pendingSubmit.approvalId}</span>
+                {' · '}
+                <Link href="/approvals" style={{ color: 'var(--accent)', textDecoration: 'none', fontWeight: 600 }}>
+                  {t('Otevřít Centrum schvalování', 'Open Approval Centre')}
+                </Link>
               </div>
             </div>
           ) : (

--- a/openbank-admin-ui/src/app/parties/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/parties/[id]/page.tsx
@@ -328,8 +328,8 @@ function MessagesTab({ partyId, partyEmail, roles }: { partyId: string; partyEma
   // fleet's first 202/X-Approval-Id UI flow; a real approval notification channel is a separate,
   // larger piece of work). We hold the EXACT request that was paused: the retry must resend the
   // byte-identical body (the interceptor binds the approval to the request's content), and the
-  // maker relays `approvalId` to a colleague, who decides it on the Notifications page. The maker
-  // then clicks "Retry send".
+  // Approval Centre exposes the request to a different operator, who decides it in the
+  // Notifications workspace. The maker then clicks "Retry send".
   const [pendingSubmit, setPendingSubmit] = useState<{ request: ComposeMessageRequest; approvalId: string } | null>(null)
   const [retrying, setRetrying] = useState(false)
 

--- a/openbank-admin-ui/src/lib/api.ts
+++ b/openbank-admin-ui/src/lib/api.ts
@@ -138,9 +138,9 @@ export interface ApprovalDecision {
 
 export const opsMessageApi = {
   // 201 -> {status:'SENT', id}. 202 (four-eyes on) -> {status:'PENDING_APPROVAL', approvalId}:
-  // relay that id to a DIFFERENT operator to decide, then replay this exact request (same body)
-  // with `approvalId` set — the interceptor binds the approval to the request's content, so the
-  // retry must be byte-identical or it mints a fresh pending approval.
+  // a DIFFERENT operator discovers and decides it through the Approval Centre; the maker then
+  // replays this exact request (same body) with `approvalId` set. The interceptor binds the
+  // approval to the request's content, so the retry must be byte-identical or it mints a fresh one.
   compose: async (req: ComposeMessageRequest, approvalId?: string): Promise<ComposeResult> => {
     const res = await fetch(`${NOTIFICATION_SERVICE}/api/v1/notifications/messages`, {
       method: 'POST',

--- a/openbank-admin-ui/src/lib/api.ts
+++ b/openbank-admin-ui/src/lib/api.ts
@@ -161,7 +161,7 @@ export const opsMessageApi = {
   // Checker decision (ApprovalResource.decide): one PATCH with an approve boolean. Self-approval
   // is refused server-side (403); an unknown/already-decided id is 404/409 — all thrown here.
   decide: (id: string, approve: boolean) =>
-    apiFetchSimple<ApprovalDecision>(`${NOTIFICATION_SERVICE}/api/v1/notifications/approvals/${id}`, {
+    apiFetchSimple<ApprovalDecision>(`${NOTIFICATION_SERVICE}/api/v1/notifications/approvals/${encodeURIComponent(id)}`, {
       method: 'PATCH',
       body: JSON.stringify({ approve }),
     }),
@@ -268,4 +268,3 @@ export async function fetchAllServiceSnapshots(): Promise<ServiceSnapshot[]> {
     return SERVICES.map(s => ({ name: s.name, port: s.port, info: null, health: null, rateLimitMax: null, rateLimitRemaining: null, apiVersion: null, latencyMs: null, reachable: false }))
   }
 }
-

--- a/openbank-admin-ui/src/test/notification-approval-navigation.guard.test.ts
+++ b/openbank-admin-ui/src/test/notification-approval-navigation.guard.test.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const approvals = readFileSync(resolve(process.cwd(), 'src/app/approvals/page.tsx'), 'utf8')
+const notifications = readFileSync(resolve(process.cwd(), 'src/app/notifications/page.tsx'), 'utf8')
+const partyDetail = readFileSync(resolve(process.cwd(), 'src/app/parties/[id]/page.tsx'), 'utf8')
+
+describe('notification approval navigation', () => {
+  it('deep-links a discovered notification approval into its decision workspace', () => {
+    expect(approvals).toContain("item.domain === 'notification'")
+    expect(approvals).toContain('/notifications?approvalId=')
+    expect(notifications).toContain("get('approvalId')")
+    expect(notifications).toContain('id="message-approvals"')
+  })
+
+  it('teaches makers that the queue is discoverable instead of requiring out-of-band ID relay', () => {
+    expect(partyDetail).toContain('automaticky zobrazí jinému operátorovi v Centru schvalování')
+    expect(partyDetail).toContain('automatically appears for another operator in the Approval Centre')
+    expect(partyDetail).not.toContain('Give this approval id to a second operator')
+    expect(notifications).not.toContain('there is no list endpoint')
+  })
+})

--- a/openbank-admin-ui/src/test/opsmessage-api.contract.test.ts
+++ b/openbank-admin-ui/src/test/opsmessage-api.contract.test.ts
@@ -91,6 +91,16 @@ describe('opsMessageApi — shipped notification-service contract', () => {
     expect(decision).toEqual(approvalResponse)
   })
 
+  it('encodes an approval id before placing it in the decision path', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonRes(200, {
+      id: 'approval/with separator', action: 'opsmessage.compose', resourceId: null, status: 'REJECTED', decidedBy: 'op-2',
+    })))
+
+    await opsMessageApi.decide('approval/with separator', false)
+
+    expect(lastCall().url).toBe('/api/svc/notification-service/api/v1/notifications/approvals/approval%2Fwith%20separator')
+  })
+
   it('decide sends approve:false on a reject', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => jsonRes(200, {
       id: 'appr-1', action: 'opsmessage.compose', resourceId: null, status: 'REJECTED', decidedBy: 'op-2',


### PR DESCRIPTION
## Summary
- expose notification approval IDs in the unified Approval Centre
- deep-link notification approvals into the existing four-eyes decision workspace with the selected ID
- replace obsolete out-of-band ID relay guidance with truthful queue discovery and tracking copy

## Safety
- preserves the notification-service decision endpoint, RBAC, self-approval rejection, and maker-checker boundary
- keeps direct ID entry as an operational recovery path
- changes no message payload, retry, approval, or send semantics

## Verification
- `npm run type-check`
- `npx vitest run src/test/notification-approval-navigation.guard.test.ts src/test/approvals-inbox.test.ts src/test/approvals-source-truth.guard.test.ts src/test/approvals-refresh.guard.test.ts src/test/approvals-rbac.guard.test.ts` (28 passed)
- scoped ESLint: 0 errors; only pre-existing set-state-in-effect warnings remain
- `git diff --check`

Refs #5679