### PR TITLE
fix(admin-ui): connect sanctions approvals

### DIFF
--- a/openbank-admin-ui/src/app/approvals/page.tsx
+++ b/openbank-admin-ui/src/app/approvals/page.tsx
@@ -18,6 +18,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader } from '@/components/ui/PageHeader'
 import { AgentIdentityBadge } from '@/components/approvals/AgentIdentityBadge'
 import { resolveAgentIdentity, type AgentIdentityRegistry } from '@/lib/governance/agentIdentity'
+import { approvalActionLabel, approvalDomainLabel, approvalExpiresAt, type ApprovalDomain } from '@/lib/approvals/presentation'
 import { AuthGuard, Can } from '@/components/auth/AuthGuard'
 
 interface Proposal {
@@ -37,7 +38,7 @@ interface Proposal {
 
 interface InboxItem {
   id: string
-  domain: 'lending' | 'sanctions' | 'transaction' | 'domestic-payment' | 'clearing' | 'fx' | 'ledger' | 'swift' | 'sepa-payment' | 'sepa-instant' | 'notification' | 'party' | 'account' | 'balance' | 'billing' | 'consent' | 'agent'
+  domain: ApprovalDomain
   action: string
   resourceId: string | null
   maker: string | null
@@ -202,22 +203,27 @@ export default function ApprovalsPage() {
         </div>
       )}
       <div style={{ display: 'grid', gap: 10, marginBottom: 24 }}>
-        {domainItems.filter(i => i.domain !== 'agent').map(item => (
-          <div key={`${item.domain}:${item.id}`} className="card" style={{ padding: 14, display: 'flex', alignItems: 'center', gap: 12 }}>
+        {domainItems.filter(i => i.domain !== 'agent').map(item => {
+          const expiresAt = approvalExpiresAt(item.proposedAt)
+          return (
+          <div key={`${item.domain}:${item.id}`} className="card" style={{ padding: 14, display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
             <span style={{
               fontSize: 10, fontWeight: 800, padding: '2px 8px', borderRadius: 10, textTransform: 'uppercase',
               color: '#1d4ed8', background: '#eff6ff', border: '1px solid #bfdbfe', flexShrink: 0,
             }}>
-              {item.domain}
+              {approvalDomainLabel(item.domain, language)}
             </span>
             <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-primary)', fontFamily: 'var(--font-mono)' }}>{item.action}</div>
+              <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-primary)' }}>{approvalActionLabel(item.action, language)}</div>
               <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 2 }}>
+                <span title={t('Přesný klíč autorizační politiky', 'Exact authorization policy key')} style={{ fontFamily: 'var(--font-mono)' }}>{item.action}</span>
+                <span> · </span>
                 <span style={{ fontFamily: 'var(--font-mono)' }}>{item.id}</span>
                 {(item.resourceId || item.maker || item.proposedAt) && <span> · </span>}
                 {item.resourceId && <span style={{ fontFamily: 'var(--font-mono)' }}>{item.resourceId} · </span>}
                 {item.maker && <span>{t('navrhl', 'by')} {item.maker}</span>}
                 {item.proposedAt && <span> · {new Date(item.proposedAt).toLocaleString(dateLocale)}</span>}
+                {expiresAt && <span style={{ color: 'var(--warning-text)' }}> · {t('vyprší', 'expires')} {expiresAt.toLocaleString(dateLocale)}</span>}
               </div>
             </div>
             {item.domain === 'notification' && (
@@ -242,7 +248,8 @@ export default function ApprovalsPage() {
               {t('Čeká', 'Pending')}
             </span>
           </div>
-        ))}
+          )
+        })}
       </div>
 
       <div style={{ fontSize: 12, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-secondary)', margin: '4px 0 10px' }}>

--- a/openbank-admin-ui/src/app/approvals/page.tsx
+++ b/openbank-admin-ui/src/app/approvals/page.tsx
@@ -229,6 +229,15 @@ export default function ApprovalsPage() {
                 {t('Otevřít rozhodnutí', 'Open decision')}
               </Link>
             )}
+            {item.domain === 'sanctions' && (
+              <Link
+                href={`/sanctions?approvalId=${encodeURIComponent(item.id)}#sanctions-approvals`}
+                className="btn btn-secondary"
+                style={{ textDecoration: 'none', flexShrink: 0 }}
+              >
+                {t('Otevřít rozhodnutí', 'Open decision')}
+              </Link>
+            )}
             <span style={{ fontSize: 10, fontWeight: 700, color: '#d97706', background: '#fffbeb', border: '1px solid #fcd34d', padding: '2px 7px', borderRadius: 20, textTransform: 'uppercase', flexShrink: 0 }}>
               {t('Čeká', 'Pending')}
             </span>

--- a/openbank-admin-ui/src/app/sanctions/page.tsx
+++ b/openbank-admin-ui/src/app/sanctions/page.tsx
@@ -3,7 +3,8 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 'use client'
-import { useState, useEffect, useCallback, Fragment } from 'react'
+import { Suspense, useState, useEffect, useCallback, Fragment } from 'react'
+import { useSearchParams } from 'next/navigation'
 import {
   ShieldAlert, Search, CheckCircle2, Clock, RefreshCw,
   AlertTriangle, User, Play, List, ChevronDown, ChevronUp,
@@ -186,7 +187,8 @@ function ListCard({ list, onToggle, onRefresh, onSave }: {
   )
 }
 
-export default function SanctionsPage() {
+function SanctionsContent() {
+  const searchParams = useSearchParams()
   const { t, language } = useLanguage()
   const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const dateLocale = numberLocale
@@ -222,7 +224,7 @@ export default function SanctionsPage() {
   // The id has to survive in the UI — it is the only way back to this exact decision, and the
   // retry must carry it as X-Approval-Id or the interceptor mints a fresh one and 202s forever.
   const [pendingApproval, setPendingApproval] = useState<{ id: string; checkId: string } | null>(null)
-  const [decideId, setDecideId] = useState('')
+  const [decideId, setDecideId] = useState(() => searchParams.get('approvalId')?.trim() ?? '')
   // The checker's queue (#3472). Before sanctions-service served this list, a decision parked at
   // 202 was reachable only by whoever had been handed its id out of band.
   const [pendingQueue, setPendingQueue] = useState<PendingApprovalItem[]>([])
@@ -640,8 +642,8 @@ export default function SanctionsPage() {
                                     {t('Čeká na druhého schvalovatele (čtyři oči, ADR-0155)', 'Awaiting a second approver (four-eyes, ADR-0155)')}
                                   </div>
                                   <div style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>
-                                    {t('Předejte toto ID jinému operátorovi. Rozhodnutí schválí níže v poli „Schválit žádost“ — vlastní žádost schválit nelze.',
-                                       'Hand this id to another operator. They decide it in the "Decide an approval" box below — nobody can approve their own request.')}
+                                    {t('Žádost se automaticky zobrazí jinému oprávněnému operátorovi v Centru schvalování i ve frontě níže. Vlastní žádost schválit nelze.',
+                                       'The request automatically appears for another authorised operator in the Approval Centre and in the queue below. Nobody can approve their own request.')}
                                   </div>
                                   <code style={{ fontSize: '12px', fontFamily: 'var(--font-mono)', color: 'var(--text-primary)', wordBreak: 'break-all' }}>
                                     {pendingApproval.id}
@@ -706,12 +708,11 @@ export default function SanctionsPage() {
                 </table>
               )}
 
-              {/* Checker half of the four-eyes gate. It is an id field rather than a queue because
-                  sanctions-service exposes no pending-approvals list endpoint — ApprovalResource
-                  serves only PATCH /{id}, so the id has to be handed over out of band. The
-                  ADR-0227 inbox federates lending and agent only, and is read-only by design. */}
+              {/* Checker half of the four-eyes gate. The domain queue is authoritative and the
+                  unified Approval Centre deep-links here with the selected id. Manual id entry is
+                  retained as an operational recovery path. */}
               <Can permission="sanctions:review" fallback={<div style={{ padding: '16px', borderTop: '1px solid var(--border)', color: 'var(--text-tertiary)', fontSize: '12px' }}>{t('Rozhodování sankčních žádostí je dostupné pouze operátorům a administrátorům.', 'Sanctions decisions are available to operators and administrators only.')}</div>}>
-              <div style={{ padding: '16px', borderTop: '1px solid var(--border)' }}>
+              <div id="sanctions-approvals" style={{ padding: '16px', borderTop: '1px solid var(--border)', scrollMarginTop: '16px' }}>
                 <div style={{ maxWidth: '560px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
                   <div style={{ fontSize: '12px', fontWeight: 700, color: 'var(--text-primary)' }}>
                     {t('Schválit žádost (druhý pár očí)', 'Decide an approval (second pair of eyes)')}
@@ -975,4 +976,8 @@ export default function SanctionsPage() {
       </div>
     </AuthGuard>
   )
+}
+
+export default function SanctionsPage() {
+  return <Suspense fallback={null}><SanctionsContent /></Suspense>
 }

--- a/openbank-admin-ui/src/lib/approvals/presentation.ts
+++ b/openbank-admin-ui/src/lib/approvals/presentation.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+export type ApprovalLanguage = 'cs' | 'en'
+
+export type ApprovalDomain =
+  | 'lending' | 'sanctions' | 'transaction' | 'domestic-payment' | 'clearing' | 'fx'
+  | 'ledger' | 'swift' | 'sepa-payment' | 'sepa-instant' | 'notification' | 'party'
+  | 'account' | 'balance' | 'billing' | 'consent' | 'agent'
+
+type BilingualLabel = { cs: string; en: string }
+
+const APPROVAL_TTL_MS = 24 * 60 * 60 * 1000
+
+const DOMAIN_LABELS: Record<ApprovalDomain, BilingualLabel> = {
+  lending: { cs: 'Úvěry', en: 'Lending' },
+  sanctions: { cs: 'Sankce', en: 'Sanctions' },
+  transaction: { cs: 'Transakce', en: 'Transactions' },
+  'domestic-payment': { cs: 'Tuzemské platby', en: 'Domestic payments' },
+  clearing: { cs: 'Clearing', en: 'Clearing' },
+  fx: { cs: 'Měnové konverze', en: 'Foreign exchange' },
+  ledger: { cs: 'Hlavní kniha', en: 'Ledger' },
+  swift: { cs: 'SWIFT', en: 'SWIFT' },
+  'sepa-payment': { cs: 'SEPA platby', en: 'SEPA payments' },
+  'sepa-instant': { cs: 'Okamžité SEPA platby', en: 'SEPA instant payments' },
+  notification: { cs: 'Provozní zprávy', en: 'Operator messages' },
+  party: { cs: 'Klientské profily', en: 'Party profiles' },
+  account: { cs: 'Účty', en: 'Accounts' },
+  balance: { cs: 'Zůstatky', en: 'Balances' },
+  billing: { cs: 'Poplatky a účtování', en: 'Billing' },
+  consent: { cs: 'Souhlasy', en: 'Consents' },
+  agent: { cs: 'AI návrhy', en: 'AI proposals' },
+}
+
+// Exact policy actions that can currently enter the four-eyes queue. The technical key remains
+// visible beside this label in the UI, so localization never weakens auditability.
+const ACTION_LABELS: Record<string, BilingualLabel> = {
+  'account.freeze': { cs: 'Zmrazit účet', en: 'Freeze account' },
+  'account.unfreeze': { cs: 'Odblokovat účet', en: 'Unfreeze account' },
+  'balance.credit': { cs: 'Připsat korekci zůstatku', en: 'Credit balance adjustment' },
+  'balance.debit': { cs: 'Odepsat korekci zůstatku', en: 'Debit balance adjustment' },
+  'billing.post': { cs: 'Zaúčtovat poplatek', en: 'Post fee' },
+  'billing.reverse': { cs: 'Stornovat poplatek', en: 'Reverse fee' },
+  'clearingBatch.settle': { cs: 'Vypořádat clearingovou dávku', en: 'Settle clearing batch' },
+  'consent.grant': { cs: 'Udělit souhlas', en: 'Grant consent' },
+  'consent.revoke': { cs: 'Odvolat souhlas', en: 'Revoke consent' },
+  'domestic-payment.transitionStatus': { cs: 'Změnit stav tuzemské platby', en: 'Transition domestic payment' },
+  'fx.convert': { cs: 'Provést měnovou konverzi', en: 'Execute currency conversion' },
+  'ledger.reverse': { cs: 'Stornovat účetní zápis', en: 'Reverse ledger journal' },
+  'lending.collateralRegister': { cs: 'Zaregistrovat zajištění', en: 'Register collateral' },
+  'lending.disburse': { cs: 'Čerpat úvěr', en: 'Disburse loan' },
+  'opsmessage.compose': { cs: 'Odeslat provozní zprávu klientovi', en: 'Send operator message to customer' },
+  'party.merge': { cs: 'Sloučit klientské profily', en: 'Merge party profiles' },
+  'sanctions.clear': { cs: 'Rozhodnout sankční nález', en: 'Decide sanctions hit' },
+  'sctInstPayment.recall': { cs: 'Odvolat okamžitou SEPA platbu', en: 'Recall SEPA instant payment' },
+  'sepaPayment.transitionStatus': { cs: 'Změnit stav SEPA platby', en: 'Transition SEPA payment' },
+  'swift.send': { cs: 'Odeslat SWIFT zprávu', en: 'Send SWIFT message' },
+  'transaction.reverse': { cs: 'Stornovat transakci', en: 'Reverse transaction' },
+  'transaction.sweep': { cs: 'Převést zůstatek při sloučení klienta', en: 'Sweep balance during party merge' },
+}
+
+export function approvalDomainLabel(domain: ApprovalDomain, language: ApprovalLanguage): string {
+  return DOMAIN_LABELS[domain][language]
+}
+
+export function approvalActionLabel(action: string, language: ApprovalLanguage): string {
+  const exact = ACTION_LABELS[action]
+  if (exact) return exact[language]
+
+  const verb = action.split('.').at(-1) ?? action
+  const words = verb.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/[-_]/g, ' ').trim()
+  return words ? words.charAt(0).toUpperCase() + words.slice(1) : action
+}
+
+export function approvalExpiresAt(createdAt: string | null): Date | null {
+  if (!createdAt) return null
+  const createdMillis = Date.parse(createdAt)
+  return Number.isFinite(createdMillis) ? new Date(createdMillis + APPROVAL_TTL_MS) : null
+}

--- a/openbank-admin-ui/src/test/approval-presentation.test.ts
+++ b/openbank-admin-ui/src/test/approval-presentation.test.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { describe, expect, it } from 'vitest'
+import { approvalActionLabel, approvalDomainLabel, approvalExpiresAt } from '@/lib/approvals/presentation'
+
+describe('approval presentation', () => {
+  it('uses bank-language domain names instead of infrastructure slugs', () => {
+    expect(approvalDomainLabel('domestic-payment', 'cs')).toBe('Tuzemské platby')
+    expect(approvalDomainLabel('sepa-instant', 'en')).toBe('SEPA instant payments')
+    expect(approvalDomainLabel('notification', 'cs')).toBe('Provozní zprávy')
+  })
+
+  it('explains high-risk policy actions in the selected language', () => {
+    expect(approvalActionLabel('sanctions.clear', 'cs')).toBe('Rozhodnout sankční nález')
+    expect(approvalActionLabel('transaction.sweep', 'en')).toBe('Sweep balance during party merge')
+    expect(approvalActionLabel('opsmessage.compose', 'cs')).toBe('Odeslat provozní zprávu klientovi')
+  })
+
+  it('humanizes an unknown future action without hiding its technical key from the page', () => {
+    expect(approvalActionLabel('futureDomain.reviewCase', 'en')).toBe('Review Case')
+  })
+
+  it('exposes the store-backed 24-hour expiry without inventing a client countdown', () => {
+    expect(approvalExpiresAt('2026-08-26T08:15:00Z')?.toISOString()).toBe('2026-08-27T08:15:00.000Z')
+    expect(approvalExpiresAt(null)).toBeNull()
+    expect(approvalExpiresAt('not-a-timestamp')).toBeNull()
+  })
+})

--- a/openbank-admin-ui/src/test/sanctions-approval-navigation.guard.test.ts
+++ b/openbank-admin-ui/src/test/sanctions-approval-navigation.guard.test.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const approvals = readFileSync(resolve(process.cwd(), 'src/app/approvals/page.tsx'), 'utf8')
+const sanctions = readFileSync(resolve(process.cwd(), 'src/app/sanctions/page.tsx'), 'utf8')
+
+describe('sanctions approval navigation', () => {
+  it('deep-links a discovered sanctions approval into its governed decision workspace', () => {
+    expect(approvals).toContain("item.domain === 'sanctions'")
+    expect(approvals).toContain('/sanctions?approvalId=')
+    expect(sanctions).toContain("searchParams.get('approvalId')")
+    expect(sanctions).toContain('id="sanctions-approvals"')
+  })
+
+  it('describes the real discoverable queue instead of out-of-band handover', () => {
+    expect(sanctions).toContain('automatically appears for another authorised operator')
+    expect(sanctions).not.toContain('Hand this id to another operator')
+    expect(sanctions).not.toContain('exposes no pending-approvals list endpoint')
+  })
+})


### PR DESCRIPTION
## Summary
- deep-link sanctions items from the unified Approval Centre into the governed sanctions decision workspace
- preselect the URL-encoded pending approval id while preserving manual entry for recovery
- replace obsolete out-of-band handover guidance with truthful queue discovery copy

## Safety
- preserves sanctions-service PATCH decision endpoint, sanctions:review RBAC, self-approval rejection, audit rationale, and retry semantics
- does not change screening data, disposition payloads, or four-eyes enforcement

## Verification
- `npm run type-check`
- 15 focused sanctions/Approval Centre files: 60 tests passed
- sanctions render-smoke: 1 passed
- scoped ESLint: 0 errors; pre-existing warnings only
- `git diff --check`

Refs #5679