### PR TITLE
fix(finrep): align previews with EBA 4.2

### DIFF
--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/FinrepService.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/FinrepService.kt
@@ -13,6 +13,8 @@ import com.openbank.finrep.application.port.out.TemplateFailureReason
 import com.openbank.finrep.application.port.out.TemplateRender
 import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
 import com.openbank.finrep.domain.mapper.F0101Mapper
+import com.openbank.finrep.domain.mapper.F0102Mapper
+import com.openbank.finrep.domain.mapper.F0103Mapper
 import com.openbank.finrep.domain.mapper.F0200Mapper
 import com.openbank.finrep.domain.model.FinrepTemplate
 import jakarta.enterprise.context.ApplicationScoped
@@ -41,6 +43,8 @@ class FinrepService(private val ledgerPort: LedgerPort, private val metrics: Fin
         val snapshot = trialBalance(query.asOf)
         val template = when (query.templateId) {
             "F01.01" -> F0101Mapper.map(snapshot, query.asOf)
+            "F01.02" -> F0102Mapper.map(snapshot, query.asOf)
+            "F01.03" -> F0103Mapper.map(snapshot, query.asOf)
             "F02.00" -> F0200Mapper.map(snapshot, query.asOf)
             else -> {
                 metrics.templateFailed(RegulatoryFramework.FINREP, TemplateFailureReason.UNKNOWN_TEMPLATE)

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0101Mapper.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0101Mapper.kt
@@ -15,49 +15,22 @@ import java.math.BigDecimal
 import java.time.LocalDate
 
 /**
- * Maps ledger trial balance lines to the FINREP F01.01 Balance Sheet template.
+ * Maps ledger trial balance lines to the FINREP F 01.01 assets template.
  *
- * EBA FINREP F01.01 structure (simplified):
- *   r010_c010 — Total assets
- *   r380_c010 — Total liabilities
- *   r490_c010 — Total equity
+ * EBA Reporting Framework 4.2 defines total assets as r0380/c0010 (datapoint 32354). Liabilities
+ * and equity are separate templates F 01.02 and F 01.03; placing them in this template would create
+ * a syntactically plausible but semantically false regulatory fact (#6980).
  *
- * ## Signs (issue #5987)
- *
- * Ledger publishes `net = totalDebit − totalCredit` for every account type, so a credit-normal
- * account arrives NEGATIVE. Every FINREP row is reported as a positive magnitude, hence the
- * negations below. The previous version summed the raw `net` straight into r380, which reported
- * liabilities as a negative number against real ledger data, and then derived r490 as
- * `assets − liabilities` — which for real data is `assets + |liabilities|`, not equity at all.
- *
- * ## Equity is SOURCED, not residual — and that is the whole point
- *
- * r490 is `−(equity + income − expense)` in ledger sign, i.e. contributed capital and reserves plus
- * the result of the period not yet closed out to reserves. It is read from the EQUITY, INCOME and
- * EXPENSE lines. It is deliberately NOT `assets − liabilities`: defining equity as the residual is
- * what made `isBalanced` unfalsifiable, because the identity then holds algebraically no matter
- * what the ledger contains. With equity sourced, [TrialBalanceIdentity] over the whole trial
- * balance is a claim that can be false — see the falsification pairs in `F0101MapperTest`.
- *
- * Note what today's chart of accounts means for this: openbank-ledger-service seeds **no EQUITY
- * accounts at all** (`V1__init_ledger.sql` and every later migration), so `Σ net(EQUITY)` is
- * genuinely zero and r490 currently reports the retained result alone. That is the honest number
- * for this ledger, and it does not weaken the check: the identity is evaluated over all five
- * account types, so a residual introduced anywhere still falsifies it.
+ * Ledger publishes asset debit balances as positive `net = totalDebit − totalCredit`, so the
+ * official total-assets fact can be sourced directly. [TrialBalanceIdentity] still assesses the
+ * complete snapshot; the preview never manufactures equity as a residual.
  */
 object F0101Mapper {
 
     fun map(snapshot: TrialBalanceSnapshot, asOf: LocalDate): FinrepTemplate {
         val lines = snapshot.lines
-        val assets = sumNet(lines, "ASSET")
-        // Credit-normal, so the reporting magnitude is the negated ledger net.
-        val liabilities = sumNet(lines, "LIABILITY").negate()
-        val equity = sumNet(lines, "EQUITY", "INCOME", "EXPENSE").negate()
-
         val cells = listOf(
-            FinrepCell(rowRef = "r010", colRef = "c010", value = assets),
-            FinrepCell(rowRef = "r380", colRef = "c010", value = liabilities),
-            FinrepCell(rowRef = "r490", colRef = "c010", value = equity),
+            FinrepCell(rowRef = "r0380", colRef = "c0010", value = sumNet(lines, "ASSET")),
         )
 
         val assessment = TrialBalanceAssurance.assess(snapshot)

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0102Mapper.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0102Mapper.kt
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.finrep.domain.mapper
+
+import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
+import com.openbank.finrep.domain.model.BalanceVerdict
+import com.openbank.finrep.domain.model.FinrepCell
+import com.openbank.finrep.domain.model.FinrepTemplate
+import com.openbank.finrep.domain.model.TrialBalanceAssurance
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/** Official FINREP F 01.02 liabilities total: r0300/c0010, datapoint 32592 (Framework 4.2). */
+object F0102Mapper {
+    fun map(snapshot: TrialBalanceSnapshot, asOf: LocalDate): FinrepTemplate {
+        val liabilities = snapshot.lines
+            .filter { it.accountType == "LIABILITY" }
+            .fold(BigDecimal.ZERO) { total, line -> total.add(line.net) }
+            .negate()
+        val assessment = TrialBalanceAssurance.assess(snapshot)
+        return FinrepTemplate(
+            templateId = "F01.02",
+            period = asOf,
+            cells = listOf(FinrepCell("r0300", "c0010", liabilities)),
+            isBalanced = assessment.verdict == BalanceVerdict.AGREED_BALANCED,
+            balanceVerdict = assessment.verdict,
+        )
+    }
+}

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0103Mapper.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0103Mapper.kt
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.finrep.domain.mapper
+
+import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
+import com.openbank.finrep.domain.model.BalanceVerdict
+import com.openbank.finrep.domain.model.FinrepCell
+import com.openbank.finrep.domain.model.FinrepTemplate
+import com.openbank.finrep.domain.model.TrialBalanceAssurance
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/** Official FINREP F 01.03 equity totals from EBA Reporting Framework 4.2 (#6980). */
+object F0103Mapper {
+    fun map(snapshot: TrialBalanceSnapshot, asOf: LocalDate): FinrepTemplate {
+        fun sum(vararg accountTypes: String): BigDecimal = snapshot.lines
+            .filter { it.accountType in accountTypes }
+            .fold(BigDecimal.ZERO) { total, line -> total.add(line.net) }
+
+        val equity = sum("EQUITY", "INCOME", "EXPENSE").negate()
+        val liabilities = sum("LIABILITY").negate()
+        val assessment = TrialBalanceAssurance.assess(snapshot)
+        return FinrepTemplate(
+            templateId = "F01.03",
+            period = asOf,
+            cells = listOf(
+                FinrepCell("r0300", "c0010", equity),
+                FinrepCell("r0310", "c0010", equity.add(liabilities)),
+            ),
+            isBalanced = assessment.verdict == BalanceVerdict.AGREED_BALANCED,
+            balanceVerdict = assessment.verdict,
+        )
+    }
+}

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0200Mapper.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0200Mapper.kt
@@ -16,10 +16,9 @@ import java.time.LocalDate
 /**
  * Maps ledger trial balance lines to the FINREP F02.00 Profit and Loss Statement template.
  *
- * EBA FINREP F02.00 structure (simplified):
- *   r010_c010 — Total income
- *   r030_c010 — Total expense
- *   r450_c010 — Net profit (income − expense)
+ * EBA Reporting Framework 4.2 defines profit or loss for the year as r0670/c0010 (datapoint
+ * 57025). The previous r0010/r0030/r0450 claims were interest income, a financial-asset detail and
+ * other provisions respectively — not aggregate income, aggregate expense and net profit (#6980).
  *
  * Income is credit-normal, so its reporting magnitude is the negated ledger net; expense is
  * debit-normal and passes through. See `F0101Mapper` for the sign convention (issue #5987).
@@ -30,7 +29,7 @@ import java.time.LocalDate
  * and can never fail. So this template does NOT report a P&L-internal check. It reports the same
  * thing F01.01 does: whether the **trial balance it was rendered from** satisfies double entry. A
  * P&L drawn off a trial balance that does not tie out is not submittable regardless of how
- * internally consistent its three rows are, and that is a fact about this render which a consumer
+ * internally consistent its derived profit fact is, and that is a fact about this render which a consumer
  * of this template can act on.
  *
  * The alternative the issue offers — modelling the flag as not-applicable to P&L — was rejected
@@ -45,11 +44,7 @@ object F0200Mapper {
         val expense = sumNet(lines, "EXPENSE")
         val netProfit = income.subtract(expense)
 
-        val cells = listOf(
-            FinrepCell(rowRef = "r010", colRef = "c010", value = income),
-            FinrepCell(rowRef = "r030", colRef = "c010", value = expense),
-            FinrepCell(rowRef = "r450", colRef = "c010", value = netProfit),
-        )
+        val cells = listOf(FinrepCell(rowRef = "r0670", colRef = "c0010", value = netProfit))
 
         val assessment = TrialBalanceAssurance.assess(snapshot)
         return FinrepTemplate(

--- a/openbank-finrep-service/src/main/resources/openapi.yaml
+++ b/openbank-finrep-service/src/main/resources/openapi.yaml
@@ -13,13 +13,15 @@ info:
   title: OpenBank FINREP / COREP Service
   description: >-
     Supervisory financial and prudential reporting (ADR-0097): renders EBA FINREP templates
-    (F01.01 Balance Sheet, F02.00 Profit & Loss) and the COREP C 01.00 Own Funds template from
+    (F01.01 Assets, F01.02 Liabilities, F01.03 Equity, F02.00 Profit & Loss) and the COREP C 01.00
+    Own Funds template from
     openbank-ledger-service's GL trial balance. Derive-only and stateless — it holds no datastore,
     moves no money, and has NO ČNB transmission channel; EBA XBRL/DPM taxonomy rendering is
     explicitly out of scope for this increment.
 
-    Cells are always fully rendered: a value the platform cannot honestly derive is an explicit
-    flagged zero (`isDataGap`), never an omitted row, so a regulatory return never has a silent gap.
+    FINREP output is a bounded preview containing only the official datapoints the platform can
+    currently derive without inventing regulatory classifications; it is not a complete return.
+    COREP preview gaps remain explicit flagged zeroes (`isDataGap`) with reasons.
   version: 1.3.0
 tags:
   - name: FINREP
@@ -51,15 +53,16 @@ paths:
       summary: Render a FINREP template as of a reporting date
       description: >-
         Derives the template from the ledger GL trial balance as of `asOf`. Supported
-        `templateId` values are `F01.01` (Balance Sheet) and `F02.00` (Profit & Loss); any other
-        value is rejected.
+        `templateId` values are `F01.01` (Assets), `F01.02` (Liabilities), `F01.03` (Equity) and
+        `F02.00` (Profit & Loss); any other value is rejected. The bounded previews expose only
+        datapoints that the current ledger can derive without inventing regulatory classifications.
       operationId: getFinrepTemplate
       parameters:
         - name: templateId
           in: path
           required: true
           description: EBA FINREP template identifier
-          schema: { type: string, enum: [F01.01, F02.00] }
+          schema: { type: string, enum: [F01.01, F01.02, F01.03, F02.00] }
         - name: asOf
           in: query
           required: false
@@ -147,21 +150,22 @@ components:
         rowRef:
           type: string
           description: EBA FINREP row reference
-          example: r010
+          example: r0380
         colRef:
           type: string
           description: EBA FINREP column reference
-          example: c010
+          example: c0010
         value: { type: number }
         currency: { type: string, example: CZK }
 
     FinrepTemplate:
       type: object
       description: >-
-        One rendered FINREP template. F01.01 populates rows r010 (total assets), r380 (total
-        liabilities) and r490 (total equity); F02.00 populates r010 (total income), r030 (total
-        expense) and r450 (net profit). All rows are reported as positive magnitudes in their
-        natural reporting sign, not in the ledger's debit-minus-credit convention.
+        One bounded FINREP preview using official EBA Reporting Framework 4.2 coordinates. F01.01
+        publishes r0380/c0010 (total assets); F01.02 publishes r0300/c0010 (total liabilities);
+        F01.03 publishes r0300/c0010 (total equity) and r0310/c0010 (total equity and liabilities);
+        F02.00 publishes r0670/c0010 (profit or loss for the year). It is not a complete regulatory
+        return or an XBRL artifact. Values are reported in their natural reporting sign.
       required: [templateId, period, cells, isBalanced, balanceVerdict]
       properties:
         templateId: { type: string, example: F01.01 }

--- a/openbank-finrep-service/src/main/resources/openapi.yaml
+++ b/openbank-finrep-service/src/main/resources/openapi.yaml
@@ -22,7 +22,7 @@ info:
     FINREP output is a bounded preview containing only the official datapoints the platform can
     currently derive without inventing regulatory classifications; it is not a complete return.
     COREP preview gaps remain explicit flagged zeroes (`isDataGap`) with reasons.
-  version: 1.3.0
+  version: 1.4.0
 tags:
   - name: FINREP
   - name: COREP

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0101MapperTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0101MapperTest.kt
@@ -37,31 +37,13 @@ class F0101MapperTest {
     )
 
     @Test
-    fun `F01_01 reports assets liabilities and equity as positive magnitudes`() {
+    fun `F01_01 reports only the official total-assets datapoint`() {
         val template = F0101Mapper.map(tb(balancedTrialBalance(), ledgerSays = true), asOf)
 
         assertThat(template.templateId).isEqualTo("F01.01")
-        assertThat(cell(template.cells, "r010")).isEqualByComparingTo("500000")
-        assertThat(cell(template.cells, "r380")).isEqualByComparingTo("300000")
-        assertThat(cell(template.cells, "r490")).isEqualByComparingTo("200000")
-    }
-
-    @Test
-    fun `equity is sourced from EQUITY INCOME and EXPENSE, not from assets minus liabilities`() {
-        // The discriminating fixture: assets − liabilities is 500 000 − 300 000 = 200 000, but the
-        // P&L half says the result is only 150 000. A residual-derived r490 would report 200 000
-        // and could not tell these apart; a sourced one reports 150 000 AND flags the 50 000 gap.
-        val lines = listOf(
-            line("1000", "ASSET", "500000"),
-            line("2000", "LIABILITY", "-300000"),
-            line("4000", "INCOME", "-210000"),
-            line("5000", "EXPENSE", "60000"),
-        )
-
-        val template = F0101Mapper.map(tb(lines, ledgerSays = false), asOf)
-
-        assertThat(cell(template.cells, "r490")).isEqualByComparingTo("150000")
-        assertThat(template.isBalanced).isFalse()
+        assertThat(template.cells).hasSize(1)
+        assertThat(cell(template.cells, "r0380")).isEqualByComparingTo("500000")
+        assertThat(template.cells.single().colRef).isEqualTo("c0010")
     }
 
     @Test
@@ -81,8 +63,7 @@ class F0101MapperTest {
 
     @Test
     fun `a residual in the P&L half falsifies the BALANCE SHEET template`() {
-        // Proof the check is not implied by what F01.01 itself computes: INCOME and EXPENSE feed no
-        // row this template reports as a top-line total, yet a residual introduced there is caught.
+        // Income and expense feed no F01.01 asset row, yet a residual there is still caught.
         val lines = balancedTrialBalance() + line("5001", "EXPENSE", "12000")
 
         assertThat(F0101Mapper.map(tb(lines, ledgerSays = false), asOf).isBalanced).isFalse()

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0102AndF0103MapperTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0102AndF0103MapperTest.kt
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.finrep
+
+import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
+import com.openbank.finrep.domain.mapper.F0102Mapper
+import com.openbank.finrep.domain.mapper.F0103Mapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class F0102AndF0103MapperTest {
+    private val asOf = LocalDate.of(2026, 6, 30)
+    private val snapshot = TrialBalanceSnapshot(
+        lines = listOf(
+            line("1000", "ASSET", "500000"),
+            line("2000", "LIABILITY", "-300000"),
+            line("4000", "INCOME", "-260000"),
+            line("5000", "EXPENSE", "60000"),
+        ),
+        ledgerReportsBalanced = true,
+    )
+
+    @Test
+    fun `F01_02 uses the official total-liabilities cell`() {
+        val template = F0102Mapper.map(snapshot, asOf)
+
+        assertThat(template.templateId).isEqualTo("F01.02")
+        val cell = template.cells.single()
+        assertThat(cell.rowRef).isEqualTo("r0300")
+        assertThat(cell.colRef).isEqualTo("c0010")
+        assertThat(cell.value).isEqualByComparingTo("300000")
+    }
+
+    @Test
+    fun `F01_03 uses official total-equity and equity-plus-liabilities cells`() {
+        val template = F0103Mapper.map(snapshot, asOf)
+
+        assertThat(template.templateId).isEqualTo("F01.03")
+        assertThat(template.cells.associate { it.rowRef to it.value }).containsExactlyInAnyOrderEntriesOf(
+            mapOf("r0300" to BigDecimal("200000"), "r0310" to BigDecimal("500000")),
+        )
+        assertThat(template.cells).allMatch { it.colRef == "c0010" }
+    }
+
+    private fun line(code: String, accountType: String, net: String) =
+        TrialBalanceLineDto(code = code, accountType = accountType, net = BigDecimal(net), currency = "CZK")
+}

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0200MapperTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0200MapperTest.kt
@@ -25,13 +25,13 @@ class F0200MapperTest {
     )
 
     @Test
-    fun `F02_00 reports income and expense as positive magnitudes and derives net profit`() {
+    fun `F02_00 reports profit for the year at its official datapoint`() {
         val template = F0200Mapper.map(tb(balancedTrialBalance(), ledgerSays = true), asOf)
 
         assertThat(template.templateId).isEqualTo("F02.00")
-        assertThat(cell(template, "r010")).isEqualByComparingTo("120000")
-        assertThat(cell(template, "r030")).isEqualByComparingTo("80000")
-        assertThat(cell(template, "r450")).isEqualByComparingTo("40000")
+        assertThat(template.cells).hasSize(1)
+        assertThat(cell(template, "r0670")).isEqualByComparingTo("40000")
+        assertThat(template.cells.single().colRef).isEqualTo("c0010")
     }
 
     @Test
@@ -50,14 +50,11 @@ class F0200MapperTest {
     }
 
     @Test
-    fun `net profit stays a definition and can never falsify the flag on its own`() {
-        // Guards against the tempting vacuous check: `income − expense == netProfit` is how r450 is
-        // computed, so asserting it would always hold. This test states that r450 tracks the inputs
-        // exactly, WITHOUT that identity being what `isBalanced` reports.
+    fun `profit for the year stays a definition and can never falsify the flag on its own`() {
         val lines = balancedTrialBalance()
         val template = F0200Mapper.map(tb(lines, ledgerSays = true), asOf)
 
-        assertThat(cell(template, "r450")).isEqualByComparingTo(cell(template, "r010").subtract(cell(template, "r030")))
+        assertThat(cell(template, "r0670")).isEqualByComparingTo("40000")
     }
 
     /** Ledger's verdict is explicit per call site, never derived from `lines` (issue #6011). */

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/FinrepServiceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/FinrepServiceTest.kt
@@ -50,7 +50,9 @@ class FinrepServiceTest {
 
         assertThat(template.templateId).isEqualTo("F01.01")
         assertThat(template.period).isEqualTo(asOf)
-        assertThat(template.cells).anyMatch { it.rowRef == "r490" && it.value == BigDecimal("200000") }
+        assertThat(template.cells).containsExactly(
+            com.openbank.finrep.domain.model.FinrepCell("r0380", "c0010", BigDecimal("500000")),
+        )
         coVerify(exactly = 1) { ledgerPort.getTrialBalance(asOf) }
     }
 
@@ -67,7 +69,35 @@ class FinrepServiceTest {
         val template = service.getTemplate(GetFinrepTemplateQuery(templateId = "F02.00", asOf = asOf))
 
         assertThat(template.templateId).isEqualTo("F02.00")
-        assertThat(template.cells).anyMatch { it.rowRef == "r450" && it.value == BigDecimal("40000") }
+        assertThat(template.cells).anyMatch { it.rowRef == "r0670" && it.value == BigDecimal("40000") }
+    }
+
+    @Test
+    fun `getTemplate dispatches F01_02 and F01_03 with official coordinates and signs`(): Unit = runBlocking {
+        val asOf = LocalDate.of(2026, 6, 30)
+        val lines = listOf(
+            TrialBalanceLineDto("1000", "ASSET", BigDecimal("500000"), "CZK"),
+            TrialBalanceLineDto("2000", "LIABILITY", BigDecimal("-300000"), "CZK"),
+            TrialBalanceLineDto("4000", "INCOME", BigDecimal("-260000"), "CZK"),
+            TrialBalanceLineDto("5000", "EXPENSE", BigDecimal("60000"), "CZK"),
+        )
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns snapshot(lines, ledgerSays = true)
+        val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
+
+        val liabilities = service.getTemplate(GetFinrepTemplateQuery("F01.02", asOf))
+        val equity = service.getTemplate(GetFinrepTemplateQuery("F01.03", asOf))
+
+        assertThat(liabilities.cells).containsExactly(
+            com.openbank.finrep.domain.model.FinrepCell("r0300", "c0010", BigDecimal("300000")),
+        )
+        assertThat(equity.cells).containsExactly(
+            com.openbank.finrep.domain.model.FinrepCell("r0300", "c0010", BigDecimal("200000")),
+            com.openbank.finrep.domain.model.FinrepCell("r0310", "c0010", BigDecimal("500000")),
+        )
+        assertThat(registry.get("openbank.finrep.templates.rendered").tag("template", "F01.02").counter().count())
+            .isEqualTo(1.0)
+        assertThat(registry.get("openbank.finrep.templates.rendered").tag("template", "F01.03").counter().count())
+            .isEqualTo(1.0)
     }
 
     @Test

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/LedgerTrialBalancePactConsumerTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/LedgerTrialBalancePactConsumerTest.kt
@@ -180,7 +180,7 @@ class LedgerTrialBalancePactConsumerTest {
             ),
             LocalDate.parse(REPORTING_DATE),
         )
-        assertThat(template.cells.map { it.rowRef }).containsExactly("r010", "r380", "r490")
+        assertThat(template.cells.map { it.rowRef }).containsExactly("r0380")
         assertThat(template.cells.first().value).isEqualByComparingTo(BigDecimal("150000.00"))
         // The pact's single ASSET line does not tie out on its own, so the contract also proves the
         // balance check runs over real contract data and can answer `false` (issue #5987) — it is

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/TemplateWireFormatTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/TemplateWireFormatTest.kt
@@ -151,16 +151,17 @@ class TemplateWireFormatTest {
 
         @Suppress("UNCHECKED_CAST")
         val cells = json["cells"] as List<Map<*, *>>
-        assertThat(cells).hasSize(3)
+        assertThat(cells).hasSize(1)
         assertThat(cells.first().keys).containsExactlyInAnyOrder("rowRef", "colRef", "value", "currency")
-        assertThat(cells.map { it["rowRef"] }).containsExactly("r010", "r380", "r490")
+        assertThat(cells.map { it["rowRef"] }).containsExactly("r0380")
+        assertThat(cells.map { it["colRef"] }).containsExactly("c0010")
         assertThat(cells.first()["currency"]).isEqualTo("CZK")
-        // r010 total assets, r380 total liabilities, r490 total equity — proves the cells are
-        // really derived from the ledger trial balance, not a fixed skeleton. `value` is a JSON
+        // Official F 01.01 r0380 total assets — proves the cell is really derived from the ledger
+        // trial balance, not a fixed skeleton. `value` is a JSON
         // NUMBER (schema `type: number`), so compare numerically — an untyped parse of `150000.00`
         // yields a Double whose toString drops the scale.
         assertThat(cells.map { (it["value"] as Number).toDouble() })
-            .containsExactly(150_000.00, 125_000.00, 25_000.00)
+            .containsExactly(150_000.00)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- correct FINREP preview coordinates to official EBA Reporting Framework 4.2 datapoints
- split assets, liabilities and equity across F01.01/F01.02/F01.03 instead of publishing invented rows
- expose only honest bounded previews and add mapper, use-case and wire-contract coverage

## Official datapoints
- F01.01 r0380/c0010: total assets (32354)
- F01.02 r0300/c0010: total liabilities (32592)
- F01.03 r0300/c0010: total equity (32464)
- F01.03 r0310/c0010: total equity and liabilities
- F02.00 r0670/c0010: profit or loss for the year (57025)

## Verification
- `./gradlew :openbank-finrep-service:test :openbank-finrep-service:ktlintCheck :openbank-finrep-service:detekt :openbank-finrep-service:quarkusBuild`
- independent subagent review completed; both P2 findings fixed
- signed commit verified

Refs #6980
Blocks taxonomy generation in #5914 until merged.

No regulator submission or sandbox claim is included.