### PR TITLE
fix(admin-ui): contain card dialog focus

### DIFF
--- a/openbank-admin-ui/src/components/cards/ConfirmTransitionDialog.tsx
+++ b/openbank-admin-ui/src/components/cards/ConfirmTransitionDialog.tsx
@@ -12,11 +12,12 @@
 
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { AlertTriangle } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import type { CardTransition } from '@/lib/cards/lifecycle'
 import type { Card } from '@/lib/cards/types'
+import { trapDialogFocus } from '@/lib/a11y/trapDialogFocus'
 import { CardStatusChip } from './CardStatusChip'
 
 export function ConfirmTransitionDialog({
@@ -29,6 +30,7 @@ export function ConfirmTransitionDialog({
   onConfirm: (reason: string) => void
 }) {
   const { t } = useLanguage()
+  const dialogRef = useRef<HTMLDivElement>(null)
   const [reason, setReason] = useState('')
   const label = transition.action === 'block'
     ? t('Blokovat kartu', 'Block card')
@@ -36,10 +38,15 @@ export function ConfirmTransitionDialog({
 
   return (
     <div
+      ref={dialogRef}
       role="dialog"
       aria-modal="true"
       aria-label={label}
-      onKeyDown={e => { if (e.key === 'Escape' && !busy) onCancel() }}
+      aria-busy={busy}
+      onKeyDown={e => {
+        if (e.key === 'Escape' && !busy) onCancel()
+        trapDialogFocus(e, dialogRef.current)
+      }}
       style={{
         position: 'fixed', inset: 0, zIndex: 60, background: 'rgba(15,23,42,0.45)',
         display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '24px',
@@ -47,7 +54,7 @@ export function ConfirmTransitionDialog({
     >
       <div className="card" style={{ width: '100%', maxWidth: '460px', padding: '22px 24px', background: 'var(--surface-1)' }}>
         <div style={{ display: 'flex', gap: '10px', alignItems: 'flex-start', marginBottom: '14px' }}>
-          <AlertTriangle size={18} style={{ color: 'var(--danger)', flexShrink: 0, marginTop: '2px' }} />
+          <AlertTriangle size={18} aria-hidden="true" style={{ color: 'var(--danger)', flexShrink: 0, marginTop: '2px' }} />
           <div>
             <div style={{ fontSize: '15px', fontWeight: 700, color: 'var(--text-primary)' }}>{label}</div>
             <div style={{ fontSize: '12px', color: 'var(--text-secondary)', marginTop: '4px' }}>
@@ -83,12 +90,14 @@ export function ConfirmTransitionDialog({
         />
 
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '16px' }}>
-          <button className="btn btn-ghost btn-sm" onClick={onCancel} disabled={busy}>
+          <button type="button" className="btn btn-ghost btn-sm" onClick={onCancel} disabled={busy}>
             {t('Zpět', 'Back')}
           </button>
           <button
+            type="button"
             className="btn btn-danger btn-sm"
             disabled={busy || reason.trim().length === 0}
+            aria-busy={busy}
             onClick={() => onConfirm(reason.trim())}
           >
             {busy

--- a/openbank-admin-ui/src/components/cards/IssueCardDialog.tsx
+++ b/openbank-admin-ui/src/components/cards/IssueCardDialog.tsx
@@ -20,7 +20,7 @@
 
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { AlertTriangle, ArrowLeft, ArrowRight, Check, CreditCard, RefreshCw, Search, X } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
@@ -36,6 +36,7 @@ import {
 } from '@/lib/cards/issue'
 import { formatMajor, formatMinor, minorToMajorString, parseMajorToMinor } from '@/lib/cards/money'
 import { useCardOperations } from '@/lib/cards/useCardOperations'
+import { trapDialogFocus } from '@/lib/a11y/trapDialogFocus'
 import { CardOperationFeedback } from './CardOperationFeedback'
 
 const SEARCH_LIMIT = 10
@@ -106,6 +107,7 @@ function Row({ label, value, mono }: { label: string; value: React.ReactNode; mo
 export function IssueCardDialog({ onClose, onIssued }: { onClose: () => void; onIssued: (card: Card) => void }) {
   const { t, language } = useLanguage()
   const ops = useCardOperations()
+  const dialogRef = useRef<HTMLDivElement>(null)
 
   const [step, setStep] = useState<IssueStep>('party')
   const [draft, setDraft] = useState<IssueDraft>(initialDraft)
@@ -312,10 +314,15 @@ export function IssueCardDialog({ onClose, onIssued }: { onClose: () => void; on
 
   return (
     <div
+      ref={dialogRef}
       role="dialog"
       aria-modal="true"
       aria-label={t('Vydat kartu', 'Issue a card')}
-      onKeyDown={e => { if (e.key === 'Escape' && !busy) onClose() }}
+      aria-busy={busy}
+      onKeyDown={e => {
+        if (e.key === 'Escape' && !busy) onClose()
+        trapDialogFocus(e, dialogRef.current)
+      }}
       style={{
         position: 'fixed', inset: 0, zIndex: 60, background: 'rgba(15,23,42,0.45)',
         display: 'flex', alignItems: 'flex-start', justifyContent: 'center', padding: '40px 24px', overflowY: 'auto',
@@ -326,12 +333,12 @@ export function IssueCardDialog({ onClose, onIssued }: { onClose: () => void; on
         <div style={{ padding: '18px 22px 14px', borderBottom: '1px solid var(--border)' }}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '12px' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '9px' }}>
-              <CreditCard size={16} style={{ color: 'var(--accent)' }} />
+              <CreditCard size={16} aria-hidden="true" style={{ color: 'var(--accent)' }} />
               <span style={{ fontSize: '15px', fontWeight: 700, color: 'var(--text-primary)' }}>{t('Vydat kartu', 'Issue a card')}</span>
             </div>
-            <button onClick={onClose} disabled={busy} aria-label={t('Zavřít', 'Close')}
+            <button type="button" onClick={onClose} disabled={busy} aria-label={t('Zavřít', 'Close')}
               style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-tertiary)', padding: 0, lineHeight: 1 }}>
-              <X size={16} />
+              <X size={16} aria-hidden="true" />
             </button>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginTop: '12px', flexWrap: 'wrap' }}>
@@ -497,8 +504,8 @@ export function IssueCardDialog({ onClose, onIssued }: { onClose: () => void; on
                     )}</span>
                   </div>
                   <div>
-                    <button className="btn btn-ghost btn-sm" onClick={() => setResolveNonce(n => n + 1)}>
-                      <RefreshCw size={12} /> {t('Zkusit znovu', 'Try again')}
+                    <button type="button" className="btn btn-ghost btn-sm" onClick={() => setResolveNonce(n => n + 1)}>
+                      <RefreshCw size={12} aria-hidden="true" /> {t('Zkusit znovu', 'Try again')}
                     </button>
                   </div>
                 </div>
@@ -635,19 +642,19 @@ export function IssueCardDialog({ onClose, onIssued }: { onClose: () => void; on
 
         {/* footer */}
         <div style={{ padding: '14px 22px', borderTop: '1px solid var(--border)', display: 'flex', justifyContent: 'space-between', gap: '8px' }}>
-          <button className="btn btn-ghost btn-sm" disabled={busy || step === 'party'} onClick={() => go(prevStep(step))}>
-            <ArrowLeft size={12} /> {t('Zpět', 'Back')}
+          <button type="button" className="btn btn-ghost btn-sm" disabled={busy || step === 'party'} onClick={() => go(prevStep(step))}>
+            <ArrowLeft size={12} aria-hidden="true" /> {t('Zpět', 'Back')}
           </button>
           {step === 'review' ? (
-            <button className="btn btn-primary btn-sm" disabled={busy || !canContinue} onClick={() => void submit()}>
+            <button type="button" className="btn btn-primary btn-sm" disabled={busy || !canContinue} aria-busy={busy} onClick={() => void submit()}>
               {busy
-                ? <RefreshCw size={12} style={{ animation: 'spin 0.8s linear infinite' }} />
-                : <CreditCard size={12} />}
+                ? <RefreshCw size={12} aria-hidden="true" style={{ animation: 'spin 0.8s linear infinite' }} />
+                : <CreditCard size={12} aria-hidden="true" />}
               {t('Vydat kartu', 'Issue the card')}
             </button>
           ) : (
-            <button className="btn btn-primary btn-sm" disabled={busy || !canContinue} onClick={() => go(nextStep(step))}>
-              {t('Pokračovat', 'Continue')} <ArrowRight size={12} />
+            <button type="button" className="btn btn-primary btn-sm" disabled={busy || !canContinue} onClick={() => go(nextStep(step))}>
+              {t('Pokračovat', 'Continue')} <ArrowRight size={12} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/openbank-admin-ui/src/lib/a11y/trapDialogFocus.ts
+++ b/openbank-admin-ui/src/lib/a11y/trapDialogFocus.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+const FOCUSABLE = [
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[href]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ')
+
+type TabEvent = {
+  key: string
+  shiftKey: boolean
+  preventDefault: () => void
+}
+
+/** Keeps sequential keyboard navigation inside a modal dialog. */
+export function trapDialogFocus(event: TabEvent, dialog: HTMLElement | null) {
+  if (event.key !== 'Tab' || !dialog) return
+
+  const focusable = Array.from(dialog.querySelectorAll<HTMLElement>(FOCUSABLE))
+    .filter(element => element.getAttribute('aria-hidden') !== 'true')
+  if (focusable.length === 0) return
+
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault()
+    last.focus()
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault()
+    first.focus()
+  }
+}

--- a/openbank-admin-ui/src/test/card-issue-dialog.test.tsx
+++ b/openbank-admin-ui/src/test/card-issue-dialog.test.tsx
@@ -63,6 +63,20 @@ async function walkToReview() {
 }
 
 describe('issue-card flow', () => {
+  it('keeps keyboard focus inside the modal', () => {
+    mount()
+    const dialog = screen.getByRole('dialog', { name: 'Issue a card' })
+    const close = screen.getByRole('button', { name: 'Close' })
+    const search = screen.getByLabelText('Search for a client')
+
+    search.focus()
+    fireEvent.keyDown(dialog, { key: 'Tab' })
+    expect(document.activeElement).toBe(close)
+
+    fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(search)
+  })
+
   it('walks party → account → product and shows the entitlement context', async () => {
     mount()
     await walkToReview()

--- a/openbank-admin-ui/src/test/card-transition-dialog.test.tsx
+++ b/openbank-admin-ui/src/test/card-transition-dialog.test.tsx
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ConfirmTransitionDialog } from '@/components/cards/ConfirmTransitionDialog'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import type { Card } from '@/lib/cards/types'
+
+const CARD = {
+  id: 'card-1', partyId: 'party-1', accountId: 'account-1', productCode: 'CURRENT_CZK',
+  cardType: 'DEBIT', network: 'VISA', maskedPan: '**** 4242', cardholderName: 'A',
+  embossedName: 'A', expiryDate: '2030-01', status: 'ACTIVE', dailyLimitMinorUnits: 1,
+  monthlyLimitMinorUnits: 2, currency: 'CZK', createdAt: '2026-08-26T00:00:00Z',
+} satisfies Card
+
+afterEach(cleanup)
+
+describe('card transition dialog', () => {
+  it('contains focus and exposes the submitting state', () => {
+    const onConfirm = vi.fn()
+    render(
+      <LanguageProvider>
+        <ConfirmTransitionDialog
+          card={CARD}
+          transition={{ action: 'block', to: 'BLOCKED', irreversible: true, reason: true }}
+          busy={false}
+          onCancel={vi.fn()}
+          onConfirm={onConfirm}
+        />
+      </LanguageProvider>,
+    )
+
+    const dialog = screen.getByRole('dialog', { name: 'Block card' })
+    const reason = screen.getByLabelText('Reason for the operation')
+    const back = screen.getByRole('button', { name: 'Back' })
+
+    reason.focus()
+    fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(back)
+    fireEvent.keyDown(dialog, { key: 'Tab' })
+    expect(document.activeElement).toBe(reason)
+
+    fireEvent.change(reason, { target: { value: 'Customer request' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm block' }))
+    expect(onConfirm).toHaveBeenCalledWith('Customer request')
+  })
+
+  it('marks the modal and confirmation action busy', () => {
+    render(
+      <LanguageProvider>
+        <ConfirmTransitionDialog
+          card={CARD}
+          transition={{ action: 'cancel', to: 'CANCELLED', irreversible: true, reason: true }}
+          busy
+          onCancel={vi.fn()}
+          onConfirm={vi.fn()}
+        />
+      </LanguageProvider>,
+    )
+
+    expect(screen.getByRole('dialog', { name: 'Cancel card' }).getAttribute('aria-busy')).toBe('true')
+    expect(screen.getByRole('button', { name: 'Submitting…' }).getAttribute('aria-busy')).toBe('true')
+  })
+})


### PR DESCRIPTION
## Summary

- keep Tab and Shift+Tab navigation inside the card issuance and irreversible card-transition dialogs
- expose modal and submit busy state, use explicit button semantics, and hide decorative action icons
- add DOM-level regression coverage for focus wrapping, audited reason submission, and busy state

## Safety

Card issuance payload construction, stable Idempotency-Key behavior, account/product/entitlement resolution, lifecycle endpoint selection, required block/cancel reasons, and RBAC remain unchanged.

## Validation

- focused Vitest: 2 files, 6 tests passed
- `npm run type-check`
- scoped ESLint: 0 errors (2 pre-existing effect warnings in IssueCardDialog)
- `git diff --check`

Closes #7057