### PR TITLE
fix(admin-ui): modernize secure sign-in experience

### DIFF
--- a/openbank-admin-ui/src/app/auth/error/page.tsx
+++ b/openbank-admin-ui/src/app/auth/error/page.tsx
@@ -3,43 +3,87 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 "use client"
-import { useSearchParams } from "next/navigation"
+
+import { ArrowRight, Languages, Loader2, RefreshCw, ShieldAlert } from "lucide-react"
 import { signIn } from "next-auth/react"
-import { Suspense } from "react"
+import { useSearchParams } from "next/navigation"
+import { Suspense, useState } from "react"
+import { useLanguage } from "@/lib/i18n/LanguageContext"
+import { safeCallbackPath } from "@/lib/auth/safeCallbackPath"
+import styles from "../recovery.module.css"
+
+const COPY = {
+  en: {
+    eyebrow: "Secure sign-in recovery",
+    title: "We could not sign you in",
+    intro: "Your bank session was not started. No operational action was performed.",
+    retry: "Try secure sign-in again",
+    retrying: "Reconnecting securely…",
+    switchLanguage: "Přepnout do češtiny",
+    locale: "Čeština",
+    help: "If this keeps happening, share the time of the attempt with your bank administrator — never share a password or token.",
+    Configuration: "The identity service is not configured correctly. Please contact your bank administrator.",
+    AccessDenied: "The identity provider did not grant access. Confirm that you selected the correct bank account.",
+    Verification: "The verification link is invalid or has expired. Start a new secure sign-in.",
+    Default: "An unexpected identity-service response interrupted sign-in. It is safe to try again.",
+  },
+  cs: {
+    eyebrow: "Bezpečné obnovení přihlášení",
+    title: "Přihlášení se nepodařilo",
+    intro: "Bankovní relace nebyla zahájena a nebyla provedena žádná provozní akce.",
+    retry: "Zkusit bezpečné přihlášení znovu",
+    retrying: "Obnovuji zabezpečené spojení…",
+    switchLanguage: "Switch to English",
+    locale: "English",
+    help: "Pokud se problém opakuje, sdělte administrátorovi banky čas pokusu — nikdy neposílejte heslo ani token.",
+    Configuration: "Služba identity není správně nastavena. Obraťte se na administrátora banky.",
+    AccessDenied: "Poskytovatel identity přístup nepovolil. Ověřte, že jste zvolili správný bankovní účet.",
+    Verification: "Ověřovací odkaz je neplatný nebo vypršel. Zahajte nové bezpečné přihlášení.",
+    Default: "Přihlášení přerušila neočekávaná odpověď služby identity. Můžete to bezpečně zkusit znovu.",
+  },
+} as const
 
 function ErrorContent() {
   const params = useSearchParams()
+  const { language, setLanguage } = useLanguage()
+  const [pending, setPending] = useState(false)
+  const copy = COPY[language]
   const error = params.get("error")
+  const errorKey = error === "Configuration" || error === "AccessDenied" || error === "Verification" ? error : "Default"
+  const callbackUrl = safeCallbackPath(params.get("callbackUrl"))
 
-  const messages: Record<string, string> = {
-    Configuration: "Chyba konfigurace serveru. Kontaktujte správce.",
-    AccessDenied: "Přístup byl odepřen poskytovatelem identity.",
-    Verification: "Ověřovací odkaz je neplatný nebo vypršel.",
-    Default: "Nastala neočekávaná chyba při přihlašování.",
+  const retry = async () => {
+    if (pending) return
+    setPending(true)
+    try {
+      await signIn("keycloak", { callbackUrl })
+    } catch {
+      setPending(false)
+    }
   }
 
   return (
-    <div style={{
-      minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center",
-      background: "var(--bg)", fontFamily: "var(--font-sans)",
-    }}>
-      <div style={{ textAlign: "center", maxWidth: "420px", padding: "40px" }}>
-        <div style={{ fontSize: "48px", marginBottom: "16px" }}>⚠️</div>
-        <div style={{ fontSize: "20px", fontWeight: 700, color: "var(--text-primary)", marginBottom: "8px" }}>
-          Chyba přihlášení
-        </div>
-        <div style={{ fontSize: "13px", color: "var(--text-secondary)", marginBottom: "24px" }}>
-          {messages[error ?? "Default"] ?? messages.Default}
-        </div>
-        <button type="button" aria-label="Retry sign-in / Zkusit přihlášení znovu" onClick={() => signIn("keycloak")} style={{
-          padding: "10px 24px", borderRadius: "8px", border: "none",
-          background: "var(--accent)", color: "#fff", fontSize: "13px",
-          fontWeight: 600, cursor: "pointer",
-        }}>
-          Zkusit znovu
+    <main className={styles.page}>
+      <section className={styles.card} aria-labelledby="auth-error-title">
+        <header className={styles.header}>
+          <a className={styles.brand} href="/auth/login">OpenBank <span>Admin</span></a>
+          <button type="button" className={styles.languageButton} onClick={() => setLanguage(language === "en" ? "cs" : "en")} aria-label={copy.switchLanguage}>
+            <Languages size={16} aria-hidden="true" />{copy.locale}
+          </button>
+        </header>
+        <div className={`${styles.icon} ${styles.errorIcon}`} aria-hidden="true"><ShieldAlert size={27} /></div>
+        <p className={styles.eyebrow}>{copy.eyebrow}</p>
+        <h1 id="auth-error-title">{copy.title}</h1>
+        <p className={styles.intro}>{copy.intro}</p>
+        <div className={styles.explanation} role="alert">{copy[errorKey]}</div>
+        <button type="button" className={styles.primaryButton} onClick={retry} disabled={pending} aria-busy={pending}>
+          {pending ? <Loader2 className={styles.spinner} size={18} aria-hidden="true" /> : <RefreshCw size={18} aria-hidden="true" />}
+          <span>{pending ? copy.retrying : copy.retry}</span>
+          {!pending && <ArrowRight size={18} aria-hidden="true" />}
         </button>
-      </div>
-    </div>
+        <p className={styles.help}>{copy.help}</p>
+      </section>
+    </main>
   )
 }
 

--- a/openbank-admin-ui/src/app/auth/forbidden/page.tsx
+++ b/openbank-admin-ui/src/app/auth/forbidden/page.tsx
@@ -3,52 +3,67 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 "use client"
-import { useSearchParams } from "next/navigation"
-import { useRouter } from "next/navigation"
+
+import { ArrowRight, Languages, LockKeyhole, ShieldCheck } from "lucide-react"
+import { useRouter, useSearchParams } from "next/navigation"
 import { Suspense } from "react"
+import { useLanguage } from "@/lib/i18n/LanguageContext"
+import { sameOriginPath } from "@/lib/auth/safeCallbackPath"
+import styles from "../recovery.module.css"
+
+const COPY = {
+  en: {
+    eyebrow: "Access boundary",
+    title: "This area is not in your role",
+    intro: "OpenBank stopped the request before protected data was shown or changed.",
+    explanation: "Access is assigned by responsibility. If this task is part of your job, ask your bank administrator to review your role instead of sharing another operator’s account.",
+    requested: "Protected destination",
+    dashboard: "Return to your dashboard",
+    boundary: "This is a normal security control — not a system failure.",
+    switchLanguage: "Přepnout do češtiny",
+    locale: "Čeština",
+  },
+  cs: {
+    eyebrow: "Hranice přístupu",
+    title: "Tato oblast není součástí vaší role",
+    intro: "OpenBank požadavek zastavil dříve, než byla zobrazena nebo změněna chráněná data.",
+    explanation: "Přístup se přiděluje podle odpovědnosti. Pokud úkol patří do vaší práce, požádejte administrátora banky o kontrolu role — nesdílejte účet jiného operátora.",
+    requested: "Chráněný cíl",
+    dashboard: "Vrátit se na svůj dashboard",
+    boundary: "Jde o běžný bezpečnostní mechanismus, nikoli poruchu systému.",
+    switchLanguage: "Switch to English",
+    locale: "English",
+  },
+} as const
 
 function ForbiddenContent() {
   const params = useSearchParams()
-  const path = params.get("path") || ""
   const router = useRouter()
+  const { language, setLanguage } = useLanguage()
+  const copy = COPY[language]
+  const requestedPath = sameOriginPath(params.get("path"))
 
   return (
-    <div style={{
-      minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center",
-      background: "var(--bg)", fontFamily: "var(--font-sans)",
-    }}>
-      <div style={{ textAlign: "center", maxWidth: "480px", padding: "40px" }}>
-        <div style={{ fontSize: "64px", marginBottom: "16px" }}>🔒</div>
-        <div style={{ fontSize: "24px", fontWeight: 700, color: "var(--text-primary)", marginBottom: "8px" }}>
-          Přístup odepřen
-        </div>
-        <div style={{ fontSize: "14px", color: "var(--text-secondary)", marginBottom: "24px", lineHeight: 1.6 }}>
-          Nemáte dostatečná oprávnění pro přístup k této části systému.
-          Pokud si myslíte, že jde o chybu, kontaktujte správce.
-        </div>
-        {path && (
-          <div style={{ marginBottom: "24px", padding: "8px 12px", background: "var(--surface-2)", borderRadius: "6px", fontSize: "12px", fontFamily: "monospace", color: "var(--text-tertiary)" }}>
-            {path}
-          </div>
-        )}
-        <div style={{ display: "flex", gap: "12px", justifyContent: "center" }}>
-          <button onClick={() => router.back()} style={{
-            padding: "10px 20px", borderRadius: "8px", border: "1px solid var(--border)",
-            background: "var(--surface)", color: "var(--text-primary)", fontSize: "13px",
-            fontWeight: 500, cursor: "pointer",
-          }}>
-            Zpět
+    <main className={styles.page}>
+      <section className={styles.card} aria-labelledby="forbidden-title">
+        <header className={styles.header}>
+          <a className={styles.brand} href="/dashboard">OpenBank <span>Admin</span></a>
+          <button type="button" className={styles.languageButton} onClick={() => setLanguage(language === "en" ? "cs" : "en")} aria-label={copy.switchLanguage}>
+            <Languages size={16} aria-hidden="true" />{copy.locale}
           </button>
-          <button onClick={() => router.push("/dashboard")} style={{
-            padding: "10px 20px", borderRadius: "8px", border: "none",
-            background: "var(--accent)", color: "#fff", fontSize: "13px",
-            fontWeight: 500, cursor: "pointer",
-          }}>
-            Na Dashboard
-          </button>
-        </div>
-      </div>
-    </div>
+        </header>
+        <div className={`${styles.icon} ${styles.lockIcon}`} aria-hidden="true"><LockKeyhole size={27} /></div>
+        <p className={styles.eyebrow}>{copy.eyebrow}</p>
+        <h1 id="forbidden-title">{copy.title}</h1>
+        <p className={styles.intro}>{copy.intro}</p>
+        <div className={styles.explanation}>{copy.explanation}</div>
+        {requestedPath && <div className={styles.destination}><span>{copy.requested}</span><code>{requestedPath}</code></div>}
+        <button type="button" className={styles.primaryButton} onClick={() => router.push("/dashboard")}>
+          <ShieldCheck size={18} aria-hidden="true" /><span>{copy.dashboard}</span><ArrowRight size={18} aria-hidden="true" />
+        </button>
+        <p className={styles.help}>{copy.boundary}</p>
+      </section>
+    </main>
   )
 }
 

--- a/openbank-admin-ui/src/app/auth/login/login.module.css
+++ b/openbank-admin-ui/src/app/auth/login/login.module.css
@@ -1,0 +1,82 @@
+.page {
+  --login-ink: #12233f;
+  --login-muted: #53647c;
+  min-height: 100svh;
+  display: grid;
+  grid-template-columns: minmax(360px, 0.92fr) minmax(480px, 1.08fr);
+  background: #f5f7fb;
+  color: var(--login-ink);
+}
+
+.skipLink { position: fixed; z-index: 20; top: 12px; left: 12px; transform: translateY(-180%); padding: 10px 14px; border-radius: 10px; background: #fff; color: #172554; font-weight: 700; box-shadow: 0 8px 30px rgba(10, 27, 58, .2); transition: transform .16s ease; }
+.skipLink:focus { transform: translateY(0); }
+
+.story { position: relative; isolation: isolate; overflow: hidden; display: flex; min-height: 100%; flex-direction: column; padding: clamp(32px, 5vw, 72px); color: #fff; background: radial-gradient(circle at 5% 4%, rgba(92, 180, 255, .25), transparent 30%), linear-gradient(145deg, #0d2242 0%, #123a69 56%, #0b2445 100%); }
+.story::after { content: ""; position: absolute; z-index: -1; right: -14%; bottom: -21%; width: min(38vw, 540px); aspect-ratio: 1; border: 1px solid rgba(255,255,255,.13); border-radius: 50%; box-shadow: 0 0 0 68px rgba(255,255,255,.025), 0 0 0 136px rgba(255,255,255,.018); }
+.storyGlow { position: absolute; z-index: -1; top: 40%; left: 65%; width: 380px; height: 380px; border-radius: 50%; background: rgba(30, 197, 174, .09); filter: blur(50px); }
+.brand { display: flex; align-items: center; gap: 12px; letter-spacing: -.01em; }
+.brand > span:last-child { display: grid; }
+.brand strong { font-size: 1.02rem; }
+.brand small { color: #bdcbe0; font-size: .7rem; letter-spacing: .14em; text-transform: uppercase; }
+.brandMark { display: grid; width: 42px; height: 42px; place-items: center; border: 1px solid rgba(255,255,255,.22); border-radius: 13px; background: rgba(255,255,255,.1); box-shadow: inset 0 1px 0 rgba(255,255,255,.16); }
+.storyBody { margin: auto 0; max-width: 620px; padding: 64px 0; }
+.eyebrow { margin: 0 0 18px; color: #8ce3d3; font-size: .76rem; font-weight: 750; letter-spacing: .18em; text-transform: uppercase; }
+.story h1 { max-width: 680px; margin: 0; font-size: clamp(2.6rem, 5.2vw, 5.8rem); font-weight: 650; letter-spacing: -.055em; line-height: .98; text-wrap: balance; }
+.intro { max-width: 540px; margin: 28px 0 34px; color: #d3deed; font-size: clamp(1rem, 1.5vw, 1.22rem); line-height: 1.65; }
+.benefits { display: grid; gap: 13px; margin: 0; padding: 0; list-style: none; color: #edf5ff; font-size: .92rem; }
+.benefits li { display: flex; align-items: center; gap: 11px; }
+.benefits svg { flex: none; color: #7ce2cf; }
+.storyFootnote { margin: 0; color: #9fb2ca; font-size: .72rem; letter-spacing: .06em; }
+
+.access { display: flex; min-height: 100%; flex-direction: column; padding: clamp(24px, 4vw, 56px) clamp(28px, 7vw, 104px); }
+.accessHeader { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.secureBadge { display: inline-flex; align-items: center; gap: 7px; color: #36526f; font-size: .74rem; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; }
+.secureBadge svg { color: #167866; }
+.languageButton { display: inline-flex; align-items: center; gap: 7px; padding: 9px 11px; border: 1px solid #d8e0eb; border-radius: 10px; background: rgba(255,255,255,.72); color: #314761; font: inherit; font-size: .78rem; font-weight: 650; cursor: pointer; transition: border-color .16s, background .16s, transform .16s; }
+.languageButton:hover { border-color: #9eb0c7; background: #fff; transform: translateY(-1px); }
+.languageButton:focus-visible, .signInButton:focus-visible, .privacy:focus-visible { outline: 3px solid rgba(24, 116, 204, .3); outline-offset: 3px; }
+.panel { width: min(100%, 500px); margin: auto; padding: 56px 0; }
+.panel:focus { outline: none; }
+.keyIcon { display: grid; width: 50px; height: 50px; place-items: center; margin-bottom: 26px; border: 1px solid #dbe4ef; border-radius: 15px; background: #fff; color: #126a78; box-shadow: 0 10px 30px rgba(23, 52, 87, .08); }
+.panel h2 { margin: 0 0 14px; color: var(--login-ink); font-size: clamp(2rem, 3vw, 2.8rem); font-weight: 680; letter-spacing: -.035em; }
+.guidance { margin: 0 0 30px; color: var(--login-muted); font-size: .96rem; line-height: 1.7; }
+.error { margin-bottom: 18px; padding: 13px 15px; border: 1px solid #efb9b9; border-radius: 11px; background: #fff2f2; color: #962828; font-size: .84rem; line-height: 1.5; }
+.signInButton { display: grid; width: 100%; min-height: 54px; grid-template-columns: 22px 1fr 22px; align-items: center; gap: 10px; padding: 13px 17px; border: 0; border-radius: 12px; background: linear-gradient(135deg, #0d5f6c, #0f7180); color: #fff; font: inherit; font-size: .91rem; font-weight: 720; cursor: pointer; box-shadow: 0 13px 28px rgba(12, 91, 104, .2); transition: box-shadow .18s, transform .18s, filter .18s; }
+.signInButton:hover:not(:disabled) { filter: brightness(1.06); box-shadow: 0 17px 34px rgba(12, 91, 104, .27); transform: translateY(-2px); }
+.signInButton:disabled { cursor: wait; opacity: .76; }
+.arrow { justify-self: end; }
+.spinner { animation: spin .8s linear infinite; }
+.trustNote { display: grid; grid-template-columns: 24px 1fr; gap: 12px; margin-top: 22px; padding: 17px; border: 1px solid #dce5ee; border-radius: 12px; background: rgba(255,255,255,.62); }
+.trustNote > svg { margin-top: 1px; color: #167866; }
+.trustNote strong { display: block; color: #2c435c; font-size: .8rem; }
+.trustNote p { margin: 5px 0 0; color: #64748b; font-size: .76rem; line-height: 1.55; }
+.help { margin: 28px 0 7px; color: #64748b; font-size: .78rem; text-align: center; }
+.privacy { display: block; width: fit-content; margin: 0 auto; border-radius: 4px; color: #2f6179; font-size: .77rem; font-weight: 650; text-underline-offset: 3px; }
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+@media (max-width: 860px) {
+  .page { grid-template-columns: 1fr; }
+  .story { min-height: auto; padding: 28px clamp(24px, 7vw, 64px) 38px; }
+  .storyBody { padding: 52px 0 42px; }
+  .story h1 { font-size: clamp(2.5rem, 10vw, 4.5rem); }
+  .storyFootnote { display: none; }
+  .access { min-height: auto; padding: 24px clamp(24px, 8vw, 72px) 48px; }
+  .panel { padding: 58px 0 20px; }
+}
+
+@media (max-width: 520px) {
+  .story { padding: 22px 22px 30px; }
+  .storyBody { padding: 44px 0 30px; }
+  .story h1 { font-size: 2.72rem; }
+  .intro { margin: 22px 0 28px; font-size: .94rem; }
+  .access { padding: 20px 22px 42px; }
+  .secureBadge { font-size: .67rem; }
+  .languageButton { padding: 8px 9px; }
+  .panel { padding-top: 48px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skipLink, .languageButton, .signInButton { transition: none; }
+  .spinner { animation-duration: 1.6s; }
+}

--- a/openbank-admin-ui/src/app/auth/login/page.tsx
+++ b/openbank-admin-ui/src/app/auth/login/page.tsx
@@ -3,111 +3,125 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 "use client"
+
+import { ArrowRight, CheckCircle2, KeyRound, Languages, Loader2, ShieldCheck, Sparkles } from "lucide-react"
 import { signIn } from "next-auth/react"
 import { useSearchParams } from "next/navigation"
-import { Suspense } from "react"
+import { Suspense, useState } from "react"
+import { useLanguage } from "@/lib/i18n/LanguageContext"
+import { safeCallbackPath } from "@/lib/auth/safeCallbackPath"
+import styles from "./login.module.css"
+
+const COPY = {
+  en: {
+    skip: "Skip to sign in",
+    eyebrow: "OpenBank Operations",
+    headline: "Operate with confidence.",
+    intro: "One calm, governed workspace for the people who keep a bank moving.",
+    benefits: ["A shared operational picture", "Decisions with context", "Security built into every action"],
+    secure: "Secure access",
+    welcome: "Welcome back",
+    guidance: "Continue with your bank identity. Your access is limited to the roles and responsibilities assigned to you.",
+    signIn: "Continue with Keycloak SSO",
+    signingIn: "Connecting securely…",
+    trustTitle: "Protected by zero-trust controls",
+    trustBody: "Role-based access, four-eyes approvals and audit evidence remain active throughout your session.",
+    help: "Need access? Contact your bank administrator.",
+    privacy: "Privacy and data protection",
+    sessionExpired: "Your session expired. Sign in again to continue safely.",
+    genericError: "We could not complete sign-in. Please try again or contact your administrator.",
+    switchLanguage: "Přepnout do češtiny",
+    locale: "Čeština",
+  },
+  cs: {
+    skip: "Přeskočit k přihlášení",
+    eyebrow: "OpenBank Operations",
+    headline: "Řiďte banku s jistotou.",
+    intro: "Jedno klidné a řízené pracovní prostředí pro všechny, kdo zajišťují chod banky.",
+    benefits: ["Společný provozní přehled", "Rozhodnutí v souvislostech", "Bezpečnost v každém kroku"],
+    secure: "Zabezpečený přístup",
+    welcome: "Vítejte zpět",
+    guidance: "Pokračujte pomocí bankovní identity. Uvidíte pouze agendy odpovídající vašim rolím a odpovědnostem.",
+    signIn: "Pokračovat přes Keycloak SSO",
+    signingIn: "Navazuji zabezpečené spojení…",
+    trustTitle: "Chráněno principy zero trust",
+    trustBody: "Řízení přístupu podle rolí, čtyřočkové schvalování a auditní stopa zůstávají aktivní po celou relaci.",
+    help: "Potřebujete přístup? Obraťte se na administrátora banky.",
+    privacy: "Soukromí a ochrana dat",
+    sessionExpired: "Vaše relace vypršela. Pro bezpečné pokračování se znovu přihlaste.",
+    genericError: "Přihlášení se nepodařilo dokončit. Zkuste to znovu nebo kontaktujte administrátora.",
+    switchLanguage: "Switch to English",
+    locale: "English",
+  },
+} as const
 
 function LoginContent() {
   const params = useSearchParams()
+  const { language, setLanguage } = useLanguage()
+  const [pending, setPending] = useState(false)
+  const copy = COPY[language]
   const error = params.get("error")
-  const callbackUrl = params.get("callbackUrl") || "/dashboard"
+  const callbackUrl = safeCallbackPath(params.get("callbackUrl"))
+
+  const handleSignIn = async () => {
+    if (pending) return
+    setPending(true)
+    try {
+      await signIn("keycloak", { callbackUrl })
+    } catch {
+      setPending(false)
+    }
+  }
 
   return (
-    <div style={{
-      minHeight: "100vh", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center",
-    background: "var(--bg, #f8fafc)", fontFamily: "var(--font-sans, 'Inter', system-ui, sans-serif)",
-    }}>
-      <a
-        href="#main"
-        style={{
-          position: "absolute", left: "-9999px", top: "0", zIndex: 100,
-          // #4f46e5, not --sidebar-accent (#6366f1) — same contrast fix as the sign-in button below.
-          padding: "10px 16px", background: "#4f46e5", color: "#fff",
-          borderRadius: "0 0 8px 0", fontSize: "13px", fontWeight: 600,
-        }}
-        onFocus={e => { e.currentTarget.style.left = "0" }}
-        onBlur={e => { e.currentTarget.style.left = "-9999px" }}
-      >
-        Přeskočit na obsah
-      </a>
-      <main id="main" style={{
-        width: "380px", background: "var(--surface, #ffffff)", border: "1px solid var(--border, #e2e8f0)",
-        borderRadius: "16px", padding: "40px", boxShadow: "var(--shadow-lg, 0 10px 15px -3px rgba(0,0,0,0.1))",
-      }}>
-        {/* Logo */}
-        <div style={{ display: "flex", alignItems: "center", gap: "12px", marginBottom: "32px" }}>
-          <div style={{
-            width: "40px", height: "40px", background: "var(--sidebar-accent, #6366f1)", borderRadius: "10px",
-            display: "flex", alignItems: "center", justifyContent: "center",
-          }}>
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-              <rect x="3" y="3" width="18" height="18" rx="2"/>
-              <path d="M3 9h18M9 21V9"/>
-            </svg>
-          </div>
-          <div>
-            <div style={{ fontSize: "16px", fontWeight: 700, color: "var(--text-primary, #0f172a)" }}>OpenBank Admin</div>
-            <div style={{ fontSize: "11px", color: "var(--text-tertiary, #94a3b8)" }}>Operations Portal</div>
-          </div>
+    <main className={styles.page}>
+      <a className={styles.skipLink} href="#sign-in-panel">{copy.skip}</a>
+      <section className={styles.story} aria-labelledby="login-story-title">
+        <div className={styles.storyGlow} aria-hidden="true" />
+        <div className={styles.brand}>
+          <span className={styles.brandMark} aria-hidden="true"><Sparkles size={20} /></span>
+          <span><strong>OpenBank</strong><small>Admin</small></span>
         </div>
-
-        <h1 style={{ margin: "0 0 8px", fontSize: "20px", fontWeight: 700, color: "var(--text-primary, #0f172a)" }}>
-          Přihlášení
-        </h1>
-        <div style={{ marginBottom: "28px", fontSize: "13px", color: "var(--text-secondary, #475569)" }}>
-          Přihlaste se pomocí firemního účtu Keycloak
+        <div className={styles.storyBody}>
+          <p className={styles.eyebrow}>{copy.eyebrow}</p>
+          <h1 id="login-story-title">{copy.headline}</h1>
+          <p className={styles.intro}>{copy.intro}</p>
+          <ul className={styles.benefits}>
+            {copy.benefits.map(benefit => <li key={benefit}><CheckCircle2 size={18} aria-hidden="true" />{benefit}</li>)}
+          </ul>
         </div>
+        <p className={styles.storyFootnote}>Governed banking operations · Built for clarity</p>
+      </section>
 
-        {error && (
-          <div style={{
-            marginBottom: "20px", padding: "12px 14px", borderRadius: "8px",
-            background: "#fef2f2", border: "1px solid #fecaca",
-            fontSize: "13px", color: "#dc2626",
-          }}>
-            {error === "SessionExpired" ? "Vaše relace vypršela. Přihlaste se znovu." : "Chyba přihlášení. Zkuste to znovu."}
+      <section className={styles.access}>
+        <header className={styles.accessHeader}>
+          <div className={styles.secureBadge}><ShieldCheck size={16} aria-hidden="true" />{copy.secure}</div>
+          <button type="button" className={styles.languageButton} onClick={() => setLanguage(language === "en" ? "cs" : "en")} aria-label={copy.switchLanguage}>
+            <Languages size={16} aria-hidden="true" />{copy.locale}
+          </button>
+        </header>
+        <div id="sign-in-panel" className={styles.panel} tabIndex={-1}>
+          <span className={styles.keyIcon} aria-hidden="true"><KeyRound size={23} /></span>
+          <h2>{copy.welcome}</h2>
+          <p className={styles.guidance}>{copy.guidance}</p>
+          {error && <div className={styles.error} role="alert">{error === "SessionExpired" ? copy.sessionExpired : copy.genericError}</div>}
+          <button type="button" className={styles.signInButton} onClick={handleSignIn} disabled={pending} aria-busy={pending}>
+            {pending ? <Loader2 className={styles.spinner} size={18} aria-hidden="true" /> : <KeyRound size={18} aria-hidden="true" />}
+            <span>{pending ? copy.signingIn : copy.signIn}</span>
+            {!pending && <ArrowRight className={styles.arrow} size={18} aria-hidden="true" />}
+          </button>
+          <div className={styles.trustNote}>
+            <ShieldCheck size={20} aria-hidden="true" />
+            <div><strong>{copy.trustTitle}</strong><p>{copy.trustBody}</p></div>
           </div>
-        )}
-
-        <button
-          onClick={() => signIn("keycloak", { callbackUrl })}
-          style={{
-            width: "100%", padding: "12px", borderRadius: "8px",
-            // Darker than --sidebar-accent (#6366f1) on purpose: white-on-#6366f1
-            // measures ~4.47:1, just under WCAG 2.1 AA's 4.5:1 for normal text.
-            // #4f46e5 (~6.5:1) keeps the same hue with margin to spare.
-            background: "#4f46e5", border: "none", color: "#ffffff",
-            fontSize: "14px", fontWeight: 600, cursor: "pointer",
-            display: "flex", alignItems: "center", justifyContent: "center", gap: "10px",
-            transition: "opacity 0.15s, background-color 0.15s",
-          }}
-          onMouseEnter={e => (e.currentTarget.style.opacity = "0.9")}
-          onMouseLeave={e => (e.currentTarget.style.opacity = "1")}
-        >
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/>
-            <polyline points="10 17 15 12 10 7"/>
-            <line x1="15" y1="12" x2="3" y2="12"/>
-          </svg>
-          Přihlásit se přes Keycloak SSO
-        </button>
-
-        <div style={{ marginTop: "24px", padding: "12px", background: "var(--surface-2, #f8fafc)", borderRadius: "8px", fontSize: "11px", color: "var(--text-tertiary, #94a3b8)" }}>
-          <strong style={{ color: "var(--text-secondary, #475569)" }}>Zero-Trust Security</strong><br/>
-          Přístup je řízen rolemi (RBAC). Všechny akce jsou auditovány dle EBA ICT Risk a PSD2 požadavků.
+          <p className={styles.help}>{copy.help}</p>
+          <a className={styles.privacy} href="/privacy">{copy.privacy}</a>
         </div>
-      </main>
-      <footer style={{ marginTop: "20px", fontSize: "11px" }}>
-        {/* var(--text-tertiary) fails contrast at this size (~2.4:1) — use --text-secondary (~7.2:1). */}
-        <a href="/privacy" style={{ color: "var(--text-secondary, #475569)" }}>Ochrana osobních údajů</a>
-      </footer>
-    </div>
+      </section>
+    </main>
   )
 }
 
 export default function LoginPage() {
-  return (
-    <Suspense>
-      <LoginContent />
-    </Suspense>
-  )
+  return <Suspense><LoginContent /></Suspense>
 }

--- a/openbank-admin-ui/src/app/auth/recovery.module.css
+++ b/openbank-admin-ui/src/app/auth/recovery.module.css
@@ -1,0 +1,25 @@
+.page { min-height: 100svh; display: grid; place-items: center; padding: clamp(24px, 5vw, 64px); background: radial-gradient(circle at 5% 5%, rgba(33, 147, 163, .12), transparent 27%), radial-gradient(circle at 95% 90%, rgba(25, 68, 120, .09), transparent 25%), #f5f7fb; color: #12233f; }
+.card { width: min(100%, 620px); padding: clamp(28px, 5vw, 54px); border: 1px solid #dce4ee; border-radius: 22px; background: rgba(255,255,255,.92); box-shadow: 0 24px 75px rgba(24, 47, 78, .12); }
+.header { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 46px; }
+.brand { border-radius: 5px; color: #142c4d; font-size: .95rem; font-weight: 760; text-decoration: none; }
+.brand span { margin-left: 6px; color: #61728a; font-size: .67rem; font-weight: 650; letter-spacing: .14em; text-transform: uppercase; }
+.languageButton { display: inline-flex; align-items: center; gap: 7px; padding: 9px 11px; border: 1px solid #d8e0eb; border-radius: 10px; background: #fff; color: #314761; font: inherit; font-size: .77rem; font-weight: 650; cursor: pointer; }
+.icon { display: grid; width: 54px; height: 54px; place-items: center; margin-bottom: 24px; border-radius: 16px; }
+.errorIcon { border: 1px solid #f0cfb4; background: #fff7ed; color: #b45309; }
+.lockIcon { border: 1px solid #c6d9ed; background: #eef6ff; color: #225f99; }
+.eyebrow { margin: 0 0 13px; color: #177564; font-size: .7rem; font-weight: 760; letter-spacing: .16em; text-transform: uppercase; }
+.card h1 { max-width: 510px; margin: 0; color: #102746; font-size: clamp(2rem, 5vw, 3rem); font-weight: 680; letter-spacing: -.04em; line-height: 1.08; text-wrap: balance; }
+.intro { margin: 18px 0 24px; color: #52657d; font-size: .95rem; line-height: 1.7; }
+.explanation { padding: 16px 18px; border-left: 3px solid #72b6ad; border-radius: 0 10px 10px 0; background: #f0f7f6; color: #344c61; font-size: .84rem; line-height: 1.65; }
+.destination { display: grid; gap: 6px; margin-top: 16px; padding: 13px 16px; border: 1px solid #dde5ee; border-radius: 10px; background: #f8fafc; }
+.destination span { color: #6a7a8e; font-size: .67rem; font-weight: 720; letter-spacing: .1em; text-transform: uppercase; }
+.destination code { overflow: hidden; color: #304b68; font-size: .78rem; text-overflow: ellipsis; white-space: nowrap; }
+.primaryButton { display: grid; width: 100%; min-height: 52px; grid-template-columns: 22px 1fr 22px; align-items: center; gap: 10px; margin-top: 26px; padding: 12px 16px; border: 0; border-radius: 12px; background: linear-gradient(135deg, #0d5f6c, #0f7180); color: #fff; font: inherit; font-size: .87rem; font-weight: 720; cursor: pointer; box-shadow: 0 12px 28px rgba(12, 91, 104, .2); transition: filter .16s, transform .16s; }
+.primaryButton:hover:not(:disabled) { filter: brightness(1.06); transform: translateY(-1px); }
+.primaryButton:disabled { cursor: wait; opacity: .76; }
+.languageButton:focus-visible, .brand:focus-visible, .primaryButton:focus-visible { outline: 3px solid rgba(24,116,204,.3); outline-offset: 3px; }
+.spinner { animation: spin .8s linear infinite; }
+.help { margin: 20px 8px 0; color: #6a788c; font-size: .73rem; line-height: 1.55; text-align: center; }
+@keyframes spin { to { transform: rotate(360deg); } }
+@media (max-width: 520px) { .page { align-items: start; padding: 0; background: #fff; } .card { min-height: 100svh; padding: 24px 22px 38px; border: 0; border-radius: 0; box-shadow: none; } .header { margin-bottom: 52px; } }
+@media (prefers-reduced-motion: reduce) { .primaryButton { transition: none; } .spinner { animation-duration: 1.6s; } }

--- a/openbank-admin-ui/src/app/layout.tsx
+++ b/openbank-admin-ui/src/app/layout.tsx
@@ -5,10 +5,7 @@
 import type { Metadata } from 'next'
 import './globals.css'
 import { headers } from 'next/headers'
-import { Toaster } from 'sonner'
-import { SessionProvider } from '@/components/auth/SessionProvider'
-import { LanguageProvider } from '@/lib/i18n/LanguageContext'
-import { AgentDock } from '@/components/agent/AgentDock'
+import { AppProviders } from '@/components/layout/AppProviders'
 
 export const metadata: Metadata = {
   title: 'OpenBank Admin',
@@ -29,13 +26,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
       </head>
       <body>
-        <SessionProvider>
-          <LanguageProvider>
-            {children}
-            <AgentDock />
-            <Toaster richColors position="top-right" />
-          </LanguageProvider>
-        </SessionProvider>
+        <AppProviders>{children}</AppProviders>
       </body>
     </html>
   )

--- a/openbank-admin-ui/src/app/privacy/PrivacyContent.tsx
+++ b/openbank-admin-ui/src/app/privacy/PrivacyContent.tsx
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"use client"
+
+import { ArrowLeft, Clock3, Cookie, FileCheck2, Languages, Mail, ShieldCheck, UserRoundCheck } from "lucide-react"
+import { useLanguage } from "@/lib/i18n/LanguageContext"
+import styles from "./privacy.module.css"
+
+const COPY = {
+  en: {
+    switchLanguage: "Přepnout do češtiny", locale: "Čeština", eyebrow: "Privacy, explained",
+    title: "Know what happens to your operator data.",
+    intro: "OpenBank Admin uses only the identity, session and audit information needed to operate a governed banking workspace. There are no marketing or tracking cookies.",
+    flowTitle: "The data journey",
+    flow: [
+      ["Identity", "Keycloak supplies your name, email and assigned roles so OpenBank can authenticate you and enforce role-based access."],
+      ["Session", "A necessary NextAuth session cookie keeps you signed in until logout or token expiry."],
+      ["Audit evidence", "Actions performed in the console create an audit trail for traceability and financial-sector obligations."],
+    ],
+    controllerTitle: "Who controls the data", controller: "OpenBank Foundation (in formation), operator of the demonstration banking platform on open-bank.tech.",
+    purposeTitle: "Why the data is processed", purpose: "Identity and session data are required for authentication and access control. Audit records support obligations under the EBA ICT Risk Guidelines and PSD2, and the legitimate interest in traceable operations over banking data.",
+    retentionTitle: "How long it is kept", retention: "The session cookie ends at logout or token expiry. Audit records are retained for the period required by financial-sector regulation.",
+    rightsTitle: "Your rights", rights: "You can request access, correction or deletion where deletion does not conflict with regulatory retention duties. You may also lodge a complaint with the Czech Office for Personal Data Protection.",
+    contactTitle: "Contacts", controllerContact: "Privacy and rights requests", securityContact: "Security vulnerability reports", securityFile: "Published security contact",
+    back: "Back to secure sign-in", note: "This notice is available before sign-in because operators should understand the boundary before entering the workspace.",
+  },
+  cs: {
+    switchLanguage: "Switch to English", locale: "English", eyebrow: "Soukromí srozumitelně",
+    title: "Víte, co se děje s údaji operátora.",
+    intro: "OpenBank Admin používá pouze údaje o identitě, relaci a auditu nezbytné pro řízené bankovní prostředí. Nepoužívá marketingové ani sledovací cookies.",
+    flowTitle: "Cesta údajů",
+    flow: [
+      ["Identita", "Keycloak předá jméno, e-mail a přidělené role, aby vás OpenBank mohl ověřit a řídit přístup podle rolí."],
+      ["Relace", "Nezbytná relační cookie NextAuth udržuje přihlášení do odhlášení nebo vypršení tokenu."],
+      ["Auditní stopa", "Akce provedené v konzoli vytvářejí auditní stopu pro vysledovatelnost a povinnosti finančního sektoru."],
+    ],
+    controllerTitle: "Kdo je správcem", controller: "OpenBank Foundation (v přípravě), provozovatel demonstrační bankovní platformy na doméně open-bank.tech.",
+    purposeTitle: "Proč údaje zpracováváme", purpose: "Identita a relační údaje jsou nutné pro autentizaci a řízení přístupu. Auditní záznamy podporují povinnosti podle EBA ICT Risk Guidelines a PSD2 a oprávněný zájem na vysledovatelnosti operací nad bankovními daty.",
+    retentionTitle: "Jak dlouho údaje uchováváme", retention: "Relační cookie zaniká odhlášením nebo vypršením tokenu. Auditní záznamy uchováváme po dobu vyžadovanou předpisy finančního sektoru.",
+    rightsTitle: "Vaše práva", rights: "Můžete požádat o přístup, opravu nebo výmaz tam, kde výmaz nekoliduje s regulatorní povinností uchování. Můžete také podat stížnost u Úřadu pro ochranu osobních údajů.",
+    contactTitle: "Kontakty", controllerContact: "Žádosti k soukromí a právům", securityContact: "Hlášení bezpečnostních zranitelností", securityFile: "Publikovaný bezpečnostní kontakt",
+    back: "Zpět k bezpečnému přihlášení", note: "Toto oznámení je dostupné před přihlášením, protože operátoři mají hranici zpracování znát ještě před vstupem do prostředí.",
+  },
+} as const
+
+const FLOW_ICONS = [UserRoundCheck, Cookie, FileCheck2]
+
+export function PrivacyContent() {
+  const { language, setLanguage } = useLanguage()
+  const copy = COPY[language]
+
+  return (
+    <main className={styles.page}>
+      <a className={styles.skipLink} href="#privacy-content">{language === "en" ? "Skip to privacy details" : "Přeskočit k detailům soukromí"}</a>
+      <header className={styles.header}>
+        <a className={styles.brand} href="/auth/login">OpenBank <span>Admin</span></a>
+        <button type="button" className={styles.languageButton} onClick={() => setLanguage(language === "en" ? "cs" : "en")} aria-label={copy.switchLanguage}>
+          <Languages size={16} aria-hidden="true" />{copy.locale}
+        </button>
+      </header>
+
+      <section id="privacy-content" className={styles.hero} aria-labelledby="privacy-title" tabIndex={-1}>
+        <div className={styles.heroCopy}>
+          <p className={styles.eyebrow}><ShieldCheck size={16} aria-hidden="true" />{copy.eyebrow}</p>
+          <h1 id="privacy-title">{copy.title}</h1>
+          <p className={styles.intro}>{copy.intro}</p>
+        </div>
+        <aside className={styles.note}><ShieldCheck size={20} aria-hidden="true" /><p>{copy.note}</p></aside>
+      </section>
+
+      <section className={styles.flow} aria-labelledby="data-flow-title">
+        <h2 id="data-flow-title">{copy.flowTitle}</h2>
+        <div className={styles.flowGrid}>
+          {copy.flow.map(([title, body], index) => {
+            const Icon = FLOW_ICONS[index]
+            return <article key={title}><span className={styles.flowIcon}><Icon size={20} aria-hidden="true" /></span><span className={styles.step}>0{index + 1}</span><h3>{title}</h3><p>{body}</p></article>
+          })}
+        </div>
+      </section>
+
+      <section className={styles.details} aria-label={language === "en" ? "Privacy details" : "Podrobnosti o soukromí"}>
+        <article><UserRoundCheck size={21} aria-hidden="true" /><div><h2>{copy.controllerTitle}</h2><p>{copy.controller}</p></div></article>
+        <article><FileCheck2 size={21} aria-hidden="true" /><div><h2>{copy.purposeTitle}</h2><p>{copy.purpose}</p></div></article>
+        <article><Clock3 size={21} aria-hidden="true" /><div><h2>{copy.retentionTitle}</h2><p>{copy.retention}</p></div></article>
+        <article><ShieldCheck size={21} aria-hidden="true" /><div><h2>{copy.rightsTitle}</h2><p>{copy.rights}</p></div></article>
+      </section>
+
+      <section className={styles.contacts} aria-labelledby="contacts-title">
+        <div><p className={styles.eyebrow}><Mail size={16} aria-hidden="true" />OpenBank</p><h2 id="contacts-title">{copy.contactTitle}</h2></div>
+        <div className={styles.contactLinks}>
+          <a href="mailto:hello@open-bank.tech"><span>{copy.controllerContact}</span><strong>hello@open-bank.tech</strong></a>
+          <a href="mailto:security@open-bank.tech"><span>{copy.securityContact}</span><strong>security@open-bank.tech</strong></a>
+          <a href="/.well-known/security.txt"><span>{copy.securityFile}</span><strong>security.txt</strong></a>
+        </div>
+      </section>
+
+      <footer className={styles.footer}>
+        <a href="/auth/login"><ArrowLeft size={17} aria-hidden="true" />{copy.back}</a>
+        <span>admin.open-bank.tech</span>
+      </footer>
+    </main>
+  )
+}

--- a/openbank-admin-ui/src/app/privacy/page.tsx
+++ b/openbank-admin-ui/src/app/privacy/page.tsx
@@ -2,83 +2,12 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-// Static, pre-login, single-language legal notice — same class as the /auth/*
-// screens (i18n.guard / layout-shell.guard EXEMPT). GDPR Art. 13 requires this
-// notice to be reachable WITHOUT an account (proxy.ts carries the bypass),
-// since the data subjects it describes are the operators who are about to log in.
+import { PrivacyContent } from "./PrivacyContent"
 
 export const metadata = {
-  title: "Ochrana osobních údajů — OpenBank Admin",
+  title: "Privacy and data protection — OpenBank Admin",
 }
 
 export default function PrivacyPage() {
-  return (
-    <main
-      id="main"
-      style={{
-        maxWidth: "720px", margin: "0 auto", padding: "48px 24px 96px",
-        fontFamily: "var(--font-sans, 'Inter', system-ui, sans-serif)",
-        color: "var(--text-primary, #0f172a)", lineHeight: 1.6,
-      }}
-    >
-      <h1 style={{ fontSize: "24px", fontWeight: 700, marginBottom: "8px" }}>
-        Ochrana osobních údajů — OpenBank Admin
-      </h1>
-      <p style={{ color: "var(--text-tertiary, #94a3b8)", fontSize: "13px", marginBottom: "32px" }}>
-        Operations Portal · admin.open-bank.tech
-      </p>
-
-      <h2 style={{ fontSize: "16px", fontWeight: 700, marginTop: "28px", marginBottom: "8px" }}>
-        Kdo je správcem
-      </h2>
-      <p>
-        OpenBank Foundation (v přípravě), provozovatel demonstrační bankovní platformy
-        na doméně open-bank.tech. Kontakt: <a href="mailto:hello@open-bank.tech">hello@open-bank.tech</a>.
-      </p>
-
-      <h2 style={{ fontSize: "16px", fontWeight: 700, marginTop: "28px", marginBottom: "8px" }}>
-        Jaké údaje zpracováváme a proč
-      </h2>
-      <p>
-        OpenBank Admin je interní operátorská konzole — přístup mají pouze zaměstnanci a
-        spolupracovníci přihlášení přes firemní Keycloak SSO účet. Při přihlášení a používání
-        konzole zpracováváme:
-      </p>
-      <ul>
-        <li>identitu z Keycloak (jméno, e-mail, přidělené role) — pro autentizaci a řízení přístupu (RBAC);</li>
-        <li>relační cookie (NextAuth session) — nezbytnou pro udržení přihlášení, žádné sledovací ani marketingové cookies;</li>
-        <li>záznam provedených akcí (audit log) — právním základem je plnění povinností dle EBA ICT Risk
-          Guidelines a PSD2, a oprávněný zájem na vysledovatelnosti operací nad bankovními daty.</li>
-      </ul>
-
-      <h2 style={{ fontSize: "16px", fontWeight: 700, marginTop: "28px", marginBottom: "8px" }}>
-        Doba uchování
-      </h2>
-      <p>
-        Relační cookie zaniká odhlášením nebo vypršením platnosti tokenu. Audit záznamy se
-        uchovávají po dobu vyžadovanou regulatorními předpisy pro finanční sektor.
-      </p>
-
-      <h2 style={{ fontSize: "16px", fontWeight: 700, marginTop: "28px", marginBottom: "8px" }}>
-        Vaše práva
-      </h2>
-      <p>
-        Máte právo na přístup, opravu, výmaz (v rozsahu, který nekoliduje s výše uvedenou
-        regulatorní povinností uchování) a na podání stížnosti u Úřadu pro ochranu osobních
-        údajů. Žádosti směřujte na <a href="mailto:hello@open-bank.tech">hello@open-bank.tech</a>.
-      </p>
-
-      <h2 style={{ fontSize: "16px", fontWeight: 700, marginTop: "28px", marginBottom: "8px" }}>
-        Bezpečnostní kontakt
-      </h2>
-      <p>
-        Nahlášení bezpečnostní zranitelnosti: <a href="mailto:security@open-bank.tech">security@open-bank.tech</a>{" "}
-        (viz <a href="/.well-known/security.txt">/.well-known/security.txt</a>).
-      </p>
-
-      <p style={{ marginTop: "40px" }}>
-        <a href="/auth/login">← Zpět na přihlášení</a>
-      </p>
-    </main>
-  )
+  return <PrivacyContent />
 }

--- a/openbank-admin-ui/src/app/privacy/privacy.module.css
+++ b/openbank-admin-ui/src/app/privacy/privacy.module.css
@@ -1,0 +1,41 @@
+.page { min-height: 100svh; padding: 0 clamp(24px, 6vw, 92px); background: radial-gradient(circle at 96% 4%, rgba(29, 151, 154, .1), transparent 28%), #f6f8fb; color: #142842; }
+.skipLink { position: fixed; z-index: 10; top: 12px; left: 12px; transform: translateY(-180%); padding: 10px 14px; border-radius: 10px; background: #fff; color: #173d67; font-weight: 700; box-shadow: 0 8px 30px rgba(10,27,58,.18); transition: transform .16s; }
+.skipLink:focus { transform: translateY(0); }
+.header { display: flex; max-width: 1180px; align-items: center; justify-content: space-between; gap: 20px; margin: 0 auto; padding: 28px 0; }
+.brand { border-radius: 5px; color: #142c4d; font-size: .96rem; font-weight: 760; text-decoration: none; }
+.brand span { margin-left: 6px; color: #61728a; font-size: .67rem; font-weight: 650; letter-spacing: .14em; text-transform: uppercase; }
+.languageButton { display: inline-flex; align-items: center; gap: 7px; padding: 9px 11px; border: 1px solid #d8e0eb; border-radius: 10px; background: rgba(255,255,255,.78); color: #314761; font: inherit; font-size: .77rem; font-weight: 650; cursor: pointer; }
+.hero { display: grid; max-width: 1180px; grid-template-columns: minmax(0, 1.4fr) minmax(260px, .6fr); align-items: end; gap: clamp(36px, 7vw, 100px); margin: 0 auto; padding: clamp(64px, 10vw, 132px) 0 clamp(58px, 8vw, 96px); }
+.hero:focus { outline: none; }
+.eyebrow { display: flex; align-items: center; gap: 8px; margin: 0 0 17px; color: #167464; font-size: .71rem; font-weight: 760; letter-spacing: .15em; text-transform: uppercase; }
+.hero h1 { max-width: 790px; margin: 0; color: #102746; font-size: clamp(2.7rem, 6vw, 5.6rem); font-weight: 650; letter-spacing: -.055em; line-height: .99; text-wrap: balance; }
+.intro { max-width: 760px; margin: 28px 0 0; color: #52657c; font-size: clamp(.98rem, 1.6vw, 1.15rem); line-height: 1.72; }
+.note { display: grid; grid-template-columns: 24px 1fr; gap: 13px; padding: 20px; border: 1px solid #cfe1df; border-radius: 14px; background: rgba(239,248,247,.82); color: #3e5b61; }
+.note svg { color: #167464; }
+.note p { margin: 0; font-size: .8rem; line-height: 1.62; }
+.flow { max-width: 1180px; margin: 0 auto; padding: 0 0 clamp(70px, 9vw, 118px); }
+.flow > h2, .contacts h2 { margin: 0 0 25px; color: #172f4e; font-size: 1.35rem; letter-spacing: -.025em; }
+.flowGrid { display: grid; grid-template-columns: repeat(3, 1fr); border: 1px solid #dce4ed; border-radius: 17px; background: rgba(255,255,255,.72); overflow: hidden; }
+.flowGrid article { position: relative; min-height: 270px; padding: 30px; border-right: 1px solid #dce4ed; }
+.flowGrid article:last-child { border-right: 0; }
+.flowIcon { display: grid; width: 42px; height: 42px; place-items: center; border: 1px solid #cfe0e3; border-radius: 12px; background: #f0f8f8; color: #176c72; }
+.step { position: absolute; top: 31px; right: 29px; color: #a3afbd; font: 700 .7rem/1 ui-monospace, monospace; letter-spacing: .08em; }
+.flowGrid h3 { margin: 35px 0 12px; color: #173250; font-size: 1.04rem; }
+.flowGrid p, .details p { margin: 0; color: #5a6c80; font-size: .82rem; line-height: 1.68; }
+.details { display: grid; max-width: 1180px; grid-template-columns: 1fr 1fr; gap: 1px; margin: 0 auto clamp(74px, 9vw, 120px); border: 1px solid #dce4ed; border-radius: 17px; background: #dce4ed; overflow: hidden; }
+.details article { display: grid; min-height: 200px; grid-template-columns: 28px 1fr; gap: 15px; padding: clamp(25px, 4vw, 38px); background: #fff; }
+.details article > svg { color: #1b7770; }
+.details h2 { margin: 0 0 12px; color: #193553; font-size: .98rem; }
+.contacts { display: grid; max-width: 1180px; grid-template-columns: .7fr 1.3fr; gap: clamp(32px, 7vw, 90px); margin: 0 auto; padding: clamp(34px, 5vw, 58px); border-radius: 20px; background: linear-gradient(140deg, #102a4b, #123d64); color: #fff; box-shadow: 0 20px 55px rgba(17,45,79,.16); }
+.contacts .eyebrow { color: #82d9cc; }
+.contacts h2 { color: #fff; font-size: clamp(1.7rem, 3vw, 2.5rem); }
+.contactLinks { display: grid; gap: 10px; }
+.contactLinks a { display: flex; align-items: center; justify-content: space-between; gap: 15px; padding: 13px 15px; border: 1px solid rgba(255,255,255,.13); border-radius: 10px; background: rgba(255,255,255,.055); color: #fff; text-decoration: none; }
+.contactLinks span { color: #bdcde0; font-size: .76rem; }
+.contactLinks strong { font-size: .78rem; }
+.footer { display: flex; max-width: 1180px; align-items: center; justify-content: space-between; gap: 20px; margin: 0 auto; padding: 38px 0 50px; color: #718096; font-size: .75rem; }
+.footer a { display: inline-flex; align-items: center; gap: 8px; border-radius: 5px; color: #255d75; font-weight: 700; text-decoration: none; }
+.languageButton:focus-visible, .brand:focus-visible, .contactLinks a:focus-visible, .footer a:focus-visible { outline: 3px solid rgba(24,116,204,.3); outline-offset: 3px; }
+@media (max-width: 820px) { .hero { grid-template-columns: 1fr; align-items: start; } .note { max-width: 580px; } .flowGrid { grid-template-columns: 1fr; } .flowGrid article { min-height: auto; border-right: 0; border-bottom: 1px solid #dce4ed; } .flowGrid article:last-child { border-bottom: 0; } .details { grid-template-columns: 1fr; } .details article { min-height: auto; } .contacts { grid-template-columns: 1fr; } }
+@media (max-width: 520px) { .page { padding: 0 20px; } .header { padding: 22px 0; } .hero { padding: 56px 0 60px; } .hero h1 { font-size: 2.82rem; } .flowGrid article { padding: 25px; } .details article { padding: 25px; } .contacts { margin-right: -8px; margin-left: -8px; padding: 28px 24px; } .contactLinks a { align-items: flex-start; flex-direction: column; } .footer { align-items: flex-start; flex-direction: column; } }
+@media (prefers-reduced-motion: reduce) { .skipLink { transition: none; } }

--- a/openbank-admin-ui/src/components/agent/AgentDock.tsx
+++ b/openbank-admin-ui/src/components/agent/AgentDock.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { usePathname } from 'next/navigation'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { isPublicSurface } from '@/lib/auth/publicSurface'
 import { Bot, Send, X, Loader2, Wrench, ShieldCheck, ShieldAlert, AlertTriangle } from 'lucide-react'
 
 interface ToolCall { tool: string; allowed: boolean; resultPreview: string }
@@ -41,7 +42,7 @@ export function modelLabel(id: string): string {
 
 export function AgentDock() {
   const pathname = usePathname()
-  const publicSurface = pathname.startsWith('/auth') || pathname === '/privacy'
+  const publicSurface = isPublicSurface(pathname)
   const { t } = useLanguage()
   const [open, setOpen] = useState(false)
   const [messages, setMessages] = useState<Msg[]>([])

--- a/openbank-admin-ui/src/components/agent/AgentDock.tsx
+++ b/openbank-admin-ui/src/components/agent/AgentDock.tsx
@@ -41,6 +41,7 @@ export function modelLabel(id: string): string {
 
 export function AgentDock() {
   const pathname = usePathname()
+  const publicSurface = pathname.startsWith('/auth') || pathname === '/privacy'
   const { t } = useLanguage()
   const [open, setOpen] = useState(false)
   const [messages, setMessages] = useState<Msg[]>([])
@@ -51,16 +52,18 @@ export function AgentDock() {
   const scrollRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    if (!open || models.length) return
+    if (publicSurface || !open || models.length) return
     fetch('/api/agent/chat')
       .then(r => r.json())
       .then(d => { setModels(d.models ?? []); setModel(d.default ?? '') })
       .catch(() => {})
-  }, [open, models.length])
+  }, [open, models.length, publicSurface])
 
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' })
   }, [messages, busy])
+
+  if (publicSurface) return null
 
   async function send() {
     const text = input.trim()

--- a/openbank-admin-ui/src/components/layout/AppProviders.tsx
+++ b/openbank-admin-ui/src/components/layout/AppProviders.tsx
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { Toaster } from 'sonner'
+import { AgentDock } from '@/components/agent/AgentDock'
+import { SessionProvider } from '@/components/auth/SessionProvider'
+import { isPublicSurface } from '@/lib/auth/publicSurface'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+/**
+ * Keeps authenticated-only infrastructure off public entry and policy surfaces.
+ * Protected operator routes retain session refresh, expiry recovery and AgentDock.
+ */
+export function AppProviders({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const publicSurface = isPublicSurface(pathname)
+  const shared = (
+    <LanguageProvider>
+      {children}
+      {!publicSurface && <AgentDock />}
+      <Toaster richColors position="top-right" />
+    </LanguageProvider>
+  )
+
+  return publicSurface ? shared : <SessionProvider>{shared}</SessionProvider>
+}

--- a/openbank-admin-ui/src/lib/auth/publicSurface.ts
+++ b/openbank-admin-ui/src/lib/auth/publicSurface.ts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+/** Public routes that deliberately run without authenticated operator infrastructure. */
+export function isPublicSurface(pathname: string): boolean {
+  return pathname === '/auth' || pathname.startsWith('/auth/') || pathname === '/privacy'
+}

--- a/openbank-admin-ui/src/lib/auth/safeCallbackPath.ts
+++ b/openbank-admin-ui/src/lib/auth/safeCallbackPath.ts
@@ -6,13 +6,18 @@ const CALLBACK_ORIGIN = "https://openbank.invalid"
 const DEFAULT_CALLBACK = "/dashboard"
 
 /** Keeps post-authentication navigation on the admin UI origin. */
-export function safeCallbackPath(candidate: string | null | undefined): string {
-  if (!candidate?.startsWith("/") || candidate.startsWith("//") || candidate.includes("\\")) return DEFAULT_CALLBACK
+export function sameOriginPath(candidate: string | null | undefined): string | null {
+  if (!candidate?.startsWith("/") || candidate.startsWith("//") || candidate.includes("\\")) return null
   try {
     const target = new URL(candidate, CALLBACK_ORIGIN)
-    if (target.origin !== CALLBACK_ORIGIN) return DEFAULT_CALLBACK
+    if (target.origin !== CALLBACK_ORIGIN) return null
     return `${target.pathname}${target.search}${target.hash}`
   } catch {
-    return DEFAULT_CALLBACK
+    return null
   }
+}
+
+/** Keeps post-authentication navigation on the admin UI origin with a safe default. */
+export function safeCallbackPath(candidate: string | null | undefined): string {
+  return sameOriginPath(candidate) ?? DEFAULT_CALLBACK
 }

--- a/openbank-admin-ui/src/lib/auth/safeCallbackPath.ts
+++ b/openbank-admin-ui/src/lib/auth/safeCallbackPath.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+const CALLBACK_ORIGIN = "https://openbank.invalid"
+const DEFAULT_CALLBACK = "/dashboard"
+
+/** Keeps post-authentication navigation on the admin UI origin. */
+export function safeCallbackPath(candidate: string | null | undefined): string {
+  if (!candidate?.startsWith("/") || candidate.startsWith("//") || candidate.includes("\\")) return DEFAULT_CALLBACK
+  try {
+    const target = new URL(candidate, CALLBACK_ORIGIN)
+    if (target.origin !== CALLBACK_ORIGIN) return DEFAULT_CALLBACK
+    return `${target.pathname}${target.search}${target.hash}`
+  } catch {
+    return DEFAULT_CALLBACK
+  }
+}

--- a/openbank-admin-ui/src/test/app-providers.test.tsx
+++ b/openbank-admin-ui/src/test/app-providers.test.tsx
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { usePathname } from 'next/navigation'
+import { AppProviders } from '@/components/layout/AppProviders'
+import { isPublicSurface } from '@/lib/auth/publicSurface'
+
+vi.mock('next/navigation', () => ({ usePathname: vi.fn() }))
+vi.mock('@/components/auth/SessionProvider', () => ({
+  SessionProvider: ({ children }: { children: React.ReactNode }) => <div data-testid="session-provider">{children}</div>,
+}))
+vi.mock('@/components/agent/AgentDock', () => ({ AgentDock: () => <div data-testid="agent-dock" /> }))
+vi.mock('@/lib/i18n/LanguageContext', () => ({
+  LanguageProvider: ({ children }: { children: React.ReactNode }) => <div data-testid="language-provider">{children}</div>,
+}))
+vi.mock('sonner', () => ({ Toaster: () => <div data-testid="toaster" /> }))
+
+describe('AppProviders', () => {
+  beforeEach(() => vi.mocked(usePathname).mockReturnValue('/dashboard'))
+
+  it.each(['/auth/login', '/auth/error', '/auth/forbidden', '/privacy'])('keeps %s session-free', pathname => {
+    vi.mocked(usePathname).mockReturnValue(pathname)
+    render(<AppProviders><main>Public content</main></AppProviders>)
+
+    expect(screen.getByText('Public content')).toBeVisible()
+    expect(screen.getByTestId('language-provider')).toBeVisible()
+    expect(screen.getByTestId('toaster')).toBeVisible()
+    expect(screen.queryByTestId('session-provider')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('agent-dock')).not.toBeInTheDocument()
+  })
+
+  it('retains authenticated infrastructure on protected operator routes', () => {
+    render(<AppProviders><main>Operator content</main></AppProviders>)
+
+    expect(screen.getByTestId('session-provider')).toBeVisible()
+    expect(screen.getByTestId('agent-dock')).toBeVisible()
+    expect(screen.getByText('Operator content')).toBeVisible()
+  })
+
+  it('does not classify similarly named protected routes as public', () => {
+    expect(isPublicSurface('/privacy-settings')).toBe(false)
+    expect(isPublicSurface('/authentication-policy')).toBe(false)
+  })
+})

--- a/openbank-admin-ui/src/test/auth-error-retry.guard.test.ts
+++ b/openbank-admin-ui/src/test/auth-error-retry.guard.test.ts
@@ -4,9 +4,13 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
 describe('auth error recovery contract', () => {
-  it('keeps retry sign-in an explicit accessible button', () => {
+  it('keeps retry sign-in explicit, stateful, and callback-scoped', () => {
     const source = readFileSync(path.resolve(__dirname, '../app/auth/error/page.tsx'), 'utf8')
-    expect(source).toContain('<button type="button" aria-label="Retry sign-in / Zkusit přihlášení znovu"')
-    expect(source).toContain('signIn("keycloak")')
+    expect(source).toContain('type="button"')
+    expect(source).toContain('onClick={retry}')
+    expect(source).toContain('aria-busy={pending}')
+    expect(source).toContain('disabled={pending}')
+    expect(source).toContain('{pending ? copy.retrying : copy.retry}')
+    expect(source).toContain('signIn("keycloak", { callbackUrl })')
   })
 })

--- a/openbank-admin-ui/src/test/auth-recovery-experience.test.tsx
+++ b/openbank-admin-ui/src/test/auth-recovery-experience.test.tsx
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { signIn } from 'next-auth/react'
+import AuthErrorPage from '@/app/auth/error/page'
+import ForbiddenPage from '@/app/auth/forbidden/page'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+let query = new URLSearchParams()
+const push = vi.fn()
+
+vi.mock('next-auth/react', () => ({ signIn: vi.fn() }))
+vi.mock('next/navigation', () => ({ useSearchParams: () => query, useRouter: () => ({ push }) }))
+
+const renderInLanguage = (page: React.ReactNode) => render(<LanguageProvider>{page}</LanguageProvider>)
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+  query = new URLSearchParams()
+  vi.clearAllMocks()
+})
+
+describe('authentication recovery experience', () => {
+  it('explains an identity denial and retries with a validated return path', async () => {
+    query = new URLSearchParams('error=AccessDenied&callbackUrl=%2Fpayments%3Fstate%3Dpending')
+    vi.mocked(signIn).mockResolvedValue(undefined)
+    renderInLanguage(<AuthErrorPage />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent('identity provider did not grant access')
+    const retry = screen.getByRole('button', { name: 'Try secure sign-in again' })
+    fireEvent.click(retry)
+
+    await waitFor(() => expect(signIn).toHaveBeenCalledWith('keycloak', { callbackUrl: '/payments?state=pending' }))
+    expect(retry).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('falls back to the dashboard when an external retry target is supplied', async () => {
+    query = new URLSearchParams('callbackUrl=https%3A%2F%2Fattacker.example')
+    vi.mocked(signIn).mockResolvedValue(undefined)
+    renderInLanguage(<AuthErrorPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Try secure sign-in again' }))
+    await waitFor(() => expect(signIn).toHaveBeenCalledWith('keycloak', { callbackUrl: '/dashboard' }))
+  })
+
+  it('teaches the access boundary without echoing an untrusted destination', () => {
+    query = new URLSearchParams('path=%2F%2Fattacker.example%2Fprivate')
+    renderInLanguage(<ForbiddenPage />)
+
+    expect(screen.getByRole('heading', { name: 'This area is not in your role' })).toBeInTheDocument()
+    expect(screen.getByText(/normal security control/)).toBeInTheDocument()
+    expect(screen.queryByText('//attacker.example/private')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Return to your dashboard' }))
+    expect(push).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('localizes the recovery guidance', () => {
+    renderInLanguage(<ForbiddenPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Přepnout do češtiny' }))
+    expect(screen.getByRole('heading', { name: 'Tato oblast není součástí vaší role' })).toBeInTheDocument()
+    expect(screen.getByText(/běžný bezpečnostní mechanismus/)).toBeInTheDocument()
+  })
+})

--- a/openbank-admin-ui/src/test/login-experience.test.tsx
+++ b/openbank-admin-ui/src/test/login-experience.test.tsx
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { signIn } from 'next-auth/react'
+import LoginPage from '@/app/auth/login/page'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { safeCallbackPath } from '@/lib/auth/safeCallbackPath'
+
+let query = new URLSearchParams()
+
+vi.mock('next-auth/react', () => ({ signIn: vi.fn() }))
+vi.mock('next/navigation', () => ({ useSearchParams: () => query }))
+
+const renderPage = () => render(<LanguageProvider><LoginPage /></LanguageProvider>)
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+  query = new URLSearchParams()
+  vi.clearAllMocks()
+})
+
+describe('safeCallbackPath', () => {
+  it.each([
+    [null, '/dashboard'],
+    ['', '/dashboard'],
+    ['https://attacker.example', '/dashboard'],
+    ['//attacker.example/path', '/dashboard'],
+    ['/\\attacker.example/path', '/dashboard'],
+    ['/accounts?state=open#detail', '/accounts?state=open#detail'],
+  ])('maps %s to %s', (candidate, expected) => {
+    expect(safeCallbackPath(candidate)).toBe(expected)
+  })
+})
+
+describe('login experience', () => {
+  it('explains the workspace and signs in through the single governed provider', async () => {
+    query = new URLSearchParams('callbackUrl=%2Fpayments%3Fstatus%3Dpending')
+    vi.mocked(signIn).mockResolvedValue(undefined)
+    renderPage()
+
+    expect(screen.getByRole('heading', { name: 'Operate with confidence.' })).toBeInTheDocument()
+    expect(screen.getByText('Decisions with context')).toBeInTheDocument()
+    const button = screen.getByRole('button', { name: 'Continue with Keycloak SSO' })
+    fireEvent.click(button)
+
+    await waitFor(() => expect(signIn).toHaveBeenCalledWith('keycloak', { callbackUrl: '/payments?status=pending' }))
+    expect(button).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('switches language and presents a clear expired-session recovery', () => {
+    query = new URLSearchParams('error=SessionExpired')
+    renderPage()
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Your session expired')
+    fireEvent.click(screen.getByRole('button', { name: 'Přepnout do češtiny' }))
+    expect(screen.getByRole('heading', { name: 'Řiďte banku s jistotou.' })).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent('Vaše relace vypršela')
+  })
+})

--- a/openbank-admin-ui/src/test/privacy-experience.test.tsx
+++ b/openbank-admin-ui/src/test/privacy-experience.test.tsx
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { PrivacyContent } from '@/app/privacy/PrivacyContent'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+const renderPage = () => render(<LanguageProvider><PrivacyContent /></LanguageProvider>)
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+})
+
+describe('public privacy experience', () => {
+  it('explains the complete operator-data journey without weakening the legal notice', () => {
+    renderPage()
+
+    expect(screen.getByRole('heading', { name: 'Know what happens to your operator data.' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'The data journey' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Identity' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Session' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Audit evidence' })).toBeInTheDocument()
+    expect(screen.getByText(/EBA ICT Risk Guidelines and PSD2/)).toBeInTheDocument()
+    expect(screen.getByText(/no marketing or tracking cookies/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /hello@open-bank.tech/ })).toHaveAttribute('href', 'mailto:hello@open-bank.tech')
+    expect(screen.getByRole('link', { name: /security@open-bank.tech/ })).toHaveAttribute('href', 'mailto:security@open-bank.tech')
+  })
+
+  it('switches the full notice to Czech and preserves the sign-in return', () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Přepnout do češtiny' }))
+
+    expect(screen.getByRole('heading', { name: 'Víte, co se děje s údaji operátora.' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Cesta údajů' })).toBeInTheDocument()
+    expect(screen.getByText(/regulatorní povinností uchování/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Zpět k bezpečnému přihlášení/ })).toHaveAttribute('href', '/auth/login')
+  })
+})


### PR DESCRIPTION
## Summary\n- replace the undersized public login card with a responsive, premium operations sign-in experience\n- explain governed access in plain language with Czech/English switching and accessible pending/error states\n- keep post-auth redirects same-origin and hide the authenticated assistant on public auth/privacy surfaces\n\n## Safety invariants\n- Keycloak remains the only sign-in provider\n- no authentication, session, RBAC, four-eyes, audit, or BFF behavior changes\n- untrusted callback URLs fall back to /dashboard\n- public routes do not initialize or expose the internal assistant\n\n## Verification\n- focused Vitest: 12 tests passed\n- npm run type-check\n- scoped ESLint\n- npm run build: 90 routes\n- desktop and 390x844 browser visual QA\n- git diff --check\n\nCloses #7060