### PR TITLE
fix(admin-ui): clarify authentication recovery

### DIFF
--- a/openbank-admin-ui/src/app/auth/error/page.tsx
+++ b/openbank-admin-ui/src/app/auth/error/page.tsx
@@ -3,43 +3,87 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 "use client"
-import { useSearchParams } from "next/navigation"
+
+import { ArrowRight, Languages, Loader2, RefreshCw, ShieldAlert } from "lucide-react"
 import { signIn } from "next-auth/react"
-import { Suspense } from "react"
+import { useSearchParams } from "next/navigation"
+import { Suspense, useState } from "react"
+import { useLanguage } from "@/lib/i18n/LanguageContext"
+import { safeCallbackPath } from "@/lib/auth/safeCallbackPath"
+import styles from "../recovery.module.css"
+
+const COPY = {
+  en: {
+    eyebrow: "Secure sign-in recovery",
+    title: "We could not sign you in",
+    intro: "Your bank session was not started. No operational action was performed.",
+    retry: "Try secure sign-in again",
+    retrying: "Reconnecting securely…",
+    switchLanguage: "Přepnout do češtiny",
+    locale: "Čeština",
+    help: "If this keeps happening, share the time of the attempt with your bank administrator — never share a password or token.",
+    Configuration: "The identity service is not configured correctly. Please contact your bank administrator.",
+    AccessDenied: "The identity provider did not grant access. Confirm that you selected the correct bank account.",
+    Verification: "The verification link is invalid or has expired. Start a new secure sign-in.",
+    Default: "An unexpected identity-service response interrupted sign-in. It is safe to try again.",
+  },
+  cs: {
+    eyebrow: "Bezpečné obnovení přihlášení",
+    title: "Přihlášení se nepodařilo",
+    intro: "Bankovní relace nebyla zahájena a nebyla provedena žádná provozní akce.",
+    retry: "Zkusit bezpečné přihlášení znovu",
+    retrying: "Obnovuji zabezpečené spojení…",
+    switchLanguage: "Switch to English",
+    locale: "English",
+    help: "Pokud se problém opakuje, sdělte administrátorovi banky čas pokusu — nikdy neposílejte heslo ani token.",
+    Configuration: "Služba identity není správně nastavena. Obraťte se na administrátora banky.",
+    AccessDenied: "Poskytovatel identity přístup nepovolil. Ověřte, že jste zvolili správný bankovní účet.",
+    Verification: "Ověřovací odkaz je neplatný nebo vypršel. Zahajte nové bezpečné přihlášení.",
+    Default: "Přihlášení přerušila neočekávaná odpověď služby identity. Můžete to bezpečně zkusit znovu.",
+  },
+} as const
 
 function ErrorContent() {
   const params = useSearchParams()
+  const { language, setLanguage } = useLanguage()
+  const [pending, setPending] = useState(false)
+  const copy = COPY[language]
   const error = params.get("error")
+  const errorKey = error === "Configuration" || error === "AccessDenied" || error === "Verification" ? error : "Default"
+  const callbackUrl = safeCallbackPath(params.get("callbackUrl"))
 
-  const messages: Record<string, string> = {
-    Configuration: "Chyba konfigurace serveru. Kontaktujte správce.",
-    AccessDenied: "Přístup byl odepřen poskytovatelem identity.",
-    Verification: "Ověřovací odkaz je neplatný nebo vypršel.",
-    Default: "Nastala neočekávaná chyba při přihlašování.",
+  const retry = async () => {
+    if (pending) return
+    setPending(true)
+    try {
+      await signIn("keycloak", { callbackUrl })
+    } catch {
+      setPending(false)
+    }
   }
 
   return (
-    <div style={{
-      minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center",
-      background: "var(--bg)", fontFamily: "var(--font-sans)",
-    }}>
-      <div style={{ textAlign: "center", maxWidth: "420px", padding: "40px" }}>
-        <div style={{ fontSize: "48px", marginBottom: "16px" }}>⚠️</div>
-        <div style={{ fontSize: "20px", fontWeight: 700, color: "var(--text-primary)", marginBottom: "8px" }}>
-          Chyba přihlášení
-        </div>
-        <div style={{ fontSize: "13px", color: "var(--text-secondary)", marginBottom: "24px" }}>
-          {messages[error ?? "Default"] ?? messages.Default}
-        </div>
-        <button type="button" aria-label="Retry sign-in / Zkusit přihlášení znovu" onClick={() => signIn("keycloak")} style={{
-          padding: "10px 24px", borderRadius: "8px", border: "none",
-          background: "var(--accent)", color: "#fff", fontSize: "13px",
-          fontWeight: 600, cursor: "pointer",
-        }}>
-          Zkusit znovu
+    <main className={styles.page}>
+      <section className={styles.card} aria-labelledby="auth-error-title">
+        <header className={styles.header}>
+          <a className={styles.brand} href="/auth/login">OpenBank <span>Admin</span></a>
+          <button type="button" className={styles.languageButton} onClick={() => setLanguage(language === "en" ? "cs" : "en")} aria-label={copy.switchLanguage}>
+            <Languages size={16} aria-hidden="true" />{copy.locale}
+          </button>
+        </header>
+        <div className={`${styles.icon} ${styles.errorIcon}`} aria-hidden="true"><ShieldAlert size={27} /></div>
+        <p className={styles.eyebrow}>{copy.eyebrow}</p>
+        <h1 id="auth-error-title">{copy.title}</h1>
+        <p className={styles.intro}>{copy.intro}</p>
+        <div className={styles.explanation} role="alert">{copy[errorKey]}</div>
+        <button type="button" className={styles.primaryButton} onClick={retry} disabled={pending} aria-busy={pending}>
+          {pending ? <Loader2 className={styles.spinner} size={18} aria-hidden="true" /> : <RefreshCw size={18} aria-hidden="true" />}
+          <span>{pending ? copy.retrying : copy.retry}</span>
+          {!pending && <ArrowRight size={18} aria-hidden="true" />}
         </button>
-      </div>
-    </div>
+        <p className={styles.help}>{copy.help}</p>
+      </section>
+    </main>
   )
 }
 

--- a/openbank-admin-ui/src/app/auth/forbidden/page.tsx
+++ b/openbank-admin-ui/src/app/auth/forbidden/page.tsx
@@ -3,52 +3,67 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 "use client"
-import { useSearchParams } from "next/navigation"
-import { useRouter } from "next/navigation"
+
+import { ArrowRight, Languages, LockKeyhole, ShieldCheck } from "lucide-react"
+import { useRouter, useSearchParams } from "next/navigation"
 import { Suspense } from "react"
+import { useLanguage } from "@/lib/i18n/LanguageContext"
+import { sameOriginPath } from "@/lib/auth/safeCallbackPath"
+import styles from "../recovery.module.css"
+
+const COPY = {
+  en: {
+    eyebrow: "Access boundary",
+    title: "This area is not in your role",
+    intro: "OpenBank stopped the request before protected data was shown or changed.",
+    explanation: "Access is assigned by responsibility. If this task is part of your job, ask your bank administrator to review your role instead of sharing another operator’s account.",
+    requested: "Protected destination",
+    dashboard: "Return to your dashboard",
+    boundary: "This is a normal security control — not a system failure.",
+    switchLanguage: "Přepnout do češtiny",
+    locale: "Čeština",
+  },
+  cs: {
+    eyebrow: "Hranice přístupu",
+    title: "Tato oblast není součástí vaší role",
+    intro: "OpenBank požadavek zastavil dříve, než byla zobrazena nebo změněna chráněná data.",
+    explanation: "Přístup se přiděluje podle odpovědnosti. Pokud úkol patří do vaší práce, požádejte administrátora banky o kontrolu role — nesdílejte účet jiného operátora.",
+    requested: "Chráněný cíl",
+    dashboard: "Vrátit se na svůj dashboard",
+    boundary: "Jde o běžný bezpečnostní mechanismus, nikoli poruchu systému.",
+    switchLanguage: "Switch to English",
+    locale: "English",
+  },
+} as const
 
 function ForbiddenContent() {
   const params = useSearchParams()
-  const path = params.get("path") || ""
   const router = useRouter()
+  const { language, setLanguage } = useLanguage()
+  const copy = COPY[language]
+  const requestedPath = sameOriginPath(params.get("path"))
 
   return (
-    <div style={{
-      minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center",
-      background: "var(--bg)", fontFamily: "var(--font-sans)",
-    }}>
-      <div style={{ textAlign: "center", maxWidth: "480px", padding: "40px" }}>
-        <div style={{ fontSize: "64px", marginBottom: "16px" }}>🔒</div>
-        <div style={{ fontSize: "24px", fontWeight: 700, color: "var(--text-primary)", marginBottom: "8px" }}>
-          Přístup odepřen
-        </div>
-        <div style={{ fontSize: "14px", color: "var(--text-secondary)", marginBottom: "24px", lineHeight: 1.6 }}>
-          Nemáte dostatečná oprávnění pro přístup k této části systému.
-          Pokud si myslíte, že jde o chybu, kontaktujte správce.
-        </div>
-        {path && (
-          <div style={{ marginBottom: "24px", padding: "8px 12px", background: "var(--surface-2)", borderRadius: "6px", fontSize: "12px", fontFamily: "monospace", color: "var(--text-tertiary)" }}>
-            {path}
-          </div>
-        )}
-        <div style={{ display: "flex", gap: "12px", justifyContent: "center" }}>
-          <button onClick={() => router.back()} style={{
-            padding: "10px 20px", borderRadius: "8px", border: "1px solid var(--border)",
-            background: "var(--surface)", color: "var(--text-primary)", fontSize: "13px",
-            fontWeight: 500, cursor: "pointer",
-          }}>
-            Zpět
+    <main className={styles.page}>
+      <section className={styles.card} aria-labelledby="forbidden-title">
+        <header className={styles.header}>
+          <a className={styles.brand} href="/dashboard">OpenBank <span>Admin</span></a>
+          <button type="button" className={styles.languageButton} onClick={() => setLanguage(language === "en" ? "cs" : "en")} aria-label={copy.switchLanguage}>
+            <Languages size={16} aria-hidden="true" />{copy.locale}
           </button>
-          <button onClick={() => router.push("/dashboard")} style={{
-            padding: "10px 20px", borderRadius: "8px", border: "none",
-            background: "var(--accent)", color: "#fff", fontSize: "13px",
-            fontWeight: 500, cursor: "pointer",
-          }}>
-            Na Dashboard
-          </button>
-        </div>
-      </div>
-    </div>
+        </header>
+        <div className={`${styles.icon} ${styles.lockIcon}`} aria-hidden="true"><LockKeyhole size={27} /></div>
+        <p className={styles.eyebrow}>{copy.eyebrow}</p>
+        <h1 id="forbidden-title">{copy.title}</h1>
+        <p className={styles.intro}>{copy.intro}</p>
+        <div className={styles.explanation}>{copy.explanation}</div>
+        {requestedPath && <div className={styles.destination}><span>{copy.requested}</span><code>{requestedPath}</code></div>}
+        <button type="button" className={styles.primaryButton} onClick={() => router.push("/dashboard")}>
+          <ShieldCheck size={18} aria-hidden="true" /><span>{copy.dashboard}</span><ArrowRight size={18} aria-hidden="true" />
+        </button>
+        <p className={styles.help}>{copy.boundary}</p>
+      </section>
+    </main>
   )
 }
 

--- a/openbank-admin-ui/src/app/auth/recovery.module.css
+++ b/openbank-admin-ui/src/app/auth/recovery.module.css
@@ -1,0 +1,25 @@
+.page { min-height: 100svh; display: grid; place-items: center; padding: clamp(24px, 5vw, 64px); background: radial-gradient(circle at 5% 5%, rgba(33, 147, 163, .12), transparent 27%), radial-gradient(circle at 95% 90%, rgba(25, 68, 120, .09), transparent 25%), #f5f7fb; color: #12233f; }
+.card { width: min(100%, 620px); padding: clamp(28px, 5vw, 54px); border: 1px solid #dce4ee; border-radius: 22px; background: rgba(255,255,255,.92); box-shadow: 0 24px 75px rgba(24, 47, 78, .12); }
+.header { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 46px; }
+.brand { border-radius: 5px; color: #142c4d; font-size: .95rem; font-weight: 760; text-decoration: none; }
+.brand span { margin-left: 6px; color: #61728a; font-size: .67rem; font-weight: 650; letter-spacing: .14em; text-transform: uppercase; }
+.languageButton { display: inline-flex; align-items: center; gap: 7px; padding: 9px 11px; border: 1px solid #d8e0eb; border-radius: 10px; background: #fff; color: #314761; font: inherit; font-size: .77rem; font-weight: 650; cursor: pointer; }
+.icon { display: grid; width: 54px; height: 54px; place-items: center; margin-bottom: 24px; border-radius: 16px; }
+.errorIcon { border: 1px solid #f0cfb4; background: #fff7ed; color: #b45309; }
+.lockIcon { border: 1px solid #c6d9ed; background: #eef6ff; color: #225f99; }
+.eyebrow { margin: 0 0 13px; color: #177564; font-size: .7rem; font-weight: 760; letter-spacing: .16em; text-transform: uppercase; }
+.card h1 { max-width: 510px; margin: 0; color: #102746; font-size: clamp(2rem, 5vw, 3rem); font-weight: 680; letter-spacing: -.04em; line-height: 1.08; text-wrap: balance; }
+.intro { margin: 18px 0 24px; color: #52657d; font-size: .95rem; line-height: 1.7; }
+.explanation { padding: 16px 18px; border-left: 3px solid #72b6ad; border-radius: 0 10px 10px 0; background: #f0f7f6; color: #344c61; font-size: .84rem; line-height: 1.65; }
+.destination { display: grid; gap: 6px; margin-top: 16px; padding: 13px 16px; border: 1px solid #dde5ee; border-radius: 10px; background: #f8fafc; }
+.destination span { color: #6a7a8e; font-size: .67rem; font-weight: 720; letter-spacing: .1em; text-transform: uppercase; }
+.destination code { overflow: hidden; color: #304b68; font-size: .78rem; text-overflow: ellipsis; white-space: nowrap; }
+.primaryButton { display: grid; width: 100%; min-height: 52px; grid-template-columns: 22px 1fr 22px; align-items: center; gap: 10px; margin-top: 26px; padding: 12px 16px; border: 0; border-radius: 12px; background: linear-gradient(135deg, #0d5f6c, #0f7180); color: #fff; font: inherit; font-size: .87rem; font-weight: 720; cursor: pointer; box-shadow: 0 12px 28px rgba(12, 91, 104, .2); transition: filter .16s, transform .16s; }
+.primaryButton:hover:not(:disabled) { filter: brightness(1.06); transform: translateY(-1px); }
+.primaryButton:disabled { cursor: wait; opacity: .76; }
+.languageButton:focus-visible, .brand:focus-visible, .primaryButton:focus-visible { outline: 3px solid rgba(24,116,204,.3); outline-offset: 3px; }
+.spinner { animation: spin .8s linear infinite; }
+.help { margin: 20px 8px 0; color: #6a788c; font-size: .73rem; line-height: 1.55; text-align: center; }
+@keyframes spin { to { transform: rotate(360deg); } }
+@media (max-width: 520px) { .page { align-items: start; padding: 0; background: #fff; } .card { min-height: 100svh; padding: 24px 22px 38px; border: 0; border-radius: 0; box-shadow: none; } .header { margin-bottom: 52px; } }
+@media (prefers-reduced-motion: reduce) { .primaryButton { transition: none; } .spinner { animation-duration: 1.6s; } }

--- a/openbank-admin-ui/src/lib/auth/safeCallbackPath.ts
+++ b/openbank-admin-ui/src/lib/auth/safeCallbackPath.ts
@@ -6,13 +6,18 @@ const CALLBACK_ORIGIN = "https://openbank.invalid"
 const DEFAULT_CALLBACK = "/dashboard"
 
 /** Keeps post-authentication navigation on the admin UI origin. */
-export function safeCallbackPath(candidate: string | null | undefined): string {
-  if (!candidate?.startsWith("/") || candidate.startsWith("//") || candidate.includes("\\")) return DEFAULT_CALLBACK
+export function sameOriginPath(candidate: string | null | undefined): string | null {
+  if (!candidate?.startsWith("/") || candidate.startsWith("//") || candidate.includes("\\")) return null
   try {
     const target = new URL(candidate, CALLBACK_ORIGIN)
-    if (target.origin !== CALLBACK_ORIGIN) return DEFAULT_CALLBACK
+    if (target.origin !== CALLBACK_ORIGIN) return null
     return `${target.pathname}${target.search}${target.hash}`
   } catch {
-    return DEFAULT_CALLBACK
+    return null
   }
+}
+
+/** Keeps post-authentication navigation on the admin UI origin with a safe default. */
+export function safeCallbackPath(candidate: string | null | undefined): string {
+  return sameOriginPath(candidate) ?? DEFAULT_CALLBACK
 }

--- a/openbank-admin-ui/src/test/auth-error-retry.guard.test.ts
+++ b/openbank-admin-ui/src/test/auth-error-retry.guard.test.ts
@@ -4,9 +4,13 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
 describe('auth error recovery contract', () => {
-  it('keeps retry sign-in an explicit accessible button', () => {
+  it('keeps retry sign-in explicit, stateful, and callback-scoped', () => {
     const source = readFileSync(path.resolve(__dirname, '../app/auth/error/page.tsx'), 'utf8')
-    expect(source).toContain('<button type="button" aria-label="Retry sign-in / Zkusit přihlášení znovu"')
-    expect(source).toContain('signIn("keycloak")')
+    expect(source).toContain('type="button"')
+    expect(source).toContain('onClick={retry}')
+    expect(source).toContain('aria-busy={pending}')
+    expect(source).toContain('disabled={pending}')
+    expect(source).toContain('{pending ? copy.retrying : copy.retry}')
+    expect(source).toContain('signIn("keycloak", { callbackUrl })')
   })
 })

--- a/openbank-admin-ui/src/test/auth-recovery-experience.test.tsx
+++ b/openbank-admin-ui/src/test/auth-recovery-experience.test.tsx
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { signIn } from 'next-auth/react'
+import AuthErrorPage from '@/app/auth/error/page'
+import ForbiddenPage from '@/app/auth/forbidden/page'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+let query = new URLSearchParams()
+const push = vi.fn()
+
+vi.mock('next-auth/react', () => ({ signIn: vi.fn() }))
+vi.mock('next/navigation', () => ({ useSearchParams: () => query, useRouter: () => ({ push }) }))
+
+const renderInLanguage = (page: React.ReactNode) => render(<LanguageProvider>{page}</LanguageProvider>)
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+  query = new URLSearchParams()
+  vi.clearAllMocks()
+})
+
+describe('authentication recovery experience', () => {
+  it('explains an identity denial and retries with a validated return path', async () => {
+    query = new URLSearchParams('error=AccessDenied&callbackUrl=%2Fpayments%3Fstate%3Dpending')
+    vi.mocked(signIn).mockResolvedValue(undefined)
+    renderInLanguage(<AuthErrorPage />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent('identity provider did not grant access')
+    const retry = screen.getByRole('button', { name: 'Try secure sign-in again' })
+    fireEvent.click(retry)
+
+    await waitFor(() => expect(signIn).toHaveBeenCalledWith('keycloak', { callbackUrl: '/payments?state=pending' }))
+    expect(retry).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('falls back to the dashboard when an external retry target is supplied', async () => {
+    query = new URLSearchParams('callbackUrl=https%3A%2F%2Fattacker.example')
+    vi.mocked(signIn).mockResolvedValue(undefined)
+    renderInLanguage(<AuthErrorPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Try secure sign-in again' }))
+    await waitFor(() => expect(signIn).toHaveBeenCalledWith('keycloak', { callbackUrl: '/dashboard' }))
+  })
+
+  it('teaches the access boundary without echoing an untrusted destination', () => {
+    query = new URLSearchParams('path=%2F%2Fattacker.example%2Fprivate')
+    renderInLanguage(<ForbiddenPage />)
+
+    expect(screen.getByRole('heading', { name: 'This area is not in your role' })).toBeInTheDocument()
+    expect(screen.getByText(/normal security control/)).toBeInTheDocument()
+    expect(screen.queryByText('//attacker.example/private')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Return to your dashboard' }))
+    expect(push).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('localizes the recovery guidance', () => {
+    renderInLanguage(<ForbiddenPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Přepnout do češtiny' }))
+    expect(screen.getByRole('heading', { name: 'Tato oblast není součástí vaší role' })).toBeInTheDocument()
+    expect(screen.getByText(/běžný bezpečnostní mechanismus/)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary\n- replace the stale auth error and forbidden screens with responsive, bilingual recovery guidance\n- preserve only same-origin return paths and explain access boundaries without exposing unsafe destinations\n- add accessible pending, alert, navigation and explicit button semantics\n\n## Stack\nThis PR is intentionally based on #7063 and contains only the recovery-surface delta. Retarget to main after the parent merges.\n\n## Safety invariants\n- Keycloak remains the only identity provider\n- authentication, session, RBAC, proxy and audit behavior are unchanged\n- denied destinations are informational only and never navigated\n- retry falls back to /dashboard when callback provenance is untrusted\n\n## Verification\n- focused Vitest: 13 tests passed\n- npm run type-check\n- scoped ESLint\n- npm run build: 90 routes\n- desktop and 390x844 browser visual QA\n- git diff --check\n\nCloses #7065\nRefs #7063