### PR TITLE
fix(finrep): expose official coverage gaps

### DIFF
--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/FinrepService.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/FinrepService.kt
@@ -57,8 +57,7 @@ class FinrepService(private val ledgerPort: LedgerPort, private val metrics: Fin
                 templateId = template.templateId,
                 trialBalanceLines = snapshot.lines.size,
                 cells = template.cells.size,
-                // FINREP cells carry no data-gap flag; only COREP C 01.00 has unavailable inputs today.
-                dataGapCells = 0,
+                dataGapCells = template.dataGaps.size,
                 balanced = template.isBalanced,
                 balanceVerdict = template.balanceVerdict,
                 duration = Duration.ofNanos(System.nanoTime() - startedAt),

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0101Mapper.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0101Mapper.kt
@@ -38,6 +38,7 @@ object F0101Mapper {
             templateId = "F01.01",
             period = asOf,
             cells = cells,
+            dataGaps = FinrepCoverage.gapsFor("F01.01"),
             isBalanced = assessment.verdict == BalanceVerdict.AGREED_BALANCED,
             balanceVerdict = assessment.verdict,
         )

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0102Mapper.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0102Mapper.kt
@@ -23,6 +23,7 @@ object F0102Mapper {
             templateId = "F01.02",
             period = asOf,
             cells = listOf(FinrepCell("r0300", "c0010", liabilities)),
+            dataGaps = FinrepCoverage.gapsFor("F01.02"),
             isBalanced = assessment.verdict == BalanceVerdict.AGREED_BALANCED,
             balanceVerdict = assessment.verdict,
         )

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0103Mapper.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0103Mapper.kt
@@ -28,6 +28,7 @@ object F0103Mapper {
                 FinrepCell("r0300", "c0010", equity),
                 FinrepCell("r0310", "c0010", equity.add(liabilities)),
             ),
+            dataGaps = FinrepCoverage.gapsFor("F01.03"),
             isBalanced = assessment.verdict == BalanceVerdict.AGREED_BALANCED,
             balanceVerdict = assessment.verdict,
         )

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0200Mapper.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/F0200Mapper.kt
@@ -51,6 +51,7 @@ object F0200Mapper {
             templateId = "F02.00",
             period = asOf,
             cells = cells,
+            dataGaps = FinrepCoverage.gapsFor("F02.00"),
             isBalanced = assessment.verdict == BalanceVerdict.AGREED_BALANCED,
             balanceVerdict = assessment.verdict,
         )

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/FinrepCoverage.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/mapper/FinrepCoverage.kt
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.finrep.domain.mapper
+
+import com.openbank.finrep.domain.model.FinrepDataGap
+
+/** Explicit coverage boundary for the EBA Reporting Framework 4.2 bounded previews (#6980). */
+object FinrepCoverage {
+    private val supportedCells = mapOf(
+        "F01.01" to "r0380/c0010",
+        "F01.02" to "r0300/c0010",
+        "F01.03" to "r0300/c0010, r0310/c0010",
+        "F02.00" to "r0670/c0010",
+    )
+
+    fun gapsFor(templateId: String): List<FinrepDataGap> {
+        val supported = requireNotNull(supportedCells[templateId]) { "Unknown FINREP coverage: $templateId" }
+        return listOf(
+            FinrepDataGap(
+                code = "UNMAPPED_OFFICIAL_CELLS",
+                affectedScope = "$templateId except $supported",
+                reason = "The ledger lacks the regulatory classifications required to derive the remaining " +
+                    "EBA Reporting Framework 4.2 cells; this preview must not be submitted as a return.",
+            ),
+        )
+    }
+}

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/FinrepDataGap.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/FinrepDataGap.kt
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.finrep.domain.model
+
+/** A machine-readable reason why a FINREP preview is not a complete regulatory return. */
+data class FinrepDataGap(val code: String, val affectedScope: String, val reason: String)

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/FinrepTemplate.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/FinrepTemplate.kt
@@ -14,6 +14,8 @@ data class FinrepTemplate(
     val templateId: String,
     val period: LocalDate,
     val cells: List<FinrepCell>,
+    /** Explicit findings that make this bounded preview ineligible as a regulatory artifact. */
+    val dataGaps: List<FinrepDataGap>,
     /**
      * Whether this template may be treated as balanced — TRUE only when finrep's own recomputation
      * (`Σ net == 0` per currency, `TrialBalanceIdentity`) and openbank-ledger-service's published
@@ -34,4 +36,6 @@ data class FinrepTemplate(
      * `PushResult.skipped()` failure this repo already paid for once.
      */
     val balanceVerdict: BalanceVerdict,
-)
+) {
+    val hasDataGaps: Boolean get() = dataGaps.isNotEmpty()
+}

--- a/openbank-finrep-service/src/main/resources/openapi.yaml
+++ b/openbank-finrep-service/src/main/resources/openapi.yaml
@@ -22,7 +22,7 @@ info:
     FINREP output is a bounded preview containing only the official datapoints the platform can
     currently derive without inventing regulatory classifications; it is not a complete return.
     COREP preview gaps remain explicit flagged zeroes (`isDataGap`) with reasons.
-  version: 1.4.0
+  version: 1.5.0
 tags:
   - name: FINREP
   - name: COREP
@@ -166,7 +166,7 @@ components:
         F01.03 publishes r0300/c0010 (total equity) and r0310/c0010 (total equity and liabilities);
         F02.00 publishes r0670/c0010 (profit or loss for the year). It is not a complete regulatory
         return or an XBRL artifact. Values are reported in their natural reporting sign.
-      required: [templateId, period, cells, isBalanced, balanceVerdict]
+      required: [templateId, period, cells, dataGaps, hasDataGaps, isBalanced, balanceVerdict]
       properties:
         templateId: { type: string, example: F01.01 }
         period:
@@ -176,6 +176,15 @@ components:
         cells:
           type: array
           items: { $ref: '#/components/schemas/FinrepCell' }
+        dataGaps:
+          type: array
+          description: Machine-readable findings covering the official cells this preview cannot derive.
+          items: { $ref: '#/components/schemas/FinrepDataGap' }
+        hasDataGaps:
+          type: boolean
+          description: >-
+            Derived from `dataGaps`. A true value makes this bounded preview ineligible for use as
+            a complete regulatory artifact.
         isBalanced:
           type: boolean
           description: >-
@@ -205,6 +214,16 @@ components:
             paginated response — an evidence defect, not an accounting one); `LEDGER_FLAG_ABSENT`
             means the ledger response carried no verdict at all, which is a contract change rather
             than a statement about the books, and is kept distinct from a verdict of `false`.
+
+    FinrepDataGap:
+      type: object
+      required: [code, affectedScope, reason]
+      properties:
+        code: { type: string, example: UNMAPPED_OFFICIAL_CELLS }
+        affectedScope: { type: string, example: "F01.01 except r0380/c0010" }
+        reason:
+          type: string
+          description: Why the affected official cells cannot be derived and why submission is blocked.
 
     CorepCell:
       type: object

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0101MapperTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0101MapperTest.kt
@@ -44,6 +44,8 @@ class F0101MapperTest {
         assertThat(template.cells).hasSize(1)
         assertThat(cell(template.cells, "r0380")).isEqualByComparingTo("500000")
         assertThat(template.cells.single().colRef).isEqualTo("c0010")
+        assertThat(template.hasDataGaps).isTrue()
+        assertThat(template.dataGaps.single().affectedScope).isEqualTo("F01.01 except r0380/c0010")
     }
 
     @Test

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0102AndF0103MapperTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0102AndF0103MapperTest.kt
@@ -33,6 +33,7 @@ class F0102AndF0103MapperTest {
         assertThat(cell.rowRef).isEqualTo("r0300")
         assertThat(cell.colRef).isEqualTo("c0010")
         assertThat(cell.value).isEqualByComparingTo("300000")
+        assertThat(template.dataGaps.single().affectedScope).isEqualTo("F01.02 except r0300/c0010")
     }
 
     @Test
@@ -44,6 +45,8 @@ class F0102AndF0103MapperTest {
             mapOf("r0300" to BigDecimal("200000"), "r0310" to BigDecimal("500000")),
         )
         assertThat(template.cells).allMatch { it.colRef == "c0010" }
+        assertThat(template.dataGaps.single().affectedScope)
+            .isEqualTo("F01.03 except r0300/c0010, r0310/c0010")
     }
 
     private fun line(code: String, accountType: String, net: String) =

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0200MapperTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/F0200MapperTest.kt
@@ -32,6 +32,8 @@ class F0200MapperTest {
         assertThat(template.cells).hasSize(1)
         assertThat(cell(template, "r0670")).isEqualByComparingTo("40000")
         assertThat(template.cells.single().colRef).isEqualTo("c0010")
+        assertThat(template.hasDataGaps).isTrue()
+        assertThat(template.dataGaps.single().affectedScope).isEqualTo("F02.00 except r0670/c0010")
     }
 
     @Test

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/Eba42DatapointFixtureTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/Eba42DatapointFixtureTest.kt
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.finrep.contract
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
+import com.openbank.finrep.domain.mapper.F0101Mapper
+import com.openbank.finrep.domain.mapper.F0102Mapper
+import com.openbank.finrep.domain.mapper.F0103Mapper
+import com.openbank.finrep.domain.mapper.F0200Mapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/** Regression lock derived from the pinned official EBA Framework 4.2 annotated templates. */
+class Eba42DatapointFixtureTest {
+    private val fixture = ObjectMapper().readTree(
+        requireNotNull(javaClass.getResourceAsStream("/eba/reporting-framework-4.2-datapoints.json")),
+    )
+
+    @Test
+    fun `official package identity and supported mapper coordinates stay pinned`() {
+        assertThat(fixture["reportingFramework"].asText()).isEqualTo("4.2")
+        assertThat(fixture["dpmVersion"].asText()).isEqualTo("4.2.1")
+        assertThat(fixture["taxonomyVersion"].asText()).isEqualTo("4.2.0.0")
+        assertThat(fixture["taxonomyPackageSha256"].asText())
+            .isEqualTo("0bf9e33720de1472e809417999cfd29e4b5eadb31750c7770622e502590bbdd0")
+        assertThat(fixture["supportedFacts"].map { it["datapointId"]?.takeUnless { id -> id.isNull }?.asInt() })
+            .containsExactly(32354, 32592, 32464, null, 57025)
+        assertThat(fixture["supportedFacts"].map { it["meaning"].asText() })
+            .containsExactly(
+                "TOTAL ASSETS",
+                "TOTAL LIABILITIES",
+                "TOTAL EQUITY",
+                "TOTAL EQUITY AND LIABILITIES",
+                "PROFIT OR LOSS FOR THE YEAR",
+            )
+
+        val snapshot = TrialBalanceSnapshot(
+            lines = listOf(
+                line("ASSET", "500000"),
+                line("LIABILITY", "-300000"),
+                line("INCOME", "-260000"),
+                line("EXPENSE", "60000"),
+            ),
+            ledgerReportsBalanced = true,
+        )
+        val asOf = LocalDate.of(2026, 6, 30)
+        val actual = listOf(
+            F0101Mapper.map(snapshot, asOf),
+            F0102Mapper.map(snapshot, asOf),
+            F0103Mapper.map(snapshot, asOf),
+            F0200Mapper.map(snapshot, asOf),
+        ).flatMap { template -> template.cells.map { Triple(template.templateId, it.rowRef, it.colRef) } }
+        val expected = fixture["supportedFacts"].map {
+            Triple(it["templateId"].asText(), it["rowRef"].asText(), it["colRef"].asText())
+        }
+
+        assertThat(actual).containsExactlyElementsOf(expected)
+    }
+
+    private fun line(accountType: String, net: String) = TrialBalanceLineDto(
+        code = accountType,
+        accountType = accountType,
+        net = BigDecimal(net),
+        currency = "CZK",
+    )
+}

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/TemplateWireFormatTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/TemplateWireFormatTest.kt
@@ -142,12 +142,28 @@ class TemplateWireFormatTest {
     fun `the FINREP template wire format matches the published openapi schema`() {
         val json = getJson("/api/v1/finrep/templates/F01.01", LocalDate.of(2026, 6, 30))
 
-        assertThat(json.keys).containsExactlyInAnyOrder("templateId", "period", "cells", "isBalanced", "balanceVerdict")
+        assertThat(json.keys).containsExactlyInAnyOrder(
+            "templateId",
+            "period",
+            "cells",
+            "dataGaps",
+            "hasDataGaps",
+            "isBalanced",
+            "balanceVerdict",
+        )
         assertThat(json["templateId"]).isEqualTo("F01.01")
         assertThat(json["period"]).isEqualTo("2026-06-30")
         assertThat(json["isBalanced"]).isEqualTo(true)
         // The verdict is served as the ENUM NAME, which is what `openapi.yaml` documents (#6011).
         assertThat(json["balanceVerdict"]).isEqualTo("AGREED_BALANCED")
+        assertThat(json["hasDataGaps"]).isEqualTo(true)
+
+        @Suppress("UNCHECKED_CAST")
+        val gaps = json["dataGaps"] as List<Map<*, *>>
+        assertThat(gaps).hasSize(1)
+        assertThat(gaps.single().keys).containsExactlyInAnyOrder("code", "affectedScope", "reason")
+        assertThat(gaps.single()["code"]).isEqualTo("UNMAPPED_OFFICIAL_CELLS")
+        assertThat(gaps.single()["affectedScope"]).isEqualTo("F01.01 except r0380/c0010")
 
         @Suppress("UNCHECKED_CAST")
         val cells = json["cells"] as List<Map<*, *>>

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/rest/FinrepResourceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/rest/FinrepResourceTest.kt
@@ -45,6 +45,7 @@ class FinrepResourceTest {
             templateId = "F01.01",
             period = LocalDate.now(fixedClock),
             cells = listOf(FinrepCell(rowRef = "r010", colRef = "c010", value = BigDecimal.ZERO)),
+            dataGaps = emptyList(),
             isBalanced = true,
             balanceVerdict = BalanceVerdict.AGREED_BALANCED,
         )
@@ -66,6 +67,7 @@ class FinrepResourceTest {
             templateId = "F02.00",
             period = explicitDate,
             cells = emptyList(),
+            dataGaps = emptyList(),
             isBalanced = true,
             balanceVerdict = BalanceVerdict.AGREED_BALANCED,
         )

--- a/openbank-finrep-service/src/test/resources/eba/reporting-framework-4.2-datapoints.json
+++ b/openbank-finrep-service/src/test/resources/eba/reporting-framework-4.2-datapoints.json
@@ -1,0 +1,15 @@
+{
+  "reportingFramework": "4.2",
+  "dpmVersion": "4.2.1",
+  "taxonomyVersion": "4.2.0.0",
+  "taxonomyPackageUrl": "https://www.eba.europa.eu/sites/default/files/2026-01/b54d2c74-877c-4195-a32a-6591253d8b0f/taxo_package_4.2_hotfix.zip",
+  "taxonomyPackageSha256": "0bf9e33720de1472e809417999cfd29e4b5eadb31750c7770622e502590bbdd0",
+  "annotatedTemplatesUrl": "https://www.eba.europa.eu/sites/default/files/2026-02/c92d5e2b-bcd7-4767-ab5b-cdf0b1737368/260106%20Annotated%20templates_with_finpre9dp_4.2.1.zip",
+  "supportedFacts": [
+    { "templateId": "F01.01", "rowRef": "r0380", "colRef": "c0010", "datapointId": 32354, "meaning": "TOTAL ASSETS" },
+    { "templateId": "F01.02", "rowRef": "r0300", "colRef": "c0010", "datapointId": 32592, "meaning": "TOTAL LIABILITIES" },
+    { "templateId": "F01.03", "rowRef": "r0300", "colRef": "c0010", "datapointId": 32464, "meaning": "TOTAL EQUITY" },
+    { "templateId": "F01.03", "rowRef": "r0310", "colRef": "c0010", "datapointId": null, "meaning": "TOTAL EQUITY AND LIABILITIES" },
+    { "templateId": "F02.00", "rowRef": "r0670", "colRef": "c0010", "datapointId": 57025, "meaning": "PROFIT OR LOSS FOR THE YEAR" }
+  ]
+}


### PR DESCRIPTION
## Summary
- emit machine-readable `UNMAPPED_OFFICIAL_CELLS` findings on every bounded FINREP preview
- expose `dataGaps` and derived `hasDataGaps` in API v1.5.0 so incomplete previews cannot masquerade as complete returns
- pin EBA Framework 4.2 / DPM 4.2.1 / taxonomy 4.2.0.0 source metadata, package SHA-256 and supported datapoints in a regression fixture
- verify mapper coordinates against that fixture and assert the served wire contract

## Verification
- `./gradlew :openbank-finrep-service:test :openbank-finrep-service:ktlintCheck :openbank-finrep-service:detekt :openbank-finrep-service:quarkusBuild`
- signed commit verified
- rebased on current main after #7046 and release v0.9.2

Closes #6980
Unblocks the safe taxonomy-generation portion of #5914 after merge.

This PR does not implement or claim ČNB submission; transport remains blocked without real sandbox/onboarding specification and approved test identity.