### PR TITLE
fix(admin-ui): explain operator privacy clearly

### DIFF
--- a/openbank-admin-ui/src/app/privacy/PrivacyContent.tsx
+++ b/openbank-admin-ui/src/app/privacy/PrivacyContent.tsx
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"use client"
+
+import { ArrowLeft, Clock3, Cookie, FileCheck2, Languages, Mail, ShieldCheck, UserRoundCheck } from "lucide-react"
+import { useLanguage } from "@/lib/i18n/LanguageContext"
+import styles from "./privacy.module.css"
+
+const COPY = {
+  en: {
+    switchLanguage: "Přepnout do češtiny", locale: "Čeština", eyebrow: "Privacy, explained",
+    title: "Know what happens to your operator data.",
+    intro: "OpenBank Admin uses only the identity, session and audit information needed to operate a governed banking workspace. There are no marketing or tracking cookies.",
+    flowTitle: "The data journey",
+    flow: [
+      ["Identity", "Keycloak supplies your name, email and assigned roles so OpenBank can authenticate you and enforce role-based access."],
+      ["Session", "A necessary NextAuth session cookie keeps you signed in until logout or token expiry."],
+      ["Audit evidence", "Actions performed in the console create an audit trail for traceability and financial-sector obligations."],
+    ],
+    controllerTitle: "Who controls the data", controller: "OpenBank Foundation (in formation), operator of the demonstration banking platform on open-bank.tech.",
+    purposeTitle: "Why the data is processed", purpose: "Identity and session data are required for authentication and access control. Audit records support obligations under the EBA ICT Risk Guidelines and PSD2, and the legitimate interest in traceable operations over banking data.",
+    retentionTitle: "How long it is kept", retention: "The session cookie ends at logout or token expiry. Audit records are retained for the period required by financial-sector regulation.",
+    rightsTitle: "Your rights", rights: "You can request access, correction or deletion where deletion does not conflict with regulatory retention duties. You may also lodge a complaint with the Czech Office for Personal Data Protection.",
+    contactTitle: "Contacts", controllerContact: "Privacy and rights requests", securityContact: "Security vulnerability reports", securityFile: "Published security contact",
+    back: "Back to secure sign-in", note: "This notice is available before sign-in because operators should understand the boundary before entering the workspace.",
+  },
+  cs: {
+    switchLanguage: "Switch to English", locale: "English", eyebrow: "Soukromí srozumitelně",
+    title: "Víte, co se děje s údaji operátora.",
+    intro: "OpenBank Admin používá pouze údaje o identitě, relaci a auditu nezbytné pro řízené bankovní prostředí. Nepoužívá marketingové ani sledovací cookies.",
+    flowTitle: "Cesta údajů",
+    flow: [
+      ["Identita", "Keycloak předá jméno, e-mail a přidělené role, aby vás OpenBank mohl ověřit a řídit přístup podle rolí."],
+      ["Relace", "Nezbytná relační cookie NextAuth udržuje přihlášení do odhlášení nebo vypršení tokenu."],
+      ["Auditní stopa", "Akce provedené v konzoli vytvářejí auditní stopu pro vysledovatelnost a povinnosti finančního sektoru."],
+    ],
+    controllerTitle: "Kdo je správcem", controller: "OpenBank Foundation (v přípravě), provozovatel demonstrační bankovní platformy na doméně open-bank.tech.",
+    purposeTitle: "Proč údaje zpracováváme", purpose: "Identita a relační údaje jsou nutné pro autentizaci a řízení přístupu. Auditní záznamy podporují povinnosti podle EBA ICT Risk Guidelines a PSD2 a oprávněný zájem na vysledovatelnosti operací nad bankovními daty.",
+    retentionTitle: "Jak dlouho údaje uchováváme", retention: "Relační cookie zaniká odhlášením nebo vypršením tokenu. Auditní záznamy uchováváme po dobu vyžadovanou předpisy finančního sektoru.",
+    rightsTitle: "Vaše práva", rights: "Můžete požádat o přístup, opravu nebo výmaz tam, kde výmaz nekoliduje s regulatorní povinností uchování. Můžete také podat stížnost u Úřadu pro ochranu osobních údajů.",
+    contactTitle: "Kontakty", controllerContact: "Žádosti k soukromí a právům", securityContact: "Hlášení bezpečnostních zranitelností", securityFile: "Publikovaný bezpečnostní kontakt",
+    back: "Zpět k bezpečnému přihlášení", note: "Toto oznámení je dostupné před přihlášením, protože operátoři mají hranici zpracování znát ještě před vstupem do prostředí.",
+  },
+} as const
+
+const FLOW_ICONS = [UserRoundCheck, Cookie, FileCheck2]
+
+export function PrivacyContent() {
+  const { language, setLanguage } = useLanguage()
+  const copy = COPY[language]
+
+  return (
+    <main className={styles.page}>
+      <a className={styles.skipLink} href="#privacy-content">{language === "en" ? "Skip to privacy details" : "Přeskočit k detailům soukromí"}</a>
+      <header className={styles.header}>
+        <a className={styles.brand} href="/auth/login">OpenBank <span>Admin</span></a>
+        <button type="button" className={styles.languageButton} onClick={() => setLanguage(language === "en" ? "cs" : "en")} aria-label={copy.switchLanguage}>
+          <Languages size={16} aria-hidden="true" />{copy.locale}
+        </button>
+      </header>
+
+      <section id="privacy-content" className={styles.hero} aria-labelledby="privacy-title" tabIndex={-1}>
+        <div className={styles.heroCopy}>
+          <p className={styles.eyebrow}><ShieldCheck size={16} aria-hidden="true" />{copy.eyebrow}</p>
+          <h1 id="privacy-title">{copy.title}</h1>
+          <p className={styles.intro}>{copy.intro}</p>
+        </div>
+        <aside className={styles.note}><ShieldCheck size={20} aria-hidden="true" /><p>{copy.note}</p></aside>
+      </section>
+
+      <section className={styles.flow} aria-labelledby="data-flow-title">
+        <h2 id="data-flow-title">{copy.flowTitle}</h2>
+        <div className={styles.flowGrid}>
+          {copy.flow.map(([title, body], index) => {
+            const Icon = FLOW_ICONS[index]
+            return <article key={title}><span className={styles.flowIcon}><Icon size={20} aria-hidden="true" /></span><span className={styles.step}>0{index + 1}</span><h3>{title}</h3><p>{body}</p></article>
+          })}
+        </div>
+      </section>
+
+      <section className={styles.details} aria-label={language === "en" ? "Privacy details" : "Podrobnosti o soukromí"}>
+        <article><UserRoundCheck size={21} aria-hidden="true" /><div><h2>{copy.controllerTitle}</h2><p>{copy.controller}</p></div></article>
+        <article><FileCheck2 size={21} aria-hidden="true" /><div><h2>{copy.purposeTitle}</h2><p>{copy.purpose}</p></div></article>
+        <article><Clock3 size={21} aria-hidden="true" /><div><h2>{copy.retentionTitle}</h2><p>{copy.retention}</p></div></article>
+        <article><ShieldCheck size={21} aria-hidden="true" /><div><h2>{copy.rightsTitle}</h2><p>{copy.rights}</p></div></article>
+      </section>
+
+      <section className={styles.contacts} aria-labelledby="contacts-title">
+        <div><p className={styles.eyebrow}><Mail size={16} aria-hidden="true" />OpenBank</p><h2 id="contacts-title">{copy.contactTitle}</h2></div>
+        <div className={styles.contactLinks}>
+          <a href="mailto:hello@open-bank.tech"><span>{copy.controllerContact}</span><strong>hello@open-bank.tech</strong></a>
+          <a href="mailto:security@open-bank.tech"><span>{copy.securityContact}</span><strong>security@open-bank.tech</strong></a>
+          <a href="/.well-known/security.txt"><span>{copy.securityFile}</span><strong>security.txt</strong></a>
+        </div>
+      </section>
+
+      <footer className={styles.footer}>
+        <a href="/auth/login"><ArrowLeft size={17} aria-hidden="true" />{copy.back}</a>
+        <span>admin.open-bank.tech</span>
+      </footer>
+    </main>
+  )
+}

--- a/openbank-admin-ui/src/app/privacy/page.tsx
+++ b/openbank-admin-ui/src/app/privacy/page.tsx
@@ -2,83 +2,12 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-// Static, pre-login, single-language legal notice — same class as the /auth/*
-// screens (i18n.guard / layout-shell.guard EXEMPT). GDPR Art. 13 requires this
-// notice to be reachable WITHOUT an account (proxy.ts carries the bypass),
-// since the data subjects it describes are the operators who are about to log in.
+import { PrivacyContent } from "./PrivacyContent"
 
 export const metadata = {
-  title: "Ochrana osobních údajů — OpenBank Admin",
+  title: "Privacy and data protection — OpenBank Admin",
 }
 
 export default function PrivacyPage() {
-  return (
-    <main
-      id="main"
-      style={{
-        maxWidth: "720px", margin: "0 auto", padding: "48px 24px 96px",
-        fontFamily: "var(--font-sans, 'Inter', system-ui, sans-serif)",
-        color: "var(--text-primary, #0f172a)", lineHeight: 1.6,
-      }}
-    >
-      <h1 style={{ fontSize: "24px", fontWeight: 700, marginBottom: "8px" }}>
-        Ochrana osobních údajů — OpenBank Admin
-      </h1>
-      <p style={{ color: "var(--text-tertiary, #94a3b8)", fontSize: "13px", marginBottom: "32px" }}>
-        Operations Portal · admin.open-bank.tech
-      </p>
-
-      <h2 style={{ fontSize: "16px", fontWeight: 700, marginTop: "28px", marginBottom: "8px" }}>
-        Kdo je správcem
-      </h2>
-      <p>
-        OpenBank Foundation (v přípravě), provozovatel demonstrační bankovní platformy
-        na doméně open-bank.tech. Kontakt: <a href="mailto:hello@open-bank.tech">hello@open-bank.tech</a>.
-      </p>
-
-      <h2 style={{ fontSize: "16px", fontWeight: 700, marginTop: "28px", marginBottom: "8px" }}>
-        Jaké údaje zpracováváme a proč
-      </h2>
-      <p>
-        OpenBank Admin je interní operátorská konzole — přístup mají pouze zaměstnanci a
-        spolupracovníci přihlášení přes firemní Keycloak SSO účet. Při přihlášení a používání
-        konzole zpracováváme:
-      </p>
-      <ul>
-        <li>identitu z Keycloak (jméno, e-mail, přidělené role) — pro autentizaci a řízení přístupu (RBAC);</li>
-        <li>relační cookie (NextAuth session) — nezbytnou pro udržení přihlášení, žádné sledovací ani marketingové cookies;</li>
-        <li>záznam provedených akcí (audit log) — právním základem je plnění povinností dle EBA ICT Risk
-          Guidelines a PSD2, a oprávněný zájem na vysledovatelnosti operací nad bankovními daty.</li>
-      </ul>
-
-      <h2 style={{ fontSize: "16px", fontWeight: 700, marginTop: "28px", marginBottom: "8px" }}>
-        Doba uchování
-      </h2>
-      <p>
-        Relační cookie zaniká odhlášením nebo vypršením platnosti tokenu. Audit záznamy se
-        uchovávají po dobu vyžadovanou regulatorními předpisy pro finanční sektor.
-      </p>
-
-      <h2 style={{ fontSize: "16px", fontWeight: 700, marginTop: "28px", marginBottom: "8px" }}>
-        Vaše práva
-      </h2>
-      <p>
-        Máte právo na přístup, opravu, výmaz (v rozsahu, který nekoliduje s výše uvedenou
-        regulatorní povinností uchování) a na podání stížnosti u Úřadu pro ochranu osobních
-        údajů. Žádosti směřujte na <a href="mailto:hello@open-bank.tech">hello@open-bank.tech</a>.
-      </p>
-
-      <h2 style={{ fontSize: "16px", fontWeight: 700, marginTop: "28px", marginBottom: "8px" }}>
-        Bezpečnostní kontakt
-      </h2>
-      <p>
-        Nahlášení bezpečnostní zranitelnosti: <a href="mailto:security@open-bank.tech">security@open-bank.tech</a>{" "}
-        (viz <a href="/.well-known/security.txt">/.well-known/security.txt</a>).
-      </p>
-
-      <p style={{ marginTop: "40px" }}>
-        <a href="/auth/login">← Zpět na přihlášení</a>
-      </p>
-    </main>
-  )
+  return <PrivacyContent />
 }

--- a/openbank-admin-ui/src/app/privacy/privacy.module.css
+++ b/openbank-admin-ui/src/app/privacy/privacy.module.css
@@ -1,0 +1,41 @@
+.page { min-height: 100svh; padding: 0 clamp(24px, 6vw, 92px); background: radial-gradient(circle at 96% 4%, rgba(29, 151, 154, .1), transparent 28%), #f6f8fb; color: #142842; }
+.skipLink { position: fixed; z-index: 10; top: 12px; left: 12px; transform: translateY(-180%); padding: 10px 14px; border-radius: 10px; background: #fff; color: #173d67; font-weight: 700; box-shadow: 0 8px 30px rgba(10,27,58,.18); transition: transform .16s; }
+.skipLink:focus { transform: translateY(0); }
+.header { display: flex; max-width: 1180px; align-items: center; justify-content: space-between; gap: 20px; margin: 0 auto; padding: 28px 0; }
+.brand { border-radius: 5px; color: #142c4d; font-size: .96rem; font-weight: 760; text-decoration: none; }
+.brand span { margin-left: 6px; color: #61728a; font-size: .67rem; font-weight: 650; letter-spacing: .14em; text-transform: uppercase; }
+.languageButton { display: inline-flex; align-items: center; gap: 7px; padding: 9px 11px; border: 1px solid #d8e0eb; border-radius: 10px; background: rgba(255,255,255,.78); color: #314761; font: inherit; font-size: .77rem; font-weight: 650; cursor: pointer; }
+.hero { display: grid; max-width: 1180px; grid-template-columns: minmax(0, 1.4fr) minmax(260px, .6fr); align-items: end; gap: clamp(36px, 7vw, 100px); margin: 0 auto; padding: clamp(64px, 10vw, 132px) 0 clamp(58px, 8vw, 96px); }
+.hero:focus { outline: none; }
+.eyebrow { display: flex; align-items: center; gap: 8px; margin: 0 0 17px; color: #167464; font-size: .71rem; font-weight: 760; letter-spacing: .15em; text-transform: uppercase; }
+.hero h1 { max-width: 790px; margin: 0; color: #102746; font-size: clamp(2.7rem, 6vw, 5.6rem); font-weight: 650; letter-spacing: -.055em; line-height: .99; text-wrap: balance; }
+.intro { max-width: 760px; margin: 28px 0 0; color: #52657c; font-size: clamp(.98rem, 1.6vw, 1.15rem); line-height: 1.72; }
+.note { display: grid; grid-template-columns: 24px 1fr; gap: 13px; padding: 20px; border: 1px solid #cfe1df; border-radius: 14px; background: rgba(239,248,247,.82); color: #3e5b61; }
+.note svg { color: #167464; }
+.note p { margin: 0; font-size: .8rem; line-height: 1.62; }
+.flow { max-width: 1180px; margin: 0 auto; padding: 0 0 clamp(70px, 9vw, 118px); }
+.flow > h2, .contacts h2 { margin: 0 0 25px; color: #172f4e; font-size: 1.35rem; letter-spacing: -.025em; }
+.flowGrid { display: grid; grid-template-columns: repeat(3, 1fr); border: 1px solid #dce4ed; border-radius: 17px; background: rgba(255,255,255,.72); overflow: hidden; }
+.flowGrid article { position: relative; min-height: 270px; padding: 30px; border-right: 1px solid #dce4ed; }
+.flowGrid article:last-child { border-right: 0; }
+.flowIcon { display: grid; width: 42px; height: 42px; place-items: center; border: 1px solid #cfe0e3; border-radius: 12px; background: #f0f8f8; color: #176c72; }
+.step { position: absolute; top: 31px; right: 29px; color: #a3afbd; font: 700 .7rem/1 ui-monospace, monospace; letter-spacing: .08em; }
+.flowGrid h3 { margin: 35px 0 12px; color: #173250; font-size: 1.04rem; }
+.flowGrid p, .details p { margin: 0; color: #5a6c80; font-size: .82rem; line-height: 1.68; }
+.details { display: grid; max-width: 1180px; grid-template-columns: 1fr 1fr; gap: 1px; margin: 0 auto clamp(74px, 9vw, 120px); border: 1px solid #dce4ed; border-radius: 17px; background: #dce4ed; overflow: hidden; }
+.details article { display: grid; min-height: 200px; grid-template-columns: 28px 1fr; gap: 15px; padding: clamp(25px, 4vw, 38px); background: #fff; }
+.details article > svg { color: #1b7770; }
+.details h2 { margin: 0 0 12px; color: #193553; font-size: .98rem; }
+.contacts { display: grid; max-width: 1180px; grid-template-columns: .7fr 1.3fr; gap: clamp(32px, 7vw, 90px); margin: 0 auto; padding: clamp(34px, 5vw, 58px); border-radius: 20px; background: linear-gradient(140deg, #102a4b, #123d64); color: #fff; box-shadow: 0 20px 55px rgba(17,45,79,.16); }
+.contacts .eyebrow { color: #82d9cc; }
+.contacts h2 { color: #fff; font-size: clamp(1.7rem, 3vw, 2.5rem); }
+.contactLinks { display: grid; gap: 10px; }
+.contactLinks a { display: flex; align-items: center; justify-content: space-between; gap: 15px; padding: 13px 15px; border: 1px solid rgba(255,255,255,.13); border-radius: 10px; background: rgba(255,255,255,.055); color: #fff; text-decoration: none; }
+.contactLinks span { color: #bdcde0; font-size: .76rem; }
+.contactLinks strong { font-size: .78rem; }
+.footer { display: flex; max-width: 1180px; align-items: center; justify-content: space-between; gap: 20px; margin: 0 auto; padding: 38px 0 50px; color: #718096; font-size: .75rem; }
+.footer a { display: inline-flex; align-items: center; gap: 8px; border-radius: 5px; color: #255d75; font-weight: 700; text-decoration: none; }
+.languageButton:focus-visible, .brand:focus-visible, .contactLinks a:focus-visible, .footer a:focus-visible { outline: 3px solid rgba(24,116,204,.3); outline-offset: 3px; }
+@media (max-width: 820px) { .hero { grid-template-columns: 1fr; align-items: start; } .note { max-width: 580px; } .flowGrid { grid-template-columns: 1fr; } .flowGrid article { min-height: auto; border-right: 0; border-bottom: 1px solid #dce4ed; } .flowGrid article:last-child { border-bottom: 0; } .details { grid-template-columns: 1fr; } .details article { min-height: auto; } .contacts { grid-template-columns: 1fr; } }
+@media (max-width: 520px) { .page { padding: 0 20px; } .header { padding: 22px 0; } .hero { padding: 56px 0 60px; } .hero h1 { font-size: 2.82rem; } .flowGrid article { padding: 25px; } .details article { padding: 25px; } .contacts { margin-right: -8px; margin-left: -8px; padding: 28px 24px; } .contactLinks a { align-items: flex-start; flex-direction: column; } .footer { align-items: flex-start; flex-direction: column; } }
+@media (prefers-reduced-motion: reduce) { .skipLink { transition: none; } }

--- a/openbank-admin-ui/src/test/privacy-experience.test.tsx
+++ b/openbank-admin-ui/src/test/privacy-experience.test.tsx
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { PrivacyContent } from '@/app/privacy/PrivacyContent'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+const renderPage = () => render(<LanguageProvider><PrivacyContent /></LanguageProvider>)
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+})
+
+describe('public privacy experience', () => {
+  it('explains the complete operator-data journey without weakening the legal notice', () => {
+    renderPage()
+
+    expect(screen.getByRole('heading', { name: 'Know what happens to your operator data.' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'The data journey' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Identity' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Session' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Audit evidence' })).toBeInTheDocument()
+    expect(screen.getByText(/EBA ICT Risk Guidelines and PSD2/)).toBeInTheDocument()
+    expect(screen.getByText(/no marketing or tracking cookies/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /hello@open-bank.tech/ })).toHaveAttribute('href', 'mailto:hello@open-bank.tech')
+    expect(screen.getByRole('link', { name: /security@open-bank.tech/ })).toHaveAttribute('href', 'mailto:security@open-bank.tech')
+  })
+
+  it('switches the full notice to Czech and preserves the sign-in return', () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Přepnout do češtiny' }))
+
+    expect(screen.getByRole('heading', { name: 'Víte, co se děje s údaji operátora.' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Cesta údajů' })).toBeInTheDocument()
+    expect(screen.getByText(/regulatorní povinností uchování/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Zpět k bezpečnému přihlášení/ })).toHaveAttribute('href', '/auth/login')
+  })
+})


### PR DESCRIPTION
## Summary\n- turn the public privacy notice into a responsive Czech/English educational data journey\n- preserve controller, purpose, legal basis, retention, rights and security-reporting facts\n- provide scannable identity, session and audit explanations with a clear return to secure sign-in\n\n## Stack\nThis PR is intentionally based on #7063 and contains only the privacy-experience delta. Retarget to main after the parent merges.\n\n## Safety invariants\n- no data-processing, cookie, retention, authentication, proxy or CSP behavior changes\n- no tracking, analytics or consent mechanism added\n- public unauthenticated availability and security contacts are preserved\n- the authenticated assistant remains absent on the public surface\n\n## Verification\n- focused Vitest: 11 tests passed\n- npm run type-check\n- scoped ESLint\n- npm run build: 90 routes\n- desktop and 390x844 browser visual QA with no horizontal overflow\n- git diff --check\n\nCloses #7068\nRefs #7063