### PR TITLE
perf(admin-ui): keep public surfaces session-free

### DIFF
--- a/openbank-admin-ui/src/app/layout.tsx
+++ b/openbank-admin-ui/src/app/layout.tsx
@@ -5,10 +5,7 @@
 import type { Metadata } from 'next'
 import './globals.css'
 import { headers } from 'next/headers'
-import { Toaster } from 'sonner'
-import { SessionProvider } from '@/components/auth/SessionProvider'
-import { LanguageProvider } from '@/lib/i18n/LanguageContext'
-import { AgentDock } from '@/components/agent/AgentDock'
+import { AppProviders } from '@/components/layout/AppProviders'
 
 export const metadata: Metadata = {
   title: 'OpenBank Admin',
@@ -29,13 +26,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
       </head>
       <body>
-        <SessionProvider>
-          <LanguageProvider>
-            {children}
-            <AgentDock />
-            <Toaster richColors position="top-right" />
-          </LanguageProvider>
-        </SessionProvider>
+        <AppProviders>{children}</AppProviders>
       </body>
     </html>
   )

--- a/openbank-admin-ui/src/components/agent/AgentDock.tsx
+++ b/openbank-admin-ui/src/components/agent/AgentDock.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { usePathname } from 'next/navigation'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { isPublicSurface } from '@/lib/auth/publicSurface'
 import { Bot, Send, X, Loader2, Wrench, ShieldCheck, ShieldAlert, AlertTriangle } from 'lucide-react'
 
 interface ToolCall { tool: string; allowed: boolean; resultPreview: string }
@@ -41,7 +42,7 @@ export function modelLabel(id: string): string {
 
 export function AgentDock() {
   const pathname = usePathname()
-  const publicSurface = pathname.startsWith('/auth') || pathname === '/privacy'
+  const publicSurface = isPublicSurface(pathname)
   const { t } = useLanguage()
   const [open, setOpen] = useState(false)
   const [messages, setMessages] = useState<Msg[]>([])

--- a/openbank-admin-ui/src/components/layout/AppProviders.tsx
+++ b/openbank-admin-ui/src/components/layout/AppProviders.tsx
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { Toaster } from 'sonner'
+import { AgentDock } from '@/components/agent/AgentDock'
+import { SessionProvider } from '@/components/auth/SessionProvider'
+import { isPublicSurface } from '@/lib/auth/publicSurface'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+/**
+ * Keeps authenticated-only infrastructure off public entry and policy surfaces.
+ * Protected operator routes retain session refresh, expiry recovery and AgentDock.
+ */
+export function AppProviders({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const publicSurface = isPublicSurface(pathname)
+  const shared = (
+    <LanguageProvider>
+      {children}
+      {!publicSurface && <AgentDock />}
+      <Toaster richColors position="top-right" />
+    </LanguageProvider>
+  )
+
+  return publicSurface ? shared : <SessionProvider>{shared}</SessionProvider>
+}

--- a/openbank-admin-ui/src/lib/auth/publicSurface.ts
+++ b/openbank-admin-ui/src/lib/auth/publicSurface.ts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+/** Public routes that deliberately run without authenticated operator infrastructure. */
+export function isPublicSurface(pathname: string): boolean {
+  return pathname === '/auth' || pathname.startsWith('/auth/') || pathname === '/privacy'
+}

--- a/openbank-admin-ui/src/test/app-providers.test.tsx
+++ b/openbank-admin-ui/src/test/app-providers.test.tsx
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { usePathname } from 'next/navigation'
+import { AppProviders } from '@/components/layout/AppProviders'
+import { isPublicSurface } from '@/lib/auth/publicSurface'
+
+vi.mock('next/navigation', () => ({ usePathname: vi.fn() }))
+vi.mock('@/components/auth/SessionProvider', () => ({
+  SessionProvider: ({ children }: { children: React.ReactNode }) => <div data-testid="session-provider">{children}</div>,
+}))
+vi.mock('@/components/agent/AgentDock', () => ({ AgentDock: () => <div data-testid="agent-dock" /> }))
+vi.mock('@/lib/i18n/LanguageContext', () => ({
+  LanguageProvider: ({ children }: { children: React.ReactNode }) => <div data-testid="language-provider">{children}</div>,
+}))
+vi.mock('sonner', () => ({ Toaster: () => <div data-testid="toaster" /> }))
+
+describe('AppProviders', () => {
+  beforeEach(() => vi.mocked(usePathname).mockReturnValue('/dashboard'))
+
+  it.each(['/auth/login', '/auth/error', '/auth/forbidden', '/privacy'])('keeps %s session-free', pathname => {
+    vi.mocked(usePathname).mockReturnValue(pathname)
+    render(<AppProviders><main>Public content</main></AppProviders>)
+
+    expect(screen.getByText('Public content')).toBeVisible()
+    expect(screen.getByTestId('language-provider')).toBeVisible()
+    expect(screen.getByTestId('toaster')).toBeVisible()
+    expect(screen.queryByTestId('session-provider')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('agent-dock')).not.toBeInTheDocument()
+  })
+
+  it('retains authenticated infrastructure on protected operator routes', () => {
+    render(<AppProviders><main>Operator content</main></AppProviders>)
+
+    expect(screen.getByTestId('session-provider')).toBeVisible()
+    expect(screen.getByTestId('agent-dock')).toBeVisible()
+    expect(screen.getByText('Operator content')).toBeVisible()
+  })
+
+  it('does not classify similarly named protected routes as public', () => {
+    expect(isPublicSurface('/privacy-settings')).toBe(false)
+    expect(isPublicSurface('/authentication-policy')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- introduce a route-aware provider boundary for public auth and privacy surfaces
- keep NextAuth session refresh, expiry recovery and AgentDock on protected operator routes only
- share exact public-route classification with AgentDock and avoid the overly broad `/auth*` prefix match
- preserve language and toast infrastructure on every route

## Why
The public first impression previously mounted authenticated-only client infrastructure and triggered session discovery that those routes do not consume. This removes avoidable auth work from the fastest and most security-sensitive surfaces without changing protected-route behavior.

## Verification
- 14 focused tests passed
- TypeScript type-check passed
- scoped ESLint passed
- production Next.js build passed (90 routes)
- browser render verified `/auth/login` without AgentDock
- `git diff --check` passed

Closes #7073