### PR TITLE
perf(admin-ui): make party search interruptible

### DIFF
--- a/openbank-admin-ui/src/components/party/PartySearch.tsx
+++ b/openbank-admin-ui/src/components/party/PartySearch.tsx
@@ -19,13 +19,14 @@
 // Shared deliberately (ADR-0208): two callers need it (Customer 360, Consents), and a copy in each
 // would be two divergent search behaviours over one endpoint.
 
-import { useRef, useState, type ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { Search } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { StatusBadge } from '@/components/ui'
 
 const PARTY_SERVICE = '/api/svc/party-service'
+const SEARCH_TIMEOUT_MS = 8_000
 
 export const PARTY_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -64,26 +65,41 @@ export function PartySearch({ onSelect, selectedId, busy = false, placeholder, l
   // Only the newest search may commit its hits — otherwise a slow query for "Nov" lands after a fast
   // one for "Svoboda" and the operator picks from a list that does not match what they typed.
   const generation = useRef(0)
+  const activeRequest = useRef<AbortController | null>(null)
+
+  useEffect(() => () => {
+    generation.current += 1
+    activeRequest.current?.abort()
+  }, [])
 
   const run = async () => {
     const q = term.trim()
-    if (!q) return
+    const gen = ++generation.current
+    activeRequest.current?.abort()
+    activeRequest.current = null
+    if (!q) {
+      setSearching(false)
+      return
+    }
     // A pasted party id is not a name — skip the trigram search entirely, so an operator who already
     // has an id keeps the direct path instead of being forced through a result list of one.
-    const gen = ++generation.current
     if (PARTY_UUID_RE.test(q)) {
+      setSearching(false)
       setHits(null)
       setFailure(null)
       onSelect({ id: q })
       return
     }
+    const controller = new AbortController()
+    const timeout = window.setTimeout(() => controller.abort(), SEARCH_TIMEOUT_MS)
+    activeRequest.current = controller
     setSearching(true)
     setFailure(null)
     setHits(null)
     try {
       const res = await fetch(
         `${PARTY_SERVICE}/api/v1/parties/search?q=${encodeURIComponent(q)}&limit=20`,
-        { cache: 'no-store' },
+        { cache: 'no-store', signal: controller.signal },
       )
       if (gen !== generation.current) return // superseded by a newer search
       if (!res.ok) {
@@ -96,13 +112,15 @@ export function PartySearch({ onSelect, selectedId, busy = false, placeholder, l
     } catch {
       if (gen === generation.current) setFailure('unreachable')
     } finally {
+      window.clearTimeout(timeout)
+      if (activeRequest.current === controller) activeRequest.current = null
       if (gen === generation.current) setSearching(false)
     }
   }
 
   return (
     <>
-      <div className="card" style={{ marginBottom: '20px', padding: '20px' }}>
+      <div className="card" role="search" aria-label={t('Vyhledání klienta nebo firmy', 'Find a customer or company')} aria-busy={searching} style={{ marginBottom: '20px', padding: '20px' }}>
         <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', alignItems: 'center' }}>
           {leading}
           <input
@@ -111,14 +129,17 @@ export function PartySearch({ onSelect, selectedId, busy = false, placeholder, l
             onKeyDown={e => { if (e.key === 'Enter') run() }}
             placeholder={placeholder ?? t('Jméno nebo název firmy (nebo UUID party)', 'Name or company name (or party UUID)')}
             aria-label={t('Vyhledat stranu', 'Search parties')}
+            aria-controls="party-search-results"
             style={{
               flex: '1 1 340px', padding: '8px 12px', borderRadius: '8px', border: '1px solid var(--border)',
               background: 'var(--surface)', color: 'var(--text-primary)', fontSize: '13px',
             }}
           />
           <button
+            type="button"
             onClick={run}
             disabled={searching || busy || !term.trim()}
+            aria-busy={searching}
             style={{
               display: 'flex', alignItems: 'center', gap: '6px', padding: '8px 16px',
               cursor: searching || busy || !term.trim() ? 'not-allowed' : 'pointer', borderRadius: '8px',
@@ -127,34 +148,35 @@ export function PartySearch({ onSelect, selectedId, busy = false, placeholder, l
               opacity: searching || busy || !term.trim() ? 0.6 : 1,
             }}
           >
-            <Search size={15} /> {t('Vyhledat', 'Search')}
+            <Search size={15} aria-hidden="true" /> {searching ? t('Hledám…', 'Searching…') : t('Vyhledat', 'Search')}
           </button>
         </div>
         <p style={{ margin: '10px 0 0', fontSize: '11px', color: 'var(--text-tertiary)' }}>
           {t(
-            'Hledá se v party-service (ADR-0055) — jména vlastní ta služba.',
-            'Search runs against party-service (ADR-0055) — it owns names.',
+            'Začněte jménem klienta nebo názvem firmy. Pokud už máte Party ID, můžete ho vložit přímo.',
+            'Start with the customer or company name. If you already have a Party ID, paste it directly.',
           )}
         </p>
       </div>
 
-      {searching && (
-        <div style={{ color: 'var(--text-secondary)', padding: '24px', textAlign: 'center' }}>
-          {t('Hledám…', 'Searching…')}
-        </div>
-      )}
+      <div id="party-search-results" aria-live="polite">
+        {searching && (
+          <div role="status" style={{ color: 'var(--text-secondary)', padding: '24px', textAlign: 'center' }}>
+            {t('Hledám…', 'Searching…')}
+          </div>
+        )}
 
-      {!searching && failure && (
-        <DataUnavailable
-          kind={failure}
-          service="party-service"
-          feature={t('Hledání party', 'Party search')}
-          lang={language === 'cs' ? 'cs' : 'en'}
-        />
-      )}
+        {!searching && failure && (
+          <DataUnavailable
+            kind={failure}
+            service="party-service"
+            feature={t('Hledání party', 'Party search')}
+            lang={language === 'cs' ? 'cs' : 'en'}
+          />
+        )}
 
-      {!searching && hits && hits.length === 0 && (
-        <div className="card" style={{ padding: '28px', textAlign: 'center', marginBottom: '20px' }}>
+        {!searching && hits && hits.length === 0 && (
+          <div className="card" style={{ padding: '28px', textAlign: 'center', marginBottom: '20px' }}>
           {/* Stated as a search result, not as an unavailable data source: party-service answered. */}
           <p style={{ margin: 0, fontWeight: 600, color: 'var(--text-primary)' }}>
             {t('Žádná party neodpovídá hledání', 'No party matches that search')}
@@ -162,11 +184,11 @@ export function PartySearch({ onSelect, selectedId, busy = false, placeholder, l
           <p style={{ margin: '6px 0 0', fontSize: '12px', color: 'var(--text-secondary)' }}>
             {t('party-service odpověděla — hledaný výraz nic nenašel.', 'party-service answered — the term matched nothing.')}
           </p>
-        </div>
-      )}
+          </div>
+        )}
 
-      {!searching && hits && hits.length > 0 && (
-        <div className="card" style={{ marginBottom: '20px', overflowX: 'auto', padding: '20px' }}>
+        {!searching && hits && hits.length > 0 && (
+          <div className="card" style={{ marginBottom: '20px', overflowX: 'auto', padding: '20px' }}>
           <h2 className="section-title" style={{ marginBottom: '12px' }}>
             {t('Nalezené party', 'Matching parties')} ({hits.length})
           </h2>
@@ -189,8 +211,11 @@ export function PartySearch({ onSelect, selectedId, busy = false, placeholder, l
                   <td>{p.kycStatus ? <StatusBadge status={p.kycStatus} /> : '—'}</td>
                   <td style={{ textAlign: 'right' }}>
                     <button
+                      type="button"
                       onClick={() => onSelect(p)}
                       disabled={busy}
+                      aria-pressed={selectedId === p.id}
+                      aria-label={t(`Vybrat ${partyDisplayName(p)}`, `Select ${partyDisplayName(p)}`)}
                       style={{
                         padding: '5px 12px', borderRadius: '6px', border: '1px solid var(--border)',
                         background: 'var(--surface)', color: 'var(--text-secondary)', fontSize: '12px',
@@ -204,8 +229,9 @@ export function PartySearch({ onSelect, selectedId, busy = false, placeholder, l
               ))}
             </tbody>
           </table>
-        </div>
-      )}
+          </div>
+        )}
+      </div>
     </>
   )
 }

--- a/openbank-admin-ui/src/test/kyc-party-search.test.tsx
+++ b/openbank-admin-ui/src/test/kyc-party-search.test.tsx
@@ -29,7 +29,7 @@ describe('KYC party search', () => {
     fireEvent.change(screen.getByLabelText('Search parties'), { target: { value: 'Oldrich Vanek' } })
     fireEvent.click(screen.getByRole('button', { name: 'Search' }))
     await waitFor(() => expect(screen.getByText('Oldřich Vaněk')).toBeInTheDocument())
-    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Select Oldřich Vaněk' }))
 
     await waitFor(() => expect(f.mock.calls.some(([u]) => String(u).endsWith(`/api/v1/kyc/cases/party/${PARTY}`))).toBe(true))
     expect(screen.getByText('All cases')).toBeInTheDocument()

--- a/openbank-admin-ui/src/test/party-search.test.tsx
+++ b/openbank-admin-ui/src/test/party-search.test.tsx
@@ -53,6 +53,42 @@ describe('PartySearch', () => {
     expect(fetchSpy).not.toHaveBeenCalled() // the id IS the answer — no trigram round-trip
   })
 
+  it('cancels a superseded name lookup and clears busy state for a pasted UUID', async () => {
+    let firstSignal: AbortSignal | undefined
+    const fetchSpy = vi.fn((_url: string, init?: RequestInit) => {
+      firstSignal = init?.signal ?? undefined
+      return new Promise<Response>(() => {})
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+    const onSelect = vi.fn()
+
+    mount(onSelect)
+    fireEvent.keyDown(type('Novák'), { key: 'Enter' })
+    expect(await screen.findByRole('status')).toHaveTextContent(/Hledám|Searching/)
+
+    fireEvent.keyDown(type(UUID), { key: 'Enter' })
+
+    await waitFor(() => expect(onSelect).toHaveBeenCalledWith({ id: UUID }))
+    expect(firstSignal?.aborted).toBe(true)
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels an in-flight lookup when its workflow unmounts', async () => {
+    let signal: AbortSignal | undefined
+    vi.stubGlobal('fetch', vi.fn((_url: string, init?: RequestInit) => {
+      signal = init?.signal ?? undefined
+      return new Promise<Response>(() => {})
+    }))
+
+    const view = mount(vi.fn())
+    fireEvent.keyDown(type('Novák'), { key: 'Enter' })
+    expect(await screen.findByRole('status')).toBeVisible()
+
+    view.unmount()
+    expect(signal?.aborted).toBe(true)
+  })
+
   it('searches party-service by name and does not select until a row is chosen', async () => {
     const hit = { id: UUID, legalName: 'Jan Novák', email: 'jan@example.test', status: 'ACTIVE' }
     const fetchSpy = vi.fn(async () => ({ ok: true, json: async () => ({ data: [hit] }) }) as unknown as Response)
@@ -70,6 +106,20 @@ describe('PartySearch', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Vybrat|Select/ }))
     expect(onSelect).toHaveBeenCalledWith(hit)
+  })
+
+  it('exposes truthful search and selection state', async () => {
+    const hit = { id: UUID, legalName: 'Jan Novák', status: 'ACTIVE' }
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [hit] }) }) as unknown as Response))
+
+    mount(vi.fn())
+    const input = type('Novák')
+    expect(input).toHaveAttribute('aria-controls', 'party-search-results')
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    const select = await screen.findByRole('button', { name: /Vybrat Jan Novák|Select Jan Novák/ })
+    expect(select).toHaveAttribute('type', 'button')
+    expect(select).toHaveAttribute('aria-pressed', 'false')
   })
 
   it('renders zero matches as a search result, never as an unavailable data source', async () => {


### PR DESCRIPTION
## Summary
- cancel superseded and unmounted party-service searches and bound lookup latency to eight seconds
- prevent a fast UUID selection from inheriting a stale name-search busy state
- expose explicit search, busy, live-result and row-selection semantics
- replace internal ADR/service jargon with task-oriented bilingual guidance
- preserve the party-service endpoint, ownership, caller contracts and RBAC boundaries

## Impact
The shared resolver powers Accounts, Account opening, Consents, Customer 360 and KYC. Operators can now change direction without waiting for stale requests or getting trapped behind a permanent “Searching” state.

## Verification
- 11 focused tests passed, including superseded-request and unmount cancellation
- TypeScript type-check passed
- scoped ESLint passed
- production Next.js build passed (90 routes)
- `git diff --check` passed

Closes #7079