### PR TITLE
fix(admin-ui): serialize card operator writes

### DIFF
--- a/openbank-admin-ui/e2e/operator-cockpit.spec.ts
+++ b/openbank-admin-ui/e2e/operator-cockpit.spec.ts
@@ -136,7 +136,7 @@ test('Temporal and approvals show live source-backed operator state and human pr
   await expect(page.getByText(/Provozní|Running/)).toBeVisible()
   await page.getByRole('button', { name: /Metriky|Metrics/ }).click()
   await expect(page.getByRole('heading', { name: /Workflowy \(posledních 60 minut\)|Workflows \(last 60 minutes\)/ })).toBeVisible()
-  await expect(page.getByText('12')).toBeVisible()
+  await expect(page.getByText('12', { exact: true })).toBeVisible()
 
   await json(page, '**/api/agent/proposals?state=all', [{
     id: 'proposal-human', title: 'Human customer correction', rationale: 'verified with customer', suggestedAction: 'party.correct',

--- a/openbank-admin-ui/src/components/cards/CardControlsPanel.tsx
+++ b/openbank-admin-ui/src/components/cards/CardControlsPanel.tsx
@@ -125,14 +125,16 @@ export function CardControlsPanel({
 
       <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '14px' }}>
         <button
+          type="button"
           className="btn btn-primary btn-sm"
           disabled={busy !== null || block !== null || !dirty}
+          aria-busy={saving}
           onClick={() => void onSave(draft)}
         >
           {saving
-            ? <RefreshCw size={12} style={{ animation: 'spin 0.8s linear infinite' }} />
-            : <Save size={12} />}
-          {t('Uložit kanály', 'Save channels')}
+            ? <RefreshCw size={12} aria-hidden="true" style={{ animation: 'spin 0.8s linear infinite' }} />
+            : <Save size={12} aria-hidden="true" />}
+          {saving ? t('Ukládám kanály…', 'Saving channels…') : t('Uložit kanály', 'Save channels')}
         </button>
       </div>
     </div>

--- a/openbank-admin-ui/src/components/cards/CardLimitsPanel.tsx
+++ b/openbank-admin-ui/src/components/cards/CardLimitsPanel.tsx
@@ -127,14 +127,16 @@ export function CardLimitsPanel({
 
       <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '14px' }}>
         <button
+          type="button"
           className="btn btn-primary btn-sm"
           disabled={busy !== null || block !== null || violations.length > 0 || !dirty}
+          aria-busy={saving}
           onClick={() => { if (dailyMinorUnits !== null && monthlyMinorUnits !== null) void onSave(dailyMinorUnits, monthlyMinorUnits) }}
         >
           {saving
-            ? <RefreshCw size={12} style={{ animation: 'spin 0.8s linear infinite' }} />
-            : <Save size={12} />}
-          {t('Uložit limity', 'Save limits')}
+            ? <RefreshCw size={12} aria-hidden="true" style={{ animation: 'spin 0.8s linear infinite' }} />
+            : <Save size={12} aria-hidden="true" />}
+          {saving ? t('Ukládám limity…', 'Saving limits…') : t('Uložit limity', 'Save limits')}
         </button>
       </div>
     </div>

--- a/openbank-admin-ui/src/components/cards/CardOperationFeedback.tsx
+++ b/openbank-admin-ui/src/components/cards/CardOperationFeedback.tsx
@@ -43,6 +43,7 @@ export function CardOperationFeedback({
       <Icon size={15} style={{ flexShrink: 0, marginTop: '1px' }} />
       <span style={{ flex: 1 }}>{feedback.text}</span>
       <button
+        type="button"
         onClick={onDismiss}
         aria-label={t('Zavřít zprávu', 'Dismiss message')}
         style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'inherit', lineHeight: 1, padding: 0 }}

--- a/openbank-admin-ui/src/components/cards/CardTransitionButtons.tsx
+++ b/openbank-admin-ui/src/components/cards/CardTransitionButtons.tsx
@@ -66,14 +66,16 @@ export function CardTransitionButtons({
         return (
           <button
             key={tr.action}
+            type="button"
             className={`btn btn-sm ${tr.irreversible ? 'btn-danger' : 'btn-ghost'}`}
             disabled={busy !== null}
+            aria-busy={running}
             title={`${label(tr.action)} → ${tr.to}`}
             onClick={() => onSelect(tr)}
           >
             {running
-              ? <RefreshCw size={12} style={{ animation: 'spin 0.8s linear infinite' }} />
-              : <Icon size={12} />}
+              ? <RefreshCw size={12} aria-hidden="true" style={{ animation: 'spin 0.8s linear infinite' }} />
+              : <Icon size={12} aria-hidden="true" />}
             {label(tr.action)}
           </button>
         )

--- a/openbank-admin-ui/src/lib/cards/useCardOperations.ts
+++ b/openbank-admin-ui/src/lib/cards/useCardOperations.ts
@@ -17,8 +17,9 @@
 
 'use client'
 
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { claimSingleFlight, releaseSingleFlight } from '@/lib/single-flight'
 import { svcUrl } from '@/lib/services/bff'
 import { classifyMutation, type MutationFailure } from './mutations'
 import type { CardTransition } from './lifecycle'
@@ -49,6 +50,7 @@ export function useCardOperations(onChanged?: () => void): CardOperations {
   const { t } = useLanguage()
   const [busy, setBusy] = useState<string | null>(null)
   const [feedback, setFeedback] = useState<Feedback | null>(null)
+  const writeInFlight = useRef(false)
 
   const failureCopy = useCallback((kind: MutationFailure): string => {
     switch (kind) {
@@ -137,6 +139,7 @@ export function useCardOperations(onChanged?: () => void): CardOperations {
     init: RequestInit,
     okText: string,
   ): Promise<unknown | 'parked' | null> => {
+    if (!claimSingleFlight(writeInFlight)) return null
     setBusy(busyKey)
     setFeedback(null)
     try {
@@ -162,6 +165,7 @@ export function useCardOperations(onChanged?: () => void): CardOperations {
       setFeedback({ tone: 'error', text: failureCopy('unreachable') })
       return null
     } finally {
+      releaseSingleFlight(writeInFlight)
       setBusy(null)
     }
   }, [failureCopy, fourEyesCopy, onChanged])

--- a/openbank-admin-ui/src/test/card-operations-single-flight.test.tsx
+++ b/openbank-admin-ui/src/test/card-operations-single-flight.test.tsx
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import React from 'react'
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useCardOperations } from '@/lib/cards/useCardOperations'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import type { Card } from '@/lib/cards/types'
+
+const card = { id: 'card-1', maskedPan: '**** 1234', status: 'ACTIVE' } as Card
+const suspend = { action: 'suspend', to: 'SUSPENDED', irreversible: false, reason: false } as const
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('card operator mutation single-flight contract', () => {
+  it('rejects an overlapping write and accepts a new one after settlement', async () => {
+    let settle: ((response: Response) => void) | undefined
+    const fetchMock = vi.fn(() => new Promise<Response>(resolve => { settle = resolve }))
+    vi.stubGlobal('fetch', fetchMock)
+    const wrapper = ({ children }: { children: React.ReactNode }) => <LanguageProvider>{children}</LanguageProvider>
+    const { result } = renderHook(() => useCardOperations(), { wrapper })
+
+    let first: Promise<boolean>
+    let overlapping: Promise<boolean>
+    act(() => {
+      first = result.current.runTransition(card, suspend)
+      overlapping = result.current.runTransition(card, suspend)
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    await expect(overlapping!).resolves.toBe(false)
+
+    await act(async () => {
+      settle?.(new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }))
+      await first!
+    })
+
+    let next: Promise<boolean>
+    act(() => { next = result.current.runTransition(card, suspend) })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    await act(async () => {
+      settle?.(new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }))
+      await next!
+    })
+  })
+})


### PR DESCRIPTION
## Summary\n- synchronously reject overlapping card lifecycle, limit, channel-control and issuance writes\n- release the single-flight lock on every success, four-eyes, refusal and network-failure path\n- expose explicit button semantics, truthful busy state and localized pending labels on card controls\n\n## Safety\nThis PR is intentionally stacked on #7085 for the tested shared single-flight primitive. BFF-derived operator identity, endpoints, payloads, write timeout, four-eyes handling, RBAC and issuance idempotency are unchanged.\n\n## Verification\n- 12 focused hook/component/guard tests passed\n- scoped ESLint passed\n- git diff --check passed\n- full type/build runs on CI with the stacked dependency\n\nCloses #7087