### PR TITLE
fix(admin-ui): serialize document-template writes

### DIFF
--- a/openbank-admin-ui/e2e/operator-cockpit.spec.ts
+++ b/openbank-admin-ui/e2e/operator-cockpit.spec.ts
@@ -136,7 +136,7 @@ test('Temporal and approvals show live source-backed operator state and human pr
   await expect(page.getByText(/Provozní|Running/)).toBeVisible()
   await page.getByRole('button', { name: /Metriky|Metrics/ }).click()
   await expect(page.getByRole('heading', { name: /Workflowy \(posledních 60 minut\)|Workflows \(last 60 minutes\)/ })).toBeVisible()
-  await expect(page.getByText('12')).toBeVisible()
+  await expect(page.getByText('12', { exact: true })).toBeVisible()
 
   await json(page, '**/api/agent/proposals?state=all', [{
     id: 'proposal-human', title: 'Human customer correction', rationale: 'verified with customer', suggestedAction: 'party.correct',

--- a/openbank-admin-ui/src/app/document-templates/page.tsx
+++ b/openbank-admin-ui/src/app/document-templates/page.tsx
@@ -17,6 +17,7 @@ import { svcUrl, classifyBffFailure, type BffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { looksLikeUuid } from '@/lib/validation/iban'
 import { PageHeader } from '@/components/ui/PageHeader'
+import { claimSingleFlight, releaseSingleFlight } from '@/lib/single-flight'
 
 // Go through the BFF proxy directly (svcUrl → /api/svc/document-service/...), the
 // same pattern product-catalog/standing-orders/kyc now use — NOT a dedicated
@@ -251,6 +252,7 @@ export default function DocumentTemplatesPage() {
   // so this bar is modelled on the app's own modal-overlay convention instead.
   const [pendingAction, setPendingAction] = useState<{ id: string; kind: 'publish' | 'retire' } | null>(null)
   const [actioning, setActioning] = useState(false)
+  const writeInFlight = useRef(false)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -405,6 +407,7 @@ export default function DocumentTemplatesPage() {
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault()
+    if (!claimSingleFlight(writeInFlight)) return
     setSaving(true)
     setActionError(null)
     try {
@@ -425,11 +428,13 @@ export default function DocumentTemplatesPage() {
     } catch (err) {
       setActionError(err instanceof Error ? err.message : t('Uložení šablony selhalo', 'Failed to save the template'))
     } finally {
+      releaseSingleFlight(writeInFlight)
       setSaving(false)
     }
   }
 
   const runAction = async (id: string, kind: 'publish' | 'retire') => {
+    if (!claimSingleFlight(writeInFlight)) return
     setActioning(true)
     setActionError(null)
     try {
@@ -439,6 +444,7 @@ export default function DocumentTemplatesPage() {
     } catch (err) {
       setActionError(err instanceof Error ? err.message : t('Akci se nepodařilo provést', 'The action could not be completed'))
     } finally {
+      releaseSingleFlight(writeInFlight)
       setActioning(false)
     }
   }
@@ -775,7 +781,7 @@ export default function DocumentTemplatesPage() {
               <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', paddingTop: '4px' }}>
                 <button type="button" className="btn btn-secondary" onClick={() => setModalOpen(false)} disabled={saving}>{t('Zavřít', 'Close')}</button>
                 {canEdit && (
-                  <button type="submit" className="btn btn-primary" disabled={saving}>
+                  <button type="submit" className="btn btn-primary" disabled={saving || actioning} aria-busy={saving}>
                     {saving ? t('Ukládám…', 'Saving…') : t('Uložit šablonu', 'Save Template')}
                   </button>
                 )}

--- a/openbank-admin-ui/src/test/document-template-controls.guard.test.ts
+++ b/openbank-admin-ui/src/test/document-template-controls.guard.test.ts
@@ -12,5 +12,8 @@ describe('document template workflow controls contract', () => {
     expect(source).toContain('aria-busy={loading}')
     expect(source).toContain("aria-label={t('Vyhledat dokument podle ID', 'Look up document by ID')}")
     expect(source).toContain('type="button" onClick={() => runAction(pendingAction.id, pendingAction.kind)}')
+    expect(source.match(/claimSingleFlight\(writeInFlight\)/g)).toHaveLength(2)
+    expect(source.match(/releaseSingleFlight\(writeInFlight\)/g)).toHaveLength(2)
+    expect(source).toContain('type="submit" className="btn btn-primary" disabled={saving || actioning} aria-busy={saving}')
   })
 })


### PR DESCRIPTION
## Summary\n- synchronously reject overlapping template save, publish and retire writes\n- share one lock across draft and lifecycle actions and release it on every outcome\n- expose truthful save busy state while preserving the existing confirmation workflow\n\n## Safety\nThis PR is intentionally stacked on #7085 for the tested shared single-flight primitive. BFF routing, request payloads, immutable published versions, RBAC and four-eyes semantics are unchanged.\n\n## Verification\n- 7 focused guard/workflow assertions passed\n- scoped ESLint: 0 errors (one pre-existing out-of-diff effect warning)\n- git diff --check passed\n- full type/build runs on CI with the stacked dependency\n\nCloses #7091