### PR TITLE
fix(admin-ui): preserve payment attempt idempotency

### DIFF
--- a/openbank-admin-ui/e2e/operator-cockpit.spec.ts
+++ b/openbank-admin-ui/e2e/operator-cockpit.spec.ts
@@ -136,7 +136,7 @@ test('Temporal and approvals show live source-backed operator state and human pr
   await expect(page.getByText(/Provozní|Running/)).toBeVisible()
   await page.getByRole('button', { name: /Metriky|Metrics/ }).click()
   await expect(page.getByRole('heading', { name: /Workflowy \(posledních 60 minut\)|Workflows \(last 60 minutes\)/ })).toBeVisible()
-  await expect(page.getByText('12')).toBeVisible()
+  await expect(page.getByText('12', { exact: true })).toBeVisible()
 
   await json(page, '**/api/agent/proposals?state=all', [{
     id: 'proposal-human', title: 'Human customer correction', rationale: 'verified with customer', suggestedAction: 'party.correct',

--- a/openbank-admin-ui/src/app/payments/page.tsx
+++ b/openbank-admin-ui/src/app/payments/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState, useEffect, useCallback, Suspense } from 'react'
+import { useState, useEffect, useCallback, useRef, Suspense } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -16,6 +16,8 @@ import { stashRow } from '@/lib/services/rowHandoff'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { hasPermission } from '@/lib/auth/roles'
 import { PageHeader, StatusBadge } from '@/components/ui'
+import { clearPaymentAttempt, idempotencyKeyForPayload, type PaymentAttempt } from '@/lib/payments/idempotency'
+import { claimSingleFlight, releaseSingleFlight } from '@/lib/single-flight'
 
 // ADR-0080 P1 (pentest FIND-S3-03/04): all backend access goes through same-origin BFF
 // routes — never NEXT_PUBLIC_ localhost URLs, which leaked the internal port map into the
@@ -268,6 +270,9 @@ function PaymentsContent() {
   const [createSuccess, setCreateSuccess] = useState<string | null>(null)
   const [domesticForm, setDomesticForm] = useState<DomesticFormData>(emptyDomestic(false))
   const [sepaForm, setSepaForm] = useState<SepaFormData>(emptySepa(false))
+  const createInFlight = useRef(false)
+  const domesticAttempt = useRef<PaymentAttempt | null>(null)
+  const sepaAttempt = useRef<PaymentAttempt | null>(null)
 
   // SCT Inst monitoring state
   const [sctPayments, setSctPayments] = useState<SctInstPayment[]>([])
@@ -339,33 +344,36 @@ function PaymentsContent() {
       setCreateError(t('Vyplňte všechna povinná pole', 'Please fill all required fields'))
       return
     }
+    const payload = {
+      debtorAccountId: f.debtorAccountId, debtorAccountNumber: f.debtorAccountNumber,
+      debtorBankCode: f.debtorBankCode, debtorName: f.debtorName,
+      creditorAccountNumber: f.creditorAccountNumber, creditorBankCode: f.creditorBankCode,
+      creditorName: f.creditorName, amount: Number(f.amount), currency: f.currency,
+      priority: f.priority, transferScope: f.transferScope, instant: f.instant,
+      ...(f.variableSymbol && { variableSymbol: f.variableSymbol }),
+      ...(f.specificSymbol && { specificSymbol: f.specificSymbol }),
+      ...(f.constantSymbol && { constantSymbol: f.constantSymbol }),
+      ...(f.messageForPayee && { messageForPayee: f.messageForPayee }),
+      ...(f.transferScope === 'TECHNICAL_ACCOUNT' && f.technicalAccountCode && { technicalAccountCode: f.technicalAccountCode }),
+      ...(f.statementLabel && { statementLabel: f.statementLabel }),
+      ...(f.endToEndId && { endToEndId: f.endToEndId }),
+    }
+    if (!claimSingleFlight(createInFlight)) return
     setCreating(true)
     try {
-      const payload = {
-        debtorAccountId: f.debtorAccountId, debtorAccountNumber: f.debtorAccountNumber,
-        debtorBankCode: f.debtorBankCode, debtorName: f.debtorName,
-        creditorAccountNumber: f.creditorAccountNumber, creditorBankCode: f.creditorBankCode,
-        creditorName: f.creditorName, amount: Number(f.amount), currency: f.currency,
-        priority: f.priority, transferScope: f.transferScope, instant: f.instant,
-        ...(f.variableSymbol && { variableSymbol: f.variableSymbol }),
-        ...(f.specificSymbol && { specificSymbol: f.specificSymbol }),
-        ...(f.constantSymbol && { constantSymbol: f.constantSymbol }),
-        ...(f.messageForPayee && { messageForPayee: f.messageForPayee }),
-        ...(f.transferScope === 'TECHNICAL_ACCOUNT' && f.technicalAccountCode && { technicalAccountCode: f.technicalAccountCode }),
-        ...(f.statementLabel && { statementLabel: f.statementLabel }),
-        ...(f.endToEndId && { endToEndId: f.endToEndId }),
-      }
+      const body = JSON.stringify(payload)
+      const idempotencyKey = idempotencyKeyForPayload(domesticAttempt, body, () => crypto.randomUUID())
       const res = await fetch(`/api/domestic-payments`, {
-        method: 'POST', headers: { 'Content-Type': 'application/json', 'Idempotency-Key': crypto.randomUUID() },
-        body: JSON.stringify(payload),
+        method: 'POST', headers: { 'Content-Type': 'application/json', 'Idempotency-Key': idempotencyKey }, body,
       })
       if (!res.ok) throw new Error(await res.text() || t('Vytvoření platby selhalo', 'Failed to create payment'))
+      clearPaymentAttempt(domesticAttempt)
       setCreateSuccess(t(f.instant ? 'Okamžitá platba vytvořena' : 'Platba vytvořena', f.instant ? 'Instant payment created' : 'Payment created'))
       setShowCreate(null)
       load()
     } catch (err: unknown) {
       setCreateError(err instanceof Error ? err.message : t('Neznámá chyba', 'Unknown error'))
-    } finally { setCreating(false) }
+    } finally { releaseSingleFlight(createInFlight); setCreating(false) }
   }
 
   const handleSepaCreate = async (e: React.FormEvent) => {
@@ -393,28 +401,31 @@ function PaymentsContent() {
       setCreateError(t('Jméno příjemce nesouhlasí (VoP NO_MATCH) — platbu nelze odeslat', 'Payee name does not match (VoP NO_MATCH) — payment cannot be sent'))
       return
     }
+    const payload = {
+      debtorIban: f.debtorIban, creditorIban: f.creditorIban,
+      creditorName: f.creditorName, amount: Number(f.amount),
+      currency: 'EUR', instant: f.instant,
+      ...(f.bic && { bic: f.bic }),
+      ...(f.endToEndId && { endToEndId: f.endToEndId }),
+      ...(f.remittanceInfo && { remittanceInfo: f.remittanceInfo }),
+      ...(f.purposeCode && { purposeCode: f.purposeCode }),
+    }
+    if (!claimSingleFlight(createInFlight)) return
     setCreating(true)
     try {
-      const payload = {
-        debtorIban: f.debtorIban, creditorIban: f.creditorIban,
-        creditorName: f.creditorName, amount: Number(f.amount),
-        currency: 'EUR', instant: f.instant,
-        ...(f.bic && { bic: f.bic }),
-        ...(f.endToEndId && { endToEndId: f.endToEndId }),
-        ...(f.remittanceInfo && { remittanceInfo: f.remittanceInfo }),
-        ...(f.purposeCode && { purposeCode: f.purposeCode }),
-      }
+      const body = JSON.stringify(payload)
+      const idempotencyKey = idempotencyKeyForPayload(sepaAttempt, body, () => crypto.randomUUID())
       const res = await fetch(`/api/sepa-payments`, {
-        method: 'POST', headers: { 'Content-Type': 'application/json', 'Idempotency-Key': crypto.randomUUID() },
-        body: JSON.stringify(payload),
+        method: 'POST', headers: { 'Content-Type': 'application/json', 'Idempotency-Key': idempotencyKey }, body,
       })
       if (!res.ok) throw new Error(await res.text() || t('Vytvoření platby selhalo', 'Failed to create payment'))
+      clearPaymentAttempt(sepaAttempt)
       setCreateSuccess(t(f.instant ? 'SCT Inst platba vytvořena' : 'SEPA platba vytvořena', f.instant ? 'SCT Inst payment created' : 'SEPA payment created'))
       setShowCreate(null)
       load()
     } catch (err: unknown) {
       setCreateError(err instanceof Error ? err.message : t('Neznámá chyba', 'Unknown error'))
-    } finally { setCreating(false) }
+    } finally { releaseSingleFlight(createInFlight); setCreating(false) }
   }
 
   // ── Filtered data ──────────────────────────────────────────────
@@ -785,7 +796,7 @@ function PaymentsContent() {
                 {createError && <div style={{ color: 'var(--red)', fontSize: '13px', marginTop: '4px' }}>{createError}</div>}
                 <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '8px' }}>
                   <button type="button" className="btn btn-secondary" onClick={() => setShowCreate(null)}>{t('Zrušit', 'Cancel')}</button>
-                  <button type="submit" className="btn btn-primary" disabled={creating}>
+                  <button type="submit" className="btn btn-primary" disabled={creating} aria-busy={creating}>
                     {creating ? t('Odesílám...', 'Sending...') : t(domesticForm.instant ? 'Odeslat okamžitě' : 'Vytvořit', domesticForm.instant ? 'Send instant' : 'Create')}
                   </button>
                 </div>
@@ -867,7 +878,7 @@ function PaymentsContent() {
                 {createError && <div style={{ color: 'var(--red)', fontSize: '13px', marginTop: '4px' }}>{createError}</div>}
                 <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '8px' }}>
                   <button type="button" className="btn btn-secondary" onClick={() => setShowCreate(null)}>{t('Zrušit', 'Cancel')}</button>
-                  <button type="submit" className="btn btn-primary" disabled={creating}>
+                  <button type="submit" className="btn btn-primary" disabled={creating} aria-busy={creating}>
                     {creating ? t('Odesílám...', 'Sending...') : t(sepaForm.instant ? 'Odeslat okamžitě' : 'Vytvořit', sepaForm.instant ? 'Send instant' : 'Create')}
                   </button>
                 </div>

--- a/openbank-admin-ui/src/lib/payments/idempotency.ts
+++ b/openbank-admin-ui/src/lib/payments/idempotency.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+export interface PaymentAttempt {
+  payload: string
+  key: string
+}
+
+export interface PaymentAttemptRef {
+  current: PaymentAttempt | null
+}
+
+export function idempotencyKeyForPayload(
+  attempt: PaymentAttemptRef,
+  payload: string,
+  mint: () => string,
+): string {
+  if (attempt.current?.payload === payload) return attempt.current.key
+  const key = mint()
+  attempt.current = { payload, key }
+  return key
+}
+
+export function clearPaymentAttempt(attempt: PaymentAttemptRef): void {
+  attempt.current = null
+}

--- a/openbank-admin-ui/src/test/payment-create-single-flight.guard.test.ts
+++ b/openbank-admin-ui/src/test/payment-create-single-flight.guard.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(path.resolve(__dirname, '../app/payments/page.tsx'), 'utf8')
+
+describe('payment creation single-flight contract', () => {
+  it('guards both money-path submit handlers and exposes truthful progress', () => {
+    expect(page.match(/claimSingleFlight\(createInFlight\)/g)).toHaveLength(2)
+    expect(page.match(/releaseSingleFlight\(createInFlight\)/g)).toHaveLength(2)
+    expect(page.match(/aria-busy=\{creating\}/g)).toHaveLength(2)
+    expect(page).toContain('idempotencyKeyForPayload(domesticAttempt, body')
+    expect(page).toContain('idempotencyKeyForPayload(sepaAttempt, body')
+    expect(page).not.toContain("'Idempotency-Key': crypto.randomUUID()")
+  })
+})

--- a/openbank-admin-ui/src/test/payment-idempotency.test.ts
+++ b/openbank-admin-ui/src/test/payment-idempotency.test.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it, vi } from 'vitest'
+import { clearPaymentAttempt, idempotencyKeyForPayload, type PaymentAttemptRef } from '@/lib/payments/idempotency'
+
+describe('payment creation idempotency attempts', () => {
+  it('reuses a key for an identical retry and rotates it for edited payloads', () => {
+    const attempt: PaymentAttemptRef = { current: null }
+    const mint = vi.fn().mockReturnValueOnce('key-1').mockReturnValueOnce('key-2')
+
+    expect(idempotencyKeyForPayload(attempt, '{"amount":100}', mint)).toBe('key-1')
+    expect(idempotencyKeyForPayload(attempt, '{"amount":100}', mint)).toBe('key-1')
+    expect(idempotencyKeyForPayload(attempt, '{"amount":101}', mint)).toBe('key-2')
+    expect(mint).toHaveBeenCalledTimes(2)
+  })
+
+  it('clears a successful attempt so the next payment gets a new key', () => {
+    const attempt: PaymentAttemptRef = { current: null }
+    const mint = vi.fn().mockReturnValueOnce('key-1').mockReturnValueOnce('key-2')
+
+    expect(idempotencyKeyForPayload(attempt, 'same-body', mint)).toBe('key-1')
+    clearPaymentAttempt(attempt)
+    expect(idempotencyKeyForPayload(attempt, 'same-body', mint)).toBe('key-2')
+  })
+})

--- a/openbank-admin-ui/src/test/payments-create-rbac.guard.test.ts
+++ b/openbank-admin-ui/src/test/payments-create-rbac.guard.test.ts
@@ -14,8 +14,10 @@ describe('payment initiation access boundary', () => {
     expect(page).toContain('{canCreate && (')
   })
 
-  it('does not change the backend-backed idempotent money path', () => {
-    expect(page).toContain("'Idempotency-Key': crypto.randomUUID()")
+  it('keeps the backend-backed money path and stable attempt idempotency', () => {
+    expect(page).toContain("'Idempotency-Key': idempotencyKey")
+    expect(page).toContain('idempotencyKeyForPayload(domesticAttempt, body')
+    expect(page).toContain('idempotencyKeyForPayload(sepaAttempt, body')
     expect(page).toContain('const SEPA_API         = \'/api/sepa-payments\'')
     expect(page).toContain('const DOMESTIC_API     = \'/api/domestic-payments\'')
     expect(page).toContain('f.vopStatus === \'no_match\'')


### PR DESCRIPTION
## Summary
- enforce a synchronous single-flight lock across domestic and SEPA payment creation
- reuse the same idempotency key for byte-identical retries after uncertain failures
- rotate the key when the payment payload changes and clear it after confirmed success
- expose truthful submit progress without changing validation, VoP, BFF, RBAC or approval semantics

## Verification
- 4 focused Vitest assertions passed (idempotency helper, payment guard and shared single-flight primitive)
- scoped ESLint passed with zero errors (three pre-existing warnings in the payments page)
- git diff --check passed
- signed commit verified

This PR is intentionally stacked on #7085 because it reuses the reviewed shared single-flight primitive.

Closes #7093