### PR TITLE
fix(admin-ui): serialize identity case decisions

### DIFF
--- a/openbank-admin-ui/e2e/operator-cockpit.spec.ts
+++ b/openbank-admin-ui/e2e/operator-cockpit.spec.ts
@@ -136,7 +136,7 @@ test('Temporal and approvals show live source-backed operator state and human pr
   await expect(page.getByText(/Provozní|Running/)).toBeVisible()
   await page.getByRole('button', { name: /Metriky|Metrics/ }).click()
   await expect(page.getByRole('heading', { name: /Workflowy \(posledních 60 minut\)|Workflows \(last 60 minutes\)/ })).toBeVisible()
-  await expect(page.getByText('12')).toBeVisible()
+  await expect(page.getByText('12', { exact: true })).toBeVisible()
 
   await json(page, '**/api/agent/proposals?state=all', [{
     id: 'proposal-human', title: 'Human customer correction', rationale: 'verified with customer', suggestedAction: 'party.correct',

--- a/openbank-admin-ui/src/app/identity-cases/page.tsx
+++ b/openbank-admin-ui/src/app/identity-cases/page.tsx
@@ -4,13 +4,14 @@
 
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader } from '@/components/ui/PageHeader'
 import { AuthGuard, Can } from '@/components/auth/AuthGuard'
 import { Fingerprint, RefreshCw, ShieldAlert, Users, Check } from 'lucide-react'
+import { claimSingleFlight, releaseSingleFlight } from '@/lib/single-flight'
 
 const SVC = 'pid-service'
 
@@ -75,10 +76,12 @@ function DecisionForm({
   const [notes, setNotes] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const mutationInFlight = useRef(false)
 
   const isSecond = c.status === 'AWAITING_SECOND_APPROVAL'
 
   const submit = useCallback(async () => {
+    if (!claimSingleFlight(mutationInFlight)) return
     setBusy(true)
     setError(null)
     try {
@@ -106,11 +109,13 @@ function DecisionForm({
     } catch {
       setError(t('Služba je nedostupná.', 'Service unavailable.'))
     } finally {
+      releaseSingleFlight(mutationInFlight)
       setBusy(false)
     }
   }, [verdict, linkPartyId, notes, c.id, onDecided, t])
 
   const reopen = useCallback(async () => {
+    if (!claimSingleFlight(mutationInFlight)) return
     setBusy(true)
     setError(null)
     try {
@@ -126,6 +131,7 @@ function DecisionForm({
     } catch {
       setError(t('Služba je nedostupná.', 'Service unavailable.'))
     } finally {
+      releaseSingleFlight(mutationInFlight)
       setBusy(false)
     }
   }, [c.id, onDecided, t])
@@ -198,12 +204,14 @@ function DecisionForm({
 
         <button type="button" aria-busy={busy} className="btn btn-primary" onClick={submit} disabled={busy} style={{ fontSize: '13px' }}>
           <Check size={14} aria-hidden="true" style={{ marginRight: '4px' }} />
-          {isSecond ? t('Potvrdit a rozhodnout', 'Confirm & decide') : t('Odeslat hlas', 'Submit vote')}
+          {busy
+            ? t('Odesílám…', 'Submitting…')
+            : isSecond ? t('Potvrdit a rozhodnout', 'Confirm & decide') : t('Odeslat hlas', 'Submit vote')}
         </button>
 
         {isSecond && (
           <button type="button" aria-busy={busy} className="btn btn-secondary" onClick={reopen} disabled={busy} style={{ fontSize: '13px' }}>
-            {t('Znovu otevřít', 'Reopen')}
+            {busy ? t('Pracuji…', 'Working…') : t('Znovu otevřít', 'Reopen')}
           </button>
         )}
       </div>

--- a/openbank-admin-ui/src/test/identity-case-single-flight.guard.test.ts
+++ b/openbank-admin-ui/src/test/identity-case-single-flight.guard.test.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(path.resolve(__dirname, '../app/identity-cases/page.tsx'), 'utf8')
+
+describe('identity case mutation single-flight contract', () => {
+  it('guards both four-eyes writes before network dispatch and reports progress', () => {
+    expect(page.match(/claimSingleFlight\(mutationInFlight\)/g)).toHaveLength(2)
+    expect(page.match(/releaseSingleFlight\(mutationInFlight\)/g)).toHaveLength(2)
+    expect(page.match(/aria-busy=\{busy\}/g)).toHaveLength(2)
+    expect(page).toContain('/decision`')
+    expect(page).toContain('/reopen`')
+  })
+})


### PR DESCRIPTION
## Summary
- protect identity-case vote and reopen mutations with one synchronous single-flight lock
- prevent duplicate four-eyes writes before React can render the disabled state
- show localized in-progress labels while preserving endpoints, payloads, RBAC and four-eyes enforcement

## Verification
- focused guard test passed
- scoped ESLint passed with zero errors (one pre-existing effect warning)
- git diff --check passed
- signed commit verified

This PR is intentionally stacked on #7085 for the shared single-flight primitive.

Closes #7096