### PR TITLE
fix(admin-ui): clarify audience lifecycle state

### DIFF
--- a/openbank-admin-ui/e2e/operator-cockpit.spec.ts
+++ b/openbank-admin-ui/e2e/operator-cockpit.spec.ts
@@ -136,7 +136,7 @@ test('Temporal and approvals show live source-backed operator state and human pr
   await expect(page.getByText(/Provozní|Running/)).toBeVisible()
   await page.getByRole('button', { name: /Metriky|Metrics/ }).click()
   await expect(page.getByRole('heading', { name: /Workflowy \(posledních 60 minut\)|Workflows \(last 60 minutes\)/ })).toBeVisible()
-  await expect(page.getByText('12')).toBeVisible()
+  await expect(page.getByText('12', { exact: true })).toBeVisible()
 
   await json(page, '**/api/agent/proposals?state=all', [{
     id: 'proposal-human', title: 'Human customer correction', rationale: 'verified with customer', suggestedAction: 'party.correct',

--- a/openbank-admin-ui/src/app/segments/page.tsx
+++ b/openbank-admin-ui/src/app/segments/page.tsx
@@ -4,13 +4,14 @@
 
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { ArrowRight, Clock3, Plus, ShieldCheck, Sparkles, Users } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader } from '@/components/ui'
 import { AuthGuard, Can } from '@/components/auth/AuthGuard'
+import { claimSingleFlight, releaseSingleFlight } from '@/lib/single-flight'
 
 // Read-only by design. ADR-0201 D1: a segment is a versioned artifact defined in code, reviewed and
 // released like anything else — "no free-form SQL from a UI". A marketer picks from this catalogue;
@@ -37,6 +38,9 @@ export default function SegmentsPage() {
   const [unavailable, setUnavailable] = useState<UnavailableKind | null>(null)
   const [loading, setLoading] = useState(true)
   const [previews, setPreviews] = useState<Record<string, Preview | 'loading'>>({})
+  const [lifecycleBusy, setLifecycleBusy] = useState<string | null>(null)
+  const [lifecycleError, setLifecycleError] = useState<string | null>(null)
+  const lifecycleInFlight = useRef(false)
 
   const loadAudiences = useCallback(() => {
     fetch('/api/audiences').then(r => r.json()).then((d: { items: Segment[]; state: string }) => {
@@ -51,11 +55,26 @@ export default function SegmentsPage() {
     loadAudiences()
   }, [loadAudiences])
 
-  const lifecycle = (s: Segment, action: 'submit' | 'approve') => {
-    fetch(`/api/audiences/${encodeURIComponent(s.name)}/${s.version}/${action}`, { method: 'POST' }).then(r => {
-      if (!r.ok) throw new Error()
+  const lifecycle = async (s: Segment, action: 'submit' | 'approve') => {
+    if (!claimSingleFlight(lifecycleInFlight)) return
+    const actionKey = `${key(s)}:${action}`
+    setLifecycleBusy(actionKey)
+    setLifecycleError(null)
+    try {
+      const response = await fetch(`/api/audiences/${encodeURIComponent(s.name)}/${s.version}/${action}`, { method: 'POST' })
+      if (!response.ok) {
+        throw new Error(t(
+          `Změnu publika se nepodařilo uložit (HTTP ${response.status}).`,
+          `Could not save the audience lifecycle change (HTTP ${response.status}).`,
+        ))
+      }
       loadAudiences()
-    }).catch(() => setUnavailable('unreachable'))
+    } catch (error) {
+      setLifecycleError(error instanceof Error ? error.message : t('Změna publika se nezdařila.', 'Audience lifecycle change failed.'))
+    } finally {
+      releaseSingleFlight(lifecycleInFlight)
+      setLifecycleBusy(null)
+    }
   }
 
   const key = (s: Segment) => `${s.name}@${s.version}`
@@ -158,6 +177,11 @@ export default function SegmentsPage() {
 
       {!loading && !unavailable && items.length > 0 && (
         <>
+          {lifecycleError && (
+            <div role="alert" className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+              {lifecycleError}
+            </div>
+          )}
           <section className="grid gap-4 lg:grid-cols-[1.35fr_.65fr]">
             <div className="rounded-2xl border border-violet-100 bg-[radial-gradient(circle_at_top_left,_rgba(116,91,255,.18),_transparent_42%),linear-gradient(135deg,_#fff,_#f8f7ff)] p-5 shadow-sm">
               <p className="flex items-center gap-2 text-xs font-bold uppercase tracking-[.12em] text-violet-700"><Sparkles className="h-3.5 w-3.5" /> {t('Audience library', 'Audience library')}</p>
@@ -198,7 +222,7 @@ export default function SegmentsPage() {
                     data-use-audience={key(s)}
                   >
                     {t('Použít v kampani', 'Use in campaign')} <ArrowRight className="h-3.5 w-3.5" />
-                  </Link> : s.state === 'DRAFT' ? <Can permission="campaign:submit" fallback={<span className="text-xs text-muted-foreground">{t('Čeká na oprávněného autora', 'Awaiting an authorized author')}</span>}><button type="button" onClick={() => lifecycle(s, 'submit')} className="rounded-lg bg-violet-700 px-3 py-2 text-xs font-semibold text-white transition hover:bg-violet-800">{t('Odeslat ke schválení', 'Submit for approval')}</button></Can> : <Can permission="campaign:activate" fallback={<span className="text-xs text-muted-foreground">{t('Čeká na oprávněného schvalovatele', 'Awaiting an authorized approver')}</span>}><button type="button" onClick={() => lifecycle(s, 'approve')} className="rounded-lg bg-emerald-600 px-3 py-2 text-xs font-semibold text-white transition hover:bg-emerald-700">{t('Schválit publikum', 'Approve audience')}</button></Can>}
+                  </Link> : s.state === 'DRAFT' ? <Can permission="campaign:submit" fallback={<span className="text-xs text-muted-foreground">{t('Čeká na oprávněného autora', 'Awaiting an authorized author')}</span>}><button type="button" onClick={() => lifecycle(s, 'submit')} disabled={lifecycleBusy !== null} aria-busy={lifecycleBusy === `${key(s)}:submit`} className="rounded-lg bg-violet-700 px-3 py-2 text-xs font-semibold text-white transition hover:bg-violet-800 disabled:cursor-wait disabled:opacity-60">{lifecycleBusy === `${key(s)}:submit` ? t('Odesílám…', 'Submitting…') : t('Odeslat ke schválení', 'Submit for approval')}</button></Can> : <Can permission="campaign:activate" fallback={<span className="text-xs text-muted-foreground">{t('Čeká na oprávněného schvalovatele', 'Awaiting an authorized approver')}</span>}><button type="button" onClick={() => lifecycle(s, 'approve')} disabled={lifecycleBusy !== null} aria-busy={lifecycleBusy === `${key(s)}:approve`} className="rounded-lg bg-emerald-600 px-3 py-2 text-xs font-semibold text-white transition hover:bg-emerald-700 disabled:cursor-wait disabled:opacity-60">{lifecycleBusy === `${key(s)}:approve` ? t('Schvaluji…', 'Approving…') : t('Schválit publikum', 'Approve audience')}</button></Can>}
                 </div>
                 <p className="mt-3 flex items-center gap-1.5 text-[.68rem] text-slate-400"><Clock3 className="h-3 w-3" />{t('Dosah se mění s aktuálním stavem; verze pravidel zůstává stejná.', 'Reach changes with current state; the rule version stays fixed.')}</p>
               </article>

--- a/openbank-admin-ui/src/test/audience-lifecycle-single-flight.guard.test.ts
+++ b/openbank-admin-ui/src/test/audience-lifecycle-single-flight.guard.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(path.resolve(__dirname, '../app/segments/page.tsx'), 'utf8')
+const lifecycle = page.slice(page.indexOf('const lifecycle ='), page.indexOf('const key ='))
+
+describe('audience lifecycle mutation contract', () => {
+  it('serializes lifecycle writes and keeps action failures local and visible', () => {
+    expect(page).toContain('claimSingleFlight(lifecycleInFlight)')
+    expect(page).toContain('releaseSingleFlight(lifecycleInFlight)')
+    expect(page).toContain('setLifecycleError(error instanceof Error')
+    expect(page).toContain('role="alert"')
+    expect(lifecycle).not.toContain('setUnavailable')
+  })
+})


### PR DESCRIPTION
## Summary
- serialize audience submit/approve writes before React can render disabled controls
- show per-action localized progress and disable competing lifecycle mutations
- keep valid catalogue data visible when a lifecycle mutation fails and surface a local actionable alert
- preserve endpoints, lifecycle payload shape and campaign:submit/campaign:activate maker-checker permissions

## Verification
- two focused Vitest guards passed
- scoped ESLint passed with zero errors
- git diff --check passed
- signed commit verified

This PR is intentionally stacked on #7085 for the shared single-flight primitive.

Closes #7100