### PR TITLE
fix(admin-ui): serialize month-close trigger

### DIFF
--- a/openbank-admin-ui/src/app/day-end/page.tsx
+++ b/openbank-admin-ui/src/app/day-end/page.tsx
@@ -26,6 +26,7 @@ import {
   ArrowRightLeft, CalendarCheck2, Play, ChevronDown, ChevronRight, History, FileClock,
 } from 'lucide-react'
 import { svcUrl, classifyBffFailure, type BffFailure } from '@/lib/services/bff'
+import { claimSingleFlight, releaseSingleFlight } from '@/lib/single-flight'
 import { hasPermission } from '@/lib/auth/roles'
 import { useCheckLog, type CheckLogEntry } from '@/lib/services/useCheckLog'
 import { PageHeader } from '@/components/ui/PageHeader'
@@ -130,6 +131,7 @@ function EodPanel() {
   const [refreshing, setRefreshing] = useState(false)
   const [lastRefreshed, setLastRefreshed] = useState<Date | null>(null)
   const busyRef = useRef(false)
+  const triggerInFlight = useRef(false)
 
   const refresh = useCallback(async (spinner = false) => {
     if (busyRef.current) return
@@ -494,6 +496,7 @@ function EomPanel() {
   }, [loading, unavailable, empty, latest, runs.length, recordCheck])
 
   const trigger = useCallback(async () => {
+    if (!claimSingleFlight(triggerInFlight)) return
     setTriggering(true); setNotice(null)
     try {
       const res = await fetch('/api/closings/runs', {
@@ -513,6 +516,7 @@ function EomPanel() {
     } catch {
       setNotice({ ok: false, text: t('Spuštění catch-up uzávěrky se nezdařilo.', 'Could not start the catch-up close run.') })
     } finally {
+      releaseSingleFlight(triggerInFlight)
       setTriggering(false)
     }
   }, [t, load, recordCheck])

--- a/openbank-admin-ui/src/app/day-end/page.tsx
+++ b/openbank-admin-ui/src/app/day-end/page.tsx
@@ -131,7 +131,6 @@ function EodPanel() {
   const [refreshing, setRefreshing] = useState(false)
   const [lastRefreshed, setLastRefreshed] = useState<Date | null>(null)
   const busyRef = useRef(false)
-  const triggerInFlight = useRef(false)
 
   const refresh = useCallback(async (spinner = false) => {
     if (busyRef.current) return
@@ -439,6 +438,7 @@ function EomPanel() {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
   const [failures, setFailures] = useState<Record<string, FailuresState>>({})
   const busyRef = useRef(false)
+  const triggerInFlight = useRef(false)
   // Operator-local check trail — survives reloads and (crucially) statement-service
   // outages, so a later operator/agent can see WHEN the close was checked and what
   // state it was in, even when the live run history isn't answering.

--- a/openbank-admin-ui/src/test/month-close-single-flight.guard.test.ts
+++ b/openbank-admin-ui/src/test/month-close-single-flight.guard.test.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(path.resolve(__dirname, '../app/day-end/page.tsx'), 'utf8')
+
+describe('month-end catch-up trigger contract', () => {
+  it('claims a synchronous lock before the close POST and releases it in finally', () => {
+    const trigger = page.slice(page.indexOf('const trigger ='), page.indexOf('const toggleFailures ='))
+    expect(trigger.indexOf('claimSingleFlight(triggerInFlight)')).toBeLessThan(trigger.indexOf("fetch('/api/closings/runs'"))
+    expect(trigger).toContain('releaseSingleFlight(triggerInFlight)')
+    expect(page).toContain('aria-busy={triggering}')
+    expect(page).toContain('disabled={triggering || running || unavailable !== null}')
+  })
+})


### PR DESCRIPTION
## Summary
- claim a synchronous lock before the month-end catch-up POST leaves the browser
- release the lock in finally across success, HTTP failure and timeout paths
- preserve existing truthful progress, accepted-run rendering, polling, operator check trail, BFF and RBAC

## Verification
- two focused Vitest guards passed
- scoped ESLint passed with zero errors (two pre-existing effect warnings)
- git diff --check passed
- signed commit verified

This PR is intentionally stacked on #7085 for the shared single-flight primitive.

Closes #7102