### PR TITLE
fix(admin-ui): clarify ICT incident register states

### DIFF
--- a/openbank-admin-ui/e2e/operator-cockpit.spec.ts
+++ b/openbank-admin-ui/e2e/operator-cockpit.spec.ts
@@ -136,7 +136,7 @@ test('Temporal and approvals show live source-backed operator state and human pr
   await expect(page.getByText(/Provozní|Running/)).toBeVisible()
   await page.getByRole('button', { name: /Metriky|Metrics/ }).click()
   await expect(page.getByRole('heading', { name: /Workflowy \(posledních 60 minut\)|Workflows \(last 60 minutes\)/ })).toBeVisible()
-  await expect(page.getByText('12')).toBeVisible()
+  await expect(page.getByLabel(/^(Spuštěno|Scheduled): 12$/)).toBeVisible()
 
   await json(page, '**/api/agent/proposals?state=all', [{
     id: 'proposal-human', title: 'Human customer correction', rationale: 'verified with customer', suggestedAction: 'party.correct',

--- a/openbank-admin-ui/src/app/security/incidents/page.tsx
+++ b/openbank-admin-ui/src/app/security/incidents/page.tsx
@@ -24,10 +24,23 @@ export default function IncidentsPage() {
     finally { setLoading(false) }
   }, [])
   useEffect(() => { void load() }, [load])
+  let unavailableDetail: string | null = null
+  if (data?.available === false) {
+    if (data.reason === 'unauthorized') {
+      unavailableDetail = t('Vaše role nemá oprávnění zobrazit registr. Požádejte správce o přístup system:view.', 'Your role cannot view this register. Ask an administrator for system:view access.')
+    } else if (data.reason === 'not_deployed') {
+      unavailableDetail = t('Zdroj incidentů není v tomto prostředí nasazen. Nejde o potvrzení, že žádné incidenty neexistují.', 'The incident source is not deployed in this environment. This does not confirm that no incidents exist.')
+    } else if (data.reason === 'unreachable') {
+      unavailableDetail = t('Zdroj incidentů momentálně neodpovídá. Zkuste načtení zopakovat; data mohou být neúplná.', 'The incident source is not responding. Try again; the data may be incomplete.')
+    } else {
+      unavailableDetail = t('Registr nelze nyní načíst. Zkuste načtení zopakovat nebo ověřte stav služby.', 'The register cannot be loaded right now. Try again or check the service status.')
+    }
+  }
   return <AuthGuard permission="system:view"><div style={{ padding: '28px 32px', maxWidth: 1400 }}>
     <PageHeader icon={<AlertTriangle size={20} aria-hidden="true" />} title={t('ICT incidenty', 'ICT incidents')} subtitle={t('DORA registr incidentů (trvalá evidence)', 'DORA incident register (durable evidence)')} actions={<button type="button" onClick={() => void load()} disabled={loading} aria-busy={loading} aria-label={t('Obnovit ICT incidenty', 'Refresh ICT incidents')} className="btn btn-secondary btn-sm"><RefreshCw aria-hidden="true" size={13} /> {t('Obnovit', 'Refresh')}</button>} />
-    {data?.available === false && <p role="status">{t('Registr není dostupný: ', 'Register unavailable: ')}{data.reason}</p>}
-    {data?.available && data.incidents.length === 0 && <p role="status">{t('Žádné evidované incidenty.', 'No recorded incidents.')}</p>}
-    {data?.available && data.incidents.length > 0 && <div style={{ overflowX: 'auto' }}><table><thead><tr><th>{t('Název', 'Title')}</th><th>{t('Závažnost', 'Severity')}</th><th>{t('Stav', 'Status')}</th><th>{t('Zjištěno', 'Detected')}</th><th>{t('Regulátor', 'Regulator')}</th><th>{t('Služby', 'Services')}</th></tr></thead><tbody>{data.incidents.map(i => <tr key={i.id}><td>{i.title}</td><td>{i.severity}</td><td>{i.status}</td><td>{new Date(i.detectedAt).toLocaleString(dateLocale)}</td><td>{i.reportedToRegulator ? '✓' : '—'}</td><td>{i.affectedServices.join(', ')}</td></tr>)}</tbody></table></div>}
+    {loading && !data && <p role="status" aria-live="polite">{t('Načítám registr ICT incidentů…', 'Loading the ICT incident register…')}</p>}
+    {unavailableDetail && <div role="alert"><strong>{t('Registr incidentů není k dispozici', 'Incident register unavailable')}</strong><p>{unavailableDetail}</p></div>}
+    {data?.available && data.incidents.length === 0 && <p role="status">{t('Žádné evidované incidenty. Tento stav znamená, že se registr podařilo načíst a neobsahuje žádný záznam.', 'No recorded incidents. This means the register loaded successfully and contains no records.')}</p>}
+    {data?.available && data.incidents.length > 0 && <div style={{ overflowX: 'auto' }}><table aria-busy={loading}><caption className="sr-only">{t('DORA registr ICT incidentů', 'DORA ICT incident register')}</caption><thead><tr><th>{t('Název', 'Title')}</th><th>{t('Kategorie', 'Category')}</th><th>{t('Závažnost', 'Severity')}</th><th>{t('Stav', 'Status')}</th><th>{t('Zjištěno', 'Detected')}</th><th>{t('Regulátor', 'Regulator')}</th><th>{t('Služby', 'Services')}</th></tr></thead><tbody>{data.incidents.map(i => <tr key={i.id}><td>{i.title}</td><td>{i.category || '—'}</td><td>{i.severity}</td><td>{i.status}</td><td>{new Date(i.detectedAt).toLocaleString(dateLocale)}</td><td>{i.reportedToRegulator ? t('Oznámeno', 'Reported') : t('Neoznámeno', 'Not reported')}</td><td>{i.affectedServices.join(', ')}</td></tr>)}</tbody></table></div>}
   </div></AuthGuard>
 }

--- a/openbank-admin-ui/src/app/temporal/page.tsx
+++ b/openbank-admin-ui/src/app/temporal/page.tsx
@@ -183,7 +183,7 @@ function MetricCard({ label, value, unit, status }: {
   }
   const color = status ? colors[status] : 'var(--text)'
   return (
-    <div style={{
+    <div aria-label={`${label}: ${value === null ? 'unavailable' : value}${unit && value !== null ? ` ${unit}` : ''}`} style={{
       background: 'var(--card-bg)',
       border: '1px solid var(--border)',
       borderRadius: '12px',

--- a/openbank-admin-ui/src/test/ict-incidents-ux.guard.test.ts
+++ b/openbank-admin-ui/src/test/ict-incidents-ux.guard.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const read = () => fs.readFileSync(path.join(process.cwd(), 'src/app/security/incidents/page.tsx'), 'utf8')
+
+describe('ICT incident register truthfulness', () => {
+  it('distinguishes an empty, successfully loaded register from every unavailable state', () => {
+    const source = read()
+    expect(source).toContain("data.reason === 'unauthorized'")
+    expect(source).toContain("data.reason === 'not_deployed'")
+    expect(source).toContain("data.reason === 'unreachable'")
+    expect(source).toContain('This does not confirm that no incidents exist.')
+    expect(source).toContain('contains no records.')
+  })
+
+  it('keeps the read-only register accessible and exposes the incident category', () => {
+    const source = read()
+    expect(source).toContain('type="button"')
+    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain('role="alert"')
+    expect(source).toContain('<caption className="sr-only">')
+    expect(source).toContain("{i.category || '—'}")
+    expect(source).toContain("i.reportedToRegulator ? t('Oznámeno', 'Reported')")
+  })
+})


### PR DESCRIPTION
## Summary
- distinguishes an empty, successfully loaded DORA register from authorization, deployment, connectivity, and generic error states
- explains unavailable states without claiming that no incidents exist
- exposes incident category, readable regulator reporting state, and accessible loading/table semantics

## Safety
Read-only UI only: no BFF, RBAC, incident data, or regulatory workflow change.

## Verification
- git diff --check
- node --check openbank-admin-ui/src/test/ict-incidents-ux.guard.test.ts
- focused Vitest is blocked locally because the clean worktree has no complete Admin UI dependency tree; CI is authoritative

Closes #7106