### PR TITLE
fix(admin-ui): guard account lifecycle mutations

### DIFF
--- a/openbank-admin-ui/src/app/accounts/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/accounts/[id]/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useParams } from 'next/navigation'
 import Link from 'next/link'
 import { ArrowLeft, RefreshCw, Lock, Unlock, XCircle, AlertCircle } from 'lucide-react'
@@ -33,6 +33,7 @@ export default function AccountDetailPage() {
   const [error, setError]       = useState<string | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
   const [acting, setActing]     = useState(false)
+  const actionInFlight = useRef(false)
   const [actionIntent, setActionIntent] = useState<'freeze' | 'unfreeze' | 'close' | null>(null)
   const [actionReason, setActionReason] = useState('')
 
@@ -60,12 +61,18 @@ export default function AccountDetailPage() {
   }
 
   async function doAction(action: 'freeze' | 'unfreeze' | 'close', reason: string) {
-    if (!account) return
+    if (!account || actionInFlight.current) return
+    const normalizedReason = reason.trim()
+    if (!normalizedReason) {
+      setActionError(t('Pro tuto změnu uveďte důvod do auditní stopy.', 'Provide a reason for this change in the audit trail.'))
+      return
+    }
+    actionInFlight.current = true
     setActing(true); setActionError(null)
     try {
-      if (action === 'freeze')   await accountApi.freeze(id, reason)
-      if (action === 'unfreeze') await accountApi.unfreeze(id, reason)
-      if (action === 'close')    await accountApi.close(id, reason)
+      if (action === 'freeze')   await accountApi.freeze(id, normalizedReason)
+      if (action === 'unfreeze') await accountApi.unfreeze(id, normalizedReason)
+      if (action === 'close')    await accountApi.close(id, normalizedReason)
       await load()
       setActionIntent(null)
       setActionReason('')
@@ -78,7 +85,10 @@ export default function AccountDetailPage() {
         close:    t('Účet se nepodařilo zrušit. Zkuste to prosím znovu.', 'The account could not be closed. Please try again.'),
       }
       setActionError(human[action])
-    } finally { setActing(false) }
+    } finally {
+      actionInFlight.current = false
+      setActing(false)
+    }
   }
 
   if (loading) return (
@@ -172,7 +182,7 @@ export default function AccountDetailPage() {
             <button type="button" className="btn btn-secondary" onClick={() => { setActionIntent(null); setActionReason(''); setActionError(null) }} disabled={acting}>
               {t('Zrušit', 'Cancel')}
             </button>
-            <button type="button" className="btn btn-primary" onClick={() => doAction(actionIntent, actionReason)} disabled={acting}>
+            <button type="button" className="btn btn-primary" onClick={() => doAction(actionIntent, actionReason)} disabled={acting || !actionReason.trim()} aria-busy={acting}>
               {acting ? t('Ukládám…', 'Saving…') : t('Potvrdit změnu', 'Confirm change')}
             </button>
           </div>
@@ -181,6 +191,7 @@ export default function AccountDetailPage() {
 
       {actionError && (
         <div
+          role="alert"
           className="form-error"
           style={{
             marginBottom: '16px', padding: '12px 16px',

--- a/openbank-admin-ui/src/test/account-lifecycle-single-flight.guard.test.ts
+++ b/openbank-admin-ui/src/test/account-lifecycle-single-flight.guard.test.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const read = () => readFileSync(path.resolve(__dirname, '../app/accounts/[id]/page.tsx'), 'utf8')
+
+describe('account lifecycle mutation guard', () => {
+  it('prevents duplicate lifecycle writes before React state can rerender', () => {
+    const source = read()
+    expect(source).toContain("import { useEffect, useRef, useState } from 'react'")
+    expect(source).toContain('const actionInFlight = useRef(false)')
+    expect(source).toContain('if (!account || actionInFlight.current) return')
+    expect(source).toContain('actionInFlight.current = true')
+    expect(source).toContain('actionInFlight.current = false')
+  })
+
+  it('requires a meaningful audit reason before freeze, unfreeze, or close', () => {
+    const source = read()
+    expect(source).toContain('const normalizedReason = reason.trim()')
+    expect(source).toContain('if (!normalizedReason)')
+    expect(source).toContain("disabled={acting || !actionReason.trim()}")
+    expect(source).toContain('role="alert"')
+    expect(source).toContain('accountApi.freeze(id, normalizedReason)')
+    expect(source).toContain('accountApi.unfreeze(id, normalizedReason)')
+    expect(source).toContain('accountApi.close(id, normalizedReason)')
+  })
+})


### PR DESCRIPTION
## Summary
- prevents duplicate freeze, unfreeze, and close requests before React can rerender the controls
- requires and normalizes the operator audit reason before sending the existing action request
- announces local validation and mutation failures accessibly

## Safety
No BFF, endpoint, RBAC, account-state, approval, or data-model change.

## Verification
- git diff --check
- node --check openbank-admin-ui/src/test/account-lifecycle-single-flight.guard.test.ts
- focused Vitest is blocked locally because the clean worktree has no complete Admin UI dependency tree; CI is authoritative

Closes #7112