### PR TITLE
feat(finrep): add XBRL CSV preflight

### DIFF
--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/inbound/XbrlCsvPorts.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/inbound/XbrlCsvPorts.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.finrep.application.port.inbound
+
+import com.openbank.finrep.domain.model.XbrlCsvPreflight
+import java.time.LocalDate
+
+data class GetXbrlCsvPreflightQuery(val templateId: String, val asOf: LocalDate)
+
+/** Safeguard-only entrypoint. It does not create an XBRL-CSV artifact or submit anything. */
+interface XbrlCsvPreflightUseCase {
+    suspend fun getPreflight(query: GetXbrlCsvPreflightQuery): XbrlCsvPreflight
+}

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/XbrlCsvPreflightService.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/XbrlCsvPreflightService.kt
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.finrep.application.usecase
+
+import com.openbank.finrep.application.port.inbound.FinrepUseCase
+import com.openbank.finrep.application.port.inbound.GetFinrepTemplateQuery
+import com.openbank.finrep.application.port.inbound.GetXbrlCsvPreflightQuery
+import com.openbank.finrep.application.port.inbound.XbrlCsvPreflightUseCase
+import com.openbank.finrep.domain.model.EbaReportingFramework42
+import com.openbank.finrep.domain.model.XbrlCsvBlocker
+import com.openbank.finrep.domain.model.XbrlCsvPreflight
+import com.openbank.finrep.domain.model.XbrlCsvPreflightState
+import jakarta.enterprise.context.ApplicationScoped
+
+/**
+ * First safe stage of #5914: decide whether a FINREP preview is even eligible to reach an
+ * XBRL-CSV renderer. No archive, instance document or regulator request is constructed here.
+ */
+@ApplicationScoped
+class XbrlCsvPreflightService(private val finrepUseCase: FinrepUseCase) : XbrlCsvPreflightUseCase {
+
+    override suspend fun getPreflight(query: GetXbrlCsvPreflightQuery): XbrlCsvPreflight {
+        val template = finrepUseCase.getTemplate(GetFinrepTemplateQuery(query.templateId, query.asOf))
+        val blockers = buildList {
+            if (template.hasDataGaps) {
+                add(
+                    XbrlCsvBlocker(
+                        code = "INCOMPLETE_OFFICIAL_MAPPING",
+                        reason = "This preview has unmapped official EBA cells and cannot be rendered as a return.",
+                    ),
+                )
+            }
+            if (!template.isBalanced) {
+                add(
+                    XbrlCsvBlocker(
+                        code = "TRIAL_BALANCE_NOT_AGREED",
+                        reason = "The independent trial-balance checks did not agree that this " +
+                            "reporting period balances.",
+                    ),
+                )
+            }
+        }
+        return XbrlCsvPreflight(
+            templateId = template.templateId,
+            period = template.period,
+            reportingFrameworkVersion = EbaReportingFramework42.REPORTING_FRAMEWORK_VERSION,
+            dpmVersion = EbaReportingFramework42.DPM_VERSION,
+            taxonomyVersion = EbaReportingFramework42.TAXONOMY_VERSION,
+            state = if (blockers.isEmpty()) {
+                XbrlCsvPreflightState.READY_FOR_RENDERING
+            } else {
+                XbrlCsvPreflightState.BLOCKED
+            },
+            blockers = blockers,
+        )
+    }
+}

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/EbaReportingFramework42.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/EbaReportingFramework42.kt
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.finrep.domain.model
+
+/** Pinned EBA Reporting Framework metadata used by the XBRL-CSV preflight (#5914). */
+object EbaReportingFramework42 {
+    const val REPORTING_FRAMEWORK_VERSION = "4.2"
+    const val DPM_VERSION = "4.2.1"
+    const val TAXONOMY_VERSION = "4.2.0.0"
+}

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/XbrlCsvPreflight.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/domain/model/XbrlCsvPreflight.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.finrep.domain.model
+
+import java.time.LocalDate
+
+/**
+ * Honest readiness result for a future EBA XBRL-CSV renderer.
+ *
+ * This is deliberately a preflight, not an export: a bounded preview must never be packaged or
+ * labelled as a validated regulatory return. `READY_FOR_RENDERING` only means the mapped source
+ * data passes the safeguards implemented here; a renderer and taxonomy validation remain a
+ * separate subsequent stage.
+ */
+data class XbrlCsvPreflight(
+    val templateId: String,
+    val period: LocalDate,
+    val reportingFrameworkVersion: String,
+    val dpmVersion: String,
+    val taxonomyVersion: String,
+    val state: XbrlCsvPreflightState,
+    val blockers: List<XbrlCsvBlocker>,
+)
+
+enum class XbrlCsvPreflightState {
+    READY_FOR_RENDERING,
+    BLOCKED,
+}
+
+/** A machine-readable safeguard which prevents local XBRL-CSV rendering. */
+data class XbrlCsvBlocker(val code: String, val reason: String)

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/rest/XbrlCsvPreflightResource.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/rest/XbrlCsvPreflightResource.kt
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.finrep.infrastructure.rest
+
+import com.openbank.finrep.application.port.inbound.GetXbrlCsvPreflightQuery
+import com.openbank.finrep.application.port.inbound.XbrlCsvPreflightUseCase
+import com.openbank.libs.security.Roles
+import jakarta.annotation.security.RolesAllowed
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.DefaultValue
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import java.time.Clock
+import java.time.LocalDate
+
+/** Exposes rendering eligibility only; this endpoint never returns an XBRL-CSV artifact. */
+@ApplicationScoped
+@Path("/api/v1/finrep/templates/{templateId}/xbrl-csv/preflight")
+@Produces(MediaType.APPLICATION_JSON)
+@RolesAllowed(Roles.ADMIN, Roles.OPERATOR)
+class XbrlCsvPreflightResource(private val useCase: XbrlCsvPreflightUseCase, private val clock: Clock) {
+
+    @GET
+    suspend fun getPreflight(
+        @PathParam("templateId") templateId: String,
+        @QueryParam("asOf") @DefaultValue("") asOf: String,
+    ): Response {
+        val date = if (asOf.isBlank()) LocalDate.now(clock) else LocalDate.parse(asOf)
+        return Response.ok(useCase.getPreflight(GetXbrlCsvPreflightQuery(templateId, date))).build()
+    }
+}

--- a/openbank-finrep-service/src/main/resources/openapi.yaml
+++ b/openbank-finrep-service/src/main/resources/openapi.yaml
@@ -16,17 +16,55 @@ info:
     (F01.01 Assets, F01.02 Liabilities, F01.03 Equity, F02.00 Profit & Loss) and the COREP C 01.00
     Own Funds template from
     openbank-ledger-service's GL trial balance. Derive-only and stateless — it holds no datastore,
-    moves no money, and has NO ČNB transmission channel; EBA XBRL/DPM taxonomy rendering is
-    explicitly out of scope for this increment.
+    moves no money, and has NO ČNB transmission channel. It exposes an EBA XBRL-CSV *preflight*
+    only: the preflight states why a bounded preview is blocked before a future renderer can create
+    a local artifact. It never creates an XBRL file or submits anything.
 
     FINREP output is a bounded preview containing only the official datapoints the platform can
     currently derive without inventing regulatory classifications; it is not a complete return.
     COREP preview gaps remain explicit flagged zeroes (`isDataGap`) with reasons.
-  version: 1.5.0
+  version: 1.6.0
 tags:
   - name: FINREP
   - name: COREP
 paths:
+  /api/v1/finrep/templates/{templateId}/xbrl-csv/preflight:
+    get:
+      tags: [FINREP]
+      summary: Check whether a FINREP preview is eligible for future XBRL-CSV rendering
+      description: >-
+        Returns an explicit, local readiness result; it does not produce an XBRL-CSV archive,
+        validate an XBRL instance, or contact ČNB. Missing official mappings and a trial-balance
+        disagreement are blockers. A `READY_FOR_RENDERING` result is not a validated regulatory
+        artifact and does not imply a submission is possible.
+      operationId: getFinrepXbrlCsvPreflight
+      parameters:
+        - name: templateId
+          in: path
+          required: true
+          description: EBA FINREP template identifier
+          schema: { type: string, enum: [F01.01, F01.02, F01.03, F02.00] }
+        - name: asOf
+          in: query
+          required: false
+          description: Reporting reference date, ISO yyyy-MM-dd. Defaults to today when omitted.
+          schema: { type: string, format: date }
+      responses:
+        '200':
+          description: Local rendering preflight; a blocked result is a successful safety check
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/XbrlCsvPreflight' }
+        '400':
+          description: Unknown templateId or an invalid reporting date
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+        '401':
+          description: Missing or invalid access token
+        '403':
+          description: Token lacks ROLE_ADMIN or ROLE_OPERATOR
+
   /api/v1/finrep/periods:
     get:
       tags: [FINREP]
@@ -130,6 +168,36 @@ paths:
 
 components:
   schemas:
+    XbrlCsvPreflight:
+      type: object
+      description: >-
+        Local safeguard result for a future EBA XBRL-CSV renderer. This is not an XBRL artifact,
+        validation result, or regulator submission acknowledgement.
+      required: [templateId, period, reportingFrameworkVersion, dpmVersion, taxonomyVersion, state, blockers]
+      properties:
+        templateId: { type: string, example: F01.01 }
+        period: { type: string, format: date }
+        reportingFrameworkVersion: { type: string, example: '4.2' }
+        dpmVersion: { type: string, example: '4.2.1' }
+        taxonomyVersion: { type: string, example: '4.2.0.0' }
+        state:
+          type: string
+          enum: [READY_FOR_RENDERING, BLOCKED]
+          description: >-
+            READY_FOR_RENDERING only means the implemented safeguards pass. It is not a validated
+            XBRL-CSV artifact and must not be submitted to a regulator.
+        blockers:
+          type: array
+          items: { $ref: '#/components/schemas/XbrlCsvBlocker' }
+    XbrlCsvBlocker:
+      type: object
+      required: [code, reason]
+      properties:
+        code:
+          type: string
+          enum: [INCOMPLETE_OFFICIAL_MAPPING, TRIAL_BALANCE_NOT_AGREED]
+        reason: { type: string }
+
     ReportingPeriods:
       type: object
       required: [periods]

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/XbrlCsvPreflightServiceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/XbrlCsvPreflightServiceTest.kt
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.finrep.application.usecase
+
+import com.openbank.finrep.application.port.inbound.FinrepUseCase
+import com.openbank.finrep.application.port.inbound.GetXbrlCsvPreflightQuery
+import com.openbank.finrep.domain.model.BalanceVerdict
+import com.openbank.finrep.domain.model.FinrepDataGap
+import com.openbank.finrep.domain.model.FinrepTemplate
+import com.openbank.finrep.domain.model.XbrlCsvPreflightState
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class XbrlCsvPreflightServiceTest {
+
+    private val finrepUseCase: FinrepUseCase = mockk()
+    private val asOf = LocalDate.of(2026, 6, 30)
+
+    @Test
+    fun `blocks rendering for unmapped official cells even when the trial balance agrees`(): Unit = runBlocking {
+        coEvery { finrepUseCase.getTemplate(any()) } returns template(
+            dataGaps = listOf(FinrepDataGap("UNMAPPED_OFFICIAL_CELLS", "F01.01 except r0380/c0010", "missing")),
+            isBalanced = true,
+            balanceVerdict = BalanceVerdict.AGREED_BALANCED,
+        )
+
+        val result = XbrlCsvPreflightService(finrepUseCase)
+            .getPreflight(GetXbrlCsvPreflightQuery("F01.01", asOf))
+
+        assertThat(result.state).isEqualTo(XbrlCsvPreflightState.BLOCKED)
+        assertThat(result.blockers).extracting<String> { it.code }.containsExactly("INCOMPLETE_OFFICIAL_MAPPING")
+        assertThat(result.reportingFrameworkVersion).isEqualTo("4.2")
+        assertThat(result.dpmVersion).isEqualTo("4.2.1")
+        assertThat(result.taxonomyVersion).isEqualTo("4.2.0.0")
+    }
+
+    @Test
+    fun `blocks rendering when the independent trial balance checks do not agree`(): Unit = runBlocking {
+        coEvery { finrepUseCase.getTemplate(any()) } returns template(
+            dataGaps = emptyList(),
+            isBalanced = false,
+            balanceVerdict = BalanceVerdict.SOURCES_DISAGREE,
+        )
+
+        val result = XbrlCsvPreflightService(finrepUseCase)
+            .getPreflight(GetXbrlCsvPreflightQuery("F01.01", asOf))
+
+        assertThat(result.state).isEqualTo(XbrlCsvPreflightState.BLOCKED)
+        assertThat(result.blockers).extracting<String> { it.code }.containsExactly("TRIAL_BALANCE_NOT_AGREED")
+    }
+
+    @Test
+    fun `marks a complete and independently balanced mapping ready for a later renderer`(): Unit = runBlocking {
+        coEvery { finrepUseCase.getTemplate(any()) } returns template(
+            dataGaps = emptyList(),
+            isBalanced = true,
+            balanceVerdict = BalanceVerdict.AGREED_BALANCED,
+        )
+
+        val result = XbrlCsvPreflightService(finrepUseCase)
+            .getPreflight(GetXbrlCsvPreflightQuery("F01.01", asOf))
+
+        assertThat(result.state).isEqualTo(XbrlCsvPreflightState.READY_FOR_RENDERING)
+        assertThat(result.blockers).isEmpty()
+    }
+
+    private fun template(
+        dataGaps: List<FinrepDataGap>,
+        isBalanced: Boolean,
+        balanceVerdict: BalanceVerdict,
+    ): FinrepTemplate = FinrepTemplate(
+        templateId = "F01.01",
+        period = asOf,
+        cells = emptyList(),
+        dataGaps = dataGaps,
+        isBalanced = isBalanced,
+        balanceVerdict = balanceVerdict,
+    )
+}

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/Eba42DatapointFixtureTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/Eba42DatapointFixtureTest.kt
@@ -10,6 +10,7 @@ import com.openbank.finrep.domain.mapper.F0101Mapper
 import com.openbank.finrep.domain.mapper.F0102Mapper
 import com.openbank.finrep.domain.mapper.F0103Mapper
 import com.openbank.finrep.domain.mapper.F0200Mapper
+import com.openbank.finrep.domain.model.EbaReportingFramework42
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
@@ -26,6 +27,10 @@ class Eba42DatapointFixtureTest {
         assertThat(fixture["reportingFramework"].asText()).isEqualTo("4.2")
         assertThat(fixture["dpmVersion"].asText()).isEqualTo("4.2.1")
         assertThat(fixture["taxonomyVersion"].asText()).isEqualTo("4.2.0.0")
+        assertThat(EbaReportingFramework42.REPORTING_FRAMEWORK_VERSION)
+            .isEqualTo(fixture["reportingFramework"].asText())
+        assertThat(EbaReportingFramework42.DPM_VERSION).isEqualTo(fixture["dpmVersion"].asText())
+        assertThat(EbaReportingFramework42.TAXONOMY_VERSION).isEqualTo(fixture["taxonomyVersion"].asText())
         assertThat(fixture["taxonomyPackageSha256"].asText())
             .isEqualTo("0bf9e33720de1472e809417999cfd29e4b5eadb31750c7770622e502590bbdd0")
         assertThat(fixture["supportedFacts"].map { it["datapointId"]?.takeUnless { id -> id.isNull }?.asInt() })

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/TemplateWireFormatTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/TemplateWireFormatTest.kt
@@ -181,6 +181,33 @@ class TemplateWireFormatTest {
     }
 
     @Test
+    fun `the XBRL CSV preflight exposes blockers rather than an artifact`() {
+        val json = getJson("/api/v1/finrep/templates/F01.01/xbrl-csv/preflight", LocalDate.of(2026, 6, 30))
+
+        assertThat(json.keys).containsExactlyInAnyOrder(
+            "templateId",
+            "period",
+            "reportingFrameworkVersion",
+            "dpmVersion",
+            "taxonomyVersion",
+            "state",
+            "blockers",
+        )
+        assertThat(json["templateId"]).isEqualTo("F01.01")
+        assertThat(json["period"]).isEqualTo("2026-06-30")
+        assertThat(json["reportingFrameworkVersion"]).isEqualTo("4.2")
+        assertThat(json["dpmVersion"]).isEqualTo("4.2.1")
+        assertThat(json["taxonomyVersion"]).isEqualTo("4.2.0.0")
+        assertThat(json["state"]).isEqualTo("BLOCKED")
+
+        @Suppress("UNCHECKED_CAST")
+        val blockers = json["blockers"] as List<Map<*, *>>
+        assertThat(blockers).hasSize(1)
+        assertThat(blockers.single().keys).containsExactlyInAnyOrder("code", "reason")
+        assertThat(blockers.single()["code"]).isEqualTo("INCOMPLETE_OFFICIAL_MAPPING")
+    }
+
+    @Test
     fun `the COREP template wire format matches the published openapi schema`() {
         val json = getJson("/api/v1/corep/templates/C_01.00", LocalDate.of(2026, 6, 30))
 

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/rest/XbrlCsvPreflightResourceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/rest/XbrlCsvPreflightResourceTest.kt
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.finrep.infrastructure.rest
+
+import com.openbank.finrep.application.port.inbound.GetXbrlCsvPreflightQuery
+import com.openbank.finrep.application.port.inbound.XbrlCsvPreflightUseCase
+import com.openbank.finrep.domain.model.XbrlCsvPreflight
+import com.openbank.finrep.domain.model.XbrlCsvPreflightState
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import jakarta.ws.rs.core.Response
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+class XbrlCsvPreflightResourceTest {
+
+    @Test
+    fun `preflight defaults reporting date to the injected clock and never returns an export`(): Unit = runBlocking {
+        val useCase: XbrlCsvPreflightUseCase = mockk()
+        val clock = Clock.fixed(Instant.parse("2026-06-30T10:00:00Z"), ZoneOffset.UTC)
+        val query = slot<GetXbrlCsvPreflightQuery>()
+        val expected = XbrlCsvPreflight(
+            templateId = "F01.01",
+            period = LocalDate.now(clock),
+            reportingFrameworkVersion = "4.2",
+            dpmVersion = "4.2.1",
+            taxonomyVersion = "4.2.0.0",
+            state = XbrlCsvPreflightState.BLOCKED,
+            blockers = emptyList(),
+        )
+        coEvery { useCase.getPreflight(capture(query)) } returns expected
+
+        val response: Response = XbrlCsvPreflightResource(useCase, clock).getPreflight("F01.01", "")
+
+        assertThat(response.status).isEqualTo(200)
+        assertThat(response.entity).isEqualTo(expected)
+        assertThat(query.captured.asOf).isEqualTo(LocalDate.now(clock))
+    }
+}


### PR DESCRIPTION
## Summary
- pins EBA Reporting Framework 4.2 / DPM 4.2.1 / taxonomy 4.2.0.0 in production preflight metadata
- exposes a protected FINREP XBRL-CSV preflight that blocks incomplete mappings and disagreeing trial-balance evidence
- adds unit, REST, and served HTTP contract coverage

## Safety
This creates no XBRL artifact, performs no taxonomy validation, and has no ČNB transport. `READY_FOR_RENDERING` is only a local eligibility result, never a validated return or submission acknowledgement.

## Verification
- `./gradlew --quiet :openbank-finrep-service:test --tests ... --rerun-tasks`
- `./gradlew --quiet :openbank-finrep-service:ktlintCheck :openbank-finrep-service:detekt :openbank-finrep-service:quarkusBuild`

Refs #5914