### PR TITLE
chore(gitops): deploy verified regulatory product set

### DIFF
--- a/openbank-infra/gitops/components/finrep/finrep-service.yaml
+++ b/openbank-infra/gitops/components/finrep/finrep-service.yaml
@@ -42,7 +42,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: finrep-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-finrep-service:sandbox-9302207d
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-finrep-service:sandbox-d688dc4c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -49,7 +49,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ledger-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-ledger-service:sandbox-f8d165dd
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-ledger-service:sandbox-d688dc4c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Deploys the exact ledger + FINREP product set approved by the green `can-i-deploy` verdict in run 32978342505.

Both images are KMS-signed, SBOM-attested, Trivy-gated, and built from merge commit `d688dc4c3596bf41cf17abf7b161c4f9b6904882`. This clean PR replaces contaminated auto-generated PRs #7121 and #7127.

Refs #7042