### PR TITLE
test(copilot): record pgvector container evidence

### DIFF
--- a/openbank-copilot-service/build.gradle.kts
+++ b/openbank-copilot-service/build.gradle.kts
@@ -56,6 +56,9 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
+    // The custom pgvector lifecycle resources emit the same secret-free runtime evidence as the
+    // shared Testcontainers kit; this remains strictly on the test classpath.
+    testImplementation(project(":openbank-libs-testing"))
     testImplementation(libs.rest.assured.kotlin)
     // Consumer-driven contract with customer-edge (ADR-0063, issue #2322).
     testImplementation(libs.pact.consumer)

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/persistence/PostgresConversationStoreIT.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/persistence/PostgresConversationStoreIT.kt
@@ -8,6 +8,7 @@ import com.openbank.copilot.application.port.out.ConversationStore
 import com.openbank.copilot.domain.model.ChatMessage
 import com.openbank.copilot.domain.model.ChatRole
 import com.openbank.copilot.it.PGVECTOR_IMAGE
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import io.quarkus.test.junit.QuarkusTest
@@ -32,6 +33,7 @@ class PostgresConversationStoreIT {
                 .withUsername("openbank")
                 .withPassword("openbank")
             postgres.start()
+            TestInfrastructureEvidence.record("postgres", PGVECTOR_IMAGE.asCanonicalNameString(), "started")
             return mapOf(
                 "quarkus.datasource.reactive.url" to
                     "postgresql://${postgres.host}:${postgres.firstMappedPort}/${postgres.databaseName}",
@@ -44,7 +46,10 @@ class PostgresConversationStoreIT {
             )
         }
         override fun stop() {
-            if (::postgres.isInitialized) postgres.stop()
+            if (::postgres.isInitialized) {
+                postgres.stop()
+                TestInfrastructureEvidence.record("postgres", PGVECTOR_IMAGE.asCanonicalNameString(), "stopped")
+            }
         }
     }
 

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/it/CopilotPostgresTestResource.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/it/CopilotPostgresTestResource.kt
@@ -4,6 +4,7 @@
 // See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
 package com.openbank.copilot.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.testcontainers.containers.PostgreSQLContainer
 
@@ -20,6 +21,7 @@ class CopilotPostgresTestResource : QuarkusTestResourceLifecycleManager {
             .withUsername("openbank")
             .withPassword("openbank")
         postgres.start()
+        TestInfrastructureEvidence.record("postgres", PGVECTOR_IMAGE.asCanonicalNameString(), "started")
         return mapOf(
             "quarkus.datasource.reactive.url" to
                 "postgresql://${postgres.host}:${postgres.firstMappedPort}/${postgres.databaseName}",
@@ -33,7 +35,10 @@ class CopilotPostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        if (::postgres.isInitialized) postgres.stop()
+        if (::postgres.isInitialized) {
+            postgres.stop()
+            TestInfrastructureEvidence.record("postgres", PGVECTOR_IMAGE.asCanonicalNameString(), "stopped")
+        }
     }
 }
 


### PR DESCRIPTION
Closes #7134 (copilot Testcontainers observation portion).

The copilot service owns two custom pgvector `QuarkusTestResourceLifecycleManager` implementations. They run a real Postgres container but previously emitted no secret-free runtime lifecycle evidence, causing the Test Intelligence projection to show declared Postgres with no observed runtime.

This PR adds the test-scoped shared evidence dependency and records only resource, public image name, lifecycle and timestamp on start/stop. No production dependency, credentials, hosts, mapped ports or container IDs are recorded.

Validation:
- `./gradlew :openbank-copilot-service:compileTestKotlin --no-daemon --console=plain`
- `./gradlew :openbank-copilot-service:ktlintCheck --no-daemon --console=plain`

A local Docker IT did not reach a JUnit result in this runner, so the PR CI remains the authoritative container execution proof.