### PR TITLE
fix(testing): pin Pact evidence to contract version

### DIFF
--- a/openbank-admin-ui/scripts/collect-quality-report.mjs
+++ b/openbank-admin-ui/scripts/collect-quality-report.mjs
@@ -8,6 +8,7 @@
 
 import fs from 'fs'
 import path from 'path'
+import { execFileSync } from 'child_process'
 import { parseStringPromise } from 'xml2js'
 import { moneyPathServices } from './lib/service-inventory.mjs'
 
@@ -63,6 +64,25 @@ async function collectMutation(service) {
 
 // ── Pact contracts ────────────────────────────────────────────────────────────
 
+function pactConsumerVersion(pactFile) {
+  // `_service-ci.yml` publishes a consumer pact with the exact Git SHA of the
+  // build that generated it. Pin the broker query to the last committed version
+  // of this particular file; "latest" would otherwise let an unrelated, newer
+  // consumer build turn an older contract green in the Admin UI.
+  try {
+    const version = execFileSync('git', ['log', '-1', '--format=%H', '--', `pacts/${pactFile}`], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+    return /^[0-9a-f]{40}$/.test(version) ? version : null
+  } catch {
+    // A source archive or intentionally shallow checkout without the file's
+    // history cannot prove provenance. Keep the contract pending, never latest.
+    return null
+  }
+}
+
 function collectContracts() {
   const pactsDir = path.join(REPO_ROOT, 'pacts')
   if (!fs.existsSync(pactsDir)) return []
@@ -76,6 +96,7 @@ function collectContracts() {
           consumer: pact.consumer?.name ?? 'unknown',
           provider: pact.provider?.name ?? 'unknown',
           pactFile: f,
+          consumerVersion: pactConsumerVersion(f),
           // Default to pending; enrichWithVerification() overwrites this with the
           // real provider-verification verdict from the Pact Broker when reachable.
           status: 'pending',
@@ -107,12 +128,15 @@ function brokerAuthHeader() {
   return 'Basic ' + Buffer.from(`${user}:${pass}`).toString('base64')
 }
 
-async function fetchPairVerification(baseUrl, auth, consumer, provider) {
-  // Matrix API — the same source can-i-deploy reasons over. Latest version of each
-  // pacticipant, joined cvpv (consumer-version × provider-version).
+async function fetchPairVerification(baseUrl, auth, consumer, consumerVersion, provider) {
+  if (!consumerVersion) return { status: 'pending', verifiedAt: null, providerVersion: null }
+  // Matrix API — pin the consumer to the commit that authored this exact pact
+  // file. The provider remains latest because it is the provider replay asked
+  // to validate that consumer version. Pact Broker documents `version` as a
+  // pacticipant build/version selector, normally a Git SHA.
   const qs = new URLSearchParams()
   qs.append('q[][pacticipant]', consumer)
-  qs.append('q[][latest]', 'true')
+  qs.append('q[][version]', consumerVersion)
   qs.append('q[][pacticipant]', provider)
   qs.append('q[][latest]', 'true')
   qs.append('latestby', 'cvpv')
@@ -122,21 +146,22 @@ async function fetchPairVerification(baseUrl, auth, consumer, provider) {
   if (auth) headers.Authorization = auth
 
   const res = await fetch(url, { headers, signal: AbortSignal.timeout(15000) })
-  if (!res.ok) return { status: 'pending', verifiedAt: null }
+  if (!res.ok) return { status: 'pending', verifiedAt: null, providerVersion: null }
 
   const body = await res.json()
   const rows = Array.isArray(body?.matrix) ? body.matrix : []
   const verifs = rows.map(r => r?.verificationResult).filter(Boolean)
+  const providerVersion = rows.map(r => r?.providerVersion?.number).find(version => typeof version === 'string') ?? null
 
   if (verifs.some(v => v.success === false)) {
     const at = verifs.filter(v => v.verifiedAt).map(v => v.verifiedAt).sort().pop() ?? null
-    return { status: 'failed', verifiedAt: at }
+    return { status: 'failed', verifiedAt: at, providerVersion }
   }
   if (verifs.length > 0 && verifs.every(v => v.success === true)) {
     const at = verifs.map(v => v.verifiedAt).filter(Boolean).sort().pop() ?? null
-    return { status: 'passed', verifiedAt: at }
+    return { status: 'passed', verifiedAt: at, providerVersion }
   }
-  return { status: 'pending', verifiedAt: null }
+  return { status: 'pending', verifiedAt: null, providerVersion: null }
 }
 
 async function enrichWithVerification(contracts) {
@@ -149,9 +174,10 @@ async function enrichWithVerification(contracts) {
   let resolved = 0
   for (const c of contracts) {
     try {
-      const v = await fetchPairVerification(baseUrl, auth, c.consumer, c.provider)
+      const v = await fetchPairVerification(baseUrl, auth, c.consumer, c.consumerVersion, c.provider)
       c.status = v.status
       c.verifiedAt = v.verifiedAt
+      c.providerVersion = v.providerVersion
       c.interactions = c.interactions.map(i => ({ ...i, status: v.status }))
       if (v.status !== 'pending') resolved++
     } catch (e) {

--- a/openbank-admin-ui/scripts/collect-test-intelligence.mjs
+++ b/openbank-admin-ui/scripts/collect-test-intelligence.mjs
@@ -327,11 +327,14 @@ function contracts() {
   const quality = readJson(path.join(repo, 'openbank-admin-ui', 'quality-report.json'))
   if (quality?.contracts) return quality.contracts.map(item => ({
     consumer: item.consumer, provider: item.provider, pactFile: item.pactFile,
+    consumerVersion: item.consumerVersion ?? null, providerVersion: item.providerVersion ?? null,
     state: item.status === 'pending' ? 'unknown' : freshnessAwareState(item.status, item.verifiedAt),
     observedAt: item.verifiedAt ?? null, interactions: item.interactions?.length ?? 0,
     verificationDetail: item.status === 'pending'
-      ? 'Pact Broker provider-verification verdict was unavailable when this immutable deployment snapshot was built. This is not a passing result.'
-      : 'Verified by the Pact Broker provider-verification verdict retained in this deployment snapshot.',
+      ? item.consumerVersion
+        ? `Pact Broker provider-verification verdict for consumer ${item.consumerVersion.slice(0, 12)} was unavailable when this immutable deployment snapshot was built. This is not a passing result.`
+        : 'The committed Pact has no immutable consumer-version provenance in this snapshot, so the Broker was not queried. This is not a passing result.'
+      : `Verified by the Pact Broker provider replay for consumer ${item.consumerVersion?.slice(0, 12) ?? 'unknown'} and provider ${item.providerVersion?.slice(0, 12) ?? 'unknown'} retained in this deployment snapshot.`,
   }))
   const dir = path.join(repo, 'pacts')
   if (!exists(dir)) return []

--- a/openbank-admin-ui/src/lib/types/quality-report.ts
+++ b/openbank-admin-ui/src/lib/types/quality-report.ts
@@ -16,6 +16,10 @@ export interface ContractVerification {
   consumer: string
   provider: string
   pactFile: string
+  /** Git SHA of the committed consumer pact version used for the broker query. */
+  consumerVersion?: string | null
+  /** Provider version whose replay produced the displayed verdict. */
+  providerVersion?: string | null
   status: 'passed' | 'failed' | 'pending'
   verifiedAt: string | null
   interactions: PactInteractionResult[]

--- a/openbank-admin-ui/src/lib/types/test-intelligence.ts
+++ b/openbank-admin-ui/src/lib/types/test-intelligence.ts
@@ -93,6 +93,10 @@ export interface ContractEvidence {
   consumer: string
   provider: string
   pactFile: string
+  /** Consumer commit that authored the committed Pact used in the broker query. */
+  consumerVersion?: string | null
+  /** Provider build whose replay produced the broker verdict. */
+  providerVersion?: string | null
   state: EvidenceState
   observedAt: string | null
   interactions: number

--- a/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-import { execFileSync } from 'child_process'
+import { execFile, execFileSync } from 'child_process'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { createServer } from 'http'
 import { tmpdir } from 'os'
 import path from 'path'
+import { promisify } from 'util'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { TestIntelligenceReport } from '@/lib/types/test-intelligence'
 
 const SCRIPT = path.resolve(__dirname, '../../scripts/collect-test-intelligence.mjs')
+const QUALITY_SCRIPT = path.resolve(__dirname, '../../scripts/collect-quality-report.mjs')
+const execFileAsync = promisify(execFile)
 const dirs: string[] = []
 const write = (root: string, relative: string, body: string) => {
   const file = path.join(root, relative)
@@ -482,5 +486,71 @@ journeys:
     expect(report.syntheticJourneys[0].ci).toMatchObject({ state: 'stale' })
     expect(report.contracts[0]).toMatchObject({ state: 'stale' })
     expect(report.totals).toMatchObject({ failingEvidence: 1, staleEvidence: 5 })
+  })
+
+  it('pins a Pact verdict to the committed consumer version instead of the broker latest pair', async () => {
+    const repo = mkdtempSync(path.join(tmpdir(), 'quality-contract-provenance-'))
+    const output = mkdtempSync(path.join(tmpdir(), 'quality-contract-output-'))
+    dirs.push(repo, output)
+    write(repo, 'openbank-libs/governance/rules.yaml', 'money_path_services: []\n')
+    write(repo, 'pacts/openbank-consumer-openbank-provider.json', JSON.stringify({
+      consumer: { name: 'openbank-consumer' }, provider: { name: 'openbank-provider' }, interactions: [],
+    }))
+    execFileSync('git', ['init'], { cwd: repo })
+    execFileSync('git', ['config', 'user.email', 'test@example.test'], { cwd: repo })
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repo })
+    execFileSync('git', ['config', 'commit.gpgSign', 'false'], { cwd: repo })
+    execFileSync('git', ['add', '.'], { cwd: repo })
+    execFileSync('git', ['commit', '-m', 'test pact provenance'], { cwd: repo })
+    const consumerVersion = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8' }).trim()
+
+    let requestUrl = ''
+    const server = createServer((request, response) => {
+      requestUrl = request.url ?? ''
+      response.setHeader('content-type', 'application/json')
+      response.end(JSON.stringify({ matrix: [{
+        providerVersion: { number: 'provider-replay-sha' },
+        verificationResult: { success: true, verifiedAt: '2026-08-26T12:00:00Z' },
+      }] }))
+    })
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+    const address = server.address()
+    if (!address || typeof address === 'string') throw new Error('test broker did not bind a TCP port')
+    try {
+      await execFileAsync('node', [QUALITY_SCRIPT, '--repo-root', repo], {
+        cwd: output,
+        env: { ...process.env, PACT_BROKER_URL: `http://127.0.0.1:${address.port}` },
+      })
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()))
+    }
+    const report = JSON.parse(readFileSync(path.join(output, 'quality-report.json'), 'utf8'))
+    expect(report.contracts).toEqual([expect.objectContaining({
+      consumerVersion, providerVersion: 'provider-replay-sha', status: 'passed',
+    })])
+    const query = new URL(`http://broker${requestUrl}`).searchParams
+    expect(query.getAll('q[][pacticipant]')).toEqual(['openbank-consumer', 'openbank-provider'])
+    expect(query.getAll('q[][version]')).toEqual([consumerVersion])
+    expect(query.getAll('q[][latest]')).toEqual(['true'])
+  })
+
+  it('does not query a broker latest pair when the committed Pact has no Git provenance', () => {
+    const repo = mkdtempSync(path.join(tmpdir(), 'quality-contract-no-provenance-'))
+    const output = mkdtempSync(path.join(tmpdir(), 'quality-contract-no-provenance-output-'))
+    dirs.push(repo, output)
+    write(repo, 'openbank-libs/governance/rules.yaml', 'money_path_services: []\n')
+    write(repo, 'pacts/openbank-consumer-openbank-provider.json', JSON.stringify({
+      consumer: { name: 'openbank-consumer' }, provider: { name: 'openbank-provider' }, interactions: [],
+    }))
+    execFileSync('node', [QUALITY_SCRIPT, '--repo-root', repo], {
+      cwd: output,
+      // A deliberately unavailable endpoint proves the collector returns before
+      // network I/O when it cannot pin the Pact to a committed consumer version.
+      env: { ...process.env, PACT_BROKER_URL: 'http://127.0.0.1:1' },
+    })
+    const report = JSON.parse(readFileSync(path.join(output, 'quality-report.json'), 'utf8'))
+    expect(report.contracts).toEqual([expect.objectContaining({
+      consumerVersion: null, providerVersion: null, status: 'pending', verifiedAt: null,
+    })])
   })
 })


### PR DESCRIPTION
## What

Make Test Intelligence contract evidence fail closed on a specific committed consumer Pact version. The broker Matrix query now selects the Git SHA that last changed each `pacts/*.json` file instead of consumer `latest`; the provider selector remains latest because that provider replay is being assessed against the pinned contract.

The snapshot carries consumer/provider version provenance in its evidence explanation. Source archives or history-less checkouts remain `pending` and do not make a broker network request.

## Proof

- `npm run test -- --run src/test/test-intelligence-collector.test.ts` — 10/10
- `npm run type-check`
- `git diff --check`

The focused test uses a local mock broker to prove the version-pinned Matrix query and provider replay provenance; its negative case proves unavailable Git provenance stays pending.

Refs #7134