### PR TITLE
fix(observability): recover missed RUM audit runs

### DIFF
--- a/openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml
+++ b/openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml
@@ -26,6 +26,11 @@ spec:
   # Sunday 02:00 UTC — low-traffic window, well before European business hours.
   schedule: "0 2 * * 0"
   concurrencyPolicy: Forbid
+  # A short controller outage must not silently erase an entire weekly audit, as
+  # happened in sandbox on 2026-08-23. Keep the catch-up window bounded: an audit
+  # started more than one hour late belongs to the wrong observation window and
+  # must remain visibly stale rather than manufacturing fresh-looking evidence.
+  startingDeadlineSeconds: 3600
   successfulJobsHistoryLimit: 4
   # failedJobsHistoryLimit: 1 — keep the LATEST failure for triage, not an archive.
   # kube-prometheus-stack's KubeJobFailed fires per surviving failed Job OBJECT, so a


### PR DESCRIPTION
## What

Add a bounded one-hour `startingDeadlineSeconds` to the weekly, read-only `rum-attribute-audit` CronJob.

Live sandbox evidence on 2026-08-26: the CronJob recorded a 2026-08-23 schedule but created no Job, leaving the last scheduled success at 2026-08-16. A manually instantiated copy of the existing CronJob completed successfully, proving the audit logic and Tempo path; it does not replace scheduled evidence.

A 1h catch-up handles short controller outages. Runs missed for longer remain stale rather than being attributed to the wrong weekly observation window.

## Proof

- YAML parsed with the exact schedule and `startingDeadlineSeconds: 3600` invariant
- `git diff --check`

Refs #6613