### PR TITLE
ci(synthetics): enforce money-path journey coverage

### DIFF
--- a/.github/workflows/synthetic-journeys.yml
+++ b/.github/workflows/synthetic-journeys.yml
@@ -11,8 +11,10 @@ on:
   pull_request:
     paths:
       - ".github/scripts/check-journey-catalog.py"
+      - ".github/scripts/check-journey-coverage.py"
       - ".github/workflows/synthetic-journeys.yml"
       - "openbank-libs/governance/journeys.yaml"
+      - "openbank-libs/governance/rules.yaml"
       - "openbank-infra/gitops/components/observability/cronjob-journey-public-edge.yaml"
   push:
     branches: [main]
@@ -20,8 +22,11 @@ on:
       # Re-prove and publish main-branch evidence when the executor or envelope producer
       # changes; manifest merges remain the actual post-GitOps call site.
       - ".github/scripts/check-journey-catalog.py"
+      - ".github/scripts/check-journey-coverage.py"
       - ".github/scripts/collect-test-run-evidence.py"
       - ".github/workflows/synthetic-journeys.yml"
+      - "openbank-libs/governance/journeys.yaml"
+      - "openbank-libs/governance/rules.yaml"
       - "openbank-infra/gitops/components/observability/cronjob-journey-public-edge.yaml"
   workflow_dispatch:
 
@@ -47,6 +52,8 @@ jobs:
         run: |
           python3 .github/scripts/check-journey-catalog.py --self-test
           python3 .github/scripts/check-journey-catalog.py --root . --enforce
+          python3 .github/scripts/check-journey-coverage.py --self-test
+          python3 .github/scripts/check-journey-coverage.py --root . --enforce
           mkdir -p synthetic-evidence
           python3 .github/scripts/check-journey-catalog.py \
             --root . --extract public-edge --out synthetic-evidence/journey.js


### PR DESCRIPTION
## Summary
- run the existing money-path journey-accountability gate in the synthetic journey workflow
- trigger it when its checker, the governed journey catalog, or the money-path source of truth changes
- re-prove the same guard on main before publishing synthetic evidence

## Linked issues
Refs #6613

## Verification
- journey catalog self-test and enforced catalog gate
- journey coverage self-test and enforced coverage gate
- workflow YAML parsing
- git diff --check