### PR TITLE
feat(domestic-payment): persist trusted synthetic taint

### DIFF
--- a/docs/threat-models/openbank-domestic-payment.md
+++ b/docs/threat-models/openbank-domestic-payment.md
@@ -90,6 +90,20 @@ not change any existing request's outcome until explicitly flipped.
 
 ## 6. Change log
 
+- **2026-08-26** — The existing authenticated initiation edge now carries a bounded synthetic
+  classification into the existing `domestic_payment_outbox` event boundary. The resource copies
+  it only from the `SyntheticTaintRequestFilter` request property after that filter has accepted a
+  configured trusted principal; it does **not** accept a request header, JWT claim, MDC value, or
+  an unconfigured caller as synthetic. The property is persisted on the payment-created outbox
+  message so an asynchronous consumer can retain the classification instead of treating a canary
+  payment as real. This adds no caller, role, OPA grant, endpoint, payment-control bypass, or new
+  network edge: authentication, authorisation, SCA, limits, sanctions and fraud remain on the
+  normal initiation path. **STRIDE-S/T:** an untrusted caller attempting to label a real payment as
+  synthetic is mitigated by the fail-closed filter decision and by copying only that server-side
+  property. **Residual risk:** no trusted principal is configured and no downstream regulatory
+  exclusion is claimed here; activating either remains a separately reviewed production change.
+  Rollback: revert this propagation, which restores the previous default of `synthetic=false`.
+
 - **2026-08-24** — Synthetic-journey taint now propagates over this service's existing internal REST clients through `SyntheticTaintClientFilter` (ADR-0252, #4348). This adds no caller, endpoint, network-policy edge, privilege or payment-control bypass: sanctions, fraud, limits and SCA continue to run. It prevents a canary payment becoming indistinguishable before a downstream persistence/event boundary; a fleet gate requires every new client to choose propagation or a reasoned external boundary.
 
 - **2026-08-19** — `ApprovalResource` served only `PATCH /{id}` (decide), so a

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/port/in/DomesticPaymentPorts.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/port/in/DomesticPaymentPorts.kt
@@ -33,6 +33,8 @@ data class CreateDomesticPaymentCommand(
     val statementLabel: String?,
     val endToEndId: String?,
     val actorId: UUID? = null,
+    /** Trusted inbound synthetic taint, copied into the durable outbox boundary. */
+    val synthetic: Boolean = false,
 )
 
 data class ListDomesticPaymentsQuery(

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentService.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentService.kt
@@ -114,6 +114,7 @@ class DomesticPaymentService(
                 aggregateId = payment.id,
                 eventType = PAYMENT_CREATED_EVENT,
                 payload = eventPublisher.paymentCreatedPayload(payment),
+                synthetic = command.synthetic,
             ),
         )
 

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/rest/DomesticPaymentResource.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/rest/DomesticPaymentResource.kt
@@ -14,6 +14,7 @@ import com.openbank.domestic.infrastructure.rest.dto.TransitionDomesticPaymentSt
 import com.openbank.domestic.infrastructure.rest.dto.toResponse
 import com.openbank.libs.authz.Authorize
 import com.openbank.libs.idempotency.IdempotencyStore
+import com.openbank.libs.web.SYNTHETIC_TAINT_PROPERTY
 import io.quarkus.security.identity.SecurityIdentity
 import jakarta.annotation.security.RolesAllowed
 import jakarta.inject.Inject
@@ -27,6 +28,8 @@ import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.core.Context
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.jwt.JsonWebToken
@@ -64,6 +67,7 @@ class DomesticPaymentResource(
     suspend fun createPayment(
         request: CreateDomesticPaymentRequest,
         @HeaderParam("Idempotency-Key") idempotencyKey: String?,
+        @Context requestContext: ContainerRequestContext,
     ): Response {
         // #3104 — the guard below could not run when the header was ABSENT: JAX-RS injected null,
         // and `null.isNotBlank()` threw NPE, so the very case it exists for answered 500. `suspend`
@@ -79,7 +83,16 @@ class DomesticPaymentResource(
                 .build()
         }
 
-        val payment = paymentUseCase.createPayment(request.toCommand(idempotencyKey, actorId))
+        // SyntheticTaintRequestFilter accepts this flag only after authenticating a configured
+        // canary principal. Read its request property, never the caller's header or coroutine MDC,
+        // then persist it through the outbox boundary for asynchronous consumers.
+        val payment = paymentUseCase.createPayment(
+            request.toCommand(
+                idempotencyKey,
+                actorId,
+                requestContext.getProperty(SYNTHETIC_TAINT_PROPERTY) == true,
+            ),
+        )
         val responseBody = payment.toResponse()
         idempotencyStore.save(idempotencyKey, 201, objectMapper.writeValueAsString(responseBody))
 

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/rest/dto/DomesticPaymentDtos.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/rest/dto/DomesticPaymentDtos.kt
@@ -37,7 +37,11 @@ data class CreateDomesticPaymentRequest(
     val statementLabel: String?,
     val endToEndId: String?,
 ) {
-    fun toCommand(idempotencyKey: String, actorId: UUID? = null) = CreateDomesticPaymentCommand(
+    fun toCommand(
+        idempotencyKey: String,
+        actorId: UUID? = null,
+        synthetic: Boolean = false,
+    ): CreateDomesticPaymentCommand = CreateDomesticPaymentCommand(
         idempotencyKey = idempotencyKey,
         debtorAccountId = debtorAccountId,
         debtorAccountNumber = debtorAccountNumber,
@@ -57,6 +61,7 @@ data class CreateDomesticPaymentRequest(
         statementLabel = statementLabel,
         endToEndId = endToEndId,
         actorId = actorId,
+        synthetic = synthetic,
     )
 }
 

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentServiceTemporalTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentServiceTemporalTest.kt
@@ -13,6 +13,7 @@ import com.openbank.domestic.domain.model.DomesticPaymentPriority
 import com.openbank.domestic.domain.model.DomesticPaymentStatus
 import com.openbank.domestic.domain.model.DomesticTransferScope
 import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.persistence.outbox.OutboxMessage
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -109,6 +110,17 @@ class DomesticPaymentServiceTemporalTest {
     }
 
     @Test
+    fun `createPayment persists trusted synthetic taint in the durable outbox boundary`() {
+        val outbox = io.mockk.slot<OutboxMessage>()
+        coEvery { repo.findByIdempotencyKey(any()) } returns null
+        coEvery { repo.save(any(), capture(outbox)) } answers { firstArg() }
+
+        runBlocking { service.createPayment(command(synthetic = true)) }
+
+        assertThat(outbox.captured.synthetic).isTrue()
+    }
+
+    @Test
     fun `createPayment derives EXTERNAL scope for a non-own-bank creditor`() {
         coEvery { repo.findByIdempotencyKey(any()) } returns null
 
@@ -141,6 +153,7 @@ class DomesticPaymentServiceTemporalTest {
         idempotencyKey: String = "dom-idem-new",
         creditorBankCode: String = " 0100 ",
         actorId: UUID? = null,
+        synthetic: Boolean = false,
     ) = CreateDomesticPaymentCommand(
         idempotencyKey = idempotencyKey,
         debtorAccountId = UUID.randomUUID(),
@@ -161,6 +174,7 @@ class DomesticPaymentServiceTemporalTest {
         statementLabel = "  Monthly settlement  ",
         endToEndId = "   ",
         actorId = actorId,
+        synthetic = synthetic,
     )
 
     /** No-op workflow so the dispatch has a registered type on the queue; behaviour is tested elsewhere. */


### PR DESCRIPTION
## Summary
- copy the SyntheticTaint request-filter decision into the domestic payment command
- persist that trusted decision on the payment-created outbox message for asynchronous propagation
- keep the default real and do not trust a caller-provided header, MDC, or unconfigured principal

## Linked issues
Refs #6613

## Verification
- focused DomesticPaymentService and real in-memory Temporal dispatch tests
- domestic-payment Kotlin formatting gate
- git diff --check

## Scope
This does not configure any trusted synthetic principal or activate a money-moving journey. Ledger propagation and regulatory exclusion remain separate proof obligations.