### PR TITLE
fix(admin-ui): preserve account opening idempotency

### DIFF
--- a/openbank-admin-ui/src/app/accounts/new/page.tsx
+++ b/openbank-admin-ui/src/app/accounts/new/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { ArrowLeft, Save, AlertCircle } from 'lucide-react'
@@ -43,6 +43,11 @@ export default function NewAccountPage() {
   const [errors, setErrors]   = useState<Record<string, string>>({})
   const [submitting, setSubmitting] = useState(false)
   const [apiError, setApiError]     = useState<string | null>(null)
+  // A double submit can arrive before React renders `submitting`. Keep the request key stable
+  // for this account-opening attempt so the account service can return a safe replay after an
+  // interrupted response instead of opening a second account.
+  const openingInFlight = useRef(false)
+  const idempotencyKey = useRef<string | null>(null)
   const [products, setProducts] = useState<CatalogProduct[]>([])
   const [productsLoading, setProductsLoading] = useState(true)
   const [productsUnavailable, setProductsUnavailable] = useState(false)
@@ -102,20 +107,23 @@ export default function NewAccountPage() {
     e.preventDefault()
     const errs = validate()
     if (Object.keys(errs).length) { setErrors(errs); return }
+    if (openingInFlight.current) return
+    openingInFlight.current = true
     setErrors({}); setSubmitting(true); setApiError(null)
     try {
-      const idempotencyKey = crypto.randomUUID()
+      const stableIdempotencyKey = idempotencyKey.current ??= crypto.randomUUID()
       const account = await accountApi.open({
         partyId:     form.partyId.trim(),
         productId:   form.productId.trim(),
         accountType: form.accountType,
         currencyCode: form.currencyCode,
         legalName:   form.legalName.trim(),
-      }, idempotencyKey)
+      }, stableIdempotencyKey)
       router.push(`/accounts/${account.id}`)
     } catch (err: unknown) {
       setApiError(err instanceof Error ? err.message : t('Otevření účtu selhalo', 'Failed to open account'))
     } finally {
+      openingInFlight.current = false
       setSubmitting(false)
     }
   }

--- a/openbank-admin-ui/src/test/accounts-new-accessibility.guard.test.ts
+++ b/openbank-admin-ui/src/test/accounts-new-accessibility.guard.test.ts
@@ -36,4 +36,14 @@ describe('new account form accessibility', () => {
     expect(page).toContain('partyId:     form.partyId.trim()')
     expect(page).toContain('legalName:   form.legalName.trim()')
   })
+
+  it('keeps one account-opening request and its idempotency key stable across a retry', () => {
+    expect(page).toContain("import { useEffect, useRef, useState } from 'react'")
+    expect(page).toContain('const openingInFlight = useRef(false)')
+    expect(page).toContain('const idempotencyKey = useRef<string | null>(null)')
+    expect(page).toContain('if (openingInFlight.current) return')
+    expect(page).toContain('idempotencyKey.current ??= crypto.randomUUID()')
+    expect(page).toContain('}, stableIdempotencyKey)')
+    expect(page).toContain('openingInFlight.current = false')
+  })
 })


### PR DESCRIPTION
Closes #7167.

The account-opening key now remains stable for one operator attempt, allowing the account service to safely replay a request after an interrupted response. A synchronous single-flight lock also rejects a second submit event before React renders the button disabled.

Verification: git diff --check; node --check on the guard test. Focused Vitest is unavailable in the clean worktree because dependencies are not installed; CI remains authoritative.