### PR TITLE
fix(admin-ui): prevent duplicate card issuance

### DIFF
--- a/openbank-admin-ui/src/components/cards/IssueCardDialog.tsx
+++ b/openbank-admin-ui/src/components/cards/IssueCardDialog.tsx
@@ -131,10 +131,11 @@ export function IssueCardDialog({ onClose, onIssued }: { onClose: () => void; on
   const [entitlementsUnknown, setEntitlementsUnknown] = useState(false)
   const [resolveNonce, setResolveNonce] = useState(0)
 
-  // Step 4 — the idempotency key for THIS attempt, generated once and reused on
-  // every retry so a dropped response replays the same card rather than minting
-  // a second one.
-  const [idempotencyKey, setIdempotencyKey] = useState('')
+  // Step 4 — refs update synchronously, before React can render the button disabled.
+  // Keep one key for this attempt so a dropped response replays the same card rather
+  // than minting a second one, and reject a second click in the same event turn.
+  const idempotencyKey = useRef<string | null>(null)
+  const issuingInFlight = useRef(false)
 
   const [dailyText, setDailyText] = useState('')
   const [monthlyText, setMonthlyText] = useState('')
@@ -296,10 +297,15 @@ export function IssueCardDialog({ onClose, onIssued }: { onClose: () => void; on
   const submit = async () => {
     const body = issueRequestBody(draft)
     if (!body) return
-    const key = idempotencyKey || crypto.randomUUID()
-    if (!idempotencyKey) setIdempotencyKey(key)
-    const issued = await ops.issueCard(body, key)
-    if (issued?.id) onIssued(issued)
+    if (issuingInFlight.current) return
+    issuingInFlight.current = true
+    try {
+      const key = idempotencyKey.current ??= crypto.randomUUID()
+      const issued = await ops.issueCard(body, key)
+      if (issued?.id) onIssued(issued)
+    } finally {
+      issuingInFlight.current = false
+    }
   }
 
   const stepTitle: Record<IssueStep, string> = {

--- a/openbank-admin-ui/src/test/card-issue-dialog.test.tsx
+++ b/openbank-admin-ui/src/test/card-issue-dialog.test.tsx
@@ -111,6 +111,23 @@ describe('issue-card flow', () => {
     expect(JSON.stringify(init.headers)).not.toContain('Operator')
   })
 
+  it('rejects a double click before React can render the issue button disabled', async () => {
+    const randomUUID = vi.fn().mockReturnValueOnce('idem-key-first').mockReturnValueOnce('idem-key-second')
+    vi.stubGlobal('crypto', { ...globalThis.crypto, randomUUID })
+    mount()
+    await walkToReview()
+    fireEvent.click(screen.getByText('Continue'))
+    await waitFor(() => expect(screen.getByText('Issue the card')).toBeTruthy())
+
+    const issueButton = screen.getByText('Issue the card').closest('button') as HTMLButtonElement
+    fireEvent.click(issueButton)
+    fireEvent.click(issueButton)
+
+    await waitFor(() => expect(posted).toHaveLength(1))
+    expect((posted[0].init.headers as Record<string, string>)['Idempotency-Key']).toBe('idem-key-first')
+    expect(randomUUID).toHaveBeenCalledTimes(1)
+  })
+
   it('refuses an exhausted quota up front and says why', async () => {
     vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)


### PR DESCRIPTION
Closes #7170.

The card issuance dialog now takes a synchronous single-flight lock and retains its idempotency key in a ref. A regression test sends two clicks before React can render disabled and proves that only one request leaves the UI.

Verification: git diff --check. Focused Vitest is unavailable in the clean worktree because dependencies are not installed; CI remains authoritative.