### PR TITLE
feat(ledger): persist trusted synthetic taint

### DIFF
--- a/docs/threat-models/openbank-ledger-service.md
+++ b/docs/threat-models/openbank-ledger-service.md
@@ -238,6 +238,16 @@ set) apply equally to the new `ledger.approval.decide` action.
 
 ## 8. Change log
 
+- **2026-08-26** — `POST /api/v1/journals` now copies the trusted synthetic classification from
+  `SyntheticTaintRequestFilter` into the `JournalPosted` and derived `AccountBookedChanged` outbox
+  rows for that posting. The REST resource reads only the server-side request property after the
+  filter authenticates a configured canary principal; it does not trust a request header, JWT
+  claim, coroutine MDC value or unconfigured caller. **STRIDE-S/T:** a normal caller cannot label
+  a real ledger event synthetic, because the default is false and only the filter's fail-closed
+  decision is copied. No principal is configured and no regulatory consumer is changed here; this
+  neither activates a money-moving synthetic journey nor claims FINREP/COREP/AML exclusion.
+  Rollback: revert propagation, restoring false on newly written rows.
+
 - **2026-08-24** — Synthetic-journey taint now reaches this service over its existing internal FX REST edge through `SyntheticTaintClientFilter` (ADR-0252, #4348). This adds no caller, endpoint, network-policy edge, privilege or ledger-control bypass. It is the prerequisite for correctly classifying synthetic postings at a later persistence-backed ledger boundary; a fleet gate requires every new client to choose propagation or a reasoned external boundary.
 
 - **2026-08-19** — `ApprovalResource` served only `PATCH /{id}` (decide), so a `ledger.reverse`

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/in/LedgerPorts.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/in/LedgerPorts.kt
@@ -23,6 +23,8 @@ data class PostJournalCommand(
     val description: String?,
     val lines: List<JournalLineRequest>,
     val postedBy: UUID,
+    /** Trusted inbound synthetic taint, copied only into this posting's durable outbox events. */
+    val synthetic: Boolean = false,
     /**
      * Extra outbox rows to enqueue in the SAME transaction as this posting's own `JournalPosted`
      * + `AccountBookedChanged` rows (#1201 proposed fix 3) — for a caller whose own domain event

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/usecase/LedgerService.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/usecase/LedgerService.kt
@@ -125,7 +125,9 @@ class LedgerService(
         }
 
         val messages =
-            listOf(journalPostedMessage(entry)) + bookedChangedMessages(entry) + command.additionalOutboxMessages(entry)
+            listOf(journalPostedMessage(entry, command.synthetic)) +
+                bookedChangedMessages(entry, command.synthetic) +
+                command.additionalOutboxMessages(entry)
         val saved = try {
             journalRepository.save(entry, command.idempotencyKey, messages)
         } catch (e: PersistenceException) {
@@ -152,9 +154,10 @@ class LedgerService(
         return journalRepository.findByIdempotencyKey(idempotencyKey) ?: throw e
     }
 
-    private fun journalPostedMessage(entry: JournalEntry): OutboxMessage = OutboxMessage(
+    private fun journalPostedMessage(entry: JournalEntry, synthetic: Boolean): OutboxMessage = OutboxMessage(
         aggregateId = entry.id,
         eventType = JOURNAL_POSTED,
+        synthetic = synthetic,
         payload = objectMapper.writeValueAsString(
             JournalPostedEvent(
                 aggregateId = entry.id,
@@ -314,24 +317,26 @@ class LedgerService(
      * (pure GL movements). Computed from the SAME entry that is being persisted, so a reversal's
      * flipped sides naturally yield negated deltas, keyed by the reversal entry's id.
      */
-    private fun bookedChangedMessages(entry: JournalEntry): List<OutboxMessage> = entry.bookedDeltas().map { d ->
-        OutboxMessage(
-            aggregateId = d.accountId,
-            eventType = ACCOUNT_BOOKED_CHANGED,
-            payload = objectMapper.writeValueAsString(
-                AccountBookedChangedEvent(
-                    aggregateId = d.accountId,
-                    version = entry.version,
-                    currency = d.currency,
-                    delta = d.delta,
-                    journalEntryId = entry.id,
-                    transactionId = entry.transactionId,
-                    entryDate = entry.entryDate,
-                    occurredAt = clock.instant(),
+    private fun bookedChangedMessages(entry: JournalEntry, synthetic: Boolean = false): List<OutboxMessage> =
+        entry.bookedDeltas().map { d ->
+            OutboxMessage(
+                aggregateId = d.accountId,
+                eventType = ACCOUNT_BOOKED_CHANGED,
+                synthetic = synthetic,
+                payload = objectMapper.writeValueAsString(
+                    AccountBookedChangedEvent(
+                        aggregateId = d.accountId,
+                        version = entry.version,
+                        currency = d.currency,
+                        delta = d.delta,
+                        journalEntryId = entry.id,
+                        transactionId = entry.transactionId,
+                        entryDate = entry.entryDate,
+                        occurredAt = clock.instant(),
+                    ),
                 ),
-            ),
-        )
-    }
+            )
+        }
 
     companion object {
         // The bank time zone constant that used to live here is gone: the accounting date is no

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/LedgerResource.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/LedgerResource.kt
@@ -24,6 +24,7 @@ import com.openbank.ledger.domain.model.TrialBalance
 import com.openbank.libs.api.pagination.CursorPage
 import com.openbank.libs.authz.Authorize
 import com.openbank.libs.security.Roles
+import com.openbank.libs.web.SYNTHETIC_TAINT_PROPERTY
 import jakarta.annotation.security.RolesAllowed
 import jakarta.ws.rs.Consumes
 import jakarta.ws.rs.DefaultValue
@@ -33,6 +34,8 @@ import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.core.Context
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.openapi.annotations.Operation
@@ -130,7 +133,11 @@ class LedgerResource(
     @RolesAllowed(Roles.OPERATOR)
     @Authorize(action = "ledger.create", resource = "")
     @Operation(summary = "Post a balanced journal entry")
-    suspend fun postJournal(request: PostJournalRequest): Response {
+    suspend fun postJournal(
+        request: PostJournalRequest,
+        @Context
+        requestContext: ContainerRequestContext,
+    ): Response {
         val command = PostJournalCommand(
             idempotencyKey = request.idempotencyKey,
             transactionId = request.transactionId,
@@ -139,6 +146,9 @@ class LedgerResource(
             description = request.description,
             lines = request.lines.map { it.toCommand() },
             postedBy = request.createdBy,
+            // The filter sets this property only after authenticating a configured canary
+            // principal. Never accept a caller-supplied header or coroutine MDC as synthetic.
+            synthetic = requestContext.getProperty(SYNTHETIC_TAINT_PROPERTY) == true,
         )
         val entry = ledgerUseCase.postJournal(command)
         return Response.created(URI.create("/api/v1/journals/${entry.id}"))

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/application/usecase/LedgerServiceTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/application/usecase/LedgerServiceTest.kt
@@ -205,6 +205,20 @@ class LedgerServiceTest {
         }
 
         @Test
+        fun `persists trusted synthetic taint on posting outbox messages`(): Unit = runBlocking {
+            mockGlAccounts()
+            coEvery { journalRepository.nextEntryNumber() } returns 1L
+            val messages = slot<List<OutboxMessage>>()
+            coEvery { journalRepository.save(any(), any(), capture(messages)) } answers { firstArg() }
+
+            service.postJournal(postCommand().copy(synthetic = true))
+
+            assertThat(messages.captured).isNotEmpty().allSatisfy { message ->
+                assertThat(message.synthetic).isTrue()
+            }
+        }
+
+        @Test
         fun `replays original entry on idempotency hit without re-posting`(): Unit = runBlocking {
             val command = postCommand()
             val existing = postedEntry(command.transactionId)


### PR DESCRIPTION
## Summary
- copy only the server-side trusted SyntheticTaint request decision into ledger journal posting commands
- persist the classification on JournalPosted and derived AccountBookedChanged outbox rows
- retain a false default and leave reversal or scheduled flows unchanged
- record the inbound-to-outbox trust boundary in the ledger money-path threat model

## Linked issues
Refs #6613

## Verification
- LedgerServiceTest
- ledger Kotlin formatting gate
- git diff check

## Scope
This does not configure a trusted sandbox principal, activate a money-moving journey, or claim regulatory consumer exclusion. Those remain independently required E2E evidence.