### PR TITLE
fix(admin-ui): prevent duplicate audience drafts

### DIFF
--- a/openbank-admin-ui/src/app/segments/new/page.tsx
+++ b/openbank-admin-ui/src/app/segments/new/page.tsx
@@ -3,7 +3,7 @@
 
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { ArrowLeft, CheckCircle2, ShieldCheck, Users } from 'lucide-react'
@@ -20,8 +20,14 @@ export default function NewAudiencePage() {
   const [minDays, setMinDays] = useState('')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // React state is rendered asynchronously. Keep the one operator action single-flight before a
+  // second click can observe the disabled button; audience creation otherwise allocates a new,
+  // governed version on each request.
+  const createInFlight = useRef(false)
 
   const create = async () => {
+    if (createInFlight.current) return
+    createInFlight.current = true
     setSaving(true); setError(null)
     const rules: Array<Record<string, unknown>> = [{ type: 'PARTY_STATUS_IS', status }]
     if (minDays.trim() !== '') rules.push({ type: 'TENURE_AT_LEAST_DAYS', minDays: Number(minDays) })
@@ -29,7 +35,10 @@ export default function NewAudiencePage() {
       const response = await fetch('/api/audiences', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ name, rules }) })
       if (!response.ok) throw new Error((await response.json()).error ?? 'Unable to create audience')
       router.push('/segments')
-    } catch (e) { setError(e instanceof Error ? e.message : 'Unable to create audience') } finally { setSaving(false) }
+    } catch (e) { setError(e instanceof Error ? e.message : 'Unable to create audience') } finally {
+      createInFlight.current = false
+      setSaving(false)
+    }
   }
 
   const validName = /^[a-z0-9][a-z0-9-]*$/.test(name)

--- a/openbank-admin-ui/src/test/audience-create-single-flight.guard.test.ts
+++ b/openbank-admin-ui/src/test/audience-create-single-flight.guard.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(path.resolve(__dirname, '../app/segments/new/page.tsx'), 'utf8')
+
+describe('audience draft creation', () => {
+  it('synchronously rejects a second submit while the first create request is pending', () => {
+    expect(source).toContain("import { useRef, useState } from 'react'")
+    expect(source).toContain('const createInFlight = useRef(false)')
+    expect(source).toContain('if (createInFlight.current) return')
+    expect(source).toContain('createInFlight.current = true')
+    expect(source).toContain("fetch('/api/audiences', { method: 'POST'")
+    expect(source).toContain('createInFlight.current = false')
+  })
+})


### PR DESCRIPTION
Closes #7175

## Why

The audience-draft endpoint deliberately versions every create and provides no idempotency key. A rapid double-submit can run twice before React renders `saving` and produce multiple governed drafts from one operator intent.

## Change

- add a synchronous client-side single-flight ref around draft creation;
- retain the existing disabled state as feedback;
- add a focused guard test.

## Preserved invariants

Closed rule vocabulary, `campaign.create` authorization, audience versioning, lifecycle semantics and maker-checker approval are unchanged.

## Verification

- `git diff --check`
- `node --check openbank-admin-ui/src/test/audience-create-single-flight.guard.test.ts`
- focused Vitest unavailable locally: clean isolated worktree has no `node_modules`; CI required before merge.