### PR TITLE
fix(admin-ui): keep campaign drafts single-flight

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { ArrowLeft, BellRing, Clock3, Mail, Megaphone, PanelsTopLeft, Send, Sparkles, Users } from 'lucide-react'
@@ -134,6 +134,9 @@ export default function NewCampaignPage() {
   const [contentExperiment, setContentExperiment] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
+  // State only disables the button after React renders. Keep the network action single-flight so a
+  // rapid second submit cannot allocate another campaign draft before that render.
+  const saveInFlight = useRef(false)
 
   const templates = Object.fromEntries(contentCatalogue.map(entry => [entry.template, entry.variables])) as Record<string, string[]>
   const templateChannel = Object.fromEntries(contentCatalogue.map(entry => [entry.template, entry.channel])) as Record<string, EditorChannel>
@@ -475,6 +478,8 @@ export default function NewCampaignPage() {
   }
 
   const submit = () => {
+    if (saveInFlight.current) return
+    saveInFlight.current = true
     setSaving(true)
     setError(null)
     const [segName, segVersion] = segment.split('@')
@@ -535,7 +540,10 @@ export default function NewCampaignPage() {
         )
       })
       .catch(() => setError(t('Campaign-service neodpovídá.', 'Campaign-service is not responding.')))
-      .finally(() => setSaving(false))
+      .finally(() => {
+        saveInFlight.current = false
+        setSaving(false)
+      })
   }
 
   return <AuthGuard permission="campaign:create">

--- a/openbank-admin-ui/src/test/campaign-create-single-flight.guard.test.ts
+++ b/openbank-admin-ui/src/test/campaign-create-single-flight.guard.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(path.resolve(__dirname, '../app/campaigns/new/page.tsx'), 'utf8')
+
+describe('Campaign Studio draft submission', () => {
+  it('synchronously keeps create and revise requests single-flight', () => {
+    expect(source).toContain("import { useEffect, useRef, useState } from 'react'")
+    expect(source).toContain('const saveInFlight = useRef(false)')
+    expect(source).toContain('if (saveInFlight.current) return')
+    expect(source).toContain('saveInFlight.current = true')
+    expect(source).toContain("draftId ? `/api/campaigns/${encodeURIComponent(draftId)}` : '/api/campaigns'")
+    expect(source).toContain('saveInFlight.current = false')
+  })
+})


### PR DESCRIPTION
Closes #7178

## Why

Campaign Studio creates a server-assigned draft ID and has no idempotency key. React state disables the submit button only after rendering, so two immediate submit events could create duplicate governed drafts.

## Change

Add a synchronous single-flight ref around the existing create/revise request and a focused guard test.

## Preserved invariants

Server-side draft validation, audience resolution, `campaign:create` authorization, maker-checker lifecycle, delivery consent and Temporal activation are unchanged.

## Verification

- `git diff --check`
- `node --check openbank-admin-ui/src/test/campaign-create-single-flight.guard.test.ts`
- focused Vitest unavailable locally: clean isolated worktree has no `node_modules`; CI required before merge.