### PR TITLE
fix(admin-ui): meet AA contrast for muted text

### DIFF
--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -10,7 +10,9 @@
   --sidebar-active-bg:    rgba(99,102,241,0.12);
   --sidebar-active-text:  #c7d2fe;
   --sidebar-text:         #8b9cb6;
-  --sidebar-text-muted:   #475569;
+  /* Muted navigation is still operational text. #94a3b8 reaches 7.54:1 against the
+     sidebar, whereas the previous #475569 was 2.55:1 and unreadable at its shipped size. */
+  --sidebar-text-muted:   #94a3b8;
   --sidebar-border:       rgba(255,255,255,0.04);
   --sidebar-accent:       #6366f1;
 
@@ -32,8 +34,10 @@
   /* ── Text ── */
   --text-primary:         #0f172a;
   --text-secondary:       #475569;
-  --text-tertiary:        #94a3b8;
-  --text-muted:           #94a3b8;
+  /* Used for labels, metadata and empty-state guidance across the operator console. #64748b
+     keeps a clear hierarchy while meeting AA on both white (4.76:1) and surface-2 (4.55:1). */
+  --text-tertiary:        #64748b;
+  --text-muted:           var(--text-tertiary);
 
   /* ── Shorthand semantic aliases ── */
   --green:  #10b981;

--- a/openbank-admin-ui/src/test/ui-token-contrast.guard.test.ts
+++ b/openbank-admin-ui/src/test/ui-token-contrast.guard.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const css = readFileSync(path.resolve(__dirname, '../app/globals.css'), 'utf8')
+
+function token(name: string): string {
+  const match = css.match(new RegExp(`${name}:\\s*(#[0-9a-fA-F]{6})`))
+  if (!match) throw new Error(`Missing hexadecimal value for ${name}`)
+  return match[1]
+}
+
+function luminance(hex: string): number {
+  const channels = hex.slice(1).match(/../g)!.map(channel => parseInt(channel, 16) / 255)
+  const [red, green, blue] = channels.map(channel =>
+    channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4,
+  )
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+}
+
+function contrast(foreground: string, background: string): number {
+  const [lighter, darker] = [luminance(foreground), luminance(background)].sort((a, b) => b - a)
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+describe('shared admin UI text token contrast', () => {
+  it('keeps the high-volume muted text legible on operator surfaces', () => {
+    const tertiary = token('--text-tertiary')
+    expect(contrast(tertiary, token('--surface'))).toBeGreaterThanOrEqual(4.5)
+    expect(contrast(tertiary, token('--surface-2'))).toBeGreaterThanOrEqual(4.5)
+  })
+
+  it('keeps muted navigation text legible on the dark sidebar', () => {
+    expect(contrast(token('--sidebar-text-muted'), token('--sidebar-bg'))).toBeGreaterThanOrEqual(4.5)
+  })
+})


### PR DESCRIPTION
Closes #7182

## Why

Two shared text tokens fail WCAG AA while appearing across the operator console: `--text-tertiary` was 2.56:1 on white / 2.45:1 on `--surface-2`, and `--sidebar-text-muted` was 2.55:1 on the sidebar.

## Change

- set `--text-tertiary` to slate-500 and alias the legacy `--text-muted` token to it;
- increase sidebar muted text contrast;
- add a deterministic token-source guard that computes contrast against the actual composed surfaces.

## Verification

- exact contrast calculation against `globals.css`: 4.759:1 on white, 4.548:1 on `surface-2`, 7.536:1 on the sidebar;
- `git diff --check`;
- focused Vitest could not resolve dependencies from the clean isolated worktree; CI is required before merge.

No layouts, routes, data flows, permissions or behaviour change.