### PR TITLE
fix(admin-ui): fail fast stalled image builds

### DIFF
--- a/openbank-infra/scripts/build-push-admin-ui.sh
+++ b/openbank-infra/scripts/build-push-admin-ui.sh
@@ -28,6 +28,7 @@
 #   AWS_REGION    eu-north-1
 #   AWS_PROFILE   openbank
 #   ADMIN_UI_IMAGE_TAG_SUFFIX  optional immutable CI retry suffix (`run<id>`)
+#   ADMIN_UI_BUILDX_TIMEOUT_SECONDS  CI-only upper bound for the image build (default: 1440)
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -346,7 +347,7 @@ else
   echo "    sourcemaps: no GLITCHTIP_AUTH_TOKEN — upload skipped"
 fi
 
-docker buildx build \
+buildx_args=(
   "${SECRET_ARGS[@]}" \
   --platform "${PLATFORM}" \
   --file openbank-admin-ui/Dockerfile \
@@ -356,6 +357,25 @@ docker buildx build \
   --tag "${IMAGE}" \
   --push \
   .
+)
+
+# The GitHub job has a 30-minute ceiling, but an unbounded BuildKit invocation can consume the
+# entire deploy slot and leave no time for a useful failure or cleanup signal. GNU timeout is
+# available on the Linux CI runner; keep the local macOS path portable and unbounded, because
+# macOS does not ship that command. 24 minutes leaves time inside the job for attestation and the
+# GitOps handoff while making a hung daemon observable as an ordinary failed build.
+if command -v timeout >/dev/null 2>&1; then
+  BUILDX_TIMEOUT_SECONDS="${ADMIN_UI_BUILDX_TIMEOUT_SECONDS:-1440}"
+  if ! [[ "${BUILDX_TIMEOUT_SECONDS}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: ADMIN_UI_BUILDX_TIMEOUT_SECONDS must be a positive integer." >&2
+    exit 2
+  fi
+  echo "    buildx timeout: ${BUILDX_TIMEOUT_SECONDS}s (CI fail-fast guard)"
+  timeout --foreground --kill-after=30s "${BUILDX_TIMEOUT_SECONDS}s" docker buildx build "${buildx_args[@]}"
+else
+  echo "    buildx timeout: unavailable on this host; relying on the caller's process limit"
+  docker buildx build "${buildx_args[@]}"
+fi
 
 echo "==> pushed ${IMAGE}"
 


### PR DESCRIPTION
## Linked issues

Refs #4348 — reliable Admin UI deployment is required for the Test Intelligence evidence surface.

## Why

The Admin UI deployment relies on a job-level 30 minute limit. An unbounded `docker buildx build` can consume that complete slot and make an eventual failure harder to diagnose or retry.

## Change

- bound Linux CI BuildKit execution to 24 minutes with a 30 second kill grace period
- retain macOS portability by falling back to the caller process limit when GNU `timeout` is unavailable
- validate the optional timeout override before invoking Docker

## Verification

- `bash -n openbank-infra/scripts/build-push-admin-ui.sh`
- `.github/scripts/check-admin-ui-version-sync.sh --self-test`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py --self-test`
- `git diff --check`