### PR TITLE
feat(test-intelligence): retain test definition provenance

### DIFF
--- a/.github/scripts/collect-test-run-evidence.py
+++ b/.github/scripts/collect-test-run-evidence.py
@@ -102,12 +102,19 @@ def validate_envelope(envelope: dict) -> None:
         if item["kind"] not in SPECIALIZED_KINDS or item["state"] not in SPECIALIZED_STATES or not item["source"]:
             raise ValueError("specialized evidence values are invalid")
     for item in envelope.get("testCases", []):
-        if set(item) != {"fingerprint", "kind", "classname", "name", "state", "durationMs"}:
+        required_case_fields = {"fingerprint", "kind", "classname", "name", "state", "durationMs"}
+        if set(item) - (required_case_fields | {"testDefinitionPath"}) or not required_case_fields.issubset(item):
             raise ValueError("test case fields are invalid")
         if (not re.fullmatch(r"[0-9a-f]{24}", item["fingerprint"]) or item["kind"] not in SUITE_KINDS
                 or item["state"] not in {"passed", "failed", "skipped"}
                 or not item["classname"] or not item["name"] or item["durationMs"] < 0):
             raise ValueError("test case values are invalid")
+        path = item.get("testDefinitionPath")
+        if (path is not None and (
+                not re.fullmatch(r"src/test/(?:kotlin|java)/[A-Za-z0-9_./-]+\.(?:kt|java)", path)
+                or any(segment in {".", ".."} for segment in path.split("/"))
+        )):
+            raise ValueError("test case definition path is invalid")
     for item in envelope.get("diagnostics", []):
         if set(item) != {"kind", "suiteKind", "name", "url", "retentionDays", "access", "mayContainSensitiveData"}:
             raise ValueError("diagnostic artifact fields are invalid")
@@ -204,8 +211,26 @@ def suites(component: str, service: Path) -> list[dict]:
     return sorted(totals.values(), key=lambda row: row["kind"])
 
 
+def test_definition_path(service: Path, classname: str) -> str | None:
+    """Return a directly verified test source path, never an inferred production dependency.
+
+    JUnit's classname normally names the compiled Kotlin/Java test class. Nested classes map to
+    their enclosing source file. Non-JVM reporters (for example Playwright) deliberately return
+    no path: guessing would turn missing provenance into false impact-analysis evidence.
+    """
+    top_level = classname.split("$", 1)[0]
+    if not re.fullmatch(r"(?:[A-Za-z_][A-Za-z0-9_]*\.)*[A-Za-z_][A-Za-z0-9_]*", top_level):
+        return None
+    relative = Path(*top_level.split("."))
+    for language, suffix in (("kotlin", ".kt"), ("java", ".java")):
+        candidate = service / "src" / "test" / language / relative.with_suffix(suffix)
+        if candidate.is_file():
+            return candidate.relative_to(service).as_posix()
+    return None
+
+
 def test_cases(component: str, service: Path) -> list[dict]:
-    """Emit secret-free observations with a stable test-definition identity."""
+    """Emit secret-free observations with stable identity and verified test-source provenance."""
     result = []
     root = service / "build" / "test-results"
     for task, tree in junit_suites(root):
@@ -218,11 +243,15 @@ def test_cases(component: str, service: Path) -> list[dict]:
             state = "skipped" if case.find("skipped") is not None else "failed" if (
                 case.find("failure") is not None or case.find("error") is not None
             ) else "passed"
-            result.append({
+            item = {
                 "fingerprint": hashlib.sha256(identity.encode()).hexdigest()[:24],
                 "kind": kind, "classname": classname, "name": definition, "state": state,
                 "durationMs": max(0, round(float(case.attrib.get("time", 0)) * 1000)),
-            })
+            }
+            source_path = test_definition_path(service, classname)
+            if source_path is not None:
+                item["testDefinitionPath"] = source_path
+            result.append(item)
     return sorted(result, key=lambda item: (item["fingerprint"], item["state"]))
 
 
@@ -373,8 +402,8 @@ def main() -> None:
             for task, payload in (
                 ("test", '<testsuites name="vitest" tests="2" failures="1" errors="0" skipped="0" time="1.5">'
                           '<testsuite name="unit" tests="2" failures="1" errors="0" skipped="0" time="1.5">'
-                          '<testcase classname="guard" name="allows" time="0.5"/>'
-                          '<testcase classname="guard" name="denies" time="1.0"><failure/></testcase>'
+                          '<testcase classname="com.openbank.GuardTest" name="allows" time="0.5"/>'
+                          '<testcase classname="com.openbank.GuardTest" name="denies" time="1.0"><failure/></testcase>'
                           '<system-out>OPENBANK_TRACE_CONTRACT_V1:failed-contract\n'
                           'OPENBANK_TRACE_CONTRACT_V1:customer supplied trace id</system-out>'
                           '</testsuite></testsuites>'),
@@ -387,11 +416,16 @@ def main() -> None:
                 directory = service / "build/test-results" / task
                 directory.mkdir(parents=True, exist_ok=True)
                 (directory / f"{task}.xml").write_text(payload)
+            source = service / "src/test/kotlin/com/openbank/GuardTest.kt"
+            source.parent.mkdir(parents=True, exist_ok=True)
+            source.write_text("package com.openbank\nclass GuardTest\n")
             discovered = {row["kind"]: row for row in suites("openbank-admin-ui", service)}
             assert set(discovered) == {"unit", "e2e"}, discovered
             assert (discovered["unit"]["discovered"], discovered["unit"]["failed"]) == (2, 1), discovered
             assert discovered["unit"]["state"] == "failed" and discovered["e2e"]["state"] == "passed"
-            assert len(test_cases("openbank-admin-ui", service)) == 3
+            cases = test_cases("openbank-admin-ui", service)
+            assert len(cases) == 3
+            assert {item.get("testDefinitionPath") for item in cases} == {"src/test/kotlin/com/openbank/GuardTest.kt", None}
             assert trace_contract_evidence(service) == [
                 {"kind": "trace", "state": "failed", "source": "trace-contract:failed-contract",
                  "detail": "1 executed marker(s); JUnit suite failed"},
@@ -430,6 +464,16 @@ def main() -> None:
                 "specializedEvidence": [{"kind": "performance", "state": "passed", "source": "summary.json"}],
                 "testCases": [],
             }
+            traversal = {**valid, "testCases": [{
+                "fingerprint": "0123456789abcdef01234567", "kind": "integration",
+                "classname": "com.openbank.GuardTest", "name": "guards", "state": "passed",
+                "durationMs": 1, "testDefinitionPath": "src/test/kotlin/../../outside.kt",
+            }]}
+            try:
+                validate_envelope(traversal)
+                raise AssertionError("a traversing test definition path was accepted")
+            except ValueError:
+                pass
             (service / "playwright-report").mkdir()
             (service / "playwright-report/index.html").write_text("diagnostic")
             valid["diagnostics"] = browser_diagnostics(str(service / "playwright-report"), "1", 1, "https://github.com/JiRaska/open-bank-oss/actions/runs/1")

--- a/openbank-admin-ui/scripts/collect-test-intelligence.mjs
+++ b/openbank-admin-ui/scripts/collect-test-intelligence.mjs
@@ -233,6 +233,9 @@ function testCaseHistory(currentEnvelopes) {
     const last = rows.at(-1)
     return {
       fingerprint, component: last.component, kind: last.kind, classname: last.classname, name: last.name,
+      // This is a verified path to the test definition, when a JVM report can provide one. It
+      // is intentionally not a claimed production dependency or a test-selection recommendation.
+      testDefinitionPath: last.testDefinitionPath ?? null,
       owner: ownership.owners.get(last.component) ?? ownership.fallback,
       state: sameCommitTransitions > 0 ? 'flaky' : last.state === 'failed' ? 'failing' : last.state === 'skipped' ? 'skipped' : 'stable',
       lastState: last.state, observations: rows.length,

--- a/openbank-admin-ui/src/app/system/tests/page.tsx
+++ b/openbank-admin-ui/src/app/system/tests/page.tsx
@@ -216,10 +216,11 @@ function TestCases({ report }: { report: TestIntelligenceReport }) {
     </div>
     <div aria-live="polite" style={{ color: 'var(--text-secondary)', fontSize: 12 }}>{t(`${visibleTests.length}/${report.testCases.length} testových definic odpovídá aktuální triage.`, `${visibleTests.length}/${report.testCases.length} test definitions match the active triage.`)}</div>
     <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}><table style={tableStyle}>
-      <thead><tr>{['State', 'Test definition', 'Component', 'Kind', 'Owner', 'Runs', 'Failure rate', 'Avg duration', 'Failed runtime', 'Fingerprint'].map(label => <th key={label} style={thStyle}>{label}</th>)}</tr></thead>
+      <thead><tr>{['State', 'Test definition', 'Test source', 'Component', 'Kind', 'Owner', 'Runs', 'Failure rate', 'Avg duration', 'Failed runtime', 'Fingerprint'].map(label => <th key={label} style={thStyle}>{label}</th>)}</tr></thead>
       <tbody>{visibleTests.map(item => <tr key={item.fingerprint}>
         <td style={tdStyle}><StateBadge state={item.state === 'stable' ? 'passed' : item.state === 'failing' ? 'failed' : item.state === 'skipped' ? 'skipped' : 'stale'} /></td>
         <td style={{ ...tdStyle, minWidth: 230 }}><strong>{item.name}</strong><div style={{ color: 'var(--text-tertiary)', fontSize: 10, marginTop: 3 }}>{item.classname}</div>{item.sameCommitTransitions > 0 && <div style={{ color: '#d97706', fontSize: 10, marginTop: 3 }}>{item.sameCommitTransitions} same-commit pass/fail transition(s)</div>}</td>
+        <td style={{ ...tdStyle, fontFamily: 'monospace', fontSize: 10, maxWidth: 260, overflowWrap: 'anywhere' }}>{item.testDefinitionPath ?? 'not reported'}</td>
         <td style={tdStyle}>{item.component}</td><td style={tdStyle}>{item.kind}</td><td style={tdStyle}>{item.owner}</td><td style={tdStyle}>{item.observations}</td>
         <td style={tdStyle}>{item.failureRate === null ? '—' : `${item.failureRate}%`}</td><td style={tdStyle}>{item.averageDurationMs} ms</td><td style={tdStyle}>{item.wastedDurationMs} ms</td>
         <td style={{ ...tdStyle, fontFamily: 'monospace', fontSize: 10 }}>{item.fingerprint}</td>

--- a/openbank-admin-ui/src/lib/test-intelligence-triage.ts
+++ b/openbank-admin-ui/src/lib/test-intelligence-triage.ts
@@ -29,6 +29,7 @@ export function filterTestCases(
     .filter(testCase => !normalizedQuery || [
       testCase.name,
       testCase.classname,
+      testCase.testDefinitionPath ?? '',
       testCase.component,
       testCase.kind,
       testCase.owner,

--- a/openbank-admin-ui/src/lib/types/test-intelligence.ts
+++ b/openbank-admin-ui/src/lib/types/test-intelligence.ts
@@ -260,6 +260,8 @@ export interface TestCaseHistory {
   kind: Extract<EvidenceKind, 'unit' | 'integration' | 'contract' | 'e2e' | 'simulation'>
   classname: string
   name: string
+  /** Verified path to the test definition; never a claimed production dependency. */
+  testDefinitionPath?: string | null
   owner: string
   state: 'stable' | 'flaky' | 'failing' | 'skipped'
   lastState: 'passed' | 'failed' | 'skipped'

--- a/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
@@ -169,7 +169,7 @@ scenarios:
         { kind: 'e2e', state: 'failed', discovered: 2, executed: 2, passed: 1, failed: 1, skipped: 0, errors: 0, durationMs: 1200 },
       ],
       specializedEvidence: [{ kind: 'trace', state: 'passed', source: 'trace-contract:payment-booking', detail: '1 executed marker(s); JUnit suite passed' }],
-      testCases: [{ fingerprint: '0123456789abcdef01234567', kind: 'integration', classname: 'com.openbank.PaymentApiIT', name: 'books payment', state: 'passed', durationMs: 400 }],
+      testCases: [{ fingerprint: '0123456789abcdef01234567', kind: 'integration', classname: 'com.openbank.PaymentApiIT', name: 'books payment', state: 'passed', durationMs: 400, testDefinitionPath: 'src/test/kotlin/com/openbank/PaymentApiIT.kt' }],
       coverage: { lines: { covered: 8, missed: 2, percentage: 80 }, branches: { covered: 3, missed: 1, percentage: 75 } },
       testInfrastructure: { declared: ['postgres'], observed: [
         { resource: 'postgres', image: 'postgres:16.3-alpine', lifecycle: 'started', observedAt: '2026-08-22T09:59:00Z' },
@@ -205,6 +205,7 @@ scenarios:
     expect(report.testCases[0]).toMatchObject({
       fingerprint: '0123456789abcdef01234567', state: 'flaky', observations: 2,
       failureRate: 50, wastedDurationMs: 500, sameCommitTransitions: 1, owner: 'unowned',
+      testDefinitionPath: 'src/test/kotlin/com/openbank/PaymentApiIT.kt',
     })
   })
 

--- a/openbank-libs/governance/test-intelligence-run.schema.json
+++ b/openbank-libs/governance/test-intelligence-run.schema.json
@@ -85,7 +85,8 @@
         "classname": { "type": "string", "minLength": 1 },
         "name": { "type": "string", "minLength": 1 },
         "state": { "enum": ["passed", "failed", "skipped"] },
-        "durationMs": { "type": "integer", "minimum": 0 }
+        "durationMs": { "type": "integer", "minimum": 0 },
+        "testDefinitionPath": { "type": "string", "pattern": "^(?!.*\\/(?:\\.|\\.\\.)\\/)src/test/(?:kotlin|java)/[A-Za-z0-9_./-]+\\.(?:kt|java)$" }
       },
       "additionalProperties": false
     },


### PR DESCRIPTION
## Linked issues

Refs #7207

## Change

- retain a verified `src/test/kotlin` or `src/test/java` path with each JUnit test observation when the reported class maps to a real source file
- preserve missing provenance for non-JVM or ambiguous reporters rather than guessing
- expose the path in immutable aggregation, triage search and the Test Intelligence table

The field identifies the test definition only. It is explicitly not a production dependency mapping, impact recommendation or CI selector.

## Verification

- `python3 .github/scripts/collect-test-run-evidence.py --self-test`
- `npm test -- src/test/test-intelligence-collector.test.ts src/test/test-intelligence-triage.test.ts src/test/test-intelligence-route.test.ts` (20 passed)
- `npx tsc --noEmit`
- `python3 -m py_compile .github/scripts/collect-test-run-evidence.py`
- `node --check openbank-admin-ui/scripts/collect-test-intelligence.mjs`
- `git diff --check`