### PR TITLE
docs(governance): put the 2026-07-26 ledger restore drill in the drill log

### DIFF
--- a/.github/scripts/check-readiness-attestations.py
+++ b/.github/scripts/check-readiness-attestations.py
@@ -94,14 +94,7 @@ DRILL_LOGS = ("docs/bcp/dr-test-log.md", "docs/bcp/chaos-test-log.md")
 # Exercise attestations that predate this rule and still cite a runbook. Shrink-only and
 # checked BOTH WAYS: a new one fails, and an entry that healed is reported so the list
 # cannot rot into a permanent exemption. Key: "<service>.<attestation key>".
-EXERCISE_REF_DEBT = {
-    "ledger.restore_drill": (
-        "#5673 — cites runbook-0003 (a PG major-upgrade procedure) for a 2026-07-26 "
-        "restore drill that has no entry in docs/bcp/dr-test-log.md. Left in place rather "
-        "than deleted because the drill may genuinely have happened; the attestant must "
-        "either log it with measured RTO/RPO or drop the claim."
-    ),
-}
+EXERCISE_REF_DEBT: dict[str, str] = {}
 
 DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 ISSUE_RE = re.compile(r"^#\d+$")

--- a/.github/scripts/check-readiness-attestations.py
+++ b/.github/scripts/check-readiness-attestations.py
@@ -384,15 +384,6 @@ def _self_test(stale_fail_days: int = DEFAULT_STALE_FAIL_DAYS) -> int:
             True,
         ),
         (
-            # This line used to be the gate's own proof that a runbook is acceptable
-            # evidence for a drill. It is not (R7) — it is the fleet's one baselined debt,
-            # and the case now tests the EXEMPTION, not the rule.
-            "BASELINED DEBT: ledger.restore_drill's runbook ref is exempt, not endorsed",
-            "ledger:\n  restore_drill: { date: 2026-07-26, ttl_days: 180, by: jiri, ref: runbook-0003 }\n",
-            "clean",
-            True,
-        ),
-        (
             "R7: an exercise attestation citing a runbook fails for anyone not baselined",
             "consent:\n  dr_drill: { date: 2026-07-26, ttl_days: 180, by: jiri, ref: runbook-0003 }\n",
             "error",
@@ -554,6 +545,68 @@ def _self_test(stale_fail_days: int = DEFAULT_STALE_FAIL_DAYS) -> int:
             else:
                 print(f"  ok  [{got:5}] {name}")
 
+        # Scope guard: the EXEMPTION MECHANISM, now that EXERCISE_REF_DEBT is empty.
+        #
+        # #5673 emptied the list: the drill it covered really happened (#2495) and its record
+        # now lives in docs/bcp/dr-test-log.md, so nothing is exempt any more. That removed the
+        # gate's only live exercise of the exemption path -- and an unexercised escape hatch is
+        # exactly the kind of code that is discovered to be broken by the next person who needs
+        # it. So the case no longer reads the real list; it injects a debt entry, asserts the
+        # SAME body flips from error to clean, and asserts the stale-declaration direction. Both
+        # halves must move, or the exemption is not what makes the difference.
+        debt_body = "ledger:\n  restore_drill: { date: 2026-07-26, ttl_days: 180, by: jiri, ref: runbook-0003 }\n"
+        (tmp / rel).write_text(debt_body, encoding="utf-8")
+
+        errors, _, _ = check(tmp, rel, _TODAY)
+        if not errors:
+            print("::error::self-test: a runbook ref was clean with EXERCISE_REF_DEBT empty")
+            failures += 1
+        else:
+            print("  ok  [error] with the debt list EMPTY, a runbook ref for a drill fails")
+
+        _saved = dict(EXERCISE_REF_DEBT)
+        try:
+            EXERCISE_REF_DEBT["ledger.restore_drill"] = "self-test injected exemption"
+            errors, _, _ = check(tmp, rel, _TODAY)
+            if errors:
+                print(
+                    "::error::self-test: EXERCISE_REF_DEBT no longer exempts a baselined entry "
+                    f"-- errors={errors}"
+                )
+                failures += 1
+            else:
+                print("  ok  [clean] an INJECTED debt entry exempts that same runbook ref")
+
+            # ...and the other direction: exempt something that no longer cites a runbook and
+            # the stale-declaration error must fire, so the list cannot rot into a permanent
+            # exemption once the data is fixed.
+            # This one must be written at FILE_REL: the stale-declaration check is scoped
+            # `if file_rel == FILE_REL`, so against the self-test's own "att.yaml" it silently
+            # does nothing -- which is why this direction had never actually been exercised.
+            real = tmp / FILE_REL
+            real.parent.mkdir(parents=True, exist_ok=True)
+            real.write_text(
+                "ledger:\n  restore_drill: { date: 2026-06-30, ttl_days: 180, by: jiri, "
+                "ref: docs/bcp/dr-test-log.md }\n",
+                encoding="utf-8",
+            )
+            (tmp / "docs" / "bcp").mkdir(parents=True, exist_ok=True)
+            (tmp / "docs" / "bcp" / "dr-test-log.md").write_text(
+                "## 2026-06-30 — entry\n", encoding="utf-8"
+            )
+            errors, _, _ = check(tmp, FILE_REL, _TODAY)
+            if not any("no longer cites a runbook" in e for e in errors):
+                print(
+                    "::error::self-test: a STALE EXERCISE_REF_DEBT declaration was not reported "
+                    f"-- errors={errors}"
+                )
+                failures += 1
+            else:
+                print("  ok  [error] a debt entry whose attestation healed is reported as stale")
+        finally:
+            EXERCISE_REF_DEBT.clear()
+            EXERCISE_REF_DEBT.update(_saved)
+
         # Scope guard: an empty file must report zero, and zero must be visible.
         (tmp / rel).write_text("# nothing attested\n", encoding="utf-8")
         errors, warnings, n = check(tmp, rel, _TODAY)
@@ -574,7 +627,7 @@ def _self_test(stale_fail_days: int = DEFAULT_STALE_FAIL_DAYS) -> int:
     if failures:
         print(f"::error::self-test: {failures} case(s) failed")
         return 1
-    print(f"self-test: all {len(cases) + 2} cases passed (both directions)")
+    print(f"self-test: all {len(cases) + 5} cases passed (both directions)")
     return 0
 
 

--- a/docs/bcp/dr-test-log.md
+++ b/docs/bcp/dr-test-log.md
@@ -19,6 +19,39 @@ Format:
 
 ---
 
+## 2026-07-26 — Live restore drill: ledger-db PITR from S3 (PASS)
+
+- **Type**: live drill (not a table-top — a real cluster was restored from the real backup)
+- **Scope**: ledger-service (`ledger/ledger-db`), the first money-path database to carry a
+  restore drill.
+- **Participants**: BCP Owner (CTO / maintainer)
+- **Scenario**: Restored `ledger-db` into a throwaway `ledger-db-drill` CNPG cluster from the
+  live S3 barman object store, targeting `2026-07-26T02:05:08Z` (the `stoppedAt` of backup
+  `ledger-db-daily-20260726020500`), then compared the recovered data against the live primary.
+- **Result**: **PASS** — recovered `journal_entries` count 96, matching the live `ledger-db`
+  primary exactly.
+- **RTO achieved**: ~84s (Cluster created 06:50:04Z → primary Healthy 06:51:28Z). This is
+  restore time only; it excludes detection and the decision to restore.
+- **RPO achieved**: ~4h45m at the chosen target — the distance from the daily base backup
+  (02:05:08Z) to the drill. PITR to a later point was available via the WAL archive and was
+  not exercised, so the measured figure is the base-backup interval, not the floor.
+- **Lessons learned**:
+  - `externalClusters[].barmanObjectStore.serverName` defaults to the *externalCluster entry's*
+    name, not the original cluster's. It therefore searched an empty S3 prefix and reported
+    `no target backup found` with no access error — an empty list, not a failure. Always verify
+    the real prefix with `aws s3 ls s3://<bucket>/<svc>-db/` **before** writing the manifest.
+  - A first attempt on 2026-06-26 failed on IAM credentials; the Pod Identity association for
+    `<svc>-drill` must be `tofu apply`d, not merely declared (#1759).
+  - `journal_entries` is partitioned; the singular `journal_entry` named in an earlier version
+    of runbook-0003 has never existed.
+- **Actions**:
+  - Procedure and both footguns recorded in `docs/runbooks/0003-postgresql-16-to-18-major-upgrade.md`
+    (the repo's de-facto CNPG restore/PITR procedure), verified end-to-end (#2495).
+  - Remaining ~19 money-path databases still have no restore drill; the procedure above is now
+    proven and applies per service.
+
+---
+
 ## 2026-06-30 — Initial table-top: sandbox database PITR restore
 
 - **Type**: table-top

--- a/openbank-libs/governance/attestations.yaml
+++ b/openbank-libs/governance/attestations.yaml
@@ -35,7 +35,7 @@
 #   pentest:       { date: 2026-05-01, ttl_days: 365, by: ext,  ref: schemathesis-fleet }
 
 ledger:
-  restore_drill: { date: 2026-07-26, ttl_days: 180, by: jiri, ref: runbook-0003 }
+  restore_drill: { date: 2026-07-26, ttl_days: 180, by: jiri, ref: docs/bcp/dr-test-log.md }
   pentest:       { date: 2026-08-18, ttl_days: 21, by: ci-zap-baseline, ref: https://github.com/JiRaska/open-bank-oss/actions/runs/32173390301 }
 
 consent:


### PR DESCRIPTION
Closes #5673.

## The determination

#5673 posed the issue as a fork the attestant had to resolve: *either the drill
happened and the record is wrong, or no drill happened and the attestation is false.*

**The drill happened.** `77d3b68de` / PR #2495, 2026-07-26 — *"docs(ledger): record a
real restore-drill PASS and its serverName gotcha"* — restored `ledger-db` into a
throwaway CNPG cluster from the real S3 barman object store, targeted the `stoppedAt`
of `ledger-db-daily-20260726020500`, and verified the recovered data against the live
primary. RTO ~84s. Row count 96, exact match. It also found and fixed a second footgun
(`externalClusters[].barmanObjectStore.serverName` defaults to the *externalCluster
entry's* name, so it searched an empty S3 prefix and returned an empty list rather than
an error).

So the attestation is not false, and its evidence is not missing. It was written into
`docs/runbooks/0003-postgresql-16-to-18-major-upgrade.md` — the same commit that added
the attestation added 73 lines of drill record to that runbook — and never into
`docs/bcp/dr-test-log.md`.

That is a third case the issue did not enumerate, and it is the one that made the
citation look like a lie: `runbook-0003` genuinely is where the record lives, but a
runbook is not a drill log, is not dated, and is not what a DORA Art. 24–26 reader
opens. The 2026-06-30 table-top already treated runbook-0003 as the repo's CNPG
restore/PITR procedure despite its filename saying major upgrade, which is the
underlying naming problem and is left alone here.

## What this changes

- `docs/bcp/dr-test-log.md` gains the `## 2026-07-26` entry with the measured figures
  from #2495, marked `Type: live drill` to distinguish it from the 2026-06-30 table-top.
  RPO is recorded as ~4h45m *to the chosen target* with an explicit note that PITR to a
  later point was available and not exercised — the honest figure is the base-backup
  interval, not a floor.
- The attestation's `ref` moves from `runbook-0003` to `docs/bcp/dr-test-log.md`.
- The single `EXERCISE_REF_DEBT` exemption is removed; the list is now empty.

The readiness score is unchanged — `collect-prod-readiness.mjs` scores on `date`/`ttl_days`,
not on `ref` — so this makes the existing 3 checkable rather than raising anything.

## Proven by what it prevents

Exit codes read from `$?` after redirecting output to a file:

| tree | `$?` |
|---|---|
| this PR as committed | **0** |
| drill-log entry dated `2026-07-27` instead of `2026-07-26` | **1** — *"cites `docs/bcp/dr-test-log.md`, which carries no `## 2026-07-26` entry"* |
| `ref` reverted to `runbook-0003`, debt list empty | **1** — *"a runbook is the PLAN, not evidence anyone executed it"* |
| debt entry restored while `ref` is the log | **1** — *"is in EXERCISE_REF_DEBT but no longer cites a runbook"* |

Both directions of the shrink-only list are live, so this exemption cannot come back
silently.

## Noticed in passing, not fixed here

`check-readiness-attestations.py` warns that `consent.pentest` **expired 8 days ago**
(2026-07-28 + 21d). The collector already stops counting it, but the file still reads as
a live claim. That is the `ci-schemathesis` lane's TTL working as designed; whether the
lane is still running is a separate question.
