### PR TITLE
fix(admin-ui): link unresolved agent eval evidence

### DIFF
--- a/openbank-admin-ui/src/components/testing/TestAgentPanel.tsx
+++ b/openbank-admin-ui/src/components/testing/TestAgentPanel.tsx
@@ -15,6 +15,8 @@ type AgentGovernance = {
   evalEvidence: 'recorded' | 'awaiting-recording' | 'missing-suite' | 'unavailable'
 }
 
+const FLAKY_HUNTER_EVAL_BACKLOG_URL = 'https://github.com/JiRaska/open-bank-oss/issues/7040'
+
 function evalEvidenceDetail(state: AgentGovernance['evalEvidence'], t: (cs: string, en: string) => string): string {
   switch (state) {
     case 'recorded': return t('Scénář i ověřený záznam odpovídají aktuálnímu promptu.', 'A scenario suite and verified recording match the current prompt.')
@@ -45,6 +47,9 @@ export function TestAgentPanel() {
         <span style={{ border: '1px solid var(--border)', borderRadius: 999, padding: '4px 8px', color: 'var(--text-secondary)' }}>{t('Aktivní prompt', 'Active prompt')}: <strong>{governance.activePrompt ?? t('neověřený', 'unverified')}</strong></span>
         <span style={{ border: '1px solid var(--border)', borderRadius: 999, padding: '4px 8px', color: governance.evalEvidence === 'recorded' ? '#16a34a' : '#d97706' }}>{t('Eval evidence', 'Eval evidence')}: <strong>{governance.evalEvidence}</strong></span>
         <span style={{ flexBasis: '100%', color: 'var(--text-secondary)' }}>{evalEvidenceDetail(governance.evalEvidence, t)}</span>
+        {governance.evalEvidence !== 'recorded' && governance.evalEvidence !== 'unavailable' && <a href={FLAKY_HUNTER_EVAL_BACKLOG_URL} target="_blank" rel="noreferrer" style={{ color: persona.accent, fontWeight: 650 }}>
+          {t('Otevřít backlog evalů', 'Open evaluation backlog')} <ExternalLink size={12} aria-hidden="true" />
+        </a>}
       </div>}
       {canAnalyze && <button className="btn btn-secondary btn-sm" disabled={analyzing} onClick={() => {
         setAnalyzing(true)

--- a/openbank-admin-ui/src/test/test-agent-panel-governance.test.tsx
+++ b/openbank-admin-ui/src/test/test-agent-panel-governance.test.tsx
@@ -30,6 +30,7 @@ describe('Test Agent governance evidence', () => {
     expect(await screen.findByText('system.v2')).toBeVisible()
     expect(screen.getByText('missing-suite')).toBeVisible()
     expect(screen.getByText('No eval suite is registered for this charter. The agent remains advisory, never an automation authority.')).toBeVisible()
+    expect(screen.getByRole('link', { name: /Open evaluation backlog/ })).toHaveAttribute('href', 'https://github.com/JiRaska/open-bank-oss/issues/7040')
     expect(screen.getByText(/agent is unavailable/i)).toBeVisible()
   })
 })


### PR DESCRIPTION
Refs #7040

## Why
The Test Intelligence agent panel correctly exposes missing or unrecorded evaluation evidence, but left the operator without an actionable route to the governed backlog.

## What
- link non-recorded evaluation states to the public eval backlog
- preserve the distinction between recorded, pending, and unavailable evidence
- cover the link with a component test

## Verification
- `npm test -- src/test/test-agent-panel-governance.test.tsx`
- `npx tsc --noEmit`
- `git diff --check`