### PR TITLE
fix(infra): alert on a Postgres base backup that has stopped advancing

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-db.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-db.yaml
@@ -150,11 +150,7 @@ spec:
           # (2026-08-19): primaries with a recovery point = 54, replicas without = 19, primaries
           # without = 0 — so today's silence is a measured zero, not a join that never matches.
           #
-          # NOT paired with a backup-staleness alert, deliberately:
-          # cnpg_collector_last_available_backup_timestamp reported swift-service-db as 37.7h stale
-          # while its ScheduledBackup had completed 13h earlier, so any threshold under ~48h fires
-          # on healthy clusters. That metric's semantics need establishing before an alert rests on
-          # it (issue filed).
+          # Paired with PostgresBackupStale below since #5756 established the metric's semantics.
           expr: |
             cnpg_collector_first_recoverability_point == 0
               and on(namespace, pod) cnpg_pg_replication_in_recovery == 0
@@ -164,6 +160,48 @@ spec:
           annotations:
             summary: "Postgres has NO recovery point on {{ $labels.namespace }}/{{ $labels.pod }}"
             description: "This primary has no first recoverability point — no base backup exists, so the database cannot be restored to any moment. WAL archiving alone is not a backup. Check `kubectl get cluster -n {{ $labels.namespace }}` for a barmanObjectStore, then force a base backup with an on-demand `kind: Backup`. Verify by listing the destination in S3, never by reading ContinuousArchiving (runbook 0003)."
+        - alert: PostgresBackupStale
+          # The companion PostgresNoRecoveryPoint deliberately shipped without (#5755): the metric
+          # had reported swift-service-db 37.7h stale while its ScheduledBackup completed 13h
+          # earlier, so "any threshold under ~48h fires on healthy clusters". #5756 re-measured it
+          # and that premise does not hold.
+          #
+          # cnpg_collector_last_available_backup_timestamp mirrors the Cluster's own
+          # .status.lastSuccessfulBackup. Measured 2026-08-26 21:14Z: swift-service-db-2 read
+          # 17.15h and its status said 2026-08-26T04:05:05Z -- the same instant, not a cycle behind.
+          # Across 57 primaries, 56 sat in a 16.4-19.16h band and every ScheduledBackup in the
+          # fleet is daily, so the 37.7h reading was a one-off, not a structural lag.
+          #
+          # 30h, not the 2x-interval 48h the issue proposed: 48h is two missed dailies before
+          # anyone hears, and the measured healthy ceiling is 19.16h, so 30h still leaves ~11h of
+          # headroom over the worst healthy cluster while catching a single missed backup.
+          #
+          # The `> 0` guard is the load-bearing clause, and it is the gauge-boot-zero shape again:
+          # a cluster that has never had a base backup reports the metric as 0, so `time() - 0` is
+          # ~56 YEARS, not a large-but-plausible age. Without the guard this alert pages for
+          # pricing-db-1 -- the exact cluster PostgresNoRecoveryPoint is already firing on -- and
+          # would do the same for every freshly created cluster from the moment it is scraped until
+          # its first backup. "No backup at all" is that alert's job; this one is only about a
+          # backup chain that has stopped advancing.
+          #
+          # The primary filter is currently redundant (replicas report exactly 0 and are already
+          # excluded by the guard above) and is kept deliberately: it states the semantics rather
+          # than relying on the sentinel value staying 0, and it matches PostgresNoRecoveryPoint.
+          #
+          # Verified against live Prometheus, 2026-08-26 (series counts):
+          #   as written                              -> 0    (no false positives)
+          #   same expression at 16h                  -> 56   (the join is not vacuous)
+          #   without the `> 0` guard, at 30h         -> 1    (pricing-db-1, the double-page)
+          expr: |
+            (time() - cnpg_collector_last_available_backup_timestamp) > 30 * 3600
+              and cnpg_collector_last_available_backup_timestamp > 0
+              and on(namespace, pod) cnpg_pg_replication_in_recovery == 0
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Postgres base backup has gone stale on {{ $labels.namespace }}/{{ $labels.pod }}"
+            description: "This primary's newest completed base backup is over 30h old and every ScheduledBackup in the fleet is daily, so at least one run has been missed. A recovery point still exists, so this is not PostgresNoRecoveryPoint -- the chain has stopped advancing. Check `kubectl get scheduledbackup -n {{ $labels.namespace }}` and `kubectl get backup -n {{ $labels.namespace }}` for the newest attempt and its failure, and confirm against the Cluster's own .status.lastSuccessfulBackup, which is what this metric mirrors (runbook 0003)."
         - alert: PostgresLowCacheHitRatio
           expr: |
             sum by (namespace, pod) (rate(cnpg_pg_stat_database_blks_hit[10m]))


### PR DESCRIPTION
Refs #5756, #5755. Answers the three questions #5756 asked, and writes the alert they were blocking.

## The three questions

**1. Does "last available" mean something other than "last backup that completed"?**
It means `Cluster.status.lastSuccessfulBackup`. Measured 2026-08-26 21:14Z:

```
metric: (time() - cnpg_collector_last_available_backup_timestamp)
        payments/swift-service-db-2 (primary)  ->  17.15h
kubectl get cluster -n payments swift-service-db -o jsonpath='{.status.lastSuccessfulBackup}'
        2026-08-26T04:05:05Z                   ->  17.15h before the reading
```

The same instant, to the second. **The metric does not structurally lag a cycle**, and #5756's
headline premise does not survive re-measurement. Across the fleet, 56 of 57 primaries sat in a
**16.4–19.16h** band, and every one of the 59 `ScheduledBackup`s is daily — exactly what a healthy
daily chain looks like when read at 21:14Z. The 2026-08-19 swift reading of 37.7h was a one-off
(most plausibly a reconcile that had not yet updated `.status`), not a property of the metric.

So "any threshold under ~48h fires on healthy clusters" is false today: 30h clears the worst
healthy cluster by ~11h.

**2. Is `cnpg_collector_last_failed_backup_timestamp` similarly lagged?**
Not established, and not needed here — 38 series carry a non-zero value, but this alert rests on
the success timestamp, so its behaviour does not matter to the rule. Left open in #5756.

**3. Is there a better source?**
No change needed. The instance collector's metric is already a faithful projection of the operator's
own `Cluster.status`, which is the field kube-state-metrics on `Backup` resources would be
reconstructing anyway.

## What was actually blocking the alert

Not the lag — the **sentinel**. A cluster with no base backup reports the metric as `0`, so
`time() - 0` is **~56 years**, not a large-but-plausible age. This is the gauge-boot-zero shape
CLAUDE.md already records for `openbank_workflow_last_success_age_seconds`, one repo over.

Without a `> 0` guard the alert pages for `pricing/pricing-db-1` — the **exact cluster
`PostgresNoRecoveryPoint` is firing on right now** — and would do the same for every newly created
cluster from first scrape until its first backup. "No backup at all" is that alert's job. This one
is only about a chain that has stopped advancing.

## Also found while measuring (not fixed here)

- **`pricing/pricing-db-1` has no recovery point and `PostgresNoRecoveryPoint` is firing on it.**
  The rule's own comment records "primaries without = 0" as of 2026-08-19; it is 1 today. That is
  the alert doing its job, and it needs someone to act on it.
- **`observability/glitchtip-pg` reads `<none>` for both `lastSuccessfulBackup` and
  `firstRecoverabilityPoint`, and is not scraped at all** — `count(cnpg_collector_up{namespace="observability"})`
  returns no series. So a cluster with no backup is invisible to `PostgresNoRecoveryPoint` for the
  reason the alert structurally cannot cover: the alert needs the metric, and there is none. A
  gate's coverage set and the artifacts it covers have drifted apart again. Worth its own issue.

## Proven by what it prevents

The expression is parsed back **out of the committed YAML** for these runs, not retyped — a
retyped copy proves nothing about what ships.

| check | result |
|---|---|
| expr as committed, live Prometheus | **0 series** — no false positives |
| same expression at 16h | **56 series** — the join really matches primaries; not vacuous |
| without the `> 0` guard, at 30h | **1 series** — `pricing-db-1`, the double-page the guard prevents |
| `promtool check rules`, valid file | `$? = 0` |
| `promtool check rules`, expr broken on purpose | `$? = 1` |

The primary filter is currently **redundant** (replicas report exactly 0 and the guard already
excludes them) and is kept anyway, with a comment saying so — it states the semantics rather than
depending on the sentinel staying 0, and it matches the sibling alert.
