### PR TITLE
fix(ci): read deployed commits over git, not the rate-limited contents API

### DIFF
--- a/.github/scripts/check-msg-channel-image-parity.py
+++ b/.github/scripts/check-msg-channel-image-parity.py
@@ -40,6 +40,29 @@
 #   It deliberately does NOT check the reverse (a connector with no ConfigMap override): that
 #   is the normal, safe state — channels that need no group.id override have no ConfigMap entry.
 #
+# HOW IT READS A HISTORICAL COMMIT, AND WHY THAT IS A RATE-LIMIT QUESTION (issue #6290)
+#   CI checks out with fetch-depth: 1, so the commit an image tag points at is not in the
+#   local clone. This gate used to read every one of them through the GitHub CONTENTS API —
+#   one REST call per service with a channel override, ~21 per run, on a workflow that runs on
+#   every PR and every push. In Actions those calls spend the `GITHUB_TOKEN` installation
+#   quota, which GitHub documents at 1,000 requests/hour PER REPOSITORY for a repo outside
+#   Enterprise Cloud, and which every concurrent run shares. So under load this gate was both a
+#   large consumer of that quota and its most visible victim: it answered `HTTP 403 API rate
+#   limit exceeded for installation` and rendered that as "that commit could not be read",
+#   i.e. as a finding about the PR's own diff.
+#
+#   The earlier note here said GitHub "will NOT serve an arbitrary sha to `git fetch origin
+#   <sha>`". That conclusion came from a broken probe: the image tag carries an ABBREVIATED
+#   sha, and git's want-sha1 fetch requires the full 40 characters — an abbreviated one fails
+#   with the identical `couldn't find remote ref`. Measured 2026-08-26 against a real
+#   `--depth 1` clone of this repository: the abbreviated form fails and the full form
+#   succeeds, after which `git show <sha>:<path>` reads the file locally.
+#
+#   So the content is now read over git transport, which is not REST-rate-limited at all. The
+#   only REST call left is one abbreviated -> full sha resolution per DISTINCT deployed sha
+#   (7 today, against 21 content lookups before), and it falls back to the contents API when
+#   the fetch is unavailable, so an offline or restricted environment behaves as before.
+#
 # Run:  python3 .github/scripts/check-msg-channel-image-parity.py [--root .]
 
 import argparse
@@ -63,6 +86,42 @@ except ImportError:
 GITOPS = "openbank-infra/gitops"
 CHANNEL_RE = re.compile(r"^mp\.messaging\.(?:incoming|outgoing)\.([A-Za-z0-9_-]+)\.")
 IMAGE_RE = re.compile(r"image:\s*\S*/(openbank-[a-z0-9-]+):sandbox-([0-9a-f]{7,40})")
+
+
+class Unreadable:
+    """A file that could not be read, carrying WHY.
+
+    The whole point of #6290: "I read the commit and it disagrees with the config" and "a
+    shared CI quota is exhausted so I read nothing" are different states, and collapsing both
+    into a bare `None` is what made an infrastructure fact render as a finding about the
+    author's diff. `kind` is what separates them; nothing here decides severity.
+    """
+
+    QUOTA = "quota"          # the installation API quota is exhausted — true of every PR in flight
+    UNREADABLE = "unreadable"  # the commit or file genuinely could not be read
+
+    def __init__(self, kind: str, detail: str = ""):
+        self.kind = kind
+        self.detail = detail.strip()
+
+    def __repr__(self):  # pragma: no cover - diagnostics only
+        return f"Unreadable({self.kind}, {self.detail[:60]!r})"
+
+
+def _is_quota_exhausted(stderr: str) -> bool:
+    """A rate limit and a permission denial are BOTH HTTP 403 and differ only in the message.
+
+    Same rule as `.github/scripts/spot-kill-retry.sh`: classify on the text, never on the
+    status code. A permission answer is deliberately NOT quota — retrying or waiting cannot
+    fix it, and reporting it as a capacity fact would hide a real misconfiguration.
+    """
+    t = stderr or ""
+    return (
+        "API rate limit exceeded" in t
+        or "secondary rate limit" in t
+        or "Secondary rate limit" in t
+        or "(HTTP 429)" in t
+    )
 
 
 def _git_show(root: pathlib.Path, ref: str, path: str):
@@ -103,41 +162,104 @@ def _api_show(repo: str, ref: str, path: str):
             try:
                 return base64.b64decode(p.stdout.strip()).decode("utf-8", "replace")
             except (ValueError, binascii.Error):
-                return None
+                return Unreadable(Unreadable.UNREADABLE, "content is not valid base64 UTF-8")
         if p.returncode == 0:
             # Success but an empty body — e.g. the path is a directory, not a file. Not
             # something a retry can fix.
-            return None
+            return Unreadable(Unreadable.UNREADABLE, "empty body (path is not a file?)")
         last_stderr = p.stderr
         if "(HTTP 404)" in p.stderr or "Not Found" in p.stderr:
-            return None  # terminal: no such ref/file, retrying cannot help
+            # terminal: no such ref/file, retrying cannot help
+            return Unreadable(Unreadable.UNREADABLE, p.stderr)
         if attempt < _TRANSIENT_RETRIES:
             time.sleep(_TRANSIENT_BACKOFF_SECONDS * (attempt + 1))
+    kind = Unreadable.QUOTA if _is_quota_exhausted(last_stderr) else Unreadable.UNREADABLE
     sys.stderr.write(
         f"::warning::gh api contents lookup for {repo}@{ref}:{path} failed "
         f"{1 + _TRANSIENT_RETRIES} times with no HTTP 404 (last error: "
-        f"{last_stderr.strip() or '(no stderr)'}) — treating as unreadable after retrying "
-        f"transient failures.\n"
+        f"{last_stderr.strip() or '(no stderr)'}) — classified as {kind}.\n"
     )
+    return Unreadable(kind, last_stderr)
+
+
+_FULL_SHA_CACHE: dict = {}
+_FETCHED: set = set()
+
+
+def _resolve_full_sha(root: pathlib.Path, repo: str, ref: str):
+    """Abbreviated sha -> full 40-char sha. ONE REST call per DISTINCT sha, memoised.
+
+    git's want-sha1 fetch takes nothing shorter than 40 characters, and an image tag carries
+    an abbreviation, so this resolution is unavoidable — but it is per sha, not per service,
+    which is what turns 21 calls a run into 7.
+    """
+    if len(ref) == 40 and all(c in "0123456789abcdef" for c in ref.lower()):
+        return ref
+    if ref in _FULL_SHA_CACHE:
+        return _FULL_SHA_CACHE[ref]
+    # A full clone can answer this with no network at all.
+    p = subprocess.run(["git", "rev-parse", f"{ref}^{{commit}}"], cwd=root,
+                       capture_output=True, text=True)
+    if p.returncode == 0 and len(p.stdout.strip()) == 40:
+        _FULL_SHA_CACHE[ref] = p.stdout.strip()
+        return _FULL_SHA_CACHE[ref]
+    if not repo:
+        return None
+    p = subprocess.run(["gh", "api", f"repos/{repo}/commits/{ref}", "--jq", ".sha"],
+                       capture_output=True, text=True)
+    if p.returncode == 0 and len(p.stdout.strip()) == 40:
+        _FULL_SHA_CACHE[ref] = p.stdout.strip()
+        return _FULL_SHA_CACHE[ref]
+    if _is_quota_exhausted(p.stderr):
+        # Do NOT memoise: the quota resets, and caching the failure would make one unlucky
+        # moment permanent for the rest of the run.
+        return Unreadable(Unreadable.QUOTA, p.stderr)
+    _FULL_SHA_CACHE[ref] = None
     return None
 
 
-def git_show(root: pathlib.Path, ref: str, path: str, repo: str):
-    """The file at <ref>, from the local clone if it has it, else from the GitHub API.
+def _fetch_commit(root: pathlib.Path, full_sha: str) -> bool:
+    """Bring one commit into a shallow clone over git transport (no REST quota spent)."""
+    if full_sha in _FETCHED:
+        return True
+    p = subprocess.run(["git", "fetch", "--depth", "1", "--quiet", "origin", full_sha],
+                       cwd=root, capture_output=True, text=True)
+    if p.returncode == 0:
+        _FETCHED.add(full_sha)
+        return True
+    return False
 
-    Local first so `./check...` works offline against a full clone. The API fallback exists
-    because CI checks out with fetch-depth: 1 and the historical commits image tags point at
-    are simply not there — and, unlike most remotes, GitHub will NOT serve an arbitrary sha to
-    `git fetch origin <sha>` ("couldn't find remote ref"), so deepening on demand is not
-    available either. The first version of this guard passed locally against a full clone and
-    failed in CI against every service; the second tried the on-demand fetch and failed the
-    same way. Neither was visible without running it in a shallow clone, which is the only
-    honest test for this.
+
+def git_show(root: pathlib.Path, ref: str, path: str, repo: str):
+    """The file at <ref>: local clone, else a git fetch of that one commit, else the API.
+
+    Order matters and is the #6290 fix. Local first so `./check...` works offline against a
+    full clone. Then a `git fetch --depth 1 origin <full-sha>` — measured to work against this
+    remote, contrary to the note this function used to carry — because git transport spends no
+    REST quota, and this gate reading ~21 files a run was the single largest identified
+    consumer of a 1,000/hour repository budget shared by every concurrent run. The contents API
+    remains as the fallback, so nothing that worked before stops working.
+
+    Returns the file's text, or an `Unreadable` saying WHY there is none.
     """
     out = _git_show(root, ref, path)
     if out is not None:
         return out
-    return _api_show(repo, ref, path) if repo else None
+
+    full = _resolve_full_sha(root, repo, ref)
+    if isinstance(full, Unreadable):
+        return full
+    if full and _fetch_commit(root, full):
+        out = _git_show(root, full, path)
+        if out is not None:
+            return out
+        # The commit is present and simply has no such file. Terminal, and free to state.
+        return Unreadable(Unreadable.UNREADABLE,
+                          f"commit {full[:9]} fetched, but it has no {path}")
+
+    if not repo:
+        return Unreadable(Unreadable.UNREADABLE, "no GITHUB_REPOSITORY and not in the clone")
+    return _api_show(repo, ref, path)
 
 
 def channels_with_connector(app_yaml: str):
@@ -232,19 +354,24 @@ def main() -> int:
         )
         return 2
 
-    errors, checked = [], 0
+    errors, quota_blocked, checked = [], [], 0
     for svc, channels in sorted(declared.items()):
         sha = images.get(svc)
         if not sha:
             continue  # config with no image pinned here — nothing this guard can compare
         app = git_show(root, sha, f"{svc}/src/main/resources/application.yaml", repo)
-        if app is None:
-            errors.append(
-                f"{svc}: the deployed image is sandbox-{sha}, and that commit could not be "
-                f"read even after fetching it, so this channel cannot be checked. Either the tag "
-                f"does not correspond to a commit on this remote, or the service has no "
-                f"application.yaml there. Unverifiable is not the same as fine."
-            )
+        if isinstance(app, Unreadable):
+            if app.kind == Unreadable.QUOTA:
+                # NOT a finding about this PR. See the QUOTA branch below.
+                quota_blocked.append(f"{svc} @ sandbox-{sha}")
+            else:
+                errors.append(
+                    f"{svc}: the deployed image is sandbox-{sha}, and that commit could not be "
+                    f"read even after fetching it, so this channel cannot be checked. Either "
+                    f"the tag does not correspond to a commit on this remote, or the service "
+                    f"has no application.yaml there ({app.detail or 'no detail'}). "
+                    f"Unverifiable is not the same as fine."
+                )
             continue
         servable = channels_with_connector(app)
         if servable is None:
@@ -265,6 +392,30 @@ def main() -> int:
                     f"starting. Deploy an image built from a commit that declares the channel "
                     f"BEFORE, or with, the config that names it."
                 )
+
+    # The QUOTA branch is reported FIRST and separately, and it never borrows the parity
+    # gate's wording. #6290: a shared installation quota being exhausted is a fact about CI
+    # capacity that is true of every PR in flight; rendering it as "that commit could not be
+    # read" sent authors to debug their own diff. It still is not a pass — it exits non-zero —
+    # but the first line names the real cause, and it is distinguishable from a real finding by
+    # the title, the text and the absence of any service/channel verdict.
+    if quota_blocked:
+        sys.stderr.write(
+            "::error title=CI API quota exhausted — NOT a finding about this PR::"
+            "The GitHub installation API quota is exhausted, so this gate read nothing and "
+            "reached no verdict about your diff. In Actions this quota is shared by every "
+            "concurrent run in the repository (GitHub documents GITHUB_TOKEN at 1,000 "
+            "requests/hour per repository outside Enterprise Cloud), so it is a function of "
+            "fleet-wide CI load, not of your change. Your own token being healthy proves "
+            "nothing. Re-run this job once the queue has drained; if it recurs on a quiet "
+            "queue, that is a real regression and issue #6290 is the thread. "
+            f"Could not resolve: {'; '.join(quota_blocked)}.\n"
+        )
+        # Reported even when a genuine finding also exists, so a real defect is never hidden
+        # behind an infrastructure notice.
+        for e in errors:
+            sys.stderr.write(f"::error title=Messaging channel/image parity::{e}\n")
+        return 1
 
     if errors:
         for e in errors:
@@ -352,21 +503,42 @@ def _self_test_api_show_retry():
         not_found = mock.Mock(returncode=1, stdout="", stderr="gh: No commit found (HTTP 404)")
         with mock.patch("subprocess.run", side_effect=[not_found, transient, ok]) as m:
             out = _api_show("owner/repo", "0000000", "some/path")
-            if out is not None:
-                bad.append(f"a 404 must be terminal (no retry), got {out!r}")
+            if not (isinstance(out, Unreadable) and out.kind == Unreadable.UNREADABLE):
+                bad.append(f"a 404 must be terminal and UNREADABLE (not quota), got {out!r}")
             if m.call_count != 1:
                 bad.append(f"a 404 must not be retried, got {m.call_count} call(s)")
 
         always_transient = mock.Mock(returncode=1, stdout="", stderr="gh: … (HTTP 429)")
         with mock.patch("subprocess.run", return_value=always_transient) as m:
             out = _api_show("owner/repo", "deadbeef", "some/path")
-            if out is not None:
-                bad.append(f"exhausting all retries must still return None, got {out!r}")
+            if not isinstance(out, Unreadable):
+                bad.append(f"exhausting all retries must return an Unreadable, got {out!r}")
             if m.call_count != 1 + _TRANSIENT_RETRIES:
                 bad.append(
                     f"expected {1 + _TRANSIENT_RETRIES} attempts before giving up, "
                     f"got {m.call_count}"
                 )
+
+        # #6290, the distinction the whole change exists for. A rate limit and a permission
+        # denial are both HTTP 403; only the text separates them, and calling a permission
+        # answer "capacity" would hide a real misconfiguration.
+        rate_limited = mock.Mock(
+            returncode=1, stdout="",
+            stderr="gh: API rate limit exceeded for installation ... (HTTP 403)")
+        with mock.patch("subprocess.run", return_value=rate_limited):
+            out = _api_show("owner/repo", "deadbeef", "some/path")
+            if not (isinstance(out, Unreadable) and out.kind == Unreadable.QUOTA):
+                bad.append(f"an installation rate limit must classify as QUOTA, got {out!r}")
+
+        denied = mock.Mock(
+            returncode=1, stdout="",
+            stderr="gh: Resource not accessible by integration (HTTP 403)")
+        with mock.patch("subprocess.run", return_value=denied):
+            out = _api_show("owner/repo", "deadbeef", "some/path")
+            if not (isinstance(out, Unreadable) and out.kind == Unreadable.UNREADABLE):
+                bad.append(
+                    f"a PERMISSION 403 must NOT be reported as a quota fact, got {out!r}")
+
     finally:
         time.sleep = orig_sleep
 
@@ -374,6 +546,7 @@ def _self_test_api_show_retry():
         print(f"  BAD {msg}")
     if not bad:
         print("  ok  a transient gh-api failure is retried; a real 404 is not")
+        print("  ok  an installation rate limit is QUOTA; a permission 403 is not")
     return bad
 
 


### PR DESCRIPTION
## One defect, two filed symptoms

`#6853` (spot-kill auto-retry fails on `HTTP 403 API rate limit exceeded for installation`) and
`#6290` (a gitops gate turns the same 403 into a verification failure, red-gating every PR) are
the same fact: **this repository's own workflow volume exhausts the `GITHUB_TOKEN` installation
quota, which is shared across every concurrent run.**

## The measurement (re-taken for this PR — window and query stated)

Window `2026-08-26T13:12Z .. 21:12Z` (8 h), per workflow:

```
gh api "repos/JiRaska/open-bank-oss/actions/workflows/<id>/runs?per_page=1&created=%3E<START>" --jq .total_count
```

(the unfiltered `/actions/runs` listing caps at 1000 and silently truncates — per-workflow
`total_count` does not.)

**4,035 runs in 8 h ≈ 504 runs/hour.** Top consumers:

| runs / 8 h | workflow |
|---|---|
| 1157 | `main-red-watch.yml` |
| 417 | `auto-retry-cancelled.yml` |
| 356 | `admin-ui-deploy.yml` |
| 258 | `dependabot-auto-merge.yml` |
| 174 / 172 / 172 / 172 / 171 | `security.yml` / `services-ci.yml` / `opa-policy.yml` / `ci.yml` / `secret-scan.yml` |

### Splitting by run is the wrong split — the quota is spent by API CALLS

A run whose only job is skipped never gets a token and issues **zero** API requests. So the
headline "`auto-retry-cancelled.yml` fires 378 times and skips 93 % of them" is real but
**costs nothing**: only its ~46 executing runs touch the API. Narrowing its trigger would have
been a fix aimed at the wrong quantity. Same for `dependabot-auto-merge.yml` (252 of 258
skipped).

Re-split by estimated REST calls per hour:

| est. calls/hr | source | basis |
|---|---|---|
| **~450** (up to ~1,350 while retrying under saturation) | `ci.yml` → `gitops` shard → **`msg-channel-image-parity`** | 19 contents lookups per run, measured; ~21.5 CI runs/hr |
| ~190 | `main-red-watch.yml` | 513 executing runs / 8 h × ~3 calls (attempt-scoped jobs + `issues.listForRepo` pagination) |
| ~20 | `auto-retry-cancelled.yml` | 46 executing runs / 8 h |

And the ceiling is lower than assumed. GitHub documents `GITHUB_TOKEN` in Actions at
**1,000 requests/hour per repository** outside Enterprise Cloud (an installation token is
5,000/hr; the Actions token is not). Against a 1,000/hr budget, one gate at ~450/hr baseline is
decisive on its own — and self-amplifying, because its retries fire hardest exactly when the
quota is scarce.

## What this PR changes

**`check-msg-channel-image-parity.py`** — the largest identified consumer and the `#6290`
symptom, fixed at both ends.

1. **Volume.** The gate now reads a deployed commit's `application.yaml` over **git transport**
   (`git fetch --depth 1 origin <full-sha>` then `git show`), which spends no REST quota. The
   function's old note said GitHub will not serve an arbitrary sha to `git fetch origin <sha>`
   — that conclusion came from a broken probe: an image tag carries an **abbreviated** sha and
   git's want-sha1 fetch requires all 40 characters, and both cases print the identical
   `couldn't find remote ref`. Measured against a real `--depth 1` clone of this repo, the
   abbreviated form fails and the full form succeeds. Only the abbreviated → full resolution
   stays on REST, and it is memoised **per distinct sha** (7 today) rather than per service.

   Measured in two pristine `git clone --depth 1` checkouts with `gh` wrapped in a counter,
   same verdict both times (`30 channel override(s) across 19 service(s)`):

   | | REST calls |
   |---|---|
   | `origin/main` | **19** |
   | this branch | **7** |

   The contents API remains as a fallback, so an offline or restricted environment behaves
   exactly as before.

2. **Legibility.** `_api_show` returned a bare `None` for two different states — "this commit
   genuinely has no such file" and "a shared quota is exhausted, so nothing was read" — which is
   precisely what made an infrastructure fact render as a finding about the author's diff. They
   are now separate (`Unreadable.UNREADABLE` vs `Unreadable.QUOTA`), classified **on the message
   text**, because a rate limit and a permission denial are both HTTP 403; a permission answer
   is deliberately *not* reported as capacity, since retrying cannot fix it and calling it
   capacity would hide a real misconfiguration. The quota case still exits non-zero (it is not
   a pass), but it is reported first, under its own title, naming CI capacity, and carrying no
   service/channel verdict.

## Prove it by what it prevents

Both exit codes read from `$?` after redirecting to a file — never off a pipeline.

| control | exit | `CI API quota exhausted` lines | `Messaging channel/image parity` lines |
|---|---|---|---|
| every subprocess answers `API rate limit exceeded for installation ... (HTTP 403)` | **1** | **1** | **0** |
| commit reads fine, `application.yaml` declares no matching connector | **1** | **0** | **30** |

The two outputs are mutually exclusive: a real finding cannot be mistaken for the quota notice,
and a quota notice cannot be mistaken for a finding. In-script self-test additionally asserts
that an installation rate limit classifies as `QUOTA` while `Resource not accessible by
integration` (the other 403) classifies as `UNREADABLE`.

## What this does NOT do — and what needs the repository owner

- **It does not close `#6853`.** The spot-kill retry's own 403 is caused by the same saturation;
  this reduces the pressure but does not remove it. Its existing 3 attempts with 15 s/30 s
  backoff cannot outlast an hourly quota reset by construction.
- **The residual volume is inherent.** ~500 runs/hour from ~70 pushes to `main` in 8 h is what
  the parallel-agent workflow produces; `main-red-watch.yml` fans out to one run per watched
  workflow per push (20 watched, 513 executing runs / 8 h) and that fan-out is its design, not
  a defect. No workflow edit gets the fleet comfortably under 1,000 REST calls/hour on its own.
- **The structural fixes are the owner's, and are named rather than worked around**: a GitHub
  App with its own quota for the API-heavy controls, or GitHub Enterprise Cloud (15,000/hr per
  repository), or a repository-level Actions concurrency limit. Repository settings were not
  touched.

## Verification

- `run-gates.py --only msg-channel-image-parity` — **PASS**, foreground.
- `run-gates.py --group gitops` (exit 1) and `--group lint` (exit 0), foreground. The gitops
  failures (`litellm-config-revision` FAIL, plus 4 UNFALSIFIED) reproduce **identically** on a
  pristine `git worktree add --detach <tmp> origin/main` control, so none is from this branch.
  The `lint` shard's `[t]` entries are its own expected self-test fixtures.
- No workflow YAML changed, so `actionlint` has no subject here.

Refs #6853
Closes #6290
