### PR TITLE
fix(ci): let a verdict line carry trailing reasoning without failing the job

### DIFF
--- a/.github/workflows/agent-issue-worker.yml
+++ b/.github/workflows/agent-issue-worker.yml
@@ -265,7 +265,7 @@ jobs:
             echo "::error::the worker produced no output at all — it did not run, which is not the same as having nothing to do"
             exit 1
           fi
-          verdict=$(grep -oE '^WORKER-VERDICT: (OPENED .*|NOTHING QUALIFIED|BLOCKED .*)$' /tmp/worker-output.txt | tail -1)
+          verdict=$(grep -oE '^WORKER-VERDICT: (OPENED|NOTHING QUALIFIED|BLOCKED).*$' /tmp/worker-output.txt | tail -1)
           if [ -z "${verdict}" ]; then
             echo "::error::the worker never stated a verdict. It talked, but nothing here can tell whether it worked an issue, found nothing to do, or was blocked. Treating as NOT having run."
             echo "--- last 20 lines of what it did say ---"

--- a/.github/workflows/agent-pr-steward.yml
+++ b/.github/workflows/agent-pr-steward.yml
@@ -187,7 +187,7 @@ jobs:
             echo "::error::the steward produced no output — it did not run, which is not the same as having nothing to tend"
             exit 1
           fi
-          verdict=$(grep -oE '^STEWARD-VERDICT: (TENDED .*|NOTHING TO TEND|BLOCKED .*)$' /tmp/steward-output.txt | tail -1)
+          verdict=$(grep -oE '^STEWARD-VERDICT: (TENDED|NOTHING TO TEND|BLOCKED).*$' /tmp/steward-output.txt | tail -1)
           if [ -z "${verdict}" ]; then
             echo "::error::the steward never stated a verdict. Treating as NOT having run."
             tail -20 /tmp/steward-output.txt


### PR DESCRIPTION
## What was wrong

Both `agent-pr-steward.yml` and `agent-issue-worker.yml` assert a verdict line by regex before
treating the run as valid. `NOTHING TO TEND` / `NOTHING QUALIFIED` were anchored with `$` right
after the literal token, but both prompts explicitly instruct trailing reasoning on that same
line (`pr-steward.md`: "end with `STEWARD-VERDICT: NOTHING TO TEND` followed by your reasoning").
Any trailing text made the regex not match at all, so the assert step reported "the steward never
stated a verdict" and failed the job — even when the agent had correctly reasoned through the
work and reached a legitimate NOTHING TO TEND / NOTHING QUALIFIED.

## How I found it

Dispatched the steward against PR #7108, which turned out to be conflicting because it duplicated
already-merged #7071 (same privacy-page files, two independent implementations). The steward
correctly declined to pick a side — that's a design call outside its mandate — and said so:

    STEWARD-VERDICT: NOTHING TO TEND — PR #7108 is conflicting, but resolving it requires
    choosing between two independently-built bilingual privacy-page implementations ...

Run 33015112195 then failed anyway, on the assert step, not on the steward's own reasoning. Closed
#7108 as the duplicate it is; this PR fixes the regex so a correct verdict with a reason attached
stops reading as a crash.

## The fix

`NOTHING TO TEND|NOTHING QUALIFIED|BLOCKED` (and `OPENED`/`TENDED`) now match on the token alone
with a wildcard tail, instead of requiring either bare-token-then-EOL or a literal space before
more text on only some branches. No change to the BLOCKED-fails-the-job behavior.
