### PR TITLE
fix(regulatory): show actual values before first close

### DIFF
--- a/openbank-admin-ui/src/app/regulatory/page.tsx
+++ b/openbank-admin-ui/src/app/regulatory/page.tsx
@@ -48,7 +48,7 @@ type PreviewData =
   | { status: 'unavailable'; kind: BffFailure }
   | { status: 'no-periods' }
   | { status: 'unsupported' }
-  | { status: 'ready'; templates: RegulatoryTemplate[] }
+  | { status: 'ready'; templates: RegulatoryTemplate[]; evidence: 'FROZEN' | 'LIVE_PREVIEW' }
 
 type TemplateLoadResult = { template: RegulatoryTemplate } | { kind: BffFailure }
 
@@ -77,6 +77,11 @@ function money(value: number, currency: string): string {
   return new Intl.NumberFormat('cs-CZ', { style: 'currency', currency, maximumFractionDigits: 2 }).format(value)
 }
 
+function lastCompletedMonthEnd(): string {
+  const now = new Date()
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 0)).toISOString().slice(0, 10)
+}
+
 function buildExportRows(report: Report, data: PreviewData): ExportRow[] {
   const meta: ExportRow[] = [
     { field: 'ID výkazu', value: report.id },
@@ -98,7 +103,10 @@ function buildExportRows(report: Report, data: PreviewData): ExportRow[] {
         value: `${money(cell.value, cell.currency)}${cell.isDataGap ? ' · DATOVÁ MEZERA' : ''}`,
       })),
     ])
-    return [...meta, { field: 'Zdroj', value: 'finrep-service ← ledger trial balance (ne ClickHouse)' }, ...rendered]
+    const source = data.evidence === 'FROZEN'
+      ? 'finrep-service ← zmrazená ledger předvaha (FROZEN / LINES_V1)'
+      : 'finrep-service ← živá ledger předvaha (PRACOVNÍ NÁHLED, měnitelná)'
+    return [...meta, { field: 'Zdroj', value: source }, ...rendered]
   }
   const message = data.status === 'loading' || data.status === 'idle'
     ? 'Načítám…'
@@ -244,8 +252,13 @@ export default function RegulatoryPage() {
   const [previewData, setPreviewData] = useState<PreviewData>({ status: 'idle' })
   const [reportingDate, setReportingDate] = useState('')
   const [reportingPeriods, setReportingPeriods] = useState<string[]>([])
+  const [reportingEvidence, setReportingEvidence] = useState<'FROZEN' | 'LIVE_PREVIEW'>('FROZEN')
 
-  async function loadPreview(report: Report, requestedAsOf?: string) {
+  async function loadPreview(
+    report: Report,
+    requestedAsOf?: string,
+    requestedEvidence: 'FROZEN' | 'LIVE_PREVIEW' = 'FROZEN',
+  ) {
     const paths = TEMPLATE_PATHS[report.id]
     if (!paths) {
       setPreviewData({ status: 'unsupported' })
@@ -254,6 +267,7 @@ export default function RegulatoryPage() {
     setPreviewData({ status: 'loading' })
     try {
       let asOf = requestedAsOf
+      let evidence = requestedEvidence
       if (!asOf) {
         const periodsResponse = await fetch(svcUrl('finrep-service', '/api/v1/finrep/periods'), {
           cache: 'no-store', signal: AbortSignal.timeout(15_000),
@@ -265,14 +279,19 @@ export default function RegulatoryPage() {
         const available = await periodsResponse.json() as { latest: string | null; periods: string[] }
         setReportingPeriods(available.periods)
         if (!available.latest) {
-          setPreviewData({ status: 'no-periods' })
-          return
+          asOf = lastCompletedMonthEnd()
+          evidence = 'LIVE_PREVIEW'
+          setReportingPeriods([asOf])
+          setReportingDate(asOf)
+          setReportingEvidence(evidence)
+        } else {
+          asOf = available.latest
+          setReportingDate(asOf)
+          setReportingEvidence(evidence)
         }
-        asOf = available.latest
-        setReportingDate(asOf)
       }
       const results: TemplateLoadResult[] = await Promise.all(paths.map(async (path): Promise<TemplateLoadResult> => {
-        const response = await fetch(svcUrl('finrep-service', path, { asOf }), {
+        const response = await fetch(svcUrl('finrep-service', path, { asOf, evidence }), {
           cache: 'no-store', signal: AbortSignal.timeout(15_000),
         })
         return response.ok
@@ -286,6 +305,7 @@ export default function RegulatoryPage() {
       }
       setPreviewData({
         status: 'ready',
+        evidence,
         templates: results.filter((result): result is { template: RegulatoryTemplate } => 'template' in result).map(result => result.template),
       })
     } catch {
@@ -593,7 +613,7 @@ export default function RegulatoryPage() {
                     {reportingPeriods.map(period => <option key={period} value={period}>{period}</option>)}
                   </select>
                 </label>
-                <button type="button" className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={() => void loadPreview(preview, reportingDate || undefined)} disabled={previewData.status === 'loading' || !reportingDate} aria-busy={previewData.status === 'loading'} aria-label={t('Načíst data pro náhled', 'Load preview data')}>
+                <button type="button" className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={() => void loadPreview(preview, reportingDate || undefined, reportingEvidence)} disabled={previewData.status === 'loading' || !reportingDate} aria-busy={previewData.status === 'loading'} aria-label={t('Načíst data pro náhled', 'Load preview data')}>
                   <RefreshCw size={13} aria-hidden="true" className={previewData.status === 'loading' ? 'animate-spin' : ''} />
                   {t('Načíst data', 'Load data')}
                 </button>
@@ -604,11 +624,14 @@ export default function RegulatoryPage() {
             <div style={{ overflowY: 'auto', padding: '0' }}>
               {previewData.status === 'unavailable' ? (
                 <DataUnavailable kind={previewData.kind} service="FINREP / COREP service" feature={t('regulatorní šablony', 'regulatory templates')} lang="cs" dense />
-              ) : previewData.status === 'no-periods' ? (
-                <div style={{ padding: '20px', color: 'var(--text-secondary)', fontSize: '13px' }}>
-                  {t('Ledger zatím nemá žádné zmrazené měsíční období s neměnnou řádkovou evidencí. Výkaz nelze správně sestavit, dokud operátor nedokončí uzávěrku.', 'The ledger has no frozen monthly period with immutable line evidence yet. A correct report cannot be rendered until an operator completes the close.')}
-                </div>
               ) : (
+                <>
+                {previewData.status === 'ready' && previewData.evidence === 'LIVE_PREVIEW' && (
+                  <div role="status" style={{ padding: '12px 20px', color: '#92400e', background: '#fffbeb', borderBottom: '1px solid #fde68a', fontSize: '12px' }}>
+                    <strong>{t('Pracovní náhled skutečných hodnot', 'Working preview of actual values')}</strong>
+                    {' — '}{t('období ještě není zapečetěné. Hodnoty se mohou změnit; finální regulatorní export zůstává zablokovaný.', 'the period is not sealed yet. Values may change; final regulatory export remains blocked.')}
+                  </div>
+                )}
                 <table className="data-table" style={{ width: '100%' }}>
                   <thead>
                     <tr>
@@ -625,6 +648,7 @@ export default function RegulatoryPage() {
                     ))}
                   </tbody>
                 </table>
+                </>
               )}
             </div>
 

--- a/openbank-admin-ui/src/lib/regulatory/exportReadiness.ts
+++ b/openbank-admin-ui/src/lib/regulatory/exportReadiness.ts
@@ -56,7 +56,7 @@ export type PreviewLike =
   | { status: 'unavailable'; kind: string }
   | { status: 'no-periods' }
   | { status: 'unsupported' }
-  | { status: 'ready'; templates: ReadonlyArray<TemplateLike> }
+  | { status: 'ready'; templates: ReadonlyArray<TemplateLike>; evidence?: 'FROZEN' | 'LIVE_PREVIEW' }
 
 export interface CellLike {
   isDataGap?: boolean
@@ -86,6 +86,8 @@ export type ExportBlockReason =
   | 'source_unavailable'
   /** Ledger has no immutable frozen month evidence from which a return may be rendered. */
   | 'no_closed_periods'
+  /** Values are real, but sourced from a mutable working trial balance rather than frozen evidence. */
+  | 'provisional_data'
   /** A template came back with no cells — malformed against the contract. */
   | 'missing_cells'
   /** At least one cell is a flagged data gap (`isDataGap`). */
@@ -163,6 +165,10 @@ export function evaluateExportReadiness(data: PreviewLike): ExportReadiness {
     return { ok: false, reason: 'data_gaps', templateIds: gapped.map(template => template.templateId) }
   }
 
+  if (data.evidence === 'LIVE_PREVIEW') {
+    return { ok: false, reason: 'provisional_data', templateIds: data.templates.map(template => template.templateId) }
+  }
+
   return { ok: true }
 }
 
@@ -191,6 +197,10 @@ export function blockReasonCopy(
       return cs
         ? { title: 'Export je zablokován: chybí uzavřené období', detail: 'Ledger nemá žádné zmrazené měsíční období s neměnnou řádkovou evidencí (FROZEN / LINES_V1). Dokončete uzávěrku; živá předvaha se pro regulatorní výkaz nikdy nepoužije.' }
         : { title: 'Export blocked: no closed reporting period', detail: 'The ledger has no frozen monthly period with immutable line evidence (FROZEN / LINES_V1). Complete the close; a live trial balance is never used for a regulatory return.' }
+    case 'provisional_data':
+      return cs
+        ? { title: 'Export je zablokován: pracovní náhled není zapečetěný', detail: `Šablona ${list} zobrazuje skutečné hodnoty z živé předvahy, ale období ještě nemá FROZEN / LINES_V1 evidenci. Hodnoty lze kontrolovat, nelze je vydat za regulatorní artefakt.` }
+        : { title: 'Export blocked: working preview is not sealed', detail: `Template ${list} shows real values from the live trial balance, but the period has no FROZEN / LINES_V1 evidence yet. Values may be reviewed, not represented as a regulatory artefact.` }
     case 'missing_cells':
       return cs
         ? { title: 'Export je zablokován: šablona je prázdná', detail: `Šablona ${list} se vrátila bez buněk. Podle kontraktu se vykresluje vždy každý řádek, takže jde o vadnou odpověď.` }

--- a/openbank-admin-ui/src/test/regulatory-export-gate.test.tsx
+++ b/openbank-admin-ui/src/test/regulatory-export-gate.test.tsx
@@ -61,6 +61,15 @@ describe('evaluateExportReadiness', () => {
     expect(verdict).toEqual({ ok: false, reason: 'data_gaps', templateIds: ['C_01.00'] })
   })
 
+  it('shows live values for review but blocks exporting them as a sealed return', () => {
+    const verdict = evaluateExportReadiness({
+      status: 'ready',
+      evidence: 'LIVE_PREVIEW',
+      templates: [{ templateId: 'F01.01', cells: [cell()], isBalanced: true, hasDataGaps: false }],
+    })
+    expect(verdict).toEqual({ ok: false, reason: 'provisional_data', templateIds: ['F01.01'] })
+  })
+
   it('blocks as INCOMPLETE on the derived hasDataGaps flag alone', () => {
     const verdict = evaluateExportReadiness({
       status: 'ready',

--- a/openbank-admin-ui/src/test/regulatory-preview.guard.test.ts
+++ b/openbank-admin-ui/src/test/regulatory-preview.guard.test.ts
@@ -9,6 +9,8 @@ describe('regulatory preview loading contract', () => {
     expect(source).toContain('type="button"')
     expect(source).toContain("aria-busy={previewData.status === 'loading'}")
     expect(source).toContain("aria-label={t('Načíst data pro náhled', 'Load preview data')}")
-    expect(source).toContain('onClick={() => void loadPreview(preview, reportingDate || undefined)}')
+    expect(source).toContain(
+      'onClick={() => void loadPreview(preview, reportingDate || undefined, reportingEvidence)}',
+    )
   })
 })

--- a/openbank-admin-ui/src/test/regulatory-report-preview.test.tsx
+++ b/openbank-admin-ui/src/test/regulatory-report-preview.test.tsx
@@ -74,7 +74,7 @@ describe('Regulatory report preview', () => {
     expect(String(fetchMock.mock.calls[0][0])).toContain('/api/svc/finrep-service/api/v1/finrep/periods')
     expect(String(fetchMock.mock.calls[1][0])).toContain('/api/svc/finrep-service/api/v1/finrep/templates/F01.01?asOf=2026-06-30')
     expect(String(fetchMock.mock.calls[2][0])).toContain('/api/svc/finrep-service/api/v1/finrep/templates/F02.00?asOf=2026-06-30')
-    expect(screen.getByText('finrep-service ← ledger trial balance (ne ClickHouse)')).toBeInTheDocument()
+    expect(screen.getByText('finrep-service ← zmrazená ledger předvaha (FROZEN / LINES_V1)')).toBeInTheDocument()
     expect(screen.getByTestId('export-readiness')).toHaveTextContent(/Ready for internal export/)
     expect(screen.getByRole('button', { name: 'Export preview as JSON' })).toBeEnabled()
   })
@@ -99,21 +99,24 @@ describe('Regulatory report preview', () => {
     expect(screen.queryByText('Dostupnost dat')).not.toBeInTheDocument()
   })
 
-  it('explains and blocks export when no immutable closed period exists', async () => {
-    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ latest: null, periods: [] }), {
-      status: 200,
-      headers: { 'content-type': 'application/json' },
-    }))
+  it('shows actual working-preview values but blocks regulatory export when no immutable period exists', async () => {
+    const fetchMock = vi.fn(async (url: string) => new Response(JSON.stringify(
+      url.includes('/api/v1/finrep/periods')
+        ? { latest: null, periods: [] }
+        : finrepResponse(url.includes('F01.01') ? 'F01.01' : 'F02.00'),
+    ), { status: 200, headers: { 'content-type': 'application/json' } }))
     vi.stubGlobal('fetch', fetchMock)
     render(<LanguageProvider><RegulatoryPage /></LanguageProvider>)
 
     const finrepCard = screen.getByText('CNB — Finanční výkazy (FINREP)').closest('.card')
     fireEvent.click(within(finrepCard as HTMLElement).getByRole('button', { name: 'Preview export' }))
 
-    expect(await screen.findByText(/A correct report cannot be rendered/i)).toBeInTheDocument()
-    expect(screen.getByTestId('export-blocked')).toHaveAttribute('data-block-reason', 'no_closed_periods')
+    expect(await screen.findByText(/Working preview of actual values/i)).toBeInTheDocument()
+    expect(screen.getByText(/Celková aktiva/)).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(String(fetchMock.mock.calls[1][0])).toContain('evidence=LIVE_PREVIEW')
+    expect(screen.getByTestId('export-blocked')).toHaveAttribute('data-block-reason', 'provisional_data')
     expect(screen.getByRole('button', { name: 'Export preview as JSON' })).toBeDisabled()
-    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
   it('blocks export when COREP honestly reports a data gap', async () => {

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/inbound/CorepPorts.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/inbound/CorepPorts.kt
@@ -7,7 +7,11 @@ package com.openbank.finrep.application.port.inbound
 import com.openbank.finrep.domain.model.CorepTemplate
 import java.time.LocalDate
 
-data class GetCorepTemplateQuery(val templateId: String, val asOf: LocalDate)
+data class GetCorepTemplateQuery(
+    val templateId: String,
+    val asOf: LocalDate,
+    val evidence: TrialBalanceEvidence = TrialBalanceEvidence.FROZEN,
+)
 
 interface CorepUseCase {
     suspend fun getTemplate(query: GetCorepTemplateQuery): CorepTemplate

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/inbound/FinrepPorts.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/inbound/FinrepPorts.kt
@@ -7,7 +7,13 @@ package com.openbank.finrep.application.port.inbound
 import com.openbank.finrep.domain.model.FinrepTemplate
 import java.time.LocalDate
 
-data class GetFinrepTemplateQuery(val templateId: String, val asOf: LocalDate)
+enum class TrialBalanceEvidence { FROZEN, LIVE_PREVIEW }
+
+data class GetFinrepTemplateQuery(
+    val templateId: String,
+    val asOf: LocalDate,
+    val evidence: TrialBalanceEvidence = TrialBalanceEvidence.FROZEN,
+)
 
 interface FinrepUseCase {
     suspend fun getTemplate(query: GetFinrepTemplateQuery): FinrepTemplate

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/out/FinrepPorts.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/out/FinrepPorts.kt
@@ -46,5 +46,8 @@ data class ClosedPeriodDto(val periodType: String, val to: LocalDate, val status
 interface LedgerPort {
     suspend fun getTrialBalance(asOf: LocalDate): TrialBalanceSnapshot
 
+    /** Mutable period aggregate for an explicitly labelled internal working preview only. */
+    suspend fun getLiveTrialBalance(asOf: LocalDate): TrialBalanceSnapshot
+
     suspend fun listClosedPeriods(): List<ClosedPeriodDto>
 }

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/CorepService.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/CorepService.kt
@@ -6,6 +6,7 @@ package com.openbank.finrep.application.usecase
 
 import com.openbank.finrep.application.port.inbound.CorepUseCase
 import com.openbank.finrep.application.port.inbound.GetCorepTemplateQuery
+import com.openbank.finrep.application.port.inbound.TrialBalanceEvidence
 import com.openbank.finrep.application.port.out.FinrepMetricsPort
 import com.openbank.finrep.application.port.out.LedgerPort
 import com.openbank.finrep.application.port.out.RegulatoryFramework
@@ -33,7 +34,7 @@ class CorepService(private val ledgerPort: LedgerPort, private val metrics: Finr
 
     override suspend fun getTemplate(query: GetCorepTemplateQuery): CorepTemplate {
         val startedAt = System.nanoTime()
-        val snapshot = trialBalance(query.asOf)
+        val snapshot = trialBalance(query.asOf, query.evidence)
         val template = when (query.templateId) {
             "C_01.00" -> C0100Mapper.map(snapshot.lines, query.asOf)
             else -> {
@@ -64,8 +65,11 @@ class CorepService(private val ledgerPort: LedgerPort, private val metrics: Finr
      * REST-client failure mode (connect, timeout, 5xx, deserialisation) means the same thing here.
      */
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun trialBalance(asOf: LocalDate): TrialBalanceSnapshot = try {
-        ledgerPort.getTrialBalance(asOf)
+    private suspend fun trialBalance(asOf: LocalDate, evidence: TrialBalanceEvidence): TrialBalanceSnapshot = try {
+        when (evidence) {
+            TrialBalanceEvidence.FROZEN -> ledgerPort.getTrialBalance(asOf)
+            TrialBalanceEvidence.LIVE_PREVIEW -> ledgerPort.getLiveTrialBalance(asOf)
+        }
     } catch (e: Exception) {
         metrics.templateFailed(RegulatoryFramework.COREP, TemplateFailureReason.LEDGER_UNAVAILABLE)
         throw e

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/FinrepService.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/FinrepService.kt
@@ -6,6 +6,7 @@ package com.openbank.finrep.application.usecase
 
 import com.openbank.finrep.application.port.inbound.FinrepUseCase
 import com.openbank.finrep.application.port.inbound.GetFinrepTemplateQuery
+import com.openbank.finrep.application.port.inbound.TrialBalanceEvidence
 import com.openbank.finrep.application.port.out.FinrepMetricsPort
 import com.openbank.finrep.application.port.out.LedgerPort
 import com.openbank.finrep.application.port.out.RegulatoryFramework
@@ -40,7 +41,7 @@ class FinrepService(private val ledgerPort: LedgerPort, private val metrics: Fin
 
     override suspend fun getTemplate(query: GetFinrepTemplateQuery): FinrepTemplate {
         val startedAt = System.nanoTime()
-        val snapshot = trialBalance(query.asOf)
+        val snapshot = trialBalance(query.asOf, query.evidence)
         val template = when (query.templateId) {
             "F01.01" -> F0101Mapper.map(snapshot, query.asOf)
             "F01.02" -> F0102Mapper.map(snapshot, query.asOf)
@@ -72,8 +73,11 @@ class FinrepService(private val ledgerPort: LedgerPort, private val metrics: Fin
      * REST-client failure mode (connect, timeout, 5xx, deserialisation) means the same thing here.
      */
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun trialBalance(asOf: LocalDate): TrialBalanceSnapshot = try {
-        ledgerPort.getTrialBalance(asOf)
+    private suspend fun trialBalance(asOf: LocalDate, evidence: TrialBalanceEvidence): TrialBalanceSnapshot = try {
+        when (evidence) {
+            TrialBalanceEvidence.FROZEN -> ledgerPort.getTrialBalance(asOf)
+            TrialBalanceEvidence.LIVE_PREVIEW -> ledgerPort.getLiveTrialBalance(asOf)
+        }
     } catch (e: Exception) {
         metrics.templateFailed(RegulatoryFramework.FINREP, TemplateFailureReason.LEDGER_UNAVAILABLE)
         throw e

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/client/LedgerClient.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/client/LedgerClient.kt
@@ -52,6 +52,10 @@ interface LedgerRestClient {
     fun getTrialBalance(@PathParam("asOf") asOf: String): Uni<ClosedPeriodTrialBalanceResponse>
 
     @GET
+    @Path("/MONTH/{asOf}/trial-balance")
+    fun getLiveTrialBalance(@PathParam("asOf") asOf: String): Uni<ClosedPeriodTrialBalanceResponse>
+
+    @GET
     fun listClosedPeriods(
         @QueryParam("from") from: String,
         @QueryParam("to") to: String,
@@ -95,18 +99,25 @@ class LedgerAdapter(@RestClient private val client: LedgerRestClient) : LedgerPo
      */
     override suspend fun getTrialBalance(asOf: LocalDate): TrialBalanceSnapshot {
         val response = client.getTrialBalance(asOf.toString()).awaitSuspending()
-        return TrialBalanceSnapshot(
-            lines = response.lines.map { line ->
-                TrialBalanceLineDto(
-                    code = line.code,
-                    accountType = line.type,
-                    net = line.net,
-                    currency = line.currency,
-                )
-            },
-            ledgerReportsBalanced = response.balanced,
-        )
+        return response.toSnapshot()
     }
+
+    override suspend fun getLiveTrialBalance(asOf: LocalDate): TrialBalanceSnapshot {
+        val response = client.getLiveTrialBalance(asOf.toString()).awaitSuspending()
+        return response.toSnapshot()
+    }
+
+    private fun ClosedPeriodTrialBalanceResponse.toSnapshot(): TrialBalanceSnapshot = TrialBalanceSnapshot(
+        lines = lines.map { line ->
+            TrialBalanceLineDto(
+                code = line.code,
+                accountType = line.type,
+                net = line.net,
+                currency = line.currency,
+            )
+        },
+        ledgerReportsBalanced = balanced,
+    )
 
     override suspend fun listClosedPeriods(): List<ClosedPeriodDto> =
         client.listClosedPeriods(CLOSED_PERIODS_FROM, CLOSED_PERIODS_TO).awaitSuspending().map {

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/rest/CorepResource.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/rest/CorepResource.kt
@@ -6,6 +6,7 @@ package com.openbank.finrep.infrastructure.rest
 
 import com.openbank.finrep.application.port.inbound.CorepUseCase
 import com.openbank.finrep.application.port.inbound.GetCorepTemplateQuery
+import com.openbank.finrep.application.port.inbound.TrialBalanceEvidence
 import com.openbank.finrep.domain.model.CorepTemplate
 import com.openbank.libs.security.Roles
 import jakarta.annotation.security.RolesAllowed
@@ -46,10 +47,15 @@ class CorepResource(private val corepUseCase: CorepUseCase, private val clock: C
     suspend fun getTemplate(
         @PathParam("templateId") templateId: String,
         @QueryParam("asOf") @DefaultValue("") asOf: String,
+        @QueryParam("evidence") @DefaultValue("FROZEN") evidence: String = "FROZEN",
     ): Response {
         val date = if (asOf.isBlank()) LocalDate.now(clock) else LocalDate.parse(asOf)
         val template: CorepTemplate = corepUseCase.getTemplate(
-            GetCorepTemplateQuery(templateId = templateId, asOf = date),
+            GetCorepTemplateQuery(
+                templateId = templateId,
+                asOf = date,
+                evidence = TrialBalanceEvidence.valueOf(evidence.uppercase()),
+            ),
         )
         return Response.ok(template).build()
     }

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/rest/FinrepResource.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/rest/FinrepResource.kt
@@ -6,6 +6,7 @@ package com.openbank.finrep.infrastructure.rest
 
 import com.openbank.finrep.application.port.inbound.FinrepUseCase
 import com.openbank.finrep.application.port.inbound.GetFinrepTemplateQuery
+import com.openbank.finrep.application.port.inbound.TrialBalanceEvidence
 import com.openbank.finrep.domain.model.FinrepTemplate
 import com.openbank.libs.security.Roles
 import jakarta.annotation.security.RolesAllowed
@@ -46,10 +47,15 @@ class FinrepResource(private val finrepUseCase: FinrepUseCase, private val clock
     suspend fun getTemplate(
         @PathParam("templateId") templateId: String,
         @QueryParam("asOf") @DefaultValue("") asOf: String,
+        @QueryParam("evidence") @DefaultValue("FROZEN") evidence: String = "FROZEN",
     ): Response {
         val date = if (asOf.isBlank()) LocalDate.now(clock) else LocalDate.parse(asOf)
         val template: FinrepTemplate = finrepUseCase.getTemplate(
-            GetFinrepTemplateQuery(templateId = templateId, asOf = date),
+            GetFinrepTemplateQuery(
+                templateId = templateId,
+                asOf = date,
+                evidence = TrialBalanceEvidence.valueOf(evidence.uppercase()),
+            ),
         )
         return Response.ok(template).build()
     }

--- a/openbank-finrep-service/src/main/resources/openapi.yaml
+++ b/openbank-finrep-service/src/main/resources/openapi.yaml
@@ -23,7 +23,7 @@ info:
     FINREP output is a bounded preview containing only the official datapoints the platform can
     currently derive without inventing regulatory classifications; it is not a complete return.
     COREP preview gaps remain explicit flagged zeroes (`isDataGap`) with reasons.
-  version: 1.6.0
+  version: 1.7.0
 tags:
   - name: FINREP
   - name: COREP
@@ -94,6 +94,9 @@ paths:
         `templateId` values are `F01.01` (Assets), `F01.02` (Liabilities), `F01.03` (Equity) and
         `F02.00` (Profit & Loss); any other value is rejected. The bounded previews expose only
         datapoints that the current ledger can derive without inventing regulatory classifications.
+        `FROZEN` (the default) requires immutable FROZEN / LINES_V1 evidence. `LIVE_PREVIEW`
+        explicitly reads the mutable period aggregate for internal review only; callers must label
+        it provisional and must not export or submit it as a regulatory artefact.
       operationId: getFinrepTemplate
       parameters:
         - name: templateId
@@ -106,6 +109,11 @@ paths:
           required: false
           description: Reporting reference date, ISO yyyy-MM-dd. Defaults to today when omitted.
           schema: { type: string, format: date }
+        - name: evidence
+          in: query
+          required: false
+          description: Evidence source. LIVE_PREVIEW is mutable and for internal review only.
+          schema: { type: string, enum: [FROZEN, LIVE_PREVIEW], default: FROZEN }
       responses:
         '200':
           description: The rendered FINREP template
@@ -134,7 +142,9 @@ paths:
 
         The ledger's chart of accounts has no capital-structure GL accounts today, so every
         capital row comes back as an explicit zero with `isDataGap: true` and a `gapReason` — a
-        documented gap, never to be read as an attested zero balance.
+        documented gap, never to be read as an attested zero balance. `FROZEN` (the default)
+        requires immutable evidence; `LIVE_PREVIEW` is a mutable internal working view that must
+        never be exported or submitted as a regulatory artefact.
       operationId: getCorepTemplate
       parameters:
         - name: templateId
@@ -147,6 +157,11 @@ paths:
           required: false
           description: Reporting reference date, ISO yyyy-MM-dd. Defaults to today when omitted.
           schema: { type: string, format: date }
+        - name: evidence
+          in: query
+          required: false
+          description: Evidence source. LIVE_PREVIEW is mutable and for internal review only.
+          schema: { type: string, enum: [FROZEN, LIVE_PREVIEW], default: FROZEN }
       responses:
         '200':
           description: The rendered COREP template

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/CorepServiceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/CorepServiceTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.finrep.application.usecase
 
 import com.openbank.finrep.application.port.inbound.GetCorepTemplateQuery
+import com.openbank.finrep.application.port.inbound.TrialBalanceEvidence
 import com.openbank.finrep.application.port.out.LedgerPort
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
 import com.openbank.finrep.application.port.out.TrialBalanceSnapshot
@@ -27,6 +28,18 @@ class CorepServiceTest {
     // The REAL metrics adapter over a SimpleMeterRegistry rather than a mock port, so the
     // instrumentation assertions below fail if the use case stops emitting.
     private val registry = SimpleMeterRegistry()
+
+    @Test
+    fun `live working preview never reads frozen evidence implicitly`(): Unit = runBlocking {
+        val asOf = LocalDate.of(2026, 7, 31)
+        coEvery { ledgerPort.getLiveTrialBalance(asOf) } returns snapshot(emptyList(), ledgerSays = true)
+        val service = CorepService(ledgerPort, FinrepMetricsAdapter(registry))
+
+        service.getTemplate(GetCorepTemplateQuery("C_01.00", asOf, TrialBalanceEvidence.LIVE_PREVIEW))
+
+        coVerify(exactly = 1) { ledgerPort.getLiveTrialBalance(asOf) }
+        coVerify(exactly = 0) { ledgerPort.getTrialBalance(any()) }
+    }
 
     @Test
     fun `getTemplate dispatches C_01_00 to the own funds mapper`(): Unit = runBlocking {

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/LedgerTrialBalancePactConsumerTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/LedgerTrialBalancePactConsumerTest.kt
@@ -127,6 +127,30 @@ class LedgerTrialBalancePactConsumerTest {
         .toPact()
 
     @Pact(consumer = "openbank-finrep-service", provider = "openbank-ledger-service")
+    fun livePreviewTrialBalancePact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("ledger has frozen monthly trial balance for the reporting date")
+        .uponReceiving("GET the mutable monthly GL trial balance for an internal working preview")
+        .path("$LEDGER_MONTH_TRIAL_BALANCE_PATH/$REPORTING_DATE/trial-balance")
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                o.stringValue("period", "MONTH:2026-06")
+                o.booleanType("balanced", true)
+                o.minArrayLike("lines", 0, 1) { line ->
+                    line.stringType("code", "1100-CASH-CLEARING-CZK")
+                    line.stringType("type", "ASSET")
+                    line.decimalType("net", 150_000.00)
+                    line.stringType("currency", "CZK")
+                }
+            }.build(),
+        )
+        .toPact()
+
+    @Pact(consumer = "openbank-finrep-service", provider = "openbank-ledger-service")
     fun closedPeriodsPact(builder: PactDslWithProvider): RequestResponsePact = builder
         .given("ledger has frozen monthly trial balance for the reporting date")
         .uponReceiving("GET closed periods available for regulatory reporting")
@@ -218,6 +242,20 @@ class LedgerTrialBalancePactConsumerTest {
         assertThat(period.evidenceState).isEqualTo("LINES_V1")
     }
 
+    @Test
+    @PactTestFor(pactMethod = "livePreviewTrialBalancePact")
+    fun `the ledger client uses a distinct explicit path for the mutable working preview`(mockServer: MockServer) {
+        assertThat(ledgerLiveTrialBalancePath)
+            .isEqualTo("$LEDGER_MONTH_TRIAL_BALANCE_PATH/{asOf}/trial-balance")
+
+        given()
+            .baseUri(mockServer.getUrl())
+            .accept("application/json")
+            .get(ledgerLiveTrialBalancePath.replace("{asOf}", REPORTING_DATE))
+            .then()
+            .statusCode(200)
+    }
+
     /** Issues the request against the path the production client is annotated with. */
     private fun fetchTrialBalance(mockServer: MockServer, asOf: String): ClosedPeriodTrialBalanceResponse {
         val body = given()
@@ -253,6 +291,8 @@ class LedgerTrialBalancePactConsumerTest {
 
         private val getTrialBalanceMethod =
             LedgerRestClient::class.java.getDeclaredMethod("getTrialBalance", String::class.java)
+        private val getLiveTrialBalanceMethod =
+            LedgerRestClient::class.java.getDeclaredMethod("getLiveTrialBalance", String::class.java)
         private val listClosedPeriodsMethod = LedgerRestClient::class.java.getDeclaredMethod(
             "listClosedPeriods",
             String::class.java,
@@ -266,6 +306,11 @@ class LedgerTrialBalancePactConsumerTest {
         val ledgerTrialBalancePath: String = listOf(
             LedgerRestClient::class.java.getAnnotation(Path::class.java).value,
             getTrialBalanceMethod.getAnnotation(Path::class.java).value,
+        ).joinToString("/") { it.trim('/') }.let { "/$it" }
+
+        val ledgerLiveTrialBalancePath: String = listOf(
+            LedgerRestClient::class.java.getAnnotation(Path::class.java).value,
+            getLiveTrialBalanceMethod.getAnnotation(Path::class.java).value,
         ).joinToString("/") { it.trim('/') }.let { "/$it" }
 
         val ledgerPeriodsPath: String = LedgerRestClient::class.java.getAnnotation(Path::class.java).value

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/client/LedgerAdapterTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/client/LedgerAdapterTest.kt
@@ -10,9 +10,31 @@ import io.smallrye.mutiny.Uni
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
 import java.time.LocalDate
 
 class LedgerAdapterTest {
+
+    @Test
+    fun `live preview uses the explicit mutable period endpoint and preserves the balance verdict`(): Unit =
+        runBlocking {
+            val client = mockk<LedgerRestClient>()
+            val asOf = LocalDate.parse("2026-07-31")
+            every { client.getLiveTrialBalance(asOf.toString()) } returns Uni.createFrom().item(
+                ClosedPeriodTrialBalanceResponse(
+                    period = "2026-07",
+                    balanced = true,
+                    lines = listOf(TrialBalanceLineResponse("1000", "ASSET", BigDecimal("1250.50"), "CZK")),
+                ),
+            )
+
+            val snapshot = LedgerAdapter(client).getLiveTrialBalance(asOf)
+
+            assertThat(snapshot.ledgerReportsBalanced).isTrue()
+            assertThat(snapshot.lines.single().net).isEqualByComparingTo("1250.50")
+            verify(exactly = 1) { client.getLiveTrialBalance("2026-07-31") }
+            verify(exactly = 0) { client.getTrialBalance(any()) }
+        }
 
     @Test
     fun `closed periods use the complete date range and preserve ledger evidence`(): Unit = runBlocking {

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/rest/CorepResourceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/rest/CorepResourceTest.kt
@@ -6,6 +6,7 @@ package com.openbank.finrep.infrastructure.rest
 
 import com.openbank.finrep.application.port.inbound.CorepUseCase
 import com.openbank.finrep.application.port.inbound.GetCorepTemplateQuery
+import com.openbank.finrep.application.port.inbound.TrialBalanceEvidence
 import com.openbank.finrep.domain.model.CorepCell
 import com.openbank.finrep.domain.model.CorepTemplate
 import io.mockk.coEvery
@@ -63,6 +64,7 @@ class CorepResourceTest {
         assertThat(resp.entity).isEqualTo(expected)
         assertThat(captured.captured.asOf).isEqualTo(LocalDate.now(fixedClock))
         assertThat(captured.captured.templateId).isEqualTo("C_01.00")
+        assertThat(captured.captured.evidence).isEqualTo(TrialBalanceEvidence.FROZEN)
     }
 
     @Test

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/rest/FinrepResourceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/rest/FinrepResourceTest.kt
@@ -6,6 +6,7 @@ package com.openbank.finrep.infrastructure.rest
 
 import com.openbank.finrep.application.port.inbound.FinrepUseCase
 import com.openbank.finrep.application.port.inbound.GetFinrepTemplateQuery
+import com.openbank.finrep.application.port.inbound.TrialBalanceEvidence
 import com.openbank.finrep.domain.model.BalanceVerdict
 import com.openbank.finrep.domain.model.FinrepCell
 import com.openbank.finrep.domain.model.FinrepTemplate
@@ -58,6 +59,25 @@ class FinrepResourceTest {
         assertThat(resp.entity).isEqualTo(expected)
         assertThat(captured.captured.asOf).isEqualTo(LocalDate.now(fixedClock))
         assertThat(captured.captured.templateId).isEqualTo("F01.01")
+        assertThat(captured.captured.evidence).isEqualTo(TrialBalanceEvidence.FROZEN)
+    }
+
+    @Test
+    fun `getTemplate exposes live preview only when explicitly requested`(): Unit = runBlocking {
+        val expected = FinrepTemplate(
+            templateId = "F01.01",
+            period = LocalDate.of(2026, 7, 31),
+            cells = emptyList(),
+            dataGaps = emptyList(),
+            isBalanced = true,
+            balanceVerdict = BalanceVerdict.AGREED_BALANCED,
+        )
+        val captured = slot<GetFinrepTemplateQuery>()
+        coEvery { finrepUseCase.getTemplate(capture(captured)) } returns expected
+
+        resource.getTemplate("F01.01", "2026-07-31", "LIVE_PREVIEW")
+
+        assertThat(captured.captured.evidence).isEqualTo(TrialBalanceEvidence.LIVE_PREVIEW)
     }
 
     @Test

--- a/pacts/openbank-finrep-service-openbank-ledger-service.json
+++ b/pacts/openbank-finrep-service-openbank-ledger-service.json
@@ -125,6 +125,92 @@
         },
         "status": 200
       }
+    },
+    {
+      "description": "GET the mutable monthly GL trial balance for an internal working preview",
+      "providerStates": [
+        {
+          "name": "ledger has frozen monthly trial balance for the reporting date"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/ledger/periods/MONTH/2026-06-30/trial-balance"
+      },
+      "response": {
+        "body": {
+          "balanced": true,
+          "lines": [
+            {
+              "code": "1100-CASH-CLEARING-CZK",
+              "currency": "CZK",
+              "net": 150000.0,
+              "type": "ASSET"
+            }
+          ],
+          "period": "MONTH:2026-06"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.balanced": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.lines": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 0
+                }
+              ]
+            },
+            "$.lines[*].code": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.lines[*].currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.lines[*].net": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.lines[*].type": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
     }
   ],
   "metadata": {


### PR DESCRIPTION
## Summary

Administrators can now inspect actual FINREP and COREP values before the first immutable ledger period exists. The fallback is an explicitly requested and visibly labelled live working preview; final regulatory exports remain fail-closed until FROZEN / LINES_V1 evidence exists.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #7225

## Changes

- add an explicit `LIVE_PREVIEW` evidence mode to FINREP/COREP while preserving `FROZEN` as the API default
- consume the ledger's current-period trial balance through a provider-replayed Pact contract
- fall back to the last completed month in Admin UI when there is no frozen period
- label mutable values as provisional and keep CSV/JSON export blocked
- preserve ROLE_ADMIN read access and ROLE_OPERATOR-only period closing

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [x] Contract tests updated (if public API changed).
- [x] Service detekt, ktlint, tests and quarkusBuild pass locally.
- [x] No new lint warnings.
- [x] OpenAPI spec updated (1.7.0).
- [x] Flyway migration N/A.
- [x] Avro schema N/A.
- [x] Operator-facing documentation is embedded in API and UI copy.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new suppressions or unsafe casts.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code unchanged.
- [x] PII path unchanged.
- [x] Cardholder data path unchanged.

## Compliance impact

- [x] CNB reporting

Mutable ledger values are reviewable but cannot be exported as a regulatory artefact. Immutable evidence remains mandatory for final export, and the four-eyes close operation remains operator-only.

## Rollout / Rollback

- Deployment strategy: rolling, backend then Admin UI
- Rollback plan: revert both commits and redeploy the previous FINREP/Admin UI images
- Data migration reversible: N/A

## Screenshots / demo

The Admin UI regression test verifies the live cells, provisional banner, and disabled export controls.

## Reviewer notes

The default API call still uses FROZEN evidence. LIVE_PREVIEW is explicit, read-only, and cannot relax export readiness.
