### PR TITLE
feat(test-intelligence): expose shadow impact evidence

### DIFF
--- a/.github/scripts/collect-test-run-evidence.py
+++ b/.github/scripts/collect-test-run-evidence.py
@@ -50,7 +50,7 @@ def trusted_run_url(url: str, run_id: str) -> bool:
 def validate_envelope(envelope: dict) -> None:
     """Fail closed before CI publishes an envelope that violates the v1 contract."""
     required = {"schemaVersion", "run", "component", "suites", "coverage", "testInfrastructure"}
-    if set(envelope) - (required | {"specializedEvidence", "testCases", "diagnostics"}) or not required.issubset(envelope):
+    if set(envelope) - (required | {"specializedEvidence", "testCases", "diagnostics", "testImpact"}) or not required.issubset(envelope):
         raise ValueError("run envelope has missing or unknown top-level fields")
     if envelope["schemaVersion"] != 1 or not str(envelope["component"]).startswith("openbank-"):
         raise ValueError("run envelope schemaVersion/component is invalid")
@@ -115,6 +115,14 @@ def validate_envelope(envelope: dict) -> None:
                 or any(segment in {".", ".."} for segment in path.split("/"))
         )):
             raise ValueError("test case definition path is invalid")
+    impact = envelope.get("testImpact")
+    if impact is not None and impact != {
+        "schemaVersion": 1,
+        "mode": "shadow",
+        "mappingState": "unknown",
+        "selectionState": "unavailable",
+    }:
+        raise ValueError("test impact evidence must remain the explicit v1 unknown/shadow state")
     for item in envelope.get("diagnostics", []):
         if set(item) != {"kind", "suiteKind", "name", "url", "retentionDays", "access", "mayContainSensitiveData"}:
             raise ValueError("diagnostic artifact fields are invalid")
@@ -463,6 +471,7 @@ def main() -> None:
                 "testInfrastructure": {"declared": ["postgres"], "observed": observations(service)},
                 "specializedEvidence": [{"kind": "performance", "state": "passed", "source": "summary.json"}],
                 "testCases": [],
+                "testImpact": {"schemaVersion": 1, "mode": "shadow", "mappingState": "unknown", "selectionState": "unavailable"},
             }
             traversal = {**valid, "testCases": [{
                 "fingerprint": "0123456789abcdef01234567", "kind": "integration",
@@ -472,6 +481,13 @@ def main() -> None:
             try:
                 validate_envelope(traversal)
                 raise AssertionError("a traversing test definition path was accepted")
+            except ValueError:
+                pass
+            invented_impact = json.loads(json.dumps(valid))
+            invented_impact["testImpact"]["mappingState"] = "mapped"
+            try:
+                validate_envelope(invented_impact)
+                raise AssertionError("unverified test impact mapping was accepted")
             except ValueError:
                 pass
             (service / "playwright-report").mkdir()
@@ -555,6 +571,10 @@ def main() -> None:
             "observedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         },
         "component": component, "suites": suites(component, service), "testCases": test_cases(component, service), "coverage": coverage(service),
+        # v1 intentionally records absence rather than guessing a test-to-production mapping.
+        # A future producer may only advance this after emitting versioned, verified coverage or
+        # dependency edges and measuring recommendations against the preserved full suite (#7207).
+        "testImpact": {"schemaVersion": 1, "mode": "shadow", "mappingState": "unknown", "selectionState": "unavailable"},
         "testInfrastructure": {"declared": declared_infrastructure(service), "observed": observations(service)},
         "specializedEvidence": specialized,
         "diagnostics": browser_diagnostics(args.browser_report_dir, run_id, run_attempt, run_url),

--- a/docs/adr/0273-unified-test-intelligence-evidence-and-admin-ui.md
+++ b/docs/adr/0273-unified-test-intelligence-evidence-and-admin-ui.md
@@ -289,6 +289,12 @@ may become an advisory ordering or parallelism input only after full-suite prese
 it cannot be the sole required gate. Synthetic traffic must retain trusted identity and taint across
 HTTP, Kafka, traces and regulatory projections; an untrusted HTTP header is never sufficient.
 
+The v1 run envelope therefore records test impact only as an explicit `shadow` / `unknown` /
+`unavailable` observation. This is not a placeholder that consumers may reinterpret as an unaffected
+set: it is a guardrail propagated through the collector, operator UI and browser E2E test. Promotion
+requires versioned, verified test-to-production coverage or dependency edges, plus a measured
+comparison of shadow recommendations against the preserved full suite (#7207).
+
 Test-to-trace correlation uses the existing privacy-preserving `TraceContract`. A successful test
 emits a bounded marker only after at least one trace assertion has passed; the run collector turns
 that JUnit marker into `trace` evidence with the same commit and workflow provenance. Trace ids,

--- a/openbank-admin-ui/e2e/test-intelligence.spec.ts
+++ b/openbank-admin-ui/e2e/test-intelligence.spec.ts
@@ -15,6 +15,7 @@ test.beforeEach(async ({ context, baseURL, page }) => {
     history: [{ collectedAt: '2026-08-22T12:00:00.000Z', components: 1, componentsWithExecutionEvidence: 1, failingEvidence: 0, missingEvidence: 0, staleEvidence: 0 }],
     runHistory: [{ component: 'openbank-ledger-service', run: { id: '4242', attempt: 1, commit: '1234567890abcdef', branch: 'main', workflow: 'Services CI', url: 'https://example.test/run/4242', observedAt: '2026-08-22T11:00:00.000Z' }, states: { integration: 'passed' }, infrastructureStarted: 1, infrastructureStopped: 1 }],
     testCases: [{ fingerprint: '0123456789abcdef01234567', component: 'openbank-ledger-service', kind: 'integration', classname: 'com.openbank.LedgerApiIT', name: 'posts balanced journal', owner: '@JiRaska', state: 'flaky', lastState: 'passed', observations: 3, failureRate: 33.33, averageDurationMs: 400, wastedDurationMs: 420, sameCommitTransitions: 1, lastObservedAt: '2026-08-22T11:00:00.000Z' }],
+    testImpact: { schemaVersion: 1, mode: 'shadow', mappingState: 'unknown', selectionState: 'unavailable', declaredByAllRetainedRuns: true, detail: 'Every retained run explicitly reports that no verified test-to-production mapping was collected. Full suites remain authoritative.' },
     totals: { components: 1, componentsWithExecutionEvidence: 1, moneyPathComponents: 1, failingEvidence: 0, missingEvidence: 0, staleEvidence: 0 }, warnings: [],
   }) }))
   await page.route('**/api/test-intelligence/agents', route => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ findings: [], available: true }) }))
@@ -53,6 +54,8 @@ test('renders the animated evidence system and consolidates test dimensions', as
   await page.getByRole('button', { name: /Testy a flaky|Tests & flaky/ }).click()
   await expect(page.getByText('posts balanced journal')).toBeVisible()
   await expect(page.getByText('1 same-commit pass/fail transition(s)')).toBeVisible()
+  await expect(page.getByLabel('Test impact mapping state')).toContainText('Test impact selection: shadow only')
+  await expect(page.getByText('AI must not infer it or select a required gate.')).toBeVisible()
   await page.getByRole('button', { name: /Testovací runtime|Test runtime/ }).click()
   await expect(page.getByText('1 started · 1 stopped')).toBeVisible()
   await page.getByRole('button', { name: /Historie|History/ }).click()

--- a/openbank-admin-ui/scripts/collect-test-intelligence.mjs
+++ b/openbank-admin-ui/scripts/collect-test-intelligence.mjs
@@ -180,6 +180,7 @@ function runEnvelope(component) {
       observedAt: run.run?.observedAt ?? observedAt(file), lines: run.coverage.lines,
       branches: run.coverage.branches, source: 'test-intelligence-run:v1',
     } : null,
+    testImpact: run.testImpact ?? null,
     testInfrastructure: run.testInfrastructure ?? { declared: [], observed: [] },
   }
 }
@@ -248,6 +249,25 @@ function testCaseHistory(currentEnvelopes) {
     const priority = { flaky: 0, failing: 1, skipped: 2, stable: 3 }
     return priority[a.state] - priority[b.state] || b.wastedDurationMs - a.wastedDurationMs || a.name.localeCompare(b.name)
   }).slice(0, 2000)
+}
+
+function testImpact(currentEnvelopes) {
+  // Do not infer "unaffected" from a definition path or a passing suite. The current contract
+  // intentionally exposes exactly what is known: source provenance exists for some JVM tests,
+  // while a verified test-to-production mapping has not been collected yet (#7207).
+  const retained = currentEnvelopes.map(item => item?.testImpact)
+    .filter(item => item?.schemaVersion === 1)
+  const fullyDeclared = currentEnvelopes.length > 0 && retained.length === currentEnvelopes.length
+  return {
+    schemaVersion: 1,
+    mode: 'shadow',
+    mappingState: 'unknown',
+    selectionState: 'unavailable',
+    declaredByAllRetainedRuns: fullyDeclared,
+    detail: fullyDeclared
+      ? 'Every retained run explicitly reports that no verified test-to-production mapping was collected. Full suites remain authoritative.'
+      : 'One or more retained runs predate the impact contract. No test-to-production mapping is assumed; full suites remain authoritative.',
+  }
 }
 
 function ratio(covered, missed) {
@@ -631,6 +651,7 @@ async function main() {
   const syntheticCoverage = journeyCoverage(synthetic)
   const clientExperience = await clientExperiences()
   const testCases = testCaseHistory(currentEnvelopes)
+  const impact = testImpact(currentEnvelopes)
   const failingEvidence = components.flatMap(item => item.evidence).filter(item => item.state === 'failed').length
   const staleEvidence = components.flatMap(item => item.evidence).filter(item => item.state === 'stale').length
   const unknownEvidence = components.flatMap(item => item.evidence).filter(item => item.state === 'unknown').length
@@ -679,7 +700,7 @@ async function main() {
   const report = {
     schemaVersion: 1, collectedAt: collectedAt.toISOString(), components,
     contracts: contractEvidence, mutations: mutationEvidence, performance: performanceEvidence,
-    syntheticJourneys: synthetic, journeyCoverage: syntheticCoverage, history, runHistory, testCases,
+    syntheticJourneys: synthetic, journeyCoverage: syntheticCoverage, history, runHistory, testCases, testImpact: impact,
     clientExperiences: clientExperience,
     totals: {
       components: components.length,

--- a/openbank-admin-ui/src/app/api/test-intelligence/route.ts
+++ b/openbank-admin-ui/src/app/api/test-intelligence/route.ts
@@ -254,6 +254,7 @@ export async function GET(): Promise<NextResponse> {
     }
     const compatible = {
       ...parsed, history: parsed.history ?? [], runHistory: parsed.runHistory ?? [], testCases: parsed.testCases ?? [], clientExperiences: parsed.clientExperiences ?? [],
+      testImpact: parsed.testImpact ?? { schemaVersion: 1, mode: 'shadow', mappingState: 'unknown', selectionState: 'unavailable', declaredByAllRetainedRuns: false, detail: 'This retained report predates the impact contract. No test-to-production mapping is assumed; full suites remain authoritative.' },
       components: parsed.components.map(component => ({
         ...component,
         testInfrastructure: component.testInfrastructure ?? { declared: [], observed: [] },

--- a/openbank-admin-ui/src/app/system/tests/page.tsx
+++ b/openbank-admin-ui/src/app/system/tests/page.tsx
@@ -187,6 +187,7 @@ function TestCases({ report }: { report: TestIntelligenceReport }) {
   const flaky = report.testCases.filter(item => item.state === 'flaky')
   const failing = report.testCases.filter(item => item.state === 'failing')
   const wasted = report.testCases.reduce((sum, item) => sum + item.wastedDurationMs, 0)
+  const impact = report.testImpact
   const visibleTests = useMemo(() => filterTestCases(report.testCases, filter, query), [report.testCases, filter, query])
   const filters: Array<{ id: TestTriageFilter; label: string }> = [
     { id: 'all', label: t('Vše', 'All') },
@@ -205,6 +206,9 @@ function TestCases({ report }: { report: TestIntelligenceReport }) {
     <div style={{ padding: 12, border: '1px solid color-mix(in srgb, #16a34a 35%, var(--border))', borderRadius: 9, color: 'var(--text-secondary)', fontSize: 12 }}>
       {t('Test je označen jako flaky až po úspěšném i neúspěšném pozorování stejného commitu. Vlastnictví vychází z CODEOWNERS. Triage nikdy nemění deterministický verdikt CI ani nepřeskakuje peněžní kontroly.', 'A test is marked flaky only after pass and fail observations on the same commit. Ownership comes from CODEOWNERS. Triage never changes the deterministic CI verdict or skips money-path controls.')}
     </div>
+    {impact && <div aria-label={t('Stav mapování test impactu', 'Test impact mapping state')} style={{ padding: 12, border: '1px solid color-mix(in srgb, #64748b 42%, var(--border))', borderRadius: 9, color: 'var(--text-secondary)', fontSize: 12, background: 'var(--surface-2)' }}>
+      <strong>{t('Test impact selection: shadow only', 'Test impact selection: shadow only')}</strong><span style={{ marginLeft: 8 }}><StateBadge state="unknown" /></span><div style={{ marginTop: 5 }}>{impact.detail}</div><div style={{ marginTop: 5, color: 'var(--text-tertiary)' }}>{t('Cesta k testu není mapa závislostí do produkce. AI ji nesmí domýšlet ani vybírat povinné gate.', 'A test source path is not a production dependency map. AI must not infer it or select a required gate.')}</div>
+    </div>}
     <div style={{ display: 'flex', gap: 10, justifyContent: 'space-between', flexWrap: 'wrap', alignItems: 'center' }}>
       <div role="group" aria-label={t('Filtr testovací triage', 'Test triage filter')} style={{ display: 'flex', gap: 5, flexWrap: 'wrap' }}>
         {filters.map(item => <button key={item.id} type="button" aria-pressed={filter === item.id} onClick={() => setFilter(item.id)} style={{ cursor: 'pointer', padding: '5px 9px', borderRadius: 999, border: `1px solid ${filter === item.id ? 'var(--accent)' : 'var(--border)'}`, color: filter === item.id ? 'var(--accent)' : 'var(--text-secondary)', background: filter === item.id ? 'color-mix(in srgb, var(--accent) 9%, var(--surface-1))' : 'var(--surface-1)', fontSize: 11, fontWeight: filter === item.id ? 700 : 500 }}>{item.label}</button>)}

--- a/openbank-admin-ui/src/lib/types/test-intelligence.ts
+++ b/openbank-admin-ui/src/lib/types/test-intelligence.ts
@@ -241,6 +241,7 @@ export interface TestIntelligenceReport {
   history: TestIntelligenceHistoryPoint[]
   runHistory: TestRunHistoryPoint[]
   testCases: TestCaseHistory[]
+  testImpact?: TestImpactEvidence
   totals: {
     components: number
     componentsWithExecutionEvidence: number
@@ -252,6 +253,19 @@ export interface TestIntelligenceReport {
     unresolvedEvidence?: number
   }
   warnings: string[]
+}
+
+/**
+ * Impact selection is deliberately a separate, bounded evidence surface. `unknown` means no
+ * verified test-to-production map was collected; it never means a test is unaffected.
+ */
+export interface TestImpactEvidence {
+  schemaVersion: 1
+  mode: 'shadow'
+  mappingState: 'unknown'
+  selectionState: 'unavailable'
+  declaredByAllRetainedRuns: boolean
+  detail: string
 }
 
 export interface TestCaseHistory {

--- a/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
@@ -207,6 +207,11 @@ scenarios:
       failureRate: 50, wastedDurationMs: 500, sameCommitTransitions: 1, owner: 'unowned',
       testDefinitionPath: 'src/test/kotlin/com/openbank/PaymentApiIT.kt',
     })
+    expect(report.testImpact).toEqual({
+      schemaVersion: 1, mode: 'shadow', mappingState: 'unknown', selectionState: 'unavailable',
+      declaredByAllRetainedRuns: false,
+      detail: expect.stringContaining('No test-to-production mapping is assumed'),
+    })
   })
 
   it('projects the unreleased simulation tooling envelope instead of reporting missing evidence', () => {

--- a/openbank-admin-ui/src/test/test-intelligence-route.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-route.test.ts
@@ -32,6 +32,9 @@ describe('GET /api/test-intelligence', () => {
     expect(body.schemaVersion).toBe(1)
     expect(body.components[0].coverage.state).toBe('not-run')
     expect(body.totals.missingEvidence).toBe(1)
+    expect(body.testImpact).toMatchObject({
+      mode: 'shadow', mappingState: 'unknown', selectionState: 'unavailable', declaredByAllRetainedRuns: false,
+    })
   })
 
   it('returns explicit unavailable evidence when the bundle is absent', async () => {

--- a/openbank-libs/governance/test-intelligence-run.schema.json
+++ b/openbank-libs/governance/test-intelligence-run.schema.json
@@ -26,6 +26,7 @@
     "component": { "type": "string", "pattern": "^openbank-" },
     "suites": { "type": "array", "items": { "$ref": "#/$defs/suite" } },
     "testCases": { "type": "array", "items": { "$ref": "#/$defs/testCase" } },
+    "testImpact": { "$ref": "#/$defs/testImpact" },
     "coverage": { "oneOf": [{ "$ref": "#/$defs/coverageObservation" }, { "type": "null" }] },
     "testInfrastructure": {
       "type": "object",
@@ -87,6 +88,17 @@
         "state": { "enum": ["passed", "failed", "skipped"] },
         "durationMs": { "type": "integer", "minimum": 0 },
         "testDefinitionPath": { "type": "string", "pattern": "^(?!.*\\/(?:\\.|\\.\\.)\\/)src/test/(?:kotlin|java)/[A-Za-z0-9_./-]+\\.(?:kt|java)$" }
+      },
+      "additionalProperties": false
+    },
+    "testImpact": {
+      "type": "object",
+      "required": ["schemaVersion", "mode", "mappingState", "selectionState"],
+      "properties": {
+        "schemaVersion": { "const": 1 },
+        "mode": { "const": "shadow" },
+        "mappingState": { "const": "unknown" },
+        "selectionState": { "const": "unavailable" }
       },
       "additionalProperties": false
     },


### PR DESCRIPTION
## What

Expose the current, intentionally bounded state of Test Impact Analysis end-to-end: every CI run declares that impact mapping is unknown, selection is unavailable, and the mode is shadow-only. The Admin UI makes that limitation explicit.

No test selection or skipping is introduced. A test definition path is not treated as a production dependency map; AI cannot infer either or select a required gate.

Refs #7207

## Evidence

- `python3 .github/scripts/collect-test-run-evidence.py --self-test`
- `openbank-admin-ui`: focused Test Intelligence Vitest suite (20 tests)
- JSON schema parse and `git diff --check`

## Follow-up

A future version can advance this only with versioned, verified coverage/dependency edges and a measured shadow-vs-full-suite evaluation.