### PR TITLE
fix(deploy): fail no-op provider verification

### DIFF
--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -64,6 +64,14 @@ on:
         required: false
         default: ""
         type: string
+      require_provider_pact_test:
+        # A targeted historical provider re-verification has a different contract from an
+        # ordinary fleet build: success must mean a provider result was actually published.
+        # Leave ordinary consumer-only/service-less modules unaffected.
+        description: "Fail when this targeted verification has no providerPactTest."
+        required: false
+        default: false
+        type: boolean
     secrets:
       PACT_BROKER_PASSWORD:
         # Must be declared here for the caller to pass it explicitly: an undeclared
@@ -751,6 +759,9 @@ jobs:
             echo "${SERVICE} exposes providerPactTest — provider verification will run."
           elif [ -n "$provider_test" ]; then
             echo "::error::${SERVICE} has ${provider_test} but does not expose providerPactTest. Apply the service convention or register an equivalent provider task."
+            exit 1
+          elif [ "${{ inputs.require_provider_pact_test }}" = "true" ]; then
+            echo "::error::${SERVICE} at ${PACT_PROVIDER_VERSION} has no providerPactTest. No Pact provider verification was published; do not treat this targeted run as deployment evidence."
             exit 1
           else
             echo "available=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/verify-provider.yml
+++ b/.github/workflows/verify-provider.yml
@@ -74,5 +74,8 @@ jobs:
       service: ${{ inputs.service }}
       ref: ${{ inputs.ref }}
       provider_version: ${{ inputs.provider_version }}
+      # A maintainer explicitly requested a provider proof. A no-op consumer-only outcome
+      # would otherwise make this workflow green without publishing the promised evidence.
+      require_provider_pact_test: true
     secrets:
       PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}


### PR DESCRIPTION
## Why

A targeted `Verify one provider` run for a historical version without `providerPactTest` currently succeeds after doing no verification. That can be misread as proof for can-i-deploy.

## Change

Adds a reusable-workflow input used only by `verify-provider.yml`. A maintainer-requested provider proof now fails loudly when the exact checked-out version has no provider test. Ordinary service CI retains its consumer-only behavior.

## Evidence

- Reproduced from workflow run 33017453707: `openbank-document-service@ee974ea3` had no provider test and published no provider result despite a green run.
- Both workflow YAML files parse successfully.
- `git diff --check` passes.

Refs #3223