### PR TITLE
fix(test-intelligence): verify mobile RUM source contract

### DIFF
--- a/openbank-admin-ui/scripts/collect-test-intelligence.mjs
+++ b/openbank-admin-ui/scripts/collect-test-intelligence.mjs
@@ -26,6 +26,9 @@ const exists = file => fs.existsSync(file)
 const readJson = file => {
   try { return JSON.parse(fs.readFileSync(file, 'utf8')) } catch { return null }
 }
+const readText = file => {
+  try { return fs.readFileSync(file, 'utf8') } catch { return '' }
+}
 const trustedRunUrl = (value, runId) => {
   if (!value) return false
   try {
@@ -545,8 +548,21 @@ async function clientExperiences() {
   }
   const appSource = path.join(repo, '.app-src')
   const appSourceAvailable = exists(appSource)
-  const androidRum = exists(path.join(appSource, 'shared/src/androidMain/kotlin/tech/openbank/app/telemetry/RumMonitor.android.kt'))
-  const iosRum = exists(path.join(appSource, 'shared/src/iosMain/kotlin/tech/openbank/app/telemetry/RumMonitor.ios.kt'))
+  // A file named RumMonitor is not evidence that it exports a useful, privacy-bounded
+  // signal. Verify the closed schema at collection time: source capability stays separate
+  // from runtime arrival, and a missing attribute cannot render as a passing exporter.
+  const androidSource = readText(path.join(appSource, 'shared/src/androidMain/kotlin/tech/openbank/app/telemetry/RumMonitor.android.kt'))
+  const iosSource = readText(path.join(appSource, 'shared/src/iosMain/kotlin/tech/openbank/app/telemetry/RumMonitor.ios.kt'))
+  const tracePropagationSource = readText(path.join(appSource, 'shared/src/commonMain/kotlin/tech/openbank/app/telemetry/TraceparentPlugin.kt'))
+  const iosPayloadTest = readText(path.join(appSource, 'shared/src/iosTest/kotlin/tech/openbank/app/telemetry/RumMonitorIosTest.kt'))
+  const tracePropagationTest = readText(path.join(appSource, 'shared/src/commonTest/kotlin/tech/openbank/app/telemetry/TraceparentPluginTest.kt'))
+  const requiredResourceAttributes = ['app.version', 'os.type', 'os.version', 'device.model']
+  const sourceHas = (source, values) => values.every(value => source.includes(value))
+  const correlationImplemented = sourceHas(tracePropagationSource, ['traceparent', 'x-correlation-id'])
+    && sourceHas(tracePropagationTest, ['traceparent', 'x-correlation-id'])
+  const androidRum = sourceHas(androidSource, [...requiredResourceAttributes, 'screen.name']) && correlationImplemented
+  const iosRum = sourceHas(iosSource, [...requiredResourceAttributes, 'screen.name'])
+    && sourceHas(iosPayloadTest, [...requiredResourceAttributes, 'screen.name']) && correlationImplemented
   // Tempo's bounded arrival projection deliberately does not query `os.*`: the current
   // gateway retains such attributes only when a newly built consented client happens to
   // be sampled, and older clients are allowed to omit them. A generic openbank-app trace
@@ -556,9 +572,9 @@ async function clientExperiences() {
     capability: implemented ? 'passed' : appSourceAvailable ? 'not-run' : 'unknown',
     runtime: 'unknown',
     detail: implemented
-      ? `${platform === 'android' ? 'Android' : 'iOS'} exporter exists in the staged client source; generic Tempo arrival cannot attribute a sampled trace to this OS.`
+      ? `${platform === 'android' ? 'Android' : 'iOS'} exporter source contains the allow-listed attributes, screen.name and tested trace/correlation propagation; generic Tempo arrival cannot attribute a sampled trace to this OS.`
       : appSourceAvailable
-        ? `${platform === 'android' ? 'Android' : 'iOS'} exporter was not found in the staged client source.`
+        ? `${platform === 'android' ? 'Android' : 'iOS'} source does not prove the complete allow-listed exporter contract.`
         : 'Client source was not staged for this deployment; platform capability is unknown.',
   })
   const webEvidence = runEnvelope('openbank-admin-ui')?.evidence ?? await junitEvidence('openbank-admin-ui')
@@ -588,7 +604,7 @@ async function clientExperiences() {
         source: null, sampledSpansLast7d: null, errorSpansLast7d: null,
         platforms: [platformRum('android', androidRum), platformRum('ios', iosRum)],
         detail: androidRum || iosRum
-          ? `Mobile RUM is implemented in source for ${androidRum ? 'Android' : ''}${androidRum && iosRum ? ' and ' : ''}${iosRum ? 'iOS' : ''}; runtime arrival is intentionally not inferred from a CI artifact.`
+          ? `Mobile RUM source contract is verified for ${androidRum ? 'Android' : ''}${androidRum && iosRum ? ' and ' : ''}${iosRum ? 'iOS' : ''}; runtime arrival is intentionally not inferred from a CI artifact.`
           : 'openbank-app source was not staged for this deployment, so RUM implementation status is unknown.',
       }, blocker: latestMobile ? null : 'Latest private-app CI evidence artifact was not available to this deployment.',
     },

--- a/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
@@ -277,8 +277,11 @@ scenarios:
     dirs.push(repo)
     write(repo, 'openbank-libs/governance/rules.yaml', 'money_path_services: []\n')
     write(repo, 'openbank-libs/governance/journeys.yaml', 'version: 1\njourneys: []\n')
-    write(repo, '.app-src/shared/src/androidMain/kotlin/tech/openbank/app/telemetry/RumMonitor.android.kt', 'actual object RumMonitor')
-    write(repo, '.app-src/shared/src/iosMain/kotlin/tech/openbank/app/telemetry/RumMonitor.ios.kt', 'actual object RumMonitor')
+    write(repo, '.app-src/shared/src/androidMain/kotlin/tech/openbank/app/telemetry/RumMonitor.android.kt', 'actual object RumMonitor { val keys = "app.version os.type os.version device.model screen.name" }')
+    write(repo, '.app-src/shared/src/iosMain/kotlin/tech/openbank/app/telemetry/RumMonitor.ios.kt', 'actual object RumMonitor { val keys = "app.version os.type os.version device.model screen.name" }')
+    write(repo, '.app-src/shared/src/commonMain/kotlin/tech/openbank/app/telemetry/TraceparentPlugin.kt', 'traceparent x-correlation-id')
+    write(repo, '.app-src/shared/src/commonTest/kotlin/tech/openbank/app/telemetry/TraceparentPluginTest.kt', 'traceparent x-correlation-id')
+    write(repo, '.app-src/shared/src/iosTest/kotlin/tech/openbank/app/telemetry/RumMonitorIosTest.kt', 'app.version os.type os.version device.model screen.name')
     write(repo, 'openbank-admin-ui/client-test-evidence/openbank-app-unit.json', JSON.stringify({
       schemaVersion: 1, component: 'openbank-app',
       run: { id: '9', attempt: 1, commit: 'abc', branch: 'main', workflow: 'app build', url: 'https://github.com/JiRaska/open-bank-app/actions/runs/9', observedAt: '2026-08-23T10:00:00Z' },
@@ -310,6 +313,26 @@ scenarios:
       expect.objectContaining({ platform: 'ios', capability: 'passed', runtime: 'unknown' }),
     ])
     expect(report.runHistory.filter(item => item.component === 'openbank-app').map(item => item.run.id)).toEqual(['10', '9', '8'])
+  })
+
+  it('does not promote a mobile RUM source file missing its closed attribute contract', () => {
+    const repo = mkdtempSync(path.join(tmpdir(), 'test-intelligence-rum-contract-'))
+    dirs.push(repo)
+    write(repo, 'openbank-libs/governance/rules.yaml', 'money_path_services: []\n')
+    write(repo, 'openbank-libs/governance/journeys.yaml', 'version: 1\njourneys: []\n')
+    write(repo, '.app-src/shared/src/androidMain/kotlin/tech/openbank/app/telemetry/RumMonitor.android.kt', 'app.version os.type screen.name')
+    write(repo, '.app-src/shared/src/iosMain/kotlin/tech/openbank/app/telemetry/RumMonitor.ios.kt', 'app.version os.type os.version device.model screen.name')
+    write(repo, '.app-src/shared/src/commonMain/kotlin/tech/openbank/app/telemetry/TraceparentPlugin.kt', 'traceparent x-correlation-id')
+    write(repo, '.app-src/shared/src/commonTest/kotlin/tech/openbank/app/telemetry/TraceparentPluginTest.kt', 'traceparent x-correlation-id')
+    write(repo, '.app-src/shared/src/iosTest/kotlin/tech/openbank/app/telemetry/RumMonitorIosTest.kt', 'app.version os.type os.version device.model screen.name')
+    const out = path.join(repo, 'report.json')
+    execFileSync('node', [SCRIPT, '--repo', repo, '--out', out, '--stale-after-days', '99999'])
+    const report = JSON.parse(readFileSync(out, 'utf8')) as TestIntelligenceReport
+    const platforms = report.clientExperiences.find(item => item.id === 'openbank-app')!.rum.platforms!
+    expect(platforms).toEqual(expect.arrayContaining([
+      expect.objectContaining({ platform: 'android', capability: 'not-run', runtime: 'unknown' }),
+      expect.objectContaining({ platform: 'ios', capability: 'passed', runtime: 'unknown' }),
+    ]))
   })
 
   it('marks old mobile CI evidence stale without hiding a recorded failure', () => {


### PR DESCRIPTION
## What

Verify the staged mobile RUM source contract instead of treating the mere presence of a `RumMonitor` file as a passing exporter capability. Android/iOS capability now requires the allow-listed attributes, `screen.name`, and tested W3C/correlation propagation; runtime arrival remains explicitly independent and unknown without consented traces.

## Why

The Test Intelligence UI must distinguish source evidence from runtime evidence. This consolidates the delivered private-app implementation from openbank-app #549 without converting it into a false sandbox RUM verdict.

## Verification

- `npx vitest run src/test/test-intelligence-collector.test.ts src/test/test-intelligence-route.test.ts src/test/test-intelligence-flow-attention.test.tsx --reporter=dot`
  - 3 files, 21 tests passed
- Negative test: an Android source missing required attributes remains `not-run`; iOS remains source-verified only when its payload test carries the closed schema.

Refs #6069