### PR TITLE
feat(incentive): expose published offer catalogue

### DIFF
--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/application/IncentiveApplication.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/application/IncentiveApplication.kt
@@ -20,6 +20,7 @@ import java.util.UUID
 
 @ApplicationScoped
 @Startup
+@Suppress("TooManyFunctions") // One cohesive lifecycle facade; each operation remains an explicit use case.
 class IncentiveApplication(
     private val store: IncentiveStore,
     private val metrics: IncentiveMetrics,
@@ -48,6 +49,8 @@ class IncentiveApplication(
         store.publishOffer(id, actor, now).also {
             metrics.offerPublished()
         }
+    suspend fun findOffer(id: UUID) = store.findOffer(id)
+    suspend fun listPublishedOffers() = store.listPublishedOffers()
 
     suspend fun addCodes(id: UUID, codes: List<String>, actor: String, now: Instant = Instant.now()): Int {
         require(codes.isNotEmpty() && codes.none { it.isBlank() }) { "codes are required" }

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/application/IncentiveStore.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/application/IncentiveStore.kt
@@ -10,6 +10,7 @@ import java.util.UUID
 interface IncentiveStore {
     suspend fun createOffer(offer: IncentiveOffer): IncentiveOffer
     suspend fun findOffer(id: UUID): IncentiveOffer?
+    suspend fun listPublishedOffers(): List<IncentiveOffer>
     suspend fun submitOffer(id: UUID, actor: String): IncentiveOffer
     suspend fun publishOffer(id: UUID, actor: String, at: Instant): IncentiveOffer
     suspend fun addCodes(offerId: UUID, digests: Set<CodeDigest>, actor: String, at: Instant): Int

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/persistence/IncentivePersistence.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/persistence/IncentivePersistence.kt
@@ -260,6 +260,10 @@ class PanacheIncentiveStore(
     override suspend fun findOffer(id: UUID): IncentiveOffer? =
         Panache.withSession { offers.find("id", id).firstResult<OfferEntity>() }.awaitSuspending()?.toDomain()
 
+    override suspend fun listPublishedOffers(): List<IncentiveOffer> = Panache.withSession {
+        offers.list("status = ?1 order by name asc, version desc", OfferStatus.PUBLISHED.name)
+    }.awaitSuspending().map { it.toDomain() }
+
     override suspend fun submitOffer(id: UUID, actor: String): IncentiveOffer = Panache.withTransaction {
         lockedOffer(id).flatMap { entity ->
             val current = entity?.toDomain() ?: throw IncentiveNotFound("offer not found")

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/rest/IncentiveResource.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/rest/IncentiveResource.kt
@@ -9,6 +9,7 @@ import com.openbank.incentive.domain.ReservationStatus
 import com.openbank.incentive.domain.StackingPolicy
 import jakarta.annotation.security.RolesAllowed
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
 import jakarta.ws.rs.HeaderParam
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
@@ -45,8 +46,19 @@ data class ReservationResponse(
 @Path("/api/v1/incentives")
 @ApplicationScoped
 @RolesAllowed("ROLE_OPERATOR")
+@Suppress("TooManyFunctions") // Each method is a separately governed HTTP lifecycle operation.
 class IncentiveResource(private val application: IncentiveApplication, private val identity: JsonWebToken) {
     private fun actor() = identity.name
+
+    @GET
+    @Path("/offers")
+    suspend fun listPublished(): Response = Response.ok(mapOf("items" to application.listPublishedOffers())).build()
+
+    @GET
+    @Path("/offers/{id}")
+    suspend fun getOffer(@PathParam("id") id: UUID): Response = application.findOffer(id)
+        ?.let { Response.ok(it).build() }
+        ?: Response.status(Response.Status.NOT_FOUND).build()
 
     @POST
     @Path("/offers")

--- a/openbank-incentive-service/src/main/resources/openapi.yaml
+++ b/openbank-incentive-service/src/main/resources/openapi.yaml
@@ -1,10 +1,22 @@
 openapi: 3.0.3
 info:
   title: OpenBank Incentive Service
-  version: 1.0.0
+  version: 1.1.0
   description: Governed fixed-benefit offers and opaque promo-code reservations.
 paths:
   /api/v1/incentives/offers:
+    get:
+      summary: List immutable published incentive offers for governed catalogue selection
+      responses:
+        "200":
+          description: Published offers
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items: {type: array, items: {$ref: '#/components/schemas/Offer'}}
     post:
       summary: Create a versioned draft incentive offer
       requestBody:
@@ -15,6 +27,13 @@ paths:
       responses:
         "201": {description: Draft created, content: {application/json: {schema: {$ref: '#/components/schemas/Offer'}}}}
         "400": {description: Invalid offer}
+  /api/v1/incentives/offers/{id}:
+    get:
+      summary: Resolve an immutable incentive offer reference
+      parameters: [{$ref: '#/components/parameters/OfferId'}]
+      responses:
+        "200": {description: Offer found, content: {application/json: {schema: {$ref: '#/components/schemas/Offer'}}}}
+        "404": {description: Offer not found}
   /api/v1/incentives/offers/{id}/submit:
     post:
       summary: Submit an offer for independent approval

--- a/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/integration/IncentiveRestContractIT.kt
+++ b/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/integration/IncentiveRestContractIT.kt
@@ -27,6 +27,7 @@ import org.eclipse.microprofile.reactive.messaging.Message
 import org.eclipse.microprofile.reactive.messaging.spi.Connector
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasKey
+import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.not
 import org.junit.jupiter.api.Test
 import java.nio.charset.StandardCharsets
@@ -87,6 +88,11 @@ class IncentiveRestContractIT {
             body("status", equalTo("DRAFT"))
         } Extract { path<String>("ref.id") }
 
+        When { get("/api/v1/incentives/offers") } Then {
+            statusCode(200)
+            body("items", hasSize<Any>(0))
+        }
+
         Given { contentType("application/json") }
             .When { post("/api/v1/incentives/offers/$offerId/publish") }
             .Then { statusCode(409) }
@@ -122,6 +128,20 @@ class IncentiveRestContractIT {
             }
         assertThat(meterRegistry.counter("openbank.incentive.offers.published").count())
             .isEqualTo(publicationsBefore + 1.0)
+
+        When { get("/api/v1/incentives/offers/$offerId") } Then {
+            statusCode(200)
+            body("ref.id", equalTo(offerId))
+            body("ref.name", equalTo("summer-current-account"))
+            body("ref.version", equalTo(1))
+            body("status", equalTo("PUBLISHED"))
+        }
+        When { get("/api/v1/incentives/offers") } Then {
+            statusCode(200)
+            body("items", hasSize<Any>(1))
+            body("items[0].ref.id", equalTo(offerId))
+            body("items[0].status", equalTo("PUBLISHED"))
+        }
 
         val start = CountDownLatch(1)
         val pool = Executors.newFixedThreadPool(6)


### PR DESCRIPTION
## Summary
- expose authenticated read-only GET collection and exact-offer endpoints
- list only PUBLISHED immutable revisions
- prove draft exclusion and published lookup over real HTTP/Postgres

## Evidence
- IncentiveRestContractIT green
- ktlintCheck, detekt, quarkusBuild green
- OpenAPI 1.1.0 additive bump

Refs #7210

Stacked on #7250; merge only after the base and this PR pass independent review.