### PR TITLE
feat(campaign): pin immutable incentive offers

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -12,6 +12,7 @@ import com.openbank.campaign.domain.model.DeliveryStatus
 import com.openbank.campaign.domain.model.Enrolment
 import com.openbank.campaign.domain.model.ExperimentCohort
 import com.openbank.campaign.domain.model.InAppSurface
+import com.openbank.campaign.domain.model.IncentiveOfferRef
 import com.openbank.campaign.domain.model.Segment
 import com.openbank.campaign.domain.model.SendOutcome
 import com.openbank.campaign.domain.model.SendRecord
@@ -32,6 +33,11 @@ interface CampaignRepository {
      * guard in the service — a DRAFT campaign has not passed four-eyes and must not enrol anyone.
      */
     suspend fun findActiveByTrigger(trigger: String): List<Campaign>
+}
+
+/** Resolve only immutable published offers; reservation and redemption never cross this port. */
+interface IncentiveOfferRegistry {
+    suspend fun resolvePublished(ref: IncentiveOfferRef): IncentiveOfferRef?
 }
 
 interface EnrolmentRepository {

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
@@ -9,6 +9,7 @@ import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.CampaignScheduler
 import com.openbank.campaign.application.port.out.EnrolmentAttempt
 import com.openbank.campaign.application.port.out.EnrolmentRepository
+import com.openbank.campaign.application.port.out.IncentiveOfferRegistry
 import com.openbank.campaign.application.port.out.JourneySignaller
 import com.openbank.campaign.application.port.out.JourneyType
 import com.openbank.campaign.application.port.out.SegmentEvaluationPort
@@ -24,6 +25,7 @@ import com.openbank.campaign.domain.model.ConversionCatalog
 import com.openbank.campaign.domain.model.Enrolment
 import com.openbank.campaign.domain.model.EnrolmentState
 import com.openbank.campaign.domain.model.ExperimentCohort
+import com.openbank.campaign.domain.model.IncentiveOfferRef
 import com.openbank.campaign.domain.model.ScheduleCatalog
 import com.openbank.campaign.domain.model.SegmentRef
 import com.openbank.campaign.domain.model.StopCondition
@@ -76,6 +78,9 @@ class CampaignService @Inject constructor(
     private val explicitGraphActivationEnabled: Boolean,
 ) {
 
+    @Inject
+    lateinit var incentiveOffers: IncentiveOfferRegistry
+
     private val log = Logger.getLogger(CampaignService::class.java)
 
     suspend fun createDraft(
@@ -90,8 +95,10 @@ class CampaignService @Inject constructor(
         schedule: CampaignSchedule? = null,
         trigger: String? = null,
         decisions: List<CampaignDecision> = emptyList(),
+        incentiveOfferRef: IncentiveOfferRef? = null,
     ): Campaign {
         val resolvedSegment = validateDraftReferences(segmentRef, conversionRule, trigger)
+        val resolvedIncentive = validateIncentiveOffer(incentiveOfferRef)
         val campaign = Campaign(
             id = Ids.newId(),
             name = name,
@@ -107,6 +114,7 @@ class CampaignService @Inject constructor(
             schedule = schedule,
             trigger = trigger,
             decisions = decisions,
+            incentiveOfferRef = resolvedIncentive,
             state = CampaignState.DRAFT,
             createdBy = createdBy,
             approvedBy = null,
@@ -125,8 +133,9 @@ class CampaignService @Inject constructor(
             definition.conversionRule,
             definition.trigger,
         )
+        val resolvedIncentive = validateIncentiveOffer(definition.incentiveOfferRef)
         return campaigns.save(
-            existing.revise(definition.copy(segmentRef = resolvedSegment)),
+            existing.revise(definition.copy(segmentRef = resolvedSegment, incentiveOfferRef = resolvedIncentive)),
         )
     }
 
@@ -152,6 +161,7 @@ class CampaignService @Inject constructor(
             schedule = source.schedule,
             trigger = source.trigger,
             decisions = source.decisions,
+            incentiveOfferRef = source.incentiveOfferRef,
         )
     }
 
@@ -175,6 +185,15 @@ class CampaignService @Inject constructor(
             "unknown trigger '$trigger' — must be one of ${TriggerCatalog.ALL.keys.sorted()}"
         }
         return SegmentRef(segment.name, segment.version)
+    }
+
+    /** Pins only an exact published offer revision; Studio never owns redemption or value mutation. */
+    private suspend fun validateIncentiveOffer(ref: IncentiveOfferRef?): IncentiveOfferRef? {
+        if (ref == null) return null
+        return incentiveOffers.resolvePublished(ref)
+            ?: throw CampaignReferenceNotFoundException(
+                "published incentive offer ${ref.name}@${ref.version} (${ref.id}) not found",
+            )
     }
 
     suspend fun get(id: UUID): Campaign? = campaigns.findById(id)

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -30,7 +30,16 @@ data class CampaignDefinition(
      * journey exactly; a non-empty list opts the draft into the bounded graph model below.
      */
     val decisions: List<CampaignDecision> = emptyList(),
+    /** Immutable published incentive catalogue reference; redemption remains incentive-service-owned. */
+    val incentiveOfferRef: IncentiveOfferRef? = null,
 )
+
+data class IncentiveOfferRef(val id: UUID, val name: String, val version: Int) {
+    init {
+        require(name.isNotBlank()) { "incentive offer name must not be blank" }
+        require(version > 0) { "incentive offer version must be positive" }
+    }
+}
 
 /**
  * Campaign aggregate (ADR-0200). A definition — steps, delays, stop conditions — that is executed
@@ -76,6 +85,7 @@ data class Campaign(
     val updatedAt: Instant,
     /** Explicit graph nodes; persisted separately from legacy step JSON for reversible rollout. */
     val decisions: List<CampaignDecision> = emptyList(),
+    val incentiveOfferRef: IncentiveOfferRef? = null,
 ) {
     init {
         require(name.isNotBlank()) { "campaign name must not be blank" }
@@ -136,6 +146,7 @@ data class Campaign(
             schedule = definition.schedule,
             trigger = definition.trigger,
             decisions = definition.decisions,
+            incentiveOfferRef = definition.incentiveOfferRef,
             updatedAt = Instant.now(),
         )
     }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/incentive/IncentiveOfferClient.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/incentive/IncentiveOfferClient.kt
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.openbank.campaign.infrastructure.incentive
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.openbank.campaign.application.port.out.IncentiveOfferRegistry
+import com.openbank.campaign.domain.model.IncentiveOfferRef
+import com.openbank.libs.web.SyntheticTaintClientFilter
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.jboss.resteasy.reactive.RestResponse
+import java.util.UUID
+
+@RegisterRestClient(configKey = "incentive-service")
+@RegisterProvider(SyntheticTaintClientFilter::class)
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/incentives")
+@Produces(MediaType.APPLICATION_JSON)
+interface IncentiveServiceClient {
+    @GET
+    @Path("/offers/{id}")
+    fun offer(@PathParam("id") id: UUID): Uni<RestResponse<IncentiveOfferResponse>>
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class IncentiveOfferResponse(val ref: IncentiveOfferRef, val status: String)
+
+@ApplicationScoped
+class LiveIncentiveOfferRegistry(@RestClient private val client: IncentiveServiceClient) : IncentiveOfferRegistry {
+    override suspend fun resolvePublished(ref: IncentiveOfferRef): IncentiveOfferRef? {
+        val http = client.offer(ref.id).awaitSuspending()
+        if (http.status != RestResponse.StatusCode.OK) return null
+        val response = http.entity ?: return null
+        return response.ref.takeIf { response.status == "PUBLISHED" && it == ref }
+    }
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -40,6 +40,7 @@ import com.openbank.campaign.domain.model.Enrolment
 import com.openbank.campaign.domain.model.EnrolmentState
 import com.openbank.campaign.domain.model.ExperimentCohort
 import com.openbank.campaign.domain.model.InAppSurface
+import com.openbank.campaign.domain.model.IncentiveOfferRef
 import com.openbank.campaign.domain.model.Segment
 import com.openbank.campaign.domain.model.SegmentCatalog
 import com.openbank.campaign.domain.model.SegmentRef
@@ -121,6 +122,15 @@ class CampaignEntity : PanacheEntityBase() {
     /** Percentage assigned to the durable no-contact control cohort (V8). */
     @Column(nullable = false)
     var holdoutPercent: Int = 0
+
+    @Column
+    var incentiveOfferId: UUID? = null
+
+    @Column(length = 160)
+    var incentiveOfferName: String? = null
+
+    @Column
+    var incentiveOfferVersion: Int? = null
 
     @Column(nullable = false)
     lateinit var state: String
@@ -311,6 +321,9 @@ class PanacheCampaignRepository(private val mapper: ObjectMapper) :
         scheduleEndAt = this@toEntity.schedule?.endAt
         triggerEvent = this@toEntity.trigger
         holdoutPercent = this@toEntity.holdoutPercent
+        incentiveOfferId = this@toEntity.incentiveOfferRef?.id
+        incentiveOfferName = this@toEntity.incentiveOfferRef?.name
+        incentiveOfferVersion = this@toEntity.incentiveOfferRef?.version
         state = this@toEntity.state.name
         createdBy = this@toEntity.createdBy
         approvedBy = this@toEntity.approvedBy
@@ -337,6 +350,9 @@ class PanacheCampaignRepository(private val mapper: ObjectMapper) :
         approvedBy = approvedBy,
         createdAt = createdAt,
         updatedAt = updatedAt,
+        incentiveOfferRef = incentiveOfferId?.let { offerId ->
+            IncentiveOfferRef(offerId, requireNotNull(incentiveOfferName), requireNotNull(incentiveOfferVersion))
+        },
     )
 }
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -13,6 +13,7 @@ import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
 import com.openbank.campaign.domain.model.InAppSurface
+import com.openbank.campaign.domain.model.IncentiveOfferRef
 import com.openbank.campaign.domain.model.MobileDestination
 import com.openbank.campaign.domain.model.SegmentRef
 import com.openbank.campaign.domain.model.StepCondition
@@ -49,7 +50,11 @@ data class CreateCampaignRequest(
     val trigger: String? = null,
     /** Bounded, explicit yes/no delivery branches. Absent preserves a linear campaign. */
     val decisions: List<DecisionRequest> = emptyList(),
+    /** Exact published incentive revision; redemption remains owned by incentive-service. */
+    val incentiveOfferRef: IncentiveOfferRefRequest? = null,
 )
+
+data class IncentiveOfferRefRequest(val id: UUID, val name: String, val version: Int)
 
 /** Optional on create (ADR-0200 D1, #3585): absent means the journey runs every step, as before. */
 data class StopConditionRequest(val maxSendsPerParty: Int)
@@ -178,6 +183,7 @@ private fun CreateCampaignRequest.toDefinition(): CampaignDefinition = CampaignD
     schedule = schedule?.let { CampaignSchedule(it.cadence, it.endAt) },
     trigger = trigger,
     decisions = toDecisions(),
+    incentiveOfferRef = incentiveOfferRef?.let { IncentiveOfferRef(it.id, it.name, it.version) },
 )
 
 /**
@@ -216,6 +222,7 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
             request.schedule?.let { CampaignSchedule(it.cadence, it.endAt) },
             request.trigger,
             request.toDecisions(),
+            request.incentiveOfferRef?.let { IncentiveOfferRef(it.id, it.name, it.version) },
         )
         Response.status(Response.Status.CREATED).entity(campaign).build()
     } catch (e: CampaignReferenceNotFoundException) {

--- a/openbank-campaign-service/src/main/resources/application.yaml
+++ b/openbank-campaign-service/src/main/resources/application.yaml
@@ -102,6 +102,9 @@ openbank:
 consent-service:
   url: http://localhost:8106
 
+incentive-service:
+  url: ${INCENTIVE_SERVICE_URL:http://localhost:8156}
+
 analytics:
   clickhouse-url: ${CLICKHOUSE_URL:http://localhost:8123}
   clickhouse-user: ${CLICKHOUSE_USER:}

--- a/openbank-campaign-service/src/main/resources/db/migration/V17__campaign_incentive_offer_reference.sql
+++ b/openbank-campaign-service/src/main/resources/db/migration/V17__campaign_incentive_offer_reference.sql
@@ -1,0 +1,13 @@
+-- Immutable published incentive revision selected by Campaign Studio. Redemption and value mutation
+-- remain owned by incentive-service; these columns are intentionally nullable for legacy campaigns.
+ALTER TABLE campaigns
+    ADD COLUMN incentive_offer_id UUID,
+    ADD COLUMN incentive_offer_name VARCHAR(160),
+    ADD COLUMN incentive_offer_version INTEGER,
+    ADD CONSTRAINT campaigns_incentive_offer_complete_ck CHECK (
+        (incentive_offer_id IS NULL AND incentive_offer_name IS NULL AND incentive_offer_version IS NULL)
+        OR
+        (incentive_offer_id IS NOT NULL AND incentive_offer_name IS NOT NULL AND incentive_offer_version > 0)
+    );
+
+-- Rollback: remove campaigns_incentive_offer_complete_ck, then the three incentive_offer_* columns.

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.39.0
+  version: 1.40.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -850,6 +850,8 @@ components:
             Percentage of the audience assigned deterministically to the durable no-contact
             control cohort. A non-zero value requires conversionRule; zero retains the campaign's
             historical all-treatment behaviour.
+        incentiveOfferRef:
+          $ref: '#/components/schemas/IncentiveOfferRef'
         state:
           type: string
           enum: [DRAFT, PENDING_APPROVAL, ACTIVE, PAUSED, CLOSED]
@@ -861,6 +863,17 @@ components:
       type: object
       properties:
         name: { type: string }
+        version: { type: integer, minimum: 1 }
+    IncentiveOfferRef:
+      type: object
+      required: [id, name, version]
+      description: >-
+        Exact published incentive revision selected during authoring. Campaign-service stores this
+        immutable reference only; incentive-service exclusively owns reservation, redemption and
+        reward value mutation.
+      properties:
+        id: { type: string, format: uuid }
+        name: { type: string, minLength: 1 }
         version: { type: integer, minimum: 1 }
     CampaignStep:
       type: object
@@ -1038,6 +1051,8 @@ components:
           description: >-
             Percentage assigned to a no-contact control cohort. Requires conversionRule so an
             author cannot withhold a message from people without a measurable outcome.
+        incentiveOfferRef:
+          $ref: '#/components/schemas/IncentiveOfferRef'
     CampaignSchedule:
       type: object
       required: [cadence]

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -4,6 +4,8 @@
 
 package com.openbank.campaign.integration
 
+import com.openbank.campaign.domain.model.IncentiveOfferRef
+import com.openbank.campaign.infrastructure.incentive.LiveIncentiveOfferRegistry
 import com.openbank.campaign.infrastructure.segment.SilverSegmentEvaluator
 import com.openbank.campaign.it.CampaignPostgresRedisTestResource
 import io.agroal.api.AgroalDataSource
@@ -58,6 +60,7 @@ class CampaignRestContractIT {
 
     private val audienceJwt = mockk<JsonWebToken>()
     private val segmentEvaluator = mockk<SilverSegmentEvaluator>()
+    private val incentiveRegistry = mockk<LiveIncentiveOfferRegistry>()
 
     @BeforeEach
     fun installAudiencePrincipal() {
@@ -66,6 +69,7 @@ class CampaignRestContractIT {
         QuarkusMock.installMockForType(audienceJwt, JsonWebToken::class.java)
         coEvery { segmentEvaluator.evaluate(any()) } returns emptyList()
         QuarkusMock.installMockForType(segmentEvaluator, SilverSegmentEvaluator::class.java)
+        QuarkusMock.installMockForType(incentiveRegistry, LiveIncentiveOfferRegistry::class.java)
     }
 
     /**
@@ -89,6 +93,13 @@ class CampaignRestContractIT {
         {"name":"$name","goal":"prove the HTTP contract","segmentName":"$segmentName","segmentVersion":1,
          "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
                    "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0}]}
+    """.trimIndent()
+
+    private fun draftBodyWithIncentive(name: String, ref: IncentiveOfferRef) = """
+        {"name":"$name","goal":"prove immutable incentive selection","segmentName":"actives","segmentVersion":1,
+         "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
+                   "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0}],
+         "incentiveOfferRef":{"id":"${ref.id}","name":"${ref.name}","version":${ref.version}}}
     """.trimIndent()
 
     private fun audienceBody(name: String) = """
@@ -203,6 +214,49 @@ class CampaignRestContractIT {
         } Then {
             statusCode(200)
             body("name", equalTo(revisedName))
+        }
+    }
+
+    @Test
+    fun `campaign pins and reloads the exact published incentive revision`() {
+        val ref = IncentiveOfferRef(UUID.randomUUID(), "summer-current-account", 3)
+        coEvery { incentiveRegistry.resolvePublished(ref) } returns ref
+
+        val id = Given {
+            contentType("application/json")
+            body(draftBodyWithIncentive("incentive-${UUID.randomUUID()}", ref))
+        } When {
+            post("/api/v1/campaigns")
+        } Then {
+            statusCode(201)
+            body("incentiveOfferRef.id", equalTo(ref.id.toString()))
+            body("incentiveOfferRef.name", equalTo(ref.name))
+            body("incentiveOfferRef.version", equalTo(ref.version))
+        } Extract {
+            path<String>("id")
+        }
+
+        When { get("/api/v1/campaigns/$id") } Then {
+            statusCode(200)
+            body("incentiveOfferRef.id", equalTo(ref.id.toString()))
+            body("incentiveOfferRef.name", equalTo(ref.name))
+            body("incentiveOfferRef.version", equalTo(ref.version))
+        }
+    }
+
+    @Test
+    fun `campaign rejects an incentive revision that is not published exactly`() {
+        val ref = IncentiveOfferRef(UUID.randomUUID(), "retired-reward", 1)
+        coEvery { incentiveRegistry.resolvePublished(ref) } returns null
+
+        Given {
+            contentType("application/json")
+            body(draftBodyWithIncentive("rejected-${UUID.randomUUID()}", ref))
+        } When {
+            post("/api/v1/campaigns")
+        } Then {
+            statusCode(409)
+            body("error", equalTo("published incentive offer ${ref.name}@${ref.version} (${ref.id}) not found"))
         }
     }
 


### PR DESCRIPTION
## Summary
- pin an optional immutable incentive offer reference on campaign definitions
- validate the exact published offer through the incentive catalogue and fail closed
- persist and expose the reference across create, revise, duplicate, and read flows

## Evidence
- OpenAPI 1.40.0 and contract coverage
- V17 additive nullable migration with consistency constraint and rollback note
- real HTTP/Postgres/Redis tests cover accepted published refs and 409 rejection
- compile, ktlint, detekt, and quarkusBuild green locally

## Stack
Depends on #7253. Refs #7210. This PR does not deploy or activate incentive-service and makes no live E2E claim.