### PR TITLE
feat(admin-ui): select published incentive offers

### DIFF
--- a/openbank-admin-ui/src/app/api/incentives/route.ts
+++ b/openbank-admin-ui/src/app/api/incentives/route.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.accessToken) return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  try {
+    const response = await fetch(serverSvcUrl('incentive-service', 'incentive', 8156, '/api/v1/incentives/offers'), {
+      headers: { authorization: `Bearer ${session.user.accessToken}` },
+      signal: AbortSignal.timeout(4000),
+      cache: 'no-store',
+    })
+    if (!response.ok) {
+      return NextResponse.json({
+        items: [],
+        state: response.status === 401 || response.status === 403
+          ? 'unauthorized'
+          : response.status === 404 ? 'not_deployed' : 'unreachable',
+      })
+    }
+    const body = await response.json() as { items?: unknown[] }
+    return NextResponse.json({ items: body.items ?? [], state: 'ok' })
+  } catch {
+    return NextResponse.json({ items: [], state: 'unreachable' })
+  }
+}

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -23,6 +23,7 @@ interface Campaign {
   name: string
   goal: string
   segmentRef: { name: string; version: number }
+  incentiveOfferRef?: { id: string; name: string; version: number } | null
   state: string
   createdBy: string
   approvedBy: string | null
@@ -798,6 +799,15 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
               hasHoldout={(c.holdoutPercent ?? 0) > 0}
             />
           )}
+
+          <section className="space-y-2">
+            <h2 className="text-sm font-semibold">{t('Motivace', 'Incentive')}</h2>
+            <p className="text-sm text-muted-foreground">
+              {c.incentiveOfferRef
+                ? `${c.incentiveOfferRef.name}@${c.incentiveOfferRef.version}`
+                : t('Bez odměny', 'No reward')}
+            </p>
+          </section>
 
           <section className="space-y-2">
             <h2 className="text-sm font-semibold">{t('Čtyři oči', 'Four-eyes')}</h2>

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -73,6 +73,24 @@ interface IncentiveOffer {
   stackingPolicy: 'EXCLUSIVE' | 'STACKABLE'
 }
 
+function isIncentiveOffer(value: unknown): value is IncentiveOffer {
+  if (!value || typeof value !== 'object') return false
+  const offer = value as Partial<IncentiveOffer>
+  const ref = offer.ref as Partial<IncentiveOffer['ref']> | undefined
+  return Boolean(
+    ref
+    && typeof ref.id === 'string'
+    && ref.id.length > 0
+    && typeof ref.name === 'string'
+    && ref.name.length > 0
+    && typeof ref.version === 'number'
+    && Number.isInteger(ref.version)
+    && ref.version > 0
+    && Array.isArray(offer.productScope)
+    && offer.productScope.every(scope => typeof scope === 'string'),
+  )
+}
+
 type IncentiveCatalogueState = 'loading' | 'ok' | 'not_deployed' | 'unauthorized' | 'unreachable'
 
 /** The reviewed content choice served by campaign-service, rather than a second client-side copy. */
@@ -202,7 +220,13 @@ export default function NewCampaignPage() {
       .then(r => r.json())
       .then((response: { items?: IncentiveOffer[]; state?: string }) => {
         if (response.state === 'ok') {
-          setIncentiveOffers(response.items ?? [])
+          const items = response.items ?? []
+          if (!Array.isArray(items) || !items.every(isIncentiveOffer)) {
+            setIncentiveOffers([])
+            setIncentiveCatalogueState('unreachable')
+            return
+          }
+          setIncentiveOffers(items)
           setIncentiveCatalogueState('ok')
           return
         }

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -77,17 +77,24 @@ function isIncentiveOffer(value: unknown): value is IncentiveOffer {
   if (!value || typeof value !== 'object') return false
   const offer = value as Partial<IncentiveOffer>
   const ref = offer.ref as Partial<IncentiveOffer['ref']> | undefined
+  const effectiveFrom = typeof offer.effectiveFrom === 'string' ? Date.parse(offer.effectiveFrom) : Number.NaN
+  const expiresAt = typeof offer.expiresAt === 'string' ? Date.parse(offer.expiresAt) : Number.NaN
   return Boolean(
     ref
     && typeof ref.id === 'string'
-    && ref.id.length > 0
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(ref.id)
     && typeof ref.name === 'string'
-    && ref.name.length > 0
+    && ref.name.trim().length > 0
     && typeof ref.version === 'number'
     && Number.isInteger(ref.version)
     && ref.version > 0
     && Array.isArray(offer.productScope)
-    && offer.productScope.every(scope => typeof scope === 'string'),
+    && offer.productScope.length > 0
+    && offer.productScope.every(scope => typeof scope === 'string' && scope.trim().length > 0)
+    && Number.isFinite(effectiveFrom)
+    && Number.isFinite(expiresAt)
+    && expiresAt > effectiveFrom
+    && (offer.stackingPolicy === 'EXCLUSIVE' || offer.stackingPolicy === 'STACKABLE'),
   )
 }
 
@@ -220,7 +227,7 @@ export default function NewCampaignPage() {
       .then(r => r.json())
       .then((response: { items?: IncentiveOffer[]; state?: string }) => {
         if (response.state === 'ok') {
-          const items = response.items ?? []
+          const items = response.items
           if (!Array.isArray(items) || !items.every(isIncentiveOffer)) {
             setIncentiveOffers([])
             setIncentiveCatalogueState('unreachable')

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -65,6 +65,16 @@ interface CampaignTrigger {
   humanForm: string
 }
 
+interface IncentiveOffer {
+  ref: { id: string; name: string; version: number }
+  productScope: string[]
+  effectiveFrom: string
+  expiresAt: string
+  stackingPolicy: 'EXCLUSIVE' | 'STACKABLE'
+}
+
+type IncentiveCatalogueState = 'loading' | 'ok' | 'not_deployed' | 'unauthorized' | 'unreachable'
+
 /** The reviewed content choice served by campaign-service, rather than a second client-side copy. */
 interface CampaignTemplate {
   template: string
@@ -107,6 +117,9 @@ export default function NewCampaignPage() {
   const [goal, setGoal] = useState('')
   const [segment, setSegment] = useState('')
   const [segments, setSegments] = useState<Segment[]>([])
+  const [incentiveOffers, setIncentiveOffers] = useState<IncentiveOffer[]>([])
+  const [incentiveOfferRef, setIncentiveOfferRef] = useState<IncentiveOffer['ref'] | null>(null)
+  const [incentiveCatalogueState, setIncentiveCatalogueState] = useState<IncentiveCatalogueState>('loading')
   const [segmentSource, setSegmentSource] = useState<'audiences' | 'segments' | null>(null)
   const [cadences, setCadences] = useState<Cadence[]>([])
   const [triggers, setTriggers] = useState<CampaignTrigger[]>([])
@@ -184,6 +197,24 @@ export default function NewCampaignPage() {
       .catch(() => undefined)
   }, [])
 
+  useEffect(() => {
+    fetch('/api/incentives')
+      .then(r => r.json())
+      .then((response: { items?: IncentiveOffer[]; state?: string }) => {
+        if (response.state === 'ok') {
+          setIncentiveOffers(response.items ?? [])
+          setIncentiveCatalogueState('ok')
+          return
+        }
+        setIncentiveCatalogueState(
+          response.state === 'not_deployed' || response.state === 'unauthorized'
+            ? response.state
+            : 'unreachable',
+        )
+      })
+      .catch(() => setIncentiveCatalogueState('unreachable'))
+  }, [])
+
   // The reach is the segment's own preview, run by the service — the same evaluation enrolment runs.
   // A number computed here from a different query would agree with the send only by luck.
   function previewReach(ref: string) {
@@ -212,6 +243,7 @@ export default function NewCampaignPage() {
           confirmedStepOrder: number; notConfirmedStepOrder: number
         }>; stopCondition?: { maxSendsPerParty: number } | null; conversionRule?: string | null
         holdoutPercent?: number; schedule?: { cadence: string } | null; trigger?: string | null
+        incentiveOfferRef?: { id: string; name: string; version: number } | null
       }; sources?: { campaign?: string } }) => {
         const campaign = d.campaign
         if (d.sources?.campaign !== 'ok' || !campaign || campaign.state !== 'DRAFT') {
@@ -268,6 +300,7 @@ export default function NewCampaignPage() {
         setStopAfter(campaign.stopCondition?.maxSendsPerParty ?? null)
         setConversionRule(campaign.conversionRule ?? null)
         setHoldoutPercent(campaign.holdoutPercent ?? 0)
+        setIncentiveOfferRef(campaign.incentiveOfferRef ?? null)
         setContentExperiment(campaign.steps?.some(step => step.variantBVariables !== undefined) ?? false)
         if (campaign.schedule) {
           setEntryMode('SCHEDULE')
@@ -433,8 +466,11 @@ export default function NewCampaignPage() {
     entryMode === 'MANUAL' ||
     (entryMode === 'SCHEDULE' && cadence !== '') ||
     (entryMode === 'TRIGGER' && trigger !== '')
+  const pinnedIncentiveUnavailable = incentiveOfferRef !== null &&
+    !incentiveOffers.some(offer => offer.ref.id === incentiveOfferRef.id)
   const ready = name.trim() !== '' && goal.trim() !== '' && segment !== '' && steps.length > 0 &&
-    contentCatalogueState === 'ok' && !incomplete && entryConfigured && (!contentExperiment || conversionRule !== null)
+    contentCatalogueState === 'ok' && !incomplete && entryConfigured && (!contentExperiment || conversionRule !== null) &&
+    !pinnedIncentiveUnavailable
   // A campaign is an experience across surfaces, not a list of transport rows. Keep this compact
   // overview next to the canvas so a marketer can scan the whole customer footprint without
   // opening every node. It is derived solely from the steps that will be sent to campaign-service.
@@ -494,6 +530,7 @@ export default function NewCampaignPage() {
         ...(stopAfter !== null ? { stopCondition: { maxSendsPerParty: stopAfter } } : {}),
         ...(conversionRule ? { conversionRule } : {}),
         ...(holdoutPercent > 0 ? { holdoutPercent } : {}),
+        ...(incentiveOfferRef ? { incentiveOfferRef } : {}),
         ...(entryMode === 'SCHEDULE' && cadence ? { schedule: { cadence } } : {}),
         ...(entryMode === 'TRIGGER' && trigger ? { trigger } : {}),
         ...(decisions.length > 0 ? {
@@ -655,6 +692,64 @@ export default function NewCampaignPage() {
             {t(
               'Segmenty jsou definované v kódu a verzované. Nový segment je pull request, ne akce v UI.',
               'Segments are defined in code and versioned. A new segment is a pull request, not a UI action.',
+            )}
+          </p>
+        </div>
+
+        <div className="campaign-audience-card" data-incentive-selection>
+          <div className="campaign-section-heading">
+            <div>
+              <p>{t('Motivace', 'Incentive')}</p>
+              <h2>{t('Volitelná odměna', 'Optional reward')}</h2>
+            </div>
+          </div>
+          <label htmlFor="c-incentive" className="text-sm font-medium">
+            {t('Publikovaná nabídka', 'Published offer')}
+          </label>
+          <select
+            id="c-incentive"
+            className="input w-full"
+            value={incentiveOfferRef?.id ?? ''}
+            disabled={incentiveCatalogueState !== 'ok'}
+            onChange={event => setIncentiveOfferRef(
+              incentiveOffers.find(offer => offer.ref.id === event.target.value)?.ref ?? null,
+            )}
+          >
+            <option value="">{t('Bez odměny', 'No reward')}</option>
+            {pinnedIncentiveUnavailable && incentiveOfferRef && (
+              <option value={incentiveOfferRef.id}>
+                {incentiveOfferRef.name}@{incentiveOfferRef.version} · {t('již není dostupná', 'no longer available')}
+              </option>
+            )}
+            {incentiveOffers.map(offer => (
+              <option key={offer.ref.id} value={offer.ref.id}>
+                {offer.ref.name}@{offer.ref.version} · {offer.productScope.join(', ')}
+              </option>
+            ))}
+          </select>
+          {incentiveCatalogueState !== 'ok' && (
+            <p role="status" className="text-xs text-muted-foreground" style={{ marginTop: '0.5rem' }}>
+              {incentiveCatalogueState === 'not_deployed'
+                ? t('Incentive service není v tomto prostředí nasazená.', 'Incentive service is not deployed in this environment.')
+                : incentiveCatalogueState === 'unauthorized'
+                  ? t('Katalog odměn nemáte oprávnění zobrazit.', 'You are not authorized to view the incentive catalogue.')
+                  : incentiveCatalogueState === 'loading'
+                    ? t('Načítám katalog odměn…', 'Loading incentive catalogue…')
+                    : t('Katalog odměn teď není dostupný.', 'The incentive catalogue is currently unavailable.')}
+            </p>
+          )}
+          {incentiveCatalogueState === 'ok' && pinnedIncentiveUnavailable && incentiveOfferRef && (
+            <p role="alert" className="text-xs text-muted-foreground" style={{ marginTop: '0.5rem' }}>
+              {t(
+                `Připnutá nabídka ${incentiveOfferRef.name}@${incentiveOfferRef.version} už není publikovaná. Vyberte jinou nebo odměnu výslovně odeberte.`,
+                `Pinned offer ${incentiveOfferRef.name}@${incentiveOfferRef.version} is no longer published. Choose another offer or explicitly remove the reward.`,
+              )}
+            </p>
+          )}
+          <p className="text-xs text-muted-foreground" style={{ marginTop: '0.5rem' }}>
+            {t(
+              'Kampaň uloží přesnou publikovanou verzi. Rezervaci kódu a hodnotu odměny řídí Incentive service.',
+              'The campaign pins the exact published revision. Incentive service owns code reservation and reward value.',
             )}
           </p>
         </div>

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -17,8 +17,12 @@ vi.mock('next-auth/react', () => ({
 }))
 
 const routerPush = vi.hoisted(() => vi.fn())
+const navigation = vi.hoisted(() => ({ query: '' }))
 
-vi.mock('next/navigation', () => ({ useRouter: () => ({ push: routerPush }), useSearchParams: () => new URLSearchParams() }))
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: routerPush }),
+  useSearchParams: () => new URLSearchParams(navigation.query),
+}))
 
 const CAMPAIGN_ID = '7b1f1d5e-0d2a-4a6a-8f7e-2c1b9a0d3e4f'
 
@@ -35,6 +39,17 @@ const CADENCES = {
 const TRIGGERS = {
   state: 'ok',
   items: [{ trigger: 'ACCOUNT_OPENED', humanForm: 'when an account is opened' }],
+}
+
+const INCENTIVES = {
+  state: 'ok',
+  items: [{
+    ref: { id: '0c42be3d-f632-4f12-bdb3-2e326a471a7f', name: 'welcome-reward', version: 2 },
+    productScope: ['current-account'],
+    effectiveFrom: '2026-08-01T00:00:00Z',
+    expiresAt: '2026-12-31T23:59:59Z',
+    stackingPolicy: 'EXCLUSIVE',
+  }],
 }
 
 const TEMPLATES = {
@@ -96,6 +111,7 @@ describe('campaign studio', () => {
   beforeEach(() => {
     vi.unstubAllGlobals()
     routerPush.mockReset()
+    navigation.query = ''
   })
 
   /**
@@ -212,6 +228,96 @@ describe('campaign studio', () => {
 
     await waitFor(() => expect(createBody).toMatchObject({ schedule: { cadence: 'DAILY_MORNING' } }))
     expect(createBody).not.toHaveProperty('trigger')
+  }, 15000)
+
+  it('pins the exact published incentive revision in the campaign draft', async () => {
+    let createBody: Record<string, unknown> | undefined
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('/api/segments')) return { ok: true, status: 200, json: async () => SEGMENTS }
+      if (url.includes('/api/incentives')) return { ok: true, status: 200, json: async () => INCENTIVES }
+      if (url.includes('/api/campaigns/templates')) return { ok: true, status: 200, json: async () => TEMPLATES }
+      if (url.includes('/api/campaigns/cadences')) return { ok: true, status: 200, json: async () => CADENCES }
+      if (url.includes('/api/campaigns/triggers')) return { ok: true, status: 200, json: async () => TRIGGERS }
+      if (url === '/api/campaigns') {
+        createBody = JSON.parse(String(init?.body))
+        return { ok: true, status: 200, json: async () => ({ state: 'ok', campaign: { id: CAMPAIGN_ID } }) }
+      }
+      return { ok: true, status: 200, json: async () => ({}) }
+    }))
+    render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
+
+    await waitFor(() => expect(screen.getByRole('option', { name: /welcome-reward@2/ })).toBeTruthy())
+    fireEvent.change(document.getElementById('c-name')!, { target: { value: 'Rewarded welcome' } })
+    fireEvent.change(document.getElementById('c-goal')!, { target: { value: 'Open current accounts' } })
+    fireEvent.click(document.querySelector('[data-segment="actives@1"]')!)
+    fireEvent.change(document.getElementById('c-incentive')!, { target: { value: INCENTIVES.items[0].ref.id } })
+    fireEvent.change(document.getElementById('var-0-offerTitle')!, { target: { value: 'Welcome' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create draft' }))
+
+    await waitFor(() => expect(createBody).toMatchObject({ incentiveOfferRef: INCENTIVES.items[0].ref }))
+  }, 15000)
+
+  it('restores the pinned incentive when an existing draft is reopened', async () => {
+    navigation.query = 'draft=draft-with-reward'
+    const stored = {
+      ...detail('DRAFT').campaign,
+      incentiveOfferRef: INCENTIVES.items[0].ref,
+      steps: [{
+        order: 1,
+        template: 'MARKETING_PRODUCT_OFFER_PUSH',
+        channel: 'PUSH',
+        variables: { offerTitle: 'Welcome' },
+        delaySeconds: 0,
+      }],
+    }
+    vi.stubGlobal('fetch', mockFetch({
+      '/api/segments': SEGMENTS,
+      '/api/incentives': INCENTIVES,
+      '/api/campaigns/draft-with-reward': { campaign: stored, sources: { campaign: 'ok' } },
+    }))
+    render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
+
+    await waitFor(() => expect(document.getElementById('c-incentive')).toHaveValue(INCENTIVES.items[0].ref.id))
+  }, 15000)
+
+  it('shows and blocks a pinned draft revision that is no longer published', async () => {
+    navigation.query = 'draft=retired-reward-draft'
+    const retiredRef = { id: 'f53d192d-c6ac-4dac-a889-86416674925a', name: 'retired-reward', version: 4 }
+    vi.stubGlobal('fetch', mockFetch({
+      '/api/segments': SEGMENTS,
+      '/api/incentives': { state: 'ok', items: [] },
+      '/api/campaigns/retired-reward-draft': {
+        campaign: {
+          ...detail('DRAFT').campaign,
+          incentiveOfferRef: retiredRef,
+          steps: [{
+            order: 1,
+            template: 'MARKETING_PRODUCT_OFFER_PUSH',
+            channel: 'PUSH',
+            variables: { offerTitle: 'Welcome' },
+            delaySeconds: 0,
+          }],
+        },
+        sources: { campaign: 'ok' },
+      },
+    }))
+    render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/no longer published/))
+    expect(document.getElementById('c-incentive')).toHaveValue(retiredRef.id)
+    expect(screen.getByRole('button', { name: 'Save draft' })).toBeDisabled()
+  }, 15000)
+
+  it('distinguishes an undeployed incentive service from a valid empty catalogue', async () => {
+    vi.stubGlobal('fetch', mockFetch({
+      '/api/segments': SEGMENTS,
+      '/api/incentives': { state: 'not_deployed', items: [] },
+    }))
+    render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
+
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent(/not deployed in this environment/))
+    expect(document.getElementById('c-incentive')).toBeDisabled()
   }, 15000)
 
   it('authors both content arms and submits a measurable A/B experiment', async () => {

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -320,19 +320,33 @@ describe('campaign studio', () => {
     expect(document.getElementById('c-incentive')).toBeDisabled()
   }, 15000)
 
-  it('fails closed when the incentive catalogue returns a malformed item', async () => {
+  it('fails closed when an almost-valid incentive item omits a required contract field', async () => {
     vi.stubGlobal('fetch', mockFetch({
       '/api/segments': SEGMENTS,
       '/api/incentives': {
         state: 'ok',
-        items: [{ name: 'legacy-segment-shaped-item', version: 1 }],
+        items: [{
+          ...INCENTIVES.items[0],
+          stackingPolicy: undefined,
+        }],
       },
     }))
     render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
 
     await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent(/catalogue is currently unavailable/))
     expect(document.getElementById('c-incentive')).toBeDisabled()
-    expect(screen.queryByRole('option', { name: /legacy-segment-shaped-item/ })).toBeNull()
+    expect(screen.queryByRole('option', { name: /welcome-reward/ })).toBeNull()
+  }, 15000)
+
+  it('does not reinterpret a missing items field as a valid empty catalogue', async () => {
+    vi.stubGlobal('fetch', mockFetch({
+      '/api/segments': SEGMENTS,
+      '/api/incentives': { state: 'ok' },
+    }))
+    render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
+
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent(/catalogue is currently unavailable/))
+    expect(document.getElementById('c-incentive')).toBeDisabled()
   }, 15000)
 
   it('authors both content arms and submits a measurable A/B experiment', async () => {

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -320,6 +320,21 @@ describe('campaign studio', () => {
     expect(document.getElementById('c-incentive')).toBeDisabled()
   }, 15000)
 
+  it('fails closed when the incentive catalogue returns a malformed item', async () => {
+    vi.stubGlobal('fetch', mockFetch({
+      '/api/segments': SEGMENTS,
+      '/api/incentives': {
+        state: 'ok',
+        items: [{ name: 'legacy-segment-shaped-item', version: 1 }],
+      },
+    }))
+    render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
+
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent(/catalogue is currently unavailable/))
+    expect(document.getElementById('c-incentive')).toBeDisabled()
+    expect(screen.queryByRole('option', { name: /legacy-segment-shaped-item/ })).toBeNull()
+  }, 15000)
+
   it('authors both content arms and submits a measurable A/B experiment', async () => {
     let createBody: Record<string, unknown> | undefined
     vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/openbank-admin-ui/src/test/incentive-catalogue-bff.test.ts
+++ b/openbank-admin-ui/src/test/incentive-catalogue-bff.test.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/auth', () => ({ auth: async () => ({ user: { accessToken: 'token' } }) }))
+vi.mock('@/lib/services/bff', () => ({
+  serverSvcUrl: (_service: string, _name: string, _port: number, path: string) => `http://incentive${path}`,
+}))
+
+describe('incentive catalogue BFF', () => {
+  beforeEach(() => vi.resetModules())
+
+  it('forwards only the service catalogue envelope through authenticated BFF', async () => {
+    const offer = { ref: { id: '0c42be3d-f632-4f12-bdb3-2e326a471a7f', name: 'welcome', version: 2 } }
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ items: [offer] }) }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { GET } = await import('@/app/api/incentives/route')
+    await expect((await GET()).json()).resolves.toEqual({ items: [offer], state: 'ok' })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://incentive/api/v1/incentives/offers',
+      expect.objectContaining({ headers: { authorization: 'Bearer token' } }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add an authenticated incentive catalogue BFF and optional reward selection to Campaign Studio
- preserve exact immutable offer refs through create and draft hydration
- distinguish unavailable catalogue states and block unsafe saves for retired pinned refs

## Evidence
- focused Vitest: 25/25 green
- BFF, create, hydration, retired-ref, and not-deployed regressions covered
- focused ESLint has no errors
- independent code re-review found no blocking UI findings

## Stack
Depends on the campaign incentive-reference PR and #7253. Refs #7210. This PR does not deploy incentive-service and makes no live E2E claim.