### PR TITLE
feat(campaign): expose trusted incentive attribution

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -136,7 +136,13 @@ data class CampaignEnrolmentCount(val campaignId: UUID, val count: Long)
 data class ConversionContext(val firstSentAt: Instant?, val alreadyConverted: Boolean)
 
 /** Server-owned campaign context for one opaque app interaction reference. */
-data class CampaignInteractionAttribution(val campaignId: UUID, val stepOrder: Int, val channel: Channel)
+data class CampaignInteractionAttribution(
+    val campaignId: UUID,
+    val stepOrder: Int,
+    val channel: Channel,
+    /** Immutable treatment selected on the reviewed campaign; null means the campaign has no reward. */
+    val incentiveOfferRef: IncentiveOfferRef? = null,
+)
 
 @Suppress("TooManyFunctions") // One aggregate port; see PanacheSendLogRepository's matching rationale.
 interface SendLogRepository {

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignInteractionQuery.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignInteractionQuery.kt
@@ -19,7 +19,10 @@ import java.util.UUID
  */
 @ApplicationScoped
 class CampaignInteractionQuery(private val sendLog: SendLogRepository, private val campaigns: CampaignRepository) {
-    suspend fun resolve(interactionRef: UUID, partyId: UUID): CampaignInteractionAttribution? {
+    suspend fun validate(interactionRef: UUID, partyId: UUID): Boolean =
+        sendLog.attributionForAppInteraction(interactionRef, partyId) != null
+
+    suspend fun resolveAttribution(interactionRef: UUID, partyId: UUID): CampaignInteractionAttribution? {
         val attribution = sendLog.attributionForAppInteraction(interactionRef, partyId) ?: return null
         val campaign = campaigns.findById(attribution.campaignId) ?: return null
         return attribution.copy(incentiveOfferRef = campaign.incentiveOfferRef)

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignInteractionQuery.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignInteractionQuery.kt
@@ -5,6 +5,7 @@
 package com.openbank.campaign.application.usecase
 
 import com.openbank.campaign.application.port.out.CampaignInteractionAttribution
+import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.SendLogRepository
 import jakarta.enterprise.context.ApplicationScoped
 import java.util.UUID
@@ -17,7 +18,10 @@ import java.util.UUID
  * the app nor a client-supplied campaign id can choose attribution.
  */
 @ApplicationScoped
-class CampaignInteractionQuery(private val sendLog: SendLogRepository) {
-    suspend fun resolve(interactionRef: UUID, partyId: UUID): CampaignInteractionAttribution? =
-        sendLog.attributionForAppInteraction(interactionRef, partyId)
+class CampaignInteractionQuery(private val sendLog: SendLogRepository, private val campaigns: CampaignRepository) {
+    suspend fun resolve(interactionRef: UUID, partyId: UUID): CampaignInteractionAttribution? {
+        val attribution = sendLog.attributionForAppInteraction(interactionRef, partyId) ?: return null
+        val campaign = campaigns.findById(attribution.campaignId) ?: return null
+        return attribution.copy(incentiveOfferRef = campaign.incentiveOfferRef)
+    }
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignInteractionResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignInteractionResource.kt
@@ -35,7 +35,8 @@ class CampaignInteractionResource(private val query: CampaignInteractionQuery) {
         @PathParam("interactionRef") interactionRef: UUID,
         @HeaderParam("X-Customer-Party-Id") partyId: String?,
     ): Response {
-        resolve(interactionRef, partyId) ?: return invalidInteractionResponse(partyId)
+        val parsedPartyId = parsePartyId(partyId) ?: return invalidInteractionResponse(partyId)
+        if (!query.validate(interactionRef, parsedPartyId)) return invalidInteractionResponse(partyId)
         return Response.noContent().build()
     }
 
@@ -47,7 +48,7 @@ class CampaignInteractionResource(private val query: CampaignInteractionQuery) {
         @PathParam("interactionRef") interactionRef: UUID,
         @HeaderParam("X-Customer-Party-Id") partyId: String?,
     ): Response {
-        val attribution = resolve(interactionRef, partyId)
+        val attribution = parsePartyId(partyId)?.let { query.resolveAttribution(interactionRef, it) }
             ?: return invalidInteractionResponse(partyId)
         return Response.ok(
             CampaignInteractionAttributionResponse(
@@ -59,9 +60,7 @@ class CampaignInteractionResource(private val query: CampaignInteractionQuery) {
         ).build()
     }
 
-    private suspend fun resolve(interactionRef: UUID, partyId: String?) = partyId
-        ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
-        ?.let { query.resolve(interactionRef, it) }
+    private fun parsePartyId(partyId: String?): UUID? = partyId?.let { runCatching { UUID.fromString(it) }.getOrNull() }
 
     private fun invalidInteractionResponse(partyId: String?): Response =
         if (partyId?.let { runCatching { UUID.fromString(it) }.isSuccess } == true) {

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignInteractionResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignInteractionResource.kt
@@ -5,6 +5,7 @@
 package com.openbank.campaign.infrastructure.rest
 
 import com.openbank.campaign.application.usecase.CampaignInteractionQuery
+import com.openbank.campaign.domain.model.IncentiveOfferRef
 import com.openbank.libs.authz.Authorize
 import jakarta.annotation.security.RolesAllowed
 import jakarta.enterprise.context.ApplicationScoped
@@ -53,6 +54,7 @@ class CampaignInteractionResource(private val query: CampaignInteractionQuery) {
                 campaignId = attribution.campaignId,
                 stepOrder = attribution.stepOrder,
                 channel = attribution.channel.name,
+                incentiveOfferRef = attribution.incentiveOfferRef,
             ),
         ).build()
     }
@@ -69,4 +71,9 @@ class CampaignInteractionResource(private val query: CampaignInteractionQuery) {
         }
 }
 
-data class CampaignInteractionAttributionResponse(val campaignId: UUID, val stepOrder: Int, val channel: String)
+data class CampaignInteractionAttributionResponse(
+    val campaignId: UUID,
+    val stepOrder: Int,
+    val channel: String,
+    val incentiveOfferRef: IncentiveOfferRef?,
+)

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.40.0
+  version: 1.41.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -54,8 +54,9 @@ paths:
       summary: Resolve server-owned attribution for an opaque app interaction reference
       description: >-
         Additive internal customer-edge capability. Only after ownership, app channel and handoff
-        are established does the trusted response return campaign/step/channel context for the edge
-        to attach to the downstream event. The app never receives or supplies these fields.
+        are established does the trusted response return campaign/step/channel context and the
+        campaign's immutable incentive reference for the edge to attach to a downstream claim.
+        The app never receives or supplies campaign or offer identity.
       parameters:
         - name: interactionRef
           in: path
@@ -77,6 +78,10 @@ paths:
                   campaignId: { type: string, format: uuid }
                   stepOrder: { type: integer, minimum: 0 }
                   channel: { type: string, enum: [PUSH, BANNER] }
+                  incentiveOfferRef:
+                    oneOf:
+                      - $ref: '#/components/schemas/IncentiveOfferRef'
+                      - type: 'null'
         "400":
           description: Missing or malformed caller party header
         "404":

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignInteractionQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignInteractionQueryTest.kt
@@ -34,8 +34,41 @@ class CampaignInteractionQueryTest {
         coEvery { sendLog.attributionForAppInteraction(interactionRef, partyId) } returns attribution
         coEvery { campaigns.findById(attribution.campaignId) } returns campaign
 
-        assertThat(query.resolve(interactionRef, partyId)).isEqualTo(attribution.copy(incentiveOfferRef = offer))
+        assertThat(query.resolveAttribution(interactionRef, partyId))
+            .isEqualTo(attribution.copy(incentiveOfferRef = offer))
         coVerify(exactly = 1) { sendLog.attributionForAppInteraction(interactionRef, partyId) }
         coVerify(exactly = 1) { campaigns.findById(attribution.campaignId) }
+    }
+
+    @Test
+    fun `invalid interaction never reads a campaign`(): Unit = runBlocking {
+        val interactionRef = UUID.randomUUID()
+        val partyId = UUID.randomUUID()
+        coEvery { sendLog.attributionForAppInteraction(interactionRef, partyId) } returns null
+
+        assertThat(query.resolveAttribution(interactionRef, partyId)).isNull()
+        coVerify(exactly = 0) { campaigns.findById(any()) }
+    }
+
+    @Test
+    fun `attribution fails closed when its campaign is missing`(): Unit = runBlocking {
+        val interactionRef = UUID.randomUUID()
+        val partyId = UUID.randomUUID()
+        val attribution = CampaignInteractionAttribution(UUID.randomUUID(), 0, Channel.PUSH)
+        coEvery { sendLog.attributionForAppInteraction(interactionRef, partyId) } returns attribution
+        coEvery { campaigns.findById(attribution.campaignId) } returns null
+
+        assertThat(query.resolveAttribution(interactionRef, partyId)).isNull()
+    }
+
+    @Test
+    fun `validation remains independent of campaign hydration`(): Unit = runBlocking {
+        val interactionRef = UUID.randomUUID()
+        val partyId = UUID.randomUUID()
+        coEvery { sendLog.attributionForAppInteraction(interactionRef, partyId) } returns
+            CampaignInteractionAttribution(UUID.randomUUID(), 0, Channel.BANNER)
+
+        assertThat(query.validate(interactionRef, partyId)).isTrue()
+        coVerify(exactly = 0) { campaigns.findById(any()) }
     }
 }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignInteractionQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignInteractionQueryTest.kt
@@ -5,10 +5,14 @@
 package com.openbank.campaign.application.usecase
 
 import com.openbank.campaign.application.port.out.CampaignInteractionAttribution
+import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.SendLogRepository
+import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.IncentiveOfferRef
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -17,16 +21,21 @@ import java.util.UUID
 
 class CampaignInteractionQueryTest {
     private val sendLog = mockk<SendLogRepository>()
-    private val query = CampaignInteractionQuery(sendLog)
+    private val campaigns = mockk<CampaignRepository>()
+    private val query = CampaignInteractionQuery(sendLog, campaigns)
 
     @Test
     fun `delegates the opaque reference and authoritative party to the send log`(): Unit = runBlocking {
         val interactionRef = UUID.randomUUID()
         val partyId = UUID.randomUUID()
         val attribution = CampaignInteractionAttribution(UUID.randomUUID(), 0, Channel.PUSH)
+        val offer = IncentiveOfferRef(UUID.randomUUID(), "term-deposit-welcome", 2)
+        val campaign = mockk<Campaign> { every { incentiveOfferRef } returns offer }
         coEvery { sendLog.attributionForAppInteraction(interactionRef, partyId) } returns attribution
+        coEvery { campaigns.findById(attribution.campaignId) } returns campaign
 
-        assertThat(query.resolve(interactionRef, partyId)).isEqualTo(attribution)
+        assertThat(query.resolve(interactionRef, partyId)).isEqualTo(attribution.copy(incentiveOfferRef = offer))
         coVerify(exactly = 1) { sendLog.attributionForAppInteraction(interactionRef, partyId) }
+        coVerify(exactly = 1) { campaigns.findById(attribution.campaignId) }
     }
 }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -532,9 +532,28 @@ class CampaignRestContractIT {
         Given {
             header("X-Customer-Party-Id", UUID.randomUUID().toString())
         } When {
-            get("/api/v1/campaigns/interactions/$interactionRef")
+            get("/api/v1/campaigns/interactions/$interactionRef/attribution")
         } Then {
             statusCode(404)
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "service-account-openbank-edge", roles = ["ROLE_API"])
+    fun `legacy campaign attribution keeps an explicit null incentive reference`() {
+        val campaignId = UUID.randomUUID()
+        insertCampaignForSendLog(campaignId)
+        val owner = UUID.randomUUID()
+        val interactionRef = insertPushSend(campaignId, owner)
+
+        Given {
+            header("X-Customer-Party-Id", owner.toString())
+        } When {
+            get("/api/v1/campaigns/interactions/$interactionRef/attribution")
+        } Then {
+            statusCode(200)
+            body("campaignId", equalTo(campaignId.toString()))
+            body("incentiveOfferRef", nullValue())
         }
     }
 

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -434,14 +434,15 @@ class CampaignRestContractIT {
      * /api/v1/campaigns/planning` — then answers 400 for the entire portfolio because of one row the
      * HTTP API could never have created (#4825).
      */
-    private fun insertCampaignForSendLog(campaignId: UUID) {
+    private fun insertCampaignForSendLog(campaignId: UUID, incentiveOfferRef: IncentiveOfferRef? = null) {
         dataSource.connection.use { connection ->
             connection.prepareStatement(
                 """
                 INSERT INTO campaigns (
                     id, name, goal, segment_name, segment_version, steps_json, holdout_percent,
-                    state, created_by, created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    state, created_by, created_at, updated_at,
+                    incentive_offer_id, incentive_offer_name, incentive_offer_version
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """.trimIndent(),
             ).use { statement ->
                 statement.setObject(1, campaignId)
@@ -455,6 +456,13 @@ class CampaignRestContractIT {
                 statement.setString(9, "fixture")
                 statement.setObject(10, OffsetDateTime.now())
                 statement.setObject(11, OffsetDateTime.now())
+                statement.setObject(12, incentiveOfferRef?.id)
+                statement.setString(13, incentiveOfferRef?.name)
+                if (incentiveOfferRef == null) {
+                    statement.setNull(14, java.sql.Types.INTEGER)
+                } else {
+                    statement.setInt(14, incentiveOfferRef.version)
+                }
                 statement.executeUpdate()
             }
         }
@@ -493,7 +501,8 @@ class CampaignRestContractIT {
         // durable parent directly, so this test runs entirely under the edge's ROLE_API identity
         // rather than borrowing an operator token to create a draft.
         val campaignId = UUID.randomUUID()
-        insertCampaignForSendLog(campaignId)
+        val offer = IncentiveOfferRef(UUID.randomUUID(), "term-deposit-welcome", 2)
+        insertCampaignForSendLog(campaignId, offer)
         val owner = UUID.randomUUID()
         val interactionRef = insertPushSend(campaignId, owner)
 
@@ -514,6 +523,9 @@ class CampaignRestContractIT {
             body("campaignId", equalTo(campaignId.toString()))
             body("stepOrder", equalTo(0))
             body("channel", equalTo("PUSH"))
+            body("incentiveOfferRef.id", equalTo(offer.id.toString()))
+            body("incentiveOfferRef.name", equalTo(offer.name))
+            body("incentiveOfferRef.version", equalTo(offer.version))
             body("partyId", nullValue())
         }
 


### PR DESCRIPTION
## Summary

Expose the campaign-owned immutable incentive reference only after the existing opaque interaction reference and customer-party ownership predicate succeeds. This establishes the trusted Campaign → customer-edge attribution boundary for the MGM claim flow without exposing reward codes or accepting campaign/offer identity from the app.

## Type of change

- [x] feat (new functionality)

## Linked issues

Refs #7210

## Changes

- enrich trusted interaction attribution from the persisted Campaign aggregate
- add the nullable incentive reference to the additive OpenAPI response
- prove exact server-owned attribution through unit and real HTTP/PostgreSQL integration tests

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [x] Contract tests updated (if public API changed).
- [x] Focused tests, ktlintCheck, detekt, and quarkusBuild pass.
- [x] No new lint warnings.
- [x] OpenAPI spec updated (if REST API changed).
- [x] Flyway migration N/A.
- [x] Event schema N/A.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new suppressions.
- [x] No new third-party dependency.
- [x] Auth/crypto/payment code unchanged.
- [x] PII path unchanged: response contains only campaign, step, channel, and immutable offer identity after the existing party ownership check.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: rolling
- Rollback plan: revert the additive response enrichment; nullable clients remain compatible
- Data migration reversible: N/A

## Reviewer notes

Please verify that CampaignRepository enrichment occurs only after the existing send-log ownership/channel predicate, and that the HTTP regression proves the value comes from the persisted campaign rather than caller input.