### PR TITLE
feat(incentive): add attributed customer reservations

### DIFF
--- a/openbank-contracts/openbank-incentive-service/asyncapi.yaml
+++ b/openbank-contracts/openbank-incentive-service/asyncapi.yaml
@@ -4,7 +4,7 @@ asyncapi: 3.0.0
 
 info:
   title: OpenBank Incentive Service — events
-  version: 1.0.0
+  version: 1.1.0
   description: |
     Lifecycle evidence emitted from the incentive transactional outbox. This topic does not
     authorize pricing, settlement, account mutation or cash rewards; consumers treat it as an
@@ -31,6 +31,10 @@ channels:
       reservationCommitted: {$ref: '#/components/messages/reservationCommitted'}
       reservationReleased: {$ref: '#/components/messages/reservationReleased'}
       reservationExpired: {$ref: '#/components/messages/reservationExpired'}
+      attributedReservationCreated: {$ref: '#/components/messages/attributedReservationCreated'}
+      attributedReservationCommitted: {$ref: '#/components/messages/attributedReservationCommitted'}
+      attributedReservationReleased: {$ref: '#/components/messages/attributedReservationReleased'}
+      attributedReservationExpired: {$ref: '#/components/messages/attributedReservationExpired'}
 
 operations:
   publishIncentiveEvidence:
@@ -46,6 +50,10 @@ operations:
       - $ref: '#/channels/incentiveEvents/messages/reservationCommitted'
       - $ref: '#/channels/incentiveEvents/messages/reservationReleased'
       - $ref: '#/channels/incentiveEvents/messages/reservationExpired'
+      - $ref: '#/channels/incentiveEvents/messages/attributedReservationCreated'
+      - $ref: '#/channels/incentiveEvents/messages/attributedReservationCommitted'
+      - $ref: '#/channels/incentiveEvents/messages/attributedReservationReleased'
+      - $ref: '#/channels/incentiveEvents/messages/attributedReservationExpired'
 
 components:
   schemas:
@@ -75,6 +83,10 @@ components:
         - incentive.reservation.committed.v1
         - incentive.reservation.released.v1
         - incentive.reservation.expired.v1
+        - incentive.reservation.created.v2
+        - incentive.reservation.committed.v2
+        - incentive.reservation.released.v2
+        - incentive.reservation.expired.v2
     lifecycleEnvelope:
       type: object
       additionalProperties: false
@@ -85,6 +97,45 @@ components:
         aggregateId: {type: string, format: uuid}
         eventType: {type: string}
         occurredAt: {type: string, format: date-time}
+    attributedReservationLifecycle:
+      type: object
+      additionalProperties: false
+      required:
+        - eventId
+        - correlationId
+        - aggregateId
+        - eventType
+        - occurredAt
+        - reservationId
+        - offerRef
+        - attributionRef
+        - status
+      properties:
+        eventId: {type: string, format: uuid}
+        correlationId: {type: string, format: uuid}
+        aggregateId: {type: string, format: uuid}
+        eventType:
+          type: string
+          enum:
+            - incentive.reservation.created.v2
+            - incentive.reservation.committed.v2
+            - incentive.reservation.released.v2
+            - incentive.reservation.expired.v2
+        occurredAt: {type: string, format: date-time}
+        reservationId: {type: string, format: uuid}
+        offerRef:
+          type: object
+          additionalProperties: false
+          required: [id, name, version]
+          properties:
+            id: {type: string, format: uuid}
+            name: {type: string, minLength: 1}
+            version: {type: integer, minimum: 1}
+        attributionRef:
+          type: string
+          format: uuid
+          description: Opaque campaign interaction reference; never a party identifier or promo code.
+        status: {type: string, enum: [RESERVED, COMMITTED, RELEASED, EXPIRED]}
 
   messages:
     offerCreated:
@@ -193,3 +244,55 @@ components:
         allOf:
           - $ref: '#/components/schemas/lifecycleEnvelope'
           - properties: {eventType: {const: incentive.reservation.expired.v1}}
+    attributedReservationCreated:
+      <<: *lifecycleEvidence
+      name: incentive.reservation.created.v2
+      headers:
+        allOf:
+          - $ref: '#/components/schemas/outboxHeaders'
+          - type: object
+            required: [ce-type]
+            properties: {ce-type: {const: incentive.reservation.created.v2}}
+      payload:
+        allOf:
+          - $ref: '#/components/schemas/attributedReservationLifecycle'
+          - properties: {eventType: {const: incentive.reservation.created.v2}}
+    attributedReservationCommitted:
+      <<: *lifecycleEvidence
+      name: incentive.reservation.committed.v2
+      headers:
+        allOf:
+          - $ref: '#/components/schemas/outboxHeaders'
+          - type: object
+            required: [ce-type]
+            properties: {ce-type: {const: incentive.reservation.committed.v2}}
+      payload:
+        allOf:
+          - $ref: '#/components/schemas/attributedReservationLifecycle'
+          - properties: {eventType: {const: incentive.reservation.committed.v2}}
+    attributedReservationReleased:
+      <<: *lifecycleEvidence
+      name: incentive.reservation.released.v2
+      headers:
+        allOf:
+          - $ref: '#/components/schemas/outboxHeaders'
+          - type: object
+            required: [ce-type]
+            properties: {ce-type: {const: incentive.reservation.released.v2}}
+      payload:
+        allOf:
+          - $ref: '#/components/schemas/attributedReservationLifecycle'
+          - properties: {eventType: {const: incentive.reservation.released.v2}}
+    attributedReservationExpired:
+      <<: *lifecycleEvidence
+      name: incentive.reservation.expired.v2
+      headers:
+        allOf:
+          - $ref: '#/components/schemas/outboxHeaders'
+          - type: object
+            required: [ce-type]
+            properties: {ce-type: {const: incentive.reservation.expired.v2}}
+      payload:
+        allOf:
+          - $ref: '#/components/schemas/attributedReservationLifecycle'
+          - properties: {eventType: {const: incentive.reservation.expired.v2}}

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/application/IncentiveApplication.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/application/IncentiveApplication.kt
@@ -62,18 +62,22 @@ class IncentiveApplication(
         code: String,
         partyRef: String,
         productRef: String,
+        attributionRef: UUID?,
         key: String,
         actor: String,
         now: Instant = Instant.now(),
     ): PromoReservation = store.reserve(
-        offerId,
-        digest(code),
-        partyRef,
-        productRef,
-        key,
-        actor,
-        now,
-        now.plus(reservationTtl),
+        ReserveIncentive(
+            offerId,
+            digest(code),
+            partyRef,
+            productRef,
+            attributionRef,
+            key,
+            actor,
+            now,
+            now.plus(reservationTtl),
+        ),
     )
 
     suspend fun commit(id: UUID, actor: String, now: Instant = Instant.now()) = store.commit(id, actor, now)

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/application/IncentiveStore.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/application/IncentiveStore.kt
@@ -14,17 +14,20 @@ interface IncentiveStore {
     suspend fun submitOffer(id: UUID, actor: String): IncentiveOffer
     suspend fun publishOffer(id: UUID, actor: String, at: Instant): IncentiveOffer
     suspend fun addCodes(offerId: UUID, digests: Set<CodeDigest>, actor: String, at: Instant): Int
-    suspend fun reserve(
-        offerId: UUID,
-        digest: CodeDigest,
-        partyRef: String,
-        productRef: String,
-        idempotencyKey: String,
-        actor: String,
-        now: Instant,
-        expiresAt: Instant,
-    ): PromoReservation
+    suspend fun reserve(command: ReserveIncentive): PromoReservation
     suspend fun commit(id: UUID, actor: String, at: Instant): PromoReservation
     suspend fun release(id: UUID, actor: String, at: Instant): PromoReservation
     suspend fun expireDue(at: Instant): Int
 }
+
+data class ReserveIncentive(
+    val offerId: UUID,
+    val digest: CodeDigest,
+    val partyRef: String,
+    val productRef: String,
+    val attributionRef: UUID?,
+    val idempotencyKey: String,
+    val actor: String,
+    val now: Instant,
+    val expiresAt: Instant,
+)

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/domain/PromoReservation.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/domain/PromoReservation.kt
@@ -22,6 +22,7 @@ data class PromoReservation(
     val idempotencyKey: String,
     val reservedAt: Instant,
     val expiresAt: Instant,
+    val attributionRef: UUID? = null,
     val status: ReservationStatus = ReservationStatus.RESERVED,
 ) {
     init {

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/persistence/IncentivePersistence.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/persistence/IncentivePersistence.kt
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.openbank.incentive.infrastructure.persistence
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.incentive.application.IncentiveStore
+import com.openbank.incentive.application.ReserveIncentive
 import com.openbank.incentive.domain.CodeDigest
 import com.openbank.incentive.domain.IncentiveConflict
 import com.openbank.incentive.domain.IncentiveNotFound
@@ -72,6 +74,7 @@ class ReservationEntity : PanacheEntityBase() {
     lateinit var codeDigest: String
     lateinit var partyRef: String
     lateinit var productRef: String
+    var attributionRef: UUID? = null
     lateinit var idempotencyKey: String
     lateinit var status: String
     lateinit var reservedAt: Instant
@@ -249,6 +252,7 @@ class PanacheIncentiveStore(
     private val reservations: ReservationEntities,
     private val audits: AuditEntities,
     private val outbox: OutboxEntities,
+    private val objectMapper: ObjectMapper,
 ) : IncentiveStore {
     override suspend fun createOffer(offer: IncentiveOffer): IncentiveOffer = Panache.withTransaction {
         offers.persist(offer.toEntity()).flatMap {
@@ -313,70 +317,73 @@ class PanacheIncentiveStore(
         const val RETENTION_MONTHS = 13L
     }
 
-    override suspend fun reserve(
-        offerId: UUID,
-        digest: CodeDigest,
-        partyRef: String,
-        productRef: String,
-        idempotencyKey: String,
-        actor: String,
-        now: Instant,
-        expiresAt: Instant,
-    ): PromoReservation = Panache.withTransaction {
-        lockedOffer(offerId).flatMap { offerEntity ->
-            reservations.find("offerId = ?1 and idempotencyKey = ?2", offerId, idempotencyKey)
+    override suspend fun reserve(command: ReserveIncentive): PromoReservation = Panache.withTransaction {
+        lockedOffer(command.offerId).flatMap { offerEntity ->
+            reservations.find("offerId = ?1 and idempotencyKey = ?2", command.offerId, command.idempotencyKey)
                 .firstResult<ReservationEntity>().flatMap { replay ->
                     if (replay != null) {
-                        if (
-                            replay.codeDigest != digest.value ||
-                            replay.partyRef != partyRef ||
-                            replay.productRef != productRef
-                        ) {
+                        if (!replay.matches(command)) {
                             throw IncentiveConflict("idempotency key was already used for a different request")
                         }
                         return@flatMap Uni.createFrom().item(replay.toDomain())
                     }
-                    val offer = offerEntity?.toDomain() ?: throw IncentiveNotFound("offer not found")
-                    if (!offer.accepts(productRef, now)) throw IncentiveConflict("offer is not redeemable")
-                    reservations.count("offerId = ?1 and status in (?2, ?3)", offerId, "RESERVED", "COMMITTED")
-                        .flatMap { total ->
-                            if (total >= offer.totalLimit) throw IncentiveConflict("offer total limit reached")
-                            reservations.count(
-                                "offerId = ?1 and partyRef = ?2 and status in (?3, ?4)",
-                                offerId,
-                                partyRef,
-                                "RESERVED",
-                                "COMMITTED",
-                            )
-                        }.flatMap { partyCount ->
-                            if (partyCount >= offer.perPartyLimit) throw IncentiveConflict("party limit reached")
-                            lockedCode(digest.value)
-                        }.flatMap { code ->
-                            if (code == null || code.offerId != offerId || code.status != "AVAILABLE") {
-                                throw IncentiveConflict("code is unavailable")
-                            }
-                            code.status = "RESERVED"
-                            val reservation = PromoReservation(
-                                Ids.newId(),
-                                offer.ref,
-                                digest,
-                                partyRef,
-                                productRef,
-                                idempotencyKey,
-                                now,
-                                expiresAt,
-                            )
-                            reservations.persist(reservation.toEntity()).flatMap {
-                                evidence(
-                                    reservation.id,
-                                    eventType = "incentive.reservation.created.v1",
-                                    actor = actor,
+                    existingAttribution(command.attributionRef).flatMap { attributed ->
+                        if (attributed != null) throw IncentiveConflict("attribution was already reserved")
+                        val offer = redeemableOffer(offerEntity, command)
+                        reservations.count(
+                            "offerId = ?1 and status in (?2, ?3)",
+                            command.offerId,
+                            "RESERVED",
+                            "COMMITTED",
+                        )
+                            .flatMap { total ->
+                                if (total >= offer.totalLimit) throw IncentiveConflict("offer total limit reached")
+                                reservations.count(
+                                    "offerId = ?1 and partyRef = ?2 and status in (?3, ?4)",
+                                    command.offerId,
+                                    command.partyRef,
+                                    "RESERVED",
+                                    "COMMITTED",
                                 )
-                            }.replaceWith(reservation)
-                        }
+                            }.flatMap { partyCount ->
+                                if (partyCount >= offer.perPartyLimit) throw IncentiveConflict("party limit reached")
+                                lockedCode(command.digest.value)
+                            }.flatMap { code ->
+                                if (code == null || code.offerId != command.offerId || code.status != "AVAILABLE") {
+                                    throw IncentiveConflict("code is unavailable")
+                                }
+                                code.status = "RESERVED"
+                                val reservation = PromoReservation(
+                                    Ids.newId(),
+                                    offer.ref,
+                                    command.digest,
+                                    command.partyRef,
+                                    command.productRef,
+                                    command.idempotencyKey,
+                                    command.now,
+                                    command.expiresAt,
+                                    command.attributionRef,
+                                )
+                                reservations.persist(reservation.toEntity()).flatMap {
+                                    reservationEvidence(reservation, ReservationStatus.RESERVED, command.actor)
+                                }.replaceWith(reservation)
+                            }
+                    }
                 }
         }
     }.awaitSuspending()
+
+    private fun redeemableOffer(entity: OfferEntity?, command: ReserveIncentive): IncentiveOffer {
+        val offer = entity?.toDomain() ?: throw IncentiveNotFound("offer not found")
+        if (!offer.accepts(command.productRef, command.now)) throw IncentiveConflict("offer is not redeemable")
+        return offer
+    }
+
+    private fun existingAttribution(attributionRef: UUID?): Uni<ReservationEntity?> = if (attributionRef == null) {
+        Uni.createFrom().nullItem()
+    } else {
+        reservations.find("attributionRef", attributionRef).firstResult()
+    }
 
     override suspend fun commit(id: UUID, actor: String, at: Instant): PromoReservation =
         transition(id, actor, at, ReservationStatus.COMMITTED)
@@ -426,16 +433,8 @@ class PanacheIncentiveStore(
                     requireNotNull(code)
                     code.status = if (target == ReservationStatus.COMMITTED) "REDEEMED" else "AVAILABLE"
                     when (target) {
-                        ReservationStatus.COMMITTED -> evidence(
-                            id,
-                            eventType = "incentive.reservation.committed.v1",
-                            actor = actor,
-                        )
-                        ReservationStatus.RELEASED -> evidence(
-                            id,
-                            eventType = "incentive.reservation.released.v1",
-                            actor = actor,
-                        )
+                        ReservationStatus.COMMITTED -> reservationEvidence(updated, target, actor)
+                        ReservationStatus.RELEASED -> reservationEvidence(updated, target, actor)
                         else -> error("unsupported transition")
                     }
                         .replaceWith(updated)
@@ -448,8 +447,49 @@ class PanacheIncentiveStore(
             entity.status = ReservationStatus.EXPIRED.name
             entity.releasedAt = at
             requireNotNull(code).status = "AVAILABLE"
-            evidence(entity.id, eventType = "incentive.reservation.expired.v1", actor = "expiry")
+            reservationEvidence(
+                entity.toDomain().copy(status = ReservationStatus.EXPIRED),
+                ReservationStatus.EXPIRED,
+                "expiry",
+            )
         }
+
+    private fun reservationEvidence(
+        reservation: PromoReservation,
+        status: ReservationStatus,
+        actor: String,
+    ): Uni<Void> {
+        val attributionRef = reservation.attributionRef
+        if (attributionRef == null) {
+            return evidence(
+                reservation.id,
+                eventType = ReservationEventTypes.forStatus(status, attributed = false),
+                actor = actor,
+            )
+        }
+        val eventType = ReservationEventTypes.forStatus(status, attributed = true)
+        val at = Instant.now()
+        val audit = AuditEntity().apply {
+            id = Ids.newId()
+            aggregateId = reservation.id
+            this.eventType = eventType
+            this.actor = actor
+            occurredAt = at
+            details = "{}"
+        }
+        val eventId = Ids.newId()
+        val payload = attributedEvidence(eventId, reservation, attributionRef, status, at)
+        val event = OutboxEntity().apply {
+            id = eventId
+            aggregateId = reservation.id
+            this.eventType = eventType
+            this.payload = objectMapper.writeValueAsString(payload)
+            occurredAt = at
+            this.status = OutboxStatus.PENDING.name
+            updatedAt = at
+        }
+        return audits.persist(audit).flatMap { outbox.persist(event) }.replaceWithVoid()
+    }
 
     private fun evidence(id: UUID, eventType: String, actor: String): Uni<Void> {
         val at = Instant.now()
@@ -522,6 +562,7 @@ private fun PromoReservation.toEntity() = ReservationEntity().also { entity ->
     entity.offerVersion = offerRef.version
     entity.partyRef = partyRef
     entity.productRef = productRef
+    entity.attributionRef = attributionRef
     entity.idempotencyKey = idempotencyKey
     entity.status = status.name
     entity.reservedAt = reservedAt
@@ -530,5 +571,191 @@ private fun PromoReservation.toEntity() = ReservationEntity().also { entity ->
 
 private fun ReservationEntity.toDomain() = PromoReservation(
     id, OfferRef(offerId, offerName, offerVersion), CodeDigest(codeDigest), partyRef, productRef,
-    idempotencyKey, reservedAt, expiresAt, ReservationStatus.valueOf(status),
+    idempotencyKey, reservedAt, expiresAt, attributionRef, ReservationStatus.valueOf(status),
 )
+
+private fun ReservationEntity.matches(command: ReserveIncentive): Boolean = codeDigest == command.digest.value &&
+    partyRef == command.partyRef &&
+    productRef == command.productRef &&
+    attributionRef == command.attributionRef
+
+private object ReservationEventTypes {
+    const val CREATED_V1 = "incentive.reservation.created.v1"
+    const val COMMITTED_V1 = "incentive.reservation.committed.v1"
+    const val RELEASED_V1 = "incentive.reservation.released.v1"
+    const val EXPIRED_V1 = "incentive.reservation.expired.v1"
+    const val CREATED_V2 = "incentive.reservation.created.v2"
+    const val COMMITTED_V2 = "incentive.reservation.committed.v2"
+    const val RELEASED_V2 = "incentive.reservation.released.v2"
+    const val EXPIRED_V2 = "incentive.reservation.expired.v2"
+
+    fun forStatus(status: ReservationStatus, attributed: Boolean): String = when (status) {
+        ReservationStatus.RESERVED -> if (attributed) CREATED_V2 else CREATED_V1
+        ReservationStatus.COMMITTED -> if (attributed) COMMITTED_V2 else COMMITTED_V1
+        ReservationStatus.RELEASED -> if (attributed) RELEASED_V2 else RELEASED_V1
+        ReservationStatus.EXPIRED -> if (attributed) EXPIRED_V2 else EXPIRED_V1
+    }
+}
+
+private fun attributedEvidence(
+    eventId: UUID,
+    reservation: PromoReservation,
+    attributionRef: UUID,
+    status: ReservationStatus,
+    occurredAt: Instant,
+): AttributedReservationEvidence = when (status) {
+    ReservationStatus.RESERVED -> ReservationCreatedV2(
+        eventId,
+        reservation.id,
+        reservation.id,
+        occurredAt,
+        reservation.id,
+        reservation.offerRef,
+        attributionRef,
+        status,
+    )
+    ReservationStatus.COMMITTED -> ReservationCommittedV2(
+        eventId,
+        reservation.id,
+        reservation.id,
+        occurredAt,
+        reservation.id,
+        reservation.offerRef,
+        attributionRef,
+        status,
+    )
+    ReservationStatus.RELEASED -> ReservationReleasedV2(
+        eventId,
+        reservation.id,
+        reservation.id,
+        occurredAt,
+        reservation.id,
+        reservation.offerRef,
+        attributionRef,
+        status,
+    )
+    ReservationStatus.EXPIRED -> ReservationExpiredV2(
+        eventId,
+        reservation.id,
+        reservation.id,
+        occurredAt,
+        reservation.id,
+        reservation.offerRef,
+        attributionRef,
+        status,
+    )
+}
+
+private sealed interface AttributedReservationEvidence
+
+private data class ReservationCreatedV2(
+    val eventId: UUID,
+    val correlationId: UUID,
+    val aggregateId: UUID,
+    val occurredAt: Instant,
+    val reservationId: UUID,
+    val offerRef: OfferRef,
+    val attributionRef: UUID,
+    val status: ReservationStatus,
+    val eventType: String = EVENT_TYPE,
+) : AttributedReservationEvidence {
+    companion object {
+        const val EVENT_TYPE = "incentive.reservation.created.v2"
+    }
+}
+
+private data class ReservationCommittedV2(
+    val eventId: UUID,
+    val correlationId: UUID,
+    val aggregateId: UUID,
+    val occurredAt: Instant,
+    val reservationId: UUID,
+    val offerRef: OfferRef,
+    val attributionRef: UUID,
+    val status: ReservationStatus,
+    val eventType: String = EVENT_TYPE,
+) : AttributedReservationEvidence {
+    companion object {
+        const val EVENT_TYPE = "incentive.reservation.committed.v2"
+    }
+}
+
+private data class ReservationReleasedV2(
+    val eventId: UUID,
+    val correlationId: UUID,
+    val aggregateId: UUID,
+    val occurredAt: Instant,
+    val reservationId: UUID,
+    val offerRef: OfferRef,
+    val attributionRef: UUID,
+    val status: ReservationStatus,
+    val eventType: String = EVENT_TYPE,
+) : AttributedReservationEvidence {
+    companion object {
+        const val EVENT_TYPE = "incentive.reservation.released.v2"
+    }
+}
+
+private data class ReservationExpiredV2(
+    val eventId: UUID,
+    val correlationId: UUID,
+    val aggregateId: UUID,
+    val occurredAt: Instant,
+    val reservationId: UUID,
+    val offerRef: OfferRef,
+    val attributionRef: UUID,
+    val status: ReservationStatus,
+    val eventType: String = EVENT_TYPE,
+) : AttributedReservationEvidence {
+    companion object {
+        const val EVENT_TYPE = "incentive.reservation.expired.v2"
+    }
+}
+
+internal data class ReservationCreatedV1(
+    val eventId: UUID,
+    val correlationId: UUID,
+    val aggregateId: UUID,
+    val eventType: String,
+    val occurredAt: Instant,
+) {
+    companion object {
+        const val EVENT_TYPE = "incentive.reservation.created.v1"
+    }
+}
+
+internal data class ReservationCommittedV1(
+    val eventId: UUID,
+    val correlationId: UUID,
+    val aggregateId: UUID,
+    val eventType: String,
+    val occurredAt: Instant,
+) {
+    companion object {
+        const val EVENT_TYPE = "incentive.reservation.committed.v1"
+    }
+}
+
+internal data class ReservationReleasedV1(
+    val eventId: UUID,
+    val correlationId: UUID,
+    val aggregateId: UUID,
+    val eventType: String,
+    val occurredAt: Instant,
+) {
+    companion object {
+        const val EVENT_TYPE = "incentive.reservation.released.v1"
+    }
+}
+
+internal data class ReservationExpiredV1(
+    val eventId: UUID,
+    val correlationId: UUID,
+    val aggregateId: UUID,
+    val eventType: String,
+    val occurredAt: Instant,
+) {
+    companion object {
+        const val EVENT_TYPE = "incentive.reservation.expired.v1"
+    }
+}

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/rest/CustomerIncentiveResource.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/rest/CustomerIncentiveResource.kt
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.openbank.incentive.infrastructure.rest
+
+import com.openbank.incentive.application.IncentiveApplication
+import com.openbank.incentive.domain.OfferRef
+import com.openbank.incentive.domain.ReservationStatus
+import io.quarkus.security.identity.SecurityIdentity
+import jakarta.annotation.security.RolesAllowed
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.HeaderParam
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import java.time.Instant
+import java.util.Optional
+import java.util.UUID
+
+data class CustomerReserveCodeRequest(
+    val code: String,
+    val productRef: String,
+    val attributionRef: UUID,
+    val partyRef: String? = null,
+)
+
+data class CustomerReservationResponse(
+    val id: UUID,
+    val offerRef: OfferRef,
+    val productRef: String,
+    val attributionRef: UUID,
+    val reservedAt: Instant,
+    val expiresAt: Instant,
+    val status: ReservationStatus,
+)
+
+/**
+ * Trusted customer-edge boundary. The retail client never supplies party identity or offer terms:
+ * customer-edge derives the party from its Keycloak JWT and resolves the offer from the opaque
+ * campaign interaction before calling this ROLE_API endpoint.
+ */
+@Path("/api/v1/customer-incentives")
+@ApplicationScoped
+@RolesAllowed("ROLE_API")
+class CustomerIncentiveResource(
+    private val application: IncentiveApplication,
+    private val identity: SecurityIdentity,
+    @ConfigProperty(name = "openbank.incentive.customer-caller-principal")
+    private val callerPrincipal: Optional<String>,
+) {
+    @POST
+    @Path("/offers/{id}/reservations")
+    suspend fun reserve(
+        @PathParam("id") id: UUID,
+        @HeaderParam("X-Customer-Party-Id") partyId: String?,
+        @HeaderParam("Idempotency-Key") key: String?,
+        request: CustomerReserveCodeRequest,
+    ): Response {
+        val permittedCaller = callerPrincipal.orElse("")
+        if (permittedCaller.isBlank() || identity.principal?.name != permittedCaller) {
+            return Response.status(Response.Status.FORBIDDEN).build()
+        }
+        require(request.partyRef == null) { "partyRef must not be supplied by the customer request" }
+        val trustedParty = requireNotNull(partyId?.let(::parseUuid)) { "X-Customer-Party-Id is required" }
+        require(trustedParty != ZERO_UUID) { "X-Customer-Party-Id must not be the nil UUID" }
+        require(!key.isNullOrBlank()) { "Idempotency-Key is required" }
+        val reservation = application.reserve(
+            id,
+            request.code,
+            trustedParty.toString(),
+            request.productRef,
+            request.attributionRef,
+            key,
+            identity.principal.name,
+        )
+        return Response.status(Response.Status.CREATED).entity(
+            CustomerReservationResponse(
+                reservation.id,
+                reservation.offerRef,
+                reservation.productRef,
+                requireNotNull(reservation.attributionRef),
+                reservation.reservedAt,
+                reservation.expiresAt,
+                reservation.status,
+            ),
+        ).build()
+    }
+
+    private fun parseUuid(value: String): UUID? = runCatching { UUID.fromString(value) }.getOrNull()
+
+    private companion object {
+        val ZERO_UUID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
+    }
+}

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/rest/IncentiveResource.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/rest/IncentiveResource.kt
@@ -102,7 +102,8 @@ class IncentiveResource(private val application: IncentiveApplication, private v
         require(!key.isNullOrBlank()) { "Idempotency-Key is required" }
         return Response.status(Response.Status.CREATED)
             .entity(
-                application.reserve(id, request.code, request.partyRef, request.productRef, key, actor()).toResponse(),
+                application.reserve(id, request.code, request.partyRef, request.productRef, null, key, actor())
+                    .toResponse(),
             ).build()
     }
 

--- a/openbank-incentive-service/src/main/resources/application.yaml
+++ b/openbank-incentive-service/src/main/resources/application.yaml
@@ -61,11 +61,15 @@ openbank:
   incentive:
     code-pepper: ${PROMO_CODE_PEPPER:}
     reservation-ttl: ${PROMO_RESERVATION_TTL:PT15M}
+    # Fail closed: only customer-edge's configured workload principal may assert a customer party.
+    customer-caller-principal: ${INCENTIVE_CUSTOMER_CALLER_PRINCIPAL:}
 
 "%test":
   openbank:
     outbox:
       dispatch-enabled: false
+    incentive:
+      customer-caller-principal: maker@openbank.test
   quarkus:
     management:
       enabled: false

--- a/openbank-incentive-service/src/main/resources/db/migration/V3__reservation_attribution.sql
+++ b/openbank-incentive-service/src/main/resources/db/migration/V3__reservation_attribution.sql
@@ -1,0 +1,8 @@
+-- Rollback: stop customer claims and event dispatch, then drop the partial unique index and
+-- attribution_ref column. Existing v2 evidence is append-only and intentionally remains on Kafka.
+ALTER TABLE promo_reservation
+  ADD COLUMN attribution_ref UUID;
+
+CREATE UNIQUE INDEX promo_reservation_attribution_ref_uq
+  ON promo_reservation(attribution_ref)
+  WHERE attribution_ref IS NOT NULL;

--- a/openbank-incentive-service/src/main/resources/openapi.yaml
+++ b/openbank-incentive-service/src/main/resources/openapi.yaml
@@ -1,9 +1,39 @@
 openapi: 3.0.3
 info:
   title: OpenBank Incentive Service
-  version: 1.1.0
+  version: 1.2.0
   description: Governed fixed-benefit offers and opaque promo-code reservations.
 paths:
+  /api/v1/customer-incentives/offers/{id}/reservations:
+    post:
+      summary: Reserve an attributed offer for an authenticated customer through customer-edge
+      description: >-
+        Internal ROLE_API boundary. The caller derives X-Customer-Party-Id from the customer JWT
+        and resolves the immutable offer and attribution reference from trusted server state.
+      parameters:
+        - {$ref: '#/components/parameters/OfferId'}
+        - name: X-Customer-Party-Id
+          in: header
+          required: true
+          schema: {type: string, format: uuid}
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema: {type: string, minLength: 1}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/CustomerReserveCode'}
+      responses:
+        "201":
+          description: Reserved or idempotently replayed
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/CustomerReservation'}
+        "400": {description: Missing trusted party, idempotency key, or invalid request}
+        "404": {description: Offer or code not found}
+        "409": {description: Replay mismatch, inventory, offer, attribution, or limit conflict}
   /api/v1/incentives/offers:
     get:
       summary: List immutable published incentive offers for governed catalogue selection
@@ -131,6 +161,29 @@ components:
         code: {type: string, minLength: 8, maxLength: 128, writeOnly: true}
         partyRef: {type: string}
         productRef: {type: string}
+    CustomerReserveCode:
+      type: object
+      additionalProperties: false
+      required: [code, productRef, attributionRef]
+      properties:
+        code: {type: string, minLength: 8, maxLength: 128, writeOnly: true}
+        productRef: {type: string, minLength: 1}
+        attributionRef:
+          type: string
+          format: uuid
+          description: Opaque campaign interaction reference resolved by customer-edge.
+    CustomerReservation:
+      type: object
+      additionalProperties: false
+      required: [id, offerRef, productRef, attributionRef, reservedAt, expiresAt, status]
+      properties:
+        id: {type: string, format: uuid}
+        offerRef: {$ref: '#/components/schemas/OfferRef'}
+        productRef: {type: string}
+        attributionRef: {type: string, format: uuid}
+        reservedAt: {type: string, format: date-time}
+        expiresAt: {type: string, format: date-time}
+        status: {type: string, enum: [RESERVED, COMMITTED, RELEASED, EXPIRED]}
     Offer:
       type: object
       required: [ref, productScope, effectiveFrom, expiresAt, totalLimit, perPartyLimit, stackingPolicy, status, maker]

--- a/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/integration/IncentiveRestContractIT.kt
+++ b/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/integration/IncentiveRestContractIT.kt
@@ -41,7 +41,7 @@ import javax.sql.DataSource
 @QuarkusTest
 @QuarkusTestResource(IncentivePostgresTestResource::class)
 @QuarkusTestResource(IncentiveRestContractIT.InMemoryKafkaResource::class)
-@TestSecurity(user = "maker@openbank.test", roles = ["ROLE_OPERATOR"])
+@TestSecurity(user = "maker@openbank.test", roles = ["ROLE_OPERATOR", "ROLE_API"])
 class IncentiveRestContractIT {
     class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
         override fun start(): Map<String, String> =
@@ -101,10 +101,10 @@ class IncentiveRestContractIT {
 
         Given {
             contentType("application/json")
-            body("""{"codes":["SUMMER-0001","SUMMER-0002","SUMMER-0003"]}""")
+            body("""{"codes":["SUMMER-0001","SUMMER-0002","SUMMER-0003","SUMMER-0004"]}""")
         } When { post("/api/v1/incentives/offers/$offerId/codes") } Then {
             statusCode(201)
-            body("imported", equalTo(3))
+            body("imported", equalTo(4))
         }
 
         Given { contentType("application/json") }
@@ -165,6 +165,107 @@ class IncentiveRestContractIT {
         pool.shutdown()
         assertThat(ids.toSet()).hasSize(1)
         assertThat(count("select count(*) from promo_reservation where offer_id = '$offerId'")).isEqualTo(1)
+
+        val customerParty = java.util.UUID.randomUUID()
+        val attributionRef = java.util.UUID.randomUUID()
+        Given {
+            contentType("application/json")
+            header("Idempotency-Key", "customer-claim-$offerId")
+            body(
+                """{
+                    "code":"SUMMER-0004",
+                    "productRef":"current-account",
+                    "attributionRef":"$attributionRef"
+                }
+                """.trimIndent(),
+            )
+        } When { post("/api/v1/customer-incentives/offers/$offerId/reservations") } Then {
+            statusCode(400)
+        }
+
+        Given {
+            contentType("application/json")
+            header("X-Customer-Party-Id", customerParty.toString())
+            header("Idempotency-Key", "spoofed-party-$offerId")
+            body(
+                """{
+                    "code":"SUMMER-0004",
+                    "productRef":"current-account",
+                    "attributionRef":"$attributionRef",
+                    "partyRef":"spoofed-party"
+                }
+                """.trimIndent(),
+            )
+        } When { post("/api/v1/customer-incentives/offers/$offerId/reservations") } Then {
+            statusCode(400)
+        }
+
+        val attributedId = Given {
+            contentType("application/json")
+            header("X-Customer-Party-Id", customerParty.toString())
+            header("Idempotency-Key", "customer-claim-$offerId")
+            body(
+                """{
+                    "code":"SUMMER-0004",
+                    "productRef":"current-account",
+                    "attributionRef":"$attributionRef"
+                }
+                """.trimIndent(),
+            )
+        } When { post("/api/v1/customer-incentives/offers/$offerId/reservations") } Then {
+            statusCode(201)
+            body("attributionRef", equalTo(attributionRef.toString()))
+            body("$", not(hasKey("partyRef")))
+            body("$", not(hasKey("idempotencyKey")))
+            body("$", not(hasKey("codeDigest")))
+        } Extract { path<String>("id") }
+        assertThat(string("select party_ref from promo_reservation where id = '$attributedId'"))
+            .isEqualTo(customerParty.toString())
+        assertThat(string("select attribution_ref::text from promo_reservation where id = '$attributedId'"))
+            .isEqualTo(attributionRef.toString())
+        assertThat(
+            count(
+                """select count(*) from incentive_outbox where aggregate_id = '$attributedId'
+                    and event_type = 'incentive.reservation.created.v2'
+                    and payload::jsonb ->> 'attributionRef' = '$attributionRef'
+                    and payload::jsonb -> 'offerRef' ->> 'id' = '$offerId'
+                    and not (payload::jsonb ?| array['partyRef','code','codeDigest'])
+                """.trimIndent(),
+            ),
+        ).isEqualTo(1)
+
+        Given {
+            contentType("application/json")
+            header("X-Customer-Party-Id", customerParty.toString())
+            header("Idempotency-Key", "customer-claim-$offerId")
+            body(
+                """{
+                    "code":"SUMMER-0004",
+                    "productRef":"current-account",
+                    "attributionRef":"$attributionRef"
+                }
+                """.trimIndent(),
+            )
+        } When { post("/api/v1/customer-incentives/offers/$offerId/reservations") } Then {
+            statusCode(201)
+            body("id", equalTo(attributedId))
+        }
+
+        Given {
+            contentType("application/json")
+            header("X-Customer-Party-Id", customerParty.toString())
+            header("Idempotency-Key", "second-key-$offerId")
+            body(
+                """{
+                    "code":"SUMMER-0004",
+                    "productRef":"current-account",
+                    "attributionRef":"$attributionRef"
+                }
+                """.trimIndent(),
+            )
+        } When { post("/api/v1/customer-incentives/offers/$offerId/reservations") } Then {
+            statusCode(409)
+        }
         assertThat(string("select digest from promo_code_inventory where offer_id = '$offerId' limit 1"))
             .doesNotContain("SUMMER")
 
@@ -175,7 +276,7 @@ class IncentiveRestContractIT {
         } When { post("/api/v1/incentives/offers/$offerId/reservations") } Then {
             statusCode(409)
         }
-        assertThat(count("select count(*) from promo_reservation where offer_id = '$offerId'")).isEqualTo(1)
+        assertThat(count("select count(*) from promo_reservation where offer_id = '$offerId'")).isEqualTo(2)
 
         val firstId = ids.toSet().single()
         Given { contentType("application/json") }
@@ -210,7 +311,13 @@ class IncentiveRestContractIT {
         } When { post("/api/v1/incentives/offers/$offerId/reservations") } Then {
             statusCode(201)
         } Extract { path<String>("id") }
-        execute("update promo_reservation set expires_at = now() - interval '1 second' where id = '$expiringId'")
+        execute(
+            """
+            update promo_reservation
+            set reserved_at = now() - interval '2 seconds', expires_at = now() - interval '1 second'
+            where id = '$expiringId'
+            """.trimIndent(),
+        )
 
         val expiryStart = CountDownLatch(1)
         val expiryPool = Executors.newFixedThreadPool(2)
@@ -303,6 +410,31 @@ class IncentiveRestContractIT {
     private fun header(metadata: OutgoingKafkaRecordMetadata<*>, name: String): String =
         String(metadata.headers.lastHeader(name).value(), StandardCharsets.UTF_8)
 
+    @Test
+    @TestSecurity(user = "other-service", roles = ["ROLE_API"])
+    fun `customer reservation refuses a different api workload principal`() {
+        customerReservationRequest(java.util.UUID.randomUUID().toString()).Then { statusCode(403) }
+    }
+
+    @Test
+    fun `customer reservation refuses the nil party uuid`() {
+        customerReservationRequest("00000000-0000-0000-0000-000000000000").Then { statusCode(400) }
+    }
+
+    private fun customerReservationRequest(partyId: String) = Given {
+        contentType("application/json")
+        header("X-Customer-Party-Id", partyId)
+        header("Idempotency-Key", "trust-boundary-check")
+        body(
+            """{
+                "code":"SUMMER-0001",
+                "productRef":"current-account",
+                "attributionRef":"${java.util.UUID.randomUUID()}"
+            }
+            """.trimIndent(),
+        )
+    } When { post("/api/v1/customer-incentives/offers/${java.util.UUID.randomUUID()}/reservations") }
+
     companion object {
         private val CONTRACTED_EVENT_TYPES =
             setOf(
@@ -314,6 +446,10 @@ class IncentiveRestContractIT {
                 "incentive.reservation.committed.v1",
                 "incentive.reservation.released.v1",
                 "incentive.reservation.expired.v1",
+                "incentive.reservation.created.v2",
+                "incentive.reservation.committed.v2",
+                "incentive.reservation.released.v2",
+                "incentive.reservation.expired.v2",
             )
     }
 


### PR DESCRIPTION
## Summary
- add a fail-closed customer-edge reservation boundary with exact workload-principal and trusted party checks
- persist opaque campaign attribution and emit additive v2 reservation lifecycle evidence without party/code data
- add OpenAPI, AsyncAPI, Flyway and real HTTP/Postgres lifecycle proof

## Verification
- focused Incentive domain + HTTP/Postgres tests
- ktlintCheck, detekt, quarkusBuild
- event contract code agreement and coverage
- duplicate YAML keys and git diff checks
- independent API/security and event reviews: no findings after fixes

Refs #7210

Rollout boundary: this PR does not deploy the service or configure `INCENTIVE_CUSTOMER_CALLER_PRINCIPAL`; without that reviewed GitOps wiring the endpoint intentionally returns 403.