### PR TITLE
feat(customer-edge): add campaign incentive claims

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -134,6 +134,12 @@ class CustomerEdgeResource(
     )
     lateinit var productCatalogUrl: String
 
+    @ConfigProperty(
+        name = "openbank.edge.incentive-service-url",
+        defaultValue = "http://localhost:8156",
+    )
+    lateinit var incentiveServiceUrl: String
+
     @ConfigProperty(name = "openbank.edge.transaction-service-url")
     lateinit var transactionServiceUrl: String
 
@@ -444,6 +450,68 @@ class CustomerEdgeResource(
             TermDepositResolution.NotFound -> termDepositNotFound()
             TermDepositResolution.Unavailable -> termDepositCatalogueUnavailable()
         }
+
+    /**
+     * Reserve the fixed reward attached to a campaign treatment the signed-in customer received.
+     * The phone supplies only the opaque interaction reference, promo code and intended product.
+     * Party and offer identity are resolved server-side; the product must still be an ACTIVE,
+     * public term-deposit offer before Incentive Service sees the request.
+     */
+    @POST
+    @Path("/incentives/claims")
+    @Authorize(action = "customer.incentives.claim")
+    @Blocking
+    fun claimIncentive(body: String, @HeaderParam("Idempotency-Key") idempotencyKey: String?): Response {
+        require(!idempotencyKey.isNullOrBlank()) { "Idempotency-Key header is required" }
+        val customer = customer()
+        val request = runCatching { objectMapper.readTree(body) }.getOrNull()?.takeIf { it.isObject }
+            ?: return badRequest("Malformed incentive claim")
+        if (request.fieldNames().asSequence().any { it !in INCENTIVE_CLAIM_FIELDS }) {
+            return badRequest("Incentive claim contains unsupported fields")
+        }
+        val interactionRef = request.uuidField("interactionRef")
+            ?: return badRequest("interactionRef must be a UUID")
+        val productId = request.uuidField("productId")
+            ?: return badRequest("productId must be a UUID")
+        val code = request.path("code").asText().takeIf { it.isNotBlank() }
+            ?: return badRequest("code is required")
+
+        when (resolvePublicTermDeposit(customer, productId)) {
+            is TermDepositResolution.Found -> Unit
+            TermDepositResolution.NotFound -> return termDepositNotFound()
+            TermDepositResolution.Unavailable -> return termDepositCatalogueUnavailable()
+        }
+
+        val attributionResponse = upstream.get(
+            "$campaignServiceUrl/api/v1/campaigns/interactions/$interactionRef/attribution",
+            customer.partyId.toString(),
+        )
+        if (attributionResponse.status != Response.Status.OK.statusCode) {
+            return if (attributionResponse.status >= UPSTREAM_SERVER_ERROR_MIN) {
+                Response.status(Response.Status.BAD_GATEWAY).build()
+            } else {
+                badRequest("Invalid interaction reference")
+            }
+        }
+        val attribution = parseJson(attributionResponse)
+            ?: return Response.status(Response.Status.BAD_GATEWAY).build()
+        val offerId = attribution.path("incentiveOfferRef").uuidField("id")
+            ?: return Response.status(Response.Status.CONFLICT)
+                .entity("{\"error\":\"Campaign treatment has no claimable incentive\"}")
+                .type(MediaType.APPLICATION_JSON)
+                .build()
+
+        val trustedRequest = objectMapper.createObjectNode()
+            .put("code", code)
+            .put("productRef", productId.toString())
+            .put("attributionRef", interactionRef.toString())
+        return upstream.post(
+            "$incentiveServiceUrl/api/v1/customer-incentives/offers/$offerId/reservations",
+            customer.partyId.toString(),
+            objectMapper.writeValueAsString(trustedRequest),
+            idempotencyKey,
+        )
+    }
 
     /**
      * Opens a term-deposit account selected from [listTermDepositOffers]. The app intentionally
@@ -4578,6 +4646,7 @@ class CustomerEdgeResource(
             "PRODUCT_FEED",
             "REWARDS_HUB",
         )
+        private val INCENTIVE_CLAIM_FIELDS = setOf("interactionRef", "code", "productId")
 
         // A ThemeSpec is a small token document; 8 KiB leaves headroom for future fields
         // while keeping Redis abuse-proof (ADR-0190).

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -463,6 +463,7 @@ class CustomerEdgeResource(
     @Blocking
     fun claimIncentive(body: String, @HeaderParam("Idempotency-Key") idempotencyKey: String?): Response {
         require(!idempotencyKey.isNullOrBlank()) { "Idempotency-Key header is required" }
+        require(idempotencyKey.length <= MAX_IDEMPOTENCY_KEY_LENGTH) { "Idempotency-Key is too long" }
         val customer = customer()
         val request = runCatching { objectMapper.readTree(body) }.getOrNull()?.takeIf { it.isObject }
             ?: return badRequest("Malformed incentive claim")
@@ -473,8 +474,9 @@ class CustomerEdgeResource(
             ?: return badRequest("interactionRef must be a UUID")
         val productId = request.uuidField("productId")
             ?: return badRequest("productId must be a UUID")
-        val code = request.path("code").asText().takeIf { it.isNotBlank() }
-            ?: return badRequest("code is required")
+        val code = request.path("code").takeIf { it.isTextual }?.textValue()?.trim()
+            ?.takeIf { it.length in MIN_PROMO_CODE_LENGTH..MAX_PROMO_CODE_LENGTH }
+            ?: return badRequest("code must be a string between 8 and 128 characters")
 
         when (resolvePublicTermDeposit(customer, productId)) {
             is TermDepositResolution.Found -> Unit
@@ -4647,6 +4649,9 @@ class CustomerEdgeResource(
             "REWARDS_HUB",
         )
         private val INCENTIVE_CLAIM_FIELDS = setOf("interactionRef", "code", "productId")
+        private const val MIN_PROMO_CODE_LENGTH = 8
+        private const val MAX_PROMO_CODE_LENGTH = 128
+        private const val MAX_IDEMPOTENCY_KEY_LENGTH = 255
 
         // A ThemeSpec is a small token document; 8 KiB leaves headroom for future fields
         // while keeping Redis abuse-proof (ADR-0190).

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -40,6 +40,7 @@ import org.eclipse.microprofile.jwt.JsonWebToken
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.time.Clock
+import java.time.Instant
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.UUID
@@ -530,10 +531,20 @@ class CustomerEdgeResource(
     fun openTermDeposit(body: String, @HeaderParam("Idempotency-Key") idempotencyKey: String?): Response {
         requireNotNull(idempotencyKey) { "Idempotency-Key header is required" }
         require(idempotencyKey.isNotBlank()) { "Idempotency-Key header must not be blank" }
+        require(idempotencyKey.length <= MAX_IDEMPOTENCY_KEY_LENGTH) { "Idempotency-Key is too long" }
         val customer = customer()
-        val productId = extractTextField(objectMapper, body, "productId")
-            ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+        val request = runCatching { objectMapper.readTree(body) }.getOrNull()?.takeIf { it.isObject }
+            ?: return badRequest("Malformed term-deposit request")
+        if (request.fieldNames().asSequence().any { it !in TERM_DEPOSIT_OPEN_FIELDS }) {
+            return badRequest("Term-deposit request contains unsupported fields")
+        }
+        val productId = request.uuidField("productId")
             ?: return Response.status(400).entity("{\"error\":\"productId must be a UUID\"}").build()
+        val reservationId = request.get("incentiveReservationId")?.takeUnless { it.isNull }?.let {
+            it.takeIf { node -> node.isTextual }?.textValue()?.let { value ->
+                runCatching { UUID.fromString(value) }.getOrNull()
+            } ?: return badRequest("incentiveReservationId must be a UUID")
+        }
         val offer = when (val result = resolvePublicTermDeposit(customer, productId)) {
             is TermDepositResolution.Found -> result.offer
             TermDepositResolution.NotFound -> return termDepositNotFound()
@@ -563,7 +574,63 @@ class CustomerEdgeResource(
             resourceId = extractTextField(objectMapper, (response.entity as? String).orEmpty(), "id"),
             details = mapOf("productId" to productId.toString(), "currency" to offer.path("currency").asText()),
         )
+        if (reservationId != null) {
+            return reconcileTermDepositIncentive(response, customer, productId, reservationId, idempotencyKey)
+        }
         return response
+    }
+
+    private fun reconcileTermDepositIncentive(
+        accountResponse: Response,
+        customer: CustomerIdentity,
+        productId: UUID,
+        reservationId: UUID,
+        idempotencyKey: String,
+    ): Response {
+        if (accountResponse.statusInfo.family == Response.Status.Family.SUCCESSFUL) {
+            val account = parseJson(accountResponse)?.takeIf { it.isObject }
+                ?: return Response.status(Response.Status.BAD_GATEWAY)
+                    .entity("{\"error\":\"Account outcome lacked qualifying evidence\"}").build()
+            val qualifiedAt = qualifyingAccountOpenedAt(account, customer.partyId, productId)
+                ?: return Response.status(Response.Status.BAD_GATEWAY)
+                    .entity("{\"error\":\"Account outcome lacked qualifying evidence\"}").build()
+            val commitBody = objectMapper.createObjectNode()
+                .put("productRef", productId.toString())
+                .put("qualifiedAt", qualifiedAt.toString())
+            val commit = upstream.post(
+                "$incentiveServiceUrl/api/v1/customer-incentives/reservations/$reservationId/commit",
+                customer.partyId.toString(),
+                objectMapper.writeValueAsString(commitBody),
+                idempotencyKey,
+            )
+            if (commit.statusInfo.family != Response.Status.Family.SUCCESSFUL) return commit
+            val incentive = parseJson(commit)?.takeIf { it.isObject }
+                ?: return Response.status(Response.Status.BAD_GATEWAY).build()
+            val result = (account.deepCopy<JsonNode>() as ObjectNode).set<JsonNode>("incentiveReservation", incentive)
+            return Response.status(accountResponse.status).entity(result).type(MediaType.APPLICATION_JSON).build()
+        }
+
+        if (accountResponse.status !in TERMINAL_ACCOUNT_REJECTION_STATUSES) {
+            return accountResponse
+        }
+        val releaseBody = objectMapper.createObjectNode().put("productRef", productId.toString())
+        val release = upstream.post(
+            "$incentiveServiceUrl/api/v1/customer-incentives/reservations/$reservationId/release",
+            customer.partyId.toString(),
+            objectMapper.writeValueAsString(releaseBody),
+            idempotencyKey,
+        )
+        return if (release.statusInfo.family == Response.Status.Family.SUCCESSFUL) accountResponse else release
+    }
+
+    private fun qualifyingAccountOpenedAt(account: JsonNode, partyId: UUID, productId: UUID): Instant? {
+        val authoritative = account.path("partyId").asText() == partyId.toString() &&
+            account.path("productId").asText() == productId.toString() &&
+            account.path("accountType").asText() == "TERM_DEPOSIT" &&
+            account.path("status").asText() == "ACTIVE"
+        if (!authoritative) return null
+        return account.path("openedAt").takeIf { it.isTextual }?.textValue()
+            ?.let { runCatching { Instant.parse(it) }.getOrNull() }
     }
 
     // --- KYC / identity verification status (AML Act §8, ADR-0116) ---
@@ -4649,6 +4716,8 @@ class CustomerEdgeResource(
             "REWARDS_HUB",
         )
         private val INCENTIVE_CLAIM_FIELDS = setOf("interactionRef", "code", "productId")
+        private val TERM_DEPOSIT_OPEN_FIELDS = setOf("productId", "incentiveReservationId")
+        private val TERMINAL_ACCOUNT_REJECTION_STATUSES = setOf(422)
         private const val MIN_PROMO_CODE_LENGTH = 8
         private const val MAX_PROMO_CODE_LENGTH = 128
         private const val MAX_IDEMPOTENCY_KEY_LENGTH = 255

--- a/openbank-customer-edge/src/main/resources/application.yaml
+++ b/openbank-customer-edge/src/main/resources/application.yaml
@@ -148,6 +148,7 @@ openbank:
     notification-service-url: ${NOTIFICATION_SERVICE_URL:http://notification-service.notifications.svc:8112}
     engagement-service-url: ${ENGAGEMENT_SERVICE_URL:http://engagement-service.engagement.svc:8153}
     campaign-service-url: ${CAMPAIGN_SERVICE_URL:https://campaign-service.campaign.svc:8443}
+    incentive-service-url: ${INCENTIVE_SERVICE_URL:http://localhost:8156}
     statement-service-url: ${STATEMENT_SERVICE_URL:http://statement-service.statements.svc:8136}
     standing-order-service-url: ${STANDING_ORDER_SERVICE_URL:http://standing-order-service.payments.svc:8121}
     fx-service-url:      ${FX_SERVICE_URL:http://fx-service.fx.svc:8119}

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.42.0
+  version: 1.43.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -128,6 +128,40 @@ paths:
           description: Product is not an active public term-deposit offer, or party is absent
         '422':
           description: KYC not approved
+
+  /incentives/claims:
+    post:
+      tags: [Engagement]
+      summary: Reserve the fixed reward attached to an authenticated campaign treatment
+      description: >-
+        Party identity comes only from the customer Keycloak JWT. The opaque interaction reference
+        is resolved against Campaign Service and supplies the immutable offer reference; the phone
+        cannot choose either value. The product must be an active public term-deposit offer.
+        Reservation is not redemption: only a later authoritative product outcome may commit it.
+      operationId: claimCampaignIncentive
+      security:
+        - customerOidc: [accounts:read]
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema: {type: string, minLength: 1, maxLength: 255}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClaimCampaignIncentiveRequest'
+      responses:
+        '201':
+          description: Reward inventory reserved; this is not yet redeemed
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/IncentiveReservation'}
+        '400': {description: Malformed or foreign interaction reference}
+        '404': {description: Product is not an active public term-deposit offer}
+        '409': {description: Campaign treatment has no claimable incentive, or reservation conflicts}
+        '502': {description: Campaign, catalogue or Incentive Service unavailable}
 
   /feedback:
     post:
@@ -4247,6 +4281,44 @@ components:
           type: string
           format: uuid
           description: ID returned by /products/term-deposits
+
+    ClaimCampaignIncentiveRequest:
+      type: object
+      additionalProperties: false
+      required: [interactionRef, code, productId]
+      properties:
+        interactionRef:
+          type: string
+          format: uuid
+          description: Opaque PUSH/BANNER interaction reference supplied with the treatment.
+        code:
+          type: string
+          minLength: 8
+          maxLength: 128
+          writeOnly: true
+        productId:
+          type: string
+          format: uuid
+          description: Active public term-deposit catalogue product selected by the customer.
+
+    IncentiveReservation:
+      type: object
+      additionalProperties: false
+      required: [id, offerRef, productRef, attributionRef, reservedAt, expiresAt, status]
+      properties:
+        id: {type: string, format: uuid}
+        offerRef:
+          type: object
+          required: [id, name, version]
+          properties:
+            id: {type: string, format: uuid}
+            name: {type: string}
+            version: {type: integer, minimum: 1}
+        productRef: {type: string}
+        attributionRef: {type: string, format: uuid}
+        reservedAt: {type: string, format: date-time}
+        expiresAt: {type: string, format: date-time}
+        status: {type: string, enum: [RESERVED]}
 
     TermDepositOfferList:
       type: object

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.43.0
+  version: 1.44.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -122,6 +122,9 @@ paths:
       responses:
         '201':
           description: Term-deposit account opened
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Account'}
         '400':
           description: Missing idempotency key or malformed product ID
         '404':
@@ -3564,6 +3567,10 @@ components:
         nickname:
           type: string
           nullable: true
+        incentiveReservation:
+          allOf:
+            - {$ref: '#/components/schemas/IncentiveReservation'}
+          description: Present only when this account opening committed a campaign incentive.
 
     # Mirrors openbank-account-service AccountPage (GET /api/v1/accounts is cursor-paginated,
     # not a bare array).
@@ -4281,6 +4288,13 @@ components:
           type: string
           format: uuid
           description: ID returned by /products/term-deposits
+        incentiveReservationId:
+          type: string
+          format: uuid
+          description: >-
+            Optional opaque reservation returned by /incentives/claims. The edge commits it only
+            after account-service returns the authoritative openedAt; deterministic rejection
+            releases it, while transient failure leaves it retryable until its TTL.
 
     ClaimCampaignIncentiveRequest:
       type: object

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
@@ -49,6 +49,8 @@ class CustomerEdgeResourceTest {
         balanceServiceUrl = "http://balance"
         engagementServiceUrl = "http://engagement"
         campaignServiceUrl = "http://campaign"
+        productCatalogUrl = "http://catalog"
+        incentiveServiceUrl = "http://incentive"
     }
 
     private fun accountJson(accountId: UUID, ownerParty: UUID) =
@@ -62,6 +64,83 @@ class CustomerEdgeResourceTest {
         "earlyWithdrawalNoticeDays":0}, "termsAndConditions":[]
     }
     """.trimIndent()
+
+    @Test
+    fun `claimIncentive derives party and offer from trusted sources and forwards exact idempotency`() {
+        val caller = UUID.randomUUID()
+        val interactionRef = UUID.randomUUID()
+        val productId = UUID.randomUUID()
+        val offerId = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        val forwarded = slot<String>()
+        every { upstream.get("http://catalog/api/v1/products/$productId", caller.toString()) } returns
+            Response.ok(termDepositProduct(productId)).build()
+        every {
+            upstream.get(
+                "http://campaign/api/v1/campaigns/interactions/$interactionRef/attribution",
+                caller.toString(),
+            )
+        } returns Response.ok(
+            """{"campaignId":"${UUID.randomUUID()}","stepOrder":0,"channel":"PUSH","incentiveOfferRef":{"id":"$offerId","name":"WELCOME","version":1}}""",
+        ).build()
+        every {
+            upstream.post(
+                "http://incentive/api/v1/customer-incentives/offers/$offerId/reservations",
+                caller.toString(),
+                capture(forwarded),
+                "claim-once",
+            )
+        } returns Response.status(201).entity("{\"status\":\"RESERVED\"}").build()
+
+        val response = resourceFor(upstream, caller).claimIncentive(
+            """{"interactionRef":"$interactionRef","code":"WELCOME10","productId":"$productId"}""",
+            "claim-once",
+        )
+
+        assertThat(response.status).isEqualTo(201)
+        val request = ObjectMapper().readTree(forwarded.captured)
+        assertThat(request.path("productRef").asText()).isEqualTo(productId.toString())
+        assertThat(request.path("attributionRef").asText()).isEqualTo(interactionRef.toString())
+        assertThat(request.path("code").asText()).isEqualTo("WELCOME10")
+        assertThat(request.has("partyRef")).isFalse()
+        assertThat(request.has("offerId")).isFalse()
+    }
+
+    @Test
+    fun `claimIncentive rejects client supplied party or offer identity before any upstream call`() {
+        val caller = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        val response = resourceFor(upstream, caller).claimIncentive(
+            """{"interactionRef":"${UUID.randomUUID()}","code":"WELCOME10","productId":"${UUID.randomUUID()}","partyRef":"${UUID.randomUUID()}"}""",
+            "claim-once",
+        )
+
+        assertThat(response.status).isEqualTo(400)
+        verify(exactly = 0) { upstream.get(any(), any()) }
+        verify(exactly = 0) { upstream.post(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `claimIncentive rejects foreign interaction before calling Incentive Service`() {
+        val caller = UUID.randomUUID()
+        val interactionRef = UUID.randomUUID()
+        val productId = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get("http://catalog/api/v1/products/$productId", caller.toString()) } returns
+            Response.ok(termDepositProduct(productId)).build()
+        every {
+            upstream.get(match { it.contains("/interactions/$interactionRef/attribution") }, caller.toString())
+        } returns
+            Response.status(404).build()
+
+        val response = resourceFor(upstream, caller).claimIncentive(
+            """{"interactionRef":"$interactionRef","code":"WELCOME10","productId":"$productId"}""",
+            "claim-once",
+        )
+
+        assertThat(response.status).isEqualTo(400)
+        verify(exactly = 0) { upstream.post(match { it.startsWith("http://incentive/") }, any(), any(), any()) }
+    }
 
     @Test
     fun `getBalance rejects an account owned by another party and does not proxy (IDOR guard)`() {

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
@@ -65,6 +65,12 @@ class CustomerEdgeResourceTest {
     }
     """.trimIndent()
 
+    private fun termDepositAccount(caller: UUID, product: UUID, openedAt: String): String = """{
+        "id":"${UUID.randomUUID()}","partyId":"$caller","productId":"$product",
+        "accountType":"TERM_DEPOSIT","status":"ACTIVE","openedAt":"$openedAt"
+    }
+    """.trimIndent()
+
     @Test
     fun `claimIncentive derives party and offer from trusted sources and forwards exact idempotency`() {
         val caller = UUID.randomUUID()
@@ -224,16 +230,149 @@ class CustomerEdgeResourceTest {
         every { upstream.post(match { it.contains("/api/v1/accounts") }, any(), capture(sent), "retry-key") } returns
             Response.status(201).entity("""{"id":"${UUID.randomUUID()}"}""").build()
 
-        val response = resourceFor(upstream, caller).apply {
+        val resource = resourceFor(upstream, caller).apply {
             productCatalogUrl = "http://catalog"
             partyServiceUrl = "http://party"
-        }.openTermDeposit("""{"productId":"$product","accountType":"CURRENT","currencyCode":"EUR"}""", "retry-key")
+        }
+        assertThat(
+            resource.openTermDeposit(
+                """{"productId":"$product","accountType":"CURRENT","currencyCode":"EUR"}""",
+                "retry-key",
+            ).status,
+        ).isEqualTo(400)
+        val response = resource.openTermDeposit("""{"productId":"$product"}""", "retry-key")
 
         assertThat(response.status).isEqualTo(201)
         val body = ObjectMapper().readTree(sent.captured)
         assertThat(body.path("accountType").asText()).isEqualTo("TERM_DEPOSIT")
         assertThat(body.path("currencyCode").asText()).isEqualTo("CZK")
         assertThat(body.path("legalName").asText()).isEqualTo("Ada Customer")
+    }
+
+    @Test
+    fun `term deposit success commits the matching reservation with authoritative openedAt`() {
+        val caller = UUID.randomUUID()
+        val product = UUID.randomUUID()
+        val reservation = UUID.randomUUID()
+        val openedAt = "2026-08-27T03:00:00Z"
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.endsWith("/products/$product") }, any()) } returns
+            Response.ok(termDepositProduct(product)).build()
+        every { upstream.get(match { it.contains("/parties/$caller") }, any()) } returns
+            Response.ok("""{"status":"ACTIVE","legalName":"Ada Customer"}""").build()
+        every { upstream.post("http://account/api/v1/accounts", caller.toString(), any(), "open-once") } returns
+            Response.status(201).entity(termDepositAccount(caller, product, openedAt)).build()
+        val commitBody = slot<String>()
+        every {
+            upstream.post(
+                "http://incentive/api/v1/customer-incentives/reservations/$reservation/commit",
+                caller.toString(),
+                capture(commitBody),
+                "open-once",
+            )
+        } returns Response.ok("""{"id":"$reservation","status":"COMMITTED"}""").build()
+
+        val response = resourceFor(upstream, caller).apply {
+            productCatalogUrl = "http://catalog"
+            partyServiceUrl = "http://party"
+        }.openTermDeposit(
+            """{"productId":"$product","incentiveReservationId":"$reservation"}""",
+            "open-once",
+        )
+
+        assertThat(response.status).isEqualTo(201)
+        val responseJson = ObjectMapper().readTree(response.entity.toString())
+        assertThat(responseJson.path("incentiveReservation").path("status").asText()).isEqualTo("COMMITTED")
+        val evidence = ObjectMapper().readTree(commitBody.captured)
+        assertThat(evidence.path("productRef").asText()).isEqualTo(product.toString())
+        assertThat(evidence.path("qualifiedAt").asText()).isEqualTo(openedAt)
+    }
+
+    @Test
+    fun `term deposit success without matching authoritative account evidence does not commit`() {
+        val caller = UUID.randomUUID()
+        val product = UUID.randomUUID()
+        val reservation = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.endsWith("/products/$product") }, any()) } returns
+            Response.ok(termDepositProduct(product)).build()
+        every { upstream.get(match { it.contains("/parties/$caller") }, any()) } returns
+            Response.ok("""{"status":"ACTIVE","legalName":"Ada Customer"}""").build()
+        every { upstream.post("http://account/api/v1/accounts", caller.toString(), any(), "mismatch") } returns
+            Response.status(201).entity(
+                termDepositAccount(caller, UUID.randomUUID(), "2026-08-27T03:00:00Z"),
+            ).build()
+
+        val response = resourceFor(upstream, caller).apply {
+            productCatalogUrl = "http://catalog"
+            partyServiceUrl = "http://party"
+        }.openTermDeposit("""{"productId":"$product","incentiveReservationId":"$reservation"}""", "mismatch")
+
+        assertThat(response.status).isEqualTo(502)
+        verify(exactly = 0) {
+            upstream.post(match { it.contains("/customer-incentives/reservations/") }, any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `deterministic term deposit rejection releases the matching reservation`() {
+        val caller = UUID.randomUUID()
+        val product = UUID.randomUUID()
+        val reservation = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.endsWith("/products/$product") }, any()) } returns
+            Response.ok(termDepositProduct(product)).build()
+        every { upstream.get(match { it.contains("/parties/$caller") }, any()) } returns
+            Response.ok("""{"status":"ACTIVE","legalName":"Ada Customer"}""").build()
+        every { upstream.post("http://account/api/v1/accounts", caller.toString(), any(), "reject-once") } returns
+            Response.status(422).entity("""{"error":"rejected"}""").build()
+        every {
+            upstream.post(
+                "http://incentive/api/v1/customer-incentives/reservations/$reservation/release",
+                caller.toString(),
+                match { ObjectMapper().readTree(it).path("productRef").asText() == product.toString() },
+                "reject-once",
+            )
+        } returns Response.ok("""{"id":"$reservation","status":"RELEASED"}""").build()
+
+        val response = resourceFor(upstream, caller).apply {
+            productCatalogUrl = "http://catalog"
+            partyServiceUrl = "http://party"
+        }.openTermDeposit(
+            """{"productId":"$product","incentiveReservationId":"$reservation"}""",
+            "reject-once",
+        )
+
+        assertThat(response.status).isEqualTo(422)
+    }
+
+    @Test
+    fun `unknown auth routing and transient failures leave reservation retryable`() {
+        listOf(401, 403, 404, 408, 409, 425, 429, 500, 502).forEach { status ->
+            val caller = UUID.randomUUID()
+            val product = UUID.randomUUID()
+            val reservation = UUID.randomUUID()
+            val upstream = mockk<UpstreamClient>()
+            every { upstream.get(match { it.endsWith("/products/$product") }, any()) } returns
+                Response.ok(termDepositProduct(product)).build()
+            every { upstream.get(match { it.contains("/parties/$caller") }, any()) } returns
+                Response.ok("""{"status":"ACTIVE","legalName":"Ada Customer"}""").build()
+            every { upstream.post("http://account/api/v1/accounts", caller.toString(), any(), "retry-$status") } returns
+                Response.status(status).entity("""{"error":"unavailable"}""").build()
+
+            val response = resourceFor(upstream, caller).apply {
+                productCatalogUrl = "http://catalog"
+                partyServiceUrl = "http://party"
+            }.openTermDeposit(
+                """{"productId":"$product","incentiveReservationId":"$reservation"}""",
+                "retry-$status",
+            )
+
+            assertThat(response.status).isEqualTo(status)
+            verify(exactly = 0) {
+                upstream.post(match { it.contains("/customer-incentives/reservations/") }, any(), any(), any())
+            }
+        }
     }
 
     // ── party_id claim resolution (B1 fix, ADR-0069 §2) ─────────────────────

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeIncentivePactConsumerTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeIncentivePactConsumerTest.kt
@@ -31,6 +31,8 @@ import java.time.Clock
 @PactTestFor(providerName = "openbank-incentive-service", pactVersion = PactSpecVersion.V3)
 class CustomerEdgeIncentivePactConsumerTest {
     private lateinit var trustedStub: HttpServer
+    private var accountStatus = 201
+    private var accountBody = ACCOUNT_OPENED
 
     @BeforeEach
     fun startTrustedStub() {
@@ -43,6 +45,12 @@ class CustomerEdgeIncentivePactConsumerTest {
             }
             createContext("/api/v1/campaigns/interactions/$INTERACTION_REF/attribution") { exchange ->
                 respond(exchange, 200, ATTRIBUTION)
+            }
+            createContext("/api/v1/parties/$PARTY_ID") { exchange ->
+                respond(exchange, 200, """{"status":"ACTIVE","legalName":"Ada Customer"}""")
+            }
+            createContext("/api/v1/accounts") { exchange ->
+                respond(exchange, accountStatus, accountBody)
             }
             start()
         }
@@ -91,9 +99,95 @@ class CustomerEdgeIncentivePactConsumerTest {
         )
         .toPact()
 
+    @Pact(consumer = "openbank-customer-edge", provider = "openbank-incentive-service")
+    fun commitAttributedIncentive(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("an attributed reservation is reserved for qualifying commit")
+        .uponReceiving("POST a trusted qualifying account outcome")
+        .path("/api/v1/customer-incentives/reservations/$RESERVATION_ID/commit")
+        .method("POST")
+        .headers(
+            mapOf(
+                "Content-Type" to "application/json",
+                "X-Customer-Party-Id" to PARTY_ID,
+                "Idempotency-Key" to OPEN_IDEMPOTENCY_KEY,
+            ),
+        )
+        .body(
+            newJsonBody { body ->
+                body.stringValue("productRef", PRODUCT_ID)
+                body.stringValue("qualifiedAt", QUALIFIED_AT)
+            }.build(),
+        )
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(customerReservationBody("COMMITTED"))
+        .toPact()
+
+    @Pact(consumer = "openbank-customer-edge", provider = "openbank-incentive-service")
+    fun releaseAttributedIncentive(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("an attributed reservation is reserved for deterministic release")
+        .uponReceiving("POST a trusted deterministic qualifying rejection")
+        .path("/api/v1/customer-incentives/reservations/$RESERVATION_ID/release")
+        .method("POST")
+        .headers(
+            mapOf(
+                "Content-Type" to "application/json",
+                "X-Customer-Party-Id" to PARTY_ID,
+                "Idempotency-Key" to OPEN_IDEMPOTENCY_KEY,
+            ),
+        )
+        .body(newJsonBody { body -> body.stringValue("productRef", PRODUCT_ID) }.build())
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(customerReservationBody("RELEASED"))
+        .toPact()
+
     @Test
     @PactTestFor(pactMethod = "reserveAttributedIncentive")
     fun `real edge client reserves against the provider contract`(mockServer: MockServer) {
+        val resource = resource(mockServer)
+
+        val response = resource.claimIncentive(
+            """{"interactionRef":"$INTERACTION_REF","code":"WELCOME10","productId":"$PRODUCT_ID"}""",
+            IDEMPOTENCY_KEY,
+        )
+
+        assertThat(response.status).isEqualTo(201)
+        assertThat(ObjectMapper().readTree(response.entity.toString()).path("status").asText()).isEqualTo("RESERVED")
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "commitAttributedIncentive")
+    fun `real qualifying account flow commits against the provider contract`(mockServer: MockServer) {
+        accountStatus = 201
+        accountBody = ACCOUNT_OPENED
+        val response = resource(mockServer).openTermDeposit(
+            """{"productId":"$PRODUCT_ID","incentiveReservationId":"$RESERVATION_ID"}""",
+            OPEN_IDEMPOTENCY_KEY,
+        )
+
+        assertThat(response.status).isEqualTo(201)
+        assertThat(
+            ObjectMapper().readTree(response.entity.toString()).path("incentiveReservation").path("status").asText(),
+        ).isEqualTo("COMMITTED")
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "releaseAttributedIncentive")
+    fun `real deterministic rejection releases against the provider contract`(mockServer: MockServer) {
+        accountStatus = 422
+        accountBody = """{"error":"qualifying action rejected"}"""
+        val response = resource(mockServer).openTermDeposit(
+            """{"productId":"$PRODUCT_ID","incentiveReservationId":"$RESERVATION_ID"}""",
+            OPEN_IDEMPOTENCY_KEY,
+        )
+
+        assertThat(response.status).isEqualTo(422)
+    }
+
+    private fun resource(mockServer: MockServer): CustomerEdgeResource {
         val base = "http://127.0.0.1:${trustedStub.address.port}"
         val upstream = UpstreamClient().apply {
             tokenEndpointBase = base
@@ -102,7 +196,7 @@ class CustomerEdgeIncentivePactConsumerTest {
             tlsTrustCertificateFile = java.util.Optional.empty()
             allowedHostSuffixes = ".svc,127.0.0.1,localhost"
         }
-        val resource = CustomerEdgeResource(
+        return CustomerEdgeResource(
             upstream,
             mockk(relaxed = true),
             PaymentSessionStore(),
@@ -119,17 +213,11 @@ class CustomerEdgeIncentivePactConsumerTest {
                 every { resolve(any()) } answers { firstArg() }
             }
             productCatalogUrl = base
+            partyServiceUrl = base
+            accountServiceUrl = base
             campaignServiceUrl = base
             incentiveServiceUrl = mockServer.getUrl()
         }
-
-        val response = resource.claimIncentive(
-            """{"interactionRef":"$INTERACTION_REF","code":"WELCOME10","productId":"$PRODUCT_ID"}""",
-            IDEMPOTENCY_KEY,
-        )
-
-        assertThat(response.status).isEqualTo(201)
-        assertThat(ObjectMapper().readTree(response.entity.toString()).path("status").asText()).isEqualTo("RESERVED")
     }
 
     private companion object {
@@ -139,6 +227,13 @@ class CustomerEdgeIncentivePactConsumerTest {
         const val OFFER_ID = "44444444-4444-4444-8444-444444444444"
         const val RESERVATION_ID = "55555555-5555-4555-8555-555555555555"
         const val IDEMPOTENCY_KEY = "claim-pact-once"
+        const val OPEN_IDEMPOTENCY_KEY = "open-pact-once"
+        const val QUALIFIED_AT = "2026-08-27T03:00:00Z"
+        val ACCOUNT_OPENED =
+            """
+            {"id":"77777777-7777-4777-8777-777777777777","partyId":"$PARTY_ID","productId":"$PRODUCT_ID",
+            "accountType":"TERM_DEPOSIT","status":"ACTIVE","openedAt":"$QUALIFIED_AT"}
+            """.trimIndent()
         val TERM_DEPOSIT_PRODUCT = """
             {"id":"$PRODUCT_ID","code":"TERM_6M","name":"Term deposit","type":"TERM_DEPOSIT",
             "currency":"CZK","status":"ACTIVE","isPublic":true,
@@ -148,6 +243,20 @@ class CustomerEdgeIncentivePactConsumerTest {
             {"campaignId":"66666666-6666-4666-8666-666666666666","stepOrder":0,"channel":"PUSH",
             "incentiveOfferRef":{"id":"$OFFER_ID","name":"WELCOME","version":1}}
         """.trimIndent()
+
+        fun customerReservationBody(status: String) = newJsonBody { body ->
+            body.uuid("id", java.util.UUID.fromString(RESERVATION_ID))
+            body.`object`("offerRef") { ref ->
+                ref.uuid("id", java.util.UUID.fromString(OFFER_ID))
+                ref.stringValue("name", "WELCOME")
+                ref.integerType("version", 1)
+            }
+            body.stringValue("productRef", PRODUCT_ID)
+            body.uuid("attributionRef", java.util.UUID.fromString(INTERACTION_REF))
+            body.stringType("reservedAt", "2026-08-27T00:00:00Z")
+            body.stringType("expiresAt", "2026-08-28T00:00:00Z")
+            body.stringValue("status", status)
+        }.build()
 
         fun respond(exchange: com.sun.net.httpserver.HttpExchange, status: Int, body: String) {
             val bytes = body.toByteArray()

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeIncentivePactConsumerTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeIncentivePactConsumerTest.kt
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.openbank.customeredge.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.customeredge.infrastructure.rest.CustomerEdgeResource
+import com.openbank.customeredge.infrastructure.rest.PartyMergeResolver
+import com.openbank.customeredge.infrastructure.rest.PaymentSessionStore
+import com.openbank.customeredge.infrastructure.rest.UpstreamClient
+import com.sun.net.httpserver.HttpServer
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.jwt.JsonWebToken
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.net.InetSocketAddress
+import java.time.Clock
+
+/** Consumer proof for the authenticated edge -> Incentive reservation contract. */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-incentive-service", pactVersion = PactSpecVersion.V3)
+class CustomerEdgeIncentivePactConsumerTest {
+    private lateinit var trustedStub: HttpServer
+
+    @BeforeEach
+    fun startTrustedStub() {
+        trustedStub = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
+            createContext("/protocol/openid-connect/token") { exchange ->
+                respond(exchange, 200, """{"access_token":"pact-token","expires_in":300}""")
+            }
+            createContext("/api/v1/products/$PRODUCT_ID") { exchange ->
+                respond(exchange, 200, TERM_DEPOSIT_PRODUCT)
+            }
+            createContext("/api/v1/campaigns/interactions/$INTERACTION_REF/attribution") { exchange ->
+                respond(exchange, 200, ATTRIBUTION)
+            }
+            start()
+        }
+    }
+
+    @AfterEach
+    fun stopTrustedStub() = trustedStub.stop(0)
+
+    @Pact(consumer = "openbank-customer-edge", provider = "openbank-incentive-service")
+    fun reserveAttributedIncentive(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("a published offer contains the pact promo code for the pact product")
+        .uponReceiving("POST an attributed customer reservation with trusted party identity")
+        .path("/api/v1/customer-incentives/offers/$OFFER_ID/reservations")
+        .method("POST")
+        .headers(
+            mapOf(
+                "Content-Type" to "application/json",
+                "X-Customer-Party-Id" to PARTY_ID,
+                "Idempotency-Key" to IDEMPOTENCY_KEY,
+            ),
+        )
+        .body(
+            newJsonBody { body ->
+                body.stringValue("code", "WELCOME10")
+                body.stringValue("productRef", PRODUCT_ID)
+                body.stringValue("attributionRef", INTERACTION_REF)
+            }.build(),
+        )
+        .willRespondWith()
+        .status(201)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { body ->
+                body.uuid("id", java.util.UUID.fromString(RESERVATION_ID))
+                body.`object`("offerRef") { ref ->
+                    ref.uuid("id", java.util.UUID.fromString(OFFER_ID))
+                    ref.stringValue("name", "WELCOME")
+                    ref.integerType("version", 1)
+                }
+                body.stringValue("productRef", PRODUCT_ID)
+                body.uuid("attributionRef", java.util.UUID.fromString(INTERACTION_REF))
+                body.stringType("reservedAt", "2026-08-27T00:00:00Z")
+                body.stringType("expiresAt", "2026-08-27T00:15:00Z")
+                body.stringValue("status", "RESERVED")
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "reserveAttributedIncentive")
+    fun `real edge client reserves against the provider contract`(mockServer: MockServer) {
+        val base = "http://127.0.0.1:${trustedStub.address.port}"
+        val upstream = UpstreamClient().apply {
+            tokenEndpointBase = base
+            clientId = "openbank-customer-edge"
+            clientSecret = "pact"
+            tlsTrustCertificateFile = java.util.Optional.empty()
+            allowedHostSuffixes = ".svc,127.0.0.1,localhost"
+        }
+        val resource = CustomerEdgeResource(
+            upstream,
+            mockk(relaxed = true),
+            PaymentSessionStore(),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            Clock.systemUTC(),
+        ).apply {
+            objectMapper = ObjectMapper()
+            jwt = mockk<JsonWebToken> {
+                every { getClaim<String>("party_id") } returns PARTY_ID
+                every { subject } returns PARTY_ID
+            }
+            partyMergeResolver = mockk<PartyMergeResolver> {
+                every { resolve(any()) } answers { firstArg() }
+            }
+            productCatalogUrl = base
+            campaignServiceUrl = base
+            incentiveServiceUrl = mockServer.getUrl()
+        }
+
+        val response = resource.claimIncentive(
+            """{"interactionRef":"$INTERACTION_REF","code":"WELCOME10","productId":"$PRODUCT_ID"}""",
+            IDEMPOTENCY_KEY,
+        )
+
+        assertThat(response.status).isEqualTo(201)
+        assertThat(ObjectMapper().readTree(response.entity.toString()).path("status").asText()).isEqualTo("RESERVED")
+    }
+
+    private companion object {
+        const val PARTY_ID = "11111111-1111-4111-8111-111111111111"
+        const val INTERACTION_REF = "22222222-2222-4222-8222-222222222222"
+        const val PRODUCT_ID = "33333333-3333-4333-8333-333333333333"
+        const val OFFER_ID = "44444444-4444-4444-8444-444444444444"
+        const val RESERVATION_ID = "55555555-5555-4555-8555-555555555555"
+        const val IDEMPOTENCY_KEY = "claim-pact-once"
+        val TERM_DEPOSIT_PRODUCT = """
+            {"id":"$PRODUCT_ID","code":"TERM_6M","name":"Term deposit","type":"TERM_DEPOSIT",
+            "currency":"CZK","status":"ACTIVE","isPublic":true,
+            "termDepositConfig":{"termMonths":6,"interestRateAnnual":5.8},"termsAndConditions":[]}
+        """.trimIndent()
+        val ATTRIBUTION = """
+            {"campaignId":"66666666-6666-4666-8666-666666666666","stepOrder":0,"channel":"PUSH",
+            "incentiveOfferRef":{"id":"$OFFER_ID","name":"WELCOME","version":1}}
+        """.trimIndent()
+
+        fun respond(exchange: com.sun.net.httpserver.HttpExchange, status: Int, body: String) {
+            val bytes = body.toByteArray()
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(status, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+    }
+}

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/StubUpstreamResource.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/StubUpstreamResource.kt
@@ -34,8 +34,10 @@ class StubUpstreamResource : QuarkusTestResourceLifecycleManager {
 
         /** path (no query string) -> fixed (status, contentType, body) the stub answers with. */
         private val routes = ConcurrentHashMap<String, Fixture>()
+        private val requests = mutableListOf<Request>()
 
         data class Fixture(val status: Int, val contentType: String, val body: String)
+        data class Request(val path: String, val headers: Map<String, List<String>>, val body: String)
 
         /** Registers (or replaces) the fixed response for [path]. Call from a `@State` handler. */
         fun stub(path: String, status: Int = 200, contentType: String = "application/json", body: String) {
@@ -43,7 +45,12 @@ class StubUpstreamResource : QuarkusTestResourceLifecycleManager {
         }
 
         /** Clears every registered route — call at the start of each `@State` handler. */
-        fun reset() = routes.clear()
+        fun reset() {
+            routes.clear()
+            synchronized(requests) { requests.clear() }
+        }
+
+        fun requests(path: String): List<Request> = synchronized(requests) { requests.filter { it.path == path } }
     }
 
     override fun start(): Map<String, String> {
@@ -53,6 +60,10 @@ class StubUpstreamResource : QuarkusTestResourceLifecycleManager {
         }
         s.createContext("/") { exchange ->
             val path = exchange.requestURI.path
+            val requestBody = exchange.requestBody.bufferedReader().use { it.readText() }
+            synchronized(requests) {
+                requests += Request(path, exchange.requestHeaders.mapValues { it.value.toList() }, requestBody)
+            }
             val fixture = routes[path]
             if (fixture != null) {
                 respond(exchange, fixture.status, fixture.contentType, fixture.body)
@@ -73,6 +84,10 @@ class StubUpstreamResource : QuarkusTestResourceLifecycleManager {
             "openbank.edge.standing-order-service-url" to base,
             "openbank.edge.fx-service-url" to base,
             "openbank.edge.card-issuance-service-url" to base,
+            "openbank.edge.party-service-url" to base,
+            "openbank.edge.product-catalog-url" to base,
+            "openbank.edge.campaign-service-url" to base,
+            "openbank.edge.incentive-service-url" to base,
         )
     }
 
@@ -80,6 +95,7 @@ class StubUpstreamResource : QuarkusTestResourceLifecycleManager {
         server?.stop(0)
         server = null
         routes.clear()
+        synchronized(requests) { requests.clear() }
     }
 
     private fun respond(exchange: HttpExchange, status: Int, contentType: String, body: String) {

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/integration/CustomerIncentiveClaimIT.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/integration/CustomerIncentiveClaimIT.kt
@@ -100,6 +100,42 @@ class CustomerIncentiveClaimIT {
         assertThat(StubUpstreamResource.requests(PRODUCT_PATH)).isEmpty()
     }
 
+    @Test
+    fun `authoritative account opening commits the claimed reservation over real http`() {
+        StubUpstreamResource.stub(PRODUCT_PATH, body = PRODUCT_JSON)
+        StubUpstreamResource.stub(
+            PARTY_PATH,
+            body = """{"status":"ACTIVE","legalName":"Ada Customer"}""",
+        )
+        StubUpstreamResource.stub(
+            ACCOUNT_PATH,
+            status = 201,
+            body = """
+                {"id":"77777777-7777-4777-8777-777777777777","partyId":"$CLAIM_PARTY_ID","productId":"$PRODUCT_ID",
+                "accountType":"TERM_DEPOSIT","status":"ACTIVE","openedAt":"$OPENED_AT"}
+            """.trimIndent(),
+        )
+        StubUpstreamResource.stub(
+            COMMIT_PATH,
+            body = RESERVATION_JSON.replace("RESERVED", "COMMITTED"),
+        )
+
+        Given {
+            contentType("application/json")
+            header("Idempotency-Key", "open-term-with-reward")
+            body("""{"productId":"$PRODUCT_ID","incentiveReservationId":"$RESERVATION_ID"}""")
+        } When {
+            post("/customer/v1/term-deposits")
+        } Then {
+            statusCode(201)
+            body("incentiveReservation.status", org.hamcrest.Matchers.equalTo("COMMITTED"))
+        }
+
+        val commit = ObjectMapper().readTree(StubUpstreamResource.requests(COMMIT_PATH).single().body)
+        assertThat(commit.path("productRef").asText()).isEqualTo(PRODUCT_ID)
+        assertThat(commit.path("qualifiedAt").asText()).isEqualTo(OPENED_AT)
+    }
+
     private fun stubProductAndAttribution() {
         StubUpstreamResource.stub(PRODUCT_PATH, body = PRODUCT_JSON)
         StubUpstreamResource.stub(ATTRIBUTION_PATH, body = ATTRIBUTION_JSON)
@@ -130,6 +166,10 @@ private const val RESERVATION_ID = "55555555-5555-4555-8555-555555555555"
 private const val PRODUCT_PATH = "/api/v1/products/$PRODUCT_ID"
 private const val ATTRIBUTION_PATH = "/api/v1/campaigns/interactions/$INTERACTION_ID/attribution"
 private const val INCENTIVE_PATH = "/api/v1/customer-incentives/offers/$OFFER_ID/reservations"
+private const val PARTY_PATH = "/api/v1/parties/$CLAIM_PARTY_ID"
+private const val ACCOUNT_PATH = "/api/v1/accounts"
+private const val COMMIT_PATH = "/api/v1/customer-incentives/reservations/$RESERVATION_ID/commit"
+private const val OPENED_AT = "2026-08-27T03:00:00Z"
 private const val CLAIM_JSON =
     """{"interactionRef":"$INTERACTION_ID","code":"WELCOME10","productId":"$PRODUCT_ID"}"""
 private const val PRODUCT_JSON =

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/integration/CustomerIncentiveClaimIT.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/integration/CustomerIncentiveClaimIT.kt
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.openbank.customeredge.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.customeredge.contract.StubUpstreamResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.test.security.oidc.Claim
+import io.quarkus.test.security.oidc.OidcSecurity
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+@QuarkusTestResource(StubUpstreamResource::class, restrictToAnnotatedClass = true)
+@TestSecurity(user = "customer:$CLAIM_PARTY_ID", roles = ["ROLE_CUSTOMER"])
+@OidcSecurity(claims = [Claim(key = "party_id", value = CLAIM_PARTY_ID)])
+class CustomerIncentiveClaimIT {
+    @BeforeEach
+    fun resetUpstreams() = StubUpstreamResource.reset()
+
+    @Test
+    fun `authenticated customer claim derives party and reaches trusted incentive route`() {
+        stubProductAndAttribution()
+        StubUpstreamResource.stub(
+            INCENTIVE_PATH,
+            status = 201,
+            body = RESERVATION_JSON,
+        )
+
+        Given {
+            contentType("application/json")
+            header("Idempotency-Key", "claim-http-once")
+            body(CLAIM_JSON)
+        } When {
+            post("/customer/v1/incentives/claims")
+        } Then {
+            statusCode(201)
+            body(containsString("RESERVED"))
+        }
+
+        val request = StubUpstreamResource.requests(INCENTIVE_PATH).single()
+        assertThat(request.headers.entries.single { it.key.equals("X-Customer-Party-Id", true) }.value)
+            .containsExactly(CLAIM_PARTY_ID)
+        assertThat(request.headers.entries.single { it.key.equals("Idempotency-Key", true) }.value)
+            .containsExactly("claim-http-once")
+        val json = ObjectMapper().readTree(request.body)
+        assertThat(json.path("attributionRef").asText()).isEqualTo(INTERACTION_ID)
+        assertThat(json.path("productRef").asText()).isEqualTo(PRODUCT_ID)
+        assertThat(json.has("partyRef")).isFalse()
+    }
+
+    @Test
+    fun `foreign interaction fails closed before incentive service`() {
+        StubUpstreamResource.stub(PRODUCT_PATH, body = PRODUCT_JSON)
+        StubUpstreamResource.stub(ATTRIBUTION_PATH, status = 404, body = "{\"error\":\"not found\"}")
+
+        Given {
+            contentType("application/json")
+            header("Idempotency-Key", "claim-foreign")
+            body(CLAIM_JSON)
+        } When {
+            post("/customer/v1/incentives/claims")
+        } Then {
+            statusCode(400)
+        }
+
+        assertThat(StubUpstreamResource.requests(INCENTIVE_PATH)).isEmpty()
+    }
+
+    @Test
+    fun `invalid public bounds fail before upstream calls`() {
+        Given {
+            contentType("application/json")
+            header("Idempotency-Key", "x".repeat(256))
+            body(CLAIM_JSON)
+        } When {
+            post("/customer/v1/incentives/claims")
+        } Then {
+            statusCode(400)
+            body(containsString("Idempotency-Key"))
+        }
+
+        Given {
+            contentType("application/json")
+            header("Idempotency-Key", "claim-numeric-code")
+            body("""{"interactionRef":"$INTERACTION_ID","code":12345678,"productId":"$PRODUCT_ID"}""")
+        } When {
+            post("/customer/v1/incentives/claims")
+        } Then {
+            statusCode(400)
+            body(containsString("code must be a string"))
+        }
+
+        assertThat(StubUpstreamResource.requests(PRODUCT_PATH)).isEmpty()
+    }
+
+    private fun stubProductAndAttribution() {
+        StubUpstreamResource.stub(PRODUCT_PATH, body = PRODUCT_JSON)
+        StubUpstreamResource.stub(ATTRIBUTION_PATH, body = ATTRIBUTION_JSON)
+    }
+}
+
+@QuarkusTest
+class CustomerIncentiveClaimUnauthenticatedIT {
+    @Test
+    fun `claim route rejects an unauthenticated caller`() {
+        Given {
+            contentType("application/json")
+            header("Idempotency-Key", "claim-unauthenticated")
+            body(CLAIM_JSON)
+        } When {
+            post("/customer/v1/incentives/claims")
+        } Then {
+            statusCode(401)
+        }
+    }
+}
+
+private const val CLAIM_PARTY_ID = "11111111-1111-4111-8111-111111111111"
+private const val INTERACTION_ID = "22222222-2222-4222-8222-222222222222"
+private const val PRODUCT_ID = "33333333-3333-4333-8333-333333333333"
+private const val OFFER_ID = "44444444-4444-4444-8444-444444444444"
+private const val RESERVATION_ID = "55555555-5555-4555-8555-555555555555"
+private const val PRODUCT_PATH = "/api/v1/products/$PRODUCT_ID"
+private const val ATTRIBUTION_PATH = "/api/v1/campaigns/interactions/$INTERACTION_ID/attribution"
+private const val INCENTIVE_PATH = "/api/v1/customer-incentives/offers/$OFFER_ID/reservations"
+private const val CLAIM_JSON =
+    """{"interactionRef":"$INTERACTION_ID","code":"WELCOME10","productId":"$PRODUCT_ID"}"""
+private const val PRODUCT_JSON =
+    """{"id":"$PRODUCT_ID","code":"TD-12M","name":"12 month deposit","type":"TERM_DEPOSIT","status":"ACTIVE","isPublic":true,"currency":"CZK","termDepositConfig":{"termMonths":12,"interestRateAnnual":3.5},"termsAndConditions":[]}"""
+private const val ATTRIBUTION_JSON =
+    """{"campaignId":"66666666-6666-4666-8666-666666666666","stepOrder":0,"channel":"PUSH","incentiveOfferRef":{"id":"$OFFER_ID","name":"WELCOME","version":1}}"""
+private const val RESERVATION_JSON =
+    """{"id":"$RESERVATION_ID","offerRef":{"id":"$OFFER_ID","name":"WELCOME","version":1},"productRef":"$PRODUCT_ID","attributionRef":"$INTERACTION_ID","reservedAt":"2026-08-27T00:00:00Z","expiresAt":"2026-08-27T00:15:00Z","status":"RESERVED"}"""

--- a/openbank-incentive-service/build.gradle.kts
+++ b/openbank-incentive-service/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(project(":openbank-libs-testing"))
+    testImplementation(libs.pact.provider)
 }
 
 kover {

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/application/IncentiveApplication.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/application/IncentiveApplication.kt
@@ -82,6 +82,24 @@ class IncentiveApplication(
 
     suspend fun commit(id: UUID, actor: String, now: Instant = Instant.now()) = store.commit(id, actor, now)
     suspend fun release(id: UUID, actor: String, now: Instant = Instant.now()) = store.release(id, actor, now)
+    suspend fun commitAttributed(
+        id: UUID,
+        partyRef: String,
+        productRef: String,
+        actor: String,
+        qualifiedAt: Instant,
+        now: Instant = Instant.now(),
+    ): PromoReservation {
+        require(!qualifiedAt.isAfter(now.plus(MAX_QUALIFYING_CLOCK_SKEW))) { "qualifiedAt must not be in the future" }
+        return store.commitAttributed(id, partyRef, productRef, actor, qualifiedAt)
+    }
+    suspend fun releaseAttributed(
+        id: UUID,
+        partyRef: String,
+        productRef: String,
+        actor: String,
+        now: Instant = Instant.now(),
+    ) = store.releaseAttributed(id, partyRef, productRef, actor, now)
     suspend fun expireDue(now: Instant = Instant.now()) = store.expireDue(now)
 
     private fun digest(code: String): CodeDigest {
@@ -96,6 +114,7 @@ class IncentiveApplication(
         const val MIN_CODE_LENGTH = 8
         const val MAX_CODE_LENGTH = 128
         const val MIN_PEPPER_LENGTH = 32
+        val MAX_QUALIFYING_CLOCK_SKEW: Duration = Duration.ofMinutes(1)
     }
 }
 

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/application/IncentiveStore.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/application/IncentiveStore.kt
@@ -7,6 +7,7 @@ import com.openbank.incentive.domain.PromoReservation
 import java.time.Instant
 import java.util.UUID
 
+@Suppress("TooManyFunctions")
 interface IncentiveStore {
     suspend fun createOffer(offer: IncentiveOffer): IncentiveOffer
     suspend fun findOffer(id: UUID): IncentiveOffer?
@@ -17,6 +18,20 @@ interface IncentiveStore {
     suspend fun reserve(command: ReserveIncentive): PromoReservation
     suspend fun commit(id: UUID, actor: String, at: Instant): PromoReservation
     suspend fun release(id: UUID, actor: String, at: Instant): PromoReservation
+    suspend fun commitAttributed(
+        id: UUID,
+        partyRef: String,
+        productRef: String,
+        actor: String,
+        qualifiedAt: Instant,
+    ): PromoReservation
+    suspend fun releaseAttributed(
+        id: UUID,
+        partyRef: String,
+        productRef: String,
+        actor: String,
+        at: Instant,
+    ): PromoReservation
     suspend fun expireDue(at: Instant): Int
 }
 

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/domain/PromoReservation.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/domain/PromoReservation.kt
@@ -34,8 +34,13 @@ data class PromoReservation(
 
     fun commit(at: Instant): PromoReservation {
         if (status == ReservationStatus.COMMITTED) return this
-        if (status != ReservationStatus.RESERVED) throw IncentiveConflict("only a reservation can be committed")
-        if (!at.isBefore(expiresAt)) throw IncentiveConflict("an expired reservation cannot be committed")
+        val conflict = when {
+            status != ReservationStatus.RESERVED -> "only a reservation can be committed"
+            at.isBefore(reservedAt) -> "qualifying action predates the reservation"
+            !at.isBefore(expiresAt) -> "an expired reservation cannot be committed"
+            else -> null
+        }
+        if (conflict != null) throw IncentiveConflict(conflict)
         return copy(status = ReservationStatus.COMMITTED)
     }
 

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/persistence/IncentivePersistence.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/persistence/IncentivePersistence.kt
@@ -315,6 +315,7 @@ class PanacheIncentiveStore(
 
     private companion object {
         const val RETENTION_MONTHS = 13L
+        val ATTRIBUTED_FINALIZATION_GRACE: Duration = Duration.ofHours(24)
     }
 
     override suspend fun reserve(command: ReserveIncentive): PromoReservation = Panache.withTransaction {
@@ -391,6 +392,22 @@ class PanacheIncentiveStore(
     override suspend fun release(id: UUID, actor: String, at: Instant): PromoReservation =
         transition(id, actor, at, ReservationStatus.RELEASED)
 
+    override suspend fun commitAttributed(
+        id: UUID,
+        partyRef: String,
+        productRef: String,
+        actor: String,
+        qualifiedAt: Instant,
+    ): PromoReservation = transition(id, actor, qualifiedAt, ReservationStatus.COMMITTED, partyRef, productRef)
+
+    override suspend fun releaseAttributed(
+        id: UUID,
+        partyRef: String,
+        productRef: String,
+        actor: String,
+        at: Instant,
+    ): PromoReservation = transition(id, actor, at, ReservationStatus.RELEASED, partyRef, productRef)
+
     override suspend fun expireDue(at: Instant): Int {
         val ids = Panache.withSession {
             reservations.find("status = ?1 and expiresAt <= ?2", "RESERVED", at)
@@ -404,10 +421,13 @@ class PanacheIncentiveStore(
 
     private suspend fun expireOne(id: UUID, at: Instant): Int = Panache.withTransaction {
         lockedReservation(id).flatMap { locked ->
+            val finalizationDeadline = locked?.expiresAt?.let { expiry ->
+                if (locked.attributionRef == null) expiry else expiry.plus(ATTRIBUTED_FINALIZATION_GRACE)
+            }
             if (
                 locked == null ||
                 locked.status != ReservationStatus.RESERVED.name ||
-                locked.expiresAt.isAfter(at)
+                requireNotNull(finalizationDeadline).isAfter(at)
             ) {
                 Uni.createFrom().item(0)
             } else {
@@ -416,31 +436,50 @@ class PanacheIncentiveStore(
         }
     }.awaitSuspending()
 
-    private suspend fun transition(id: UUID, actor: String, at: Instant, target: ReservationStatus): PromoReservation =
-        Panache.withTransaction {
-            lockedReservation(id).flatMap { entity ->
-                if (entity == null) throw IncentiveNotFound("reservation not found")
-                val current = entity.toDomain()
-                val updated = when (target) {
-                    ReservationStatus.COMMITTED -> current.commit(at)
-                    ReservationStatus.RELEASED -> current.release()
-                    else -> throw IllegalArgumentException("unsupported transition")
-                }
-                if (updated === current) return@flatMap Uni.createFrom().item(current)
-                entity.status = target.name
-                if (target == ReservationStatus.COMMITTED) entity.committedAt = at else entity.releasedAt = at
-                lockedCode(entity.codeDigest).flatMap { code ->
-                    requireNotNull(code)
-                    code.status = if (target == ReservationStatus.COMMITTED) "REDEEMED" else "AVAILABLE"
-                    when (target) {
-                        ReservationStatus.COMMITTED -> reservationEvidence(updated, target, actor)
-                        ReservationStatus.RELEASED -> reservationEvidence(updated, target, actor)
-                        else -> error("unsupported transition")
-                    }
-                        .replaceWith(updated)
-                }
+    private suspend fun transition(
+        id: UUID,
+        actor: String,
+        at: Instant,
+        target: ReservationStatus,
+        expectedPartyRef: String? = null,
+        expectedProductRef: String? = null,
+    ): PromoReservation = Panache.withTransaction {
+        lockedReservation(id).flatMap { entity ->
+            if (entity == null) throw IncentiveNotFound("reservation not found")
+            val current = entity.toDomain()
+            requireAttributedOwner(current, expectedPartyRef, expectedProductRef)
+            val updated = when (target) {
+                ReservationStatus.COMMITTED -> current.commit(at)
+                ReservationStatus.RELEASED -> current.release()
+                else -> throw IllegalArgumentException("unsupported transition")
             }
-        }.awaitSuspending()
+            if (updated === current) return@flatMap Uni.createFrom().item(current)
+            entity.status = target.name
+            if (target == ReservationStatus.COMMITTED) entity.committedAt = at else entity.releasedAt = at
+            lockedCode(entity.codeDigest).flatMap { code ->
+                requireNotNull(code)
+                code.status = if (target == ReservationStatus.COMMITTED) "REDEEMED" else "AVAILABLE"
+                when (target) {
+                    ReservationStatus.COMMITTED -> reservationEvidence(updated, target, actor)
+                    ReservationStatus.RELEASED -> reservationEvidence(updated, target, actor)
+                    else -> error("unsupported transition")
+                }
+                    .replaceWith(updated)
+            }
+        }
+    }.awaitSuspending()
+
+    private fun requireAttributedOwner(
+        reservation: PromoReservation,
+        expectedPartyRef: String?,
+        expectedProductRef: String?,
+    ) {
+        if (expectedPartyRef == null) return
+        val owned = reservation.attributionRef != null &&
+            reservation.partyRef == expectedPartyRef &&
+            reservation.productRef == expectedProductRef
+        if (!owned) throw IncentiveNotFound("reservation not found")
+    }
 
     private fun expireEntity(entity: ReservationEntity, at: Instant): Uni<Void> =
         lockedCode(entity.codeDigest).flatMap { code ->

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/rest/CustomerIncentiveResource.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/rest/CustomerIncentiveResource.kt
@@ -34,6 +34,14 @@ data class CustomerReservationResponse(
     val status: ReservationStatus,
 )
 
+data class CustomerCommitReservationRequest(
+    val productRef: String,
+    val qualifiedAt: Instant,
+    val partyRef: String? = null,
+)
+
+data class CustomerReleaseReservationRequest(val productRef: String, val partyRef: String? = null)
+
 /**
  * Trusted customer-edge boundary. The retail client never supplies party identity or offer terms:
  * customer-edge derives the party from its Keycloak JWT and resolves the offer from the opaque
@@ -56,13 +64,11 @@ class CustomerIncentiveResource(
         @HeaderParam("Idempotency-Key") key: String?,
         request: CustomerReserveCodeRequest,
     ): Response {
-        val permittedCaller = callerPrincipal.orElse("")
-        if (permittedCaller.isBlank() || identity.principal?.name != permittedCaller) {
+        if (!callerPermitted()) {
             return Response.status(Response.Status.FORBIDDEN).build()
         }
         require(request.partyRef == null) { "partyRef must not be supplied by the customer request" }
-        val trustedParty = requireNotNull(partyId?.let(::parseUuid)) { "X-Customer-Party-Id is required" }
-        require(trustedParty != ZERO_UUID) { "X-Customer-Party-Id must not be the nil UUID" }
+        val trustedParty = requireTrustedParty(partyId)
         require(!key.isNullOrBlank()) { "Idempotency-Key is required" }
         val reservation = application.reserve(
             id,
@@ -86,9 +92,69 @@ class CustomerIncentiveResource(
         ).build()
     }
 
+    @POST
+    @Path("/reservations/{id}/commit")
+    suspend fun commit(
+        @PathParam("id") id: UUID,
+        @HeaderParam("X-Customer-Party-Id") partyId: String?,
+        request: CustomerCommitReservationRequest,
+    ): Response {
+        if (!callerPermitted()) return Response.status(Response.Status.FORBIDDEN).build()
+        require(request.partyRef == null) { "partyRef must not be supplied by the customer request" }
+        val trustedParty = requireTrustedParty(partyId)
+        val reservation = application.commitAttributed(
+            id,
+            trustedParty.toString(),
+            request.productRef,
+            identity.principal.name,
+            request.qualifiedAt,
+        )
+        return Response.ok(reservation.toCustomerResponse()).build()
+    }
+
+    @POST
+    @Path("/reservations/{id}/release")
+    suspend fun release(
+        @PathParam("id") id: UUID,
+        @HeaderParam("X-Customer-Party-Id") partyId: String?,
+        request: CustomerReleaseReservationRequest,
+    ): Response {
+        if (!callerPermitted()) return Response.status(Response.Status.FORBIDDEN).build()
+        require(request.partyRef == null) { "partyRef must not be supplied by the customer request" }
+        val trustedParty = requireTrustedParty(partyId)
+        val reservation = application.releaseAttributed(
+            id,
+            trustedParty.toString(),
+            request.productRef,
+            identity.principal.name,
+        )
+        return Response.ok(reservation.toCustomerResponse()).build()
+    }
+
+    private fun callerPermitted(): Boolean {
+        val permittedCaller = callerPrincipal.orElse("")
+        return permittedCaller.isNotBlank() && identity.principal?.name == permittedCaller
+    }
+
+    private fun requireTrustedParty(partyId: String?): UUID {
+        val trustedParty = requireNotNull(partyId?.let(::parseUuid)) { "X-Customer-Party-Id is required" }
+        require(trustedParty != ZERO_UUID) { "X-Customer-Party-Id must not be the nil UUID" }
+        return trustedParty
+    }
+
     private fun parseUuid(value: String): UUID? = runCatching { UUID.fromString(value) }.getOrNull()
 
     private companion object {
         val ZERO_UUID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
     }
 }
+
+private fun com.openbank.incentive.domain.PromoReservation.toCustomerResponse() = CustomerReservationResponse(
+    id,
+    offerRef,
+    productRef,
+    requireNotNull(attributionRef),
+    reservedAt,
+    expiresAt,
+    status,
+)

--- a/openbank-incentive-service/src/main/resources/openapi.yaml
+++ b/openbank-incentive-service/src/main/resources/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: OpenBank Incentive Service
-  version: 1.2.0
+  version: 1.3.0
   description: Governed fixed-benefit offers and opaque promo-code reservations.
 paths:
   /api/v1/customer-incentives/offers/{id}/reservations:
@@ -34,6 +34,50 @@ paths:
         "400": {description: Missing trusted party, idempotency key, or invalid request}
         "404": {description: Offer or code not found}
         "409": {description: Replay mismatch, inventory, offer, attribution, or limit conflict}
+  /api/v1/customer-incentives/reservations/{id}/commit:
+    post:
+      summary: Commit an attributed reservation after the trusted qualifying action succeeds
+      description: >-
+        Internal customer-edge boundary. Party identity comes from the customer JWT and productRef
+        is the validated catalogue product. qualifiedAt is the authoritative account openedAt so a
+        crash-window retry can replay the same business outcome without extending reservation TTL.
+      parameters:
+        - {$ref: '#/components/parameters/ReservationId'}
+        - name: X-Customer-Party-Id
+          in: header
+          required: true
+          schema: {type: string, format: uuid}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/CustomerCommitReservation'}
+      responses:
+        "200": {description: Committed or idempotently replayed, content: {application/json: {schema: {$ref: '#/components/schemas/CustomerReservation'}}}}
+        "400": {description: Missing trusted party or malformed qualifying evidence}
+        "403": {description: Caller is not the configured customer-edge workload}
+        "404": {description: Reservation does not belong to the trusted party and product}
+        "409": {description: Reservation expired or is terminal in another state}
+  /api/v1/customer-incentives/reservations/{id}/release:
+    post:
+      summary: Release an attributed reservation after a deterministic qualifying-action rejection
+      parameters:
+        - {$ref: '#/components/parameters/ReservationId'}
+        - name: X-Customer-Party-Id
+          in: header
+          required: true
+          schema: {type: string, format: uuid}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/CustomerReleaseReservation'}
+      responses:
+        "200": {description: Released or idempotently replayed, content: {application/json: {schema: {$ref: '#/components/schemas/CustomerReservation'}}}}
+        "400": {description: Missing trusted party or malformed request}
+        "403": {description: Caller is not the configured customer-edge workload}
+        "404": {description: Reservation does not belong to the trusted party and product}
+        "409": {description: Reservation is committed or terminal in another state}
   /api/v1/incentives/offers:
     get:
       summary: List immutable published incentive offers for governed catalogue selection
@@ -184,6 +228,19 @@ components:
         reservedAt: {type: string, format: date-time}
         expiresAt: {type: string, format: date-time}
         status: {type: string, enum: [RESERVED, COMMITTED, RELEASED, EXPIRED]}
+    CustomerCommitReservation:
+      type: object
+      additionalProperties: false
+      required: [productRef, qualifiedAt]
+      properties:
+        productRef: {type: string, minLength: 1}
+        qualifiedAt: {type: string, format: date-time}
+    CustomerReleaseReservation:
+      type: object
+      additionalProperties: false
+      required: [productRef]
+      properties:
+        productRef: {type: string, minLength: 1}
     Offer:
       type: object
       required: [ref, productScope, effectiveFrom, expiresAt, totalLimit, perPartyLimit, stackingPolicy, status, maker]

--- a/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/contract/IncentivePactFolderProviderVerificationTest.kt
+++ b/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/contract/IncentivePactFolderProviderVerificationTest.kt
@@ -75,9 +75,42 @@ class IncentivePactFolderProviderVerificationTest {
         }
     }
 
+    @State("an attributed reservation is reserved for qualifying commit")
+    fun attributedReservationForCommit() = insertReservedAttribution()
+
+    @State("an attributed reservation is reserved for deterministic release")
+    fun attributedReservationForRelease() = insertReservedAttribution()
+
+    private fun insertReservedAttribution() {
+        dataSource.connection.use { connection ->
+            connection.autoCommit = false
+            deletePreviousReservation(connection)
+            if (!offerExists(connection)) insertOffer(connection)
+            if (!codeExists(connection)) insertCode(connection)
+            connection.prepareStatement(INSERT_RESERVATION).use { statement ->
+                statement.setString(1, RESERVATION_ID)
+                statement.setString(2, OFFER_ID)
+                statement.setString(3, codeDigest())
+                statement.setString(4, PARTY_ID)
+                statement.setString(5, PRODUCT_ID)
+                statement.setString(6, ATTRIBUTION_ID)
+                statement.executeUpdate()
+            }
+            connection.prepareStatement("UPDATE promo_code_inventory SET status = 'RESERVED' WHERE digest = ?")
+                .use { statement ->
+                    statement.setString(1, codeDigest())
+                    statement.executeUpdate()
+                }
+            connection.commit()
+        }
+    }
+
     private fun deletePreviousReservation(connection: Connection) {
-        connection.prepareStatement("DELETE FROM promo_reservation WHERE attribution_ref = ?::uuid").use { statement ->
-            statement.setString(1, ATTRIBUTION_ID)
+        connection.prepareStatement(
+            "DELETE FROM promo_reservation WHERE id = ?::uuid OR attribution_ref = ?::uuid",
+        ).use { statement ->
+            statement.setString(1, RESERVATION_ID)
+            statement.setString(2, ATTRIBUTION_ID)
             statement.executeUpdate()
         }
         connection.prepareStatement(
@@ -124,6 +157,9 @@ class IncentivePactFolderProviderVerificationTest {
     private companion object {
         const val OFFER_ID = "44444444-4444-4444-8444-444444444444"
         const val ATTRIBUTION_ID = "22222222-2222-4222-8222-222222222222"
+        const val PARTY_ID = "11111111-1111-4111-8111-111111111111"
+        const val PRODUCT_ID = "33333333-3333-4333-8333-333333333333"
+        const val RESERVATION_ID = "55555555-5555-4555-8555-555555555555"
         const val CODE = "WELCOME10"
         const val PEPPER = "integration-pepper-with-32-characters-minimum"
         const val INSERT_OFFER = """
@@ -138,6 +174,15 @@ class IncentivePactFolderProviderVerificationTest {
         const val INSERT_CODE = """
             INSERT INTO promo_code_inventory (digest, offer_id, status, created_at, retained_until)
             VALUES (?, ?::uuid, 'AVAILABLE', now(), now() + interval '13 months')
+        """
+        const val INSERT_RESERVATION = """
+            INSERT INTO promo_reservation (
+              id, offer_id, offer_name, offer_version, code_digest, party_ref, product_ref,
+              idempotency_key, status, reserved_at, expires_at, attribution_ref
+            ) VALUES (
+              ?::uuid, ?::uuid, 'WELCOME', 1, ?, ?, ?, 'open-pact-once', 'RESERVED',
+              '2026-08-27T00:00:00Z', '2099-01-01T00:00:00Z', ?::uuid
+            )
         """
     }
 }

--- a/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/contract/IncentivePactFolderProviderVerificationTest.kt
+++ b/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/contract/IncentivePactFolderProviderVerificationTest.kt
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.openbank.incentive.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import com.openbank.incentive.it.IncentivePostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import jakarta.inject.Inject
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.sql.Connection
+import java.time.Instant
+import javax.sql.DataSource
+
+/**
+ * Replays every committed consumer contract for incentive-service on every pull request. The state
+ * uses the real Flyway schema because the customer claim contract must prove the HTTP boundary,
+ * one-way code lookup and attributed reservation persistence together.
+ */
+@QuarkusTest
+@QuarkusTestResource(IncentivePostgresTestResource::class)
+@QuarkusTestResource(IncentivePactFolderProviderVerificationTest.InMemoryKafkaResource::class)
+@TestSecurity(user = "maker@openbank.test", roles = ["ROLE_API"])
+@Provider("openbank-incentive-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class IncentivePactFolderProviderVerificationTest {
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> =
+            InMemoryConnector.switchOutgoingChannelsToInMemory("incentive-events-out")
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        if (context == null) return
+        context.target = HttpTestTarget("localhost", testPort.toInt())
+        context.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    @State("a published offer contains the pact promo code for the pact product")
+    fun publishedOfferContainsCode() {
+        dataSource.connection.use { connection ->
+            connection.autoCommit = false
+            deletePreviousReservation(connection)
+            if (!offerExists(connection)) insertOffer(connection)
+            if (!codeExists(connection)) insertCode(connection)
+            connection.commit()
+        }
+    }
+
+    private fun deletePreviousReservation(connection: Connection) {
+        connection.prepareStatement("DELETE FROM promo_reservation WHERE attribution_ref = ?::uuid").use { statement ->
+            statement.setString(1, ATTRIBUTION_ID)
+            statement.executeUpdate()
+        }
+        connection.prepareStatement(
+            "UPDATE promo_code_inventory SET status = 'AVAILABLE' WHERE digest = ?",
+        ).use { statement ->
+            statement.setString(1, codeDigest())
+            statement.executeUpdate()
+        }
+    }
+
+    private fun offerExists(connection: Connection): Boolean =
+        connection.prepareStatement("SELECT 1 FROM incentive_offer WHERE id = ?::uuid").use { statement ->
+            statement.setString(1, OFFER_ID)
+            statement.executeQuery().use { it.next() }
+        }
+
+    private fun codeExists(connection: Connection): Boolean =
+        connection.prepareStatement("SELECT 1 FROM promo_code_inventory WHERE digest = ?").use { statement ->
+            statement.setString(1, codeDigest())
+            statement.executeQuery().use { it.next() }
+        }
+
+    private fun insertOffer(connection: Connection) {
+        connection.prepareStatement(INSERT_OFFER).use { statement ->
+            statement.setString(1, OFFER_ID)
+            statement.setObject(2, java.sql.Timestamp.from(Instant.now().minusSeconds(60)))
+            statement.setObject(3, java.sql.Timestamp.from(Instant.now().plusSeconds(86_400)))
+            statement.executeUpdate()
+        }
+    }
+
+    private fun insertCode(connection: Connection) {
+        connection.prepareStatement(INSERT_CODE).use { statement ->
+            statement.setString(1, codeDigest())
+            statement.setString(2, OFFER_ID)
+            statement.executeUpdate()
+        }
+    }
+
+    private fun codeDigest(): String = MessageDigest.getInstance("SHA-256")
+        .digest("$PEPPER:$CODE".toByteArray(StandardCharsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }
+
+    private companion object {
+        const val OFFER_ID = "44444444-4444-4444-8444-444444444444"
+        const val ATTRIBUTION_ID = "22222222-2222-4222-8222-222222222222"
+        const val CODE = "WELCOME10"
+        const val PEPPER = "integration-pepper-with-32-characters-minimum"
+        const val INSERT_OFFER = """
+            INSERT INTO incentive_offer (
+              id, name, version, product_scope, effective_from, expires_at, total_limit,
+              per_party_limit, stacking_policy, status, maker, checker, created_at, published_at
+            ) VALUES (
+              ?::uuid, 'WELCOME', 1, '33333333-3333-4333-8333-333333333333', ?, ?, 10,
+              1, 'EXCLUSIVE', 'PUBLISHED', 'maker@openbank.test', 'checker@openbank.test', now(), now()
+            )
+        """
+        const val INSERT_CODE = """
+            INSERT INTO promo_code_inventory (digest, offer_id, status, created_at, retained_until)
+            VALUES (?, ?::uuid, 'AVAILABLE', now(), now() + interval '13 months')
+        """
+    }
+}

--- a/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/domain/IncentiveDomainTest.kt
+++ b/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/domain/IncentiveDomainTest.kt
@@ -39,6 +39,13 @@ class IncentiveDomainTest {
     }
 
     @Test
+    fun `qualifying action cannot predate reservation`() {
+        val reservation = reservation()
+        assertThatThrownBy { reservation.commit(reservation.reservedAt.minusSeconds(1)) }
+            .isInstanceOf(IncentiveConflict::class.java)
+    }
+
+    @Test
     fun `expiry closes inventory and cannot be converted into success`() {
         val reservation = reservation()
         assertThatThrownBy { reservation.expire(now) }.isInstanceOf(IncentiveConflict::class.java)

--- a/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/integration/IncentiveRestContractIT.kt
+++ b/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/integration/IncentiveRestContractIT.kt
@@ -26,6 +26,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.microprofile.reactive.messaging.Message
 import org.eclipse.microprofile.reactive.messaging.spi.Connector
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasItem
 import org.hamcrest.Matchers.hasKey
 import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.not
@@ -90,7 +91,7 @@ class IncentiveRestContractIT {
 
         When { get("/api/v1/incentives/offers") } Then {
             statusCode(200)
-            body("items", hasSize<Any>(0))
+            body("items.ref.id", not(hasItem(offerId)))
         }
 
         Given { contentType("application/json") }

--- a/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/integration/IncentiveRestContractIT.kt
+++ b/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/integration/IncentiveRestContractIT.kt
@@ -28,7 +28,6 @@ import org.eclipse.microprofile.reactive.messaging.spi.Connector
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasItem
 import org.hamcrest.Matchers.hasKey
-import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.not
 import org.junit.jupiter.api.Test
 import java.nio.charset.StandardCharsets
@@ -139,9 +138,8 @@ class IncentiveRestContractIT {
         }
         When { get("/api/v1/incentives/offers") } Then {
             statusCode(200)
-            body("items", hasSize<Any>(1))
-            body("items[0].ref.id", equalTo(offerId))
-            body("items[0].status", equalTo("PUBLISHED"))
+            body("items.ref.id", hasItem(offerId))
+            body("items.find { it.ref.id == '$offerId' }.status", equalTo("PUBLISHED"))
         }
 
         val start = CountDownLatch(1)

--- a/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/integration/IncentiveRestContractIT.kt
+++ b/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/integration/IncentiveRestContractIT.kt
@@ -250,6 +250,70 @@ class IncentiveRestContractIT {
             body("id", equalTo(attributedId))
         }
 
+        execute(
+            """
+            update promo_reservation
+            set reserved_at = now() - interval '3 seconds', expires_at = now() - interval '1 second'
+            where id = '$attributedId'
+            """.trimIndent(),
+        )
+        Given { contentType("application/json") }
+            .When { post("/api/v1/incentives/maintenance/expire") }
+            .Then { statusCode(200) }
+        assertThat(string("select status from promo_reservation where id = '$attributedId'"))
+            .isEqualTo("RESERVED")
+        assertThat(
+            count(
+                """select count(*) from incentive_outbox where aggregate_id = '$attributedId'
+                    and event_type = 'incentive.reservation.expired.v2'
+                """.trimIndent(),
+            ),
+        ).isZero()
+
+        val qualifiedAt = Instant.now().minusSeconds(2)
+        Given {
+            contentType("application/json")
+            header("X-Customer-Party-Id", customerParty.toString())
+            body(
+                """{"productRef":"current-account","qualifiedAt":"$qualifiedAt","partyRef":"spoofed"}""",
+            )
+        } When { post("/api/v1/customer-incentives/reservations/$attributedId/commit") } Then {
+            statusCode(400)
+        }
+        Given {
+            contentType("application/json")
+            header("X-Customer-Party-Id", java.util.UUID.randomUUID().toString())
+            body("""{"productRef":"current-account","qualifiedAt":"$qualifiedAt"}""")
+        } When { post("/api/v1/customer-incentives/reservations/$attributedId/commit") } Then {
+            statusCode(404)
+        }
+        repeat(2) {
+            Given {
+                contentType("application/json")
+                header("X-Customer-Party-Id", customerParty.toString())
+                body("""{"productRef":"current-account","qualifiedAt":"$qualifiedAt"}""")
+            } When { post("/api/v1/customer-incentives/reservations/$attributedId/commit") } Then {
+                statusCode(200)
+                body("status", equalTo("COMMITTED"))
+                body("attributionRef", equalTo(attributionRef.toString()))
+                body("$", not(hasKey("partyRef")))
+            }
+        }
+        Given {
+            contentType("application/json")
+            header("X-Customer-Party-Id", customerParty.toString())
+            body("""{"productRef":"current-account"}""")
+        } When { post("/api/v1/customer-incentives/reservations/$attributedId/release") } Then {
+            statusCode(409)
+        }
+        assertThat(
+            count(
+                """select count(*) from incentive_outbox where aggregate_id = '$attributedId'
+                    and event_type = 'incentive.reservation.committed.v2'
+                """.trimIndent(),
+            ),
+        ).isEqualTo(1)
+
         Given {
             contentType("application/json")
             header("X-Customer-Party-Id", customerParty.toString())

--- a/pacts/openbank-customer-edge-openbank-incentive-service.json
+++ b/pacts/openbank-customer-edge-openbank-incentive-service.json
@@ -1,0 +1,114 @@
+{
+  "consumer": {
+    "name": "openbank-customer-edge"
+  },
+  "interactions": [
+    {
+      "description": "POST an attributed customer reservation with trusted party identity",
+      "providerStates": [
+        {
+          "name": "a published offer contains the pact promo code for the pact product"
+        }
+      ],
+      "request": {
+        "body": {
+          "attributionRef": "22222222-2222-4222-8222-222222222222",
+          "code": "WELCOME10",
+          "productRef": "33333333-3333-4333-8333-333333333333"
+        },
+        "headers": {
+          "Content-Type": "application/json",
+          "Idempotency-Key": "claim-pact-once",
+          "X-Customer-Party-Id": "11111111-1111-4111-8111-111111111111"
+        },
+        "method": "POST",
+        "path": "/api/v1/customer-incentives/offers/44444444-4444-4444-8444-444444444444/reservations"
+      },
+      "response": {
+        "body": {
+          "attributionRef": "22222222-2222-4222-8222-222222222222",
+          "expiresAt": "2026-08-27T00:15:00Z",
+          "id": "55555555-5555-4555-8555-555555555555",
+          "offerRef": {
+            "id": "44444444-4444-4444-8444-444444444444",
+            "name": "WELCOME",
+            "version": 1
+          },
+          "productRef": "33333333-3333-4333-8333-333333333333",
+          "reservedAt": "2026-08-27T00:00:00Z",
+          "status": "RESERVED"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.attributionRef": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.expiresAt": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.offerRef.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.offerRef.version": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.reservedAt": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 201
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-incentive-service"
+  }
+}

--- a/pacts/openbank-customer-edge-openbank-incentive-service.json
+++ b/pacts/openbank-customer-edge-openbank-incentive-service.json
@@ -98,6 +98,195 @@
         },
         "status": 201
       }
+    },
+    {
+      "description": "POST a trusted deterministic qualifying rejection",
+      "providerStates": [
+        {
+          "name": "an attributed reservation is reserved for deterministic release"
+        }
+      ],
+      "request": {
+        "body": {
+          "productRef": "33333333-3333-4333-8333-333333333333"
+        },
+        "headers": {
+          "Content-Type": "application/json",
+          "Idempotency-Key": "open-pact-once",
+          "X-Customer-Party-Id": "11111111-1111-4111-8111-111111111111"
+        },
+        "method": "POST",
+        "path": "/api/v1/customer-incentives/reservations/55555555-5555-4555-8555-555555555555/release"
+      },
+      "response": {
+        "body": {
+          "attributionRef": "22222222-2222-4222-8222-222222222222",
+          "expiresAt": "2026-08-28T00:00:00Z",
+          "id": "55555555-5555-4555-8555-555555555555",
+          "offerRef": {
+            "id": "44444444-4444-4444-8444-444444444444",
+            "name": "WELCOME",
+            "version": 1
+          },
+          "productRef": "33333333-3333-4333-8333-333333333333",
+          "reservedAt": "2026-08-27T00:00:00Z",
+          "status": "RELEASED"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.attributionRef": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.expiresAt": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.offerRef.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.offerRef.version": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.reservedAt": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "POST a trusted qualifying account outcome",
+      "providerStates": [
+        {
+          "name": "an attributed reservation is reserved for qualifying commit"
+        }
+      ],
+      "request": {
+        "body": {
+          "productRef": "33333333-3333-4333-8333-333333333333",
+          "qualifiedAt": "2026-08-27T03:00:00Z"
+        },
+        "headers": {
+          "Content-Type": "application/json",
+          "Idempotency-Key": "open-pact-once",
+          "X-Customer-Party-Id": "11111111-1111-4111-8111-111111111111"
+        },
+        "method": "POST",
+        "path": "/api/v1/customer-incentives/reservations/55555555-5555-4555-8555-555555555555/commit"
+      },
+      "response": {
+        "body": {
+          "attributionRef": "22222222-2222-4222-8222-222222222222",
+          "expiresAt": "2026-08-28T00:00:00Z",
+          "id": "55555555-5555-4555-8555-555555555555",
+          "offerRef": {
+            "id": "44444444-4444-4444-8444-444444444444",
+            "name": "WELCOME",
+            "version": 1
+          },
+          "productRef": "33333333-3333-4333-8333-333333333333",
+          "reservedAt": "2026-08-27T00:00:00Z",
+          "status": "COMMITTED"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.attributionRef": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.expiresAt": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.offerRef.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.offerRef.version": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.reservedAt": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
     }
   ],
   "metadata": {


### PR DESCRIPTION
## Summary
- add an authenticated retail claim route that derives party identity from Keycloak and resolves the immutable offer from a trusted campaign interaction
- validate the selected term-deposit product server-side and forward only trusted party, offer, product, attribution and idempotency data
- commit a consumer Pact and replay it on Incentive Service against real HTTP and PostgreSQL in every PR

## Verification
- focused Customer Edge unit and consumer Pact tests
- Incentive @PactFolder provider replay against PostgreSQL
- ktlintCheck and detekt for both modules
- check-pact-provider-replay.py: 55/55
- duplicate YAML keys: 78 files clean

## Boundaries
- RESERVED is not redemption; authoritative commit/release remains a later reviewed slice
- no GitOps deployment or live E2E claim is asserted here

Refs #7210