### PR TITLE
feat(customer-edge): reconcile qualifying incentives

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -591,8 +591,7 @@ class CustomerEdgeResource(
             val account = parseJson(accountResponse)?.takeIf { it.isObject }
                 ?: return Response.status(Response.Status.BAD_GATEWAY)
                     .entity("{\"error\":\"Account outcome lacked qualifying evidence\"}").build()
-            val qualifiedAt = account.path("openedAt").asText().takeIf { it.isNotBlank() }
-                ?.let { runCatching { Instant.parse(it) }.getOrNull() }
+            val qualifiedAt = qualifyingAccountOpenedAt(account, customer.partyId, productId)
                 ?: return Response.status(Response.Status.BAD_GATEWAY)
                     .entity("{\"error\":\"Account outcome lacked qualifying evidence\"}").build()
             val commitBody = objectMapper.createObjectNode()
@@ -611,7 +610,7 @@ class CustomerEdgeResource(
             return Response.status(accountResponse.status).entity(result).type(MediaType.APPLICATION_JSON).build()
         }
 
-        if (accountResponse.status >= TRANSIENT_UPSTREAM_STATUS_MIN || accountResponse.status in TRANSIENT_STATUSES) {
+        if (accountResponse.status !in TERMINAL_ACCOUNT_REJECTION_STATUSES) {
             return accountResponse
         }
         val releaseBody = objectMapper.createObjectNode().put("productRef", productId.toString())
@@ -622,6 +621,16 @@ class CustomerEdgeResource(
             idempotencyKey,
         )
         return if (release.statusInfo.family == Response.Status.Family.SUCCESSFUL) accountResponse else release
+    }
+
+    private fun qualifyingAccountOpenedAt(account: JsonNode, partyId: UUID, productId: UUID): Instant? {
+        val authoritative = account.path("partyId").asText() == partyId.toString() &&
+            account.path("productId").asText() == productId.toString() &&
+            account.path("accountType").asText() == "TERM_DEPOSIT" &&
+            account.path("status").asText() == "ACTIVE"
+        if (!authoritative) return null
+        return account.path("openedAt").takeIf { it.isTextual }?.textValue()
+            ?.let { runCatching { Instant.parse(it) }.getOrNull() }
     }
 
     // --- KYC / identity verification status (AML Act §8, ADR-0116) ---
@@ -4708,8 +4717,7 @@ class CustomerEdgeResource(
         )
         private val INCENTIVE_CLAIM_FIELDS = setOf("interactionRef", "code", "productId")
         private val TERM_DEPOSIT_OPEN_FIELDS = setOf("productId", "incentiveReservationId")
-        private val TRANSIENT_STATUSES = setOf(408, 425, 429)
-        private const val TRANSIENT_UPSTREAM_STATUS_MIN = 500
+        private val TERMINAL_ACCOUNT_REJECTION_STATUSES = setOf(409, 422)
         private const val MIN_PROMO_CODE_LENGTH = 8
         private const val MAX_PROMO_CODE_LENGTH = 128
         private const val MAX_IDEMPOTENCY_KEY_LENGTH = 255

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -4717,7 +4717,7 @@ class CustomerEdgeResource(
         )
         private val INCENTIVE_CLAIM_FIELDS = setOf("interactionRef", "code", "productId")
         private val TERM_DEPOSIT_OPEN_FIELDS = setOf("productId", "incentiveReservationId")
-        private val TERMINAL_ACCOUNT_REJECTION_STATUSES = setOf(409, 422)
+        private val TERMINAL_ACCOUNT_REJECTION_STATUSES = setOf(422)
         private const val MIN_PROMO_CODE_LENGTH = 8
         private const val MAX_PROMO_CODE_LENGTH = 128
         private const val MAX_IDEMPOTENCY_KEY_LENGTH = 255

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -40,6 +40,7 @@ import org.eclipse.microprofile.jwt.JsonWebToken
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.time.Clock
+import java.time.Instant
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.UUID
@@ -530,10 +531,20 @@ class CustomerEdgeResource(
     fun openTermDeposit(body: String, @HeaderParam("Idempotency-Key") idempotencyKey: String?): Response {
         requireNotNull(idempotencyKey) { "Idempotency-Key header is required" }
         require(idempotencyKey.isNotBlank()) { "Idempotency-Key header must not be blank" }
+        require(idempotencyKey.length <= MAX_IDEMPOTENCY_KEY_LENGTH) { "Idempotency-Key is too long" }
         val customer = customer()
-        val productId = extractTextField(objectMapper, body, "productId")
-            ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+        val request = runCatching { objectMapper.readTree(body) }.getOrNull()?.takeIf { it.isObject }
+            ?: return badRequest("Malformed term-deposit request")
+        if (request.fieldNames().asSequence().any { it !in TERM_DEPOSIT_OPEN_FIELDS }) {
+            return badRequest("Term-deposit request contains unsupported fields")
+        }
+        val productId = request.uuidField("productId")
             ?: return Response.status(400).entity("{\"error\":\"productId must be a UUID\"}").build()
+        val reservationId = request.get("incentiveReservationId")?.takeUnless { it.isNull }?.let {
+            it.takeIf { node -> node.isTextual }?.textValue()?.let { value ->
+                runCatching { UUID.fromString(value) }.getOrNull()
+            } ?: return badRequest("incentiveReservationId must be a UUID")
+        }
         val offer = when (val result = resolvePublicTermDeposit(customer, productId)) {
             is TermDepositResolution.Found -> result.offer
             TermDepositResolution.NotFound -> return termDepositNotFound()
@@ -563,7 +574,54 @@ class CustomerEdgeResource(
             resourceId = extractTextField(objectMapper, (response.entity as? String).orEmpty(), "id"),
             details = mapOf("productId" to productId.toString(), "currency" to offer.path("currency").asText()),
         )
+        if (reservationId != null) {
+            return reconcileTermDepositIncentive(response, customer, productId, reservationId, idempotencyKey)
+        }
         return response
+    }
+
+    private fun reconcileTermDepositIncentive(
+        accountResponse: Response,
+        customer: CustomerIdentity,
+        productId: UUID,
+        reservationId: UUID,
+        idempotencyKey: String,
+    ): Response {
+        if (accountResponse.statusInfo.family == Response.Status.Family.SUCCESSFUL) {
+            val account = parseJson(accountResponse)?.takeIf { it.isObject }
+                ?: return Response.status(Response.Status.BAD_GATEWAY)
+                    .entity("{\"error\":\"Account outcome lacked qualifying evidence\"}").build()
+            val qualifiedAt = account.path("openedAt").asText().takeIf { it.isNotBlank() }
+                ?.let { runCatching { Instant.parse(it) }.getOrNull() }
+                ?: return Response.status(Response.Status.BAD_GATEWAY)
+                    .entity("{\"error\":\"Account outcome lacked qualifying evidence\"}").build()
+            val commitBody = objectMapper.createObjectNode()
+                .put("productRef", productId.toString())
+                .put("qualifiedAt", qualifiedAt.toString())
+            val commit = upstream.post(
+                "$incentiveServiceUrl/api/v1/customer-incentives/reservations/$reservationId/commit",
+                customer.partyId.toString(),
+                objectMapper.writeValueAsString(commitBody),
+                idempotencyKey,
+            )
+            if (commit.statusInfo.family != Response.Status.Family.SUCCESSFUL) return commit
+            val incentive = parseJson(commit)?.takeIf { it.isObject }
+                ?: return Response.status(Response.Status.BAD_GATEWAY).build()
+            val result = (account.deepCopy<JsonNode>() as ObjectNode).set<JsonNode>("incentiveReservation", incentive)
+            return Response.status(accountResponse.status).entity(result).type(MediaType.APPLICATION_JSON).build()
+        }
+
+        if (accountResponse.status >= TRANSIENT_UPSTREAM_STATUS_MIN || accountResponse.status in TRANSIENT_STATUSES) {
+            return accountResponse
+        }
+        val releaseBody = objectMapper.createObjectNode().put("productRef", productId.toString())
+        val release = upstream.post(
+            "$incentiveServiceUrl/api/v1/customer-incentives/reservations/$reservationId/release",
+            customer.partyId.toString(),
+            objectMapper.writeValueAsString(releaseBody),
+            idempotencyKey,
+        )
+        return if (release.statusInfo.family == Response.Status.Family.SUCCESSFUL) accountResponse else release
     }
 
     // --- KYC / identity verification status (AML Act §8, ADR-0116) ---
@@ -4649,6 +4707,9 @@ class CustomerEdgeResource(
             "REWARDS_HUB",
         )
         private val INCENTIVE_CLAIM_FIELDS = setOf("interactionRef", "code", "productId")
+        private val TERM_DEPOSIT_OPEN_FIELDS = setOf("productId", "incentiveReservationId")
+        private val TRANSIENT_STATUSES = setOf(408, 425, 429)
+        private const val TRANSIENT_UPSTREAM_STATUS_MIN = 500
         private const val MIN_PROMO_CODE_LENGTH = 8
         private const val MAX_PROMO_CODE_LENGTH = 128
         private const val MAX_IDEMPOTENCY_KEY_LENGTH = 255

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.43.0
+  version: 1.44.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -122,6 +122,9 @@ paths:
       responses:
         '201':
           description: Term-deposit account opened
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Account'}
         '400':
           description: Missing idempotency key or malformed product ID
         '404':
@@ -3564,6 +3567,10 @@ components:
         nickname:
           type: string
           nullable: true
+        incentiveReservation:
+          allOf:
+            - {$ref: '#/components/schemas/IncentiveReservation'}
+          description: Present only when this account opening committed a campaign incentive.
 
     # Mirrors openbank-account-service AccountPage (GET /api/v1/accounts is cursor-paginated,
     # not a bare array).
@@ -4281,6 +4288,13 @@ components:
           type: string
           format: uuid
           description: ID returned by /products/term-deposits
+        incentiveReservationId:
+          type: string
+          format: uuid
+          description: >-
+            Optional opaque reservation returned by /incentives/claims. The edge commits it only
+            after account-service returns the authoritative openedAt; deterministic rejection
+            releases it, while transient failure leaves it retryable until its TTL.
 
     ClaimCampaignIncentiveRequest:
       type: object

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
@@ -348,7 +348,7 @@ class CustomerEdgeResourceTest {
 
     @Test
     fun `unknown auth routing and transient failures leave reservation retryable`() {
-        listOf(401, 403, 404, 408, 425, 429, 500, 502).forEach { status ->
+        listOf(401, 403, 404, 408, 409, 425, 429, 500, 502).forEach { status ->
             val caller = UUID.randomUUID()
             val product = UUID.randomUUID()
             val reservation = UUID.randomUUID()

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
@@ -65,6 +65,12 @@ class CustomerEdgeResourceTest {
     }
     """.trimIndent()
 
+    private fun termDepositAccount(caller: UUID, product: UUID, openedAt: String): String = """{
+        "id":"${UUID.randomUUID()}","partyId":"$caller","productId":"$product",
+        "accountType":"TERM_DEPOSIT","status":"ACTIVE","openedAt":"$openedAt"
+    }
+    """.trimIndent()
+
     @Test
     fun `claimIncentive derives party and offer from trusted sources and forwards exact idempotency`() {
         val caller = UUID.randomUUID()
@@ -255,7 +261,7 @@ class CustomerEdgeResourceTest {
         every { upstream.get(match { it.contains("/parties/$caller") }, any()) } returns
             Response.ok("""{"status":"ACTIVE","legalName":"Ada Customer"}""").build()
         every { upstream.post("http://account/api/v1/accounts", caller.toString(), any(), "open-once") } returns
-            Response.status(201).entity("""{"id":"${UUID.randomUUID()}","openedAt":"$openedAt"}""").build()
+            Response.status(201).entity(termDepositAccount(caller, product, openedAt)).build()
         val commitBody = slot<String>()
         every {
             upstream.post(
@@ -280,6 +286,32 @@ class CustomerEdgeResourceTest {
         val evidence = ObjectMapper().readTree(commitBody.captured)
         assertThat(evidence.path("productRef").asText()).isEqualTo(product.toString())
         assertThat(evidence.path("qualifiedAt").asText()).isEqualTo(openedAt)
+    }
+
+    @Test
+    fun `term deposit success without matching authoritative account evidence does not commit`() {
+        val caller = UUID.randomUUID()
+        val product = UUID.randomUUID()
+        val reservation = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.endsWith("/products/$product") }, any()) } returns
+            Response.ok(termDepositProduct(product)).build()
+        every { upstream.get(match { it.contains("/parties/$caller") }, any()) } returns
+            Response.ok("""{"status":"ACTIVE","legalName":"Ada Customer"}""").build()
+        every { upstream.post("http://account/api/v1/accounts", caller.toString(), any(), "mismatch") } returns
+            Response.status(201).entity(
+                termDepositAccount(caller, UUID.randomUUID(), "2026-08-27T03:00:00Z"),
+            ).build()
+
+        val response = resourceFor(upstream, caller).apply {
+            productCatalogUrl = "http://catalog"
+            partyServiceUrl = "http://party"
+        }.openTermDeposit("""{"productId":"$product","incentiveReservationId":"$reservation"}""", "mismatch")
+
+        assertThat(response.status).isEqualTo(502)
+        verify(exactly = 0) {
+            upstream.post(match { it.contains("/customer-incentives/reservations/") }, any(), any(), any())
+        }
     }
 
     @Test
@@ -315,29 +347,31 @@ class CustomerEdgeResourceTest {
     }
 
     @Test
-    fun `transient term deposit failure leaves reservation retryable`() {
-        val caller = UUID.randomUUID()
-        val product = UUID.randomUUID()
-        val reservation = UUID.randomUUID()
-        val upstream = mockk<UpstreamClient>()
-        every { upstream.get(match { it.endsWith("/products/$product") }, any()) } returns
-            Response.ok(termDepositProduct(product)).build()
-        every { upstream.get(match { it.contains("/parties/$caller") }, any()) } returns
-            Response.ok("""{"status":"ACTIVE","legalName":"Ada Customer"}""").build()
-        every { upstream.post("http://account/api/v1/accounts", caller.toString(), any(), "retry-later") } returns
-            Response.status(502).entity("""{"error":"unavailable"}""").build()
+    fun `unknown auth routing and transient failures leave reservation retryable`() {
+        listOf(401, 403, 404, 408, 425, 429, 500, 502).forEach { status ->
+            val caller = UUID.randomUUID()
+            val product = UUID.randomUUID()
+            val reservation = UUID.randomUUID()
+            val upstream = mockk<UpstreamClient>()
+            every { upstream.get(match { it.endsWith("/products/$product") }, any()) } returns
+                Response.ok(termDepositProduct(product)).build()
+            every { upstream.get(match { it.contains("/parties/$caller") }, any()) } returns
+                Response.ok("""{"status":"ACTIVE","legalName":"Ada Customer"}""").build()
+            every { upstream.post("http://account/api/v1/accounts", caller.toString(), any(), "retry-$status") } returns
+                Response.status(status).entity("""{"error":"unavailable"}""").build()
 
-        val response = resourceFor(upstream, caller).apply {
-            productCatalogUrl = "http://catalog"
-            partyServiceUrl = "http://party"
-        }.openTermDeposit(
-            """{"productId":"$product","incentiveReservationId":"$reservation"}""",
-            "retry-later",
-        )
+            val response = resourceFor(upstream, caller).apply {
+                productCatalogUrl = "http://catalog"
+                partyServiceUrl = "http://party"
+            }.openTermDeposit(
+                """{"productId":"$product","incentiveReservationId":"$reservation"}""",
+                "retry-$status",
+            )
 
-        assertThat(response.status).isEqualTo(502)
-        verify(exactly = 0) {
-            upstream.post(match { it.contains("/customer-incentives/reservations/") }, any(), any(), any())
+            assertThat(response.status).isEqualTo(status)
+            verify(exactly = 0) {
+                upstream.post(match { it.contains("/customer-incentives/reservations/") }, any(), any(), any())
+            }
         }
     }
 

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
@@ -224,16 +224,121 @@ class CustomerEdgeResourceTest {
         every { upstream.post(match { it.contains("/api/v1/accounts") }, any(), capture(sent), "retry-key") } returns
             Response.status(201).entity("""{"id":"${UUID.randomUUID()}"}""").build()
 
-        val response = resourceFor(upstream, caller).apply {
+        val resource = resourceFor(upstream, caller).apply {
             productCatalogUrl = "http://catalog"
             partyServiceUrl = "http://party"
-        }.openTermDeposit("""{"productId":"$product","accountType":"CURRENT","currencyCode":"EUR"}""", "retry-key")
+        }
+        assertThat(
+            resource.openTermDeposit(
+                """{"productId":"$product","accountType":"CURRENT","currencyCode":"EUR"}""",
+                "retry-key",
+            ).status,
+        ).isEqualTo(400)
+        val response = resource.openTermDeposit("""{"productId":"$product"}""", "retry-key")
 
         assertThat(response.status).isEqualTo(201)
         val body = ObjectMapper().readTree(sent.captured)
         assertThat(body.path("accountType").asText()).isEqualTo("TERM_DEPOSIT")
         assertThat(body.path("currencyCode").asText()).isEqualTo("CZK")
         assertThat(body.path("legalName").asText()).isEqualTo("Ada Customer")
+    }
+
+    @Test
+    fun `term deposit success commits the matching reservation with authoritative openedAt`() {
+        val caller = UUID.randomUUID()
+        val product = UUID.randomUUID()
+        val reservation = UUID.randomUUID()
+        val openedAt = "2026-08-27T03:00:00Z"
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.endsWith("/products/$product") }, any()) } returns
+            Response.ok(termDepositProduct(product)).build()
+        every { upstream.get(match { it.contains("/parties/$caller") }, any()) } returns
+            Response.ok("""{"status":"ACTIVE","legalName":"Ada Customer"}""").build()
+        every { upstream.post("http://account/api/v1/accounts", caller.toString(), any(), "open-once") } returns
+            Response.status(201).entity("""{"id":"${UUID.randomUUID()}","openedAt":"$openedAt"}""").build()
+        val commitBody = slot<String>()
+        every {
+            upstream.post(
+                "http://incentive/api/v1/customer-incentives/reservations/$reservation/commit",
+                caller.toString(),
+                capture(commitBody),
+                "open-once",
+            )
+        } returns Response.ok("""{"id":"$reservation","status":"COMMITTED"}""").build()
+
+        val response = resourceFor(upstream, caller).apply {
+            productCatalogUrl = "http://catalog"
+            partyServiceUrl = "http://party"
+        }.openTermDeposit(
+            """{"productId":"$product","incentiveReservationId":"$reservation"}""",
+            "open-once",
+        )
+
+        assertThat(response.status).isEqualTo(201)
+        val responseJson = ObjectMapper().readTree(response.entity.toString())
+        assertThat(responseJson.path("incentiveReservation").path("status").asText()).isEqualTo("COMMITTED")
+        val evidence = ObjectMapper().readTree(commitBody.captured)
+        assertThat(evidence.path("productRef").asText()).isEqualTo(product.toString())
+        assertThat(evidence.path("qualifiedAt").asText()).isEqualTo(openedAt)
+    }
+
+    @Test
+    fun `deterministic term deposit rejection releases the matching reservation`() {
+        val caller = UUID.randomUUID()
+        val product = UUID.randomUUID()
+        val reservation = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.endsWith("/products/$product") }, any()) } returns
+            Response.ok(termDepositProduct(product)).build()
+        every { upstream.get(match { it.contains("/parties/$caller") }, any()) } returns
+            Response.ok("""{"status":"ACTIVE","legalName":"Ada Customer"}""").build()
+        every { upstream.post("http://account/api/v1/accounts", caller.toString(), any(), "reject-once") } returns
+            Response.status(422).entity("""{"error":"rejected"}""").build()
+        every {
+            upstream.post(
+                "http://incentive/api/v1/customer-incentives/reservations/$reservation/release",
+                caller.toString(),
+                match { ObjectMapper().readTree(it).path("productRef").asText() == product.toString() },
+                "reject-once",
+            )
+        } returns Response.ok("""{"id":"$reservation","status":"RELEASED"}""").build()
+
+        val response = resourceFor(upstream, caller).apply {
+            productCatalogUrl = "http://catalog"
+            partyServiceUrl = "http://party"
+        }.openTermDeposit(
+            """{"productId":"$product","incentiveReservationId":"$reservation"}""",
+            "reject-once",
+        )
+
+        assertThat(response.status).isEqualTo(422)
+    }
+
+    @Test
+    fun `transient term deposit failure leaves reservation retryable`() {
+        val caller = UUID.randomUUID()
+        val product = UUID.randomUUID()
+        val reservation = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.endsWith("/products/$product") }, any()) } returns
+            Response.ok(termDepositProduct(product)).build()
+        every { upstream.get(match { it.contains("/parties/$caller") }, any()) } returns
+            Response.ok("""{"status":"ACTIVE","legalName":"Ada Customer"}""").build()
+        every { upstream.post("http://account/api/v1/accounts", caller.toString(), any(), "retry-later") } returns
+            Response.status(502).entity("""{"error":"unavailable"}""").build()
+
+        val response = resourceFor(upstream, caller).apply {
+            productCatalogUrl = "http://catalog"
+            partyServiceUrl = "http://party"
+        }.openTermDeposit(
+            """{"productId":"$product","incentiveReservationId":"$reservation"}""",
+            "retry-later",
+        )
+
+        assertThat(response.status).isEqualTo(502)
+        verify(exactly = 0) {
+            upstream.post(match { it.contains("/customer-incentives/reservations/") }, any(), any(), any())
+        }
     }
 
     // ── party_id claim resolution (B1 fix, ADR-0069 §2) ─────────────────────

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeIncentivePactConsumerTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeIncentivePactConsumerTest.kt
@@ -31,6 +31,8 @@ import java.time.Clock
 @PactTestFor(providerName = "openbank-incentive-service", pactVersion = PactSpecVersion.V3)
 class CustomerEdgeIncentivePactConsumerTest {
     private lateinit var trustedStub: HttpServer
+    private var accountStatus = 201
+    private var accountBody = ACCOUNT_OPENED
 
     @BeforeEach
     fun startTrustedStub() {
@@ -43,6 +45,12 @@ class CustomerEdgeIncentivePactConsumerTest {
             }
             createContext("/api/v1/campaigns/interactions/$INTERACTION_REF/attribution") { exchange ->
                 respond(exchange, 200, ATTRIBUTION)
+            }
+            createContext("/api/v1/parties/$PARTY_ID") { exchange ->
+                respond(exchange, 200, """{"status":"ACTIVE","legalName":"Ada Customer"}""")
+            }
+            createContext("/api/v1/accounts") { exchange ->
+                respond(exchange, accountStatus, accountBody)
             }
             start()
         }
@@ -91,9 +99,95 @@ class CustomerEdgeIncentivePactConsumerTest {
         )
         .toPact()
 
+    @Pact(consumer = "openbank-customer-edge", provider = "openbank-incentive-service")
+    fun commitAttributedIncentive(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("an attributed reservation is reserved for qualifying commit")
+        .uponReceiving("POST a trusted qualifying account outcome")
+        .path("/api/v1/customer-incentives/reservations/$RESERVATION_ID/commit")
+        .method("POST")
+        .headers(
+            mapOf(
+                "Content-Type" to "application/json",
+                "X-Customer-Party-Id" to PARTY_ID,
+                "Idempotency-Key" to OPEN_IDEMPOTENCY_KEY,
+            ),
+        )
+        .body(
+            newJsonBody { body ->
+                body.stringValue("productRef", PRODUCT_ID)
+                body.stringValue("qualifiedAt", QUALIFIED_AT)
+            }.build(),
+        )
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(customerReservationBody("COMMITTED"))
+        .toPact()
+
+    @Pact(consumer = "openbank-customer-edge", provider = "openbank-incentive-service")
+    fun releaseAttributedIncentive(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("an attributed reservation is reserved for deterministic release")
+        .uponReceiving("POST a trusted deterministic qualifying rejection")
+        .path("/api/v1/customer-incentives/reservations/$RESERVATION_ID/release")
+        .method("POST")
+        .headers(
+            mapOf(
+                "Content-Type" to "application/json",
+                "X-Customer-Party-Id" to PARTY_ID,
+                "Idempotency-Key" to OPEN_IDEMPOTENCY_KEY,
+            ),
+        )
+        .body(newJsonBody { body -> body.stringValue("productRef", PRODUCT_ID) }.build())
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(customerReservationBody("RELEASED"))
+        .toPact()
+
     @Test
     @PactTestFor(pactMethod = "reserveAttributedIncentive")
     fun `real edge client reserves against the provider contract`(mockServer: MockServer) {
+        val resource = resource(mockServer)
+
+        val response = resource.claimIncentive(
+            """{"interactionRef":"$INTERACTION_REF","code":"WELCOME10","productId":"$PRODUCT_ID"}""",
+            IDEMPOTENCY_KEY,
+        )
+
+        assertThat(response.status).isEqualTo(201)
+        assertThat(ObjectMapper().readTree(response.entity.toString()).path("status").asText()).isEqualTo("RESERVED")
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "commitAttributedIncentive")
+    fun `real qualifying account flow commits against the provider contract`(mockServer: MockServer) {
+        accountStatus = 201
+        accountBody = ACCOUNT_OPENED
+        val response = resource(mockServer).openTermDeposit(
+            """{"productId":"$PRODUCT_ID","incentiveReservationId":"$RESERVATION_ID"}""",
+            OPEN_IDEMPOTENCY_KEY,
+        )
+
+        assertThat(response.status).isEqualTo(201)
+        assertThat(
+            ObjectMapper().readTree(response.entity.toString()).path("incentiveReservation").path("status").asText(),
+        ).isEqualTo("COMMITTED")
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "releaseAttributedIncentive")
+    fun `real deterministic rejection releases against the provider contract`(mockServer: MockServer) {
+        accountStatus = 422
+        accountBody = """{"error":"qualifying action rejected"}"""
+        val response = resource(mockServer).openTermDeposit(
+            """{"productId":"$PRODUCT_ID","incentiveReservationId":"$RESERVATION_ID"}""",
+            OPEN_IDEMPOTENCY_KEY,
+        )
+
+        assertThat(response.status).isEqualTo(422)
+    }
+
+    private fun resource(mockServer: MockServer): CustomerEdgeResource {
         val base = "http://127.0.0.1:${trustedStub.address.port}"
         val upstream = UpstreamClient().apply {
             tokenEndpointBase = base
@@ -102,7 +196,7 @@ class CustomerEdgeIncentivePactConsumerTest {
             tlsTrustCertificateFile = java.util.Optional.empty()
             allowedHostSuffixes = ".svc,127.0.0.1,localhost"
         }
-        val resource = CustomerEdgeResource(
+        return CustomerEdgeResource(
             upstream,
             mockk(relaxed = true),
             PaymentSessionStore(),
@@ -119,17 +213,11 @@ class CustomerEdgeIncentivePactConsumerTest {
                 every { resolve(any()) } answers { firstArg() }
             }
             productCatalogUrl = base
+            partyServiceUrl = base
+            accountServiceUrl = base
             campaignServiceUrl = base
             incentiveServiceUrl = mockServer.getUrl()
         }
-
-        val response = resource.claimIncentive(
-            """{"interactionRef":"$INTERACTION_REF","code":"WELCOME10","productId":"$PRODUCT_ID"}""",
-            IDEMPOTENCY_KEY,
-        )
-
-        assertThat(response.status).isEqualTo(201)
-        assertThat(ObjectMapper().readTree(response.entity.toString()).path("status").asText()).isEqualTo("RESERVED")
     }
 
     private companion object {
@@ -139,6 +227,10 @@ class CustomerEdgeIncentivePactConsumerTest {
         const val OFFER_ID = "44444444-4444-4444-8444-444444444444"
         const val RESERVATION_ID = "55555555-5555-4555-8555-555555555555"
         const val IDEMPOTENCY_KEY = "claim-pact-once"
+        const val OPEN_IDEMPOTENCY_KEY = "open-pact-once"
+        const val QUALIFIED_AT = "2026-08-27T03:00:00Z"
+        const val ACCOUNT_OPENED =
+            """{"id":"77777777-7777-4777-8777-777777777777","openedAt":"$QUALIFIED_AT"}"""
         val TERM_DEPOSIT_PRODUCT = """
             {"id":"$PRODUCT_ID","code":"TERM_6M","name":"Term deposit","type":"TERM_DEPOSIT",
             "currency":"CZK","status":"ACTIVE","isPublic":true,
@@ -148,6 +240,20 @@ class CustomerEdgeIncentivePactConsumerTest {
             {"campaignId":"66666666-6666-4666-8666-666666666666","stepOrder":0,"channel":"PUSH",
             "incentiveOfferRef":{"id":"$OFFER_ID","name":"WELCOME","version":1}}
         """.trimIndent()
+
+        fun customerReservationBody(status: String) = newJsonBody { body ->
+            body.uuid("id", java.util.UUID.fromString(RESERVATION_ID))
+            body.`object`("offerRef") { ref ->
+                ref.uuid("id", java.util.UUID.fromString(OFFER_ID))
+                ref.stringValue("name", "WELCOME")
+                ref.integerType("version", 1)
+            }
+            body.stringValue("productRef", PRODUCT_ID)
+            body.uuid("attributionRef", java.util.UUID.fromString(INTERACTION_REF))
+            body.stringType("reservedAt", "2026-08-27T00:00:00Z")
+            body.stringType("expiresAt", "2026-08-28T00:00:00Z")
+            body.stringValue("status", status)
+        }.build()
 
         fun respond(exchange: com.sun.net.httpserver.HttpExchange, status: Int, body: String) {
             val bytes = body.toByteArray()

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeIncentivePactConsumerTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeIncentivePactConsumerTest.kt
@@ -229,8 +229,11 @@ class CustomerEdgeIncentivePactConsumerTest {
         const val IDEMPOTENCY_KEY = "claim-pact-once"
         const val OPEN_IDEMPOTENCY_KEY = "open-pact-once"
         const val QUALIFIED_AT = "2026-08-27T03:00:00Z"
-        const val ACCOUNT_OPENED =
-            """{"id":"77777777-7777-4777-8777-777777777777","openedAt":"$QUALIFIED_AT"}"""
+        val ACCOUNT_OPENED =
+            """
+            {"id":"77777777-7777-4777-8777-777777777777","partyId":"$PARTY_ID","productId":"$PRODUCT_ID",
+            "accountType":"TERM_DEPOSIT","status":"ACTIVE","openedAt":"$QUALIFIED_AT"}
+            """.trimIndent()
         val TERM_DEPOSIT_PRODUCT = """
             {"id":"$PRODUCT_ID","code":"TERM_6M","name":"Term deposit","type":"TERM_DEPOSIT",
             "currency":"CZK","status":"ACTIVE","isPublic":true,

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/integration/CustomerIncentiveClaimIT.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/integration/CustomerIncentiveClaimIT.kt
@@ -110,7 +110,10 @@ class CustomerIncentiveClaimIT {
         StubUpstreamResource.stub(
             ACCOUNT_PATH,
             status = 201,
-            body = """{"id":"77777777-7777-4777-8777-777777777777","openedAt":"$OPENED_AT"}""",
+            body = """
+                {"id":"77777777-7777-4777-8777-777777777777","partyId":"$CLAIM_PARTY_ID","productId":"$PRODUCT_ID",
+                "accountType":"TERM_DEPOSIT","status":"ACTIVE","openedAt":"$OPENED_AT"}
+            """.trimIndent(),
         )
         StubUpstreamResource.stub(
             COMMIT_PATH,

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/integration/CustomerIncentiveClaimIT.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/integration/CustomerIncentiveClaimIT.kt
@@ -100,6 +100,39 @@ class CustomerIncentiveClaimIT {
         assertThat(StubUpstreamResource.requests(PRODUCT_PATH)).isEmpty()
     }
 
+    @Test
+    fun `authoritative account opening commits the claimed reservation over real http`() {
+        StubUpstreamResource.stub(PRODUCT_PATH, body = PRODUCT_JSON)
+        StubUpstreamResource.stub(
+            PARTY_PATH,
+            body = """{"status":"ACTIVE","legalName":"Ada Customer"}""",
+        )
+        StubUpstreamResource.stub(
+            ACCOUNT_PATH,
+            status = 201,
+            body = """{"id":"77777777-7777-4777-8777-777777777777","openedAt":"$OPENED_AT"}""",
+        )
+        StubUpstreamResource.stub(
+            COMMIT_PATH,
+            body = RESERVATION_JSON.replace("RESERVED", "COMMITTED"),
+        )
+
+        Given {
+            contentType("application/json")
+            header("Idempotency-Key", "open-term-with-reward")
+            body("""{"productId":"$PRODUCT_ID","incentiveReservationId":"$RESERVATION_ID"}""")
+        } When {
+            post("/customer/v1/term-deposits")
+        } Then {
+            statusCode(201)
+            body("incentiveReservation.status", org.hamcrest.Matchers.equalTo("COMMITTED"))
+        }
+
+        val commit = ObjectMapper().readTree(StubUpstreamResource.requests(COMMIT_PATH).single().body)
+        assertThat(commit.path("productRef").asText()).isEqualTo(PRODUCT_ID)
+        assertThat(commit.path("qualifiedAt").asText()).isEqualTo(OPENED_AT)
+    }
+
     private fun stubProductAndAttribution() {
         StubUpstreamResource.stub(PRODUCT_PATH, body = PRODUCT_JSON)
         StubUpstreamResource.stub(ATTRIBUTION_PATH, body = ATTRIBUTION_JSON)
@@ -130,6 +163,10 @@ private const val RESERVATION_ID = "55555555-5555-4555-8555-555555555555"
 private const val PRODUCT_PATH = "/api/v1/products/$PRODUCT_ID"
 private const val ATTRIBUTION_PATH = "/api/v1/campaigns/interactions/$INTERACTION_ID/attribution"
 private const val INCENTIVE_PATH = "/api/v1/customer-incentives/offers/$OFFER_ID/reservations"
+private const val PARTY_PATH = "/api/v1/parties/$CLAIM_PARTY_ID"
+private const val ACCOUNT_PATH = "/api/v1/accounts"
+private const val COMMIT_PATH = "/api/v1/customer-incentives/reservations/$RESERVATION_ID/commit"
+private const val OPENED_AT = "2026-08-27T03:00:00Z"
 private const val CLAIM_JSON =
     """{"interactionRef":"$INTERACTION_ID","code":"WELCOME10","productId":"$PRODUCT_ID"}"""
 private const val PRODUCT_JSON =

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/application/IncentiveApplication.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/application/IncentiveApplication.kt
@@ -82,6 +82,24 @@ class IncentiveApplication(
 
     suspend fun commit(id: UUID, actor: String, now: Instant = Instant.now()) = store.commit(id, actor, now)
     suspend fun release(id: UUID, actor: String, now: Instant = Instant.now()) = store.release(id, actor, now)
+    suspend fun commitAttributed(
+        id: UUID,
+        partyRef: String,
+        productRef: String,
+        actor: String,
+        qualifiedAt: Instant,
+        now: Instant = Instant.now(),
+    ): PromoReservation {
+        require(!qualifiedAt.isAfter(now.plus(MAX_QUALIFYING_CLOCK_SKEW))) { "qualifiedAt must not be in the future" }
+        return store.commitAttributed(id, partyRef, productRef, actor, qualifiedAt)
+    }
+    suspend fun releaseAttributed(
+        id: UUID,
+        partyRef: String,
+        productRef: String,
+        actor: String,
+        now: Instant = Instant.now(),
+    ) = store.releaseAttributed(id, partyRef, productRef, actor, now)
     suspend fun expireDue(now: Instant = Instant.now()) = store.expireDue(now)
 
     private fun digest(code: String): CodeDigest {
@@ -96,6 +114,7 @@ class IncentiveApplication(
         const val MIN_CODE_LENGTH = 8
         const val MAX_CODE_LENGTH = 128
         const val MIN_PEPPER_LENGTH = 32
+        val MAX_QUALIFYING_CLOCK_SKEW: Duration = Duration.ofMinutes(1)
     }
 }
 

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/application/IncentiveStore.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/application/IncentiveStore.kt
@@ -7,6 +7,7 @@ import com.openbank.incentive.domain.PromoReservation
 import java.time.Instant
 import java.util.UUID
 
+@Suppress("TooManyFunctions")
 interface IncentiveStore {
     suspend fun createOffer(offer: IncentiveOffer): IncentiveOffer
     suspend fun findOffer(id: UUID): IncentiveOffer?
@@ -17,6 +18,20 @@ interface IncentiveStore {
     suspend fun reserve(command: ReserveIncentive): PromoReservation
     suspend fun commit(id: UUID, actor: String, at: Instant): PromoReservation
     suspend fun release(id: UUID, actor: String, at: Instant): PromoReservation
+    suspend fun commitAttributed(
+        id: UUID,
+        partyRef: String,
+        productRef: String,
+        actor: String,
+        qualifiedAt: Instant,
+    ): PromoReservation
+    suspend fun releaseAttributed(
+        id: UUID,
+        partyRef: String,
+        productRef: String,
+        actor: String,
+        at: Instant,
+    ): PromoReservation
     suspend fun expireDue(at: Instant): Int
 }
 

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/domain/PromoReservation.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/domain/PromoReservation.kt
@@ -34,8 +34,13 @@ data class PromoReservation(
 
     fun commit(at: Instant): PromoReservation {
         if (status == ReservationStatus.COMMITTED) return this
-        if (status != ReservationStatus.RESERVED) throw IncentiveConflict("only a reservation can be committed")
-        if (!at.isBefore(expiresAt)) throw IncentiveConflict("an expired reservation cannot be committed")
+        val conflict = when {
+            status != ReservationStatus.RESERVED -> "only a reservation can be committed"
+            at.isBefore(reservedAt) -> "qualifying action predates the reservation"
+            !at.isBefore(expiresAt) -> "an expired reservation cannot be committed"
+            else -> null
+        }
+        if (conflict != null) throw IncentiveConflict(conflict)
         return copy(status = ReservationStatus.COMMITTED)
     }
 

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/persistence/IncentivePersistence.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/persistence/IncentivePersistence.kt
@@ -391,6 +391,22 @@ class PanacheIncentiveStore(
     override suspend fun release(id: UUID, actor: String, at: Instant): PromoReservation =
         transition(id, actor, at, ReservationStatus.RELEASED)
 
+    override suspend fun commitAttributed(
+        id: UUID,
+        partyRef: String,
+        productRef: String,
+        actor: String,
+        qualifiedAt: Instant,
+    ): PromoReservation = transition(id, actor, qualifiedAt, ReservationStatus.COMMITTED, partyRef, productRef)
+
+    override suspend fun releaseAttributed(
+        id: UUID,
+        partyRef: String,
+        productRef: String,
+        actor: String,
+        at: Instant,
+    ): PromoReservation = transition(id, actor, at, ReservationStatus.RELEASED, partyRef, productRef)
+
     override suspend fun expireDue(at: Instant): Int {
         val ids = Panache.withSession {
             reservations.find("status = ?1 and expiresAt <= ?2", "RESERVED", at)
@@ -416,31 +432,50 @@ class PanacheIncentiveStore(
         }
     }.awaitSuspending()
 
-    private suspend fun transition(id: UUID, actor: String, at: Instant, target: ReservationStatus): PromoReservation =
-        Panache.withTransaction {
-            lockedReservation(id).flatMap { entity ->
-                if (entity == null) throw IncentiveNotFound("reservation not found")
-                val current = entity.toDomain()
-                val updated = when (target) {
-                    ReservationStatus.COMMITTED -> current.commit(at)
-                    ReservationStatus.RELEASED -> current.release()
-                    else -> throw IllegalArgumentException("unsupported transition")
-                }
-                if (updated === current) return@flatMap Uni.createFrom().item(current)
-                entity.status = target.name
-                if (target == ReservationStatus.COMMITTED) entity.committedAt = at else entity.releasedAt = at
-                lockedCode(entity.codeDigest).flatMap { code ->
-                    requireNotNull(code)
-                    code.status = if (target == ReservationStatus.COMMITTED) "REDEEMED" else "AVAILABLE"
-                    when (target) {
-                        ReservationStatus.COMMITTED -> reservationEvidence(updated, target, actor)
-                        ReservationStatus.RELEASED -> reservationEvidence(updated, target, actor)
-                        else -> error("unsupported transition")
-                    }
-                        .replaceWith(updated)
-                }
+    private suspend fun transition(
+        id: UUID,
+        actor: String,
+        at: Instant,
+        target: ReservationStatus,
+        expectedPartyRef: String? = null,
+        expectedProductRef: String? = null,
+    ): PromoReservation = Panache.withTransaction {
+        lockedReservation(id).flatMap { entity ->
+            if (entity == null) throw IncentiveNotFound("reservation not found")
+            val current = entity.toDomain()
+            requireAttributedOwner(current, expectedPartyRef, expectedProductRef)
+            val updated = when (target) {
+                ReservationStatus.COMMITTED -> current.commit(at)
+                ReservationStatus.RELEASED -> current.release()
+                else -> throw IllegalArgumentException("unsupported transition")
             }
-        }.awaitSuspending()
+            if (updated === current) return@flatMap Uni.createFrom().item(current)
+            entity.status = target.name
+            if (target == ReservationStatus.COMMITTED) entity.committedAt = at else entity.releasedAt = at
+            lockedCode(entity.codeDigest).flatMap { code ->
+                requireNotNull(code)
+                code.status = if (target == ReservationStatus.COMMITTED) "REDEEMED" else "AVAILABLE"
+                when (target) {
+                    ReservationStatus.COMMITTED -> reservationEvidence(updated, target, actor)
+                    ReservationStatus.RELEASED -> reservationEvidence(updated, target, actor)
+                    else -> error("unsupported transition")
+                }
+                    .replaceWith(updated)
+            }
+        }
+    }.awaitSuspending()
+
+    private fun requireAttributedOwner(
+        reservation: PromoReservation,
+        expectedPartyRef: String?,
+        expectedProductRef: String?,
+    ) {
+        if (expectedPartyRef == null) return
+        val owned = reservation.attributionRef != null &&
+            reservation.partyRef == expectedPartyRef &&
+            reservation.productRef == expectedProductRef
+        if (!owned) throw IncentiveNotFound("reservation not found")
+    }
 
     private fun expireEntity(entity: ReservationEntity, at: Instant): Uni<Void> =
         lockedCode(entity.codeDigest).flatMap { code ->

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/persistence/IncentivePersistence.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/persistence/IncentivePersistence.kt
@@ -315,6 +315,7 @@ class PanacheIncentiveStore(
 
     private companion object {
         const val RETENTION_MONTHS = 13L
+        val ATTRIBUTED_FINALIZATION_GRACE: Duration = Duration.ofHours(24)
     }
 
     override suspend fun reserve(command: ReserveIncentive): PromoReservation = Panache.withTransaction {
@@ -420,10 +421,13 @@ class PanacheIncentiveStore(
 
     private suspend fun expireOne(id: UUID, at: Instant): Int = Panache.withTransaction {
         lockedReservation(id).flatMap { locked ->
+            val finalizationDeadline = locked?.expiresAt?.let { expiry ->
+                if (locked.attributionRef == null) expiry else expiry.plus(ATTRIBUTED_FINALIZATION_GRACE)
+            }
             if (
                 locked == null ||
                 locked.status != ReservationStatus.RESERVED.name ||
-                locked.expiresAt.isAfter(at)
+                requireNotNull(finalizationDeadline).isAfter(at)
             ) {
                 Uni.createFrom().item(0)
             } else {

--- a/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/rest/CustomerIncentiveResource.kt
+++ b/openbank-incentive-service/src/main/kotlin/com/openbank/incentive/infrastructure/rest/CustomerIncentiveResource.kt
@@ -34,6 +34,14 @@ data class CustomerReservationResponse(
     val status: ReservationStatus,
 )
 
+data class CustomerCommitReservationRequest(
+    val productRef: String,
+    val qualifiedAt: Instant,
+    val partyRef: String? = null,
+)
+
+data class CustomerReleaseReservationRequest(val productRef: String, val partyRef: String? = null)
+
 /**
  * Trusted customer-edge boundary. The retail client never supplies party identity or offer terms:
  * customer-edge derives the party from its Keycloak JWT and resolves the offer from the opaque
@@ -56,13 +64,11 @@ class CustomerIncentiveResource(
         @HeaderParam("Idempotency-Key") key: String?,
         request: CustomerReserveCodeRequest,
     ): Response {
-        val permittedCaller = callerPrincipal.orElse("")
-        if (permittedCaller.isBlank() || identity.principal?.name != permittedCaller) {
+        if (!callerPermitted()) {
             return Response.status(Response.Status.FORBIDDEN).build()
         }
         require(request.partyRef == null) { "partyRef must not be supplied by the customer request" }
-        val trustedParty = requireNotNull(partyId?.let(::parseUuid)) { "X-Customer-Party-Id is required" }
-        require(trustedParty != ZERO_UUID) { "X-Customer-Party-Id must not be the nil UUID" }
+        val trustedParty = requireTrustedParty(partyId)
         require(!key.isNullOrBlank()) { "Idempotency-Key is required" }
         val reservation = application.reserve(
             id,
@@ -86,9 +92,69 @@ class CustomerIncentiveResource(
         ).build()
     }
 
+    @POST
+    @Path("/reservations/{id}/commit")
+    suspend fun commit(
+        @PathParam("id") id: UUID,
+        @HeaderParam("X-Customer-Party-Id") partyId: String?,
+        request: CustomerCommitReservationRequest,
+    ): Response {
+        if (!callerPermitted()) return Response.status(Response.Status.FORBIDDEN).build()
+        require(request.partyRef == null) { "partyRef must not be supplied by the customer request" }
+        val trustedParty = requireTrustedParty(partyId)
+        val reservation = application.commitAttributed(
+            id,
+            trustedParty.toString(),
+            request.productRef,
+            identity.principal.name,
+            request.qualifiedAt,
+        )
+        return Response.ok(reservation.toCustomerResponse()).build()
+    }
+
+    @POST
+    @Path("/reservations/{id}/release")
+    suspend fun release(
+        @PathParam("id") id: UUID,
+        @HeaderParam("X-Customer-Party-Id") partyId: String?,
+        request: CustomerReleaseReservationRequest,
+    ): Response {
+        if (!callerPermitted()) return Response.status(Response.Status.FORBIDDEN).build()
+        require(request.partyRef == null) { "partyRef must not be supplied by the customer request" }
+        val trustedParty = requireTrustedParty(partyId)
+        val reservation = application.releaseAttributed(
+            id,
+            trustedParty.toString(),
+            request.productRef,
+            identity.principal.name,
+        )
+        return Response.ok(reservation.toCustomerResponse()).build()
+    }
+
+    private fun callerPermitted(): Boolean {
+        val permittedCaller = callerPrincipal.orElse("")
+        return permittedCaller.isNotBlank() && identity.principal?.name == permittedCaller
+    }
+
+    private fun requireTrustedParty(partyId: String?): UUID {
+        val trustedParty = requireNotNull(partyId?.let(::parseUuid)) { "X-Customer-Party-Id is required" }
+        require(trustedParty != ZERO_UUID) { "X-Customer-Party-Id must not be the nil UUID" }
+        return trustedParty
+    }
+
     private fun parseUuid(value: String): UUID? = runCatching { UUID.fromString(value) }.getOrNull()
 
     private companion object {
         val ZERO_UUID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
     }
 }
+
+private fun com.openbank.incentive.domain.PromoReservation.toCustomerResponse() = CustomerReservationResponse(
+    id,
+    offerRef,
+    productRef,
+    requireNotNull(attributionRef),
+    reservedAt,
+    expiresAt,
+    status,
+)

--- a/openbank-incentive-service/src/main/resources/openapi.yaml
+++ b/openbank-incentive-service/src/main/resources/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: OpenBank Incentive Service
-  version: 1.2.0
+  version: 1.3.0
   description: Governed fixed-benefit offers and opaque promo-code reservations.
 paths:
   /api/v1/customer-incentives/offers/{id}/reservations:
@@ -34,6 +34,50 @@ paths:
         "400": {description: Missing trusted party, idempotency key, or invalid request}
         "404": {description: Offer or code not found}
         "409": {description: Replay mismatch, inventory, offer, attribution, or limit conflict}
+  /api/v1/customer-incentives/reservations/{id}/commit:
+    post:
+      summary: Commit an attributed reservation after the trusted qualifying action succeeds
+      description: >-
+        Internal customer-edge boundary. Party identity comes from the customer JWT and productRef
+        is the validated catalogue product. qualifiedAt is the authoritative account openedAt so a
+        crash-window retry can replay the same business outcome without extending reservation TTL.
+      parameters:
+        - {$ref: '#/components/parameters/ReservationId'}
+        - name: X-Customer-Party-Id
+          in: header
+          required: true
+          schema: {type: string, format: uuid}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/CustomerCommitReservation'}
+      responses:
+        "200": {description: Committed or idempotently replayed, content: {application/json: {schema: {$ref: '#/components/schemas/CustomerReservation'}}}}
+        "400": {description: Missing trusted party or malformed qualifying evidence}
+        "403": {description: Caller is not the configured customer-edge workload}
+        "404": {description: Reservation does not belong to the trusted party and product}
+        "409": {description: Reservation expired or is terminal in another state}
+  /api/v1/customer-incentives/reservations/{id}/release:
+    post:
+      summary: Release an attributed reservation after a deterministic qualifying-action rejection
+      parameters:
+        - {$ref: '#/components/parameters/ReservationId'}
+        - name: X-Customer-Party-Id
+          in: header
+          required: true
+          schema: {type: string, format: uuid}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/CustomerReleaseReservation'}
+      responses:
+        "200": {description: Released or idempotently replayed, content: {application/json: {schema: {$ref: '#/components/schemas/CustomerReservation'}}}}
+        "400": {description: Missing trusted party or malformed request}
+        "403": {description: Caller is not the configured customer-edge workload}
+        "404": {description: Reservation does not belong to the trusted party and product}
+        "409": {description: Reservation is committed or terminal in another state}
   /api/v1/incentives/offers:
     get:
       summary: List immutable published incentive offers for governed catalogue selection
@@ -184,6 +228,19 @@ components:
         reservedAt: {type: string, format: date-time}
         expiresAt: {type: string, format: date-time}
         status: {type: string, enum: [RESERVED, COMMITTED, RELEASED, EXPIRED]}
+    CustomerCommitReservation:
+      type: object
+      additionalProperties: false
+      required: [productRef, qualifiedAt]
+      properties:
+        productRef: {type: string, minLength: 1}
+        qualifiedAt: {type: string, format: date-time}
+    CustomerReleaseReservation:
+      type: object
+      additionalProperties: false
+      required: [productRef]
+      properties:
+        productRef: {type: string, minLength: 1}
     Offer:
       type: object
       required: [ref, productScope, effectiveFrom, expiresAt, totalLimit, perPartyLimit, stackingPolicy, status, maker]

--- a/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/contract/IncentivePactFolderProviderVerificationTest.kt
+++ b/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/contract/IncentivePactFolderProviderVerificationTest.kt
@@ -75,9 +75,42 @@ class IncentivePactFolderProviderVerificationTest {
         }
     }
 
+    @State("an attributed reservation is reserved for qualifying commit")
+    fun attributedReservationForCommit() = insertReservedAttribution()
+
+    @State("an attributed reservation is reserved for deterministic release")
+    fun attributedReservationForRelease() = insertReservedAttribution()
+
+    private fun insertReservedAttribution() {
+        dataSource.connection.use { connection ->
+            connection.autoCommit = false
+            deletePreviousReservation(connection)
+            if (!offerExists(connection)) insertOffer(connection)
+            if (!codeExists(connection)) insertCode(connection)
+            connection.prepareStatement(INSERT_RESERVATION).use { statement ->
+                statement.setString(1, RESERVATION_ID)
+                statement.setString(2, OFFER_ID)
+                statement.setString(3, codeDigest())
+                statement.setString(4, PARTY_ID)
+                statement.setString(5, PRODUCT_ID)
+                statement.setString(6, ATTRIBUTION_ID)
+                statement.executeUpdate()
+            }
+            connection.prepareStatement("UPDATE promo_code_inventory SET status = 'RESERVED' WHERE digest = ?")
+                .use { statement ->
+                    statement.setString(1, codeDigest())
+                    statement.executeUpdate()
+                }
+            connection.commit()
+        }
+    }
+
     private fun deletePreviousReservation(connection: Connection) {
-        connection.prepareStatement("DELETE FROM promo_reservation WHERE attribution_ref = ?::uuid").use { statement ->
-            statement.setString(1, ATTRIBUTION_ID)
+        connection.prepareStatement(
+            "DELETE FROM promo_reservation WHERE id = ?::uuid OR attribution_ref = ?::uuid",
+        ).use { statement ->
+            statement.setString(1, RESERVATION_ID)
+            statement.setString(2, ATTRIBUTION_ID)
             statement.executeUpdate()
         }
         connection.prepareStatement(
@@ -124,6 +157,9 @@ class IncentivePactFolderProviderVerificationTest {
     private companion object {
         const val OFFER_ID = "44444444-4444-4444-8444-444444444444"
         const val ATTRIBUTION_ID = "22222222-2222-4222-8222-222222222222"
+        const val PARTY_ID = "11111111-1111-4111-8111-111111111111"
+        const val PRODUCT_ID = "33333333-3333-4333-8333-333333333333"
+        const val RESERVATION_ID = "55555555-5555-4555-8555-555555555555"
         const val CODE = "WELCOME10"
         const val PEPPER = "integration-pepper-with-32-characters-minimum"
         const val INSERT_OFFER = """
@@ -138,6 +174,15 @@ class IncentivePactFolderProviderVerificationTest {
         const val INSERT_CODE = """
             INSERT INTO promo_code_inventory (digest, offer_id, status, created_at, retained_until)
             VALUES (?, ?::uuid, 'AVAILABLE', now(), now() + interval '13 months')
+        """
+        const val INSERT_RESERVATION = """
+            INSERT INTO promo_reservation (
+              id, offer_id, offer_name, offer_version, code_digest, party_ref, product_ref,
+              idempotency_key, status, reserved_at, expires_at, attribution_ref
+            ) VALUES (
+              ?::uuid, ?::uuid, 'WELCOME', 1, ?, ?, ?, 'open-pact-once', 'RESERVED',
+              '2026-08-27T00:00:00Z', '2099-01-01T00:00:00Z', ?::uuid
+            )
         """
     }
 }

--- a/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/domain/IncentiveDomainTest.kt
+++ b/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/domain/IncentiveDomainTest.kt
@@ -39,6 +39,13 @@ class IncentiveDomainTest {
     }
 
     @Test
+    fun `qualifying action cannot predate reservation`() {
+        val reservation = reservation()
+        assertThatThrownBy { reservation.commit(reservation.reservedAt.minusSeconds(1)) }
+            .isInstanceOf(IncentiveConflict::class.java)
+    }
+
+    @Test
     fun `expiry closes inventory and cannot be converted into success`() {
         val reservation = reservation()
         assertThatThrownBy { reservation.expire(now) }.isInstanceOf(IncentiveConflict::class.java)

--- a/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/integration/IncentiveRestContractIT.kt
+++ b/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/integration/IncentiveRestContractIT.kt
@@ -250,7 +250,27 @@ class IncentiveRestContractIT {
             body("id", equalTo(attributedId))
         }
 
-        val qualifiedAt = Instant.now()
+        execute(
+            """
+            update promo_reservation
+            set reserved_at = now() - interval '3 seconds', expires_at = now() - interval '1 second'
+            where id = '$attributedId'
+            """.trimIndent(),
+        )
+        Given { contentType("application/json") }
+            .When { post("/api/v1/incentives/maintenance/expire") }
+            .Then { statusCode(200) }
+        assertThat(string("select status from promo_reservation where id = '$attributedId'"))
+            .isEqualTo("RESERVED")
+        assertThat(
+            count(
+                """select count(*) from incentive_outbox where aggregate_id = '$attributedId'
+                    and event_type = 'incentive.reservation.expired.v2'
+                """.trimIndent(),
+            ),
+        ).isZero()
+
+        val qualifiedAt = Instant.now().minusSeconds(2)
         Given {
             contentType("application/json")
             header("X-Customer-Party-Id", customerParty.toString())

--- a/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/integration/IncentiveRestContractIT.kt
+++ b/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/integration/IncentiveRestContractIT.kt
@@ -250,6 +250,50 @@ class IncentiveRestContractIT {
             body("id", equalTo(attributedId))
         }
 
+        val qualifiedAt = Instant.now()
+        Given {
+            contentType("application/json")
+            header("X-Customer-Party-Id", customerParty.toString())
+            body(
+                """{"productRef":"current-account","qualifiedAt":"$qualifiedAt","partyRef":"spoofed"}""",
+            )
+        } When { post("/api/v1/customer-incentives/reservations/$attributedId/commit") } Then {
+            statusCode(400)
+        }
+        Given {
+            contentType("application/json")
+            header("X-Customer-Party-Id", java.util.UUID.randomUUID().toString())
+            body("""{"productRef":"current-account","qualifiedAt":"$qualifiedAt"}""")
+        } When { post("/api/v1/customer-incentives/reservations/$attributedId/commit") } Then {
+            statusCode(404)
+        }
+        repeat(2) {
+            Given {
+                contentType("application/json")
+                header("X-Customer-Party-Id", customerParty.toString())
+                body("""{"productRef":"current-account","qualifiedAt":"$qualifiedAt"}""")
+            } When { post("/api/v1/customer-incentives/reservations/$attributedId/commit") } Then {
+                statusCode(200)
+                body("status", equalTo("COMMITTED"))
+                body("attributionRef", equalTo(attributionRef.toString()))
+                body("$", not(hasKey("partyRef")))
+            }
+        }
+        Given {
+            contentType("application/json")
+            header("X-Customer-Party-Id", customerParty.toString())
+            body("""{"productRef":"current-account"}""")
+        } When { post("/api/v1/customer-incentives/reservations/$attributedId/release") } Then {
+            statusCode(409)
+        }
+        assertThat(
+            count(
+                """select count(*) from incentive_outbox where aggregate_id = '$attributedId'
+                    and event_type = 'incentive.reservation.committed.v2'
+                """.trimIndent(),
+            ),
+        ).isEqualTo(1)
+
         Given {
             contentType("application/json")
             header("X-Customer-Party-Id", customerParty.toString())

--- a/pacts/openbank-customer-edge-openbank-incentive-service.json
+++ b/pacts/openbank-customer-edge-openbank-incentive-service.json
@@ -98,6 +98,195 @@
         },
         "status": 201
       }
+    },
+    {
+      "description": "POST a trusted deterministic qualifying rejection",
+      "providerStates": [
+        {
+          "name": "an attributed reservation is reserved for deterministic release"
+        }
+      ],
+      "request": {
+        "body": {
+          "productRef": "33333333-3333-4333-8333-333333333333"
+        },
+        "headers": {
+          "Content-Type": "application/json",
+          "Idempotency-Key": "open-pact-once",
+          "X-Customer-Party-Id": "11111111-1111-4111-8111-111111111111"
+        },
+        "method": "POST",
+        "path": "/api/v1/customer-incentives/reservations/55555555-5555-4555-8555-555555555555/release"
+      },
+      "response": {
+        "body": {
+          "attributionRef": "22222222-2222-4222-8222-222222222222",
+          "expiresAt": "2026-08-28T00:00:00Z",
+          "id": "55555555-5555-4555-8555-555555555555",
+          "offerRef": {
+            "id": "44444444-4444-4444-8444-444444444444",
+            "name": "WELCOME",
+            "version": 1
+          },
+          "productRef": "33333333-3333-4333-8333-333333333333",
+          "reservedAt": "2026-08-27T00:00:00Z",
+          "status": "RELEASED"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.attributionRef": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.expiresAt": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.offerRef.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.offerRef.version": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.reservedAt": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "POST a trusted qualifying account outcome",
+      "providerStates": [
+        {
+          "name": "an attributed reservation is reserved for qualifying commit"
+        }
+      ],
+      "request": {
+        "body": {
+          "productRef": "33333333-3333-4333-8333-333333333333",
+          "qualifiedAt": "2026-08-27T03:00:00Z"
+        },
+        "headers": {
+          "Content-Type": "application/json",
+          "Idempotency-Key": "open-pact-once",
+          "X-Customer-Party-Id": "11111111-1111-4111-8111-111111111111"
+        },
+        "method": "POST",
+        "path": "/api/v1/customer-incentives/reservations/55555555-5555-4555-8555-555555555555/commit"
+      },
+      "response": {
+        "body": {
+          "attributionRef": "22222222-2222-4222-8222-222222222222",
+          "expiresAt": "2026-08-28T00:00:00Z",
+          "id": "55555555-5555-4555-8555-555555555555",
+          "offerRef": {
+            "id": "44444444-4444-4444-8444-444444444444",
+            "name": "WELCOME",
+            "version": 1
+          },
+          "productRef": "33333333-3333-4333-8333-333333333333",
+          "reservedAt": "2026-08-27T00:00:00Z",
+          "status": "COMMITTED"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.attributionRef": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.expiresAt": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.offerRef.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.offerRef.version": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.reservedAt": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
     }
   ],
   "metadata": {


### PR DESCRIPTION
## Summary
- add trusted party/product-bound Incentive commit and release transitions
- reconcile an optional opaque reservation only after authoritative term-deposit account opening
- release deterministic rejections while preserving retryable reservations on transient failures
- extend consumer/provider Pact and real HTTP/Postgres lifecycle evidence

## Boundary
This is stacked on #7281. It does not deploy Incentive Service, wire GitOps, project Campaign outcomes, or claim live E2E completion. Campaign never mints codes, decides eligibility, or posts money.

## Verification
- Incentive HTTP/Postgres lifecycle: green
- customer-edge HTTP/unit suite: green
- consumer Pact: 3/3, no skips/failures
- provider Pact replay: 3/3, no skips/failures
- both modules ktlintCheck + detekt: green
- both modules quarkusBuild: green

Refs #7210