### PR TITLE
feat(campaign): project incentive outcomes

### DIFF
--- a/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
@@ -124,7 +124,7 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
   const { id } = await ctx.params
   const headers = { authorization: `Bearer ${session.user.accessToken}` }
 
-  const [campaign, enrolments, sends, sendSummary, journey, engagement, experiment] = await Promise.all([
+  const [campaign, enrolments, sends, sendSummary, journey, engagement, incentives, experiment] = await Promise.all([
     read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}`, null),
     read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/enrolments`, []),
     // First page only. Paging and filtering go through /api/campaigns/[id]/sends so turning a
@@ -146,6 +146,9 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     // App attention is a separate, privacy-minimised projection.  It is never inferred from a
     // banner handoff, so a missing/lagging source remains visible as unavailable in Campaign Studio.
     read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/engagement`, []),
+    // Authoritative reward outcomes are independent from attention. Keeping this positional read
+    // adjacent to engagement makes the two funnels visible without ever equating a click to value.
+    read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/incentives`, null),
     readExperiment(headers, id),
   ])
 
@@ -184,6 +187,7 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     sendSummary: sendSummary.data,
     journey: journey.data,
     engagement: engagement.data,
+    incentives: incentives.data,
     experiment: experiment.data,
     contentExperiment: contentExperiment.data,
     entryCatalogues: { cadences: cadences.data, triggers: triggers.data },
@@ -197,6 +201,7 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
       sendSummary: sendSummary.state,
       journey: journey.state,
       engagement: engagement.state,
+      incentives: incentives.state,
       experiment: experiment.state,
       contentExperiment: contentExperiment.state,
       cadences: cadences.state,

--- a/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
@@ -13,7 +13,7 @@ import { resolvePartyNames } from '@/lib/campaigns/party-names'
 
 export const dynamic = 'force-dynamic'
 
-type PartState = 'ok' | 'unauthorized' | 'not_deployed' | 'unreachable' | 'not_configured'
+type PartState = 'ok' | 'unauthorized' | 'not_deployed' | 'unreachable' | 'not_configured' | 'not_ready'
 type Part = { data: unknown; state: PartState }
 
 const EMPTY_SENDS = { items: [], total: 0, page: 0, size: 0 }
@@ -116,6 +116,26 @@ async function readContentExperiment(headers: HeadersInit, id: string): Promise<
   }
 }
 
+/** A 503 here means the separately activated Kafka projection has not caught up, never zero. */
+async function readIncentives(headers: HeadersInit, id: string): Promise<Part> {
+  try {
+    const res = await fetch(
+      serverSvcUrl('campaign-service', 'campaign', 8128, `/api/v1/campaigns/${encodeURIComponent(id)}/incentives`),
+      { headers, signal: AbortSignal.timeout(4000), cache: 'no-store' },
+    )
+    if (res.status === 503) return { data: null, state: 'not_ready' }
+    if (!res.ok) {
+      return {
+        data: null,
+        state: res.status === 401 || res.status === 403 ? 'unauthorized' : res.status === 404 ? 'not_deployed' : 'unreachable',
+      }
+    }
+    return { data: await res.json(), state: 'ok' }
+  } catch {
+    return { data: null, state: 'unreachable' }
+  }
+}
+
 export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
   const session = await auth()
   if (!session?.user?.accessToken) {
@@ -148,7 +168,7 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/engagement`, []),
     // Authoritative reward outcomes are independent from attention. Keeping this positional read
     // adjacent to engagement makes the two funnels visible without ever equating a click to value.
-    read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/incentives`, null),
+    readIncentives(headers, id),
     readExperiment(headers, id),
   ])
 

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -114,6 +114,7 @@ type Detail = {
   sendSummary: Record<string, number>
   journey: StepFunnel[]
   engagement: CampaignAttentionMetric[]
+  incentives: { reserved: number; committed: number; released: number; expired: number } | null
   experiment: Experiment | null
   contentExperiment: ContentExperiment | null
   entryCatalogues?: {
@@ -313,6 +314,7 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
   }
   const summary = detail?.sendSummary ?? {}
   const engagement = Array.isArray(detail?.engagement) ? detail.engagement : []
+  const incentiveFunnel = detail?.incentives
   const experiment = detail?.experiment
   const contentExperiment = detail?.contentExperiment
   const cadence = c?.schedule
@@ -807,6 +809,29 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
                 ? `${c.incentiveOfferRef.name}@${c.incentiveOfferRef.version}`
                 : t('Bez odměny', 'No reward')}
             </p>
+            {c.incentiveOfferRef && detail?.sources?.incentives !== 'ok' ? (
+              <DataUnavailable
+                kind={detail?.sources?.incentives === 'unauthorized' ? 'unauthorized' : detail?.sources?.incentives === 'not_deployed' ? 'not_deployed' : 'unreachable'}
+                service="Campaign-service"
+                feature={t('Výsledky odměn', 'Reward outcomes')}
+                dense
+              />
+            ) : c.incentiveOfferRef && incentiveFunnel ? (
+              <div className="grid grid-cols-2 gap-2 md:grid-cols-4" data-testid="campaign-incentive-funnel">
+                {[
+                  [t('Rezervováno', 'Reserved'), incentiveFunnel.reserved, t('Držená odměna, ne uplatnění', 'Held, not redeemed')],
+                  [t('Uplatněno', 'Redeemed'), incentiveFunnel.committed, t('Pouze potvrzené splnění', 'Committed only')],
+                  [t('Uvolněno', 'Released'), incentiveFunnel.released, t('Nesplněná podmínka', 'Qualification not completed')],
+                  [t('Expirováno', 'Expired'), incentiveFunnel.expired, t('Rezervace vypršela', 'Reservation expired')],
+                ].map(([label, value, hint]) => (
+                  <div key={String(label)} className="rounded-lg border p-3">
+                    <p className="text-xs text-muted-foreground">{label}</p>
+                    <p className="text-xl font-semibold tabular-nums">{value}</p>
+                    <p className="text-xs text-muted-foreground">{hint}</p>
+                  </div>
+                ))}
+              </div>
+            ) : null}
           </section>
 
           <section className="space-y-2">

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -811,9 +811,11 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
             </p>
             {c.incentiveOfferRef && detail?.sources?.incentives !== 'ok' ? (
               <DataUnavailable
-                kind={detail?.sources?.incentives === 'unauthorized' ? 'unauthorized' : detail?.sources?.incentives === 'not_deployed' ? 'not_deployed' : 'unreachable'}
+                kind={detail?.sources?.incentives === 'not_ready' ? 'no_data' : detail?.sources?.incentives === 'unauthorized' ? 'unauthorized' : detail?.sources?.incentives === 'not_deployed' ? 'not_deployed' : 'unreachable'}
                 service="Campaign-service"
                 feature={t('Výsledky odměn', 'Reward outcomes')}
+                title={detail?.sources?.incentives === 'not_ready' ? t('Projekce výsledků se připravuje', 'Outcome projection is preparing') : undefined}
+                detail={detail?.sources?.incentives === 'not_ready' ? t('Kafka projekce se po nasazení ještě ověřuje; nuly by nebyly spolehlivý výsledek.', 'The Kafka projection is still being verified after rollout; zeroes would not be reliable outcomes.') : undefined}
                 dense
               />
             ) : c.incentiveOfferRef && incentiveFunnel ? (

--- a/openbank-admin-ui/src/test/campaign-detail-bff.test.ts
+++ b/openbank-admin-ui/src/test/campaign-detail-bff.test.ts
@@ -77,6 +77,24 @@ describe('campaign detail bundle', () => {
     expect(Array.isArray(d.journey)).toBe(true)
   })
 
+  it('keeps an uninitialised incentive projection unavailable instead of reporting zero outcomes', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        const u = String(url)
+        if (u.includes('/incentives')) return { ok: false, status: 503, json: async () => ({ error: 'projection not ready' }), headers: new Headers() }
+        return { ok: true, status: 200, json: async () => ({}), headers: new Headers() }
+      }),
+    )
+
+    const { GET } = await import('@/app/api/campaigns/[id]/route')
+    const res = await GET(new Request('http://x/api/campaigns/abc'), { params: Promise.resolve({ id: 'abc' }) })
+    const d = await res.json()
+
+    expect(d.incentives).toBeNull()
+    expect(d.sources.incentives).toBe('not_ready')
+  })
+
   it('reads A/B measurement only for a campaign that configured variant B', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       const u = String(url)

--- a/openbank-admin-ui/src/test/campaign-detail-bff.test.ts
+++ b/openbank-admin-ui/src/test/campaign-detail-bff.test.ts
@@ -31,6 +31,8 @@ describe('campaign detail bundle', () => {
             ? { from: 'summary' }
             : u.includes('/journey')
               ? [{ from: 'journey' }]
+              : u.includes('/incentives')
+                ? { from: 'incentives' }
               : u.includes('/sends')
                 ? [{ from: 'sends' }]
                 : { from: 'campaign' }
@@ -47,6 +49,8 @@ describe('campaign detail bundle', () => {
     expect(d.sends.items).toEqual([{ from: 'sends' }])
     expect(d.sendSummary).toEqual({ from: 'summary' })
     expect(d.journey).toEqual([{ from: 'journey' }])
+    expect(d.incentives).toEqual({ from: 'incentives' })
+    expect(d.sources.incentives).toBe('ok')
   })
 
   /**

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -444,6 +444,29 @@ describe('campaign studio', () => {
     expect(funnel.getByText(/18 click events; 120 impression events on Home banner/)).toBeTruthy()
   }, 15000)
 
+  it('reports only committed incentive outcomes as redeemed', async () => {
+    const active = detail('ACTIVE')
+    vi.stubGlobal('fetch', mockFetch({
+      [`/api/campaigns/${CAMPAIGN_ID}`]: {
+        ...active,
+        campaign: {
+          ...active.campaign,
+          incentiveOfferRef: { id: 'f69b33a4-07e4-4bf6-b61c-f08bfc019136', name: 'term-deposit-welcome', version: 2 },
+        },
+        incentives: { reserved: 18, committed: 7, released: 4, expired: 3 },
+        sources: { ...active.sources, incentives: 'ok' },
+      },
+    }))
+    renderDetail()
+
+    await waitFor(() => expect(screen.getByTestId('campaign-incentive-funnel')).toBeTruthy(), { timeout: 8000 })
+    const funnel = within(screen.getByTestId('campaign-incentive-funnel'))
+    expect(funnel.getByText('Redeemed')).toBeTruthy()
+    expect(funnel.getByText('7')).toBeTruthy()
+    expect(funnel.getByText('Held, not redeemed')).toBeTruthy()
+    expect(funnel.getByText('18')).toBeTruthy()
+  }, 15000)
+
   it('keeps independent app events out of a made-up attention funnel', async () => {
     const active = detail('ACTIVE')
     vi.stubGlobal('fetch', mockFetch({

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -116,6 +116,28 @@ interface CampaignEngagementRepository {
     suspend fun metrics(campaignId: UUID): List<CampaignEngagementMetric>
 }
 
+/** Authoritative incentive lifecycle outcomes; only [COMMITTED] is a redeemed reward. */
+enum class CampaignIncentiveOutcomeStatus { RESERVED, COMMITTED, RELEASED, EXPIRED }
+
+/** No-PII evidence projected from the Incentive Service's attributed v2 events. */
+data class CampaignIncentiveOutcomeEvent(
+    val eventId: UUID,
+    val reservationId: UUID,
+    val attributionRef: UUID,
+    val offerRef: IncentiveOfferRef,
+    val status: CampaignIncentiveOutcomeStatus,
+    val occurredAt: Instant,
+)
+
+data class CampaignIncentiveFunnel(val reserved: Long, val committed: Long, val released: Long, val expired: Long)
+
+interface CampaignIncentiveOutcomeRepository {
+    /** False means the event or lifecycle transition was already projected. */
+    suspend fun record(campaignId: UUID, stepOrder: Int, event: CampaignIncentiveOutcomeEvent): Boolean
+
+    suspend fun funnel(campaignId: UUID): CampaignIncentiveFunnel
+}
+
 /** A single cell of the per-step funnel: how many sends of [outcome] step [stepOrder] produced. */
 data class StepOutcomeCount(val stepOrder: Int, val outcome: SendOutcome, val count: Long)
 
@@ -160,6 +182,12 @@ interface SendLogRepository {
      */
     suspend fun attributionForAppInteraction(interactionRef: UUID, partyId: UUID): CampaignInteractionAttribution? =
         null
+
+    /**
+     * Resolve a server-produced interaction for an internal outcome event. No party is returned or
+     * stored; callers must additionally match the immutable campaign offer before projecting it.
+     */
+    suspend fun attributionForIncentiveOutcome(interactionRef: UUID): CampaignInteractionAttribution? = null
 
     /**
      * Lifetime SENT rows for one party in one campaign — the observable state the ADR-0200 D1

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignIncentiveOutcomeProjector.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignIncentiveOutcomeProjector.kt
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.application.usecase
+
+import com.openbank.campaign.application.port.out.CampaignIncentiveFunnel
+import com.openbank.campaign.application.port.out.CampaignIncentiveOutcomeEvent
+import com.openbank.campaign.application.port.out.CampaignIncentiveOutcomeRepository
+import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.SendLogRepository
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.UUID
+
+/** Validates opaque treatment ownership before admitting an Incentive event to reporting. */
+@ApplicationScoped
+class CampaignIncentiveOutcomeProjector(
+    private val sends: SendLogRepository,
+    private val campaigns: CampaignRepository,
+    private val outcomes: CampaignIncentiveOutcomeRepository,
+) {
+    suspend fun project(event: CampaignIncentiveOutcomeEvent): Boolean {
+        val attribution = sends.attributionForIncentiveOutcome(event.attributionRef) ?: return false
+        val campaign = campaigns.findById(attribution.campaignId) ?: return false
+        if (campaign.incentiveOfferRef != event.offerRef) return false
+        return outcomes.record(attribution.campaignId, attribution.stepOrder, event)
+    }
+
+    suspend fun funnel(campaignId: UUID): CampaignIncentiveFunnel = outcomes.funnel(campaignId)
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignIncentiveOutcomeConsumer.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignIncentiveOutcomeConsumer.kt
@@ -12,7 +12,6 @@ import com.openbank.campaign.application.usecase.CampaignIncentiveOutcomeProject
 import com.openbank.campaign.domain.model.IncentiveOfferRef
 import jakarta.enterprise.context.ApplicationScoped
 import org.eclipse.microprofile.reactive.messaging.Incoming
-import org.jboss.logging.Logger
 import java.time.Instant
 import java.util.UUID
 
@@ -22,30 +21,38 @@ class CampaignIncentiveOutcomeConsumer(
     private val mapper: ObjectMapper,
     private val projector: CampaignIncentiveOutcomeProjector,
 ) {
-    private val log = Logger.getLogger(CampaignIncentiveOutcomeConsumer::class.java)
-
     @Incoming("incentive-events-in")
     suspend fun onEvent(payload: String) {
-        val node = runCatching { mapper.readTree(payload) }.getOrElse {
-            log.errorf(it, "Unparseable incentive event — dropped from campaign projection")
-            return
-        }
-        node.toOutcome()?.let { projector.project(it) }
+        val node = runCatching { mapper.readTree(payload) }
+            .getOrElse { throw IllegalArgumentException("Invalid incentive event JSON", it) }
+        val eventType = node.path("eventType").asText()
+        // This topic also carries legacy/operator evidence.  Only the four v2 lifecycle events are
+        // this projection's contract; unknown types must not poison their shared partition.
+        val expectedStatus = expectedStatus(eventType) ?: return
+        projector.project(node.toOutcome(expectedStatus, eventType))
     }
 
-    private fun JsonNode.toOutcome(): CampaignIncentiveOutcomeEvent? {
-        val expectedStatus = expectedStatus(path("eventType").asText()) ?: return null
-        val status = named("status", CampaignIncentiveOutcomeStatus.entries) ?: return null
-        if (status != expectedStatus) return null
+    /** A recognized v2 event is all-or-nothing: malformed evidence must reach the configured DLQ. */
+    private fun JsonNode.toOutcome(
+        expectedStatus: CampaignIncentiveOutcomeStatus,
+        eventType: String,
+    ): CampaignIncentiveOutcomeEvent {
+        val status = named("status", CampaignIncentiveOutcomeStatus.entries)
+            ?: invalid(eventType, "status is absent or unknown")
+        if (status != expectedStatus) invalid(eventType, "status $status does not match $expectedStatus")
         return CampaignIncentiveOutcomeEvent(
-            eventId = uuid("eventId") ?: return null,
-            reservationId = uuid("reservationId") ?: return null,
-            attributionRef = uuid("attributionRef") ?: return null,
-            offerRef = path("offerRef").toOfferRef() ?: return null,
+            eventId = uuid("eventId") ?: invalid(eventType, "eventId is invalid"),
+            reservationId = uuid("reservationId") ?: invalid(eventType, "reservationId is invalid"),
+            attributionRef = uuid("attributionRef") ?: invalid(eventType, "attributionRef is invalid"),
+            offerRef = path("offerRef").toOfferRef() ?: invalid(eventType, "offerRef is invalid"),
             status = status,
-            occurredAt = runCatching { Instant.parse(path("occurredAt").asText()) }.getOrNull() ?: return null,
+            occurredAt = runCatching { Instant.parse(path("occurredAt").asText()) }.getOrNull()
+                ?: invalid(eventType, "occurredAt is invalid"),
         )
     }
+
+    private fun invalid(eventType: String, reason: String): Nothing =
+        throw IllegalArgumentException("Malformed supported incentive event $eventType: $reason")
 
     private fun expectedStatus(eventType: String): CampaignIncentiveOutcomeStatus? = when (eventType) {
         "incentive.reservation.created.v2" -> CampaignIncentiveOutcomeStatus.RESERVED

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignIncentiveOutcomeConsumer.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignIncentiveOutcomeConsumer.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.campaign.application.port.out.CampaignIncentiveOutcomeEvent
+import com.openbank.campaign.application.port.out.CampaignIncentiveOutcomeStatus
+import com.openbank.campaign.application.usecase.CampaignIncentiveOutcomeProjector
+import com.openbank.campaign.domain.model.IncentiveOfferRef
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.jboss.logging.Logger
+import java.time.Instant
+import java.util.UUID
+
+/** Projects only attributed v2 reservation evidence; v1/operator events are intentionally ignored. */
+@ApplicationScoped
+class CampaignIncentiveOutcomeConsumer(
+    private val mapper: ObjectMapper,
+    private val projector: CampaignIncentiveOutcomeProjector,
+) {
+    private val log = Logger.getLogger(CampaignIncentiveOutcomeConsumer::class.java)
+
+    @Incoming("incentive-events-in")
+    suspend fun onEvent(payload: String) {
+        val node = runCatching { mapper.readTree(payload) }.getOrElse {
+            log.errorf(it, "Unparseable incentive event — dropped from campaign projection")
+            return
+        }
+        node.toOutcome()?.let { projector.project(it) }
+    }
+
+    private fun JsonNode.toOutcome(): CampaignIncentiveOutcomeEvent? {
+        val expectedStatus = expectedStatus(path("eventType").asText()) ?: return null
+        val status = named("status", CampaignIncentiveOutcomeStatus.entries) ?: return null
+        if (status != expectedStatus) return null
+        return CampaignIncentiveOutcomeEvent(
+            eventId = uuid("eventId") ?: return null,
+            reservationId = uuid("reservationId") ?: return null,
+            attributionRef = uuid("attributionRef") ?: return null,
+            offerRef = path("offerRef").toOfferRef() ?: return null,
+            status = status,
+            occurredAt = runCatching { Instant.parse(path("occurredAt").asText()) }.getOrNull() ?: return null,
+        )
+    }
+
+    private fun expectedStatus(eventType: String): CampaignIncentiveOutcomeStatus? = when (eventType) {
+        "incentive.reservation.created.v2" -> CampaignIncentiveOutcomeStatus.RESERVED
+        "incentive.reservation.committed.v2" -> CampaignIncentiveOutcomeStatus.COMMITTED
+        "incentive.reservation.released.v2" -> CampaignIncentiveOutcomeStatus.RELEASED
+        "incentive.reservation.expired.v2" -> CampaignIncentiveOutcomeStatus.EXPIRED
+        else -> null
+    }
+
+    private fun JsonNode.toOfferRef(): IncentiveOfferRef? = runCatching {
+        IncentiveOfferRef(
+            id = uuid("id") ?: return null,
+            name = path("name").asText().takeIf { it.isNotBlank() } ?: return null,
+            version = path("version").takeIf { it.isInt }?.intValue()?.takeIf { it > 0 } ?: return null,
+        )
+    }.getOrNull()
+
+    private fun JsonNode.uuid(field: String): UUID? = path(field).asText()
+        .takeIf { it.isNotBlank() }
+        ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+
+    private fun <T : Enum<T>> JsonNode.named(field: String, values: Iterable<T>): T? = path(field).asText()
+        .takeIf { it.isNotBlank() }
+        ?.let { raw -> values.find { it.name == raw } }
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -14,6 +14,9 @@ import com.openbank.campaign.application.port.out.CampaignEngagementMetric
 import com.openbank.campaign.application.port.out.CampaignEngagementRepository
 import com.openbank.campaign.application.port.out.CampaignEnrolmentCount
 import com.openbank.campaign.application.port.out.CampaignExperimentRepository
+import com.openbank.campaign.application.port.out.CampaignIncentiveFunnel
+import com.openbank.campaign.application.port.out.CampaignIncentiveOutcomeEvent
+import com.openbank.campaign.application.port.out.CampaignIncentiveOutcomeRepository
 import com.openbank.campaign.application.port.out.CampaignInteractionAttribution
 import com.openbank.campaign.application.port.out.CampaignOutcomeCount
 import com.openbank.campaign.application.port.out.CampaignRepository
@@ -247,6 +250,42 @@ class CampaignEngagementEventEntity : PanacheEntityBase() {
 
     @Column(nullable = false, length = 16)
     lateinit var type: String
+
+    @Column(nullable = false)
+    lateinit var occurredAt: Instant
+}
+
+/** No party, promo code or digest is retained in this operator-facing projection. */
+@Entity
+@Table(name = "campaign_incentive_outcome")
+class CampaignIncentiveOutcomeEntity : PanacheEntityBase() {
+    @Id
+    @Column(nullable = false, updatable = false)
+    lateinit var eventId: UUID
+
+    @Column(nullable = false)
+    lateinit var reservationId: UUID
+
+    @Column(nullable = false)
+    lateinit var campaignId: UUID
+
+    @Column(nullable = false)
+    var stepOrder: Int = 0
+
+    @Column(nullable = false)
+    lateinit var attributionRef: UUID
+
+    @Column(nullable = false)
+    lateinit var offerId: UUID
+
+    @Column(nullable = false)
+    lateinit var offerName: String
+
+    @Column(nullable = false)
+    var offerVersion: Int = 1
+
+    @Column(nullable = false, length = 16)
+    lateinit var status: String
 
     @Column(nullable = false)
     lateinit var occurredAt: Instant
@@ -519,6 +558,52 @@ class PanacheCampaignEngagementRepository : CampaignEngagementRepository {
 }
 
 @ApplicationScoped
+class PanacheCampaignIncentiveOutcomeRepository : CampaignIncentiveOutcomeRepository {
+    override suspend fun record(campaignId: UUID, stepOrder: Int, event: CampaignIncentiveOutcomeEvent): Boolean =
+        Panache.withTransaction {
+            Panache.getSession().flatMap { session ->
+                session.createNativeQuery<Any>(
+                    "INSERT INTO campaign_incentive_outcome " +
+                        "(event_id, reservation_id, campaign_id, step_order, attribution_ref, " +
+                        "offer_id, offer_name, offer_version, status, occurred_at) " +
+                        "VALUES (:eventId, :reservationId, :campaignId, :stepOrder, :attributionRef, " +
+                        ":offerId, :offerName, :offerVersion, :status, :occurredAt) " +
+                        "ON CONFLICT DO NOTHING",
+                )
+                    .setParameter("eventId", event.eventId)
+                    .setParameter("reservationId", event.reservationId)
+                    .setParameter("campaignId", campaignId)
+                    .setParameter("stepOrder", stepOrder)
+                    .setParameter("attributionRef", event.attributionRef)
+                    .setParameter("offerId", event.offerRef.id)
+                    .setParameter("offerName", event.offerRef.name)
+                    .setParameter("offerVersion", event.offerRef.version)
+                    .setParameter("status", event.status.name)
+                    .setParameter("occurredAt", event.occurredAt)
+                    .executeUpdate()
+            }
+        }.awaitSuspending() == 1
+
+    override suspend fun funnel(campaignId: UUID): CampaignIncentiveFunnel {
+        val counts = Panache.withSession {
+            Panache.getSession().flatMap { session ->
+                session.createQuery(
+                    "select e.status, count(e) from CampaignIncentiveOutcomeEntity e " +
+                        "where e.campaignId = :campaignId group by e.status",
+                    Array<Any>::class.java,
+                ).setParameter("campaignId", campaignId).resultList
+            }
+        }.awaitSuspending().associate { (it[0] as String) to (it[1] as Long) }
+        return CampaignIncentiveFunnel(
+            reserved = counts["RESERVED"] ?: 0,
+            committed = counts["COMMITTED"] ?: 0,
+            released = counts["RELEASED"] ?: 0,
+            expired = counts["EXPIRED"] ?: 0,
+        )
+    }
+}
+
+@ApplicationScoped
 /**
  * Detekt caps a class at 11 functions and fires AT the threshold, which this repository now sits on.
  * Suppressed rather than split: the count is ten interface methods plus one private query helper,
@@ -683,6 +768,19 @@ class PanacheSendLogRepository :
     }.awaitSuspending()?.let {
         CampaignInteractionAttribution(it.campaignId, it.stepOrder, Channel.valueOf(requireNotNull(it.channel)))
     }
+
+    override suspend fun attributionForIncentiveOutcome(interactionRef: UUID): CampaignInteractionAttribution? =
+        Panache.withSession {
+            find(
+                "id = ?1 and channel in (?2, ?3) and outcome = ?4",
+                interactionRef,
+                Channel.PUSH.name,
+                Channel.BANNER.name,
+                SendOutcome.SENT.name,
+            ).firstResult<SendLogEntity>()
+        }.awaitSuspending()?.let {
+            CampaignInteractionAttribution(it.campaignId, it.stepOrder, Channel.valueOf(requireNotNull(it.channel)))
+        }
 
     /**
      * The predecessor send's delivery status (#3585 branch conditions).

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResource.kt
@@ -17,6 +17,7 @@ import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.config.inject.ConfigProperty
 import java.util.UUID
 
 /**
@@ -30,6 +31,8 @@ class CampaignSendLogResource(
     private val summaries: CampaignSummaryQuery,
     private val engagement: CampaignEngagementQuery,
     private val incentives: CampaignIncentiveOutcomeProjector,
+    @ConfigProperty(name = "openbank.campaign.incentive-outcome-projection.ready", defaultValue = "false")
+    private val incentiveOutcomeProjectionReady: Boolean,
 ) {
 
     /**
@@ -113,7 +116,14 @@ class CampaignSendLogResource(
     @GET
     @Path("/{id}/incentives")
     @Authorize(action = "campaign.read", resource = "#id")
-    suspend fun incentives(@PathParam("id") id: UUID): Response = Response.ok(incentives.funnel(id)).build()
+    suspend fun incentives(@PathParam("id") id: UUID): Response {
+        if (!incentiveOutcomeProjectionReady) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                .entity(mapOf("error" to "incentive outcome projection is not initialized"))
+                .build()
+        }
+        return Response.ok(incentives.funnel(id)).build()
+    }
 
     private fun badOutcome(cause: Throwable): Response = Response.status(Response.Status.BAD_REQUEST)
         .entity(

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResource.kt
@@ -5,6 +5,7 @@
 package com.openbank.campaign.infrastructure.rest
 
 import com.openbank.campaign.application.usecase.CampaignEngagementQuery
+import com.openbank.campaign.application.usecase.CampaignIncentiveOutcomeProjector
 import com.openbank.campaign.application.usecase.CampaignSendLogQuery
 import com.openbank.campaign.application.usecase.CampaignSummaryQuery
 import com.openbank.campaign.domain.model.SendOutcome
@@ -28,6 +29,7 @@ class CampaignSendLogResource(
     private val query: CampaignSendLogQuery,
     private val summaries: CampaignSummaryQuery,
     private val engagement: CampaignEngagementQuery,
+    private val incentives: CampaignIncentiveOutcomeProjector,
 ) {
 
     /**
@@ -106,6 +108,12 @@ class CampaignSendLogResource(
     @Path("/{id}/engagement")
     @Authorize(action = "campaign.read", resource = "#id")
     suspend fun engagement(@PathParam("id") id: UUID): Response = Response.ok(engagement.metrics(id)).build()
+
+    /** Reward lifecycle funnel. Only `committed` is an authoritative redemption. */
+    @GET
+    @Path("/{id}/incentives")
+    @Authorize(action = "campaign.read", resource = "#id")
+    suspend fun incentives(@PathParam("id") id: UUID): Response = Response.ok(incentives.funnel(id)).build()
 
     private fun badOutcome(cause: Throwable): Response = Response.status(Response.Status.BAD_REQUEST)
         .entity(

--- a/openbank-campaign-service/src/main/resources/application.yaml
+++ b/openbank-campaign-service/src/main/resources/application.yaml
@@ -129,6 +129,21 @@ mp:
         value:
           serializer: org.apache.kafka.common.serialization.StringSerializer
     incoming:
+      # Producer-owned, no-PII reservation outcomes. Earliest is deliberate: this derived funnel
+      # must rebuild retained attributed history when the consumer is first rolled out.
+      incentive-events-in:
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.campaign.incentive-events-in
+        connector: smallrye-kafka
+        topic: openbank.incentive.events
+        value:
+          deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        group:
+          id: openbank-campaign-service-incentive-events
+        auto:
+          offset:
+            reset: earliest
       # Attributable in-app attention events emitted by engagement-service.  This is aggregate-only
       # reporting: lag can make a metric temporarily unavailable, but can never affect delivery or
       # enrolment.  Start at latest so enabling the projection cannot reprocess historic, pre-

--- a/openbank-campaign-service/src/main/resources/application.yaml
+++ b/openbank-campaign-service/src/main/resources/application.yaml
@@ -81,6 +81,12 @@ quarkus:
   # policy is covered by the OPA gate and the rego tests, neither of which needs the app running.
   authz:
     enforce: false
+  openbank:
+    campaign:
+      # HTTP contract tests exercise a seeded, complete local projection. Production stays
+      # fail-closed until a reviewed rollout/catch-up confirmation enables this read model.
+      incentive-outcome-projection:
+        ready: true
 
 
 openbank:
@@ -90,6 +96,10 @@ openbank:
     namespace: ${OPENBANK_TEMPORAL_NAMESPACE:openbank}
     task-queue: ${OPENBANK_TEMPORAL_TASK_QUEUE:openbank-campaign}
   campaign:
+    # Never render an empty local read model as an authoritative zero during the first Kafka
+    # catch-up. A reviewed operational step enables this only after the consumer is usable.
+    incentive-outcome-projection:
+      ready: ${CAMPAIGN_INCENTIVE_OUTCOME_PROJECTION_READY:false}
     decision-task-queue: ${OPENBANK_CAMPAIGN_DECISION_TASK_QUEUE:openbank-campaign-decision}
     worker:
       enabled: ${CAMPAIGN_WORKER_ENABLED:true}

--- a/openbank-campaign-service/src/main/resources/db/migration/V18__campaign_incentive_outcome_projection.sql
+++ b/openbank-campaign-service/src/main/resources/db/migration/V18__campaign_incentive_outcome_projection.sql
@@ -1,0 +1,19 @@
+-- No customer, promo code or digest is retained: Campaign Studio needs aggregate outcomes only.
+-- Rollback: DROP TABLE campaign_incentive_outcome; this derived projection can be rebuilt from
+-- retained incentive v2 events after restoring a compatible consumer.
+CREATE TABLE campaign_incentive_outcome (
+    event_id UUID PRIMARY KEY,
+    reservation_id UUID NOT NULL,
+    campaign_id UUID NOT NULL REFERENCES campaigns(id),
+    step_order INTEGER NOT NULL CHECK (step_order >= 0),
+    attribution_ref UUID NOT NULL,
+    offer_id UUID NOT NULL,
+    offer_name VARCHAR(255) NOT NULL,
+    offer_version INTEGER NOT NULL CHECK (offer_version > 0),
+    status VARCHAR(16) NOT NULL CHECK (status IN ('RESERVED', 'COMMITTED', 'RELEASED', 'EXPIRED')),
+    occurred_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT campaign_incentive_reservation_status_uk UNIQUE (reservation_id, status)
+);
+
+CREATE INDEX campaign_incentive_outcome_funnel_idx
+    ON campaign_incentive_outcome (campaign_id, status);

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -553,6 +553,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CampaignIncentiveFunnel'
+        '503':
+          description: >-
+            Incentive outcome projection has not completed its reviewed initial catch-up. Clients
+            must show the funnel as unavailable rather than treating it as zero.
 
   /api/v1/campaigns/{id}/sends/summary:
     get:

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.41.0
+  version: 1.42.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -534,6 +534,25 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/CampaignEngagementMetric'
+
+  /api/v1/campaigns/{id}/incentives:
+    get:
+      tags: [Campaigns]
+      summary: Authoritative incentive lifecycle funnel
+      description: >-
+        Aggregate attributed reservation outcomes. Reserved means inventory is held, not redeemed;
+        only committed is a completed reward. Released and expired remain visible so delivery or
+        clicks can never be mistaken for economic success. No party, code or digest is retained.
+      operationId: campaignIncentiveFunnel
+      parameters:
+        - $ref: '#/components/parameters/CampaignId'
+      responses:
+        '200':
+          description: Counts by authoritative incentive lifecycle state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CampaignIncentiveFunnel'
 
   /api/v1/campaigns/{id}/sends/summary:
     get:
@@ -1250,6 +1269,18 @@ components:
           type: string
           enum: [IMPRESSION, CLICK, DISMISS]
         count: { type: integer, format: int64, minimum: 0 }
+
+    CampaignIncentiveFunnel:
+      type: object
+      required: [reserved, committed, released, expired]
+      description: >-
+        Reservation lifecycle counts deduplicated by event id and reservation/status. Only
+        committed is an authoritative redemption; reserved is never reported as redeemed.
+      properties:
+        reserved: { type: integer, format: int64, minimum: 0 }
+        committed: { type: integer, format: int64, minimum: 0 }
+        released: { type: integer, format: int64, minimum: 0 }
+        expired: { type: integer, format: int64, minimum: 0 }
 
     SuppressionCount:
       type: object

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignIncentiveOutcomeProjectorTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignIncentiveOutcomeProjectorTest.kt
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.application.usecase
+
+import com.openbank.campaign.application.port.out.CampaignIncentiveOutcomeEvent
+import com.openbank.campaign.application.port.out.CampaignIncentiveOutcomeRepository
+import com.openbank.campaign.application.port.out.CampaignIncentiveOutcomeStatus
+import com.openbank.campaign.application.port.out.CampaignInteractionAttribution
+import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.SendLogRepository
+import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.IncentiveOfferRef
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class CampaignIncentiveOutcomeProjectorTest {
+    private val sends = mockk<SendLogRepository>()
+    private val campaigns = mockk<CampaignRepository>()
+    private val outcomes = mockk<CampaignIncentiveOutcomeRepository>()
+    private val projector = CampaignIncentiveOutcomeProjector(sends, campaigns, outcomes)
+    private val offer = IncentiveOfferRef(UUID.randomUUID(), "term-deposit-welcome", 2)
+
+    @Test
+    fun `projects exact immutable offer after server interaction ownership`(): Unit = runBlocking {
+        val event = event(offer)
+        val attribution = CampaignInteractionAttribution(UUID.randomUUID(), 3, Channel.BANNER)
+        val campaign = mockk<Campaign> { every { incentiveOfferRef } returns offer }
+        coEvery { sends.attributionForIncentiveOutcome(event.attributionRef) } returns attribution
+        coEvery { campaigns.findById(attribution.campaignId) } returns campaign
+        coEvery { outcomes.record(attribution.campaignId, attribution.stepOrder, event) } returns true
+
+        assertThat(projector.project(event)).isTrue()
+        coVerify(exactly = 1) { outcomes.record(attribution.campaignId, 3, event) }
+    }
+
+    @Test
+    fun `unknown interaction and offer mismatch are rejected before storage`(): Unit = runBlocking {
+        val unknown = event(offer)
+        coEvery { sends.attributionForIncentiveOutcome(unknown.attributionRef) } returns null
+        assertThat(projector.project(unknown)).isFalse()
+
+        val mismatch = event(offer.copy(version = 3))
+        val attribution = CampaignInteractionAttribution(UUID.randomUUID(), 0, Channel.PUSH)
+        val campaign = mockk<Campaign> { every { incentiveOfferRef } returns offer }
+        coEvery { sends.attributionForIncentiveOutcome(mismatch.attributionRef) } returns attribution
+        coEvery { campaigns.findById(attribution.campaignId) } returns campaign
+        assertThat(projector.project(mismatch)).isFalse()
+
+        coVerify(exactly = 0) { outcomes.record(any(), any(), any()) }
+    }
+
+    private fun event(ref: IncentiveOfferRef) = CampaignIncentiveOutcomeEvent(
+        eventId = UUID.randomUUID(),
+        reservationId = UUID.randomUUID(),
+        attributionRef = UUID.randomUUID(),
+        offerRef = ref,
+        status = CampaignIncentiveOutcomeStatus.COMMITTED,
+        occurredAt = Instant.parse("2026-08-27T09:00:00Z"),
+    )
+}

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignIncentiveOutcomeConsumerTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignIncentiveOutcomeConsumerTest.kt
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.campaign.application.port.out.CampaignIncentiveOutcomeEvent
+import com.openbank.campaign.application.port.out.CampaignIncentiveOutcomeStatus
+import com.openbank.campaign.application.usecase.CampaignIncentiveOutcomeProjector
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class CampaignIncentiveOutcomeConsumerTest {
+    private val projector = mockk<CampaignIncentiveOutcomeProjector>(relaxed = true)
+
+    @Test
+    fun `projects attributed v2 event without party or code`(): Unit = runBlocking {
+        coEvery { projector.project(any()) } returns true
+        consumer().onEvent(event("incentive.reservation.committed.v2", "COMMITTED"))
+
+        val captured = slot<CampaignIncentiveOutcomeEvent>()
+        coVerify(exactly = 1) { projector.project(capture(captured)) }
+        assertThat(captured.captured.status).isEqualTo(CampaignIncentiveOutcomeStatus.COMMITTED)
+        assertThat(captured.captured.offerRef.name).isEqualTo("term-deposit-welcome")
+    }
+
+    @Test
+    fun `v1 malformed and unknown lifecycle events never enter campaign reporting`(): Unit = runBlocking {
+        consumer().onEvent(event("incentive.reservation.committed.v1", "COMMITTED"))
+        consumer().onEvent(event("incentive.reservation.created.v2", "CLICKED"))
+        consumer().onEvent(event("incentive.reservation.created.v2", "COMMITTED"))
+        consumer().onEvent("not-json")
+
+        coVerify(exactly = 0) { projector.project(any()) }
+    }
+
+    private fun consumer() = CampaignIncentiveOutcomeConsumer(ObjectMapper(), projector)
+
+    private fun event(eventType: String, status: String) = """
+        {
+          "eventId":"${UUID.randomUUID()}",
+          "reservationId":"${UUID.randomUUID()}",
+          "attributionRef":"${UUID.randomUUID()}",
+          "eventType":"$eventType",
+          "status":"$status",
+          "offerRef":{"id":"${UUID.randomUUID()}","name":"term-deposit-welcome","version":2},
+          "occurredAt":"2026-08-27T09:00:00Z"
+        }
+    """.trimIndent()
+}

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignIncentiveOutcomeConsumerTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignIncentiveOutcomeConsumerTest.kt
@@ -14,6 +14,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
@@ -32,13 +33,25 @@ class CampaignIncentiveOutcomeConsumerTest {
     }
 
     @Test
-    fun `v1 malformed and unknown lifecycle events never enter campaign reporting`(): Unit = runBlocking {
+    fun `unknown or legacy events never enter campaign reporting`(): Unit = runBlocking {
         consumer().onEvent(event("incentive.reservation.committed.v1", "COMMITTED"))
-        consumer().onEvent(event("incentive.reservation.created.v2", "CLICKED"))
-        consumer().onEvent(event("incentive.reservation.created.v2", "COMMITTED"))
-        consumer().onEvent("not-json")
 
         coVerify(exactly = 0) { projector.project(any()) }
+    }
+
+    @Test
+    fun `malformed supported event fails so the connector parks it in its DLQ`() {
+        assertThatThrownBy {
+            runBlocking { consumer().onEvent(event("incentive.reservation.created.v2", "COMMITTED")) }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Malformed supported incentive event")
+    }
+
+    @Test
+    fun `invalid JSON fails so the connector parks it in its DLQ`() {
+        assertThatThrownBy { runBlocking { consumer().onEvent("not-json") } }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Invalid incentive event JSON")
     }
 
     private fun consumer() = CampaignIncentiveOutcomeConsumer(ObjectMapper(), projector)

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResourceTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResourceTest.kt
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.campaign.infrastructure.rest
+
+import com.openbank.campaign.application.usecase.CampaignEngagementQuery
+import com.openbank.campaign.application.usecase.CampaignIncentiveOutcomeProjector
+import com.openbank.campaign.application.usecase.CampaignSendLogQuery
+import com.openbank.campaign.application.usecase.CampaignSummaryQuery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class CampaignSendLogResourceTest {
+    @Test
+    fun `incentive funnel refuses authoritative zero before reviewed projection readiness`(): Unit = runBlocking {
+        val resource = CampaignSendLogResource(
+            query = mockk<CampaignSendLogQuery>(),
+            summaries = mockk<CampaignSummaryQuery>(),
+            engagement = mockk<CampaignEngagementQuery>(),
+            incentives = mockk<CampaignIncentiveOutcomeProjector>(),
+            incentiveOutcomeProjectionReady = false,
+        )
+
+        val response = resource.incentives(UUID.randomUUID())
+
+        assertThat(response.status).isEqualTo(503)
+        assertThat(response.entity).isEqualTo(mapOf("error" to "incentive outcome projection is not initialized"))
+    }
+}

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -494,6 +494,31 @@ class CampaignRestContractIT {
         }
     }
 
+    private fun insertIncentiveOutcome(campaignId: UUID, status: String) {
+        dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                """
+                INSERT INTO campaign_incentive_outcome (
+                    event_id, reservation_id, campaign_id, step_order, attribution_ref,
+                    offer_id, offer_name, offer_version, status, occurred_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setObject(1, UUID.randomUUID())
+                statement.setObject(2, UUID.randomUUID())
+                statement.setObject(3, campaignId)
+                statement.setInt(4, 0)
+                statement.setObject(5, UUID.randomUUID())
+                statement.setObject(6, UUID.randomUUID())
+                statement.setString(7, "term-deposit-welcome")
+                statement.setInt(8, 2)
+                statement.setString(9, status)
+                statement.setObject(10, OffsetDateTime.now())
+                statement.executeUpdate()
+            }
+        }
+    }
+
     @Test
     @TestSecurity(user = "service-account-openbank-edge", roles = ["ROLE_API"])
     fun `interaction validation resolves only server-owned context for the owning party`() {
@@ -572,6 +597,24 @@ class CampaignRestContractIT {
             body("[0].surface", equalTo("STORIES"))
             body("[0].type", equalTo("IMPRESSION"))
             body("[0].count", equalTo(1))
+        }
+    }
+
+    @Test
+    fun `campaign incentive funnel distinguishes held inventory from redemption`() {
+        val campaignId = UUID.randomUUID()
+        insertCampaignForSendLog(campaignId)
+        insertIncentiveOutcome(campaignId, "RESERVED")
+        insertIncentiveOutcome(campaignId, "COMMITTED")
+
+        When {
+            get("/api/v1/campaigns/$campaignId/incentives")
+        } Then {
+            statusCode(200)
+            body("reserved", equalTo(1))
+            body("committed", equalTo(1))
+            body("released", equalTo(0))
+            body("expired", equalTo(0))
         }
     }
 

--- a/openbank-infra/gitops/components/campaign/kafka-campaign-mtls.yaml
+++ b/openbank-infra/gitops/components/campaign/kafka-campaign-mtls.yaml
@@ -58,6 +58,14 @@ spec:
           name: openbank.engagement.events
           patternType: literal
         operations: [Read, Describe]
+      # Authoritative, no-PII attributed incentive lifecycle outcomes. Campaign only projects
+      # these after it validates the opaque interaction ref and immutable campaign offer; it never
+      # reserves, commits or issues a reward.
+      - resource:
+          type: topic
+          name: openbank.incentive.events
+          patternType: literal
+        operations: [Read, Describe]
       # Consume the product events that count as a conversion (ADR-0245 D2). Read-only, and the
       # service only ever appends an outcome row from them — it cannot cause, suppress or alter a
       # send, so the blast radius of this grant is a reporting number.
@@ -112,6 +120,11 @@ spec:
       - resource:
           type: group
           name: openbank-campaign-service-engagement-events
+          patternType: literal
+        operations: [Read, Describe]
+      - resource:
+          type: group
+          name: openbank-campaign-service-incentive-events
           patternType: literal
         operations: [Read, Describe]
       # #5745: SmallRye dead-letter topic for the `account-conversions-in` channel (failure-strategy:
@@ -171,6 +184,15 @@ spec:
       - resource:
           type: topic
           name: openbank.dlq.campaign.engagement-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # Dead-letter sink for malformed or persistently unprojectable Incentive events. It must be
+      # writable independently of the source-topic read grant, otherwise the configured parking
+      # strategy becomes a consumer retry loop.
+      - resource:
+          type: topic
+          name: openbank.dlq.campaign.incentive-events-in
           patternType: literal
         operations: [Write, Describe]
         host: "*"

--- a/openbank-infra/gitops/components/kafka/kafka-dlq-topics.yaml
+++ b/openbank-infra/gitops/components/kafka/kafka-dlq-topics.yaml
@@ -242,6 +242,21 @@ spec:
     retention.ms: 2592000000
     cleanup.policy: delete
 ---
+# openbank-campaign-service :: channel `incentive-events-in`
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.campaign.incentive-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
 # openbank-campaign-service :: channel `notification-outcomes-in`
 apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic


### PR DESCRIPTION
## Summary

Projects authoritative attributed Incentive Service lifecycle events into Campaign Service and Campaign Studio. Only `COMMITTED` is labelled redeemed; reserved, released, and expired remain separate and no party, promo code, or digest is retained.

## Type of change

- [x] feat (new functionality)
- [x] fix (Kafka desired-state prerequisite)

## Linked issues

Refs #7210

## Changes

- validate opaque `SENT` interaction ownership and exact immutable campaign offer before projection
- persist an idempotent no-PII outcome read model with Flyway V18 and expose an additive Campaign API
- render a fail-visible Studio reward funnel that never treats reservation or engagement as redemption
- grant only the Campaign consumer group/source read and its explicit DLQ write access; the existing Incentive event topic is reused

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (real HTTP + PostgreSQL).
- [x] Contract updated for the additive REST endpoint.
- [x] `ktlintCheck`, `detekt`, and `quarkusBuild` pass.
- [x] Flyway migration added + rollback note.
- [x] Kafka topic, ACL and deployment-wiring gates pass locally.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new suppression or dependency.
- [x] Attribution and immutable offer ownership fail closed before storage.
- [x] Kafka grants are least-privilege: one source Read, one consumer group, one DLQ Write.

## Compliance impact

- [x] GDPR — projection deliberately excludes party identity and reward material.

## Rollout / Rollback

- Deployment strategy: separate reviewed image rollout after the stacked prerequisites merge.
- Rollback plan: roll back Campaign/Admin images; the derived projection table is inert and rebuildable. Kafka ACL/DLQ state may remain safely inert until the consumer image is deployed.
- Data migration reversible: yes; rollback note is in V18.

## Reviewer notes

This PR is stacked on #7281, which contains the prerequisite customer claim and qualifying-action flow. Its broker desired state is required for the projection to be operable, but it is not evidence of a live deployment, cluster health or authenticated end-to-end completion.