### PR TITLE
test(incentive): record Testcontainers lifecycle evidence (fix red main)

### DIFF
--- a/openbank-incentive-service/build.gradle.kts
+++ b/openbank-incentive-service/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
+    testImplementation(project(":openbank-libs-testing"))
 }
 
 kover {

--- a/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/it/IncentivePostgresTestResource.kt
+++ b/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/it/IncentivePostgresTestResource.kt
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.openbank.incentive.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.opentest4j.TestAbortedException
 import org.testcontainers.DockerClientFactory
@@ -14,11 +15,12 @@ class IncentivePostgresTestResource : QuarkusTestResourceLifecycleManager {
         if (!DockerClientFactory.instance().isDockerAvailable) {
             throw TestAbortedException("Docker not available — skipping incentive HTTP IT")
         }
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withUsername("openbank")
             .withPassword("openbank_secret")
             .withDatabaseName("openbank_incentive_it")
         pg.start()
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         postgres = pg
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
@@ -34,5 +36,10 @@ class IncentivePostgresTestResource : QuarkusTestResourceLifecycleManager {
 
     override fun stop() {
         postgres?.stop()
+        if (postgres != null) TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+    }
+
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:16.3-alpine"
     }
 }


### PR DESCRIPTION
## Red `main`

`gates (kotlin)` fails on the current head of `main` (`44dc80532`, run 33040146313). Exact assertion:

```
new service-owned Testcontainers resource lacks lifecycle evidence:
openbank-incentive-service/src/test/kotlin/com/openbank/incentive/it/IncentivePostgresTestResource.kt
```

`Validate manifests` is red on the same runs only as the downstream aggregator ("One or more gate shards failed"). One root cause.

## True first red run

- Last green `gates (kotlin)`: run 33035281877, `89ebb79f0` (#7280).
- First red: run 33040093230, `78012e3ba` — **#7243** `test(test-intelligence): ratchet container lifecycle evidence`, merged 04:39:53Z.
- #7232 added the resource file (00:27Z) and was green at the time; the ratchet did not yet exist. #7243's baseline was computed on a base predating it, so the path is neither recorded nor baselined.

## Fix

Emit `TestInfrastructureEvidence.record("postgres", …, "started"/"stopped")` from the incentive resource, matching shared `PostgresBase`. Baseline untouched — the ratchet is for *awaiting migration*, and a new file should not be added to it.

## Verification (exit codes read from `$?` after redirecting to a file)

| command | exit |
|---|---|
| `python3 -u .github/scripts/check-test-intelligence-ecosystem.py` (with fix) | `0` — `SUBJECTS=60` |
| same, with fix stashed (negative control) | `1` — reproduces the assertion verbatim |
| `./gradlew --no-daemon :openbank-incentive-service:compileTestKotlin :openbank-incentive-service:ktlintCheck` | `0` — both tasks appear in the output |

## Not verified

The integration test was not executed (no Docker run here); only compilation and the gate. No other gate shard was re-run locally.

Refs #7243
