### PR TITLE
test(incentive): emit container lifecycle evidence

### DIFF
--- a/openbank-incentive-service/build.gradle.kts
+++ b/openbank-incentive-service/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
+    testImplementation(project(":openbank-libs-testing"))
 }
 
 kover {

--- a/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/it/IncentivePostgresTestResource.kt
+++ b/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/it/IncentivePostgresTestResource.kt
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.openbank.incentive.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.opentest4j.TestAbortedException
 import org.testcontainers.DockerClientFactory
@@ -20,6 +21,7 @@ class IncentivePostgresTestResource : QuarkusTestResourceLifecycleManager {
             .withDatabaseName("openbank_incentive_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
         return mapOf(
@@ -33,6 +35,13 @@ class IncentivePostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        postgres?.stop()
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
+    }
+
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:16.3-alpine"
     }
 }


### PR DESCRIPTION
## Summary

- records PostgreSQL Testcontainers start and stop as secret-free Test Intelligence runtime evidence
- fixes the enforced ADR-0273 producer/runtime contract for incentive HTTP integration tests

Refs #7284

## Verification

- `python3 .github/scripts/check-test-intelligence-ecosystem.py --self-test`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py`
- `./gradlew :openbank-incentive-service:compileTestKotlin :openbank-incentive-service:ktlintCheck --no-daemon`