### PR TITLE
test(agent): evidence denied trace contract

### DIFF
--- a/openbank-agent-service/src/test/kotlin/com/openbank/agent/application/AgentChatServiceTracingTest.kt
+++ b/openbank-agent-service/src/test/kotlin/com/openbank/agent/application/AgentChatServiceTracingTest.kt
@@ -149,6 +149,11 @@ class AgentChatServiceTracingTest {
             assertThat(a["openbank.agent.result"]).isEqualTo("DENIED")
             assertThat(a["openbank.agent.detail"]).isEqualTo("kill_switch")
             assertThat(a["openbank.agent.tool_calls"]).isEqualTo(0L)
+            TraceContract.from(exported)
+                .requiresSpan("agent.run")
+                .requiresAttribute("agent.run", "openbank.agent.detail")
+                .hasNoErrorSpan()
+                .verifiedAs("agent-denied-run")
         }
     }
 }


### PR DESCRIPTION
## Summary

- proves the governed agent kill-switch path emits a queryable denied trace
- projects the assertion as a second executed trace-contract evidence item

Refs #7284

## Verification

- `./gradlew :openbank-agent-service:test --tests com.openbank.agent.application.AgentChatServiceTracingTest --no-daemon`
- `python3 .github/scripts/collect-test-run-evidence.py --self-test`