### PR TITLE
test(libs): record Testcontainers lifecycle evidence for three pilots

### DIFF
--- a/.github/scripts/check-test-intelligence-ecosystem.py
+++ b/.github/scripts/check-test-intelligence-ecosystem.py
@@ -18,6 +18,26 @@ def text(path: Path) -> str:
     return path.read_text(errors="ignore") if path.exists() else ""
 
 
+RECORD_CALL = re.compile(
+    r"""TestInfrastructureEvidence\.record\s*\((?:[^()"']|\((?:[^()]*)\)|"[^"]*"|'[^']*')*?["'](started|stopped)["']\s*[,)]""",
+    re.DOTALL,
+)
+
+
+def recorded_lifecycles(source: str) -> set[str]:
+    """Lifecycle literals a file really passes to the shared recorder, ignoring comments.
+
+    The mere PRESENCE of the identifier is not evidence of a lifecycle: an import line, a
+    KDoc sentence, or a resource that records only `started` all contain it. #7246's
+    acceptance is start AND stop, and a substring test cannot tell those apart — the same
+    shape as scoring a service "contract tested" off a comment containing the word
+    (check-pact-provider-replay.py's KNOWN_UNCOVERED note).
+    """
+    stripped = re.sub(r"/\*.*?\*/", " ", source, flags=re.DOTALL)
+    stripped = "\n".join(line.split("//")[0] for line in stripped.splitlines())
+    return set(RECORD_CALL.findall(stripped))
+
+
 def unrecorded_service_testcontainers_resources(root: Path) -> set[str]:
     """Find service-owned Testcontainers lifecycle managers without shared evidence."""
     resources = set()
@@ -25,7 +45,7 @@ def unrecorded_service_testcontainers_resources(root: Path) -> set[str]:
         source = text(path)
         if ("QuarkusTestResourceLifecycleManager" in source
                 and re.search(r"org\.testcontainers|PostgreSQLContainer|GenericContainer|KafkaContainer|RedpandaContainer", source)
-                and "TestInfrastructureEvidence.record" not in source):
+                and recorded_lifecycles(source) != {"started", "stopped"}):
             resources.add(path.relative_to(root).as_posix())
     return resources
 
@@ -327,6 +347,38 @@ def self_test() -> int:
         baseline.write_text(f"{new_resource}\n")
         if any(new_resource in failure for failure in check(root)):
             print("self-test failed: baseline did not account for existing migration debt")
+            return 1
+        # A half-migrated resource must not clear the ratchet. Recording only `started`
+        # leaves teardown unobservable while the identifier is present, so a substring
+        # test would accept it and its baseline entry would have to be deleted --
+        # permanently declaring the migration done (#7246).
+        baseline.write_text("")
+        prefix = (
+            "import com.openbank.libs.testing.evidence.TestInfrastructureEvidence\n"
+            "import io.quarkus.test.common.QuarkusTestResourceLifecycleManager\n"
+            "import org.testcontainers.containers.PostgreSQLContainer\n"
+            "class PostgresTestResource : QuarkusTestResourceLifecycleManager {\n"
+        )
+        started_only = prefix + '  fun start() { TestInfrastructureEvidence.record("postgres", IMG, "started") }\n}\n'
+        resource.write_text(started_only)
+        if not any(new_resource in failure for failure in check(root)):
+            print("self-test failed: start-only lifecycle evidence was accepted as migrated")
+            return 1
+        # A file that only NAMES the recorder in prose or an import is not evidence either.
+        resource.write_text(
+            prefix + '  // TestInfrastructureEvidence.record("postgres", IMG, "started") and "stopped"\n}\n'
+        )
+        if not any(new_resource in failure for failure in check(root)):
+            print("self-test failed: commented-out lifecycle evidence was accepted as migrated")
+            return 1
+        # ...and the honest start+stop pair must PASS, or the check is red for everyone.
+        resource.write_text(
+            prefix
+            + '  fun start() { TestInfrastructureEvidence.record("postgres", IMG.asCanonicalNameString(), "started") }\n'
+            + '  fun stop() { TestInfrastructureEvidence.record("postgres", IMG.asCanonicalNameString(), "stopped") }\n}\n'
+        )
+        if any(new_resource in failure for failure in check(root)):
+            print("self-test failed: a genuine start/stop lifecycle pair was rejected")
             return 1
     print("test-intelligence ecosystem self-test: red path proven")
     return 0

--- a/openbank-analytics-sink/build.gradle.kts
+++ b/openbank-analytics-sink/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation(libs.jackson.module.kotlin)
     implementation(libs.jackson.datatype.jsr310)
     implementation(project(":openbank-libs"))
+    testImplementation(project(":openbank-libs-testing"))
     testImplementation(libs.quarkus.junit5)
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)

--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/it/RedpandaTestResource.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/it/RedpandaTestResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.analytics.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.opentest4j.TestAbortedException
 import org.testcontainers.DockerClientFactory
@@ -27,7 +28,7 @@ class RedpandaTestResource : QuarkusTestResourceLifecycleManager {
             throw TestAbortedException("Docker not available — skipping Testcontainers IT")
         }
         val rp = RedpandaContainer(
-            DockerImageName.parse("redpandadata/redpanda:v24.1.2")
+            DockerImageName.parse(REDPANDA_IMAGE)
                 .asCompatibleSubstituteFor("docker.redpanda.com/redpandadata/redpanda"),
         )
         try {
@@ -36,6 +37,7 @@ class RedpandaTestResource : QuarkusTestResourceLifecycleManager {
             throw TestAbortedException("Redpanda failed to start — skipping IT: ${e.message}", e)
         }
         redpanda = rp
+        TestInfrastructureEvidence.record("redpanda", REDPANDA_IMAGE, "started")
         lastBootstrapServers = rp.bootstrapServers
 
         return mapOf(
@@ -55,10 +57,15 @@ class RedpandaTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        redpanda?.stop()
+        redpanda?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("redpanda", REDPANDA_IMAGE, "stopped")
+        }
     }
 
     companion object {
+        const val REDPANDA_IMAGE = "redpandadata/redpanda:v24.1.2"
+
         /**
          * Set by [start] and read by test classes that need to talk to the broker directly (e.g.
          * [com.openbank.analytics.integration.AnalyticsEventsConsumerGroupIdBootIT]'s `AdminClient`).

--- a/openbank-audit-service/build.gradle.kts
+++ b/openbank-audit-service/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(libs.aws.sdk.kms)
     implementation(project(":openbank-libs-domain"))
     implementation(project(":openbank-libs-runtime"))
+    testImplementation(project(":openbank-libs-testing"))
     testImplementation(libs.quarkus.junit5)
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/it/PostgresTestResource.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/it/PostgresTestResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.audit.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.opentest4j.TestAbortedException
 import org.testcontainers.DockerClientFactory
@@ -19,12 +20,13 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
         if (!DockerClientFactory.instance().isDockerAvailable) {
             throw TestAbortedException("Docker not available — skipping Testcontainers IT")
         }
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withUsername("openbank")
             .withPassword("openbank_secret")
             .withDatabaseName("openbank_audit_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
         return mapOf(
@@ -37,6 +39,13 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        postgres?.stop()
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
+    }
+
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:16.3-alpine"
     }
 }

--- a/openbank-incentive-service/build.gradle.kts
+++ b/openbank-incentive-service/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation(project(":openbank-libs-domain"))
     implementation(project(":openbank-libs-runtime"))
 
+    testImplementation(project(":openbank-libs-testing"))
     testImplementation(libs.quarkus.junit5)
     testImplementation(libs.quarkus.test.security)
     testImplementation(libs.smallrye.reactive.messaging.inmemory)

--- a/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/it/IncentivePostgresTestResource.kt
+++ b/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/it/IncentivePostgresTestResource.kt
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.openbank.incentive.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.opentest4j.TestAbortedException
 import org.testcontainers.DockerClientFactory
@@ -14,12 +15,13 @@ class IncentivePostgresTestResource : QuarkusTestResourceLifecycleManager {
         if (!DockerClientFactory.instance().isDockerAvailable) {
             throw TestAbortedException("Docker not available — skipping incentive HTTP IT")
         }
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withUsername("openbank")
             .withPassword("openbank_secret")
             .withDatabaseName("openbank_incentive_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
         return mapOf(
@@ -33,6 +35,13 @@ class IncentivePostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        postgres?.stop()
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
+    }
+
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:16.3-alpine"
     }
 }

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -1,13 +1,21 @@
 # Service-owned Testcontainers resources awaiting migration to
 # TestInfrastructureEvidence. This is a ratchet: a new unrecorded resource
-# fails CI, and a migrated path must be removed from this list.
+# fails CI, and a migrated path must be removed from this list. The gate also requires a
+# real start AND stop lifecycle pair, not merely the recorder's name in the file (#7246):
+# a start-only resource leaves teardown unobservable while reading as migrated.
+#
+# NEXT SAFE CANDIDATES (non-money-path, single-container, no shared topology to preserve):
+#   openbank-agent-service, openbank-authz-policy-auditor, openbank-case-coordinator-agent,
+#   openbank-control-liveness-sentinel, openbank-devops-agent, openbank-docs-truth-agent,
+#   openbank-finops-agent, openbank-governance-auditor, openbank-release-steward.
+# Money-path entries (ledger, transaction, account, balance, sepa-*, domestic-payment,
+# clearing, swift, fx, lending, sdd, interest, sca, consent) are tracked separately: they
+# need the two-approval + threat-model process before their topology is touched.
 openbank-account-service/src/test/kotlin/com/openbank/account/it/PostgresRedpandaRedisTestResource.kt
 openbank-agent-service/src/test/kotlin/com/openbank/agent/it/PostgresTestResource.kt
 openbank-aml-service/src/test/kotlin/com/openbank/aml/it/PostgresRedisTestResource.kt
 openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/it/PostgresRedpandaTestResource.kt
 openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/it/PostgresTestResource.kt
-openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/it/RedpandaTestResource.kt
-openbank-audit-service/src/test/kotlin/com/openbank/audit/it/PostgresTestResource.kt
 openbank-authz-policy-auditor/src/test/kotlin/com/openbank/authzaudit/PostgresTestResource.kt
 openbank-balance-service/src/test/kotlin/com/openbank/balance/it/PostgresRedpandaTestResource.kt
 openbank-billing-service/src/test/kotlin/com/openbank/billing/it/PostgresRedisTestResource.kt


### PR DESCRIPTION
## What

Closes the first executable slice of #7246, and fixes an enforced gate that is red on `main` right now.

### 1. `main` is red on `test-intelligence-ecosystem`

Reproduced with the **unmodified** `origin/main` script against a clean `origin/main` worktree:

```
git show origin/main:.github/scripts/check-test-intelligence-ecosystem.py > /tmp/orig-gate.py
python3 /tmp/orig-gate.py --root . > /tmp/out.txt 2>&1; echo "EXIT=$?"
# EXIT=1
# ::error ...: new service-owned Testcontainers resource lacks lifecycle evidence:
#   openbank-incentive-service/src/test/kotlin/com/openbank/incentive/it/IncentivePostgresTestResource.kt
```

Introduced by `e156db259` (`feat(incentive): deliver governed promo reservations`, #7232) — a new Testcontainers resource with neither shared lifecycle evidence nor a baseline entry. The ratchet is doing its job; migrating the resource is the fix.

### 2. Three non-money-path pilots migrated

`openbank-incentive-service` (Postgres), `openbank-audit-service` (Postgres), `openbank-analytics-sink` (Redpanda — the first service-owned Redpanda resource to emit evidence). Each keeps its existing topology, image and credentials handling; only the shared `TestInfrastructureEvidence.record` start/stop pair is added, and each migrated path is removed from the baseline in the same commit.

### 3. The gate could not tell a migration from a mention

Scope test was:

```python
and "TestInfrastructureEvidence.record" not in source
```

A substring. An `import` line, a KDoc sentence, or a resource recording only `"started"` all read as migrated — and a "migrated" path must then be **deleted** from the baseline, permanently declaring a half-done migration finished. #7246's acceptance criterion is explicitly *start **and** stop*. This is the same shape as scoring a service contract-tested off a comment containing the word "contract".

Detection now strips comments and parses the lifecycle literal actually passed to the recorder, requiring both `started` and `stopped`. All six previously-migrated files pass unchanged — the stricter rule produces zero new findings beyond the incentive-service one the current gate already reports.

## Negative controls

Every exit code read from `$?` immediately after redirecting to a file (never through a pipe).

| Control | Command | Exit |
|---|---|---|
| substring detection restored | `check-test-intelligence-ecosystem.py --self-test` | **1** — `start-only lifecycle evidence was accepted as migrated` |
| `"stopped"` record removed from a migrated pilot | `check-test-intelligence-ecosystem.py` | **1** — `lacks lifecycle evidence: .../audit/it/PostgresTestResource.kt` |
| migrated path left in the baseline | `check-test-intelligence-ecosystem.py` | **1** — `baseline is stale; remove migrated path: ...` |
| restored | `check-test-intelligence-ecosystem.py` | **0** |
| restored | `check-test-intelligence-ecosystem.py --self-test` | **0** |
| restored | `collect-test-run-evidence.py --self-test` | **0** |

The self-test gains fixtures for all three discriminations — start-only, commented-out, and a must-**PASS** honest start/stop pair so the stricter rule cannot go red for everyone.

## Build verification

Redirected to a file, `$?` read immediately, and the task list checked for what actually ran (Gradle stops at the first failure):

- `:openbank-incentive-service:compileTestKotlin :openbank-audit-service:compileTestKotlin :openbank-analytics-sink:compileTestKotlin` — **exit 0**, all three `compileTestKotlin` tasks present in the output.
- `ktlintCheck` + `detekt` for the same three modules — **exit 0**, all six tasks present.

## Not claimed

- **No IT was executed.** `TestInfrastructureEvidence.record` no-ops unless `OPENBANK_TEST_EVIDENCE_DIR` is set, which only service CI does. That the pilots' JSONL lines actually land in a CI envelope is proven by the service CI run on this PR, not by anything here.
- No money-path resource is touched. The 55 remaining baseline entries stay; the file now names the next safe non-money-path candidates (#7246 acceptance criterion 3) and records that money-path entries need the two-approval + threat-model process first.
- No Admin UI projection change. #7246's "Test Intelligence presents the evidence without treating unmigrated resources as covered" is already satisfied by the baseline being the explicit denominator; I did not re-verify the rendered page.

## Release scope

Type `test` — no shipped code changes, so no component releases. Scope `libs` selects the governance/tooling change that is the substance of the PR.

Refs #7246
