### PR TITLE
feat(admin-ui): project runtime synthetic performance

### DIFF
--- a/openbank-admin-ui/src/app/api/test-intelligence/route.ts
+++ b/openbank-admin-ui/src/app/api/test-intelligence/route.ts
@@ -200,7 +200,30 @@ async function attachLiveJourneys(report: TestIntelligenceReport): Promise<TestI
       },
     }
   }))
-  return { ...report, syntheticJourneys }
+  // A scheduled k6 synthetic is both an availability journey and a measured runtime
+  // performance observation. Keep the Kubernetes verdict authoritative for the journey,
+  // but surface only actually published k6 metrics in the dedicated Performance view too.
+  // This does not turn a missing metric into a green benchmark or duplicate CI artifacts.
+  const runtimePerformance = syntheticJourneys.flatMap(journey => {
+    const measured = journey.live?.performance
+    if (!measured || (measured.worstP95Ms === null && measured.worstCheckPassRatePercent === null)) return []
+    return [{
+      id: `synthetic-${journey.id}`,
+      component: null,
+      state: journey.state,
+      observedAt: journey.live?.observedAt ?? null,
+      source: `runtime-synthetic:${journey.id}`,
+      thresholds: 0,
+      metrics: {
+        p95Ms: measured.worstP95Ms,
+        errorRatePercent: null,
+        checkPassRatePercent: measured.worstCheckPassRatePercent,
+        requests: null,
+      },
+      detail: `Sandbox synthetic runtime observation over the last ${Math.round(measured.windowSeconds / 60)} minutes; the Kubernetes Job verdict remains authoritative.`,
+    }]
+  })
+  return { ...report, syntheticJourneys, performance: [...report.performance, ...runtimePerformance] }
 }
 
 async function attachLiveClientExperience(report: TestIntelligenceReport): Promise<TestIntelligenceReport> {

--- a/openbank-admin-ui/src/test/test-intelligence-route.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-route.test.ts
@@ -246,6 +246,10 @@ describe('GET /api/test-intelligence', () => {
       state: 'passed',
       live: { performance: { source: 'prometheus', windowSeconds: 900, worstP95Ms: 1834.8, worstCheckPassRatePercent: 99.7 } },
     })
+    expect(body.performance).toEqual(expect.arrayContaining([expect.objectContaining({
+      id: 'synthetic-public-edge', state: 'passed', source: 'runtime-synthetic:public-edge', thresholds: 0,
+      metrics: { p95Ms: 1834.8, errorRatePercent: null, checkPassRatePercent: 99.7, requests: null },
+    })]))
     expect(queries.some(query => query.includes('max_over_time(k6_http_req_duration_p95{journey="public-edge"}[900s])'))).toBe(true)
     expect(queries.some(query => query.includes('min_over_time(k6_checks_rate{journey="public-edge"}[900s])'))).toBe(true)
   })
@@ -277,6 +281,7 @@ describe('GET /api/test-intelligence', () => {
       state: 'passed',
       live: { performance: { worstP95Ms: null, worstCheckPassRatePercent: null } },
     })
+    expect(body.performance).toEqual([])
   })
 
   it('shows a first scheduled Job still running as unresolved instead of claiming it was not run', async () => {


### PR DESCRIPTION
## Summary

- projects only published sandbox k6 runtime metrics into the dedicated Test Intelligence Performance view
- keeps the Kubernetes Job verdict authoritative and retains absent metrics as absent, never green

Refs #7284

## Verification

- `npm test -- --run src/test/test-intelligence-route.test.ts` (10 passed)
- `npx eslint src/app/api/test-intelligence/route.ts src/test/test-intelligence-route.test.ts`
- `git diff --check`

`npx tsc --noEmit` reaches existing missing local optional type dependencies for `@axe-core/playwright` and OTel packages after the focused route suite passes; this PR does not touch those modules.