### PR TITLE
ci(simulation): run DST for every modeled money path

### DIFF
--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -176,7 +176,7 @@ jobs:
                   # (No dedup here: the matrix JSON below is built with `sort -u`, so a service
                   # named by both its src and a pact edge collapses to one job downstream.)
                   # DST-harness edge (ADR-0115/#267) — same as the PR path.
-                  if { grep -qE '(^| )openbank-(ledger|balance|transaction)-service( |$)' <<< " $CHANGED " \
+                  if { grep -qE '(^| )openbank-(ledger|balance|transaction|billing|interest|statement)-service( |$)' <<< " $CHANGED " \
                        || grep -qE '(^| )openbank-sepa-payment( |$)' <<< " $CHANGED " \
                        || grep -qE '(^| )openbank-settlement-service( |$)' <<< " $CHANGED "; } \
                      && ! grep -qE '(^| )openbank-simulation( |$)' <<< " $CHANGED "; then
@@ -278,9 +278,10 @@ jobs:
               # already build everything incl. the simulation, so this only matters per-module.
               # Issue #267 (ADR-0100 full-service adoption) extended the same project-dependency
               # binding to sepa-payment (directory openbank-sepa-payment, no "-service" suffix)
-              # and settlement-service — add both to the edge so a change to either also rebuilds
-              # the simulation, exactly like ledger/balance/transaction already do.
-              if { grep -qE '(^| )openbank-(ledger|balance|transaction)-service( |$)' <<< " $CHANGED " \
+              # and settlement-service. Billing, interest and statement are also imported into
+              # the DST runner: without these edges their domain changes could ship without
+              # running the invariant/fault sweep that exercises them.
+              if { grep -qE '(^| )openbank-(ledger|balance|transaction|billing|interest|statement)-service( |$)' <<< " $CHANGED " \
                    || grep -qE '(^| )openbank-sepa-payment( |$)' <<< " $CHANGED " \
                    || grep -qE '(^| )openbank-settlement-service( |$)' <<< " $CHANGED "; } \
                  && ! grep -qE '(^| )openbank-simulation( |$)' <<< " $CHANGED "; then


### PR DESCRIPTION
## What

Make the path-scoped Services CI select openbank-simulation when billing, interest, or statement changes. The deterministic simulation runner imports these real domain models, so their changes need the same invariant/fault-sweep proof as the existing ledger, balance, transaction, SEPA, and settlement paths.

Refs #667

## Verification

- check-test-intelligence-ecosystem self-test
- Test Intelligence ecosystem enforcement
- parsed .github/workflows/services-ci.yml
- exercised the selection expression for billing, interest and statement
- git diff --check