### PR TITLE
ci(admin-ui): rebuild snapshot for synthetic manifests

### DIFF
--- a/.github/scripts/check-test-intelligence-ecosystem.py
+++ b/.github/scripts/check-test-intelligence-ecosystem.py
@@ -154,6 +154,8 @@ def check(root: Path) -> list[str]:
         ("github.event.workflow_run.head_sha || 'eligible'", "workflow-run events can evict the current push/dispatch Admin UI deploy queue"),
         ("git ls-remote origin refs/heads/main", "admin deployment does not reject a source commit that is stale before privileged build"),
         ("Skipping stale source", "admin deployment does not make stale-source rejection observable"),
+        ('"openbank-libs/governance/journeys.yaml"', "admin deployment does not rebuild the Test Intelligence snapshot when the journey catalog changes"),
+        ('"openbank-infra/gitops/components/observability/cronjob-journey-*.yaml"', "admin deployment does not rebuild the Test Intelligence snapshot when a synthetic runtime manifest changes"),
     ):
         if needle not in deploy:
             errors.append(message)

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -60,6 +60,10 @@ on:
       - "openbank-libs/governance/agents.yaml"
       - "openbank-libs/governance/compliance-controls.yaml"
       - "openbank-libs/governance/rules.yaml"
+      # Test Intelligence snapshot inputs. A journey catalog/manifest change must rebuild
+      # the image: the sandbox CronJob alone proves runtime, but the operator's bundled
+      # inventory and blockers would otherwise remain stale until an unrelated UI edit.
+      - "openbank-infra/gitops/components/observability/cronjob-journey-*.yaml"
       - "openbank-libs/governance/journeys.yaml"
       # openbank-libs/docs is the ONLY docs tree baked into the image: the Dockerfile's
       # docs-collector copies /repo/openbank-*/docs, and src/lib/services/docs.ts serves the


### PR DESCRIPTION
## What

Trigger the standard Admin UI deployment workflow when an observability synthetic journey runtime manifest changes. The Test Intelligence snapshot is built into the image; without this trigger, a new sandbox CronJob can be live while the operator UI remains stale.

## Linked issues

Refs #7305

## Verification

- Test Intelligence ecosystem self-test
- Test Intelligence ecosystem enforcement
- admin-ui-deploy workflow YAML parsing
- git diff --check