### PR TITLE
fix(synthetics): allow catalog read journey

### DIFF
--- a/docs/threat-models/openbank-account-service.md
+++ b/docs/threat-models/openbank-account-service.md
@@ -95,6 +95,15 @@ not change any existing request's outcome until explicitly flipped.
 
 ## 6. Change log
 
+- **2026-08-27** — **New tightly scoped inbound diagnostic edge:** the sandbox's
+  `journey-product-catalog-read` k6 CronJob may make one read-only request to
+  product-catalog `:8104`. The additive NetworkPolicy selects both its `observability`
+  namespace and its immutable journey pod labels; it does not admit Grafana, Prometheus,
+  or any other observability workload. The Job has no ServiceAccount token or credentials
+  and the endpoint returns only the public product list. This is a production-like
+  availability assertion, not an access-control bypass: Product Catalog still owns
+  request handling, and removing the policy restores fail-closed connection denial.
+
 - **2026-08-24** — Synthetic-journey taint now propagates over this service's existing internal REST clients through `SyntheticTaintClientFilter` (ADR-0252, #4348). This adds no caller, endpoint, network-policy edge, privilege or control bypass: sanctions, SCA and all other downstream controls still see the journey. It prevents synthetic activity from becoming indistinguishable before a downstream persistence/event boundary; a separate fleet gate requires every new client to choose propagation or a reasoned external boundary.
 
 - **2026-08-20** — Product-catalog product/currency enforcement (#668). This existing reference-data

--- a/openbank-infra/gitops/components/accounts/networkpolicy-product-catalog-synthetic-journey.yaml
+++ b/openbank-infra/gitops/components/accounts/networkpolicy-product-catalog-synthetic-journey.yaml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Journey product-catalog-read → product-catalog (:8104), read-only synthetic edge.
+#
+# HAND-MAINTAINED and deliberately not named network-policies.yaml: that file is derived
+# from long-lived Deployment callers by gen-network-policies.py. The journey is a CronJob,
+# so adding this edge there would be overwritten. NetworkPolicies are additive; this
+# narrow rule leaves the generated allow-list intact while admitting only the labelled
+# one-shot k6 pod, never the rest of the observability namespace.
+#
+# The journey performs exactly one unauthenticated GET /api/v1/products and carries no
+# credentials or ServiceAccount token. Port 8104 is the catalog HTTP API; management
+# port 8085 remains governed by the generated Prometheus rule. Removing this file rolls
+# back the edge and makes the journey fail closed with a connection timeout.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: product-catalog-ingress-synthetic-read-journey
+  namespace: accounts
+  labels:
+    app.kubernetes.io/part-of: accounts
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: product-catalog
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: journey
+              openbank.tech/journey: product-catalog-read
+      ports:
+        - protocol: TCP
+          port: 8104


### PR DESCRIPTION
## Why

The deployed sandbox CronJob journey-product-catalog-read was proven to fail with a TCP timeout to product-catalog.accounts.svc:8104. The generated Product Catalog policy permits observability only on its management port, so the expected API call is fail-closed.

## Change

Adds an additive, hand-maintained ingress policy selecting exactly `observability` pods with `app.kubernetes.io/component=journey` and `openbank.tech/journey=product-catalog-read`, on TCP 8104 only. No other observability workload is admitted. The Job has no ServiceAccount token or credentials and performs a single read-only GET.

## Evidence

- YAML parsing passed
- network-policy code-edge check passed
- threat-model diff gate passed
- Test Intelligence ecosystem, journey catalog and coverage checks passed

Refs #7308