### PR TITLE
feat(admin-ui): surface assurance evidence gaps

### DIFF
--- a/openbank-admin-ui/e2e/test-intelligence.spec.ts
+++ b/openbank-admin-ui/e2e/test-intelligence.spec.ts
@@ -32,6 +32,10 @@ test('renders the animated evidence system and consolidates test dimensions', as
   await expect(page.getByRole('heading', { name: /From change to confidence/ })).toBeVisible()
   await expect(page.getByRole('group', { name: /Seven Test Intelligence layers/ })).toBeVisible()
   await expect(page.getByRole('region', { name: /Testing assurance map/ })).toBeVisible()
+  // The queue must expose absent layers as evidence gaps instead of silently
+  // treating the fixture's missing simulation evidence as a pass.
+  await expect(page.getByText('Deterministic simulations', { exact: true })).toBeVisible()
+  await expect(page.getByText(/0\/1 components published current simulation evidence/)).toBeVisible()
   // A planned, blocked customer journey is unresolved evidence. The prominent health signal
   // must remain attention-worthy even when the ordinary component evidence is otherwise green.
   await expect(page.getByText('NEEDS ATTENTION', { exact: true })).toBeVisible()

--- a/openbank-admin-ui/src/app/system/tests/page.tsx
+++ b/openbank-admin-ui/src/app/system/tests/page.tsx
@@ -93,7 +93,30 @@ function AssuranceBoard({ report, selectTab }: { report: TestIntelligenceReport;
  */
 function EvidenceGapQueue({ report, selectTab }: { report: TestIntelligenceReport; selectTab: (tab: Tab) => void }) {
   const { t } = useLanguage()
+  // A component that has never emitted a particular test layer is not a green result.
+  // Do not infer that every component *must* own every layer: this is a visibility and
+  // prioritisation signal, while governed journey coverage remains the obligation source.
+  const layerVisibility = ([
+    { kind: 'e2e' as const, tab: 'execution' as const, title: t('E2E důkazy', 'E2E evidence') },
+    { kind: 'trace' as const, tab: 'execution' as const, title: t('Trace kontrakty', 'Trace contracts') },
+    { kind: 'simulation' as const, tab: 'execution' as const, title: t('Deterministické simulace', 'Deterministic simulations') },
+  ]).flatMap(layer => {
+    const observations = report.components.flatMap(component => component.evidence.filter(item => item.kind === layer.kind))
+    const componentsWithEvidence = new Set(report.components.filter(component => component.evidence.some(item => item.kind === layer.kind)).map(component => component.component))
+    const missing = report.components.length - componentsWithEvidence.size
+    if (missing === 0 && observations.every(item => item.state === 'passed')) return []
+    const state: EvidenceState = observations.some(item => item.state === 'failed') ? 'failed'
+      : missing > 0 ? 'not-run' : aggregateEvidenceState(observations.map(item => item.state), 'unknown')
+    return [{
+      id: `layer-${layer.kind}`, tab: layer.tab, state, title: layer.title,
+      detail: t(
+        `${componentsWithEvidence.size}/${report.components.length} komponent publikovalo aktuální ${layer.kind} důkaz; ${missing} jej zatím nepublikovalo. Jde o viditelnost evidence, ne o tvrzení, že každá komponenta musí mít tento typ testu.`,
+        `${componentsWithEvidence.size}/${report.components.length} components published current ${layer.kind} evidence; ${missing} have not published it yet. This is evidence visibility, not a claim that every component must own this test type.`,
+      ),
+    }]
+  })
   const gaps: Array<{ id: string; tab: Tab; title: string; detail: string; state: EvidenceState }> = [
+    ...layerVisibility,
     ...report.performance.filter(row => row.state !== 'passed' || row.plan?.blocker).map(row => ({
       id: `performance-${row.id}`, tab: 'performance' as const, state: row.state,
       title: t(`Výkon: ${row.id}`, `Performance: ${row.id}`),


### PR DESCRIPTION
Refs #7311

Makes E2E, trace-contract and deterministic-simulation evidence visibility explicit in the Test Intelligence evidence-gap queue. Missing evidence is shown as not-run without asserting every component must own every test type; governed journey coverage remains the obligation source.

This PR does not implement the executable money-path performance baseline requested in #7311; it makes the absence visible to operators.

Verified locally: npm run type-check, targeted ESLint, git diff --check. Playwright was started but Turbopack rejects a dependency symlink outside the worktree; CI runs it with a native dependency tree.