### PR TITLE
chore(incentive): register first image build

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -31,6 +31,9 @@ on:
     branches: [main]
     paths:
       - "openbank-*/src/main/**"
+      # The canonical runtime image reads the service Dockerfile's EXPOSE declaration.
+      # A port-only change therefore requires a rebuild just as source does.
+      - "openbank-*/Dockerfile"
       # openbank-libs/src/main no longer holds compiled code (ADR-0122 moved it to
       # openbank-libs-domain / openbank-libs-runtime, both already covered by the
       # openbank-*/src/main/** glob above) — only its build file and Gradle wrapper
@@ -209,7 +212,7 @@ jobs:
             # see it either, because its subject set was release-please's released components and
             # analytics-sink has no version.txt (it owns no OLTP database and cuts no release —
             # ADR-0022). That blindness is fixed in the same PR; this line is the gap it found.
-            ALL_SERVICES='openbank-account-service openbank-ledger-service openbank-transaction-service openbank-pid-service openbank-balance-service openbank-consent-service openbank-psd2-service openbank-tpp-registry-service openbank-agent-service openbank-copilot-service openbank-sca-service openbank-party-service openbank-notification-service openbank-audit-service openbank-kyc-service openbank-document-service openbank-sepa-payment openbank-domestic-payment openbank-aml-service openbank-card-issuance-service openbank-fx-service openbank-standing-order-service openbank-swift-service openbank-sanctions-service openbank-fraud-service openbank-security-scanner openbank-product-catalog openbank-clearing-service openbank-interest-service openbank-dispute-service openbank-engagement-service openbank-sepa-instant openbank-lending-service openbank-statement-service openbank-sdd-service openbank-customer-edge openbank-onboarding-service openbank-settlement-service openbank-finops-agent openbank-devops-agent openbank-billing-service openbank-anacredit-service openbank-control-liveness-sentinel openbank-governance-auditor openbank-release-steward openbank-docs-truth-agent openbank-authz-policy-auditor openbank-flaky-test-hunter openbank-clearing-simulator openbank-vop-service openbank-finrep-service openbank-mcp-service openbank-ap2-service openbank-campaign-service openbank-delegation-service openbank-case-coordinator-agent openbank-analytics-sink'
+            ALL_SERVICES='openbank-account-service openbank-ledger-service openbank-transaction-service openbank-pid-service openbank-balance-service openbank-consent-service openbank-psd2-service openbank-tpp-registry-service openbank-agent-service openbank-copilot-service openbank-sca-service openbank-party-service openbank-notification-service openbank-audit-service openbank-kyc-service openbank-document-service openbank-sepa-payment openbank-domestic-payment openbank-aml-service openbank-card-issuance-service openbank-fx-service openbank-standing-order-service openbank-swift-service openbank-sanctions-service openbank-fraud-service openbank-security-scanner openbank-product-catalog openbank-clearing-service openbank-interest-service openbank-dispute-service openbank-engagement-service openbank-sepa-instant openbank-lending-service openbank-statement-service openbank-sdd-service openbank-customer-edge openbank-onboarding-service openbank-settlement-service openbank-finops-agent openbank-devops-agent openbank-billing-service openbank-anacredit-service openbank-control-liveness-sentinel openbank-governance-auditor openbank-release-steward openbank-docs-truth-agent openbank-authz-policy-auditor openbank-flaky-test-hunter openbank-clearing-simulator openbank-vop-service openbank-finrep-service openbank-mcp-service openbank-ap2-service openbank-campaign-service openbank-delegation-service openbank-case-coordinator-agent openbank-analytics-sink openbank-incentive-service'
 
           # Which files changed in this push (compare to the parent commit). We compute this
           # early because the workflow_dispatch guard below also needs to know which services
@@ -244,7 +247,7 @@ jobs:
           for svc in $ALL_SERVICES; do
             # Keep this aligned with the push trigger: release-please changes only
             # version.txt, and that release marker must rebuild/deploy the component.
-            if grep -qE "^${svc}/(src/main|build\.gradle\.kts|version\.txt)" <<< "$CHANGED_FILES"; then
+            if grep -qE "^${svc}/(src/main|build\.gradle\.kts|version\.txt|Dockerfile)" <<< "$CHANGED_FILES"; then
               DIRECT_SERVICES+=("$svc")
             fi
           done

--- a/openbank-incentive-service/Dockerfile
+++ b/openbank-incentive-service/Dockerfile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# The deploy pipeline owns the runtime Dockerfile; it reads this port declaration only.
+EXPOSE 8156

--- a/openbank-incentive-service/Dockerfile
+++ b/openbank-incentive-service/Dockerfile
@@ -1,3 +1,14 @@
-# SPDX-License-Identifier: Apache-2.0
-# The deploy pipeline owns the runtime Dockerfile; it reads this port declaration only.
+# NOT a build recipe. The deploy pipeline supplies the prepared quarkus-app/ context.
+# Keep this runtime recipe aligned with .github/workflows/Dockerfile.deploy (#3016).
+FROM eclipse-temurin:25-jre@sha256:f19dbf0a22d0b3658fda48ce7d7181df05ad14bda151dd5ad12cc09d1451c70e
+WORKDIR /app
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
+USER openbank
+COPY quarkus-app/lib/ /app/lib/
+COPY quarkus-app/*.jar /app/
+COPY quarkus-app/app/ /app/app/
+COPY quarkus-app/quarkus/ /app/quarkus/
+
 EXPOSE 8156
+ENTRYPOINT ["java","-XX:+UseZGC","-Djava.util.logging.manager=org.jboss.logmanager.LogManager","-jar","/app/quarkus-run.jar"]


### PR DESCRIPTION
Refs #7210

Registers Incentive Service in the standard auto-deploy set and makes its declared HTTP port visible to the canonical image builder. A Dockerfile-only change now triggers the same release pipeline, which creates the first ECR repository/image through the existing signed and attested workflow.

No GitOps workload, customer-edge wiring, or activation is included here; those remain a separately reviewed step after the artifact exists.