### PR TITLE
fix(performance): reject auth-only baselines

### DIFF
--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -8,10 +8,12 @@
 # uploaded, never fails the run or blocks a deploy (issue #334). Money-path perf gating
 # is a deliberate later step, not a surprise red build.
 #
-# Target: the services must already be reachable. Set the repo/environment variables
-# PERF_LEDGER_URL and PERF_TXN_URL (e.g. a sandbox internal URL reached via a
-# self-hosted runner, or a port-forward). If unset, the job SKIPS with a notice rather
-# than pretending to have measured something — no silent green.
+# Target: the services must already be reachable AND the runner must carry a dedicated,
+# least-privilege read identity. Set the repo/environment variables PERF_LEDGER_URL and
+# PERF_TXN_URL (e.g. a sandbox internal URL reached via a self-hosted runner, or a
+# port-forward). If unset, the job SKIPS with a notice rather than pretending to have
+# measured something — no silent green. An authenticated 200 is required; a 401 is retained
+# as failed evidence because it did not execute the handler.
 name: Perf baseline
 
 on:

--- a/openbank-admin-ui/src/test/test-intelligence-performance-scope.guard.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-performance-scope.guard.test.ts
@@ -22,8 +22,20 @@ describe('Test Intelligence performance coverage scope', () => {
 
     expect(scenarios).toContain('id: money-path-smoke')
     expect(scenarios).toContain('execution_mode: planned-read-only-sandbox')
-    expect(scenarios).toContain('blocker: No isolated authenticated read-only money-path target')
+    expect(scenarios).toContain('blocker: No isolated money-path target, dedicated runner, and verified least-privilege read identity')
     expect(workflow).toContain('DECLARED = ["openbank-product-catalog"]')
+  })
+
+  it('refuses to turn an authorization rejection into money-path latency evidence', () => {
+    const smoke = readFileSync(path.join(root(), 'perf/k6/money-path-smoke.js'), 'utf8')
+
+    expect(smoke).toContain('http.expectedStatuses(200)')
+    expect(smoke).not.toContain('http.expectedStatuses(200, 401)')
+    expect(smoke).toContain('"checks": ["rate==1.0"]')
+    expect(smoke).toContain('"ledger journals 200"')
+    expect(smoke).toContain('"txn list 200"')
+    expect(smoke).not.toContain('"ledger journals 200|401"')
+    expect(smoke).not.toContain('"txn list 200|401"')
   })
 
   it('keeps cross-layer evidence gaps visible from the primary operator view', () => {

--- a/perf/k6/money-path-smoke.js
+++ b/perf/k6/money-path-smoke.js
@@ -19,12 +19,11 @@ import http from "k6/http";
 import { check } from "k6";
 import { Trend } from "k6/metrics";
 
-// The two money-path reads sit behind auth and legitimately answer 401 unauthenticated.
-// Without this, k6's http_req_failed counts every 401 as a failure → the built-in
-// reliability metric would be ~0.67 by construction whenever OIDC is on, breaching its
-// threshold on every run and making the "trend" meaningless. Treat 200 AND 401 as expected
-// so http_req_failed only counts real transport errors / 5xx.
-http.setResponseCallback(http.expectedStatuses(200, 401));
+// A 401 proves only that the identity boundary rejected the request. It does NOT prove
+// that either money-path handler, database projection, or read query ran, so it must never
+// become a latency baseline. A runner without a dedicated read-only identity will therefore
+// emit a failed evidence envelope instead of a green-looking measurement of the rejection.
+http.setResponseCallback(http.expectedStatuses(200));
 
 const LEDGER_URL = __ENV.LEDGER_URL || "http://localhost:8101";
 const TXN_URL = __ENV.TXN_URL || "http://localhost:8102";
@@ -54,6 +53,10 @@ export const options = {
     "txn_list_ms": ["p(95)<800"],
     "info_ms": ["p(95)<200"],
     "http_req_failed": ["rate<0.01"],
+    // A transport percentile is not a handler baseline unless every asserted route answered.
+    // The workflow keeps thresholds advisory; Test Intelligence retains the breach as failed
+    // evidence until a least-privilege runner identity is configured.
+    "checks": ["rate==1.0"],
   },
 };
 
@@ -63,14 +66,14 @@ export default function () {
     tags: { name: "ledger_journals" },
   });
   ledgerLatency.add(j.timings.duration);
-  check(j, { "ledger journals 200|401": (r) => r.status === 200 || r.status === 401 });
+  check(j, { "ledger journals 200": (r) => r.status === 200 });
 
   // Transaction: list (read side of the money path).
   const t = http.get(`${TXN_URL}/api/v1/transactions?limit=20`, {
     tags: { name: "txn_list" },
   });
   txnLatency.add(t.timings.duration);
-  check(t, { "txn list 200|401": (r) => r.status === 200 || r.status === 401 });
+  check(t, { "txn list 200": (r) => r.status === 200 });
 
   // libs-served service-info (unauthenticated; cheap liveness+version surface).
   const i = http.get(`${LEDGER_URL}/api/v1/info`, { tags: { name: "info" } });

--- a/perf/scenarios.yaml
+++ b/perf/scenarios.yaml
@@ -5,7 +5,7 @@ scenarios:
     execution_mode: planned-read-only-sandbox
     safety_boundary: Runs only when a safe read-only money-path target is configured for the GitHub-hosted runner.
     target_schedule: "0 5 * * *"
-    blocker: No isolated authenticated read-only money-path target and dedicated runner are configured yet; the current scheduled performance gate measures only openbank-product-catalog.
+    blocker: No isolated money-path target, dedicated runner, and verified least-privilege read identity are configured yet; a 401 is rejection evidence, not a handler performance baseline. The current scheduled performance gate measures only openbank-product-catalog.
 
   - id: money-path-write-benchmark
     definition: perf/k6/money-path-write-benchmark.js


### PR DESCRIPTION
## What\n\n- makes the money-path k6 baseline require HTTP 200 from ledger and transaction handlers\n- marks any authentication rejection as failed Test Intelligence evidence, never a latency baseline\n- preserves advisory thresholds while keeping the evidence truthful\n\n## Linked issues\n\nRefs #7311\n\n## Verification\n\n- local money-path baseline truthfulness contract\n- Test Intelligence ecosystem: schema -> every service CI -> runtime proof -> deployment projection
SUBJECTS=60 ()\n- \n\nThe actual least-privilege runner identity remains an external provisioning requirement; this PR intentionally refuses to claim handler performance before it exists.