### PR TITLE
fix(admin-ui): expose Explorer brand asset

### DIFF
--- a/openbank-admin-ui/src/proxy.ts
+++ b/openbank-admin-ui/src/proxy.ts
@@ -104,7 +104,8 @@ export const config = {
     // api/sanctions reachable WITHOUT a token — the same unauthenticated-info-disclosure class as
     // F-AUTH-01/02. They are consumed only by gated pages (security, system/tests, product-catalog,
     // fees, devops), so the session cookie still reaches them; nothing pre-auth needs them. Now the
-    // ONLY exclusions are Auth.js's own handlers and Next static assets — everything else is gated.
+    // ONLY exclusions are Auth.js's own handlers, Next static assets, and the public brand assets
+    // needed by the pre-auth login page — everything else is gated.
     // (k8s probes the pod via tcpSocket, not an /api path, so gating /api can't break liveness.)
     // NOTE: /auth/* is intentionally NOT excluded (ADR-0080 P1): the middleware must run there to
     // emit the nonce CSP on the pre-auth login page. The callback short-circuits /auth so the auth
@@ -114,6 +115,6 @@ export const config = {
     // not 2xx/401/403 to a 500 — so the middleware's 302-to-login would make the gate fail closed on
     // precisely the unauthenticated request it exists to reject cleanly. The route runs the same
     // session + role check itself, returns 204/401/403 with no body, and proxies nothing.
-    "/((?!api/auth|api/gate|_next/static|_next/image|favicon.ico|robots.txt).*)",
+    "/((?!api/auth|api/gate|_next/static|_next/image|brand/|favicon.ico|robots.txt).*)",
   ],
 }

--- a/openbank-admin-ui/src/test/tools-gate.test.ts
+++ b/openbank-admin-ui/src/test/tools-gate.test.ts
@@ -149,7 +149,7 @@ describe('ADR-0234 wiring — the halves of the boundary agree', () => {
     expect(gateTools).toContain(tool)
   })
 
-  it('the middleware matcher excludes /api/gate', () => {
+  it('the middleware matcher excludes /api/gate and pre-auth brand assets', () => {
     // Without this the middleware answers an unauthenticated sub-request with a
     // 302 and nginx turns the gate into a 500 — dashboards unreachable for
     // everyone, including the operators the gate would have admitted.
@@ -163,6 +163,10 @@ describe('ADR-0234 wiring — the halves of the boundary agree', () => {
       .match(/matcher:\s*\[([\s\S]*?)\]/)?.[1]
     expect(matcher, 'middleware config.matcher not found').toBeDefined()
     expect(matcher).toMatch(/api\/gate/)
+    // The login page renders the Explorer from /public/brand before a session
+    // exists. Matching /brand here redirects the image request back to login,
+    // leaving the new experience deployed but the mascot invisible.
+    expect(matcher).toMatch(/brand\//)
   })
 
   // Every tool, not just the first one. A gate wider than the nav hides access


### PR DESCRIPTION
## Summary
- exclude public `/brand/` assets from the authentication proxy matcher
- keep all business and internal routes behind the existing session gate
- add a regression assertion for pre-auth brand assets

## Verification
- `npm test -- --run src/test/tools-gate.test.ts` (24/24)
- `npm run type-check`
- `npm run build`

Closes #7335