### PR TITLE
feat(testing): add admin UI browser synthetic

### DIFF
--- a/.github/workflows/admin-ui-browser-synthetic.yml
+++ b/.github/workflows/admin-ui-browser-synthetic.yml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+name: Admin UI browser synthetic
+
+on:
+  schedule:
+    - cron: '13 */2 * * *'
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'openbank-admin-ui/scripts/admin-login-synthetic.mjs'
+      - '.github/workflows/admin-ui-browser-synthetic.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  sso-boundary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '26'
+          cache: npm
+          cache-dependency-path: openbank-admin-ui/package-lock.json
+      - working-directory: openbank-admin-ui
+        run: npm ci --no-audit --no-fund
+      - working-directory: openbank-admin-ui
+        run: npx playwright install --with-deps chromium
+      - id: synthetic
+        working-directory: openbank-admin-ui
+        run: node scripts/admin-login-synthetic.mjs
+      - if: always()
+        run: |
+          python3 .github/scripts/collect-test-run-evidence.py \
+            --service openbank-admin-ui --component openbank-admin-ui \
+            --out openbank-admin-ui/build/test-intelligence/run.json
+      - if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-intelligence-run-openbank-admin-ui-browser-${{ github.run_id }}-a${{ github.run_attempt }}
+          path: openbank-admin-ui/build/test-intelligence/run.json
+          retention-days: 30
+          if-no-files-found: error

--- a/.github/workflows/main-red-watch.yml
+++ b/.github/workflows/main-red-watch.yml
@@ -74,6 +74,7 @@ on:
       - "Product Catalog Native Build (T1 enabler smoke test)"
       - "Schema registry apply (document-service pilot)"
       - "Synthetic journeys"
+      - "Admin UI browser synthetic"
     types: [completed]
   pull_request:
     paths:

--- a/openbank-admin-ui/scripts/admin-login-synthetic.mjs
+++ b/openbank-admin-ui/scripts/admin-login-synthetic.mjs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// A credential-free browser synthetic. It proves the public Admin UI reaches its SSO boundary;
+// it deliberately does not authenticate or claim an authorised operator journey.
+import { chromium } from 'playwright'
+import { mkdir, writeFile } from 'node:fs/promises'
+
+const target = process.env.ADMIN_UI_SYNTHETIC_URL ?? 'https://admin.open-bank.tech/system/tests'
+const report = process.env.PLAYWRIGHT_JUNIT_OUTPUT_FILE ?? 'build/test-results/e2e/admin-login-synthetic.xml'
+const started = Date.now()
+let failure = null
+let browser
+try {
+  browser = await chromium.launch({ headless: true })
+  const page = await browser.newPage()
+  const response = await page.goto(target, { waitUntil: 'domcontentloaded', timeout: 20_000 })
+  if (!response || response.status() >= 500) throw new Error(`Admin UI returned ${response?.status() ?? 'no response'}`)
+  const signIn = page.getByRole('button', { name: 'Continue with Keycloak SSO' })
+  if (!await signIn.isVisible({ timeout: 10_000 })) throw new Error('SSO boundary was not rendered')
+} catch (error) {
+  failure = error instanceof Error ? error.message : 'unknown browser synthetic failure'
+} finally {
+  await browser?.close()
+}
+await mkdir(report.slice(0, report.lastIndexOf('/')), { recursive: true })
+const seconds = ((Date.now() - started) / 1000).toFixed(3)
+const escaped = failure?.replace(/[&<>"']/g, char => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&apos;' })[char])
+await writeFile(report, `<testsuites><testsuite name="admin-login-synthetic" tests="1" failures="${failure ? 1 : 0}" errors="0" skipped="0" time="${seconds}"><testcase classname="admin-login-synthetic" name="renders SSO boundary" time="${seconds}">${failure ? `<failure message="${escaped}"/>` : ''}</testcase></testsuite></testsuites>\n`)
+if (failure) throw new Error(failure)


### PR DESCRIPTION
## Summary
- run a credential-free browser synthetic against the public Admin UI SSO boundary every two hours
- retain a JUnit-backed immutable E2E envelope in Test Intelligence history
- never authenticate, submit a form or claim an authorised operator journey

## Verification
- `node --check openbank-admin-ui/scripts/admin-login-synthetic.mjs`
- `python3 .github/scripts/collect-test-run-evidence.py --self-test`
- `git diff --check`

Refs #4348