### PR TITLE
feat(testing): retain browser synthetic evidence

### DIFF
--- a/.github/scripts/collect-test-run-evidence.py
+++ b/.github/scripts/collect-test-run-evidence.py
@@ -399,6 +399,7 @@ def specialized_evidence(
     performance_not_run_detail: str | None = None,
     synthetic_summary: str | None = None,
     synthetic_journey: str | None = None,
+    suite_evidence: list[dict] | None = None,
 ) -> list[dict]:
     specialized = []
     if performance_summary:
@@ -440,6 +441,15 @@ def specialized_evidence(
             "detail": "synthetic summary absent" if summary is None else
                       f"{len(thresholds)} threshold result(s), {failed} breached",
         })
+    elif synthetic_journey:
+        if not re.fullmatch(r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?", synthetic_journey):
+            raise ValueError("--synthetic-journey must be a valid journey id")
+        e2e = next((item for item in (suite_evidence or []) if item["kind"] == "e2e"), None)
+        state = e2e["state"] if e2e else "not-run"
+        detail = (f"{e2e['executed']}/{e2e['discovered']} browser E2E checks executed"
+                  if e2e else "browser E2E JUnit report absent")
+        specialized.append({"kind": "synthetic", "state": state,
+                            "source": f"journey:{synthetic_journey}", "detail": detail})
     return specialized
 
 
@@ -544,6 +554,8 @@ def main() -> None:
             assert absent == [{"kind": "performance", "state": "not-run", "source": str(service / "missing-summary.json"), "detail": "no safe target configured"}]
             synthetic = specialized_evidence(None, None, synthetic_summary=str(performance), synthetic_journey="public-edge")
             assert synthetic == [{"kind": "synthetic", "state": "failed", "source": "journey:public-edge", "detail": "1 threshold result(s), 1 breached"}]
+            browser_synthetic = specialized_evidence(None, None, synthetic_journey="admin-ui-sso-boundary", suite_evidence=[discovered["e2e"]])
+            assert browser_synthetic == [{"kind": "synthetic", "state": "passed", "source": "journey:admin-ui-sso-boundary", "detail": "1/1 browser E2E checks executed"}]
             valid = {
                 "schemaVersion": 1,
                 "run": {"id": "1", "attempt": 1, "commit": "1234567", "branch": "main", "workflow": "CI", "url": "https://github.com/JiRaska/open-bank-oss/actions/runs/1", "observedAt": "2026-08-22T21:12:00Z"},
@@ -634,12 +646,14 @@ def main() -> None:
     run_id = os.getenv("GITHUB_RUN_ID", "local")
     run_attempt = int(os.getenv("GITHUB_RUN_ATTEMPT", "1"))
     run_url = f"{server}/{repository}/actions/runs/{run_id}" if server and repository else ""
+    suite_evidence = suites(component, service)
     specialized = specialized_evidence(
         args.performance_summary,
         args.mutation_report,
         args.performance_not_run_detail,
         args.synthetic_summary,
         args.synthetic_journey,
+        suite_evidence,
     )
     specialized.extend(trace_contract_evidence(service))
     envelope = {
@@ -652,7 +666,7 @@ def main() -> None:
             "url": run_url,
             "observedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         },
-        "component": component, "suites": suites(component, service), "testCases": test_cases(component, service), "coverage": coverage(service),
+        "component": component, "suites": suite_evidence, "testCases": test_cases(component, service), "coverage": coverage(service),
         # v1 intentionally records absence rather than guessing a test-to-production mapping.
         # A future producer may only advance this after emitting versioned, verified coverage or
         # dependency edges and measuring recommendations against the preserved full suite (#7207).

--- a/.github/workflows/admin-ui-browser-synthetic.yml
+++ b/.github/workflows/admin-ui-browser-synthetic.yml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+name: Admin UI browser synthetic
+
+on:
+  schedule:
+    - cron: '13 */2 * * *'
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'openbank-admin-ui/scripts/admin-login-synthetic.mjs'
+      - '.github/workflows/admin-ui-browser-synthetic.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  sso-boundary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '26'
+          cache: npm
+          cache-dependency-path: openbank-admin-ui/package-lock.json
+      - working-directory: openbank-admin-ui
+        run: npm ci --no-audit --no-fund
+      - working-directory: openbank-admin-ui
+        run: npx playwright install --with-deps chromium
+      - id: synthetic
+        working-directory: openbank-admin-ui
+        run: node scripts/admin-login-synthetic.mjs
+      - if: always()
+        run: |
+          python3 .github/scripts/collect-test-run-evidence.py \
+            --service openbank-admin-ui --component openbank-admin-ui \
+            --out openbank-admin-ui/build/test-intelligence/run.json
+      - if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-intelligence-run-openbank-admin-ui-browser-${{ github.run_id }}-a${{ github.run_attempt }}
+          path: openbank-admin-ui/build/test-intelligence/run.json
+          retention-days: 30
+          if-no-files-found: error

--- a/.github/workflows/admin-ui-browser-synthetic.yml
+++ b/.github/workflows/admin-ui-browser-synthetic.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           python3 .github/scripts/collect-test-run-evidence.py \
             --service openbank-admin-ui --component openbank-admin-ui \
+            --synthetic-journey admin-ui-sso-boundary \
             --out openbank-admin-ui/build/test-intelligence/run.json
       - if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/main-red-watch.yml
+++ b/.github/workflows/main-red-watch.yml
@@ -74,6 +74,7 @@ on:
       - "Product Catalog Native Build (T1 enabler smoke test)"
       - "Schema registry apply (document-service pilot)"
       - "Synthetic journeys"
+      - "Admin UI browser synthetic"
     types: [completed]
   pull_request:
     paths:

--- a/openbank-admin-ui/scripts/admin-login-synthetic.mjs
+++ b/openbank-admin-ui/scripts/admin-login-synthetic.mjs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// A credential-free browser synthetic. It proves the public Admin UI reaches its SSO boundary;
+// it deliberately does not authenticate or claim an authorised operator journey.
+import { chromium } from 'playwright'
+import { mkdir, writeFile } from 'node:fs/promises'
+
+const target = process.env.ADMIN_UI_SYNTHETIC_URL ?? 'https://admin.open-bank.tech/system/tests'
+const report = process.env.PLAYWRIGHT_JUNIT_OUTPUT_FILE ?? 'build/test-results/e2e/admin-login-synthetic.xml'
+const started = Date.now()
+let failure = null
+let browser
+try {
+  browser = await chromium.launch({ headless: true })
+  const page = await browser.newPage()
+  const response = await page.goto(target, { waitUntil: 'domcontentloaded', timeout: 20_000 })
+  if (!response || response.status() >= 500) throw new Error(`Admin UI returned ${response?.status() ?? 'no response'}`)
+  const signIn = page.getByRole('button', { name: 'Continue with Keycloak SSO' })
+  if (!await signIn.isVisible({ timeout: 10_000 })) throw new Error('SSO boundary was not rendered')
+} catch (error) {
+  failure = error instanceof Error ? error.message : 'unknown browser synthetic failure'
+} finally {
+  await browser?.close()
+}
+await mkdir(report.slice(0, report.lastIndexOf('/')), { recursive: true })
+const seconds = ((Date.now() - started) / 1000).toFixed(3)
+const escaped = failure?.replace(/[&<>"']/g, char => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&apos;' })[char])
+await writeFile(report, `<testsuites><testsuite name="admin-login-synthetic" tests="1" failures="${failure ? 1 : 0}" errors="0" skipped="0" time="${seconds}"><testcase classname="admin-login-synthetic" name="renders SSO boundary" time="${seconds}">${failure ? `<failure message="${escaped}"/>` : ''}</testcase></testsuite></testsuites>\n`)
+if (failure) throw new Error(failure)


### PR DESCRIPTION
Closes #7284

The browser SSO-boundary synthetic now emits a provenance-complete `synthetic` Test Intelligence evidence row derived from its executed E2E JUnit suite. This makes immutable history associate the result with `journey:admin-ui-sso-boundary` without claiming an authenticated operator journey.

Verified locally:
- `python3 .github/scripts/collect-test-run-evidence.py --self-test`
- `python3 .github/scripts/check-main-red-watch.py --self-test`
- workflow YAML parse
- `git diff --check`