### PR TITLE
feat(testing): govern browser synthetic journeys

### DIFF
--- a/.github/scripts/check-journey-catalog.py
+++ b/.github/scripts/check-journey-catalog.py
@@ -162,12 +162,14 @@ def cronjob_facts(root: pathlib.Path, rel_path: str, journey_id: str):
     return None, defined_configmaps, f"{rel_path} defines no CronJob named {CRONJOB_PREFIX}{journey_id}"
 
 
-def workflow_facts(root: pathlib.Path, rel_path: str, schedule: str):
+def workflow_facts(root: pathlib.Path, rel_path: str, schedule: str, workflow_name: str):
     """Validate a GitHub Actions-backed journey from its committed schedule, not prose."""
     path = root / rel_path
     if not path.is_file():
         return f"workflow not found: {rel_path}"
     text = path.read_text(encoding="utf-8")
+    if not re.search(rf"(?m)^name:\s*{re.escape(workflow_name)}\s*$", text):
+        return f"workflow {rel_path} does not declare name {workflow_name!r}"
     # The literal scheduled trigger is the executable cadence. Quotes are optional in Actions YAML.
     if not re.search(rf"(?m)^\s*-\s*cron:\s*['\"]?{re.escape(schedule)}['\"]?\s*$", text):
         return f"workflow {rel_path} does not schedule {schedule!r}"
@@ -325,10 +327,12 @@ def check(root: pathlib.Path):
                 findings.append(f"{jid}: an active journey declares one executor, not both workflow and cronjob")
             if not entry.get("schedule"):
                 findings.append(f"{jid}: workflow-backed active journeys need `schedule`")
+            if not entry.get("workflow_name"):
+                findings.append(f"{jid}: workflow-backed active journeys need `workflow_name`")
             elif not CRON_EXPRESSION.match(str(entry.get("schedule"))):
                 findings.append(f"{jid}: schedule is not a five-field cron expression")
             else:
-                error = workflow_facts(root, str(entry["workflow"]), str(entry["schedule"]))
+                error = workflow_facts(root, str(entry["workflow"]), str(entry["schedule"]), str(entry["workflow_name"]))
                 if error:
                     findings.append(f"{jid}: {error}")
             continue
@@ -444,6 +448,7 @@ journeys:
     severity: ticket
     money_moving: false
     workflow: .github/workflows/browser-synthetic.yml
+    workflow_name: Browser synthetic
     schedule: "13 */2 * * *"
     falsification: remove the SSO boundary
 """

--- a/.github/scripts/check-journey-catalog.py
+++ b/.github/scripts/check-journey-catalog.py
@@ -434,13 +434,38 @@ spec:
           expr: absent(kube_cronjob_status_last_successful_time{cronjob="journey-demo"})
 """
 
+SELF_TEST_CATALOG_WORKFLOW = """
+version: 1
+journeys:
+  - id: browser-boundary
+    title: Browser boundary
+    capability: proves the public browser hand-off
+    status: active
+    severity: ticket
+    money_moving: false
+    workflow: .github/workflows/browser-synthetic.yml
+    schedule: "13 */2 * * *"
+    falsification: remove the SSO boundary
+"""
 
-def write_tree(root: pathlib.Path, catalog: str, cronjob: str, rules: str, cronjob_name="cronjob-journey-demo.yaml"):
+SELF_TEST_WORKFLOW = """
+name: Browser synthetic
+on:
+  schedule:
+    - cron: '13 */2 * * *'
+"""
+
+
+def write_tree(root: pathlib.Path, catalog: str, cronjob: str, rules: str, cronjob_name="cronjob-journey-demo.yaml", workflow=None):
     (root / "openbank-libs/governance").mkdir(parents=True, exist_ok=True)
     (root / COMPONENTS / "observability").mkdir(parents=True, exist_ok=True)
     (root / CATALOG).write_text(catalog, encoding="utf-8")
     if cronjob is not None:
         (root / COMPONENTS / "observability" / cronjob_name).write_text(cronjob, encoding="utf-8")
+    if workflow is not None:
+        target = root / ".github/workflows/browser-synthetic.yml"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(workflow, encoding="utf-8")
     (root / RULES).write_text(rules, encoding="utf-8")
 
 
@@ -451,10 +476,10 @@ def self_test():
     """
     cases = []
 
-    def run(label, catalog, cronjob, rules, expect_finding, cronjob_name="cronjob-journey-demo.yaml"):
+    def run(label, catalog, cronjob, rules, expect_finding, cronjob_name="cronjob-journey-demo.yaml", workflow=None):
         with tempfile.TemporaryDirectory() as tmp:
             root = pathlib.Path(tmp)
-            write_tree(root, catalog, cronjob, rules, cronjob_name)
+            write_tree(root, catalog, cronjob, rules, cronjob_name, workflow)
             findings, fatal, _ = check(root)
             got = bool(findings) or bool(fatal)
             ok = got == expect_finding
@@ -462,6 +487,14 @@ def self_test():
 
     run("control: a consistent catalog is clean",
         SELF_TEST_CATALOG_OK, SELF_TEST_CRONJOB, SELF_TEST_RULES, expect_finding=False)
+
+    run("control: a workflow-backed active journey is schedule-verified",
+        SELF_TEST_CATALOG_WORKFLOW, None, SELF_TEST_RULES, expect_finding=False,
+        workflow=SELF_TEST_WORKFLOW)
+
+    run("workflow-backed journey schedule drift is detected",
+        SELF_TEST_CATALOG_WORKFLOW, None, SELF_TEST_RULES, expect_finding=True,
+        workflow=SELF_TEST_WORKFLOW.replace("13 */2 * * *", "0 * * * *"))
 
     run("catalog entry whose manifest does not exist",
         SELF_TEST_CATALOG_OK.replace("cronjob-journey-demo.yaml", "cronjob-journey-ghost.yaml"),

--- a/.github/scripts/check-journey-catalog.py
+++ b/.github/scripts/check-journey-catalog.py
@@ -162,6 +162,18 @@ def cronjob_facts(root: pathlib.Path, rel_path: str, journey_id: str):
     return None, defined_configmaps, f"{rel_path} defines no CronJob named {CRONJOB_PREFIX}{journey_id}"
 
 
+def workflow_facts(root: pathlib.Path, rel_path: str, schedule: str):
+    """Validate a GitHub Actions-backed journey from its committed schedule, not prose."""
+    path = root / rel_path
+    if not path.is_file():
+        return f"workflow not found: {rel_path}"
+    text = path.read_text(encoding="utf-8")
+    # The literal scheduled trigger is the executable cadence. Quotes are optional in Actions YAML.
+    if not re.search(rf"(?m)^\s*-\s*cron:\s*['\"]?{re.escape(schedule)}['\"]?\s*$", text):
+        return f"workflow {rel_path} does not schedule {schedule!r}"
+    return None
+
+
 def extract_script(root: pathlib.Path, journey_id: str) -> str:
     """Return the exact ConfigMap-mounted k6 program for one active catalog journey.
 
@@ -192,7 +204,12 @@ def extract_script(root: pathlib.Path, journey_id: str) -> str:
 
 
 def active_ids(root: pathlib.Path) -> list[str]:
-    """Return active journey ids only after the catalog has passed its structural checks."""
+    """Return active Kubernetes journey ids whose mounted k6 program CI can extract.
+
+    The catalog also admits active GitHub Actions browser synthetics. They have no ConfigMap
+    script by design, so including them here would ask the k6 workflow to execute an artifact
+    that does not exist. Their workflow is independently validated by ``workflow_facts``.
+    """
     findings, fatal, _ = check(root)
     if fatal:
         raise ValueError(fatal)
@@ -200,7 +217,7 @@ def active_ids(root: pathlib.Path) -> list[str]:
         raise ValueError("catalog is not consistent: " + "; ".join(findings))
     catalog = yaml.safe_load((root / CATALOG).read_text(encoding="utf-8")) or {}
     return sorted(str(item["id"]) for item in (catalog.get("journeys") or [])
-                  if isinstance(item, dict) and item.get("status") == "active")
+                  if isinstance(item, dict) and item.get("status") == "active" and item.get("cronjob"))
 
 
 def alerted_journeys(root: pathlib.Path):
@@ -303,6 +320,18 @@ def check(root: pathlib.Path):
         if runtime_note is not None and (not isinstance(runtime_note, str) or not runtime_note.strip()):
             findings.append(f"{jid}: runtime_note must be a non-empty string when declared")
 
+        if entry.get("workflow"):
+            if entry.get("cronjob"):
+                findings.append(f"{jid}: an active journey declares one executor, not both workflow and cronjob")
+            if not entry.get("schedule"):
+                findings.append(f"{jid}: workflow-backed active journeys need `schedule`")
+            elif not CRON_EXPRESSION.match(str(entry.get("schedule"))):
+                findings.append(f"{jid}: schedule is not a five-field cron expression")
+            else:
+                error = workflow_facts(root, str(entry["workflow"]), str(entry["schedule"]))
+                if error:
+                    findings.append(f"{jid}: {error}")
+            continue
         for field in REQUIRED_ACTIVE:
             if entry.get(field) in (None, ""):
                 findings.append(f"{jid}: active journeys need `{field}`")

--- a/openbank-admin-ui/scripts/collect-test-intelligence.mjs
+++ b/openbank-admin-ui/scripts/collect-test-intelligence.mjs
@@ -469,6 +469,9 @@ function syntheticJourneys() {
   try {
     const raw = parseYaml(fs.readFileSync(file, 'utf8'))
     const latestCi = new Map()
+    const workflowByJourney = new Map((raw?.journeys ?? [])
+      .filter(item => item?.workflow && item?.workflow_name)
+      .map(item => [item.id, item.workflow_name]))
     const history = allFiles(path.join(repo, 'openbank-admin-ui', 'test-run-history'), candidate => candidate.endsWith('.json'))
       .map(readJson).filter(item => item?.schemaVersion === 1 && item?.run)
       .sort((a, b) => Date.parse(a.run.observedAt) - Date.parse(b.run.observedAt))
@@ -476,7 +479,13 @@ function syntheticJourneys() {
       const provenance = safeRun(envelope.run, `synthetic:${envelope.component ?? 'unknown'}`)
       for (const evidence of envelope.specializedEvidence ?? []) {
         if (evidence.kind !== 'synthetic' || !evidence.source?.startsWith('journey:')) continue
-        latestCi.set(evidence.source.slice('journey:'.length), {
+        const journeyId = evidence.source.slice('journey:'.length)
+        const expectedWorkflow = workflowByJourney.get(journeyId)
+        if (expectedWorkflow && envelope.run.workflow !== expectedWorkflow) {
+          warnings.push(`synthetic evidence workflow mismatch omitted: ${journeyId}`)
+          continue
+        }
+        latestCi.set(journeyId, {
           state: freshnessAwareState(evidence.state, envelope.run.observedAt), observedAt: envelope.run.observedAt,
           detail: evidence.detail ?? 'Synthetic run retained without detail.',
           ...(provenance ? { run: provenance } : {}),

--- a/openbank-admin-ui/scripts/collect-test-intelligence.mjs
+++ b/openbank-admin-ui/scripts/collect-test-intelligence.mjs
@@ -487,6 +487,7 @@ function syntheticJourneys() {
       id: item.id, title: item.name ?? item.title ?? item.id, status: item.status,
       capability: item.capability ?? '',
       state: item.status === 'active' ? 'unknown' : 'blocked', severity: item.severity,
+      executor: item.workflow ? 'github-actions' : 'kubernetes-cronjob',
       schedule: item.schedule ?? item.target_schedule ?? null, environment: item.environment ?? null,
       covers: item.covers ?? item.covered_services ?? [],
       falsifies: item.falsification ?? '', blocker: item.blocked_by ?? null,

--- a/openbank-admin-ui/src/app/api/test-intelligence/route.ts
+++ b/openbank-admin-ui/src/app/api/test-intelligence/route.ts
@@ -172,6 +172,13 @@ async function attachLiveJourneys(report: TestIntelligenceReport): Promise<TestI
   const nowSeconds = Date.now() / 1000
   const syntheticJourneys = await Promise.all(report.syntheticJourneys.map(async journey => {
     if (journey.status !== 'active') return journey
+    // Browser synthetics run in GitHub Actions, not Kubernetes. Their immutable run envelope is
+    // the authoritative verdict; querying a non-existent CronJob would turn valid evidence into
+    // a false "not run" result in the operator UI.
+    if (journey.executor === 'github-actions') return {
+      ...journey,
+      state: journey.ci?.state ?? 'not-run' as EvidenceState,
+    }
     const cronjob = cronjobSelector(journey.id)
     if (!cronjob) return journey
     // A failure must remain visible for the same evidence window used to judge a

--- a/openbank-admin-ui/src/lib/types/test-intelligence.ts
+++ b/openbank-admin-ui/src/lib/types/test-intelligence.ts
@@ -143,6 +143,7 @@ export interface SyntheticJourneyEvidence {
   status: 'active' | 'planned'
   state: EvidenceState
   severity: string
+  executor?: 'kubernetes-cronjob' | 'github-actions'
   schedule: string | null
   environment: string | null
   covers: string[]

--- a/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
@@ -51,6 +51,15 @@ journeys:
     capability: proves the mobile critical path
     falsification: break the app route
     blocked_by: needs canary devices
+  - id: admin-ui-sso-boundary
+    title: Admin UI SSO boundary
+    status: active
+    severity: ticket
+    money_moving: false
+    workflow: .github/workflows/admin-ui-browser-synthetic.yml
+    schedule: "13 */2 * * *"
+    capability: proves the public SSO hand-off
+    falsification: remove the SSO boundary
 money_path_accountability:
   default_blocker: needs synthetic parties
   services:
@@ -95,7 +104,10 @@ scenarios:
       schemaVersion: 1,
       run: { id: 'synthetic-9', attempt: 1, commit: '123456789abc', branch: 'main', workflow: 'Synthetic journeys', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/synthetic-9', observedAt: '2026-08-25T08:00:00Z' },
       component: 'openbank-platform', suites: [], coverage: null, testInfrastructure: { declared: [], observed: [] },
-      specializedEvidence: [{ kind: 'synthetic', state: 'passed', source: 'journey:edge', detail: '2 threshold result(s), 0 breached' }],
+      specializedEvidence: [
+        { kind: 'synthetic', state: 'passed', source: 'journey:edge', detail: '2 threshold result(s), 0 breached' },
+        { kind: 'synthetic', state: 'passed', source: 'journey:admin-ui-sso-boundary', detail: '1/1 browser E2E checks executed' },
+      ],
     }))
     const out = path.join(repo, 'report.json')
     execFileSync('node', [SCRIPT, '--repo', repo, '--out', out, '--stale-after-days', '99999'])
@@ -117,6 +129,9 @@ scenarios:
       state: 'passed', detail: '2 threshold result(s), 0 breached', run: { id: 'synthetic-9', workflow: 'Synthetic journeys' },
     } })
     expect(report.syntheticJourneys[1]).toMatchObject({ id: 'mobile', state: 'blocked', schedule: '0 * * * *', blocker: 'needs canary devices' })
+    expect(report.syntheticJourneys.find(item => item.id === 'admin-ui-sso-boundary')).toMatchObject({
+      status: 'active', executor: 'github-actions', ci: { state: 'passed', detail: '1/1 browser E2E checks executed' },
+    })
     expect(report.journeyCoverage).toMatchObject({ moneyPathTotal: 2, activelyCovered: 1, explicitlyUnwatched: 1 })
     expect(report.journeyCoverage?.services).toEqual([
       expect.objectContaining({ component: 'openbank-alpha-service', state: 'covered', journeys: ['edge'] }),

--- a/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
@@ -57,6 +57,7 @@ journeys:
     severity: ticket
     money_moving: false
     workflow: .github/workflows/admin-ui-browser-synthetic.yml
+    workflow_name: Admin UI browser synthetic
     schedule: "13 */2 * * *"
     capability: proves the public SSO hand-off
     falsification: remove the SSO boundary
@@ -106,8 +107,13 @@ scenarios:
       component: 'openbank-platform', suites: [], coverage: null, testInfrastructure: { declared: [], observed: [] },
       specializedEvidence: [
         { kind: 'synthetic', state: 'passed', source: 'journey:edge', detail: '2 threshold result(s), 0 breached' },
-        { kind: 'synthetic', state: 'passed', source: 'journey:admin-ui-sso-boundary', detail: '1/1 browser E2E checks executed' },
       ],
+    }))
+    write(repo, 'openbank-admin-ui/test-run-history/browser-synthetic.json', JSON.stringify({
+      schemaVersion: 1,
+      run: { id: 'browser-10', attempt: 1, commit: '123456789abc', branch: 'main', workflow: 'Admin UI browser synthetic', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/browser-10', observedAt: '2026-08-25T08:10:00Z' },
+      component: 'openbank-admin-ui', suites: [], coverage: null, testInfrastructure: { declared: [], observed: [] },
+      specializedEvidence: [{ kind: 'synthetic', state: 'passed', source: 'journey:admin-ui-sso-boundary', detail: '1/1 browser E2E checks executed' }],
     }))
     const out = path.join(repo, 'report.json')
     execFileSync('node', [SCRIPT, '--repo', repo, '--out', out, '--stale-after-days', '99999'])

--- a/openbank-libs/governance/journeys.yaml
+++ b/openbank-libs/governance/journeys.yaml
@@ -97,6 +97,25 @@ journeys:
       CATALOG_BASE to a route that returns 5xx. The exact mounted k6 program must fail its
       status, JSON-shape, and latency thresholds within one scheduled interval.
 
+  - id: admin-ui-sso-boundary
+    title: "Admin UI SSO boundary"
+    capability: >-
+      The public Admin UI reaches and renders its Keycloak SSO boundary in a real browser. This
+      proves the unauthenticated hand-off only; it does not claim an authenticated operator flow.
+    status: active
+    severity: ticket
+    money_moving: false
+    workflow: .github/workflows/admin-ui-browser-synthetic.yml
+    schedule: "13 */2 * * *"
+    environment: sandbox
+    falsification: >-
+      Return a 5xx from the Admin UI, remove the Keycloak SSO boundary, or point the browser
+      target at a host that cannot render it. The scheduled Chromium run must fail and retain
+      its immutable evidence envelope.
+    runtime_note: >-
+      This is deliberately credential-free. A separate least-privilege canary identity is still
+      required before an authenticated operator journey can be claimed.
+
   # ---------------------------------------------------------------------------------------
   # PLANNED — the journeys that would have caught the two reported outages. Both need a
   # synthetic party that can hold an account and a device, which is ADR-0252 phase 1.

--- a/openbank-libs/governance/journeys.yaml
+++ b/openbank-libs/governance/journeys.yaml
@@ -106,6 +106,7 @@ journeys:
     severity: ticket
     money_moving: false
     workflow: .github/workflows/admin-ui-browser-synthetic.yml
+    workflow_name: Admin UI browser synthetic
     schedule: "13 */2 * * *"
     environment: sandbox
     falsification: >-


### PR DESCRIPTION
Refs #7284

Makes the Admin UI browser SSO-boundary probe a governed active synthetic: the catalog verifies its committed GitHub Actions schedule, retains its executor type, and Admin UI uses its immutable CI verdict instead of querying a non-existent Kubernetes CronJob.

It remains credential-free and explicitly does not claim authenticated operator access.

Verified locally:
- `python3 .github/scripts/check-journey-catalog.py --self-test`
- `python3 .github/scripts/check-journey-catalog.py --root . --enforce`
- `npm run test -- --run src/test/test-intelligence-collector.test.ts src/test/test-intelligence-route.test.ts` (19/19)
- ESLint and `git diff --check`