### PR TITLE
test(release-steward): record container lifecycle evidence

### DIFF
--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -52,7 +52,6 @@ openbank-party-service/src/test/kotlin/com/openbank/party/it/PostgresRedpandaTes
 openbank-pid-service/src/test/kotlin/com/openbank/pid/it/PostgresTestResource.kt
 openbank-psd2-service/src/test/kotlin/com/openbank/psd2/it/PostgresRedisTestResource.kt
 openbank-referral-service/src/test/kotlin/com/openbank/referral/it/ReferralPostgresTestResource.kt
-openbank-release-steward/src/test/kotlin/com/openbank/releasesteward/PostgresTestResource.kt
 openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/it/PostgresTestResource.kt
 openbank-sca-service/src/test/kotlin/com/openbank/sca/it/PostgresRedisTestResource.kt
 openbank-sdd-service/src/test/kotlin/com/openbank/sdd/it/PostgresTestResource.kt

--- a/openbank-release-steward/build.gradle.kts
+++ b/openbank-release-steward/build.gradle.kts
@@ -44,6 +44,9 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.testcontainers.postgresql)
+    // Emits secret-free start/stop evidence for the real PostgreSQL Testcontainer. The CI
+    // envelope consumes it; test topology and datasource configuration stay unchanged.
+    testImplementation(project(":openbank-libs-testing"))
     testImplementation(libs.rest.assured.kotlin)
 }
 

--- a/openbank-release-steward/src/test/kotlin/com/openbank/releasesteward/PostgresTestResource.kt
+++ b/openbank-release-steward/src/test/kotlin/com/openbank/releasesteward/PostgresTestResource.kt
@@ -5,6 +5,7 @@
 
 package com.openbank.releasesteward
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.testcontainers.containers.PostgreSQLContainer
 
@@ -23,6 +24,7 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
             .withUsername("openbank")
             .withPassword("openbank")
         postgres.start()
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         // reactive URL for Panache (vertx-pg-client) + JDBC URL for Flyway.
         val reactiveUrl = "postgresql://${postgres.host}:${postgres.firstMappedPort}/${postgres.databaseName}"
         return mapOf(
@@ -34,6 +36,13 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        if (::postgres.isInitialized) postgres.stop()
+        if (::postgres.isInitialized) {
+            postgres.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
+    }
+
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:18-alpine"
     }
 }


### PR DESCRIPTION
Refs #7246

Migrates the non-money-path release-steward PostgreSQL Testcontainers resource to the shared secret-free lifecycle recorder. It preserves existing container topology and datasource handling; only started/stopped image lifecycle evidence is emitted to the CI envelope.

Verified locally:
- `./gradlew --no-daemon :openbank-release-steward:test --tests com.openbank.releasesteward.ReleaseStewardBootSmokeIT` (1/1)
- versioned envelope contains declared postgres plus observed started/stopped events
- `git diff --check`