### PR TITLE
fix(admin-ui): keep Explorer head visible

### DIFF
--- a/openbank-admin-ui/e2e/ui-primitives.spec.ts
+++ b/openbank-admin-ui/e2e/ui-primitives.spec.ts
@@ -107,6 +107,16 @@ test.describe('ADR-0208 primitives render with real CSS applied', () => {
     expect(Math.round((await page.locator('#admin-sidebar').boundingBox())!.width)).toBe(264)
     expect(Math.round((await page.locator('header').boundingBox())!.height)).toBe(60)
     expect(await page.locator('.page-header').evaluate(el => getComputedStyle(el).backgroundImage)).toContain('linear-gradient')
+
+    // The Explorer portrait is deliberately oversized and clipped by the guide,
+    // but its top (and therefore its head) must remain inside the visible banner.
+    // A negative portrait top previously left only the torso visible in production.
+    const explorerGuide = page.getByLabel('Welcome to your operations cockpit')
+    const guideBox = await explorerGuide.boundingBox()
+    const portraitBox = await explorerGuide.locator('img').boundingBox()
+    expect(guideBox).not.toBeNull()
+    expect(portraitBox).not.toBeNull()
+    expect(portraitBox!.y).toBeGreaterThanOrEqual(guideBox!.y)
   })
 
   test('tone swatches are square with zero padding, at both sizes', async ({ page }) => {

--- a/openbank-admin-ui/src/components/brand/ExplorerGuide.module.css
+++ b/openbank-admin-ui/src/components/brand/ExplorerGuide.module.css
@@ -64,8 +64,9 @@
 
 .portrait {
   position: absolute;
+  top: 0;
   right: -12px;
-  bottom: -150px;
+  bottom: auto;
   width: 300px;
   height: 450px;
   overflow: hidden;
@@ -94,8 +95,9 @@
 }
 
 .compact .portrait {
+  top: 0;
   right: -8px;
-  bottom: -108px;
+  bottom: auto;
   width: 168px;
   height: 252px;
 }
@@ -114,6 +116,7 @@
 
   .portrait,
   .compact .portrait {
+    top: auto;
     right: -18px;
     bottom: -112px;
     width: 172px;


### PR DESCRIPTION
## Summary
- anchor desktop and compact Explorer portraits to the top of the guide
- preserve the bottom-aligned mobile composition
- assert the portrait starts inside the visible guide in Chromium

## Verification
- `npx playwright test e2e/ui-primitives.spec.ts --grep "dashboard distinguishes"` (1/1)
- `git diff --check`

Closes #7361