### PR TITLE
test(admin-ui): bound synthetic SSO response time

### DIFF
--- a/openbank-admin-ui/scripts/admin-login-synthetic.mjs
+++ b/openbank-admin-ui/scripts/admin-login-synthetic.mjs
@@ -6,23 +6,36 @@ import { mkdir, writeFile } from 'node:fs/promises'
 
 const target = process.env.ADMIN_UI_SYNTHETIC_URL ?? 'https://admin.open-bank.tech/system/tests'
 const report = process.env.PLAYWRIGHT_JUNIT_OUTPUT_FILE ?? 'build/test-results/e2e/admin-login-synthetic.xml'
+// A deliberately forgiving public-edge budget. This is a synthetic availability guard, not an
+// authenticated operator-flow SLO or a substitute for RUM Web Vitals. It prevents a page that
+// eventually renders after a multi-second upstream stall from reading as simply "healthy".
+const RESPONSE_START_BUDGET_MS = 5_000
 const started = Date.now()
-let failure = null
+let boundaryFailure = null
+let latencyFailure = null
 let browser
 try {
   browser = await chromium.launch({ headless: true })
   const page = await browser.newPage()
   const response = await page.goto(target, { waitUntil: 'domcontentloaded', timeout: 20_000 })
-  if (!response || response.status() >= 500) throw new Error(`Admin UI returned ${response?.status() ?? 'no response'}`)
+  if (!response || response.status() >= 500) boundaryFailure = `Admin UI returned ${response?.status() ?? 'no response'}`
   const signIn = page.getByRole('button', { name: 'Continue with Keycloak SSO' })
-  if (!await signIn.isVisible({ timeout: 10_000 })) throw new Error('SSO boundary was not rendered')
+  if (!await signIn.isVisible({ timeout: 10_000 })) boundaryFailure ??= 'SSO boundary was not rendered'
+  const responseStart = await page.evaluate(() => performance.getEntriesByType('navigation')[0]?.responseStart)
+  if (!Number.isFinite(responseStart) || responseStart > RESPONSE_START_BUDGET_MS) {
+    latencyFailure = `SSO boundary responseStart ${Number.isFinite(responseStart) ? Math.round(responseStart) : 'unavailable'}ms exceeds ${RESPONSE_START_BUDGET_MS}ms budget`
+  }
 } catch (error) {
-  failure = error instanceof Error ? error.message : 'unknown browser synthetic failure'
+  boundaryFailure ??= error instanceof Error ? error.message : 'unknown browser synthetic failure'
+  latencyFailure ??= boundaryFailure
 } finally {
   await browser?.close()
 }
 await mkdir(report.slice(0, report.lastIndexOf('/')), { recursive: true })
 const seconds = ((Date.now() - started) / 1000).toFixed(3)
-const escaped = failure?.replace(/[&<>"']/g, char => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&apos;' })[char])
-await writeFile(report, `<testsuites><testsuite name="admin-login-synthetic" tests="1" failures="${failure ? 1 : 0}" errors="0" skipped="0" time="${seconds}"><testcase classname="admin-login-synthetic" name="renders SSO boundary" time="${seconds}">${failure ? `<failure message="${escaped}"/>` : ''}</testcase></testsuite></testsuites>\n`)
-if (failure) throw new Error(failure)
+const escape = value => value.replace(/[&<>"']/g, char => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&apos;' })[char])
+const boundary = boundaryFailure && `<failure message="${escape(boundaryFailure)}"/>`
+const latency = latencyFailure && `<failure message="${escape(latencyFailure)}"/>`
+const failureCount = Number(Boolean(boundaryFailure)) + Number(Boolean(latencyFailure))
+await writeFile(report, `<testsuites><testsuite name="admin-login-synthetic" tests="2" failures="${failureCount}" errors="0" skipped="0" time="${seconds}"><testcase classname="admin-login-synthetic" name="renders SSO boundary" time="${seconds}">${boundary ?? ''}</testcase><testcase classname="admin-login-synthetic" name="SSO boundary responds within public latency budget" time="${seconds}">${latency ?? ''}</testcase></testsuite></testsuites>\n`)
+if (failureCount) throw new Error([boundaryFailure, latencyFailure].filter(Boolean).join('; '))


### PR DESCRIPTION
Refs #7284

Adds a credential-free response-start budget to the existing Admin UI SSO-boundary browser synthetic. The JUnit evidence keeps availability and latency as separate assertions, so the versioned envelope projects two executed E2E checks without claiming an authenticated operator flow or RUM Web Vitals.

Verified against sandbox:
- `node scripts/admin-login-synthetic.mjs` (2/2)
- versioned envelope projects `2/2 browser E2E checks executed`
- `python3 .github/scripts/collect-test-run-evidence.py --self-test`
- `git diff --check`