### PR TITLE
fix(perf): retain performance evidence in run history

### DIFF
--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -253,6 +253,18 @@ jobs:
           path: perf-reports/
           retention-days: 30
 
+      # The Admin UI deploy collector intentionally reads only immutable, provenance-complete
+      # `test-intelligence-run-*` artifacts. Keep the human-facing report bundle above, but
+      # publish this same versioned envelope under the fleet-wide projection contract too.
+      - name: Upload immutable Test Intelligence performance envelope
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-intelligence-run-${{ matrix.service }}-${{ github.run_id }}-a${{ github.run_attempt }}
+          path: perf-reports/${{ matrix.service }}-run.json
+          retention-days: 30
+          if-no-files-found: error
+
   # ── The alarm (ADR-0243 decision 2, issue #3768) ──────────────────────────────
   # ADR-0243 and this file's own header both promise that an advisory-phase threshold
   # breach "creates issues rather than blocking merges". Until now nothing did: a breach


### PR DESCRIPTION
Refs #7284

The Admin UI Performance tab already stages the latest k6 report separately. This change closes a different gap: the same provenance-complete performance envelope was not published under the immutable `test-intelligence-run-*` contract, so it could not participate in the unified per-attempt Test Intelligence history alongside CI, synthetic and trace evidence.

This adds a second upload of the existing versioned envelope under that fleet-wide history contract. It does not change the load test, target, threshold policy, advisory behavior, or the existing Performance-tab staging.

Verified:
- workflow YAML parses
- `python3 .github/scripts/collect-test-run-evidence.py --self-test`
- `git diff --check`