### PR TITLE
test(governance-auditor): record container lifecycle

### DIFF
--- a/openbank-governance-auditor/build.gradle.kts
+++ b/openbank-governance-auditor/build.gradle.kts
@@ -41,6 +41,8 @@ dependencies {
     testImplementation("io.temporal:temporal-testing:1.25.1")
     testImplementation("io.grpc:grpc-inprocess:1.68.1")
     testImplementation(libs.quarkus.junit5)
+    // Emits secret-free Testcontainers lifecycle evidence into the versioned CI envelope.
+    testImplementation(project(":openbank-libs-testing"))
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.testcontainers.postgresql)

--- a/openbank-governance-auditor/src/test/kotlin/com/openbank/govaudit/PostgresTestResource.kt
+++ b/openbank-governance-auditor/src/test/kotlin/com/openbank/govaudit/PostgresTestResource.kt
@@ -5,6 +5,7 @@
 
 package com.openbank.govaudit
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.testcontainers.containers.PostgreSQLContainer
 
@@ -15,14 +16,19 @@ import org.testcontainers.containers.PostgreSQLContainer
  */
 class PostgresTestResource : QuarkusTestResourceLifecycleManager {
 
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:18-alpine"
+    }
+
     private lateinit var postgres: PostgreSQLContainer<*>
 
     override fun start(): Map<String, String> {
-        postgres = PostgreSQLContainer("postgres:18-alpine")
+        postgres = PostgreSQLContainer(POSTGRES_IMAGE)
             .withDatabaseName("openbank_govaudit")
             .withUsername("openbank")
             .withPassword("openbank")
         postgres.start()
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         // reactive URL for Panache (vertx-pg-client) + JDBC URL for Flyway.
         val reactiveUrl = "postgresql://${postgres.host}:${postgres.firstMappedPort}/${postgres.databaseName}"
         return mapOf(
@@ -34,6 +40,9 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        if (::postgres.isInitialized) postgres.stop()
+        if (::postgres.isInitialized) {
+            postgres.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
     }
 }

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -38,7 +38,6 @@ openbank-finops-agent/src/test/kotlin/com/openbank/finops/PostgresTestResource.k
 openbank-fraud-service/src/test/kotlin/com/openbank/fraud/it/PostgresRedisRedpandaTestResource.kt
 openbank-fraud-service/src/test/kotlin/com/openbank/fraud/it/PostgresRedisTestResource.kt
 openbank-fx-service/src/test/kotlin/com/openbank/fx/it/PostgresRedisTestResource.kt
-openbank-governance-auditor/src/test/kotlin/com/openbank/govaudit/PostgresTestResource.kt
 openbank-interest-service/src/test/kotlin/com/openbank/interest/it/PostgresRedisTestResource.kt
 openbank-kyc-service/src/test/kotlin/com/openbank/kyc/it/PostgresTestResource.kt
 openbank-ledger-service/src/test/kotlin/com/openbank/ledger/it/PostgresRedpandaTestResource.kt


### PR DESCRIPTION
Refs #7246

Migrates the non-money-path governance-auditor PostgreSQL Testcontainers resource to the shared secret-free lifecycle recorder. Existing container topology and datasource handling are unchanged; the versioned CI envelope now records observed PostgreSQL start/stop.

Verified locally:
- `./gradlew --no-daemon :openbank-governance-auditor:test --tests com.openbank.govaudit.GovernanceAuditorBootSmokeIT` (1/1)
- generated envelope contains declared postgres and observed started/stopped lifecycle
- Test Intelligence ecosystem gate and self-test
- `git diff --check`