### PR TITLE
test(finops): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-finops-agent/build.gradle.kts
+++ b/openbank-finops-agent/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.rest.assured.kotlin)
+    testImplementation(project(":openbank-libs-testing"))
 }
 
 // Package the ADR-0148 prompt registry onto the classpath so LlmDiagnosisAdapter loads its

--- a/openbank-finops-agent/src/test/kotlin/com/openbank/finops/PostgresTestResource.kt
+++ b/openbank-finops-agent/src/test/kotlin/com/openbank/finops/PostgresTestResource.kt
@@ -5,6 +5,7 @@
 
 package com.openbank.finops
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.testcontainers.containers.PostgreSQLContainer
 
@@ -15,14 +16,19 @@ import org.testcontainers.containers.PostgreSQLContainer
  */
 class PostgresTestResource : QuarkusTestResourceLifecycleManager {
 
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:18-alpine"
+    }
+
     private lateinit var postgres: PostgreSQLContainer<*>
 
     override fun start(): Map<String, String> {
-        postgres = PostgreSQLContainer("postgres:18-alpine")
+        postgres = PostgreSQLContainer(POSTGRES_IMAGE)
             .withDatabaseName("openbank_finops")
             .withUsername("openbank")
             .withPassword("openbank")
         postgres.start()
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         val reactiveUrl = "postgresql://${postgres.host}:${postgres.firstMappedPort}/${postgres.databaseName}"
         return mapOf(
             "quarkus.datasource.reactive.url" to reactiveUrl,
@@ -33,6 +39,9 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        if (::postgres.isInitialized) postgres.stop()
+        if (::postgres.isInitialized) {
+            postgres.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
     }
 }

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -34,7 +34,6 @@ openbank-docs-truth-agent/src/test/kotlin/com/openbank/docstruth/PostgresTestRes
 openbank-document-service/src/test/kotlin/com/openbank/document/it/PostgresRedisTestResource.kt
 openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/it/PostgresRedisTestResource.kt
 openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/EngagementPostgresTestResource.kt
-openbank-finops-agent/src/test/kotlin/com/openbank/finops/PostgresTestResource.kt
 openbank-fraud-service/src/test/kotlin/com/openbank/fraud/it/PostgresRedisRedpandaTestResource.kt
 openbank-fraud-service/src/test/kotlin/com/openbank/fraud/it/PostgresRedisTestResource.kt
 openbank-fx-service/src/test/kotlin/com/openbank/fx/it/PostgresRedisTestResource.kt


### PR DESCRIPTION
## Summary
- record the actual PostgreSQL Testcontainers start/stop lifecycle for the FinOps integration suite
- remove the migrated service-owned resource from the ratcheted evidence baseline
- keep runtime evidence secret-free (no host, port, container id or credential)

## Verification
- `./gradlew --no-daemon :openbank-finops-agent:test --tests 'com.openbank.finops.PostgresAnomalyRepositoryIT'` (6/6)\n- `python3 .github/scripts/collect-test-run-evidence.py --service openbank-finops-agent --out /tmp/finops-container-evidence-run.json` (PostgreSQL started/stopped observed)\n- `python3 .github/scripts/check-test-intelligence-ecosystem.py --root .`\n- `git diff --check`\n\nRefs #7246