### PR TITLE
test(case-coordinator): record container lifecycle evidence

### DIFF
--- a/openbank-case-coordinator-agent/build.gradle.kts
+++ b/openbank-case-coordinator-agent/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.rest.assured.kotlin)
+    testImplementation(project(":openbank-libs-testing"))
     // Phase 2 (#4185): git-pact for the admin-ui read contract — consumer test generates
     // pacts/openbank-admin-ui-openbank-case-coordinator-agent.json, provider replays it (ADR-0063).
     testImplementation(libs.pact.consumer)

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/PostgresTestResource.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/PostgresTestResource.kt
@@ -5,6 +5,7 @@
 
 package com.openbank.casecoordinator
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.testcontainers.containers.PostgreSQLContainer
 
@@ -15,14 +16,19 @@ import org.testcontainers.containers.PostgreSQLContainer
  */
 class PostgresTestResource : QuarkusTestResourceLifecycleManager {
 
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:18-alpine"
+    }
+
     private lateinit var postgres: PostgreSQLContainer<*>
 
     override fun start(): Map<String, String> {
-        postgres = PostgreSQLContainer("postgres:18-alpine")
+        postgres = PostgreSQLContainer(POSTGRES_IMAGE)
             .withDatabaseName("openbank_casecoordinator")
             .withUsername("openbank")
             .withPassword("openbank")
         postgres.start()
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         // reactive URL for Panache (vertx-pg-client) + JDBC URL for Flyway.
         val reactiveUrl = "postgresql://${postgres.host}:${postgres.firstMappedPort}/${postgres.databaseName}"
         return mapOf(
@@ -34,6 +40,9 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        if (::postgres.isInitialized) postgres.stop()
+        if (::postgres.isInitialized) {
+            postgres.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
     }
 }

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -21,7 +21,6 @@ openbank-balance-service/src/test/kotlin/com/openbank/balance/it/PostgresRedpand
 openbank-billing-service/src/test/kotlin/com/openbank/billing/it/PostgresRedisTestResource.kt
 openbank-campaign-service/src/test/kotlin/com/openbank/campaign/it/CampaignPostgresRedisTestResource.kt
 openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/it/PostgresRedisTestResource.kt
-openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/PostgresTestResource.kt
 openbank-clearing-service/src/test/kotlin/com/openbank/clearing/it/PostgresRedpandaRedisTestResource.kt
 openbank-consent-service/src/test/kotlin/com/openbank/consent/it/ConsentPostgresRedisTestResource.kt
 openbank-consent-service/src/test/kotlin/com/openbank/consent/it/PostgresTestResource.kt


### PR DESCRIPTION
## Summary
- record the actual PostgreSQL Testcontainers lifecycle for case-coordinator agent integration tests
- remove the migrated resource from the ratcheted baseline
- keep envelope evidence secret-free

## Verification
- `./gradlew --no-daemon :openbank-case-coordinator-agent:test --tests 'com.openbank.casecoordinator.CaseCoordinatorBootSmokeIT'` (2/2)\n- Test Intelligence envelope: PostgreSQL started/stopped observed\n- `python3 .github/scripts/check-test-intelligence-ecosystem.py --root .`\n- `git diff --check`\n\nRefs #7246