### PR TITLE
test(devops): record container lifecycle evidence

### DIFF
--- a/openbank-devops-agent/build.gradle.kts
+++ b/openbank-devops-agent/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.testcontainers.postgresql)
+    testImplementation(project(":openbank-libs-testing"))
     testImplementation(libs.rest.assured.kotlin)
 }
 

--- a/openbank-devops-agent/src/test/kotlin/com/openbank/devops/PostgresTestResource.kt
+++ b/openbank-devops-agent/src/test/kotlin/com/openbank/devops/PostgresTestResource.kt
@@ -5,6 +5,7 @@
 
 package com.openbank.devops
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.testcontainers.containers.PostgreSQLContainer
 
@@ -15,14 +16,19 @@ import org.testcontainers.containers.PostgreSQLContainer
  */
 class PostgresTestResource : QuarkusTestResourceLifecycleManager {
 
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:18-alpine"
+    }
+
     private lateinit var postgres: PostgreSQLContainer<*>
 
     override fun start(): Map<String, String> {
-        postgres = PostgreSQLContainer("postgres:18-alpine")
+        postgres = PostgreSQLContainer(POSTGRES_IMAGE)
             .withDatabaseName("openbank_devops")
             .withUsername("openbank")
             .withPassword("openbank")
         postgres.start()
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         // reactive URL for Panache (vertx-pg-client) + JDBC URL for Flyway.
         val reactiveUrl = "postgresql://${postgres.host}:${postgres.firstMappedPort}/${postgres.databaseName}"
         return mapOf(
@@ -34,6 +40,9 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        if (::postgres.isInitialized) postgres.stop()
+        if (::postgres.isInitialized) {
+            postgres.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
     }
 }

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -28,7 +28,6 @@ openbank-consent-service/src/test/kotlin/com/openbank/consent/it/PostgresTestRes
 openbank-control-liveness-sentinel/src/test/kotlin/com/openbank/liveness/PostgresTestResource.kt
 openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/it/RedpandaRedisTestResource.kt
 openbank-delegation-service/src/test/kotlin/com/openbank/delegation/it/PostgresTestResource.kt
-openbank-devops-agent/src/test/kotlin/com/openbank/devops/PostgresTestResource.kt
 openbank-dispute-service/src/test/kotlin/com/openbank/dispute/it/PostgresTestResource.kt
 openbank-docs-truth-agent/src/test/kotlin/com/openbank/docstruth/PostgresTestResource.kt
 openbank-document-service/src/test/kotlin/com/openbank/document/it/PostgresRedisTestResource.kt


### PR DESCRIPTION
## Summary
- record actual PostgreSQL Testcontainers lifecycle evidence from DevOps agent integration tests
- retire the migrated resource from the ratcheted baseline
- preserve secret-free envelope output

## Verification
- `./gradlew --no-daemon :openbank-devops-agent:test --tests 'com.openbank.devops.DevOpsBootSmokeIT'` (1/1)\n- Test Intelligence envelope contains PostgreSQL started/stopped observations\n- `python3 .github/scripts/check-test-intelligence-ecosystem.py --root .`\n- `git diff --check`\n\nRefs #7246