### PR TITLE
perf(flaky-test-hunter): add read-path smoke coverage

### DIFF
--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -6,8 +6,8 @@
 # PR gate during the pilot: it runs weekly on openbank-batch and on manual
 # dispatch, and its failures create issues rather than blocking merges.
 #
-# v1 scope: openbank-product-catalog only. Money-path services follow once the
-# harness is proven (issue #3348).
+# v1 scope: read-only Product Catalog and Flaky Test Hunter paths. Money-path services follow
+# only once the isolated harness and synthetic-data boundary are proven (issue #3348).
 name: Performance gate
 
 on:
@@ -46,7 +46,10 @@ jobs:
           import json, os, pathlib, re
           # The declared v1 scope (ADR-0243, issue #3348). Kept as a named constant so the
           # summary can say what the run was SUPPOSED to measure, not only what it did.
-          DECLARED = ["openbank-product-catalog"]
+          # Both subjects are non-mutating reads booted against disposable PostgreSQL.  Keep
+          # money-path flows out of this GitHub-hosted lane until their isolated target and
+          # synthetic identities exist (perf/scenarios.yaml).
+          DECLARED = ["openbank-product-catalog", "openbank-flaky-test-hunter"]
           override = (os.environ.get("OVERRIDE") or "").split()
           services = override or list(DECLARED)
           matrix, skipped = [], []

--- a/openbank-authz-policy-auditor/build.gradle.kts
+++ b/openbank-authz-policy-auditor/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     testImplementation("io.temporal:temporal-testing:1.25.1")
     testImplementation("io.grpc:grpc-inprocess:1.68.1")
     testImplementation(libs.quarkus.junit5)
+    testImplementation(libs.quarkus.test.security)
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.testcontainers.postgresql)

--- a/openbank-authz-policy-auditor/src/main/kotlin/com/openbank/authzaudit/infrastructure/rest/AuthzPolicyResource.kt
+++ b/openbank-authz-policy-auditor/src/main/kotlin/com/openbank/authzaudit/infrastructure/rest/AuthzPolicyResource.kt
@@ -36,14 +36,11 @@ class AuthzPolicyResource(
     @GET
     @Path("/findings")
     @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
-    fun getActiveFindings(): List<AuthzPolicyFinding> = runBlocking {
-        getFindings.getActive()
-    }
+    suspend fun getActiveFindings(): List<AuthzPolicyFinding> = getFindings.getActive()
 
     @GET
     @Path("/findings/{id}")
     @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
-    fun getFinding(@PathParam("id") id: String): AuthzPolicyFinding = runBlocking {
+    suspend fun getFinding(@PathParam("id") id: String): AuthzPolicyFinding =
         getFindings.getById(id) ?: throw NotFoundException("Finding $id not found")
-    }
 }

--- a/openbank-authz-policy-auditor/src/test/kotlin/com/openbank/authzaudit/AuthzPolicyAuditorBootSmokeIT.kt
+++ b/openbank-authz-policy-auditor/src/test/kotlin/com/openbank/authzaudit/AuthzPolicyAuditorBootSmokeIT.kt
@@ -7,6 +7,7 @@ package com.openbank.authzaudit
 
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
 import io.restassured.RestAssured.given
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
@@ -22,6 +23,14 @@ import org.junit.jupiter.api.Test
 @QuarkusTest
 @QuarkusTestResource(PostgresTestResource::class)
 class AuthzPolicyAuditorBootSmokeIT {
+
+    @Test
+    @TestSecurity(user = "viewer", roles = ["ROLE_VIEWER"])
+    fun `viewer findings query reaches reactive persistence`() {
+        given()
+            .`when`().get("/api/v1/authz-policy-auditor/findings")
+            .then().statusCode(200)
+    }
 
     @Test
     fun `application boots and reports ready against a live database`() {

--- a/openbank-control-liveness-sentinel/build.gradle.kts
+++ b/openbank-control-liveness-sentinel/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     testImplementation("io.temporal:temporal-testing:1.25.1")
     testImplementation("io.grpc:grpc-inprocess:1.68.1")
     testImplementation(libs.quarkus.junit5)
+    testImplementation(libs.quarkus.test.security)
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.testcontainers.postgresql)

--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/rest/LivenessSentinelResource.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/rest/LivenessSentinelResource.kt
@@ -36,14 +36,11 @@ class LivenessSentinelResource(
     @GET
     @Path("/findings")
     @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
-    fun getActiveFindings(): List<LivenessFinding> = runBlocking {
-        getFindings.getActive()
-    }
+    suspend fun getActiveFindings(): List<LivenessFinding> = getFindings.getActive()
 
     @GET
     @Path("/findings/{id}")
     @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
-    fun getFinding(@PathParam("id") id: String): LivenessFinding = runBlocking {
+    suspend fun getFinding(@PathParam("id") id: String): LivenessFinding =
         getFindings.getById(id) ?: throw NotFoundException("Finding $id not found")
-    }
 }

--- a/openbank-control-liveness-sentinel/src/test/kotlin/com/openbank/liveness/LivenessBootSmokeIT.kt
+++ b/openbank-control-liveness-sentinel/src/test/kotlin/com/openbank/liveness/LivenessBootSmokeIT.kt
@@ -7,6 +7,7 @@ package com.openbank.liveness
 
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
 import io.restassured.RestAssured.given
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
@@ -22,6 +23,14 @@ import org.junit.jupiter.api.Test
 @QuarkusTest
 @QuarkusTestResource(PostgresTestResource::class)
 class LivenessBootSmokeIT {
+
+    @Test
+    @TestSecurity(user = "viewer", roles = ["ROLE_VIEWER"])
+    fun `viewer findings query reaches reactive persistence`() {
+        given()
+            .`when`().get("/api/v1/liveness-sentinel/findings")
+            .then().statusCode(200)
+    }
 
     @Test
     fun `application boots and reports ready against a live database`() {

--- a/openbank-finops-agent/build.gradle.kts
+++ b/openbank-finops-agent/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     testImplementation("io.temporal:temporal-testing:1.25.1")
     testImplementation("io.grpc:grpc-inprocess:1.68.1")
     testImplementation(libs.quarkus.junit5)
+    testImplementation(libs.quarkus.test.security)
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.testcontainers.postgresql)

--- a/openbank-finops-agent/src/main/kotlin/com/openbank/finops/infrastructure/rest/FinOpsResource.kt
+++ b/openbank-finops-agent/src/main/kotlin/com/openbank/finops/infrastructure/rest/FinOpsResource.kt
@@ -36,14 +36,11 @@ class FinOpsResource(
     @GET
     @Path("/anomalies")
     @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
-    fun getActiveAnomalies(): List<CostAnomaly> = runBlocking {
-        getAnomalies.getActive()
-    }
+    suspend fun getActiveAnomalies(): List<CostAnomaly> = getAnomalies.getActive()
 
     @GET
     @Path("/anomalies/{id}")
     @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
-    fun getAnomaly(@PathParam("id") id: String): CostAnomaly = runBlocking {
+    suspend fun getAnomaly(@PathParam("id") id: String): CostAnomaly =
         getAnomalies.getById(id) ?: throw NotFoundException("Anomaly $id not found")
-    }
 }

--- a/openbank-finops-agent/src/test/kotlin/com/openbank/finops/FinOpsResourceRoutingIT.kt
+++ b/openbank-finops-agent/src/test/kotlin/com/openbank/finops/FinOpsResourceRoutingIT.kt
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.finops
+
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured.given
+import org.junit.jupiter.api.Test
+
+/** Proves the viewer read uses the live reactive repository, not a worker-thread bridge. */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class FinOpsResourceRoutingIT {
+
+    @Test
+    @TestSecurity(user = "viewer", roles = ["ROLE_VIEWER"])
+    fun `viewer anomalies query reaches reactive persistence`() {
+        given()
+            .`when`().get("/api/v1/finops/anomalies")
+            .then().statusCode(200)
+    }
+}

--- a/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/infrastructure/rest/FlakyTestResource.kt
+++ b/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/infrastructure/rest/FlakyTestResource.kt
@@ -59,16 +59,13 @@ class FlakyTestResource(
     @GET
     @Path("/findings")
     @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
-    fun getActiveFindings(): List<FlakyTestFinding> = runBlocking {
-        getFindings.getActive()
-    }
+    suspend fun getActiveFindings(): List<FlakyTestFinding> = getFindings.getActive()
 
     @GET
     @Path("/findings/{id}")
     @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
-    fun getFinding(@PathParam("id") id: String): FlakyTestFinding = runBlocking {
+    suspend fun getFinding(@PathParam("id") id: String): FlakyTestFinding =
         getFindings.getById(id) ?: throw NotFoundException("Finding $id not found")
-    }
 }
 
 data class FlakyTestCheckStarted(val workflowId: String)

--- a/openbank-flaky-test-hunter/src/test/k6/flaky-test-hunter-smoke.js
+++ b/openbank-flaky-test-hunter/src/test/k6/flaky-test-hunter-smoke.js
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+// Read-only performance smoke for the control-plane findings query. The perf gate starts the
+// service with OIDC disabled in its disposable dev stack; no operator credential or live finding
+// data leaves the runner.
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8148';
+
+export const options = {
+  vus: 5,
+  duration: '30s',
+  thresholds: {
+    http_req_duration: ['p(95)<2000'],
+    http_req_failed: ['rate<0.01'],
+    checks: ['rate==1.0'],
+  },
+};
+
+export default function () {
+  group('flaky-test-hunter findings read-only smoke', () => {
+    const res = http.get(`${BASE_URL}/api/v1/flaky-test-hunter/findings`, {
+      tags: { endpoint: 'findings-list', service: 'flaky-test-hunter' },
+    });
+
+    check(res, {
+      'findings-list status is 200': (r) => r.status === 200,
+      'findings-list returns JSON': (r) =>
+        r.headers['Content-Type'] && r.headers['Content-Type'].includes('application/json'),
+      'findings-list body is array': (r) => Array.isArray(JSON.parse(r.body)),
+    });
+
+    sleep(1);
+  });
+}

--- a/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/infrastructure/rest/FlakyTestResourceRoutingIT.kt
+++ b/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/infrastructure/rest/FlakyTestResourceRoutingIT.kt
@@ -16,6 +16,14 @@ import org.junit.jupiter.api.Test
 class FlakyTestResourceRoutingIT {
 
     @Test
+    @TestSecurity(user = "viewer", roles = ["ROLE_VIEWER"])
+    fun `findings read is served from the reactive Vertx context`() {
+        given()
+            .`when`().get("/api/v1/flaky-test-hunter/findings")
+            .then().statusCode(200)
+    }
+
+    @Test
     fun `async trigger is a served route that rejects an anonymous caller`() {
         given()
             .`when`().post("/api/v1/flaky-test-hunter/check/trigger-async")

--- a/openbank-governance-auditor/build.gradle.kts
+++ b/openbank-governance-auditor/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     testImplementation("io.temporal:temporal-testing:1.25.1")
     testImplementation("io.grpc:grpc-inprocess:1.68.1")
     testImplementation(libs.quarkus.junit5)
+    testImplementation(libs.quarkus.test.security)
     // Emits secret-free Testcontainers lifecycle evidence into the versioned CI envelope.
     testImplementation(project(":openbank-libs-testing"))
     testImplementation(libs.assertj)

--- a/openbank-governance-auditor/src/main/kotlin/com/openbank/govaudit/infrastructure/rest/GovernanceAuditorResource.kt
+++ b/openbank-governance-auditor/src/main/kotlin/com/openbank/govaudit/infrastructure/rest/GovernanceAuditorResource.kt
@@ -36,14 +36,11 @@ class GovernanceAuditorResource(
     @GET
     @Path("/findings")
     @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
-    fun getActiveFindings(): List<GovernanceFinding> = runBlocking {
-        getFindings.getActive()
-    }
+    suspend fun getActiveFindings(): List<GovernanceFinding> = getFindings.getActive()
 
     @GET
     @Path("/findings/{id}")
     @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
-    fun getFinding(@PathParam("id") id: String): GovernanceFinding = runBlocking {
+    suspend fun getFinding(@PathParam("id") id: String): GovernanceFinding =
         getFindings.getById(id) ?: throw NotFoundException("Finding $id not found")
-    }
 }

--- a/openbank-governance-auditor/src/test/kotlin/com/openbank/govaudit/GovernanceAuditorBootSmokeIT.kt
+++ b/openbank-governance-auditor/src/test/kotlin/com/openbank/govaudit/GovernanceAuditorBootSmokeIT.kt
@@ -7,6 +7,7 @@ package com.openbank.govaudit
 
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
 import io.restassured.RestAssured.given
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
@@ -22,6 +23,14 @@ import org.junit.jupiter.api.Test
 @QuarkusTest
 @QuarkusTestResource(PostgresTestResource::class)
 class GovernanceAuditorBootSmokeIT {
+
+    @Test
+    @TestSecurity(user = "viewer", roles = ["ROLE_VIEWER"])
+    fun `viewer findings query reaches reactive persistence`() {
+        given()
+            .`when`().get("/api/v1/governance-auditor/findings")
+            .then().statusCode(200)
+    }
 
     @Test
     fun `application boots and reports ready against a live database`() {


### PR DESCRIPTION
## What changed
- fixes a fleet-wide reactive Vert.x-context failure on agent findings/anomalies reads: Flaky Test Hunter, Authz Policy Auditor, Control Liveness Sentinel, FinOps and Governance Auditor
- adds live HTTP + Testcontainers regression coverage for all affected read paths
- adds Flaky Test Hunter as a non-mutating, disposable-PostgreSQL subject of the scheduled k6 performance gate

## Evidence
- Flaky Test Hunter routing 3/3 and evidence routing 2/2
- Authz Policy Auditor boot/read 2/2; Control Liveness boot/read 2/2; FinOps routing 1/1; Governance Auditor boot/read 2/2
- `check-test-intelligence-ecosystem.py` passes (`SUBJECTS=60`)
- k6 path extractor and JavaScript syntax checks pass

Refs #3348