### PR TITLE
fix(perf): allow cold Quarkus smoke startup

### DIFF
--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -196,8 +196,12 @@ jobs:
             > "perf-reports/${SERVICE}-boot.log" 2>&1 &
           DEV_PID=$!
 
+          # A cold Quarkus dev boot of the Flaky Test Hunter was measured at 188 seconds on
+          # the hosted runner (run 33070206256). The former 180-second probe window killed a
+          # still-starting process and incorrectly published performance as `not-run`. Keep a
+          # finite, visible five-minute ceiling: this is a smoke gate, not an unbounded build.
           UP=0
-          for _ in $(seq 1 90); do
+          for _ in $(seq 1 150); do
             code="$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${PORT}/q/health/ready" || true)"
             if [ "$code" = "200" ]; then UP=1; break; fi
             kill -0 "$DEV_PID" 2>/dev/null || break


### PR DESCRIPTION
Refs #3348

The main Flaky Test Hunter performance run reached the former 180-second readiness ceiling before k6 started, so its compatible envelope correctly reported `not-run`. The prior successful run on the same subject took 188 seconds from smoke-step start to completion.

This changes only the finite cold-start budget to 300 seconds. It does not weaken the ready-route probe, route-200 preflight, k6 thresholds, or failure envelope.