### PR TITLE
test(flaky-test-hunter): prove findings read trace contract

### DIFF
--- a/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/application/usecase/FlakyTestHunterService.kt
+++ b/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/application/usecase/FlakyTestHunterService.kt
@@ -20,6 +20,9 @@ import com.openbank.flakytest.domain.model.RunTrigger
 import com.openbank.flakytest.domain.model.TestIntelligenceAnalysisRequest
 import com.openbank.flakytest.domain.model.TestIntelligenceComponentInput
 import com.openbank.libs.temporal.TemporalConfig
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.api.trace.Tracer
 import io.temporal.client.WorkflowClient
 import io.temporal.client.WorkflowExecutionAlreadyStarted
 import io.temporal.client.WorkflowOptions
@@ -40,6 +43,7 @@ class FlakyTestHunterService(
     private val findingRepository: FindingRepository,
     private val llmDiagnosis: LlmDiagnosisPort,
     private val clock: Clock,
+    private val tracer: Tracer,
 ) : RunFlakyTestCheckUseCase,
     GetFindingsUseCase,
     AnalyzeTestIntelligenceUseCase {
@@ -74,7 +78,27 @@ class FlakyTestHunterService(
         return workflowId
     }
 
-    override suspend fun getActive(): List<FlakyTestFinding> = findingRepository.findActive()
+    /**
+     * A read of the evidence-backed operator queue is a control-plane operation, not merely an
+     * HTTP transport event.  Emit a bounded semantic span so an executable trace contract can
+     * prove the operation reached its repository without putting findings, IDs or prompt data in
+     * telemetry.
+     */
+    override suspend fun getActive(): List<FlakyTestFinding> {
+        val span = tracer.spanBuilder("flaky-test-hunter.findings.read")
+            .setSpanKind(SpanKind.INTERNAL)
+            .startSpan()
+        return runCatching {
+            findingRepository.findActive().also { findings ->
+                span.setAttribute("openbank.flaky.findings.count", findings.size.toLong())
+            }
+        }.onFailure { failure ->
+            span.recordException(failure)
+            span.setStatus(StatusCode.ERROR)
+        }.also {
+            span.end()
+        }.getOrThrow()
+    }
 
     override suspend fun getById(id: String): FlakyTestFinding? = findingRepository.findById(id)
 

--- a/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/application/usecase/TestIntelligenceAnalysisTest.kt
+++ b/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/application/usecase/TestIntelligenceAnalysisTest.kt
@@ -10,8 +10,11 @@ import com.openbank.flakytest.domain.model.TestIntelligenceAnalysisRequest
 import com.openbank.flakytest.domain.model.TestIntelligenceComponentInput
 import com.openbank.flakytest.domain.model.TestIntelligenceEvidenceInput
 import com.openbank.libs.temporal.TemporalConfig
+import com.openbank.libs.testing.trace.RecordingSpanExporter
 import io.mockk.coEvery
 import io.mockk.mockk
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
 import io.temporal.client.WorkflowClient
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -23,12 +26,17 @@ import java.time.ZoneOffset
 class TestIntelligenceAnalysisTest {
     private val repository = mockk<FindingRepository>()
     private val llm = mockk<LlmDiagnosisPort>()
+    private val exporter = RecordingSpanExporter()
+    private val tracerProvider = SdkTracerProvider.builder()
+        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+        .build()
     private val service = FlakyTestHunterService(
         mockk<WorkflowClient>(),
         mockk<TemporalConfig>(),
         repository,
         llm,
         Clock.fixed(Instant.parse("2026-08-22T12:00:00Z"), ZoneOffset.UTC),
+        tracerProvider.get("test"),
     )
 
     @Test
@@ -93,6 +101,19 @@ class TestIntelligenceAnalysisTest {
         assertThat(finding.severity).isEqualTo(FindingSeverity.CRITICAL)
         assertThat(finding.rawMetricValue).isEqualByComparingTo("1")
         assertThat(finding.title).contains("2 test-infrastructure start", "1 stop")
+    }
+
+    @Test
+    fun `findings read emits a bounded trace contract after repository execution`(): Unit = runBlocking {
+        coEvery { repository.findActive() } returns emptyList()
+
+        service.getActive()
+
+        exporter.contract()
+            .requiresSpan("flaky-test-hunter.findings.read")
+            .requiresAttribute("flaky-test-hunter.findings.read", "openbank.flaky.findings.count")
+            .hasNoErrorSpan()
+            .verifiedAs("flaky-findings-read")
     }
 
     private fun analysisRequest() = TestIntelligenceAnalysisRequest(


### PR DESCRIPTION
## What

Adds an executable, bounded trace contract to the read-only Flaky Test Hunter findings query.

The span proves repository-backed operator-read execution without exporting findings, IDs, prompt data, or trace IDs. The existing Test Intelligence collector projects its JUnit marker into immutable `trace` evidence.

Closes #7387

## Verification

- `./gradlew :openbank-flaky-test-hunter:ktlintCheck :openbank-flaky-test-hunter:detekt :openbank-flaky-test-hunter:test --tests com.openbank.flakytest.application.usecase.TestIntelligenceAnalysisTest --console=plain`
- `python3 .github/scripts/collect-test-run-evidence.py --service openbank-flaky-test-hunter --out /tmp/flaky-trace-run.json` → `trace-contract:flaky-findings-read`, `passed`
- `python3 .github/scripts/collect-test-run-evidence.py --self-test`

No money-path behavior, external telemetry endpoint, credential, or review bypass is introduced.