### PR TITLE
test(liveness): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-control-liveness-sentinel/build.gradle.kts
+++ b/openbank-control-liveness-sentinel/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     testImplementation(libs.quarkus.test.security)
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
+    testImplementation(project(":openbank-libs-testing"))
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.rest.assured.kotlin)
 }

--- a/openbank-control-liveness-sentinel/src/test/kotlin/com/openbank/liveness/PostgresTestResource.kt
+++ b/openbank-control-liveness-sentinel/src/test/kotlin/com/openbank/liveness/PostgresTestResource.kt
@@ -5,6 +5,7 @@
 
 package com.openbank.liveness
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.testcontainers.containers.PostgreSQLContainer
 
@@ -15,14 +16,19 @@ import org.testcontainers.containers.PostgreSQLContainer
  */
 class PostgresTestResource : QuarkusTestResourceLifecycleManager {
 
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:18-alpine"
+    }
+
     private lateinit var postgres: PostgreSQLContainer<*>
 
     override fun start(): Map<String, String> {
-        postgres = PostgreSQLContainer("postgres:18-alpine")
+        postgres = PostgreSQLContainer(POSTGRES_IMAGE)
             .withDatabaseName("openbank_liveness")
             .withUsername("openbank")
             .withPassword("openbank")
         postgres.start()
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         // reactive URL for Panache (vertx-pg-client) + JDBC URL for Flyway.
         val reactiveUrl = "postgresql://${postgres.host}:${postgres.firstMappedPort}/${postgres.databaseName}"
         return mapOf(
@@ -34,6 +40,9 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        if (::postgres.isInitialized) postgres.stop()
+        if (::postgres.isInitialized) {
+            postgres.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
     }
 }

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -24,7 +24,6 @@ openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/it/Post
 openbank-clearing-service/src/test/kotlin/com/openbank/clearing/it/PostgresRedpandaRedisTestResource.kt
 openbank-consent-service/src/test/kotlin/com/openbank/consent/it/ConsentPostgresRedisTestResource.kt
 openbank-consent-service/src/test/kotlin/com/openbank/consent/it/PostgresTestResource.kt
-openbank-control-liveness-sentinel/src/test/kotlin/com/openbank/liveness/PostgresTestResource.kt
 openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/it/RedpandaRedisTestResource.kt
 openbank-delegation-service/src/test/kotlin/com/openbank/delegation/it/PostgresTestResource.kt
 openbank-dispute-service/src/test/kotlin/com/openbank/dispute/it/PostgresTestResource.kt


### PR DESCRIPTION
## What

Migrates the non-money control-liveness-sentinel PostgreSQL Testcontainers resource to the shared, secret-free lifecycle evidence contract and removes its ratchet baseline exception.

## Evidence

A real local Quarkus/Testcontainers run produced paired JSONL records in the CI-standard evidence directory:

- `postgres:18-alpine` started
- `postgres:18-alpine` stopped

No host, port, credential or container ID is recorded.

## Verification

- `./gradlew :openbank-control-liveness-sentinel:ktlintCheck :openbank-control-liveness-sentinel:detekt :openbank-control-liveness-sentinel:test --console=plain`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py --root .`

Refs #7246