### PR TITLE
test(agent): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-agent-service/src/test/kotlin/com/openbank/agent/it/PostgresTestResource.kt
+++ b/openbank-agent-service/src/test/kotlin/com/openbank/agent/it/PostgresTestResource.kt
@@ -5,6 +5,7 @@
 
 package com.openbank.agent.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
@@ -16,13 +17,18 @@ import org.testcontainers.utility.DockerImageName
 class PostgresTestResource : QuarkusTestResourceLifecycleManager {
     private var postgres: PostgreSQLContainer<*>? = null
 
+    companion object {
+        private const val POSTGRES_IMAGE = "postgres:16.3-alpine"
+    }
+
     override fun start(): Map<String, String> {
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withUsername("openbank")
             .withPassword("openbank_secret")
             .withDatabaseName("openbank_agent_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
         return mapOf(
@@ -38,5 +44,6 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
 
     override fun stop() {
         postgres?.stop()
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
     }
 }

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -12,7 +12,6 @@
 # clearing, swift, fx, lending, sdd, interest, sca, consent) are tracked separately: they
 # need the two-approval + threat-model process before their topology is touched.
 openbank-account-service/src/test/kotlin/com/openbank/account/it/PostgresRedpandaRedisTestResource.kt
-openbank-agent-service/src/test/kotlin/com/openbank/agent/it/PostgresTestResource.kt
 openbank-aml-service/src/test/kotlin/com/openbank/aml/it/PostgresRedisTestResource.kt
 openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/it/PostgresRedpandaTestResource.kt
 openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/it/PostgresTestResource.kt


### PR DESCRIPTION
Refs #7246

Migrates the non-money-path agent-service PostgreSQL Testcontainer to the shared, secret-free `TestInfrastructureEvidence` contract and removes its baseline exception.

Local evidence: 173 tests, 0 failures/errors/skips; runtime JSONL contains paired `postgres:16.3-alpine` `started` / `stopped` records.

Verification:
- `:openbank-agent-service:ktlintCheck detekt test`
- `check-test-intelligence-ecosystem.py --root .`
- `git diff --check`