### PR TITLE
test(docs-truth): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-docs-truth-agent/build.gradle.kts
+++ b/openbank-docs-truth-agent/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     testImplementation("io.temporal:temporal-testing:1.25.1")
     testImplementation("io.grpc:grpc-inprocess:1.68.1")
     testImplementation(libs.quarkus.junit5)
+    testImplementation(project(":openbank-libs-testing"))
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.testcontainers.postgresql)

--- a/openbank-docs-truth-agent/src/test/kotlin/com/openbank/docstruth/PostgresTestResource.kt
+++ b/openbank-docs-truth-agent/src/test/kotlin/com/openbank/docstruth/PostgresTestResource.kt
@@ -5,6 +5,7 @@
 
 package com.openbank.docstruth
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.testcontainers.containers.PostgreSQLContainer
 
@@ -17,12 +18,17 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
 
     private lateinit var postgres: PostgreSQLContainer<*>
 
+    companion object {
+        private const val POSTGRES_IMAGE = "postgres:18-alpine"
+    }
+
     override fun start(): Map<String, String> {
-        postgres = PostgreSQLContainer("postgres:18-alpine")
+        postgres = PostgreSQLContainer(POSTGRES_IMAGE)
             .withDatabaseName("openbank_docstruth")
             .withUsername("openbank")
             .withPassword("openbank")
         postgres.start()
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         // reactive URL for Panache (vertx-pg-client) + JDBC URL for Flyway.
         val reactiveUrl = "postgresql://${postgres.host}:${postgres.firstMappedPort}/${postgres.databaseName}"
         return mapOf(
@@ -34,6 +40,9 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        if (::postgres.isInitialized) postgres.stop()
+        if (::postgres.isInitialized) {
+            postgres.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
     }
 }

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -27,7 +27,6 @@ openbank-consent-service/src/test/kotlin/com/openbank/consent/it/PostgresTestRes
 openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/it/RedpandaRedisTestResource.kt
 openbank-delegation-service/src/test/kotlin/com/openbank/delegation/it/PostgresTestResource.kt
 openbank-dispute-service/src/test/kotlin/com/openbank/dispute/it/PostgresTestResource.kt
-openbank-docs-truth-agent/src/test/kotlin/com/openbank/docstruth/PostgresTestResource.kt
 openbank-document-service/src/test/kotlin/com/openbank/document/it/PostgresRedisTestResource.kt
 openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/it/PostgresRedisTestResource.kt
 openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/EngagementPostgresTestResource.kt


### PR DESCRIPTION
Refs #7246

Migrates the non-money docs-truth-agent PostgreSQL Testcontainer to shared secret-free Test Intelligence lifecycle evidence and removes its baseline exception.

Verification:
- 57 tests, 0 failures/errors/skips
- recorded runtime `postgres:18-alpine` start/stop pairs
- `:openbank-docs-truth-agent:ktlintCheck detekt test`
- `check-test-intelligence-ecosystem.py --root .`
- `git diff --check`