### PR TITLE
test(authz-policy-auditor): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-authz-policy-auditor/build.gradle.kts
+++ b/openbank-authz-policy-auditor/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.rest.assured.kotlin)
+    testImplementation(project(":openbank-libs-testing"))
 }
 
 // Package the ADR-0148 prompt registry onto the classpath so LlmDiagnosisAdapter loads its

--- a/openbank-authz-policy-auditor/src/test/kotlin/com/openbank/authzaudit/PostgresTestResource.kt
+++ b/openbank-authz-policy-auditor/src/test/kotlin/com/openbank/authzaudit/PostgresTestResource.kt
@@ -5,6 +5,7 @@
 
 package com.openbank.authzaudit
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.testcontainers.containers.PostgreSQLContainer
 
@@ -15,14 +16,19 @@ import org.testcontainers.containers.PostgreSQLContainer
  */
 class PostgresTestResource : QuarkusTestResourceLifecycleManager {
 
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:18-alpine"
+    }
+
     private lateinit var postgres: PostgreSQLContainer<*>
 
     override fun start(): Map<String, String> {
-        postgres = PostgreSQLContainer("postgres:18-alpine")
+        postgres = PostgreSQLContainer(POSTGRES_IMAGE)
             .withDatabaseName("openbank_authzaudit")
             .withUsername("openbank")
             .withPassword("openbank")
         postgres.start()
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         // reactive URL for Panache (vertx-pg-client) + JDBC URL for Flyway.
         val reactiveUrl = "postgresql://${postgres.host}:${postgres.firstMappedPort}/${postgres.databaseName}"
         return mapOf(
@@ -34,6 +40,9 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        if (::postgres.isInitialized) postgres.stop()
+        if (::postgres.isInitialized) {
+            postgres.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
     }
 }

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -15,7 +15,6 @@ openbank-account-service/src/test/kotlin/com/openbank/account/it/PostgresRedpand
 openbank-aml-service/src/test/kotlin/com/openbank/aml/it/PostgresRedisTestResource.kt
 openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/it/PostgresRedpandaTestResource.kt
 openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/it/PostgresTestResource.kt
-openbank-authz-policy-auditor/src/test/kotlin/com/openbank/authzaudit/PostgresTestResource.kt
 openbank-balance-service/src/test/kotlin/com/openbank/balance/it/PostgresRedpandaTestResource.kt
 openbank-billing-service/src/test/kotlin/com/openbank/billing/it/PostgresRedisTestResource.kt
 openbank-campaign-service/src/test/kotlin/com/openbank/campaign/it/CampaignPostgresRedisTestResource.kt


### PR DESCRIPTION
## Summary
- record actual Postgres Testcontainers start/stop lifecycle after each successful operation
- remove the resource from the governed unrecorded-runtime baseline
- add the shared evidence kit only to test scope

## Verification
- `:openbank-authz-policy-auditor:test` — passed; real container emitted secret-free start/stop pairs
- `:openbank-authz-policy-auditor:ktlintCheck` — passed
- `:openbank-authz-policy-auditor:detekt` — passed
- `check-test-intelligence-ecosystem.py` — SUBJECTS=60
- `git diff --check` — passed

Refs #7246