### PR TITLE
fix(ci): resolve historical provider refs safely

### DIFF
--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -440,27 +440,34 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Default: F (or the triggering ref) is checked out and published, unchanged. The
-          # exceptional mode checks out deployed P; its one approved fixture is later read as a
-          # named blob from F, never by merging/checking out F's runtime.
-          ref: ${{ inputs.provider_version != '' && inputs.provider_version || inputs.ref }}
+          # Start from the workflow's trusted main checkout.  `actions/checkout` resolves a
+          # workflow-dispatch input as a branch/tag lookup before it resolves an arbitrary
+          # historical SHA, which makes the documented `verify-provider --ref <deployed-sha>`
+          # recovery path fail before our on-main ancestry gate can run.  A subsequent explicit
+          # `git checkout --detach` resolves that already-fetched commit after proving it is on
+          # main; blank inputs retain the triggering SHA exactly as before.
+          ref: ${{ github.sha }}
           fetch-depth: ${{ inputs.ref == '' && inputs.provider_version == '' && 1 || 0 }}
 
-      - name: Refuse a default ref that is not an ancestor of main
-        if: inputs.ref != '' && inputs.provider_version == ''
+      - name: Check out a requested provider version only after proving it is on main
+        if: inputs.ref != '' || inputs.provider_version != ''
         env:
-          REF: ${{ inputs.ref }}
+          REF: ${{ inputs.provider_version != '' && inputs.provider_version || inputs.ref }}
         run: |
+          set -euo pipefail
           # Publishing a verification says "this provider version satisfies the consumer contract",
-          # and can-i-deploy then lets a deploy through on it. Allowing an off-main sha would let a
-          # branch that never merged authorise a production deploy, so this is a gate, not a nicety.
+          # and can-i-deploy then lets a deploy through on it.  Resolve the requested commit from
+          # the full main history, then reject anything that is not an on-main ancestor before it
+          # replaces the trusted triggering checkout.
           git fetch --quiet origin main
-          if ! git merge-base --is-ancestor "$REF" origin/main; then
+          RESOLVED_REF="$(git rev-parse --verify "${REF}^{commit}")"
+          if ! git merge-base --is-ancestor "$RESOLVED_REF" origin/main; then
             echo "::error::$REF is not an ancestor of origin/main. A verification may only be" \
                  "published for a commit that is on main (#3306)."
             exit 1
           fi
-          echo "$REF is on main — publishing the verification against it."
+          git checkout --detach --quiet "$RESOLVED_REF"
+          echo "$RESOLVED_REF is on main — publishing the verification against it."
 
       - name: Check out P and overlay the one approved Ledger provider fixture from F
         env:


### PR DESCRIPTION
## Summary
- check out the workflow-triggering main revision first
- resolve a requested provider SHA only from full `main` history
- retain the existing fail-closed ancestor gate before detached checkout

## Proof
- YAML parse passed
- `git diff --check` passed
- reproduced the deployed Consent SHA (`6265ea86…`) resolving and checking out from a main-history clone

Refs #2549