### PR TITLE
test(notification): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -35,8 +35,6 @@ openbank-kyc-service/src/test/kotlin/com/openbank/kyc/it/PostgresTestResource.kt
 openbank-ledger-service/src/test/kotlin/com/openbank/ledger/it/PostgresRedpandaTestResource.kt
 openbank-ledger-service/src/test/kotlin/com/openbank/ledger/it/PostgresTestResource.kt
 openbank-lending-service/src/test/kotlin/com/openbank/lending/it/PostgresRedisTestResource.kt
-openbank-notification-service/src/test/kotlin/com/openbank/notification/it/PostgresTestResource.kt
-openbank-notification-service/src/test/kotlin/com/openbank/notification/it/RedisTestResource.kt
 openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/it/OnboardingPostgresTestResource.kt
 openbank-party-service/src/test/kotlin/com/openbank/party/it/PostgresRedpandaTestResource.kt
 openbank-pid-service/src/test/kotlin/com/openbank/pid/it/PostgresTestResource.kt

--- a/openbank-notification-service/build.gradle.kts
+++ b/openbank-notification-service/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     implementation(libs.jackson.datatype.jsr310)
     implementation(project(":openbank-libs-domain"))
     implementation(project(":openbank-libs-runtime"))
+    testImplementation(project(":openbank-libs-testing"))
     testImplementation(libs.quarkus.junit5)
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/it/PostgresTestResource.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/it/PostgresTestResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.notification.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
@@ -21,15 +22,20 @@ import org.testcontainers.utility.DockerImageName
  */
 class PostgresTestResource : QuarkusTestResourceLifecycleManager {
 
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:16.3-alpine"
+    }
+
     private var postgres: PostgreSQLContainer<*>? = null
 
     override fun start(): Map<String, String> {
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withUsername("openbank")
             .withPassword("openbank_secret")
             .withDatabaseName("openbank_notification_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
 
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
@@ -43,6 +49,9 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        postgres?.stop()
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
     }
 }

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/it/RedisTestResource.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/it/RedisTestResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.notification.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.opentest4j.TestAbortedException
 import org.testcontainers.DockerClientFactory
@@ -21,13 +22,17 @@ import org.testcontainers.utility.DockerImageName
  */
 class RedisTestResource : QuarkusTestResourceLifecycleManager {
 
+    private companion object {
+        const val VALKEY_IMAGE = "valkey/valkey:8-alpine"
+    }
+
     private var redis: GenericContainer<*>? = null
 
     override fun start(): Map<String, String> {
         if (!DockerClientFactory.instance().isDockerAvailable) {
             throw TestAbortedException("Docker not available — skipping Testcontainers IT")
         }
-        val rd = GenericContainer(DockerImageName.parse("valkey/valkey:8-alpine")).withExposedPorts(6379)
+        val rd = GenericContainer(DockerImageName.parse(VALKEY_IMAGE)).withExposedPorts(6379)
         // Assign the field BEFORE start() (issue #1395), not after: if start() throws after the
         // container process was actually created on the Docker daemon (a wait-strategy timeout,
         // as opposed to Docker being wholly unavailable), the field must still be reachable so
@@ -36,12 +41,16 @@ class RedisTestResource : QuarkusTestResourceLifecycleManager {
         // host with no external reaper other than Ryuk to eventually catch it.
         redis = rd
         rd.start()
+        TestInfrastructureEvidence.record("valkey", VALKEY_IMAGE, "started")
         return mapOf(
             "quarkus.redis.hosts" to "redis://${rd.host}:${rd.getFirstMappedPort()}",
         )
     }
 
     override fun stop() {
-        redis?.stop()
+        redis?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("valkey", VALKEY_IMAGE, "stopped")
+        }
     }
 }


### PR DESCRIPTION
Closes #7410\n\nRecords secret-free started/stopped evidence for the existing PostgreSQL and Valkey Testcontainers resources. The records happen only after a successful start and after stop; the shared evidence library is test-scoped.\n\nVerified with git diff --check and the existing ApprovalStoreWiringIT plus NotificationOutboxClaimIT: 3 tests passed and emitted started/stopped events for both resources.\n\nNo production behavior or money-path control changes.