### PR TITLE
test(mcp): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -35,7 +35,6 @@ openbank-kyc-service/src/test/kotlin/com/openbank/kyc/it/PostgresTestResource.kt
 openbank-ledger-service/src/test/kotlin/com/openbank/ledger/it/PostgresRedpandaTestResource.kt
 openbank-ledger-service/src/test/kotlin/com/openbank/ledger/it/PostgresTestResource.kt
 openbank-lending-service/src/test/kotlin/com/openbank/lending/it/PostgresRedisTestResource.kt
-openbank-mcp-service/src/test/kotlin/com/openbank/mcp/PostgresTestResource.kt
 openbank-notification-service/src/test/kotlin/com/openbank/notification/it/PostgresTestResource.kt
 openbank-notification-service/src/test/kotlin/com/openbank/notification/it/RedisTestResource.kt
 openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/it/OnboardingPostgresTestResource.kt

--- a/openbank-mcp-service/build.gradle.kts
+++ b/openbank-mcp-service/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     // (PolicyDecisionPoint / OpaSidecarPolicyDecisionPoint) lives here.
     implementation(project(":openbank-libs-domain"))
     implementation(project(":openbank-libs-runtime"))
+    testImplementation(project(":openbank-libs-testing"))
     testImplementation(libs.quarkus.junit5)
     testImplementation(libs.assertj)
     testImplementation(libs.rest.assured.kotlin)

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/PostgresTestResource.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/PostgresTestResource.kt
@@ -5,6 +5,7 @@
 
 package com.openbank.mcp
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.opentest4j.TestAbortedException
 import org.testcontainers.DockerClientFactory
@@ -14,18 +15,23 @@ import org.testcontainers.utility.DockerImageName
 /** Isolated PostgreSQL per test JVM via Testcontainers (audit-service pattern, ADR-0224 D2). */
 class PostgresTestResource : QuarkusTestResourceLifecycleManager {
 
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:16.3-alpine"
+    }
+
     private var postgres: PostgreSQLContainer<*>? = null
 
     override fun start(): Map<String, String> {
         if (!DockerClientFactory.instance().isDockerAvailable) {
             throw TestAbortedException("Docker not available — skipping Testcontainers IT")
         }
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withUsername("openbank")
             .withPassword("openbank_secret")
             .withDatabaseName("openbank_mcp_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
         return mapOf(
@@ -34,10 +40,17 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
             "quarkus.datasource.username" to "openbank",
             "quarkus.datasource.password" to "openbank_secret",
             "quarkus.devservices.enabled" to "false",
+            // Keep JsonWebToken available for @TestSecurity while preventing this isolated
+            // database test from discovering the in-cluster Keycloak endpoint.
+            "quarkus.oidc.tenant-enabled" to "false",
+            "quarkus.oidc-client.enabled" to "false",
         )
     }
 
     override fun stop() {
-        postgres?.stop()
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
     }
 }


### PR DESCRIPTION
Closes #7412\n\nRecords secret-free Postgres started/stopped evidence for the real MCP session lifecycle Testcontainers resource, removes its stale ratchet baseline entry, and prevents this isolated test resource from discovering in-cluster Keycloak while preserving JsonWebToken for TestSecurity.\n\nVerified: McpSessionLifecycleIT passed 3/3 and emitted a complete Postgres started/stopped evidence pair; enforced Test Intelligence ecosystem self-test and checker passed.\n\nNo production or money-path behavior changes.