### PR TITLE
fix(synthetics): expose catalog boundary diagnostics

### DIFF
--- a/openbank-infra/gitops/components/observability/cronjob-journey-product-catalog-read.yaml
+++ b/openbank-infra/gitops/components/observability/cronjob-journey-product-catalog-read.yaml
@@ -40,6 +40,13 @@ data:
       const response = http.get(`${CATALOG_BASE}/api/v1/products`, {
         tags: { endpoint: 'products-list', service: 'product-catalog' },
       });
+      // A threshold exit proves the journey is red but does not say whether its first
+      // boundary was authentication, routing, or the service itself. Status and content type
+      // are operational metadata only: never log response bodies or request headers because
+      // a future read-only identity must remain secret-free in retained Job logs.
+      if (response.status !== 200) {
+        console.error(`product-catalog-read unexpected response: status=${response.status} content_type=${response.headers['Content-Type'] || 'absent'}`);
+      }
       const contentType = response.headers['Content-Type'] || '';
       let isArray = false;
       try { isArray = Array.isArray(response.json()); } catch (_) { /* checked below */ }


### PR DESCRIPTION
Closes #7415\n\nWhen the Product Catalog read synthetic gets a non-200 response, the retained k6 Job log now records only HTTP status and Content-Type. It deliberately never logs request headers, credentials, or response body content.\n\nThe target, request method, threshold verdict, schedule, and failure semantics are unchanged.\n\nVerified: check-journey-catalog self-test 19/19 and catalog consistency check passed; git diff --check passed.