### PR TITLE
test(devops): prove detector trace contract

### DIFF
--- a/openbank-devops-agent/build.gradle.kts
+++ b/openbank-devops-agent/build.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(project(":openbank-libs-testing"))
     testImplementation(libs.rest.assured.kotlin)
+    // Executable, assertion-backed trace evidence for the detector boundary.
+    testImplementation(project(":openbank-libs-testing"))
 }
 
 // Package the ADR-0148 prompt registry onto the classpath so LlmDiagnosisAdapter loads its system

--- a/openbank-devops-agent/src/main/kotlin/com/openbank/devops/application/workflow/DetectFindingsActivityImpl.kt
+++ b/openbank-devops-agent/src/main/kotlin/com/openbank/devops/application/workflow/DetectFindingsActivityImpl.kt
@@ -13,6 +13,9 @@ import com.openbank.devops.domain.model.FindingStatus
 import com.openbank.devops.domain.model.RemediationKind
 import com.openbank.devops.infrastructure.config.DevOpsConfig
 import com.openbank.libs.domain.identifiers.Ids
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.api.trace.Tracer
 import jakarta.enterprise.context.ApplicationScoped
 import java.math.BigDecimal
 import java.time.Instant
@@ -24,15 +27,39 @@ import java.time.Instant
  * would fix it (the agent's whole purpose: a permanent fix, not a band-aid).
  */
 @ApplicationScoped
-class DetectFindingsActivityImpl(private val config: DevOpsConfig) : DetectFindingsActivity {
+class DetectFindingsActivityImpl(
+    private val config: DevOpsConfig,
+    private val tracer: Tracer,
+) : DetectFindingsActivity {
 
-    override fun detect(detectorId: DetectorId, signals: Map<String, Double>): List<DevOpsFinding> = when (detectorId) {
-        DetectorId.D1_CI_PIPELINE_HEALTH -> detectCiPipeline(signals)
-        DetectorId.D2_DORA_REGRESSION -> detectDoraRegression(signals)
-        DetectorId.D3_RUNNER_CAPACITY -> detectRunnerCapacity(signals)
-        DetectorId.D4_DEPLOY_HEALTH -> detectDeployHealth(signals)
-        DetectorId.D5_SSDLC_HYGIENE -> detectSsdlcHygiene(signals)
-        DetectorId.D6_INCIDENT_RECURRENCE -> detectIncidentRecurrence(signals)
+    /**
+     * The detector boundary is where collected observability signals become an actionable finding.
+     * Its span contains only the bounded detector enum and result count — never raw signals, titles,
+     * resource names, or remediation payloads.
+     */
+    override fun detect(detectorId: DetectorId, signals: Map<String, Double>): List<DevOpsFinding> {
+        val span = tracer.spanBuilder("devops-agent.detector.evaluate")
+            .setSpanKind(SpanKind.INTERNAL)
+            .startSpan()
+        return try {
+            val findings = when (detectorId) {
+                DetectorId.D1_CI_PIPELINE_HEALTH -> detectCiPipeline(signals)
+                DetectorId.D2_DORA_REGRESSION -> detectDoraRegression(signals)
+                DetectorId.D3_RUNNER_CAPACITY -> detectRunnerCapacity(signals)
+                DetectorId.D4_DEPLOY_HEALTH -> detectDeployHealth(signals)
+                DetectorId.D5_SSDLC_HYGIENE -> detectSsdlcHygiene(signals)
+                DetectorId.D6_INCIDENT_RECURRENCE -> detectIncidentRecurrence(signals)
+            }
+            span.setAttribute("openbank.devops.detector", detectorId.name)
+            span.setAttribute("openbank.devops.findings.count", findings.size.toLong())
+            findings
+        } catch (failure: Exception) {
+            span.recordException(failure)
+            span.setStatus(StatusCode.ERROR)
+            throw failure
+        } finally {
+            span.end()
+        }
     }
 
     @Suppress("MagicNumber")

--- a/openbank-devops-agent/src/main/kotlin/com/openbank/devops/application/workflow/DetectFindingsActivityImpl.kt
+++ b/openbank-devops-agent/src/main/kotlin/com/openbank/devops/application/workflow/DetectFindingsActivityImpl.kt
@@ -27,10 +27,8 @@ import java.time.Instant
  * would fix it (the agent's whole purpose: a permanent fix, not a band-aid).
  */
 @ApplicationScoped
-class DetectFindingsActivityImpl(
-    private val config: DevOpsConfig,
-    private val tracer: Tracer,
-) : DetectFindingsActivity {
+class DetectFindingsActivityImpl(private val config: DevOpsConfig, private val tracer: Tracer) :
+    DetectFindingsActivity {
 
     /**
      * The detector boundary is where collected observability signals become an actionable finding.

--- a/openbank-devops-agent/src/main/kotlin/com/openbank/devops/application/workflow/DetectFindingsActivityImpl.kt
+++ b/openbank-devops-agent/src/main/kotlin/com/openbank/devops/application/workflow/DetectFindingsActivityImpl.kt
@@ -35,6 +35,7 @@ class DetectFindingsActivityImpl(private val config: DevOpsConfig, private val t
      * Its span contains only the bounded detector enum and result count — never raw signals, titles,
      * resource names, or remediation payloads.
      */
+    @Suppress("TooGenericExceptionCaught") // Trace every detector failure before it propagates unchanged.
     override fun detect(detectorId: DetectorId, signals: Map<String, Double>): List<DevOpsFinding> {
         val span = tracer.spanBuilder("devops-agent.detector.evaluate")
             .setSpanKind(SpanKind.INTERNAL)

--- a/openbank-devops-agent/src/test/kotlin/com/openbank/devops/application/workflow/DetectFindingsActivityImplTest.kt
+++ b/openbank-devops-agent/src/test/kotlin/com/openbank/devops/application/workflow/DetectFindingsActivityImplTest.kt
@@ -9,8 +9,12 @@ import com.openbank.devops.domain.model.DetectorId
 import com.openbank.devops.domain.model.DoraMetric
 import com.openbank.devops.domain.model.FindingSeverity
 import com.openbank.devops.infrastructure.config.DevOpsConfig
+import com.openbank.libs.testing.trace.RecordingSpanExporter
+import com.openbank.libs.testing.trace.TraceContract
 import io.mockk.every
 import io.mockk.mockk
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -23,6 +27,8 @@ import org.junit.jupiter.api.Test
 class DetectFindingsActivityImplTest {
 
     private lateinit var detect: DetectFindingsActivityImpl
+    private lateinit var exporter: RecordingSpanExporter
+    private lateinit var tracerProvider: SdkTracerProvider
 
     @BeforeEach
     fun setUp() {
@@ -32,7 +38,9 @@ class DetectFindingsActivityImplTest {
         every { config.runnerQueuePressureThreshold() } returns 0.80
         every { config.ssdlcDriftThreshold() } returns 3
         every { config.incidentRecurrenceThreshold() } returns 3
-        detect = DetectFindingsActivityImpl(config)
+        exporter = RecordingSpanExporter()
+        tracerProvider = SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)).build()
+        detect = DetectFindingsActivityImpl(config, tracerProvider.get("test"))
     }
 
     @Test
@@ -123,5 +131,17 @@ class DetectFindingsActivityImplTest {
         )
         assertThat(findings).hasSize(1)
         assertThat(findings.single().doraMetricImpacted).isEqualTo(DoraMetric.TIME_TO_RESTORE)
+    }
+
+    @Test
+    fun `detector evaluation emits an assertion-backed trace contract`() {
+        detect.detect(DetectorId.D3_RUNNER_CAPACITY, mapOf("arc_assigned_runners" to 3.0, "arc_running_runners" to 0.0))
+
+        exporter.contract()
+            .requiresSpan("devops-agent.detector.evaluate")
+            .requiresAttribute("devops-agent.detector.evaluate", "openbank.devops.detector")
+            .requiresAttribute("devops-agent.detector.evaluate", "openbank.devops.findings.count")
+            .hasNoErrorSpan()
+            .verifiedAs("devops-detector-evaluate")
     }
 }

--- a/openbank-devops-agent/src/test/kotlin/com/openbank/devops/application/workflow/DetectFindingsActivityImplTest.kt
+++ b/openbank-devops-agent/src/test/kotlin/com/openbank/devops/application/workflow/DetectFindingsActivityImplTest.kt
@@ -10,7 +10,6 @@ import com.openbank.devops.domain.model.DoraMetric
 import com.openbank.devops.domain.model.FindingSeverity
 import com.openbank.devops.infrastructure.config.DevOpsConfig
 import com.openbank.libs.testing.trace.RecordingSpanExporter
-import com.openbank.libs.testing.trace.TraceContract
 import io.mockk.every
 import io.mockk.mockk
 import io.opentelemetry.sdk.trace.SdkTracerProvider


### PR DESCRIPTION
Closes #7418\n\nAdds one safe internal span at the production DevOps detector boundary with only detector enum and findings count. The real SDK exporter test asserts the span and attribute keys through TraceContract, then emits the bounded trace marker consumed by Test Intelligence.\n\nVerified: DetectFindingsActivityImplTest 11/11 passed; JUnit output contains OPENBANK_TRACE_CONTRACT_V1:devops-detector-evaluate; git diff --check passed.\n\nNo raw signals, finding titles, affected resources, or remediation payloads enter telemetry.