### PR TITLE
test(ledger): prove journal posting trace contract

### DIFF
--- a/docs/threat-models/openbank-ledger-service.md
+++ b/docs/threat-models/openbank-ledger-service.md
@@ -383,3 +383,15 @@ set) apply equally to the new `ledger.approval.decide` action.
   line inserts occur only during an operator four-eyes freeze, not on the posting path. **Rollback:**
   before FINREP depends on the source, stop writers and archive frozen evidence, then remove the
   trigger/function/table; never delete attested evidence as a convenience rollback.
+
+- **2026-08-27** — Journal posting now emits the bounded internal span
+  `ledger.journal.post`, asserted against an SDK exporter while the real reactive repository writes
+  a balanced journal and transactional outbox rows in `LedgerOutboxProjectionIT` (issue #7383).
+  **Information disclosure:** the span has one allow-listed attribute only,
+  `openbank.ledger.journal.status`; it carries no journal/account/transaction IDs, actor,
+  idempotency key, amount, currency, description, or payload. **Tampering:** telemetry is
+  observational and cannot alter the posting, its balance validation, day/period locks,
+  idempotency, or transactional outbox. **Availability:** tracing failure is not caught or
+  translated into a financial success; an application failure remains an error span and propagates
+  unchanged. Rollback: revert the instrumentation and its contract test; no stored financial data,
+  schema, caller, endpoint, role, or policy changes.

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/usecase/LedgerService.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/usecase/LedgerService.kt
@@ -35,8 +35,13 @@ import com.openbank.libs.api.pagination.PageInfo
 import com.openbank.libs.domain.money.Money
 import com.openbank.libs.observability.DomainMetrics
 import com.openbank.libs.persistence.outbox.OutboxMessage
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.api.trace.Tracer
 import io.vertx.pgclient.PgException
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
 import jakarta.persistence.PersistenceException
 import java.time.Clock
 import java.util.UUID
@@ -52,6 +57,9 @@ class LedgerService(
     private val periodFreezeLock: PeriodFreezeLock,
     private val clock: Clock,
 ) : LedgerUseCase {
+    /** Field injection keeps the established money-path constructor shape stable for direct tests. */
+    @Inject
+    lateinit var tracer: Tracer
     // The single constructor is the CDI entry point; tests pass a fixed Clock for deterministic
     // timestamps (ADR-0100 Layer 1).
     //
@@ -62,7 +70,33 @@ class LedgerService(
     // now the injected UTC bean (correct for timestamps); the accounting DATE comes from
     // AccountingClock via [accountingDayLock], the single authority for it.
 
+    /**
+     * A successful posting is a money-path execution boundary. The span deliberately excludes
+     * journal, account, transaction, actor, amount, and idempotency data: it proves execution
+     * without becoming a second financial record.
+     */
+    @Suppress("TooGenericExceptionCaught") // The span must record every failure before propagation.
     override suspend fun postJournal(command: PostJournalCommand): JournalEntry {
+        val span = activeTracer().spanBuilder("ledger.journal.post")
+            .setSpanKind(SpanKind.INTERNAL)
+            .startSpan()
+        return try {
+            postJournalInternal(command).also { entry ->
+                span.setAttribute("openbank.ledger.journal.status", entry.status.name)
+            }
+        } catch (failure: Exception) {
+            span.recordException(failure)
+            span.setStatus(StatusCode.ERROR)
+            throw failure
+        } finally {
+            span.end()
+        }
+    }
+
+    private fun activeTracer(): Tracer =
+        if (::tracer.isInitialized) tracer else GlobalOpenTelemetry.getTracer("openbank-ledger-service")
+
+    private suspend fun postJournalInternal(command: PostJournalCommand): JournalEntry {
         // Idempotent replay: a repeated key returns the original entry, never double-posts.
         // Checked BEFORE the period lock so replaying an entry that was legitimately booked while
         // the year was still open stays idempotent even after the year is later attested.

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/LedgerOutboxProjectionIT.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/LedgerOutboxProjectionIT.kt
@@ -4,11 +4,22 @@
 
 package com.openbank.ledger.integration
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.ledger.application.port.`in`.JournalLineRequest
 import com.openbank.ledger.application.port.`in`.LedgerUseCase
 import com.openbank.ledger.application.port.`in`.PostJournalCommand
+import com.openbank.ledger.application.port.out.GlAccountRepository
+import com.openbank.ledger.application.port.out.JournalRepository
+import com.openbank.ledger.application.port.out.YearCloseRepository
+import com.openbank.ledger.application.usecase.AccountingDayLock
+import com.openbank.ledger.application.usecase.LedgerService
+import com.openbank.ledger.application.usecase.PeriodFreezeLock
 import com.openbank.ledger.domain.model.JournalSide
+import com.openbank.libs.observability.DomainMetrics
 import com.openbank.libs.persistence.outbox.OutboxMessage
+import com.openbank.libs.testing.trace.RecordingSpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.test.junit.QuarkusTest
 import io.quarkus.vertx.VertxContextSupport
@@ -21,6 +32,7 @@ import kotlinx.coroutines.async
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
+import java.time.Clock
 import java.time.LocalDate
 import java.util.UUID
 
@@ -43,6 +55,30 @@ class LedgerOutboxProjectionIT {
 
     @Inject
     lateinit var ledger: LedgerUseCase
+
+    @Inject
+    lateinit var journalRepository: JournalRepository
+
+    @Inject
+    lateinit var glAccountRepository: GlAccountRepository
+
+    @Inject
+    lateinit var objectMapper: ObjectMapper
+
+    @Inject
+    lateinit var metrics: DomainMetrics
+
+    @Inject
+    lateinit var yearCloseRepository: YearCloseRepository
+
+    @Inject
+    lateinit var accountingDayLock: AccountingDayLock
+
+    @Inject
+    lateinit var periodFreezeLock: PeriodFreezeLock
+
+    @Inject
+    lateinit var clock: Clock
 
     // Deterministic posting accounts seeded by V3__ledger_governance.sql.
     private val glAssetId = UUID.fromString("a0000000-0000-0000-0000-000000000001") // 1100 ASSET
@@ -108,6 +144,63 @@ class LedgerOutboxProjectionIT {
         // customer account id — both committed atomically with the journal.
         assertThat(outboxCount(entry.id, "JournalPosted")).isEqualTo(1L)
         assertThat(outboxCount(subAccount, "AccountBookedChanged")).isEqualTo(1L)
+    }
+
+    @Test
+    fun `real journal posting emits a bounded assertion-backed trace contract`() {
+        val exporter = RecordingSpanExporter()
+        val provider = SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)).build()
+        try {
+            val tracedLedger = LedgerService(
+                journalRepository,
+                glAccountRepository,
+                objectMapper,
+                metrics,
+                yearCloseRepository,
+                accountingDayLock,
+                periodFreezeLock,
+                clock,
+            ).also { it.tracer = provider.get("ledger-trace-contract-it") }
+            val command = PostJournalCommand(
+                idempotencyKey = UUID.randomUUID().toString(),
+                transactionId = UUID.randomUUID(),
+                entryDate = LocalDate.now(),
+                valueDate = LocalDate.now(),
+                description = "Trace contract journal posting (IT)",
+                lines = listOf(
+                    JournalLineRequest(
+                        glAssetId,
+                        JournalSide.DEBIT,
+                        BigDecimal("10.00"),
+                        "CZK",
+                        null,
+                        BigDecimal("10.00"),
+                        "CZK",
+                    ),
+                    JournalLineRequest(
+                        glDepositControlId,
+                        JournalSide.CREDIT,
+                        BigDecimal("10.00"),
+                        "CZK",
+                        null,
+                        BigDecimal("10.00"),
+                        "CZK",
+                        UUID.randomUUID(),
+                    ),
+                ),
+                postedBy = UUID.randomUUID(),
+            )
+
+            onVertxContext { tracedLedger.postJournal(command) }
+
+            exporter.contract()
+                .requiresSpan("ledger.journal.post")
+                .requiresAttribute("ledger.journal.post", "openbank.ledger.journal.status")
+                .hasNoErrorSpan()
+                .verifiedAs("ledger-journal-post")
+        } finally {
+            provider.close()
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes #7383

## Evidence
- Exercises the real reactive journal repository and transactional outbox against the ledger integration database.
- Exports and asserts the bounded `ledger.journal.post` trace contract after a successful posting.
- Emits `OPENBANK_TRACE_CONTRACT_V1:ledger-journal-post` only after the assertion succeeds, for Test Intelligence collection.
- Threat model documents the allow-listed telemetry surface, preserved money-path controls, and rollback.

## Verification
- `:openbank-ledger-service:detekt`
- `:openbank-ledger-service:test --tests com.openbank.ledger.integration.LedgerOutboxProjectionIT` (4 tests, 0 failures/errors)

Money-path review remains mandatory: threat model is included and no review bypass is requested.