### PR TITLE
docs(perf): state measured continuous scope accurately

### DIFF
--- a/perf/scenarios.yaml
+++ b/perf/scenarios.yaml
@@ -5,7 +5,7 @@ scenarios:
     execution_mode: planned-read-only-sandbox
     safety_boundary: Runs only when a safe read-only money-path target is configured for the GitHub-hosted runner.
     target_schedule: "0 5 * * *"
-    blocker: No isolated money-path target, dedicated runner, and verified least-privilege read identity are configured yet; a 401 is rejection evidence, not a handler performance baseline. The current scheduled performance gate measures only openbank-product-catalog.
+    blocker: No isolated money-path target, dedicated runner, and verified least-privilege read identity are configured yet; a 401 is rejection evidence, not a handler performance baseline. The current scheduled performance gate measures the non-money-path openbank-product-catalog and openbank-flaky-test-hunter subjects only.
 
   - id: money-path-write-benchmark
     definition: perf/k6/money-path-write-benchmark.js


### PR DESCRIPTION
## Why\n\nThe Test Intelligence performance catalog incorrectly stated that the scheduled performance gate measured only Product Catalog. The latest successful run also measured Flaky Test Hunter.\n\n## Change\n\nMake the blocker text truthful: the continuous lane covers those two non-money-path subjects; money-path remains planned until its isolated target and least-privilege read identity exist.\n\n## Verification\n\n- Test Intelligence ecosystem: schema -> every service CI -> runtime proof -> deployment projection
SUBJECTS=60 ()\n- \n\nRefs #3348