### PR TITLE
feat(perf): pass dedicated read identity to k6

### DIFF
--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -11,9 +11,10 @@
 # Target: the services must already be reachable AND the runner must carry a dedicated,
 # least-privilege read identity. Set the repo/environment variables PERF_LEDGER_URL and
 # PERF_TXN_URL (e.g. a sandbox internal URL reached via a self-hosted runner, or a
-# port-forward). If unset, the job SKIPS with a notice rather than pretending to have
-# measured something — no silent green. An authenticated 200 is required; a 401 is retained
-# as failed evidence because it did not execute the handler.
+# port-forward), and the PERF_READ_TOKEN environment secret. If any are absent, the job
+# SKIPS with a notice rather than pretending to have measured something — no silent green.
+# An authenticated 200 is required; a 401 is retained as failed evidence because it did not
+# execute the handler.
 name: Perf baseline
 
 on:
@@ -39,6 +40,9 @@ jobs:
     env:
       # Keep both performance lanes on one immutable, independently verified executor.
       K6_IMAGE: ghcr.io/grafana/k6:0.54.0@sha256:32000aaa40b848add83425ed7cc77535c343ca473498b0bd29464d00fdca6c79
+      # A dedicated, read-only client credential. GitHub masks the value and the workflow
+      # never prints it; URL variables alone cannot make an authenticated handler measurable.
+      PERF_READ_TOKEN: ${{ secrets.PERF_READ_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -53,10 +57,10 @@ jobs:
           set -euo pipefail
           ledger="${IN_LEDGER:-$VAR_LEDGER}"
           txn="${IN_TXN:-$VAR_TXN}"
-          if [ -z "$ledger" ] || [ -z "$txn" ]; then
-            echo "::notice::PERF_LEDGER_URL / PERF_TXN_URL not configured — skipping the perf baseline (no target to measure)."
+          if [ -z "$ledger" ] || [ -z "$txn" ] || [ -z "${PERF_READ_TOKEN:-}" ]; then
+            echo "::notice::PERF_LEDGER_URL, PERF_TXN_URL, or PERF_READ_TOKEN is not configured — skipping the perf baseline (no authenticated target to measure)."
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "reason=No safe money-path target is configured for this GitHub-hosted runner." >> "$GITHUB_OUTPUT"
+            echo "reason=No safe authenticated money-path target is configured for this GitHub-hosted runner." >> "$GITHUB_OUTPUT"
           else
             echo "run=true" >> "$GITHUB_OUTPUT"
             echo "ledger=$ledger" >> "$GITHUB_OUTPUT"
@@ -75,12 +79,14 @@ jobs:
         env:
           LEDGER_URL: ${{ steps.target.outputs.ledger }}
           TXN_URL: ${{ steps.target.outputs.txn }}
+          PERF_READ_TOKEN: ${{ env.PERF_READ_TOKEN }}
         run: |
           set -euo pipefail
           docker run --rm \
             --user "$(id -u):$(id -g)" \
             --env LEDGER_URL \
             --env TXN_URL \
+            --env PERF_READ_TOKEN \
             --volume "$PWD:/work" \
             --workdir /work \
             "${K6_IMAGE}" run \

--- a/openbank-admin-ui/src/test/test-intelligence-performance-scope.guard.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-performance-scope.guard.test.ts
@@ -28,6 +28,7 @@ describe('Test Intelligence performance coverage scope', () => {
 
   it('refuses to turn an authorization rejection into money-path latency evidence', () => {
     const smoke = readFileSync(path.join(root(), 'perf/k6/money-path-smoke.js'), 'utf8')
+    const workflow = readFileSync(path.join(root(), '.github/workflows/perf-baseline.yml'), 'utf8')
 
     expect(smoke).toContain('http.expectedStatuses(200)')
     expect(smoke).not.toContain('http.expectedStatuses(200, 401)')
@@ -36,6 +37,10 @@ describe('Test Intelligence performance coverage scope', () => {
     expect(smoke).toContain('"txn list 200"')
     expect(smoke).not.toContain('"ledger journals 200|401"')
     expect(smoke).not.toContain('"txn list 200|401"')
+    expect(smoke).toContain('Authorization: `Bearer ${__ENV.PERF_READ_TOKEN || ""}`')
+    expect(workflow).toContain('PERF_READ_TOKEN: ${{ secrets.PERF_READ_TOKEN }}')
+    expect(workflow).toContain('--env PERF_READ_TOKEN')
+    expect(workflow).toContain('No safe authenticated money-path target')
   })
 
   it('keeps cross-layer evidence gaps visible from the primary operator view', () => {

--- a/perf/k6/money-path-smoke.js
+++ b/perf/k6/money-path-smoke.js
@@ -27,6 +27,9 @@ http.setResponseCallback(http.expectedStatuses(200));
 
 const LEDGER_URL = __ENV.LEDGER_URL || "http://localhost:8101";
 const TXN_URL = __ENV.TXN_URL || "http://localhost:8102";
+// PERF_READ_TOKEN is injected only by the scheduled workflow from an environment secret.
+// It is deliberately never given a default and is never logged or added to k6 tags.
+const readHeaders = { Authorization: `Bearer ${__ENV.PERF_READ_TOKEN || ""}` };
 
 const ledgerLatency = new Trend("ledger_journals_ms", true);
 const txnLatency = new Trend("txn_list_ms", true);
@@ -63,6 +66,7 @@ export const options = {
 export default function () {
   // Ledger: list journal entries (cursor-paginated read).
   const j = http.get(`${LEDGER_URL}/api/v1/journals?limit=20`, {
+    headers: readHeaders,
     tags: { name: "ledger_journals" },
   });
   ledgerLatency.add(j.timings.duration);
@@ -70,13 +74,14 @@ export default function () {
 
   // Transaction: list (read side of the money path).
   const t = http.get(`${TXN_URL}/api/v1/transactions?limit=20`, {
+    headers: readHeaders,
     tags: { name: "txn_list" },
   });
   txnLatency.add(t.timings.duration);
   check(t, { "txn list 200": (r) => r.status === 200 });
 
   // libs-served service-info (unauthenticated; cheap liveness+version surface).
-  const i = http.get(`${LEDGER_URL}/api/v1/info`, { tags: { name: "info" } });
+  const i = http.get(`${LEDGER_URL}/api/v1/info`, { headers: readHeaders, tags: { name: "info" } });
   infoLatency.add(i.timings.duration);
   check(i, { "info 200": (r) => r.status === 200 });
 }


### PR DESCRIPTION
## Problem

The money-path performance workflow accepted target URLs but never supplied credentials to k6. A configured least-privilege identity therefore could not reach the protected ledger and transaction handlers; a 401 must not be treated as latency evidence.

## Change

- require PERF_READ_TOKEN as a GitHub Environment secret alongside the two target URL variables
- pass it as an unlogged bearer header to the read-only k6 calls
- emit not-run evidence when any prerequisite is absent
- add an Admin UI guard to retain this cross-layer contract

No token, URL, or internal endpoint is committed.

## Verification

- python3 .github/scripts/check-test-intelligence-ecosystem.py --root . (SUBJECTS=60)
- git diff --check
- targeted Vitest guard is included but could not run locally because the isolated worktree has no installed Admin UI dependencies; CI will execute it.

Refs #3348