### PR TITLE
fix(admin-ui): rebuild evidence for performance plans

### DIFF
--- a/.github/scripts/check-test-intelligence-ecosystem.py
+++ b/.github/scripts/check-test-intelligence-ecosystem.py
@@ -155,6 +155,8 @@ def check(root: Path) -> list[str]:
         ("git ls-remote origin refs/heads/main", "admin deployment does not reject a source commit that is stale before privileged build"),
         ("Skipping stale source", "admin deployment does not make stale-source rejection observable"),
         ('"openbank-libs/governance/journeys.yaml"', "admin deployment does not rebuild the Test Intelligence snapshot when the journey catalog changes"),
+        ('"perf/scenarios.yaml"', "admin deployment does not rebuild the Test Intelligence snapshot when the performance catalog changes"),
+        ('"perf/k6/**"', "admin deployment does not rebuild the Test Intelligence snapshot when a performance definition changes"),
         ('"openbank-infra/gitops/components/observability/cronjob-journey-*.yaml"', "admin deployment does not rebuild the Test Intelligence snapshot when a synthetic runtime manifest changes"),
     ):
         if needle not in deploy:

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -59,6 +59,11 @@ on:
       - "openbank-infra/gitops/components/*/feature-flags.yaml"
       - "openbank-libs/governance/agents.yaml"
       - "openbank-libs/governance/compliance-controls.yaml"
+      # Test Intelligence's governed performance plans are baked into
+      # test-intelligence.json. Without these inputs a GitOps manifest can be Synced
+      # while the running UI still presents the prior plan/blocker snapshot.
+      - "perf/scenarios.yaml"
+      - "perf/k6/**"
       - "openbank-libs/governance/rules.yaml"
       # Test Intelligence snapshot inputs. A journey catalog/manifest change must rebuild
       # the image: the sandbox CronJob alone proves runtime, but the operator's bundled


### PR DESCRIPTION
## Problem

The deployed Test Intelligence page was visually current but served an old performance-plan snapshot after #7433: Argo CD was Synced and Healthy at main, while the pod image remained sandbox-f0609f4cb. The Admin UI deploy workflow did not trigger on perf/scenarios.yaml or perf/k6/** even though the bundled collector reads both.

## Change

- rebuild the Admin UI image when the performance catalog or k6 definition changes
- make the fleet Test Intelligence ecosystem gate enforce both deploy inputs

## Verification

- python3 .github/scripts/check-test-intelligence-ecosystem.py --root . (SUBJECTS=60)
- python3 .github/scripts/check-test-intelligence-ecosystem.py --root . --self-test
- git diff --check
- authenticated browser audit: https://admin.open-bank.tech/system/tests showed the stale scope while Argo CD reported revision 3e600512e

Refs #3348