### PR TITLE
feat(testing): retain fail-closed browser Web Vitals evidence

### DIFF
--- a/.github/scripts/collect-test-run-evidence.py
+++ b/.github/scripts/collect-test-run-evidence.py
@@ -400,6 +400,7 @@ def specialized_evidence(
     synthetic_summary: str | None = None,
     synthetic_journey: str | None = None,
     suite_evidence: list[dict] | None = None,
+    browser_vitals: str | None = None,
 ) -> list[dict]:
     specialized = []
     if performance_summary:
@@ -445,9 +446,16 @@ def specialized_evidence(
         if not re.fullmatch(r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?", synthetic_journey):
             raise ValueError("--synthetic-journey must be a valid journey id")
         e2e = next((item for item in (suite_evidence or []) if item["kind"] == "e2e"), None)
-        state = e2e["state"] if e2e else "not-run"
-        detail = (f"{e2e['executed']}/{e2e['discovered']} browser E2E checks executed"
-                  if e2e else "browser E2E JUnit report absent")
+        vital_file = Path(browser_vitals) if browser_vitals else None
+        try:
+            vitals = json.loads(vital_file.read_text()) if vital_file and vital_file.exists() else None
+        except json.JSONDecodeError:
+            vitals = None
+        metrics = (vitals or {}).get("metrics") if (vitals or {}).get("schemaVersion") == 1 and (vitals or {}).get("journey") == synthetic_journey else None
+        valid = isinstance(metrics, dict) and all(isinstance(metrics.get(key), (int, float)) and metrics[key] >= 0 for key in ("fcpMs", "cls"))
+        state = e2e["state"] if e2e and e2e["state"] == "failed" else "passed" if e2e and valid else "not-run"
+        detail = (f"{e2e['executed']}/{e2e['discovered']} browser E2E checks; FCP {round(metrics['fcpMs'])}ms, CLS {metrics['cls']:.3f}"
+                  if e2e and valid else "browser Web Vitals sample absent or unattributable" if e2e else "browser E2E JUnit report absent")
         specialized.append({"kind": "synthetic", "state": state,
                             "source": f"journey:{synthetic_journey}", "detail": detail})
     return specialized
@@ -463,6 +471,7 @@ def main() -> None:
     parser.add_argument("--mutation-report")
     parser.add_argument("--synthetic-summary")
     parser.add_argument("--synthetic-journey")
+    parser.add_argument("--browser-vitals")
     parser.add_argument("--browser-report-dir")
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
@@ -555,7 +564,11 @@ def main() -> None:
             synthetic = specialized_evidence(None, None, synthetic_summary=str(performance), synthetic_journey="public-edge")
             assert synthetic == [{"kind": "synthetic", "state": "failed", "source": "journey:public-edge", "detail": "1 threshold result(s), 1 breached"}]
             browser_synthetic = specialized_evidence(None, None, synthetic_journey="admin-ui-sso-boundary", suite_evidence=[discovered["e2e"]])
-            assert browser_synthetic == [{"kind": "synthetic", "state": "passed", "source": "journey:admin-ui-sso-boundary", "detail": "1/1 browser E2E checks executed"}]
+            assert browser_synthetic == [{"kind": "synthetic", "state": "not-run", "source": "journey:admin-ui-sso-boundary", "detail": "browser Web Vitals sample absent or unattributable"}]
+            browser_vitals = service / "browser-vitals.json"
+            browser_vitals.write_text('{"schemaVersion":1,"journey":"admin-ui-sso-boundary","browser":"chromium","metrics":{"fcpMs":321,"cls":0.004}}')
+            browser_synthetic = specialized_evidence(None, None, synthetic_journey="admin-ui-sso-boundary", suite_evidence=[discovered["e2e"]], browser_vitals=str(browser_vitals))
+            assert browser_synthetic == [{"kind": "synthetic", "state": "passed", "source": "journey:admin-ui-sso-boundary", "detail": "1/1 browser E2E checks; FCP 321ms, CLS 0.004"}]
             valid = {
                 "schemaVersion": 1,
                 "run": {"id": "1", "attempt": 1, "commit": "1234567", "branch": "main", "workflow": "CI", "url": "https://github.com/JiRaska/open-bank-oss/actions/runs/1", "observedAt": "2026-08-22T21:12:00Z"},
@@ -654,6 +667,7 @@ def main() -> None:
         args.synthetic_summary,
         args.synthetic_journey,
         suite_evidence,
+        args.browser_vitals,
     )
     specialized.extend(trace_contract_evidence(service))
     envelope = {

--- a/.github/workflows/admin-ui-browser-synthetic.yml
+++ b/.github/workflows/admin-ui-browser-synthetic.yml
@@ -37,6 +37,7 @@ jobs:
           python3 .github/scripts/collect-test-run-evidence.py \
             --service openbank-admin-ui --component openbank-admin-ui \
             --synthetic-journey admin-ui-sso-boundary \
+            --browser-vitals openbank-admin-ui/build/test-intelligence/browser-vitals.json \
             --out openbank-admin-ui/build/test-intelligence/run.json
       - if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/openbank-admin-ui/scripts/admin-login-synthetic.mjs
+++ b/openbank-admin-ui/scripts/admin-login-synthetic.mjs
@@ -6,6 +6,7 @@ import { mkdir, writeFile } from 'node:fs/promises'
 
 const target = process.env.ADMIN_UI_SYNTHETIC_URL ?? 'https://admin.open-bank.tech/system/tests'
 const report = process.env.PLAYWRIGHT_JUNIT_OUTPUT_FILE ?? 'build/test-results/e2e/admin-login-synthetic.xml'
+const vitalsReport = process.env.OPENBANK_BROWSER_VITALS_OUTPUT ?? 'build/test-intelligence/browser-vitals.json'
 // Deliberately forgiving public-edge budgets. These are synthetic availability guards, not an
 // authenticated operator-flow SLO or a substitute for RUM. Together they prevent a page that
 // eventually renders after a multi-second upstream or client-side stall from reading as healthy.
@@ -19,6 +20,7 @@ let latencyFailure = null
 let renderFailure = null
 let fcpFailure = null
 let clsFailure = null
+let measuredVitals = null
 let browser
 try {
   browser = await chromium.launch({ headless: true })
@@ -61,6 +63,9 @@ try {
     const firstContentfulPaint = performance.getEntriesByName('first-contentful-paint')[0]?.startTime
     return { firstContentfulPaint, ...(window.__openbankSyntheticVitals ?? {}) }
   })
+  if (Number.isFinite(vitals.firstContentfulPaint) && vitals.clsAvailable && Number.isFinite(vitals.cls)) {
+    measuredVitals = { fcpMs: Math.round(vitals.firstContentfulPaint), cls: Math.round(vitals.cls * 1000) / 1000 }
+  }
   if (!Number.isFinite(vitals.firstContentfulPaint) || vitals.firstContentfulPaint > FCP_BUDGET_MS) {
     fcpFailure = `SSO boundary FCP ${Number.isFinite(vitals.firstContentfulPaint) ? Math.round(vitals.firstContentfulPaint) : 'unavailable'}ms exceeds ${FCP_BUDGET_MS}ms budget`
   }
@@ -77,6 +82,7 @@ try {
   await browser?.close()
 }
 await mkdir(report.slice(0, report.lastIndexOf('/')), { recursive: true })
+await mkdir(vitalsReport.slice(0, vitalsReport.lastIndexOf('/')), { recursive: true })
 const seconds = ((Date.now() - started) / 1000).toFixed(3)
 const escape = value => value.replace(/[&<>"']/g, char => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&apos;' })[char])
 const boundary = boundaryFailure && `<failure message="${escape(boundaryFailure)}"/>`
@@ -87,4 +93,5 @@ const cls = clsFailure && `<failure message="${escape(clsFailure)}"/>`
 const failures = [boundaryFailure, latencyFailure, renderFailure, fcpFailure, clsFailure]
 const failureCount = failures.filter(Boolean).length
 await writeFile(report, `<testsuites><testsuite name="admin-login-synthetic" tests="5" failures="${failureCount}" errors="0" skipped="0" time="${seconds}"><testcase classname="admin-login-synthetic" name="renders SSO boundary" time="${seconds}">${boundary ?? ''}</testcase><testcase classname="admin-login-synthetic" name="SSO boundary responds within public latency budget" time="${seconds}">${latency ?? ''}</testcase><testcase classname="admin-login-synthetic" name="SSO boundary DOMContentLoaded within public render budget" time="${seconds}">${render ?? ''}</testcase><testcase classname="admin-login-synthetic" name="SSO boundary FCP is within public Web Vitals budget" time="${seconds}">${fcp ?? ''}</testcase><testcase classname="admin-login-synthetic" name="SSO boundary CLS is within public Web Vitals budget" time="${seconds}">${cls ?? ''}</testcase></testsuite></testsuites>\n`)
+if (measuredVitals) await writeFile(vitalsReport, `${JSON.stringify({ schemaVersion: 1, journey: 'admin-ui-sso-boundary', browser: 'chromium', metrics: measuredVitals })}\n`)
 if (failureCount) throw new Error(failures.filter(Boolean).join('; '))


### PR DESCRIPTION
Closes #7386\n\nPublishes only attributable FCP/CLS measurements from the credential-free SSO boundary probe. A missing or malformed sidecar is projected as `not-run`, never zero or passed. The existing browser E2E remains the authority for the test verdict.\n\nVerified locally: collector self-test, workflow YAML parse, ESLint, TypeScript.