### PR TITLE
test(ledger): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/it/PostgresRedpandaTestResource.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/it/PostgresRedpandaTestResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.ledger.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.PostgreSQLContainer
@@ -20,20 +21,30 @@ class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
     private var postgres: PostgreSQLContainer<*>? = null
     private var redpanda: RedpandaContainer? = null
     private var redis: GenericContainer<*>? = null
+
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:16.3-alpine"
+        const val REDPANDA_IMAGE = "redpandadata/redpanda:v24.1.2"
+        const val VALKEY_IMAGE = "valkey/valkey:7.2-alpine"
+    }
+
     override fun start(): Map<String, String> {
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withUsername("openbank").withPassword("openbank_secret").withDatabaseName("openbank_ledger_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         val rp = RedpandaContainer(
-            DockerImageName.parse("redpandadata/redpanda:v24.1.2")
+            DockerImageName.parse(REDPANDA_IMAGE)
                 .asCompatibleSubstituteFor("docker.redpanda.com/redpandadata/redpanda"),
         )
         rp.start()
         redpanda = rp
-        val rd = GenericContainer(DockerImageName.parse("valkey/valkey:7.2-alpine")).withExposedPorts(6379)
+        TestInfrastructureEvidence.record("redpanda", REDPANDA_IMAGE, "started")
+        val rd = GenericContainer(DockerImageName.parse(VALKEY_IMAGE)).withExposedPorts(6379)
         rd.start()
         redis = rd
+        TestInfrastructureEvidence.record("valkey", VALKEY_IMAGE, "started")
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
         val bootstrap = rp.bootstrapServers
@@ -49,8 +60,17 @@ class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
         )
     }
     override fun stop() {
-        redis?.stop()
-        redpanda?.stop()
-        postgres?.stop()
+        redis?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("valkey", VALKEY_IMAGE, "stopped")
+        }
+        redpanda?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("redpanda", REDPANDA_IMAGE, "stopped")
+        }
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
     }
 }

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/it/PostgresTestResource.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/it/PostgresTestResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.ledger.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
@@ -12,11 +13,17 @@ import org.testcontainers.utility.DockerImageName
  *  channel is already switched to the in-memory connector (outbox dispatch tests). */
 class PostgresTestResource : QuarkusTestResourceLifecycleManager {
     private var postgres: PostgreSQLContainer<*>? = null
+
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:16.3-alpine"
+    }
+
     override fun start(): Map<String, String> {
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withUsername("openbank").withPassword("openbank_secret").withDatabaseName("openbank_ledger_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
         return mapOf(
@@ -28,6 +35,9 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
         )
     }
     override fun stop() {
-        postgres?.stop()
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
     }
 }

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -32,8 +32,6 @@ openbank-fraud-service/src/test/kotlin/com/openbank/fraud/it/PostgresRedisTestRe
 openbank-fx-service/src/test/kotlin/com/openbank/fx/it/PostgresRedisTestResource.kt
 openbank-interest-service/src/test/kotlin/com/openbank/interest/it/PostgresRedisTestResource.kt
 openbank-kyc-service/src/test/kotlin/com/openbank/kyc/it/PostgresTestResource.kt
-openbank-ledger-service/src/test/kotlin/com/openbank/ledger/it/PostgresRedpandaTestResource.kt
-openbank-ledger-service/src/test/kotlin/com/openbank/ledger/it/PostgresTestResource.kt
 openbank-lending-service/src/test/kotlin/com/openbank/lending/it/PostgresRedisTestResource.kt
 openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/it/OnboardingPostgresTestResource.kt
 openbank-party-service/src/test/kotlin/com/openbank/party/it/PostgresRedpandaTestResource.kt


### PR DESCRIPTION
## What

Records secret-free start/stop lifecycle evidence for Ledger’s real PostgreSQL, Redpanda and Valkey Testcontainers resources.

## Why

Test Intelligence can already retain shared Testcontainers runtime evidence, but the money-path Ledger resources did not emit it. This makes the runtime tab prove the actual test topology rather than only declare it.

## Verification

- `git diff --check`
- Records only after successful starts and only for containers actually stopped.
- Uses `TestInfrastructureEvidence`; no host, mapped port, credential or container ID is emitted.

Refs #7246