### PR TITLE
feat(notification): add safe no-device push fallback

### DIFF
--- a/openbank-contracts/openbank-notification-service/asyncapi.yaml
+++ b/openbank-contracts/openbank-notification-service/asyncapi.yaml
@@ -175,7 +175,7 @@ components:
             an unrelated template being added.
         outcome:
           type: string
-          enum: [SENT, SUPPRESSED, FAILED, BOUNCED]
+          enum: [SENT, SUPPRESSED, FAILED, BOUNCED, REROUTED]
           description: |
             The terminal fate. `SENT` means the channel adapter accepted it — for EMAIL that is an
             SMTP accept, which a later bounce can still refine.
@@ -184,6 +184,10 @@ components:
             because ADR-0239 D4 gives it a defined meaning (a later refinement of an earlier `SENT`),
             so a consumer written now must already tolerate it; adding it later would be the breaking
             change. Do not read its presence here as evidence bounce handling exists.
+
+            `REROUTED` means a PUSH had no active device and a separate generic EMAIL request was
+            durably created in the same transaction. It does not mean that email was delivered; the
+            EMAIL row emits its own terminal outcome.
         reason:
           type: [string, 'null']
           description: |
@@ -202,7 +206,8 @@ components:
             one), `mailer_mocked` (issue #4737 — the EMAIL mirror of the above: the mailer is the
             Quarkus mock, so nothing left the process. A mocked send completes *successfully*, so
             this case used to be reported as `SENT` with `sentAt` populated, for a message that was
-            never transmitted). Null on `SENT`.
+            never transmitted), `rerouted_no_active_device` (a PUSH was atomically handed to a
+            separate generic EMAIL request). Null on `SENT`.
         occurredAt:
           type: string
           format: date-time

--- a/openbank-infra/gitops/components/observability/prometheus-rules-push.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-push.yaml
@@ -97,41 +97,35 @@ spec:
         # create a fallback request, otherwise the policy is configured but inert.
         - alert: PushFallbackConfiguredButInert
           expr: |
-            max(openbank_notification_push_fallback_enabled) == 1
-            and on (template) (
+            (
               (
-                sum by (template) (openbank_notification_push_fanouts_total{
+                sum by (template) (increase(openbank_notification_push_fanouts_total{
                   devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
-                })
-                -
-                (
+                }[15m]))
+                or on (template) (
                   sum by (template) (openbank_notification_push_fanouts_total{
                     devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
+                  }) unless on (template) sum by (template) (openbank_notification_push_fanouts_total{
+                    devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
                   } offset 15m)
-                  or on (template) (
-                    sum by (template) (openbank_notification_push_fanouts_total{
-                      devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
-                    }) * 0
-                  )
                 )
               )
               >
               (
                 (
-                  sum by (template) (openbank_notification_fallback_routed_total{outcome="REROUTED"})
-                  -
-                  (
-                    sum by (template) (openbank_notification_fallback_routed_total{outcome="REROUTED"} offset 15m)
-                    or on (template) (sum by (template) (openbank_notification_fallback_routed_total{outcome="REROUTED"}) * 0)
+                  sum by (template) (increase(openbank_notification_fallback_routed_total{outcome="REROUTED"}[15m]))
+                  or on (template) (
+                    sum by (template) (openbank_notification_fallback_routed_total{outcome="REROUTED"})
+                    unless on (template) sum by (template) (openbank_notification_fallback_routed_total{outcome="REROUTED"} offset 15m)
                   )
-                )
-                or on (template) (
+                ) or on (template) (
                   sum by (template) (openbank_notification_push_fanouts_total{
                     devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
                   }) * 0
                 )
               )
             )
+            and on () (max(openbank_notification_push_fallback_enabled) == 1)
           for: 0m
           labels:
             severity: warning

--- a/openbank-infra/gitops/components/observability/prometheus-rules-push.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-push.yaml
@@ -99,18 +99,18 @@ spec:
           expr: |
             max(openbank_notification_push_fallback_enabled) == 1
             and (
-              (sum(openbank_notification_push_fanouts_total{
+              (sum by (template) (openbank_notification_push_fanouts_total{
                 devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
               }) or vector(0))
               -
-              (sum(openbank_notification_push_fanouts_total{
+              (sum by (template) (openbank_notification_push_fanouts_total{
                 devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
               } offset 15m) or vector(0)) > 0
             )
-            unless (
-              (sum(openbank_notification_fallback_routed_total{outcome="REROUTED"}) or vector(0))
+            unless on (template) (
+              (sum by (template) (openbank_notification_fallback_routed_total{outcome="REROUTED"}) or vector(0))
               -
-              (sum(openbank_notification_fallback_routed_total{outcome="REROUTED"} offset 15m) or vector(0)) > 0
+              (sum by (template) (openbank_notification_fallback_routed_total{outcome="REROUTED"} offset 15m) or vector(0)) > 0
             )
           for: 0m
           labels:
@@ -118,8 +118,8 @@ spec:
           annotations:
             summary: "Enabled no-device push fallback did not create a routed request"
             description: >-
-              A policy-approved PUSH found no active device while fallback was enabled, but no
-              separate EMAIL fallback was recorded. Check notification-service logs and the
+              A policy-approved PUSH template found no active device while fallback was enabled, but
+              that template has no separate EMAIL fallback record. Check notification-service logs and the
               openbank_notification_fallback_routed_total counter; this says nothing about e-mail
               delivery, only that the handoff was not created.
 

--- a/openbank-infra/gitops/components/observability/prometheus-rules-push.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-push.yaml
@@ -91,6 +91,38 @@ spec:
               device-registration path (POST /api/v1/devices) or a mass token invalidation, not
               the push provider.
 
+        # #4363: only evaluated after the explicit, default-off fallback flag is enabled. This
+        # watches the *routed* handoff, not a target-channel delivery; SMTP acceptance/bounce is a
+        # distinct outcome on the separate EMAIL row. A supported template with no device must
+        # create a fallback request, otherwise the policy is configured but inert.
+        - alert: PushFallbackConfiguredButInert
+          expr: |
+            max(openbank_notification_push_fallback_enabled) == 1
+            and (
+              (sum(openbank_notification_push_fanouts_total{
+                devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
+              }) or vector(0))
+              -
+              (sum(openbank_notification_push_fanouts_total{
+                devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
+              } offset 15m) or vector(0)) > 0
+            )
+            unless (
+              (sum(openbank_notification_fallback_routed_total{outcome="REROUTED"}) or vector(0))
+              -
+              (sum(openbank_notification_fallback_routed_total{outcome="REROUTED"} offset 15m) or vector(0)) > 0
+            )
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Enabled no-device push fallback did not create a routed request"
+            description: >-
+              A policy-approved PUSH found no active device while fallback was enabled, but no
+              separate EMAIL fallback was recorded. Check notification-service logs and the
+              openbank_notification_fallback_routed_total counter; this says nothing about e-mail
+              delivery, only that the handoff was not created.
+
         # A terminal transition that found no row to write itself onto (issue #4512). The service
         # then publishes a NotificationOutcome event for a notification the table cannot show:
         # the producer's funnel is told about a message that has no durable record, which is an

--- a/openbank-infra/gitops/components/observability/prometheus-rules-push.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-push.yaml
@@ -98,19 +98,39 @@ spec:
         - alert: PushFallbackConfiguredButInert
           expr: |
             max(openbank_notification_push_fallback_enabled) == 1
-            and (
-              (sum by (template) (openbank_notification_push_fanouts_total{
-                devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
-              }) or vector(0))
-              -
-              (sum by (template) (openbank_notification_push_fanouts_total{
-                devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
-              } offset 15m) or vector(0)) > 0
-            )
-            unless on (template) (
-              (sum by (template) (openbank_notification_fallback_routed_total{outcome="REROUTED"}) or vector(0))
-              -
-              (sum by (template) (openbank_notification_fallback_routed_total{outcome="REROUTED"} offset 15m) or vector(0)) > 0
+            and on (template) (
+              (
+                sum by (template) (openbank_notification_push_fanouts_total{
+                  devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
+                })
+                -
+                (
+                  sum by (template) (openbank_notification_push_fanouts_total{
+                    devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
+                  } offset 15m)
+                  or on (template) (
+                    sum by (template) (openbank_notification_push_fanouts_total{
+                      devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
+                    }) * 0
+                  )
+                )
+              )
+              >
+              (
+                (
+                  sum by (template) (openbank_notification_fallback_routed_total{outcome="REROUTED"})
+                  -
+                  (
+                    sum by (template) (openbank_notification_fallback_routed_total{outcome="REROUTED"} offset 15m)
+                    or on (template) (sum by (template) (openbank_notification_fallback_routed_total{outcome="REROUTED"}) * 0)
+                  )
+                )
+                or on (template) (
+                  sum by (template) (openbank_notification_push_fanouts_total{
+                    devices_bucket="0", template=~"ACCOUNT_FROZEN|KYC_REJECTED|KYC_DOCUMENT_REQUIRED|TRANSACTION_FAILED"
+                  }) * 0
+                )
+              )
             )
           for: 0m
           labels:

--- a/openbank-infra/gitops/components/observability/prometheus-rules-push.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-push.yaml
@@ -130,6 +130,9 @@ spec:
           labels:
             severity: warning
           annotations:
+            # Subject: inbound PUSH traffic is continuous rather than a scheduled batch. The
+            # window therefore measures live request handoffs, not a periodic invocation.
+            subject_period: continuous
             summary: "Enabled no-device push fallback did not create a routed request"
             description: >-
               A policy-approved PUSH template found no active device while fallback was enabled, but

--- a/openbank-notification-service/build.gradle.kts
+++ b/openbank-notification-service/build.gradle.kts
@@ -68,6 +68,16 @@ kover {
     }
 }
 
+tasks.withType<Test> {
+    // The notification suite has three @QuarkusTestProfile variants (fast scheduler, Slack
+    // oversight and default-off push fallback). Each variant forces another Quarkus bootstrap
+    // alongside Testcontainers in the same forked JVM. The Gradle default 512m heap exhausted
+    // in CI while Quarkus loaded Hibernate's parser, which then surfaced as unrelated OIDC
+    // availability failures. Keep the capacity correction local to this module: no test is
+    // skipped and fleet-wide test memory remains unchanged.
+    maxHeapSize = "2g"
+}
+
 // Pact: write generated consumer contracts to pacts/ and forward broker config.
 // Pact rootDir + Pact Broker property forwarding centralised into
 // build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -62,6 +62,8 @@ import java.time.Clock
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.Executor
+import java.util.function.Function
+import java.util.function.Supplier
 
 @ApplicationScoped
 @Suppress("TooManyFunctions") // one delivery path per channel + shared helpers; grows with channels
@@ -69,6 +71,13 @@ class NotificationConsumer @Inject constructor(
     /** See the KDoc on the `mailerMocked` declaration site below (issue #4737). */
     @ConfigProperty(name = "quarkus.mailer.mock", defaultValue = "false")
     val mailerMocked: Boolean,
+    /**
+     * Default-off guard for the reviewed no-device fallback policy (#4363). Enabling it is a
+     * separate reviewed GitOps decision: sandbox mail is deliberately mocked, so a false default
+     * must never be mistaken for delivery readiness.
+     */
+    @ConfigProperty(name = "openbank.notification.push-fallback.enabled", defaultValue = "false")
+    val pushFallbackEnabled: Boolean,
 ) {
 
     companion object {
@@ -80,6 +89,10 @@ class NotificationConsumer @Inject constructor(
          * party-scoped GET /api/v1/notifications/{id}/self.
          */
         const val GENERIC_PUSH_BODY = "Open the OpenBank app to view details."
+
+        /** PII-free fallback e-mail body. Full detail remains behind the authenticated app. */
+        const val GENERIC_FALLBACK_EMAIL_BODY =
+            "A notification is waiting in the OpenBank app. Open the app to view details."
 
         /**
          * The consent scope a MARKETING send is checked against, per target channel (ADR-0198 D4).
@@ -223,6 +236,7 @@ class NotificationConsumer @Inject constructor(
 
     @PostConstruct
     fun init() {
+        pushMetrics.recordFallbackEnabled(pushFallbackEnabled)
         cdiOversightAdapters = jakarta.enterprise.inject.spi.CDI.current()
             .select(OversightWebhookPublisher::class.java).toList()
         log.infof("notification.consumer.init oversight_adapters=%d", cdiOversightAdapters.size)
@@ -727,12 +741,7 @@ class NotificationConsumer @Inject constructor(
                 if (tokens.isEmpty()) {
                     log.infof("PUSH: no active devices for party=%s template=%s", req.partyId, req.template)
                     pushMetrics.recordFanOut(req.template, NotificationOutcome.FAILED, 0)
-                    return@chain markStatus(
-                        req,
-                        entity,
-                        NotificationOutcome.FAILED,
-                        NotificationOutcomeEvent.REASON_NO_DEVICE,
-                    )
+                    return@chain rerouteNoDevice(req, subject, entity)
                 }
                 // Snapshot detached values before crossing the async send boundary — the
                 // managed entities belong to the (now closed) read transaction.
@@ -756,6 +765,80 @@ class NotificationConsumer @Inject constructor(
                     .replaceWithVoid()
             }
     }
+
+    /**
+     * Keep the original row truthful (`FAILED` / no active device) and publish the more precise
+     * REROUTED outcome and fresh EMAIL request commit in one transaction. The fallback has a new
+     * row and its own terminal outcome, so neither row claims that a different channel delivered
+     * it. In particular, a crash cannot publish REROUTED without a durable fallback request.
+     */
+    private fun rerouteNoDevice(req: NotificationRequest, subject: String, entity: NotificationEntity): Uni<Void> {
+        val fallback = req.template.noDeviceFallbackChannel
+        if (!pushFallbackEnabled || fallback == null) {
+            return markStatus(req, entity, NotificationOutcome.FAILED, NotificationOutcomeEvent.REASON_NO_DEVICE)
+        }
+        val fallbackRequest = req.copy(
+            channel = fallback,
+            deepLink = null,
+            interactionRef = null,
+        )
+        val fallbackEntity = fallbackNotificationEntity(fallbackRequest, subject)
+        return persistReroute(req, entity, fallbackEntity)
+            .invoke(
+                Runnable {
+                    pushMetrics.recordFallbackRouted(
+                        req.template,
+                        NotificationChannel.PUSH,
+                        NotificationChannel.EMAIL,
+                        NotificationOutcome.REROUTED,
+                    )
+                },
+            )
+            .chain(Supplier { sendEmail(fallbackRequest, subject, GENERIC_FALLBACK_EMAIL_BODY, fallbackEntity) })
+    }
+
+    /** Builds the separate generic EMAIL notification persisted with the original reroute evidence. */
+    private fun fallbackNotificationEntity(req: NotificationRequest, subject: String): NotificationEntity =
+        NotificationEntity().also { entity ->
+            entity.notificationId = Ids.newId()
+            entity.partyId = req.partyId
+            entity.channel = NotificationChannel.EMAIL.name
+            entity.template = req.template.name
+            entity.recipient = req.recipient
+            entity.subject = subject
+            entity.body = GENERIC_FALLBACK_EMAIL_BODY
+            entity.correlationId = req.correlationId
+            entity.status = "PENDING"
+            entity.createdAt = Instant.now(clock)
+        }
+
+    /** Atomically records the original failed PUSH outcome, its REROUTED evidence, and the fallback request. */
+    private fun persistReroute(
+        req: NotificationRequest,
+        original: NotificationEntity,
+        fallback: NotificationEntity,
+    ): Uni<Void> = Panache.withTransaction {
+        notificationRepo.find("notificationId", original.notificationId).firstResult()
+            .chain(
+                Function { persisted: NotificationEntity? ->
+                    if (persisted == null) {
+                        reportMissingRow(req, original, NotificationOutcome.REROUTED)
+                        Uni.createFrom().failure<Void>(IllegalStateException("notification row missing during reroute"))
+                    } else {
+                        persisted.status = NotificationStatus.FAILED.name
+                        persisted.failureReason = NotificationOutcomeEvent.REASON_REROUTED_NO_DEVICE
+                        outboxRepo.persistInTransaction(
+                            outcomeMessage(
+                                req,
+                                original,
+                                NotificationOutcome.REROUTED,
+                                NotificationOutcomeEvent.REASON_REROUTED_NO_DEVICE,
+                            ),
+                        ).chain(Supplier { notificationRepo.persist(fallback) })
+                    }
+                },
+            )
+    }.replaceWithVoid()
 
     /**
      * FCM/APNs data is a routing envelope, not customer content. `notificationId` lets an app
@@ -833,12 +916,13 @@ class NotificationConsumer @Inject constructor(
         status: NotificationOutcome,
         reason: String?,
         sent: Boolean = false,
+        persistedStatus: String = status.name,
     ): Uni<Void> = Panache.withTransaction {
         notificationRepo.find("notificationId", entity.notificationId).firstResult()
             .map { e ->
                 if (e == null) reportMissingRow(req, entity, status)
                 e?.also {
-                    it.status = status.name
+                    it.status = persistedStatus
                     // Persist the reason alongside the status (V13): the outcome event below
                     // carries the same value, but its outbox row is pruned after dispatch, so
                     // without this the table can only ever say FAILED.

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/port/out/PushMetricsPort.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/port/out/PushMetricsPort.kt
@@ -50,6 +50,20 @@ interface PushMetricsPort {
     fun recordFanOut(template: NotificationTemplate, outcome: NotificationOutcome, devices: Int)
 
     /**
+     * Record a policy-authorised handoff from a no-device PUSH to a separately persisted channel.
+     * `REROUTED` means a fallback request exists; it never claims that the target delivered it.
+     */
+    fun recordFallbackRouted(
+        template: NotificationTemplate,
+        from: NotificationChannel,
+        to: NotificationChannel,
+        outcome: NotificationOutcome,
+    )
+
+    /** Exposes the default-off fallback guard so alerts only evaluate after a reviewed activation. */
+    fun recordFallbackEnabled(enabled: Boolean)
+
+    /**
      * Record that a terminal transition found **no row** to write it onto (issue #4512).
      *
      * The status writers locate the row by `notificationId` and update it through a null-safe

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
@@ -84,6 +84,42 @@ enum class NotificationTemplate(val variables: Set<String>) {
     fun unknownVariables(vars: Map<String, String>): Set<String> = vars.keys - variables
 
     /**
+     * Owner-approved no-device fallback policy (#4363). This is intentionally part of the closed
+     * template model rather than a free-form configuration map: adding a template forces an
+     * explicit delivery decision in review. `null` means the existing in-app-feed-only behaviour
+     * remains correct.
+     *
+     * A fallback e-mail never contains the rendered notification body. It is a generic prompt to
+     * open the authenticated app, so a missing device cannot turn lock-screen-safe push content
+     * into unbounded e-mail PII (ADR-0135 §3).
+     */
+    val noDeviceFallbackChannel: NotificationChannel?
+        get() = when (this) {
+            ACCOUNT_FROZEN,
+            KYC_REJECTED,
+            KYC_DOCUMENT_REQUIRED,
+            TRANSACTION_FAILED,
+            -> NotificationChannel.EMAIL
+            ACCOUNT_OPENED,
+            ACCOUNT_CLOSED,
+            TRANSACTION_COMPLETED,
+            KYC_APPROVED,
+            CONSENT_GRANTED,
+            CONSENT_REVOKED,
+            OTP_CODE,
+            PASSWORD_RESET,
+            WELCOME,
+            SCA_APPROVAL,
+            MARKETING_PRODUCT_OFFER,
+            DELEGATION_OFFERED,
+            DELEGATION_ACCEPTED,
+            DELEGATION_DECLINED,
+            DELEGATION_REVOKED,
+            DELEGATION_EXPIRED,
+            -> null
+        }
+
+    /**
      * The customer-facing category a template belongs to (#2). SECURITY is deliberately un-mutable:
      * a customer can never silence OTP / SCA / KYC / account-freeze pushes, so those are always sent
      * regardless of preferences. Everything else maps to a togglable category.

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/NotificationOutcome.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/NotificationOutcome.kt
@@ -21,7 +21,7 @@ import java.util.UUID
  * D4 gives it a defined meaning for consumers — a later refinement of an earlier `SENT`. A consumer
  * written now must already tolerate it; adding it later would be the breaking change.
  */
-enum class NotificationOutcome { SENT, SUPPRESSED, FAILED, BOUNCED }
+enum class NotificationOutcome { SENT, SUPPRESSED, FAILED, BOUNCED, REROUTED }
 
 /**
  * The `openbank.notification.outcomes.v1` payload (ADR-0239 D2).
@@ -58,6 +58,9 @@ data class NotificationOutcomeEvent(
         const val REASON_NO_RECIPIENT: String = "no_deliverable_recipient"
         const val REASON_MAILER_REFUSED: String = "mailer_refused"
         const val REASON_NO_DEVICE: String = "no_active_device"
+
+        /** The original PUSH had no device; a separately persisted safe-channel request was created. */
+        const val REASON_REROUTED_NO_DEVICE: String = "rerouted_no_active_device"
         const val REASON_PUSH_REJECTED: String = "push_rejected_by_provider"
         const val REASON_PREFERENCE_MUTED: String = "channel_muted_by_preference"
 

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/observability/PushMetricsAdapter.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/observability/PushMetricsAdapter.kt
@@ -11,6 +11,7 @@ import com.openbank.notification.domain.model.NotificationTemplate
 import com.openbank.notification.domain.model.PushPlatform
 import com.openbank.notification.domain.model.PushSendOutcome
 import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.inject.Instance
@@ -79,6 +80,32 @@ class PushMetricsAdapter(private val registry: MeterRegistry?) : PushMetricsPort
         }
     }
 
+    override fun recordFallbackRouted(
+        template: NotificationTemplate,
+        from: NotificationChannel,
+        to: NotificationChannel,
+        outcome: NotificationOutcome,
+    ) {
+        registry?.let { r ->
+            Counter.builder("openbank.notification.fallback.routed")
+                .tag("service", SERVICE)
+                .tag("template", template.name)
+                .tag("from_channel", from.name)
+                .tag("to_channel", to.name)
+                .tag("outcome", outcome.name)
+                .register(r)
+                .increment()
+        }
+    }
+
+    override fun recordFallbackEnabled(enabled: Boolean) {
+        registry?.let { r ->
+            Gauge.builder("openbank.notification.push.fallback.enabled") { if (enabled) ENABLED else DISABLED }
+                .tag("service", SERVICE)
+                .register(r)
+        }
+    }
+
     override fun recordMissingRow(channel: NotificationChannel, template: NotificationTemplate) {
         registry?.let { r ->
             Counter.builder("openbank.notification.status.row.missing")
@@ -98,6 +125,8 @@ class PushMetricsAdapter(private val registry: MeterRegistry?) : PushMetricsPort
 
         private const val FEW_DEVICES = 1
         private const val SEVERAL_DEVICES = 3
+        private const val ENABLED = 1.0
+        private const val DISABLED = 0.0
 
         /** `none` for the success case, so the label is always present and never empty. */
         fun normalizeErrorCode(errorCode: String?): String {

--- a/openbank-notification-service/src/main/resources/application.yaml
+++ b/openbank-notification-service/src/main/resources/application.yaml
@@ -279,6 +279,10 @@ openbank:
   # from Vault via ExternalSecret (never in git). Only anonymized, allow-listed
   # oversight signals egress — see com.openbank.notification.application.OversightWebhook.
   notification:
+    push-fallback:
+      # #4363: a reviewed policy exists, but e-mail fallback is off until a separate GitOps
+      # activation proves a real transport and address-quality gate. Never treat this as live.
+      enabled: ${PUSH_FALLBACK_ENABLED:false}
     webhook:
       slack:
         enabled: ${SLACK_WEBHOOK_ENABLED:false}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
@@ -103,4 +103,21 @@ class NotificationModelTest {
         assertThat(MobileDeepLink.isAllowed("https://example.invalid/redirect")).isFalse()
         assertThat(MobileDeepLink.isAllowed("openbank://savings?next=https://evil.invalid")).isFalse()
     }
+
+    @Test
+    fun `no-device fallback is a closed reviewed template policy`() {
+        assertThat(
+            NotificationTemplate.entries.filter { it.noDeviceFallbackChannel == NotificationChannel.EMAIL },
+        ).containsExactlyInAnyOrder(
+            NotificationTemplate.ACCOUNT_FROZEN,
+            NotificationTemplate.KYC_REJECTED,
+            NotificationTemplate.KYC_DOCUMENT_REQUIRED,
+            NotificationTemplate.TRANSACTION_FAILED,
+        )
+        assertThat(NotificationTemplate.SCA_APPROVAL.noDeviceFallbackChannel).isNull()
+        assertThat(NotificationTemplate.OTP_CODE.noDeviceFallbackChannel).isNull()
+        assertThat(NotificationTemplate.PASSWORD_RESET.noDeviceFallbackChannel).isNull()
+        assertThat(NotificationTemplate.MARKETING_PRODUCT_OFFER.noDeviceFallbackChannel).isNull()
+        assertThat(NotificationTemplate.TRANSACTION_COMPLETED.noDeviceFallbackChannel).isNull()
+    }
 }

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/observability/PushMetricsAdapterTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/observability/PushMetricsAdapterTest.kt
@@ -60,6 +60,24 @@ class PushMetricsAdapterTest {
     }
 
     @Test
+    fun `fallback metric says routed, keeps its closed policy labels, and exposes activation`() {
+        adapter.recordFallbackEnabled(true)
+        adapter.recordFallbackRouted(
+            NotificationTemplate.ACCOUNT_FROZEN,
+            NotificationChannel.PUSH,
+            NotificationChannel.EMAIL,
+            NotificationOutcome.REROUTED,
+        )
+
+        val routed = registry.find("openbank.notification.fallback.routed").counter()
+        assertThat(routed?.count()).isEqualTo(1.0)
+        assertThat(routed?.id?.getTag("from_channel")).isEqualTo("PUSH")
+        assertThat(routed?.id?.getTag("to_channel")).isEqualTo("EMAIL")
+        assertThat(routed?.id?.getTag("outcome")).isEqualTo("REROUTED")
+        assertThat(registry.find("openbank.notification.push.fallback.enabled").gauge()?.value()).isEqualTo(1.0)
+    }
+
+    @Test
     fun `the template tag distinguishes one template's failures from another's`() {
         adapter.recordFanOut(NotificationTemplate.SCA_APPROVAL, NotificationOutcome.FAILED, 0)
         adapter.recordFanOut(NotificationTemplate.TRANSACTION_COMPLETED, NotificationOutcome.FAILED, 0)

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
@@ -4,6 +4,7 @@
 package com.openbank.notification.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.notification.application.NotificationConsumer.Companion.GENERIC_FALLBACK_EMAIL_BODY
 import com.openbank.notification.application.NotificationConsumer.Companion.GENERIC_PUSH_BODY
 import com.openbank.notification.application.port.out.PushMessage
 import com.openbank.notification.application.port.out.PushSender
@@ -72,7 +73,10 @@ class NotificationConsumerIT {
                 // alias, so the outgoing channel's kafka connector is unconfigured and the emitter
                 // fails with "has no downstream" — killing consume() before the oversight side-channel
                 // (OversightWebhookIT). Switching outgoing to in-memory keeps the out event flowing.
-                InMemoryConnector.switchOutgoingChannelsToInMemory("notification-events-out")
+                InMemoryConnector.switchOutgoingChannelsToInMemory("notification-events-out") +
+                // Exercise #4363 through the real consumer. The service config remains default-off;
+                // production activation is a separately reviewed GitOps decision.
+                mapOf("openbank.notification.push-fallback.enabled" to "true")
 
         override fun stop() = InMemoryConnector.clear()
     }
@@ -119,6 +123,10 @@ class NotificationConsumerIT {
     private fun correlationIdFor(partyId: UUID): UUID? = VertxContextSupport.subscribeAndAwait {
         Panache.withSession { repository.find("partyId", partyId).firstResult() }
     }?.correlationId
+
+    private fun notificationsFor(partyId: UUID) = VertxContextSupport.subscribeAndAwait {
+        Panache.withSession { repository.find("partyId", partyId).list() }
+    }
 
     /** Drive one request through the in-memory inbound channel and wait for the ack. */
     private fun consumeAndAwait(request: NotificationRequest) {
@@ -496,6 +504,42 @@ class NotificationConsumerIT {
         assertThat(countFor(partyId)).isEqualTo(1)
         assertThat(statusFor(partyId)).isEqualTo("FAILED")
         assertThat(failureReasonFor(partyId)).isEqualTo(NotificationOutcomeEvent.REASON_NO_DEVICE)
+    }
+
+    @Test
+    fun `approved no-device template creates a separate generic EMAIL fallback`() {
+        val partyId = UUID.randomUUID()
+        mailbox.clear()
+
+        consumeAndAwait(
+            NotificationRequest(
+                partyId = partyId,
+                channel = NotificationChannel.PUSH,
+                template = NotificationTemplate.ACCOUNT_FROZEN,
+                recipient = "fallback@example.com",
+                variables = mapOf("accountNumber" to "synthetic-account-token", "reason" to "synthetic-reason"),
+            ),
+        )
+
+        val rows = notificationsFor(partyId)
+        assertThat(rows).hasSize(2)
+        val original = rows.single { it.channel == NotificationChannel.PUSH.name }
+        val fallback = rows.single { it.channel == NotificationChannel.EMAIL.name }
+        // The original never claims a different-channel success; the generic fallback has its own row.
+        assertThat(original.status).isEqualTo("FAILED")
+        assertThat(original.failureReason).isEqualTo(NotificationOutcomeEvent.REASON_REROUTED_NO_DEVICE)
+        assertThat(fallback.status).isEqualTo("SUPPRESSED")
+        assertThat(fallback.failureReason).isEqualTo(NotificationOutcomeEvent.REASON_MAILER_MOCKED)
+        assertThat(fallback.body)
+            .isEqualTo(GENERIC_FALLBACK_EMAIL_BODY)
+            .doesNotContain("synthetic-account-token")
+            .doesNotContain("synthetic-reason")
+        assertThat(mailbox.getMailMessagesSentTo("fallback@example.com")).hasSize(1)
+
+        val originalEvent = objectMapper.readTree(outcomeRowsFor(original.notificationId).single().payload)
+        assertThat(originalEvent.path("outcome").asText()).isEqualTo("REROUTED")
+        assertThat(originalEvent.path("reason").asText())
+            .isEqualTo(NotificationOutcomeEvent.REASON_REROUTED_NO_DEVICE)
     }
 
     /**

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/PushFallbackDefaultOffIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/PushFallbackDefaultOffIT.kt
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root for license information.
+
+package com.openbank.notification.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.notification.domain.model.NotificationChannel
+import com.openbank.notification.domain.model.NotificationOutcomeEvent
+import com.openbank.notification.domain.model.NotificationRequest
+import com.openbank.notification.domain.model.NotificationTemplate
+import com.openbank.notification.infrastructure.persistence.entity.NotificationOutboxEntity
+import com.openbank.notification.infrastructure.persistence.repository.NotificationOutboxRepositoryImpl
+import com.openbank.notification.infrastructure.persistence.repository.NotificationRepository
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import io.smallrye.reactive.messaging.memory.InMemorySource
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.reactive.messaging.Message
+import org.eclipse.microprofile.reactive.messaging.spi.Connector
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.TimeUnit
+import java.util.function.Supplier
+
+/** Proves #4363 is inert until a separately reviewed deployment enables it. */
+@QuarkusTest
+@TestProfile(PushFallbackDefaultOffIT.DefaultOffProfile::class)
+@QuarkusTestResource(PushFallbackDefaultOffIT.InMemoryKafkaResource::class)
+@QuarkusTestResource(com.openbank.notification.it.PostgresTestResource::class)
+class PushFallbackDefaultOffIT {
+
+    /** Profile overrides outrank ambient shell variables, preserving the production default-off contract. */
+    class DefaultOffProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> =
+            mapOf("openbank.notification.push-fallback.enabled" to "false")
+    }
+
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> =
+            InMemoryConnector.switchIncomingChannelsToInMemory("notification-events-in") +
+                InMemoryConnector.switchOutgoingChannelsToInMemory("notification-events-out")
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    @Inject lateinit var repository: NotificationRepository
+
+    @Inject lateinit var outboxRepo: NotificationOutboxRepositoryImpl
+
+    @Inject lateinit var objectMapper: ObjectMapper
+
+    @Inject
+    @Connector("smallrye-in-memory")
+    lateinit var connector: InMemoryConnector
+
+    @Test
+    fun `approved no-device template remains PUSH-only while fallback is disabled`() {
+        val partyId = UUID.randomUUID()
+        val request = NotificationRequest(
+            partyId = partyId,
+            channel = NotificationChannel.PUSH,
+            template = NotificationTemplate.ACCOUNT_FROZEN,
+            recipient = "fallback-default-off@example.com",
+            variables = mapOf("accountNumber" to "synthetic-account-token"),
+        )
+        val source: InMemorySource<Message<String>> = connector.source("notification-events-in")
+        source.runOnVertxContext(true)
+        val acked = CompletableFuture<Void>()
+        source.send(
+            Message.of(
+                objectMapper.writeValueAsString(request),
+                Supplier<CompletionStage<Void>> {
+                    acked.complete(null)
+                    CompletableFuture.completedFuture<Void>(null)
+                },
+            ),
+        )
+        acked.get(20, TimeUnit.SECONDS)
+
+        val rows = VertxContextSupport.subscribeAndAwait {
+            Panache.withSession { repository.find("partyId", partyId).list() }
+        }
+        assertThat(rows).hasSize(1)
+        assertThat(rows.single().channel).isEqualTo(NotificationChannel.PUSH.name)
+        assertThat(rows.single().status).isEqualTo("FAILED")
+        assertThat(rows.single().failureReason).isEqualTo(NotificationOutcomeEvent.REASON_NO_DEVICE)
+
+        val outcomes = VertxContextSupport.subscribeAndAwait {
+            Panache.withSession {
+                outboxRepo.find("aggregateId", rows.single().notificationId).list()
+            }
+        }
+        assertThat(outcomes.map(NotificationOutboxEntity::payload))
+            .noneMatch { objectMapper.readTree(it).path("outcome").asText() == "REROUTED" }
+    }
+}


### PR DESCRIPTION
Refs #4363

Adds the approved default-disabled EMAIL fallback only for ACCOUNT_FROZEN, KYC_REJECTED, KYC_DOCUMENT_REQUIRED, and TRANSACTION_FAILED when PUSH has no active device.

The original PUSH remains persisted as FAILED while a REROUTED outcome, fallback EMAIL request, and outbox evidence commit atomically. The fallback body is generic and contains no rendered customer data. Includes metrics/alerting, AsyncAPI update, and HTTP/Postgres integration coverage.

Activation remains a separate reviewed GitOps decision with real mail transport and health evidence; this PR does not claim delivery or enable the flag.