### PR TITLE
test(transaction): prove initiation trace contract

### DIFF
--- a/docs/threat-models/openbank-transaction-service.md
+++ b/docs/threat-models/openbank-transaction-service.md
@@ -293,3 +293,10 @@ what the catalogue may hold.
   Risk class = **integrity** (segregation of duties + auditability of a correction), mitigated by
   `MergeSweepDescriptionTest` and `TransactionResourceMergeSweepTest`. `authz.four-eyes.enforce`
   remains `false`; the verb is inert until that flip.
+- **2026-08-27** — Transaction-initiation trace contract. `TransactionService` emits the internal
+  `transaction.initiate` span only with the terminal transaction status. It deliberately excludes
+  amount, account/party identifiers, description, idempotency key and payment metadata. Risk class
+  = **confidentiality** (telemetry data minimisation) and **availability** (a trace exporter must not
+  alter initiation); the span is assertion-backed by `TransactionApiIT`, which drives the real HTTP
+  endpoint against PostgreSQL/Redpanda Testcontainers and the test Temporal terminal-write workflow.
+  The contract proves this service boundary only — it does not claim a distributed downstream trace.

--- a/openbank-transaction-service/build.gradle.kts
+++ b/openbank-transaction-service/build.gradle.kts
@@ -66,6 +66,9 @@ dependencies {
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.testcontainers.redpanda)
+    // Assertion-backed trace contracts: the integration test owns the exporter and emits
+    // a machine-readable marker only after its span/attribute assertions pass.
+    testImplementation(project(":openbank-libs-testing"))
     // ADR-0120 Phase 1: in-memory Temporal test environment for the payment workflow tests.
     testImplementation("io.temporal:temporal-testing:1.25.1")
     testImplementation("io.grpc:grpc-inprocess:1.68.1")

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/usecase/TransactionService.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/usecase/TransactionService.kt
@@ -27,6 +27,9 @@ import com.openbank.transaction.domain.model.TransactionType
 import com.openbank.transaction.domain.saga.SagaState
 import com.openbank.transaction.domain.settlement.SettlementDateResolver
 import com.openbank.transaction.domain.settlement.SettlementDates
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.Tracer
 import io.temporal.client.WorkflowClient
 import io.temporal.client.WorkflowOptions
 import io.vertx.pgclient.PgException
@@ -49,6 +52,13 @@ class TransactionService(
     private val workflowClient: WorkflowClient,
     private val clock: Clock,
 ) : TransactionUseCase {
+
+    /**
+     * Field injection keeps the public constructor used by existing unit tests stable while
+     * making the trace provider replaceable in the assertion-backed integration contract.
+     */
+    @Inject
+    lateinit var tracer: Tracer
 
     @Inject
     constructor(
@@ -76,7 +86,32 @@ class TransactionService(
         private const val IMPLIED_FX_RATE_SCALE = 8
     }
 
+    @Suppress("TooGenericExceptionCaught")
     override suspend fun initiateTransaction(command: InitiateTransactionCommand): Transaction {
+        val span = activeTracer().spanBuilder("transaction.initiate")
+            .setSpanKind(SpanKind.INTERNAL)
+            .startSpan()
+        try {
+            return initiateTransactionInternal(command).also {
+                // A controlled vocabulary: neither amount, account, party, description nor idempotency key.
+                span.setAttribute("openbank.transaction.status", it.status.name)
+            }
+        } catch (error: Exception) {
+            span.recordException(error)
+            throw error
+        } finally {
+            span.end()
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun activeTracer(): Tracer =
+        if (this::tracer.isInitialized) tracer else GlobalOpenTelemetry.getTracer("openbank-transaction-service")
+
+    // Existing orchestration stays deliberately contiguous; extracting it only to host the
+    // span boundary must not alter payment/Temporal sequencing.
+    @Suppress("LongMethod")
+    private suspend fun initiateTransactionInternal(command: InitiateTransactionCommand): Transaction {
         val existing = transactionRepository.findByIdempotencyKey(command.idempotencyKey)
         if (existing != null) return existing
 

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/integration/TransactionApiIT.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/integration/TransactionApiIT.kt
@@ -4,12 +4,17 @@
 
 package com.openbank.transaction.integration
 
+import com.openbank.libs.testing.trace.RecordingSpanExporter
+import com.openbank.transaction.application.usecase.TransactionService
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
 import io.quarkus.test.security.TestSecurity
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
+import jakarta.inject.Inject
 import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.notNullValue
@@ -24,6 +29,9 @@ import java.util.UUID
 @QuarkusTestResource(com.openbank.transaction.it.PostgresRedpandaTestResource::class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class TransactionApiIT {
+
+    @Inject
+    lateinit var transactionService: TransactionService
 
     companion object {
         private val sourceAccountId = UUID.randomUUID()
@@ -225,5 +233,47 @@ class TransactionApiIT {
             ).extract().body().jsonPath().getString("id")
 
         assertThat(id1).isEqualTo(id2)
+    }
+
+    @Test
+    @Order(10)
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `real transaction initiation emits a bounded trace contract`() {
+        val exporter = RecordingSpanExporter()
+        val provider = SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)).build()
+        try {
+            transactionService.tracer = provider.get("transaction-trace-contract-it")
+            val payload = """
+                {
+                  "idempotencyKey": "${UUID.randomUUID()}",
+                  "type": "CREDIT",
+                  "targetAccountId": "${UUID.randomUUID()}",
+                  "amount": "10.00",
+                  "currencyCode": "CZK",
+                  "baseAmount": "10.00",
+                  "baseCurrencyCode": "CZK",
+                  "description": "Trace contract transaction",
+                  "valueDate": "$today",
+                  "bookingDate": "$today"
+                }
+            """.trimIndent()
+
+            Given {
+                contentType("application/json")
+                body(payload)
+            } When {
+                post("/api/v1/transactions")
+            } Then {
+                statusCode(201)
+            }
+
+            exporter.contract()
+                .requiresSpan("transaction.initiate")
+                .requiresAttribute("transaction.initiate", "openbank.transaction.status")
+                .hasNoErrorSpan()
+                .verifiedAs("transaction-initiate")
+        } finally {
+            provider.close()
+        }
     }
 }


### PR DESCRIPTION
Refs #7284

## What
- records the transaction-initiation span from a real HTTP integration flow backed by PostgreSQL, Redpanda and Valkey Testcontainers
- asserts an explicit, bounded telemetry contract: the span name, terminal status attribute and no error span
- keeps sensitive business and identity fields out of the span, documented in the transaction threat model

## Evidence
- `./gradlew :openbank-transaction-service:compileTestKotlin --no-daemon`
- `git diff --check origin/main...HEAD`

This proves the service boundary only; it does not claim a distributed downstream trace.