### PR TITLE
test(transaction): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -50,5 +50,4 @@ openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/it/Po
 openbank-statement-service/src/test/kotlin/com/openbank/statement/it/PostgresTestResource.kt
 openbank-swift-service/src/test/kotlin/com/openbank/swift/it/PostgresRedisTestResource.kt
 openbank-tpp-registry-service/src/test/kotlin/com/openbank/tppregistry/it/PostgresRedisTestResource.kt
-openbank-transaction-service/src/test/kotlin/com/openbank/transaction/it/PostgresRedpandaTestResource.kt
 openbank-vop-service/src/test/kotlin/com/openbank/vop/PostgresTestResource.kt

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/it/PostgresRedpandaTestResource.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/it/PostgresRedpandaTestResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.transaction.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.jboss.logging.Logger
 import org.opentest4j.TestAbortedException
@@ -34,15 +35,16 @@ class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
         if (!DockerClientFactory.instance().isDockerAvailable) {
             throw TestAbortedException("Docker not available — skipping Testcontainers IT")
         }
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withUsername("openbank")
             .withPassword("openbank_secret")
             .withDatabaseName("openbank_transactions_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
 
         val rp = RedpandaContainer(
-            DockerImageName.parse("redpandadata/redpanda:v24.1.2")
+            DockerImageName.parse(REDPANDA_IMAGE)
                 .asCompatibleSubstituteFor("docker.redpanda.com/redpandadata/redpanda"),
         )
         try {
@@ -51,10 +53,12 @@ class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
             throw TestAbortedException("Redpanda failed to start — skipping IT: ${e.message}", e)
         }
         redpanda = rp
+        TestInfrastructureEvidence.record("redpanda", REDPANDA_IMAGE, "started")
 
-        val rd = GenericContainer(DockerImageName.parse("valkey/valkey:7.2-alpine")).withExposedPorts(6379)
+        val rd = GenericContainer(DockerImageName.parse(VALKEY_IMAGE)).withExposedPorts(6379)
         rd.start()
         redis = rd
+        TestInfrastructureEvidence.record("valkey", VALKEY_IMAGE, "started")
 
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
@@ -85,15 +89,27 @@ class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
                 rp.bootstrapServers,
             )
         }
-        redis?.stop()
-        redpanda?.stop()
-        postgres?.stop()
+        redis?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("valkey", VALKEY_IMAGE, "stopped")
+        }
+        redpanda?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("redpanda", REDPANDA_IMAGE, "stopped")
+        }
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
         redis = null
         redpanda = null
         postgres = null
     }
 
     private companion object {
+        const val POSTGRES_IMAGE = "postgres:16.3-alpine"
+        const val REDPANDA_IMAGE = "redpandadata/redpanda:v24.1.2"
+        const val VALKEY_IMAGE = "valkey/valkey:7.2-alpine"
         private val LOG: Logger = Logger.getLogger(PostgresRedpandaTestResource::class.java)
     }
 }


### PR DESCRIPTION
Refs #7284

## What
- records secret-free start/stop lifecycle evidence for the transaction service PostgreSQL, Redpanda and Valkey Testcontainers resources
- records a lifecycle only after the corresponding container action succeeds
- removes only the migrated resource from the enforced Testcontainers-evidence baseline

## Evidence
- `./gradlew :openbank-transaction-service:compileTestKotlin --no-daemon`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py --self-test`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py` (`SUBJECTS=60`)
- `git diff --check`

The event payload deliberately excludes hosts, mapped ports, credentials and container IDs. Transaction is money-path; the existing service threat model and standard two-approval policy remain applicable.