### PR TITLE
test(kyc): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-kyc-service/build.gradle.kts
+++ b/openbank-kyc-service/build.gradle.kts
@@ -56,6 +56,8 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
+    // Shared, secret-free lifecycle evidence collected into the Test Intelligence envelope in CI.
+    testImplementation(project(":openbank-libs-testing"))
 }
 
 // Pact: write the generated consumer contract to pacts/ and forward broker config, matching

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/it/PostgresTestResource.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/it/PostgresTestResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.kyc.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.opentest4j.TestAbortedException
 import org.testcontainers.DockerClientFactory
@@ -19,12 +20,13 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
         if (!DockerClientFactory.instance().isDockerAvailable) {
             throw TestAbortedException("Docker not available — skipping Testcontainers IT")
         }
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withUsername("openbank")
             .withPassword("openbank_secret")
             .withDatabaseName("openbank_kyc_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
         return mapOf(
@@ -37,6 +39,13 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        postgres?.stop()
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
+    }
+
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:16.3-alpine"
     }
 }

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -31,7 +31,6 @@ openbank-fraud-service/src/test/kotlin/com/openbank/fraud/it/PostgresRedisRedpan
 openbank-fraud-service/src/test/kotlin/com/openbank/fraud/it/PostgresRedisTestResource.kt
 openbank-fx-service/src/test/kotlin/com/openbank/fx/it/PostgresRedisTestResource.kt
 openbank-interest-service/src/test/kotlin/com/openbank/interest/it/PostgresRedisTestResource.kt
-openbank-kyc-service/src/test/kotlin/com/openbank/kyc/it/PostgresTestResource.kt
 openbank-lending-service/src/test/kotlin/com/openbank/lending/it/PostgresRedisTestResource.kt
 openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/it/OnboardingPostgresTestResource.kt
 openbank-party-service/src/test/kotlin/com/openbank/party/it/PostgresRedpandaTestResource.kt


### PR DESCRIPTION
Refs #7284

## What
- records secret-free PostgreSQL Testcontainers start/stop evidence for KYC integration tests
- records each lifecycle only after the matching action succeeds
- adds the shared evidence helper and retires exactly the migrated baseline entry

## Evidence
- `./gradlew :openbank-kyc-service:compileTestKotlin --no-daemon`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py --self-test`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py` (`SUBJECTS=60`)
- `git diff --check`

The emitted record deliberately excludes host, mapped port, credentials and container ID.