### PR TITLE
test(delegation): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-delegation-service/build.gradle.kts
+++ b/openbank-delegation-service/build.gradle.kts
@@ -52,6 +52,8 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
+    // Secret-free Testcontainers lifecycle evidence for the immutable Test Intelligence envelope.
+    testImplementation(project(":openbank-libs-testing"))
     testImplementation(libs.smallrye.reactive.messaging.inmemory)
     // Consumer-driven contracts for the four services delegation-service calls before it will
     // mint a grant (sca, pid, account, card-issuance) — issue #2991.

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/it/PostgresTestResource.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/it/PostgresTestResource.kt
@@ -4,29 +4,41 @@
 
 package com.openbank.delegation.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import org.opentest4j.TestAbortedException
+import org.testcontainers.DockerClientFactory
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
 
 class PostgresTestResource : QuarkusTestResourceLifecycleManager {
 
-    private lateinit var postgres: PostgreSQLContainer<*>
-    private lateinit var valkey: GenericContainer<*>
+    private var postgres: PostgreSQLContainer<*>? = null
+    private var valkey: GenericContainer<*>? = null
 
     override fun start(): Map<String, String> {
-        postgres = PostgreSQLContainer("postgres:16-alpine")
+        if (!DockerClientFactory.instance().isDockerAvailable) {
+            throw TestAbortedException("Docker not available — skipping Testcontainers IT")
+        }
+        val pg = PostgreSQLContainer(POSTGRES_IMAGE)
             .withDatabaseName("openbank_delegations_it")
             .withUsername("openbank")
             .withPassword("openbank_secret")
-        valkey = GenericContainer(DockerImageName.parse("docker.io/valkey/valkey:8-alpine"))
+        val vk = GenericContainer(DockerImageName.parse(VALKEY_IMAGE))
             .withExposedPorts(6379)
-        postgres.start()
-        valkey.start()
-        val pgHost = postgres.host
-        val pgPort = postgres.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
-        val db = postgres.databaseName
-        val redisPort = valkey.getMappedPort(6379)
+        // Retain both handles before starting: stop() can then clean up and record a completed
+        // lifecycle even when the second container's startup fails partway through.
+        postgres = pg
+        valkey = vk
+        pg.start()
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
+        vk.start()
+        TestInfrastructureEvidence.record("valkey", VALKEY_IMAGE, "started")
+        val pgHost = pg.host
+        val pgPort = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
+        val db = pg.databaseName
+        val redisPort = vk.getMappedPort(6379)
         return mapOf(
             "quarkus.datasource.reactive.url" to "vertx-reactive:postgresql://$pgHost:$pgPort/$db",
             "quarkus.datasource.jdbc.url" to "jdbc:postgresql://$pgHost:$pgPort/$db",
@@ -38,7 +50,18 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        valkey.stop()
-        postgres.stop()
+        valkey?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("valkey", VALKEY_IMAGE, "stopped")
+        }
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
+    }
+
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:16-alpine"
+        const val VALKEY_IMAGE = "docker.io/valkey/valkey:8-alpine"
     }
 }

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -22,7 +22,6 @@ openbank-clearing-service/src/test/kotlin/com/openbank/clearing/it/PostgresRedpa
 openbank-consent-service/src/test/kotlin/com/openbank/consent/it/ConsentPostgresRedisTestResource.kt
 openbank-consent-service/src/test/kotlin/com/openbank/consent/it/PostgresTestResource.kt
 openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/it/RedpandaRedisTestResource.kt
-openbank-delegation-service/src/test/kotlin/com/openbank/delegation/it/PostgresTestResource.kt
 openbank-dispute-service/src/test/kotlin/com/openbank/dispute/it/PostgresTestResource.kt
 openbank-document-service/src/test/kotlin/com/openbank/document/it/PostgresRedisTestResource.kt
 openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/it/PostgresRedisTestResource.kt


### PR DESCRIPTION
Refs #7246.

Delegation now emits secret-free PostgreSQL and Valkey start/stop lifecycle observations into the immutable Test Intelligence envelope. The resource retains each container handle before startup so partial startup can still be cleaned up and observed.

Verification: `:openbank-delegation-service:compileTestKotlin`, `:openbank-delegation-service:ktlintCheck`, and `check-test-intelligence-ecosystem.py`.