### PR TITLE
test(pid): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -34,7 +34,6 @@ openbank-interest-service/src/test/kotlin/com/openbank/interest/it/PostgresRedis
 openbank-lending-service/src/test/kotlin/com/openbank/lending/it/PostgresRedisTestResource.kt
 openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/it/OnboardingPostgresTestResource.kt
 openbank-party-service/src/test/kotlin/com/openbank/party/it/PostgresRedpandaTestResource.kt
-openbank-pid-service/src/test/kotlin/com/openbank/pid/it/PostgresTestResource.kt
 openbank-psd2-service/src/test/kotlin/com/openbank/psd2/it/PostgresRedisTestResource.kt
 openbank-referral-service/src/test/kotlin/com/openbank/referral/it/ReferralPostgresTestResource.kt
 openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/it/PostgresTestResource.kt

--- a/openbank-pid-service/build.gradle.kts
+++ b/openbank-pid-service/build.gradle.kts
@@ -48,6 +48,8 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
+    // Secret-free Testcontainers lifecycle evidence for the immutable Test Intelligence envelope.
+    testImplementation(project(":openbank-libs-testing"))
     // @TestSecurity for the boot smoke-test's DB-touch assertion (calls /resolve with a role).
     testImplementation(libs.quarkus.test.security)
     // PidApiContractTest compares the served API against the committed openapi.yaml, which it PARSES

--- a/openbank-pid-service/src/test/kotlin/com/openbank/pid/it/PostgresTestResource.kt
+++ b/openbank-pid-service/src/test/kotlin/com/openbank/pid/it/PostgresTestResource.kt
@@ -4,7 +4,10 @@
 
 package com.openbank.pid.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import org.opentest4j.TestAbortedException
+import org.testcontainers.DockerClientFactory
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
 
@@ -21,12 +24,18 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
     private var postgres: PostgreSQLContainer<*>? = null
 
     override fun start(): Map<String, String> {
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        if (!DockerClientFactory.instance().isDockerAvailable) {
+            throw TestAbortedException("Docker not available — skipping Testcontainers IT")
+        }
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withUsername("openbank")
             .withPassword("openbank_secret")
             .withDatabaseName("openbank_pid_it")
-        pg.start()
+        // Keep the handle before start() so a partial container startup remains observable and
+        // stop() can perform the same cleanup guarantee as a successful boot.
         postgres = pg
+        pg.start()
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
         return mapOf(
@@ -39,6 +48,13 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        postgres?.stop()
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
+    }
+
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:16.3-alpine"
     }
 }


### PR DESCRIPTION
Refs #7246.

PID now emits secret-free PostgreSQL start/stop lifecycle observations into the immutable Test Intelligence envelope. The resource retains its container handle before startup so partial startup remains eligible for cleanup.

Verification: `:openbank-pid-service:compileTestKotlin`, `:openbank-pid-service:ktlintCheck`, and `check-test-intelligence-ecosystem.py`.