### PR TITLE
test(anacredit): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-anacredit-service/build.gradle.kts
+++ b/openbank-anacredit-service/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.rest.assured.kotlin)
+    testImplementation(project(":openbank-libs-testing"))
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)

--- a/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/it/PostgresTestResource.kt
+++ b/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/it/PostgresTestResource.kt
@@ -4,8 +4,12 @@
 
 package com.openbank.anacredit.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import org.opentest4j.TestAbortedException
+import org.testcontainers.DockerClientFactory
 import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
 
 /**
  * Spins up a real PostgreSQL (Testcontainers) and points the datasource at it, so a @QuarkusTest
@@ -15,24 +19,38 @@ import org.testcontainers.containers.PostgreSQLContainer
  */
 class PostgresTestResource : QuarkusTestResourceLifecycleManager {
 
-    private lateinit var postgres: PostgreSQLContainer<*>
+    private var postgres: PostgreSQLContainer<*>? = null
 
     override fun start(): Map<String, String> {
-        postgres = PostgreSQLContainer("postgres:18-alpine")
+        if (!DockerClientFactory.instance().isDockerAvailable) {
+            throw TestAbortedException("Docker not available — skipping Testcontainers IT")
+        }
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withDatabaseName("openbank_anacredit")
             .withUsername("openbank")
             .withPassword("openbank")
-        postgres.start()
-        val reactiveUrl = "postgresql://${postgres.host}:${postgres.firstMappedPort}/${postgres.databaseName}"
+        // Keep the handle before start: Quarkus calls stop() after a partial start too, where
+        // lifecycle cleanup must remain visible in Test Intelligence evidence.
+        postgres = pg
+        pg.start()
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
+        val reactiveUrl = "postgresql://${pg.host}:${pg.firstMappedPort}/${pg.databaseName}"
         return mapOf(
             "quarkus.datasource.reactive.url" to reactiveUrl,
-            "quarkus.datasource.jdbc.url" to postgres.jdbcUrl,
-            "quarkus.datasource.username" to postgres.username,
-            "quarkus.datasource.password" to postgres.password,
+            "quarkus.datasource.jdbc.url" to pg.jdbcUrl,
+            "quarkus.datasource.username" to pg.username,
+            "quarkus.datasource.password" to pg.password,
         )
     }
 
     override fun stop() {
-        if (::postgres.isInitialized) postgres.stop()
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
+    }
+
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:18-alpine"
     }
 }

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -13,7 +13,6 @@
 openbank-account-service/src/test/kotlin/com/openbank/account/it/PostgresRedpandaRedisTestResource.kt
 openbank-aml-service/src/test/kotlin/com/openbank/aml/it/PostgresRedisTestResource.kt
 openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/it/PostgresRedpandaTestResource.kt
-openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/it/PostgresTestResource.kt
 openbank-balance-service/src/test/kotlin/com/openbank/balance/it/PostgresRedpandaTestResource.kt
 openbank-billing-service/src/test/kotlin/com/openbank/billing/it/PostgresRedisTestResource.kt
 openbank-campaign-service/src/test/kotlin/com/openbank/campaign/it/CampaignPostgresRedisTestResource.kt


### PR DESCRIPTION
## Summary

- records PostgreSQL Testcontainers `started` and `stopped` lifecycle evidence for AnaCredit’s dedicated real-DB resource
- removes that migrated resource from the fleet ratchet baseline
- preserves a clean Docker-unavailable test abort and partial-start cleanup

Refs #7246

## Verification

- `./gradlew --no-daemon :openbank-anacredit-service:compileTestKotlin :openbank-anacredit-service:ktlintCheck`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py` (`SUBJECTS=60`)

The focused Testcontainers runtime test was attempted locally but did not produce a report in this environment; CI must provide the runtime lifecycle proof before merge.