### PR TITLE
test(onboarding): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -32,7 +32,6 @@ openbank-fraud-service/src/test/kotlin/com/openbank/fraud/it/PostgresRedisTestRe
 openbank-fx-service/src/test/kotlin/com/openbank/fx/it/PostgresRedisTestResource.kt
 openbank-interest-service/src/test/kotlin/com/openbank/interest/it/PostgresRedisTestResource.kt
 openbank-lending-service/src/test/kotlin/com/openbank/lending/it/PostgresRedisTestResource.kt
-openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/it/OnboardingPostgresTestResource.kt
 openbank-party-service/src/test/kotlin/com/openbank/party/it/PostgresRedpandaTestResource.kt
 openbank-pid-service/src/test/kotlin/com/openbank/pid/it/PostgresTestResource.kt
 openbank-psd2-service/src/test/kotlin/com/openbank/psd2/it/PostgresRedisTestResource.kt

--- a/openbank-onboarding-service/build.gradle.kts
+++ b/openbank-onboarding-service/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.rest.assured.kotlin)
+    testImplementation(project(":openbank-libs-testing"))
     // Consumer-driven contracts for party-service (REST + Kafka) and kyc-service (Kafka)
     // (ADR-0063, issue #468).
     testImplementation(libs.pact.consumer)

--- a/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/it/OnboardingPostgresTestResource.kt
+++ b/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/it/OnboardingPostgresTestResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.onboarding.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.opentest4j.TestAbortedException
 import org.testcontainers.DockerClientFactory
@@ -26,12 +27,14 @@ class OnboardingPostgresTestResource : QuarkusTestResourceLifecycleManager {
         if (!DockerClientFactory.instance().isDockerAvailable) {
             throw TestAbortedException("Docker not available — skipping Testcontainers IT")
         }
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withUsername("openbank")
             .withPassword("openbank_secret")
             .withDatabaseName(DB)
-        pg.start()
+        // Retain the handle before start so partial startup can still be cleaned up and observed.
         postgres = pg
+        pg.start()
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
 
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
@@ -46,10 +49,14 @@ class OnboardingPostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        postgres?.stop()
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
     }
 
     private companion object {
         const val DB = "openbank_onboarding_it"
+        const val POSTGRES_IMAGE = "postgres:16.3-alpine"
     }
 }


### PR DESCRIPTION
## Summary

- records PostgreSQL Testcontainers start/stop lifecycle evidence for Onboarding’s real-DB projection tests
- keeps partial startup cleanup observable
- removes the migrated resource from the fleet ratchet baseline

Refs #7246

## Verification

- `./gradlew --no-daemon :openbank-onboarding-service:compileTestKotlin :openbank-onboarding-service:ktlintCheck`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py` (`SUBJECTS=60`)

CI must provide immutable runtime lifecycle proof before merge.