### PR TITLE
test(referral): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -32,7 +32,6 @@ openbank-interest-service/src/test/kotlin/com/openbank/interest/it/PostgresRedis
 openbank-lending-service/src/test/kotlin/com/openbank/lending/it/PostgresRedisTestResource.kt
 openbank-party-service/src/test/kotlin/com/openbank/party/it/PostgresRedpandaTestResource.kt
 openbank-psd2-service/src/test/kotlin/com/openbank/psd2/it/PostgresRedisTestResource.kt
-openbank-referral-service/src/test/kotlin/com/openbank/referral/it/ReferralPostgresTestResource.kt
 openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/it/PostgresTestResource.kt
 openbank-sca-service/src/test/kotlin/com/openbank/sca/it/PostgresRedisTestResource.kt
 openbank-sdd-service/src/test/kotlin/com/openbank/sdd/it/PostgresTestResource.kt

--- a/openbank-referral-service/build.gradle.kts
+++ b/openbank-referral-service/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation(project(":openbank-libs-domain"))
     implementation(project(":openbank-libs-runtime"))
 
+    testImplementation(project(":openbank-libs-testing"))
     testImplementation(libs.quarkus.junit5)
     testImplementation(libs.quarkus.test.security)
     testImplementation(libs.assertj)

--- a/openbank-referral-service/src/test/kotlin/com/openbank/referral/it/ReferralPostgresTestResource.kt
+++ b/openbank-referral-service/src/test/kotlin/com/openbank/referral/it/ReferralPostgresTestResource.kt
@@ -1,5 +1,6 @@
 package com.openbank.referral.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.opentest4j.TestAbortedException
 import org.testcontainers.DockerClientFactory
@@ -12,10 +13,11 @@ class ReferralPostgresTestResource : QuarkusTestResourceLifecycleManager {
         if (!DockerClientFactory.instance().isDockerAvailable) {
             throw TestAbortedException("Docker not available — skipping referral HTTP IT")
         }
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withUsername("openbank").withPassword("openbank_secret").withDatabaseName("openbank_referral_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
         return mapOf(
@@ -27,6 +29,13 @@ class ReferralPostgresTestResource : QuarkusTestResourceLifecycleManager {
         )
     }
     override fun stop() {
-        postgres?.stop()
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
+    }
+
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:16.3-alpine"
     }
 }


### PR DESCRIPTION
## Summary
- record secret-free PostgreSQL Testcontainers start and stop lifecycle evidence for the non-money-path referral IT resource
- consume the existing test-only shared recorder and remove the migrated resource from the lifecycle-evidence ratchet baseline

## Verification
- `python3 .github/scripts/check-test-intelligence-ecosystem.py --self-test`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py --root .`
- `./gradlew --no-daemon :openbank-referral-service:test --tests 'com.openbank.referral.integration.ReferralRestContractIT'`\n\nThe focused IT emitted both lifecycle JSONL events locally without host, port, credentials, or container ID.\n\nRefs #7246