### PR TITLE
test(dispute): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-dispute-service/src/test/kotlin/com/openbank/dispute/it/PostgresTestResource.kt
+++ b/openbank-dispute-service/src/test/kotlin/com/openbank/dispute/it/PostgresTestResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.dispute.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.opentest4j.TestAbortedException
 import org.testcontainers.DockerClientFactory
@@ -19,12 +20,13 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
         if (!DockerClientFactory.instance().isDockerAvailable) {
             throw TestAbortedException("Docker not available — skipping Testcontainers IT")
         }
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withUsername("openbank")
             .withPassword("openbank_secret")
             .withDatabaseName("openbank_dispute_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
         return mapOf(
@@ -37,6 +39,13 @@ class PostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        postgres?.stop()
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
+    }
+
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:16.3-alpine"
     }
 }

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -21,7 +21,6 @@ openbank-clearing-service/src/test/kotlin/com/openbank/clearing/it/PostgresRedpa
 openbank-consent-service/src/test/kotlin/com/openbank/consent/it/ConsentPostgresRedisTestResource.kt
 openbank-consent-service/src/test/kotlin/com/openbank/consent/it/PostgresTestResource.kt
 openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/it/RedpandaRedisTestResource.kt
-openbank-dispute-service/src/test/kotlin/com/openbank/dispute/it/PostgresTestResource.kt
 openbank-document-service/src/test/kotlin/com/openbank/document/it/PostgresRedisTestResource.kt
 openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/it/PostgresRedisTestResource.kt
 openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/EngagementPostgresTestResource.kt


### PR DESCRIPTION
## Summary
- record secret-free PostgreSQL Testcontainers start and stop lifecycle evidence for the non-money-path dispute IT resource
- remove the migrated resource from the enforced lifecycle-evidence baseline

## Verification
- `python3 .github/scripts/check-test-intelligence-ecosystem.py --self-test`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py --root .`
- `./gradlew --no-daemon :openbank-dispute-service:test --tests 'com.openbank.dispute.integration.DisputeOutboxClaimIT'`\n\nThe focused IT emitted both lifecycle JSONL events locally without host, port, credentials, or container ID.\n\nRefs #7246