### PR TITLE
fix(ci): detect stalled service build jobs

### DIFF
--- a/.github/scripts/check-stuck-service-build.py
+++ b/.github/scripts/check-stuck-service-build.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Classify a genuinely stalled GitHub-hosted service-build job (issue #7477).
+
+This deliberately answers a narrower question than "is a workflow old?". A service CI
+build can spend legitimate time uploading Kover, generating its envelope or publishing
+artifacts. The only automatically-cancellable shape is the mandatory `Build + test`
+step itself remaining in progress past the bounded interval. A different job, a completed
+step, malformed API data or a fresh build is never an implicit cancellation candidate.
+
+The workflow owns reading the GitHub Actions API and cancellation. Keeping this classifier
+pure makes both the positive and the "do not cancel normal work" paths executable in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+BUILD_PREFIX = "build (openbank-"
+STEP_PREFIX = "Build + test (:openbank-"
+
+
+def parse_time(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def classify(payload: dict[str, Any], now: datetime, timeout_minutes: int) -> list[dict[str, str]]:
+    jobs = payload.get("jobs")
+    if not isinstance(jobs, list):
+        raise ValueError("Actions jobs payload has no jobs list")
+    stalled: list[dict[str, str]] = []
+    for job in jobs:
+        if not isinstance(job, dict):
+            raise ValueError("Actions jobs payload contains a non-object job")
+        name = job.get("name")
+        if not isinstance(name, str) or not name.startswith(BUILD_PREFIX):
+            continue
+        if job.get("status") != "in_progress":
+            continue
+        started = parse_time(job.get("started_at"))
+        if started is None:
+            raise ValueError(f"{name} is in progress but has no valid started_at")
+        age_minutes = (now - started).total_seconds() / 60
+        if age_minutes < timeout_minutes:
+            continue
+        steps = job.get("steps")
+        if not isinstance(steps, list):
+            raise ValueError(f"{name} is in progress but has no steps list")
+        build_step = next((step for step in steps if isinstance(step, dict) and isinstance(step.get("name"), str)
+                           and step["name"].startswith(STEP_PREFIX)), None)
+        if build_step is None:
+            # The service build has not reached its mandatory command. It may be queued or
+            # warming a cache; do not cancel it as though it had stalled (#7477's correction).
+            continue
+        if build_step.get("status") != "in_progress":
+            continue
+        job_id = job.get("id")
+        html_url = job.get("html_url")
+        if not isinstance(job_id, int) or not isinstance(html_url, str):
+            raise ValueError(f"{name} has no stable job id or URL")
+        stalled.append({
+            "jobId": str(job_id), "job": name, "step": str(build_step["name"]),
+            "startedAt": started.isoformat().replace("+00:00", "Z"), "ageMinutes": str(int(age_minutes)),
+            "url": html_url,
+        })
+    return stalled
+
+
+def self_test() -> int:
+    now = datetime(2026, 8, 28, 12, 0, tzinfo=timezone.utc)
+    base = {"id": 42, "name": "build (openbank-example-service) / openbank-example-service (build)",
+            "status": "in_progress", "started_at": "2026-08-28T11:00:00Z",
+            "html_url": "https://github.com/JiRaska/open-bank-oss/actions/runs/1/job/42",
+            "steps": [{"name": "Build + test (:openbank-example-service)", "status": "in_progress"}]}
+    cases = [
+        ("stalled mandatory build is selected", {"jobs": [base]}, 1),
+        ("fresh mandatory build is not selected", {"jobs": [{**base, "started_at": "2026-08-28T11:40:00Z"}]}, 0),
+        ("long Kover report is not selected", {"jobs": [{**base, "steps": [{"name": "Build + test (:openbank-example-service)", "status": "completed"}, {"name": "Generate Kover XML report", "status": "in_progress"}]}]}, 0),
+        ("other workflow job is not selected", {"jobs": [{**base, "name": "CodeQL (java-kotlin, manual)"}]}, 0),
+    ]
+    failures = 0
+    for label, payload, expected in cases:
+        actual = len(classify(payload, now, 45))
+        if actual != expected:
+            print(f"FAIL {label}: expected {expected}, got {actual}")
+            failures += 1
+        else:
+            print(f"ok {label}")
+    try:
+        classify({"jobs": [{**base, "started_at": None}]}, now, 45)
+        print("FAIL invalid started_at was accepted")
+        failures += 1
+    except ValueError:
+        print("ok invalid in-progress metadata refuses a verdict")
+    return 1 if failures else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--jobs-json", type=Path)
+    parser.add_argument("--now")
+    parser.add_argument("--timeout-minutes", type=int, default=45)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        return self_test()
+    if not args.jobs_json or not args.now or args.timeout_minutes <= 0:
+        parser.error("--jobs-json, --now and positive --timeout-minutes are required")
+    now = parse_time(args.now)
+    if now is None:
+        parser.error("--now must be ISO-8601 UTC")
+    try:
+        print(json.dumps(classify(json.loads(args.jobs_json.read_text()), now, args.timeout_minutes)))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"::error title=CI stalled-build watchdog::{exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/service-build-stall-watch.yml
+++ b/.github/workflows/service-build-stall-watch.yml
@@ -1,0 +1,65 @@
+# Cancel only a proven-stalled mandatory service build, then leave an addressed audit trail.
+# A cancelled test run is never turned green; Services CI's normal failure/retry path owns its
+# immutable diagnostics and any later rerun. This control prevents an invisible in-progress job
+# from blocking its PR forever (issue #7477).
+name: Service build stall watch
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report candidates without cancelling them'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  actions: write
+  issues: write
+
+concurrency:
+  group: service-build-stall-watch
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Self-test classifier
+        run: python3 .github/scripts/check-stuck-service-build.py --self-test
+      - name: Find and cancel only stalled mandatory service builds
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+          now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          gh api "repos/${REPO}/actions/runs?status=in_progress&per_page=100" --jq '[.workflow_runs[] | select(.name == "Services CI") | {id,run_attempt,html_url}]' > /tmp/service-runs.json
+          printf '[]' > /tmp/stalled.json
+          jq -c '.[]' /tmp/service-runs.json | while IFS= read -r run; do
+            run_id=$(jq -r '.id' <<<"$run")
+            attempt=$(jq -r '.run_attempt' <<<"$run")
+            run_url=$(jq -r '.html_url' <<<"$run")
+            gh api "repos/${REPO}/actions/runs/${run_id}/attempts/${attempt}/jobs?per_page=100" > /tmp/jobs.json
+            candidates=$(python3 .github/scripts/check-stuck-service-build.py --jobs-json /tmp/jobs.json --now "$now" --timeout-minutes 45)
+            jq -c --arg runId "$run_id" --arg attempt "$attempt" --arg runUrl "$run_url" '.[] + {runId:$runId,attempt:$attempt,runUrl:$runUrl}' <<<"$candidates" \
+              | while IFS= read -r candidate; do
+                  jq --argjson candidate "$candidate" '. + [$candidate]' /tmp/stalled.json > /tmp/stalled.next && mv /tmp/stalled.next /tmp/stalled.json
+                done
+          done
+          jq -c '.[]' /tmp/stalled.json | while IFS= read -r candidate; do
+            run_id=$(jq -r '.runId' <<<"$candidate")
+            title="CI stalled service build: $(jq -r '.job' <<<"$candidate")"
+            body=$(jq -r '"<!-- service-build-stall:" + .runId + ":" + .jobId + " -->\n\n## Mandatory service build was cancelled after no progress\n\n| | |\n|---|---|\n| workflow run | [run " + .runId + " attempt " + .attempt + "](" + .runUrl + ") |\n| stalled job | [" + .job + "](" + .url + ") |\n| stalled step | `" + .step + "` |\n| started | `" + .startedAt + "` |\n| observed age | `" + .ageMinutes + " minutes` |\n\nThe watchdog only acts when the mandatory `Build + test` step itself exceeds 45 minutes. It does not cancel Kover, envelope or artifact publication. The cancellation preserves GitHub attempt diagnostics and does **not** create a green verdict. Inspect and rerun through the normal CI path.\n\n_Automated by Service build stall watch (issue #7477)._"' <<<"$candidate")
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "::warning title=CI stalled-build dry run::${title}"
+              continue
+            fi
+            gh api --method POST "repos/${REPO}/actions/runs/${run_id}/cancel" >/dev/null
+            gh issue create --repo "$REPO" --title "$title" --body "$body" --label fleet-health
+          done


### PR DESCRIPTION
## Summary
- add a self-tested classifier for the specific stalled mandatory `Build + test` shape from #7477
- schedule a conservative 45-minute watchdog; it ignores cache warm-up, Kover, envelope and artifact phases
- on a proven candidate, cancel the Actions run without rewriting its verdict and open an issue carrying attempt/job diagnostics

## Verification
- `python3 .github/scripts/check-stuck-service-build.py --self-test`
- workflow YAML parsed locally
- dry-run classifier against live sanctions CI jobs returned `[]` while it was in its post-build Kover/reporting phase

Refs #7477