### PR TITLE
test(party): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -29,7 +29,6 @@ openbank-fraud-service/src/test/kotlin/com/openbank/fraud/it/PostgresRedisTestRe
 openbank-fx-service/src/test/kotlin/com/openbank/fx/it/PostgresRedisTestResource.kt
 openbank-interest-service/src/test/kotlin/com/openbank/interest/it/PostgresRedisTestResource.kt
 openbank-lending-service/src/test/kotlin/com/openbank/lending/it/PostgresRedisTestResource.kt
-openbank-party-service/src/test/kotlin/com/openbank/party/it/PostgresRedpandaTestResource.kt
 openbank-psd2-service/src/test/kotlin/com/openbank/psd2/it/PostgresRedisTestResource.kt
 openbank-sca-service/src/test/kotlin/com/openbank/sca/it/PostgresRedisTestResource.kt
 openbank-sdd-service/src/test/kotlin/com/openbank/sdd/it/PostgresTestResource.kt

--- a/openbank-party-service/build.gradle.kts
+++ b/openbank-party-service/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     testImplementation(libs.rest.assured.kotlin)
     // Provider-side message Pact verification for the PARTY_CREATED event (ADR-0063 P1).
     testImplementation(libs.pact.provider)
+    testImplementation(project(":openbank-libs-testing"))
 
     // CI infra pilot (P2): @QuarkusTest ITs get an isolated, per-JVM PostgreSQL +
     // Redpanda (Kafka API) via Testcontainers, instead of the shared compose stack

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/it/PostgresRedpandaTestResource.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/it/PostgresRedpandaTestResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.party.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.opentest4j.TestAbortedException
 import org.testcontainers.DockerClientFactory
@@ -36,23 +37,28 @@ class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
         if (!DockerClientFactory.instance().isDockerAvailable) {
             throw TestAbortedException("Docker not available — skipping Testcontainers IT")
         }
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withUsername("openbank")
             .withPassword("openbank_secret")
             .withDatabaseName("openbank_party_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
 
         val rp = RedpandaContainer(
-            DockerImageName.parse("redpandadata/redpanda:v24.1.2")
+            DockerImageName.parse(REDPANDA_IMAGE)
                 .asCompatibleSubstituteFor("docker.redpanda.com/redpandadata/redpanda"),
         )
         try {
             rp.start()
         } catch (e: Exception) {
+            pg.stop()
+            postgres = null
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
             throw TestAbortedException("Redpanda failed to start — skipping IT: ${e.message}", e)
         }
         redpanda = rp
+        TestInfrastructureEvidence.record("redpanda", REDPANDA_IMAGE, "started")
 
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
@@ -73,7 +79,18 @@ class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        redpanda?.stop()
-        postgres?.stop()
+        redpanda?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("redpanda", REDPANDA_IMAGE, "stopped")
+        }
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
+    }
+
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:16.3-alpine"
+        const val REDPANDA_IMAGE = "redpandadata/redpanda:v24.1.2"
     }
 }


### PR DESCRIPTION
## What\n\nCloses #7246\n\nRecords secret-free start/stop lifecycle evidence for the existing isolated PostgreSQL + Redpanda Party outbox concurrency integration test.\n\n## Proof\n\n- `./gradlew --no-daemon :openbank-party-service:test --tests com.openbank.party.integration.PartyOutboxClaimIT` — passed (2/2)\n- forced Testcontainers rerun — passed\n- `python3 .github/scripts/check-test-intelligence-ecosystem.py --root .` — passed\n- `git diff --check` — clean\n\nNo production topology or test semantics changed; the baseline entry is removed only after both lifecycle pairs are recorded.