### PR TITLE
test(campaign): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-campaign-service/build.gradle.kts
+++ b/openbank-campaign-service/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
+    testImplementation(project(":openbank-libs-testing"))
 }
 
 // Coverage is ratchet-only (never lower). Without this block koverVerify has no rule to check,

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/it/CampaignPostgresRedisTestResource.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/it/CampaignPostgresRedisTestResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.campaign.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.opentest4j.TestAbortedException
 import org.testcontainers.DockerClientFactory
@@ -33,7 +34,7 @@ class CampaignPostgresRedisTestResource : QuarkusTestResourceLifecycleManager {
             throw TestAbortedException("Docker not available — skipping Testcontainers IT")
         }
         val pg = PostgreSQLContainer(
-            DockerImageName.parse("docker.io/library/postgres:16.3-alpine")
+            DockerImageName.parse(POSTGRES_IMAGE)
                 .asCompatibleSubstituteFor("postgres"),
         )
             .withUsername("openbank")
@@ -41,10 +42,19 @@ class CampaignPostgresRedisTestResource : QuarkusTestResourceLifecycleManager {
             .withDatabaseName("openbank_campaigns_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
 
-        val rd = GenericContainer(DockerImageName.parse("docker.io/valkey/valkey:7.2-alpine")).withExposedPorts(6379)
-        rd.start()
+        val rd = GenericContainer(DockerImageName.parse(VALKEY_IMAGE)).withExposedPorts(6379)
+        try {
+            rd.start()
+        } catch (e: Exception) {
+            pg.stop()
+            postgres = null
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+            throw TestAbortedException("Valkey failed to start — skipping Testcontainers IT: ${e.message}", e)
+        }
         redis = rd
+        TestInfrastructureEvidence.record("valkey", VALKEY_IMAGE, "started")
 
         val pgHost = pg.host
         val pgPort = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
@@ -61,7 +71,18 @@ class CampaignPostgresRedisTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        redis?.stop()
-        postgres?.stop()
+        redis?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("valkey", VALKEY_IMAGE, "stopped")
+        }
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
+    }
+
+    private companion object {
+        const val POSTGRES_IMAGE = "docker.io/library/postgres:16.3-alpine"
+        const val VALKEY_IMAGE = "docker.io/valkey/valkey:7.2-alpine"
     }
 }

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -15,7 +15,6 @@ openbank-aml-service/src/test/kotlin/com/openbank/aml/it/PostgresRedisTestResour
 openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/it/PostgresRedpandaTestResource.kt
 openbank-balance-service/src/test/kotlin/com/openbank/balance/it/PostgresRedpandaTestResource.kt
 openbank-billing-service/src/test/kotlin/com/openbank/billing/it/PostgresRedisTestResource.kt
-openbank-campaign-service/src/test/kotlin/com/openbank/campaign/it/CampaignPostgresRedisTestResource.kt
 openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/it/PostgresRedisTestResource.kt
 openbank-clearing-service/src/test/kotlin/com/openbank/clearing/it/PostgresRedpandaRedisTestResource.kt
 openbank-consent-service/src/test/kotlin/com/openbank/consent/it/ConsentPostgresRedisTestResource.kt


### PR DESCRIPTION
## What\n\nCloses #7246\n\nRecords secret-free start/stop lifecycle evidence for Campaign REST contract integration tests using isolated PostgreSQL and Valkey. A failed Valkey start now explicitly tears PostgreSQL down before aborting the IT.\n\n## Proof\n\n- `./gradlew --no-daemon :openbank-campaign-service:test --tests com.openbank.campaign.integration.CampaignRestContractIT` — 42/42 passed\n- `python3 .github/scripts/check-test-intelligence-ecosystem.py --root .` — passed\n- `git diff --check` — clean\n\nNo production topology or test semantics changed.