### PR TITLE
test(document): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-document-service/src/test/kotlin/com/openbank/document/it/PostgresRedisTestResource.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/it/PostgresRedisTestResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.document.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.opentest4j.TestAbortedException
 import org.testcontainers.DockerClientFactory
@@ -20,16 +21,28 @@ class PostgresRedisTestResource : QuarkusTestResourceLifecycleManager {
         if (!DockerClientFactory.instance().isDockerAvailable) {
             throw TestAbortedException("Docker not available — skipping Testcontainers IT")
         }
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        val pg = PostgreSQLContainer(
+            DockerImageName.parse(POSTGRES_IMAGE)
+                .asCompatibleSubstituteFor("postgres"),
+        )
             .withUsername("openbank")
             .withPassword("openbank_secret")
             .withDatabaseName("openbank_documents_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
 
-        val rd = GenericContainer(DockerImageName.parse("valkey/valkey:7.2-alpine")).withExposedPorts(6379)
-        rd.start()
+        val rd = GenericContainer(DockerImageName.parse(VALKEY_IMAGE)).withExposedPorts(6379)
+        try {
+            rd.start()
+        } catch (e: Exception) {
+            pg.stop()
+            postgres = null
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+            throw TestAbortedException("Valkey failed to start — skipping Testcontainers IT: ${e.message}", e)
+        }
         redis = rd
+        TestInfrastructureEvidence.record("valkey", VALKEY_IMAGE, "started")
 
         val pgHost = pg.host
         val pgPort = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
@@ -45,7 +58,18 @@ class PostgresRedisTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        postgres?.stop()
-        redis?.stop()
+        redis?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("valkey", VALKEY_IMAGE, "stopped")
+        }
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
+    }
+
+    private companion object {
+        const val POSTGRES_IMAGE = "docker.io/library/postgres:16.3-alpine"
+        const val VALKEY_IMAGE = "docker.io/valkey/valkey:7.2-alpine"
     }
 }

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -21,7 +21,6 @@ openbank-clearing-service/src/test/kotlin/com/openbank/clearing/it/PostgresRedpa
 openbank-consent-service/src/test/kotlin/com/openbank/consent/it/ConsentPostgresRedisTestResource.kt
 openbank-consent-service/src/test/kotlin/com/openbank/consent/it/PostgresTestResource.kt
 openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/it/RedpandaRedisTestResource.kt
-openbank-document-service/src/test/kotlin/com/openbank/document/it/PostgresRedisTestResource.kt
 openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/it/PostgresRedisTestResource.kt
 openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/EngagementPostgresTestResource.kt
 openbank-fraud-service/src/test/kotlin/com/openbank/fraud/it/PostgresRedisRedpandaTestResource.kt


### PR DESCRIPTION
## Summary
- record PostgreSQL and Valkey Testcontainers start/stop lifecycle evidence for document-service integration tests
- remove the migrated resource from the ratchet baseline
- record PostgreSQL teardown if Valkey cannot start

## Verification
- `./gradlew --no-daemon :openbank-document-service:test --tests com.openbank.document.integration.DocumentOutboxClaimIT` (2 passed)
- `python3 .github/scripts/check-test-intelligence-ecosystem.py --root .`
- `git diff --check`

Refs #7246