### PR TITLE
fix(ci): preserve declared performance scope on dispatch

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -575,12 +575,15 @@ jobs:
           COUNT=$(find . -path "*/build/reports/pitest/mutations.xml" | wc -l | tr -d ' ')
           echo "Staged ${COUNT} mutations.xml files from ${DOWNLOADED} artifacts."
 
-      - name: Stage performance evidence from latest successful k6 run
+      - name: Stage performance evidence from latest complete k6 run
         # The Test Intelligence collector reads k6 summaries only from the deployment-local
         # perf-artifacts directory.  A declared scenario is deliberately not promoted to a
         # result, so bring in only artifacts emitted by the latest successful main run of the
         # governed performance workflows.  The money-path baseline may intentionally emit only
         # a `not-run` envelope when no safe runner target exists; retain that provenance too.
+        # A manually narrowed perf-gate dispatch is useful for diagnosis, but must not replace
+        # the broader declared-scope snapshot with one service's result.  Select the newest
+        # successful run that retained BOTH declared v1 artifacts instead.
         # Missing or expired evidence remains `not-run` in the
         # UI; this best-effort staging step must never turn absence into a deployment failure.
         env:
@@ -590,12 +593,24 @@ jobs:
           api() { curl -sf -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" "$@"; }
           mkdir -p openbank-admin-ui/perf-artifacts
-          RUN_ID=$(api \
-            "https://api.github.com/repos/${REPO}/actions/workflows/perf-gate.yml/runs?branch=main&status=success&per_page=1" \
-            | python3 -c "import json,sys; r=json.load(sys.stdin).get('workflow_runs',[]); print(r[0]['id'] if r else '')" \
+          RUN_ID=""
+          RUN_IDS=$(api \
+            "https://api.github.com/repos/${REPO}/actions/workflows/perf-gate.yml/runs?branch=main&status=success&per_page=20" \
+            | python3 -c "import json,sys; [print(r['id']) for r in json.load(sys.stdin).get('workflow_runs',[])]" \
             2>/dev/null || true)
+          for candidate in ${RUN_IDS}; do
+            candidate_artifacts=$(api \
+              "https://api.github.com/repos/${REPO}/actions/runs/${candidate}/artifacts?per_page=100" \
+              | python3 -c "import json,sys; [print(a['name']) for a in json.load(sys.stdin).get('artifacts',[]) if not a['expired']]" \
+              2>/dev/null || true)
+            if grep -qx 'perf-reports-openbank-product-catalog' <<< "${candidate_artifacts}" \
+              && grep -qx 'perf-reports-openbank-flaky-test-hunter' <<< "${candidate_artifacts}"; then
+              RUN_ID="${candidate}"
+              break
+            fi
+          done
           if [ -z "${RUN_ID}" ]; then
-            echo "No successful performance run found — performance evidence remains not-run."
+            echo "No successful complete declared-scope performance run found — performance evidence remains not-run."
             exit 0
           fi
           ARTIFACTS=$(api \

--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -16,9 +16,12 @@ on:
   workflow_dispatch:
     inputs:
       services:
-        description: "Space-separated service modules to test (blank = openbank-product-catalog)"
+        description: "Space-separated service modules to test (blank = declared v1 scope)"
         required: false
-        default: "openbank-product-catalog"
+        # A dispatch input's default is still a non-empty override.  Keeping this empty means
+        # an operator-triggered run measures the same declared Product Catalog + Flaky Test
+        # Hunter denominator as the scheduled run, unless they deliberately narrow it.
+        default: ""
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- keep the manual performance-gate input empty by default
- make an unscoped dispatch execute the declared Product Catalog + Flaky Test Hunter scope
- retain explicit overrides for deliberately narrowed diagnostics

## Verification
- parsed `.github/workflows/perf-gate.yml` and asserted the dispatch default is empty
- `git diff --check`

Refs #3348