### PR TITLE
test(engagement): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-engagement-service/build.gradle.kts
+++ b/openbank-engagement-service/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
+    testImplementation(project(":openbank-libs-testing"))
     testImplementation(libs.wiremock.standalone)
 }
 

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/EngagementPostgresTestResource.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/EngagementPostgresTestResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.engagement.integration
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.opentest4j.TestAbortedException
 import org.testcontainers.DockerClientFactory
@@ -24,7 +25,7 @@ class EngagementPostgresTestResource : QuarkusTestResourceLifecycleManager {
             throw TestAbortedException("Docker not available — skipping Testcontainers IT")
         }
         val pg = PostgreSQLContainer(
-            DockerImageName.parse("docker.io/library/postgres:16.3-alpine")
+            DockerImageName.parse(POSTGRES_IMAGE)
                 .asCompatibleSubstituteFor("postgres"),
         )
             .withUsername("openbank")
@@ -32,6 +33,7 @@ class EngagementPostgresTestResource : QuarkusTestResourceLifecycleManager {
             .withDatabaseName("openbank_engagement_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
 
         return mapOf(
             "quarkus.datasource.reactive.url" to
@@ -49,6 +51,13 @@ class EngagementPostgresTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        postgres?.stop()
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
+    }
+
+    private companion object {
+        const val POSTGRES_IMAGE = "docker.io/library/postgres:16.3-alpine"
     }
 }

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -21,7 +21,6 @@ openbank-consent-service/src/test/kotlin/com/openbank/consent/it/ConsentPostgres
 openbank-consent-service/src/test/kotlin/com/openbank/consent/it/PostgresTestResource.kt
 openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/it/RedpandaRedisTestResource.kt
 openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/it/PostgresRedisTestResource.kt
-openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/EngagementPostgresTestResource.kt
 openbank-fraud-service/src/test/kotlin/com/openbank/fraud/it/PostgresRedisRedpandaTestResource.kt
 openbank-fraud-service/src/test/kotlin/com/openbank/fraud/it/PostgresRedisTestResource.kt
 openbank-fx-service/src/test/kotlin/com/openbank/fx/it/PostgresRedisTestResource.kt


### PR DESCRIPTION
## Summary
- record PostgreSQL Testcontainers start/stop lifecycle evidence for engagement-service real HTTP integration tests
- remove the migrated resource from the Test Intelligence ratchet baseline

## Verification
- `./gradlew --no-daemon :openbank-engagement-service:test --tests com.openbank.engagement.integration.SurfaceRestContractIT` (14 passed)
- `python3 .github/scripts/check-test-intelligence-ecosystem.py --root .`
- `git diff --check`

Refs #7246