### PR TITLE
fix(ci): match bootstrap service tokens

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -279,7 +279,7 @@ jobs:
                 exit 1
               fi
               svc="$REQUESTED"
-              if ! grep -qxF "$svc" <<< "$ALL_SERVICES" || [ ! -f "$svc/Dockerfile" ]; then
+              if ! grep -qxF "$svc" <<< "${ALL_SERVICES// /$'\n'}" || [ ! -f "$svc/Dockerfile" ]; then
                 echo "::error::bootstrap target must be a known service with a committed Dockerfile"
                 exit 1
               fi


### PR DESCRIPTION
Refs #7525

Correct the artifact-only bootstrap guard to match one service token in the workflow’s space-separated allowlist. The prior whole-line comparison safely rejected every valid service before build. This keeps the single-service, no-GitOps-manifest constraint and all artifact-only exclusions intact.