### PR TITLE
fix(observability): keep RUM tag values out of audit logs

### DIFF
--- a/openbank-admin-ui/src/test/rum-ecosystem-parity.guard.test.ts
+++ b/openbank-admin-ui/src/test/rum-ecosystem-parity.guard.test.ts
@@ -25,4 +25,12 @@ describe('mobile RUM ecosystem parity', () => {
     expect(page).toContain("client.rum.source === 'tempo' ? 'traces' : 'span-counter increments'")
     expect(page).toContain('error span-counter increments')
   })
+
+  it('keeps RUM tag values out of the cardinality audit logs', () => {
+    const audit = read('openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml')
+    expect(audit).toContain('unique_value_count')
+    expect(audit).toContain('Never put a response sample in logs.')
+    expect(audit).not.toContain('"sample"')
+    expect(audit).not.toContain('head -c 512')
+  })
 })

--- a/openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml
+++ b/openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml
@@ -103,8 +103,10 @@ spec:
                     # `grep` exits 1 when a tag has zero values; under `set -o pipefail` that
                     # non-zero status would kill the whole job (it did, every run). Swallow it
                     # so a legitimately-empty attribute counts as 0 instead of aborting.
+                    # This is a cardinality audit, not a telemetry explorer: values may include
+                    # the pseudonymous party_id.  Never put a response sample in logs.
                     count=$(echo "$result" | { grep -o '"value"' || true; } | wc -l | tr -d ' ')
-                    echo "{\"event\":\"rum-attribute-audit\",\"attribute\":\"${attr}\",\"unique_value_count\":${count},\"sample\":$(echo "$result" | head -c 512)}"
+                    echo "{\"event\":\"rum-attribute-audit\",\"attribute\":\"${attr}\",\"unique_value_count\":${count}}"
                   done
                   # RUM-INGEST LIVENESS. The attribute audit above verifies the redaction
                   # allow-list, but app.version, device.model and screen.name are client-version


### PR DESCRIPTION
Closes #7530

The RUM cardinality audit retains only attribute names and unique-value counts. It no longer logs Tempo tag-value samples, which could include pseudonymous party identifiers.

Verification:
- npx vitest run src/test/rum-ecosystem-parity.guard.test.ts
- YAML parse with Ruby