### PR TITLE
chore(infra): reserve Incentive backup identity

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/db-backups.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/db-backups.tf
@@ -264,6 +264,10 @@ locals {
     # `kind: Cluster` manifests rather than from the rollout comments in this file, which have
     # asserted "all remaining clusters" incorrectly three times now (#1444).
     engagement = { namespace = "engagement", sa = "engagement-db" }
+    # Reserve the Pod Identity association before the reviewed Incentive CNPG Cluster is synced.
+    # The future Cluster uses barmanObjectStore under incentive-db; declaring its service account
+    # here prevents the otherwise silent "Ready but no WAL archive credentials" failure at first boot.
+    incentive = { namespace = "incentive", sa = "incentive-db" }
   }
 }
 


### PR DESCRIPTION
## Summary
- reserve the EKS Pod Identity association for the future incentive-db CNPG service account
- keep the association independent of workload, database, image, secret, and GitOps activation

## Safety
The future Incentive CNPG rollout needs this association before it declares S3/WAL backups. This PR does not create a Kubernetes workload or database, add a GitOps image pin, or configure PROMO_CODE_PEPPER.

## Verification
- tofu fmt -check openbank-infra/aws/envs/sandbox-platform/db-backups.tf
- python3 openbank-infra/scripts/check-db-backup-associations.py --enforce
- git diff --check

Refs #7210