### PR TITLE
feat(infra): stage Incentive data plane

### DIFF
--- a/docs/runbooks/svc-incentive.md
+++ b/docs/runbooks/svc-incentive.md
@@ -66,9 +66,8 @@ triaging an incident that starts on `incentive`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-incentive.md
+++ b/docs/runbooks/svc-incentive.md
@@ -8,18 +8,17 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 > Operational runbook for the `incentive` service. Data domain **open-banking**,
 > classification **confidential**, datastore **PostgreSQL**.
 
-## Deployment status — NOT DEPLOYED
+## Deployment status — WORKLOAD NOT DEPLOYED
 
-**This service has no workload anywhere in `openbank-infra/gitops/`** — no Deployment,
-no Rollout, and therefore no namespace, no CNPG cluster, no NetworkPolicy and no
-PodMonitor coverage. It is a released component (it has a `version.txt`) that has never
-run, so **every `kubectl` command below names a namespace that does not exist** and every
-procedure here is a plan rather than a rehearsed one.
+**This service has no workload anywhere in `openbank-infra/gitops/`** — no Deployment
+or Rollout. Its data plane is declared separately (Namespace `incentive` and CNPG cluster), but
+declared GitOps state is not live evidence: do not run the workload, claim
+traffic, or treat backup configuration as healthy until the separately reviewed sync and
+cluster-health checks have completed. The operational commands below remain plans for the
+absent workload, not proof that it has ever run.
 
-The production-readiness matrix reports it as **NOT-DEPLOYED** rather than NO-GO for the
-same reason: the cells it fails are consequences of the absent workload, not controls
-someone skipped, and none of them can be closed by a repo change. Whether this service
-should be deployed is an owner decision — see the service's own `CLAUDE.md`.
+The production-readiness matrix reports this as **NOT-DEPLOYED** because the service
+workload is absent; a staged namespace or database cannot close runtime-readiness cells.
 
 ## Service identity
 

--- a/openbank-infra/gitops/apps/incentive.yaml
+++ b/openbank-infra/gitops/apps/incentive.yaml
@@ -1,0 +1,29 @@
+# Data-plane-only Incentive foundation. Do not add a Deployment or image pin here: the service
+# has a fail-closed PROMO_CODE_PEPPER startup gate. This Application also deliberately has no
+# automated sync: CNPG must not create a database before the separately reviewed EKS Pod Identity
+# association is applied and observed. Workload, network policy, Kafka mTLS, and customer-edge
+# wiring remain later independently reviewed rollout steps.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: incentive
+  namespace: argocd
+  finalizers: [resources-finalizer.argocd.argoproj.io]
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:JiRaska/open-bank-oss.git
+    targetRevision: main
+    path: openbank-infra/gitops/components/incentive
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: incentive
+  syncPolicy:
+    syncOptions:
+      - ServerSideApply=true
+    retry:
+      limit: 10
+      backoff:
+        duration: 15s
+        factor: 2
+        maxDuration: 5m

--- a/openbank-infra/gitops/components/incentive/namespace.yaml
+++ b/openbank-infra/gitops/components/incentive/namespace.yaml
@@ -1,0 +1,12 @@
+# Incentive domain (ADR-0037: domain = namespace). This foundation intentionally contains no
+# service Deployment, image reference, or secret projection. Those arrive only after the signed
+# image, backup identity, and externally seeded promo-code pepper are independently evidenced.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: incentive
+  labels:
+    openbank.io/plane: app
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/openbank-infra/gitops/components/incentive/postgres.yaml
+++ b/openbank-infra/gitops/components/incentive/postgres.yaml
@@ -1,0 +1,53 @@
+# Single-owner PostgreSQL for the future Incentive service. CNPG creates the incentive-db-app
+# secret and incentive-db-rw Service; no application workload consumes either in this slice.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: incentive-db
+  namespace: incentive
+spec:
+  monitoring:
+    enablePodMonitor: true
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.1
+  storage:
+    storageClass: gp3
+    size: 2Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 512Mi
+  postgresql:
+    parameters:
+      wal_keep_size: "64MB"
+      max_wal_size: "512MB"
+  # The Pod Identity association is introduced by the parent prerequisite PR before this
+  # Application may be synced. It supplies barman-cloud through the AWS SDK chain, never Git.
+  backup:
+    retentionPolicy: "30d"
+    barmanObjectStore:
+      destinationPath: s3://openbank-sandbox-db-backups/incentive-db
+      s3Credentials:
+        inheritFromIAMRole: true
+      wal:
+        compression: gzip
+      data:
+        compression: gzip
+  bootstrap:
+    initdb:
+      database: openbank_incentive
+      owner: openbank
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: incentive-db-daily
+  namespace: incentive
+spec:
+  schedule: "0 57 4 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: incentive-db

--- a/openbank-infra/scripts/generate-service-runbooks.py
+++ b/openbank-infra/scripts/generate-service-runbooks.py
@@ -105,6 +105,38 @@ def deployment_status(short: str) -> str:
     """
     if gitops_facts.service_namespace(short, GITOPS) is not None:
         return ""
+    component = GITOPS / "components" / short
+    data_plane = "\n".join(read(path) for path in component.glob("*.yaml"))
+    staged_namespace = re.search(
+        r"^kind:\s*Namespace\s*$.*?^\s{2}name:\s*(\S+)", data_plane, re.M | re.S
+    )
+    staged_cnpg = bool(re.search(
+        r"^apiVersion:\s*postgresql\.cnpg\.io/\S+\s*$.*?^kind:\s*Cluster\s*$",
+        data_plane,
+        re.M | re.S,
+    ))
+    if staged_namespace or staged_cnpg:
+        namespace = staged_namespace.group(1) if staged_namespace else short
+        data_plane_facts = []
+        if staged_namespace:
+            data_plane_facts.append(f"Namespace `{namespace}`")
+        if staged_cnpg:
+            data_plane_facts.append("CNPG cluster")
+        data_plane_description = " and ".join(data_plane_facts)
+        return (
+            "## Deployment status — WORKLOAD NOT DEPLOYED\n"
+            "\n"
+            "**This service has no workload anywhere in `openbank-infra/gitops/`** — no Deployment\n"
+            f"or Rollout. Its data plane is declared separately ({data_plane_description}), but\n"
+            "declared GitOps state is not live evidence: do not run the workload, claim\n"
+            "traffic, or treat backup configuration as healthy until the separately reviewed sync and\n"
+            "cluster-health checks have completed. The operational commands below remain plans for the\n"
+            "absent workload, not proof that it has ever run.\n"
+            "\n"
+            "The production-readiness matrix reports this as **NOT-DEPLOYED** because the service\n"
+            "workload is absent; a staged namespace or database cannot close runtime-readiness cells.\n"
+            "\n"
+        )
     return (
         "## Deployment status — NOT DEPLOYED\n"
         "\n"
@@ -482,11 +514,27 @@ def self_test() -> int:
     case("a deployed service gets no deployment banner",
          all(deployment_status(x) == "" for x in deployed[:5]))
     if undeployed:
-        t = deployment_status(undeployed[0])
-        case("an undeployed service is told its kubectl commands name a namespace that does not exist",
-             says(t, "NOT DEPLOYED", "namespace that does not exist"))
-        case("...and the banner reaches the rendered runbook",
-             "NOT DEPLOYED" in render(undeployed[0]))
+        absent_data_plane = [
+            x for x in undeployed if "namespace that does not exist" in deployment_status(x)
+        ]
+        if absent_data_plane:
+            t = deployment_status(absent_data_plane[0])
+            case(
+                "an undeployed service without a staged data plane is told its kubectl commands name a namespace that does not exist",
+                says(t, "NOT DEPLOYED", "namespace that does not exist"),
+            )
+        staged_data_plane = [
+            x for x in undeployed if "data plane is declared separately" in deployment_status(x)
+        ]
+        if staged_data_plane:
+            t = deployment_status(staged_data_plane[0])
+            case(
+                "an undeployed service with a staged data plane never calls that declared namespace absent",
+                says(t, "WORKLOAD NOT DEPLOYED", "data plane is declared separately")
+                and "namespace that does not exist" not in t,
+            )
+        case("...and every undeployed banner reaches its rendered runbook",
+             all("NOT DEPLOYED" in render(x) for x in undeployed))
     # No `else` that passes: an empty undeployed set is the expected steady state (every released
     # component deployed), and the two cases above are then vacuous rather than wrong.
 


### PR DESCRIPTION
## Summary
- add the Incentive namespace and single-owner CNPG database with WAL/base backups
- add a deliberately manual Argo Application for the data-plane foundation
- add no service Deployment, image pin, ExternalSecret, Kafka identity, or network policy

## Sequencing
This stack depends on #7534. The application has no automated sync: after #7534 is merged and its manual OpenTofu apply has been independently observed, a later reviewed activation may sync this data plane. This prevents an uncredentialed barman bootstrap.

The later workload slice remains blocked on an externally seeded PROMO_CODE_PEPPER; no value is present here or in Git.

## Verification
- python3 openbank-infra/scripts/check-db-backup-associations.py --enforce
- python3 openbank-infra/scripts/gen-network-policies.py --check
- python3 .github/scripts/check-gitops-duplicate-resources.py --enforce
- git diff --check

Refs #7210