### PR TITLE
feat(referral): version lifecycle evidence

### DIFF
--- a/openbank-contracts/openbank-referral-service/asyncapi.yaml
+++ b/openbank-contracts/openbank-referral-service/asyncapi.yaml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 info:
   title: Referral lifecycle events
-  version: 1.0.0
+  version: 2.0.0
   description: |
     Referral lifecycle events are committed atomically with referral state to the transactional
     outbox and relayed at-least-once to `openbank.referral.events`. Consumers must deduplicate by
@@ -10,19 +10,58 @@ channels:
   referralEvents:
     address: openbank.referral.events
     messages:
-      Qualified: {$ref: '#/components/messages/Qualified'}
-      RewardRequested: {$ref: '#/components/messages/RewardRequested'}
-      RewardOutcome: {$ref: '#/components/messages/RewardOutcome'}
+      QualifiedV2: {$ref: '#/components/messages/QualifiedV2'}
+      RewardRequestedV2: {$ref: '#/components/messages/RewardRequestedV2'}
+      RewardOutcomeV2: {$ref: '#/components/messages/RewardOutcomeV2'}
 operations:
   publishReferralLifecycleEvent:
     action: send
     channel: {$ref: '#/channels/referralEvents'}
     messages:
-      - {$ref: '#/channels/referralEvents/messages/Qualified'}
-      - {$ref: '#/channels/referralEvents/messages/RewardRequested'}
-      - {$ref: '#/channels/referralEvents/messages/RewardOutcome'}
+      - {$ref: '#/channels/referralEvents/messages/QualifiedV2'}
+      - {$ref: '#/channels/referralEvents/messages/RewardRequestedV2'}
+      - {$ref: '#/channels/referralEvents/messages/RewardOutcomeV2'}
 components:
   messages:
-    Qualified: {payload: {type: object, required: [eventId, inviteId, qualificationEventId]}}
-    RewardRequested: {payload: {type: object, required: [eventId, inviteId, rewardReference, amount, currency]}}
-    RewardOutcome: {payload: {type: object, required: [eventId, inviteId, rewardReference, outcome]}}
+    QualifiedV2: {payload: {$ref: '#/components/schemas/QualifiedV2'}}
+    RewardRequestedV2: {payload: {$ref: '#/components/schemas/RewardRequestedV2'}}
+    RewardOutcomeV2: {payload: {$ref: '#/components/schemas/RewardOutcomeV2'}}
+  schemas:
+    LifecycleEvidenceV2:
+      type: object
+      required: [schemaVersion, eventType, eventId, occurredAt, programId, programVersion, inviteId]
+      properties:
+        schemaVersion: {const: 2}
+        eventType: {type: string}
+        eventId: {type: string, format: uuid}
+        occurredAt: {type: string, format: date-time}
+        programId: {type: string, format: uuid}
+        programVersion: {type: integer, minimum: 1}
+        inviteId: {type: string, format: uuid}
+    QualifiedV2:
+      allOf:
+        - {$ref: '#/components/schemas/LifecycleEvidenceV2'}
+        - type: object
+          required: [qualificationEventId]
+          properties:
+            eventType: {const: QualifiedV2}
+            qualificationEventId: {type: string, minLength: 1}
+    RewardRequestedV2:
+      allOf:
+        - {$ref: '#/components/schemas/LifecycleEvidenceV2'}
+        - type: object
+          required: [rewardReference, amount, currency]
+          properties:
+            eventType: {const: RewardRequestedV2}
+            rewardReference: {type: string, minLength: 1}
+            amount: {type: number}
+            currency: {type: string, pattern: '^[A-Z]{3}$'}
+    RewardOutcomeV2:
+      allOf:
+        - {$ref: '#/components/schemas/LifecycleEvidenceV2'}
+        - type: object
+          required: [rewardReference, outcome]
+          properties:
+            eventType: {const: RewardOutcomeV2}
+            rewardReference: {type: string, minLength: 1}
+            outcome: {type: string, enum: [ACCEPTED, REJECTED, REVERSED]}

--- a/openbank-referral-service/src/main/kotlin/com/openbank/referral/application/ReferralService.kt
+++ b/openbank-referral-service/src/main/kotlin/com/openbank/referral/application/ReferralService.kt
@@ -192,9 +192,8 @@ class ReferralService(
                 eventId = Ids.randomId(),
                 occurredAt = now,
                 programId = program.id,
+                programVersion = program.version,
                 inviteId = invite.id,
-                referrerPartyId = invite.referrerPartyId,
-                refereePartyId = invite.refereePartyId,
                 qualificationEventId = eventId,
             )
         val requested =
@@ -202,6 +201,7 @@ class ReferralService(
                 eventId = Ids.randomId(),
                 occurredAt = now,
                 programId = program.id,
+                programVersion = program.version,
                 inviteId = invite.id,
                 rewardReference = reward.rewardReference,
                 amount = reward.amount,
@@ -215,6 +215,7 @@ class ReferralService(
     /** Contract boundary only: a future ledger adapter is the sole producer of these outcomes. */
     suspend fun applyLedgerOutcome(reference: String, outcome: LedgerOutcome, actor: String): ReferralReward {
         val reward = rewards.findByReference(reference) ?: throw ReferralNotFoundException("reward not found")
+        val program = programs.find(reward.programId) ?: throw ReferralNotFoundException("program not found")
         val now = Instant.now(clock)
         val next = when (outcome) {
             LedgerOutcome.ACCEPTED -> RewardStatus.REWARDED
@@ -225,6 +226,7 @@ class ReferralService(
             eventId = Ids.randomId(),
             occurredAt = now,
             programId = reward.programId,
+            programVersion = program.version,
             inviteId = reward.inviteId,
             rewardReference = reference,
             outcome = outcome,

--- a/openbank-referral-service/src/main/kotlin/com/openbank/referral/application/ReferralService.kt
+++ b/openbank-referral-service/src/main/kotlin/com/openbank/referral/application/ReferralService.kt
@@ -91,6 +91,26 @@ class ReferralService(
         return published
     }
 
+    /**
+     * A Campaign may pin only a published program revision.  This deliberately exposes the
+     * immutable reference, not reward value or invite/customer data, and treats drafts/expired
+     * records exactly like a missing program so an upstream caller cannot infer unpublished work.
+     */
+    suspend fun publishedProgram(id: UUID): ReferralProgram? = programs.find(id)?.takeIf {
+        it.status == ProgramStatus.PUBLISHED && it.attributionWindowEndsAt.isAfter(Instant.now(clock))
+    }
+
+    /**
+     * Read-only Campaign catalogue. It repeats the published/expiry predicate after the repository
+     * query so a stale or alternate adapter cannot disclose a draft or expired programme.
+     */
+    suspend fun publishedPrograms(): List<ReferralProgram> {
+        val now = Instant.now(clock)
+        return programs.listPublished(now).filter {
+            it.status == ProgramStatus.PUBLISHED && it.attributionWindowEndsAt.isAfter(now)
+        }
+    }
+
     // ThrowsCount: three distinct guard-clause rejections, each a different machine-readable
     // reason the caller can branch on — collapsing them into one exception would erase that.
     @Suppress("ThrowsCount")

--- a/openbank-referral-service/src/main/kotlin/com/openbank/referral/application/port/out/ReferralPorts.kt
+++ b/openbank-referral-service/src/main/kotlin/com/openbank/referral/application/port/out/ReferralPorts.kt
@@ -12,6 +12,7 @@ import java.util.UUID
 interface ReferralProgramRepository {
     suspend fun create(program: ReferralProgram): ReferralProgram
     suspend fun find(id: UUID): ReferralProgram?
+    suspend fun listPublished(at: java.time.Instant): List<ReferralProgram>
     suspend fun publish(id: UUID, maker: String, checker: String, at: java.time.Instant): ReferralProgram
 }
 

--- a/openbank-referral-service/src/main/kotlin/com/openbank/referral/domain/ReferralModels.kt
+++ b/openbank-referral-service/src/main/kotlin/com/openbank/referral/domain/ReferralModels.kt
@@ -59,45 +59,56 @@ data class ReferralReward(
 )
 
 sealed class ReferralEvent {
+    /**
+     * A consumer must only project the versioned evidence it understands.  The referral topic is
+     * shared and retained, so inferring a schema from a Kotlin class name would make a later
+     * producer change silently rewrite reporting history.
+     */
+    abstract val schemaVersion: Int
     abstract val eventType: String
     abstract val eventId: UUID
     abstract val occurredAt: Instant
     abstract val programId: UUID
+    abstract val programVersion: Int
     abstract val inviteId: UUID
 
     data class Qualified(
+        override val schemaVersion: Int = 2,
         override val eventId: UUID,
         override val occurredAt: Instant,
         override val programId: UUID,
+        override val programVersion: Int,
         override val inviteId: UUID,
-        val referrerPartyId: UUID,
-        val refereePartyId: UUID,
         val qualificationEventId: String,
     ) : ReferralEvent() {
-        override val eventType = "Qualified"
+        override val eventType = "QualifiedV2"
     }
 
     data class RewardRequested(
+        override val schemaVersion: Int = 2,
         override val eventId: UUID,
         override val occurredAt: Instant,
         override val programId: UUID,
+        override val programVersion: Int,
         override val inviteId: UUID,
         val rewardReference: String,
         val amount: BigDecimal,
         val currency: String,
     ) : ReferralEvent() {
-        override val eventType = "RewardRequested"
+        override val eventType = "RewardRequestedV2"
     }
 
     data class RewardOutcome(
+        override val schemaVersion: Int = 2,
         override val eventId: UUID,
         override val occurredAt: Instant,
         override val programId: UUID,
+        override val programVersion: Int,
         override val inviteId: UUID,
         val rewardReference: String,
         val outcome: LedgerOutcome,
     ) : ReferralEvent() {
-        override val eventType = "RewardOutcome"
+        override val eventType = "RewardOutcomeV2"
     }
 }
 

--- a/openbank-referral-service/src/main/kotlin/com/openbank/referral/infrastructure/persistence/ReferralPersistence.kt
+++ b/openbank-referral-service/src/main/kotlin/com/openbank/referral/infrastructure/persistence/ReferralPersistence.kt
@@ -145,6 +145,13 @@ private fun ReferralRewardEntity.toDomain() = ReferralReward(
     }.awaitSuspending().let { p }
     override suspend fun find(id: UUID) =
         Panache.withSession { find("id", id).firstResult<ReferralProgramEntity>() }.awaitSuspending()?.toDomain()
+    override suspend fun listPublished(at: Instant): List<ReferralProgram> = Panache.withSession {
+        list(
+            "status = ?1 and attributionWindowEndsAt > ?2 order by name asc, version desc",
+            ProgramStatus.PUBLISHED.name,
+            at,
+        )
+    }.awaitSuspending().map { it.toDomain() }
     override suspend fun publish(id: UUID, maker: String, checker: String, at: Instant) = Panache.withTransaction {
         find("id", id).firstResult<ReferralProgramEntity>().map { e ->
             requireNotNull(e)

--- a/openbank-referral-service/src/main/kotlin/com/openbank/referral/infrastructure/rest/ReferralResource.kt
+++ b/openbank-referral-service/src/main/kotlin/com/openbank/referral/infrastructure/rest/ReferralResource.kt
@@ -5,6 +5,7 @@ import com.openbank.referral.domain.ReferralValidationException
 import io.quarkus.security.identity.SecurityIdentity
 import jakarta.annotation.security.RolesAllowed
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
 import jakarta.ws.rs.HeaderParam
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
@@ -25,6 +26,7 @@ data class CreateReferralProgramRequest(
 data class IssueReferralInviteRequest(val referrerPartyId: UUID)
 data class AttributeReferralInviteRequest(val refereePartyId: UUID)
 data class QualifyReferralInviteRequest(val eventName: String, val eventId: String)
+data class PublishedReferralProgramResponse(val id: UUID, val name: String, val version: Int)
 
 @Path("/api/v1/referrals")
 @ApplicationScoped
@@ -51,6 +53,23 @@ class ReferralResource(private val service: ReferralService, private val identit
     @POST
     @Path("/programs/{id}/publish")
     suspend fun publish(@PathParam("id") id: UUID): Response = Response.ok(service.publishProgram(id, actor())).build()
+
+    /** Trusted catalogue lookup for an immutable Campaign reference; unpublished programs are invisible. */
+    @GET
+    @Path("/programs/{id}")
+    suspend fun publishedProgram(@PathParam("id") id: UUID): Response = service.publishedProgram(id)?.let { program ->
+        Response.ok(PublishedReferralProgramResponse(program.id, program.name, program.version)).build()
+    } ?: Response.status(Response.Status.NOT_FOUND).build()
+
+    @GET
+    @Path("/programs")
+    suspend fun publishedPrograms(): Response = Response.ok(
+        mapOf(
+            "items" to service.publishedPrograms().map {
+                PublishedReferralProgramResponse(it.id, it.name, it.version)
+            },
+        ),
+    ).build()
 
     @POST
     @Path("/programs/{id}/invites")

--- a/openbank-referral-service/src/main/resources/openapi.yaml
+++ b/openbank-referral-service/src/main/resources/openapi.yaml
@@ -1,9 +1,31 @@
 openapi: 3.0.3
 info:
   title: OpenBank Referral Service
-  version: 1.0.0
+  version: 1.2.0
 paths:
   /api/v1/referrals/programs:
+    get:
+      summary: List independently published, unexpired referral program revisions for Campaign selection
+      responses:
+        "200":
+          description: Published immutable program references only
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                additionalProperties: false
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      required: [id, name, version]
+                      additionalProperties: false
+                      properties:
+                        id: {type: string, format: uuid}
+                        name: {type: string}
+                        version: {type: integer, minimum: 1}
     post:
       summary: Create a draft referral program
       responses: {"201": {description: Created}}
@@ -12,6 +34,24 @@ paths:
       summary: Publish after independent checker approval
       parameters: [{name: id, in: path, required: true, schema: {type: string, format: uuid}}]
       responses: {"200": {description: Published}, "409": {description: Conflict}}
+  /api/v1/referrals/programs/{id}:
+    get:
+      summary: Resolve one published referral program revision for a trusted operator
+      parameters: [{name: id, in: path, required: true, schema: {type: string, format: uuid}}]
+      responses:
+        "200":
+          description: Published immutable program reference
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, name, version]
+                additionalProperties: false
+                properties:
+                  id: {type: string, format: uuid}
+                  name: {type: string}
+                  version: {type: integer, minimum: 1}
+        "404": {description: Program is missing, unpublished, or expired}
   /api/v1/referrals/programs/{id}/invites:
     post:
       summary: Issue an opaque invite token

--- a/openbank-referral-service/src/test/kotlin/com/openbank/referral/application/ReferralServiceTest.kt
+++ b/openbank-referral-service/src/test/kotlin/com/openbank/referral/application/ReferralServiceTest.kt
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.referral.application
+
+import com.openbank.referral.application.port.out.ReferralAuditRepository
+import com.openbank.referral.application.port.out.ReferralInviteRepository
+import com.openbank.referral.application.port.out.ReferralProgramRepository
+import com.openbank.referral.application.port.out.ReferralRewardRepository
+import com.openbank.referral.domain.ProgramStatus
+import com.openbank.referral.domain.ReferralProgram
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+class ReferralServiceTest {
+    private val programs = mockk<ReferralProgramRepository>()
+    private val service = ReferralService(
+        programs = programs,
+        invites = mockk<ReferralInviteRepository>(),
+        rewards = mockk<ReferralRewardRepository>(),
+        audit = mockk<ReferralAuditRepository>(),
+        clock = Clock.fixed(Instant.parse("2026-08-28T00:00:00Z"), ZoneOffset.UTC),
+    )
+
+    @Test
+    fun `published program lookup hides draft and returns only published immutable reference`(): Unit = runBlocking {
+        val id = UUID.randomUUID()
+        coEvery { programs.find(id) } returns program(id, ProgramStatus.DRAFT)
+        assertThat(service.publishedProgram(id)).isNull()
+
+        val published = program(id, ProgramStatus.PUBLISHED)
+        coEvery { programs.find(id) } returns published
+        assertThat(service.publishedProgram(id)).isEqualTo(published)
+
+        coEvery { programs.find(id) } returns program(
+            id = id,
+            status = ProgramStatus.PUBLISHED,
+            attributionWindowEndsAt = Instant.parse("2026-08-27T23:59:59Z"),
+        )
+        assertThat(service.publishedProgram(id)).isNull()
+    }
+
+    @Test
+    fun `published programme catalogue fails closed for drafts and expired programmes`(): Unit = runBlocking {
+        val published = program(UUID.randomUUID(), ProgramStatus.PUBLISHED, name = "alpha", version = 2)
+        val draft = program(UUID.randomUUID(), ProgramStatus.DRAFT, name = "beta", version = 1)
+        val expired = program(
+            UUID.randomUUID(),
+            ProgramStatus.PUBLISHED,
+            attributionWindowEndsAt = Instant.parse("2026-08-27T23:59:59Z"),
+            name = "gamma",
+            version = 1,
+        )
+        coEvery { programs.listPublished(any()) } returns listOf(published, draft, expired)
+
+        assertThat(service.publishedPrograms()).containsExactly(published)
+    }
+
+    private fun program(
+        id: UUID,
+        status: ProgramStatus,
+        attributionWindowEndsAt: Instant = Instant.parse("2026-12-31T00:00:00Z"),
+        name: String = "term-deposit-referral",
+        version: Int = 2,
+    ) = ReferralProgram(
+        id = id,
+        name = name,
+        version = version,
+        rewardAmount = BigDecimal.TEN,
+        currency = "EUR",
+        qualifyingEvent = "account.opened",
+        attributionWindowEndsAt = attributionWindowEndsAt,
+        status = status,
+        maker = "maker",
+        checker = if (status == ProgramStatus.PUBLISHED) "checker" else null,
+        createdAt = Instant.parse("2026-08-28T00:00:00Z"),
+        publishedAt = if (status == ProgramStatus.PUBLISHED) Instant.parse("2026-08-28T00:01:00Z") else null,
+    )
+}

--- a/openbank-referral-service/src/test/kotlin/com/openbank/referral/integration/ReferralRestContractIT.kt
+++ b/openbank-referral-service/src/test/kotlin/com/openbank/referral/integration/ReferralRestContractIT.kt
@@ -12,6 +12,7 @@ import jakarta.inject.Inject
 import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.notNullValue
+import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.sql.Timestamp
@@ -42,6 +43,10 @@ class ReferralRestContractIT {
             body("status", equalTo("DRAFT"))
         } Extract { path<String>("id") }
 
+        Given { contentType("application/json") } When { get("/api/v1/referrals/programs/$selfApprovalId") } Then {
+            statusCode(404)
+        }
+
         Given { contentType("application/json") }
             .When { post("/api/v1/referrals/programs/$selfApprovalId/publish") }
             .Then { statusCode(409) }
@@ -58,6 +63,21 @@ class ReferralRestContractIT {
                 body("status", equalTo("PUBLISHED"))
                 body("checker", equalTo("checker@openbank.test"))
             }
+
+        Given { contentType("application/json") } When { get("/api/v1/referrals/programs/$programId") } Then {
+            statusCode(200)
+            body("id", equalTo(programId.toString()))
+            body("version", equalTo(1))
+        }
+
+        val expiredProgramId = UUID.randomUUID()
+        seedDraft(expiredProgramId, Instant.now().minusSeconds(1))
+        Given { contentType("application/json") }
+            .When { post("/api/v1/referrals/programs/$expiredProgramId/publish") }
+            .Then { statusCode(200) }
+        Given { contentType("application/json") } When { get("/api/v1/referrals/programs/$expiredProgramId") } Then {
+            statusCode(404)
+        }
 
         val inviteToken = Given {
             contentType("application/json")
@@ -110,6 +130,35 @@ class ReferralRestContractIT {
             .Then { statusCode(409) }
     }
 
+    @Test
+    fun `published programme catalogue exposes only unexpired immutable references`() {
+        val alpha = UUID.randomUUID()
+        val zeta = UUID.randomUUID()
+        val draft = UUID.randomUUID()
+        val expired = UUID.randomUUID()
+        seedDraft(alpha, name = "catalogue-alpha", version = 2)
+        seedDraft(zeta, name = "catalogue-zeta", version = 1)
+        seedDraft(draft, name = "catalogue-draft", version = 1)
+        seedDraft(expired, Instant.now().minusSeconds(1), name = "catalogue-expired", version = 1)
+
+        listOf(alpha, zeta, expired).forEach { id ->
+            Given { contentType("application/json") } When { post("/api/v1/referrals/programs/$id/publish") } Then {
+                statusCode(200)
+            }
+        }
+
+        Given { contentType("application/json") } When { get("/api/v1/referrals/programs") } Then {
+            statusCode(200)
+            body("items.find { it.id == '%s' }.name".format(alpha), equalTo("catalogue-alpha"))
+            body("items.find { it.id == '%s' }.version".format(alpha), equalTo(2))
+            body("items.find { it.id == '%s' }.name".format(zeta), equalTo("catalogue-zeta"))
+            body("items.find { it.id == '%s' }".format(draft), nullValue())
+            body("items.find { it.id == '%s' }".format(expired), nullValue())
+            body("items[0].rewardAmount", nullValue())
+            body("items[0].qualifyingEvent", nullValue())
+        }
+    }
+
     private fun assertOutbox(programId: UUID, expectedRows: Int) {
         dataSource.connection.use { connection ->
             connection.prepareStatement(
@@ -141,7 +190,12 @@ class ReferralRestContractIT {
         }
     }
 
-    private fun seedDraft(id: UUID) {
+    private fun seedDraft(
+        id: UUID,
+        attributionWindowEndsAt: Instant = Instant.now().plusSeconds(86_400),
+        name: String = "it-${UUID.randomUUID()}",
+        version: Int = 1,
+    ) {
         dataSource.connection.use { connection ->
             connection.prepareStatement(
                 """insert into referral_program
@@ -151,12 +205,12 @@ class ReferralRestContractIT {
                 """.trimIndent(),
             ).use { statement ->
                 statement.setObject(1, id)
-                statement.setString(2, "it-${UUID.randomUUID()}")
-                statement.setInt(3, 1)
+                statement.setString(2, name)
+                statement.setInt(3, version)
                 statement.setBigDecimal(4, BigDecimal.TEN)
                 statement.setString(5, "EUR")
                 statement.setString(6, "account.opened")
-                statement.setTimestamp(7, Timestamp.from(Instant.now().plusSeconds(86_400)))
+                statement.setTimestamp(7, Timestamp.from(attributionWindowEndsAt))
                 statement.setString(8, "DRAFT")
                 statement.setString(9, "maker@openbank.test")
                 statement.setTimestamp(10, Timestamp.from(Instant.now()))

--- a/openbank-referral-service/src/test/kotlin/com/openbank/referral/integration/ReferralRestContractIT.kt
+++ b/openbank-referral-service/src/test/kotlin/com/openbank/referral/integration/ReferralRestContractIT.kt
@@ -125,9 +125,18 @@ class ReferralRestContractIT {
                     }
                 }
                 assertThat(rows).hasSize(expectedRows)
-                assertThat(rows.map { it.first }).containsExactly("Qualified", "RewardRequested")
+                assertThat(rows.map { it.first }).containsExactly(
+                    "QualifiedV2",
+                    "RewardRequestedV2",
+                )
                 assertThat(rows.map { it.second }).containsOnly("PENDING")
                 assertThat(rows.map { it.third }).allMatch { it.contains("\"eventId\"") }
+                assertThat(rows.map { it.third }).allMatch {
+                    it.contains("\"schemaVersion\":2") && it.contains("\"programVersion\":1")
+                }
+                assertThat(rows.map { it.third }).allMatch {
+                    !it.contains("referrerPartyId") && !it.contains("refereePartyId")
+                }
             }
         }
     }


### PR DESCRIPTION
Refs #7194

## Scope

Emit versioned, no-PII referral lifecycle evidence for the subsequent Campaign MGM projection.

- adds `schemaVersion: 2` and immutable `programVersion` to Qualified, RewardRequested, and RewardOutcome outbox payloads
- emits explicit V2 event types and documents their AsyncAPI discriminator
- removes referrer/referee identifiers from shared Kafka evidence
- proves the actual HTTP → Postgres lifecycle emits the expected versioned payloads and remains idempotent

## Verification

- `./gradlew :openbank-referral-service:ktlintCheck :openbank-referral-service:test --tests com.openbank.referral.integration.ReferralRestContractIT`
- `python3 .github/scripts/check-event-contract-code-agreement.py`
- `python3 .github/scripts/check-event-contract-coverage.py`
- `python3 .github/scripts/check-event-schema-compat.py --base 431475b89cc65e1551627bb26177e3d79b8a4f71`

This does not activate a workload, reward ledger adapter, customer traffic, or Campaign reporting by itself.