### PR TITLE
feat(referral): expose published program reference

### DIFF
--- a/openbank-referral-service/src/main/kotlin/com/openbank/referral/application/ReferralService.kt
+++ b/openbank-referral-service/src/main/kotlin/com/openbank/referral/application/ReferralService.kt
@@ -91,6 +91,15 @@ class ReferralService(
         return published
     }
 
+    /**
+     * A Campaign may pin only a published program revision.  This deliberately exposes the
+     * immutable reference, not reward value or invite/customer data, and treats drafts/expired
+     * records exactly like a missing program so an upstream caller cannot infer unpublished work.
+     */
+    suspend fun publishedProgram(id: UUID): ReferralProgram? = programs.find(id)?.takeIf {
+        it.status == ProgramStatus.PUBLISHED && it.attributionWindowEndsAt.isAfter(Instant.now(clock))
+    }
+
     // ThrowsCount: three distinct guard-clause rejections, each a different machine-readable
     // reason the caller can branch on — collapsing them into one exception would erase that.
     @Suppress("ThrowsCount")

--- a/openbank-referral-service/src/main/kotlin/com/openbank/referral/application/ReferralService.kt
+++ b/openbank-referral-service/src/main/kotlin/com/openbank/referral/application/ReferralService.kt
@@ -100,6 +100,17 @@ class ReferralService(
         it.status == ProgramStatus.PUBLISHED && it.attributionWindowEndsAt.isAfter(Instant.now(clock))
     }
 
+    /**
+     * Read-only Campaign catalogue. It repeats the published/expiry predicate after the repository
+     * query so a stale or alternate adapter cannot disclose a draft or expired programme.
+     */
+    suspend fun publishedPrograms(): List<ReferralProgram> {
+        val now = Instant.now(clock)
+        return programs.listPublished(now).filter {
+            it.status == ProgramStatus.PUBLISHED && it.attributionWindowEndsAt.isAfter(now)
+        }
+    }
+
     // ThrowsCount: three distinct guard-clause rejections, each a different machine-readable
     // reason the caller can branch on — collapsing them into one exception would erase that.
     @Suppress("ThrowsCount")

--- a/openbank-referral-service/src/main/kotlin/com/openbank/referral/application/port/out/ReferralPorts.kt
+++ b/openbank-referral-service/src/main/kotlin/com/openbank/referral/application/port/out/ReferralPorts.kt
@@ -12,6 +12,7 @@ import java.util.UUID
 interface ReferralProgramRepository {
     suspend fun create(program: ReferralProgram): ReferralProgram
     suspend fun find(id: UUID): ReferralProgram?
+    suspend fun listPublished(at: java.time.Instant): List<ReferralProgram>
     suspend fun publish(id: UUID, maker: String, checker: String, at: java.time.Instant): ReferralProgram
 }
 

--- a/openbank-referral-service/src/main/kotlin/com/openbank/referral/infrastructure/persistence/ReferralPersistence.kt
+++ b/openbank-referral-service/src/main/kotlin/com/openbank/referral/infrastructure/persistence/ReferralPersistence.kt
@@ -145,6 +145,13 @@ private fun ReferralRewardEntity.toDomain() = ReferralReward(
     }.awaitSuspending().let { p }
     override suspend fun find(id: UUID) =
         Panache.withSession { find("id", id).firstResult<ReferralProgramEntity>() }.awaitSuspending()?.toDomain()
+    override suspend fun listPublished(at: Instant): List<ReferralProgram> = Panache.withSession {
+        list(
+            "status = ?1 and attributionWindowEndsAt > ?2 order by name asc, version desc",
+            ProgramStatus.PUBLISHED.name,
+            at,
+        )
+    }.awaitSuspending().map { it.toDomain() }
     override suspend fun publish(id: UUID, maker: String, checker: String, at: Instant) = Panache.withTransaction {
         find("id", id).firstResult<ReferralProgramEntity>().map { e ->
             requireNotNull(e)

--- a/openbank-referral-service/src/main/kotlin/com/openbank/referral/infrastructure/rest/ReferralResource.kt
+++ b/openbank-referral-service/src/main/kotlin/com/openbank/referral/infrastructure/rest/ReferralResource.kt
@@ -5,6 +5,7 @@ import com.openbank.referral.domain.ReferralValidationException
 import io.quarkus.security.identity.SecurityIdentity
 import jakarta.annotation.security.RolesAllowed
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
 import jakarta.ws.rs.HeaderParam
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
@@ -25,6 +26,7 @@ data class CreateReferralProgramRequest(
 data class IssueReferralInviteRequest(val referrerPartyId: UUID)
 data class AttributeReferralInviteRequest(val refereePartyId: UUID)
 data class QualifyReferralInviteRequest(val eventName: String, val eventId: String)
+data class PublishedReferralProgramResponse(val id: UUID, val name: String, val version: Int)
 
 @Path("/api/v1/referrals")
 @ApplicationScoped
@@ -51,6 +53,13 @@ class ReferralResource(private val service: ReferralService, private val identit
     @POST
     @Path("/programs/{id}/publish")
     suspend fun publish(@PathParam("id") id: UUID): Response = Response.ok(service.publishProgram(id, actor())).build()
+
+    /** Trusted catalogue lookup for an immutable Campaign reference; unpublished programs are invisible. */
+    @GET
+    @Path("/programs/{id}")
+    suspend fun publishedProgram(@PathParam("id") id: UUID): Response = service.publishedProgram(id)?.let { program ->
+        Response.ok(PublishedReferralProgramResponse(program.id, program.name, program.version)).build()
+    } ?: Response.status(Response.Status.NOT_FOUND).build()
 
     @POST
     @Path("/programs/{id}/invites")

--- a/openbank-referral-service/src/main/kotlin/com/openbank/referral/infrastructure/rest/ReferralResource.kt
+++ b/openbank-referral-service/src/main/kotlin/com/openbank/referral/infrastructure/rest/ReferralResource.kt
@@ -61,6 +61,16 @@ class ReferralResource(private val service: ReferralService, private val identit
         Response.ok(PublishedReferralProgramResponse(program.id, program.name, program.version)).build()
     } ?: Response.status(Response.Status.NOT_FOUND).build()
 
+    @GET
+    @Path("/programs")
+    suspend fun publishedPrograms(): Response = Response.ok(
+        mapOf(
+            "items" to service.publishedPrograms().map {
+                PublishedReferralProgramResponse(it.id, it.name, it.version)
+            },
+        ),
+    ).build()
+
     @POST
     @Path("/programs/{id}/invites")
     suspend fun invite(

--- a/openbank-referral-service/src/main/resources/openapi.yaml
+++ b/openbank-referral-service/src/main/resources/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: OpenBank Referral Service
-  version: 1.0.0
+  version: 1.1.0
 paths:
   /api/v1/referrals/programs:
     post:
@@ -12,6 +12,24 @@ paths:
       summary: Publish after independent checker approval
       parameters: [{name: id, in: path, required: true, schema: {type: string, format: uuid}}]
       responses: {"200": {description: Published}, "409": {description: Conflict}}
+  /api/v1/referrals/programs/{id}:
+    get:
+      summary: Resolve one published referral program revision for a trusted operator
+      parameters: [{name: id, in: path, required: true, schema: {type: string, format: uuid}}]
+      responses:
+        "200":
+          description: Published immutable program reference
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, name, version]
+                additionalProperties: false
+                properties:
+                  id: {type: string, format: uuid}
+                  name: {type: string}
+                  version: {type: integer, minimum: 1}
+        "404": {description: Program is missing, unpublished, or expired}
   /api/v1/referrals/programs/{id}/invites:
     post:
       summary: Issue an opaque invite token

--- a/openbank-referral-service/src/main/resources/openapi.yaml
+++ b/openbank-referral-service/src/main/resources/openapi.yaml
@@ -1,9 +1,31 @@
 openapi: 3.0.3
 info:
   title: OpenBank Referral Service
-  version: 1.1.0
+  version: 1.2.0
 paths:
   /api/v1/referrals/programs:
+    get:
+      summary: List independently published, unexpired referral program revisions for Campaign selection
+      responses:
+        "200":
+          description: Published immutable program references only
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                additionalProperties: false
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      required: [id, name, version]
+                      additionalProperties: false
+                      properties:
+                        id: {type: string, format: uuid}
+                        name: {type: string}
+                        version: {type: integer, minimum: 1}
     post:
       summary: Create a draft referral program
       responses: {"201": {description: Created}}

--- a/openbank-referral-service/src/test/kotlin/com/openbank/referral/application/ReferralServiceTest.kt
+++ b/openbank-referral-service/src/test/kotlin/com/openbank/referral/application/ReferralServiceTest.kt
@@ -48,14 +48,32 @@ class ReferralServiceTest {
         assertThat(service.publishedProgram(id)).isNull()
     }
 
+    @Test
+    fun `published programme catalogue fails closed for drafts and expired programmes`(): Unit = runBlocking {
+        val published = program(UUID.randomUUID(), ProgramStatus.PUBLISHED, name = "alpha", version = 2)
+        val draft = program(UUID.randomUUID(), ProgramStatus.DRAFT, name = "beta", version = 1)
+        val expired = program(
+            UUID.randomUUID(),
+            ProgramStatus.PUBLISHED,
+            attributionWindowEndsAt = Instant.parse("2026-08-27T23:59:59Z"),
+            name = "gamma",
+            version = 1,
+        )
+        coEvery { programs.listPublished(any()) } returns listOf(published, draft, expired)
+
+        assertThat(service.publishedPrograms()).containsExactly(published)
+    }
+
     private fun program(
         id: UUID,
         status: ProgramStatus,
         attributionWindowEndsAt: Instant = Instant.parse("2026-12-31T00:00:00Z"),
+        name: String = "term-deposit-referral",
+        version: Int = 2,
     ) = ReferralProgram(
         id = id,
-        name = "term-deposit-referral",
-        version = 2,
+        name = name,
+        version = version,
         rewardAmount = BigDecimal.TEN,
         currency = "EUR",
         qualifyingEvent = "account.opened",

--- a/openbank-referral-service/src/test/kotlin/com/openbank/referral/application/ReferralServiceTest.kt
+++ b/openbank-referral-service/src/test/kotlin/com/openbank/referral/application/ReferralServiceTest.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.referral.application
+
+import com.openbank.referral.application.port.out.ReferralAuditRepository
+import com.openbank.referral.application.port.out.ReferralInviteRepository
+import com.openbank.referral.application.port.out.ReferralProgramRepository
+import com.openbank.referral.application.port.out.ReferralRewardRepository
+import com.openbank.referral.domain.ProgramStatus
+import com.openbank.referral.domain.ReferralProgram
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+class ReferralServiceTest {
+    private val programs = mockk<ReferralProgramRepository>()
+    private val service = ReferralService(
+        programs = programs,
+        invites = mockk<ReferralInviteRepository>(),
+        rewards = mockk<ReferralRewardRepository>(),
+        audit = mockk<ReferralAuditRepository>(),
+        clock = Clock.fixed(Instant.parse("2026-08-28T00:00:00Z"), ZoneOffset.UTC),
+    )
+
+    @Test
+    fun `published program lookup hides draft and returns only published immutable reference`(): Unit = runBlocking {
+        val id = UUID.randomUUID()
+        coEvery { programs.find(id) } returns program(id, ProgramStatus.DRAFT)
+        assertThat(service.publishedProgram(id)).isNull()
+
+        val published = program(id, ProgramStatus.PUBLISHED)
+        coEvery { programs.find(id) } returns published
+        assertThat(service.publishedProgram(id)).isEqualTo(published)
+
+        coEvery { programs.find(id) } returns program(
+            id = id,
+            status = ProgramStatus.PUBLISHED,
+            attributionWindowEndsAt = Instant.parse("2026-08-27T23:59:59Z"),
+        )
+        assertThat(service.publishedProgram(id)).isNull()
+    }
+
+    private fun program(
+        id: UUID,
+        status: ProgramStatus,
+        attributionWindowEndsAt: Instant = Instant.parse("2026-12-31T00:00:00Z"),
+    ) = ReferralProgram(
+        id = id,
+        name = "term-deposit-referral",
+        version = 2,
+        rewardAmount = BigDecimal.TEN,
+        currency = "EUR",
+        qualifyingEvent = "account.opened",
+        attributionWindowEndsAt = attributionWindowEndsAt,
+        status = status,
+        maker = "maker",
+        checker = if (status == ProgramStatus.PUBLISHED) "checker" else null,
+        createdAt = Instant.parse("2026-08-28T00:00:00Z"),
+        publishedAt = if (status == ProgramStatus.PUBLISHED) Instant.parse("2026-08-28T00:01:00Z") else null,
+    )
+}

--- a/openbank-referral-service/src/test/kotlin/com/openbank/referral/integration/ReferralRestContractIT.kt
+++ b/openbank-referral-service/src/test/kotlin/com/openbank/referral/integration/ReferralRestContractIT.kt
@@ -42,6 +42,10 @@ class ReferralRestContractIT {
             body("status", equalTo("DRAFT"))
         } Extract { path<String>("id") }
 
+        Given { contentType("application/json") } When { get("/api/v1/referrals/programs/$selfApprovalId") } Then {
+            statusCode(404)
+        }
+
         Given { contentType("application/json") }
             .When { post("/api/v1/referrals/programs/$selfApprovalId/publish") }
             .Then { statusCode(409) }
@@ -58,6 +62,21 @@ class ReferralRestContractIT {
                 body("status", equalTo("PUBLISHED"))
                 body("checker", equalTo("checker@openbank.test"))
             }
+
+        Given { contentType("application/json") } When { get("/api/v1/referrals/programs/$programId") } Then {
+            statusCode(200)
+            body("id", equalTo(programId.toString()))
+            body("version", equalTo(1))
+        }
+
+        val expiredProgramId = UUID.randomUUID()
+        seedDraft(expiredProgramId, Instant.now().minusSeconds(1))
+        Given { contentType("application/json") }
+            .When { post("/api/v1/referrals/programs/$expiredProgramId/publish") }
+            .Then { statusCode(200) }
+        Given { contentType("application/json") } When { get("/api/v1/referrals/programs/$expiredProgramId") } Then {
+            statusCode(404)
+        }
 
         val inviteToken = Given {
             contentType("application/json")
@@ -141,7 +160,7 @@ class ReferralRestContractIT {
         }
     }
 
-    private fun seedDraft(id: UUID) {
+    private fun seedDraft(id: UUID, attributionWindowEndsAt: Instant = Instant.now().plusSeconds(86_400)) {
         dataSource.connection.use { connection ->
             connection.prepareStatement(
                 """insert into referral_program
@@ -156,7 +175,7 @@ class ReferralRestContractIT {
                 statement.setBigDecimal(4, BigDecimal.TEN)
                 statement.setString(5, "EUR")
                 statement.setString(6, "account.opened")
-                statement.setTimestamp(7, Timestamp.from(Instant.now().plusSeconds(86_400)))
+                statement.setTimestamp(7, Timestamp.from(attributionWindowEndsAt))
                 statement.setString(8, "DRAFT")
                 statement.setString(9, "maker@openbank.test")
                 statement.setTimestamp(10, Timestamp.from(Instant.now()))

--- a/openbank-referral-service/src/test/kotlin/com/openbank/referral/integration/ReferralRestContractIT.kt
+++ b/openbank-referral-service/src/test/kotlin/com/openbank/referral/integration/ReferralRestContractIT.kt
@@ -12,6 +12,7 @@ import jakarta.inject.Inject
 import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.notNullValue
+import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.sql.Timestamp
@@ -129,6 +130,35 @@ class ReferralRestContractIT {
             .Then { statusCode(409) }
     }
 
+    @Test
+    fun `published programme catalogue exposes only unexpired immutable references`() {
+        val alpha = UUID.randomUUID()
+        val zeta = UUID.randomUUID()
+        val draft = UUID.randomUUID()
+        val expired = UUID.randomUUID()
+        seedDraft(alpha, name = "catalogue-alpha", version = 2)
+        seedDraft(zeta, name = "catalogue-zeta", version = 1)
+        seedDraft(draft, name = "catalogue-draft", version = 1)
+        seedDraft(expired, Instant.now().minusSeconds(1), name = "catalogue-expired", version = 1)
+
+        listOf(alpha, zeta, expired).forEach { id ->
+            Given { contentType("application/json") } When { post("/api/v1/referrals/programs/$id/publish") } Then {
+                statusCode(200)
+            }
+        }
+
+        Given { contentType("application/json") } When { get("/api/v1/referrals/programs") } Then {
+            statusCode(200)
+            body("items.find { it.id == '%s' }.name".format(alpha), equalTo("catalogue-alpha"))
+            body("items.find { it.id == '%s' }.version".format(alpha), equalTo(2))
+            body("items.find { it.id == '%s' }.name".format(zeta), equalTo("catalogue-zeta"))
+            body("items.find { it.id == '%s' }".format(draft), nullValue())
+            body("items.find { it.id == '%s' }".format(expired), nullValue())
+            body("items[0].rewardAmount", nullValue())
+            body("items[0].qualifyingEvent", nullValue())
+        }
+    }
+
     private fun assertOutbox(programId: UUID, expectedRows: Int) {
         dataSource.connection.use { connection ->
             connection.prepareStatement(
@@ -160,7 +190,12 @@ class ReferralRestContractIT {
         }
     }
 
-    private fun seedDraft(id: UUID, attributionWindowEndsAt: Instant = Instant.now().plusSeconds(86_400)) {
+    private fun seedDraft(
+        id: UUID,
+        attributionWindowEndsAt: Instant = Instant.now().plusSeconds(86_400),
+        name: String = "it-${UUID.randomUUID()}",
+        version: Int = 1,
+    ) {
         dataSource.connection.use { connection ->
             connection.prepareStatement(
                 """insert into referral_program
@@ -170,8 +205,8 @@ class ReferralRestContractIT {
                 """.trimIndent(),
             ).use { statement ->
                 statement.setObject(1, id)
-                statement.setString(2, "it-${UUID.randomUUID()}")
-                statement.setInt(3, 1)
+                statement.setString(2, name)
+                statement.setInt(3, version)
                 statement.setBigDecimal(4, BigDecimal.TEN)
                 statement.setString(5, "EUR")
                 statement.setString(6, "account.opened")


### PR DESCRIPTION
Refs #7194

## Scope

Provide a fail-closed trusted catalogue lookup for Campaign to pin an immutable published Referral Program reference.

- `GET /api/v1/referrals/programs/{id}` returns only `id`, `name`, and `version` for a published program
- draft, expired, and absent programs are all an indistinguishable `404`
- no invite, reward value, party, or ledger data crosses this boundary

## Verification

- `./gradlew :openbank-referral-service:ktlintCheck :openbank-referral-service:test --tests com.openbank.referral.application.ReferralServiceTest`
- `python3 .github/scripts/check-api-contract.py --base 1ad5cbffb2313c23255f1331ac087750f24a7670`

The real HTTP/Postgres regression is included. Its most recent local rerun was blocked before test execution by Testcontainers PostgreSQL startup timeout; CI must provide the integration gate.