### PR TITLE
feat(referral): list published program catalogue

### DIFF
--- a/openbank-referral-service/src/main/kotlin/com/openbank/referral/application/ReferralService.kt
+++ b/openbank-referral-service/src/main/kotlin/com/openbank/referral/application/ReferralService.kt
@@ -100,6 +100,17 @@ class ReferralService(
         it.status == ProgramStatus.PUBLISHED && it.attributionWindowEndsAt.isAfter(Instant.now(clock))
     }
 
+    /**
+     * Read-only Campaign catalogue. It repeats the published/expiry predicate after the repository
+     * query so a stale or alternate adapter cannot disclose a draft or expired programme.
+     */
+    suspend fun publishedPrograms(): List<ReferralProgram> {
+        val now = Instant.now(clock)
+        return programs.listPublished(now).filter {
+            it.status == ProgramStatus.PUBLISHED && it.attributionWindowEndsAt.isAfter(now)
+        }
+    }
+
     // ThrowsCount: three distinct guard-clause rejections, each a different machine-readable
     // reason the caller can branch on — collapsing them into one exception would erase that.
     @Suppress("ThrowsCount")

--- a/openbank-referral-service/src/main/kotlin/com/openbank/referral/application/port/out/ReferralPorts.kt
+++ b/openbank-referral-service/src/main/kotlin/com/openbank/referral/application/port/out/ReferralPorts.kt
@@ -12,6 +12,7 @@ import java.util.UUID
 interface ReferralProgramRepository {
     suspend fun create(program: ReferralProgram): ReferralProgram
     suspend fun find(id: UUID): ReferralProgram?
+    suspend fun listPublished(at: java.time.Instant): List<ReferralProgram>
     suspend fun publish(id: UUID, maker: String, checker: String, at: java.time.Instant): ReferralProgram
 }
 

--- a/openbank-referral-service/src/main/kotlin/com/openbank/referral/infrastructure/persistence/ReferralPersistence.kt
+++ b/openbank-referral-service/src/main/kotlin/com/openbank/referral/infrastructure/persistence/ReferralPersistence.kt
@@ -145,6 +145,13 @@ private fun ReferralRewardEntity.toDomain() = ReferralReward(
     }.awaitSuspending().let { p }
     override suspend fun find(id: UUID) =
         Panache.withSession { find("id", id).firstResult<ReferralProgramEntity>() }.awaitSuspending()?.toDomain()
+    override suspend fun listPublished(at: Instant): List<ReferralProgram> = Panache.withSession {
+        list(
+            "status = ?1 and attributionWindowEndsAt > ?2 order by name asc, version desc",
+            ProgramStatus.PUBLISHED.name,
+            at,
+        )
+    }.awaitSuspending().map { it.toDomain() }
     override suspend fun publish(id: UUID, maker: String, checker: String, at: Instant) = Panache.withTransaction {
         find("id", id).firstResult<ReferralProgramEntity>().map { e ->
             requireNotNull(e)

--- a/openbank-referral-service/src/main/kotlin/com/openbank/referral/infrastructure/rest/ReferralResource.kt
+++ b/openbank-referral-service/src/main/kotlin/com/openbank/referral/infrastructure/rest/ReferralResource.kt
@@ -61,6 +61,16 @@ class ReferralResource(private val service: ReferralService, private val identit
         Response.ok(PublishedReferralProgramResponse(program.id, program.name, program.version)).build()
     } ?: Response.status(Response.Status.NOT_FOUND).build()
 
+    @GET
+    @Path("/programs")
+    suspend fun publishedPrograms(): Response = Response.ok(
+        mapOf(
+            "items" to service.publishedPrograms().map {
+                PublishedReferralProgramResponse(it.id, it.name, it.version)
+            },
+        ),
+    ).build()
+
     @POST
     @Path("/programs/{id}/invites")
     suspend fun invite(

--- a/openbank-referral-service/src/main/resources/openapi.yaml
+++ b/openbank-referral-service/src/main/resources/openapi.yaml
@@ -1,9 +1,31 @@
 openapi: 3.0.3
 info:
   title: OpenBank Referral Service
-  version: 1.1.0
+  version: 1.2.0
 paths:
   /api/v1/referrals/programs:
+    get:
+      summary: List independently published, unexpired referral program revisions for Campaign selection
+      responses:
+        "200":
+          description: Published immutable program references only
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                additionalProperties: false
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      required: [id, name, version]
+                      additionalProperties: false
+                      properties:
+                        id: {type: string, format: uuid}
+                        name: {type: string}
+                        version: {type: integer, minimum: 1}
     post:
       summary: Create a draft referral program
       responses: {"201": {description: Created}}

--- a/openbank-referral-service/src/test/kotlin/com/openbank/referral/application/ReferralServiceTest.kt
+++ b/openbank-referral-service/src/test/kotlin/com/openbank/referral/application/ReferralServiceTest.kt
@@ -48,14 +48,32 @@ class ReferralServiceTest {
         assertThat(service.publishedProgram(id)).isNull()
     }
 
+    @Test
+    fun `published programme catalogue fails closed for drafts and expired programmes`(): Unit = runBlocking {
+        val published = program(UUID.randomUUID(), ProgramStatus.PUBLISHED, name = "alpha", version = 2)
+        val draft = program(UUID.randomUUID(), ProgramStatus.DRAFT, name = "beta", version = 1)
+        val expired = program(
+            UUID.randomUUID(),
+            ProgramStatus.PUBLISHED,
+            attributionWindowEndsAt = Instant.parse("2026-08-27T23:59:59Z"),
+            name = "gamma",
+            version = 1,
+        )
+        coEvery { programs.listPublished(any()) } returns listOf(published, draft, expired)
+
+        assertThat(service.publishedPrograms()).containsExactly(published)
+    }
+
     private fun program(
         id: UUID,
         status: ProgramStatus,
         attributionWindowEndsAt: Instant = Instant.parse("2026-12-31T00:00:00Z"),
+        name: String = "term-deposit-referral",
+        version: Int = 2,
     ) = ReferralProgram(
         id = id,
-        name = "term-deposit-referral",
-        version = 2,
+        name = name,
+        version = version,
         rewardAmount = BigDecimal.TEN,
         currency = "EUR",
         qualifyingEvent = "account.opened",

--- a/openbank-referral-service/src/test/kotlin/com/openbank/referral/integration/ReferralRestContractIT.kt
+++ b/openbank-referral-service/src/test/kotlin/com/openbank/referral/integration/ReferralRestContractIT.kt
@@ -12,6 +12,7 @@ import jakarta.inject.Inject
 import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.notNullValue
+import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.sql.Timestamp
@@ -129,6 +130,35 @@ class ReferralRestContractIT {
             .Then { statusCode(409) }
     }
 
+    @Test
+    fun `published programme catalogue exposes only unexpired immutable references`() {
+        val alpha = UUID.randomUUID()
+        val zeta = UUID.randomUUID()
+        val draft = UUID.randomUUID()
+        val expired = UUID.randomUUID()
+        seedDraft(alpha, name = "catalogue-alpha", version = 2)
+        seedDraft(zeta, name = "catalogue-zeta", version = 1)
+        seedDraft(draft, name = "catalogue-draft", version = 1)
+        seedDraft(expired, Instant.now().minusSeconds(1), name = "catalogue-expired", version = 1)
+
+        listOf(alpha, zeta, expired).forEach { id ->
+            Given { contentType("application/json") } When { post("/api/v1/referrals/programs/$id/publish") } Then {
+                statusCode(200)
+            }
+        }
+
+        Given { contentType("application/json") } When { get("/api/v1/referrals/programs") } Then {
+            statusCode(200)
+            body("items.find { it.id == '%s' }.name".format(alpha), equalTo("catalogue-alpha"))
+            body("items.find { it.id == '%s' }.version".format(alpha), equalTo(2))
+            body("items.find { it.id == '%s' }.name".format(zeta), equalTo("catalogue-zeta"))
+            body("items.find { it.id == '%s' }".format(draft), nullValue())
+            body("items.find { it.id == '%s' }".format(expired), nullValue())
+            body("items[0].rewardAmount", nullValue())
+            body("items[0].qualifyingEvent", nullValue())
+        }
+    }
+
     private fun assertOutbox(programId: UUID, expectedRows: Int) {
         dataSource.connection.use { connection ->
             connection.prepareStatement(
@@ -160,7 +190,12 @@ class ReferralRestContractIT {
         }
     }
 
-    private fun seedDraft(id: UUID, attributionWindowEndsAt: Instant = Instant.now().plusSeconds(86_400)) {
+    private fun seedDraft(
+        id: UUID,
+        attributionWindowEndsAt: Instant = Instant.now().plusSeconds(86_400),
+        name: String = "it-${UUID.randomUUID()}",
+        version: Int = 1,
+    ) {
         dataSource.connection.use { connection ->
             connection.prepareStatement(
                 """insert into referral_program
@@ -170,8 +205,8 @@ class ReferralRestContractIT {
                 """.trimIndent(),
             ).use { statement ->
                 statement.setObject(1, id)
-                statement.setString(2, "it-${UUID.randomUUID()}")
-                statement.setInt(3, 1)
+                statement.setString(2, name)
+                statement.setInt(3, version)
                 statement.setBigDecimal(4, BigDecimal.TEN)
                 statement.setString(5, "EUR")
                 statement.setString(6, "account.opened")


### PR DESCRIPTION
Refs #7198

Adds a read-only, operator-only catalogue of independently published and unexpired MGM programme revisions. The response exposes only immutable `id`, `name`, and `version`; it does not activate a programme or expose reward, invite, or party data.

Proof: ReferralService unit tests plus real HTTP/Postgres contract coverage; `ktlintCheck` and API-contract gate pass.