### PR TITLE
fix(admin-ui): mark sandbox regulatory exports

### DIFF
--- a/openbank-admin-ui/src/app/regulatory/page.tsx
+++ b/openbank-admin-ui/src/app/regulatory/page.tsx
@@ -4,6 +4,7 @@
 
 'use client'
 
+import Link from 'next/link'
 import { useState } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl, type BffFailure } from '@/lib/services/bff'
@@ -62,6 +63,12 @@ const TEMPLATE_PATHS: Record<string, string[]> = {
   'cnb-capital': ['/api/v1/corep/templates/C_01.00'],
 }
 
+// This is the canonical environment tag already embedded in the browser bundle. Unknown
+// environments fail safe as non-production: missing deployment metadata must never remove a
+// TEST_ONLY mark from a regulatory artefact.
+const DEPLOYMENT_ENVIRONMENT = process.env.NEXT_PUBLIC_GLITCHTIP_ENVIRONMENT?.trim() || 'unknown'
+const IS_TEST_ENVIRONMENT = DEPLOYMENT_ENVIRONMENT !== 'production'
+
 const CELL_LABELS: Record<string, string> = {
   'F01.01:r0010:c0010': 'Hotovost, centrální banky a vklady na požádání',
   'F01.01:r0040:c0010': 'Ostatní vklady na požádání',
@@ -113,6 +120,14 @@ function lastCompletedMonthEnd(): string {
 
 function buildExportRows(report: Report, data: PreviewData): ExportRow[] {
   const meta: ExportRow[] = [
+    { field: 'Klasifikace artefaktu', value: IS_TEST_ENVIRONMENT ? 'TEST_ONLY' : 'INTERNÍ REGULATORNÍ NÁHLED' },
+    { field: 'Prostředí', value: DEPLOYMENT_ENVIRONMENT },
+    {
+      field: 'Povolené použití',
+      value: IS_TEST_ENVIRONMENT
+        ? 'TESTOVACÍ DATA — NESMÍ BÝT ODESLÁNO REGULÁTOROVI'
+        : 'Interní kontrola; odeslání regulátorovi není připojeno',
+    },
     { field: 'ID výkazu', value: report.id },
     { field: 'Název', value: report.name },
     { field: 'Autorita', value: report.authority },
@@ -362,7 +377,7 @@ export default function RegulatoryPage() {
       exportedAt: new Date().toISOString(),
     }
     triggerDownload(
-      `report_${report.sdatCode}_${new Date().toISOString().slice(0, 10)}.json`,
+      `${IS_TEST_ENVIRONMENT ? 'TEST_ONLY_' : ''}report_${report.sdatCode}_${new Date().toISOString().slice(0, 10)}.json`,
       JSON.stringify(data, null, 2),
       'application/json',
     )
@@ -375,7 +390,7 @@ export default function RegulatoryPage() {
     const header = `${csvCell(t('Pole', 'Field'))},${csvCell(t('Hodnota', 'Value'))}`
     const body = rows.map(r => `${csvCell(r.field)},${csvCell(r.value)}`).join('\n')
     triggerDownload(
-      `report_${report.sdatCode}_${new Date().toISOString().slice(0, 10)}.csv`,
+      `${IS_TEST_ENVIRONMENT ? 'TEST_ONLY_' : ''}report_${report.sdatCode}_${new Date().toISOString().slice(0, 10)}.csv`,
       `${header}\n${body}\n`,
       'text/csv;charset=utf-8',
     )
@@ -649,6 +664,12 @@ export default function RegulatoryPage() {
               </div>
             )}
 
+            {IS_TEST_ENVIRONMENT && (
+              <div role="status" data-testid="test-data-watermark" style={{ padding: '10px 20px', color: '#991b1b', background: '#fef2f2', borderBottom: '1px solid #fecaca', fontSize: '12px', fontWeight: 700 }}>
+                {DEPLOYMENT_ENVIRONMENT.toUpperCase()} / {t('TESTOVACÍ DATA — náhled ani stažený soubor nesmí být odeslán regulátorovi.', 'TEST DATA — neither this preview nor a downloaded file may be submitted to a regulator.')}
+              </div>
+            )}
+
             {/* Visual control table */}
             <div style={{ overflowY: 'auto', padding: '0' }}>
               {previewData.status === 'unavailable' ? (
@@ -709,6 +730,11 @@ export default function RegulatoryPage() {
                     </div>
                   )
                 })()}
+                {!exportReadiness.ok && (exportReadiness.reason === 'no_closed_periods' || exportReadiness.reason === 'provisional_data') && (
+                  <Link href="/day-end?tab=regulatory" style={{ display: 'inline-flex', alignItems: 'center', gap: '4px', marginBottom: '8px', color: 'var(--accent)', fontWeight: 700 }}>
+                    {t('Otevřít regulatorní uzávěrku', 'Open regulatory close')} <ExternalLink size={11} aria-hidden="true" />
+                  </Link>
+                )}
                 {previewData.status === 'unsupported'
                   ? t('Tento katalogový výkaz zatím nemá implementovaný datový zdroj ani odeslání. Nezobrazuje fiktivní hodnoty.', 'This catalogue report has no implemented data source or submission path yet. It does not show fictional values.')
                   : t('FINREP/COREP se při načtení ověřují ve finrep-service nad ledger trial balance; při nedostupnosti se hodnoty nezobrazí. ClickHouse ani ČNB XBRL/SDAT přenos nejsou součástí tohoto náhledu.', 'FINREP/COREP are verified on load from finrep-service over the ledger trial balance; values are not shown when unavailable. ClickHouse and ČNB XBRL/SDAT transmission are not part of this preview.')}

--- a/openbank-admin-ui/src/test/regulatory-report-preview.test.tsx
+++ b/openbank-admin-ui/src/test/regulatory-report-preview.test.tsx
@@ -77,6 +77,9 @@ describe('Regulatory report preview', () => {
     expect(String(fetchMock.mock.calls[3][0])).toContain('/api/svc/finrep-service/api/v1/finrep/templates/F01.03?asOf=2026-06-30')
     expect(String(fetchMock.mock.calls[4][0])).toContain('/api/svc/finrep-service/api/v1/finrep/templates/F02.00?asOf=2026-06-30')
     expect(screen.getByText('finrep-service ← zmrazená ledger předvaha (FROZEN / LINES_V1)')).toBeInTheDocument()
+    expect(screen.getByTestId('test-data-watermark')).toHaveTextContent(/TEST DATA/i)
+    expect(screen.getByText('TEST_ONLY')).toBeInTheDocument()
+    expect(screen.getByText(/NESMÍ BÝT ODESLÁNO REGULÁTOROVI/)).toBeInTheDocument()
     expect(screen.getByTestId('export-readiness')).toHaveTextContent(/Ready for internal export/)
     expect(screen.getByRole('button', { name: 'Export preview as JSON' })).toBeEnabled()
   })
@@ -118,6 +121,7 @@ describe('Regulatory report preview', () => {
     expect(fetchMock).toHaveBeenCalledTimes(5)
     expect(String(fetchMock.mock.calls[1][0])).toContain('evidence=LIVE_PREVIEW')
     expect(screen.getByTestId('export-blocked')).toHaveAttribute('data-block-reason', 'provisional_data')
+    expect(screen.getByRole('link', { name: /Open regulatory close/i })).toHaveAttribute('href', '/day-end?tab=regulatory')
     expect(screen.getByRole('button', { name: 'Export preview as JSON' })).toBeDisabled()
   })
 


### PR DESCRIPTION
## Summary

Make sandbox FINREP/COREP previews and downloaded CSV/JSON artefacts unambiguously TEST_ONLY, and give an operator a direct recovery path to the existing maker/checker close cockpit when immutable evidence is missing.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #7580
Refs #4348

## Changes

- add fail-safe environment, TEST_ONLY classification, and not-for-submission provenance to the exact preview/export row set
- prefix non-production filenames with TEST_ONLY_ and render an unavoidable test-data watermark
- link provisional/missing-period failures to the governed regulatory close cockpit
- cover watermark and recovery link in the focused preview test

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] No new lint warnings.
- [x] No REST API, database, event, or dependency change.

Verification:
- npm run type-check
- eslint src/app/regulatory/page.tsx src/test/regulatory-report-preview.test.tsx
- npm test -- src/test/regulatory-report-preview.test.tsx (5/5)

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new suppressions.
- [x] No new third-party dependency.
- [x] No auth, crypto, payment, PII, or cardholder-data path changed.

## Compliance impact

- [x] CNB reporting

Non-production artefacts are now explicitly non-submittable. The broader durable synthetic-taint propagation and exclusion remains tracked by #4348 and is not falsely claimed here.

## Rollout / Rollback

- Deployment strategy: existing Admin UI sandbox rollout
- Rollback plan: revert this commit through a reviewed PR
- Data migration reversible: N/A

## Screenshots / demo

Focused component test verifies the rendered watermark and close-cockpit link.

## Reviewer notes

Please verify that reusing the browser bundle's canonical environment tag is acceptable. Missing or unknown metadata deliberately fails safe as non-production.