### PR TITLE
fix(ci): pin the flake ledger to one issue instead of taking search .[0]

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1885,6 +1885,23 @@ gates:
     run: |
       bash .github/scripts/spot-kill-retry.sh --self-test
 
+  - id: resolve-tracking-issue-selftest
+    name: "a machine-written ledger resolves to exactly one issue, or fails loudly (issue #5266, enforced)"
+    group: registry
+    mode: enforced
+    selftest_exempt: >-
+      is-a-test-suite — the run: below IS the self-test. It drives the real resolver against a
+      stub gh and asserts exit code AND resolved number for all 12 cases, including a control
+      asserting that the OLD `.[0]` expression is green on the very input the new one refuses.
+      Falsified before wiring in: reinstating `.[0]` turns 2 of the 12 assertions red.
+    budget_seconds: 30   # no network; ~1s observed
+    rationale: "The old `--search \"$TITLE in:title\" | .[0].number` never checked how many candidates it had. Two open issues shared the flake-ledger title, so 85 records went to #5285 and 1 to #5266 — the ledger silently migrated between them mid-life, and a split ledger reads as a low flake count to whoever opens either half."
+    review_after: "2027-02-28"
+    # Subjects are assertions, not files: the floor drops the day someone deletes a case.
+    min_subjects: 12
+    run: |
+      bash .github/scripts/resolve-tracking-issue.sh --self-test
+
   # Nothing in this repo has ever read a merged PR's required contexts: before #4240,
   # `grep -rl 'required_status_checks\|statusCheckRollup' .github/scripts .github/workflows`
   # returned one hit and it was a comment. A ruleset bypass is recorded only in

--- a/.github/scripts/resolve-tracking-issue.sh
+++ b/.github/scripts/resolve-tracking-issue.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# Resolve the ONE issue a long-lived, machine-written ledger should be appended to.
+#
+# WHY THIS EXISTS (issue #5266)
+# `auto-retry-cancelled.yml` picked its target with
+#     gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number'
+# and `.[0]` pins nothing. Two open issues carried the byte-identical title
+# "Flaky test observations (recorded from CI re-run evidence)" — #5266 (created 14:45Z) and
+# #5285 (17:37Z, same day, same author `app/github-actions`, same labels, identical body —
+# the duplicate is itself a product of this file's other defect, see NO AUTO-CREATE below).
+# Measured 2026-08-30: the search returned #5285 first, so #5285 holds 85 flake records and
+# #5266 holds 1 — and that 1 is the proof the ledger MIGRATES: the first record went to #5266
+# at 16:19Z and every record from 17:37Z onward went to #5285. Nothing anywhere said so. A
+# split ledger is worse than an absent one: each half reads as a low flake count and neither
+# reader knows they are looking at part of the data.
+#
+# WHY NOT `--sort created --order asc`
+# It would have picked #5266 today and still selects by a MUTABLE property of a candidate SET
+# whose size nobody checks. The day a third same-titled issue appears it silently re-points
+# again. The defect is not the ordering, it is that the identity was never pinned — so this
+# script pins an identity and makes an ambiguous candidate set an ERROR rather than an
+# arbitrary choice. Reintroducing "just take one" at this level would be the same bug one
+# layer up.
+#
+# TWO MODES
+#   --pinned <n>   The strongest form: the caller names the issue. We only VERIFY (open, and
+#                  its title still matches) and print the number. No search, no ambiguity, and
+#                  no auto-create, so a race can no longer mint a rival ledger. This is what
+#                  the flake ledger uses.
+#   (no --pinned)  Title mode, for an alarm issue that must be able to open itself when none
+#                  exists. Search narrows; the DECISION is a client-side EXACT title match
+#                  (GitHub's `in:title` is fuzzy and will hand back near-misses). Then:
+#                  0 candidates -> create (only if --create-body-file was given), 1 -> use it,
+#                  >1 -> exit 1 naming every candidate. Never `.[0]`.
+#
+# NO AUTO-CREATE ON THE PINNED PATH — that is the point, not an omission.
+# GitHub's issue search index is eventually consistent, so `create` followed seconds later by
+# `list --search` in a sibling run legitimately returns nothing and creates a second issue.
+# That is the most likely origin of #5266/#5285 (2h52m apart, identical bodies). A pinned
+# number cannot lose that race because it never asks the index a question.
+#
+# LOUD FAILURE IS THE CONTRACT. Every path that cannot name exactly one issue exits 1 with the
+# reason on stderr. The caller is a `workflow_run` job whose red is addressed to nobody, so the
+# workflow routes that red to the `raise-issue` alarm; silently appending somewhere plausible
+# is the behaviour being removed.
+#
+# API COST: unchanged. Title mode makes the same single `gh issue list` call as before (the
+# strictness is client-side, over the same response). Pinned mode makes one `gh issue view`
+# instead of that one `gh issue list`. Net zero against the repo's 1,000 req/hr budget.
+#
+# `-R "$GH_REPO"` on every call: this runs in jobs with a sparse or absent checkout, where a
+# bare `gh` dies with `failed to determine base repo` (#2898, 208 silent failures).
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: resolve-tracking-issue.sh --title <title> [--pinned <number>]
+                                 [--create-body-file <path>] [--create-label <label>]...
+                                 [--status-file <path>]   # 'existing' | 'created'
+       resolve-tracking-issue.sh --self-test
+Prints the resolved issue number on stdout. Exits 1 if exactly one cannot be named.
+USAGE
+  exit 2
+}
+
+TITLE=""
+PINNED=""
+CREATE_BODY=""
+STATUS_FILE=""
+CREATE_LABELS=()
+
+# `existing` or `created`, so a caller that appends a comment can avoid posting the same text
+# twice into an issue whose BODY it just wrote. Written to a file rather than mixed into stdout
+# because stdout is the issue number and nothing else.
+note_status() { [ -n "$STATUS_FILE" ] && printf '%s' "$1" > "$STATUS_FILE"; return 0; }
+
+resolve() {
+  local repo="${GH_REPO:?GH_REPO must be set}"
+
+  if [ -n "$PINNED" ]; then
+    local meta state actual
+    if ! meta=$(gh issue view "$PINNED" -R "$repo" --json number,state,title 2>&1); then
+      echo "resolve-tracking-issue: pinned issue #${PINNED} could not be read: ${meta}" >&2
+      return 1
+    fi
+    state=$(printf '%s' "$meta" | jq -r '.state')
+    actual=$(printf '%s' "$meta" | jq -r '.title')
+    if [ "$state" != "OPEN" ]; then
+      echo "resolve-tracking-issue: pinned issue #${PINNED} is ${state}, not OPEN. The ledger is" >&2
+      echo "  append-only and must not silently relocate: re-open it, or update the pinned" >&2
+      echo "  number in the workflow in a reviewed PR." >&2
+      return 1
+    fi
+    if [ "$actual" != "$TITLE" ]; then
+      echo "resolve-tracking-issue: pinned issue #${PINNED} is titled" >&2
+      echo "  '${actual}'" >&2
+      echo "  but the caller expected '${TITLE}'. Refusing to append to an issue that may have" >&2
+      echo "  been repurposed." >&2
+      return 1
+    fi
+    note_status existing
+    printf '%s\n' "$PINNED"
+    return 0
+  fi
+
+  # Title mode. `in:title` is a fuzzy full-text match, so the response is a CANDIDATE list; the
+  # exact-title filter below is what decides. Without it a differently-titled issue sharing
+  # enough words is indistinguishable from the real one.
+  local raw matches count
+  raw=$(gh issue list -R "$repo" --state open --search "$TITLE in:title" \
+          --limit 100 --json number,title)
+  matches=$(printf '%s' "$raw" | jq --arg t "$TITLE" '[.[] | select(.title == $t) | .number] | sort')
+  count=$(printf '%s' "$matches" | jq 'length')
+
+  if [ "$count" -gt 1 ]; then
+    echo "resolve-tracking-issue: ${count} open issues share the exact title" >&2
+    echo "  '${TITLE}'" >&2
+    echo "  -> $(printf '%s' "$matches" | jq -r 'map("#\(.)") | join(", ")')" >&2
+    echo "  Refusing to pick one. Consolidate them, then pin the survivor with --pinned." >&2
+    return 1
+  fi
+
+  if [ "$count" -eq 1 ]; then
+    note_status existing
+    printf '%s' "$matches" | jq -r '.[0]'
+    return 0
+  fi
+
+  if [ -z "$CREATE_BODY" ]; then
+    echo "resolve-tracking-issue: no open issue titled '${TITLE}' and no --create-body-file given." >&2
+    return 1
+  fi
+
+  local args=(issue create -R "$repo" --title "$TITLE" --body-file "$CREATE_BODY")
+  local l
+  for l in ${CREATE_LABELS+"${CREATE_LABELS[@]}"}; do args+=(--label "$l"); done
+  local url created
+  url=$(gh "${args[@]}")
+  created=$(printf '%s' "$url" | grep -oE '[0-9]+$' || true)
+  if [ -z "$created" ]; then
+    echo "resolve-tracking-issue: could not read an issue number out of 'gh issue create' output: ${url}" >&2
+    return 1
+  fi
+  note_status created
+  printf '%s\n' "$created"
+}
+
+# ── self-test ────────────────────────────────────────────────────────────────
+# Drives the real `resolve` against a stub `gh` on PATH. Every case asserts the exit code AND
+# the resolved number, and the ambiguous case is the prevent-proof: the OLD expression takes
+# `.[0]` and is green, this one must be RED.
+self_test() {
+  local tmp; tmp=$(mktemp -d); trap 'rm -rf "$tmp"' RETURN
+  mkdir -p "$tmp/bin"
+  cat > "$tmp/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "issue view")
+    case "$3" in
+      5285) echo '{"number":5285,"state":"OPEN","title":"Ledger"}' ;;
+      5266) echo '{"number":5266,"state":"CLOSED","title":"Ledger"}' ;;
+      4242) echo '{"number":4242,"state":"OPEN","title":"Something else entirely"}' ;;
+      *) echo 'gh: Could not resolve to an Issue' >&2; exit 1 ;;
+    esac ;;
+  "issue list") cat "${STUB_LIST_JSON}" ;;
+  "issue create") echo "https://github.com/o/r/issues/9001" ;;
+  *) echo "stub gh: unexpected: $*" >&2; exit 99 ;;
+esac
+STUB
+  chmod +x "$tmp/bin/gh"
+  PATH="$tmp/bin:$PATH"; export GH_REPO="o/r"
+
+  local fails=0 n=0
+  check() { # name expected_rc expected_out
+    n=$((n + 1))
+    local name="$1" want_rc="$2" want_out="${3-}" out rc
+    set +e; out=$(resolve 2>"$tmp/err"); rc=$?; set -e
+    if [ "$rc" != "$want_rc" ] || { [ -n "$want_out" ] && [ "$out" != "$want_out" ]; }; then
+      echo "FAIL  ${name}: rc=${rc} out='${out}' (wanted rc=${want_rc} out='${want_out}')" >&2
+      sed 's/^/      /' "$tmp/err" >&2
+      fails=$((fails + 1))
+    else
+      echo "ok    ${name}"
+    fi
+  }
+
+  TITLE="Ledger"; CREATE_BODY=""; CREATE_LABELS=(); STATUS_FILE="$tmp/status"
+
+
+  PINNED=5285; check "pinned + open + title matches -> that number" 0 5285
+  PINNED=5266; check "pinned but CLOSED -> loud failure, never a fallback search" 1
+  PINNED=4242; check "pinned but retitled -> loud failure" 1
+  PINNED=9999; check "pinned but unreadable -> loud failure" 1
+
+  PINNED=""
+  # THE PREVENT-PROOF. This is the real #5266/#5285 candidate set. The old `.[0]` expression
+  # returns 5285 and exits 0; this one must refuse.
+  export STUB_LIST_JSON="$tmp/dupes.json"
+  cat > "$tmp/dupes.json" <<'J'
+[{"number":5285,"title":"Ledger"},{"number":5266,"title":"Ledger"}]
+J
+  check "two exact-title candidates -> REFUSES (old code silently took .[0])" 1
+  n=$((n + 1))
+  if [ "$(jq -r '.[0].number' "$tmp/dupes.json")" = "5285" ]; then
+    echo "ok    control: the old '.[0]' expression does answer 5285 on this same input"
+  else
+    echo "FAIL  control: stub input no longer reproduces the ambiguity" >&2; fails=$((fails + 1))
+  fi
+
+  export STUB_LIST_JSON="$tmp/one.json"
+  echo '[{"number":5285,"title":"Ledger"}]' > "$tmp/one.json"
+  check "exactly one exact-title candidate -> that number" 0 5285
+
+  # Fuzzy `in:title` near-miss: search returns it, exact match must reject it.
+  export STUB_LIST_JSON="$tmp/fuzzy.json"
+  echo '[{"number":7,"title":"Ledger (archived)"},{"number":5285,"title":"Ledger"}]' > "$tmp/fuzzy.json"
+  check "fuzzy near-miss is not a candidate -> the exact one" 0 5285
+
+  export STUB_LIST_JSON="$tmp/none.json"; echo '[]' > "$tmp/none.json"
+  check "no candidate and no --create-body-file -> loud failure, not a silent no-op" 1
+  CREATE_BODY="$tmp/body.md"; echo body > "$CREATE_BODY"; CREATE_LABELS=(tech-debt)
+  check "no candidate + --create-body-file -> creates and returns the new number" 0 9001
+  n=$((n + 1))
+  # The caller writes the issue BODY when it creates, and appends a COMMENT otherwise. Without
+  # this distinction a freshly created alarm issue gets its own text posted straight back as a
+  # duplicate comment.
+  if [ "$(cat "$tmp/status")" = "created" ]; then
+    echo "ok    status-file says 'created' on the create path"
+  else
+    echo "FAIL  status-file said '$(cat "$tmp/status")', wanted 'created'" >&2; fails=$((fails + 1))
+  fi
+
+  export STUB_LIST_JSON="$tmp/three.json"
+  echo '[{"number":1,"title":"Ledger"},{"number":2,"title":"Ledger"},{"number":3,"title":"Ledger"}]' > "$tmp/three.json"
+  check "three candidates + create allowed -> still REFUSES (never creates a 4th)" 1
+
+  # `SUBJECTS=` is the gate runner's floor check (min_subjects): it is what stops this
+  # suite from going green after someone deletes half its cases.
+  echo "SUBJECTS=${n}  # assertions driven against the stub gh"
+  echo "${n} assertions, ${fails} failed"
+  [ "$fails" -eq 0 ]
+}
+
+[ $# -gt 0 ] || usage
+if [ "$1" = "--self-test" ]; then self_test; exit; fi
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --title)            TITLE="$2"; shift 2 ;;
+    --pinned)           PINNED="$2"; shift 2 ;;
+    --create-body-file) CREATE_BODY="$2"; shift 2 ;;
+    --status-file)      STATUS_FILE="$2"; shift 2 ;;
+    --create-label)     CREATE_LABELS+=("$2"); shift 2 ;;
+    *) echo "unknown argument: $1" >&2; usage ;;
+  esac
+done
+[ -n "$TITLE" ] || usage
+resolve

--- a/.github/workflows/auto-retry-cancelled.yml
+++ b/.github/workflows/auto-retry-cancelled.yml
@@ -184,10 +184,26 @@ jobs:
     permissions:
       contents: read
       issues: write
-    # No actions/checkout, so gh cannot infer the repo from a git remote (#2841).
     env:
       GH_REPO: ${{ github.repository }}
     steps:
+      # A sparse checkout for `resolve-tracking-issue.sh` only. This job used to have none, and
+      # the note that lived here said so — that was load-bearing when the whole job was one
+      # inline `run:`, and `-R`/`GH_REPO` (both still set, above and in the script) is what
+      # actually defends against #2841's `failed to determine base repo`. Fetching one file at
+      # depth 1 is not the "clone the repo to make one API call" waste; the `retry` job took the
+      # same trade in #6255 for the same reason — an inline expression is only executable by a
+      # real `workflow_run` event, so its branches cannot be falsified before they misfire.
+      #
+      # No `ref:` on purpose: a `workflow_run` checkout defaults to the DEFAULT BRANCH, which is
+      # what a job holding `issues: write` should execute.
+      - name: Fetch the issue-resolver (sparse, default branch)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github/scripts/resolve-tracking-issue.sh
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: Open or refresh the tracking issue
         env:
           GH_TOKEN: ${{ github.token }}
@@ -244,12 +260,24 @@ jobs:
 
           This issue is refreshed on each further failure; close it once a run is green.
           EOF
-          existing=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number' || true)
-          if [ -n "$existing" ]; then
+          # `.[0].number` off a title search used to live here. It pins nothing: the candidate
+          # set's size was never checked, so two same-titled issues silently split the alarm
+          # between them and each half reads as a quieter problem than it is. That is exactly
+          # what happened to the flake ledger below (#5266/#5285). The resolver makes an
+          # ambiguous set exit 1 instead of an arbitrary pick, and it still creates the issue
+          # when there is genuinely none — same one `gh issue list` call as before.
+          status_file="${RUNNER_TEMP:-/tmp}/resolve-status"
+          existing=$(bash .github/scripts/resolve-tracking-issue.sh \
+            --title "$TITLE" \
+            --create-body-file "${RUNNER_TEMP:-/tmp}/issue-body.md" \
+            --create-label tech-debt --create-label "severity:high" \
+            --status-file "$status_file")
+          # A freshly created issue already carries this text as its BODY; only an issue that
+          # already existed gets it again as a refresh comment.
+          if [ "$(cat "$status_file")" = "existing" ]; then
             gh issue comment "$existing" --body-file "${RUNNER_TEMP:-/tmp}/issue-body.md"
           else
-            gh issue create --title "$TITLE" --body-file "${RUNNER_TEMP:-/tmp}/issue-body.md" \
-              --label tech-debt --label "severity:high"
+            echo "Opened #${existing} with this text as its body; no refresh comment needed."
           fi
 
   # ── Flake recording (issue #4878) ────────────────────────────────────────────
@@ -382,21 +410,31 @@ jobs:
         if: steps.classify.outputs.count != '0'
         run: |
           set -euo pipefail
+          # THE LEDGER IS PINNED BY NUMBER, and auto-creation is deliberately gone (#5266).
+          #
+          # This used to be `--search "$TITLE in:title" ... .[0].number` plus "create one if the
+          # search finds nothing", and both halves failed together. GitHub's issue search index
+          # is eventually consistent, so a second `workflow_run` listener querying moments after
+          # the first one created the issue legitimately sees nothing and creates a RIVAL ledger
+          # with the same title. That is how #5266 (14:45Z) and #5285 (17:37Z) came to exist:
+          # same author, same labels, byte-identical bodies. `.[0]` then chose between them by
+          # whatever order the search API happened to return — and it CHANGED: the first record
+          # landed on #5266 at 16:19Z and every record from 17:37Z onward on #5285, leaving 85
+          # records in one and 1 in the other with nothing anywhere saying so.
+          #
+          # A split ledger is worse than a missing one. Each half reads as a low flake count and
+          # neither reader can tell they are seeing part of the data — `list-recorded-flakes.py`
+          # takes one `--issue` and would have reported either half as the whole truth.
+          #
+          # Sorting the candidates would not have fixed it: that still selects by a mutable
+          # property of an unbounded set. The number below is the identity. If it must change,
+          # it changes in a reviewed PR — the ledger cannot relocate itself.
+          LEDGER_ISSUE="5285"
           TITLE="Flaky test observations (recorded from CI re-run evidence)"
-          existing=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number' || true)
-          if [ -z "${existing}" ]; then
-            printf '%s\n' \
-              "This issue is a running log, not something to action directly (#4878)." \
-              "" \
-              "Each comment below is one job that failed for a real reason (not a runner reclaim -- see auto-retry-cancelled.yml's \`record-flake\` job) and went green on a later attempt of the SAME run, with no source change in between. That is the definition of a flake this repo can act on." \
-              "" \
-              "Read it back with \`.github/scripts/list-recorded-flakes.py --issue <this-issue-number>\`." \
-              "" \
-              "Deciding what to DO with this data (thresholds, alerts, the 29-copy \`*OutboxClaimIT\` construction) is explicitly out of scope for #4878 -- this issue exists so that decision has evidence to work from." \
-              > "${RUNNER_TEMP}/issue-body.md"
-            existing=$(gh issue create --title "$TITLE" --body-file "${RUNNER_TEMP}/issue-body.md" \
-              --label flaky-test --label tech-debt | grep -oE '[0-9]+$')
-          fi
+          # Verifies open + still titled as expected, and exits 1 otherwise. Exiting 1 is the
+          # point: a record that cannot be filed correctly must not be filed somewhere plausible.
+          existing=$(bash .github/scripts/resolve-tracking-issue.sh \
+            --title "$TITLE" --pinned "$LEDGER_ISSUE")
 
           for f in "${RUNNER_TEMP}"/comments/record-*.json; do
             [ -e "$f" ] || continue


### PR DESCRIPTION
Closes #5266 (mechanism), and reports the duplicate-issue question for a human to close.

## The premise, verified on `origin/main`

`.github/workflows/auto-retry-cancelled.yml` picked the issue to write to with:

```
gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number'
```

in **two** places — the `raise-issue` alarm and the `record-flake` ledger. `.[0]` pins nothing, and the candidate set's size was never checked.

Two open issues carry the byte-identical title `Flaky test observations (recorded from CI re-run evidence)`:

| issue | created | author | labels | flake records |
|---|---|---|---|---|
| #5266 | 2026-08-17T14:45:01Z | `app/github-actions` | tech-debt, flaky-test | **1** |
| #5285 | 2026-08-17T17:37:08Z | `app/github-actions` | tech-debt, flaky-test | **85** |

Their bodies are byte-identical (`diff` exit 0).

**The ledger did not merely land on the wrong issue — it MIGRATED.** The first record went to #5266 at 16:19:38Z; every record from 17:37:09Z onward went to #5285. Nothing anywhere records that.

A split ledger is worse than a missing one: `list-recorded-flakes.py` takes a single `--issue`, so either half reads as the whole truth and as a low flake count.

## Why not `--sort created --order asc`

It would pick #5266 today and still selects by a **mutable property of a set whose size nobody checks**. It re-points silently the day a third same-titled issue appears. The defect is that the identity was never pinned, not that the ordering was wrong.

## What changed

New `.github/scripts/resolve-tracking-issue.sh`:

- `--pinned <n>` — the caller names the issue. Verifies it is OPEN and still carries the expected title, then prints it. No search, no ambiguity, **no auto-create**.
- title mode (no `--pinned`) — for an alarm that must open itself. Same single `gh issue list` call, but the DECISION is a client-side **exact** title match (`in:title` is fuzzy). Then: 0 -> create if `--create-body-file` was given, 1 -> use it, **>1 -> exit 1 naming every candidate**.
- Every non-resolving path exits 1 with the reason on stderr. Nothing ever picks arbitrarily.

Workflow:

- `record-flake` pins the ledger to **#5285** (where 85 of the 86 records already live) and no longer auto-creates. Auto-create is what made the duplicate in the first place: GitHub's issue search index is eventually consistent, so a sibling `workflow_run` listener querying moments after a create legitimately sees nothing and mints a rival ledger. A pinned number never asks the index a question.
- `raise-issue` moves to title mode, fixing the same latent `.[0]` there (one candidate today: #6853). A `--status-file` stops a freshly created issue getting its own body posted straight back as a duplicate comment. It takes a sparse checkout of the one script; `-R`/`GH_REPO` still guard #2841 on every call.

## Prove it by what it prevents

Against the **live** issue set, 2026-08-30:

```
=== OLD expression ===                              rc=0   -> 5285      (silently ambiguous)
=== NEW, title mode ===                             rc=1
  resolve-tracking-issue: 2 open issues share the exact title
    'Flaky test observations (recorded from CI re-run evidence)'
    -> #5266, #5285
    Refusing to pick one. Consolidate them, then pin the survivor with --pinned.
=== NEW, pinned mode ===                            rc=0   -> 5285      (exactly one, by identity)
=== NEW, alarm title (single match today) ===       rc=0   -> 6853
```

New gate `resolve-tracking-issue-selftest` (group `registry`, enforced, `min_subjects: 12`) drives 12 assertions against a stub `gh`, including a **control** asserting the old `.[0]` expression IS green on the very input the new one refuses.

**Negative case run before wiring it in** — reinstating `.[0]` (`if false` on the ambiguity branch, `-ge 1` instead of `-eq 1`):

```
EXIT_WITH_DEFECT_REINTRODUCED=1
FAIL  two exact-title candidates -> REFUSES ...: rc=0 out='5266'
FAIL  three candidates + create allowed -> still REFUSES ...: rc=0 out='1'
12 assertions, 2 failed
```

## API calls per run

**Unchanged.** Title mode makes the same one `gh issue list`; pinned mode makes one `gh issue view` in place of that one `gh issue list`. Zero net change against the 1,000 req/hr repo budget.

## Checks run locally

`actionlint` per file (exit 0; probe falsified — an injected YAML syntax error gives exit 1), `shellcheck -x` (exit 0), `run-gates.py --only resolve-tracking-issue-selftest` (PASS), and `check-gate-lifecycle-metadata.py --today 2026-08-30`, `check-gate-selftest-declaration.py`, `check-gate-subject-floor.py`, `check-gate-script-registration.py`, `check-gate-invocation-reachability.py`, `check-gates-not-deregistered.py`, `check-gh-repo-context.py` — all exit 0.

## The deeper question: are #5266 and #5285 duplicates?

**Yes — unambiguously.** Same title, same machine author, same labels, byte-identical bodies, 2h52m apart. They are one ledger that the index race split in two. Recommendation: **close #5266 as a duplicate of #5285** (the 85 records already live in #5285; only one record and a human triage note are in #5266, and that record should be re-posted to #5285 or accepted as lost). No title change is needed — there should only ever be one such issue.

Per the task, **neither issue is closed here**; evidence is posted on both.

## Not verified

- The workflow is not dispatched or re-run (it writes to issues), so the change is reasoned about statically plus the stub-driven self-test. The `--pinned` path against the live #5285 was exercised read-only via the script directly.
- Nothing checks that #5285 is never closed by a human; if it is, `record-flake` now fails loudly rather than relocating — that is intended, but note `raise-issue` only `needs: retry`, so a `record-flake` red is still addressed to nobody. Wiring the alarm to cover `record-flake` too is a separate, larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
