### PR TITLE
fix(lending): distinguish an unconfigured court register from a clear one

### DIFF
--- a/docs/threat-models/openbank-lending-service.md
+++ b/docs/threat-models/openbank-lending-service.md
@@ -437,10 +437,11 @@ outbound: consent-service for `CREDIT_OFFERS`, and analytics-sink for the 360 cr
 | **S**poofing | An unauthenticated caller reads a customer's cash-flow profile from analytics-sink | The route is `@RolesAllowed(OPERATOR, AUDITOR, ADMIN)`; the party id is parsed as a UUID *before* interpolation, which is also the injection boundary — ClickHouse's HTTP interface has no bound-parameter path. |
 
 **Known gap, stated rather than modelled away:** enforcement orders and insolvency proceedings have
-no source in this deployment — no service ingests a court register. They are reported as absent, not
-unknown, because permanent `complete = false` would suppress every offer forever and be
-indistinguishable from the feature being switched off. This is the first thing an operational-risk
-review of this gate should challenge.
+no source in this deployment — no service ingests a court register. The decision still treats them
+as non-suppressing, because a permanent `complete = false` would refuse every offer forever and be
+indistinguishable from the feature being switched off. What changed (#6646) is that the *state* is
+no longer indistinguishable from a clean answer: see section 9d. This remains the first thing an
+operational-risk review of this gate should challenge.
 
 ## 9c. Customer financial health (ADR-0269 rule 5) — STRIDE supplement
 
@@ -455,6 +456,31 @@ book, so it concentrates in one response things that until now lived in separate
 | **T**ampering / misleading | An unavailable upstream produces a flattering view | Every pillar can answer UNKNOWN and does so independently: a failed profile read greys out cashflow and obligations while the loan-derived pillars stand. Nothing is approximated — in particular the reserve is left UNKNOWN rather than inferred from unspent cashflow, which would show a customer a buffer they do not have. |
 | **T**ampering / misleading | No live loans reads as a healthy debt ratio | An empty loan book gives debt service 0; an *unreadable* one gives null, and null makes the obligations pillar UNKNOWN. The two are not collapsed, because only one of them means "this customer has no debts". |
 | **D**oS | The route fans out to two upstreams per call | Both reads are best-effort with the service's existing timeouts; a slow upstream costs a greyed-out pillar, never a hung request. |
+
+## 9d. The court-register signal source (ADR-0269 rule 2, #6646) — STRIDE supplement
+
+`CourtRegisterSignalSource` is declared as an outbound client edge for the INSOLVENCY and
+ENFORCEMENT suppression facts. **No upstream is configured in any environment, so no traffic
+crosses this boundary today** — the class exists to make the unconfigured state nameable, not to
+call anything. It is modelled here because the edge is now declared in code, and because the
+threat picture changes materially the day a register is procured.
+
+The defect it closes is not an exposure but an ambiguity. Both facts were previously hardcoded
+`false`, which is the identical value a genuinely consulted, empty register returns — so an empty
+INSOLVENCY set read as *no customer is insolvent* rather than *we never looked*, and the gap never
+reached the `complete` flag. On the two hardest facts in a hard suppression floor, the gate was
+therefore fail-**open** while reading as fail-closed.
+
+| Threat | Scenario | Mitigation |
+|---|---|---|
+| **T**ampering / misleading | An unconfigured feed is read as a clean register, so a customer with an insolvency marker is offered credit | `CourtRegisterSignalState` has no default: `NOT_CONFIGURED`, `CLEAR` and `MARKER_PRESENT` are distinct values and every call site must state which it means. A regression test asserts an unconfigured register is not reported as clear. |
+| **R**epudiation | The bank cannot show whether a register was consulted for a given decision | `openbank_lending_court_register_feed_configured{signal}` is 0/1 per signal, and is named for whether the feed is *configured* — not for a findings count, which would need rewriting the day one is procured, and which cannot distinguish "no markers" from "no feed". |
+| **D**oS / availability (future) | Once a register is procured, an outage silently reverts the gate to the current permissive behaviour | The state is explicit, so an outage maps to `NOT_CONFIGURED` rather than to `CLEAR`. Whether that should suppress is a policy decision recorded in #6646 and deliberately unchanged here; the point of this slice is that it becomes a decision rather than an accident. |
+| **I**nformation disclosure (future) | Court-register queries reveal which customers the bank is assessing | No upstream exists, so nothing is disclosed today. A procured register puts customer identifiers on an external boundary and needs its own entry here before it is wired. |
+
+**Boot-time visibility:** the bean is `@Startup`, not plain `@ApplicationScoped`. A lazy bean's
+`init` gate does not run until first use, which for a rarely-exercised path can be never — the
+warning that the code cannot fire would itself never fire.
 
 ## 10. Change log
 

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityService.kt
@@ -7,6 +7,7 @@ package com.openbank.lending.application.usecase
 import com.openbank.lending.application.port.out.BorrowerDistressPort
 import com.openbank.lending.application.port.out.CreditOffersConsentPort
 import com.openbank.lending.domain.model.BorrowerDistressSignals
+import com.openbank.lending.domain.model.CourtRegisterSignalState
 import com.openbank.lending.domain.model.CreditOfferDecision
 import com.openbank.lending.domain.model.CreditOfferEligibility
 import com.openbank.lending.domain.model.CreditOfferPolicy
@@ -105,8 +106,8 @@ class CreditOfferEligibilityService(
         private val UNREADABLE = BorrowerDistressSignals(
             hasArrears = true,
             hasNegativeBalance = true,
-            hasEnforcementOrder = true,
-            hasInsolvencyProceeding = true,
+            enforcementSignal = CourtRegisterSignalState.MARKER_PRESENT,
+            insolvencySignal = CourtRegisterSignalState.MARKER_PRESENT,
             inHardshipArrangement = true,
             lastAffordabilityFailureAt = null,
             bufferDays = null,

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/CreditOfferEligibility.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/CreditOfferEligibility.kt
@@ -75,6 +75,48 @@ enum class CreditOfferSuppressionCode {
 }
 
 /**
+ * Whether a court-register distress marker is present, absent, or **has no source at all**.
+ *
+ * This is deliberately not a `Boolean`. A boolean has exactly two values and this signal has
+ * three, so the third — "no register feed is configured in this deployment" — could only be
+ * expressed by picking one of the other two, and whichever is picked becomes a lie the rest of the
+ * system cannot detect. Encoded as `false` it says *we looked and the customer is clear*; encoded
+ * as `true` it suppresses every offer forever, which is indistinguishable from the feature being
+ * switched off and hides the day a real feed arrives.
+ *
+ * That collapse is a defect this repository has paid for before: a disabled push adapter returned
+ * `success = true` for a delivery that never left the process, and every downstream count agreed
+ * with it. The rule learned there — a skipped/unconfigured outcome gets its **own** value, never a
+ * flag shared with a real result — is what this enum is.
+ *
+ * [NOT_CONFIGURED] does not by itself change the offer decision (see [CreditOfferEligibility]); it
+ * exists so that the decision's *blind spot* is a fact the gate states rather than one a reader has
+ * to infer from the absence of findings.
+ */
+enum class CourtRegisterSignalState {
+    /**
+     * No upstream publishes this register in this deployment, so nothing was looked up.
+     *
+     * Not "clear". An empty result from a register that was queried and an empty result from a
+     * register that was never queried are the same number of findings and opposite facts.
+     */
+    NOT_CONFIGURED,
+
+    /** A register was consulted and holds no marker for this party. */
+    CLEAR,
+
+    /** A register was consulted and holds a marker for this party. */
+    MARKER_PRESENT,
+    ;
+
+    /**
+     * True only for [MARKER_PRESENT]. [NOT_CONFIGURED] is not a suppression reason: the gate cannot
+     * cite a register it never read, and an unattributable refusal is not auditable.
+     */
+    val suppresses: Boolean get() = this == MARKER_PRESENT
+}
+
+/**
  * The distress inputs, read at evaluation time. Every field is deliberately a fact about the
  * borrower rather than a verdict: the verdict is this file's job, and keeping the two apart is what
  * lets the thresholds move without the callers moving.
@@ -86,8 +128,13 @@ enum class CreditOfferSuppressionCode {
 data class BorrowerDistressSignals(
     val hasArrears: Boolean,
     val hasNegativeBalance: Boolean,
-    val hasEnforcementOrder: Boolean,
-    val hasInsolvencyProceeding: Boolean,
+    /**
+     * Enforcement (execution) register state. Three-valued on purpose — see
+     * [CourtRegisterSignalState].
+     */
+    val enforcementSignal: CourtRegisterSignalState,
+    /** Insolvency register state. Three-valued on purpose — see [CourtRegisterSignalState]. */
+    val insolvencySignal: CourtRegisterSignalState,
     val inHardshipArrangement: Boolean,
     val lastAffordabilityFailureAt: Instant?,
     val bufferDays: Int?,
@@ -228,8 +275,8 @@ object CreditOfferEligibility {
 
     /** Facts on file, independent of any threshold. */
     private fun hardFactCode(signals: BorrowerDistressSignals): CreditOfferSuppressionCode? = when {
-        signals.hasInsolvencyProceeding -> CreditOfferSuppressionCode.INSOLVENCY
-        signals.hasEnforcementOrder -> CreditOfferSuppressionCode.ENFORCEMENT
+        signals.insolvencySignal.suppresses -> CreditOfferSuppressionCode.INSOLVENCY
+        signals.enforcementSignal.suppresses -> CreditOfferSuppressionCode.ENFORCEMENT
         signals.hasArrears -> CreditOfferSuppressionCode.ARREARS
         signals.inHardshipArrangement -> CreditOfferSuppressionCode.HARDSHIP
         signals.hasNegativeBalance -> CreditOfferSuppressionCode.NEGATIVE_BALANCE

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/CourtRegisterSignalSource.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/CourtRegisterSignalSource.kt
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.infrastructure.client
+
+import com.openbank.lending.domain.model.CourtRegisterSignalState
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tag
+import io.quarkus.runtime.Startup
+import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Where ADR-0269's enforcement and insolvency markers would come from — and, today, the statement
+ * that they come from nowhere (#6646).
+ *
+ * ## Why this class exists rather than two `false` literals
+ *
+ * ADR-0269 rule 2 lists "an enforcement or insolvency marker" among the facts that suppress a
+ * credit offer. `CreditOfferSuppressionCode` carries both codes, the decision table routes them,
+ * and admin surfaces render them — but no service in this deployment ingests a court register, so
+ * neither code has ever fired from real data and neither can. Until #6646 the adapter expressed
+ * that with `hasInsolvencyProceeding = false`, which is the same value a genuine "we checked the
+ * register and this customer is clear" produces. Under that encoding a permanently empty set of
+ * INSOLVENCY suppressions reads as *no customer is insolvent* rather than *we never looked*, and
+ * no error, metric or log anywhere distinguishes the two.
+ *
+ * Nothing here invents a feed. Which insolvency and enforcement registers a bank consults is a
+ * jurisdiction-specific procurement decision, not something to stub: a stub would answer, and an
+ * answer is exactly what must not be fabricated for a fact that decides whether the bank markets
+ * credit to someone in distress. What this class does instead is make the absence **loud** and
+ * **measurable**.
+ *
+ * ## What it changes, and what it deliberately does not
+ *
+ * The offer decision is unchanged: [CourtRegisterSignalState.NOT_CONFIGURED] does not suppress.
+ * That trade was made in the adapter's own docs and is kept — a state that suppressed would refuse
+ * every offer forever and be indistinguishable from the feature being off. Three things change:
+ *
+ *  - the state is its own enum value, so no caller can read "unconfigured" as "clear";
+ *  - the process says so at **boot**, once, at `warn`. `@Startup` and not a lazy
+ *    `@ApplicationScoped` `init {}`: a lazy bean's guard runs on first use, which for a
+ *    config-sanity warning can be long after the deploy is green, or never;
+ *  - `openbank_lending_court_register_feed_configured{signal=...}` exports 0/1, so the alert that
+ *    matters — *this control has no input* — is expressible against a metric instead of against
+ *    the absence of one.
+ *
+ * When a register is procured, this becomes a port with a real adapter behind it and the gauge
+ * flips to 1; the meaning of every existing dashboard and alert survives that change unedited,
+ * which is the point of naming the gauge for whether a feed is CONFIGURED rather than for whether
+ * findings were returned.
+ */
+@Startup
+@ApplicationScoped
+class CourtRegisterSignalSource(meters: MeterRegistry) {
+
+    /** Strongly held so the gauges are not collected out from under the registry. */
+    private val gaugeValues = mutableListOf<AtomicInteger>()
+
+    init {
+        UNCONFIGURED_SIGNALS.forEach { signal ->
+            LOG.warnf(
+                "ADR-0269 distress floor: no %s register is configured in this deployment, so the " +
+                    "%s suppression code CANNOT fire. An empty set of %s suppressions means the " +
+                    "control has no input — not that no customer is affected (#6646).",
+                signal,
+                signal.uppercase(),
+                signal.uppercase(),
+            )
+            val value = AtomicInteger(0)
+            gaugeValues += value
+            meters.gauge(FEED_CONFIGURED_GAUGE, listOf(Tag.of("signal", signal)), value)
+        }
+    }
+
+    /**
+     * Enforcement (execution) register state for any party.
+     *
+     * Takes no party id on purpose: there is nothing to look a party up in. A signature that
+     * accepted one would imply a lookup happened, which is the same false impression in the type
+     * system that `false` made in the data.
+     */
+    fun enforcementState(): CourtRegisterSignalState = CourtRegisterSignalState.NOT_CONFIGURED
+
+    /** Insolvency register state for any party. See [enforcementState]. */
+    fun insolvencyState(): CourtRegisterSignalState = CourtRegisterSignalState.NOT_CONFIGURED
+
+    companion object {
+        const val FEED_CONFIGURED_GAUGE = "openbank_lending_court_register_feed_configured"
+        val UNCONFIGURED_SIGNALS = listOf("enforcement", "insolvency")
+        private val LOG: Logger = Logger.getLogger(CourtRegisterSignalSource::class.java)
+    }
+}

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/CreditOfferGateAdapters.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/CreditOfferGateAdapters.kt
@@ -119,11 +119,16 @@ data class CreditProfileResponse(
  * to catch.
  *
  * Enforcement orders and insolvency proceedings still have **no source in this deployment** — no
- * service ingests a court register. They are reported as absent rather than unknown, deliberately:
- * treating them as unknown would make `complete = false` permanent and suppress every offer
- * forever, which is indistinguishable from the feature being switched off and would hide the
- * moment a real signal source arrives. The gap is real and is what an operational-risk review of
- * this gate should challenge first.
+ * service ingests a court register. [CourtRegisterSignalSource] says so in its own vocabulary:
+ * `NOT_CONFIGURED`, which is neither "a marker is on file" nor "we looked and there is none".
+ *
+ * The decision is unchanged by that state — making it suppress would make `complete = false`
+ * permanent and refuse every offer forever, indistinguishable from the feature being switched off,
+ * and would hide the moment a real source arrives. What changes is that the blind spot is now
+ * *stated*: it boots loudly (see `CourtRegisterFeedVerifier`) and is exported as a gauge, so an
+ * empty set of INSOLVENCY suppressions can be read as "no register is wired" instead of "no
+ * customer is insolvent". The gap itself is real and is what an operational-risk review of this
+ * gate should challenge first.
  *
  * A profile that cannot be read is NOT substituted with defaults — `complete = false` propagates
  * and the gate refuses. That is the difference between "the customer has no surplus" and "we could
@@ -133,6 +138,7 @@ data class CreditProfileResponse(
 class LoanBookDistressAdapter(
     private val loans: LoanRepository,
     @param:RestClient private val profiles: CreditProfileClient,
+    private val courtRegister: CourtRegisterSignalSource,
 ) : BorrowerDistressPort {
 
     override suspend fun signalsFor(partyId: UUID): BorrowerDistressSignals {
@@ -149,9 +155,11 @@ class LoanBookDistressAdapter(
             // overdraft" that the profile can see. It is not a live balance read, and it is not
             // claimed to be one.
             hasNegativeBalance = profile?.netMonthlyOrNull()?.signum()?.let { it < 0 } ?: false,
-            // No source in this deployment — see the class docs.
-            hasEnforcementOrder = false,
-            hasInsolvencyProceeding = false,
+            // No source in this deployment — see the class docs. Reported as NOT_CONFIGURED and
+            // never as CLEAR: this adapter did not consult a register and must not be readable as
+            // having done so.
+            enforcementSignal = courtRegister.enforcementState(),
+            insolvencySignal = courtRegister.insolvencyState(),
             lastAffordabilityFailureAt = null,
             bufferDays = profile?.let { coverDays(it) },
             monthsObserved = profile?.monthsObserved,

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/CreditOfferEligibilityServiceTest.kt
@@ -7,6 +7,7 @@ package com.openbank.lending.application.usecase
 import com.openbank.lending.application.port.out.BorrowerDistressPort
 import com.openbank.lending.application.port.out.CreditOffersConsentPort
 import com.openbank.lending.domain.model.BorrowerDistressSignals
+import com.openbank.lending.domain.model.CourtRegisterSignalState
 import com.openbank.lending.domain.model.CreditOfferDecision
 import com.openbank.lending.domain.model.CreditOfferSuppressionCode
 import com.openbank.lending.domain.model.OfferSurface
@@ -36,8 +37,8 @@ class CreditOfferEligibilityServiceTest {
     private val healthy = BorrowerDistressSignals(
         hasArrears = false,
         hasNegativeBalance = false,
-        hasEnforcementOrder = false,
-        hasInsolvencyProceeding = false,
+        enforcementSignal = CourtRegisterSignalState.CLEAR,
+        insolvencySignal = CourtRegisterSignalState.CLEAR,
         inHardshipArrangement = false,
         lastAffordabilityFailureAt = null,
         bufferDays = 90,

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/domain/CreditOfferEligibilityTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/domain/CreditOfferEligibilityTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.lending.domain
 
 import com.openbank.lending.domain.model.BorrowerDistressSignals
+import com.openbank.lending.domain.model.CourtRegisterSignalState
 import com.openbank.lending.domain.model.CreditOfferDecision
 import com.openbank.lending.domain.model.CreditOfferEligibility
 import com.openbank.lending.domain.model.CreditOfferPolicy
@@ -31,8 +32,8 @@ class CreditOfferEligibilityTest {
     private val healthy = BorrowerDistressSignals(
         hasArrears = false,
         hasNegativeBalance = false,
-        hasEnforcementOrder = false,
-        hasInsolvencyProceeding = false,
+        enforcementSignal = CourtRegisterSignalState.CLEAR,
+        insolvencySignal = CourtRegisterSignalState.CLEAR,
         inHardshipArrangement = false,
         lastAffordabilityFailureAt = null,
         bufferDays = 90,
@@ -87,8 +88,10 @@ class CreditOfferEligibilityTest {
     @Test
     fun `each distress signal alone suppresses the offer with its own reason code`() {
         val cases = listOf(
-            healthy.copy(hasInsolvencyProceeding = true) to CreditOfferSuppressionCode.INSOLVENCY,
-            healthy.copy(hasEnforcementOrder = true) to CreditOfferSuppressionCode.ENFORCEMENT,
+            healthy.copy(insolvencySignal = CourtRegisterSignalState.MARKER_PRESENT) to
+                CreditOfferSuppressionCode.INSOLVENCY,
+            healthy.copy(enforcementSignal = CourtRegisterSignalState.MARKER_PRESENT) to
+                CreditOfferSuppressionCode.ENFORCEMENT,
             healthy.copy(hasArrears = true) to CreditOfferSuppressionCode.ARREARS,
             healthy.copy(inHardshipArrangement = true) to CreditOfferSuppressionCode.HARDSHIP,
             healthy.copy(hasNegativeBalance = true) to CreditOfferSuppressionCode.NEGATIVE_BALANCE,

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/client/CourtRegisterSignalSourceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/client/CourtRegisterSignalSourceTest.kt
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.lending.infrastructure.client
+
+import com.openbank.lending.domain.model.BorrowerDistressSignals
+import com.openbank.lending.domain.model.CourtRegisterSignalState
+import com.openbank.lending.domain.model.CreditOfferDecision
+import com.openbank.lending.domain.model.CreditOfferEligibility
+import com.openbank.lending.domain.model.CreditOfferSuppressionCode
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * The ADR-0269 blind spot (#6646) must stay *stated*, not silently encoded as a clean result.
+ *
+ * Every assertion here is written to go red under the specific regression it guards, and the
+ * regression in each case is the cheap-looking one: collapsing "no register is configured" back
+ * into the same value a real, consulted, empty register produces.
+ */
+class CourtRegisterSignalSourceTest {
+
+    private val now: Instant = Instant.parse("2026-08-30T10:00:00Z")
+
+    @Test
+    fun `an unconfigured register is not reported as clear`() {
+        val source = CourtRegisterSignalSource(SimpleMeterRegistry())
+
+        // Goes red the moment either state is written back as CLEAR — which is what the adapter
+        // said before #6646 and is indistinguishable from a genuine negative lookup.
+        assertThat(source.insolvencyState()).isEqualTo(CourtRegisterSignalState.NOT_CONFIGURED)
+        assertThat(source.enforcementState()).isEqualTo(CourtRegisterSignalState.NOT_CONFIGURED)
+        assertThat(source.insolvencyState()).isNotEqualTo(CourtRegisterSignalState.CLEAR)
+        assertThat(source.enforcementState()).isNotEqualTo(CourtRegisterSignalState.CLEAR)
+    }
+
+    @Test
+    fun `no feed configured is exported as a gauge, so an empty finding set is readable`() {
+        val meters = SimpleMeterRegistry()
+
+        CourtRegisterSignalSource(meters)
+
+        // The alert this repository was missing in the analogous push-adapter defect is
+        // "the control has no input", and it is only expressible if the absence is a series.
+        CourtRegisterSignalSource.UNCONFIGURED_SIGNALS.forEach { signal ->
+            val gauge = meters.find(CourtRegisterSignalSource.FEED_CONFIGURED_GAUGE)
+                .tag("signal", signal)
+                .gauge()
+            assertThat(gauge).describedAs("gauge for signal '%s'", signal).isNotNull
+            assertThat(gauge!!.value()).isEqualTo(0.0)
+        }
+    }
+
+    @Test
+    fun `an unconfigured register never becomes a suppression reason it did not read`() {
+        // NOT_CONFIGURED must not drift into meaning "marker present" either. The failure mode on
+        // this side is quieter than it looks: it would suppress every offer forever, which reads
+        // exactly like the feature being switched off.
+        assertThat(CourtRegisterSignalState.NOT_CONFIGURED.suppresses).isFalse()
+        assertThat(CourtRegisterSignalState.CLEAR.suppresses).isFalse()
+        assertThat(CourtRegisterSignalState.MARKER_PRESENT.suppresses).isTrue()
+    }
+
+    @Test
+    fun `the three register states are three distinct decisions, not two`() {
+        val configuredAndClear = CreditOfferEligibility.evaluate(true, signals(CourtRegisterSignalState.CLEAR), now)
+        val markerOnFile = CreditOfferEligibility.evaluate(true, signals(CourtRegisterSignalState.MARKER_PRESENT), now)
+        val noFeed = CreditOfferEligibility.evaluate(true, signals(CourtRegisterSignalState.NOT_CONFIGURED), now)
+
+        assertThat(configuredAndClear).isInstanceOf(CreditOfferDecision.Allowed::class.java)
+        assertThat(markerOnFile)
+            .isEqualTo(
+                CreditOfferDecision.Suppressed(markerOnFile.policyVersion, CreditOfferSuppressionCode.INSOLVENCY),
+            )
+
+        // The load-bearing one. An INSOLVENCY suppression must be attributable to a register that
+        // was actually consulted, so the unconfigured deployment cannot produce that code — and
+        // conversely, its absence from production must never be read as evidence about customers.
+        assertThat(noFeed).isInstanceOf(CreditOfferDecision.Allowed::class.java)
+    }
+
+    private fun signals(insolvency: CourtRegisterSignalState) = BorrowerDistressSignals(
+        hasArrears = false,
+        hasNegativeBalance = false,
+        enforcementSignal = CourtRegisterSignalState.NOT_CONFIGURED,
+        insolvencySignal = insolvency,
+        inHardshipArrangement = false,
+        lastAffordabilityFailureAt = null,
+        bufferDays = 90,
+        monthsObserved = 12,
+        lastCreditContactAt = null,
+        inputsChangedSinceLastContact = true,
+        complete = true,
+    )
+}

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerQuoteResourceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerQuoteResourceTest.kt
@@ -8,6 +8,7 @@ import com.openbank.lending.application.port.out.BorrowerDistressPort
 import com.openbank.lending.application.port.out.CreditOffersConsentPort
 import com.openbank.lending.application.usecase.CreditOfferEligibilityService
 import com.openbank.lending.domain.model.BorrowerDistressSignals
+import com.openbank.lending.domain.model.CourtRegisterSignalState
 import com.openbank.lending.infrastructure.intake.CustomerIntakeConfig
 import io.quarkus.security.identity.SecurityIdentity
 import io.quarkus.security.runtime.QuarkusSecurityIdentity
@@ -38,8 +39,8 @@ class CustomerQuoteResourceTest {
     private val healthy = BorrowerDistressSignals(
         hasArrears = false,
         hasNegativeBalance = false,
-        hasEnforcementOrder = false,
-        hasInsolvencyProceeding = false,
+        enforcementSignal = CourtRegisterSignalState.CLEAR,
+        insolvencySignal = CourtRegisterSignalState.CLEAR,
         inHardshipArrangement = false,
         lastAffordabilityFailureAt = null,
         bufferDays = 90,


### PR DESCRIPTION
## The premise, re-measured on `origin/main`

Issue #6646 says the two dead codes are safe because "the service fails closed — an unavailable
signal resolves to `SIGNALS_UNAVAILABLE` and suppresses the offer". **That is true of the credit
profile and not of these two signals.** `LoanBookDistressAdapter` (`CreditOfferGateAdapters.kt`)
supplied:

```
hasEnforcementOrder = false,
hasInsolvencyProceeding = false,
```

and `complete = profile != null` — the court-register gap never touches `complete`. So the current
behaviour for INSOLVENCY and ENFORCEMENT is not over-suppression; it is a **clear reading the gate
never took**. `false` is the identical value a genuine, consulted, empty register produces, so a
permanently empty set of INSOLVENCY suppressions reads as *no customer is insolvent* rather than
*we never looked*, and nothing — no error, no metric, no log line — distinguishes those.

Same defect class as the disabled push adapter whose `skipped()` carried `success = true`, and as
`0a4b00bfa` on this very `main` ("distinguish transient Tempo failure from absent RUM mobile
signal").

## What this does *not* do

It does not invent a feed. Which insolvency and enforcement registers a bank consults is a
jurisdiction-specific procurement decision; a stub would *answer*, and an answer is what must not
be fabricated for a fact that decides whether the bank markets credit to someone in distress.

## What it does

- **`CourtRegisterSignalState { NOT_CONFIGURED, CLEAR, MARKER_PRESENT }`** replaces the two
  booleans on `BorrowerDistressSignals`. A boolean has two values and this signal has three, so the
  third could only be expressed by borrowing one of the others — the collapse the enum removes. No
  default on the field, so every call site has to state which of the three it means.
- **`CourtRegisterSignalSource`** is `@Startup`, not lazy `@ApplicationScoped`: a lazy bean's `init`
  runs on first *use*, which for a config-sanity warning can be long after a green deploy, or never.
  It warns once per signal that the code cannot fire.
- **`openbank_lending_court_register_feed_configured{signal="insolvency"|"enforcement"}`** exports
  0/1. Named for what the service can establish — whether a feed is *configured* — not for findings,
  so the series keeps its meaning unedited on the day a register is procured. This makes *"the
  control has no input"* an alertable condition rather than an absence.

**The decision is deliberately unchanged.** `NOT_CONFIGURED` does not suppress: a state that did
would refuse every offer forever and be indistinguishable from the feature being switched off,
which is the trade the adapter's own docs already made. This PR changes what is *stated and
measurable*, not what is decided — #6646's "do not relax the fail-closed default" is respected in
both directions.

## Proven by what it prevents

Negative control — the source regressed in place to `CLEAR` (the pre-#6646 encoding), read from the
redirected log and the JUnit XML, never through a pipe:

| run | verdict | JUnit XML |
|---|---|---|
| regressed to `CLEAR` | `BUILD FAILED` — `an unconfigured register is not reported as clear() FAILED` | `tests="4" failures="1"` |
| restored | `BUILD SUCCESSFUL` (`GATE2_EXIT=0`) | module total `tests=310 skipped=0 failures=0 errors=0` |

Tasks that actually appear in the green run: `ktlintMainSourceSetCheck`, `ktlintTestSourceSetCheck`,
`detekt`, `test`, plus `quarkusBuild` separately green (CDI wiring — `LoanBookDistressAdapter` gained
a constructor parameter and the new bean injects `MeterRegistry`; ArC failures surface only there).
Skipped count read explicitly: 0, so no `@QuarkusTest` silently stopped running.

## Not verified

- Nothing was run against a cluster or a live database; the gauge is asserted against a
  `SimpleMeterRegistry`, not scraped from a pod.
- No alert rule is added here — the metric makes one expressible; wiring it is follow-up on #6646.
- `check-external-feeds.py` is structurally blind to this gap (it scans `http(s)://` URLs in
  `application.yaml`, and an unprocured register has no URL), so this feed is neither in `FEEDS` nor
  in `NOT_PROBED`. Left alone rather than forced into a gate that measures a different thing.

Refs #6646
