### PR TITLE
fix(ci): event-handler-swallow gate was blind to every read-model receiver

### DIFF
--- a/.github/scripts/check-event-handler-swallows.py
+++ b/.github/scripts/check-event-handler-swallows.py
@@ -65,7 +65,15 @@ CATCH = re.compile(r"catch\s*\(\s*\w+\s*:\s*(?:Exception|Throwable)\s*\)\s*\{")
 TRANSPORT_RECEIVER = re.compile(r"\b(httpClient|webClient|restClient|httpclient|kafkaClient)\s*\.\s*$", re.IGNORECASE)
 
 STATE_CALL = re.compile(
-    r"\b\w*(?:repository|repo|usecase|port|store|dao|publisher|client|service)\s*\.\s*"
+    # RECEIVER BLINDNESS (#5745 section C). The nine nouns above are a naming convention,
+    # not a rule, and the fleet does not universally follow it. Every read-model and
+    # sink handler spells its receiver outside the set — `projections.applyIfNewer`,
+    # `sink.write`, `sendLog.applyDeliveryOutcome`, `projection.eraseParty` — so the
+    # gate scanned 182 handler files, matched nothing, and printed "clean". A scope
+    # that is a naming convention reads as PASSING when the convention is not
+    # followed, never as UNCHECKED.
+    r"\b\w*(?:repository|repo|usecase|port|store|dao|publisher|client|service|"
+    r"projections|projection|sink|log|writer|sender|gateway|adapter)\s*\.\s*"
     r"(save|persist|insert|update|create|open|activate|grant|credit|debit|post|record|apply|"
     r"anonymize|anonymise|delete|upsert|merge|register|enrol|enroll|book|settle|publish|send|"
     r"notify|emit|write|mark|complete|cancel|approve|reject|erase|"
@@ -74,7 +82,11 @@ STATE_CALL = re.compile(
     # direct-debit debit — was not flagged: the receiver matched (which is exactly what
     # TRANSPORT_RECEIVER above keeps `client` in the list FOR), but the verb did not.
     r"initiate|execute|transfer|charge|capture|reverse|refund|submit|dispatch|trigger|"
-    r"assign|revoke|close|freeze|release|disburse|repay|withdraw|deposit)\w*\s*\(",
+    r"assign|revoke|close|freeze|release|disburse|repay|withdraw|deposit|"
+    # Read-model / sink verbs. `taxFilingService.observe(...)` matched the RECEIVER
+    # (…Service) and was still invisible, because the verb list was written from the
+    # money path and a projection does not "save", it "observes" or "ingests".
+    r"observe|ingest|index|flush|commit|advance|project)\w*\s*\(",
     re.IGNORECASE,
 )
 # Two ways to be legitimately silent, and both must be STATED where a reviewer reads them.
@@ -96,8 +108,16 @@ RECOVERED = re.compile(r"^\s*\.\s*(getOrNull|getOrElse|getOrDefault|onFailure|fo
 # .getOrThrow() / .getOrElse { throw … } are the SAFE terminators: the failure still surfaces.
 RETHROWN_TERMINATOR = re.compile(r"getOrThrow|throw")
 
+# A MANUAL NEGATIVE ACKNOWLEDGEMENT is the other correct ending, and it must be recognised
+# here or widening STATE_CALL above turns correct code red. `message.nack(e)`
+# (campaign's EnrolmentTriggerConsumer) and `settle(message, e)` (analytics-sink's
+# AnalyticsConsumer) both leave the message unacked and the work recoverable — the exact
+# outcome the gate exists to require. Neither goes through a repository, so neither matched
+# the durable-state clause below.
 HANDLED_IN_CATCH = re.compile(
-    r"\b\w*(?:repository|repo|store)\s*\.\s*(markFailed|markDead|recordFailure|reschedule|release)\w*\s*\(",
+    r"\b\w*(?:repository|repo|store)\s*\.\s*(markFailed|markDead|recordFailure|reschedule|release)\w*\s*\("
+    r"|\bnack\s*\("
+    r"|\bsettle\s*\(\s*\w*message",
     re.IGNORECASE,
 )
 
@@ -471,6 +491,101 @@ SELF_TEST_CASES = [
             }
 
             private fun walk(n: JsonNode) { walk(n) }
+        }
+        """,
+        0,
+    ),
+    # ---- #5745 section C: receivers the nine-noun convention never covered ---------------
+    # Each of these is a verbatim reduction of a real handler on main. All four `1` cases
+    # return 0 findings on the unwidened gate — which is how 182 handler files scanned
+    # "clean".
+    (
+        "a read-model projection is a state change (anacredit: projections.applyIfNewer)",
+        """
+        @Incoming("loan-stage")
+        suspend fun consume(p: String) {
+            try {
+                projections.applyIfNewer(projection)
+            } catch (e: Exception) {
+                log.error("projection failed", e)
+            }
+        }
+        """,
+        1,
+    ),
+    (
+        "a sink write is a state change (analytics-sink: sink.write)",
+        """
+        @Incoming("analytics")
+        suspend fun consume(p: String) {
+            try {
+                sink.write(rows)
+            } catch (e: Exception) {
+                log.error("write failed", e)
+            }
+        }
+        """,
+        1,
+    ),
+    (
+        "a delivery-log update is a state change (campaign: sendLog.applyDeliveryOutcome)",
+        """
+        @Incoming("notification-outcome")
+        suspend fun consume(p: String) {
+            try {
+                sendLog.applyDeliveryOutcome(id, outcome)
+            } catch (e: Exception) {
+                log.error("outcome lost", e)
+            }
+        }
+        """,
+        1,
+    ),
+    (
+        # The receiver ALREADY matched (…Service). Only the verb was missing, because the
+        # alternation was written from the money path and a projection does not "save".
+        "a domain-service verb outside the money-path vocabulary (tax: taxFilingService.observe)",
+        """
+        @Incoming("withholding-remitted")
+        suspend fun consume(p: String) {
+            try {
+                taxFilingService.observe(event)
+            } catch (e: Exception) {
+                log.error("observation lost", e)
+            }
+        }
+        """,
+        1,
+    ),
+    # ---- the two controls that must stay GREEN, or the widening above is a false-positive
+    # factory. Both are correct code on main today: the message stays unacked and the work
+    # is recoverable, without any repository being involved.
+    (
+        "manual nack is not a swallow (campaign: message.nack(e))",
+        """
+        @Incoming("enrolment-trigger")
+        suspend fun consume(message: Message<String>) {
+            try {
+                triggered.enrol(id)
+            } catch (e: Exception) {
+                log.error("enrol failed", e)
+                message.nack(e)
+            }
+        }
+        """,
+        0,
+    ),
+    (
+        "settle(message, e) is not a swallow (analytics-sink: AnalyticsConsumer)",
+        """
+        @Incoming("analytics")
+        suspend fun consume(message: Message<String>) {
+            try {
+                sink.write(rows)
+            } catch (e: Exception) {
+                log.error("write failed", e)
+                settle(message, e)
+            }
         }
         """,
         0,

--- a/openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/schedule/CnbRateIngestionScheduler.kt
+++ b/openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/schedule/CnbRateIngestionScheduler.kt
@@ -87,6 +87,12 @@ class CnbRateIngestionScheduler(
             liveness?.recordSuccess()
             feed?.record(CnbFetchOutcomes.of(result))
         } catch (ex: Exception) {
+            // observed-by: openbank_feed_fetch_* for FEED_NAME — `feed.record(ofFailure)` marks the
+            // run failed, so the feed's own gauge stops advancing and CnbFeedStale fires. This is a
+            // SCHEDULED job with no message to nack: there is nothing to hand back to a broker, and
+            // the next cron re-fetches the same fixing, so the failure is not lost work. The gauge
+            // is the signal, which is exactly the condition `observed-by:` exists to state (#5745).
+            //
             // Record before logging: the metric is the signal that survives, and a log line is what
             // this failure has already been reduced to once, for 46 days.
             feed?.record(CnbFetchOutcomes.ofFailure(ex))


### PR DESCRIPTION
The gate scanned 182 handler files and reported

    [event-handler-swallows] clean: 182 handler files, no swallowed state changes

That "clean" was the same output it would print if it had matched nothing at all,
which is what it was doing. `STATE_CALL` required the receiver to END in one of
nine nouns — repository, repo, usecase, port, store, dao, publisher, client,
service. That is a naming convention, not a rule, and every read-model and sink
handler in the fleet is spelled outside it:

    projections.applyIfNewer      anacredit  LoanStageEventConsumer.kt:145
    sink.write                    analytics-sink  AnalyticsConsumer.kt:137
    sendLog.applyDeliveryOutcome  campaign  NotificationOutcomeConsumer.kt:77
    projection.applyEvent         onboarding  OnboardingEventConsumer.kt:226
    projection.eraseParty         onboarding  OnboardingEventConsumer.kt:89

and one where the receiver DID match and the verb did not, because the verb list
was written from the money path and a projection does not "save":

    taxFilingService.observe      tax-reporting  WithholdingRemittedConsumer.kt

A scope that is a naming convention reads as PASSING wherever the convention is
not followed, never as UNCHECKED — the same shape as #6253.

Widening `STATE_CALL` alone would turn correct code red, so `HANDLED_IN_CATCH`
gains the two manual negative-acknowledgement endings that go through no
repository: `message.nack(e)` (campaign) and `settle(message, e)`
(analytics-sink). Both leave the message unacked and the work recoverable, which
is the outcome the gate exists to require.

Negative control — origin/main's LOGIC with the new fixtures grafted on:

    BAD  a read-model projection is a state change ...: want 1, got 0
    BAD  a sink write is a state change ...:            want 1, got 0
    BAD  a delivery-log update is a state change ...:   want 1, got 0
    BAD  a domain-service verb outside the vocabulary:  want 1, got 0
    ok   manual nack is not a swallow
    ok   settle(message, e) is not a swallow
    [event-handler-swallows] SELF-TEST FAILED (4)        exit 1

With this change: exit 0, 12 fixtures. The two `ok` controls pass in BOTH
directions, which is what stops the widening from being a false-positive factory.

The widened gate then found exactly one real site the old one could not see:
`CnbRateIngestionScheduler.ingestDailyFixing` catches, records
`feed.record(ofFailure)` and logs. That is legitimate — it is a SCHEDULED job
with no message to nack, the next cron re-fetches the same fixing, and the feed
gauge stops advancing so CnbFeedStale fires. It is precisely the condition
`observed-by:` exists to state, and it did not state it. The comment now does;
no behaviour changes. `:openbank-fx-service:ktlintCheck detekt` exit 0.

Refs #5745

## Note for review

This touches `openbank-fx-service`, which is money-path — so it needs 2 approvals.
The change there is a **comment only**: adding the `observed-by:` marker the gate
requires. No code, no behaviour.

## What I did not verify

- Section A of #5745 (the ten consumers listed as still acking lost work) is **stale**:
  all ten rethrow or nack on `origin/main` today. So this is regression protection for
  work already done, not a live defect — which is the cleaner case, since the gate meant
  to hold that line could not see any of it.
- I did not audit whether the widened receiver list has false positives outside the 182
  handler files the gate scans; the corpus is `src/main` `*.kt` with `@Incoming`/`@Scheduled`.
