### PR TITLE
ci(gates): fail a PR claiming an openapi version the base branch already shipped

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -2606,7 +2606,19 @@ gates:
     mode: enforced
     when: pull_request
     needs_base: required
-    min_subjects: 1
+    # No min_subjects: this gate is DIFF-SCOPED, so most PRs legitimately have zero subjects
+    # (they touch no openapi.yaml). A floor here is the "declares a floor and never prints a
+    # count" failure the subject-floor gate exists to catch -- which is exactly how it caught
+    # this entry on its own first CI run. api-contract-gate, diff-scoped for the same reason,
+    # declares none either. The gate still prints SUBJECTS=, including zero, so that "no
+    # subjects" and "did not look" never render identically.
+    rationale: >-
+      api-contract-gate classifies a bump against the merge-base, so it cannot see a version a
+      competing PR already released; four PRs were green on 2026-08-30 claiming taken numbers.
+    review_after: 2027-03-01   # Re-examine if a merge queue or up-to-date-branch enforcement
+                               # lands: either would PREVENT this collision rather than detect
+                               # it late, making this gate redundant. ADR-0048 chose detection,
+                               # so until that changes it stays.
     selftest: |
       set -euo pipefail
       python3 .github/scripts/check-openapi-version-not-taken.py --self-test

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -2578,6 +2578,43 @@ gates:
       bash .github/scripts/install-oasdiff.sh
       python3 .github/scripts/check-api-contract.py --base "${PR_DIFF_BASE}" --enforce
 
+  # The gate above classifies the bump against the MERGE-BASE, which is the right question for
+  # "is this bump big enough" and structurally blind to a number that someone else already took.
+  # Measured 2026-08-30: four PRs were green while claiming a version main had already released
+  # (account 1.11.0, consent 1.7.0, card-issuance 1.8.0, campaign 1.43.0). Each forked one minor
+  # lower and bumped by one; a competing PR then landed the same number first. The merge-base still
+  # holds the OLD value, so the contract gate sees a clean minor bump — and git sees nothing either,
+  # because identical text is not a conflict, so the merge is exit 0 and prints nothing. Two checks
+  # each answering a question that is individually right and jointly insufficient.
+  #
+  # This one asks whether the number is still free on the base branch AS IT IS NOW.
+  #
+  # DETECTION, NOT PREVENTION, and the distinction matters: a run is only as fresh as the moment it
+  # executes, so a PR whose last CI run predates a competing merge and then merges with no later run
+  # is invisible here as to any run-time check. Closing that needs a merge queue or up-to-date-branch
+  # enforcement; ADR-0048 deliberately chose detection. What this buys is that a stale claim goes RED
+  # ON THE NEXT RUN instead of merging silently — today all four collisions are green.
+  #
+  # The self-test drives the pure comparison directly and carries must-VIOLATE cases, not only
+  # passing ones, so it can detect its own vacuity. Falsified before merge against the four real
+  # colliding branches (exit 1 each, each naming the taken number) and against two non-colliding
+  # ones (#6486 1.16.0->1.17.0, #6481 1.5.0->1.6.0, exit 0) — it discriminates in both directions
+  # rather than failing everything.
+  - id: openapi-version-not-taken
+    name: "openapi-version-not-taken — info.version still free on the base tip (ADR-0048, enforced)"
+    group: api
+    mode: enforced
+    when: pull_request
+    needs_base: required
+    min_subjects: 1
+    selftest: |
+      set -euo pipefail
+      python3 .github/scripts/check-openapi-version-not-taken.py --self-test
+    run: |
+      set -euo pipefail
+      git fetch -q origin main
+      python3 .github/scripts/check-openapi-version-not-taken.py --base "${PR_DIFF_BASE}" --base-ref origin/main --enforce
+
   # ENFORCED against a declared baseline (#2314). It landed advisory because 104 findings
   # cannot be a merge blocker on day one — but an advisory check over a GENERATED comparison
   # is a contradiction (#2216): there is no judgement left to exercise, advisory just makes

--- a/.github/scripts/check-gate-subject-floor.py
+++ b/.github/scripts/check-gate-subject-floor.py
@@ -53,6 +53,11 @@ MANIFEST = ".github/gates/gates.yaml"
 # A gate with no repo corpus to count. Stated, not inferred.
 NO_CORPUS = {
     "agent-review-proof-falsifiable",
+    # DIFF-SCOPED: its corpus is the PR's own changed files, so zero is the ordinary case (most
+    # PRs touch no openapi.yaml) and a floor would fail every one of them. It is not exempt from
+    # the underlying question -- it prints SUBJECTS= including zero, so "no specs changed" and
+    # "did not look" stay distinguishable in the log.
+    "openapi-version-not-taken",
     "agent-review-scope-falsifiable",
     "auto-deploy-reconcile-probe-unit-test",
     "blocking-counterpart-probe-unit-test",

--- a/.github/scripts/check-openapi-version-not-taken.py
+++ b/.github/scripts/check-openapi-version-not-taken.py
@@ -149,6 +149,7 @@ def main() -> int:
     ]
     if not changed:
         print("openapi-version-not-taken: no openapi.yaml changed — nothing to check.")
+        print("SUBJECTS=0")
         return 0
 
     level = "error" if args.enforce else "warning"

--- a/.github/scripts/check-openapi-version-not-taken.py
+++ b/.github/scripts/check-openapi-version-not-taken.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Fail when a PR claims an `openapi.yaml` info.version that the base branch already shipped.
+
+WHY THIS IS NOT COVERED BY `api-contract-gate`
+----------------------------------------------
+`check-api-contract.py` classifies the bump from the diff against the **merge-base**. That is
+correct for asking "is this bump big enough for the change?", and structurally blind to the
+collision this gate catches.
+
+Concretely, four PRs were green on 2026-08-30 while claiming a version `main` had already
+released:
+
+    account 1.11.0, consent 1.7.0, card-issuance 1.8.0, campaign 1.43.0
+
+Each forked when the spec was one minor lower, bumped by one, and a competing PR then merged
+the same number first. The merge-base still holds the *old* value, so the contract gate sees a
+clean `1.42.0 -> 1.43.0` minor bump and passes. Git sees nothing either: identical text is not a
+conflict, so the merge is exit 0 and prints nothing. Two independent checks each answer a
+question that is individually right and jointly insufficient.
+
+WHAT THIS GATE ASKS INSTEAD
+---------------------------
+Not "is the bump correct relative to where you forked", but "**is this number still free on the
+base branch as it is right now**". Those differ exactly when someone else landed first, which is
+the whole failure mode.
+
+HONEST LIMIT, STATED SO NOBODY READS MORE INTO A GREEN RUN
+----------------------------------------------------------
+This is detection, not prevention. A run is only as fresh as the moment it executes: a PR whose
+last CI run predates a competing merge, and which then merges with no later run, is invisible to
+this gate as it is to any run-time check. Closing that needs a merge queue or up-to-date-branch
+enforcement, and the repo has deliberately chosen detection (ADR-0048). What this buys is that a
+stale claim goes **red on the next run** instead of merging silently — today all four collisions
+are green, so nothing anywhere disagrees with them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+OPENAPI_GLOB = re.compile(r"^(openbank-[^/]+)/src/main/resources/openapi\.yaml$")
+VERSION_RE = re.compile(r"^\s{2}version:\s*(.+?)\s*$", re.MULTILINE)
+
+
+def sh(*args: str, check: bool = True) -> str:
+    proc = subprocess.run(args, capture_output=True, text=True)
+    if check and proc.returncode != 0:
+        raise RuntimeError(f"{' '.join(args)} failed ({proc.returncode}): {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def info_version(text: str) -> str | None:
+    """First two-space-indented `version:` — the one under `info:`.
+
+    Deliberately not a YAML parse: a spec that fails to load is the contract gate's problem, and
+    this gate must not turn an unrelated syntax error into a version verdict.
+    """
+    m = VERSION_RE.search(text)
+    return m.group(1).strip().strip('"').strip("'") if m else None
+
+
+def parse_semver(raw: str | None) -> tuple[int, int, int] | None:
+    if not raw:
+        return None
+    m = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", raw)
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3))) if m else None
+
+
+def file_at(ref: str, path: str) -> str | None:
+    proc = subprocess.run(["git", "show", f"{ref}:{path}"], capture_output=True, text=True)
+    return proc.stdout if proc.returncode == 0 else None
+
+
+def evaluate(head_raw: str | None, base_tip_raw: str | None) -> tuple[bool, str]:
+    """Return (is_violation, explanation). Pure, so the self-test can drive it directly."""
+    head_v = parse_semver(head_raw)
+    tip_v = parse_semver(base_tip_raw)
+    if head_v is None:
+        return False, f"unparseable head version {head_raw!r} — the contract gate owns that"
+    if tip_v is None:
+        return False, f"no comparable version on the base tip ({base_tip_raw!r}) — new spec"
+    if head_v > tip_v:
+        return False, f"{head_raw} is ahead of the base tip's {base_tip_raw}"
+    if head_v == tip_v:
+        return True, f"{head_raw} is ALREADY on the base branch — that number is taken"
+    return True, f"{head_raw} is BEHIND the base tip's {base_tip_raw} — the bump was overtaken"
+
+
+SELF_TEST_CASES = [
+    # (head, base_tip, must_be_violation, label)
+    ("1.43.0", "1.42.0", False, "ordinary minor bump ahead of the tip"),
+    ("2.0.0", "1.42.0", False, "major bump"),
+    ("1.43.0", "1.43.0", True, "the real 2026-08-30 collision: number already shipped"),
+    ("1.42.0", "1.43.0", True, "bump overtaken by a larger release"),
+    ("1.43.0", None, False, "no spec on the base tip yet — a new service"),
+    (None, "1.43.0", False, "unparseable head — not this gate's verdict to give"),
+    ("1.43.1", "1.43.0", False, "patch bump"),
+    ("1.44.0", "1.43.0", False, "the fix for the collision"),
+]
+
+
+def self_test() -> int:
+    """Every case must be able to fail. A gate whose self-test only exercises the passing
+    direction cannot detect its own vacuity — the repo has shipped several of those."""
+    failures = 0
+    for head, tip, want, label in SELF_TEST_CASES:
+        got, why = evaluate(head, tip)
+        status = "ok " if got == want else "FAIL"
+        if got != want:
+            failures += 1
+        print(f"  {status} {label}: head={head!r} tip={tip!r} violation={got} ({why})")
+    # Negative control on the control itself: if `evaluate` were stubbed to always return False,
+    # the three must-violate cases above would flip. Assert at least one case of each polarity
+    # exists, so a future edit cannot leave an all-passing suite that proves nothing.
+    if not any(c[2] for c in SELF_TEST_CASES) or not all(
+        any(c[2] is p for c in SELF_TEST_CASES) for p in (True, False)
+    ):
+        print("  FAIL self-test has no must-violate case — it could not detect a dead gate")
+        failures += 1
+    print(f"self-test: {'ok' if failures == 0 else 'FAILED'} ({failures} failure(s))")
+    return 1 if failures else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", help="merge-base sha, used only to list which specs the PR touches")
+    ap.add_argument("--base-ref", default="origin/main", help="base branch TIP to compare against")
+    ap.add_argument("--enforce", action="store_true")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if not args.base:
+        # Refuse rather than pass: an empty base would report a clean sweep of nothing, which is
+        # the exact shape this repo keeps rediscovering in its own gates.
+        print("::error::--base is empty but this gate requires it — refusing to run vacuously")
+        return 1
+
+    changed = [
+        line
+        for line in sh("git", "diff", "--name-only", args.base, "HEAD").splitlines()
+        if OPENAPI_GLOB.match(line)
+    ]
+    if not changed:
+        print("openapi-version-not-taken: no openapi.yaml changed — nothing to check.")
+        return 0
+
+    level = "error" if args.enforce else "warning"
+    findings: list[str] = []
+    print(f"openapi-version-not-taken: {len(changed)} spec(s) changed, base tip = {args.base_ref}")
+
+    for rel in changed:
+        head_path = Path(rel)
+        if not head_path.is_file():
+            continue  # deletion; service removal is reviewed elsewhere
+        head_raw = info_version(head_path.read_text(encoding="utf-8", errors="replace"))
+        tip_text = file_at(args.base_ref, rel)
+        tip_raw = info_version(tip_text) if tip_text is not None else None
+
+        violation, why = evaluate(head_raw, tip_raw)
+        print(f"  {'FAIL' if violation else 'ok  '} {rel}: {why}")
+        if violation:
+            svc = OPENAPI_GLOB.match(rel).group(1)
+            nxt = parse_semver(tip_raw)
+            suggestion = f"{nxt[0]}.{nxt[1] + 1}.0" if nxt else "the next free version"
+            findings.append(
+                f"{rel}: info.version {head_raw} is not free on {args.base_ref} "
+                f"(it holds {tip_raw}). Re-bump off live main — likely {suggestion}. "
+                f"Read it with: git show {args.base_ref}:{svc}/src/main/resources/openapi.yaml "
+                f"| grep -m1 '^  version:'"
+            )
+
+    print(f"SUBJECTS={len(changed)}")
+    for f in findings:
+        print(f"::{level}::openapi-version-not-taken: {f}")
+    return 1 if (findings and args.enforce) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Four PRs are green right now while claiming a version `main` already shipped

| PR | service | branch claims | `origin/main` holds |
|---|---|---|---|
| #5986 | account | 1.11.0 | **1.11.0** |
| #6017 | consent | 1.7.0 | **1.7.0** |
| #6019 | card-issuance | 1.8.0 | **1.8.0** |
| #7192 (and #7565) | campaign | 1.43.0 | **1.43.0** |

```
git show origin/main:openbank-campaign-service/src/main/resources/openapi.yaml | grep -m1 '^  version:'
  version: 1.43.0
```

## Why nothing caught it

`api-contract-gate` classifies the bump against the **merge-base**. That is the right question for *"is this bump big enough for the change?"* and structurally blind to this one. Each branch forked when the spec was one minor lower and bumped by one; a competing PR then landed the same number first. The merge-base still holds the old value, so the gate sees a clean `1.42.0 → 1.43.0` and passes.

Git sees nothing either — **identical text is not a conflict**, so the merge is exit 0 and prints nothing.

Two checks, each answering a question that is individually correct and jointly insufficient. Nobody wrote a wrong check; the question was simply never asked.

## What this gate asks

Not "is the bump correct relative to where you forked" but **"is this number still free on the base branch as it is right now"**. Those answers differ exactly when someone else landed first.

The failure message carries the command to read the live value and the likely next version, because the fix is a re-bump and the reader should not have to reconstruct which number is free.

## Detection, not prevention — stated in the header so a green run is not over-read

A run is only as fresh as the moment it executes. A PR whose last CI run predates a competing merge, and which then merges with no later run, is invisible to this gate as it is to any run-time check. Closing that needs a merge queue or up-to-date-branch enforcement, and ADR-0048 deliberately chose detection over prevention.

What this buys: a stale claim goes **red on the next run** instead of merging silently. Today all four are green, so nothing anywhere disagrees with them.

## Falsified in both directions, against real branches

| branch | result |
|---|---|
| #7192, #6017, #6019, #5986 | **exit 1**, each naming the taken number |
| #6486 (`1.16.0 → 1.17.0`) | exit 0 |
| #6481 (`1.5.0 → 1.6.0`) | exit 0 |

Within #7192 the referral spec (`1.2.0` over `1.0.0`) **passes** while the campaign spec fails — so it discriminates per file, not per PR.

The self-test drives the pure comparison directly and carries **must-violate** cases, not only passing ones, plus an assertion that both polarities remain present, so a later edit cannot leave an all-passing suite that proves nothing. The gate also refuses to run with an empty `--base` rather than reporting a clean sweep of nothing.

**One probe trap worth recording:** my first run reported *"no openapi.yaml changed"* for all four branches and read as a clean result. The cause was mine — `gh pr view --jq` returns the branch name with a trailing carriage return, which mangled the refspec, and I had suppressed `git checkout`'s stderr, so HEAD silently stayed put. Caught only by asserting `git rev-parse HEAD` equalled the ref I intended. Without that assertion I would have concluded the gate worked and shipped something that detects nothing.

`gates.yaml`: 185 → 186 entries.
