### PR TITLE
ci(test-intelligence): restrict runtime events to containers

### DIFF
--- a/.github/scripts/check-test-intelligence-ecosystem.py
+++ b/.github/scripts/check-test-intelligence-ecosystem.py
@@ -80,7 +80,15 @@ def check(root: Path) -> list[str]:
         errors.append(f"run schema unavailable: {exc}")
 
     workflow = text(root / ".github/workflows/_service-ci.yml")
-    for needle in ("collect-test-run-evidence.py", "build/test-intelligence/run.json", "if: always()", "docker events", "--filter event=start", "--filter event=die"):
+    for needle in (
+        "collect-test-run-evidence.py",
+        "build/test-intelligence/run.json",
+        "if: always()",
+        "docker events",
+        "--filter type=container",
+        "--filter event=start",
+        "--filter event=die",
+    ):
         if needle not in workflow:
             errors.append(f"service CI does not carry required run-envelope wiring: {needle}")
     if "timeout --kill-after=10s 600s ./gradlew --no-daemon :${{ inputs.service }}:koverXmlReport" not in workflow:

--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -232,7 +232,10 @@ jobs:
           # export container id, labels, ports, hostnames or environment variables.
           EVIDENCE_DIR="${{ inputs.service }}/build/test-intelligence/runtime"
           mkdir -p "${EVIDENCE_DIR}"
-          docker events --filter event=start --filter event=die \
+          # Docker's `event=start` filter also matches exec lifecycle events used by
+          # Testcontainers wait strategies. Restrict the stream to container objects,
+          # otherwise one PostgreSQL container appears as three starts and one stop.
+          docker events --filter type=container --filter event=start --filter event=die \
             --format '{"image":"{{.Actor.Attributes.image}}","lifecycle":"{{.Action}}","observedAtUnix":{{.Time}}}' \
             > "${EVIDENCE_DIR}/docker-events.jsonl" &
           docker_events_pid=$!


### PR DESCRIPTION
## Summary

Restricts Docker lifecycle observation to container objects so Testcontainers exec wait-strategy events cannot inflate runtime starts. Adds the invariant to the fleet ecosystem gate.

Refs #6613

## Evidence

- Main Services CI 33334845604 completed successfully with all-green.
- Product Catalog immutable envelope reported 42 PostgreSQL starts / 14 stops; timestamps form three starts per real container cycle.
- Docker collection lacked an object-type filter.
- Flaky Test Hunter main envelope remains balanced at 6 / 6.

## Verification

- `python3 .github/scripts/check-test-intelligence-ecosystem.py --self-test`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py --root .` (60 subjects)
- `python3 .github/scripts/collect-test-run-evidence.py --self-test`
- `actionlint -ignore 'label ".*" is unknown' .github/workflows/_service-ci.yml`\n- `git diff --check`\n\n## Safety\n\nNo test verdict, container configuration, credential, image, or runtime cleanup behavior changes. The event stream remains secret-free and now excludes non-container Docker objects.