### PR TITLE
docs(governance): name the exact tool call the worker keeps using to background itself

### DIFF
--- a/.github/agent-prompts/issue-worker.md
+++ b/.github/agent-prompts/issue-worker.md
@@ -76,6 +76,14 @@ and read the output when it returns. Do not use background execution, do not pol
 appear, do not wait for a notification. If a command genuinely cannot finish inside the job's
 45-minute budget, the issue is too big for one run — abandon it and say so.
 
+Concretely: never call the Bash tool with `run_in_background: true`. Never call the `Monitor`
+tool. Neither exists for you — there is no later turn in which their result reaches you, only a
+job that sits until its own timeout kills it. This has now killed three separate runs
+(2026-08-22, and twice more on 2026-08-31) the same way: a build or test command backgrounded,
+then a turn ending on "waiting for it to finish" or "waiting for the scheduled fallback wakeup" —
+language that describes a *different* harness (an interactive session with a wakeup scheduler),
+not this one. You are `claude -p`; nothing schedules you a wakeup.
+
 ## Step 1 — pick one issue you can actually finish and verify
 
 List open issues with `gh issue list`. Discard, in this order:


### PR DESCRIPTION
## What happened, a third time

Two more `agent-issue-worker` runs died the same way as the 2026-08-22 incident this prompt
already documents — backgrounding a compile/test and ending the turn waiting for a notification
that `claude -p` (a single non-interactive shot) never delivers:

- Run 33346505668 (2026-08-31 01:05–01:28, 23 min): *"Compilation is still in progress in the
  background. I'll pause here and resume once the Monitor notifies me that it's finished."*
- Run 33356931139 (2026-08-31 04:24–04:30, 6 min): *"Waiting on the background test run (or the
  scheduled fallback wakeup) before continuing."*

Both jobs failed loudly (the verdict-assertion step worked as designed — no orphaned claim
branches, no silent data loss), so this is a report of a recurring prompt-compliance gap, not a
live incident. Filed as #7639.

## Why the existing instruction wasn't enough

The "You are ONE non-interactive invocation" section already explains, in prose, why
backgrounding is unsafe and says "do not use background execution" — but never names the actual
tool affordance the model reaches for. `run_in_background: true` on the Bash tool call, and the
`Monitor` tool, both exist in this harness for other contexts (an interactive session with a
scheduler) and the model apparently reasons from general capability rather than this specific
one-shot invocation. The second death's own wording — *"the scheduled fallback wakeup"* —
describes a mechanism (`ScheduleWakeup`) that literally does not exist for `claude -p`.

## The fix

Names both tool calls explicitly as forbidden, and quotes the two new death lines next to the
2026-08-22 one so a future read of this prompt sees the exact, repeating shape of the failure.
Doc-only change, no code or CI behavior touched.
