### PR TITLE
refactor(admin-ui): ratchet semantic colour migration

### DIFF
--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -254,6 +254,17 @@ main {
 .badge-info    { background: var(--info-bg);    color: var(--info-text);    border: 1px solid var(--info-border); }
 .badge-neutral { background: var(--surface-3);  color: var(--text-secondary); border: 1px solid var(--border-strong); }
 .badge-accent  { background: var(--ob-accent-light); color: var(--ob-accent-text); border: 1px solid var(--ob-accent-border); }
+.badge-sm {
+  gap: 4px;
+  padding: 2px 7px;
+  font-size: 10px;
+  letter-spacing: .04em;
+}
+.badge-detail {
+  font-weight: 600;
+  opacity: .8;
+  text-transform: none;
+}
 
 
 /* ── Button ── */

--- a/openbank-admin-ui/src/components/approvals/AgentIdentityBadge.tsx
+++ b/openbank-admin-ui/src/components/approvals/AgentIdentityBadge.tsx
@@ -17,11 +17,6 @@ interface Props {
   lang?: 'cs' | 'en'
 }
 
-const chip: React.CSSProperties = {
-  display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 10, fontWeight: 700,
-  padding: '2px 7px', borderRadius: 20, textTransform: 'uppercase', letterSpacing: '0.04em',
-}
-
 export function AgentIdentityBadge({ identity, loading = false, lang = 'en' }: Props) {
   const cs = lang === 'cs'
 
@@ -30,7 +25,7 @@ export function AgentIdentityBadge({ identity, loading = false, lang = 'en' }: P
       <span
         data-testid="agent-identity"
         data-state="loading"
-        style={{ ...chip, color: 'var(--text-tertiary)', background: 'var(--surface-2)', border: '1px solid var(--border)' }}
+        className="badge badge-sm badge-neutral"
       >
         {cs ? 'Ověřuji charter…' : 'Checking charter…'}
       </span>
@@ -45,11 +40,11 @@ export function AgentIdentityBadge({ identity, loading = false, lang = 'en' }: P
         data-state="chartered"
         data-agent-id={charter.id}
         title={charter.charter}
-        style={{ ...chip, color: '#b45309', background: '#fffbeb', border: '1px solid #fcd34d' }}
+        className="badge badge-sm badge-warning"
       >
         <Bot size={11} aria-hidden="true" />
         {charter.id}
-        <span style={{ fontWeight: 600, opacity: 0.8, textTransform: 'none' }}>
+        <span className="badge-detail">
           · {cs ? 'charter' : 'charter'} · {charter.plane}
         </span>
       </span>
@@ -61,7 +56,7 @@ export function AgentIdentityBadge({ identity, loading = false, lang = 'en' }: P
       <span
         data-testid="agent-identity"
         data-state="unresolved"
-        style={{ ...chip, color: 'var(--text-secondary)', background: 'var(--surface-2)', border: '1px solid var(--border)' }}
+        className="badge badge-sm badge-neutral"
       >
         <UserRound size={11} aria-hidden="true" />
         {cs ? 'Bez charteru v agents.yaml' : 'No charter in agents.yaml'}
@@ -73,7 +68,7 @@ export function AgentIdentityBadge({ identity, loading = false, lang = 'en' }: P
     <span
       data-testid="agent-identity"
       data-state="unverifiable"
-      style={{ ...chip, color: '#b91c1c', background: '#fef2f2', border: '1px solid #fca5a5' }}
+      className="badge badge-sm badge-danger"
     >
       <ShieldQuestion size={11} aria-hidden="true" />
       {cs ? 'Identitu nelze ověřit — registr charterů nedostupný' : 'Identity unverifiable — charter registry unavailable'}

--- a/openbank-admin-ui/src/test/approvals-agent-identity.test.tsx
+++ b/openbank-admin-ui/src/test/approvals-agent-identity.test.tsx
@@ -106,4 +106,13 @@ describe('AgentIdentityBadge — the states render distinguishably', () => {
     const out = stateOf(<AgentIdentityBadge identity={resolveAgentIdentity('totally-made-up-agent', registry)} />)
     expect(out.text).not.toContain('totally-made-up-agent')
   })
+
+  it('uses shared semantic badge tokens instead of local colour literals', () => {
+    const source = readFileSync(path.resolve(__dirname, '../components/approvals/AgentIdentityBadge.tsx'), 'utf8')
+
+    expect(source).toContain('badge-warning')
+    expect(source).toContain('badge-neutral')
+    expect(source).toContain('badge-danger')
+    expect(source).not.toMatch(/#[0-9a-fA-F]{6}\b|#[0-9a-fA-F]{3}(?![0-9a-fA-F])/)
+  })
 })

--- a/openbank-admin-ui/src/test/raw-colour-literal-ratchet.guard.test.ts
+++ b/openbank-admin-ui/src/test/raw-colour-literal-ratchet.guard.test.ts
@@ -1,0 +1,35 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const UI_ROOTS = [
+  path.resolve(__dirname, '../app'),
+  path.resolve(__dirname, '../components'),
+]
+const SOURCE_EXTENSIONS = new Set(['.tsx', '.css'])
+// Do not treat an issue reference such as `#5904` as a colour. The admin UI uses only
+// three- and six-digit hexadecimal CSS colours, so those are the two forms this ratchet owns.
+const HEX_LITERAL = /#[0-9a-fA-F]{6}\b|#[0-9a-fA-F]{3}(?![0-9a-fA-F])/g
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const file = path.join(directory, entry.name)
+    if (entry.isDirectory()) return sourceFiles(file)
+    if (file.endsWith('globals.css') || !SOURCE_EXTENSIONS.has(path.extname(file))) return []
+    return [file]
+  })
+}
+
+function rawColourCount(): number {
+  return UI_ROOTS
+    .flatMap(sourceFiles)
+    .reduce((total, file) => total + (readFileSync(file, 'utf8').match(HEX_LITERAL)?.length ?? 0), 0)
+}
+
+describe('admin UI semantic colour migration', () => {
+  it('does not add raw hexadecimal colours outside the token stylesheet', () => {
+    // Baseline captured after migrating approval identity badges to shared semantic tones.
+    // Lowering this number is always safe; raising it requires an intentional token decision.
+    expect(rawColourCount()).toBeLessThanOrEqual(1782)
+  })
+})


### PR DESCRIPTION
## Summary
- prevent new raw hex colour literals outside the shared token stylesheet
- migrate approval proposer identity states to compact shared semantic badges
- retain visible, distinct charter verification states

## Safety
No approval data, identity resolution, RBAC, BFF endpoint, or maker-checker behavior changes.

## Verification
- `vitest run src/test/approvals-agent-identity.test.tsx src/test/raw-colour-literal-ratchet.guard.test.ts` (12 passed)
- scoped ESLint (0 errors)
- `git diff --check`
- signed commit verification

Refs #7648