### PR TITLE
refactor(admin-ui): unify document template statuses

### DIFF
--- a/openbank-admin-ui/src/app/document-templates/page.tsx
+++ b/openbank-admin-ui/src/app/document-templates/page.tsx
@@ -17,7 +17,7 @@ import { hasPermission } from '@/lib/auth/roles'
 import { svcUrl, classifyBffFailure, type BffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { looksLikeUuid } from '@/lib/validation/iban'
-import { PageHeader } from '@/components/ui/PageHeader'
+import { PageHeader, StatusBadge, type Tone } from '@/components/ui'
 
 // Go through the BFF proxy directly (svcUrl → /api/svc/document-service/...), the
 // same pattern product-catalog/standing-orders/kyc now use — NOT a dedicated
@@ -91,10 +91,10 @@ async function apiFetch(path: string, opts?: RequestInit) {
   try { return JSON.parse(text) } catch { return null }
 }
 
-const STATUS_COLOR: Record<string, { bg: string; text: string; border: string }> = {
-  DRAFT:     { bg: 'var(--warning-bg)', text: 'var(--warning-text)', border: 'var(--warning-border)' },
-  PUBLISHED: { bg: 'var(--success-bg)', text: 'var(--success-text)', border: 'var(--success-border)' },
-  RETIRED:   { bg: 'var(--surface-3)',  text: 'var(--text-tertiary)', border: 'var(--border)' },
+const TEMPLATE_STATUS_TONE: Record<TemplateStatus, Tone> = {
+  DRAFT: 'warning',
+  PUBLISHED: 'success',
+  RETIRED: 'neutral',
 }
 
 // Generic merge-field tokens offered as clickable chips. These are a UX aid for
@@ -188,15 +188,6 @@ const DEFAULT_SAMPLE_DATA = {
   signature: { block: 'Podepsáno elektronicky / Signed electronically' },
 }
 const DEFAULT_SAMPLE_DATA_TEXT = JSON.stringify(DEFAULT_SAMPLE_DATA, null, 2)
-
-function StatusBadge({ status }: { status?: string }) {
-  const c = STATUS_COLOR[status ?? ''] ?? STATUS_COLOR.DRAFT
-  return (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: '4px', padding: '2px 8px', borderRadius: '10px', fontSize: '11px', fontWeight: 700, background: c.bg, color: c.text, border: `1px solid ${c.border}`, letterSpacing: '0.03em' }}>
-      {status ?? 'DRAFT'}
-    </span>
-  )
-}
 
 export default function DocumentTemplatesPage() {
   const { t, language } = useLanguage()
@@ -559,7 +550,7 @@ export default function DocumentTemplatesPage() {
                       <td style={{ fontFamily: 'var(--font-mono)', fontWeight: 700, fontSize: '11px' }}>{tpl.code}</td>
                       <td style={{ fontSize: '13px', fontWeight: 600 }}>{tpl.name}</td>
                       <td style={{ fontFamily: 'var(--font-mono)', fontSize: '12px' }}>v{tpl.version}</td>
-                      <td><StatusBadge status={tpl.status} /></td>
+                      <td><StatusBadge status={tpl.status ?? 'DRAFT'} tone={TEMPLATE_STATUS_TONE[tpl.status ?? 'DRAFT']} /></td>
                       <td style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>{tpl.locale ?? '—'}</td>
                       <td style={{ fontFamily: 'var(--font-mono)', fontSize: '11px', color: 'var(--text-tertiary)' }}>{tpl.productRef ?? '—'}</td>
                       <td style={{ textAlign: 'right' }}>

--- a/openbank-admin-ui/src/test/document-template-status-tone.guard.test.ts
+++ b/openbank-admin-ui/src/test/document-template-status-tone.guard.test.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('document template status presentation', () => {
+  it('uses the shared semantic badge rather than a page-local colour map', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/document-templates/page.tsx'), 'utf8')
+
+    expect(source).toContain("import { PageHeader, StatusBadge, type Tone } from '@/components/ui'")
+    expect(source).toContain("DRAFT: 'warning'")
+    expect(source).toContain("PUBLISHED: 'success'")
+    expect(source).toContain("RETIRED: 'neutral'")
+    expect(source).toContain("<StatusBadge status={tpl.status ?? 'DRAFT'} tone={TEMPLATE_STATUS_TONE[tpl.status ?? 'DRAFT']} />")
+    expect(source).not.toContain('STATUS_COLOR')
+  })
+})


### PR DESCRIPTION
## Summary
- replace the page-local document-template status colour map and badge with the shared semantic `StatusBadge`
- preserve DRAFT warning, PUBLISHED success, RETIRED neutral, and missing-status → DRAFT fallback

## Safety
No change to BFF paths, template preview/save/publish/retire behavior, RBAC, or maker-checker controls.

## Verification
- `vitest run src/test/document-template-controls.guard.test.ts src/test/document-template-status-tone.guard.test.ts` (2 passed)
- scoped ESLint: no new errors (one existing React effect warning in the page)
- `git diff --check`
- signed commit verification

## Known baseline check
Full `tsc --noEmit` is currently red on `main` due to missing `@axe-core/playwright`/generated sources and pre-existing Product Studio errors; none originate in this diff.

Refs #7651