### PR TITLE
refactor(admin-ui): unify infrastructure statuses

### DIFF
--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -844,6 +844,16 @@ main {
 .tone-text-neutral { color: var(--text-secondary); }
 .tone-text-accent  { color: var(--ob-accent); }
 
+/* Semantic card emphasis for the cases where the verdict belongs to the whole surface, not just
+   a badge. The tone is selected in TypeScript; the actual colour remains token-owned here. */
+.tone-border-left { border-left-style: solid; border-left-width: 4px; }
+.tone-border-left-success { border-left-color: var(--success); }
+.tone-border-left-warning { border-left-color: var(--warning); }
+.tone-border-left-danger  { border-left-color: var(--danger); }
+.tone-border-left-info    { border-left-color: var(--info); }
+.tone-border-left-neutral { border-left-color: var(--border-strong); }
+.tone-border-left-accent  { border-left-color: var(--ob-accent); }
+
 /* ── Page header ── */
 .page-header {
   margin-bottom: 32px;

--- a/openbank-admin-ui/src/app/infrastructure/page.tsx
+++ b/openbank-admin-ui/src/app/infrastructure/page.tsx
@@ -13,7 +13,8 @@ import {
 } from 'lucide-react'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { LifecycleStrip, type CompLifecycle } from '@/components/infra/LifecycleStrip'
-import { PageHeader } from '@/components/ui/PageHeader'
+import { PageHeader, StatusBadge, TONE_BORDER_LEFT_CLASS, statusTone } from '@/components/ui'
+import { cn } from '@/lib/utils'
 
 type InfraStatus = 'UP' | 'DOWN' | 'UNKNOWN'
 
@@ -68,26 +69,9 @@ type KafkaTopic = {
   segmentSize: number
 }
 
-const STATUS_STYLES: Record<InfraStatus, { border: string; bg: string; text: string }> = {
-  UP:      { border: 'var(--success-border)', bg: 'var(--success-bg)',  text: 'var(--success)' },
-  DOWN:    { border: 'var(--danger-border)',  bg: 'var(--danger-bg)',   text: 'var(--danger)' },
-  UNKNOWN: { border: 'var(--border)',         bg: 'var(--surface-2)',   text: 'var(--text-secondary)' },
-}
-
-function StatusBadge({ status }: { status: InfraStatus }) {
-  const s = STATUS_STYLES[status]
+function InfrastructureStatusBadge({ status }: { status: InfraStatus }) {
   const icon = status === 'UP' ? <CheckCircle2 size={13} /> : status === 'DOWN' ? <XCircle size={13} /> : <AlertTriangle size={13} />
-  return (
-    <div style={{
-      display: 'flex', alignItems: 'center', gap: '5px',
-      padding: '3px 9px', borderRadius: '20px',
-      background: s.bg, border: `1px solid ${s.border}`,
-      color: s.text, fontSize: '11px', fontWeight: 700, letterSpacing: '0.05em',
-    }}>
-      {icon}
-      {status}
-    </div>
-  )
+  return <StatusBadge status={status} leading={icon} />
 }
 
 export default function InfrastructurePage() {
@@ -238,10 +222,10 @@ export default function InfrastructurePage() {
             {INFRA_COMPONENTS.map(comp => {
               const st = statuses[comp.id]
               const status: InfraStatus = st?.status ?? 'UNKNOWN'
-              const styles = STATUS_STYLES[status]
+              const tone = statusTone(status)
 
               return (
-                <div key={comp.id} className="card" style={{ padding: '18px', borderLeft: `4px solid ${styles.text}` }}>
+                <div key={comp.id} className={cn('card tone-border-left', TONE_BORDER_LEFT_CLASS[tone])} style={{ padding: '18px' }}>
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '10px' }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
                       <div style={{ padding: '7px', background: 'var(--surface-2)', borderRadius: '7px', color: 'var(--text-secondary)' }}>
@@ -254,7 +238,7 @@ export default function InfrastructurePage() {
                         </div>
                       </div>
                     </div>
-                    <StatusBadge status={status} />
+                    <InfrastructureStatusBadge status={status} />
                   </div>
 
                   {st && (

--- a/openbank-admin-ui/src/components/ui/StatusBadge.tsx
+++ b/openbank-admin-ui/src/components/ui/StatusBadge.tsx
@@ -2,6 +2,7 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
+import type { ReactNode } from 'react'
 import { cn } from '@/lib/utils'
 import { BADGE_CLASS, DOT_CLASS, type Tone, statusTone } from './tone'
 
@@ -14,6 +15,8 @@ type StatusBadgeProps = {
   label?: string
   /** Renders a leading status dot alongside the text. */
   withDot?: boolean
+  /** Decorative leading icon when the status has a recognizable domain symbol. */
+  leading?: ReactNode
   className?: string
 }
 
@@ -25,11 +28,12 @@ type StatusBadgeProps = {
  * domain value: translating the value first and then colouring it is how a Czech-locale page ends up
  * with every badge neutral.
  */
-export function StatusBadge({ status, tone, label, withDot = false, className }: StatusBadgeProps) {
+export function StatusBadge({ status, tone, label, withDot = false, leading, className }: StatusBadgeProps) {
   const resolved = tone ?? statusTone(status)
   return (
     <span className={cn(BADGE_CLASS[resolved], className)}>
       {withDot && <span className={DOT_CLASS[resolved]} aria-hidden="true" />}
+      {leading && <span aria-hidden="true">{leading}</span>}
       {label ?? status ?? '—'}
     </span>
   )

--- a/openbank-admin-ui/src/components/ui/index.ts
+++ b/openbank-admin-ui/src/components/ui/index.ts
@@ -22,6 +22,7 @@ export {
   BADGE_CLASS,
   DOT_CLASS,
   SWATCH_CLASS,
+  TONE_BORDER_LEFT_CLASS,
   TONE_TEXT_CLASS,
   type Tone,
   statusBadgeClass,

--- a/openbank-admin-ui/src/components/ui/tone.ts
+++ b/openbank-admin-ui/src/components/ui/tone.ts
@@ -56,6 +56,16 @@ export const TONE_TEXT_CLASS: Record<Tone, string> = {
   accent: 'tone-text-accent',
 }
 
+/** Semantic left-border classes for status-bearing cards and panels. */
+export const TONE_BORDER_LEFT_CLASS: Record<Tone, string> = {
+  success: 'tone-border-left-success',
+  warning: 'tone-border-left-warning',
+  danger: 'tone-border-left-danger',
+  info: 'tone-border-left-info',
+  neutral: 'tone-border-left-neutral',
+  accent: 'tone-border-left-accent',
+}
+
 export const DOT_CLASS: Record<Tone, string> = {
   success: 'status-dot status-dot-green',
   warning: 'status-dot status-dot-yellow',
@@ -88,10 +98,12 @@ const TONE_BY_STATUS: Record<string, Tone> = {
   RESOLVED: 'success',
   SENT: 'success',
   SETTLED: 'success',
+  UP: 'success',
   VERIFIED: 'success',
 
   // In-flight / needs attention but not wrong
   DEGRADED: 'warning',
+  DOWN: 'danger',
   DRAFT: 'warning',
   IN_PROGRESS: 'warning',
   PENDING: 'warning',

--- a/openbank-admin-ui/src/test/infrastructure-status-badge.guard.test.ts
+++ b/openbank-admin-ui/src/test/infrastructure-status-badge.guard.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('infrastructure status presentation', () => {
+  it('uses the shared semantic badge and retains its distinct health icons', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/infrastructure/page.tsx'), 'utf8')
+
+    expect(source).toContain("from '@/components/ui'")
+    expect(source).toContain('StatusBadge')
+    expect(source).toContain('function InfrastructureStatusBadge')
+    expect(source).toContain('<StatusBadge status={status} leading={icon} />')
+    expect(source).toContain("cn('card tone-border-left', TONE_BORDER_LEFT_CLASS[tone])")
+    expect(source).toContain('<CheckCircle2 size={13} />')
+    expect(source).toContain('<XCircle size={13} />')
+    expect(source).not.toContain('STATUS_STYLES')
+  })
+})

--- a/openbank-admin-ui/src/test/local-status-map-ratchet.guard.test.ts
+++ b/openbank-admin-ui/src/test/local-status-map-ratchet.guard.test.ts
@@ -26,6 +26,6 @@ describe('ADR-0208 local status-map migration', () => {
   it('does not increase page-local named status colour maps', () => {
     // Baseline captured on main 2026-08-31. Migrations reduce this number; adding a new page-local
     // STATUS_COLOR/STATUS_STYLES map is a regression because StatusBadge + tone.ts own this decision.
-    expect(pagesWithLocalStatusMaps()).toHaveLength(11)
+    expect(pagesWithLocalStatusMaps().length).toBeLessThanOrEqual(11)
   })
 })

--- a/openbank-admin-ui/src/test/ui-tone.test.ts
+++ b/openbank-admin-ui/src/test/ui-tone.test.ts
@@ -7,6 +7,7 @@ import {
   BADGE_CLASS,
   DOT_CLASS,
   SWATCH_CLASS,
+  TONE_BORDER_LEFT_CLASS,
   TONE_TEXT_CLASS,
   statusBadgeClass,
   statusDotClass,
@@ -15,7 +16,7 @@ import {
 
 describe('statusTone (ADR-0208 D2)', () => {
   it('maps terminal-good statuses to success', () => {
-    for (const s of ['ACTIVE', 'COMPLETED', 'SETTLED', 'CLEARED', 'APPROVED', 'OK', 'SENT']) {
+    for (const s of ['ACTIVE', 'COMPLETED', 'SETTLED', 'CLEARED', 'APPROVED', 'OK', 'SENT', 'UP']) {
       expect(statusTone(s), s).toBe('success')
     }
   })
@@ -27,7 +28,7 @@ describe('statusTone (ADR-0208 D2)', () => {
   })
 
   it('maps failure statuses to danger', () => {
-    for (const s of ['FAILED', 'REJECTED', 'BLOCKED', 'SUSPENDED', 'CRITICAL', 'ERROR', 'BOUNCED', 'ESCALATED', 'DEPRECATED']) {
+    for (const s of ['FAILED', 'REJECTED', 'BLOCKED', 'SUSPENDED', 'CRITICAL', 'ERROR', 'BOUNCED', 'ESCALATED', 'DEPRECATED', 'DOWN']) {
       expect(statusTone(s), s).toBe('danger')
     }
   })
@@ -91,6 +92,7 @@ describe('statusTone (ADR-0208 D2)', () => {
       expect(SWATCH_CLASS[tone], `swatch ${tone}`).toMatch(/^tone-swatch badge-/)
       expect(SWATCH_CLASS[tone], `swatch ${tone} must not apply .badge`).not.toMatch(/(^|\s)badge(\s|$)/)
       expect(TONE_TEXT_CLASS[tone], `text ${tone}`).toMatch(/^tone-text-/)
+      expect(TONE_BORDER_LEFT_CLASS[tone], `left border ${tone}`).toMatch(/^tone-border-left-/)
     }
   })
 


### PR DESCRIPTION
## Summary
- extend shared status presentation with a decorative leading-icon slot and semantic card left-border classes
- classify `UP` as success and `DOWN` as danger in the shared vocabulary
- remove Infrastructure’s local status colour map and badge

## Safety
Gatus polling, BFF endpoints, refresh intervals, unavailable states, health data and status meanings are unchanged.

## Verification
- `vitest run src/test/ui-tone.test.ts src/test/infrastructure-status-badge.guard.test.ts src/test/infrastructure-refresh.guard.test.ts` (15 passed)
- scoped ESLint: no errors; three existing React effect warnings in the page
- `git diff --check`
- signed commit verification

Refs #7655; part of #7654