### PR TITLE
ci(gates): fail an action declared four-eyes that no policy can allow

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -2600,6 +2600,51 @@ gates:
   # colliding branches (exit 1 each, each naming the taken number) and against two non-colliding
   # ones (#6486 1.16.0->1.17.0, #6481 1.5.0->1.6.0, exit 0) — it discriminates in both directions
   # rather than failing everything.
+  # `rules.yaml: four_eyes.verbs` declares which verbs pause for a second approver. Whether that
+  # approval can ever be REQUESTED depends on something else entirely -- the action needs an allow
+  # reason, in `role_action_matrix` or a service rego. Nothing connected the two, and three
+  # money-path actions are declared four-eyes and granted nowhere (#4754): transaction.sweep,
+  # swift.send, sctInstPayment.recall.
+  #
+  # Both consequences are invisible in normal operation. `response_attributes` ride on the ALLOW
+  # object in rest.rego, so a denied decision carries no attributes: `four_eyes_required = true` is
+  # computed and never reaches AuthorizeInterceptor, making the gate structurally unreachable -- and
+  # the day AUTHZ_ENFORCE flips for that service, the endpoint 403s for every principal. The worst
+  # of both states, with no signal either way, because a control that cannot fire produces none.
+  #
+  # Falsified in three directions before merge: a new ungranted action fails (exit 1), a baseline
+  # entry that has become granted fails (exit 1), and the untouched tree passes (exit 0). It also
+  # refuses to run when the policy corpus or the @Authorize corpus comes back empty, rather than
+  # reporting a clean sweep of nothing.
+  #
+  # Two false positives were caught before shipping, both from customer-edge: `customer.*` actions
+  # are granted by ONE prefix rule (`startswith(input.action, "customer.")`), so they appear as no
+  # literal anywhere. A literal-only probe called them ungranted on a service whose AUTHZ_ENFORCE
+  # defaults TRUE, which reads exactly like a live customer-facing outage. The gate reads prefix
+  # rules, and searches bundle ConfigMaps as well as `.rego` files -- transaction-service has no
+  # `*_rest_ext.rego` at all, so a rego-only search would have missed its policy entirely.
+  - id: four-eyes-verb-grantable
+    name: "four-eyes-verb-grantable — a four-eyes action must have an allow reason (ADR-0155, enforced)"
+    group: api
+    mode: enforced
+    when: pull_request
+    min_subjects: 15   # 25 four-eyes actions today; a floor at ~60% catches corpus collapse
+                       # (a renamed annotation, a moved source root) without failing on ordinary
+                       # fleet churn.
+    rationale: >-
+      four_eyes.verbs declares the control; role_action_matrix and the service regos decide whether
+      it can ever fire. Nothing checked that the two agree, and three money-path actions did not.
+    review_after: 2027-03-01   # Re-examine when the three baselined actions are granted: if the
+                               # list reaches empty this becomes a pure ratchet, which is the
+                               # intended end state.
+    selftest: |
+      set -euo pipefail
+      python3 .github/scripts/check-four-eyes-verb-grantable.py --self-test
+    run: |
+      set -euo pipefail
+      git fetch -q origin main
+      python3 .github/scripts/check-four-eyes-verb-grantable.py --ref origin/main --enforce
+
   - id: openapi-version-not-taken
     name: "openapi-version-not-taken — info.version still free on the base tip (ADR-0048, enforced)"
     group: api

--- a/.github/scripts/check-four-eyes-verb-grantable.py
+++ b/.github/scripts/check-four-eyes-verb-grantable.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Every action declared four-eyes must be reachable by at least one allow reason.
+
+WHY THIS EXISTS
+---------------
+`rules.yaml: four_eyes.verbs` declares which verbs pause for a second approver. Whether the
+approval can ever be *requested* depends on something else entirely: the action must have an
+allow reason, either in `authz.role_action_matrix` or in a service-scoped `*_rest_ext.rego`.
+Nothing connected the two.
+
+Measured on `origin/main` (#4754): `transaction.sweep` is declared four-eyes and granted in
+neither place. Two consequences, and the second is the reason this is a gate rather than a
+comment on one issue:
+
+1. `response_attributes` rides on the **allow** object in `rest.rego`, so a denied decision
+   carries no attributes at all. `four_eyes_required = true` is computed and never reaches
+   `AuthorizeInterceptor` -- the four-eyes gate on that endpoint is structurally unreachable, and
+   no toggle changes it. `rules.yaml` asserts the merge flow's two halves "both pause for a second
+   approver, or neither does". For the sweep half that is not true and cannot become true.
+2. The day `AUTHZ_ENFORCE` flips to `true` for that service, the endpoint 403s for every
+   principal. So the state is the worst of both: the advertised control cannot fire, and enabling
+   enforcement breaks the endpoint outright.
+
+Neither is visible in normal operation, because the deny is advisory today and a control that
+cannot fire produces no signal -- the same shape as a gate whose scope list is short reading as
+passing rather than as unchecked.
+
+WHAT IT CHECKS, AND WHAT IT DOES NOT
+------------------------------------
+For every `@Authorize(action = "x.verb")` in `*/src/main/**.kt` whose trailing verb appears in
+`four_eyes.verbs`, the action must appear in `role_action_matrix` or in some `.rego` under
+`openbank-infra/gitops/components`.
+
+It asks whether an allow reason EXISTS, not whether it is correct or appropriately scoped. A
+grant that is present but wrong is out of scope here -- `opa eval` against the bundle answers
+that, and reading the rego cannot (several reasons can match; only evaluation says which fires).
+Do not read a green here as "this action's authorization is right".
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+
+REF = "origin/main"
+AUTHORIZE_RE = re.compile(r'@Authorize\(\s*action\s*=\s*"([^"]+)"')
+VERB_RE = re.compile(r"^\s+- (\w+)", re.M)
+
+# Declared, not inferred. An entry needs a reason and is expected to shrink; the gate also fails
+# on an entry that has become granted, so the declaration cannot outlive the debt.
+#
+# All three are money-path and all three are the SAME defect, found together (#4754). They are
+# baselined rather than fixed here because granting them is an authoring decision: adding them to
+# `role_action_matrix` would be a grant to a machine (M2M callers authenticate with a
+# client_credentials JWT and are classified HUMAN, and `shared_m2m_write_prohibition` is not
+# emitted into any bundle, so no policy can veto it). The defensible shape is a service-scoped
+# rego rule pinned to human operators -- which for transaction-service means creating its first
+# `*_rest_ext.rego` -- and each such edit restamps ~73 bundle files.
+KNOWN_UNGRANTED: dict[str, str] = {
+    "transaction.sweep": (
+        "#4754. Declared four-eyes, granted nowhere. Measured with `opa eval` against the "
+        "materialised transaction bundle: allow=false for every principal probed, with a "
+        "must-DENY and a must-ALLOW control in the same run. AUTHZ_ENFORCE defaults false for "
+        "transaction-service with no gitops override, so the deny is advisory today."
+    ),
+    "swift.send": (
+        "#4754 sibling, same shape. No literal and no prefix rule anywhere under "
+        "openbank-infra/gitops/components. AUTHZ_ENFORCE defaults false for swift-service."
+    ),
+    "sctInstPayment.recall": (
+        "#4754 sibling, same shape. No literal and no prefix rule anywhere under "
+        "openbank-infra/gitops/components. AUTHZ_ENFORCE defaults false for sepa-instant."
+    ),
+}
+
+
+def sh(*args: str) -> str:
+    return subprocess.run(args, capture_output=True, text=True).stdout
+
+
+def four_eyes_verbs(rules: str) -> set[str]:
+    m = re.search(r"^four_eyes:\n  verbs:\n((?:\s+-.*\n|\s+#.*\n|\s{10,}#.*\n)+)", rules, re.M)
+    if not m:
+        raise SystemExit("::error::could not locate four_eyes.verbs in rules.yaml")
+    return set(VERB_RE.findall(m.group(1)))
+
+
+def authorize_actions(ref: str) -> dict[str, str]:
+    files = [
+        line.split(":", 1)[1]
+        for line in sh("git", "grep", "-l", "@Authorize", ref, "--", "*/src/main/*.kt").split()
+    ]
+    out: dict[str, str] = {}
+    for path in files:
+        for action in AUTHORIZE_RE.findall(sh("git", "show", f"{ref}:{path}")):
+            out.setdefault(action, path)
+    return out
+
+
+def matrix_text(rules: str) -> str:
+    m = re.search(r"^\s+role_action_matrix:\n((?:.*\n)*?)^\s{2}\w", rules, re.M)
+    return m.group(1) if m else ""
+
+
+PREFIX_RE = re.compile(r'startswith\(\s*input\.action\s*,\s*"([^"]+)"')
+
+
+def rego_corpus(ref: str) -> str:
+    """Every rego AND every bundle ConfigMap, concatenated.
+
+    Bundles are read too because a service's policy may live only inside its generated
+    ConfigMap -- transaction-service has no `*_rest_ext.rego` file at all, so a rego-only
+    search would report a clean sweep of a corpus it never saw.
+    """
+    parts = []
+    for pathspec in (
+        "openbank-infra/gitops/components/**/*.rego",
+        "openbank-infra/gitops/components/**/*opa-bundle*.yaml",
+    ):
+        for line in sh("git", "grep", "-l", "--", "input.action", ref, "--", pathspec).split():
+            parts.append(sh("git", "show", f"{ref}:{line.split(':', 1)[1]}"))
+    return "\n".join(parts)
+
+
+def granted_in_policy(corpus: str, action: str) -> str | None:
+    """Return the granting mechanism, or None.
+
+    Two mechanisms, and missing the second produces false positives that read as live outages:
+    a literal action string, and a PREFIX rule -- customer-edge grants every `customer.*` action
+    through one `startswith(input.action, "customer.")`, so `customer.pockets.convert` appears
+    nowhere as a literal and is nonetheless allowed. Checked against that exact case.
+    """
+    if f'"{action}"' in corpus:
+        return "literal action in policy"
+    for prefix in PREFIX_RE.findall(corpus):
+        if action.startswith(prefix):
+            return f'prefix rule startswith(input.action, "{prefix}")'
+    return None
+
+
+def evaluate(actions: dict[str, str], verbs: set[str], matrix: str, corpus: str):
+    """Return (ungranted, granted) as lists of (action, path, where)."""
+    ungranted, granted = [], []
+    for action, path in sorted(actions.items()):
+        if action.split(".")[-1] not in verbs:
+            continue
+        if action in matrix:
+            granted.append((action, path, "role_action_matrix"))
+            continue
+        where = granted_in_policy(corpus, action)
+        if where:
+            granted.append((action, path, where))
+        else:
+            ungranted.append((action, path, None))
+    return ungranted, granted
+
+
+def self_test() -> int:
+    """Drive `evaluate` over a fixture, with must-FLAG cases as well as must-pass ones.
+
+    A self-test that only exercises the passing direction cannot detect a dead gate -- this repo
+    has shipped several of those, including one that passed with its own guard removed.
+    """
+    verbs = {"sweep", "reverse", "send", "convert"}
+    matrix = 'transaction.reverse\nledger.reverse\n'
+    actions = {
+        "transaction.reverse": "a.kt",   # in matrix          -> pass
+        "transaction.sweep": "b.kt",     # nowhere            -> FLAG (the real #4754 case)
+        "account.list": "c.kt",          # verb not four-eyes -> ignored entirely
+        "customer.pockets.convert": "d.kt",  # granted only by a PREFIX rule -> pass
+    }
+    # A corpus with one prefix rule and no literal for the sweep case.
+    corpus = 'startswith(input.action, "customer.")'
+    ungranted, granted = evaluate(actions, verbs, matrix, corpus)
+
+    failures = 0
+    got_ungranted = {a for a, _, _ in ungranted}
+    got_granted = {a for a, _, _ in granted}
+    checks = [
+        ("flags an action declared four-eyes and granted nowhere", "transaction.sweep" in got_ungranted),
+        ("does NOT flag one present in the matrix", "transaction.reverse" in got_granted),
+        ("ignores an action whose verb is not four-eyes", "account.list" not in got_ungranted | got_granted),
+        ("does NOT flag one granted only by a prefix rule", "customer.pockets.convert" in got_granted),
+        ("flags exactly one in this fixture", len(ungranted) == 1),
+    ]
+    for label, ok in checks:
+        print(f"  {'ok ' if ok else 'FAIL'} {label}")
+        failures += 0 if ok else 1
+    print(f"self-test: {'ok' if failures == 0 else 'FAILED'} ({failures} failure(s))")
+    return 1 if failures else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ref", default=REF)
+    ap.add_argument("--enforce", action="store_true")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+
+    rules = sh("git", "show", f"{args.ref}:openbank-libs/governance/rules.yaml")
+    if not rules.strip():
+        print(f"::error::could not read rules.yaml at {args.ref} — refusing to run vacuously")
+        return 1
+
+    verbs = four_eyes_verbs(rules)
+    actions = authorize_actions(args.ref)
+    if not actions:
+        print("::error::found no @Authorize actions at all — the corpus vanished, not a clean run")
+        return 1
+
+    corpus = rego_corpus(args.ref)
+    if "input.action" not in corpus:
+        print("::error::policy corpus is empty — refusing to report a clean sweep of nothing")
+        return 1
+    ungranted, granted = evaluate(actions, verbs, matrix_text(rules), corpus)
+    subjects = len(ungranted) + len(granted)
+    print(f"four-eyes-verb-grantable: {len(verbs)} verb(s), {subjects} four-eyes action(s) found")
+    for action, path, where in granted:
+        print(f"  ok   {action}  ({where})")
+
+    level = "error" if args.enforce else "warning"
+    findings = []
+    for action, path, _ in ungranted:
+        if action in KNOWN_UNGRANTED:
+            print(f"  BASELINED {action}: {KNOWN_UNGRANTED[action]}")
+            continue
+        print(f"  FAIL {action}  ({path})")
+        findings.append(
+            f"{action} is declared four-eyes (verb '{action.split('.')[-1]}' in "
+            f"rules.yaml four_eyes.verbs) but has no allow reason in role_action_matrix or any "
+            f"service rego. The approval can never be requested: response_attributes ride on the "
+            f"allow object, so four_eyes_required never reaches AuthorizeInterceptor — and the day "
+            f"AUTHZ_ENFORCE flips for this service, the endpoint 403s for every principal. "
+            f"Declared at {path}."
+        )
+
+    stale = [a for a in KNOWN_UNGRANTED if a not in {x[0] for x in ungranted}]
+    for action in stale:
+        findings.append(f"{action} is baselined in KNOWN_UNGRANTED but is now granted — remove the entry")
+
+    print(f"SUBJECTS={subjects}")
+    for f in findings:
+        print(f"::{level}::four-eyes-verb-grantable: {f}")
+    return 1 if (findings and args.enforce) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check-four-eyes-verb-grantable.py
+++ b/.github/scripts/check-four-eyes-verb-grantable.py
@@ -46,7 +46,7 @@ import sys
 
 REF = "origin/main"
 AUTHORIZE_RE = re.compile(r'@Authorize\(\s*action\s*=\s*"([^"]+)"')
-VERB_RE = re.compile(r"^\s+- (\w+)", re.M)
+VERB_RE = re.compile(r"^\s+- (\w+)", re.MULTILINE)
 
 # Declared, not inferred. An entry needs a reason and is expected to shrink; the gate also fails
 # on an entry that has become granted, so the declaration cannot outlive the debt.
@@ -77,11 +77,12 @@ KNOWN_UNGRANTED: dict[str, str] = {
 
 
 def sh(*args: str) -> str:
-    return subprocess.run(args, capture_output=True, text=True).stdout
+    # check=False: a `git grep` with no match exits 1, which is data here, not an error.
+    return subprocess.run(args, capture_output=True, text=True, check=False).stdout
 
 
 def four_eyes_verbs(rules: str) -> set[str]:
-    m = re.search(r"^four_eyes:\n  verbs:\n((?:\s+-.*\n|\s+#.*\n|\s{10,}#.*\n)+)", rules, re.M)
+    m = re.search(r"^four_eyes:\n  verbs:\n((?:\s+-.*\n|\s+#.*\n|\s{10,}#.*\n)+)", rules, re.MULTILINE)
     if not m:
         raise SystemExit("::error::could not locate four_eyes.verbs in rules.yaml")
     return set(VERB_RE.findall(m.group(1)))
@@ -100,7 +101,7 @@ def authorize_actions(ref: str) -> dict[str, str]:
 
 
 def matrix_text(rules: str) -> str:
-    m = re.search(r"^\s+role_action_matrix:\n((?:.*\n)*?)^\s{2}\w", rules, re.M)
+    m = re.search(r"^\s+role_action_matrix:\n((?:.*\n)*?)^\s{2}\w", rules, re.MULTILINE)
     return m.group(1) if m else ""
 
 
@@ -219,7 +220,7 @@ def main() -> int:
     ungranted, granted = evaluate(actions, verbs, matrix_text(rules), corpus)
     subjects = len(ungranted) + len(granted)
     print(f"four-eyes-verb-grantable: {len(verbs)} verb(s), {subjects} four-eyes action(s) found")
-    for action, path, where in granted:
+    for action, _path, where in granted:
         print(f"  ok   {action}  ({where})")
 
     level = "error" if args.enforce else "warning"


### PR DESCRIPTION
## Three money-path actions advertise a control that cannot fire

`rules.yaml: four_eyes.verbs` declares which verbs pause for a second approver. Whether that approval can ever be **requested** depends on something else entirely — the action needs an allow reason, in `role_action_matrix` or a service rego. Nothing connected the two.

| action | in `role_action_matrix` | in any rego or bundle | `AUTHZ_ENFORCE` default |
|---|---|---|---|
| `transaction.sweep` | no | no | `false` |
| `swift.send` | no | no | `false` |
| `sctInstPayment.recall` | no | no | `false` |

Confirmed for `transaction.sweep` by `opa eval` against the materialised transaction bundle (sidecar layout), with a must-DENY and a must-ALLOW control in the same run so a deny-everything answer could not read as a finding: `allow = false` for every principal probed, `allowed_reasons = []`, `four_eyes_required = true`.

## Why both consequences are invisible

`response_attributes` ride on the **allow** object in `rest.rego`, so a denied decision carries no attributes at all. `four_eyes_required = true` is computed and never reaches `AuthorizeInterceptor` — the four-eyes gate on these endpoints is **structurally unreachable**, and no toggle changes that. `rules.yaml` asserts the merge flow's two halves *"both pause for a second approver, or neither does"*; for the sweep half that is not true and cannot become true.

And the day `AUTHZ_ENFORCE` flips for one of those services, the endpoint **403s for every principal**.

So each is in the worst of both states: the advertised control cannot fire, and enabling enforcement breaks the endpoint outright. Neither produces a signal, because a control that cannot fire produces none.

## Baselined, not fixed — deliberately

Granting these is an authoring decision, not a mechanical fix. Adding them to `role_action_matrix` is **a grant to a machine**: M2M callers authenticate with a client_credentials JWT and are classified `HUMAN`, and `shared_m2m_write_prohibition` is not emitted into any bundle, so no policy can veto it. The defensible shape is a service-scoped rego rule pinned to human operators — which for transaction-service means creating its first `*_rest_ext.rego` — and each such edit restamps ~73 bundle files.

Each baseline entry carries its reason, and the gate fails on an entry that has **become granted**, so the declaration cannot outlive the debt.

## Falsified in three directions

| control | exit |
|---|---|
| a new ungranted four-eyes action | **1** |
| a baseline entry that is now granted | **1** |
| the untouched tree | 0 |

It also refuses to run when either corpus comes back empty, rather than reporting a clean sweep of nothing.

## Two false positives caught before shipping — the part worth reading

My first version searched for literal action strings and flagged `customer.consent.revoke` and `customer.pockets.convert`. Those are on **customer-edge, whose `AUTHZ_ENFORCE` defaults to `true` and whose gitops sets `"true"`** — so a literal reading of that output was "two customer-facing endpoints are being denied in production right now".

They are granted, by a single prefix rule:

```rego
allowed_reasons contains "customer-self-action" if {
    startswith(input.action, "customer.")
```

so they appear as no literal anywhere. Had I reported before checking, I would have filed a live customer-facing outage that does not exist.

The same investigation surfaced the second scope hole: **transaction-service has no `*_rest_ext.rego` file at all**, so a rego-only search would have reported a clean sweep of a policy it never read. The gate now searches bundle ConfigMaps too, and understands prefix rules.

`gates.yaml`: 186 → 187 entries.

Refs #4754
