### PR TITLE
refactor(admin-ui): unify notification status presentation

### DIFF
--- a/openbank-admin-ui/src/app/notifications/page.tsx
+++ b/openbank-admin-ui/src/app/notifications/page.tsx
@@ -12,7 +12,7 @@ import { hasPermission } from '@/lib/auth/roles'
 import { classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { opsMessageApi } from '@/lib/api'
-import { PageHeader } from '@/components/ui/PageHeader'
+import { PageHeader, StatusBadge } from '@/components/ui'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 
 const NOTIFICATION_SERVICE = '/api/svc/notification-service'
@@ -26,10 +26,6 @@ interface Notification {
 const TYPE_ICON: Record<string, React.ElementType> = {
   EMAIL: Mail, ALERT: AlertTriangle, SUCCESS: CheckCircle2, INFO: Info,
 }
-const STATUS_COLOR: Record<string, string> = {
-  SENT: 'var(--green)', FAILED: 'var(--red)', PENDING: 'var(--yellow)', QUEUED: 'var(--accent)',
-}
-
 function NotificationsContent() {
   const { t, language } = useLanguage()
   const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
@@ -151,11 +147,7 @@ function NotificationsContent() {
                   <td><span className="tag">{n.channel}</span></td>
                   <td style={{ fontSize: '12px', fontFamily: 'var(--font-mono)' }}>{n.recipient}</td>
                   <td style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>{n.subject ?? '—'}</td>
-                  <td>
-                    <span className="pill" style={{ background: `${STATUS_COLOR[n.status] ?? 'var(--text-muted)'}22`, color: STATUS_COLOR[n.status] ?? 'var(--text-muted)' }}>
-                      {n.status}
-                    </span>
-                  </td>
+                  <td><StatusBadge status={n.status} /></td>
                   <td style={{ fontSize: '12px', color: 'var(--text-muted)' }}>
                     {n.sentAt ? new Date(n.sentAt).toLocaleString(dateLocale) : '—'}
                   </td>

--- a/openbank-admin-ui/src/test/notification-status-badge.guard.test.ts
+++ b/openbank-admin-ui/src/test/notification-status-badge.guard.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('notification status presentation contract', () => {
+  it('uses the shared semantic badge rather than a page-local colour map', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/notifications/page.tsx'), 'utf8')
+
+    expect(source).toContain("import { PageHeader, StatusBadge } from '@/components/ui'")
+    expect(source).toContain('<StatusBadge status={n.status} />')
+    expect(source).not.toContain('STATUS_COLOR')
+  })
+})


### PR DESCRIPTION
## Summary
- replace the Notifications page-local status-colour map with the shared semantic `StatusBadge`
- add a guard against reintroducing local notification status colours

## Safety
- notification fetch, unavailable states, approval permissions and four-eyes action flow are unchanged.

## Verification
- `vitest run src/test/notification-status-badge.guard.test.ts src/test/ui-tone.test.ts` (14 passed)
- scoped ESLint (0 errors; one pre-existing warning in the load effect)
- `git diff --check`
- signed commit verification

Refs #7654