### PR TITLE
refactor(admin-ui): unify fee status presentation

### DIFF
--- a/openbank-admin-ui/src/app/fees/page.tsx
+++ b/openbank-admin-ui/src/app/fees/page.tsx
@@ -10,8 +10,7 @@ import { AuthGuard } from '@/components/auth/AuthGuard'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { svcUrl, classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
-import { PageHeader } from '@/components/ui/PageHeader'
-import { StatCard } from '@/components/ui/StatCard'
+import { PageHeader, StatCard, StatusBadge } from '@/components/ui'
 
 // Shape served by openbank-product-catalog GET /api/v1/fees — the bank-wide fee
 // schedule, flattened from the per-product Fee model. The UI no longer hardcodes
@@ -32,14 +31,6 @@ interface FeeScheduleItem {
   productName: string
   status: string
   updatedAt: string
-}
-
-const STATUS_COLOR: Record<string, string> = {
-  ACTIVE: 'var(--green)',
-  INACTIVE: 'var(--text-muted)',
-  DRAFT: 'var(--yellow)',
-  DEPRECATED: 'var(--text-muted)',
-  ARCHIVED: 'var(--text-muted)',
 }
 
 export default function FeesPage() {
@@ -214,11 +205,7 @@ export default function FeesPage() {
                   </td>
                   <td style={{ fontFamily: 'var(--font-mono)', fontSize: '12px' }}>{fee.currency}</td>
                   <td style={{ fontSize: '12px', color: 'var(--text-muted)' }}>{fee.frequency}</td>
-                  <td>
-                    <span className="pill" style={{ background: `${STATUS_COLOR[fee.status] ?? 'var(--text-muted)'}22`, color: STATUS_COLOR[fee.status] ?? 'var(--text-muted)' }}>
-                      {fee.status}
-                    </span>
-                  </td>
+                  <td><StatusBadge status={fee.status} /></td>
                 </tr>
               ))}
             </tbody>

--- a/openbank-admin-ui/src/test/fee-status-badge.guard.test.ts
+++ b/openbank-admin-ui/src/test/fee-status-badge.guard.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('fee status presentation contract', () => {
+  it('uses the shared semantic badge rather than a page-local colour map', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/fees/page.tsx'), 'utf8')
+
+    expect(source).toContain("import { PageHeader, StatCard, StatusBadge } from '@/components/ui'")
+    expect(source).toContain('<StatusBadge status={fee.status} />')
+    expect(source).not.toContain('STATUS_COLOR')
+  })
+})


### PR DESCRIPTION
## Summary
- replace the Fee Schedule page-local status-colour map with shared semantic `StatusBadge`
- add a guard against reintroducing a local fee status colour map

## Safety
- read-only product-catalog BFF fetch, fee data and permissions are unchanged.

## Verification
- `vitest run src/test/fee-status-badge.guard.test.ts src/test/ui-tone.test.ts` (14 passed)
- scoped ESLint (0 errors; one pre-existing load-effect warning)
- `git diff --check`
- signed commit verification

Refs #7654