### PR TITLE
fix(admin-ui): announce unavailable data states

### DIFF
--- a/openbank-admin-ui/src/components/feedback/DataUnavailable.tsx
+++ b/openbank-admin-ui/src/components/feedback/DataUnavailable.tsx
@@ -118,8 +118,17 @@ export function DataUnavailable({
   dense = false,
 }: Props) {
   const c = copyFor(kind, service, feature, lang)
+  // A missing result is a normal screen state and should not interrupt a screen-reader user.
+  // A service/session failure happens after a data request, so announce it once without moving
+  // focus away from the operator's filters or retry action. Expired credentials are the exception:
+  // they block the workflow and deserve the assertive alert channel.
+  const liveRole = kind === 'no_data' || kind === 'not_found'
+    ? undefined
+    : kind === 'unauthorized' ? 'alert' : 'status'
   return (
     <div
+      role={liveRole}
+      aria-live={liveRole === 'alert' ? 'assertive' : liveRole === 'status' ? 'polite' : undefined}
       style={{
         padding: dense ? '24px' : '40px',
         textAlign: 'center',

--- a/openbank-admin-ui/src/test/data-unavailable-a11y.test.tsx
+++ b/openbank-admin-ui/src/test/data-unavailable-a11y.test.tsx
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { DataUnavailable } from '@/components/feedback/DataUnavailable'
+
+describe('DataUnavailable accessibility announcements', () => {
+  it('politely announces an operational failure without moving focus', () => {
+    render(<DataUnavailable kind="unreachable" service="Ledger-service" lang="en" />)
+
+    const status = screen.getByRole('status')
+    expect(status).toHaveAttribute('aria-live', 'polite')
+    expect(status).toHaveTextContent('Ledger-service is not responding')
+  })
+
+  it('uses an assertive alert only for an expired session', () => {
+    render(<DataUnavailable kind="unauthorized" lang="en" />)
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveAttribute('aria-live', 'assertive')
+    expect(alert).toHaveTextContent('Session expired')
+  })
+
+  it('keeps an ordinary empty result silent', () => {
+    render(<DataUnavailable kind="no_data" feature="Fees" lang="en" />)
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByText('No data yet: Fees')).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary
- make shared operational unavailable states politely announced to assistive technologies
- reserve assertive alerts for expired sessions or missing permissions
- keep normal empty results silent and add render-level accessibility contracts

## Safety
- fetch behavior, BFF classification, permissions, data content and focus ownership are unchanged.

## Verification
- `vitest run src/test/data-unavailable-a11y.test.tsx` (3 passed)
- scoped ESLint (0 errors)
- `git diff --check`
- signed commit verification

Refs #7654