### PR TITLE
refactor(admin-ui): unify party status presentation

### DIFF
--- a/openbank-admin-ui/src/app/parties/page.tsx
+++ b/openbank-admin-ui/src/app/parties/page.tsx
@@ -10,7 +10,7 @@ import { Users, Plus, Search, RefreshCw, ChevronRight, ChevronDown } from 'lucid
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
-import { PageHeader } from '@/components/ui/PageHeader'
+import { PageHeader, StatusBadge } from '@/components/ui'
 import { Can } from '@/components/auth/AuthGuard'
 
 const PAGE_SIZE = 25
@@ -31,19 +31,6 @@ interface Pagination {
   limit: number
   hasNextPage: boolean
   nextCursor?: string
-}
-
-const KYC_COLORS: Record<string, string> = {
-  APPROVED:    'var(--green)',
-  PENDING:     'var(--yellow)',
-  REJECTED:    'var(--red)',
-  NOT_STARTED: 'var(--text-muted)',
-}
-
-const STATUS_COLORS: Record<string, string> = {
-  ACTIVE:   'var(--green)',
-  INACTIVE: 'var(--text-muted)',
-  BLOCKED:  'var(--red)',
 }
 
 export default function PartiesPage() {
@@ -250,16 +237,8 @@ export default function PartiesPage() {
                   </td>
                   <td><span className="tag">{p.partyType}</span></td>
                   <td style={{ color: 'var(--text-secondary)', fontFamily: 'var(--font-mono)', fontSize: '12px' }}>{p.email}</td>
-                  <td>
-                    <span className="pill" style={{ background: `${STATUS_COLORS[p.status] ?? 'var(--text-muted)'}22`, color: STATUS_COLORS[p.status] ?? 'var(--text-muted)' }}>
-                      {p.status}
-                    </span>
-                  </td>
-                  <td>
-                    <span className="pill" style={{ background: `${KYC_COLORS[p.kycStatus] ?? 'var(--text-muted)'}22`, color: KYC_COLORS[p.kycStatus] ?? 'var(--text-muted)' }}>
-                      {p.kycStatus?.replace('_', ' ')}
-                    </span>
-                  </td>
+                  <td><StatusBadge status={p.status} /></td>
+                  <td><StatusBadge status={p.kycStatus} label={p.kycStatus?.replace('_', ' ')} /></td>
                   <td style={{ color: 'var(--text-muted)', fontSize: '12px' }}>{new Date(p.createdAt).toLocaleDateString(dateLocale)}</td>
                   <td>
                     <Link href={`/parties/${p.id}`} style={{ color: 'var(--accent)', display: 'flex', alignItems: 'center', gap: '2px', fontSize: '12px', textDecoration: 'none' }}>

--- a/openbank-admin-ui/src/test/party-status-badges.guard.test.ts
+++ b/openbank-admin-ui/src/test/party-status-badges.guard.test.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+describe('party status presentation contract', () => {
+  it('uses shared badges for both party and KYC states', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/parties/page.tsx'), 'utf8')
+
+    expect(source).toContain("import { PageHeader, StatusBadge } from '@/components/ui'")
+    expect(source).toContain('<StatusBadge status={p.status} />')
+    expect(source).toContain("<StatusBadge status={p.kycStatus} label={p.kycStatus?.replace('_', ' ')} />")
+    expect(source).not.toContain('KYC_COLORS')
+    expect(source).not.toContain('STATUS_COLORS')
+  })
+})


### PR DESCRIPTION
## Summary
- replace page-local party and KYC status-colour maps with shared semantic `StatusBadge`
- retain readable KYC labels while preserving raw status values for tone resolution
- add a guard against reintroducing local party status maps

## Safety
- party list/search BFF calls, pagination, RBAC and links are unchanged.

## Verification
- `vitest run src/test/party-status-badges.guard.test.ts src/test/party-search.test.tsx src/test/ui-tone.test.ts` (23 passed)
- scoped ESLint (0 errors; 2 pre-existing effect warnings)
- `git diff --check`
- signed commit verification

Refs #7654