### PR TITLE
refactor(admin-ui): unify payment detail status presentation

### DIFF
--- a/openbank-admin-ui/src/app/payments/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/payments/[id]/page.tsx
@@ -12,7 +12,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure } from '@/lib/services/bff'
 import { readStashedRow } from '@/lib/services/rowHandoff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
-import { PageHeader } from '@/components/ui/PageHeader'
+import { PageHeader, StatusBadge, statusTone, type Tone } from '@/components/ui'
 
 // Mirrors the list-row shape on the payments page. The record can carry more
 // fields than the table showed — the detail view surfaces all of them.
@@ -33,9 +33,14 @@ interface Payment {
   [k: string]: unknown
 }
 
-const STATUS_COLOR: Record<string, string> = {
-  SETTLED: 'var(--success)', RECEIVED: 'var(--info-text)', SENT_TO_CLEARING: 'var(--warning)',
-  PENDING: 'var(--warning)', PROCESSING: 'var(--warning)', REJECTED: 'var(--danger)', FAILED: 'var(--danger)',
+// These two statuses are specific to payment processing. Keep their explicit
+// meaning here rather than broadening the cross-domain status vocabulary:
+// RECEIVED means accepted by the payment service, not settled; SENT_TO_CLEARING
+// remains an in-flight operator state that needs attention.
+function paymentStatusTone(status: string | undefined): Tone {
+  if (status === 'RECEIVED') return 'info'
+  if (status === 'SENT_TO_CLEARING') return 'warning'
+  return statusTone(status)
 }
 
 // The list route is the source of truth (no by-id backend endpoint exists);
@@ -108,7 +113,7 @@ function PaymentDetailContent() {
         subtitle={t('Detail platebního příkazu', 'Payment order detail')}
         breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><Link href="/payments" style={{ color: 'var(--text-tertiary)', textDecoration: 'none' }}>{t('Platby', 'Payments')}</Link><span className="breadcrumb-sep">/</span><span className="breadcrumb-current mono" style={{ fontSize: '12px' }}>{id.slice(0, 12)}…</span></div>}
         actions={<div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-          {payment?.status && <span className="pill" style={{ background: `${STATUS_COLOR[payment.status] ?? 'var(--text-muted)'}22`, color: STATUS_COLOR[payment.status] ?? 'var(--text-muted)' }}>{payment.status}</span>}
+          {payment?.status && <StatusBadge status={payment.status} tone={paymentStatusTone(payment.status)} />}
           {payment?.type && <span className="tag">{payment.type}</span>}
           <Link href="/payments" className="btn btn-secondary"><ArrowLeft size={13} aria-hidden="true" /> {t('Zpět', 'Back')}</Link>
           <button type="button" className="btn btn-secondary" onClick={load} disabled={loading} aria-busy={loading} aria-label={t('Obnovit platbu', 'Refresh payment')}>

--- a/openbank-admin-ui/src/test/payment-detail-status-badge.guard.test.ts
+++ b/openbank-admin-ui/src/test/payment-detail-status-badge.guard.test.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('payment detail status presentation', () => {
+  const source = fs.readFileSync(path.join(process.cwd(), 'src/app/payments/[id]/page.tsx'), 'utf8')
+
+  it('uses the shared status badge while preserving payment-specific in-flight meanings', () => {
+    expect(source).toContain("import { PageHeader, StatusBadge, statusTone, type Tone } from '@/components/ui'")
+    expect(source).toContain("if (status === 'RECEIVED') return 'info'")
+    expect(source).toContain("if (status === 'SENT_TO_CLEARING') return 'warning'")
+    expect(source).toContain('<StatusBadge status={payment.status} tone={paymentStatusTone(payment.status)} />')
+    expect(source).not.toMatch(/STATUS_COLOR/)
+  })
+})


### PR DESCRIPTION
## Summary
- replace the Payment Detail local colour map with the ADR-0208 shared `StatusBadge`
- preserve payment-specific status meaning: `RECEIVED` stays informational and `SENT_TO_CLEARING` stays warning
- leave endpoint selection, list refresh, row handoff, payment data and approval flow unchanged

## Verification
- `vitest run src/test/payment-detail-status-badge.guard.test.ts src/test/ui-tone.test.ts` (14 passed)
- `eslint src/app/payments/[id]/page.tsx` (0 errors; 3 pre-existing effect warnings)
- `git diff --check`

Refs #7654