### PR TITLE
refactor(admin-ui): unify pid status presentation

### DIFF
--- a/openbank-admin-ui/src/app/pid/page.tsx
+++ b/openbank-admin-ui/src/app/pid/page.tsx
@@ -11,7 +11,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { AuthGuard, Can } from '@/components/auth/AuthGuard'
-import { PageHeader } from '@/components/ui/PageHeader'
+import { PageHeader, StatusBadge, statusTone, type Tone } from '@/components/ui'
 
 const PID_SERVICE = '/api/svc/pid-service'
 
@@ -27,11 +27,13 @@ interface PidRecord {
   validUntil?: string
 }
 
-const STATUS_COLORS: Record<string, string> = {
-  ACTIVE:   'var(--success)',
-  INACTIVE: 'var(--text-muted)',
-  EXPIRED:  'var(--warning)',
-  REVOKED:  'var(--danger)',
+// PID lifecycle deliberately treats expired credentials as renewal work and a
+// revoked credential as a security concern. Those meanings are stricter than
+// the shared consent-oriented defaults for the same words.
+function pidStatusTone(status: string): Tone {
+  if (status === 'EXPIRED') return 'warning'
+  if (status === 'REVOKED') return 'danger'
+  return statusTone(status)
 }
 
 export default function PidPage() {
@@ -545,9 +547,7 @@ export default function PidPage() {
                     </Can>
                   </td>
                   <td>
-                    <span className="pill" style={{ background: `${STATUS_COLORS[r.status] ?? 'var(--text-muted)'}22`, color: STATUS_COLORS[r.status] ?? 'var(--text-muted)' }}>
-                      {r.status}
-                    </span>
+                    <StatusBadge status={r.status} tone={pidStatusTone(r.status)} />
                   </td>
                   <td>
                     {r.verified ? <CheckCircle2 size={14} color="var(--success)" /> : <Clock size={14} color="var(--warning)" />}

--- a/openbank-admin-ui/src/test/pid-status-badge.guard.test.ts
+++ b/openbank-admin-ui/src/test/pid-status-badge.guard.test.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('PID status presentation', () => {
+  const source = fs.readFileSync(path.join(process.cwd(), 'src/app/pid/page.tsx'), 'utf8')
+
+  it('uses the shared badge and preserves security-sensitive lifecycle meanings', () => {
+    expect(source).toContain("import { PageHeader, StatusBadge, statusTone, type Tone } from '@/components/ui'")
+    expect(source).toContain("if (status === 'EXPIRED') return 'warning'")
+    expect(source).toContain("if (status === 'REVOKED') return 'danger'")
+    expect(source).toContain('<StatusBadge status={r.status} tone={pidStatusTone(r.status)} />')
+    expect(source).not.toMatch(/STATUS_COLORS/)
+  })
+})


### PR DESCRIPTION
## Summary
- replace the PID lifecycle local colour map with the ADR-0208 shared `StatusBadge`
- preserve domain-specific security semantics: expired identifiers stay warning and revoked identifiers stay danger
- leave PID reads, creation flow, verification markers, permissions and BFF behavior unchanged

## Verification
- `vitest run src/test/pid-status-badge.guard.test.ts src/test/ui-tone.test.ts` (14 passed)
- `eslint src/app/pid/page.tsx` (0 errors; 1 pre-existing `react-hooks/set-state-in-effect` warning)
- `git diff --check`

Refs #7654