### PR TITLE
feat(admin-ui): establish theme token foundation

### DIFF
--- a/docs/design/admin-ui-design-system.md
+++ b/docs/design/admin-ui-design-system.md
@@ -1,0 +1,71 @@
+# Admin UI design system
+
+## Purpose
+
+OpenBank Admin UI is a dense, bilingual operator console. Its visual language must help a bank
+operator distinguish a fact, an in-flight action and a risk in a single scan. Tokens and shared
+primitives are therefore product infrastructure, not decorative CSS.
+
+`openbank-admin-ui/src/app/globals.css` is the token source of truth. It contains the light
+`:root` values and the matching `.dark` values. A theme is enabled only by adding `dark` to the
+document root; there is no per-page palette.
+
+## Token rules
+
+| Concept | Use | Do not use |
+| --- | --- | --- |
+| `--surface*`, `--border*` | page, card and grouped-control surfaces | raw white/grey literals |
+| `--text-primary/secondary/tertiary` | hierarchy of operator-facing text | `--text-muted` in new code; it is a temporary alias |
+| `--accent*` | navigation, primary action and selected state | `--ob-accent*` in new code; they are compatibility aliases |
+| `--success/warning/danger/info-*` | status background, border and text | mapping a domain status directly to a colour |
+| `--space-*`, `--text-*`, `--font-*` | primitive layout and type | a new competing literal scale |
+| `--motion-*`, `--ease-standard` | transitions | a new arbitrary transition duration |
+| `--z-*` | overlays and sticky UI | ad-hoc z-index values |
+
+Text tokens and status text tokens are protected by
+`src/test/ui-token-contrast.guard.test.ts`: AA (4.5:1) is required over their actual token
+surfaces in light and dark themes. The visual companion is `e2e/ui-primitives.spec.ts`.
+
+## Components and contracts
+
+Use `PageHeader`, `StatCard` and `StatusBadge` from `@/components/ui` today. `StatusBadge`
+maps `status -> Tone -> CSS class`; unknown values are neutral, never green. A domain may pass an
+explicit `tone` only when the same word has a documented different meaning (for example PID
+`REVOKED`). Components must accept caller-supplied Czech and English copy, expose native focus and
+disabled/loading state, and keep icons decorative unless they are the sole accessible label.
+
+The next primitive tranches, derived from repeated live page shapes, are: Button/FormField,
+Tabs, Pagination/FilterBar, dense Table, Card, modal/drawer, EmptyState and tooltip. Each needs
+default, hover, focus-visible, disabled, loading, error and empty-state evidence before adoption.
+
+## Mechanical migration map
+
+| Existing literal family | Replacement | Exception |
+| --- | --- | --- |
+| `#6366f1`, `#4f46e5`, `#eef2ff`, `#c7d2fe`, `#4338ca` | matching `--accent*` token | chart series may retain an explicit, documented data-series token |
+| `#16a34a`, `#dcfce7`, `#86efac` | `--success-text/bg/border` | never use success for an unrecognised status |
+| `#d97706`, `#fef9c3`, `#fde047` | `--warning-text/bg/border` | use only for attention, not failure |
+| `#dc2626`, `#fee2e2`, `#fca5a5` | `--danger-text/bg/border` | use only for blocking/failure/security concern |
+| `#2563eb`, `#dbeafe` | `--info-text/bg` | informational, non-terminal state only |
+| greys/white | matching surface, border or text token | data visualisations need a named series token before migration |
+
+The raw-colour and local-status-map ratchets are shrink-only. A new literal or page-local status
+map is a CI failure; a literal that cannot be mapped must be recorded with its data-visualisation
+reason before it is kept.
+
+## Migration order
+
+1. Operator money and risk surfaces: Payments, FinOps, sanctions, day-end, FX.
+2. System-control surfaces: IAOps, temporal, system tests, DevOps, observability.
+3. Documentation and educational pages, then remaining low-density pages.
+
+Each PR is a single workflow or primitive change; it preserves BFF requests, RBAC and
+maker-checker behaviour, adds focused guard coverage, passes real-browser visual checks where
+geometry changes, and is merged only after green CI plus independent review.
+
+## Dark theme decision
+
+Dark mode is supported at the token layer now because the app already declared class-based dark
+mode. It is intentionally not enabled by a user preference control until the raw-colour ratchet
+has reduced legacy surfaces enough for a coherent whole-console experience. This avoids offering
+operators a half-themed environment while preserving a testable, accessible implementation path.

--- a/openbank-admin-ui/e2e/ui-primitives.spec.ts
+++ b/openbank-admin-ui/e2e/ui-primitives.spec.ts
@@ -215,4 +215,22 @@ test.describe('ADR-0208 primitives render with real CSS applied', () => {
     const bg = (l: typeof active) => l.evaluate(el => getComputedStyle(el).backgroundColor)
     expect(await bg(active)).not.toBe(await bg(revoked))
   })
+
+  test('the dark token theme changes shared surfaces without collapsing status distinction', async ({ page }) => {
+    await page.route('**/api/prod-readiness', route =>
+      route.fulfill({ status: 200, body: JSON.stringify(READINESS) }),
+    )
+    await page.goto('/system/readiness')
+
+    const body = page.locator('body')
+    const lightBackground = await body.evaluate(el => getComputedStyle(el).backgroundColor)
+    await page.locator('html').evaluate(el => el.classList.add('dark'))
+    const darkBackground = await body.evaluate(el => getComputedStyle(el).backgroundColor)
+    expect(darkBackground).not.toBe(lightBackground)
+
+    const [go, noGo] = await Promise.all(
+      ['GO', 'NO-GO'].map(label => page.locator('.badge', { hasText: new RegExp(`^${label}$`) }).evaluate(el => getComputedStyle(el).backgroundColor)),
+    )
+    expect(go).not.toBe(noGo)
+  })
 })

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -49,6 +49,37 @@
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   --text-inverse:         #ffffff;
 
+  /* ── Foundation scales ──
+   * These are the source of truth for new primitives. Existing literal spacing
+   * is migrated tranche-by-tranche; do not introduce a competing scale. */
+  --space-1: .25rem;
+  --space-2: .5rem;
+  --space-3: .75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --text-xs: .75rem;
+  --text-sm: .875rem;
+  --text-md: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --font-normal: 400;
+  --font-medium: 500;
+  --font-semibold: 600;
+  --font-bold: 700;
+  --font-extrabold: 800;
+  --motion-fast: 120ms;
+  --motion-normal: 200ms;
+  --motion-slow: 400ms;
+  --ease-standard: cubic-bezier(.2, .8, .2, 1);
+  --z-dropdown: 20;
+  --z-sticky: 30;
+  --z-modal: 50;
+  --z-toast: 60;
+
   /* ── Brand / Accent ── */
   --ob-accent:            #6366f1;
   --ob-accent-hover:      #4f46e5;
@@ -126,6 +157,62 @@
    * colour, not a Tailwind HSL triplet. The triplet silently makes those
    * declarations invalid and leaves cards, fields and tables borderless. */
   --border: #e2e8f0;
+}
+
+/* Dark theme is token-only by design. Pages that still carry literal colours
+ * remain in the migration ratchet and must not opt into a one-off dark palette.
+ * Toggling `.dark` on the document root therefore changes every shared
+ * primitive and every token-based surface coherently. */
+.dark {
+  color-scheme: dark;
+  --bg: #0b1220;
+  --surface: #111827;
+  --surface-1: #111827;
+  --surface-2: #172033;
+  --surface-3: #243047;
+  --surface-4: #334155;
+  --border: #334155;
+  --border-strong: #475569;
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5e1;
+  --text-tertiary: #94a3b8;
+  --text-muted: var(--text-tertiary);
+  --text-inverse: #0f172a;
+  --accent: #a5b4fc;
+  --accent-hover: #c7d2fe;
+  --accent-light: #1e1b4b;
+  --accent-bg: #1e1b4b;
+  --accent-border: #4338ca;
+  --accent-text: #c7d2fe;
+  --ob-accent: var(--accent);
+  --ob-accent-hover: var(--accent-hover);
+  --ob-accent-light: var(--accent-light);
+  --ob-accent-border: var(--accent-border);
+  --ob-accent-text: var(--accent-text);
+  --success: #34d399;
+  --success-bg: #064e3b;
+  --success-border: #047857;
+  --success-text: #6ee7b7;
+  --warning: #fbbf24;
+  --warning-bg: #451a03;
+  --warning-border: #b45309;
+  --warning-text: #fcd34d;
+  --danger: #f87171;
+  --danger-bg: #450a0a;
+  --danger-border: #b91c1c;
+  --danger-text: #fecaca;
+  --info: #60a5fa;
+  --info-bg: #172554;
+  --info-border: #1d4ed8;
+  --info-text: #bfdbfe;
+  --sidebar-bg: #090e17;
+  --sidebar-hover-bg: rgba(255,255,255,0.08);
+  --sidebar-active-bg: rgba(165,180,252,0.18);
+  --sidebar-active-text: #e0e7ff;
+  --sidebar-text: #cbd5e1;
+  --sidebar-text-muted: #94a3b8;
+  --sidebar-border: rgba(255,255,255,0.09);
+  --sidebar-accent: var(--accent);
 }
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/openbank-admin-ui/src/test/ui-token-contrast.guard.test.ts
+++ b/openbank-admin-ui/src/test/ui-token-contrast.guard.test.ts
@@ -1,36 +1,68 @@
-import { readFileSync } from 'node:fs'
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const css = readFileSync(path.resolve(__dirname, '../app/globals.css'), 'utf8')
+const css = fs.readFileSync(path.join(process.cwd(), 'src/app/globals.css'), 'utf8')
 
-function token(name: string): string {
-  const match = css.match(new RegExp(`${name}:\\s*(#[0-9a-fA-F]{6})`))
-  if (!match) throw new Error(`Missing hexadecimal value for ${name}`)
-  return match[1]
+function declarations(selector: string) {
+  const match = css.match(new RegExp(`${selector}\\s*\\{([\\s\\S]*?)\\n\\}`, 'm'))
+  if (!match) throw new Error(`Missing ${selector} token block`)
+  return Object.fromEntries([...match[1].matchAll(/(--[\w-]+):\s*([^;]+);/g)].map(([, name, value]) => [name, value.trim()]))
 }
 
-function luminance(hex: string): number {
-  const channels = hex.slice(1).match(/../g)!.map(channel => parseInt(channel, 16) / 255)
-  const [red, green, blue] = channels.map(channel =>
-    channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4,
-  )
-  return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+function resolve(tokens: Record<string, string>, token: string): string {
+  const value = tokens[token]
+  if (!value) throw new Error(`Missing ${token}`)
+  const alias = value.match(/^var\((--[\w-]+)\)$/)?.[1]
+  return alias ? resolve(tokens, alias) : value
 }
 
-function contrast(foreground: string, background: string): number {
-  const [lighter, darker] = [luminance(foreground), luminance(background)].sort((a, b) => b - a)
-  return (lighter + 0.05) / (darker + 0.05)
+function luminance(hex: string) {
+  const channels = hex.slice(1).match(/.{2}/g)!.map(channel => Number.parseInt(channel, 16) / 255)
+  const linear = channels.map(channel => channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4)
+  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
 }
 
-describe('shared admin UI text token contrast', () => {
-  it('keeps the high-volume muted text legible on operator surfaces', () => {
-    const tertiary = token('--text-tertiary')
-    expect(contrast(tertiary, token('--surface'))).toBeGreaterThanOrEqual(4.5)
-    expect(contrast(tertiary, token('--surface-2'))).toBeGreaterThanOrEqual(4.5)
+function contrast(foreground: string, background: string) {
+  const [light, dark] = [luminance(foreground), luminance(background)].sort((a, b) => b - a)
+  return (light + 0.05) / (dark + 0.05)
+}
+
+describe('admin UI token contrast', () => {
+  const themes = [
+    ['light', declarations(':root')],
+    ['dark', declarations('\\.dark')],
+  ] as const
+
+  it.each(themes)('%s text tokens meet AA on the primary and secondary surfaces', (_name, tokens) => {
+    for (const foreground of ['--text-primary', '--text-secondary', '--text-tertiary']) {
+      for (const background of ['--surface', '--surface-2']) {
+        expect(contrast(resolve(tokens, foreground), resolve(tokens, background))).toBeGreaterThanOrEqual(4.5)
+      }
+    }
   })
 
-  it('keeps muted navigation text legible on the dark sidebar', () => {
-    expect(contrast(token('--sidebar-text-muted'), token('--sidebar-bg'))).toBeGreaterThanOrEqual(4.5)
+  it.each(themes)('%s status text meets AA on its semantic background', (_name, tokens) => {
+    for (const tone of ['success', 'warning', 'danger', 'info']) {
+      expect(contrast(resolve(tokens, `--${tone}-text`), resolve(tokens, `--${tone}-bg`))).toBeGreaterThanOrEqual(4.5)
+    }
+  })
+
+  it.each(themes)('%s sidebar navigation text remains legible', (_name, tokens) => {
+    expect(contrast(resolve(tokens, '--sidebar-text-muted'), resolve(tokens, '--sidebar-bg'))).toBeGreaterThanOrEqual(4.5)
+  })
+
+  it('declares a complete dark token surface and the shared foundation scales', () => {
+    const dark = declarations('\\.dark')
+    for (const token of ['--bg', '--surface', '--border', '--text-primary', '--accent', '--success', '--warning', '--danger', '--info']) {
+      expect(dark[token]).toBeTruthy()
+    }
+    const root = declarations(':root')
+    for (const token of ['--space-1', '--text-sm', '--font-semibold', '--motion-normal', '--z-modal']) {
+      expect(root[token]).toBeTruthy()
+    }
   })
 })


### PR DESCRIPTION
## Summary
- add foundation space/type/motion/layer tokens and a complete class-based dark token theme
- extend the contrast guard to prove AA text, semantic status and sidebar navigation contrast in both themes
- add a real-browser dark-theme visual contract and document token usage, migration map and dark-mode rollout decision

## Safety and scope
- no BFF, RBAC, maker-checker, data, or navigation behavior changes
- no user preference control is exposed until raw-colour migration makes a whole-console dark experience coherent

## Verification
- `vitest run src/test/ui-token-contrast.guard.test.ts src/test/ui-tone.test.ts` (20 passed)
- `eslint src/test/ui-token-contrast.guard.test.ts e2e/ui-primitives.spec.ts`
- `git diff --check`
- Playwright dark-theme contract added for CI browser execution

Refs #7654