### PR TITLE
feat(infra): alert on audit rows whose attribution was inferred, not declared

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-audit-attribution.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-audit-attribution.yaml
@@ -1,0 +1,166 @@
+# Audit attribution provenance (issue #3994, ADR-0133 neighbourhood).
+#
+# audit-service resolves the producing service of every consumed record in three tiers
+# (AuditConsumer.resolveSourceService): the producer's own `sourceService` field
+# (AttributionSource.EVENT), the Kafka topic via the verified TopicAttribution table
+# (TOPIC), or neither (ABSENT -> the literal "unknown" sentinel). Every non-EVENT
+# resolution increments
+#
+#     openbank_audit_attribution_missing_total{source_service, provenance}
+#
+# and every persisted row increments openbank_audit_actor_missing_total{...} regardless
+# of outcome, which is the only denominator either family has.
+#
+# WHY THIS IS AN ALERT AND NOT ONLY A DASHBOARD. `audit_entries` is append-only at the
+# database (a rewrite rule turns UPDATE into a no-op that still reports success) and
+# `source_service` is chain-hashed into `record_hash`. A row whose attribution was
+# inferred can therefore never be corrected — only the forward-looking signal exists.
+# Until this file, neither counter appeared in any PrometheusRule in the repository.
+#
+# WHY NOT "ANY TOPIC-DERIVED ROW". Several producers are attributed by topic today by
+# design and by a decision recorded in TopicAttribution's own comments; an alert on the
+# TOPIC provenance would be permanently firing, and noise on the control that exists to
+# make this gap visible is the thing that hides the gap. The three rules below alert on
+# what is genuinely actionable: an UNMAPPED producer (ABSENT), a producer newly joining
+# the derived set (a regression, or a topic subscribed without a table entry), and the
+# signal itself going away.
+#
+# COLD POD / COLD PROMETHEUS. Stated explicitly, because this repo has shipped an alert
+# over an existing metric that fired 15 minutes after every deploy:
+#   - rule 1 reads increase() over a counter that does not exist until the first ABSENT
+#     row. No series -> empty vector -> no firing. There is no seeded value to misread.
+#   - rule 2 compares the current derived set against the same set 6h ago and is
+#     explicitly gated on that older sample existing, so within the first ~7h of a fresh
+#     Prometheus it evaluates to nothing rather than declaring every service "new".
+#   - rule 3 is the deliberate absent() arm: a legitimately-zero counter and an unscraped
+#     one are otherwise identical, so silence is checked against the denominator family.
+# Longest lookback here is [1h] offset 6h = 7h, inside the 12h retention (no LTS).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-audit-attribution-alerts
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: observability
+spec:
+  groups:
+    - name: openbank.audit.attribution
+      interval: 5m
+      rules:
+        # Recording rule: how many distinct producers are currently attributed by topic
+        # rather than by their own declaration. This is the number the gap is measured
+        # by, and the one a dashboard should trend; it is not alerted on directly,
+        # because its healthy value today is a positive constant, not zero.
+        - record: openbank:audit_attribution_topic_derived_services:count1h
+          expr: |
+            count(
+              sum by (source_service) (
+                increase(openbank_audit_attribution_missing_total{provenance="TOPIC"}[1h])
+              ) > 0
+            )
+
+        # 1. A record was stored with NO producer attribution at all -- neither declared
+        # by the producer nor derivable from the topic, so `source_service` is the
+        # "unknown" sentinel, hashed into record_hash, permanently.
+        #
+        # Unlike TOPIC this has no expected steady state: TopicAttribution's coverage is
+        # derived from the subscribed-topic list by AuditTopicAttributionTest, so an
+        # ABSENT row means a record reached the consumer from a topic that test does not
+        # know about -- a replay, a hand-constructed record, or a subscription added
+        # outside the config the test reads. Any of those is worth a human.
+        - alert: AuditAttributionAbsent
+          expr: |
+            sum(increase(openbank_audit_attribution_missing_total{provenance="ABSENT"}[1h])) > 0
+          for: 15m
+          labels:
+            severity: warning
+            team: security
+          annotations:
+            # Driven by Kafka consumption, not by a scheduler: there is no period to
+            # size the window against.
+            subject_period: continuous
+            summary: "Audit rows stored with no producer attribution"
+            description: >-
+              audit-service resolved AttributionSource.ABSENT for at least one record in the
+              last hour, so those rows carry the "unknown" source_service sentinel. That value
+              is chain-hashed into record_hash and audit_entries is append-only, so it cannot
+              be corrected afterwards -- only the producer or the TopicAttribution table can
+              stop the next one. Find the topic in the audit-service pod log, then add the
+              verified producer to TopicAttribution (never a value derived from the topic
+              name: eight of the mapped topics do not follow the convention).
+
+        # 2. A producer that was NOT being attributed by topic six hours ago now is.
+        #
+        # This is the regression shape: a producer that used to declare `sourceService`
+        # stops (a payload refactor, a field renamed), or a newly subscribed topic starts
+        # resolving through the table. The steady-state derived set is a positive constant,
+        # so the actionable event is a CHANGE to it, not its size.
+        #
+        # The `and on()` clause is the guard, and it is load-bearing rather than
+        # decorative: without it a Prometheus with less than 7h of data has an empty
+        # offset side, `unless` subtracts nothing, and every derived producer is reported
+        # as new -- firing on the whole set after every Prometheus restart. With it, the
+        # rule is deliberately silent for the first ~7h instead. That silence is the
+        # honest trade; rule 3 is what keeps silence from being unaccountable.
+        - alert: AuditAttributionDerivedProducerNew
+          expr: |
+            (
+              sum by (source_service) (
+                increase(openbank_audit_attribution_missing_total{provenance="TOPIC"}[1h])
+              ) > 0
+              unless
+              sum by (source_service) (
+                increase(openbank_audit_attribution_missing_total{provenance="TOPIC"}[1h] offset 6h)
+              ) > 0
+            )
+            and on() (
+              count(
+                sum by (source_service) (
+                  increase(openbank_audit_attribution_missing_total{provenance="TOPIC"}[1h] offset 6h)
+                ) > 0
+              ) > 0
+            )
+          for: 30m
+          labels:
+            severity: warning
+            team: security
+          annotations:
+            # Driven by Kafka consumption, not by a scheduler: there is no period to
+            # size the window against.
+            subject_period: continuous
+            summary: "{{ $labels.source_service }} newly attributed by topic, not by declaration"
+            description: >-
+              Audit records from {{ $labels.source_service }} are being attributed from the Kafka
+              topic rather than from a `sourceService` field the producer sends, and were not six
+              hours ago. Either that producer stopped declaring the field, or a topic was newly
+              subscribed. The attribution is still correct -- TopicAttribution's values are
+              verified against the module that declares the outgoing channel -- but it is derived,
+              and every row written while this is true records that fact irreversibly.
+
+        # 3. The success state, which is the one that is always missing.
+        #
+        # Zero ABSENT rows and a stable derived set is what healthy looks like, and it is
+        # byte-for-byte what "audit-service is not being scraped" looks like through rules
+        # 1 and 2, because a threshold over a missing series never fires. The denominator
+        # is openbank_audit_actor_missing_total: AuditConsumer increments it for EVERY
+        # persisted row including the fully-declared ones (it counts ActorProvenance.DECLARED
+        # too, precisely so a ratio has a denominator), so its absence means no audit rows
+        # are being persisted or nothing is scraping the pod -- not that nothing is wrong.
+        #
+        # for: 2h matches WorkflowLivenessHeartbeatAbsent: long enough to absorb a redeploy
+        # and a genuinely quiet stretch, short enough that an unscraped audit trail does not
+        # survive a working day.
+        - alert: AuditAttributionSignalAbsent
+          expr: absent(openbank_audit_actor_missing_total)
+          for: 2h
+          labels:
+            severity: warning
+            team: security
+          annotations:
+            summary: "No audit attribution telemetry for 2h -- the quiet rules are unverified"
+            description: >-
+              openbank_audit_actor_missing_total is absent fleet-wide. That series is emitted for
+              every row AuditConsumer persists, so either audit-service is persisting nothing or
+              its pod is not being scraped. Until this resolves, AuditAttributionAbsent and
+              AuditAttributionDerivedProducerNew being quiet says nothing at all -- check the
+              Prometheus target for the audit namespace before reading them as healthy.

--- a/openbank-infra/tests/promtool/audit_attribution_alerts_test.yaml
+++ b/openbank-infra/tests/promtool/audit_attribution_alerts_test.yaml
@@ -1,0 +1,158 @@
+# PromQL unit tests for prometheus-rules-audit-attribution.yaml (issue #3994).
+#
+# Run via openbank-infra/tests/promtool/run.sh, which unwraps `.spec` out of the SHIPPED
+# PrometheusRule CR -- these assertions run against the deployed expression, not a copy.
+#
+# evaluation_interval is 1m, inside Prometheus' 5m staleness window: a wider interval would
+# leave every sample stale before the next one and no `for:` could ever mature.
+evaluation_interval: 1m
+rule_files:
+  - prometheus-rules-audit-attribution.yaml
+
+tests:
+  # ---------------------------------------------------------------------------
+  # 1. An ABSENT-provenance row fires. A TOPIC-provenance row, on its own, does
+  #    NOT -- that is the falsification of the naive "any derived attribution"
+  #    alert, which would be permanently firing against today's fleet.
+  # ---------------------------------------------------------------------------
+  - interval: 1m
+    input_series:
+      - series: 'openbank_audit_attribution_missing_total{provenance="ABSENT",source_service="unknown"}'
+        values: "0+1x120"
+      - series: 'openbank_audit_attribution_missing_total{provenance="TOPIC",source_service="ledger-service"}'
+        values: "0+5x120"
+      - series: 'openbank_audit_actor_missing_total{provenance="DECLARED",source_service="ledger-service"}'
+        values: "0+9x120"
+    alert_rule_test:
+      # Below `for: 15m` the alert is pending, not firing.
+      - eval_time: 10m
+        alertname: AuditAttributionAbsent
+        exp_alerts: []
+      - eval_time: 90m
+        alertname: AuditAttributionAbsent
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              team: security
+            exp_annotations:
+              subject_period: continuous
+              summary: "Audit rows stored with no producer attribution"
+              description: >-
+                audit-service resolved AttributionSource.ABSENT for at least one record in the last hour, so those rows carry the "unknown" source_service sentinel. That value is chain-hashed into record_hash and audit_entries is append-only, so it cannot be corrected afterwards -- only the producer or the TopicAttribution table can stop the next one. Find the topic in the audit-service pod log, then add the verified producer to TopicAttribution (never a value derived from the topic name: eight of the mapped topics do not follow the convention).
+      # The denominator series is present, so the absent-arm must stay quiet even
+      # well past its 2h grace.
+      - eval_time: 119m
+        alertname: AuditAttributionSignalAbsent
+        exp_alerts: []
+
+  # ---------------------------------------------------------------------------
+  # 2. TOPIC traffic alone -- today's expected steady state for the several
+  #    producers that do not declare `sourceService`. Nothing may fire, at any
+  #    time. If this test goes red, the alert is the permanently-firing one.
+  # ---------------------------------------------------------------------------
+  - interval: 1m
+    input_series:
+      - series: 'openbank_audit_attribution_missing_total{provenance="TOPIC",source_service="ledger-service"}'
+        values: "0+5x600"
+      - series: 'openbank_audit_attribution_missing_total{provenance="TOPIC",source_service="sdd-service"}'
+        values: "0+2x600"
+      - series: 'openbank_audit_actor_missing_total{provenance="DECLARED",source_service="ledger-service"}'
+        values: "0+9x600"
+    alert_rule_test:
+      - eval_time: 480m
+        alertname: AuditAttributionAbsent
+        exp_alerts: []
+      - eval_time: 480m
+        alertname: AuditAttributionDerivedProducerNew
+        exp_alerts: []
+    promql_expr_test:
+      # The recording rule counts the derived set: two producers, steady.
+      - expr: openbank:audit_attribution_topic_derived_services:count1h
+        eval_time: 480m
+        exp_samples:
+          - labels: '{__name__="openbank:audit_attribution_topic_derived_services:count1h"}'
+            value: 2
+
+  # ---------------------------------------------------------------------------
+  # 3. A producer JOINS the derived set 7h in. That is the actionable change,
+  #    and it fires -- while the producer that was derived all along does not.
+  # ---------------------------------------------------------------------------
+  - interval: 1m
+    input_series:
+      - series: 'openbank_audit_attribution_missing_total{provenance="TOPIC",source_service="ledger-service"}'
+        values: "0+5x600"
+      # Flat until t=420m, then rising: increase() over [1h] is 0 at the 6h-offset
+      # sample and positive now, which is exactly "newly derived".
+      - series: 'openbank_audit_attribution_missing_total{provenance="TOPIC",source_service="party-service"}'
+        values: "0+0x420 0+3x180"
+      - series: 'openbank_audit_actor_missing_total{provenance="DECLARED",source_service="ledger-service"}'
+        values: "0+9x600"
+    alert_rule_test:
+      - eval_time: 510m
+        alertname: AuditAttributionDerivedProducerNew
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              team: security
+              source_service: party-service
+            exp_annotations:
+              subject_period: continuous
+              summary: "party-service newly attributed by topic, not by declaration"
+              description: >-
+                Audit records from party-service are being attributed from the Kafka topic rather than from a `sourceService` field the producer sends, and were not six hours ago. Either that producer stopped declaring the field, or a topic was newly subscribed. The attribution is still correct -- TopicAttribution's values are verified against the module that declares the outgoing channel -- but it is derived, and every row written while this is true records that fact irreversibly.
+
+  # ---------------------------------------------------------------------------
+  # 4. THE COLD-PROMETHEUS CONTROL, and the reason the `and on()` guard exists.
+  #
+  #    At t=60m the 6h-offset side has no data at all. Without the guard the
+  #    `unless` subtracts nothing and EVERY derived producer reports as new --
+  #    an alert firing on the whole fleet after every Prometheus restart, which
+  #    is the exact shape this repo already paid for once with a gauge seeded
+  #    from the epoch. Delete the `and on()` clause from the shipped rule and
+  #    this assertion must go red; if it stays green the guard is decorative.
+  # ---------------------------------------------------------------------------
+  - interval: 1m
+    input_series:
+      - series: 'openbank_audit_attribution_missing_total{provenance="TOPIC",source_service="ledger-service"}'
+        values: "0+5x120"
+      - series: 'openbank_audit_attribution_missing_total{provenance="TOPIC",source_service="sdd-service"}'
+        values: "0+2x120"
+      - series: 'openbank_audit_actor_missing_total{provenance="DECLARED",source_service="ledger-service"}'
+        values: "0+9x120"
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: AuditAttributionDerivedProducerNew
+        exp_alerts: []
+      - eval_time: 119m
+        alertname: AuditAttributionDerivedProducerNew
+        exp_alerts: []
+
+  # ---------------------------------------------------------------------------
+  # 5. The denominator family is gone: no audit row telemetry at all. The two
+  #    threshold rules above are silent here and that silence is meaningless --
+  #    which is what this rule exists to say. It must fire, and it must NOT fire
+  #    before its 2h grace.
+  # ---------------------------------------------------------------------------
+  - interval: 1m
+    input_series:
+      - series: 'up{job="audit-service"}'
+        values: "1x200"
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: AuditAttributionSignalAbsent
+        exp_alerts: []
+      - eval_time: 150m
+        alertname: AuditAttributionSignalAbsent
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              team: security
+            exp_annotations:
+              summary: "No audit attribution telemetry for 2h -- the quiet rules are unverified"
+              description: >-
+                openbank_audit_actor_missing_total is absent fleet-wide. That series is emitted for every row AuditConsumer persists, so either audit-service is persisting nothing or its pod is not being scraped. Until this resolves, AuditAttributionAbsent and AuditAttributionDerivedProducerNew being quiet says nothing at all -- check the Prometheus target for the audit namespace before reading them as healthy.
+      # And the ABSENT-threshold rule is indeed quiet on identical evidence --
+      # the pair is the discriminator, not either rule alone.
+      - eval_time: 150m
+        alertname: AuditAttributionAbsent
+        exp_alerts: []

--- a/openbank-infra/tests/promtool/run.sh
+++ b/openbank-infra/tests/promtool/run.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Run the PromQL unit tests against the real PrometheusRule manifests.
+#
+# promtool consumes bare `groups:` documents; the repo ships Prometheus Operator
+# PrometheusRule CRs. This unwraps `.spec` from each named CR into a temp dir and points
+# promtool at that, so the tests run against the SHIPPED expression -- not a copy of it that
+# can drift. Every rule file named by a test's `rule_files:` must exist as a CR here.
+#
+# Usage: openbank-infra/tests/promtool/run.sh [test-file ...]
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../../.." && pwd)"
+RULES_DIR="$REPO/openbank-infra/gitops/components/observability"
+
+command -v promtool >/dev/null || { echo "promtool not on PATH"; exit 127; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+python3 - "$RULES_DIR" "$WORK" <<'PY'
+import sys, pathlib, yaml
+src, dst = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+for f in sorted(src.glob("prometheus-rules-*.yaml")):
+    for doc in yaml.safe_load_all(f.read_text()):
+        if isinstance(doc, dict) and doc.get("kind") == "PrometheusRule":
+            (dst / f.name).write_text(yaml.safe_dump(doc["spec"], sort_keys=False))
+PY
+
+# Sanity: promtool must accept every unwrapped file before any test runs. A test that
+# "passes" against a rule file promtool could not parse would be testing nothing.
+promtool check rules "$WORK"/*.yaml >/dev/null
+
+tests=("$@")
+if [ ${#tests[@]} -eq 0 ]; then
+  # shellcheck disable=SC2207
+  tests=($(find "$HERE" -name '*_test.yaml' | sort))
+fi
+
+status=0
+for t in "${tests[@]}"; do
+  # rule_files: are written relative to the test file; run from the unwrapped dir so the
+  # bare filenames resolve there.
+  cp "$t" "$WORK/$(basename "$t")"
+  # `set -e` would abort on the first red test before the loop could record it, so the
+  # failure is captured by the `if` rather than read from `$?` after the fact.
+  if ! ( cd "$WORK" && promtool test rules "$(basename "$t")" ); then
+    status=1
+  fi
+done
+exit $status


### PR DESCRIPTION
## The measured gap

`openbank.audit.attribution.missing{source_service,provenance}` and its sibling
`openbank.audit.event.time.missing` have been emitted by `AuditConsumer` since #3994.
Neither appears in any `PrometheusRule` in this repository, under either spelling
(Micrometer dots or Prometheus underscores).

Known-positive control for the probe: `openbank_workflow_last_success_age_seconds` is
found by the same grep in three rule files (`prometheus-rules-tier1.yaml`,
`prometheus-rules-workflow-liveness.yaml`, `prometheus-rules-fx-fixing.yaml`). The empty
result for the audit metrics is therefore a fact about the rules, not about the grep.

## Why an alert and not only a dashboard

`audit_entries` is append-only at the database and `source_service` is chain-hashed into
`record_hash`. A row whose producing service was inferred from the Kafka topic rather than
declared by the producer cannot be corrected afterwards — a normalising `UPDATE` affects
zero rows and reports success. The counter is the only forward-looking signal that a row
was attributed rather than stated.

## Why not "any TOPIC-derived row"

Several producers reach `AttributionSource.TOPIC` today by design, and `TopicAttribution`'s
own comments record that decision. An alert on the TOPIC provenance would be permanently
firing, and noise on the control that exists to make this gap visible is exactly what hides
the gap. What is actionable is a *change*:

1. **`AuditAttributionAbsent`** — a row resolved `ABSENT`, i.e. neither declared nor
   derivable. `TopicAttribution`'s coverage is derived from the subscribed-topic list by a
   test, so this has no expected steady state.
2. **`AuditAttributionDerivedProducerNew`** — a producer in the derived set now that was
   not six hours ago: a payload refactor that dropped the field, or a topic subscribed
   without a table entry.
3. **`AuditAttributionSignalAbsent`** — the success state. Zero `ABSENT` rows and a stable
   derived set is byte-for-byte what "audit-service is not scraped" looks like through
   rules 1 and 2. `openbank_audit_actor_missing_total` is the discriminator: `AuditConsumer`
   increments it for every persisted row including fully-declared ones.

Plus one recording rule, `openbank:audit_attribution_topic_derived_services:count1h`, for
the dashboard trend — not alerted on, because its healthy value today is a positive
constant.

## What the expressions read on a cold pod

- Rule 1 reads `increase()` over a counter that does not exist until the first `ABSENT`
  row. No series, empty vector, no firing. There is no seeded value to misread.
- Rule 2 is gated on the 6h-offset sample existing. Without that guard, a Prometheus with
  under ~7h of data has an empty offset side, `unless` subtracts nothing, and every derived
  producer reports as new — firing on the whole set after every restart. That is the shape
  the epoch-seeded liveness gauge already cost us. With the guard, the rule is silent for
  the first ~7h instead; rule 3 is what keeps that silence accountable.
- Rule 3 is the deliberate `absent()` arm.

Longest lookback is `[1h] offset 6h` = 7h, inside the 12h retention (no long-term store).

## Evidence

`promtool test rules` via `openbank-infra/tests/promtool/run.sh`, which unwraps `.spec`
out of the shipped `PrometheusRule` CR — the assertions run against the deployed
expression, not a copy. Exit codes read from `$?` after redirecting to a file, never
through a pipe.

| run | rc |
|---|---|
| tests with the rule file removed (rules do not exist) | `1` |
| tests with the rule file in place | `0` |
| mutant A — `and on()` cold-Prometheus guard deleted | `1` |
| mutant B — rule 1 widened to any provenance | `1` |
| mutant C — `unless` clause deleted from rule 2 | `1` |
| mutant D — `absent()` replaced by a `== 0` threshold | `1` |
| restored | `0` |

Each mutant names the right case: A and C fail the cold-start and steady-state assertions,
B fails the TOPIC-only-must-not-fire assertion, D fails the absent assertion.
The test's `evaluation_interval` is 1m, inside the 5m staleness window, so `for:` matures.
No rule here uses `time()`, so the epoch-based clock promtool starts from cannot make a
control vacuous.

Existing gates run locally: `check-alert-metric-emitted.py --enforce` rc `0`,
`check-alert-window-vs-subject-period.py --enforce` rc `0` (both new windowed rules declare
`subject_period: continuous` — they are driven by Kafka consumption, not a scheduler).

## Scope notes

- **This claims the rules are COMMITTED, not loaded.** Nothing here has been applied to a
  cluster and no ruler has been reloaded. Whether Prometheus actually evaluates them is a
  separate claim this PR does not make.
- `openbank-infra/tests/promtool/run.sh` is **byte-identical** to the copy in the open
  PR #7594 (same SHA-1) so the two additions merge without divergence; that PR also wires
  the harness into CI, and its runner globs `*_test.yaml`, so this test joins it with no
  further edit. No `gates.yaml` change here, deliberately, to avoid a competing edit.
- No new gate, so no lifecycle metadata is required.
- `openbank.audit.event.time.missing` is still unalerted. It is a different subject with a
  different steady state (7 of 21 topics send no event time today) and belongs in its own
  change.

Refs #3994
