### PR TITLE
docs(ci): qualify runtime event evidence

### DIFF
--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -232,9 +232,10 @@ jobs:
           # export container id, labels, ports, hostnames or environment variables.
           EVIDENCE_DIR="${{ inputs.service }}/build/test-intelligence/runtime"
           mkdir -p "${EVIDENCE_DIR}"
-          # Docker's `event=start` filter also matches exec lifecycle events used by
-          # Testcontainers wait strategies. Restrict the stream to container objects,
-          # otherwise one PostgreSQL container appears as three starts and one stop.
+          # Restrict the daemon stream to container objects so Testcontainers exec wait-strategy
+          # events never enter the retained envelope. This is intentionally not a container-leak
+          # verdict: redacted aggregate lifecycle counts still need correlation before they can
+          # establish cleanup or a leak (rendered as unknown by the Test Intelligence UI).
           docker events --filter type=container --filter event=start --filter event=die \
             --format '{"image":"{{.Actor.Attributes.image}}","lifecycle":"{{.Action}}","observedAtUnix":{{.Time}}}' \
             > "${EVIDENCE_DIR}/docker-events.jsonl" &


### PR DESCRIPTION
## Summary

Correct the CI workflow comment for retained Docker lifecycle events. The container-object filter excludes Testcontainers exec events, but an aggregate start/stop count still cannot establish a leak without correlation.

## Type of change

- [x] docs

## Linked issues

Refs #7640

## Verification

- [x] `check-test-intelligence-ecosystem.py --self-test`
- [x] `collect-test-run-evidence.py --self-test`
- [x] actionlint with the repository-known custom `openbank-build` runner label ignored

## Security

- [x] No runtime identifiers, host data, credentials, labels, ports, or secrets are added.

## Rollout / Rollback

- Deployment strategy: CI workflow documentation only
- Rollback plan: revert this commit
- Data migration: N/A