### PR TITLE
fix(libs-testing): record one logical Testcontainers lifecycle per resource

### DIFF
--- a/.github/scripts/collect-test-run-evidence.py
+++ b/.github/scripts/collect-test-run-evidence.py
@@ -94,10 +94,21 @@ def validate_envelope(envelope: dict) -> None:
     if set(infrastructure) != {"declared", "observed"} or not set(infrastructure["declared"]).issubset(INFRASTRUCTURE):
         raise ValueError("declared test infrastructure is invalid")
     for item in infrastructure["observed"]:
-        if set(item) != {"resource", "image", "lifecycle", "observedAt"}:
+        # `reprovisions` is optional and only ever present on a terminal `stopped`: it carries how
+        # many times Quarkus physically reprovisioned that logical resource before it was stopped
+        # (issue #7640). A record is one LOGICAL lifecycle, so without this field the reprovision
+        # count would simply stop being observable rather than being reconciled.
+        if set(item) - {"reprovisions"} != {"resource", "image", "lifecycle", "observedAt"}:
             raise ValueError("runtime observation contains unsafe or incomplete fields")
         if item["resource"] not in INFRASTRUCTURE or item["lifecycle"] not in {"started", "stopped"} or not item["image"]:
             raise ValueError("runtime observation values are invalid")
+        if "reprovisions" in item and (
+            item["lifecycle"] != "stopped"
+            or not isinstance(item["reprovisions"], int)
+            or isinstance(item["reprovisions"], bool)
+            or item["reprovisions"] < 1
+        ):
+            raise ValueError("runtime observation reprovision count is invalid")
         observed_at = parse_timestamp(item["observedAt"], "testInfrastructure.observed.observedAt")
         if observed_at - run_observed_at > MAX_FUTURE_SKEW:
             raise ValueError("runtime observation occurs after its run beyond the allowed clock skew")
@@ -571,6 +582,30 @@ def main() -> None:
                 "component": "openbank-admin-ui", "suites": suites("openbank-admin-ui", service),
                 "coverage": None, "testInfrastructure": {"declared": [], "observed": []},
             })
+            # `reprovisions` (issue #7640) is accepted only on a terminal `stopped`, and only as a
+            # positive integer — a `started` carrying one, or a zero, is a malformed record, not a
+            # quietly tolerated one.
+            def envelope_with(observation):
+                return {
+                    "schemaVersion": 1,
+                    "run": {"id": "1", "attempt": 1, "commit": "1234567", "branch": "main",
+                            "workflow": "CI", "url": "", "observedAt": "2026-08-22T00:00:00Z"},
+                    "component": "openbank-admin-ui", "suites": suites("openbank-admin-ui", service),
+                    "coverage": None,
+                    "testInfrastructure": {"declared": [], "observed": [observation]},
+                }
+            base_observation = {"resource": "postgres", "image": "postgres:16.3-alpine",
+                                "observedAt": "2026-08-22T00:00:00Z"}
+            validate_envelope(envelope_with({**base_observation, "lifecycle": "stopped", "reprovisions": 41}))
+            for rejected in ({**base_observation, "lifecycle": "started", "reprovisions": 41},
+                             {**base_observation, "lifecycle": "stopped", "reprovisions": 0},
+                             {**base_observation, "lifecycle": "stopped", "reprovisions": True}):
+                try:
+                    validate_envelope(envelope_with(rejected))
+                except ValueError:
+                    pass
+                else:
+                    raise AssertionError(f"invalid reprovision count was accepted: {rejected}")
             assert classify("PaymentApiIT", "com.openbank.PaymentApiIT", "test", "openbank-x") == "integration"
             assert classify("UnitTest", "com.openbank.UnitTest", "test", "openbank-x") == "unit"
             assert classify("creates LOAN_PACK_E2E", "com.openbank.CatalogPlatformResourceTest", "test", "openbank-x") == "unit"

--- a/openbank-admin-ui/src/lib/types/test-intelligence.ts
+++ b/openbank-admin-ui/src/lib/types/test-intelligence.ts
@@ -70,11 +70,19 @@ export interface TestRunProvenance {
   url: string
 }
 
+/**
+ * One LOGICAL resource lifecycle, not one physical container start (issue #7640). Quarkus
+ * reprovisions a test resource onto a fresh manager instance several times before the single
+ * terminal `stop()`, so the recorder collapses the repeats and publishes how many there were
+ * as `reprovisions`, present only on a `stopped` record and only when at least one repeat
+ * occurred. Absent `reprovisions` therefore means "provisioned once", never "unknown".
+ */
 export interface TestInfrastructureObservation {
   resource: 'postgres' | 'redpanda' | 'valkey'
   image: string
   lifecycle: 'started' | 'stopped'
   observedAt: string
+  reprovisions?: number
 }
 
 export interface ComponentTestPosture {

--- a/openbank-libs-testing/src/main/kotlin/com/openbank/libs/testing/evidence/TestInfrastructureEvidence.kt
+++ b/openbank-libs-testing/src/main/kotlin/com/openbank/libs/testing/evidence/TestInfrastructureEvidence.kt
@@ -8,24 +8,89 @@ import java.time.Instant
 
 /**
  * Append-only, secret-free runtime evidence emitted by shared Testcontainers resources.
- * CI supplies [OPENBANK_TEST_EVIDENCE_DIR]; local tests remain unaffected when it is absent.
+ * CI supplies [EVIDENCE_DIR]; local tests remain unaffected when it is absent.
  * Host names, mapped ports, credentials and container ids are deliberately never recorded.
+ *
+ * ## What a record MEANS (issue #7640) — read this before counting them
+ *
+ * A record is **one logical resource lifecycle**, not one physical container start. Quarkus
+ * constructs a *fresh* `QuarkusTestResourceLifecycleManager` instance every time it
+ * reprovisions test resources (`TestResourceManager.buildTestResourceEntry` calls
+ * `testResourceClass.getConstructor().newInstance()`), so one JVM runs `start()` many times
+ * over many instances while only the final manager reaches `close()` -> `stop()`. Emitting one
+ * record per `start()` presented those as many *unterminated* resources — Product Catalog read
+ * 42 `started` against 14 `stopped`. Because the reprovisioned instances are new objects, a
+ * per-instance guard cannot see the repeat; the state has to outlive them, which is why the
+ * suppression lives in this object and not in the ~14 emitters.
+ *
+ * So: a repeated `started` for the same (resource, image) is suppressed until a `stopped`
+ * closes that lifecycle, and the number of suppressed reprovisions is published on the terminal
+ * `stopped` record as `reprovisions` (absent when zero).
+ *
+ * ## What this deliberately STOPS observing, and what compensates
+ *
+ * 1. The individual timestamps of each physical provision leave this stream — only how many
+ *    there were survives. A provisioning that **failed** and was retried therefore no longer
+ *    appears here as its own `started`. That is the information cost of the fix, and it is
+ *    deliberately not silent: the physical events remain independently observable from the
+ *    Docker daemon event stream, which `collect-test-run-evidence.py` ingests into the same
+ *    `observed` list from a separate `*.jsonl` file in this directory. Deduplicating here
+ *    narrows one of two sources, never both.
+ * 2. A lifecycle that never receives its `stopped` publishes no `reprovisions` count at all,
+ *    because the count is only known once the lifecycle closes and this file is append-only.
+ *    That is exactly the JVM-exit case (Ryuk reaps the containers) and is the residual blind
+ *    spot of this design; the Docker stream above is what covers it.
+ *
+ * A `started` that is never followed by a `stopped` is still recorded and still visible as an
+ * unterminated lifecycle: suppression only ever collapses a *repeat*, never the first one.
  */
 object TestInfrastructureEvidence {
     private const val EVIDENCE_DIR = "OPENBANK_TEST_EVIDENCE_DIR"
 
+    /** Test-only override for [EVIDENCE_DIR]; the environment variable wins when both are set. */
+    private const val EVIDENCE_DIR_PROPERTY = "openbank.test.evidence.dir"
+
+    /** (resource, image) -> physical reprovisions observed since that logical lifecycle opened. */
+    private val openLifecycles = LinkedHashMap<String, Int>()
+
     @Synchronized
     fun record(resource: String, image: String, lifecycle: String, observedAt: Instant = Instant.now()) {
-        val directory = System.getenv(EVIDENCE_DIR)?.takeIf { it.isNotBlank() } ?: return
         require(lifecycle == "started" || lifecycle == "stopped") { "unsupported lifecycle" }
+        val key = "$resource $image"
+        var reprovisions = 0
+        if (lifecycle == "started") {
+            val open = openLifecycles[key]
+            if (open != null) {
+                // Same logical resource, reprovisioned onto a new manager instance: count, don't emit.
+                openLifecycles[key] = open + 1
+                return
+            }
+            openLifecycles[key] = 0
+        } else {
+            reprovisions = openLifecycles.remove(key) ?: 0
+        }
+        write(resource, image, lifecycle, observedAt, reprovisions)
+    }
+
+    private fun write(resource: String, image: String, lifecycle: String, observedAt: Instant, reprovisions: Int) {
+        val directory = System.getenv(EVIDENCE_DIR)?.takeIf { it.isNotBlank() }
+            ?: System.getProperty(EVIDENCE_DIR_PROPERTY)?.takeIf { it.isNotBlank() }
+            ?: return
         val path = Path.of(directory).resolve("testcontainers.jsonl")
         Files.createDirectories(path.parent)
+        val reprovisionField = if (reprovisions > 0) ",\"reprovisions\":$reprovisions" else ""
         val line =
             """{"schemaVersion":1,"resource":"${escape(
                 resource,
-            )}","image":"${escape(image)}","lifecycle":"$lifecycle","observedAt":"$observedAt"}""" +
+            )}","image":"${escape(image)}","lifecycle":"$lifecycle","observedAt":"$observedAt"$reprovisionField}""" +
                 "\n"
         Files.writeString(path, line, StandardOpenOption.CREATE, StandardOpenOption.APPEND)
+    }
+
+    /** Drops the in-JVM lifecycle state so a unit test can drive independent sequences. */
+    @Synchronized
+    internal fun resetForTesting() {
+        openLifecycles.clear()
     }
 
     private fun escape(value: String): String = value.replace("\\", "\\\\").replace("\"", "\\\"")

--- a/openbank-libs-testing/src/test/kotlin/com/openbank/libs/testing/evidence/TestInfrastructureEvidenceTest.kt
+++ b/openbank-libs-testing/src/test/kotlin/com/openbank/libs/testing/evidence/TestInfrastructureEvidenceTest.kt
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.openbank.libs.testing.evidence
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+
+/**
+ * Drives the real Quarkus sequence from issue #7640 — several `start()` calls (each from a
+ * freshly constructed manager instance, which is why no per-instance flag can see them) before
+ * a single terminal `stop()` — and asserts what actually lands in the JSONL.
+ *
+ * The second test is the control: it proves the dedup did not blind the evidence to the failure
+ * mode the stream exists to expose, a resource that starts and never stops.
+ */
+class TestInfrastructureEvidenceTest {
+
+    @TempDir
+    lateinit var evidenceDir: Path
+
+    @BeforeEach
+    fun setUp() {
+        TestInfrastructureEvidence.resetForTesting()
+        System.setProperty("openbank.test.evidence.dir", evidenceDir.toString())
+    }
+
+    @AfterEach
+    fun tearDown() {
+        System.clearProperty("openbank.test.evidence.dir")
+        TestInfrastructureEvidence.resetForTesting()
+    }
+
+    private fun lines(): List<String> {
+        val file = evidenceDir.resolve("testcontainers.jsonl")
+        return if (Files.exists(file)) Files.readAllLines(file).filter { it.isNotBlank() } else emptyList()
+    }
+
+    @Test
+    fun `repeated starts of one logical resource collapse to a single lifecycle carrying the reprovision count`() {
+        val image = "postgres:16.3-alpine"
+        TestInfrastructureEvidence.record("postgres", image, "started", Instant.parse("2026-08-31T10:00:00Z"))
+        TestInfrastructureEvidence.record("postgres", image, "started", Instant.parse("2026-08-31T10:01:00Z"))
+        TestInfrastructureEvidence.record("postgres", image, "started", Instant.parse("2026-08-31T10:02:00Z"))
+        TestInfrastructureEvidence.record("postgres", image, "stopped", Instant.parse("2026-08-31T10:03:00Z"))
+
+        val emitted = lines()
+        assertThat(emitted).hasSize(2)
+        assertThat(emitted[0]).contains("\"lifecycle\":\"started\"")
+        assertThat(emitted[0]).doesNotContain("reprovisions")
+        assertThat(emitted[1]).contains("\"lifecycle\":\"stopped\"")
+        // The two suppressed physical provisions are counted, not discarded.
+        assertThat(emitted[1]).contains("\"reprovisions\":2")
+    }
+
+    @Test
+    fun `a distinct image is a distinct logical lifecycle`() {
+        TestInfrastructureEvidence.record("postgres", "postgres:16.3-alpine", "started")
+        TestInfrastructureEvidence.record("postgres", "postgres:17-alpine", "started")
+
+        assertThat(lines()).hasSize(2)
+    }
+
+    @Test
+    fun `a resource that starts and never stops is still recorded as an unterminated lifecycle`() {
+        TestInfrastructureEvidence.record("redpanda", "redpandadata/redpanda:v24.1.1", "started")
+
+        val emitted = lines()
+        assertThat(emitted).hasSize(1)
+        assertThat(emitted.single()).contains("\"lifecycle\":\"started\"")
+        assertThat(emitted.none { it.contains("\"lifecycle\":\"stopped\"") }).isTrue()
+    }
+
+    @Test
+    fun `a fresh lifecycle after a stop is recorded again`() {
+        val image = "postgres:16.3-alpine"
+        TestInfrastructureEvidence.record("postgres", image, "started")
+        TestInfrastructureEvidence.record("postgres", image, "stopped")
+        TestInfrastructureEvidence.record("postgres", image, "started")
+
+        val emitted = lines()
+        assertThat(emitted).hasSize(3)
+        assertThat(emitted.map { it.substringAfter("\"lifecycle\":\"").substringBefore("\"") })
+            .containsExactly("started", "stopped", "started")
+    }
+}


### PR DESCRIPTION
## Problem (#7640)

Testcontainers lifecycle evidence recorded many `started` observations against one terminal
`stopped` — Product Catalog reported 42 starts and 14 stops, so physical provisioning events
were being presented as many *unterminated logical resources*.

## Mechanism, established (not assumed)

Quarkus does **not** call `start()` repeatedly on one manager instance. `TestResourceManager`
constructs a **fresh instance per reprovision**:

```java
// io.quarkus.test.common.TestResourceManager#buildTestResourceEntry
return new TestResourceStartInfo(testResourceClass.getConstructor().newInstance(), ...);
```

`start()` iterates those instances, `close()` iterates them once and is guarded by a `started`
flag, so one JVM produces many `start()` calls across many objects and comparatively few
`stop()` calls. **A per-instance flag would have fixed nothing** — the state has to outlive the
instances.

## The fix — one place, not 14

The suppression lives in `TestInfrastructureEvidence` itself, the only thing that outlives the
manager instances. A repeated `started` for the same `(resource, image)` is suppressed until a
`stopped` closes that lifecycle. All ~14 emitters are fixed by this, and a fifteenth added later
inherits it.

## What stopped being observable, and what compensates — read this part

Making counts agree by discarding information is exactly the failure this repo keeps hitting, so
the trade-off is stated in the KDoc and here:

1. **Individual timestamps of each physical provision leave this stream** — only how many there
   were survives. A provisioning that *failed and was retried* no longer appears here as its own
   `started`. Compensation: the count is **published**, not dropped — the terminal `stopped`
   record carries `"reprovisions": N` (absent when zero), and the physical events remain
   independently observable from the Docker daemon event stream, which
   `collect-test-run-evidence.py` already ingests into the same `observed` list from a separate
   `*.jsonl`. Deduplicating here narrows one of two sources, never both.
2. **Residual blind spot, stated plainly:** a lifecycle that never receives its `stopped`
   publishes no reprovision count, because the count is only known when the lifecycle closes and
   the file is append-only. That is the JVM-exit case (Ryuk reaps the containers); the Docker
   stream above is what covers it.
3. A `started` with no `stopped` is **still recorded** and still reads as an unterminated
   lifecycle. Suppression only ever collapses a *repeat*, never the first one.

A record now means **one logical lifecycle, not one container start** — said in the KDoc and in
the `TestInfrastructureObservation` TS doc, because the field name no longer tells the reader.

## Evidence

| check | result |
|---|---|
| new unit test vs. pre-fix recorder (only the two test seams added, dedup absent) | **exit 1** — `4 tests completed, 1 failed`, 0 skipped |
| same test with the fix | **exit 0** — JUnit XML `tests="4" skipped="0" failures="0" errors="0"` |
| `:openbank-libs-testing:ktlintCheck detekt test` | exit 0; all four tasks present in the log; 31 tests / **7 skipped / 0 failures** — same 7 skips as the baseline run |
| `check-test-intelligence-ecosystem.py` before | exit 0 |
| `check-test-intelligence-ecosystem.py` after | exit 0 |
| **falsified**: `stopped` deleted from `openbank-agent-service/.../PostgresTestResource.kt` | **exit 1** — `new service-owned Testcontainers resource lacks lifecycle evidence` |
| `collect-test-run-evidence.py --self-test` | exit 0 |
| **falsified**: reprovision validation short-circuited to `False` | **exit 1** — `invalid reprovision count was accepted` |

Every exit code was read from `$?` after a redirect to a file, never through a pipe.

The gate hardened in #7295 is untouched and still discriminates: a resource that records
`started` and never `stopped` remains detectable, proven by the falsification row above.

## Test control against blinding

`a resource that starts and never stops is still recorded as an unterminated lifecycle` is the
control — it passes both before and after, and it is what proves the dedup did not make the
evidence blind to the failure mode this stream exists to expose.

Refs #7640
