### PR TITLE
fix(admin-ui): stop the sanctions table rendering ESCALATED as a green pass

### DIFF
--- a/openbank-admin-ui/src/app/sanctions/page.tsx
+++ b/openbank-admin-ui/src/app/sanctions/page.tsx
@@ -15,7 +15,7 @@ import { classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
-import { PageHeader, StatCard, type Tone } from '@/components/ui'
+import { PageHeader, StatCard, StatusBadge, type Tone } from '@/components/ui'
 
 interface SanctionCheck {
   id: string; name: string; entityType: string; status: string
@@ -613,12 +613,14 @@ export default function SanctionsPage() {
                           </div>
                         </td>
                         <td style={{ padding: '12px 16px' }}>
-                          <span style={{ padding: '2px 8px', borderRadius: '10px', fontSize: '11px', fontWeight: 600,
-                            background: isHit ? 'var(--danger-bg)' : isPending ? 'var(--warning-bg)' : 'var(--success-bg)',
-                            color: isHit ? 'var(--danger-text)' : isPending ? 'var(--warning-text)' : 'var(--success-text)',
-                            border: `1px solid ${isHit ? 'var(--danger-border)' : isPending ? 'var(--warning-border)' : 'var(--success-border)'}` }}>
-                            {c.status}
-                          </span>
+                          {/* Delegated to StatusBadge/tone.ts on purpose. The hand-rolled ternary
+                              this replaces read `isHit ? danger : isPending ? warning : success`,
+                              so ESCALATED — a real SanctionsCheck value that isHighRisk() treats as
+                              high risk — rendered GREEN, as did any status the UI had not been
+                              taught. statusTone() resolves an unrecognised value to `neutral`,
+                              never `success`, which is the property that makes this safe by
+                              default rather than by enumeration. */}
+                          <StatusBadge status={c.status} />
                         </td>
                         <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>
                           {c.checkedAt ? new Date(c.checkedAt).toLocaleString(dateLocale) : '—'}

--- a/openbank-admin-ui/src/test/sanctions-status-tone.guard.test.ts
+++ b/openbank-admin-ui/src/test/sanctions-status-tone.guard.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { statusTone } from "@/components/ui/tone"
+
+/**
+ * The sanctions table hand-rolled its Result badge as
+ *
+ *     isHit ? danger : isPending ? warning : success
+ *
+ * so `ESCALATED` — a real `SanctionsCheck` status that `isHighRisk()` treats as high risk, and
+ * which `tone.ts` maps to `danger` — rendered GREEN. So did any status the page had not been
+ * taught. On a sanctions screening surface that is the worst direction for the error to run:
+ * the reviewer sees a pass for a check that was escalated.
+ *
+ * This guard pins the two properties that matter, and deliberately asserts them at different
+ * levels. The first is behavioural (what `statusTone` resolves), because that is the invariant
+ * worth keeping. The second is structural (the page must not re-introduce a local ternary),
+ * because a page can satisfy `statusTone` in one place and hand-roll a badge in another — which
+ * is exactly what happened here while `tone.ts` was already correct.
+ */
+
+const PAGE = join(__dirname, "..", "app", "sanctions", "page.tsx")
+
+describe("sanctions result badge", () => {
+  it("never resolves a non-clear status to success", () => {
+    // Every status the domain can produce, from SanctionsCheck.kt / openapi.yaml.
+    for (const status of ["HIT", "POTENTIAL_HIT", "ESCALATED"]) {
+      expect(statusTone(status)).not.toBe("success")
+    }
+    expect(statusTone("ESCALATED")).toBe("danger")
+  })
+
+  it("resolves an unknown status to neutral, never success", () => {
+    // The property that makes this safe by default: a status added to the backend before the UI
+    // learns about it must not render as a green tick.
+    expect(statusTone("SOME_STATUS_THE_UI_HAS_NEVER_SEEN")).toBe("neutral")
+    expect(statusTone(undefined)).toBe("neutral")
+    expect(statusTone("")).toBe("neutral")
+  })
+
+  it("the page does not hand-roll a success fallback for the result badge", () => {
+    const page = readFileSync(PAGE, "utf8")
+    // Strip comments first: this file documents the old ternary in a comment, and a guard that
+    // matches its own explanation of the defect is the vacuous shape this repo keeps finding.
+    const code = page
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/^\s*\/\/.*$/gm, "")
+      .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, "")
+    expect(code).not.toMatch(/isPending\s*\?\s*'var\(--warning-bg\)'\s*:\s*'var\(--success-bg\)'/)
+    expect(code).toContain("<StatusBadge status={c.status} />")
+  })
+})


### PR DESCRIPTION
## `ESCALATED` rendered as a green pass on the sanctions screening table

The Result badge was hand-rolled:

```tsx
background: isHit ? 'var(--danger-bg)' : isPending ? 'var(--warning-bg)' : 'var(--success-bg)'
```

`isHit` is `status === 'HIT'`, `isPending` is `status === 'POTENTIAL_HIT'`. Everything else falls through to **success** — including `ESCALATED`, a real `SanctionsCheckStatus` that the shared helper maps to `danger`:

```
$ git show origin/main:openbank-admin-ui/src/components/ui/tone.ts | grep -n ESCALATED
125:  ESCALATED: 'danger',
```

On a sanctions screening surface this is the worst direction for the error to run: the reviewer sees a pass for a check that was escalated, and any status added to the backend before the UI learns about it renders the same way.

`tone.ts` was correct the whole time — the page bypassed it. Its KDoc already states that an unrecognised value resolves to `neutral`, **never `success`**, precisely so an unfamiliar status cannot become a green tick. Delegating to `StatusBadge` restores that property, and makes it safe by default rather than by enumeration.

## The guard asserts at two levels, deliberately

The **behavioural** assertions on `statusTone()` pass against unmodified `main`. They are not the discriminator — they pin the invariant so a future edit to `tone.ts` cannot quietly make `ESCALATED` green again.

The **structural** assertion is what goes red: the page must not re-introduce a local success fallback. That distinction is the point — a page can satisfy the helper in one place and hand-roll a badge in another, which is exactly what happened here while `tone.ts` was already right.

It strips comments before matching, because this file now documents the old ternary in a comment, and a guard that matches its own explanation of the defect proves nothing. That failure mode has shipped in this repo before.

| run | exit |
|---|---|
| guard vs **unmodified** page | **1** — the structural case, named |
| guard vs fixed page | 0 |
| `npm test` | 0 — 390 files, 1988 passed |
| `npm run lint` | 0 — 0 errors, 92 warnings (unchanged) |
| `npx tsc --noEmit` | 20 pre-existing errors, **0 in this file** |

## Deliberately not changed

The row tint still keys on `isHit` alone, so an `ESCALATED` row is not highlighted. I left it rather than widening it: which statuses deserve the tint is a design call, and the domain's own `isHighRisk()` is `HIT || (POTENTIAL_HIT && overallScore > 0.85)` — it does **not** include `ESCALATED`. So the tint and the badge are answering different questions today, and unifying them silently would be a judgement smuggled in as a bug fix.

One correction to how this was reported to me: I was told `isHighRisk()` treats `ESCALATED` as high risk. It does not — quoted above. The defect stands on `tone.ts` and on what an escalated check means, not on that function.

Found while investigating #1035 (aml-service has no consumer for `sanctions.screening.event`); this is a separate, smaller, and independently verifiable defect.

Refs #1035
