### PR TITLE
test(admin-ui): re-baseline the local status-map ratchet, and state the blind spot the sanctions defect lived in

### DIFF
--- a/openbank-admin-ui/src/test/local-status-map-ratchet.guard.test.ts
+++ b/openbank-admin-ui/src/test/local-status-map-ratchet.guard.test.ts
@@ -8,6 +8,29 @@ const APP_ROOT = path.resolve(__dirname, '../app')
 // Intentionally narrow: this detects the named, presentational status maps that duplicate
 // components/ui/tone.ts. It does not treat arbitrary Record<string, string> data structures as UI
 // debt, because that would make the ratchet noisy and encourage renaming instead of migration.
+//
+// KNOWN BLIND SPOT — do not read this count as a census of page-local status styling.
+// The regex below matches a *named map declaration* only. The other way a page hand-rolls status
+// colour is an inline ternary in a style prop:
+//
+//     background: isHit ? 'var(--danger-bg)' : isPending ? 'var(--warning-bg)' : 'var(--success-bg)'
+//
+// That shape declares nothing, so it matches this regex never, and this ratchet has always been
+// structurally unable to see it. It is the shape that produced the ESCALATED-renders-green defect
+// in src/app/sanctions/page.tsx, where a five-value SanctionsCheckStatus was discriminated by two
+// branches and every unlisted value fell through to success. statusTone() cannot fail that way:
+// an unrecognised value resolves to 'neutral', never to 'success'.
+//
+// The blind spot is documented rather than closed on purpose. A sweep on 2026-08-31 found six
+// occurrences of that ternary shape across five pages, and only the sanctions ones were defects —
+// day-end, system/agent, system/health and system/inventory all discriminate a genuine boolean or
+// count (or, in system/health's case, exhaust a three-value `boolean | 'unknown'` domain with the
+// unknown case landing on warning). A count-based ratchet over a shape that is usually CORRECT
+// would be a false-debt metric: it cannot distinguish `isUp ? success : danger` from a truncated
+// enum, so it would push authors to launder correct code through statusTone() to satisfy a number.
+// The property that actually decides it is semantic — "does the discriminator have more values
+// than the branches enumerate" — and that needs the producing enum or openapi schema, which this
+// file cannot read. If this is ever closed, close it with that check, not with a wider regex.
 const LOCAL_STATUS_COLOUR_MAP = /(?:const|let)\s+\w*(?:STATUS|Status)(?:_?COLORS?|_?STYLES?)\s*:\s*Record</
 
 function pageFiles(directory: string): string[] {
@@ -24,8 +47,14 @@ function pagesWithLocalStatusMaps(): string[] {
 
 describe('ADR-0208 local status-map migration', () => {
   it('does not increase page-local named status colour maps', () => {
-    // Baseline captured on main 2026-08-31. Migrations reduce this number; adding a new page-local
-    // STATUS_COLOR/STATUS_STYLES map is a regression because StatusBadge + tone.ts own this decision.
-    expect(pagesWithLocalStatusMaps().length).toBeLessThanOrEqual(11)
+    // Re-baselined on main 2026-08-31: the real count is 1 (src/app/swift/[id]/page.tsx). The
+    // previous bound of 11 was the historical debt, left untightened when the assertion moved from
+    // toHaveLength(11) to toBeLessThanOrEqual(11) — so migrations paid the debt from 11 down to 1
+    // and the ratchet kept ten free slots. Measured: appending a new named status map to an
+    // unrelated page still passed at <=11 (exit 0). A ratchet with slack is green about the
+    // regression it exists to catch, so the bound has to follow the count down.
+    // Migrations reduce this number; adding a new page-local STATUS_COLOR/STATUS_STYLES map is a
+    // regression because StatusBadge + tone.ts own this decision.
+    expect(pagesWithLocalStatusMaps().length).toBeLessThanOrEqual(1)
   })
 })


### PR DESCRIPTION
## What this is

The follow-up sweep to #7698. The sanctions Result badge rendered `ESCALATED` green because it
discriminated a five-value status with two branches. Four other admin-ui pages match the same
textual shape. **None of them is a defect** — this PR fixes no page, and says why in the one place
a future reader will look.

## Sweep classification

| Page | Discriminator | Domain | Verdict |
|---|---|---|---|
| `sanctions/page.tsx:617` | `isHit`/`isPending` over `status` | `SanctionsCheckStatus` = CLEAR, HIT, POTENTIAL_HIT, WHITELISTED, ESCALATED | **defect — owned by #7698** |
| `sanctions/page.tsx:909` | `screenResult.status === 'HIT'` | same 5-value enum (`SanctionsCheck.status`, `openapi.yaml`) | **defect — NOT covered by #7698**, see below |
| `day-end/page.tsx:267` | `hasDrift = drifted.length > 0` | count over `!c.withinTolerance` | correct |
| `system/agent/page.tsx:424` | `result.isError` | `isError: boolean` on the MCP tool result | correct |
| `system/health/page.tsx:254` | `governance.flywayDrift` | `boolean \| 'unknown'` | correct — and exemplary: fully exhausted with `=== true` / `=== false`, and `'unknown'` lands on **warning** |
| `system/inventory/page.tsx:217` | `drifted > 0` | count of aggregates with >1 version | correct |

`system/health` is the shape worth copying: it enumerates the whole domain explicitly and gives the
residual case a non-success tone, which is the same safety property `statusTone()` has by
construction.

## The one thing this PR does not fix

`sanctions/page.tsx:909` is a second, independent instance of the confirmed defect in the same file,
and #7698's diff does not touch it. It gates on `status === 'HIT'` alone, so `POTENTIAL_HIT`,
`WHITELISTED` and `ESCALATED` all render `--success-bg` **and the literal string
`CLEAR RECORD` / `ČISTÝ ZÁZNAM`** — a false textual assertion that a screened name is clean, which
is worse than the colour. `POTENTIAL_HIT` is directly producible by the screening endpoint this
panel renders. Left untouched because #7698 owns that file; it belongs in that PR or its successor.

## The ratchet

`local-status-map-ratchet.guard.test.ts` matches a *named map declaration*, so this entire
inline-ternary class matches it never. Two changes, no production code:

1. **Blind spot stated in the file.** Documented, not closed. The deciding property is semantic —
   does the discriminator have more values than the branches enumerate — and needs the producing
   Kotlin enum or openapi schema, which the test cannot read. A wider regex would count four correct
   pages as debt and push authors to launder correct code through `statusTone()` to satisfy a number.
2. **Bound re-baselined 11 → 1.** The real count is 1 (`swift/[id]/page.tsx`). 11 was the historical
   debt, left untightened when the assertion moved from `toHaveLength(11)` to
   `toBeLessThanOrEqual(11)`.

### Proven by what it prevents

Appending `const DAY_END_STATUS_COLORS: Record<string, string>` to an unrelated page:

| | clean tree | regression injected |
|---|---|---|
| bound `<= 11` (before) | exit **0** | exit **0** ← green about the regression it exists to catch |
| bound `<= 1` (after) | exit **0** | exit **1** — `expected 2 to be less than or equal to 1` |

Every exit code read from `$?` after redirecting to a file, never through a pipe.

`npm test`: exit 0, 389 files / 1985 passed / 1 skipped. `npx tsc --noEmit`: exit 0, 0 errors
(the 20 known errors come from missing generated files; `pretest` bakes them first).

Refs #7698
