### PR TITLE
fix(admin-ui): stop the screening panel asserting CLEAR RECORD for a potential hit

### DIFF
--- a/openbank-admin-ui/src/app/sanctions/page.tsx
+++ b/openbank-admin-ui/src/app/sanctions/page.tsx
@@ -16,6 +16,7 @@ import { DataUnavailable, type UnavailableKind } from '@/components/feedback/Dat
 import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader, StatCard, StatusBadge, type Tone } from '@/components/ui'
+import { statusTone } from '@/components/ui/tone'
 
 interface SanctionCheck {
   id: string; name: string; entityType: string; status: string
@@ -906,15 +907,34 @@ export default function SanctionsPage() {
                     {screenError}
                   </div>
                 )}
-                {screenResult && (
-                  <div style={{ padding: '16px', borderRadius: '8px', border: `2px solid ${screenResult.status === 'HIT' ? 'var(--danger-border)' : 'var(--success-border)'}`,
-                    background: screenResult.status === 'HIT' ? 'var(--danger-bg)' : 'var(--success-bg)' }}>
+                {screenResult && (() => {
+                  /* Only CLEAR and WHITELISTED may say "clear record". The previous code gated on
+                     `status === 'HIT'` alone, so POTENTIAL_HIT, ESCALATED and any unrecognised
+                     value rendered a green box, a tick, and the literal text CLEAR RECORD --
+                     a false textual assertion that a screened name is clean, which is worse than
+                     the wrong colour. POTENTIAL_HIT is directly producible by the screening
+                     endpoint this panel renders.
+
+                     The default is deliberately the cautious one: anything this UI has not been
+                     taught reads as "review required", never as clear. Same property as
+                     statusTone(), which resolves an unknown value to `neutral` and never to
+                     `success`. */
+                  const isClear = screenResult.status === 'CLEAR' || screenResult.status === 'WHITELISTED'
+                  const tone = statusTone(screenResult.status)
+                  const headline = screenResult.status === 'HIT'
+                    ? t('SHODA NALEZENA', 'MATCH FOUND')
+                    : isClear
+                      ? t('ČISTÝ ZÁZNAM', 'CLEAR RECORD')
+                      : t('NUTNÁ KONTROLA', 'REVIEW REQUIRED')
+                  return (
+                  <div style={{ padding: '16px', borderRadius: '8px', border: `2px solid var(--${tone}-border)`,
+                    background: `var(--${tone}-bg)` }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '10px' }}>
-                      {screenResult.status === 'HIT'
-                        ? <AlertTriangle size={18} style={{ color: 'var(--danger)' }} />
-                        : <CheckCircle2 size={18} style={{ color: 'var(--success)' }} />}
-                      <span style={{ fontSize: '15px', fontWeight: 800, color: screenResult.status === 'HIT' ? 'var(--danger-text)' : 'var(--success-text)' }}>
-                        {screenResult.status === 'HIT' ? t('SHODA NALEZENA', 'MATCH FOUND') : t('ČISTÝ ZÁZNAM', 'CLEAR RECORD')}
+                      {isClear
+                        ? <CheckCircle2 size={18} style={{ color: 'var(--success)' }} />
+                        : <AlertTriangle size={18} style={{ color: `var(--${tone})` }} />}
+                      <span style={{ fontSize: '15px', fontWeight: 800, color: `var(--${tone}-text)` }}>
+                        {headline}
                       </span>
                       <span style={{ marginLeft: 'auto', fontSize: '12px', fontFamily: 'var(--font-mono)', color: 'var(--text-secondary)' }}>
                         {t('Skóre', 'Score')}: {Math.round((screenResult.overallScore ?? 0) * 100)}%
@@ -937,7 +957,7 @@ export default function SanctionsPage() {
                       </div>
                     )}
                   </div>
-                )}
+                  )})()}
               </div>
             </div>
             </Can>

--- a/openbank-admin-ui/src/test/sanctions-status-tone.guard.test.ts
+++ b/openbank-admin-ui/src/test/sanctions-status-tone.guard.test.ts
@@ -22,6 +22,14 @@ import { statusTone } from "@/components/ui/tone"
 
 const PAGE = join(__dirname, "..", "app", "sanctions", "page.tsx")
 
+/** Strip comments before any structural match: this file documents the defects it guards against
+ *  in comments, and a guard that matches its own explanation proves nothing. */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "")
+}
+
 describe("sanctions result badge", () => {
   it("never resolves a non-clear status to success", () => {
     // Every status the domain can produce, from SanctionsCheck.kt / openapi.yaml.
@@ -39,14 +47,28 @@ describe("sanctions result badge", () => {
     expect(statusTone("")).toBe("neutral")
   })
 
+  it("only CLEAR and WHITELISTED may render the CLEAR RECORD headline", () => {
+    // The screening panel gated on `status === 'HIT'` alone, so POTENTIAL_HIT, ESCALATED and
+    // anything unrecognised rendered a green box, a tick, and the literal text CLEAR RECORD.
+    // A false textual assertion that a screened name is clean is worse than a wrong colour, and
+    // POTENTIAL_HIT is directly producible by the endpoint this panel renders.
+    const code = stripComments(readFileSync(PAGE, "utf8"))
+
+    // Asserted positively, on purpose. My first attempt used a negative regex for the old shape
+    // (`status === 'HIT' ? t('SHODA NALEZENA' … ČISTÝ ZÁZNAM`) and it matched the FIXED code too,
+    // because the two strings stay within a few lines of each other either way — an assertion
+    // that fails against both worlds discriminates nothing. These three do discriminate: the old
+    // code contains none of them.
+    expect(code).toContain("screenResult.status === 'CLEAR'")
+    expect(code).toContain("screenResult.status === 'WHITELISTED'")
+    expect(code).toMatch(/REVIEW REQUIRED/)
+  })
+
   it("the page does not hand-roll a success fallback for the result badge", () => {
     const page = readFileSync(PAGE, "utf8")
     // Strip comments first: this file documents the old ternary in a comment, and a guard that
     // matches its own explanation of the defect is the vacuous shape this repo keeps finding.
-    const code = page
-      .replace(/\/\*[\s\S]*?\*\//g, "")
-      .replace(/^\s*\/\/.*$/gm, "")
-      .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, "")
+    const code = stripComments(page)
     expect(code).not.toMatch(/isPending\s*\?\s*'var\(--warning-bg\)'\s*:\s*'var\(--success-bg\)'/)
     expect(code).toContain("<StatusBadge status={c.status} />")
   })


### PR DESCRIPTION
## The second, worse half of #7698 — merged without it

#7698 landed the badge fix. A second commit on the same branch, fixing the more serious instance in the same file, **did not make it into that merge** — I pushed it minutes before the PR was merged. Verified on `origin/main` after the merge:

```
$ git show origin/main:openbank-admin-ui/src/app/sanctions/page.tsx | grep -c "REVIEW REQUIRED"
0
$ git show origin/main:.../sanctions-status-tone.guard.test.ts | grep -c "  it("
3      # the extended guard has 4
```

So the defect below is **live on `main` right now**. This PR carries that commit alone, cherry-picked onto current `main`.

## What is still wrong

The screening result panel gates on `screenResult.status === 'HIT'` alone:

```tsx
background: screenResult.status === 'HIT' ? 'var(--danger-bg)' : 'var(--success-bg)'
...
{screenResult.status === 'HIT' ? t('SHODA NALEZENA', 'MATCH FOUND') : t('ČISTÝ ZÁZNAM', 'CLEAR RECORD')}
```

`SanctionsCheckStatus` has five values — `CLEAR, HIT, POTENTIAL_HIT, WHITELISTED, ESCALATED`. So `POTENTIAL_HIT` and `ESCALATED` render a green box, a `CheckCircle2` tick, and the literal words **CLEAR RECORD**.

That is worse than the badge defect this PR's sibling fixed. A wrong colour is a wrong colour; a headline saying *clear record* over a potential sanctions hit is a false statement the reviewer reads in words. **`POTENTIAL_HIT` is directly producible by the endpoint this panel renders** — it is not a theoretical enum value.

## The fix

Only `CLEAR` and `WHITELISTED` reach that headline. Everything else reads **REVIEW REQUIRED** and takes its colour from `statusTone()`, which resolves an unknown status to `neutral` and never to `success`. Safe by default rather than by enumeration — a status added to the backend before the UI learns about it cannot become a green tick.

| run | exit |
|---|---|
| guard vs **unmodified** page | **1** — both cases named |
| guard vs fixed page | 0 |
| `npm test` | 0 — 390 files, 1989 passed |
| `npm run lint` | 0 — 0 errors |
| `npx tsc --noEmit` | 0 — 0 errors |

## A correction to the guard, worth recording

My first assertion for this case was a negative regex for the old shape:

```
/status === 'HIT'\s*\?\s*t\('SHODA NALEZENA'[\s\S]{0,80}ČISTÝ ZÁZNAM/
```

**It matched the fixed code too.** The two strings stay a few lines apart either way — the fix merely inserts an `isClear` check between them. An assertion that fails against both worlds discriminates nothing, which is the exact failure mode this repo keeps finding in its own gates.

Replaced with positive assertions on properties only the fixed code has (`status === 'CLEAR'`, `status === 'WHITELISTED'`, `REVIEW REQUIRED`), and verified red-then-green rather than assumed. The guard also strips comments before any structural match, because this file now documents the defect in a comment and a guard that matches its own explanation proves nothing.

Found by a fleet sweep for the same shape; the other four matching pages were classified correct-as-written (see #7700).

Refs #1035
