### PR TITLE
fix(analytics): make the ClickHouse parity gate see a migration that only redefines objects

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -2735,13 +2735,19 @@ gates:
   # ConfigMap a FRESH cluster boots from. Nothing reconciles the two, and a migration that reaches
   # only the resources is invisible — file in git, object present in the sandbox because someone
   # applied it, CI green — until a warehouse is rebuilt without it. V4__screen_feedback_context.sql
-  # sat that way from 2026-07 until #4511. Compares created OBJECTS, not text, in both directions.
+  # sat that way from 2026-07 until #4511. Compares created OBJECTS, not text, in both directions —
+  # PLUS, since #7645, the two properties an object set cannot express: ALTER-added COLUMNS, and
+  # agreement between the last definition of an object on each side. V9__synthetic_provenance.sql
+  # creates no object (it adds bronze_events.synthetic and re-cuts four existing views with
+  # `WHERE synthetic = 0`), so it was structurally invisible to the set comparison and had never
+  # reached the ConfigMap. Definition agreement is compared on comment-stripped, whitespace-collapsed
+  # SQL — the two artefacts are indented differently and need not be byte-identical.
   - id: clickhouse-ddl-configmap-parity
-    min_subjects: 15   # 22 objects today (V1-V5 + the ConfigMap's copies, 2026-08-13)
-    name: "ClickHouse DDL reaches a fresh cluster (issue #4511, enforced)"
+    min_subjects: 15   # 28 objects today (V1-V10 + the ConfigMap's copies, 2026-08-31)
+    name: "ClickHouse DDL reaches a fresh cluster (issues #4511/#7645, enforced)"
     group: data
     mode: enforced
-    rationale: "A migration present only in the operator-applied resource path disappears on a fresh ClickHouse rebuild, silently changing the analytics schema after recovery."
+    rationale: "A migration present only in the operator-applied resource path disappears on a fresh ClickHouse rebuild, silently changing the analytics schema after recovery; a migration that only redefines existing objects is invisible to an object-set comparison, so column and definition parity are checked too."
     review_after: "2027-02-13"
     selftest: |
       python3 .github/scripts/check-clickhouse-ddl-in-configmap.py --self-test

--- a/.github/scripts/check-clickhouse-ddl-in-configmap.py
+++ b/.github/scripts/check-clickhouse-ddl-in-configmap.py
@@ -24,8 +24,30 @@
 # fresh cluster have this?"). Both directions are errors — a ConfigMap object with no resource behind
 # it is DDL with no source of record.
 #
-# WHAT IT DOES NOT CHECK: that the two definitions of an object AGREE. A caller depending on a
-# column added by a redefinition still needs its own assertion (see customer-360.test.ts).
+# It also checks the two things the object set CANNOT express, because a migration that only
+# REDEFINES existing objects moves no object into the set and is therefore invisible to a set
+# comparison by construction:
+#
+#   COLUMN PARITY  — every `ALTER TABLE openbank_analytics.<t> ADD COLUMN <c>` in a resource must be
+#   accounted for in the ConfigMap's own definition of that table (in its CREATE TABLE body, or by
+#   the same ALTER). A fresh cluster otherwise lacks the column entirely, and the sink's
+#   `FORMAT JSONEachRow` insert names it: ClickHouse 24.8 defaults `input_format_skip_unknown_fields`
+#   to 1, so the value is DROPPED rather than rejected — no error anywhere.
+#
+#   DEFINITION AGREEMENT — for an object created on both sides, the LAST definition in resource-
+#   version order must match the LAST definition in ConfigMap key order, compared on SQL with
+#   comments stripped and whitespace collapsed (not byte-identical: the two are indented
+#   differently, and forcing bytes to match is what the object-set comparison was avoiding).
+#
+# That second property is what V9__synthetic_provenance.sql needed and did not have: it adds
+# `bronze_events.synthetic` and re-cuts silver_current_state / silver_history / silver_as_of /
+# gold_daily_event_volume with `WHERE synthetic = 0`, creating no new object, so the parity check
+# was green for the whole time none of it had reached a fresh cluster (issue #7645).
+#
+# WHAT IT STILL DOES NOT CHECK: that either copy matches the LIVE warehouse. Nothing in this repo
+# executes either artefact against a running cluster — the ConfigMap runs from
+# /docker-entrypoint-initdb.d on an EMPTY data dir only, and the resources are applied by hand.
+# This gate makes the two committed artefacts agree; it cannot make the cluster agree with them.
 #
 #   python3 .github/scripts/check-clickhouse-ddl-in-configmap.py --root .
 #   python3 .github/scripts/check-clickhouse-ddl-in-configmap.py --self-test
@@ -50,18 +72,69 @@ CREATE_RE = re.compile(
 )
 
 
+# The whole CREATE statement, up to its terminating semicolon — used for definition agreement.
+CREATE_STMT_RE = re.compile(
+    r"(CREATE\s+(?:OR\s+REPLACE\s+)?(?:MATERIALIZED\s+)?(?:VIEW|TABLE|DICTIONARY)\s+"
+    r"(?:IF\s+NOT\s+EXISTS\s+)?openbank_analytics\.([A-Za-z_][A-Za-z0-9_]*)\b.*?;)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# ALTER TABLE openbank_analytics.<table> ADD COLUMN [IF NOT EXISTS] <column>
+ALTER_ADD_RE = re.compile(
+    r"ALTER\s+TABLE\s+openbank_analytics\.([A-Za-z_][A-Za-z0-9_]*)\s+"
+    r"ADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][A-Za-z0-9_]*)",
+    re.IGNORECASE,
+)
+
+VERSION_RE = re.compile(r"^V(\d+)__")
+
+
+def live_sql(text: str) -> str:
+    """DDL with comment lines removed: every one of these files quotes its own statements in prose,
+    and a commented example would otherwise count as real DDL."""
+    return "\n".join(l for l in text.splitlines() if not l.lstrip().startswith("--"))
+
+
 def objects(text: str) -> set[str]:
-    """Objects a chunk of DDL creates. Comment lines are stripped first: every one of these files
-    quotes its own statements in prose, and a commented example would otherwise count as created."""
-    live = "\n".join(l for l in text.splitlines() if not l.lstrip().startswith("--"))
-    return {m.lower() for m in CREATE_RE.findall(live)}
+    """Objects a chunk of DDL creates."""
+    return {m.lower() for m in CREATE_RE.findall(live_sql(text))}
+
+
+def normalize(stmt: str) -> str:
+    """A CREATE statement reduced to what it MEANS to ClickHouse: comments already gone, whitespace
+    collapsed, case folded. The two artefacts are indented differently on purpose, so comparing
+    bytes would fail on formatting and force them to be copies rather than to agree."""
+    return re.sub(r"\s+", " ", stmt).strip().lower()
+
+
+def last_definitions(chunks: list[str]) -> dict[str, str]:
+    """The definition of each object that WINS, given chunks in application order. A later
+    CREATE OR REPLACE supersedes an earlier one, so only the last one describes the end state."""
+    out: dict[str, str] = {}
+    for chunk in chunks:
+        for stmt, obj in CREATE_STMT_RE.findall(live_sql(chunk)):
+            out[obj.lower()] = normalize(stmt)
+    return out
+
+
+def added_columns(text: str) -> set[tuple[str, str]]:
+    """(table, column) pairs a chunk of DDL adds by ALTER."""
+    return {(t.lower(), c.lower()) for t, c in ALTER_ADD_RE.findall(live_sql(text))}
+
+
+def resource_order(path: Path) -> tuple[int, str]:
+    """Resources apply in migration-version order, ties broken by name. Two files may legitimately
+    claim one version (V9 does today); where they touch disjoint objects the tie is immaterial, and
+    where they do not, the name order is at least deterministic rather than filesystem-dependent."""
+    m = VERSION_RE.match(path.name)
+    return (int(m.group(1)) if m else 0, path.name)
 
 
 def check(root: Path) -> tuple[list[str], int]:
     """Returns (errors, objects examined). The count is the gate's subject floor: a broken glob or a
     regex that stops matching leaves the verdict clean, and only the count can say so."""
     errors: list[str] = []
-    sql_files = sorted(root.glob(SQL_GLOB))
+    sql_files = sorted(root.glob(SQL_GLOB), key=resource_order)
     cm_path = root / CONFIGMAP
 
     # A probe that finds no subject must say so, not pass. Both inputs are required to exist: this
@@ -90,6 +163,43 @@ def check(root: Path) -> tuple[list[str], int]:
             f"the init ConfigMap creates openbank_analytics.{obj}, which no clickhouse/V*.sql "
             f"resource creates — DDL with no source of record"
         )
+
+    # COLUMN PARITY. An ALTER adds no object, so the comparison above cannot see it at all.
+    cm_text = cm_path.read_text()
+    cm_live = live_sql(cm_text)
+    cm_added = added_columns(cm_text)
+    for f in sql_files:
+        for table, column in sorted(added_columns(f.read_text())):
+            if (table, column) in cm_added:
+                continue
+            # Accept the column being declared in the ConfigMap's CREATE TABLE body instead — that is
+            # the better shape for a cluster built from nothing, and it is equally correct.
+            body = next(
+                (
+                    stmt
+                    for stmt, obj in CREATE_STMT_RE.findall(cm_live)
+                    if obj.lower() == table and stmt.lstrip().upper().startswith("CREATE TABLE")
+                ),
+                "",
+            )
+            if re.search(rf"(?<![A-Za-z0-9_]){re.escape(column)}(?![A-Za-z0-9_])", body, re.IGNORECASE):
+                continue
+            errors.append(
+                f"{f.name} adds column openbank_analytics.{table}.{column}, which the init ConfigMap "
+                f"neither declares on {table} nor adds — a warehouse built from scratch would not "
+                f"have it, and an insert naming it is silently dropped, not rejected"
+            )
+
+    # DEFINITION AGREEMENT. A migration that only redefines existing objects is invisible above.
+    res_last = last_definitions([f.read_text() for f in sql_files])
+    cm_last = last_definitions([cm_text])
+    for obj in sorted(set(res_last) & set(cm_last)):
+        if res_last[obj] != cm_last[obj]:
+            errors.append(
+                f"openbank_analytics.{obj} is defined differently by the clickhouse/V*.sql resources "
+                f"and by the init ConfigMap — the last resource to define it has not reached the "
+                f"ConfigMap, so a fresh warehouse would build an older version of this object"
+            )
 
     return (errors, len(set(seen) | cm_objects))
 

--- a/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
+++ b/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
@@ -845,6 +845,83 @@ data:
     FROM openbank_analytics.gold_credit_funnel_events
     GROUP BY day;
 
+  09-synthetic-provenance.sql: |
+    -- SPDX-License-Identifier: Apache-2.0
+    -- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+    -- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+    --
+    -- Mirrors openbank-analytics-sink/src/main/resources/clickhouse/V9__synthetic_provenance.sql.
+    --
+    -- WHY THIS KEY EXISTS AT ALL. V9 creates no new object — it adds one column and re-cuts four
+    -- views that V1/V07/V08 already created — so the #4511 object-set parity check could not see it,
+    -- and it sat unmirrored (issue #7645). The sink names `synthetic` in its JSONEachRow insert and
+    -- ClickHouse 24.8 defaults input_format_skip_unknown_fields to 1, so on a warehouse built
+    -- without this key the flag is DROPPED on every write rather than rejected, and every silver and
+    -- gold aggregate then counts synthetic activity as real. The gate now checks column parity and
+    -- definition agreement for exactly that reason.
+    --
+    -- The ALTER runs against the table 01-bronze-silver.sql has just created; ADD COLUMN
+    -- IF NOT EXISTS is a no-op if a future 01 ever declares the column inline.
+    -- ADR-0252: retain synthetic activity as auditable bronze provenance, but never let it enter
+    -- baseline state/history/as-of or daily-volume projections.
+    ALTER TABLE openbank_analytics.bronze_events
+        ADD COLUMN IF NOT EXISTS synthetic UInt8 DEFAULT 0;
+
+    CREATE OR REPLACE VIEW openbank_analytics.silver_current_state AS
+    SELECT
+        upper(b.aggregate_type) AS aggregate_type,
+        b.aggregate_id,
+        argMax(b.event_id, (b.aggregate_version, b.occurred_at, b.ingested_at)) AS event_id,
+        max(b.aggregate_version) AS aggregate_version,
+        argMax(b.event_type, (b.aggregate_version, b.occurred_at, b.ingested_at)) AS event_type,
+        argMax(b.occurred_at, (b.aggregate_version, b.occurred_at, b.ingested_at)) AS occurred_at,
+        argMax(b.source_service, (b.aggregate_version, b.occurred_at, b.ingested_at)) AS source_service,
+        argMax(b.schema_version, (b.aggregate_version, b.occurred_at, b.ingested_at)) AS schema_version,
+        argMax(b.payload, (b.aggregate_version, b.occurred_at, b.ingested_at)) AS payload
+    FROM openbank_analytics.bronze_events AS b
+    WHERE b.synthetic = 0
+    GROUP BY upper(b.aggregate_type), b.aggregate_id;
+
+    CREATE OR REPLACE VIEW openbank_analytics.gold_daily_event_volume AS
+    SELECT
+        toDate(occurred_at) AS day,
+        source_service,
+        aggregate_type,
+        event_type,
+        count() AS events
+    FROM openbank_analytics.bronze_events
+    WHERE synthetic = 0
+    GROUP BY day, source_service, aggregate_type, event_type;
+
+    CREATE OR REPLACE VIEW openbank_analytics.silver_history AS
+    SELECT
+        upper(aggregate_type) AS aggregate_type,
+        aggregate_id,
+        aggregate_version,
+        event_type,
+        occurred_at AS valid_from,
+        leadInFrame(occurred_at) OVER (
+            PARTITION BY upper(aggregate_type), aggregate_id
+            ORDER BY aggregate_version, occurred_at, ingested_at
+            ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+        ) AS valid_to,
+        payload
+    FROM openbank_analytics.bronze_events
+    WHERE synthetic = 0;
+
+    CREATE OR REPLACE VIEW openbank_analytics.silver_as_of AS
+    SELECT
+        upper(b.aggregate_type) AS aggregate_type,
+        b.aggregate_id,
+        argMax(b.event_id, (b.aggregate_version, b.occurred_at, b.ingested_at)) AS event_id,
+        max(b.aggregate_version) AS aggregate_version,
+        argMax(b.event_type, (b.aggregate_version, b.occurred_at, b.ingested_at)) AS event_type,
+        argMax(b.occurred_at, (b.aggregate_version, b.occurred_at, b.ingested_at)) AS occurred_at,
+        argMax(b.payload, (b.aggregate_version, b.occurred_at, b.ingested_at)) AS payload
+    FROM openbank_analytics.bronze_events AS b
+    WHERE b.synthetic = 0
+      AND b.occurred_at <= {t:DateTime64(3, 'UTC')}
+    GROUP BY upper(b.aggregate_type), b.aggregate_id;
 kind: ConfigMap
 metadata:
   name: clickhouse-init


### PR DESCRIPTION
Closes #7645

## What the issue got right, and what it got wrong

**Right:** the ClickHouse warehouse has no migration *runner*. `clickhouse.yaml` mounts the
`clickhouse-init` ConfigMap into `/docker-entrypoint-initdb.d`, which the container executes only
when the data directory is empty. Nothing in this repository applies the `clickhouse/V*.sql`
resources to a running cluster. That half stands.

**Wrong, and it matters:** the directory is not unreferenced, and the ConfigMap is not stuck at V8.
`.github/scripts/check-clickhouse-ddl-in-configmap.py` (gate `clickhouse-ddl-configmap-parity`,
`mode: enforced`, added for #4511) already compares the two artefacts. And `V9__party_credit_profile`
and `V10__credit_funnel` *are* mirrored — #6235 appended them to the tail of the
`08-fold-silver-layer-case.sql` block scalar instead of giving them their own keys. Counting keys
finds eight and concludes three migrations are missing; parsing the YAML finds all of their objects
present. The issue's `grep -oE '^  [0-9]+-'` probe measured key names, not content.

## The real defect: one migration the gate is structurally unable to see

`V9__synthetic_provenance.sql` creates **no object**. It adds `bronze_events.synthetic` and re-cuts
`silver_current_state`, `silver_history`, `silver_as_of` and `gold_daily_event_volume` with
`WHERE synthetic = 0`. An object-set comparison moves no element, so the gate was green for the whole
time none of it had reached the ConfigMap — which the script's own header named as its blind spot
("WHAT IT DOES NOT CHECK: that the two definitions of an object AGREE"). `grep -c synthetic` over the
ConfigMap on `origin/main`: **0**.

What that costs on a warehouse built from the ConfigMap alone:

- The column does not exist. `ClickHouseAnalyticsSink.bronzeRowJson` names `"synthetic"` in its
  `INSERT ... FORMAT JSONEachRow` body, and ClickHouse 24.8 defaults `input_format_skip_unknown_fields`
  to 1 — so the flag is **dropped on every write, not rejected**. No error, no metric, nothing to find.
- The four views carry no `synthetic = 0` filter, so synthetic activity is counted as real in
  `silver_current_state` (read by the Customer 360 BFF and by campaign segment evaluation) and in
  `gold_daily_event_volume` (the business-warehouse Grafana board).

## What this PR does

**Extends the existing gate** with the two properties an object set cannot express:

- **Column parity** — every `ALTER TABLE ... ADD COLUMN` in a resource must be accounted for in the
  ConfigMap, either as the same ALTER or as a column in its `CREATE TABLE` body.
- **Definition agreement** — for an object created on both sides, the last definition in resource
  version order must match the last definition in ConfigMap key order, compared on comment-stripped,
  whitespace-collapsed SQL. Not bytes: the two are indented differently on purpose, which is exactly
  why the original check compared object sets instead.

**Mirrors V9** as a new `09-synthetic-provenance.sql` key, following the one-key-per-migration
convention the gate's own failure message states.

`gates.yaml` gains **no entry** — 186 before, 186 after. Only the existing entry's comment,
`rationale` and stale `min_subjects` comment (said 22 objects; there are 28) change.

## Negative controls

Every exit code read from `$?` after redirecting to a file, never through a pipe.

| Tree state | Exit |
|---|---|
| `origin/main` content, extended gate | **1** — 5 errors: the `synthetic` column plus all four re-cut views, and nothing else |
| after adding the `09-` key | **0** |
| `--self-test` | **0** (`SELF-TEST PASS`) |
| plus a `V99__probe.sql` the ConfigMap does not account for | **1** — both new properties fire independently |
| probe removed | **0** |
| `check-gate-lifecycle-metadata.py --today 2026-08-31` | **0**, 0 overdue |

## What this does NOT fix, deliberately

**The live warehouse.** No cluster was touched and no DDL was applied — read-only throughout. This PR
makes the two *committed* artefacts agree; it cannot make a running cluster agree with either, and
whether the existing warehouse has had V9 applied by an operator is not answerable from this
repository. **Building a real apply-Job is an operational decision, not a gate change** — the shape
exists next door in `ci-gate-runs-schema-apply-job.yaml` if that is the direction chosen. Until then
the gate at least guarantees a rebuild produces the schema the resources describe.

**The duplicate V9.** Two files claim version 9 (`V9__party_credit_profile`, `V9__synthetic_provenance`).
They touch disjoint objects, so the ambiguity is currently immaterial; the gate now sorts resources by
version with a deterministic name tiebreak rather than relying on filesystem order. Renumbering is left
alone — it is a statement about what has already been applied, which this PR cannot establish.
