### PR TITLE
refactor(admin-ui): unify topology live-status semantics

### DIFF
--- a/openbank-admin-ui/e2e/infrastructure-topology.spec.ts
+++ b/openbank-admin-ui/e2e/infrastructure-topology.spec.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const STATUS = {
+  argocd: { status: 'UP', latencyMs: 12, checkedAt: '2026-08-31T12:00:00Z' },
+  postgres: { status: 'DOWN', latencyMs: 34, checkedAt: '2026-08-31T12:00:00Z' },
+}
+
+test.beforeEach(async ({ context, baseURL, page }) => {
+  await signInAsOperator(context, baseURL!)
+  await page.route('**/api/infra/status', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(STATUS),
+  }))
+  await page.route('**/api/infra/lifecycle', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ components: [{ id: 'postgres', urgency: 'patch-available' }] }),
+  }))
+})
+
+test('filters the live infrastructure map and keeps a DOWN state semantically explicit', async ({ page }) => {
+  await page.goto('/infrastructure/topology')
+
+  await expect(page.getByRole('heading', { name: 'Infrastructure Topology' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'PostgreSQL' })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Platform / control plane' }).click()
+  await expect(page.getByRole('button', { name: 'ArgoCD' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'PostgreSQL' })).toHaveCount(0)
+
+  await page.getByRole('button', { name: 'All' }).click()
+  await page.getByRole('button', { name: 'PostgreSQL' }).click()
+
+  const details = page.getByRole('region', { name: 'Infrastructure component details' })
+  await expect(details).toBeVisible()
+  await expect(details.getByText('Probe latency')).toBeVisible()
+  await expect(details.getByText('34 ms')).toBeVisible()
+  await expect(details.locator('.badge-danger', { hasText: 'DOWN' })).toBeVisible()
+
+  const refresh = page.getByRole('button', { name: 'Refresh infrastructure status' })
+  await refresh.click()
+  await expect(refresh).toHaveAttribute('aria-busy', 'false')
+})

--- a/openbank-admin-ui/playwright.config.ts
+++ b/openbank-admin-ui/playwright.config.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // ADR-0076 Layer 2 — Playwright E2E configuration
 //
-// Runs against a dedicated Next.js dev server (auto-started before tests, torn down after).
+// Runs against the Next.js dev server (auto-started before tests, torn down after).
 // Tests live in e2e/ and mock BFF endpoints via page.route() — no live services needed.
 // Scoped to pages that render live service state (docs coverage, health, governance).
 
@@ -41,15 +41,9 @@ export default defineConfig({
   ],
 
   webServer: {
-    // Webpack is deliberate here: Turbopack rejects the safe shared-dependency
-    // symlink used by isolated worktrees, while production builds retain their
-    // configured bundler. E2E needs a deterministic server, not a bundler test.
-    command: `npm run dev -- --webpack -p ${e2ePort}`,
+    command: `npm run dev -- -p ${e2ePort}`,
     url: e2eBaseUrl,
-    // A reachable port is not evidence that it serves admin-ui: locally a different
-    // project can already own 3001 and make every assertion target the wrong app.
-    // Fail fast instead; callers that need parallel runs choose OPENBANK_E2E_PORT.
-    reuseExistingServer: false,
+    reuseExistingServer: !process.env.CI,
     timeout: 120_000,
     env: {
       // Point docs bundle to the repo root so libs docs are found

--- a/openbank-admin-ui/playwright.config.ts
+++ b/openbank-admin-ui/playwright.config.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // ADR-0076 Layer 2 — Playwright E2E configuration
 //
-// Runs against the Next.js dev server (auto-started before tests, torn down after).
+// Runs against a dedicated Next.js dev server (auto-started before tests, torn down after).
 // Tests live in e2e/ and mock BFF endpoints via page.route() — no live services needed.
 // Scoped to pages that render live service state (docs coverage, health, governance).
 
@@ -41,9 +41,15 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: `npm run dev -- -p ${e2ePort}`,
+    // Webpack is deliberate here: Turbopack rejects the safe shared-dependency
+    // symlink used by isolated worktrees, while production builds retain their
+    // configured bundler. E2E needs a deterministic server, not a bundler test.
+    command: `npm run dev -- --webpack -p ${e2ePort}`,
     url: e2eBaseUrl,
-    reuseExistingServer: !process.env.CI,
+    // A reachable port is not evidence that it serves admin-ui: locally a different
+    // project can already own 3001 and make every assertion target the wrong app.
+    // Fail fast instead; callers that need parallel runs choose OPENBANK_E2E_PORT.
+    reuseExistingServer: false,
     timeout: 120_000,
     env: {
       // Point docs bundle to the repo root so libs docs are found

--- a/openbank-admin-ui/src/app/infrastructure/topology/page.tsx
+++ b/openbank-admin-ui/src/app/infrastructure/topology/page.tsx
@@ -5,7 +5,7 @@
 'use client'
 import { useState, useEffect } from 'react'
 import {
-  Network, RefreshCw, Play, Pause, CheckCircle2, XCircle, HelpCircle,
+  Network, RefreshCw, Play, Pause,
   Cloud, GitBranch, Database, Eye, Server, X,
 } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -14,7 +14,7 @@ import { FlowParticle } from '@/components/topology/FlowParticle'
 import { useFlowAnimation } from '@/components/topology/useFlowAnimation'
 import { NodeShadow, ArrowMarker } from '@/components/topology/TopologyDefs'
 import { layoutBands } from '@/components/topology/layout'
-import { PageHeader } from '@/components/ui/PageHeader'
+import { PageHeader, StatusBadge, statusTone } from '@/components/ui'
 
 // ---------------------------------------------------------------------------
 // Infrastructure topology (ADR-0027/0029). A companion to the code-derived
@@ -230,7 +230,15 @@ export default function InfraTopologyPage() {
   const selectedEdges = selected ? EDGES.filter(e => e.from === selected || e.to === selected) : []
 
   const groupLabel = (g: GroupKey) => t(GROUPS[g].cs, GROUPS[g].en)
-  const statusColor = (s: Status) => (s === 'UP' ? '#10b981' : s === 'DOWN' ? '#ef4444' : '#94a3b8')
+  // SVG cannot consume the HTML StatusBadge primitive, but it still derives
+  // colour from the same central vocabulary. The CSS tokens preserve dark-mode
+  // contrast without inventing a second UP/DOWN/UNKNOWN colour taxonomy here.
+  const liveStatusFill = (status: Status) => {
+    const tone = statusTone(status)
+    if (tone === 'success') return 'var(--success)'
+    if (tone === 'danger') return 'var(--danger)'
+    return 'var(--text-muted)'
+  }
 
   return (
     <div style={{ padding: '28px 32px', maxWidth: '1400px' }}>
@@ -353,7 +361,7 @@ export default function InfraTopologyPage() {
                   <text x={x + 26} y={p.cy + 4} fontSize="11" fontWeight="600" fill={isSel ? '#fff' : 'var(--text-primary)'}>{n.label}</text>
                   {st && (
                     <g transform={`translate(${x + p.w - 12}, ${y + 2})`}>
-                      <circle cx="0" cy="0" r="6.5" fill={statusColor(st)} stroke="var(--surface)" strokeWidth="1.5" />
+                      <circle cx="0" cy="0" r="6.5" fill={liveStatusFill(st)} stroke="var(--surface)" strokeWidth="1.5" />
                       {st === 'UP' && <path d="M-2.5,0 L-0.8,1.8 L2.6,-2.2" fill="none" stroke="#fff" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />}
                       {st === 'DOWN' && <path d="M-2,-2 L2,2 M-2,2 L2,-2" fill="none" stroke="#fff" strokeWidth="1.4" strokeLinecap="round" />}
                       {st === 'UNKNOWN' && <text x="0" y="2.5" fontSize="8" fill="#fff" textAnchor="middle" fontWeight="bold">?</text>}
@@ -375,7 +383,7 @@ export default function InfraTopologyPage() {
               </div>
             ))}
             <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
-              <span style={{ width: '10px', height: '10px', borderRadius: '50%', background: '#10b981' }} />{t('Živý stav (UP/DOWN)', 'Live status (UP/DOWN)')}
+              <span style={{ width: '10px', height: '10px', borderRadius: '50%', background: 'var(--success)' }} />{t('Živý stav (UP/DOWN)', 'Live status (UP/DOWN)')}
             </div>
           </div>
         </div>
@@ -392,15 +400,11 @@ export default function InfraTopologyPage() {
                 <X aria-hidden="true" size={16} />
               </button>
               {statusOf(selectedNode.id) && (
-                <div style={{
-                  marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: '4px', padding: '2px 8px',
-                  borderRadius: '12px', fontSize: '11px', fontWeight: 600,
-                  background: `${statusColor(statusOf(selectedNode.id)!)}22`, color: statusColor(statusOf(selectedNode.id)!),
-                }}>
-                  {statusOf(selectedNode.id) === 'UP' && <CheckCircle2 aria-hidden="true" size={12} />}
-                  {statusOf(selectedNode.id) === 'DOWN' && <XCircle aria-hidden="true" size={12} />}
-                  {statusOf(selectedNode.id) === 'UNKNOWN' && <HelpCircle aria-hidden="true" size={12} />}
-                  {statusOf(selectedNode.id)}
+                <div style={{ marginLeft: 'auto' }}>
+                  <StatusBadge
+                    status={statusOf(selectedNode.id)}
+                    withDot
+                  />
                 </div>
               )}
             </div>

--- a/openbank-admin-ui/src/test/infrastructure-topology-controls-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/infrastructure-topology-controls-a11y.guard.test.ts
@@ -21,4 +21,15 @@ describe('infrastructure topology controls accessibility contract', () => {
     expect(page).toContain('<Pause aria-hidden="true"')
     expect(page).toContain('<X aria-hidden="true"')
   })
+
+  it('uses the shared semantic status vocabulary for live probes', () => {
+    expect(page).toContain("import { PageHeader, StatusBadge, statusTone } from '@/components/ui'")
+    expect(page).toContain('const tone = statusTone(status)')
+    expect(page).toContain("return 'var(--success)'")
+    expect(page).toContain("return 'var(--danger)'")
+    expect(page).toContain('<StatusBadge')
+    expect(page).toContain('status={statusOf(selectedNode.id)}')
+    expect(page).toContain('withDot')
+    expect(page).not.toContain('const statusColor')
+  })
 })


### PR DESCRIPTION
## Summary
- derive topology SVG live-state colour from the shared status vocabulary and theme tokens
- render the selected component's UP/DOWN/UNKNOWN state through the shared StatusBadge
- add a browser E2E contract for filtering, probe latency, semantic DOWN rendering and refresh
- retain topology data, polling endpoints, shared Playwright configuration, controls and node interaction behavior

## Verification
- `npm run pretest`
- Vitest: infrastructure topology behavior and accessibility guards (7 passed)
- ESLint: 0 errors; one pre-existing react-hooks warning remains on the existing initial load effect
- Playwright E2E added; local isolated runner was blocked by environment process handling, so CI is the required browser-run evidence
- `git diff --check`

Refs #7654