### PR TITLE
fix(standing-order): disable outbox dispatcher scheduler under %test

### DIFF
--- a/openbank-standing-order-service/src/main/resources/application.yaml
+++ b/openbank-standing-order-service/src/main/resources/application.yaml
@@ -115,6 +115,15 @@ quarkus:
       enabled: false
     management:
       enabled: false
+  openbank:
+    outbox:
+      # #7539: the real StandingOrderOutboxDispatcher scheduled tick (poll-interval 5s,
+      # initial-delay 5s) is otherwise live during every @QuarkusTest in this module and can
+      # race a test's own manual outbox manipulation (e.g. StandingOrderOutboxClaimIT stomping
+      # claimed_at to force a stale row) -- the scheduler can claim/dispatch/markSent the row
+      # out from under the test before its own assertion runs, an intermittent false failure of
+      # the reclaim assertion, not a defect in claimProcessable itself.
+      dispatch-enabled: false
 openbank:
   rate-limit:
     enabled: true


### PR DESCRIPTION
## Summary
- `StandingOrderOutboxClaimIT` failed intermittently in CI (#7539, Services CI run 33145481933): `a stale DISPATCHING row is reclaimed instead of stranded forever()` FAILED on `AssertionFailedError at StandingOrderOutboxClaimIT.kt:107`.
- Root cause found: `openbank-standing-order-service`'s real `StandingOrderOutboxDispatcher` `@Scheduled` tick (`poll-interval: 5s`, `initial-delay: 5s`) has `dispatch-enabled: true` unconditionally, with no `%test` override anywhere in the module — so the live scheduler runs during every `@QuarkusTest` in this module, including this IT.
- The test forces a stale row by directly updating `claimed_at` to `Instant.EPOCH`, then calls `claimProcessable` itself to assert the row is reclaimed. If the live background dispatcher's own tick fires in that window, it can legitimately claim/publish/`markSent` the same row first (it is just as eligible under the real reclaim SQL), leaving nothing for the test's own reclaim call to find — an intermittent false failure of the test, not a defect in `claimProcessable`.
- **This is a test-isolation flake, not a production bug.** `claimProcessable`'s native `FOR UPDATE SKIP LOCKED` claim/reclaim SQL (`StandingOrderOutboxRepositoryImpl.CLAIM_SQL`) was reproduced locally against real Testcontainers PostgreSQL (`postgres:16.3-alpine`) — both in isolation and as part of the full module test suite, across several repeated runs — and reclaimed the stale row correctly every single time.
- Fix: add `openbank.outbox.dispatch-enabled: false` under the existing `%test` profile block in `application.yaml`, following the same convention other services (e.g. `openbank-statement-service`) already use to keep a live scheduler from firing during tests. **No production behavior changes** — the top-level `dispatch-enabled: true` used outside `%test` is untouched.

## Why this is flagged by the money-path guard
`check-agent-pr-guard.py` flags this PR because it touches `openbank-standing-order-service/src/main/resources/application.yaml`, a money-path service's main config file. The change is scoped entirely to the `%test` SmallRye profile block and has zero effect on any deployed/production configuration — but per repo policy this still needs 2 human approvals before merge. Flagging explicitly for reviewer awareness.

## Investigation detail
- CI failure log (job 98784080167 of run 33145481933) shows the assertion failing ~7s after the app's HTTP endpoint came up in the test JVM — right around the dispatcher's 5s `initial-delay` window.
- Verified `dispatch-enabled: true` with no `%test` override exists anywhere under `openbank-standing-order-service/src/main/resources` or `src/test/resources` prior to this change.
- Local repro: `./gradlew :openbank-standing-order-service:test --tests "com.openbank.standingorder.integration.StandingOrderOutboxClaimIT"` and full-module `./gradlew :openbank-standing-order-service:test`, run several times each, both before and after this change — `StandingOrderOutboxClaimIT` was green every time (the SQL logic was never observed to fail locally, consistent with the race-window theory rather than a genuine SQL defect).

Refs #7539

## Test plan
- [x] `StandingOrderOutboxClaimIT` (both test methods) run in isolation against real Testcontainers Postgres — green, several times
- [x] Full `openbank-standing-order-service` test module run — green (one unrelated `QuarkusBindException` port-collision flake observed in a separate class, a known local-environment artifact per this repo's own CLAUDE.md notes, not related to this change)
- [x] `python3 .github/scripts/check-agent-pr-guard.py --paths openbank-standing-order-service/src/main/resources/application.yaml` — confirmed PROTECTED (expected; flagged above for reviewers)
- [ ] Human review + 2 approvals (money-path service) + CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
