### PR TITLE
feat(ledger): declare sourceService on five money-path event producers

### DIFF
--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/messaging/KafkaDelegationOutboxEventPublisher.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/messaging/KafkaDelegationOutboxEventPublisher.kt
@@ -54,8 +54,9 @@ class KafkaDelegationOutboxEventPublisher(
      *
      * The literal key matters: the payload is a serialised data class, so the wire key exists only
      * as a Kotlin property name at runtime and a quoted-string probe over this module finds nothing.
-     * Writing it through an ObjectNode is what makes the claim greppable AND resolvable by
-     * `.github/scripts/check-source-service-presence.py`.
+     * Writing it through an ObjectNode is what makes the claim greppable by a quoted-key probe as
+     * well as visible to one that reads the emitting type -- the fleet has both, and a claim only
+     * one of them can see is a claim that gets miscounted.
      *
      * A payload that is not a JSON object is emitted unchanged and logged: this is the money path,
      * and refusing to publish would be a strictly worse failure than an unattributed row.

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/messaging/KafkaDelegationOutboxEventPublisher.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/messaging/KafkaDelegationOutboxEventPublisher.kt
@@ -3,6 +3,9 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 package com.openbank.delegation.infrastructure.messaging
 
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import com.openbank.libs.persistence.outbox.OutboxEntry
 import com.openbank.libs.persistence.outbox.OutboxEventPublisher
 import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
@@ -13,10 +16,12 @@ import jakarta.enterprise.context.ApplicationScoped
 import org.apache.kafka.common.header.internals.RecordHeaders
 import org.eclipse.microprofile.reactive.messaging.Channel
 import org.eclipse.microprofile.reactive.messaging.Message
+import org.jboss.logging.Logger
 
 @ApplicationScoped
 class KafkaDelegationOutboxEventPublisher(
     @Channel("delegation-events-out") private val emitter: MutinyEmitter<String>,
+    private val objectMapper: ObjectMapper,
 ) : OutboxEventPublisher {
 
     override suspend fun publish(entry: OutboxEntry) {
@@ -26,6 +31,52 @@ class KafkaDelegationOutboxEventPublisher(
             .withKey(OutboxKafkaHeaders.partitionKey(entry))
             .withHeaders(kafkaHeaders)
             .build()
-        emitter.sendMessage(Message.of(entry.payload).addMetadata(meta)).awaitSuspending()
+        emitter.sendMessage(Message.of(withSourceService(entry.payload)).addMetadata(meta)).awaitSuspending()
+    }
+
+    /**
+     * Stamps the producer's own name onto the outgoing payload as `sourceService`.
+     *
+     * WHY HERE AND NOT ON THE EVENT TYPE. audit-service resolves attribution strongest-claim-first:
+     * a `sourceService` on the event body is `AttributionSource.EVENT`, and without it the row falls
+     * back to the topic ladder (`TopicAttribution`) and is recorded as `AttributionSource.TOPIC` --
+     * a value DERIVED from the topic name rather than STATED by the producer. Both spell
+     * "delegation-service" today, so this is not a wrong value being corrected; it is an inferred one
+     * becoming a declared one. That distinction cannot be repaired later: `audit_entries` is
+     * append-only AT THE DATABASE (V2's rules are `DO INSTEAD NOTHING`, so a normalising UPDATE
+     * touches zero rows and REPORTS SUCCESS) and `source_service` is chain-hashed into
+     * `record_hash`. Every day the field is absent produces rows whose attribution is permanently
+     * inferred, so the fix is forward-only by construction.
+     *
+     * The stamp lives on the publisher, not on each event data class, because this module has no
+     * shared event supertype -- a per-class field would have to be repeated on every event type and
+     * silently omitted by the next one added. The channel has exactly one exit and this is it.
+     *
+     * The literal key matters: the payload is a serialised data class, so the wire key exists only
+     * as a Kotlin property name at runtime and a quoted-string probe over this module finds nothing.
+     * Writing it through an ObjectNode is what makes the claim greppable AND resolvable by
+     * `.github/scripts/check-source-service-presence.py`.
+     *
+     * A payload that is not a JSON object is emitted unchanged and logged: this is the money path,
+     * and refusing to publish would be a strictly worse failure than an unattributed row.
+     */
+    private fun withSourceService(payload: String): String = try {
+        when (val node = objectMapper.readTree(payload)) {
+            is ObjectNode -> objectMapper.writeValueAsString(node.put("sourceService", SOURCE_SERVICE))
+            else -> payload.also { log.warn("outbox payload is not a JSON object; emitting without sourceService") }
+        }
+    } catch (e: JsonProcessingException) {
+        log.warn("outbox payload is not parseable JSON; emitting without sourceService", e)
+        payload
+    }
+
+    companion object {
+        /**
+         * The module directory name minus the `openbank-` prefix -- the fleet's audit convention,
+         * and the same spelling `TopicAttribution` already derives for this topic.
+         */
+        internal const val SOURCE_SERVICE = "delegation-service"
+
+        private val log: Logger = Logger.getLogger(KafkaDelegationOutboxEventPublisher::class.java)
     }
 }

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/infrastructure/messaging/KafkaDelegationOutboxEventPublisherTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/infrastructure/messaging/KafkaDelegationOutboxEventPublisherTest.kt
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.delegation.infrastructure.messaging
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.openbank.delegation.domain.event.DelegationRevoked
+import com.openbank.libs.persistence.outbox.OutboxEntry
+import com.openbank.libs.persistence.outbox.OutboxStatus
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.smallrye.mutiny.Uni
+import io.smallrye.reactive.messaging.MutinyEmitter
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.reactive.messaging.Message
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * `sourceService` must be ON THE WIRE, not merely mentioned in this module.
+ *
+ * WHY THIS TEST EXISTS. audit-service resolves attribution strongest-claim-first: a `sourceService`
+ * on the event body is recorded as `AttributionSource.EVENT`, and without it the row falls back to
+ * the topic ladder (`TopicAttribution`) and is recorded as `AttributionSource.TOPIC` -- a value
+ * DERIVED from the topic name rather than STATED by this service. Both spell "delegation-service"
+ * today, so nothing was ever WRONG; what was missing is the producer's own claim.
+ *
+ * That is worth a test because it cannot be repaired later. `audit_entries` is append-only AT THE
+ * DATABASE (the V2 rules are `DO INSTEAD NOTHING`, so a normalising UPDATE touches zero rows and
+ * REPORTS SUCCESS) and `source_service` is chain-hashed into `record_hash`. Every event emitted
+ * without the field is one more permanently-inferred row; the fix is forward-only by construction.
+ *
+ * THE PROBE TRAP THIS TEST IS WRITTEN AROUND -- AND WHY THIS MODULE IS THE WORKED EXAMPLE.
+ * `DelegationRepositoryImpl` serialises a Kotlin data class (`objectMapper.writeValueAsString(event)`),
+ * so the wire keys exist ONLY at runtime as property names. There is no literal `"sourceService"`
+ * for a grep to find, and there is no literal `"grantorPartyId"` either -- a quoted-string probe
+ * over this module returns zero for every field it emits. A test that asserted on source text, or
+ * on a substring of the payload, would inherit exactly that blindness. So this test serialises a
+ * REAL event through the module's own idiom and asserts the PARSED wire value.
+ */
+class KafkaDelegationOutboxEventPublisherTest {
+
+    private val mapper = ObjectMapper().registerModule(JavaTimeModule())
+
+    private fun realEventPayload(): String = mapper.writeValueAsString(
+        DelegationRevoked(
+            aggregateId = UUID.randomUUID(),
+            grantorPartyId = UUID.randomUUID(),
+            granteePartyId = UUID.randomUUID(),
+            resourceType = com.openbank.delegation.domain.model.DelegationResourceType.ACCOUNT,
+            resourceId = UUID.randomUUID(),
+            capabilities = emptySet(),
+            reason = "revoked by grantor",
+            occurredAt = Instant.now(),
+        ),
+    )
+
+    private fun entry(payload: String) = OutboxEntry(
+        eventId = UUID.randomUUID(),
+        aggregateId = UUID.randomUUID(),
+        eventType = "DelegationRevoked",
+        payload = payload,
+        status = OutboxStatus.PENDING,
+        attemptCount = 0,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now(),
+        sentAt = null,
+        lastError = null,
+    )
+
+    @Test
+    fun `a real serialised domain event carries no sourceService of its own`() {
+        // The state the stamp exists to fix, asserted against the module's actual event type
+        // rather than a hand-written fixture -- so adding the field to the data class later
+        // makes this line fail loudly instead of leaving two competing sources of the value.
+        assertThat(mapper.readTree(realEventPayload()).has("sourceService")).isFalse()
+    }
+
+    @Test
+    fun `publish stamps sourceService on the emitted payload`() {
+        val emitter = mockk<MutinyEmitter<String>>()
+        val captured = slot<Message<String>>()
+        every { emitter.sendMessage(capture(captured)) } returns Uni.createFrom().voidItem()
+
+        runBlocking {
+            KafkaDelegationOutboxEventPublisher(emitter, mapper).publish(entry(realEventPayload()))
+        }
+
+        assertThat(mapper.readTree(captured.captured.payload).get("sourceService").asText())
+            .isEqualTo("delegation-service")
+    }
+
+    @Test
+    fun `stamping preserves every field the producer already emitted`() {
+        val emitter = mockk<MutinyEmitter<String>>()
+        val captured = slot<Message<String>>()
+        every { emitter.sendMessage(capture(captured)) } returns Uni.createFrom().voidItem()
+        val payload = realEventPayload()
+
+        runBlocking { KafkaDelegationOutboxEventPublisher(emitter, mapper).publish(entry(payload)) }
+
+        val before = mapper.readTree(payload)
+        val after = mapper.readTree(captured.captured.payload)
+        before.fieldNames().forEach { field ->
+            assertThat(after.get(field)).describedAs("field %s survived stamping", field).isEqualTo(before.get(field))
+        }
+    }
+
+    @Test
+    fun `the stamped value is this module's directory name minus the openbank prefix`() {
+        assertThat(KafkaDelegationOutboxEventPublisher.SOURCE_SERVICE).isEqualTo("delegation-service")
+    }
+
+    @Test
+    fun `a payload that is not JSON is emitted unchanged rather than dropped`() {
+        val emitter = mockk<MutinyEmitter<String>>()
+        val captured = slot<Message<String>>()
+        every { emitter.sendMessage(capture(captured)) } returns Uni.createFrom().voidItem()
+
+        runBlocking { KafkaDelegationOutboxEventPublisher(emitter, mapper).publish(entry("not json at all")) }
+
+        // This is the money path: an unattributed row is a strictly better outcome than a publish
+        // that throws and wedges the outbox dispatcher.
+        assertThat(captured.captured.payload).isEqualTo("not json at all")
+    }
+}

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/kafka/KafkaFraudOutboxEventPublisher.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/kafka/KafkaFraudOutboxEventPublisher.kt
@@ -56,8 +56,9 @@ class KafkaFraudOutboxEventPublisher(
      *
      * The literal key matters: the payload is a serialised data class, so the wire key exists only
      * as a Kotlin property name at runtime and a quoted-string probe over this module finds nothing.
-     * Writing it through an ObjectNode is what makes the claim greppable AND resolvable by
-     * `.github/scripts/check-source-service-presence.py`.
+     * Writing it through an ObjectNode is what makes the claim greppable by a quoted-key probe as
+     * well as visible to one that reads the emitting type -- the fleet has both, and a claim only
+     * one of them can see is a claim that gets miscounted.
      *
      * A payload that is not a JSON object is emitted unchanged and logged: this is the money path,
      * and refusing to publish would be a strictly worse failure than an unattributed row.

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/kafka/KafkaFraudOutboxEventPublisher.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/kafka/KafkaFraudOutboxEventPublisher.kt
@@ -4,6 +4,9 @@
 
 package com.openbank.fraud.infrastructure.kafka
 
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import com.openbank.libs.persistence.outbox.OutboxEntry
 import com.openbank.libs.persistence.outbox.OutboxEventPublisher
 import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
@@ -14,11 +17,14 @@ import jakarta.enterprise.context.ApplicationScoped
 import org.apache.kafka.common.header.internals.RecordHeaders
 import org.eclipse.microprofile.reactive.messaging.Channel
 import org.eclipse.microprofile.reactive.messaging.Message
+import org.jboss.logging.Logger
 
 /** Publishes to `openbank.fraud.hold.changed` (ADR-0220 D3.5, issue #2749). */
 @ApplicationScoped
-class KafkaFraudOutboxEventPublisher(@Channel("fraud-outbox-out") private val emitter: MutinyEmitter<String>) :
-    OutboxEventPublisher {
+class KafkaFraudOutboxEventPublisher(
+    @Channel("fraud-outbox-out") private val emitter: MutinyEmitter<String>,
+    private val objectMapper: ObjectMapper,
+) : OutboxEventPublisher {
 
     override suspend fun publish(entry: OutboxEntry) {
         val kafkaHeaders = RecordHeaders()
@@ -27,6 +33,52 @@ class KafkaFraudOutboxEventPublisher(@Channel("fraud-outbox-out") private val em
             .withKey(OutboxKafkaHeaders.partitionKey(entry))
             .withHeaders(kafkaHeaders)
             .build()
-        emitter.sendMessage(Message.of(entry.payload).addMetadata(meta)).awaitSuspending()
+        emitter.sendMessage(Message.of(withSourceService(entry.payload)).addMetadata(meta)).awaitSuspending()
+    }
+
+    /**
+     * Stamps the producer's own name onto the outgoing payload as `sourceService`.
+     *
+     * WHY HERE AND NOT ON THE EVENT TYPE. audit-service resolves attribution strongest-claim-first:
+     * a `sourceService` on the event body is `AttributionSource.EVENT`, and without it the row falls
+     * back to the topic ladder (`TopicAttribution`) and is recorded as `AttributionSource.TOPIC` --
+     * a value DERIVED from the topic name rather than STATED by the producer. Both spell
+     * "fraud-service" today, so this is not a wrong value being corrected; it is an inferred one
+     * becoming a declared one. That distinction cannot be repaired later: `audit_entries` is
+     * append-only AT THE DATABASE (V2's rules are `DO INSTEAD NOTHING`, so a normalising UPDATE
+     * touches zero rows and REPORTS SUCCESS) and `source_service` is chain-hashed into
+     * `record_hash`. Every day the field is absent produces rows whose attribution is permanently
+     * inferred, so the fix is forward-only by construction.
+     *
+     * The stamp lives on the publisher, not on each event data class, because this module has no
+     * shared event supertype -- a per-class field would have to be repeated on every event type and
+     * silently omitted by the next one added. The channel has exactly one exit and this is it.
+     *
+     * The literal key matters: the payload is a serialised data class, so the wire key exists only
+     * as a Kotlin property name at runtime and a quoted-string probe over this module finds nothing.
+     * Writing it through an ObjectNode is what makes the claim greppable AND resolvable by
+     * `.github/scripts/check-source-service-presence.py`.
+     *
+     * A payload that is not a JSON object is emitted unchanged and logged: this is the money path,
+     * and refusing to publish would be a strictly worse failure than an unattributed row.
+     */
+    private fun withSourceService(payload: String): String = try {
+        when (val node = objectMapper.readTree(payload)) {
+            is ObjectNode -> objectMapper.writeValueAsString(node.put("sourceService", SOURCE_SERVICE))
+            else -> payload.also { log.warn("outbox payload is not a JSON object; emitting without sourceService") }
+        }
+    } catch (e: JsonProcessingException) {
+        log.warn("outbox payload is not parseable JSON; emitting without sourceService", e)
+        payload
+    }
+
+    companion object {
+        /**
+         * The module directory name minus the `openbank-` prefix -- the fleet's audit convention,
+         * and the same spelling `TopicAttribution` already derives for this topic.
+         */
+        internal const val SOURCE_SERVICE = "fraud-service"
+
+        private val log: Logger = Logger.getLogger(KafkaFraudOutboxEventPublisher::class.java)
     }
 }

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/kafka/KafkaInterestOutboxEventPublisher.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/kafka/KafkaInterestOutboxEventPublisher.kt
@@ -3,6 +3,9 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 package com.openbank.interest.infrastructure.kafka
 
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import com.openbank.libs.persistence.outbox.OutboxEntry
 import com.openbank.libs.persistence.outbox.OutboxEventPublisher
 import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
@@ -17,6 +20,7 @@ import org.eclipse.microprofile.faulttolerance.Retry
 import org.eclipse.microprofile.faulttolerance.Timeout
 import org.eclipse.microprofile.reactive.messaging.Channel
 import org.eclipse.microprofile.reactive.messaging.Message
+import org.jboss.logging.Logger
 
 /**
  * Relays an interest outbox row to Kafka (ADR-0050 N2/N3).
@@ -33,8 +37,8 @@ import org.eclipse.microprofile.reactive.messaging.Message
 @ApplicationScoped
 class KafkaInterestOutboxEventPublisher(
     @Channel("interest-events-out") private val emitter: MutinyEmitter<String>,
-) :
-    OutboxEventPublisher {
+    private val objectMapper: ObjectMapper,
+) : OutboxEventPublisher {
 
     @Bulkhead(value = 1, waitingTaskQueue = 1)
     @CircuitBreaker(requestVolumeThreshold = 10, failureRatio = 0.5, delay = 5000, successThreshold = 2)
@@ -47,6 +51,52 @@ class KafkaInterestOutboxEventPublisher(
             .withKey(OutboxKafkaHeaders.partitionKey(entry))
             .withHeaders(kafkaHeaders)
             .build()
-        emitter.sendMessage(Message.of(entry.payload).addMetadata(metadata)).awaitSuspending()
+        emitter.sendMessage(Message.of(withSourceService(entry.payload)).addMetadata(metadata)).awaitSuspending()
+    }
+
+    /**
+     * Stamps the producer's own name onto the outgoing payload as `sourceService`.
+     *
+     * WHY HERE AND NOT ON THE EVENT TYPE. audit-service resolves attribution strongest-claim-first:
+     * a `sourceService` on the event body is `AttributionSource.EVENT`, and without it the row falls
+     * back to the topic ladder (`TopicAttribution`) and is recorded as `AttributionSource.TOPIC` --
+     * a value DERIVED from the topic name rather than STATED by the producer. Both spell
+     * "interest-service" today, so this is not a wrong value being corrected; it is an inferred one
+     * becoming a declared one. That distinction cannot be repaired later: `audit_entries` is
+     * append-only AT THE DATABASE (V2's rules are `DO INSTEAD NOTHING`, so a normalising UPDATE
+     * touches zero rows and REPORTS SUCCESS) and `source_service` is chain-hashed into
+     * `record_hash`. Every day the field is absent produces rows whose attribution is permanently
+     * inferred, so the fix is forward-only by construction.
+     *
+     * The stamp lives on the publisher, not on each event data class, because this module has no
+     * shared event supertype -- a per-class field would have to be repeated on every event type and
+     * silently omitted by the next one added. The channel has exactly one exit and this is it.
+     *
+     * The literal key matters: the payload is a serialised data class, so the wire key exists only
+     * as a Kotlin property name at runtime and a quoted-string probe over this module finds nothing.
+     * Writing it through an ObjectNode is what makes the claim greppable AND resolvable by
+     * `.github/scripts/check-source-service-presence.py`.
+     *
+     * A payload that is not a JSON object is emitted unchanged and logged: this is the money path,
+     * and refusing to publish would be a strictly worse failure than an unattributed row.
+     */
+    private fun withSourceService(payload: String): String = try {
+        when (val node = objectMapper.readTree(payload)) {
+            is ObjectNode -> objectMapper.writeValueAsString(node.put("sourceService", SOURCE_SERVICE))
+            else -> payload.also { log.warn("outbox payload is not a JSON object; emitting without sourceService") }
+        }
+    } catch (e: JsonProcessingException) {
+        log.warn("outbox payload is not parseable JSON; emitting without sourceService", e)
+        payload
+    }
+
+    companion object {
+        /**
+         * The module directory name minus the `openbank-` prefix -- the fleet's audit convention,
+         * and the same spelling `TopicAttribution` already derives for this topic.
+         */
+        internal const val SOURCE_SERVICE = "interest-service"
+
+        private val log: Logger = Logger.getLogger(KafkaInterestOutboxEventPublisher::class.java)
     }
 }

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/kafka/KafkaInterestOutboxEventPublisher.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/kafka/KafkaInterestOutboxEventPublisher.kt
@@ -74,8 +74,9 @@ class KafkaInterestOutboxEventPublisher(
      *
      * The literal key matters: the payload is a serialised data class, so the wire key exists only
      * as a Kotlin property name at runtime and a quoted-string probe over this module finds nothing.
-     * Writing it through an ObjectNode is what makes the claim greppable AND resolvable by
-     * `.github/scripts/check-source-service-presence.py`.
+     * Writing it through an ObjectNode is what makes the claim greppable by a quoted-key probe as
+     * well as visible to one that reads the emitting type -- the fleet has both, and a claim only
+     * one of them can see is a claim that gets miscounted.
      *
      * A payload that is not a JSON object is emitted unchanged and logged: this is the money path,
      * and refusing to publish would be a strictly worse failure than an unattributed row.

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/kafka/KafkaInterestOutboxEventPublisherTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/kafka/KafkaInterestOutboxEventPublisherTest.kt
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
-package com.openbank.fraud.infrastructure.kafka
+package com.openbank.interest.infrastructure.kafka
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.libs.persistence.outbox.OutboxEntry
@@ -37,7 +37,7 @@ import java.util.UUID
  * test that asserted on the source, or on a substring of the payload string, would inherit the same
  * blindness. So this parses the captured message and reads the resolved value.
  */
-class KafkaFraudOutboxEventPublisherTest {
+class KafkaInterestOutboxEventPublisherTest {
 
     @Test
     fun `publish stamps sourceService on the emitted payload`() {
@@ -46,7 +46,7 @@ class KafkaFraudOutboxEventPublisherTest {
         every { emitter.sendMessage(capture(captured)) } returns Uni.createFrom().voidItem()
         val mapper = ObjectMapper()
 
-        val payload = """{"partyId":"p-1","accountId":"a-1","active":true,"reason":"RULE"}"""
+        val payload = """{"accrualId":"acc-1","accountId":"a-1","amount":1.23}"""
 
         // The producer's own payload does not carry the field -- this is the state the stamp fixes.
         assertThat(mapper.readTree(payload).has("sourceService")).isFalse()
@@ -54,7 +54,7 @@ class KafkaFraudOutboxEventPublisherTest {
         val entry = OutboxEntry(
             eventId = UUID.randomUUID(),
             aggregateId = UUID.randomUUID(),
-            eventType = "fraud.hold_changed",
+            eventType = "interest.accrual.posted",
             payload = payload,
             status = OutboxStatus.PENDING,
             attemptCount = 0,
@@ -64,10 +64,10 @@ class KafkaFraudOutboxEventPublisherTest {
             lastError = null,
         )
 
-        runBlocking { KafkaFraudOutboxEventPublisher(emitter, mapper).publish(entry) }
+        runBlocking { KafkaInterestOutboxEventPublisher(emitter, mapper).publish(entry) }
 
         assertThat(mapper.readTree(captured.captured.payload).get("sourceService").asText())
-            .isEqualTo("fraud-service")
+            .isEqualTo("interest-service")
     }
 
     @Test
@@ -76,7 +76,7 @@ class KafkaFraudOutboxEventPublisherTest {
         // directory name without `openbank-`; a producer that drifts to a second spelling splits
         // its own history into two apparent producers at a merge date, and those rows cannot be
         // converged afterwards (append-only + chain-hashed).
-        assertThat(KafkaFraudOutboxEventPublisher.SOURCE_SERVICE).isEqualTo("fraud-service")
+        assertThat(KafkaInterestOutboxEventPublisher.SOURCE_SERVICE).isEqualTo("interest-service")
     }
 
     @Test
@@ -88,7 +88,7 @@ class KafkaFraudOutboxEventPublisherTest {
         val entry = OutboxEntry(
             eventId = UUID.randomUUID(),
             aggregateId = UUID.randomUUID(),
-            eventType = "fraud.hold_changed",
+            eventType = "interest.accrual.posted",
             payload = "not json at all",
             status = OutboxStatus.PENDING,
             attemptCount = 0,
@@ -98,7 +98,7 @@ class KafkaFraudOutboxEventPublisherTest {
             lastError = null,
         )
 
-        runBlocking { KafkaFraudOutboxEventPublisher(emitter, ObjectMapper()).publish(entry) }
+        runBlocking { KafkaInterestOutboxEventPublisher(emitter, ObjectMapper()).publish(entry) }
 
         // This is the money path: an unattributed row is a strictly better outcome than a
         // publish that throws and wedges the outbox dispatcher.

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/integration/InterestOutboxDispatchIT.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/integration/InterestOutboxDispatchIT.kt
@@ -3,6 +3,7 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 package com.openbank.interest.integration
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.interest.infrastructure.outbox.InterestOutboxDispatcher
 import com.openbank.interest.infrastructure.persistence.entity.InterestOutboxEntity
 import com.openbank.interest.infrastructure.persistence.repository.InterestOutboxRepositoryImpl
@@ -148,7 +149,21 @@ class InterestOutboxDispatchIT {
                 .isEqualTo(id.toString())
             assertThat(headerValue(produced, OutboxKafkaHeaders.HEADER_EVENT_TYPE))
                 .isEqualTo(eventType)
-            assertThat(produced.payload).isEqualTo(payload)
+            // NOT byte equality: KafkaInterestOutboxEventPublisher stamps `sourceService` so
+            // audit-service records this module's own claim (AttributionSource.EVENT) rather than
+            // deriving one from the topic name. The relay must still never lose or rewrite a
+            // producer field, and must add nothing but attribution — two guarantees that byte
+            // equality collapsed into one assertion.
+            val mapper = ObjectMapper()
+            val producedJson = mapper.readTree(produced.payload)
+            val seededJson = mapper.readTree(payload)
+            seededJson.fieldNames().forEach { field ->
+                assertThat(producedJson.get(field)).isEqualTo(seededJson.get(field))
+            }
+            assertThat(producedJson.get("sourceService").asText()).isEqualTo("interest-service")
+            val added = producedJson.fieldNames().asSequence().toSet() -
+                seededJson.fieldNames().asSequence().toSet()
+            assertThat(added).isEqualTo(setOf("sourceService"))
         }
 
         // Persistence side committed: both rows are now SENT with a stamped sentAt and one attempt.

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/messaging/KafkaLedgerOutboxEventPublisher.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/messaging/KafkaLedgerOutboxEventPublisher.kt
@@ -68,8 +68,9 @@ class KafkaLedgerOutboxEventPublisher(
      *
      * The literal key matters: the payload is a serialised data class, so the wire key exists only
      * as a Kotlin property name at runtime and a quoted-string probe over this module finds nothing.
-     * Writing it through an ObjectNode is what makes the claim greppable AND resolvable by
-     * `.github/scripts/check-source-service-presence.py`.
+     * Writing it through an ObjectNode is what makes the claim greppable by a quoted-key probe as
+     * well as visible to one that reads the emitting type -- the fleet has both, and a claim only
+     * one of them can see is a claim that gets miscounted.
      *
      * A payload that is not a JSON object is emitted unchanged and logged: this is the money path,
      * and refusing to publish would be a strictly worse failure than an unattributed row.

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/messaging/KafkaLedgerOutboxEventPublisher.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/messaging/KafkaLedgerOutboxEventPublisher.kt
@@ -3,6 +3,9 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 package com.openbank.ledger.infrastructure.messaging
 
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import com.openbank.libs.persistence.outbox.OutboxEntry
 import com.openbank.libs.persistence.outbox.OutboxEventPublisher
 import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
@@ -13,6 +16,7 @@ import jakarta.enterprise.context.ApplicationScoped
 import org.apache.kafka.common.header.internals.RecordHeaders
 import org.eclipse.microprofile.reactive.messaging.Channel
 import org.eclipse.microprofile.reactive.messaging.Message
+import org.jboss.logging.Logger
 
 /**
  * Relays an outbox row to Kafka (ADR-0050 N2/N3).
@@ -29,8 +33,10 @@ import org.eclipse.microprofile.reactive.messaging.Message
  * (ADR-0013 / AbstractOutboxDispatcher KDoc).
  */
 @ApplicationScoped
-class KafkaLedgerOutboxEventPublisher(@Channel("ledger-events-out") private val emitter: MutinyEmitter<String>) :
-    OutboxEventPublisher {
+class KafkaLedgerOutboxEventPublisher(
+    @Channel("ledger-events-out") private val emitter: MutinyEmitter<String>,
+    private val objectMapper: ObjectMapper,
+) : OutboxEventPublisher {
 
     override suspend fun publish(entry: OutboxEntry) {
         val kafkaHeaders = RecordHeaders()
@@ -39,6 +45,52 @@ class KafkaLedgerOutboxEventPublisher(@Channel("ledger-events-out") private val 
             .withKey(OutboxKafkaHeaders.partitionKey(entry))
             .withHeaders(kafkaHeaders)
             .build()
-        emitter.sendMessage(Message.of(entry.payload).addMetadata(metadata)).awaitSuspending()
+        emitter.sendMessage(Message.of(withSourceService(entry.payload)).addMetadata(metadata)).awaitSuspending()
+    }
+
+    /**
+     * Stamps the producer's own name onto the outgoing payload as `sourceService`.
+     *
+     * WHY HERE AND NOT ON THE EVENT TYPE. audit-service resolves attribution strongest-claim-first:
+     * a `sourceService` on the event body is `AttributionSource.EVENT`, and without it the row falls
+     * back to the topic ladder (`TopicAttribution`) and is recorded as `AttributionSource.TOPIC` --
+     * a value DERIVED from the topic name rather than STATED by the producer. Both spell
+     * "ledger-service" today, so this is not a wrong value being corrected; it is an inferred one
+     * becoming a declared one. That distinction cannot be repaired later: `audit_entries` is
+     * append-only AT THE DATABASE (V2's rules are `DO INSTEAD NOTHING`, so a normalising UPDATE
+     * touches zero rows and REPORTS SUCCESS) and `source_service` is chain-hashed into
+     * `record_hash`. Every day the field is absent produces rows whose attribution is permanently
+     * inferred, so the fix is forward-only by construction.
+     *
+     * The stamp lives on the publisher, not on each event data class, because this module has no
+     * shared event supertype -- a per-class field would have to be repeated on every event type and
+     * silently omitted by the next one added. The channel has exactly one exit and this is it.
+     *
+     * The literal key matters: the payload is a serialised data class, so the wire key exists only
+     * as a Kotlin property name at runtime and a quoted-string probe over this module finds nothing.
+     * Writing it through an ObjectNode is what makes the claim greppable AND resolvable by
+     * `.github/scripts/check-source-service-presence.py`.
+     *
+     * A payload that is not a JSON object is emitted unchanged and logged: this is the money path,
+     * and refusing to publish would be a strictly worse failure than an unattributed row.
+     */
+    private fun withSourceService(payload: String): String = try {
+        when (val node = objectMapper.readTree(payload)) {
+            is ObjectNode -> objectMapper.writeValueAsString(node.put("sourceService", SOURCE_SERVICE))
+            else -> payload.also { log.warn("outbox payload is not a JSON object; emitting without sourceService") }
+        }
+    } catch (e: JsonProcessingException) {
+        log.warn("outbox payload is not parseable JSON; emitting without sourceService", e)
+        payload
+    }
+
+    companion object {
+        /**
+         * The module directory name minus the `openbank-` prefix -- the fleet's audit convention,
+         * and the same spelling `TopicAttribution` already derives for this topic.
+         */
+        internal const val SOURCE_SERVICE = "ledger-service"
+
+        private val log: Logger = Logger.getLogger(KafkaLedgerOutboxEventPublisher::class.java)
     }
 }

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/messaging/KafkaLedgerOutboxEventPublisherTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/messaging/KafkaLedgerOutboxEventPublisherTest.kt
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
-package com.openbank.fraud.infrastructure.kafka
+package com.openbank.ledger.infrastructure.messaging
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.libs.persistence.outbox.OutboxEntry
@@ -37,7 +37,7 @@ import java.util.UUID
  * test that asserted on the source, or on a substring of the payload string, would inherit the same
  * blindness. So this parses the captured message and reads the resolved value.
  */
-class KafkaFraudOutboxEventPublisherTest {
+class KafkaLedgerOutboxEventPublisherTest {
 
     @Test
     fun `publish stamps sourceService on the emitted payload`() {
@@ -46,7 +46,7 @@ class KafkaFraudOutboxEventPublisherTest {
         every { emitter.sendMessage(capture(captured)) } returns Uni.createFrom().voidItem()
         val mapper = ObjectMapper()
 
-        val payload = """{"partyId":"p-1","accountId":"a-1","active":true,"reason":"RULE"}"""
+        val payload = """{"journalId":"j-1","accountId":"a-1","amount":100.00,"currency":"CZK"}"""
 
         // The producer's own payload does not carry the field -- this is the state the stamp fixes.
         assertThat(mapper.readTree(payload).has("sourceService")).isFalse()
@@ -54,7 +54,7 @@ class KafkaFraudOutboxEventPublisherTest {
         val entry = OutboxEntry(
             eventId = UUID.randomUUID(),
             aggregateId = UUID.randomUUID(),
-            eventType = "fraud.hold_changed",
+            eventType = "ledger.journal.posted",
             payload = payload,
             status = OutboxStatus.PENDING,
             attemptCount = 0,
@@ -64,10 +64,10 @@ class KafkaFraudOutboxEventPublisherTest {
             lastError = null,
         )
 
-        runBlocking { KafkaFraudOutboxEventPublisher(emitter, mapper).publish(entry) }
+        runBlocking { KafkaLedgerOutboxEventPublisher(emitter, mapper).publish(entry) }
 
         assertThat(mapper.readTree(captured.captured.payload).get("sourceService").asText())
-            .isEqualTo("fraud-service")
+            .isEqualTo("ledger-service")
     }
 
     @Test
@@ -76,7 +76,7 @@ class KafkaFraudOutboxEventPublisherTest {
         // directory name without `openbank-`; a producer that drifts to a second spelling splits
         // its own history into two apparent producers at a merge date, and those rows cannot be
         // converged afterwards (append-only + chain-hashed).
-        assertThat(KafkaFraudOutboxEventPublisher.SOURCE_SERVICE).isEqualTo("fraud-service")
+        assertThat(KafkaLedgerOutboxEventPublisher.SOURCE_SERVICE).isEqualTo("ledger-service")
     }
 
     @Test
@@ -88,7 +88,7 @@ class KafkaFraudOutboxEventPublisherTest {
         val entry = OutboxEntry(
             eventId = UUID.randomUUID(),
             aggregateId = UUID.randomUUID(),
-            eventType = "fraud.hold_changed",
+            eventType = "ledger.journal.posted",
             payload = "not json at all",
             status = OutboxStatus.PENDING,
             attemptCount = 0,
@@ -98,7 +98,7 @@ class KafkaFraudOutboxEventPublisherTest {
             lastError = null,
         )
 
-        runBlocking { KafkaFraudOutboxEventPublisher(emitter, ObjectMapper()).publish(entry) }
+        runBlocking { KafkaLedgerOutboxEventPublisher(emitter, ObjectMapper()).publish(entry) }
 
         // This is the money path: an unattributed row is a strictly better outcome than a
         // publish that throws and wedges the outbox dispatcher.

--- a/openbank-libs-testing/src/main/kotlin/com/openbank/libs/testing/outbox/OutboxDispatchConformanceIT.kt
+++ b/openbank-libs-testing/src/main/kotlin/com/openbank/libs/testing/outbox/OutboxDispatchConformanceIT.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.libs.testing.outbox
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.libs.domain.identifiers.Ids
 import com.openbank.libs.persistence.outbox.OutboxEntry
 import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
@@ -129,7 +130,27 @@ abstract class OutboxDispatchConformanceIT {
             assertThat(headerValue(produced, OutboxKafkaHeaders.HEADER_IDEMPOTENCY_KEY))
                 .isEqualTo(msg.eventId.toString())
             assertThat(headerValue(produced, OutboxKafkaHeaders.HEADER_EVENT_TYPE)).isEqualTo(msg.eventType)
-            assertThat(produced.payload).isEqualTo(msg.payload)
+            // NOT byte equality. A publisher may stamp `sourceService` onto the outgoing payload
+            // (ledger/sdd/interest/fraud/delegation do, so audit-service records the producer's own
+            // claim as AttributionSource.EVENT instead of deriving one from the topic name). What
+            // this suite must guarantee is that relaying never LOSES or REWRITES a field the
+            // producer wrote — an equality assertion cannot express that, and would force every
+            // stamping module to fork the shared harness.
+            val producedJson = PAYLOAD_MAPPER.readTree(produced.payload)
+            val seededJson = PAYLOAD_MAPPER.readTree(msg.payload)
+            seededJson.fieldNames().forEach { field ->
+                assertThat(producedJson.get(field))
+                    .describedAs("relay preserved producer field %s of %s", field, msg.eventId)
+                    .isEqualTo(seededJson.get(field))
+            }
+            // The only addition the relay is permitted to make is attribution. Anything else is a
+            // payload rewrite this suite exists to catch, and would pass silently once the equality
+            // assertion above was relaxed.
+            val added = producedJson.fieldNames().asSequence().toSet() -
+                seededJson.fieldNames().asSequence().toSet()
+            assertThat(added)
+                .describedAs("relay added only attribution to %s", msg.eventId)
+                .isSubsetOf(setOf("sourceService"))
         }
 
         // Persistence side committed: both rows are now SENT with a stamped sentAt and one attempt.
@@ -177,6 +198,14 @@ abstract class OutboxDispatchConformanceIT {
         assertThat(secondPassCount).describedAs("SENT row must not be re-published on replay").isEqualTo(1)
     }
     private companion object {
+        /**
+         * Payload comparison in this suite is STRUCTURAL, not textual — see the relay assertions.
+         * A byte-equality assertion conflated two different guarantees ("no field was lost or
+         * rewritten" and "nothing was added"), so a publisher that stamps attribution could not
+         * satisfy it without forking the harness.
+         */
+        val PAYLOAD_MAPPER: ObjectMapper = ObjectMapper()
+
         /**
          * Any real stamp is after this; `Instant.EPOCH` is not. Deliberately a floor rather than
          * "within N seconds of now" — the point is to catch a 1970 default, not to police clock

--- a/openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/kafka/KafkaSddOutboxEventPublisher.kt
+++ b/openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/kafka/KafkaSddOutboxEventPublisher.kt
@@ -3,6 +3,9 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 package com.openbank.sdd.infrastructure.kafka
 
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import com.openbank.libs.persistence.outbox.OutboxEntry
 import com.openbank.libs.persistence.outbox.OutboxEventPublisher
 import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
@@ -13,6 +16,7 @@ import jakarta.enterprise.context.ApplicationScoped
 import org.apache.kafka.common.header.internals.RecordHeaders
 import org.eclipse.microprofile.reactive.messaging.Channel
 import org.eclipse.microprofile.reactive.messaging.Message
+import org.jboss.logging.Logger
 
 /**
  * Relays an SDD outbox row to Kafka (ADR-0050 N2/N3).
@@ -23,8 +27,10 @@ import org.eclipse.microprofile.reactive.messaging.Message
  *   delivery is safely deduplicated by consumers (N3). See [OutboxKafkaHeaders] for canonical names.
  */
 @ApplicationScoped
-class KafkaSddOutboxEventPublisher(@Channel("sdd-events-out") private val emitter: MutinyEmitter<String>) :
-    OutboxEventPublisher {
+class KafkaSddOutboxEventPublisher(
+    @Channel("sdd-events-out") private val emitter: MutinyEmitter<String>,
+    private val objectMapper: ObjectMapper,
+) : OutboxEventPublisher {
 
     override suspend fun publish(entry: OutboxEntry) {
         val kafkaHeaders = RecordHeaders()
@@ -33,6 +39,52 @@ class KafkaSddOutboxEventPublisher(@Channel("sdd-events-out") private val emitte
             .withKey(OutboxKafkaHeaders.partitionKey(entry))
             .withHeaders(kafkaHeaders)
             .build()
-        emitter.sendMessage(Message.of(entry.payload).addMetadata(meta)).awaitSuspending()
+        emitter.sendMessage(Message.of(withSourceService(entry.payload)).addMetadata(meta)).awaitSuspending()
+    }
+
+    /**
+     * Stamps the producer's own name onto the outgoing payload as `sourceService`.
+     *
+     * WHY HERE AND NOT ON THE EVENT TYPE. audit-service resolves attribution strongest-claim-first:
+     * a `sourceService` on the event body is `AttributionSource.EVENT`, and without it the row falls
+     * back to the topic ladder (`TopicAttribution`) and is recorded as `AttributionSource.TOPIC` --
+     * a value DERIVED from the topic name rather than STATED by the producer. Both spell
+     * "sdd-service" today, so this is not a wrong value being corrected; it is an inferred one
+     * becoming a declared one. That distinction cannot be repaired later: `audit_entries` is
+     * append-only AT THE DATABASE (V2's rules are `DO INSTEAD NOTHING`, so a normalising UPDATE
+     * touches zero rows and REPORTS SUCCESS) and `source_service` is chain-hashed into
+     * `record_hash`. Every day the field is absent produces rows whose attribution is permanently
+     * inferred, so the fix is forward-only by construction.
+     *
+     * The stamp lives on the publisher, not on each event data class, because this module has no
+     * shared event supertype -- a per-class field would have to be repeated on every event type and
+     * silently omitted by the next one added. The channel has exactly one exit and this is it.
+     *
+     * The literal key matters: the payload is a serialised data class, so the wire key exists only
+     * as a Kotlin property name at runtime and a quoted-string probe over this module finds nothing.
+     * Writing it through an ObjectNode is what makes the claim greppable AND resolvable by
+     * `.github/scripts/check-source-service-presence.py`.
+     *
+     * A payload that is not a JSON object is emitted unchanged and logged: this is the money path,
+     * and refusing to publish would be a strictly worse failure than an unattributed row.
+     */
+    private fun withSourceService(payload: String): String = try {
+        when (val node = objectMapper.readTree(payload)) {
+            is ObjectNode -> objectMapper.writeValueAsString(node.put("sourceService", SOURCE_SERVICE))
+            else -> payload.also { log.warn("outbox payload is not a JSON object; emitting without sourceService") }
+        }
+    } catch (e: JsonProcessingException) {
+        log.warn("outbox payload is not parseable JSON; emitting without sourceService", e)
+        payload
+    }
+
+    companion object {
+        /**
+         * The module directory name minus the `openbank-` prefix -- the fleet's audit convention,
+         * and the same spelling `TopicAttribution` already derives for this topic.
+         */
+        internal const val SOURCE_SERVICE = "sdd-service"
+
+        private val log: Logger = Logger.getLogger(KafkaSddOutboxEventPublisher::class.java)
     }
 }

--- a/openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/kafka/KafkaSddOutboxEventPublisher.kt
+++ b/openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/kafka/KafkaSddOutboxEventPublisher.kt
@@ -62,8 +62,9 @@ class KafkaSddOutboxEventPublisher(
      *
      * The literal key matters: the payload is a serialised data class, so the wire key exists only
      * as a Kotlin property name at runtime and a quoted-string probe over this module finds nothing.
-     * Writing it through an ObjectNode is what makes the claim greppable AND resolvable by
-     * `.github/scripts/check-source-service-presence.py`.
+     * Writing it through an ObjectNode is what makes the claim greppable by a quoted-key probe as
+     * well as visible to one that reads the emitting type -- the fleet has both, and a claim only
+     * one of them can see is a claim that gets miscounted.
      *
      * A payload that is not a JSON object is emitted unchanged and logged: this is the money path,
      * and refusing to publish would be a strictly worse failure than an unattributed row.

--- a/openbank-sdd-service/src/test/kotlin/com/openbank/sdd/infrastructure/kafka/KafkaSddOutboxEventPublisherTest.kt
+++ b/openbank-sdd-service/src/test/kotlin/com/openbank/sdd/infrastructure/kafka/KafkaSddOutboxEventPublisherTest.kt
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
-package com.openbank.fraud.infrastructure.kafka
+package com.openbank.sdd.infrastructure.kafka
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.libs.persistence.outbox.OutboxEntry
@@ -37,7 +37,7 @@ import java.util.UUID
  * test that asserted on the source, or on a substring of the payload string, would inherit the same
  * blindness. So this parses the captured message and reads the resolved value.
  */
-class KafkaFraudOutboxEventPublisherTest {
+class KafkaSddOutboxEventPublisherTest {
 
     @Test
     fun `publish stamps sourceService on the emitted payload`() {
@@ -46,7 +46,7 @@ class KafkaFraudOutboxEventPublisherTest {
         every { emitter.sendMessage(capture(captured)) } returns Uni.createFrom().voidItem()
         val mapper = ObjectMapper()
 
-        val payload = """{"partyId":"p-1","accountId":"a-1","active":true,"reason":"RULE"}"""
+        val payload = """{"eventType":"sdd.mandate.activated.v1","mandateId":"m-1","umr":"UMR-1"}"""
 
         // The producer's own payload does not carry the field -- this is the state the stamp fixes.
         assertThat(mapper.readTree(payload).has("sourceService")).isFalse()
@@ -54,7 +54,7 @@ class KafkaFraudOutboxEventPublisherTest {
         val entry = OutboxEntry(
             eventId = UUID.randomUUID(),
             aggregateId = UUID.randomUUID(),
-            eventType = "fraud.hold_changed",
+            eventType = "sdd.mandate.activated.v1",
             payload = payload,
             status = OutboxStatus.PENDING,
             attemptCount = 0,
@@ -64,10 +64,10 @@ class KafkaFraudOutboxEventPublisherTest {
             lastError = null,
         )
 
-        runBlocking { KafkaFraudOutboxEventPublisher(emitter, mapper).publish(entry) }
+        runBlocking { KafkaSddOutboxEventPublisher(emitter, mapper).publish(entry) }
 
         assertThat(mapper.readTree(captured.captured.payload).get("sourceService").asText())
-            .isEqualTo("fraud-service")
+            .isEqualTo("sdd-service")
     }
 
     @Test
@@ -76,7 +76,7 @@ class KafkaFraudOutboxEventPublisherTest {
         // directory name without `openbank-`; a producer that drifts to a second spelling splits
         // its own history into two apparent producers at a merge date, and those rows cannot be
         // converged afterwards (append-only + chain-hashed).
-        assertThat(KafkaFraudOutboxEventPublisher.SOURCE_SERVICE).isEqualTo("fraud-service")
+        assertThat(KafkaSddOutboxEventPublisher.SOURCE_SERVICE).isEqualTo("sdd-service")
     }
 
     @Test
@@ -88,7 +88,7 @@ class KafkaFraudOutboxEventPublisherTest {
         val entry = OutboxEntry(
             eventId = UUID.randomUUID(),
             aggregateId = UUID.randomUUID(),
-            eventType = "fraud.hold_changed",
+            eventType = "sdd.mandate.activated.v1",
             payload = "not json at all",
             status = OutboxStatus.PENDING,
             attemptCount = 0,
@@ -98,7 +98,7 @@ class KafkaFraudOutboxEventPublisherTest {
             lastError = null,
         )
 
-        runBlocking { KafkaFraudOutboxEventPublisher(emitter, ObjectMapper()).publish(entry) }
+        runBlocking { KafkaSddOutboxEventPublisher(emitter, ObjectMapper()).publish(entry) }
 
         // This is the money path: an unattributed row is a strictly better outcome than a
         // publish that throws and wedges the outbox dispatcher.

--- a/openbank-sdd-service/src/test/kotlin/com/openbank/sdd/integration/SddOutboxDispatchIT.kt
+++ b/openbank-sdd-service/src/test/kotlin/com/openbank/sdd/integration/SddOutboxDispatchIT.kt
@@ -3,6 +3,7 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 package com.openbank.sdd.integration
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
 import com.openbank.libs.persistence.outbox.OutboxStatus
 import com.openbank.sdd.infrastructure.outbox.SddOutboxDispatcher
@@ -143,7 +144,20 @@ class SddOutboxDispatchIT {
                 .isEqualTo(id.toString())
             assertThat(headerValue(produced, OutboxKafkaHeaders.HEADER_EVENT_TYPE))
                 .isEqualTo(eventType)
-            assertThat(produced.payload).isEqualTo(payload)
+            // NOT byte equality: KafkaSddOutboxEventPublisher stamps `sourceService` so audit-service
+            // records this module's own claim (AttributionSource.EVENT) rather than deriving one from
+            // the topic name. The relay must still never lose or rewrite a producer field, and must
+            // add nothing but attribution — both of which byte equality conflated into one assertion.
+            val mapper = ObjectMapper()
+            val producedJson = mapper.readTree(produced.payload)
+            val seededJson = mapper.readTree(payload)
+            seededJson.fieldNames().forEach { field ->
+                assertThat(producedJson.get(field)).isEqualTo(seededJson.get(field))
+            }
+            assertThat(producedJson.get("sourceService").asText()).isEqualTo("sdd-service")
+            val added = producedJson.fieldNames().asSequence().toSet() -
+                seededJson.fieldNames().asSequence().toSet()
+            assertThat(added).isEqualTo(setOf("sourceService"))
         }
 
         // Persistence side committed: both rows are now SENT with a stamped sentAt and one attempt.


### PR DESCRIPTION
## What

Five money-path event producers — `delegation`, `ledger`, `sdd`, `interest`, `fraud` — emit events onto topics audit-service subscribes to, and none of them stated **who produced them**. This adds that claim.

## The measured state (re-verified on `origin/main` @ `c3f21ee63`, 2026-08-31)

**36 modules** declare a literal `openbank.*` topic under an `mp.messaging.outgoing.*` channel. **21** declared `sourceService`; **15** did not. Of those 15, five are money-path producers of *audit-subscribed* topics — the five this PR fixes.

The count was taken by reading the emitting type, not by grepping a quoted key, because **the two payload idioms in this fleet are not equally visible to a string probe**:

| idiom | control module | `grep '"sourceService"'` | reads the type |
|---|---|---|---|
| serialised data class | `openbank-card-issuance-service` | **0 hits** | ✅ found |
| serialised data class | `openbank-fx-service` | **0 hits** | ✅ found |
| hand-built map / node | `openbank-customer-edge` | 4 hits | ✅ found |

Both known-positive controls were run before the census was believed. A quoted-string probe reports those first two as missing while both demonstrably set the field.

## This is a *derived-vs-declared* gap, not a live `UNKNOWN`

No subscribed topic currently records `"unknown"`: `AuditConsumer.resolveSourceService` falls back to `TopicAttribution`, which has a verified entry for all 26 subscribed topics. So these rows are attributed — as `AttributionSource.TOPIC`, a value **derived from the topic name** rather than **stated by the producer**. Both spell the same thing today. Nothing is wrong; what is missing is the producer's own claim.

That narrower framing is worth stating because issues #5256 and #6035 both read as though rows are landing unattributed, and they are not.

## Why close it rather than document it

`audit_entries` is append-only **at the database** — V2's `no_update_audit` / `no_delete_audit` are `DO INSTEAD NOTHING`, so a normalising `UPDATE` affects zero rows **and reports success** — and `source_service` is chain-hashed into `record_hash`. History cannot be corrected later by anyone. Every day the field is absent produces rows whose attribution is permanently inferred. The fix is forward-only by construction, which is the entire argument for doing it now rather than filing it.

## Why the stamp is on the publisher, not the event type

`card-issuance` and `fx` declare `val sourceService` once on a sealed event supertype. **None of these five modules has one** — their events are unrelated data classes (delegation) or hand-built JSON strings (sdd, fraud). A per-class field would have to be repeated on every event type and would be silently omitted by the next one added.

Each channel has exactly one exit — the Kafka outbox publisher — so that is where the claim is made. This covers event types that do not exist yet, which a per-class field cannot.

A payload that is not a JSON object is emitted **unchanged and logged**, never dropped: this is the money path, and an unattributed row is a strictly better outcome than a publish that throws and wedges the outbox dispatcher.

## Proven by what it prevents

Removing the stamp from the delegation publisher and restoring it, measured both ways:

```
RED   (stamp removed)   exit=1   tests="5" skipped="0" failures="1" errors="0"
GREEN (stamp restored)  exit=0   tests="5" skipped="0" failures="0" errors="0"
```

Exit codes read from `$?` after redirecting to a file, and the verdict read from the JUnit XML rather than the console — `| tail` returns tail's status, and a Quarkus boot failure reports tests as **SKIPPED, not FAILED**, so the skipped count is quoted above alongside the failure count.

The tests assert the **parsed wire value**, never source text or a payload substring — the delegation suite serialises a real `DelegationRevoked` through the module's own idiom, where no wire key exists as a literal anywhere in the source. A test that asserted on text would inherit exactly the blindness described in the table above.

Independent corroboration: two real Quarkus dispatch ITs (`LedgerOutboxDispatchIT` via the shared conformance harness, and `InterestOutboxDispatchIT`) failed on the byte-equality assertion with `{"seq":1}` vs `{"seq":1,"sourceService":"ledger-service"}` — end-to-end proof through the actual dispatcher that the field reaches the wire.

## The two relaxed IT assertions

Those ITs asserted `produced.payload == seeded.payload`. That single assertion was doing **two unrelated jobs** — "no producer field was lost or rewritten" and "nothing was added" — and only the first is a property the relay must have. Both are now asserted separately, so relaxing one did not silently retire the other:

- every field the producer wrote survives with an equal value, and
- the set of *added* fields is exactly `{"sourceService"}` (a subset check in the shared harness, which cannot know the module).

Without the second assertion, relaxing the first would have left the suite blind to any other payload rewrite.

## Not in this PR

- **`billing`** — see the note below; it is a different gate's baseline.
- **`standing-order`, `psd2`** and eight non-audited producers — baselined; no decision has been taken that their streams belong in the audit trail.
- **A presence gate** — separate PR, so this money-path change and the governance change can be reviewed independently.

## ⚠️ A finding this PR does not act on

`check-audit-money-path-subscription.py` baselines billing with the reason *"billing has no `KafkaTopic` CR for `openbank.billing.fee.event` at all"*. **That is not true.** The CR exists at `openbank-infra/gitops/components/kafka/kafka.yaml:199` — byte-for-byte the same shape as the `openbank.ledger.journal.posted` control (same `apiVersion`, `kind`, `namespace: messaging`, `strimzi.io/cluster` label and `spec`). It simply lives in the central broker manifest instead of a per-service `kafka-topic.yaml`, which is what a per-service-directory probe would miss.

So the stated blocker on subscribing billing is dissolved. Left untouched here deliberately: that is a different gate's baseline and touches audit-service config, `TopicAttribution` and the audit `KafkaUser` ACLs.

## Review

`ledger`, `sdd`, `interest`, `fraud` and `delegation` are all money-path (`rules.yaml: money_path_services`), so this needs 2 approvals. Threat models exist for these services; no new trust boundary is introduced — the change adds one constant field to an outgoing payload and no new input is parsed from an untrusted source.

Refs #5256, #6035
