### PR TITLE
fix(ci): detect a service build job wedged before its first step

### DIFF
--- a/.github/scripts/check-stuck-service-build.py
+++ b/.github/scripts/check-stuck-service-build.py
@@ -3,11 +3,15 @@
 
 This deliberately answers a narrower question than "is a workflow old?". A service CI
 build can spend legitimate time uploading Kover, generating its envelope or publishing
-artifacts. We cancel only two bounded shapes: the mandatory `Build + test` step itself,
-or a `Post Run …` action that has exceeded the interval after every substantive step
-already completed. The latter catches runner cleanup hangs without cancelling Kover,
-envelope creation or an active test. A different job, malformed API data or a fresh step
-is never an implicit cancellation candidate.
+artifacts. We cancel only three bounded shapes: the mandatory `Build + test` step itself,
+a `Post Run …` action that has exceeded the interval after every substantive step
+already completed, or a job that has recorded its `started_at` but has not moved a
+single step to `in_progress`/`completed` (the exact shape evidenced on runs 33120723738
+and 33121304719 — a job wedged before its first step). The post-action shape catches
+runner cleanup hangs without cancelling Kover, envelope creation or an active test; the
+no-first-step shape uses its own, much shorter threshold, because a healthy job's first
+step starts within seconds of the job itself, never minutes. A different job, malformed
+API data or a fresh step is never an implicit cancellation candidate.
 
 The workflow owns reading the GitHub Actions API and cancellation. Keeping this classifier
 pure makes both the positive and the "do not cancel normal work" paths executable in CI.
@@ -38,7 +42,12 @@ def parse_time(value: Any) -> datetime | None:
         return None
 
 
-def classify(payload: dict[str, Any], now: datetime, timeout_minutes: int) -> list[dict[str, str]]:
+def classify(
+    payload: dict[str, Any],
+    now: datetime,
+    timeout_minutes: int,
+    no_step_timeout_minutes: int = 5,
+) -> list[dict[str, str]]:
     jobs = payload.get("jobs")
     if not isinstance(jobs, list):
         raise ValueError("Actions jobs payload has no jobs list")
@@ -62,9 +71,20 @@ def classify(payload: dict[str, Any], now: datetime, timeout_minutes: int) -> li
         candidate_step = None
         candidate_started = job_started
         reason = "mandatory-build"
+        threshold = timeout_minutes
+        any_progress = any(isinstance(step, dict) and step.get("status") in ("in_progress", "completed")
+                           for step in steps)
         if build_step is not None and build_step.get("status") == "in_progress":
             # The service build has reached its mandatory command and that command is still live.
             candidate_step = build_step
+        elif not any_progress:
+            # started_at is set but no step has moved past "queued" — the exact wedge evidenced
+            # in #7477. A healthy job's first step starts within seconds; use a short threshold,
+            # never the long one that tolerates legitimate Kover/envelope/upload work.
+            candidate_step = {"name": "(no step started)"}
+            candidate_started = job_started
+            reason = "no-first-step"
+            threshold = no_step_timeout_minutes
         else:
             # A post-action may be cancelled only after every meaningful job step has completed.
             # This deliberately excludes an in-progress Kover/envelope/upload step even on a
@@ -82,7 +102,7 @@ def classify(payload: dict[str, Any], now: datetime, timeout_minutes: int) -> li
                 raise ValueError(f"{name} has an in-progress post-action without valid started_at")
             reason = "post-action"
         age_minutes = (now - candidate_started).total_seconds() / 60
-        if age_minutes < timeout_minutes:
+        if age_minutes < threshold:
             continue
         job_id = job.get("id")
         html_url = job.get("html_url")
@@ -111,6 +131,18 @@ def self_test() -> int:
         ("post-action beside active envelope is not selected", {"jobs": [{**base, "steps": [{"name": "Build + test (:openbank-example-service)", "status": "completed"}, {"name": "Build Test Intelligence run envelope", "status": "in_progress"}, {"name": "Post Run actions/setup-java", "status": "in_progress", "started_at": "2026-08-28T11:00:00Z"}]}]}, 0),
         ("verification post-action is selected", {"jobs": [{**base, "name": VERIFICATION_JOB, "steps": [{"name": "Check verification metadata", "status": "completed"}, {"name": "Post Run actions/setup-java", "status": "in_progress", "started_at": "2026-08-28T11:00:00Z"}]}]}, 1),
         ("other workflow job is not selected", {"jobs": [{**base, "name": "CodeQL (java-kotlin, manual)"}]}, 0),
+        # #7477's exact evidence: started_at recorded, every step still queued (or absent).
+        ("stale no-first-step job (all queued) is selected", {"jobs": [{**base, "started_at": "2026-08-28T11:50:00Z",
+            "steps": [{"name": "Set up job", "status": "queued"},
+                      {"name": "Build + test (:openbank-example-service)", "status": "queued"}]}]}, 1),
+        ("stale no-first-step job (empty steps) is selected", {"jobs": [{**base, "started_at": "2026-08-28T11:50:00Z",
+            "steps": []}]}, 1),
+        ("fresh no-first-step job is not selected", {"jobs": [{**base, "started_at": "2026-08-28T11:58:00Z",
+            "steps": [{"name": "Set up job", "status": "queued"}]}]}, 0),
+        ("queued job with a completed step is not the no-first-step shape",
+            {"jobs": [{**base, "started_at": "2026-08-28T11:50:00Z",
+            "steps": [{"name": "Set up job", "status": "completed"},
+                      {"name": "Build + test (:openbank-example-service)", "status": "queued"}]}]}, 0),
     ]
     failures = 0
     for label, payload, expected in cases:
@@ -134,17 +166,19 @@ def main() -> int:
     parser.add_argument("--jobs-json", type=Path)
     parser.add_argument("--now")
     parser.add_argument("--timeout-minutes", type=int, default=45)
+    parser.add_argument("--no-step-timeout-minutes", type=int, default=5)
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
     if args.self_test:
         return self_test()
-    if not args.jobs_json or not args.now or args.timeout_minutes <= 0:
-        parser.error("--jobs-json, --now and positive --timeout-minutes are required")
+    if not args.jobs_json or not args.now or args.timeout_minutes <= 0 or args.no_step_timeout_minutes <= 0:
+        parser.error("--jobs-json, --now, positive --timeout-minutes and positive --no-step-timeout-minutes are required")
     now = parse_time(args.now)
     if now is None:
         parser.error("--now must be ISO-8601 UTC")
     try:
-        print(json.dumps(classify(json.loads(args.jobs_json.read_text()), now, args.timeout_minutes)))
+        print(json.dumps(classify(json.loads(args.jobs_json.read_text()), now, args.timeout_minutes,
+                                   args.no_step_timeout_minutes)))
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"::error title=CI stalled-build watchdog::{exc}", file=sys.stderr)
         return 1

--- a/.github/workflows/service-build-stall-watch.yml
+++ b/.github/workflows/service-build-stall-watch.yml
@@ -1,7 +1,9 @@
 # Cancel only a proven-stalled service CI job, then leave an addressed audit trail.
 # A cancelled test run is never turned green; Services CI's normal failure/retry path owns its
 # immutable diagnostics and any later rerun. This control prevents an invisible in-progress job
-# from blocking its PR forever (issue #7477).
+# from blocking its PR forever (issue #7477) — including a job that recorded started_at but
+# never advanced past its first step, the exact shape evidenced on runs 33120723738 and
+# 33121304719.
 name: Service build stall watch
 
 on:
@@ -46,7 +48,7 @@ jobs:
             attempt=$(jq -r '.run_attempt' <<<"$run")
             run_url=$(jq -r '.html_url' <<<"$run")
             gh api "repos/${REPO}/actions/runs/${run_id}/attempts/${attempt}/jobs?per_page=100" > /tmp/jobs.json
-            candidates=$(python3 .github/scripts/check-stuck-service-build.py --jobs-json /tmp/jobs.json --now "$now" --timeout-minutes 45)
+            candidates=$(python3 .github/scripts/check-stuck-service-build.py --jobs-json /tmp/jobs.json --now "$now" --timeout-minutes 45 --no-step-timeout-minutes 5)
             jq -c --arg runId "$run_id" --arg attempt "$attempt" --arg runUrl "$run_url" '.[] + {runId:$runId,attempt:$attempt,runUrl:$runUrl}' <<<"$candidates" \
               | while IFS= read -r candidate; do
                   jq --argjson candidate "$candidate" '. + [$candidate]' /tmp/stalled.json > /tmp/stalled.next && mv /tmp/stalled.next /tmp/stalled.json
@@ -55,7 +57,7 @@ jobs:
           jq -c '.[]' /tmp/stalled.json | while IFS= read -r candidate; do
             run_id=$(jq -r '.runId' <<<"$candidate")
             title="CI stalled service build: $(jq -r '.job' <<<"$candidate")"
-            body=$(jq -r '"<!-- service-build-stall:" + .runId + ":" + .jobId + " -->\n\n## Service CI job was cancelled after no progress\n\n| | |\n|---|---|\n| workflow run | [run " + .runId + " attempt " + .attempt + "](" + .runUrl + ") |\n| stalled job | [" + .job + "](" + .url + ") |\n| stalled step | `" + .step + "` |\n| classifier | `" + .reason + "` |\n| started | `" + .startedAt + "` |\n| observed age | `" + .ageMinutes + " minutes` |\n\nThe watchdog acts only when the mandatory `Build + test` step itself exceeds 45 minutes, or when every substantive step completed and a `Post Run …` action alone exceeds 45 minutes. It never cancels Kover, envelope creation or artifact publication while those steps are active. The cancellation preserves GitHub attempt diagnostics and does **not** create a green verdict. Inspect and rerun through the normal CI path.\n\n_Automated by Service build stall watch (issue #7477)._"' <<<"$candidate")
+            body=$(jq -r '"<!-- service-build-stall:" + .runId + ":" + .jobId + " -->\n\n## Service CI job was cancelled after no progress\n\n| | |\n|---|---|\n| workflow run | [run " + .runId + " attempt " + .attempt + "](" + .runUrl + ") |\n| stalled job | [" + .job + "](" + .url + ") |\n| stalled step | `" + .step + "` |\n| classifier | `" + .reason + "` |\n| started | `" + .startedAt + "` |\n| observed age | `" + .ageMinutes + " minutes` |\n\nThe watchdog acts only on three bounded shapes: the mandatory `Build + test` step itself exceeding 45 minutes, every substantive step completing and a `Post Run …` action alone exceeding 45 minutes, or the job recording `started_at` while every step stays queued (no first step) for 5 minutes. It never cancels Kover, envelope creation or artifact publication while those steps are active. The cancellation preserves GitHub attempt diagnostics and does **not** create a green verdict. Inspect and rerun through the normal CI path.\n\n_Automated by Service build stall watch (issue #7477)._"' <<<"$candidate")
             if [ "$DRY_RUN" = "true" ]; then
               echo "::warning title=CI stalled-build dry run::${title}"
               continue


### PR DESCRIPTION
## What

Closes a gap in the existing `service-build-stall-watch.yml` watchdog (added for #7477
by #7513/#7518): a job that records `started_at` but never moves any step past `queued`
fell through the classifier untouched.

## Why the existing watchdog missed this

`check-stuck-service-build.py`'s `classify()` had two shapes: the mandatory `Build + test`
step in progress, or every substantive step completed with an in-progress `Post Run …`
action. A job whose steps are all `queued` (or whose `steps` array is empty) matches
neither: `build_step` is `None` or not `in_progress`, and the post-action branch's guard
(`if not substantive or any(... != "completed") or not post_steps: continue`) always
skips it, because nothing has completed and no post-action is running. That is exactly
the evidence in the issue — runs `33120723738` and `33121304719` — a job that starts but
executes no step.

## What this PR adds

A third classification, `no-first-step`: if no step on the job has a status of
`in_progress` or `completed` (i.e. nothing has moved), the job itself is the candidate
and `job.started_at` is the clock. It uses its own threshold —
`--no-step-timeout-minutes`, wired at 5 minutes in the workflow — separate from the
45-minute threshold used for the mandatory-build and post-action shapes, because a
healthy job's first step starts within seconds of the job itself, never minutes; reusing
the 45-minute threshold here would leave a wedged PR blocked far longer than necessary.

## Detection mechanism (unchanged plumbing)

Same as before: `service-build-stall-watch.yml` runs every 15 minutes, lists
`in_progress` runs of the `Services CI` workflow, fetches each run's jobs via
`repos/{owner}/{repo}/actions/runs/{id}/attempts/{n}/jobs`, and asks
`check-stuck-service-build.py` to classify. A classified job is cancelled via the Actions
API (never turned green) and an issue is opened carrying the run/job URL, the matched
step, the classifier reason, and the observed age — the attempt-scoped diagnostic the
acceptance criteria asks for. Cancellation-only: no auto-rerun, so no retry storm; a
human or the existing normal-CI retry path reruns it.

## Testing

`.github/scripts/check-stuck-service-build.py --self-test` — added 4 new synthetic
cases for the no-first-step shape (all-queued steps, empty steps array, a fresh job
that should NOT be flagged, and a queued-but-with-one-completed-step job that must fall
through to the *existing* post-action branch, not the new one) alongside the pre-existing
8 cases + the invalid-metadata negative case. All 13 pass. Also ran `actionlint` on the
changed workflow (clean).

## What this does NOT cover

- Still only watches the `Services CI` workflow's `build (openbank-*)` and
  `verification-metadata` jobs, matching the existing watchdog's scope — not every
  workflow in the repo.
- Cannot distinguish *why* the runner never started a step (network stall, a wedged
  GitHub-hosted runner allocation, etc.) — it only detects the observable shape
  ("started, zero step progress, N minutes") and treats every cause the same way:
  cancel + diagnose via the normal retry path.
- Still cannot be tested against a live wedged job on demand (per the issue's own
  acceptance note) — verified only via the synthetic self-test.

## Governance

Touches `.github/workflows/` and `.github/scripts/check-stuck-service-build.py`.
`check-agent-pr-guard.py --paths .github/workflows/service-build-stall-watch.yml
.github/scripts/check-stuck-service-build.py` reports **PROTECTED** (changes to CI gate
machinery / self-hosted runner execution), noted here per repo convention — a human
reviewer approval is expected before merge.

Refs #7477
