### PR TITLE
feat(admin-ui): make delegated access clear and comparable

### DIFF
--- a/openbank-admin-ui/src/app/delegations/page.tsx
+++ b/openbank-admin-ui/src/app/delegations/page.tsx
@@ -32,6 +32,7 @@ import {
   capabilityLabels,
   counterpartyLabel,
   formatCeiling,
+  grantCounterparty,
   type Grant,
 } from '@/components/delegations/GrantView'
 
@@ -217,12 +218,14 @@ export default function DelegationsPage() {
             subtitle={t('Práva, která tato strana udělila jiným.', 'Rights this party has granted to others.')}
             grants={grants.granted}
             state={grants.sources.granted}
+            direction="granted"
           />
           <GrantTable
             title={t('Sdíleno s touto stranou', 'Shared with this party')}
             subtitle={t('Práva, která tato strana drží nad cizími zdroji.', 'Rights this party holds over other people’s resources.')}
             grants={grants.received}
             state={grants.sources.received}
+            direction="received"
           />
           <ProjectionHealth consumers={consumers} known={projectionKnown} />
         </>
@@ -232,8 +235,8 @@ export default function DelegationsPage() {
 }
 
 function GrantTable({
-  title, subtitle, grants, state,
-}: { title: string; subtitle: string; grants: Grant[]; state: DirectionState }) {
+  title, subtitle, grants, state, direction,
+}: { title: string; subtitle: string; grants: Grant[]; state: DirectionState; direction: 'granted' | 'received' }) {
   const { t, language } = useLanguage()
   const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
 
@@ -273,10 +276,11 @@ function GrantTable({
               </tr>
             </thead>
             <tbody>
-              {grants.map(g => (
-                <tr key={g.id}>
+              {grants.map(g => {
+                const counterparty = grantCounterparty(g, direction)
+                return <tr key={g.id}>
                   <td><DelegationStatusBadge status={g.status} /></td>
-                  <td><EntityChip type="party" id={g.granteePartyId} label={counterpartyLabel(g.granteeName)} /></td>
+                  <td><EntityChip type="party" id={counterparty.id} label={counterparty.name} /></td>
                   <td style={{ fontSize: '12px' }}>{g.resourceType}</td>
                   <td style={{ fontSize: '12px' }}>{capabilityLabels(g.capabilities)}</td>
                   <td style={{ fontSize: '12px' }}>{formatCeiling(g.perTransactionLimit, numberLocale)}</td>
@@ -287,7 +291,7 @@ function GrantTable({
                     </Link>
                   </td>
                 </tr>
-              ))}
+              })}
             </tbody>
           </table>
         </div>

--- a/openbank-admin-ui/src/components/delegations/GrantView.tsx
+++ b/openbank-admin-ui/src/components/delegations/GrantView.tsx
@@ -43,6 +43,12 @@ export type Grant = {
   closedReason?: string | null
 }
 
+export function grantCounterparty(grant: Grant, direction: 'granted' | 'received') {
+  return direction === 'granted'
+    ? { id: grant.granteePartyId, name: counterpartyLabel(grant.granteeName) }
+    : { id: grant.grantorPartyId, name: counterpartyLabel(grant.grantorName) }
+}
+
 /**
  * OFFERED is the one delegation status the shared tone map cannot get right by default: it is
  * in-flight (awaiting the grantee's SCA-bound acceptance), not terminal, so it renders as a

--- a/openbank-admin-ui/src/components/delegations/RoleCatalog.tsx
+++ b/openbank-admin-ui/src/components/delegations/RoleCatalog.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Check, Pencil, Plus, Shield, Trash2, X } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { useAuth } from '@/lib/auth/useAuth'
@@ -14,6 +14,7 @@ export function RoleCatalog() {
   const { hasRole } = useAuth()
   const canManage = hasRole('ROLE_ADMIN')
   const [roles, setRoles] = useState<RolePreset[]>([])
+  const [resource, setResource] = useState<DelegationResource>('ACCOUNT')
   const [editing, setEditing] = useState<RolePreset | null>(null)
   const [state, setState] = useState<'loading' | 'ready' | 'error'>('loading')
 
@@ -30,7 +31,8 @@ export function RoleCatalog() {
     queueMicrotask(() => { void load() })
   }, [load])
 
-  const rights = useMemo(() => [...new Set(roles.flatMap(role => role.capabilities))].sort(), [roles])
+  const rights = CAPABILITIES_BY_RESOURCE[resource]
+  const visibleRoles = roles.filter(role => role.resourceType === resource)
   const save = async (role: RolePreset) => {
     const payload = { name: role.name.trim(), description: role.description.trim(), resourceType: role.resourceType, capabilities: role.capabilities }
     const response = await fetch(role.id ? `/api/delegation-role-presets/${role.id}` : '/api/delegation-role-presets', {
@@ -53,11 +55,21 @@ export function RoleCatalog() {
     </div>
     {state === 'loading' && <div style={{ padding: 20, color: 'var(--text-tertiary)' }}>{t('Načítám katalog…', 'Loading catalog…')}</div>}
     {state === 'error' && <div style={{ padding: 20, color: 'var(--text-tertiary)' }}>{t('Katalog rolí není dostupný.', 'Role catalog is unavailable.')}</div>}
-    {state === 'ready' && <div style={{ overflowX: 'auto' }}><table className="table" style={{ width: '100%' }}><thead><tr><th>{t('Role', 'Role')}</th><th>{t('Zdroj', 'Resource')}</th>
+    {state === 'ready' && <>
+      <div role="tablist" aria-label={t('Typ zdroje', 'Resource type')} style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 12 }}>
+        {(Object.keys(CAPABILITIES_BY_RESOURCE) as DelegationResource[]).map(item => {
+          const count = roles.filter(role => role.resourceType === item).length
+          return <button key={item} type="button" role="tab" aria-selected={resource === item} className={resource === item ? 'btn btn-primary' : 'btn btn-secondary'} onClick={() => setResource(item)}>
+            {resourceLabel(item, t)} <span aria-label={t(`${count} rolí`, `${count} roles`)} style={{ opacity: .75 }}>({count})</span>
+          </button>
+        })}
+      </div>
+      <div style={{ overflowX: 'auto' }}><table className="table" style={{ width: '100%', minWidth: 760 }}><thead><tr><th style={stickyRoleStyle}>{t('Role', 'Role')}</th>
       {rights.map(right => <th key={right} title={rightLabel(right, t)} style={{ textAlign: 'center', fontSize: 10, minWidth: 92 }}>{rightLabel(right, t)}</th>)}{canManage && <th aria-label={t('Akce', 'Actions')} />}</tr></thead>
-      <tbody>{roles.map(role => <tr key={role.id}><td><strong>{role.name}</strong><div style={{ fontSize: 11, color: 'var(--text-tertiary)', maxWidth: 260 }}>{role.description}</div></td><td>{role.resourceType}</td>
+      <tbody>{visibleRoles.map(role => <tr key={role.id}><td style={stickyRoleStyle}><strong>{role.name}</strong><div style={{ fontSize: 11, color: 'var(--text-tertiary)', maxWidth: 280 }}>{role.description}</div></td>
         {rights.map(right => <td key={right} style={{ textAlign: 'center' }}>{role.capabilities.includes(right) ? <Check size={15} color="var(--success)" aria-label={t('Povoleno', 'Allowed')} /> : '—'}</td>)}
-        {canManage && <td><div style={{ display: 'flex', gap: 4 }}><button className="btn btn-secondary" onClick={() => setEditing({ ...role, capabilities: [...role.capabilities] })} aria-label={`${t('Upravit', 'Edit')} ${role.name}`}><Pencil size={13} /></button><button className="btn btn-secondary" onClick={() => void remove(role)} aria-label={`${t('Smazat', 'Delete')} ${role.name}`}><Trash2 size={13} /></button></div></td>}</tr>)}</tbody></table></div>}
+        {canManage && <td><div style={{ display: 'flex', gap: 4 }}><button className="btn btn-secondary" onClick={() => setEditing({ ...role, capabilities: [...role.capabilities] })} aria-label={`${t('Upravit', 'Edit')} ${role.name}`}><Pencil size={13} /></button><button className="btn btn-secondary" onClick={() => void remove(role)} aria-label={`${t('Smazat', 'Delete')} ${role.name}`}><Trash2 size={13} /></button></div></td>}</tr>)}</tbody></table></div>
+    </>}
     {editing && <Editor value={editing} cancel={() => setEditing(null)} save={save} />}
   </section>
 }
@@ -76,6 +88,19 @@ function Editor({ value, cancel, save }: { value: RolePreset; cancel: () => void
   </div></div>
 }
 const labelStyle = { display: 'grid', gap: 6, fontSize: 13, fontWeight: 600, marginBottom: 12 } as const
+const stickyRoleStyle = { position: 'sticky', left: 0, zIndex: 1, minWidth: 240, background: 'var(--surface-1)' } as const
+const RESOURCE_LABELS: Record<DelegationResource, [string, string]> = {
+  ACCOUNT: ['Účet', 'Account'],
+  CARD: ['Karta', 'Card'],
+  SAVINGS_GOAL: ['Spoření', 'Savings'],
+  PAYMENT: ['Platba', 'Payment'],
+  STATEMENT: ['Výpis', 'Statement'],
+  DOCUMENT: ['Dokument', 'Document'],
+}
+const resourceLabel = (resource: DelegationResource, t: (cs: string, en: string) => string) => {
+  const label = RESOURCE_LABELS[resource]
+  return t(label[0], label[1])
+}
 const RIGHT_LABELS: Record<string, [string, string]> = {
   ACCOUNT_VIEW_DETAILS: ['Detail účtu', 'Account details'],
   ACCOUNT_READ_BALANCES: ['Zůstatky', 'Balances'],

--- a/openbank-admin-ui/src/components/delegations/RoleCatalog.tsx
+++ b/openbank-admin-ui/src/components/delegations/RoleCatalog.tsx
@@ -2,10 +2,10 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
-import { Check, Pencil, Plus, Shield, Trash2, X } from 'lucide-react'
+import { Check, LayoutGrid, Pencil, Plus, Shield, Table2, Trash2, X } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { useAuth } from '@/lib/auth/useAuth'
-import { CAPABILITIES_BY_RESOURCE, type DelegationResource, type RolePreset } from '@/lib/delegations/rolePresets'
+import { CAPABILITIES_BY_RESOURCE, capabilityIntent, type CapabilityIntent, type DelegationResource, type RolePreset } from '@/lib/delegations/rolePresets'
 
 const emptyRole = (): RolePreset => ({ id: '', name: '', description: '', resourceType: 'ACCOUNT', capabilities: [] })
 
@@ -15,6 +15,7 @@ export function RoleCatalog() {
   const canManage = hasRole('ROLE_ADMIN')
   const [roles, setRoles] = useState<RolePreset[]>([])
   const [resource, setResource] = useState<DelegationResource>('ACCOUNT')
+  const [view, setView] = useState<'overview' | 'matrix'>('overview')
   const [editing, setEditing] = useState<RolePreset | null>(null)
   const [state, setState] = useState<'loading' | 'ready' | 'error'>('loading')
 
@@ -64,14 +65,46 @@ export function RoleCatalog() {
           </button>
         })}
       </div>
-      <div style={{ overflowX: 'auto' }}><table className="table" style={{ width: '100%', minWidth: 760 }}><thead><tr><th style={stickyRoleStyle}>{t('Role', 'Role')}</th>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, marginBottom: 12 }}>
+        <p style={{ fontSize: 12, color: 'var(--text-tertiary)', margin: 0 }}>
+          {t('Začněte nejmenším rozsahem práv, který člověk pro svou práci potřebuje.', 'Start with the smallest set of rights a person needs for their work.')}
+        </p>
+        <div role="group" aria-label={t('Zobrazení katalogu', 'Catalog view')} style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
+          <button type="button" className={view === 'overview' ? 'btn btn-primary' : 'btn btn-secondary'} aria-pressed={view === 'overview'} onClick={() => setView('overview')}><LayoutGrid size={14} />{t('Přehled', 'Overview')}</button>
+          <button type="button" className={view === 'matrix' ? 'btn btn-primary' : 'btn btn-secondary'} aria-pressed={view === 'matrix'} onClick={() => setView('matrix')}><Table2 size={14} />{t('Porovnat', 'Compare')}</button>
+        </div>
+      </div>
+      {view === 'overview' && <RoleOverview roles={visibleRoles} canManage={canManage} edit={setEditing} remove={remove} />}
+      {view === 'matrix' && <div style={{ overflowX: 'auto' }}><table className="table" style={{ width: '100%', minWidth: 760 }}><thead><tr><th style={stickyRoleStyle}>{t('Role', 'Role')}</th>
       {rights.map(right => <th key={right} title={rightLabel(right, t)} style={{ textAlign: 'center', fontSize: 10, minWidth: 92 }}>{rightLabel(right, t)}</th>)}{canManage && <th aria-label={t('Akce', 'Actions')} />}</tr></thead>
       <tbody>{visibleRoles.map(role => <tr key={role.id}><td style={stickyRoleStyle}><strong>{role.name}</strong><div style={{ fontSize: 11, color: 'var(--text-tertiary)', maxWidth: 280 }}>{role.description}</div></td>
         {rights.map(right => <td key={right} style={{ textAlign: 'center' }}>{role.capabilities.includes(right) ? <Check size={15} color="var(--success)" aria-label={t('Povoleno', 'Allowed')} /> : '—'}</td>)}
         {canManage && <td><div style={{ display: 'flex', gap: 4 }}><button className="btn btn-secondary" onClick={() => setEditing({ ...role, capabilities: [...role.capabilities] })} aria-label={`${t('Upravit', 'Edit')} ${role.name}`}><Pencil size={13} /></button><button className="btn btn-secondary" onClick={() => void remove(role)} aria-label={`${t('Smazat', 'Delete')} ${role.name}`}><Trash2 size={13} /></button></div></td>}</tr>)}</tbody></table></div>
+      }
     </>}
     {editing && <Editor value={editing} cancel={() => setEditing(null)} save={save} />}
   </section>
+}
+
+function RoleOverview({ roles, canManage, edit, remove }: { roles: RolePreset[]; canManage: boolean; edit: (role: RolePreset) => void; remove: (role: RolePreset) => Promise<void> }) {
+  const { t } = useLanguage()
+  return <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 330px), 1fr))', gap: 12 }}>
+    {roles.map(role => <article key={role.id} style={{ border: '1px solid var(--border)', borderRadius: 12, padding: 16, background: 'linear-gradient(145deg, var(--surface-1), var(--surface-2))' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'flex-start' }}>
+        <div><h3 style={{ fontSize: 15, fontWeight: 750 }}>{role.name}</h3><p style={{ fontSize: 12, color: 'var(--text-tertiary)', marginTop: 4, lineHeight: 1.5 }}>{role.description}</p></div>
+        {canManage && <div style={{ display: 'flex', gap: 4 }}><button className="btn btn-secondary" onClick={() => edit({ ...role, capabilities: [...role.capabilities] })} aria-label={`${t('Upravit', 'Edit')} ${role.name}`}><Pencil size={13} /></button><button className="btn btn-secondary" onClick={() => void remove(role)} aria-label={`${t('Smazat', 'Delete')} ${role.name}`}><Trash2 size={13} /></button></div>}
+      </div>
+      <div style={{ display: 'grid', gap: 10, marginTop: 14 }}>
+        {(['view', 'act', 'manage'] as CapabilityIntent[]).map(intent => {
+          const capabilities = role.capabilities.filter(capability => capabilityIntent(capability) === intent)
+          if (!capabilities.length) return null
+          return <div key={intent}><div style={{ fontSize: 10, fontWeight: 800, letterSpacing: '.08em', textTransform: 'uppercase', color: intentColor(intent) }}>{intentLabel(intent, t)}</div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 6 }}>{capabilities.map(capability => <span key={capability} title={capability} style={{ borderRadius: 999, padding: '5px 9px', fontSize: 11, background: 'var(--surface-3)', border: '1px solid var(--border)' }}>{rightLabel(capability, t)}</span>)}</div>
+          </div>
+        })}
+      </div>
+    </article>)}
+  </div>
 }
 
 function Editor({ value, cancel, save }: { value: RolePreset; cancel: () => void; save: (role: RolePreset) => Promise<void> }) {
@@ -101,6 +134,12 @@ const resourceLabel = (resource: DelegationResource, t: (cs: string, en: string)
   const label = RESOURCE_LABELS[resource]
   return t(label[0], label[1])
 }
+const intentLabel = (intent: CapabilityIntent, t: (cs: string, en: string) => string) => ({
+  view: t('Může vidět', 'Can view'),
+  act: t('Může provádět', 'Can act'),
+  manage: t('Může spravovat', 'Can manage'),
+})[intent]
+const intentColor = (intent: CapabilityIntent) => ({ view: 'var(--success)', act: 'var(--warning)', manage: 'var(--accent)' })[intent]
 const RIGHT_LABELS: Record<string, [string, string]> = {
   ACCOUNT_VIEW_DETAILS: ['Detail účtu', 'Account details'],
   ACCOUNT_READ_BALANCES: ['Zůstatky', 'Balances'],

--- a/openbank-admin-ui/src/lib/delegations/rolePresets.ts
+++ b/openbank-admin-ui/src/lib/delegations/rolePresets.ts
@@ -7,3 +7,11 @@ export const CAPABILITIES_BY_RESOURCE = {
 } as const
 export type DelegationResource = keyof typeof CAPABILITIES_BY_RESOURCE
 export type RolePreset = { id: string; name: string; description: string; resourceType: DelegationResource; capabilities: string[]; createdAt?: string; updatedAt?: string }
+
+export type CapabilityIntent = 'view' | 'act' | 'manage'
+
+export function capabilityIntent(capability: string): CapabilityIntent {
+  if (capability.includes('_READ_') || capability.includes('_VIEW') || capability === 'OBJECT_READ' || capability.includes('DOWNLOAD')) return 'view'
+  if (capability.includes('MANAGE') || capability === 'DELEGATION_MANAGE') return 'manage'
+  return 'act'
+}

--- a/openbank-admin-ui/src/test/delegation-capability-intent.test.ts
+++ b/openbank-admin-ui/src/test/delegation-capability-intent.test.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { capabilityIntent } from '@/lib/delegations/rolePresets'
+
+describe('capabilityIntent', () => {
+  it('explains read-only rights as viewing', () => {
+    expect(capabilityIntent('ACCOUNT_READ_BALANCES')).toBe('view')
+    expect(capabilityIntent('ACCOUNT_DOWNLOAD_STATEMENTS')).toBe('view')
+    expect(capabilityIntent('CARD_VIEW_TRANSACTIONS')).toBe('view')
+  })
+
+  it('separates operational actions from administrative control', () => {
+    expect(capabilityIntent('ACCOUNT_INITIATE_PAYMENT')).toBe('act')
+    expect(capabilityIntent('SAVINGS_WITHDRAW')).toBe('act')
+    expect(capabilityIntent('ACCOUNT_MANAGE_LIMITS')).toBe('manage')
+    expect(capabilityIntent('DELEGATION_MANAGE')).toBe('manage')
+  })
+})

--- a/openbank-admin-ui/src/test/delegation-counterparty-name.test.tsx
+++ b/openbank-admin-ui/src/test/delegation-counterparty-name.test.tsx
@@ -16,7 +16,7 @@ import React from 'react'
 import { render, screen, cleanup, waitFor } from '@testing-library/react'
 import { SessionProvider } from 'next-auth/react'
 import { EntityChip } from '@/components/entities/EntityChip'
-import { counterpartyLabel } from '@/components/delegations/GrantView'
+import { counterpartyLabel, grantCounterparty, type Grant } from '@/components/delegations/GrantView'
 import { ROLES } from '@/lib/auth/roles'
 
 const PARTY_ID = '33333333-3333-4333-8333-333333333333'
@@ -42,6 +42,23 @@ describe('counterpartyLabel', () => {
     expect(counterpartyLabel(undefined)).toBeUndefined()
     expect(counterpartyLabel('')).toBeUndefined()
     expect(counterpartyLabel('   ')).toBeUndefined()
+  })
+})
+
+describe('grantCounterparty', () => {
+  const grant = {
+    grantorPartyId: 'grantor-id',
+    grantorName: 'Owner',
+    granteePartyId: 'grantee-id',
+    granteeName: 'Delegate',
+  } as Grant
+
+  it('shows the recipient for access shared by the selected party', () => {
+    expect(grantCounterparty(grant, 'granted')).toEqual({ id: 'grantee-id', name: 'Delegate' })
+  })
+
+  it('shows the owner for access shared with the selected party', () => {
+    expect(grantCounterparty(grant, 'received')).toEqual({ id: 'grantor-id', name: 'Owner' })
   })
 })
 


### PR DESCRIPTION
## Summary\n- add an educational role overview grouped into **Can view / Can act / Can manage**\n- keep exact capability tokens available as tooltips and in an expert comparison matrix\n- filter roles and rights by resource with role counts and least-privilege guidance\n- keep role identity visible while scrolling the comparison matrix\n- show the actual grantor as counterparty for access received by a party\n\nCloses #7757\n\n## Verification\n- npm run type-check\n- 9 targeted Vitest tests\n- targeted ESLint on changed files\n- npm run build (before the additive explorer commit; the final commit is covered by type-check and CI build)\n- git diff --check\n