### PR TITLE
fix(admin-ui): preserve readiness report on outage

### DIFF
--- a/openbank-admin-ui/e2e/prod-readiness-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/prod-readiness-recovery.spec.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+const REPORT = {
+  generated_for: '2026-08-31',
+  dimensions: [{ code: 'C1', name: 'Code' }],
+  services: [{
+    service: 'ledger',
+    money_path: true,
+    scores: { C1: 3 },
+    evidence: { C1: 'verified' },
+    gate: 'GO',
+  }],
+}
+
+test('preserves the last verified readiness report through an outage and retry', async ({ page }) => {
+  let request = 0
+  let failNextRequest = false
+  await page.route('**/api/prod-readiness', route => {
+    request += 1
+    if (failNextRequest) {
+      failNextRequest = false
+      return route.fulfill({ status: 503, contentType: 'application/json', body: '{"error":"unavailable"}' })
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(REPORT) })
+  })
+
+  await page.goto('/system/readiness')
+  await expect(page.getByText('ledger')).toBeVisible()
+  await expect(page.getByText('GO', { exact: true }).first()).toBeVisible()
+
+  failNextRequest = true
+  await page.getByRole('button', { name: /Obnovit připravenost na produkci|Refresh production readiness/ }).click()
+
+  const stale = page.getByRole('status')
+  await expect(stale).toContainText(/zobrazuji poslední dostupný report|showing the last available report/)
+  await expect(page.getByText('ledger')).toBeVisible()
+  await expect(page.getByText('GO', { exact: true }).first()).toBeVisible()
+
+  await page.getByRole('button', { name: /Zkusit znovu načíst report připravenosti|Retry loading the readiness report/ }).click()
+  await expect(stale).toBeHidden()
+  await expect(page.getByText('ledger')).toBeVisible()
+  expect(request).toBeGreaterThanOrEqual(3)
+})

--- a/openbank-admin-ui/e2e/prod-readiness-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/prod-readiness-recovery.spec.ts
@@ -34,7 +34,7 @@ test('preserves the last verified readiness report through an outage and retry',
   })
 
   await page.goto('/system/readiness')
-  await expect(page.getByText('ledger')).toBeVisible()
+  await expect(page.getByText('ledger', { exact: true })).toBeVisible()
   await expect(page.getByText('GO', { exact: true }).first()).toBeVisible()
 
   failNextRequest = true
@@ -42,11 +42,11 @@ test('preserves the last verified readiness report through an outage and retry',
 
   const stale = page.getByRole('status')
   await expect(stale).toContainText(/zobrazuji poslední dostupný report|showing the last available report/)
-  await expect(page.getByText('ledger')).toBeVisible()
+  await expect(page.getByText('ledger', { exact: true })).toBeVisible()
   await expect(page.getByText('GO', { exact: true }).first()).toBeVisible()
 
   await page.getByRole('button', { name: /Zkusit znovu načíst report připravenosti|Retry loading the readiness report/ }).click()
   await expect(stale).toBeHidden()
-  await expect(page.getByText('ledger')).toBeVisible()
+  await expect(page.getByText('ledger', { exact: true })).toBeVisible()
   expect(request).toBeGreaterThanOrEqual(3)
 })

--- a/openbank-admin-ui/src/app/system/readiness/page.tsx
+++ b/openbank-admin-ui/src/app/system/readiness/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useCallback, useState, useEffect } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { ClipboardCheck, RefreshCw, Star, CheckCircle2, XCircle, CircleSlash } from 'lucide-react'
 import { PageHeader, StatCard, StatusBadge, SWATCH_CLASS, type Tone } from '@/components/ui'
@@ -20,6 +20,12 @@ interface ReadinessReport {
   generated_for: string
   dimensions: { code: string; name: string }[]
   services: ReadinessService[]
+}
+
+async function fetchReadinessReport(): Promise<ReadinessReport> {
+  const response = await fetch('/api/prod-readiness', { cache: 'no-store' })
+  if (!response.ok) throw new Error(`Production readiness HTTP ${response.status}`)
+  return response.json() as Promise<ReadinessReport>
 }
 
 // 0 Absent · 1 Declared · 2 Verified · 3 Bank-grade.
@@ -40,16 +46,29 @@ export default function ReadinessPage() {
   const { t } = useLanguage()
   const [data, setData] = useState<ReadinessReport | null>(null)
   const [loading, setLoading] = useState(true)
+  const [unavailable, setUnavailable] = useState(false)
 
-  const load = () => {
+  const load = useCallback(async () => {
     setLoading(true)
-    fetch('/api/prod-readiness', { cache: 'no-store' })
-      .then(r => r.json())
-      .then((d: ReadinessReport) => setData(d))
-      .catch(() => setData({ generated_for: '', dimensions: [], services: [] }))
-      .finally(() => setLoading(false))
-  }
-  useEffect(() => { load() }, [])
+    setUnavailable(false)
+    try {
+      setData(await fetchReadinessReport())
+    } catch {
+      // A transport failure is not an empty collector result. Keep the last verified report on
+      // screen and label it stale; on first load render a recoverable unavailable state instead.
+      setUnavailable(true)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+  useEffect(() => {
+    let active = true
+    void fetchReadinessReport()
+      .then(report => { if (active) setData(report) })
+      .catch(() => { if (active) setUnavailable(true) })
+      .finally(() => { if (active) setLoading(false) })
+    return () => { active = false }
+  }, [])
 
   const services = data?.services ?? []
   const dims = data?.dimensions ?? []
@@ -87,6 +106,41 @@ export default function ReadinessPage() {
         }
       />
 
+      {unavailable && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            marginBottom: '16px', padding: '14px 16px', border: '1px solid var(--warning-border)',
+            borderRadius: '10px', background: 'var(--warning-bg)', color: 'var(--text-primary)',
+            display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '16px',
+          }}
+        >
+          <div>
+            <div style={{ fontWeight: 700 }}>
+              {data
+                ? t('Obnovení se nezdařilo — zobrazuji poslední dostupný report.', 'Refresh failed — showing the last available report.')
+                : t('Report připravenosti teď nelze načíst.', 'The readiness report is unavailable right now.')}
+            </div>
+            <div style={{ marginTop: '3px', color: 'var(--text-secondary)', fontSize: '12px' }}>
+              {t('Skóre ani gate závěry nebyly nahrazeny prázdnými daty.', 'Scores and gate verdicts were not replaced with empty data.')}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => void load()}
+            disabled={loading}
+            aria-label={t('Zkusit znovu načíst report připravenosti', 'Retry loading the readiness report')}
+            style={{
+              flexShrink: 0, padding: '7px 12px', border: '1px solid var(--border)', borderRadius: '7px',
+              background: 'var(--card-bg)', color: 'var(--text-primary)', cursor: 'pointer', fontWeight: 650,
+            }}
+          >
+            {t('Zkusit znovu', 'Try again')}
+          </button>
+        </div>
+      )}
+
       {/* Summary cards */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: '12px', marginBottom: '20px' }}>
         <StatCard label={t('Služeb', 'Services')} value={services.length} />
@@ -110,7 +164,7 @@ export default function ReadinessPage() {
 
       {loading && <div style={{ color: 'var(--text-secondary)', padding: '40px', textAlign: 'center' }}>{t('Načítám…', 'Loading…')}</div>}
 
-      {!loading && services.length === 0 && (
+      {!loading && !unavailable && services.length === 0 && (
         <div style={{ padding: '40px', textAlign: 'center', border: '1px dashed var(--border)', borderRadius: '12px', color: 'var(--text-secondary)' }}>
           {t('Žádná data — spusť prod-readiness-collector.py --all --json.', 'No data — run prod-readiness-collector.py --all --json.')}
         </div>

--- a/openbank-admin-ui/src/test/prod-readiness-recovery.test.tsx
+++ b/openbank-admin-ui/src/test/prod-readiness-recovery.test.tsx
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import ReadinessPage from '@/app/system/readiness/page'
+
+const REPORT = {
+  generated_for: '2026-08-31',
+  dimensions: [{ code: 'C1', name: 'Code' }],
+  services: [{
+    service: 'ledger',
+    money_path: true,
+    scores: { C1: 3 },
+    evidence: { C1: 'verified' },
+    gate: 'GO',
+  }],
+}
+
+function response(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+async function renderPage() {
+  await act(async () => {
+    render(<LanguageProvider><ReadinessPage /></LanguageProvider>)
+  })
+}
+
+describe('production readiness recovery states', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    cleanup()
+  })
+
+  it('labels an initial outage as unavailable instead of blaming an empty collector', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('offline') }))
+
+    await renderPage()
+
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('unavailable right now'))
+    expect(screen.queryByText(/No data — run prod-readiness-collector/)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Retry loading the readiness report' })).toBeInTheDocument()
+  })
+
+  it('keeps the last verified report when a refresh fails', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response(REPORT))
+      .mockResolvedValueOnce(response({ error: 'unavailable' }, 503))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await renderPage()
+    await waitFor(() => expect(screen.getByText('ledger')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh production readiness' }))
+
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('showing the last available report'))
+    expect(screen.getByText('ledger')).toBeInTheDocument()
+    expect(screen.getAllByText('GO')).toHaveLength(2)
+  })
+
+  it('recovers after an explicit retry', async () => {
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce(response(REPORT))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await renderPage()
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Retry loading the readiness report' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Retry loading the readiness report' }))
+
+    await waitFor(() => expect(screen.getByText('ledger')).toBeInTheDocument())
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary

- distinguish network and non-2xx readiness failures from a genuinely empty collector artifact
- preserve the last verified report with an explicit stale warning when refresh fails
- provide a localized retry path for initial and refresh failures
- keep scoring, gate verdicts, BFF boundaries, and RBAC behavior unchanged

Closes #7759

## Verification

- `npm exec vitest run src/test/prod-readiness-recovery.test.tsx src/test/prod-readiness-refresh.guard.test.ts` (4 tests passed)
- `npx eslint src/app/system/readiness/page.tsx src/test/prod-readiness-recovery.test.tsx`
- `git diff --check`