### PR TITLE
fix(admin-ui): preserve product catalog on outage

### DIFF
--- a/openbank-admin-ui/e2e/product-catalog-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/product-catalog-recovery.spec.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const PRODUCT = {
+  id: '00000000-2222-0000-0000-000000000002',
+  code: 'TERM_DEPOSIT_6M_CZK',
+  name: 'Term Deposit 6M',
+  type: 'TERM_DEPOSIT',
+  currency: 'CZK',
+  status: 'ACTIVE',
+  isPublic: true,
+  version: '1.0.0',
+  revision: 4,
+  baseRate: 0.058,
+}
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('keeps the last product catalogue visible through a failed refresh and recovery', async ({ page }) => {
+  let failNextRequest = false
+  await page.route('**/api/svc/product-catalog/api/v1/products', route => {
+    if (failNextRequest) {
+      failNextRequest = false
+      return route.fulfill({ status: 503, contentType: 'application/json', body: '{"error":"catalog unavailable"}' })
+    }
+    return route.fulfill({ contentType: 'application/json', body: JSON.stringify([PRODUCT]) })
+  })
+
+  await page.goto('/product-catalog')
+  await expect(page.getByText(PRODUCT.code, { exact: true })).toBeVisible()
+
+  failNextRequest = true
+  await page.getByRole('button', { name: /Obnovit katalog produktů|Refresh product catalog/ }).click()
+
+  const stale = page.getByRole('status').filter({ hasText: /poslední dostupná data|last available data/ })
+  await expect(stale).toContainText(/poslední dostupná data|last available data/)
+  await expect(page.getByText(PRODUCT.code, { exact: true })).toBeVisible()
+  await expect(page.getByText('1', { exact: true }).first()).toBeVisible()
+
+  await page.getByRole('button', { name: /Obnovit katalog produktů|Refresh product catalog/ }).click()
+  await expect(stale).toBeHidden()
+  await expect(page.getByText(PRODUCT.code, { exact: true })).toBeVisible()
+})

--- a/openbank-admin-ui/src/app/product-catalog/page.tsx
+++ b/openbank-admin-ui/src/app/product-catalog/page.tsx
@@ -464,7 +464,6 @@ export default function ProductCatalogPage() {
         if (refreshed) setSelectedProduct(refreshed)
       }
     } catch (e) {
-      setProducts([])
       setUnavailable({ kind: e instanceof ApiError ? e.kind : 'unreachable' })
     } finally {
       setLoading(false)
@@ -599,6 +598,11 @@ export default function ProductCatalogPage() {
                 lang={language}
                 dense
               />
+              {products.length > 0 && (
+                <div role="status" aria-live="polite" style={{ padding: '0 16px 14px', color: 'var(--warning-text)', fontSize: '12px', fontWeight: 600 }}>
+                  {t('Zobrazené produkty a souhrny jsou poslední dostupná data; obnovení katalogu se nezdařilo.', 'Displayed products and summaries are the last available data; catalog refresh failed.')}
+                </div>
+              )}
             </div>
           )}
 


### PR DESCRIPTION
## Summary

- preserve the last loaded product catalogue and summary counts when refresh fails
- identify retained products as the last available data in a polite live status
- recover through the existing read refresh without changing lifecycle behavior
- keep product mutations, optimistic locking, maker-checker, BFF boundaries, and RBAC unchanged

Closes #7763

## Verification

- `OPENBANK_E2E_PORT=3019 npx playwright test e2e/product-catalog-recovery.spec.ts --reporter=line` (1 passed)
- `npx eslint src/app/product-catalog/page.tsx e2e/product-catalog-recovery.spec.ts` (no errors; two pre-existing hook warnings on the page)
- `git diff --check`