### PR TITLE
fix(admin-ui): preserve document templates on outage

### DIFF
--- a/openbank-admin-ui/e2e/document-template-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/document-template-recovery.spec.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const TEMPLATE = {
+  id: 'template-42',
+  code: 'LOAN_AGREEMENT',
+  version: '1.0.0',
+  name: 'Loan agreement',
+  engine: 'HANDLEBARS',
+  bodyHtml: '<p>Hello {{party.name}}</p>',
+  locale: 'en',
+  classification: 'confidential',
+  status: 'PUBLISHED',
+  updatedAt: '2026-08-31T12:00:00Z',
+}
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('preserves the last template publication state through refresh outage and recovery', async ({ page }) => {
+  let failNextRequest = false
+  await page.route('**/api/svc/document-service/api/v1/documents/templates?limit=200', route => {
+    if (failNextRequest) {
+      failNextRequest = false
+      return route.fulfill({ status: 503, contentType: 'application/json', body: '{"error":"document service unavailable"}' })
+    }
+    return route.fulfill({ contentType: 'application/json', body: JSON.stringify([TEMPLATE]) })
+  })
+
+  await page.goto('/document-templates')
+  await expect(page.getByText(TEMPLATE.code, { exact: true })).toBeVisible()
+  await expect(page.getByText('PUBLISHED', { exact: true })).toBeVisible()
+
+  failNextRequest = true
+  await page.getByRole('button', { name: /Obnovit šablony dokumentů|Refresh document templates/ }).click()
+
+  const stale = page.getByRole('status').filter({ hasText: /poslední dostupná data|last available data/ })
+  await expect(stale).toBeVisible()
+  await expect(page.getByText(TEMPLATE.code, { exact: true })).toBeVisible()
+  await expect(page.getByText('PUBLISHED', { exact: true })).toBeVisible()
+
+  await page.getByRole('button', { name: /Obnovit šablony dokumentů|Refresh document templates/ }).click()
+  await expect(stale).toBeHidden()
+  await expect(page.getByText(TEMPLATE.code, { exact: true })).toBeVisible()
+})

--- a/openbank-admin-ui/src/app/document-templates/page.tsx
+++ b/openbank-admin-ui/src/app/document-templates/page.tsx
@@ -259,7 +259,6 @@ export default function DocumentTemplatesPage() {
       setTemplates(items)
       setVisibleCount(PAGE_SIZE)
     } catch (e) {
-      setTemplates([])
       setUnavailable({ kind: e instanceof ApiError ? e.kind : 'unreachable' })
     } finally {
       setLoading(false)
@@ -482,6 +481,11 @@ export default function DocumentTemplatesPage() {
             {unavailable && (
               <div className="card" style={{ padding: 0, marginBottom: '16px' }}>
                 <DataUnavailable kind={unavailable.kind} service={t('Document-service', 'Document-service')} feature={t('Šablony dokumentů', 'Document templates')} lang={language} dense />
+                {templates.length > 0 && (
+                  <div role="status" aria-live="polite" style={{ padding: '0 16px 14px', color: 'var(--warning-text)', fontSize: '12px', fontWeight: 600 }}>
+                    {t('Zobrazené šablony a jejich publikační stavy jsou poslední dostupná data; obnovení se nezdařilo.', 'Displayed templates and publication states are the last available data; refresh failed.')}
+                  </div>
+                )}
               </div>
             )}
 
@@ -540,7 +544,7 @@ export default function DocumentTemplatesPage() {
                       <td key={j}><div className="skeleton" style={{ height: '13px', width: j === 1 ? '140px' : '60px' }} /></td>
                     ))}</tr>
                   ))}
-                  {!loading && visible.length === 0 && (
+                  {!loading && !unavailable && visible.length === 0 && (
                     <tr><td colSpan={7} style={{ padding: 0 }}>
                       <DataUnavailable kind="no_data" feature={t('Šablony', 'Templates')} lang={language} dense />
                     </td></tr>


### PR DESCRIPTION
## Summary

- preserve the last loaded templates and publication states when refresh fails
- avoid rendering an empty-template state when the initial read is unavailable
- identify retained templates as the last available data and recover through the existing refresh
- keep publish/retire/save mutations, preview sandbox, maker-checker, BFF boundaries, and RBAC unchanged

Closes #7765

## Verification

- `OPENBANK_E2E_PORT=3020 npx playwright test e2e/document-template-recovery.spec.ts --reporter=line` (1 passed)
- `npx eslint src/app/document-templates/page.tsx e2e/document-template-recovery.spec.ts`
- `git diff --check`