### PR TITLE
fix(admin-ui): distinguish unavailable related accounts

### DIFF
--- a/openbank-admin-ui/e2e/party-related-accounts-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/party-related-accounts-recovery.spec.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const PARTY = {
+  id: '05a02ef1-381c-40e7-b73f-d6855eead42e',
+  partyType: 'PERSON',
+  status: 'ACTIVE',
+  legalName: 'Jan Novák',
+  email: 'jan.novak@example.test',
+  kycStatus: 'VERIFIED',
+  createdAt: '2026-08-01T08:00:00Z',
+  updatedAt: '2026-08-31T08:00:00Z',
+}
+
+const ACCOUNT = {
+  id: 'account-42',
+  accountNumber: 'CZ6508000000192000145399',
+  currencyCode: 'CZK',
+  status: 'ACTIVE',
+}
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('distinguishes unavailable related accounts from a party with no accounts and retries', async ({ page }) => {
+  let accountRequests = 0
+  let accountsAvailable = false
+  await page.route(`**/api/svc/party-service/api/v1/parties/${PARTY.id}`, route =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify(PARTY) }),
+  )
+  await page.route(`**/api/svc/kyc-service/api/v1/kyc/cases/party/${PARTY.id}`, route =>
+    route.fulfill({ status: 404, contentType: 'application/json', body: '{}' }),
+  )
+  await page.route('**/api/svc/account-service/api/v1/accounts?partyId=*&limit=20', route => {
+    accountRequests += 1
+    if (!accountsAvailable) {
+      return route.fulfill({ status: 503, contentType: 'application/json', body: '{"error":"account service unavailable"}' })
+    }
+    return route.fulfill({ contentType: 'application/json', body: JSON.stringify({ data: [ACCOUNT] }) })
+  })
+
+  await page.goto(`/parties/${PARTY.id}`)
+  await expect(page.getByRole('heading', { name: PARTY.legalName })).toBeVisible()
+
+  const unavailable = page.getByRole('status').filter({ hasText: /neznamená, že subjekt nemá žádné účty|does not mean the party has no accounts/ })
+  await expect(unavailable).toBeVisible()
+  await expect(page.getByText(/Žádné účty|No accounts/)).toHaveCount(0)
+
+  accountsAvailable = true
+  await page.getByRole('button', { name: /Zkusit znovu načíst související účty|Retry loading related accounts/ }).click()
+  await expect(unavailable).toBeHidden()
+  await expect(page.getByText(ACCOUNT.accountNumber, { exact: true })).toBeVisible()
+  expect(accountRequests).toBeGreaterThanOrEqual(2)
+})

--- a/openbank-admin-ui/src/app/parties/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/parties/[id]/page.tsx
@@ -228,7 +228,7 @@ function PartyDetailPage() {
           </div>
 
           {/* Related entities (ADR-0231 D3) — the party → accounts walk is chips, not UUID copying. */}
-          <RelatedAccounts partyId={party.id} />
+          <RelatedAccounts key={party.id} partyId={party.id} />
         </div>
       )}
 
@@ -242,17 +242,31 @@ type AccountRef = { id: string; accountNumber: string; currencyCode?: string; st
 function RelatedAccounts({ partyId }: { partyId: string }) {
   const { t } = useLanguage()
   const [accounts, setAccounts] = useState<AccountRef[] | null>(null)
+  const [unavailable, setUnavailable] = useState(false)
+  const [reloadKey, setReloadKey] = useState(0)
 
   useEffect(() => {
     const ctrl = new AbortController()
     fetch(svcUrl('account-service', '/api/v1/accounts', { partyId, limit: '20' }), {
       signal: ctrl.signal, cache: 'no-store',
     })
-      .then(r => (r.ok ? r.json() : null))
-      .then(d => setAccounts(d ? (d.data ?? []) : []))
-      .catch(() => setAccounts([]))
+      .then(r => {
+        if (!r.ok) throw new Error(`Related accounts HTTP ${r.status}`)
+        return r.json()
+      })
+      .then(d => setAccounts(d?.data ?? []))
+      .catch(error => {
+        if (error instanceof DOMException && error.name === 'AbortError') return
+        setUnavailable(true)
+      })
     return () => ctrl.abort()
-  }, [partyId])
+  }, [partyId, reloadKey])
+
+  const retry = () => {
+    setAccounts(null)
+    setUnavailable(false)
+    setReloadKey(key => key + 1)
+  }
 
   return (
     <div className="card" style={{ padding: '20px' }}>
@@ -260,7 +274,15 @@ function RelatedAccounts({ partyId }: { partyId: string }) {
         <Users size={15} style={{ color: 'var(--accent)' }} />
         <span style={{ fontWeight: 600, fontSize: '13px' }}>{t('Související účty', 'Related accounts')}</span>
       </div>
-      {accounts === null ? (
+      {unavailable ? (
+        <div role="status" aria-live="polite" style={{ fontSize: '12px', color: 'var(--warning-text)' }}>
+          <div>{t('Související účty se nepodařilo načíst — tento stav neznamená, že subjekt nemá žádné účty.', 'Related accounts could not be loaded — this does not mean the party has no accounts.')}</div>
+          <button type="button" onClick={retry} aria-label={t('Zkusit znovu načíst související účty', 'Retry loading related accounts')}
+            style={{ marginTop: '10px', padding: '6px 12px', borderRadius: '6px', border: '1px solid var(--border)', background: 'var(--surface)', color: 'var(--text-primary)', cursor: 'pointer', fontSize: '12px', fontWeight: 600 }}>
+            {t('Zkusit znovu', 'Try again')}
+          </button>
+        </div>
+      ) : accounts === null ? (
         <div style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>{t('Načítám…', 'Loading…')}</div>
       ) : accounts.length === 0 ? (
         <div style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>{t('Žádné účty', 'No accounts')}</div>


### PR DESCRIPTION
## Summary

- stop converting account-service failures into a false “No accounts” state on Party Detail
- explain that unavailability does not prove the party has no accounts and provide an explicit retry
- recover to the existing account chip without exposing additional account data
- preserve party/KYC reads, navigation, BFF boundaries, and RBAC

Closes #7767

## Verification

- `OPENBANK_E2E_PORT=3021 npx playwright test e2e/party-related-accounts-recovery.spec.ts --reporter=line` (1 passed)
- `npx eslint src/app/parties/[id]/page.tsx e2e/party-related-accounts-recovery.spec.ts` (no errors; two unrelated pre-existing hook warnings remain)
- `git diff --check`