### PR TITLE
fix(admin-ui): preserve SCT instant monitor snapshot

### DIFF
--- a/openbank-admin-ui/e2e/sct-inst-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/sct-inst-recovery.spec.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const PAYMENT = {
+  paymentId: 'sct-inst-42',
+  debtorIban: 'CZ6508000000192000145399',
+  creditorIban: 'DE89370400440532013000',
+  amount: 125.5,
+  currency: 'EUR',
+  endToEndId: 'E2E-RECOVERY-42',
+  status: 'SETTLED',
+  createdAt: '2026-08-31T08:00:00Z',
+}
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('preserves the last SCT Inst snapshot during an outage and recovers', async ({ page }) => {
+  let listRequests = 0
+  let listAvailable = true
+
+  await page.route('**/api/sepa-payments', route =>
+    route.fulfill({ contentType: 'application/json', body: '[]' }),
+  )
+  await page.route('**/api/domestic-payments', route =>
+    route.fulfill({ contentType: 'application/json', body: '[]' }),
+  )
+  await page.route('**/api/svc/sepa-instant/q/health/ready', route =>
+    route.fulfill({ status: listAvailable ? 200 : 503, contentType: 'application/json', body: '{}' }),
+  )
+  await page.route('**/api/svc/sepa-instant/api/v1/sepa-instant', route => {
+    listRequests += 1
+    if (!listAvailable) {
+      return route.fulfill({ status: 503, contentType: 'application/json', body: '{"error":"unavailable"}' })
+    }
+    return route.fulfill({ contentType: 'application/json', body: JSON.stringify([PAYMENT]) })
+  })
+
+  await page.goto('/payments?tab=sct-inst')
+  await expect(page.getByText(PAYMENT.endToEndId, { exact: true })).toBeVisible()
+
+  listAvailable = false
+  await page.getByRole('button', { name: /Obnovit SCT platby|Refresh SCT payments/ }).click()
+
+  await expect(page.getByRole('status').filter({ hasText: /mohou být zastaralé|may be stale/ })).toBeVisible()
+  await expect(page.getByText(PAYMENT.endToEndId, { exact: true })).toBeVisible()
+  await expect(page.getByText(/Žádné SCT Inst platby|No SCT Inst payments/)).toHaveCount(0)
+
+  listAvailable = true
+  await page.getByRole('button', { name: /Zkusit znovu|Retry/ }).click()
+  await expect(page.getByRole('status').filter({ hasText: /mohou být zastaralé|may be stale/ })).toBeHidden()
+  await expect(page.getByText(PAYMENT.endToEndId, { exact: true })).toBeVisible()
+  expect(listRequests).toBeGreaterThanOrEqual(3)
+})

--- a/openbank-admin-ui/src/app/payments/page.tsx
+++ b/openbank-admin-ui/src/app/payments/page.tsx
@@ -286,6 +286,7 @@ function PaymentsContent() {
   const [sctLoading, setSctLoading] = useState(true)
   const [sctSearch, setSctSearch] = useState('')
   const [sctServiceUp, setSctServiceUp] = useState<boolean | null>(null)
+  const [sctError, setSctError] = useState<string | null>(null)
 
   const handleTabChange = useCallback((t: Tab) => {
     setActiveTab(t)
@@ -311,16 +312,27 @@ function PaymentsContent() {
 
   const loadSct = useCallback(async () => {
     setSctLoading(true)
-    try {
-      await Promise.all([
-        fetch(`${SEPA_INSTANT_API}/q/health/ready`).then(r => setSctServiceUp(r.ok)).catch(() => setSctServiceUp(false)),
-        fetch(`${SEPA_INSTANT_API}/api/v1/sepa-instant`).then(r => r.json())
-          .then(d => setSctPayments(Array.isArray(d) ? d : d.payments ?? []))
-          .catch(() => setSctPayments([])),
-      ])
-    } catch { setSctServiceUp(false) }
-    finally { setSctLoading(false) }
-  }, [])
+    setSctError(null)
+    const [healthResult, paymentsResult] = await Promise.allSettled([
+      fetch(`${SEPA_INSTANT_API}/q/health/ready`).then(r => r.ok),
+      fetch(`${SEPA_INSTANT_API}/api/v1/sepa-instant`).then(async r => {
+        if (!r.ok) throw new Error(`SCT Inst request failed (${r.status})`)
+        const data = await r.json()
+        return Array.isArray(data) ? data : data.payments ?? []
+      }),
+    ])
+
+    setSctServiceUp(healthResult.status === 'fulfilled' ? healthResult.value : false)
+    if (paymentsResult.status === 'fulfilled') {
+      setSctPayments(paymentsResult.value)
+    } else {
+      setSctError(t(
+        'Aktuální SCT Inst platby nejsou dostupné. Zobrazené údaje mohou být zastaralé.',
+        'Current SCT Inst payments are unavailable. Displayed data may be stale.',
+      ))
+    }
+    setSctLoading(false)
+  }, [t])
 
   useEffect(() => { load() }, [load])
   useEffect(() => { if (activeTab === 'sct-inst') loadSct() }, [activeTab, loadSct])
@@ -539,6 +551,21 @@ function PaymentsContent() {
             </div>
           )}
 
+          {sctError && (
+            <div role="status" style={{ marginBottom: '20px', padding: '12px 16px', borderRadius: '8px',
+              background: 'var(--warning-bg)', border: '1px solid var(--warning-border)',
+              display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '12px' }}>
+              <span style={{ display: 'flex', alignItems: 'center', gap: '10px', fontSize: '13px', fontWeight: 600, color: 'var(--warning-text)' }}>
+                <AlertTriangle size={16} aria-hidden="true" style={{ flexShrink: 0 }} />
+                {sctError}
+              </span>
+              <button className="btn btn-secondary btn-sm" type="button" onClick={loadSct} disabled={sctLoading} aria-busy={sctLoading}>
+                <RefreshCw size={12} aria-hidden="true" />
+                {t('Zkusit znovu', 'Retry')}
+              </button>
+            </div>
+          )}
+
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '12px', marginBottom: '20px' }}>
             {[
               { label: t('Platby celkem', 'Total payments'), value: sctPayments.length, icon: <Zap size={16} />, color: 'var(--accent)' },
@@ -580,7 +607,7 @@ function PaymentsContent() {
               <div style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
                 <RefreshCw size={20} style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} /><div>{t('Načítám…', 'Loading…')}</div>
               </div>
-            ) : sctFiltered.length === 0 ? (
+            ) : !sctError && sctFiltered.length === 0 ? (
               <div style={{ padding: '48px', textAlign: 'center' }}>
                 <Zap size={32} style={{ color: 'var(--text-tertiary)', marginBottom: '12px' }} />
                 <div style={{ fontSize: '14px', fontWeight: 600, color: 'var(--text-primary)', marginBottom: '4px' }}>{t('Žádné SCT Inst platby', 'No SCT Inst payments')}</div>


### PR DESCRIPTION
## Summary\n- preserve the last verified SCT Inst payment snapshot when a refresh fails\n- show a truthful stale-data warning with an explicit retry action\n- reserve the empty state for a successful empty response\n- add authenticated browser coverage for outage and recovery\n\n## Verification\n- `git diff --check`\n- `npx eslint src/app/payments/page.tsx e2e/sct-inst-recovery.spec.ts` (0 errors; pre-existing hook warnings remain in the page)\n- `OPENBANK_E2E_PORT=3022 npm run test:e2e -- e2e/sct-inst-recovery.spec.ts --project=chromium` (1 passed)\n\n## Risk\nRead-only monitor recovery only. Payment creation, VoP, idempotency, approval, BFF routing, RBAC and settlement behavior are unchanged.\n\nCloses #7770