### PR TITLE
fix(admin-ui): preserve fee schedule snapshot

### DIFF
--- a/openbank-admin-ui/e2e/fee-schedule-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/fee-schedule-recovery.spec.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const FEE = {
+  id: 'fee-42',
+  code: 'SEPA_INSTANT_OUT',
+  name: 'SEPA Instant outgoing transfer',
+  productCode: 'CURRENT_ACCOUNT',
+  productName: 'Current Account',
+  type: 'TRANSACTION',
+  amount: 1.5,
+  currency: 'EUR',
+  frequency: 'PER_TRANSACTION',
+  status: 'ACTIVE',
+  waivable: false,
+}
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('keeps the last fee schedule during an outage and recovers', async ({ page }) => {
+  let available = true
+  let requests = 0
+  await page.route('**/api/svc/product-catalog/api/v1/fees', route => {
+    requests += 1
+    if (!available) {
+      return route.fulfill({ status: 503, contentType: 'application/json', body: '{"error":"unavailable"}' })
+    }
+    return route.fulfill({ contentType: 'application/json', body: JSON.stringify([FEE]) })
+  })
+
+  await page.goto('/fees')
+  await expect(page.getByText(FEE.code, { exact: true })).toBeVisible()
+  await expect(page.getByText('1', { exact: true }).first()).toBeVisible()
+
+  available = false
+  await page.getByRole('button', { name: /Obnovit ceník poplatků|Refresh fee schedule/ }).click()
+
+  await expect(page.getByText(/údaje mohou být zastaralé|data may be stale/)).toBeVisible()
+  await expect(page.getByText(FEE.code, { exact: true })).toBeVisible()
+  await expect(page.getByText(/Žádné poplatky nenalezeny|No fees found/)).toHaveCount(0)
+
+  available = true
+  await page.getByRole('button', { name: /Obnovit ceník poplatků|Refresh fee schedule/ }).click()
+  await expect(page.getByText(/údaje mohou být zastaralé|data may be stale/)).toBeHidden()
+  await expect(page.getByText(FEE.code, { exact: true })).toBeVisible()
+  expect(requests).toBeGreaterThanOrEqual(3)
+})

--- a/openbank-admin-ui/src/app/fees/page.tsx
+++ b/openbank-admin-ui/src/app/fees/page.tsx
@@ -54,20 +54,17 @@ export default function FeesPage() {
       // auth-gated). product-catalog is the KEDA-scaled fees system of record.
       const res = await fetch(svcUrl('product-catalog', '/api/v1/fees'), { cache: 'no-store' })
       if (!res.ok) {
-        setFees([])
         setUnavailable({ kind: await classifyBffFailure(res) })
         return
       }
       const data = await res.json()
       if (!Array.isArray(data)) {
-        setFees([])
         setUnavailable({ kind: 'error' })
         return
       }
       setFees(data as FeeScheduleItem[])
     } catch {
       // Timeout / abort / network — product-catalog didn't answer.
-      setFees([])
       setUnavailable({ kind: 'unreachable' })
     } finally {
       setLoading(false)
@@ -145,6 +142,9 @@ export default function FeesPage() {
               service={t('Product-catalog', 'Product-catalog')}
               feature={t('Poplatky', 'Fees')}
               lang={language}
+              detail={fees.length > 0
+                ? t('Zobrazen je poslední úspěšně načtený ceník; údaje mohou být zastaralé.', 'The last successfully loaded fee schedule is shown; data may be stale.')
+                : undefined}
               dense
             />
           </div>


### PR DESCRIPTION
## Summary\n- preserve the last verified fee schedule and summary counts when product-catalog refresh fails\n- explicitly label retained prices as potentially stale\n- reserve the empty state for successful empty responses\n- add authenticated browser coverage for outage and recovery\n\n## Verification\n- `git diff --check`\n- `npx eslint src/app/fees/page.tsx e2e/fee-schedule-recovery.spec.ts` (0 errors; one pre-existing hook warning)\n- `OPENBANK_E2E_PORT=3023 npm run test:e2e -- e2e/fee-schedule-recovery.spec.ts --project=chromium` (1 passed)\n\n## Risk\nRead-only fee display recovery only. Pricing rules, product-catalog mutations, BFF routing and RBAC are unchanged.\n\nCloses #7774