### PR TITLE
fix(admin-ui): preserve notification log snapshot

### DIFF
--- a/openbank-admin-ui/e2e/notification-log-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/notification-log-recovery.spec.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const NOTIFICATION = {
+  id: 'notification-42',
+  type: 'EMAIL',
+  channel: 'EMAIL',
+  recipient: 'customer-42@example.test',
+  subject: 'Payment received',
+  status: 'SENT',
+  sentAt: '2026-08-31T08:01:00Z',
+  createdAt: '2026-08-31T08:00:00Z',
+}
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('keeps the last notification log during an outage and recovers', async ({ page }) => {
+  let available = true
+  let requests = 0
+  await page.route('**/api/svc/notification-service/api/v1/notifications', route => {
+    requests += 1
+    if (!available) {
+      return route.fulfill({ status: 503, contentType: 'application/json', body: '{"error":"unavailable"}' })
+    }
+    return route.fulfill({ contentType: 'application/json', body: JSON.stringify([NOTIFICATION]) })
+  })
+
+  await page.goto('/notifications')
+  await expect(page.getByText(NOTIFICATION.recipient, { exact: true })).toBeVisible()
+
+  available = false
+  await page.getByRole('button', { name: /Obnovit oznámení|Refresh notifications/ }).click()
+
+  await expect(page.getByText(/stav doručení se mohl změnit|delivery status may have changed/)).toBeVisible()
+  await expect(page.getByText(NOTIFICATION.recipient, { exact: true })).toBeVisible()
+  await expect(page.getByText(/Žádné notifikace nenalezeny|No notifications found/)).toHaveCount(0)
+
+  available = true
+  await page.getByRole('button', { name: /Obnovit oznámení|Refresh notifications/ }).click()
+  await expect(page.getByText(/stav doručení se mohl změnit|delivery status may have changed/)).toBeHidden()
+  await expect(page.getByText(NOTIFICATION.recipient, { exact: true })).toBeVisible()
+  expect(requests).toBeGreaterThanOrEqual(3)
+})

--- a/openbank-admin-ui/src/app/notifications/page.tsx
+++ b/openbank-admin-ui/src/app/notifications/page.tsx
@@ -43,7 +43,6 @@ function NotificationsContent() {
       const res = await fetch(`${NOTIFICATION_SERVICE}/api/v1/notifications`, { signal: AbortSignal.timeout(5000) })
       if (!res.ok) {
         const kind = await classifyBffFailure(res)
-        setItems([])
         // A genuine 404/405 on the log endpoint means "no notifications yet",
         // not a broken app — degrade to the calm empty state.
         setUnavailable({ kind: res.status === 405 || kind === 'not_found' ? 'no_data' : kind })
@@ -53,7 +52,6 @@ function NotificationsContent() {
       setItems(Array.isArray(data) ? data : data.items ?? [])
     } catch {
       // Timeout / abort / network — the BFF or notification-service didn't answer.
-      setItems([])
       setUnavailable({ kind: 'unreachable' })
     } finally { setLoading(false) }
   }, [])
@@ -107,6 +105,9 @@ function NotificationsContent() {
             service={t('Notification-service', 'Notification-service')}
             feature={t('Notifikace', 'Notifications')}
             lang={language}
+            detail={items.length > 0
+              ? t('Zobrazen je poslední úspěšně načtený log; stav doručení se mohl změnit.', 'The last successfully loaded log is shown; delivery status may have changed.')
+              : undefined}
             dense
           />
         </div>


### PR DESCRIPTION
## Summary\n- preserve the last verified outbound notification log and delivery counts when refresh fails\n- explicitly label retained delivery state as potentially stale\n- reserve the empty state for successful empty responses\n- add authenticated browser coverage for outage and recovery\n\n## Verification\n- `git diff --check`\n- `npx eslint src/app/notifications/page.tsx e2e/notification-log-recovery.spec.ts` (0 errors; one pre-existing hook warning)\n- `OPENBANK_E2E_PORT=3024 npm run test:e2e -- e2e/notification-log-recovery.spec.ts --project=chromium` (1 passed)\n\n## Risk\nRead-only notification-log recovery only. Sending, four-eyes approval, payloads, BFF routing and RBAC are unchanged.\n\nCloses #7777