### PR TITLE
fix(admin-ui): preserve audit lookup evidence

### DIFF
--- a/openbank-admin-ui/e2e/audit-trail-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/audit-trail-recovery.spec.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const AGGREGATE_ID = '05a02ef1-381c-40e7-b73f-d6855eead42e'
+const ENTRY = {
+  id: 'audit-42',
+  aggregateId: AGGREGATE_ID,
+  aggregateType: 'ACCOUNT',
+  eventType: 'UPDATED',
+  actorId: 'operator-42',
+  actorType: 'USER',
+  occurredAt: '2026-08-31T08:00:00Z',
+  payload: { status: 'ACTIVE' },
+}
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('keeps a failed audit retry bound to the same aggregate and recovers', async ({ page }) => {
+  let available = true
+  let requests = 0
+  await page.route(`**/api/svc/audit-service/api/v1/audit/entries/${AGGREGATE_ID}?limit=100`, route => {
+    requests += 1
+    if (!available) {
+      return route.fulfill({ status: 503, contentType: 'application/json', body: '{"error":"unavailable"}' })
+    }
+    return route.fulfill({ contentType: 'application/json', body: JSON.stringify([ENTRY]) })
+  })
+
+  await page.goto('/audit')
+  await page.getByLabel(/ID agregátu|Aggregate ID/).fill(AGGREGATE_ID)
+  await page.getByRole('button', { name: /Vyhledat auditní záznam|Search audit trail/ }).click()
+  await expect(page.getByText('UPDATED', { exact: true })).toBeVisible()
+  await expect(page.getByText(AGGREGATE_ID, { exact: true })).toBeVisible()
+
+  available = false
+  await page.getByRole('button', { name: /Vyhledat auditní záznam|Search audit trail/ }).click()
+  await expect(page.getByText(/novější události mohou chybět|newer events may be missing/)).toBeVisible()
+  await expect(page.getByText('UPDATED', { exact: true })).toBeVisible()
+  await expect(page.getByText(AGGREGATE_ID, { exact: true })).toBeVisible()
+
+  available = true
+  await page.getByRole('button', { name: /Vyhledat auditní záznam|Search audit trail/ }).click()
+  await expect(page.getByText(/novější události mohou chybět|newer events may be missing/)).toBeHidden()
+  await expect(page.getByText('UPDATED', { exact: true })).toBeVisible()
+  expect(requests).toBeGreaterThanOrEqual(3)
+})
+
+test('never attributes an older audit snapshot to a different aggregate', async ({ page }) => {
+  const differentAggregateId = '86d667cb-52d7-4985-8624-e8130dc28cab'
+  await page.route(`**/api/svc/audit-service/api/v1/audit/entries/${AGGREGATE_ID}?limit=100`, route =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify([ENTRY]) }),
+  )
+  await page.route(`**/api/svc/audit-service/api/v1/audit/entries/${differentAggregateId}?limit=100`, route =>
+    route.fulfill({ status: 503, contentType: 'application/json', body: '{"error":"unavailable"}' }),
+  )
+
+  await page.goto('/audit')
+  const input = page.getByLabel(/ID agregátu|Aggregate ID/)
+  await input.fill(AGGREGATE_ID)
+  await page.getByRole('button', { name: /Vyhledat auditní záznam|Search audit trail/ }).click()
+  await expect(page.getByText('UPDATED', { exact: true })).toBeVisible()
+
+  await input.fill(differentAggregateId)
+  await page.getByRole('button', { name: /Vyhledat auditní záznam|Search audit trail/ }).click()
+  await expect(page.getByText('UPDATED', { exact: true })).toHaveCount(0)
+  await expect(page.getByText(/poslední ověřený snapshot|last verified snapshot/)).toHaveCount(0)
+})

--- a/openbank-admin-ui/src/app/audit/page.tsx
+++ b/openbank-admin-ui/src/app/audit/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState, useCallback } from 'react'
+import { Fragment, useState, useCallback } from 'react'
 import { ScrollText, Search } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure } from '@/lib/services/bff'
@@ -35,27 +35,36 @@ export default function AuditPage() {
   // environment, so a failed lookup is normally "not deployed", not "broken".
   const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
   const [aggregateId, setAggregateId] = useState('')
+  const [loadedAggregateId, setLoadedAggregateId] = useState<string | null>(null)
   const [expanded, setExpanded] = useState<string | null>(null)
 
   const search = useCallback(async () => {
-    if (!aggregateId.trim()) return
+    const query = aggregateId.trim()
+    if (!query) return
     setLoading(true); setUnavailable(null)
     try {
-      const res = await fetch(`${AUDIT_SERVICE}/api/v1/audit/entries/${aggregateId.trim()}?limit=100`, { signal: AbortSignal.timeout(5000) })
+      const res = await fetch(`${AUDIT_SERVICE}/api/v1/audit/entries/${query}?limit=100`, { signal: AbortSignal.timeout(5000) })
       if (!res.ok) {
-        setEntries([])
+        if (loadedAggregateId !== query) {
+          setEntries([])
+          setLoadedAggregateId(null)
+        }
         setUnavailable({ kind: await classifyBffFailure(res) })
         return
       }
       const data = await res.json()
       setEntries(Array.isArray(data) ? data : data.entries ?? [])
+      setLoadedAggregateId(query)
     } catch {
       // fetch threw (timeout/abort/network) — the BFF or audit-service didn't
       // answer at all. Treat as unreachable rather than leaking the raw error.
-      setEntries([])
+      if (loadedAggregateId !== query) {
+        setEntries([])
+        setLoadedAggregateId(null)
+      }
       setUnavailable({ kind: 'unreachable' })
     } finally { setLoading(false) }
-  }, [aggregateId])
+  }, [aggregateId, loadedAggregateId])
 
   return (
     <div>
@@ -98,6 +107,9 @@ export default function AuditPage() {
             service={t('Audit-service', 'Audit-service')}
             feature={t('Auditní záznamy', 'Audit trail')}
             lang={language}
+            detail={entries.length > 0 && loadedAggregateId === aggregateId.trim()
+              ? t('Zobrazen je poslední ověřený snapshot pro stejné Aggregate ID; novější události mohou chybět.', 'The last verified snapshot for this Aggregate ID is shown; newer events may be missing.')
+              : undefined}
           />
         </div>
       )}
@@ -105,7 +117,7 @@ export default function AuditPage() {
       {entries.length > 0 && (
         <div className="card" style={{ overflow: 'hidden' }}>
           <div style={{ padding: '12px 16px', borderBottom: '1px solid var(--border)', fontSize: '13px', color: 'var(--text-muted)' }}>
-            {entries.length} {t('událostí pro', 'events for')} <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>{aggregateId}</span>
+            {entries.length} {t('událostí pro', 'events for')} <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>{loadedAggregateId}</span>
           </div>
           <table className="data-table">
             <thead>
@@ -119,8 +131,8 @@ export default function AuditPage() {
             </thead>
             <tbody>
               {entries.map(e => (
-                <>
-                  <tr key={e.id} tabIndex={0} aria-expanded={expanded === e.id} aria-label={expanded === e.id ? t('Sbalit auditní událost', 'Collapse audit event') : t('Rozbalit auditní událost', 'Expand audit event')} style={{ cursor: 'pointer' }} onClick={() => setExpanded(expanded === e.id ? null : e.id)}
+                <Fragment key={e.id}>
+                  <tr tabIndex={0} aria-expanded={expanded === e.id} aria-label={expanded === e.id ? t('Sbalit auditní událost', 'Collapse audit event') : t('Rozbalit auditní událost', 'Expand audit event')} style={{ cursor: 'pointer' }} onClick={() => setExpanded(expanded === e.id ? null : e.id)}
                     onKeyDown={event => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); setExpanded(expanded === e.id ? null : e.id) } }}>
                     <td>
                       <span className="pill" style={{ background: `${EVENT_COLOR[e.eventType] ?? 'var(--text-muted)'}22`, color: EVENT_COLOR[e.eventType] ?? 'var(--text-muted)' }}>
@@ -145,7 +157,7 @@ export default function AuditPage() {
                       </td>
                     </tr>
                   )}
-                </>
+                </Fragment>
               ))}
             </tbody>
           </table>


### PR DESCRIPTION
## Summary\n- bind each successful audit snapshot to the Aggregate ID that produced it\n- preserve and clearly mark evidence only when a repeated lookup for that same ID fails\n- clear older evidence before reporting a failure for a different Aggregate ID\n- give mapped audit row fragments stable React identity\n- add authenticated browser coverage for same-ID recovery and cross-ID isolation\n\n## Verification\n- `git diff --check`\n- `npx eslint src/app/audit/page.tsx e2e/audit-trail-recovery.spec.ts` (clean)\n- `OPENBANK_E2E_PORT=3025 npm run test:e2e -- e2e/audit-trail-recovery.spec.ts --project=chromium` (2 passed, React key warning eliminated)\n\n## Risk\nRead-only audit lookup presentation only. Audit payloads, authorization, BFF routing and all mutations are unchanged.\n\nCloses #7780