### PR TITLE
fix(admin-ui): align PID console RBAC

### DIFF
--- a/openbank-admin-ui/e2e/helpers/auth.ts
+++ b/openbank-admin-ui/e2e/helpers/auth.ts
@@ -27,8 +27,8 @@ const NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET ?? 'e2e-test-secret'
 // USE_SECURE_COOKIES is false and the cookie has no `__Secure-` prefix.
 const SESSION_COOKIE_NAME = 'authjs.session-token'
 
-/** Signs the given browser context in as an operator with every role, bypassing Keycloak. */
-export async function signInAsOperator(context: BrowserContext, baseURL: string): Promise<void> {
+/** Signs a browser context in with an explicit role set, bypassing Keycloak. */
+export async function signInWithRoles(context: BrowserContext, baseURL: string, roles: string[]): Promise<void> {
   const token = await encode({
     secret: NEXTAUTH_SECRET,
     salt: SESSION_COOKIE_NAME,
@@ -36,11 +36,19 @@ export async function signInAsOperator(context: BrowserContext, baseURL: string)
       sub: 'e2e-operator',
       name: 'E2E Operator',
       email: 'e2e-operator@openbank.test',
-      // All route-guard roles (src/proxy.ts routeGuards) so any page renders.
-      roles: ['ROLE_ADMIN', 'ROLE_OPERATOR', 'ROLE_AUDITOR', 'ROLE_COMPLIANCE', 'ROLE_PAYMENTS'],
+      roles,
       accessToken: 'e2e-fake-access-token',
       accessTokenExpires: Date.now() + 60 * 60 * 1000,
     },
   })
   await context.addCookies([{ name: SESSION_COOKIE_NAME, value: token, url: baseURL }])
+}
+
+/** Signs the given browser context in as an operator with every role, bypassing Keycloak. */
+export async function signInAsOperator(context: BrowserContext, baseURL: string): Promise<void> {
+  return signInWithRoles(
+    context,
+    baseURL,
+    ['ROLE_ADMIN', 'ROLE_OPERATOR', 'ROLE_AUDITOR', 'ROLE_COMPLIANCE', 'ROLE_PAYMENTS'],
+  )
 }

--- a/openbank-admin-ui/e2e/pid-rbac.spec.ts
+++ b/openbank-admin-ui/e2e/pid-rbac.spec.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInWithRoles } from './helpers/auth'
+
+test('stops a payments viewer before the PID PII workspace renders', async ({ context, page, baseURL }) => {
+  await signInWithRoles(context, baseURL!, ['ROLE_VIEWER'])
+
+  await page.goto('/pid')
+
+  await expect(page).toHaveURL(/\/auth\/forbidden\?path=%2Fpid$/)
+  await expect(page.getByRole('heading', { name: /Tato oblast není součástí vaší role|This area is not in your role/ })).toBeVisible()
+  await expect(page.getByText('/pid', { exact: true })).toBeVisible()
+  await expect(page.getByRole('heading', { name: /Osobní identifikační údaje|Personal Identification Data/ })).toHaveCount(0)
+})

--- a/openbank-admin-ui/src/app/pid/page.tsx
+++ b/openbank-admin-ui/src/app/pid/page.tsx
@@ -191,7 +191,7 @@ export default function PidPage() {
   }
 
   return (
-    <AuthGuard>
+    <AuthGuard permission="pid:view">
       <div style={{ animation: 'fadeIn 0.2s ease-out', maxWidth: '1400px', margin: '0 auto' }}>
         <PageHeader
           icon={<Map size={18} aria-hidden="true" />}

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -90,7 +90,7 @@ const complianceNav: NavItem[] = [
 ]
 
 const opsNav: NavItem[] = [
-  { nameCs: 'PID',                   nameEn: 'PID',              href: '/pid',               icon: Map,          permission: 'payments:view' },
+  { nameCs: 'PID',                   nameEn: 'PID',              href: '/pid',               icon: Map,          permission: 'pid:view' },
   { nameCs: 'Oznámení',              nameEn: 'Notifications',    href: '/notifications',     icon: Bell,         permission: 'notifications:view' },
   { nameCs: 'Bezpečnostní kontrola', nameEn: 'Security Scan',    href: '/security',          icon: ScanLine,     permission: 'system:view' },
 ]

--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -85,6 +85,9 @@ export const PERMISSIONS = {
   // must never be offered a customer-creation workflow.
   "parties:create":       [ROLES.ADMIN, ROLES.OPERATOR, ROLES.KYC],
   "parties:edit":         [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE],
+  // PID-service's party list/detail/create and BankID sync endpoints accept only
+  // OPERATOR/ADMIN. Keep this PII workspace narrower than the generic payments area.
+  "pid:view":             [ROLES.ADMIN, ROLES.OPERATOR],
   "kyc:view":             [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE, ROLES.KYC, ROLES.KYC_OPENER, ROLES.KYC_REVIEWER],
   "kyc:approve":          [ROLES.ADMIN, ROLES.COMPLIANCE, ROLES.KYC_REVIEWER],
   // ROLES.DEMO here (and nowhere else in this file) because onboarding-service's own
@@ -225,6 +228,7 @@ const ROUTE_PREFIXES: ReadonlyArray<readonly [Permission, readonly string[]]> = 
   ['kyc:view', ['/kyc']],
   ['onboarding:view', ['/onboarding']],
   ['identity-cases:view', ['/identity-cases']],
+  ['pid:view', ['/pid']],
   ['parties:create', ['/parties/new']],
   ['parties:view', ['/parties']],
   ['transactions:view', ['/transactions']],
@@ -233,7 +237,7 @@ const ROUTE_PREFIXES: ReadonlyArray<readonly [Permission, readonly string[]]> = 
   ['cards:view', ['/cards']],
   ['payments:view', [
     '/payments', '/product-catalog', '/standing-orders', '/sdd', '/sepa-instant', '/clearing',
-    '/fx', '/swift', '/interest', '/pid', '/fees', '/lending',
+    '/fx', '/swift', '/interest', '/fees', '/lending',
   ]],
   ['sanctions:view', ['/sanctions']],
   ['compliance:view', [

--- a/openbank-admin-ui/src/test/pid-rbac-alignment.guard.test.ts
+++ b/openbank-admin-ui/src/test/pid-rbac-alignment.guard.test.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { hasPermission, permissionForPath } from '@/lib/auth/roles'
+
+const root = resolve(__dirname, '..')
+const read = (file: string) => readFileSync(resolve(root, file), 'utf8')
+
+describe('PID console mirrors pid-service RBAC', () => {
+  it('allows only the operator and admin roles accepted by PartyResource', () => {
+    expect(hasPermission(['ROLE_ADMIN'], 'pid:view')).toBe(true)
+    expect(hasPermission(['ROLE_OPERATOR'], 'pid:view')).toBe(true)
+    expect(hasPermission(['ROLE_VIEWER'], 'pid:view')).toBe(false)
+    expect(hasPermission(['ROLE_PAYMENTS'], 'pid:view')).toBe(false)
+    expect(hasPermission(['ROLE_SUPERVISOR'], 'pid:view')).toBe(false)
+  })
+
+  it('uses the same permission at the edge, navigation, and page boundary', () => {
+    expect(permissionForPath('/pid')).toBe('pid:view')
+    expect(read('components/layout/Sidebar.tsx')).toMatch(/href: '\/pid'[\s\S]*permission: 'pid:view'/)
+    expect(read('app/pid/page.tsx')).toContain('<AuthGuard permission="pid:view">')
+  })
+})


### PR DESCRIPTION
## Summary\n- add a dedicated PID read permission matching pid-service ROLE_OPERATOR/ROLE_ADMIN\n- use it consistently in sidebar visibility, edge route projection and page defense in depth\n- extend the test-only auth helper to support explicit role sets\n- add matrix/route guard tests and a negative authenticated browser test\n\n## Verification\n- `git diff --check`\n- focused ESLint: 0 errors (one pre-existing PID effect warning)\n- `npx vitest run src/test/pid-rbac-alignment.guard.test.ts src/test/route-permissions.test.ts` (4 passed)\n- `OPENBANK_E2E_PORT=3026 npm run test:e2e -- e2e/pid-rbac.spec.ts --project=chromium` (1 passed)\n\n## Security\nA ROLE_VIEWER session is redirected to the explanatory forbidden page before the PID PII workspace renders. No backend roles, data, mutation payloads or service authorization changed.\n\nCloses #7783