### PR TITLE
fix(admin-ui): preserve transaction search evidence

### DIFF
--- a/openbank-admin-ui/e2e/transactions-search-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/transactions-search-recovery.spec.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+test.describe('Transaction ledger search recovery', () => {
+  test.beforeEach(async ({ context, baseURL }) => {
+    await signInAsOperator(context, baseURL!)
+  })
+
+  test('keeps the last successful result visible when a repeated search is unavailable', async ({ page }) => {
+    let requests = 0
+
+    await page.route('**/api/svc/transaction-service/api/v1/transactions/search**', async route => {
+      requests += 1
+      expect(route.request().url()).toContain('iban=CZ6508000000192000145399')
+
+      if (requests === 1) {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: [{
+              id: 'transaction-42',
+              referenceNumber: 'TXN-EVIDENCE-42',
+              type: 'CREDIT',
+              sourceAccountId: '11111111-1111-1111-1111-111111111111',
+              targetAccountId: '22222222-2222-2222-2222-222222222222',
+              amount: 1250,
+              currencyCode: 'CZK',
+              status: 'COMPLETED',
+              description: 'Verified settlement',
+              valueDate: '2026-08-31',
+              bookingDate: '2026-08-31',
+              initiatedAt: '2026-08-31T08:00:00Z',
+            }],
+            count: 1,
+            limit: 50,
+            offset: 0,
+          }),
+        })
+        return
+      }
+
+      await route.fulfill({ status: 503, contentType: 'application/json', body: '{}' })
+    })
+
+    await page.goto('/transactions')
+    await page.getByLabel(/Filter by IBAN|Filtrovat podle IBAN/).fill('CZ6508000000192000145399')
+    await page.getByRole('button', { name: /Search transactions|Vyhledat transakce/ }).click()
+
+    await expect(page.getByText('TXN-EVIDENCE-42')).toBeVisible()
+    await expect(page.getByText('Verified settlement')).toBeVisible()
+
+    await page.getByRole('button', { name: /Search transactions|Vyhledat transakce/ }).click()
+
+    await expect(page.getByText('TXN-EVIDENCE-42')).toBeVisible()
+    await expect(page.getByText('Verified settlement')).toBeVisible()
+    await expect(page.getByText(/Failed to load: Transaction search|Načtení selhalo: Vyhledávání transakcí/)).toBeVisible()
+    expect(requests).toBe(2)
+  })
+})

--- a/openbank-admin-ui/src/app/transactions/page.tsx
+++ b/openbank-admin-ui/src/app/transactions/page.tsx
@@ -99,14 +99,12 @@ export default function TransactionsPage() {
         // sandbox), not that the search itself failed. Distinguish the cases so
         // the operator sees a meaningful state instead of a raw "HTTP 404".
         setFailure(await classifyBffFailure(res))
-        setResult(null)
         return
       }
       setResult(await res.json())
     } catch {
       // Network-level failure (BFF unreachable from the browser).
       setFailure('unreachable')
-      setResult(null)
     } finally {
       setLoading(false)
     }
@@ -224,7 +222,7 @@ export default function TransactionsPage() {
           </div>
         )}
 
-        {failure && <DataUnavailable kind={failure} service="Transaction-service" feature={t('Vyhledávání transakcí', 'Transaction search')} lang={language} />}
+        {failure && <DataUnavailable kind={failure} service="Transaction-service" feature={t('Vyhledávání transakcí', 'Transaction search')} lang={language} dense={result !== null} />}
 
         {/* Results */}
         {result && (


### PR DESCRIPTION
## Summary
- preserve the last successful transaction result when a later request fails
- render the classified outage inline without removing the evidence under review
- cover the exact IBAN query and successful-to-503 recovery journey in Playwright

## Verification
- npm run type-check
- targeted ESLint
- focused Vitest: 3 passed
- focused Playwright Chromium E2E: 1 passed
- git diff --check

Closes #7792