### PR TITLE
fix(admin-ui): preserve SDD mandate evidence

### DIFF
--- a/openbank-admin-ui/e2e/sdd-mandate-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/sdd-mandate-recovery.spec.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+test.describe('SDD mandate recovery', () => {
+  test.beforeEach(async ({ context, baseURL }) => {
+    await signInAsOperator(context, baseURL!)
+  })
+
+  test('keeps the last mandate snapshot visible when refresh becomes unavailable', async ({ page }) => {
+    let requests = 0
+    let failRefresh = false
+
+    await page.route('**/api/svc/sdd-service/api/v1/sdd/mandates/recent**', async route => {
+      requests += 1
+      expect(route.request().url()).toContain('limit=50')
+
+      if (!failRefresh) {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify([{
+            id: '11111111-1111-1111-1111-111111111111',
+            umr: 'UMR-EVIDENCE-42',
+            creditorName: 'Verified Utilities SE',
+            debtorIban: 'CZ6508000000192000145399',
+            status: 'ACTIVE',
+            scheme: 'CORE',
+            createdAt: '2026-08-31T08:00:00Z',
+          }]),
+        })
+        return
+      }
+
+      await route.fulfill({ status: 503, contentType: 'application/json', body: '{}' })
+    })
+
+    await page.goto('/sdd')
+    await expect(page.getByText('UMR-EVIDENCE-42')).toBeVisible()
+    await expect(page.getByText('Verified Utilities SE')).toBeVisible()
+
+    const initialRequests = requests
+    failRefresh = true
+    await page.getByRole('button', { name: /Refresh direct debit mandates|Obnovit mandáty inkas/ }).click()
+
+    await expect(page.getByText('UMR-EVIDENCE-42')).toBeVisible()
+    await expect(page.getByText('Verified Utilities SE')).toBeVisible()
+    await expect(page.getByText(/Failed to load: Direct debit mandates|Načtení selhalo: Mandáty inkas/)).toBeVisible()
+    expect(requests).toBe(initialRequests + 1)
+  })
+})

--- a/openbank-admin-ui/src/app/sdd/page.tsx
+++ b/openbank-admin-ui/src/app/sdd/page.tsx
@@ -92,7 +92,8 @@ export default function SddPage() {
       </div>}
 
       <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
-        {unavailable ? <DataUnavailable kind={unavailable.kind} service="sdd-service" feature={t('Mandáty inkas', 'Direct debit mandates')} lang={language} dense /> : (
+        {unavailable && <DataUnavailable kind={unavailable.kind} service="sdd-service" feature={t('Mandáty inkas', 'Direct debit mandates')} lang={language} dense={rows.length > 0} />}
+        {(!unavailable || rows.length > 0) && (
         <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
           <thead>
             <tr style={{ background: 'var(--surface-2)', textAlign: 'left' }}>


### PR DESCRIPTION
## Summary
- keep the last successful SDD mandate snapshot visible when a later refresh fails
- render the classified outage inline with the retained read-only evidence
- cover initial load, explicit refresh, 503 recovery, and snapshot preservation in Playwright

## Verification
- npm run type-check
- targeted ESLint: 0 errors
- focused Playwright Chromium E2E: 1 passed
- git diff --check

Closes #7794