### PR TITLE
fix(admin-ui): preserve standing-order evidence

### DIFF
--- a/openbank-admin-ui/e2e/standing-orders-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/standing-orders-recovery.spec.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+test.describe('Standing Orders recovery', () => {
+  test.beforeEach(async ({ context, baseURL }) => {
+    await signInAsOperator(context, baseURL!)
+  })
+
+  test('keeps the last order snapshot visible when explicit refresh fails', async ({ page }) => {
+    let requests = 0
+    let failRefresh = false
+
+    await page.route('**/api/svc/standing-order-service/api/v1/standing-orders', async route => {
+      requests += 1
+      if (!failRefresh) {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify([{
+            id: '11111111-1111-1111-1111-111111111111',
+            debtorAccountId: '22222222-2222-2222-2222-222222222222',
+            creditorAccountId: '33333333-3333-3333-3333-333333333333',
+            creditorName: 'Verified Supplier SE',
+            amount: 7250,
+            currency: 'CZK',
+            frequency: 'MONTHLY',
+            status: 'ACTIVE',
+            nextExecutionDate: '2026-09-15',
+            description: 'Monthly evidence payment',
+          }]),
+        })
+        return
+      }
+
+      await route.fulfill({ status: 503, contentType: 'application/json', body: '{}' })
+    })
+
+    await page.goto('/standing-orders')
+    await expect(page.getByText('Verified Supplier SE')).toBeVisible()
+    await expect(page.getByText('Monthly evidence payment')).toBeVisible()
+
+    const initialRequests = requests
+    failRefresh = true
+    await page.getByRole('button', { name: /Refresh standing orders|Obnovit trvalé příkazy/ }).click()
+
+    await expect(page.getByText('Verified Supplier SE')).toBeVisible()
+    await expect(page.getByText('Monthly evidence payment')).toBeVisible()
+    await expect(page.getByText(/Failed to load: Standing orders|Načtení selhalo: Trvalé příkazy/)).toBeVisible()
+    expect(requests).toBe(initialRequests + 1)
+  })
+})

--- a/openbank-admin-ui/src/app/standing-orders/page.tsx
+++ b/openbank-admin-ui/src/app/standing-orders/page.tsx
@@ -33,7 +33,7 @@ export default function StandingOrdersPage() {
   // "idle, waking…" state (KEDA/scaledown) instead of a misleading error — and
   // auto-retries while the pod wakes. (Was a raw /q/health/ready probe that read
   // a scaled-down service as "down" and always claimed "running on port 8121".)
-  const { data, loading, unavailable, waking } = useServiceResource<StandingOrder[]>(
+  const { data, loading, unavailable, waking, reload } = useServiceResource<StandingOrder[]>(
     svcUrl('standing-order-service', '/api/v1/standing-orders'),
     { select: (raw) => (Array.isArray(raw) ? (raw as StandingOrder[]) : ((raw as { standingOrders?: StandingOrder[] }).standingOrders ?? [])) },
   )
@@ -61,6 +61,17 @@ export default function StandingOrdersPage() {
                 checking: t('Zjišťuji stav služby…', 'Checking service…'),
               }}
             />
+            <button
+              type="button"
+              className="btn btn-secondary btn-sm"
+              onClick={reload}
+              disabled={loading || waking}
+              aria-busy={loading || waking}
+              aria-label={t('Obnovit trvalé příkazy', 'Refresh standing orders')}
+            >
+              <RefreshCw size={13} aria-hidden="true" className={loading || waking ? 'animate-spin' : ''} />
+              {t('Obnovit', 'Refresh')}
+            </button>
             <span role="status" style={{ padding: '5px 9px', borderRadius: '6px', border: '1px solid var(--warning-border)', background: 'var(--warning-bg)', color: 'var(--warning-text)', fontSize: '11px', fontWeight: 600 }}>
               {t('Založení příkazu není připojeno', 'Order creation is not connected')}
             </span>
@@ -76,7 +87,7 @@ export default function StandingOrdersPage() {
             <div key={k.label} className="stat-card">
               <div style={{ width: '32px', height: '32px', borderRadius: '8px', background: `${k.color}18`,
                 display: 'flex', alignItems: 'center', justifyContent: 'center', color: k.color, marginBottom: '10px' }}>{k.icon}</div>
-              <div style={{ fontSize: '28px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em' }}>{loading ? '—' : k.value}</div>
+              <div style={{ fontSize: '28px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em' }}>{loading && orders.length === 0 ? '—' : k.value}</div>
               <div style={{ fontSize: '12px', color: 'var(--text-secondary)', fontWeight: 500 }}>{k.label}</div>
             </div>
           ))}
@@ -92,13 +103,12 @@ export default function StandingOrdersPage() {
                   border: '1px solid var(--border)', fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)', outline: 'none' }} />
             </div>
           </div>
-          {loading ? (
+          {unavailable && <DataUnavailable kind={unavailable.kind} service={t('Standing-order-service', 'Standing-order-service')} feature={t('Trvalé příkazy', 'Standing orders')} lang={language} dense={orders.length > 0} />}
+          {loading && orders.length === 0 ? (
             <div role="status" aria-live="polite" style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
               <RefreshCw size={20} aria-hidden="true" style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} /><div>{t('Načítám…', 'Loading…')}</div>
             </div>
-          ) : unavailable ? (
-            <DataUnavailable kind={unavailable.kind} service={t('Standing-order-service', 'Standing-order-service')} feature={t('Trvalé příkazy', 'Standing orders')} lang={language} />
-          ) : filtered.length === 0 ? (
+          ) : unavailable && orders.length === 0 ? null : filtered.length === 0 ? (
             <DataUnavailable kind="no_data" feature={t('Trvalé příkazy', 'Standing orders')} lang={language}
               detail={orders.length === 0
                 ? t('Služba běží, zatím žádné trvalé příkazy.', 'The service is running; no standing orders yet.')


### PR DESCRIPTION
## Summary
- expose an explicit refresh action wired to the shared wake-aware resource hook
- keep the last successful standing-order metrics and table visible during refresh and later outages
- render the classified outage inline with the retained read-only evidence
- cover success, explicit refresh, 503 recovery, and snapshot preservation in Playwright

## Verification
- npm run type-check
- targeted ESLint
- focused Vitest: 3 passed
- focused Playwright Chromium E2E: 1 passed
- git diff --check

Closes #7797