### PR TITLE
fix(admin-ui): preserve masked card evidence

### DIFF
--- a/openbank-admin-ui/e2e/cards-portfolio-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/cards-portfolio-recovery.spec.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+test.describe('Masked card portfolio recovery', () => {
+  test.beforeEach(async ({ context, baseURL }) => {
+    await signInAsOperator(context, baseURL!)
+  })
+
+  test('keeps the masked portfolio visible when an explicit refresh fails', async ({ page }) => {
+    let requests = 0
+    let failRefresh = false
+
+    await page.route('**/api/svc/card-issuance-service/api/v1/cards', async route => {
+      requests += 1
+      if (!failRefresh) {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify([{
+            id: '11111111-1111-1111-1111-111111111111',
+            partyId: '22222222-2222-2222-2222-222222222222',
+            accountId: '33333333-3333-3333-3333-333333333333',
+            productCode: 'DEBIT-CLASSIC',
+            cardType: 'DEBIT',
+            network: 'VISA',
+            maskedPan: '411111******4242',
+            cardholderName: 'Verified Cardholder',
+            embossedName: 'VERIFIED CARDHOLDER',
+            expiryDate: '12/29',
+            status: 'ACTIVE',
+            dailyLimitMinorUnits: 500000,
+            monthlyLimitMinorUnits: 2000000,
+            currency: 'CZK',
+            createdAt: '2026-08-31T08:00:00Z',
+          }]),
+        })
+        return
+      }
+
+      await route.fulfill({ status: 503, contentType: 'application/json', body: '{}' })
+    })
+
+    await page.goto('/cards')
+    await expect(page.getByText('411111******4242')).toBeVisible()
+    await expect(page.getByText('Verified Cardholder')).toBeVisible()
+
+    const initialRequests = requests
+    failRefresh = true
+    await page.getByRole('button', { name: /Refresh cards|Obnovit karty/ }).click()
+
+    await expect(page.getByText('411111******4242')).toBeVisible()
+    await expect(page.getByText('Verified Cardholder')).toBeVisible()
+    await expect(page.getByText(/Failed to load: Cards|Načtení selhalo: Karty/)).toBeVisible()
+    expect(requests).toBe(initialRequests + 1)
+  })
+})

--- a/openbank-admin-ui/src/app/cards/page.tsx
+++ b/openbank-admin-ui/src/app/cards/page.tsx
@@ -188,14 +188,13 @@ export default function CardsPage() {
             </div>
           </div>
 
-          {loading ? (
+          {unavailable && <DataUnavailable kind={unavailable.kind} service={t('Card-issuance-service', 'Card-issuance-service')} feature={t('Karty', 'Cards')} lang={language} dense={cards.length > 0} />}
+          {loading && cards.length === 0 ? (
             <div style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
               <RefreshCw size={20} style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} />
               <div>{t('Načítám karty…', 'Loading cards…')}</div>
             </div>
-          ) : unavailable ? (
-            <DataUnavailable kind={unavailable.kind} service={t('Card-issuance-service', 'Card-issuance-service')} feature={t('Karty', 'Cards')} lang={language} />
-          ) : filtered.length === 0 ? (
+          ) : unavailable && cards.length === 0 ? null : filtered.length === 0 ? (
             <DataUnavailable kind="no_data" feature={t('Karty', 'Cards')} lang={language}
               detail={cards.length === 0
                 ? t('Služba běží, zatím nebyly vydány žádné karty.', 'The service is running; no cards have been issued yet.')


### PR DESCRIPTION
## Summary
- keep the last successful masked-card KPIs and portfolio visible during refresh and later outages
- render the classified card-service failure inline with the retained read-only evidence
- cover initial masked data, explicit refresh, 503 recovery, and snapshot preservation in Playwright
- leave PCI boundaries, card lifecycle mutations, and permissions unchanged

## Verification
- npm run type-check
- targeted ESLint
- focused Vitest: 6 passed
- focused Playwright Chromium E2E: 1 passed
- git diff --check

Closes #7800