### PR TITLE
fix(admin-ui): bind consent recovery snapshot

### DIFF
--- a/openbank-admin-ui/e2e/consents-query-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/consents-query-recovery.spec.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+test.describe('Consent lookup recovery', () => {
+  test.beforeEach(async ({ context, baseURL }) => {
+    await signInAsOperator(context, baseURL!)
+  })
+
+  test('retains evidence only for the exact same lens and identifier', async ({ page }) => {
+    let failLookup = false
+    let requests = 0
+
+    await page.route('**/api/svc/consent-service/api/v1/consents/grantee/**', async route => {
+      requests += 1
+      if (!failLookup) {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify([{
+            id: '11111111-1111-1111-1111-111111111111',
+            partyId: '22222222-2222-2222-2222-222222222222',
+            granteeId: 'party-service:marketing-comms',
+            granteeType: 'INTERNAL_SERVICE',
+            granteeName: 'Verified Marketing Service',
+            scopes: ['MARKETING_COMMS_EMAIL'],
+            accountIbans: null,
+            status: 'ACTIVE',
+            validFrom: '2026-01-01T00:00:00Z',
+            validTo: '2027-01-01T00:00:00Z',
+            createdAt: '2026-01-01T00:00:00Z',
+          }]),
+        })
+        return
+      }
+
+      await route.fulfill({ status: 503, contentType: 'application/json', body: '{}' })
+    })
+
+    await page.goto('/consents')
+    await page.getByLabel(/Consent lookup lens|Pohled souhlasů/).selectOption('grantee')
+    const lookup = page.getByRole('button', { name: /Look up|Vyhledat/, exact: true })
+    await lookup.click()
+
+    await expect(page.getByText('Verified Marketing Service')).toBeVisible()
+    await expect(page.getByText('MARKETING_COMMS_EMAIL')).toBeVisible()
+
+    const successfulRequests = requests
+    failLookup = true
+    await lookup.click()
+
+    await expect(page.getByText('Verified Marketing Service')).toBeVisible()
+    await expect(page.getByText('MARKETING_COMMS_EMAIL')).toBeVisible()
+    await expect(page.getByText(/Failed to load: Consents|Načtení selhalo: Souhlasy/)).toBeVisible()
+    expect(requests).toBe(successfulRequests + 1)
+
+    await page.getByLabel(/Grantee ID|ID grantee/).fill('different-service:auditing')
+    await lookup.click()
+
+    await expect(page.getByText('Verified Marketing Service')).toBeHidden()
+    await expect(page.getByText('MARKETING_COMMS_EMAIL')).toBeHidden()
+    expect(requests).toBe(successfulRequests + 2)
+  })
+})

--- a/openbank-admin-ui/src/app/consents/page.tsx
+++ b/openbank-admin-ui/src/app/consents/page.tsx
@@ -47,6 +47,7 @@ export default function ConsentsPage() {
   const [term, setTerm] = useState('')
   const [party, setParty] = useState<PartyHit | null>(null)
   const [rows, setRows] = useState<Consent[] | null>(null)
+  const [loadedQuery, setLoadedQuery] = useState<string | null>(null)
   const [failure, setFailure] = useState<UnavailableKind | null>(null)
   const [loading, setLoading] = useState(false)
 
@@ -62,9 +63,14 @@ export default function ConsentsPage() {
     if (!q) return
     const gen = ++generation.current
     const lensAtRequest = lens
+    const queryKey = `${lensAtRequest}:${q}`
+    const canRetainSnapshot = loadedQuery === queryKey && rows !== null
     setLoading(true)
     setFailure(null)
-    setRows(null)
+    if (!canRetainSnapshot) {
+      setRows(null)
+      setLoadedQuery(null)
+    }
     try {
       // The lens is read ONCE, at request time — never from the closure after the await, where it
       // may already describe a different query.
@@ -78,6 +84,7 @@ export default function ConsentsPage() {
       const data = (await res.json()) as Consent[]
       if (gen !== generation.current) return
       setRows(data)
+      setLoadedQuery(queryKey)
       // NOT `no_data`: consent-service answered, it just holds no consent for this key. The old copy
       // said "the data source contains no records yet", which an operator cannot tell apart from a
       // broken page — and was false whenever any other party had a consent. Rendered below instead.
@@ -109,6 +116,7 @@ export default function ConsentsPage() {
                 // MARKETING_COMMS_EMAIL rows on screen while the select read "By grantee".
                 generation.current += 1
                 setRows(null)
+                setLoadedQuery(null)
                 setFailure(null)
                 setParty(null)
                 setLoading(false)
@@ -213,6 +221,7 @@ export default function ConsentsPage() {
           service="Consent-service"
           feature={t('Souhlasy', 'Consents')}
           lang={language === 'cs' ? 'cs' : 'en'}
+          dense={rows !== null}
         />
       )}
 
@@ -239,7 +248,7 @@ export default function ConsentsPage() {
         </div>
       )}
 
-      {!loading && rows && rows.length > 0 && (
+      {rows && rows.length > 0 && (
         <div className="card" style={{ overflowX: 'auto' }}>
           <table className="table">
             <thead>


### PR DESCRIPTION
## Summary
- bind a retained consent snapshot to the exact lookup lens and identifier
- preserve evidence when the operator retries the same grantee or party and the service fails
- clear prior evidence immediately for a different lookup to prevent cross-party attribution
- cover both sides of that boundary in Playwright

## Verification
- npm run type-check
- targeted ESLint
- focused Vitest: 2 passed
- focused Playwright Chromium E2E: 1 passed
- git diff --check

Closes #7803