### PR TITLE
fix(admin-ui): preserve fraud review evidence

### DIFF
--- a/openbank-admin-ui/e2e/fraud-review-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/fraud-review-recovery.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const reviewRecord = {
+  scoreId: 'score-001',
+  amount: 125000,
+  currency: 'CZK',
+  rail: 'SCT_INST',
+  accountId: 'account-12345678',
+  counterpartyId: 'party-87654321',
+  verdict: 'REVIEW',
+  score: 91,
+  ruleVersion: 'fraud-rules-2026.08',
+  createdAt: '2026-08-31T08:15:00Z',
+}
+
+test.beforeEach(async ({ context, baseURL, page }) => {
+  await signInAsOperator(context, baseURL!)
+  await page.route('**/api/auth/session', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      user: {
+        name: 'E2E Compliance',
+        email: 'e2e-compliance@openbank.test',
+        roles: ['ROLE_ADMIN', 'ROLE_OPERATOR', 'ROLE_COMPLIANCE'],
+        accessToken: 'e2e-fake-access-token',
+      },
+      expires: '2099-01-01T00:00:00.000Z',
+    }),
+  }))
+})
+
+test('retains the bounded fraud evidence snapshot when refresh fails', async ({ page }) => {
+  let unavailable = false
+  await page.route('**/api/svc/fraud-service/api/v1/fraud/review-queue**', route => unavailable
+    ? route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ error: 'unavailable' }) })
+    : route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([reviewRecord]) }))
+
+  await page.goto('/fraud')
+
+  await expect(page.getByText('125,000 CZK')).toBeVisible({ timeout: 20_000 })
+  await expect(page.getByText('fraud-rules-2026.08')).toBeVisible()
+  await expect(page.getByText('91', { exact: true })).toBeVisible()
+
+  unavailable = true
+  await page.getByRole('button', { name: /Obnovit frontu podvodů|Refresh fraud queue/ }).click()
+
+  await expect(page.getByText(/Zobrazen je poslední úspěšný snapshot|Showing the last successful snapshot/)).toBeVisible()
+  await expect(page.getByText('125,000 CZK')).toBeVisible()
+  await expect(page.getByText('fraud-rules-2026.08')).toBeVisible()
+  await expect(page.getByText(/Fronta je prázdná|Queue is empty/)).toHaveCount(0)
+})

--- a/openbank-admin-ui/src/app/fraud/page.tsx
+++ b/openbank-admin-ui/src/app/fraud/page.tsx
@@ -40,6 +40,8 @@ export default function FraudPage() {
   const [rows, setRows] = useState<ScoredRecord[]>([])
   const [loading, setLoading] = useState(true)
   const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
+  const [hasSnapshot, setHasSnapshot] = useState(false)
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -51,6 +53,8 @@ export default function FraudPage() {
       }
       const data = await res.json() as unknown
       setRows(Array.isArray(data) ? data as ScoredRecord[] : [])
+      setHasSnapshot(true)
+      setLastUpdatedAt(new Date())
       setUnavailable(null)
     } catch {
       setUnavailable({ kind: 'unreachable' })
@@ -63,6 +67,7 @@ export default function FraudPage() {
 
   const critical = rows.filter(row => row.score >= 80).length
   const elevated = rows.filter(row => row.score >= 50 && row.score < 80).length
+  const showingRetainedSnapshot = unavailable !== null && hasSnapshot
 
   return (
     <div>
@@ -78,14 +83,24 @@ export default function FraudPage() {
         </button>}
       />
 
-      {!unavailable && <section style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 16, marginBottom: 16 }} aria-label={t('Souhrn fronty', 'Queue summary')}>
+      {(!unavailable || hasSnapshot) && <section style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 16, marginBottom: 16 }} aria-label={t('Souhrn fronty', 'Queue summary')}>
         <StatCard label={t('Čeká na posouzení', 'Awaiting review')} value={rows.length} hint={t('maximálně 50 nejnovějších záznamů', 'up to 50 most recent records')} icon={<Clock3 size={15} />} tone={rows.length ? 'warning' : 'neutral'} />
         <StatCard label={t('Kritické skóre', 'Critical score')} value={critical} hint={t('skóre 80 a více', 'score 80 and above')} icon={<CircleAlert size={15} />} tone={critical ? 'danger' : 'neutral'} />
         <StatCard label={t('Zvýšené skóre', 'Elevated score')} value={elevated} hint={t('skóre 50–79', 'score 50–79')} icon={<ShieldAlert size={15} />} tone={elevated ? 'warning' : 'neutral'} />
       </section>}
 
+      {showingRetainedSnapshot && <div role="status" aria-live="polite" style={{ marginBottom: 16 }}>
+        <DataUnavailable kind={unavailable.kind} service="fraud-service" feature={t('Aktualizace fraud review fronty', 'Fraud review queue refresh')} lang={language} dense />
+        <p style={{ margin: '6px 0 0', color: 'var(--text-tertiary)', fontSize: 11 }}>
+          {t(
+            `Zobrazen je poslední úspěšný snapshot z ${lastUpdatedAt?.toLocaleString(numberLocale) ?? '—'}; stav se mohl změnit.`,
+            `Showing the last successful snapshot from ${lastUpdatedAt?.toLocaleString(numberLocale) ?? '—'}; the queue may have changed.`,
+          )}
+        </p>
+      </div>}
+
       <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
-        {unavailable ? <DataUnavailable kind={unavailable.kind} service="fraud-service" feature={t('Fraud review fronta', 'Fraud review queue')} lang={language} dense /> : (
+        {unavailable && !hasSnapshot ? <DataUnavailable kind={unavailable.kind} service="fraud-service" feature={t('Fraud review fronta', 'Fraud review queue')} lang={language} dense /> : (
         <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
           <thead>
             <tr style={{ background: 'var(--surface-2)', textAlign: 'left' }}>
@@ -121,7 +136,7 @@ export default function FraudPage() {
                 </tr>
               )
             })}
-            {!loading && rows.length === 0 && (
+            {!loading && rows.length === 0 && !showingRetainedSnapshot && (
               <tr><td colSpan={6} style={{ padding: 24, textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 13 }}>
                 {t('Fronta je prázdná — žádné REVIEW verdikty.', 'Queue is empty — no REVIEW verdicts.')}
               </td></tr>


### PR DESCRIPTION
## Summary
- keep the last successful bounded fraud REVIEW snapshot and queue KPIs visible when a refresh fails
- clearly label retained evidence as potentially stale and show its last successful load time
- preserve truthful initial-failure and empty-success states without changing the read-only four-eyes boundary

## Verification
- `npx eslint src/app/fraud/page.tsx e2e/fraud-review-recovery.spec.ts` (0 errors; one pre-existing effect warning)
- `npx vitest run src/test/fraud-refresh.guard.test.ts src/test/fraud-localization-a11y.guard.test.ts` (3 passed)
- `OPENBANK_E2E_PORT=3037 npx playwright test e2e/fraud-review-recovery.spec.ts --reporter=line` (1 passed)
- `git diff --check`

Full `tsc --noEmit` remains blocked by pre-existing Product Studio/generated-module failures outside this diff.

Closes #7810