### PR TITLE
fix(admin-ui): match POST decisions in approvals-decision e2e mock

### DIFF
--- a/openbank-admin-ui/e2e/approvals-decision.spec.ts
+++ b/openbank-admin-ui/e2e/approvals-decision.spec.ts
@@ -28,7 +28,12 @@ test.describe('approval workbench', () => {
     let decided = false
     let decisionRequests = 0
 
-    await page.route('**/api/agent/proposals?state=all', async route => {
+    // Matches both the GET list read (…/proposals?state=all) and the POST decision
+    // write (…/proposals, no query string) — the two differ only by query string and
+    // method, and a pattern anchored on the literal "?state=all" suffix would only ever
+    // catch the GET, silently letting the POST fall through to the real (unmocked)
+    // network and leaving `decided` stuck false forever (#7814).
+    await page.route('**/api/agent/proposals*', async route => {
       if (route.request().method() === 'GET') {
         const row = decided ? {
           ...proposal,


### PR DESCRIPTION
## Root cause

`e2e/approvals-decision.spec.ts` mocks `/api/agent/proposals` with a single
`page.route('**/api/agent/proposals?state=all', ...)` handler that branches on
HTTP method to serve both:
- the page's `GET /api/agent/proposals?state=all` list read, and
- the page's `POST /api/agent/proposals` decision write (no query string).

The glob pattern is anchored on the literal `?state=all` suffix, which only
the GET request carries. The POST therefore never matched the route, fell
through to the real (unmocked) network in the Playwright dev-server run, and
the in-memory `decided` flag the mock uses to flip the fixture row to
`APPROVED` was never set. The "Decided" table stayed empty forever, so the
test failed **deterministically** — not flakily — at the
`getByRole('cell', { name: proposal.title })` assertion once the approve
button was clicked.

This is a test-mock-only bug (case **a** timing/fixture, specifically a
locator/pattern-mismatch in the fixture setup) — no app code in
`src/app/approvals/page.tsx` needed to change; its fetch/decide logic already
does the right thing once the mock actually intercepts the write.

## Fix

Broaden the route glob to `**/api/agent/proposals*` so both the GET (with
`?state=all`) and the POST (no query string) are intercepted by the same
handler, which already discriminates by `route.request().method()`.

## Verification

- Reproduced the exact CI failure locally, deterministically, before the fix:
  `npx playwright test e2e/approvals-decision.spec.ts --repeat-each=3` → 3/3
  failed at the same `getByRole('cell', ...)` assertion.
- After the fix: `npx playwright test e2e/approvals-decision.spec.ts --repeat-each=5`
  → 5/5 passed.
- Full `npx playwright test` run: no new failures introduced by this change
  (the two pre-existing failures in `term-deposit-account-opening.spec.ts`
  and `test-intelligence.spec.ts` are unrelated and present on `main` as well).

Closes #7814
