### PR TITLE
test(admin-ui): intercept approval decisions

### DIFF
--- a/openbank-admin-ui/e2e/approvals-decision.spec.ts
+++ b/openbank-admin-ui/e2e/approvals-decision.spec.ts
@@ -28,7 +28,7 @@ test.describe('approval workbench', () => {
     let decided = false
     let decisionRequests = 0
 
-    await page.route('**/api/agent/proposals?state=all', async route => {
+    await page.route('**/api/agent/proposals**', async route => {
       if (route.request().method() === 'GET') {
         const row = decided ? {
           ...proposal,


### PR DESCRIPTION
## Summary
- intercept both the proposal GET query and decision POST path in the approval workbench E2E
- retain strict method and decision-payload assertions
- prevent the mock POST from escaping to the real backend and blocking every admin-ui PR

## Verification
- `npx eslint e2e/approvals-decision.spec.ts`
- `OPENBANK_E2E_PORT=3039 npx playwright test e2e/approvals-decision.spec.ts --reporter=line` (1 passed)
- `git diff --check`

Closes #7809