### PR TITLE
fix(admin-ui): preserve AML evidence during outages

### DIFF
--- a/openbank-admin-ui/e2e/aml-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/aml-recovery.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const amlCase = {
+  id: 'aml-2026-0042',
+  customerName: 'Acme Trading s.r.o.',
+  customerType: 'CORPORATE',
+  riskLevel: 'CRITICAL',
+  status: 'ESCALATED',
+  score: 94,
+  timestamp: '2026-08-31T12:00:00Z',
+}
+
+test.beforeEach(async ({ context, baseURL, page }) => {
+  await signInAsOperator(context, baseURL!)
+  await page.route('**/api/auth/session', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      user: {
+        name: 'E2E Compliance',
+        email: 'e2e-compliance@openbank.test',
+        roles: ['ROLE_ADMIN', 'ROLE_OPERATOR', 'ROLE_COMPLIANCE'],
+        accessToken: 'e2e-fake-access-token',
+      },
+      expires: '2099-01-01T00:00:00.000Z',
+    }),
+  }))
+})
+
+test('keeps escalated AML evidence visible after a failed refresh', async ({ page }) => {
+  let unavailable = false
+  await page.route('**/api/svc/aml-service/api/v1/aml/cases**', route => unavailable
+    ? route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ error: 'unavailable' }) })
+    : route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([amlCase]) }))
+
+  await page.goto('/aml')
+
+  await expect(page.getByText('Acme Trading s.r.o.')).toBeVisible({ timeout: 20_000 })
+  await expect(page.getByText(/AML case escalated|AML případ byl eskalován/)).toBeVisible()
+  await expect(page.getByText('94', { exact: true })).toBeVisible()
+
+  unavailable = true
+  await page.getByRole('button', { name: /Obnovit AML případy|Refresh AML cases/ }).click()
+
+  await expect(page.getByText(/Zobrazen je poslední úspěšný snapshot|Showing the last successful snapshot/)).toBeVisible({ timeout: 25_000 })
+  await expect(page.getByText('Acme Trading s.r.o.')).toBeVisible()
+  await expect(page.getByText('94', { exact: true })).toBeVisible()
+  await expect(page.getByText(/AML case escalated|AML případ byl eskalován/)).toBeVisible()
+  await expect(page.getByText(/zatím neeviduje žádné AML případy|no AML cases recorded yet/)).toHaveCount(0)
+})

--- a/openbank-admin-ui/src/app/aml/page.tsx
+++ b/openbank-admin-ui/src/app/aml/page.tsx
@@ -28,11 +28,17 @@ export default function AmlPage() {
   const { t, language } = useLanguage()
   const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [search, setSearch] = useState('')
-  const { data, loading, unavailable, waking } = useServiceResource<AmlCase[]>(
+  const [lastSuccessfulAt, setLastSuccessfulAt] = useState<Date | null>(null)
+  const { data, loading, unavailable, waking, reload } = useServiceResource<AmlCase[]>(
     svcUrl('aml-service', '/api/v1/aml/cases'),
-    { select: (raw) => (Array.isArray(raw) ? (raw as AmlCase[]) : ((raw as { cases?: AmlCase[] }).cases ?? [])) },
+    { select: (raw) => {
+      setLastSuccessfulAt(new Date())
+      return Array.isArray(raw) ? (raw as AmlCase[]) : ((raw as { cases?: AmlCase[] }).cases ?? [])
+    } },
   )
   const cases = data ?? []
+  const hasSnapshot = data !== null
+  const showingRetainedSnapshot = unavailable !== null && hasSnapshot
   const filtered = cases.filter(c =>
     c.customerName?.toLowerCase().includes(search.toLowerCase()) ||
     c.riskLevel?.toLowerCase().includes(search.toLowerCase()) ||
@@ -66,10 +72,26 @@ export default function AmlPage() {
             <span role="status" style={{ fontSize: '12px', color: 'var(--text-tertiary)', maxWidth: '280px', textAlign: 'right' }}>
               {t('Automatické AML skenování není v tomto prostředí nakonfigurováno.', 'Automated AML scanning is not configured in this environment.')}
             </span>
+            <button type="button" onClick={reload} disabled={loading} aria-busy={loading} aria-label={t('Obnovit AML případy', 'Refresh AML cases')} className="btn btn-secondary btn-sm">
+              <RefreshCw size={14} aria-hidden="true" className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
+            </button>
           </div>}
         />
 
-        {escalated.length > 0 && (
+        {showingRetainedSnapshot && <div role="status" aria-live="polite" style={{ marginBottom: 20 }}>
+          <DataUnavailable kind={unavailable.kind} service={t('AML-service', 'AML-service')} feature={t('Aktualizace AML případů', 'AML case refresh')} lang={language} dense />
+          <p style={{ margin: '6px 0 0', color: 'var(--text-tertiary)', fontSize: 11 }}>
+            {t('Zobrazen je poslední úspěšný snapshot', 'Showing the last successful snapshot')}
+            {lastSuccessfulAt ? ` (${lastSuccessfulAt.toLocaleString(numberLocale)})` : ''}.
+            {' '}{t('Riziko, skóre i stav případu se od té doby mohly změnit.', 'Risk, score, and case status may have changed since then.')}
+          </p>
+        </div>}
+
+        {loading && hasSnapshot && <p role="status" aria-live="polite" style={{ margin: '0 0 12px', color: 'var(--text-tertiary)', fontSize: 11 }}>
+          {t('Aktualizuji AML případy; poslední snapshot zůstává dostupný.', 'Refreshing AML cases; the last snapshot remains available.')}
+        </p>}
+
+        {hasSnapshot && escalated.length > 0 && (
           <div style={{ marginBottom: '20px', padding: '12px 16px', borderRadius: '8px',
             background: 'var(--danger-bg)', border: '1px solid var(--danger-border)',
             display: 'flex', alignItems: 'center', gap: '10px' }}>
@@ -88,14 +110,14 @@ export default function AmlPage() {
           </div>
         )}
 
-        <div className="grid-4" style={{ marginBottom: '24px' }}>
+        {hasSnapshot && <div className="grid-4" style={{ marginBottom: '24px' }}>
           {[
             { label: t('Případů celkem', 'Total Cases'), value: cases.length, icon: <ShieldAlert size={16} />, color: 'var(--accent)' },
             { label: t('Vysoké riziko', 'High Risk'), value: highRisk.length, icon: <AlertTriangle size={16} />, color: 'var(--danger)' },
             { label: t('Čeká na review', 'Pending Review'), value: pending.length, icon: <Clock size={16} />, color: 'var(--warning)' },
             { label: t('Eskalováno', 'Escalated'), value: escalated.length, icon: <AlertOctagon size={16} />, color: '#dc2626' },
           ].map(k => <StatCard key={k.label} label={k.label} value={k.value} icon={k.icon} tone={k.color === 'var(--danger)' || k.color === '#dc2626' ? 'danger' : k.color === 'var(--warning)' ? 'warning' : undefined} />)}
-        </div>
+        </div>}
 
         <div className="card">
           <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--border)', display: 'flex', gap: '10px', alignItems: 'center' }}>
@@ -107,11 +129,11 @@ export default function AmlPage() {
                   border: '1px solid var(--border)', fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)', outline: 'none' }} />
             </div>
           </div>
-          {loading ? (
-            <div style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
-              <RefreshCw size={20} style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} /><div>{t('Načítám případy…', 'Loading cases…')}</div>
+          {loading && !hasSnapshot ? (
+            <div role="status" aria-live="polite" style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
+              <RefreshCw size={20} aria-hidden="true" className="animate-spin" style={{ marginBottom: '8px' }} /><div>{t('Načítám případy…', 'Loading cases…')}</div>
             </div>
-          ) : unavailable ? (
+          ) : unavailable && !hasSnapshot ? (
             // aml-service didn't answer through the BFF. Classify honestly — idle
             // (scale-to-zero, ADR-0057), not deployed, or a real outage — instead
             // of the old copy that falsely claimed the service was up.


### PR DESCRIPTION
## Summary
- keep the last successful AML case snapshot, escalations, scores, and KPIs visible during refresh failures
- label retained evidence as stale with its last successful refresh time and add an accessible manual refresh action
- avoid false-zero AML KPIs on an initial failure with no snapshot
- add browser E2E coverage for a successful load followed by a classified 503 outage

## Preserved boundaries
- AML scoring and case state are unchanged
- compliance:view RBAC is unchanged
- the existing BFF endpoint and service classification remain unchanged
- automated scanning is still truthfully described as not configured

## Verification
- targeted ESLint: passed
- focused Vitest guards: 3 passed
- targeted Playwright Chromium: 1 passed
- git diff --check: passed

Closes #7818