### PR TITLE
fix(admin-ui): preserve clearing evidence during outages

### DIFF
--- a/openbank-admin-ui/e2e/clearing-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/clearing-recovery.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const batch = {
+  id: 'batch-2026-0042',
+  batchReference: 'CLR-2026-0042',
+  paymentRail: 'SEPA',
+  status: 'PROCESSING',
+  itemCount: 18,
+  totalAmount: 125000.50,
+  currency: 'EUR',
+  createdAt: '2026-08-31T12:00:00Z',
+}
+
+test.beforeEach(async ({ context, baseURL, page }) => {
+  await signInAsOperator(context, baseURL!)
+  await page.route('**/api/auth/session', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      user: {
+        name: 'E2E Payments Operator',
+        email: 'e2e-payments@openbank.test',
+        roles: ['ROLE_ADMIN', 'ROLE_OPERATOR', 'ROLE_PAYMENTS'],
+        accessToken: 'e2e-fake-access-token',
+      },
+      expires: '2099-01-01T00:00:00.000Z',
+    }),
+  }))
+})
+
+test('keeps clearing and settlement evidence visible after a failed refresh', async ({ page }) => {
+  let unavailable = false
+  await page.route('**/api/svc/clearing-service/api/v1/clearing/batches**', route => unavailable
+    ? route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ error: 'unavailable' }) })
+    : route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([batch]) }))
+
+  await page.goto('/clearing')
+
+  await expect(page.getByText('CLR-2026-0042')).toBeVisible({ timeout: 20_000 })
+  await expect(page.getByText('125,000.50')).toBeVisible()
+  await expect(page.getByText('PROCESSING', { exact: true })).toBeVisible()
+
+  unavailable = true
+  await page.getByRole('button', { name: /Obnovit clearing dávky|Refresh clearing batches/ }).click()
+
+  await expect(page.getByText(/Zobrazen je poslední úspěšný snapshot|Showing the last successful snapshot/)).toBeVisible({ timeout: 25_000 })
+  await expect(page.getByText('CLR-2026-0042')).toBeVisible()
+  await expect(page.getByText('125,000.50')).toBeVisible()
+  await expect(page.getByText('PROCESSING', { exact: true })).toBeVisible()
+  await expect(page.getByText(/zatím žádné clearing dávky|no clearing batches yet/)).toHaveCount(0)
+})

--- a/openbank-admin-ui/src/app/clearing/page.tsx
+++ b/openbank-admin-ui/src/app/clearing/page.tsx
@@ -24,11 +24,17 @@ export default function ClearingPage() {
   const { t, language } = useLanguage()
   const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [search, setSearch] = useState('')
-  const { data, loading, unavailable, waking } = useServiceResource<ClearingBatch[]>(
+  const [lastSuccessfulAt, setLastSuccessfulAt] = useState<Date | null>(null)
+  const { data, loading, unavailable, waking, reload } = useServiceResource<ClearingBatch[]>(
     svcUrl('clearing-service', '/api/v1/clearing/batches'),
-    { select: (raw) => (Array.isArray(raw) ? (raw as ClearingBatch[]) : ((raw as { batches?: ClearingBatch[] }).batches ?? [])) },
+    { select: (raw) => {
+      setLastSuccessfulAt(new Date())
+      return Array.isArray(raw) ? (raw as ClearingBatch[]) : ((raw as { batches?: ClearingBatch[] }).batches ?? [])
+    } },
   )
   const batches = data ?? []
+  const hasSnapshot = data !== null
+  const showingRetainedSnapshot = unavailable !== null && hasSnapshot
 
   const filtered = batches.filter(b =>
     b.batchReference?.toLowerCase().includes(search.toLowerCase()) ||
@@ -47,28 +53,46 @@ export default function ClearingPage() {
           icon={<Layers size={20} aria-hidden="true" />}
           title={t('Zúčtování & Vypořádání', 'Clearing & Settlement')}
           subtitle={t('Mezibankovní zúčtování — SEPA · SWIFT · Domestic netting', 'Interbank clearing — SEPA · SWIFT · Domestic netting')}
-          actions={<ServiceStatusBadge
-            label="clearing-service :8124"
-            loading={loading}
-            waking={waking}
-            unavailable={unavailable}
-            copy={{
-              up: t('clearing-service běží', 'clearing-service is up'),
-              idle: t('clearing-service spí (scale-to-zero), probouzí se…', 'clearing-service idle (scaled to zero), waking…'),
-              down: t('clearing-service neodpovídá', 'clearing-service is not responding'),
-              checking: t('Zjišťuji stav služby…', 'Checking service…'),
-            }}
-          />}
+          actions={<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <ServiceStatusBadge
+              label="clearing-service :8124"
+              loading={loading}
+              waking={waking}
+              unavailable={unavailable}
+              copy={{
+                up: t('clearing-service běží', 'clearing-service is up'),
+                idle: t('clearing-service spí (scale-to-zero), probouzí se…', 'clearing-service idle (scaled to zero), waking…'),
+                down: t('clearing-service neodpovídá', 'clearing-service is not responding'),
+                checking: t('Zjišťuji stav služby…', 'Checking service…'),
+              }}
+            />
+            <button type="button" onClick={reload} disabled={loading} aria-busy={loading} aria-label={t('Obnovit clearing dávky', 'Refresh clearing batches')} className="btn btn-secondary btn-sm">
+              <RefreshCw size={14} aria-hidden="true" className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
+            </button>
+          </div>}
         />
 
-        <div className="grid-4" style={{ marginBottom: '24px' }}>
+        {showingRetainedSnapshot && <div role="status" aria-live="polite" style={{ marginBottom: 20 }}>
+          <DataUnavailable kind={unavailable.kind} service={t('Clearing-service', 'Clearing-service')} feature={t('Aktualizace clearing dávek', 'Clearing batch refresh')} lang={language} dense />
+          <p style={{ margin: '6px 0 0', color: 'var(--text-tertiary)', fontSize: 11 }}>
+            {t('Zobrazen je poslední úspěšný snapshot', 'Showing the last successful snapshot')}
+            {lastSuccessfulAt ? ` (${lastSuccessfulAt.toLocaleString(numberLocale)})` : ''}.
+            {' '}{t('Stav vypořádání i objem se od té doby mohly změnit.', 'Settlement status and volume may have changed since then.')}
+          </p>
+        </div>}
+
+        {loading && hasSnapshot && <p role="status" aria-live="polite" style={{ margin: '0 0 12px', color: 'var(--text-tertiary)', fontSize: 11 }}>
+          {t('Aktualizuji clearing dávky; poslední snapshot zůstává dostupný.', 'Refreshing clearing batches; the last snapshot remains available.')}
+        </p>}
+
+        {hasSnapshot && <div className="grid-4" style={{ marginBottom: '24px' }}>
           {[
             { label: t('Dávky celkem', 'Total batches'), value: batches.length, icon: <Layers size={16} aria-hidden="true" /> },
             { label: t('Vypořádáno', 'Settled'), value: settled.length, icon: <CheckCircle2 size={16} aria-hidden="true" />, tone: 'success' as const },
             { label: t('Čeká / Zpracovává', 'Pending / Processing'), value: pending.length, icon: <Clock size={16} aria-hidden="true" />, tone: 'warning' as const },
             { label: t('Objem (EUR)', 'Volume (EUR)'), value: totalVolume.toLocaleString(numberLocale, { maximumFractionDigits: 0 }), icon: <Banknote size={16} aria-hidden="true" /> },
           ].map(k => <StatCard key={k.label} label={k.label} value={k.value} icon={k.icon} tone={k.tone} />)}
-        </div>
+        </div>}
 
         <div className="card">
           <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--border)', display: 'flex', gap: '10px', alignItems: 'center' }}>
@@ -80,11 +104,11 @@ export default function ClearingPage() {
                   border: '1px solid var(--border)', fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)', outline: 'none' }} />
             </div>
           </div>
-          {loading ? (
+          {loading && !hasSnapshot ? (
             <div role="status" aria-live="polite" style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
               <RefreshCw size={20} aria-hidden="true" style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} /><div>{t('Načítám…', 'Loading…')}</div>
             </div>
-          ) : unavailable ? (
+          ) : unavailable && !hasSnapshot ? (
             <DataUnavailable kind={unavailable.kind} service={t('Clearing-service', 'Clearing-service')} feature={t('Clearing dávky', 'Clearing batches')} lang={language} />
           ) : filtered.length === 0 ? (
             <DataUnavailable kind="no_data" feature={t('Clearing dávky', 'Clearing batches')} lang={language}


### PR DESCRIPTION
## Summary
- keep the last successful clearing batch snapshot, statuses, counts, and volume visible during refresh failures
- label retained settlement evidence as stale with its last successful refresh time and add an accessible manual refresh action
- avoid false-zero clearing KPIs on an initial failure with no snapshot
- add browser E2E coverage for a successful load followed by a classified 503 outage

## Preserved boundaries
- settlement processing and payment data are unchanged
- payments:view RBAC is unchanged
- the existing BFF endpoint and service classification remain unchanged

## Verification
- targeted ESLint: passed
- focused Vitest guards: 2 passed
- targeted Playwright Chromium: 1 passed
- git diff --check: passed

Closes #7821