### PR TITLE
fix(admin-ui): secure SWIFT outage recovery

### DIFF
--- a/openbank-admin-ui/e2e/swift-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/swift-recovery.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const message = {
+  id: 'swift-2026-0042',
+  messageType: 'pacs.008',
+  senderBic: 'KOMBCZPPXXX',
+  receiverBic: 'DEUTDEFFXXX',
+  amount: 85000.25,
+  currency: 'EUR',
+  status: 'PROCESSING',
+  createdAt: '2026-08-31T12:00:00Z',
+  reference: 'SWIFT-REF-0042',
+}
+
+test.beforeEach(async ({ context, baseURL, page }) => {
+  await signInAsOperator(context, baseURL!)
+  await page.route('**/api/auth/session', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      user: {
+        name: 'E2E Payments Operator',
+        email: 'e2e-payments@openbank.test',
+        roles: ['ROLE_ADMIN', 'ROLE_OPERATOR', 'ROLE_PAYMENTS'],
+        accessToken: 'e2e-fake-access-token',
+      },
+      expires: '2099-01-01T00:00:00.000Z',
+    }),
+  }))
+})
+
+test('keeps SWIFT processing evidence visible after a failed refresh', async ({ page }) => {
+  let unavailable = false
+  await page.route('**/api/svc/swift-service/api/v1/swift/messages**', route => unavailable
+    ? route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ error: 'unavailable' }) })
+    : route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([message]) }))
+
+  await page.goto('/swift')
+
+  await expect(page.getByText('SWIFT-REF-0042')).toBeVisible({ timeout: 20_000 })
+  await expect(page.getByText('85,000.25')).toBeVisible()
+  await expect(page.getByText('PROCESSING', { exact: true })).toBeVisible()
+
+  unavailable = true
+  await page.getByRole('button', { name: /Obnovit SWIFT zprávy|Refresh SWIFT messages/ }).click()
+
+  await expect(page.getByText(/Zobrazen je poslední úspěšný snapshot|Showing the last successful snapshot/)).toBeVisible({ timeout: 25_000 })
+  await expect(page.getByText('SWIFT-REF-0042')).toBeVisible()
+  await expect(page.getByText('85,000.25')).toBeVisible()
+  await expect(page.getByText('PROCESSING', { exact: true })).toBeVisible()
+  await expect(page.getByText(/zatím žádné SWIFT zprávy|no SWIFT messages yet/)).toHaveCount(0)
+})

--- a/openbank-admin-ui/src/app/swift/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/swift/[id]/page.tsx
@@ -9,6 +9,7 @@ import { useParams } from 'next/navigation'
 import Link from 'next/link'
 import { ArrowLeft, RefreshCw, ChevronDown, ChevronRight } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { AuthGuard } from '@/components/auth/AuthGuard'
 import { svcUrl, classifyBffFailure } from '@/lib/services/bff'
 import { readStashedRow } from '@/lib/services/rowHandoff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
@@ -67,6 +68,7 @@ export default function SwiftDetailPage() {
   useEffect(() => { load() /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [id])
 
   return (
+    <AuthGuard permission="payments:view">
     <div>
       <PageHeader
         title={message?.messageType ?? t('SWIFT zpráva', 'SWIFT message')}
@@ -129,6 +131,7 @@ export default function SwiftDetailPage() {
         </div>
       ) : null}
     </div>
+    </AuthGuard>
   )
 }
 

--- a/openbank-admin-ui/src/app/swift/page.tsx
+++ b/openbank-admin-ui/src/app/swift/page.tsx
@@ -27,11 +27,17 @@ export default function SwiftPage() {
   const numberLocale = dateLocale
   const router = useRouter()
   const [search, setSearch] = useState('')
-  const { data, loading, unavailable, waking } = useServiceResource<SwiftMessage[]>(
+  const [lastSuccessfulAt, setLastSuccessfulAt] = useState<Date | null>(null)
+  const { data, loading, unavailable, waking, reload } = useServiceResource<SwiftMessage[]>(
     svcUrl('swift-service', '/api/v1/swift/messages'),
-    { select: (raw) => (Array.isArray(raw) ? (raw as SwiftMessage[]) : ((raw as { messages?: SwiftMessage[] }).messages ?? [])) },
+    { select: (raw) => {
+      setLastSuccessfulAt(new Date())
+      return Array.isArray(raw) ? (raw as SwiftMessage[]) : ((raw as { messages?: SwiftMessage[] }).messages ?? [])
+    } },
   )
   const messages = data ?? []
+  const hasSnapshot = data !== null
+  const showingRetainedSnapshot = unavailable !== null && hasSnapshot
 
   const filtered = messages.filter(m =>
     m.senderBic?.toLowerCase().includes(search.toLowerCase()) ||
@@ -41,7 +47,7 @@ export default function SwiftPage() {
   )
 
   return (
-    <AuthGuard>
+    <AuthGuard permission="payments:view">
       <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
         <PageHeader
           breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('SWIFT', 'SWIFT')}</span></div>}
@@ -64,10 +70,26 @@ export default function SwiftPage() {
             <span role="status" style={{ padding: '5px 9px', borderRadius: '6px', border: '1px solid var(--warning-border)', background: 'var(--warning-bg)', color: 'var(--warning-text)', fontSize: '11px', fontWeight: 600 }}>
               {t('Odeslání zprávy není připojeno', 'Message submission is not connected')}
             </span>
+            <button type="button" onClick={reload} disabled={loading} aria-busy={loading} aria-label={t('Obnovit SWIFT zprávy', 'Refresh SWIFT messages')} className="btn btn-secondary btn-sm">
+              <RefreshCw size={14} aria-hidden="true" className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
+            </button>
           </div>}
         />
 
-        <div className="grid-4" style={{ marginBottom: '24px' }}>
+        {showingRetainedSnapshot && <div role="status" aria-live="polite" style={{ marginBottom: 20 }}>
+          <DataUnavailable kind={unavailable.kind} service={t('SWIFT-service', 'SWIFT-service')} feature={t('Aktualizace SWIFT zpráv', 'SWIFT message refresh')} lang={language} dense />
+          <p style={{ margin: '6px 0 0', color: 'var(--text-tertiary)', fontSize: 11 }}>
+            {t('Zobrazen je poslední úspěšný snapshot', 'Showing the last successful snapshot')}
+            {lastSuccessfulAt ? ` (${lastSuccessfulAt.toLocaleString(dateLocale)})` : ''}.
+            {' '}{t('Stav zpráv se od té doby mohl změnit.', 'Message status may have changed since then.')}
+          </p>
+        </div>}
+
+        {loading && hasSnapshot && <p role="status" aria-live="polite" style={{ margin: '0 0 12px', color: 'var(--text-tertiary)', fontSize: 11 }}>
+          {t('Aktualizuji SWIFT zprávy; poslední snapshot zůstává dostupný.', 'Refreshing SWIFT messages; the last snapshot remains available.')}
+        </p>}
+
+        {hasSnapshot && <div className="grid-4" style={{ marginBottom: '24px' }}>
           {[
             { label: t('Zpráv celkem', 'Total messages'), value: messages.length, icon: <Globe size={16} />, color: 'var(--accent)' },
             { label: t('Odesláno', 'Sent'), value: messages.filter(m => m.status === 'SENT').length, icon: <CheckCircle2 size={16} />, color: 'var(--success)' },
@@ -81,7 +103,7 @@ export default function SwiftPage() {
               <div style={{ fontSize: '12px', color: 'var(--text-secondary)', fontWeight: 500 }}>{k.label}</div>
             </div>
           ))}
-        </div>
+        </div>}
 
         <div className="card">
           <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--border)', display: 'flex', gap: '10px', alignItems: 'center' }}>
@@ -92,11 +114,11 @@ export default function SwiftPage() {
                   border: '1px solid var(--border)', fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)', outline: 'none' }} />
             </div>
           </div>
-          {loading ? (
-            <div style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
-              <RefreshCw size={20} style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} /><div>{t('Načítám…', 'Loading…')}</div>
+          {loading && !hasSnapshot ? (
+            <div role="status" aria-live="polite" style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
+              <RefreshCw size={20} aria-hidden="true" className="animate-spin" style={{ marginBottom: '8px' }} /><div>{t('Načítám…', 'Loading…')}</div>
             </div>
-          ) : unavailable ? (
+          ) : unavailable && !hasSnapshot ? (
             <DataUnavailable kind={unavailable.kind} service={t('SWIFT-service', 'SWIFT-service')} feature={t('SWIFT zprávy', 'SWIFT messages')} lang={language} />
           ) : filtered.length === 0 ? (
             <DataUnavailable kind="no_data" feature={t('SWIFT zprávy', 'SWIFT messages')} lang={language}

--- a/openbank-admin-ui/src/test/swift-route-rbac.guard.test.ts
+++ b/openbank-admin-ui/src/test/swift-route-rbac.guard.test.ts
@@ -1,0 +1,12 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (relative: string) => fs.readFileSync(path.join(process.cwd(), relative), 'utf8')
+
+describe('SWIFT read-route RBAC', () => {
+  it('keeps list and detail routes aligned with the payments navigation boundary', () => {
+    expect(read('src/app/swift/page.tsx')).toContain('<AuthGuard permission="payments:view">')
+    expect(read('src/app/swift/[id]/page.tsx')).toContain('<AuthGuard permission="payments:view">')
+  })
+})


### PR DESCRIPTION
## Summary
- align SWIFT list and detail route guards with the existing payments:view navigation and edge boundary
- keep the last successful SWIFT snapshot and status KPIs visible during refresh failures
- label retained message evidence as stale with its last successful refresh time and add an accessible refresh action
- avoid false-zero SWIFT KPIs on an initial failure
- add browser outage-recovery E2E and list/detail RBAC regression coverage

## Preserved boundaries
- SWIFT submission remains explicitly disconnected
- message payloads, payment execution, and backend authorization are unchanged
- the existing BFF endpoint and service failure classification remain unchanged

## Verification
- targeted ESLint: 0 errors; existing detail-load hook warnings remain
- focused Vitest RBAC guard: 1 passed
- targeted Playwright Chromium: 1 passed
- git diff --check: passed

Closes #7824