### PR TITLE
fix(admin-ui): preserve masked card detail during outages

### DIFF
--- a/openbank-admin-ui/e2e/card-detail-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/card-detail-recovery.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const cardId = '11111111-1111-1111-1111-111111111111'
+const card = {
+  id: cardId,
+  partyId: '22222222-2222-2222-2222-222222222222',
+  accountId: '33333333-3333-3333-3333-333333333333',
+  productCode: 'DEBIT-CLASSIC',
+  cardType: 'DEBIT',
+  network: 'VISA',
+  maskedPan: '411111******4242',
+  cardholderName: 'Verified Cardholder',
+  embossedName: 'VERIFIED CARDHOLDER',
+  expiryDate: '12/29',
+  status: 'ACTIVE',
+  dailyLimitMinorUnits: 500000,
+  monthlyLimitMinorUnits: 2000000,
+  currency: 'CZK',
+  createdAt: '2026-08-31T08:00:00Z',
+}
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('keeps the masked card detail visible after a failed refresh', async ({ page }) => {
+  let unavailable = false
+  await page.route(`**/api/svc/card-issuance-service/api/v1/cards/${cardId}`, route => unavailable
+    ? route.fulfill({ status: 503, contentType: 'application/json', body: '{}' })
+    : route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(card) }))
+
+  await page.goto(`/cards/${cardId}`)
+
+  await expect(page.getByRole('heading', { name: '411111******4242' })).toBeVisible({ timeout: 20_000 })
+  await expect(page.getByText('Verified Cardholder', { exact: true })).toBeVisible()
+  await expect(page.getByText(/full card number and CVV are deliberately not available|Úplné číslo karty ani CVV zde záměrně nejsou dostupné/)).toBeVisible()
+
+  unavailable = true
+  await page.getByRole('button', { name: /Obnovit kartu|Refresh card/ }).click()
+
+  await expect(page.getByText(/Zobrazen je poslední úspěšný snapshot|Showing the last successful snapshot/)).toBeVisible({ timeout: 25_000 })
+  await expect(page.getByRole('heading', { name: '411111******4242' })).toBeVisible()
+  await expect(page.getByText('Verified Cardholder', { exact: true })).toBeVisible()
+})

--- a/openbank-admin-ui/src/app/cards/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/cards/[id]/page.tsx
@@ -83,6 +83,7 @@ export default function CardDetailPage() {
   const { data: card, loading, unavailable, waking, reload } = useServiceResource<Card>(
     id ? svcUrl('card-issuance-service', `/api/v1/cards/${id}`) : null,
   )
+  const showingRetainedSnapshot = unavailable !== null && card !== null
 
   const ops = useCardOperations(reload)
   const [pending, setPending] = useState<CardTransition | null>(null)
@@ -170,14 +171,14 @@ export default function CardDetailPage() {
           </Link>
         </div>
 
-        {loading ? (
+        {loading && !card ? (
           <div role="status" aria-live="polite" style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
             <RefreshCw size={20} aria-hidden="true" style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} />
             <div>{waking
               ? t('Služba se probouzí…', 'The service is waking up…')
               : t('Načítám kartu…', 'Loading the card…')}</div>
           </div>
-        ) : unavailable || !card ? (
+        ) : !card ? (
           <DataUnavailable
             kind={unavailable?.kind ?? 'not_found'}
             service={t('Card-issuance-service', 'Card-issuance-service')}
@@ -186,6 +187,26 @@ export default function CardDetailPage() {
           />
         ) : (
           <>
+            {showingRetainedSnapshot && <div role="status" aria-live="polite" style={{ marginBottom: 18 }}>
+              <DataUnavailable
+                kind={unavailable.kind}
+                service={t('Card-issuance-service', 'Card-issuance-service')}
+                feature={t('Aktualizace detailu karty', 'Card detail refresh')}
+                lang={language}
+                dense
+              />
+              <p style={{ margin: '6px 0 0', color: 'var(--text-tertiary)', fontSize: 11 }}>
+                {t(
+                  'Zobrazen je poslední úspěšný snapshot. Stav karty, limity i ovládací prvky se od té doby mohly změnit.',
+                  'Showing the last successful snapshot. Card status, limits, and controls may have changed since then.',
+                )}
+              </p>
+            </div>}
+
+            {loading && <p role="status" aria-live="polite" style={{ margin: '0 0 12px', color: 'var(--text-tertiary)', fontSize: 11 }}>
+              {t('Aktualizuji kartu; poslední snapshot zůstává dostupný.', 'Refreshing the card; the last snapshot remains available.')}
+            </p>}
+
             <PageHeader
               icon={<CreditCard size={20} aria-hidden="true" />}
               title={card.maskedPan}
@@ -193,8 +214,8 @@ export default function CardDetailPage() {
               actions={<div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
                 <CardStatusChip status={card.status} current />
                 {(canManage || canBlock) && <CardTransitionButtons card={card} busy={ops.busy} canManage={canManage} canBlock={canBlock} onSelect={onSelectTransition} />}
-                <button type="button" className="btn btn-ghost btn-sm" onClick={reload} disabled={ops.busy !== null} aria-label={t('Obnovit kartu', 'Refresh card')}>
-                  <RefreshCw size={12} aria-hidden="true" /> {t('Obnovit', 'Refresh')}
+                <button type="button" className="btn btn-ghost btn-sm" onClick={reload} disabled={loading || ops.busy !== null} aria-busy={loading} aria-label={t('Obnovit kartu', 'Refresh card')}>
+                  <RefreshCw size={12} aria-hidden="true" className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
                 </button>
               </div>}
             />


### PR DESCRIPTION
## Summary
- keep the last successful PCI-safe card detail visible while refresh retries or a classified outage is shown
- label the retained detail as stale and keep refresh busy semantics truthful
- preserve the initial loading/not-found behavior when no card snapshot exists
- add browser E2E for a successful masked-card load followed by 503

## Preserved boundaries
- the UI still never requests or renders secure-details, a full PAN, or CVV
- card lifecycle actions, limits, controls, entitlements, and RBAC are unchanged
- the existing BFF endpoint and service failure classification remain unchanged

## Verification
- targeted ESLint: passed
- targeted Playwright Chromium: 1 passed
- git diff --check: passed

Closes #7827