### PR TITLE
fix(admin-ui): preserve ledger evidence after failed searches

### DIFF
--- a/openbank-admin-ui/e2e/ledger-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/ledger-recovery.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const journalPage = {
+  data: [{
+    id: 'entry-0042',
+    entryNumber: 42,
+    transactionId: 'transaction-12345678',
+    entryDate: '2026-08-31',
+    valueDate: '2026-08-31',
+    description: 'Customer transfer settlement',
+    status: 'POSTED',
+    createdAt: '2026-08-31T12:00:00Z',
+    lines: [
+      { id: 'line-debit', glAccountId: 'gl-debit-12345678', side: 'DEBIT', amount: 1250, currencyCode: 'EUR', baseAmount: 1250, baseCurrencyCode: 'EUR', sequence: 1 },
+      { id: 'line-credit', glAccountId: 'gl-credit-1234567', side: 'CREDIT', amount: 1250, currencyCode: 'EUR', baseAmount: 1250, baseCurrencyCode: 'EUR', sequence: 2 },
+    ],
+  }],
+  pagination: { limit: 20, hasNextPage: false, nextCursor: null },
+}
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('keeps balanced journal evidence visible after a repeated search fails', async ({ page }) => {
+  let unavailable = false
+  await page.route('**/api/svc/ledger-service/api/v1/journals**', route => unavailable
+    ? route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ error: 'unavailable' }) })
+    : route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(journalPage) }))
+
+  await page.goto('/ledger')
+  await page.getByRole('button', { name: /Načíst záznamy|Load Entries/ }).click()
+
+  await expect(page.getByText('Customer transfer settlement')).toBeVisible({ timeout: 20_000 })
+  await page.getByRole('button', { name: /Zobrazit řádky deníku|Show journal lines/ }).click()
+  await expect(page.getByText('DEBIT', { exact: true })).toBeVisible()
+  await expect(page.getByText('CREDIT', { exact: true })).toBeVisible()
+
+  unavailable = true
+  await page.getByRole('button', { name: /Načíst záznamy|Load Entries/ }).click()
+
+  await expect(page.getByText(/Zobrazen je poslední úspěšný výsledek|Showing the last successful result/)).toBeVisible({ timeout: 20_000 })
+  await expect(page.getByText('Customer transfer settlement')).toBeVisible()
+  await expect(page.getByText('DEBIT', { exact: true })).toBeVisible()
+  await expect(page.getByText('CREDIT', { exact: true })).toBeVisible()
+})

--- a/openbank-admin-ui/src/app/ledger/page.tsx
+++ b/openbank-admin-ui/src/app/ledger/page.tsx
@@ -4,11 +4,12 @@
 
 'use client'
 
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { Search, ChevronDown, ChevronRight } from 'lucide-react'
 import { svcUrl, classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { AuthGuard } from '@/components/auth/AuthGuard'
 import type { JournalEntry, CursorPage } from '@/types'
 import { PageHeader } from '@/components/ui/PageHeader'
 
@@ -48,12 +49,13 @@ export default function LedgerPage() {
   }
 
   async function search() {
-    setLoading(true); setUnavailable(null); setMoreError(null); setExpanded(null)
+    setLoading(true); setUnavailable(null); setMoreError(null)
     try {
-      setResult(await loadPage())
+      const next = await loadPage()
+      setResult(next)
+      setExpanded(null)
     } catch (error) {
       // Timeout / abort / network — the BFF or ledger-service didn't answer.
-      setResult(null)
       setUnavailable({ kind: (error as Error).message as UnavailableKind || 'unreachable' })
     } finally { setLoading(false) }
   }
@@ -75,6 +77,7 @@ export default function LedgerPage() {
   }
 
   return (
+    <AuthGuard permission="accounts:view">
     <div>
       <PageHeader breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Hlavní kniha', 'General Ledger')}</span></div>} title={t('Hlavní kniha', 'General Ledger')} subtitle={t('Zápisy v podvojném účetnictví', 'Double-entry journal entries')} />
 
@@ -90,8 +93,8 @@ export default function LedgerPage() {
           <input id="ledger-from-date" type="date" className="input" style={{ width: '150px' }} value={fromDate} onChange={e => setFromDate(e.target.value)} />
           <label htmlFor="ledger-to-date" style={{ fontSize: '12px', fontWeight: 500, color: 'var(--text-secondary)' }}>{t('Do', 'To')}</label>
           <input id="ledger-to-date" type="date" className="input" style={{ width: '150px' }} value={toDate} onChange={e => setToDate(e.target.value)} />
-          <button className="btn btn-primary" onClick={search} disabled={loading}>
-            <Search size={13} />
+          <button type="button" className="btn btn-primary" onClick={search} disabled={loading} aria-busy={loading}>
+            <Search size={13} aria-hidden="true" />
             {loading ? t('Načítání…', 'Loading…') : t('Načíst záznamy', 'Load Entries')}
           </button>
           {result && (
@@ -102,7 +105,7 @@ export default function LedgerPage() {
         </div>
 
         {/* Calm, explained unavailable state — never a raw HTTP status. */}
-        {unavailable && (
+        {unavailable && !result && (
           <DataUnavailable
             kind={unavailable.kind}
             service={t('Ledger-service', 'Ledger-service')}
@@ -112,7 +115,27 @@ export default function LedgerPage() {
           />
         )}
 
-        {!unavailable && (
+        {unavailable && result && <div role="status" aria-live="polite">
+          <DataUnavailable
+            kind={unavailable.kind}
+            service={t('Ledger-service', 'Ledger-service')}
+            feature={t('Aktualizace hlavní knihy', 'General Ledger refresh')}
+            lang={language}
+            dense
+          />
+          <p style={{ margin: '6px 16px 10px', color: 'var(--text-tertiary)', fontSize: 11 }}>
+            {t(
+              'Zobrazen je poslední úspěšný výsledek pro vybrané období. Novější účetní zápisy zatím nemusí být zahrnuté.',
+              'Showing the last successful result for the selected period. Newer journal entries may not be included yet.',
+            )}
+          </p>
+        </div>}
+
+        {loading && result && <p role="status" aria-live="polite" style={{ margin: '10px 16px 0', color: 'var(--text-tertiary)', fontSize: 11 }}>
+          {t('Aktualizuji hlavní knihu; poslední výsledek zůstává dostupný.', 'Refreshing the General Ledger; the last result remains available.')}
+        </p>}
+
+        {(!unavailable || result) && (
         <div style={{ overflowX: 'auto' }}>
           <table className="data-table">
             <thead>
@@ -131,17 +154,17 @@ export default function LedgerPage() {
               {!result && !loading && (
                 <tr><td colSpan={8}><div className="empty-state">{t('Vyberte období a klikněte na "Načíst záznamy".', 'Select a date range and click "Load Entries".')}</div></td></tr>
               )}
-              {loading && (
+              {loading && !result && (
                 <tr><td colSpan={8}><div className="empty-state">{t('Načítání záznamů hlavní knihy…', 'Loading journal entries…')}</div></td></tr>
               )}
               {!loading && result && result.data.length === 0 && (
                 <tr><td colSpan={8}><div className="empty-state">{t('Pro toto období nebyly nalezeny žádné záznamy.', 'No journal entries found for this period.')}</div></td></tr>
               )}
-              {!loading && result?.data.map(entry => {
+              {result?.data.map(entry => {
                 const isOpen = expanded === entry.id
                 return (
-                  <>
-                    <tr key={entry.id}>
+                  <Fragment key={entry.id}>
+                    <tr>
                       <td style={{ color: 'var(--text-tertiary)', paddingLeft: '14px' }}>
                         <button type="button" className="btn btn-ghost" style={{ padding: '3px' }} aria-label={isOpen ? t('Skrýt řádky deníku', 'Hide journal lines') : t('Zobrazit řádky deníku', 'Show journal lines')} aria-expanded={isOpen} aria-controls={`ledger-entry-${entry.id}`} onClick={() => setExpanded(isOpen ? null : entry.id)}>
                           {isOpen ? <ChevronDown size={13} aria-hidden="true" /> : <ChevronRight size={13} aria-hidden="true" />}
@@ -169,7 +192,7 @@ export default function LedgerPage() {
                       </td>
                     </tr>
                     {isOpen && (
-                      <tr key={`${entry.id}-exp`}>
+                      <tr>
                         <td colSpan={8} style={{ padding: 0, background: 'var(--surface-2)' }}>
                           <div id={`ledger-entry-${entry.id}`} style={{ padding: '12px 20px 12px 50px', borderBottom: '2px solid var(--accent-border)' }}>
                             <div style={{ fontSize: '11px', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--text-tertiary)', marginBottom: '8px' }}>
@@ -216,7 +239,7 @@ export default function LedgerPage() {
                         </td>
                       </tr>
                     )}
-                  </>
+                  </Fragment>
                 )
               })}
             </tbody>
@@ -227,12 +250,13 @@ export default function LedgerPage() {
         {result?.pagination.hasNextPage && (
           <div style={{ padding: '12px 16px', borderTop: '1px solid var(--border)', textAlign: 'center' }}>
             {moreError && <p role="alert" style={{ margin: '0 0 8px', fontSize: '12px', color: 'var(--danger-text)' }}>{moreError}</p>}
-            <button className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={loadMore} disabled={loadingMore}>
+            <button type="button" className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={loadMore} disabled={loadingMore} aria-busy={loadingMore}>
               {loadingMore ? t('Načítám…', 'Loading…') : t('Načíst další', 'Load more')}
             </button>
           </div>
         )}
       </div>
     </div>
+    </AuthGuard>
   )
 }

--- a/openbank-admin-ui/src/test/ledger-pagination.test.tsx
+++ b/openbank-admin-ui/src/test/ledger-pagination.test.tsx
@@ -7,6 +7,10 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import LedgerPage from '@/app/ledger/page'
 
+vi.mock('@/components/auth/AuthGuard', () => ({
+  AuthGuard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
 const firstPage = {
   data: [{ id: 'entry-1', transactionId: 'transaction-1', entryDate: '2026-08-01', valueDate: '2026-08-01', status: 'POSTED', lines: [], description: 'First page' }],
   pagination: { limit: 20, hasNextPage: true, nextCursor: 'cursor-1' },


### PR DESCRIPTION
## Summary
- retain the last successful journal page and expanded debit/credit lines when a repeated search fails
- explain that retained ledger evidence is stale while preserving the selected date range
- keep initial unavailable behavior when no journal result exists
- align the page component guard with the existing accounts:view sidebar and edge boundary
- fix stable React keys for journal entry/expanded-row pairs
- add browser E2E for successful search, line disclosure, and a subsequent 503

## Preserved boundaries
- journal posting, reversals, pagination contract, and money movement are unchanged
- backend authorization and the BFF endpoint are unchanged
- failed next-page loads continue to preserve already-read records

## Verification
- targeted ESLint: passed
- focused ledger Vitest: 3 passed
- targeted Playwright Chromium: 1 passed
- git diff --check: passed

Closes #7830