### PR TITLE
fix(fleet): add broker-based Pact provider verification to the last three providers

### DIFF
--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/contract/CaseCoordinatorPactBrokerProviderVerificationTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/contract/CaseCoordinatorPactBrokerProviderVerificationTest.kt
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
+import com.openbank.casecoordinator.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import jakarta.inject.Inject
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import org.junit.jupiter.api.extension.ExtendWith
+import java.nio.charset.StandardCharsets
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.UUID
+import javax.sql.DataSource
+
+/**
+ * Broker-sourced provider verification for case-coordinator-agent — the published-result counterpart to
+ * [CaseCoordinatorPactProviderVerificationTest].
+ *
+ * `@PactFolder` reads pacts off disk: it never contacts the broker, publishes no verification
+ * result and creates no provider version. A provider carrying only that half is invisible to
+ * `can-i-deploy`, and a broker version row with zero pacts makes the question *unanswerable*
+ * rather than negative — every consumer paired with it resolves `UNVERIFIABLE`. document-service
+ * sat in exactly that state for 24 days and blocked three consumers, two of them money-path
+ * (#7621, fixed by #7738).
+ *
+ * The sibling's KDoc anticipated this class — "can be added when the coordinator reaches the
+ * deploy path". That condition now holds: the agent carries a gitops image pin.
+ *
+ * Gated on `pactbroker.url`, so it is skipped locally and on the PR lane — `_service-ci.yml`
+ * blanks `PACT_BROKER_URL` because the broker has no public ingress (ADR-0056) — and runs on
+ * main-push. The `@PactFolder` sibling stays ungated, so PR-time replay (#2327/#2338) is
+ * unchanged.
+ *
+ * The state handlers below are duplicated from the sibling rather than inherited. A subclass was
+ * tried first and rejected on evidence: with parent and subclass both present, Quarkus fails with
+ * `TestInstantiationException` and the sibling's own tests go red. Duplication is the shape every
+ * other pair in the fleet uses.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+@Provider("openbank-case-coordinator-agent")
+@PactBroker(enablePendingPacts = "true")
+@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+@TestSecurity(user = "pact-viewer", roles = ["ROLE_VIEWER"])
+class CaseCoordinatorPactBrokerProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port")
+    lateinit var port: String
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    @BeforeEach
+    fun before(context: PactVerificationContext) {
+        context.target = HttpTestTarget("localhost", port.toInt())
+    }
+
+    @State("an open case exists")
+    fun seedOpenCase() = seedCase(status = "OPEN", contestedRate = "0.0")
+
+    @State("a closed case with a thread exists")
+    fun seedClosedCase() = seedCase(status = "CLOSED", contestedRate = "0.5")
+
+    private fun seedCase(status: String, contestedRate: String) {
+        val caseUuid = UUID.nameUUIDFromBytes(WORKFLOW_ID.toByteArray(StandardCharsets.UTF_8))
+        dataSource.connection.use { conn ->
+            conn.autoCommit = false
+            deleteCaseFixtures(conn, caseUuid)
+            insertCaseFixtures(conn, caseUuid, status, contestedRate)
+            conn.commit()
+        }
+    }
+
+    private fun deleteCaseFixtures(conn: java.sql.Connection, caseUuid: UUID) {
+        conn.prepareStatement("DELETE FROM case_contribution WHERE case_id = ?").use { ps ->
+            ps.setObject(1, caseUuid)
+            ps.executeUpdate()
+        }
+        conn.prepareStatement("DELETE FROM case_outbox WHERE aggregate_id = ?").use { ps ->
+            ps.setObject(1, caseUuid)
+            ps.executeUpdate()
+        }
+        conn.prepareStatement("DELETE FROM case_workflow WHERE id = ?").use { ps ->
+            ps.setObject(1, caseUuid)
+            ps.executeUpdate()
+        }
+    }
+
+    private fun insertCaseFixtures(conn: java.sql.Connection, caseUuid: UUID, status: String, contestedRate: String) {
+        conn.prepareStatement(
+            """
+            INSERT INTO case_workflow
+                (id, workflow_id, case_class, disposition_target, opened_at, deadline_at,
+                 status, budget_tokens, budget_contributions, contested_rate)
+            VALUES (?, ?, 'INCIDENT_RESPONSE', 'alert-7', ?, ?, ?, 200000, 40, ?::numeric)
+            """.trimIndent(),
+        ).use { ps ->
+            ps.setObject(1, caseUuid)
+            ps.setString(2, WORKFLOW_ID)
+            ps.setTimestamp(3, Timestamp.from(Instant.ofEpochMilli(OPENED_MS)))
+            ps.setTimestamp(4, Timestamp.from(Instant.ofEpochMilli(OPENED_MS + DEADLINE_MS)))
+            ps.setString(5, status)
+            ps.setString(6, contestedRate)
+            ps.executeUpdate()
+        }
+        conn.prepareStatement(
+            """
+            INSERT INTO case_contribution
+                (id, case_id, agent_id, contributed_at, tokens_used, preemption_vote,
+                 summary, draft_version, contested, evidence_refs)
+            VALUES (?, ?, 'fraud-agent', ?, 0, NULL, 'velocity spike', 1, true, '["tx-1"]'::jsonb)
+            """.trimIndent(),
+        ).use { ps ->
+            ps.setObject(1, UUID.randomUUID())
+            ps.setObject(2, caseUuid)
+            ps.setTimestamp(3, Timestamp.from(Instant.ofEpochMilli(OPENED_MS + CONTRIBUTED_MS)))
+            ps.executeUpdate()
+        }
+        conn.prepareStatement(
+            """
+            INSERT INTO case_outbox
+                (event_id, aggregate_id, event_type, payload, status, attempt_count, created_at, updated_at)
+            VALUES (?, ?, 'case-synthesis', '{}', 'SENT', 1, ?, ?)
+            """.trimIndent(),
+        ).use { ps ->
+            ps.setObject(1, PROPOSAL_UUID)
+            ps.setObject(2, caseUuid)
+            ps.setTimestamp(3, Timestamp.from(Instant.ofEpochMilli(OPENED_MS + EMITTED_MS)))
+            ps.setTimestamp(4, Timestamp.from(Instant.ofEpochMilli(OPENED_MS + EMITTED_MS)))
+            ps.executeUpdate()
+        }
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun pactVerificationTestTemplate(context: PactVerificationContext) {
+        context.verifyInteraction()
+    }
+
+    private companion object {
+        const val WORKFLOW_ID = "case-incident-response-alert-7"
+        const val OPENED_MS = 1_760_000_000_000L
+        const val DEADLINE_MS = 1_200_000L
+        const val CONTRIBUTED_MS = 60_000L
+        const val EMITTED_MS = 120_000L
+        val PROPOSAL_UUID: UUID = UUID.fromString("11111111-1111-1111-1111-111111111111")
+    }
+}

--- a/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/contract/FlakyTestTriggerPactBrokerProviderVerificationTest.kt
+++ b/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/contract/FlakyTestTriggerPactBrokerProviderVerificationTest.kt
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.flakytest.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
+import com.openbank.flakytest.PostgresTestResource
+import com.openbank.flakytest.application.usecase.FlakyTestHunterService
+import com.openbank.flakytest.domain.model.RunTrigger
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusMock
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Broker-sourced provider verification for flaky-test-hunter — the published-result counterpart to
+ * [FlakyTestTriggerPactProviderVerificationTest].
+ *
+ * `@PactFolder` reads pacts off disk: it never contacts the broker, publishes no verification
+ * result and creates no provider version. A provider carrying only that half is invisible to
+ * `can-i-deploy`, and a broker version row with zero pacts makes the question *unanswerable*
+ * rather than negative — every consumer paired with it resolves `UNVERIFIABLE`. document-service
+ * sat in exactly that state for 24 days and blocked three consumers, two of them money-path
+ * (#7621, fixed by #7738).
+ *
+ * Gated on `pactbroker.url`, so it is skipped locally and on the PR lane — `_service-ci.yml`
+ * blanks `PACT_BROKER_URL` because the broker has no public ingress (ADR-0056) — and runs on
+ * main-push. The `@PactFolder` sibling stays ungated, so PR-time replay (#2327/#2338) is
+ * unchanged.
+ *
+ * The state handlers below are duplicated from the sibling rather than inherited. A subclass was
+ * tried first and rejected on evidence: with parent and subclass both present, Quarkus fails with
+ * `TestInstantiationException` and the sibling's own tests go red. Duplication is the shape every
+ * other pair in the fleet uses.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+@Provider("openbank-flaky-test-hunter")
+@PactBroker(enablePendingPacts = "true")
+@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
+@TestSecurity(user = "pact-admin", roles = ["ROLE_ADMIN"])
+class FlakyTestTriggerPactBrokerProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port")
+    lateinit var port: String
+
+    @BeforeEach
+    fun before(context: PactVerificationContext) {
+        val runCheck = mockk<FlakyTestHunterService>()
+        coEvery { runCheck.startDetached(RunTrigger.OPERATOR_MANUAL) } returns WORKFLOW_ID
+        QuarkusMock.installMockForType(runCheck, FlakyTestHunterService::class.java)
+        context.target = HttpTestTarget("localhost", port.toInt())
+    }
+
+    @State("an administrator may admit a flaky-test workflow")
+    fun administratorMayAdmitWorkflow() = Unit
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun pactVerificationTestTemplate(context: PactVerificationContext) {
+        context.verifyInteraction()
+    }
+
+    private companion object {
+        const val WORKFLOW_ID = "flaky-test-check-operator_manual-2026-08-18"
+    }
+}

--- a/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/contract/IncentivePactBrokerProviderVerificationTest.kt
+++ b/openbank-incentive-service/src/test/kotlin/com/openbank/incentive/contract/IncentivePactBrokerProviderVerificationTest.kt
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.openbank.incentive.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
+import com.openbank.incentive.it.IncentivePostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import jakarta.inject.Inject
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import org.junit.jupiter.api.extension.ExtendWith
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.sql.Connection
+import java.time.Instant
+import javax.sql.DataSource
+
+/**
+ * Broker-sourced provider verification for incentive-service — the published-result counterpart to
+ * [IncentivePactFolderProviderVerificationTest].
+ *
+ * `@PactFolder` reads pacts off disk: it never contacts the broker, publishes no verification
+ * result and creates no provider version. A provider carrying only that half is invisible to
+ * `can-i-deploy`, and a broker version row with zero pacts makes the question *unanswerable*
+ * rather than negative — every consumer paired with it resolves `UNVERIFIABLE`. document-service
+ * sat in exactly that state for 24 days and blocked three consumers, two of them money-path
+ * (#7621, fixed by #7738).
+ *
+ * Preventive rather than corrective: incentive-service has no gitops image pin yet, so nothing is
+ * blocked today. Wiring the broker half now means its first deploy arrives with a verifiable
+ * contract instead of meeting this gap at the gate.
+ *
+ * Gated on `pactbroker.url`, so it is skipped locally and on the PR lane — `_service-ci.yml`
+ * blanks `PACT_BROKER_URL` because the broker has no public ingress (ADR-0056) — and runs on
+ * main-push. The `@PactFolder` sibling stays ungated, so PR-time replay (#2327/#2338) is
+ * unchanged.
+ *
+ * The state handlers below are duplicated from the sibling rather than inherited. A subclass was
+ * tried first and rejected on evidence: with parent and subclass both present, Quarkus fails with
+ * `TestInstantiationException` and the sibling's own tests go red. Duplication is the shape every
+ * other pair in the fleet uses.
+ */
+@QuarkusTest
+@QuarkusTestResource(IncentivePostgresTestResource::class)
+@QuarkusTestResource(IncentivePactBrokerProviderVerificationTest.InMemoryKafkaResource::class)
+@TestSecurity(user = "maker@openbank.test", roles = ["ROLE_API"])
+@Provider("openbank-incentive-service")
+@PactBroker(enablePendingPacts = "true")
+@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class IncentivePactBrokerProviderVerificationTest {
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> =
+            InMemoryConnector.switchOutgoingChannelsToInMemory("incentive-events-out")
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        if (context == null) return
+        context.target = HttpTestTarget("localhost", testPort.toInt())
+        context.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    @State("a published offer contains the pact promo code for the pact product")
+    fun publishedOfferContainsCode() {
+        dataSource.connection.use { connection ->
+            connection.autoCommit = false
+            deletePreviousReservation(connection)
+            if (!offerExists(connection)) insertOffer(connection)
+            if (!codeExists(connection)) insertCode(connection)
+            connection.commit()
+        }
+    }
+
+    @State("an attributed reservation is reserved for qualifying commit")
+    fun attributedReservationForCommit() = insertReservedAttribution()
+
+    @State("an attributed reservation is reserved for deterministic release")
+    fun attributedReservationForRelease() = insertReservedAttribution()
+
+    private fun insertReservedAttribution() {
+        dataSource.connection.use { connection ->
+            connection.autoCommit = false
+            deletePreviousReservation(connection)
+            if (!offerExists(connection)) insertOffer(connection)
+            if (!codeExists(connection)) insertCode(connection)
+            connection.prepareStatement(INSERT_RESERVATION).use { statement ->
+                statement.setString(1, RESERVATION_ID)
+                statement.setString(2, OFFER_ID)
+                statement.setString(3, codeDigest())
+                statement.setString(4, PARTY_ID)
+                statement.setString(5, PRODUCT_ID)
+                statement.setString(6, ATTRIBUTION_ID)
+                statement.executeUpdate()
+            }
+            connection.prepareStatement("UPDATE promo_code_inventory SET status = 'RESERVED' WHERE digest = ?")
+                .use { statement ->
+                    statement.setString(1, codeDigest())
+                    statement.executeUpdate()
+                }
+            connection.commit()
+        }
+    }
+
+    private fun deletePreviousReservation(connection: Connection) {
+        connection.prepareStatement(
+            "DELETE FROM promo_reservation WHERE id = ?::uuid OR attribution_ref = ?::uuid",
+        ).use { statement ->
+            statement.setString(1, RESERVATION_ID)
+            statement.setString(2, ATTRIBUTION_ID)
+            statement.executeUpdate()
+        }
+        connection.prepareStatement(
+            "UPDATE promo_code_inventory SET status = 'AVAILABLE' WHERE digest = ?",
+        ).use { statement ->
+            statement.setString(1, codeDigest())
+            statement.executeUpdate()
+        }
+    }
+
+    private fun offerExists(connection: Connection): Boolean =
+        connection.prepareStatement("SELECT 1 FROM incentive_offer WHERE id = ?::uuid").use { statement ->
+            statement.setString(1, OFFER_ID)
+            statement.executeQuery().use { it.next() }
+        }
+
+    private fun codeExists(connection: Connection): Boolean =
+        connection.prepareStatement("SELECT 1 FROM promo_code_inventory WHERE digest = ?").use { statement ->
+            statement.setString(1, codeDigest())
+            statement.executeQuery().use { it.next() }
+        }
+
+    private fun insertOffer(connection: Connection) {
+        connection.prepareStatement(INSERT_OFFER).use { statement ->
+            statement.setString(1, OFFER_ID)
+            statement.setObject(2, java.sql.Timestamp.from(Instant.now().minusSeconds(60)))
+            statement.setObject(3, java.sql.Timestamp.from(Instant.now().plusSeconds(86_400)))
+            statement.executeUpdate()
+        }
+    }
+
+    private fun insertCode(connection: Connection) {
+        connection.prepareStatement(INSERT_CODE).use { statement ->
+            statement.setString(1, codeDigest())
+            statement.setString(2, OFFER_ID)
+            statement.executeUpdate()
+        }
+    }
+
+    private fun codeDigest(): String = MessageDigest.getInstance("SHA-256")
+        .digest("$PEPPER:$CODE".toByteArray(StandardCharsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }
+
+    private companion object {
+        const val OFFER_ID = "44444444-4444-4444-8444-444444444444"
+        const val ATTRIBUTION_ID = "22222222-2222-4222-8222-222222222222"
+        const val PARTY_ID = "11111111-1111-4111-8111-111111111111"
+        const val PRODUCT_ID = "33333333-3333-4333-8333-333333333333"
+        const val RESERVATION_ID = "55555555-5555-4555-8555-555555555555"
+        const val CODE = "WELCOME10"
+        const val PEPPER = "integration-pepper-with-32-characters-minimum"
+        const val INSERT_OFFER = """
+            INSERT INTO incentive_offer (
+              id, name, version, product_scope, effective_from, expires_at, total_limit,
+              per_party_limit, stacking_policy, status, maker, checker, created_at, published_at
+            ) VALUES (
+              ?::uuid, 'WELCOME', 1, '33333333-3333-4333-8333-333333333333', ?, ?, 10,
+              1, 'EXCLUSIVE', 'PUBLISHED', 'maker@openbank.test', 'checker@openbank.test', now(), now()
+            )
+        """
+        const val INSERT_CODE = """
+            INSERT INTO promo_code_inventory (digest, offer_id, status, created_at, retained_until)
+            VALUES (?, ?::uuid, 'AVAILABLE', now(), now() + interval '13 months')
+        """
+        const val INSERT_RESERVATION = """
+            INSERT INTO promo_reservation (
+              id, offer_id, offer_name, offer_version, code_digest, party_ref, product_ref,
+              idempotency_key, status, reserved_at, expires_at, attribution_ref
+            ) VALUES (
+              ?::uuid, ?::uuid, 'WELCOME', 1, ?, ?, ?, 'open-pact-once', 'RESERVED',
+              '2026-08-27T00:00:00Z', '2099-01-01T00:00:00Z', ?::uuid
+            )
+        """
+    }
+}


### PR DESCRIPTION
## What

Completes the sweep #7738 started for document-service. These were the **only three** providers left
with a `@PactFolder` class and no `@PactBroker` counterpart — measured across every `@Provider` class
on `main`, not guessed:

| provider | broker | folder | deployed? |
|---|---|---|---|
| `openbank-case-coordinator-agent` | 0 | 1 | yes (`sandbox-e96c8e41`) |
| `openbank-flaky-test-hunter` | 0 | 1 | yes (`sandbox-06160082`) |
| `openbank-incentive-service` | 0 | 1 | no gitops pin yet |

## Why

`@PactFolder` reads pacts off disk. It never contacts the broker, publishes no verification result and
creates no provider version. A provider with only that half is invisible to `can-i-deploy`, and a
broker version row carrying **zero pacts** makes the question *unanswerable* rather than negative — so
every consumer paired with it resolves `UNVERIFIABLE`.

document-service sat in exactly that state for 24 days and blocked three consumers, two of them
money-path — the blocker traced in #7621.

**This one is preventive, not corrective.** None of these three blocked anything in the 2026-08-31
reconcile run. case-coordinator's own KDoc anticipated the class — *"can be added when the coordinator
reaches the deploy path"* — and that condition now holds.

## Duplication over inheritance, decided on evidence

Inheritance was the obvious way to avoid copying ~160 lines of fixture logic, and a probe confirmed
pact-jvm **does** discover inherited `@State` methods (subclass alone: 4 tests, 0 failures).

That probe was insufficient, and the shipping configuration falsified it: with parent *and* subclass
both present, Quarkus raises `TestInstantiationException` and the **sibling's own tests go red** —
2, 1 and 3 failures across the three modules. A control run on unmodified `origin/main` passes, which
is what identifies the change as the cause rather than a pre-existing failure.

So these duplicate their sibling's states, which is the shape every other pair in the fleet already
uses. The cost is real and worth naming: the fleet's pairs drift — consent carries 8 states on the
folder side and 6 on the broker side. A shared-handler refactor would fix that class of problem for
all of them, and is deliberately out of scope here.

## Verified by effect, in the configuration that ships

Both classes present, per module:

```
CaseCoordinatorPactProviderVerificationTest        tests=2 skipped=0 failures=0
CaseCoordinatorPactBrokerProviderVerificationTest  tests=1 skipped=1 failures=0
FlakyTestTriggerPactProviderVerificationTest       tests=1 skipped=0 failures=0
FlakyTestTriggerPactBrokerProviderVerificationTest tests=1 skipped=1 failures=0
IncentivePactFolderProviderVerificationTest        tests=3 skipped=0 failures=0
IncentivePactBrokerProviderVerificationTest        tests=1 skipped=1 failures=0
```

`ktlintCheck` exits 0 for all three modules. No sibling file was modified.

The gate is the risky part of a change like this — a wrongly-gated class either never runs or breaks
the PR lane — so that is what the runs above exercise. The broker path itself cannot be exercised
before merge by design (`_service-ci.yml` blanks `PACT_BROKER_URL`; ADR-0056). #7738 is the evidence
the pattern works: its main-push contract job ran green and produced the first document-service broker
version since 7 August.

## Still missing

Nothing asserts that a provider whose pacts gate a deploy also publishes results to the broker.
`check-pact-provider-replay.py` checks the complementary property — that every committed pact is
replayed on a PR. Without a gate for this direction the gap returns silently, which is how
document-service went 24 days unnoticed.

Refs #7621
