### PR TITLE
feat(admin-ui): show customer effective access

### DIFF
--- a/openbank-admin-ui/src/app/api/delegations/effective-access/[partyId]/route.ts
+++ b/openbank-admin-ui/src/app/api/delegations/effective-access/[partyId]/route.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const TIMEOUT_MS = 5000
+type SourceState = 'ok' | 'forbidden' | 'unavailable'
+type SourceResult = { data: unknown; state: SourceState }
+
+const stateFor = (status: number): SourceState => status === 401 || status === 403 ? 'forbidden' : 'unavailable'
+
+async function read(url: string, headers: HeadersInit): Promise<SourceResult> {
+  try {
+    const response = await fetch(url, { headers, cache: 'no-store', signal: AbortSignal.timeout(TIMEOUT_MS) })
+    if (!response.ok) return { data: [], state: stateFor(response.status) }
+    return { data: await response.json(), state: 'ok' }
+  } catch {
+    return { data: [], state: 'unavailable' }
+  }
+}
+
+const list = (value: unknown): Record<string, unknown>[] => {
+  if (Array.isArray(value)) return value.filter(item => item && typeof item === 'object') as Record<string, unknown>[]
+  if (value && typeof value === 'object') {
+    const data = (value as { data?: unknown }).data
+    if (Array.isArray(data)) return data.filter(item => item && typeof item === 'object') as Record<string, unknown>[]
+  }
+  return []
+}
+
+export async function GET(_request: Request, { params }: { params: Promise<{ partyId: string }> }) {
+  const session = await auth()
+  if (!session?.user?.accessToken) return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  const { partyId } = await params
+  if (!UUID_RE.test(partyId)) return NextResponse.json({ error: 'invalid_party_id' }, { status: 400 })
+
+  const headers = { authorization: `Bearer ${session.user.accessToken}` }
+  const [accounts, cards, grants, presets] = await Promise.all([
+    read(serverSvcUrl('account-service', 'accounts', 8100, `/api/v1/accounts?partyId=${encodeURIComponent(partyId)}&limit=100`), headers),
+    read(serverSvcUrl('card-issuance-service', 'card-issuance', 8118, `/api/v1/cards/party/${partyId}`), headers),
+    read(serverSvcUrl('delegation-service', 'delegation', 8126, `/api/v1/delegations/grantee/${partyId}`), headers),
+    read(serverSvcUrl('delegation-service', 'delegation', 8126, '/api/v1/delegation-role-presets'), headers),
+  ])
+
+  return NextResponse.json({
+    partyId,
+    accounts: list(accounts.data),
+    cards: list(cards.data),
+    grants: list(grants.data),
+    presets: list(presets.data),
+    sources: { accounts: accounts.state, cards: cards.state, grants: grants.state, presets: presets.state },
+  }, { headers: { 'cache-control': 'no-store' } })
+}

--- a/openbank-admin-ui/src/app/delegations/page.tsx
+++ b/openbank-admin-ui/src/app/delegations/page.tsx
@@ -27,6 +27,7 @@ import { DataUnavailable, type UnavailableKind } from '@/components/feedback/Dat
 import { EntityChip } from '@/components/entities/EntityChip'
 import { PageHeader } from '@/components/ui/PageHeader'
 import { RoleCatalog } from '@/components/delegations/RoleCatalog'
+import { EffectiveAccess, type EffectiveAccessPayload } from '@/components/delegations/EffectiveAccess'
 import {
   DelegationStatusBadge,
   capabilityLabels,
@@ -60,6 +61,7 @@ export default function DelegationsPage() {
 
   const [party, setParty] = useState<EntityRef | null>(null)
   const [grants, setGrants] = useState<GrantsPayload | null>(null)
+  const [effectiveAccess, setEffectiveAccess] = useState<EffectiveAccessPayload | null>(null)
   const [grantsUnavail, setGrantsUnavail] = useState<UnavailableKind | null>(null)
   const [loading, setLoading] = useState(false)
 
@@ -90,11 +92,13 @@ export default function DelegationsPage() {
     setLoading(true)
     setGrantsUnavail(null)
     setGrants(null)
+    setEffectiveAccess(null)
     try {
-      const res = await fetch(`/api/delegations/party/${target.id}`, {
-        cache: 'no-store',
-        signal: AbortSignal.timeout(8000),
-      })
+      const [res, effectiveRes] = await Promise.all([
+        fetch(`/api/delegations/party/${target.id}`, { cache: 'no-store', signal: AbortSignal.timeout(8000) }),
+        fetch(`/api/delegations/effective-access/${target.id}`, { cache: 'no-store', signal: AbortSignal.timeout(8000) }),
+      ])
+      if (effectiveRes.ok) setEffectiveAccess((await effectiveRes.json()) as EffectiveAccessPayload)
       if (!res.ok) {
         setGrantsUnavail((await classifyBffFailure(res)) as BffFailure)
         return
@@ -210,6 +214,8 @@ export default function DelegationsPage() {
           lang={language}
         />
       )}
+
+      {party && effectiveAccess && <EffectiveAccess data={effectiveAccess} />}
 
       {party && !grantsUnavail && grants && (
         <>

--- a/openbank-admin-ui/src/app/delegations/page.tsx
+++ b/openbank-admin-ui/src/app/delegations/page.tsx
@@ -27,7 +27,7 @@ import { DataUnavailable, type UnavailableKind } from '@/components/feedback/Dat
 import { EntityChip } from '@/components/entities/EntityChip'
 import { PageHeader } from '@/components/ui/PageHeader'
 import { RoleCatalog } from '@/components/delegations/RoleCatalog'
-import { EffectiveAccess, type EffectiveAccessPayload } from '@/components/delegations/EffectiveAccess'
+import { EffectiveAccess, isEffectiveAccessPayload, type EffectiveAccessPayload } from '@/components/delegations/EffectiveAccess'
 import {
   DelegationStatusBadge,
   capabilityLabels,
@@ -98,7 +98,10 @@ export default function DelegationsPage() {
         fetch(`/api/delegations/party/${target.id}`, { cache: 'no-store', signal: AbortSignal.timeout(8000) }),
         fetch(`/api/delegations/effective-access/${target.id}`, { cache: 'no-store', signal: AbortSignal.timeout(8000) }),
       ])
-      if (effectiveRes.ok) setEffectiveAccess((await effectiveRes.json()) as EffectiveAccessPayload)
+      if (effectiveRes.ok) {
+        const payload: unknown = await effectiveRes.json()
+        if (isEffectiveAccessPayload(payload)) setEffectiveAccess(payload)
+      }
       if (!res.ok) {
         setGrantsUnavail((await classifyBffFailure(res)) as BffFailure)
         return

--- a/openbank-admin-ui/src/components/delegations/EffectiveAccess.tsx
+++ b/openbank-admin-ui/src/components/delegations/EffectiveAccess.tsx
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+'use client'
+
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+import { Crown, KeyRound, Layers3 } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { CAPABILITIES_BY_RESOURCE, capabilityLabel, type RolePreset } from '@/lib/delegations/rolePresets'
+import { DelegationStatusBadge, type Grant } from '@/components/delegations/GrantView'
+
+type SourceState = 'ok' | 'forbidden' | 'unavailable'
+type Account = { id?: string; accountNumber?: string; nickname?: string | null; accountType?: string; currencyCode?: string; status?: string }
+type Card = { id?: string; maskedPan?: string; cardType?: string; network?: string; status?: string; delegated?: boolean; delegationGrantId?: string | null }
+
+export type EffectiveAccessPayload = {
+  accounts: Account[]
+  cards: Card[]
+  grants: Grant[]
+  presets: RolePreset[]
+  sources: { accounts: SourceState; cards: SourceState; grants: SourceState; presets: SourceState }
+}
+
+const sameCapabilities = (left: string[] = [], right: string[] = []) =>
+  left.length === right.length && [...left].sort().every((item, index) => item === [...right].sort()[index])
+
+export function matchedRoleName(grant: Grant, presets: RolePreset[], language: 'cs' | 'en'): string {
+  const preset = presets.find(item => item.resourceType === grant.resourceType && sameCapabilities(item.capabilities, grant.capabilities))
+  if (preset) return preset.name
+  return language === 'cs' ? 'Vlastní kombinace práv' : 'Custom rights set'
+}
+
+export function EffectiveAccess({ data }: { data: EffectiveAccessPayload }) {
+  const { t, language } = useLanguage()
+  const partial = Object.entries(data.sources).filter(([, state]) => state !== 'ok')
+
+  return <section className="card" style={{ padding: 16, marginBottom: 20 }} aria-labelledby="effective-access-title">
+    <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+      <Layers3 size={18} color="var(--accent)" aria-hidden="true" />
+      <div><h2 id="effective-access-title" style={{ fontSize: 16, fontWeight: 750 }}>{t('Efektivní přístup klienta', 'Customer effective access')}</h2>
+        <p style={{ fontSize: 12, color: 'var(--text-tertiary)', marginTop: 3 }}>{t('Souhrn vlastnictví a přijatých delegací: jakou roli klient má, nad čím a s jakými právy.', 'Ownership and received delegations: which role the customer has, over what, and with which rights.')}</p></div>
+    </div>
+
+    {partial.length > 0 && <div role="status" style={{ marginTop: 12, padding: 10, borderRadius: 8, background: 'var(--surface-3)', fontSize: 12 }}>
+      {t('Výsledek je částečný. Nedostupné nebo nepovolené zdroje:', 'The result is partial. Unavailable or forbidden sources:')} {' '}
+      {partial.map(([source, state]) => `${source} (${state})`).join(', ')}
+    </div>}
+
+    <AccessSection title={t('Vlastní zdroje', 'Owned resources')} empty={data.accounts.length === 0 && data.cards.length === 0}>
+      {data.accounts.map(account => <AccessCard key={`account-${account.id}`} icon={<Crown size={15} />} role={t('Majitel účtu', 'Account owner')} resource={account.nickname || maskedAccount(account.accountNumber, t('Účet', 'Account')) || t('Účet', 'Account')} meta={[account.accountType, account.currencyCode, account.status].filter(Boolean).join(' · ')} href={account.id ? `/accounts/${account.id}` : undefined} capabilities={[...CAPABILITIES_BY_RESOURCE.ACCOUNT]} />)}
+      {data.cards.map(card => <AccessCard key={`card-${card.id}`} icon={<Crown size={15} />} role={card.delegated ? t('Držitel dodatkové karty', 'Additional cardholder') : t('Majitel karty', 'Card owner')} resource={card.maskedPan || t('Karta', 'Card')} meta={[card.network, card.cardType, card.status].filter(Boolean).join(' · ')} href={card.id ? `/cards/${card.id}` : undefined} capabilities={card.delegated ? delegatedCardCapabilities(card, data) : [...CAPABILITIES_BY_RESOURCE.CARD]} />)}
+    </AccessSection>
+
+    <AccessSection title={t('Delegovaná oprávnění', 'Delegated rights')} empty={!data.grants.some(grant => grant.status === 'ACTIVE')}>
+      {data.grants.filter(grant => grant.status === 'ACTIVE').map(grant => <AccessCard key={`grant-${grant.id}`} icon={<KeyRound size={15} />} role={matchedRoleName(grant, data.presets, language)} resource={`${resourceLabel(grant.resourceType, language)} · ${shortId(grant.resourceId)}`} meta={<DelegationStatusBadge status={grant.status} />} href={`/delegations/${grant.id}`} capabilities={grant.capabilities} />)}
+    </AccessSection>
+  </section>
+}
+
+function AccessSection({ title, empty, children }: { title: string; empty: boolean; children: ReactNode }) {
+  const { t } = useLanguage()
+  return <div style={{ marginTop: 16 }}><h3 style={{ fontSize: 12, fontWeight: 800, letterSpacing: '.06em', textTransform: 'uppercase' }}>{title}</h3>
+    {empty ? <p style={{ fontSize: 13, color: 'var(--text-tertiary)', marginTop: 8 }}>{t('Žádné položky z dostupných zdrojů.', 'No items from the available sources.')}</p>
+      : <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 360px), 1fr))', gap: 12, marginTop: 8 }}>{children}</div>}
+  </div>
+}
+
+function AccessCard({ icon, role, resource, meta, href, capabilities }: { icon: ReactNode; role: string; resource: string; meta: ReactNode; href?: string; capabilities: string[] }) {
+  const { t, language } = useLanguage()
+  const content = <><div style={{ display: 'flex', gap: 8, alignItems: 'center', color: 'var(--accent)' }}>{icon}<strong style={{ color: 'var(--text-primary)' }}>{role}</strong></div>
+    <div style={{ fontSize: 13, fontWeight: 650, marginTop: 9 }}>{resource}</div><div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 3 }}>{meta}</div>
+    <div aria-label={t('Práva', 'Rights')} style={{ display: 'flex', flexWrap: 'wrap', gap: 5, marginTop: 12 }}>{capabilities.map(capability => <span key={capability} title={capability} style={{ borderRadius: 999, padding: '4px 8px', fontSize: 10, background: 'var(--surface-3)', border: '1px solid var(--border)' }}>{capabilityLabel(capability, language)}</span>)}</div></>
+  const style = { display: 'block', padding: 14, border: '1px solid var(--border)', borderRadius: 11, background: 'var(--surface-1)', color: 'inherit', textDecoration: 'none' }
+  return href ? <Link href={href} style={style}>{content}</Link> : <div style={style}>{content}</div>
+}
+
+const presetCapabilities = (presets: RolePreset[], name: string) => presets.find(preset => preset.name === name)?.capabilities ?? []
+const delegatedCardCapabilities = (card: Card, data: EffectiveAccessPayload) =>
+  data.grants.find(grant => grant.id === card.delegationGrantId)?.capabilities ?? presetCapabilities(data.presets, 'Držitel dodatkové karty')
+const maskedAccount = (number: string | undefined, label: string) => number ? `${label} •••• ${number.replace(/\s/g, '').slice(-4)}` : undefined
+const shortId = (id?: string) => id ? `${id.slice(0, 8)}…` : '—'
+const resourceLabel = (resource: string, language: 'cs' | 'en') => ({ ACCOUNT: language === 'cs' ? 'Účet' : 'Account', CARD: language === 'cs' ? 'Karta' : 'Card', SAVINGS_GOAL: language === 'cs' ? 'Spoření' : 'Savings' }[resource] ?? resource)

--- a/openbank-admin-ui/src/components/delegations/EffectiveAccess.tsx
+++ b/openbank-admin-ui/src/components/delegations/EffectiveAccess.tsx
@@ -20,6 +20,14 @@ export type EffectiveAccessPayload = {
   sources: { accounts: SourceState; cards: SourceState; grants: SourceState; presets: SourceState }
 }
 
+export function isEffectiveAccessPayload(value: unknown): value is EffectiveAccessPayload {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<EffectiveAccessPayload>
+  return Array.isArray(candidate.accounts) && Array.isArray(candidate.cards) &&
+    Array.isArray(candidate.grants) && Array.isArray(candidate.presets) &&
+    !!candidate.sources && typeof candidate.sources === 'object'
+}
+
 const sameCapabilities = (left: string[] = [], right: string[] = []) =>
   left.length === right.length && [...left].sort().every((item, index) => item === [...right].sort()[index])
 

--- a/openbank-admin-ui/src/components/delegations/RoleCatalog.tsx
+++ b/openbank-admin-ui/src/components/delegations/RoleCatalog.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { Check, LayoutGrid, Pencil, Plus, Shield, Table2, Trash2, X } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { useAuth } from '@/lib/auth/useAuth'
-import { CAPABILITIES_BY_RESOURCE, capabilityIntent, type CapabilityIntent, type DelegationResource, type RolePreset } from '@/lib/delegations/rolePresets'
+import { CAPABILITIES_BY_RESOURCE, capabilityIntent, capabilityLabel, type CapabilityIntent, type DelegationResource, type RolePreset } from '@/lib/delegations/rolePresets'
 
 const emptyRole = (): RolePreset => ({ id: '', name: '', description: '', resourceType: 'ACCOUNT', capabilities: [] })
 
@@ -140,27 +140,6 @@ const intentLabel = (intent: CapabilityIntent, t: (cs: string, en: string) => st
   manage: t('Může spravovat', 'Can manage'),
 })[intent]
 const intentColor = (intent: CapabilityIntent) => ({ view: 'var(--success)', act: 'var(--warning)', manage: 'var(--accent)' })[intent]
-const RIGHT_LABELS: Record<string, [string, string]> = {
-  ACCOUNT_VIEW_DETAILS: ['Detail účtu', 'Account details'],
-  ACCOUNT_READ_BALANCES: ['Zůstatky', 'Balances'],
-  ACCOUNT_READ_TRANSACTIONS: ['Transakce', 'Transactions'],
-  ACCOUNT_DOWNLOAD_STATEMENTS: ['Výpisy', 'Statements'],
-  ACCOUNT_PROPOSE_PAYMENT: ['Připravit platbu', 'Propose payment'],
-  ACCOUNT_INITIATE_PAYMENT: ['Provést platbu', 'Execute payment'],
-  ACCOUNT_MANAGE_BENEFICIARIES: ['Příjemci', 'Beneficiaries'],
-  ACCOUNT_MANAGE_LIMITS: ['Limity účtu', 'Account limits'],
-  DELEGATION_MANAGE: ['Disponenti', 'Delegates'],
-  CARD_VIEW: ['Detail karty', 'Card details'],
-  CARD_VIEW_TRANSACTIONS: ['Transakce karty', 'Card transactions'],
-  CARD_MANAGE_LIMITS: ['Limity karty', 'Card limits'],
-  CARD_MANAGE_STATUS: ['Blokace karty', 'Card status'],
-  CARD_MANAGE_CHANNELS: ['Kanály karty', 'Card channels'],
-  SAVINGS_DEPOSIT: ['Vklad', 'Deposit'],
-  SAVINGS_WITHDRAW: ['Výběr', 'Withdraw'],
-  SAVINGS_PROPOSE_WITHDRAW: ['Připravit výběr', 'Propose withdrawal'],
-  OBJECT_READ: ['Zobrazit', 'View'],
-}
 const rightLabel = (right: string, t: (cs: string, en: string) => string) => {
-  const label = RIGHT_LABELS[right]
-  return label ? t(label[0], label[1]) : right.replace(/^(ACCOUNT|SAVINGS|CARD|OBJECT)_/, '')
+  return t(capabilityLabel(right, 'cs'), capabilityLabel(right, 'en'))
 }

--- a/openbank-admin-ui/src/lib/delegations/rolePresets.ts
+++ b/openbank-admin-ui/src/lib/delegations/rolePresets.ts
@@ -10,6 +10,32 @@ export type RolePreset = { id: string; name: string; description: string; resour
 
 export type CapabilityIntent = 'view' | 'act' | 'manage'
 
+const CAPABILITY_LABELS: Record<string, [string, string]> = {
+  ACCOUNT_VIEW_DETAILS: ['Detail účtu', 'Account details'],
+  ACCOUNT_READ_BALANCES: ['Zůstatky', 'Balances'],
+  ACCOUNT_READ_TRANSACTIONS: ['Transakce', 'Transactions'],
+  ACCOUNT_DOWNLOAD_STATEMENTS: ['Výpisy', 'Statements'],
+  ACCOUNT_PROPOSE_PAYMENT: ['Připravit platbu', 'Propose payment'],
+  ACCOUNT_INITIATE_PAYMENT: ['Provést platbu', 'Execute payment'],
+  ACCOUNT_MANAGE_BENEFICIARIES: ['Příjemci', 'Beneficiaries'],
+  ACCOUNT_MANAGE_LIMITS: ['Limity účtu', 'Account limits'],
+  DELEGATION_MANAGE: ['Disponenti', 'Delegates'],
+  CARD_VIEW: ['Detail karty', 'Card details'],
+  CARD_VIEW_TRANSACTIONS: ['Transakce karty', 'Card transactions'],
+  CARD_MANAGE_LIMITS: ['Limity karty', 'Card limits'],
+  CARD_MANAGE_STATUS: ['Blokace karty', 'Card status'],
+  CARD_MANAGE_CHANNELS: ['Kanály karty', 'Card channels'],
+  SAVINGS_DEPOSIT: ['Vklad', 'Deposit'],
+  SAVINGS_WITHDRAW: ['Výběr', 'Withdraw'],
+  SAVINGS_PROPOSE_WITHDRAW: ['Připravit výběr', 'Propose withdrawal'],
+  OBJECT_READ: ['Zobrazit', 'View'],
+}
+
+export function capabilityLabel(capability: string, language: 'cs' | 'en'): string {
+  const label = CAPABILITY_LABELS[capability]
+  return label ? label[language === 'cs' ? 0 : 1] : capability.replace(/^(ACCOUNT|SAVINGS|CARD|OBJECT)_/, '')
+}
+
 export function capabilityIntent(capability: string): CapabilityIntent {
   if (capability.includes('_READ_') || capability.includes('_VIEW') || capability === 'OBJECT_READ' || capability.includes('DOWNLOAD')) return 'view'
   if (capability.includes('MANAGE') || capability === 'DELEGATION_MANAGE') return 'manage'

--- a/openbank-admin-ui/src/test/delegation-effective-access.test.ts
+++ b/openbank-admin-ui/src/test/delegation-effective-access.test.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest'
+import { matchedRoleName } from '@/components/delegations/EffectiveAccess'
+import type { Grant } from '@/components/delegations/GrantView'
+import type { RolePreset } from '@/lib/delegations/rolePresets'
+
+const grant = { resourceType: 'ACCOUNT', capabilities: ['ACCOUNT_READ_BALANCES', 'ACCOUNT_READ_TRANSACTIONS'] } as Grant
+const presets = [{ id: 'p1', name: 'Účetní', description: '', resourceType: 'ACCOUNT', capabilities: ['ACCOUNT_READ_TRANSACTIONS', 'ACCOUNT_READ_BALANCES'] }] as RolePreset[]
+
+describe('effective access role matching', () => {
+  it('matches a preset by resource and exact capability set regardless of ordering', () => {
+    expect(matchedRoleName(grant, presets, 'cs')).toBe('Účetní')
+  })
+
+  it('does not overstate a grant that only partly resembles a preset', () => {
+    expect(matchedRoleName({ ...grant, capabilities: ['ACCOUNT_READ_BALANCES'] }, presets, 'cs')).toBe('Vlastní kombinace práv')
+  })
+})

--- a/openbank-admin-ui/src/test/delegation-effective-access.test.ts
+++ b/openbank-admin-ui/src/test/delegation-effective-access.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest'
-import { matchedRoleName } from '@/components/delegations/EffectiveAccess'
+import { isEffectiveAccessPayload, matchedRoleName } from '@/components/delegations/EffectiveAccess'
 import type { Grant } from '@/components/delegations/GrantView'
 import type { RolePreset } from '@/lib/delegations/rolePresets'
 
@@ -14,5 +14,10 @@ describe('effective access role matching', () => {
 
   it('does not overstate a grant that only partly resembles a preset', () => {
     expect(matchedRoleName({ ...grant, capabilities: ['ACCOUNT_READ_BALANCES'] }, presets, 'cs')).toBe('Vlastní kombinace práv')
+  })
+
+  it('rejects a legacy grant payload instead of crashing the customer console', () => {
+    expect(isEffectiveAccessPayload({ ...grant, id: 'g1' })).toBe(false)
+    expect(isEffectiveAccessPayload({ accounts: [], cards: [], grants: [], presets: [], sources: { accounts: 'ok' } })).toBe(true)
   })
 })

--- a/openbank-admin-ui/src/test/delegations-routes.test.ts
+++ b/openbank-admin-ui/src/test/delegations-routes.test.ts
@@ -122,6 +122,47 @@ describe('GET /api/delegations/party/[partyId]', () => {
   })
 })
 
+describe('GET /api/delegations/effective-access/[partyId]', () => {
+  async function call(partyId: string) {
+    const { GET } = await import('@/app/api/delegations/effective-access/[partyId]/route')
+    return GET({} as never, { params: Promise.resolve({ partyId }) })
+  }
+
+  it('assembles owned resources, received grants and role presets from their authoritative services', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+      const url = String(input)
+      if (url.includes('/accounts?')) return new Response(JSON.stringify({ data: [{ id: 'a1', accountNumber: '1234' }] }), { status: 200 })
+      if (url.includes('/cards/party/')) return new Response(JSON.stringify([{ id: 'c1', maskedPan: '•••• 4321' }]), { status: 200 })
+      if (url.includes('/delegations/grantee/')) return new Response(JSON.stringify([grant('r1')]), { status: 200 })
+      return new Response(JSON.stringify([{ id: 'p1', name: 'Účetní', resourceType: 'ACCOUNT', capabilities: ['ACCOUNT_READ_BALANCES'] }]), { status: 200 })
+    }))
+
+    const response = await call(PARTY)
+    const body = await response.json()
+    expect(body.accounts[0].id).toBe('a1')
+    expect(body.cards[0].id).toBe('c1')
+    expect(body.grants[0].id).toBe('r1')
+    expect(body.presets[0].name).toBe('Účetní')
+    expect(body.sources).toEqual({ accounts: 'ok', cards: 'ok', grants: 'ok', presets: 'ok' })
+    expect(fetchCalls()).toHaveLength(4)
+  })
+
+  it('keeps successful ownership visible when another source is forbidden', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+      const url = String(input)
+      if (url.includes('/cards/party/')) return new Response('{}', { status: 403 })
+      if (url.includes('/accounts?')) return new Response(JSON.stringify([{ id: 'a1' }]), { status: 200 })
+      return new Response('[]', { status: 200 })
+    }))
+
+    const body = await (await call(PARTY)).json()
+    expect(body.accounts).toEqual([{ id: 'a1' }])
+    expect(body.cards).toEqual([])
+    expect(body.sources.cards).toBe('forbidden')
+    expect(body.sources.accounts).toBe('ok')
+  })
+})
+
 describe('GET /api/delegations/[id]', () => {
   async function call(id: string) {
     const { GET } = await import('@/app/api/delegations/[id]/route')


### PR DESCRIPTION
## Summary
- aggregate owned accounts, held cards, received grants, and role presets after selecting a party
- show the effective role, concrete resource, and localized rights in an educational card view
- preserve partial results when one authoritative source is forbidden or unavailable
- match role presets only by exact resource and capability set; unmatched grants remain visibly custom

## Verification
- npm run type-check
- targeted ESLint on all changed files
- 25 focused Vitest tests
- production build reached application compilation; local npm installation lacks the Rollup native optional package, so CI is the authoritative full-build gate

Closes #7839