### PR TITLE
fix(gates): ratchet clock-injection-gate min_subjects 70 -> 153 (floor had decayed to 23% of corpus)

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -2309,7 +2309,13 @@ gates:
     name: "clock-injection gate — domain/application layers (ADR-0100, #1612)"
     group: kotlin
     mode: enforced
-    min_subjects: 70   # 142 money-path domain/application files today (2026-08-09)
+    min_subjects: 153  # 306 money-path domain/application files today (2026-08-31, #6253).
+    # Was 70 = half of the 142 files counted on 2026-08-09. The corpus then more than doubled
+    # while the floor did not, so it had decayed to 23% of the corpus: measured under #6253,
+    # narrowing rules.yaml money_path_services back to the 8 services this gate shipped with
+    # (the ORIGINAL defect, named in check-clock-injection.sh's own header) scans 143 files and
+    # PASSED floor 70 with rc=0. 153 is half of today's count, per the seeding rule in
+    # check-gate-subject-floor.py.
     selftest: bash .github/scripts/check-clock-injection.sh --self-test
     selftest_expect: pass
     run: |


### PR DESCRIPTION
## What

Ratchets `clock-injection-gate`'s `min_subjects` from **70** to **153**. One value, one gate. `gates.yaml` holds **188** entries before and after — nothing added, nothing removed.

## Why

The floor's own comment recorded how it was set:

    min_subjects: 70   # 142 money-path domain/application files today (2026-08-09)

70 was half of 142, per the seeding rule in `check-gate-subject-floor.py` ("the seeded floors are roughly half of today's count, so the fleet can shrink normally without a red, while a corpus that vanished or narrowed by an order of magnitude cannot pass").

The corpus is **306** files today. The floor never moved, so it had decayed to **23%** of the corpus. Category (3) slack — accrued by fleet growth, not by anyone's mistake.

## Falsification (red-then-green, on the real gate, not a fixture)

The regression injected is this gate's *own* documented original defect, quoted from `check-clock-injection.sh`'s header:

> The gate shipped with no falsification AND with a hand-written scope of 8 services against rules.yaml's 23 — so it reported clean about two thirds of the money path it never looked at.

So the injection narrows `rules.yaml: money_path_services` from 23 back to 8, then runs the gate through `run-gates.py --only clock-injection-gate`. Exit codes read from `$?` after redirecting to a file, never through a pipe:

| tree | floor | `SUBJECTS=` | rc | verdict |
|---|---|---|---|---|
| scope narrowed to 8 services | 70 (old) | 143 | **0** | PASS — green with 53% of the money path unexamined |
| scope narrowed to 8 services | 153 (new) | 143 | **1** | FAIL |
| real tree, restored | 153 (new) | 306 | **0** | PASS |

`rules.yaml` was restored byte-for-byte afterwards (`git status --porcelain` shows only `.github/gates/gates.yaml` modified).

## Meta-gates on the edited manifest

    check-gate-lifecycle-metadata.py --today 2026-08-31 --enforce   rc=0  (0 ::error lines)
    check-gate-subject-floor.py --enforce                           rc=0
    run-gates.py --list                                             rc=0

## Scope

Deliberately one line. The wider census from #6253 — 188 gates, 70 with a floor, 99 printing no `SUBJECTS=` at all, 19 with no corpus — is posted as a comment on the issue rather than acted on here, because widening a gate's scope changes what fails and is the owner's call.

Refs #6253
