### PR TITLE
fix(lending): order pending pack proposals by the entity property, not the column

### DIFF
--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/CompliancePackActivationRepository.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/CompliancePackActivationRepository.kt
@@ -87,7 +87,7 @@ class JpaCompliancePackActivationRepository :
 
     @WithSession
     override fun findByState(state: ProposalState): Uni<List<CompliancePackActivationEntity>> =
-        list("state = ?1 order by proposed_at", state)
+        list("state = ?1 order by proposedAt", state)
 
     @WithSession
     override fun findActivated(): Uni<List<CompliancePackActivationEntity>> = list(

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/integration/CompliancePackActivationIT.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/integration/CompliancePackActivationIT.kt
@@ -210,4 +210,30 @@ class CompliancePackActivationIT {
         assertThat(body).contains("\"pack\":{")
         assertThat(body).contains("\"jurisdiction\":\"CZ\"")
     }
+
+    /**
+     * The pending-proposals list, which had never been called by any test.
+     *
+     * `findByState` ordered by `proposed_at` -- the COLUMN name. HQL resolves entity PROPERTIES, and
+     * the property is `proposedAt`, so Hibernate answered `SemanticException: Could not interpret
+     * path expression 'proposed_at'` and this plain no-parameter GET returned 500 on every call
+     * since it shipped (#5913). The query is parsed when it is built, so the failure needs no rows
+     * and no malformed input: reaching the endpoint at all is the whole test.
+     *
+     * Invisible to `CompliancePackActivationServiceTest`, which mocks the repository -- the same
+     * shape as the consent `SuppressionEntity` defect (#5711). Only a real Hibernate session can
+     * tell a valid HQL path from an invalid one.
+     */
+    @Test
+    @Order(5)
+    @TestSecurity(user = "pack-it-reader", roles = ["ROLE_COMPLIANCE"])
+    fun `5 - the pending proposals list is queryable`() {
+        Given {
+            contentType("application/json")
+        } When {
+            get("/api/v1/lending/compliance-packs/proposals/pending")
+        } Then {
+            statusCode(200)
+        }
+    }
 }


### PR DESCRIPTION
## What

`GET /api/v1/lending/compliance-packs/proposals/pending` has answered **500 on every call since it shipped**. `CompliancePackActivationRepository.findByState` built the Panache query `state = ?1 order by proposed_at` — HQL resolves entity **properties**, and the property is `proposedAt`; `proposed_at` is only the `@Column` name.

```
org.hibernate.query.SemanticException: Could not interpret path expression 'proposed_at'
```

This is a plain no-parameter `GET`. The query is parsed when it is built, so the failure needs no rows and no malformed input — reaching the endpoint at all is enough.

## Why nothing caught it

- `CompliancePackActivationServiceTest` mocks the repository, so it cannot tell a valid HQL path from an invalid one.
- `CompliancePackActivationIT` exercised propose, decide and `/active` — but never the pending list.

Same shape as the consent `SuppressionEntity` defect (#5711): a name that exists in only one of the two worlds.

## Proven by what it prevents

The new `CompliancePackActivationIT` case 5 is a real-database `@QuarkusTest` that GETs the endpoint and asserts 200.

| run | result |
|---|---|
| against unmodified `main` | **RED** — `5 tests completed, 1 failed`, cause `SemanticException: Could not interpret path expression 'proposed_at'` |
| with this change | **GREEN** — `tests=5 skipped=0 failures=0 errors=0` |

Skipped count read from the JUnit XML, not the console. `ktlintCheck` + `detekt` exit 0.

## Scope

Behaviour fix only. No API contract change, so no `openapi.yaml` bump. Nothing else in this PR — the other #5913 findings are split per service so each can move independently.

Refs #5913
