### PR TITLE
fix(ledger): answer 400 for a null journal line and an absent body, not 500

### DIFF
--- a/docs/threat-models/openbank-ledger-service.md
+++ b/docs/threat-models/openbank-ledger-service.md
@@ -242,6 +242,23 @@ set) apply equally to the new `ledger.approval.decide` action.
 
 ## 8. Change log
 
+- **2026-09-01** — `POST /api/v1/journals` answered **500** rather than 400 for two shapes of
+  malformed input: a `null` element inside the `lines` array, and an absent request body. Neither
+  crossed a trust boundary, moved money or bypassed a control — `@RolesAllowed(OPERATOR)`, the
+  `@Authorize(action = "ledger.create")` OPA gate and `validateBalance()` all run unchanged, and
+  the request failed before reaching the domain in both cases. It is recorded here because the
+  inbound REST surface changed shape: `PostJournalRequest.lines` is now `List<PostJournalLineRequest?>`
+  and the body parameter is nullable, so the `requireNotNull` guards are reachable instead of dead
+  code (Jackson's Kotlin module null-checks constructor parameters, never collection elements; and
+  a `suspend fun` emits no `Intrinsics.checkNotNullParameter`, so the injected null flowed into the
+  body and died at the first dereference). **STRIDE-D:** the 5xx was the availability-signal defect
+  — a caller could not distinguish "I sent a bad request" from "the server is broken", which on a
+  money path decides whether it retries, and it burned SLO error budget on client error. Both now
+  raise `IllegalArgumentException`, mapped to 400 by libs-runtime's `CommonExceptionMappers`; no
+  service-local mapper is added (#526). No new caller, endpoint, role, network edge or privilege.
+  Rollback: revert the two declarations to their non-nullable form, restoring the 500.
+  Refs #5913.
+
 - **2026-08-26** — `POST /api/v1/journals` now copies the trusted synthetic classification from
   `SyntheticTaintRequestFilter` into the `JournalPosted` and derived `AccountBookedChanged` outbox
   rows for that posting. The REST resource reads only the server-side request property after the

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/LedgerResource.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/LedgerResource.kt
@@ -134,17 +134,21 @@ class LedgerResource(
     @Authorize(action = "ledger.create", resource = "")
     @Operation(summary = "Post a balanced journal entry")
     suspend fun postJournal(
-        request: PostJournalRequest,
+        // Nullable on purpose: JAX-RS injects null for an absent body, and a `suspend fun` emits no
+        // `Intrinsics.checkNotNullParameter`, so a non-nullable declaration would let that null flow
+        // into the body and NPE at the first dereference -- a 500 for what is a malformed request.
+        request: PostJournalRequest?,
         @Context
         requestContext: ContainerRequestContext,
     ): Response {
+        requireNotNull(request) { "a request body is required" }
         val command = PostJournalCommand(
             idempotencyKey = request.idempotencyKey,
             transactionId = request.transactionId,
             entryDate = LocalDate.parse(request.entryDate),
             valueDate = LocalDate.parse(request.valueDate),
             description = request.description,
-            lines = request.lines.map { it.toCommand() },
+            lines = request.requireLines().map { it.toCommand() },
             postedBy = request.createdBy,
             // The filter sets this property only after authenticating a configured canary
             // principal. Never accept a caller-supplied header or coroutine MDC as synthetic.
@@ -219,8 +223,28 @@ data class PostJournalRequest(
     val valueDate: String,
     val description: String? = null,
     val createdBy: UUID,
-    val lines: List<PostJournalLineRequest>,
-)
+    /**
+     * Declared with a NULLABLE element type on purpose, because that is the truth on the wire.
+     *
+     * Jackson's Kotlin module null-checks CONSTRUCTOR PARAMETERS; it does not check the ELEMENTS of
+     * a collection. So `"lines": [null]` deserialises happily into a `List<PostJournalLineRequest>`
+     * holding a null, and Kotlin's non-null element type is a compile-time promise nothing keeps.
+     * Writing the type honestly is what makes [requireLines] reachable instead of dead code.
+     */
+    val lines: List<PostJournalLineRequest?>,
+) {
+    /**
+     * The lines, with every element proven present.
+     *
+     * `IllegalArgumentException` is mapped to 400 by libs-runtime's `CommonExceptionMappers`, so no
+     * service-local mapper is needed or wanted (two mappers for one type are selected at random per
+     * request, #526).
+     */
+    fun requireLines(): List<PostJournalLineRequest> =
+        lines.mapIndexed { index, line ->
+            requireNotNull(line) { "lines[$index] must not be null" }
+        }
+}
 
 data class ReverseJournalRequest(val reason: String, val reversedBy: UUID)
 

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/LedgerResource.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/LedgerResource.kt
@@ -240,10 +240,9 @@ data class PostJournalRequest(
      * service-local mapper is needed or wanted (two mappers for one type are selected at random per
      * request, #526).
      */
-    fun requireLines(): List<PostJournalLineRequest> =
-        lines.mapIndexed { index, line ->
-            requireNotNull(line) { "lines[$index] must not be null" }
-        }
+    fun requireLines(): List<PostJournalLineRequest> = lines.mapIndexed { index, line ->
+        requireNotNull(line) { "lines[$index] must not be null" }
+    }
 }
 
 data class ReverseJournalRequest(val reason: String, val reversedBy: UUID)

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/LedgerApiIT.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/LedgerApiIT.kt
@@ -319,4 +319,53 @@ class LedgerApiIT {
         // Post + reverse must leave every account's net position exactly where it started.
         assertThat(netByAccount()).isEqualTo(netBefore)
     }
+
+    /**
+     * A `null` element inside the `lines` array, and an absent body.
+     *
+     * Kotlin's `List<PostJournalLineRequest>` is a compile-time promise Jackson does not keep: the
+     * Kotlin module null-checks CONSTRUCTOR PARAMETERS, never the ELEMENTS of a collection, so
+     * `"lines": [null]` deserialises to a list holding a null. `request.lines.map { it.toCommand() }`
+     * then threw NPE and `GenericExceptionMapper` answered 500 (#5913).
+     *
+     * The absent body is the same defect one level up. `postJournal` is a `suspend fun`, and the
+     * Kotlin compiler emits NO `Intrinsics.checkNotNullParameter` for a suspending function, so the
+     * null does not fail at offset 0 -- it flows into the body and dies at the first dereference.
+     *
+     * Both are malformed input, so both must be 400. A client cannot tell "I sent a bad request"
+     * from "the server is broken", and on a money path that difference decides whether it retries.
+     */
+    @Test
+    @Order(20)
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `POST journals answers 400 for a null line and for an absent body`() {
+        val today = LocalDate.now().toString()
+        val withNullLine = """
+            {
+              "idempotencyKey": "${UUID.randomUUID()}",
+              "transactionId": "${UUID.randomUUID()}",
+              "entryDate": "$today",
+              "valueDate": "$today",
+              "createdBy": "$operatorId",
+              "lines": [null]
+            }
+        """.trimIndent()
+
+        Given {
+            contentType("application/json")
+            body(withNullLine)
+        } When {
+            post("/api/v1/journals")
+        } Then {
+            statusCode(400)
+        }
+
+        Given {
+            contentType("application/json")
+        } When {
+            post("/api/v1/journals")
+        } Then {
+            statusCode(400)
+        }
+    }
 }


### PR DESCRIPTION
## What

`POST /api/v1/journals` returned **500** for two shapes of malformed input. Both are now **400**.

### 1. A null element in the `lines` array

Jackson's Kotlin module null-checks constructor **parameters**; it does not check the **elements** of a collection. So `"lines": [null]` deserialised into a `List<PostJournalLineRequest>` holding a null, and:

```
java.lang.NullPointerException: Cannot invoke
  "com.openbank.ledger.infrastructure.rest.PostJournalLineRequest.toCommand()" because "it" is null
```

The non-null element type was a compile-time promise nothing kept. `lines` is now declared `List<PostJournalLineRequest?>` — the truth on the wire — which is what makes the `requireNotNull` guard **reachable** rather than dead code.

### 2. An absent request body

`postJournal` is a `suspend fun`, and the Kotlin compiler emits **no** `Intrinsics.checkNotNullParameter` for a suspending function. The injected null therefore did not fail at offset 0; it flowed into the body and died at the first dereference. The parameter is now nullable with an explicit `requireNotNull` — the same shape the fleet rule already mandates for `@QueryParam`/`@HeaderParam` (#3104, #3624), applied one level up to the body entity, which `check-nonnull-jaxrs-params.py` does not cover.

Both now raise `IllegalArgumentException`, which libs-runtime's `CommonExceptionMappers` renders as 400 with the `ApiError` envelope and a traceId. **No service-local mapper is added** (#526).

## Proven by what it prevents

New `LedgerApiIT` case asserting 400 for both shapes.

| run | result |
|---|---|
| against unmodified `main` | **RED** — `12 tests completed, 1 failed`, cause the NPE quoted above |
| with this change | **GREEN** — `tests=12 skipped=0 failures=0` |

Full module gate: `:openbank-ledger-service:test` → **311 tests, 0 failures, 1 skipped**. The single skip is `LedgerPactBrokerProviderVerificationTest`, the known `@EnabledIfSystemProperty(pactbroker.url)` broker-sourced class, identified by name rather than assumed. `ktlintCheck` + `detekt` exit 0.

## Scope

Behaviour fix only, and it only ever converts a 500 into a 400 — every request that succeeded before still succeeds. No API contract change, so no `openapi.yaml` bump. Split per service so each #5913 finding can move independently.

Refs #5913
