### PR TITLE
fix(party): answer 400 for a null phone hash in a directory lookup, not 500

### DIFF
--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
@@ -157,7 +157,7 @@ class PartyResource {
     @RolesAllowed("ROLE_API")
     @Operation(summary = "Match phone-number hashes against parties who opted into being discoverable")
     suspend fun lookupDirectory(req: DirectoryLookupRequest): Response =
-        Response.ok(mapOf("matches" to partyUseCase.lookupByPhoneHashes(req.phoneHashes))).build()
+        Response.ok(mapOf("matches" to partyUseCase.lookupByPhoneHashes(req.requireHashes()))).build()
 
     /** Turn this party's pay-to-phone findability on or off. Revocable at any time. */
     @PUT
@@ -774,7 +774,30 @@ private const val GDPR_EXPORT_SCOPE =
         "subject-access response is a tracked follow-up (ADR-0118 §6)."
 
 /** Address-book hashes to match. See PhoneDirectory for what the hashing does and does not buy. */
-data class DirectoryLookupRequest(val phoneHashes: List<String> = emptyList())
+data class DirectoryLookupRequest(
+    /**
+     * Declared with a NULLABLE element type on purpose, because that is the truth on the wire.
+     *
+     * Jackson's Kotlin module null-checks CONSTRUCTOR PARAMETERS; it does not check the ELEMENTS of
+     * a collection. So `{"phoneHashes": [null]}` deserialises happily into a `List<String>` holding
+     * a null, and `PartyService.lookupByPhoneHashes` NPEs on `it.trim()`. Kotlin's non-null element
+     * type was a compile-time promise nothing kept; writing the type honestly is what makes
+     * [requireHashes] reachable instead of dead code.
+     */
+    val phoneHashes: List<String?> = emptyList(),
+) {
+    /**
+     * The hashes, with every element proven present.
+     *
+     * A null ENTRY is a malformed JSON document, which is a different thing from the malformed
+     * hash CONTENT the use case already tolerates by design (it silently drops anything that is not
+     * 64 hex characters). `IllegalArgumentException` is mapped to 400 by libs-runtime's
+     * `CommonExceptionMappers`; no service-local mapper is added (#526).
+     */
+    fun requireHashes(): List<String> = phoneHashes.mapIndexed { index, hash ->
+        requireNotNull(hash) { "phoneHashes[$index] must not be null" }
+    }
+}
 
 data class DiscoverableRequest(val discoverable: Boolean = false)
 

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/integration/PartyApiIT.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/integration/PartyApiIT.kt
@@ -401,4 +401,40 @@ class PartyApiIT {
             statusCode(403)
         }
     }
+
+    /**
+     * An absent body, and a null element inside `phoneHashes`.
+     *
+     * `lookupDirectory` is a `suspend fun`, and the Kotlin compiler emits NO
+     * `Intrinsics.checkNotNullParameter` for a suspending function, so the null JAX-RS injects for
+     * an absent body did not fail at offset 0 -- it flowed into the body and died at the first
+     * dereference with `Parameter specified as non-null is null` (#5913).
+     *
+     * The null element is the same defect one level down: Jackson's Kotlin module null-checks
+     * constructor PARAMETERS, never the ELEMENTS of a collection, so `[null]` deserialises into a
+     * `List<String>` holding a null and `PartyService.lookupByPhoneHashes` NPEs on `it.trim()`.
+     *
+     * Both are malformed input from the customer edge, so both must be 400.
+     */
+    @Test
+    @Order(24)
+    @TestSecurity(user = "directory-lookup-it", roles = ["ROLE_API"])
+    fun `POST directory lookup answers 400 for an absent body and for a null hash`() {
+        Given {
+            contentType("application/json")
+        } When {
+            post("/api/v1/parties/directory/lookup")
+        } Then {
+            statusCode(400)
+        }
+
+        Given {
+            contentType("application/json")
+            body("""{"phoneHashes": [null]}""")
+        } When {
+            post("/api/v1/parties/directory/lookup")
+        } Then {
+            statusCode(400)
+        }
+    }
 }


### PR DESCRIPTION
## What

`POST /api/v1/parties/directory/lookup` returned **500** for `{"phoneHashes": [null]}`. It is now **400**.

Jackson's Kotlin module null-checks constructor **parameters**; it does not check the **elements** of a collection. So the array deserialised into a `List<String>` holding a null and:

```
java.lang.NullPointerException: Parameter specified as non-null is null:
  method ...PartyService.lookupByPhoneHashes$lambda$0, parameter it
```

The non-null element type was a compile-time promise nothing kept. `phoneHashes` is now declared `List<String?>` — the truth on the wire — which is what makes the `requireNotNull` guard **reachable** rather than dead code.

## The one judgement call in here, stated so it can be overridden

This **rejects** the null rather than filtering it. A null *entry* is a malformed JSON document, which is a different thing from the malformed hash *content* the use case already tolerates by design (`lookupByPhoneHashes` silently drops anything that is not 64 hex characters). If you would rather this endpoint stay uniformly lenient, `requireHashes()` becomes `phoneHashes.filterNotNull()` and the test's second assertion becomes 200 — a one-line change either way.

## A correction to #5913 that I measured

The issue attributes this endpoint's 500 to `NullPointerException: Parameter specified as non-null is null`, which reads like the absent-body case. **An absent body on this endpoint already answers 400 today** — I asserted it before touching anything and it passed against unmodified `main`. The cause line is reached by the null list element instead, so the method signature is left alone.

## Proven by what it prevents

New `PartyApiIT` case asserting 400 for both the absent body and the null hash.

| run | result |
|---|---|
| against unmodified `main` | **RED** — `22 tests completed, 1 failed`, cause the NPE quoted above (the absent-body assertion passed, which is how the correction above was established) |
| with this change | **GREEN** |

Full module gate: `:openbank-party-service:test` → **181 tests, 0 failures, 1 skipped**. The single skip is `PartyEventPactProviderVerificationTest`, the known broker-sourced class, identified by name rather than assumed. `ktlintCheck` + `detekt` exit 0.

## Also verified while here, needing no change

The other party finding in #5913 — `PUT /api/v1/parties/{id}/payees` failing with `relation "party_payees_seq" does not exist` — is **already fixed on `main`** by migration `V19__fix_quoted_sequence_names.sql`, and covered by `PartySequenceAllocationIT`, which cites #5913 in its own KDoc.

## Scope

Behaviour fix only, and it only ever converts a 500 into a 400. No API contract change, so no `openapi.yaml` bump.

Refs #5913
