### PR TITLE
fix(admin-ui): make role catalog mutations recoverable

### DIFF
--- a/openbank-admin-ui/e2e/delegations-console.spec.ts
+++ b/openbank-admin-ui/e2e/delegations-console.spec.ts
@@ -20,6 +20,13 @@ const PARTY = '018f4a3c-1b2d-7e00-9a11-000000000001'
 const GRANTEE = '018f4a3c-1b2d-7e00-9a11-0000000000ff'
 const GRANT = '018f4a3c-1b2d-7e00-9a11-000000000002'
 const RESOURCE = '018f4a3c-1b2d-7e00-9a11-000000000003'
+const ROLE_PRESET = {
+  id: '018f4a3c-1b2d-7e00-9a11-000000000004',
+  name: 'Účetní',
+  description: 'Čte zůstatky a historii účtu.',
+  resourceType: 'ACCOUNT',
+  capabilities: ['ACCOUNT_READ_BALANCES'],
+}
 
 const GRANT_ROW = {
   id: GRANT,
@@ -144,6 +151,81 @@ test('a refused direction never renders as "no delegations"', async ({ page }) =
   await expect(main.getByText(/nebyl povolen|was refused for your role/)).toBeVisible()
   // The dangerous wrong answer must NOT be on screen for the refused direction.
   await expect(main.getByText(/Žádné delegace\.|No delegations\./)).toHaveCount(1)
+})
+
+test('role deletion explains impact and recovers from a failed request before removing the preset', async ({ page }) => {
+  await page.addInitScript(() => window.localStorage.setItem('openbank-admin-lang', 'cs'))
+  await stubBff(page)
+
+  let roles = [ROLE_PRESET]
+  let deleteAttempts = 0
+  await page.route('**/api/delegation-role-presets**', route => {
+    const request = route.request()
+    if (request.method() === 'DELETE') {
+      deleteAttempts += 1
+      if (deleteAttempts === 1) {
+        return route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ error: 'temporarily unavailable' }) })
+      }
+      roles = []
+      return route.fulfill({ status: 204, body: '' })
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(roles) })
+  })
+
+  await page.goto('/delegations')
+  await expect(page.getByRole('heading', { name: ROLE_PRESET.name, exact: true })).toBeVisible()
+  await page.getByRole('button', { name: `Smazat ${ROLE_PRESET.name}` }).click()
+
+  const dialog = page.getByRole('alertdialog', { name: `Smazat roli „${ROLE_PRESET.name}“?` })
+  await expect(dialog).toBeVisible()
+  await expect(dialog).toContainText('Již udělená práva se nezmění ani neodvolají.')
+
+  await dialog.getByRole('button', { name: 'Smazat preset' }).click()
+  await expect(dialog.getByRole('alert')).toContainText('Nic se nezměnilo; zkuste to znovu.')
+  await expect(page.getByRole('heading', { name: ROLE_PRESET.name, exact: true })).toBeVisible()
+
+  await dialog.getByRole('button', { name: 'Smazat preset' }).click()
+  await expect(dialog).toBeHidden()
+  await expect(page.getByRole('heading', { name: ROLE_PRESET.name, exact: true })).toHaveCount(0)
+  await expect(page.getByRole('heading', { name: 'Dispoziční role a práva' })).toBeFocused()
+  expect(deleteAttempts).toBe(2)
+})
+
+test('role creation stays editable after failure and retries without a duplicate submission', async ({ page }) => {
+  await page.addInitScript(() => window.localStorage.setItem('openbank-admin-lang', 'cs'))
+  await stubBff(page)
+
+  let roles: typeof ROLE_PRESET[] = []
+  let createAttempts = 0
+  await page.route('**/api/delegation-role-presets**', async route => {
+    const request = route.request()
+    if (request.method() === 'POST') {
+      createAttempts += 1
+      if (createAttempts === 1) {
+        return route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ error: 'temporarily unavailable' }) })
+      }
+      const payload = request.postDataJSON() as Omit<typeof ROLE_PRESET, 'id'>
+      roles = [{ ...payload, id: ROLE_PRESET.id }]
+      return route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(roles[0]) })
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(roles) })
+  })
+
+  await page.goto('/delegations')
+  await page.getByRole('button', { name: 'Přidat roli' }).click()
+  const editor = page.getByRole('dialog', { name: 'Nastavení dispoziční role' })
+  await editor.getByRole('textbox', { name: 'Název' }).fill(ROLE_PRESET.name)
+  await editor.getByRole('textbox', { name: 'Popis' }).fill(ROLE_PRESET.description)
+  await editor.getByRole('checkbox').first().check()
+
+  await editor.getByRole('button', { name: 'Uložit' }).click()
+  await expect(editor.getByRole('alert')).toContainText('Nic se nezměnilo; zkontrolujte údaje a zkuste to znovu.')
+  await expect(editor.getByRole('textbox', { name: 'Název' })).toHaveValue(ROLE_PRESET.name)
+
+  await editor.getByRole('button', { name: 'Uložit' }).click()
+  await expect(editor).toBeHidden()
+  await expect(page.getByRole('heading', { name: ROLE_PRESET.name, exact: true })).toBeVisible()
+  expect(createAttempts).toBe(2)
 })
 
 test('the grant detail offers NO mutation — suspend, reinstate and revoke are absent from the wire', async ({ page }) => {

--- a/openbank-admin-ui/src/components/delegations/RoleCatalog.tsx
+++ b/openbank-admin-ui/src/components/delegations/RoleCatalog.tsx
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
-import { Check, LayoutGrid, Pencil, Plus, Shield, Table2, Trash2, X } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { AlertTriangle, Check, LayoutGrid, Pencil, Plus, Shield, Table2, Trash2, X } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { useAuth } from '@/lib/auth/useAuth'
+import { trapDialogFocus } from '@/lib/a11y/trapDialogFocus'
 import { CAPABILITIES_BY_RESOURCE, capabilityIntent, capabilityLabel, type CapabilityIntent, type DelegationResource, type RolePreset } from '@/lib/delegations/rolePresets'
 
 const emptyRole = (): RolePreset => ({ id: '', name: '', description: '', resourceType: 'ACCOUNT', capabilities: [] })
@@ -17,6 +18,13 @@ export function RoleCatalog() {
   const [resource, setResource] = useState<DelegationResource>('ACCOUNT')
   const [view, setView] = useState<'overview' | 'matrix'>('overview')
   const [editing, setEditing] = useState<RolePreset | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState(false)
+  const [pendingRemoval, setPendingRemoval] = useState<RolePreset | null>(null)
+  const [removing, setRemoving] = useState(false)
+  const [removeError, setRemoveError] = useState(false)
+  const removeReturnFocusRef = useRef<HTMLButtonElement | null>(null)
+  const catalogTitleRef = useRef<HTMLHeadingElement | null>(null)
   const [state, setState] = useState<'loading' | 'ready' | 'error'>('loading')
 
   const load = useCallback(async () => {
@@ -34,25 +42,70 @@ export function RoleCatalog() {
 
   const rights = CAPABILITIES_BY_RESOURCE[resource]
   const visibleRoles = roles.filter(role => role.resourceType === resource)
+  const openEditor = (role: RolePreset) => {
+    setSaveError(false)
+    setEditing(role)
+  }
+  const closeEditor = () => {
+    if (saving) return
+    setEditing(null)
+    setSaveError(false)
+  }
   const save = async (role: RolePreset) => {
     const payload = { name: role.name.trim(), description: role.description.trim(), resourceType: role.resourceType, capabilities: role.capabilities }
-    const response = await fetch(role.id ? `/api/delegation-role-presets/${role.id}` : '/api/delegation-role-presets', {
-      method: role.id ? 'PUT' : 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payload),
-    })
-    if (!response.ok) return
-    setEditing(null); await load()
+    setSaving(true)
+    setSaveError(false)
+    try {
+      const response = await fetch(role.id ? `/api/delegation-role-presets/${role.id}` : '/api/delegation-role-presets', {
+        method: role.id ? 'PUT' : 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payload),
+      })
+      if (!response.ok) {
+        setSaveError(true)
+        return
+      }
+      setEditing(null)
+      await load()
+    } catch {
+      setSaveError(true)
+    } finally {
+      setSaving(false)
+    }
+  }
+  const requestRemoval = (role: RolePreset, trigger: HTMLButtonElement) => {
+    removeReturnFocusRef.current = trigger
+    setRemoveError(false)
+    setPendingRemoval(role)
+  }
+  const closeRemoval = () => {
+    if (removing) return
+    setPendingRemoval(null)
+    setRemoveError(false)
+    queueMicrotask(() => removeReturnFocusRef.current?.focus())
   }
   const remove = async (role: RolePreset) => {
-    if (!window.confirm(t(`Smazat roli „${role.name}“? Existující granty se nezmění.`, `Delete “${role.name}”? Existing grants will not change.`))) return
-    const response = await fetch(`/api/delegation-role-presets/${role.id}`, { method: 'DELETE' })
-    if (response.ok) await load()
+    setRemoving(true)
+    setRemoveError(false)
+    try {
+      const response = await fetch(`/api/delegation-role-presets/${role.id}`, { method: 'DELETE' })
+      if (!response.ok) {
+        setRemoveError(true)
+        return
+      }
+      setPendingRemoval(null)
+      await load()
+      queueMicrotask(() => catalogTitleRef.current?.focus())
+    } catch {
+      setRemoveError(true)
+    } finally {
+      setRemoving(false)
+    }
   }
 
   return <section className="card" style={{ padding: 16, marginBottom: 20 }} aria-labelledby="role-catalog-title">
     <div style={{ display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'flex-start', marginBottom: 14 }}>
-      <div><h2 id="role-catalog-title" style={{ fontSize: 16, fontWeight: 700, display: 'flex', gap: 8, alignItems: 'center' }}><Shield size={17} color="var(--accent)" />{t('Dispoziční role a práva', 'Delegation roles and rights')}</h2>
+      <div><h2 ref={catalogTitleRef} tabIndex={-1} id="role-catalog-title" style={{ fontSize: 16, fontWeight: 700, display: 'flex', gap: 8, alignItems: 'center' }}><Shield size={17} aria-hidden="true" color="var(--accent)" />{t('Dispoziční role a práva', 'Delegation roles and rights')}</h2>
         <p style={{ fontSize: 12, color: 'var(--text-tertiary)', marginTop: 3 }}>{t('Centrální presety pro nové delegace. Změna presetu nemění již udělená práva.', 'Central presets for new delegations. Changing one never alters existing grants.')}</p></div>
-      {canManage && <button className="btn btn-primary" onClick={() => setEditing(emptyRole())}><Plus size={14} />{t('Přidat roli', 'Add role')}</button>}
+      {canManage && <button type="button" className="btn btn-primary" onClick={() => openEditor(emptyRole())}><Plus size={14} aria-hidden="true" />{t('Přidat roli', 'Add role')}</button>}
     </div>
     {state === 'loading' && <div style={{ padding: 20, color: 'var(--text-tertiary)' }}>{t('Načítám katalog…', 'Loading catalog…')}</div>}
     {state === 'error' && <div style={{ padding: 20, color: 'var(--text-tertiary)' }}>{t('Katalog rolí není dostupný.', 'Role catalog is unavailable.')}</div>}
@@ -74,25 +127,26 @@ export function RoleCatalog() {
           <button type="button" className={view === 'matrix' ? 'btn btn-primary' : 'btn btn-secondary'} aria-pressed={view === 'matrix'} onClick={() => setView('matrix')}><Table2 size={14} />{t('Porovnat', 'Compare')}</button>
         </div>
       </div>
-      {view === 'overview' && <RoleOverview roles={visibleRoles} canManage={canManage} edit={setEditing} remove={remove} />}
+      {view === 'overview' && <RoleOverview roles={visibleRoles} canManage={canManage} edit={openEditor} remove={requestRemoval} />}
       {view === 'matrix' && <div style={{ overflowX: 'auto' }}><table className="table" style={{ width: '100%', minWidth: 760 }}><thead><tr><th style={stickyRoleStyle}>{t('Role', 'Role')}</th>
       {rights.map(right => <th key={right} title={rightLabel(right, t)} style={{ textAlign: 'center', fontSize: 10, minWidth: 92 }}>{rightLabel(right, t)}</th>)}{canManage && <th aria-label={t('Akce', 'Actions')} />}</tr></thead>
       <tbody>{visibleRoles.map(role => <tr key={role.id}><td style={stickyRoleStyle}><strong>{role.name}</strong><div style={{ fontSize: 11, color: 'var(--text-tertiary)', maxWidth: 280 }}>{role.description}</div></td>
         {rights.map(right => <td key={right} style={{ textAlign: 'center' }}>{role.capabilities.includes(right) ? <Check size={15} color="var(--success)" aria-label={t('Povoleno', 'Allowed')} /> : '—'}</td>)}
-        {canManage && <td><div style={{ display: 'flex', gap: 4 }}><button className="btn btn-secondary" onClick={() => setEditing({ ...role, capabilities: [...role.capabilities] })} aria-label={`${t('Upravit', 'Edit')} ${role.name}`}><Pencil size={13} /></button><button className="btn btn-secondary" onClick={() => void remove(role)} aria-label={`${t('Smazat', 'Delete')} ${role.name}`}><Trash2 size={13} /></button></div></td>}</tr>)}</tbody></table></div>
+        {canManage && <td><div style={{ display: 'flex', gap: 4 }}><button type="button" className="btn btn-secondary" onClick={() => openEditor({ ...role, capabilities: [...role.capabilities] })} aria-label={`${t('Upravit', 'Edit')} ${role.name}`}><Pencil size={13} aria-hidden="true" /></button><button type="button" className="btn btn-secondary" onClick={event => requestRemoval(role, event.currentTarget)} aria-label={`${t('Smazat', 'Delete')} ${role.name}`}><Trash2 size={13} aria-hidden="true" /></button></div></td>}</tr>)}</tbody></table></div>
       }
     </>}
-    {editing && <Editor value={editing} cancel={() => setEditing(null)} save={save} />}
+    {editing && <RoleEditor value={editing} busy={saving} failed={saveError} cancel={closeEditor} save={save} />}
+    {pendingRemoval && <DeleteRoleDialog role={pendingRemoval} busy={removing} failed={removeError} onCancel={closeRemoval} onConfirm={() => void remove(pendingRemoval)} />}
   </section>
 }
 
-function RoleOverview({ roles, canManage, edit, remove }: { roles: RolePreset[]; canManage: boolean; edit: (role: RolePreset) => void; remove: (role: RolePreset) => Promise<void> }) {
+function RoleOverview({ roles, canManage, edit, remove }: { roles: RolePreset[]; canManage: boolean; edit: (role: RolePreset) => void; remove: (role: RolePreset, trigger: HTMLButtonElement) => void }) {
   const { t } = useLanguage()
   return <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 330px), 1fr))', gap: 12 }}>
     {roles.map(role => <article key={role.id} style={{ border: '1px solid var(--border)', borderRadius: 12, padding: 16, background: 'linear-gradient(145deg, var(--surface-1), var(--surface-2))' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'flex-start' }}>
         <div><h3 style={{ fontSize: 15, fontWeight: 750 }}>{role.name}</h3><p style={{ fontSize: 12, color: 'var(--text-tertiary)', marginTop: 4, lineHeight: 1.5 }}>{role.description}</p></div>
-        {canManage && <div style={{ display: 'flex', gap: 4 }}><button className="btn btn-secondary" onClick={() => edit({ ...role, capabilities: [...role.capabilities] })} aria-label={`${t('Upravit', 'Edit')} ${role.name}`}><Pencil size={13} /></button><button className="btn btn-secondary" onClick={() => void remove(role)} aria-label={`${t('Smazat', 'Delete')} ${role.name}`}><Trash2 size={13} /></button></div>}
+        {canManage && <div style={{ display: 'flex', gap: 4 }}><button type="button" className="btn btn-secondary" onClick={() => edit({ ...role, capabilities: [...role.capabilities] })} aria-label={`${t('Upravit', 'Edit')} ${role.name}`}><Pencil size={13} aria-hidden="true" /></button><button type="button" className="btn btn-secondary" onClick={event => remove(role, event.currentTarget)} aria-label={`${t('Smazat', 'Delete')} ${role.name}`}><Trash2 size={13} aria-hidden="true" /></button></div>}
       </div>
       <div style={{ display: 'grid', gap: 10, marginTop: 14 }}>
         {(['view', 'act', 'manage'] as CapabilityIntent[]).map(intent => {
@@ -107,17 +161,50 @@ function RoleOverview({ roles, canManage, edit, remove }: { roles: RolePreset[];
   </div>
 }
 
-function Editor({ value, cancel, save }: { value: RolePreset; cancel: () => void; save: (role: RolePreset) => Promise<void> }) {
+export function DeleteRoleDialog({ role, busy, failed, onCancel, onConfirm }: { role: RolePreset; busy: boolean; failed: boolean; onCancel: () => void; onConfirm: () => void }) {
+  const { t } = useLanguage()
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const titleId = `delete-role-${role.id}-title`
+  const impactId = `delete-role-${role.id}-impact`
+  return <div
+    ref={dialogRef}
+    role="alertdialog"
+    aria-modal="true"
+    aria-labelledby={titleId}
+    aria-describedby={impactId}
+    aria-busy={busy}
+    onKeyDown={event => {
+      if (event.key === 'Escape' && !busy) onCancel()
+      trapDialogFocus(event, dialogRef.current)
+    }}
+    style={{ position: 'fixed', inset: 0, zIndex: 1200, background: 'rgba(15,23,42,.65)', display: 'grid', placeItems: 'center', padding: 20 }}
+  ><div className="card" style={{ width: 'min(440px, 100%)', padding: 22 }}>
+    <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+      <AlertTriangle size={19} aria-hidden="true" style={{ color: 'var(--danger)', flexShrink: 0, marginTop: 2 }} />
+      <div><h2 id={titleId} style={{ margin: 0, fontSize: 16, fontWeight: 750 }}>{t(`Smazat roli „${role.name}“?`, `Delete “${role.name}”?`)}</h2>
+        <p id={impactId} style={{ margin: '6px 0 0', color: 'var(--text-secondary)', fontSize: 12.5, lineHeight: 1.5 }}>{t('Preset přestane být dostupný pro nové delegace. Již udělená práva se nezmění ani neodvolají.', 'The preset will no longer be available for new delegations. Existing grants will not change or be revoked.')}</p></div>
+    </div>
+    {failed && <p role="alert" style={{ margin: '14px 0 0', padding: '10px 12px', borderRadius: 8, color: 'var(--danger-text)', background: 'var(--danger-bg)', border: '1px solid var(--danger-border)', fontSize: 12 }}>{t('Roli se nepodařilo smazat. Nic se nezměnilo; zkuste to znovu.', 'The role could not be deleted. Nothing changed; try again.')}</p>}
+    <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 18 }}>
+      <button type="button" className="btn btn-secondary" autoFocus disabled={busy} onClick={onCancel}>{t('Ponechat roli', 'Keep role')}</button>
+      <button type="button" className="btn btn-danger" disabled={busy} aria-busy={busy} onClick={onConfirm}>{busy ? t('Mažu…', 'Deleting…') : t('Smazat preset', 'Delete preset')}</button>
+    </div>
+  </div></div>
+}
+
+export function RoleEditor({ value, busy, failed, cancel, save }: { value: RolePreset; busy: boolean; failed: boolean; cancel: () => void; save: (role: RolePreset) => Promise<void> }) {
   const { t } = useLanguage(); const [role, setRole] = useState(value); const allowed = CAPABILITIES_BY_RESOURCE[role.resourceType]
+  const dialogRef = useRef<HTMLDivElement>(null)
   const changeResource = (resourceType: DelegationResource) => setRole({ ...role, resourceType, capabilities: [] })
   const toggle = (right: string) => setRole({ ...role, capabilities: role.capabilities.includes(right) ? role.capabilities.filter(item => item !== right) : [...role.capabilities, right] })
-  return <div role="dialog" aria-modal="true" aria-labelledby="role-editor-title" style={{ position: 'fixed', inset: 0, zIndex: 1000, background: 'rgba(0,0,0,.55)', display: 'grid', placeItems: 'center', padding: 16 }}><div className="card" style={{ padding: 20, width: 'min(620px, 100%)' }}>
-    <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}><h2 id="role-editor-title" style={{ fontWeight: 700 }}>{t('Nastavení dispoziční role', 'Delegation role settings')}</h2><button className="btn btn-secondary" onClick={cancel} aria-label={t('Zavřít', 'Close')}><X size={14} /></button></div>
-    <label style={labelStyle}>{t('Název', 'Name')}<input className="input" maxLength={100} value={role.name} onChange={event => setRole({ ...role, name: event.target.value })} /></label>
+  return <div ref={dialogRef} role="dialog" aria-modal="true" aria-labelledby="role-editor-title" aria-busy={busy} onKeyDown={event => { if (event.key === 'Escape' && !busy) cancel(); trapDialogFocus(event, dialogRef.current) }} style={{ position: 'fixed', inset: 0, zIndex: 1000, background: 'rgba(0,0,0,.55)', display: 'grid', placeItems: 'center', padding: 16 }}><div className="card" style={{ padding: 20, width: 'min(620px, 100%)', maxHeight: 'calc(100dvh - 32px)', overflowY: 'auto' }}>
+    <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}><h2 id="role-editor-title" style={{ fontWeight: 700 }}>{t('Nastavení dispoziční role', 'Delegation role settings')}</h2><button type="button" className="btn btn-secondary" disabled={busy} onClick={cancel} aria-label={t('Zavřít', 'Close')}><X size={14} aria-hidden="true" /></button></div>
+    {failed && <p role="alert" style={{ margin: '0 0 14px', padding: '10px 12px', borderRadius: 8, color: 'var(--danger-text)', background: 'var(--danger-bg)', border: '1px solid var(--danger-border)', fontSize: 12 }}>{t('Roli se nepodařilo uložit. Nic se nezměnilo; zkontrolujte údaje a zkuste to znovu.', 'The role could not be saved. Nothing changed; check the details and try again.')}</p>}
+    <label style={labelStyle}>{t('Název', 'Name')}<input autoFocus className="input" maxLength={100} value={role.name} onChange={event => setRole({ ...role, name: event.target.value })} /></label>
     <label style={labelStyle}>{t('Popis', 'Description')}<textarea className="input" maxLength={500} value={role.description} onChange={event => setRole({ ...role, description: event.target.value })} /></label>
     <label style={labelStyle}>{t('Zdroj', 'Resource')}<select className="input" value={role.resourceType} onChange={event => changeResource(event.target.value as DelegationResource)}>{Object.keys(CAPABILITIES_BY_RESOURCE).map(resource => <option key={resource}>{resource}</option>)}</select></label>
     <fieldset style={{ border: 0, padding: 0, margin: '14px 0' }}><legend style={{ fontWeight: 700, fontSize: 13, marginBottom: 8 }}>{t('Práva', 'Rights')}</legend>{allowed.map(right => <label key={right} title={right} style={{ display: 'flex', gap: 8, padding: 8 }}><input type="checkbox" checked={role.capabilities.includes(right)} onChange={() => toggle(right)} /><span>{rightLabel(right, t)}</span></label>)}</fieldset>
-    <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}><button className="btn btn-secondary" onClick={cancel}>{t('Zrušit', 'Cancel')}</button><button className="btn btn-primary" disabled={!role.name.trim() || !role.capabilities.length} onClick={() => void save(role)}>{t('Uložit', 'Save')}</button></div>
+    <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}><button type="button" className="btn btn-secondary" disabled={busy} onClick={cancel}>{t('Zrušit', 'Cancel')}</button><button type="button" className="btn btn-primary" disabled={busy || !role.name.trim() || !role.capabilities.length} aria-busy={busy} onClick={() => void save(role)}>{busy ? t('Ukládám…', 'Saving…') : t('Uložit', 'Save')}</button></div>
   </div></div>
 }
 const labelStyle = { display: 'grid', gap: 6, fontSize: 13, fontWeight: 600, marginBottom: 12 } as const

--- a/openbank-admin-ui/src/test/delegation-role-delete-dialog.test.tsx
+++ b/openbank-admin-ui/src/test/delegation-role-delete-dialog.test.tsx
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { DeleteRoleDialog, RoleEditor } from '@/components/delegations/RoleCatalog'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import type { RolePreset } from '@/lib/delegations/rolePresets'
+
+const ROLE = {
+  id: 'treasury-operator',
+  name: 'Treasury operator',
+  description: 'Can prepare treasury payments',
+  resourceType: 'PAYMENT',
+  capabilities: ['OBJECT_READ'],
+} satisfies RolePreset
+
+afterEach(cleanup)
+
+describe('delegation role deletion', () => {
+  it('never falls back to a native browser confirmation', () => {
+    const source = readFileSync(join(process.cwd(), 'src/components/delegations/RoleCatalog.tsx'), 'utf8')
+    expect(source).not.toContain('window.confirm')
+  })
+
+  it('explains the security impact and contains keyboard focus', () => {
+    const cancel = vi.fn()
+    render(
+      <LanguageProvider>
+        <DeleteRoleDialog role={ROLE} busy={false} failed={false} onCancel={cancel} onConfirm={vi.fn()} />
+      </LanguageProvider>,
+    )
+
+    const dialog = screen.getByRole('alertdialog', { name: 'Delete “Treasury operator”?' })
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(screen.getByText(/Existing grants will not change or be revoked/)).toBeVisible()
+
+    const keep = screen.getByRole('button', { name: 'Keep role' })
+    const remove = screen.getByRole('button', { name: 'Delete preset' })
+    keep.focus()
+    fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(remove)
+    fireEvent.keyDown(dialog, { key: 'Tab' })
+    expect(document.activeElement).toBe(keep)
+
+    fireEvent.keyDown(dialog, { key: 'Escape' })
+    expect(cancel).toHaveBeenCalledOnce()
+  })
+
+  it('prevents duplicate deletion and makes a failed attempt recoverable', () => {
+    const confirm = vi.fn()
+    const { rerender } = render(
+      <LanguageProvider>
+        <DeleteRoleDialog role={ROLE} busy failed={false} onCancel={vi.fn()} onConfirm={confirm} />
+      </LanguageProvider>,
+    )
+
+    expect(screen.getByRole('alertdialog')).toHaveAttribute('aria-busy', 'true')
+    const deleting = screen.getByRole('button', { name: 'Deleting…' })
+    expect(deleting).toBeDisabled()
+    fireEvent.click(deleting)
+    expect(confirm).not.toHaveBeenCalled()
+
+    rerender(
+      <LanguageProvider>
+        <DeleteRoleDialog role={ROLE} busy={false} failed onCancel={vi.fn()} onConfirm={confirm} />
+      </LanguageProvider>,
+    )
+    expect(screen.getByRole('alert')).toHaveTextContent('Nothing changed; try again.')
+    fireEvent.click(screen.getByRole('button', { name: 'Delete preset' }))
+    expect(confirm).toHaveBeenCalledOnce()
+  })
+})
+
+describe('delegation role editor recovery', () => {
+  it('keeps a failed save editable and allows a safe retry', () => {
+    const save = vi.fn(async () => undefined)
+    render(
+      <LanguageProvider>
+        <RoleEditor value={ROLE} busy={false} failed cancel={vi.fn()} save={save} />
+      </LanguageProvider>,
+    )
+
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-busy', 'false')
+    expect(screen.getByRole('alert')).toHaveTextContent('Nothing changed; check the details and try again.')
+    fireEvent.change(screen.getByRole('textbox', { name: 'Name' }), { target: { value: 'Treasury reviewer' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(save).toHaveBeenCalledWith(expect.objectContaining({ name: 'Treasury reviewer' }))
+  })
+
+  it('locks dismissal and duplicate submission while saving', () => {
+    const cancel = vi.fn()
+    const save = vi.fn(async () => undefined)
+    render(
+      <LanguageProvider>
+        <RoleEditor value={ROLE} busy failed={false} cancel={cancel} save={save} />
+      </LanguageProvider>,
+    )
+
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-busy', 'true')
+    expect(screen.getByRole('button', { name: 'Saving…' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+    fireEvent.keyDown(dialog, { key: 'Escape' })
+    expect(cancel).not.toHaveBeenCalled()
+    expect(save).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary\n\nMake delegation-role catalog mutations safe, explainable and recoverable. Native deletion confirmation is replaced by a localized accessible alert dialog; create/edit now preserves operator input and reports failure instead of silently doing nothing. The role editor also remains usable on constrained viewports.\n\n## Type of change\n\n- [x] fix (bug fix)\n\n## Linked issues\n\nCloses #7862\n\n## Changes\n\n- state the exact deletion impact: future preset use stops while existing grants remain unchanged\n- contain keyboard focus, support safe Escape handling, restore focus after deletion and expose busy state\n- keep failed delete and save attempts open with truthful retry guidance; prevent duplicate submissions\n- make the long permission editor scroll within the viewport instead of placing Save off-screen\n- make nearby controls explicit buttons and decorative icons silent\n- add functional component coverage and full-page Playwright recovery scenarios for both create and delete\n\n## Definition of Done\n\n- [x] UI-only; service boundaries and hexagonal layering unchanged\n- [x] Component tests: 5/5 passed\n- [x] Browser E2E: delete recovery 1/1 and create recovery 1/1 passed\n- [x] TypeScript type-check passed\n- [x] Focused ESLint passed\n- [x] git diff --check passed\n- [x] OpenAPI / Flyway / Avro N/A\n\n## Security checklist\n\n- [x] No secrets, tokens, passwords or PII\n- [x] No suppressions, unsafe casts or new dependencies\n- [x] Authorization remains ROLE_ADMIN only\n- [x] API payloads and existing grant semantics are unchanged\n- [x] Failed writes are never presented as success\n\n## Rollout / rollback\n\n- Deployment: existing admin-ui canary pipeline\n- Rollback: revert this UI-only commit\n- Data migration: N/A\n\n## Reviewer notes\n\nPlease verify the exact impact copy, keyboard containment, constrained-height scrolling, retry behavior, and that no path implies a preset deletion revokes existing grants.