### PR TITLE
ci(governance): state the reason for all 19 NO_CORPUS exemptions and de-vacuum a self-test

### DIFF
--- a/.github/scripts/check-gate-subject-floor.py
+++ b/.github/scripts/check-gate-subject-floor.py
@@ -52,12 +52,12 @@ MANIFEST = ".github/gates/gates.yaml"
 
 # A gate with no repo corpus to count. Stated, not inferred.
 NO_CORPUS = {
+    # SELF-TEST SUITES: the gate's `run:` IS a `--self-test`/unit-test invocation, so its subjects
+    # are in-script fixtures, not repo files. Audited 2026-09-01 by RUNNING all 19 and reading each
+    # `run:` — every one below exits 0 offline with no AWS/gh credentials, and the four that name
+    # `gh`/`aws`/`curl` stub them inside the self-test (ensure-ecr-repository.sh even validates its
+    # own stub first). No repo corpus to floor.
     "agent-review-proof-falsifiable",
-    # DIFF-SCOPED: its corpus is the PR's own changed files, so zero is the ordinary case (most
-    # PRs touch no openapi.yaml) and a floor would fail every one of them. It is not exempt from
-    # the underlying question -- it prints SUBJECTS= including zero, so "no specs changed" and
-    # "did not look" stay distinguishable in the log.
-    "openapi-version-not-taken",
     "agent-review-scope-falsifiable",
     "auto-deploy-reconcile-probe-unit-test",
     "blocking-counterpart-probe-unit-test",
@@ -66,15 +66,43 @@ NO_CORPUS = {
     "co-deploy-set-derivation-unit-test",
     "ensure-ecr-repository",
     "gate-runner-self-test",
-    "governance-script-unit-tests",
-    "libs-change-dependents",
-    "pact-version-probe-fail-closed-unit-test",
     "pact-provider-version-proof-unit-test",
+    "pact-version-probe-fail-closed-unit-test",
     "pact-version-tree-equivalence-unit-test",
-    "pr-build-cloud-credentials",
     "record-deployment-version-resolver",
     "runtime-conformance-comparators",
     "supersede-deploy-prs-ancestry",
+
+    # SELF-TEST SUITES THAT DO READ THE REAL TREE, and are fail-closed about it. These are the
+    # honest shape: the self-test carries its own known-positive, so a collapsed corpus goes RED
+    # instead of passing vacuously. A `min_subjects:` floor would be redundant with a mechanism
+    # that is already stronger than a floor.
+    #   libs-change-dependents: asserts fx-service IS detected as a libs-temporal consumer.
+    #   runtime-conformance-comparators (above): gained the same positive control on 2026-09-01
+    #     after this audit measured its whole self-test passing from an EMPTY directory.
+    "libs-change-dependents",
+
+    # GLOB-DISCOVERED TEST CORPUS, fail-closed by the runtime. `unittest discover` finds 15 files /
+    # 176 tests today (156 + 20, confirmed in CI run 33444342095 on ubuntu-24.04). Zero discovered
+    # tests exits 5 ("NO TESTS RAN") on Python >= 3.12 -- measured on python:3.12-slim, the CI
+    # image's interpreter -- and run-gates.py executes `run:` under `bash -euo pipefail`, so either
+    # discover collapsing to zero fails the gate. What a floor WOULD add is coverage of partial
+    # narrowing (176 -> 20 is currently green); left unfloored deliberately, since a test count
+    # drifts upward normally and floors here catch collapse, not drift.
+    "governance-script-unit-tests",
+
+    # VALIDATES ONE NAMED FILE, fail-closed. Not a test suite: it reads
+    # .github/workflows/_service-ci.yml and greps its `build:` job. Its corpus is exactly 1, and a
+    # `build:` job it cannot locate is returned as a finding ("missing build job fails closed"),
+    # which is the collapse case a floor would otherwise cover.
+    "pr-build-cloud-credentials",
+
+    # DIFF-SCOPED: its corpus is the PR's own changed files, so zero is the ordinary case (most
+    # PRs touch no openapi.yaml) and a floor would fail every one of them. It is not exempt from
+    # the underlying question -- it prints SUBJECTS= including zero, so "no specs changed" and
+    # "did not look" stay distinguishable in the log. This is the shape to copy for any future
+    # entry here that prints nothing at all about what it looked at.
+    "openapi-version-not-taken",
 }
 
 # Gates that examine a real corpus and do not yet report how much of it they found. This list

--- a/.github/scripts/runtime-conformance.py
+++ b/.github/scripts/runtime-conformance.py
@@ -521,10 +521,20 @@ def self_test() -> int:
             {"openbank-sepa-payment": {"constructs_outbox_message": True}},
             {"openbank-sepa": {"total": 1, "dead": 1}, "openbank-s": {"total": 9, "dead": 9}}),
         [])
+    # This pair reads the REAL tree, so it needs a known-positive next to the exclusion.
+    # `"openbank-libs-runtime" not in {}` is True, so the exclusion case alone passed from an
+    # empty directory — measured 2026-09-01, the whole self-test exited 0 with cwd on an empty
+    # tree. The exclusion is load-bearing (libs-runtime really does ship AbstractOutboxDispatcher),
+    # and a test that cannot detect the absence of its own corpus is decoration.
+    _real_outbox = claim_outbox_services(pathlib.Path("."))
     expect(
         "outbox: libs are excluded from the claim side entirely",
-        "openbank-libs-runtime" in claim_outbox_services(pathlib.Path(".")),
+        "openbank-libs-runtime" in _real_outbox,
         False)
+    expect(
+        "outbox: the real tree yields dispatcher services (else the exclusion above is vacuous)",
+        len(_real_outbox) > 0,
+        True)
 
     # canary: 1 replica + setWeight 10 => flagged; 10 replicas => clean; traffic router => exempt
     expect(


### PR DESCRIPTION
## What this is

An honesty audit of the **19 `NO_CORPUS` exemptions** in `.github/scripts/check-gate-subject-floor.py`.
`NO_CORPUS` is a claim per gate — *"this gate has no repo corpus to count"* — and the file's own
comment says **"Stated, not inferred."** Nobody had re-checked it since it was seeded (#4339).

**Result: all 19 are honest.** No exemption was removed, so `gates.yaml` is **untouched — 188 gates
before, 188 after**, partition unchanged at 70 floored / 19 no-corpus / 99 debt.

Method: each gate was classified by **running its `run:`**, not by reading it.

## The census

| # | Gate | Class | Established by |
|---|---|---|---|
| 1-15 | `agent-review-proof-falsifiable`, `agent-review-scope-falsifiable`, `auto-deploy-reconcile-probe-unit-test`, `blocking-counterpart-probe-unit-test`, `can-i-deploy-block-classifier-unit-test`, `can-i-deploy-version-selector-unit-test`, `co-deploy-set-derivation-unit-test`, `ensure-ecr-repository`, `gate-runner-self-test`, `pact-provider-version-proof-unit-test`, `pact-version-probe-fail-closed-unit-test`, `pact-version-tree-equivalence-unit-test`, `record-deployment-version-resolver`, `runtime-conformance-comparators`, `supersede-deploy-prs-ancestry` | **(a) TRUE** | Ran all 19 `run:` blocks; every one exits 0 offline with no AWS/gh credentials. Subjects are in-script fixtures. |
| 16 | `libs-change-dependents` | **(a) TRUE**, best-shaped | Its `--selftest` reads the real tree *and carries a known-positive*: fx-service must be detected as a libs-temporal consumer, so a collapsed corpus goes red. Stronger than a floor. |
| 17 | `governance-script-unit-tests` | **(a) TRUE**, fail-closed | Glob-discovered: 15 files / 176 tests. Zero discovered tests exits **5** (`NO TESTS RAN`), and `run-gates.py` executes under `bash -euo pipefail` — so collapse of either `discover` fails the gate. |
| 18 | `pr-build-cloud-credentials` | **(a) TRUE** | Not a test suite — validates one named file (`_service-ci.yml`). Corpus is exactly 1, and a `build:` job it cannot locate is returned as a finding ("missing build job fails closed"). |
| 19 | `openapi-version-not-taken` | **(a) TRUE** | Diff-scoped; prints `SUBJECTS=0`. The calibration case. |

**(b) FALSE: none. (c) Ambiguous: none.**

## Known-positive controls

Per the repo's own rule, no probe's silence was trusted:

- **The one that caught me.** Grepping a CI job log for `Ran N tests` returned nothing. The control
  (`gh run view --job ... | head`) showed *"run is still in progress; logs will be available when it
  is complete"* — the probe was silent about availability, not content. Re-run against a completed
  run (`33444342095`) gave `Ran 156 tests` / `Ran 20 tests`.
- Script-corpus grep: controlled against `run-gates.py` (19 hits) and `ensure-ecr-repository.sh` (7),
  so the zeros elsewhere are real zeros.
- `unittest discover` exit-5: controlled on `python:3.12-slim`, the interpreter on the `ubuntu-24.04`
  image CI actually uses — **not** assumed from the local 3.14.

## The one real defect found alongside

`runtime-conformance.py`'s self-test made a single assertion against the real tree:

```python
expect("outbox: libs are excluded from the claim side entirely",
       "openbank-libs-runtime" in claim_outbox_services(pathlib.Path(".")), False)
```

`"openbank-libs-runtime" in {}` is `False`, so **the entire self-test exited 0 with cwd on an empty
directory.** The exclusion is load-bearing — libs-runtime really does ship
`AbstractOutboxDispatcher` — so the assertion tested something real while being structurally
unable to detect the absence of its own corpus.

**Verified by effect, both directions:**

| | before | after |
|---|---|---|
| real tree (34 dispatcher services) | exit 0 | exit 0 |
| empty tree | **exit 0** | **exit 1** (`FAIL outbox: the real tree yields dispatcher services`) |

## Also in this PR

Each `NO_CORPUS` entry now carries its measured reason, grouped by shape. 17 of 19 previously stated
nothing beyond list membership, against a file whose doctrine is "Stated, not inferred".

## Recommendation, not included here

18 of the 19 print no `SUBJECTS=` line at all. For the 16 self-test suites that is defensible (their
subjects are fixtures), but the two that read a real corpus — `governance-script-unit-tests` (176
tests) and `pr-build-cloud-credentials` (1 file) — would be more legible printing it, following
`openapi-version-not-taken`'s pattern where a genuine zero is *stated* rather than silent. Not done
here to keep this PR to the audit plus the one measured defect.

## What I did NOT verify

- Whether each self-test's *cases* are individually meaningful — only that each gate's corpus claim
  is honest. `selftest_exempt` is a different gate's business.
- Partial narrowing of `governance-script-unit-tests` (176 → 20 tests) is still green. Left
  deliberately unfloored: a test count drifts upward normally and floors here catch collapse, not
  drift. Flagging it rather than forcing it.

## Checks run locally

- `check-gate-subject-floor.py --self-test` → exit 0; `--enforce` → exit 0, `SUBJECTS=188`
- `check-gate-lifecycle-metadata.py --today 2026-09-01` → 0 `::error::` lines (output read, not just
  the exit code — it runs advisory locally)
- Both `unittest discover` suites → 156 OK / 20 OK

Refs #4339
