### PR TITLE
fix(admin-ui): serialize regulatory period actions

### DIFF
--- a/openbank-admin-ui/e2e/regulatory-period-safety.spec.ts
+++ b/openbank-admin-ui/e2e/regulatory-period-safety.spec.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const draft = {
+  id: 'e9e37077-3b14-4e52-a450-d2a6616f616d',
+  period: '2026-07',
+  periodType: 'MONTH',
+  from: '2026-07-01',
+  to: '2026-07-31',
+  status: 'DRAFT',
+  evidenceState: 'LINES_V1',
+  computedAt: '2026-08-01T00:00:00Z',
+  accountCount: 14,
+  contentHash: 'a'.repeat(64),
+  draftedBy: 'maker-sub',
+  frozenBy: null,
+  frozenAt: null,
+}
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('checker verifies, explicitly confirms and freezes one immutable regulatory period', async ({ page }) => {
+  await page.addInitScript(() => window.localStorage.setItem('openbank-admin-lang', 'en'))
+  let freezeRequests = 0
+
+  await page.route('**/api/svc/ledger-service/api/v1/ledger/periods/MONTH/**', async route => {
+    const request = route.request()
+    const path = new URL(request.url()).pathname
+    if (path.endsWith('/verify')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ period: draft.period, status: 'DRAFT', matches: true, balanced: true, recomputedAt: '2026-08-02T00:00:00Z' }),
+      })
+    }
+    if (path.endsWith('/freeze') && request.method() === 'POST') {
+      freezeRequests += 1
+      await new Promise(resolve => setTimeout(resolve, 150))
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ...draft, status: 'FROZEN', frozenBy: 'e2e-operator', frozenAt: '2026-08-02T00:00:00Z' }),
+      })
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(draft) })
+  })
+
+  await page.goto('/day-end?tab=regulatory')
+  const freeze = page.getByRole('button', { name: 'Freeze period (checker)' })
+  await expect(freeze).toBeDisabled()
+
+  await page.getByRole('button', { name: 'Verify independently' }).click()
+  await expect(page.getByRole('status')).toContainText('The evidence hash matches and the trial balance is balanced.')
+  await expect(freeze).toBeDisabled()
+
+  await page.getByRole('checkbox', { name: /I confirm an independent review/ }).check()
+  await expect(freeze).toBeEnabled()
+  await freeze.click()
+
+  await expect(page.getByRole('status')).toContainText('The period is frozen as immutable regulatory evidence.')
+  await expect(page.getByRole('link', { name: 'Open FINREP/COREP preview' })).toHaveAttribute('href', '/regulatory')
+  expect(freezeRequests).toBe(1)
+})

--- a/openbank-admin-ui/src/components/closings/RegulatoryPeriodPanel.tsx
+++ b/openbank-admin-ui/src/components/closings/RegulatoryPeriodPanel.tsx
@@ -11,6 +11,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { hasRole, ROLES } from '@/lib/auth/roles'
 import { classifyBffFailure, svcUrl, type BffFailure } from '@/lib/services/bff'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
+import { useSingleFlight } from '@/lib/mutations/singleFlight'
 
 interface ClosedPeriod {
   id: string
@@ -66,6 +67,7 @@ export function RegulatoryPeriodPanel() {
   const [acting, setActing] = useState<'draft' | 'verify' | 'freeze' | null>(null)
   const [confirmed, setConfirmed] = useState(false)
   const [notice, setNotice] = useState<Notice>(null)
+  const flight = useSingleFlight()
 
   const isOwnDraft = !!period?.draftedBy && currentPrincipals.some(principal => principal === period.draftedBy)
   const reportReady = period?.status === 'FROZEN' && period.evidenceState === 'LINES_V1'
@@ -98,55 +100,59 @@ export function RegulatoryPeriodPanel() {
   }, [load])
 
   const mutate = useCallback(async (action: 'draft' | 'freeze') => {
-    setActing(action); setNotice(null)
-    try {
-      const response = await fetch(endpoint(date, action === 'freeze' ? '/freeze' : ''), {
-        method: 'POST', cache: 'no-store', signal: AbortSignal.timeout(20_000),
-      })
-      if (!response.ok) {
-        setNotice({
-          ok: false,
-          text: action === 'freeze'
-            ? t('Zmrazení bylo odmítnuto. Checker musí být jiný než maker a otisk musí stále souhlasit.', 'Freeze was refused. The checker must differ from the maker and the evidence hash must still match.')
-            : t('Draft nelze vytvořit. Období musí být ukončené a předvaha vyvážená.', 'The draft cannot be created. The period must have ended and the trial balance must be balanced.'),
+    await flight.run(`regulatory-period:${date}`, async () => {
+      setActing(action); setNotice(null)
+      try {
+        const response = await fetch(endpoint(date, action === 'freeze' ? '/freeze' : ''), {
+          method: 'POST', cache: 'no-store', signal: AbortSignal.timeout(20_000),
         })
-        return
+        if (!response.ok) {
+          setNotice({
+            ok: false,
+            text: action === 'freeze'
+              ? t('Zmrazení bylo odmítnuto. Checker musí být jiný než maker a otisk musí stále souhlasit.', 'Freeze was refused. The checker must differ from the maker and the evidence hash must still match.')
+              : t('Draft nelze vytvořit. Období musí být ukončené a předvaha vyvážená.', 'The draft cannot be created. The period must have ended and the trial balance must be balanced.'),
+          })
+          return
+        }
+        const updated = await response.json() as ClosedPeriod
+        setPeriod(updated); setVerification(null); setConfirmed(false)
+        setNotice({
+          ok: true,
+          text: action === 'freeze'
+            ? t('Období je zmrazené jako neměnný regulatorní důkaz.', 'The period is frozen as immutable regulatory evidence.')
+            : t('Draft vytvořen. Zmrazení musí provést jiný operátor po nezávislém ověření.', 'Draft created. A different operator must independently verify and freeze it.'),
+        })
+      } catch {
+        setNotice({ ok: false, text: t('Ledger-service neodpověděl.', 'Ledger-service did not respond.') })
+      } finally {
+        setActing(null)
       }
-      const updated = await response.json() as ClosedPeriod
-      setPeriod(updated); setVerification(null); setConfirmed(false)
-      setNotice({
-        ok: true,
-        text: action === 'freeze'
-          ? t('Období je zmrazené jako neměnný regulatorní důkaz.', 'The period is frozen as immutable regulatory evidence.')
-          : t('Draft vytvořen. Zmrazení musí provést jiný operátor po nezávislém ověření.', 'Draft created. A different operator must independently verify and freeze it.'),
-      })
-    } catch {
-      setNotice({ ok: false, text: t('Ledger-service neodpověděl.', 'Ledger-service did not respond.') })
-    } finally {
-      setActing(null)
-    }
-  }, [date, t])
+    })
+  }, [date, flight, t])
 
   const verify = useCallback(async () => {
-    setActing('verify'); setNotice(null); setConfirmed(false)
-    try {
-      const response = await fetch(endpoint(date, '/verify'), { cache: 'no-store', signal: AbortSignal.timeout(15_000) })
-      if (!response.ok) throw new Error(String(response.status))
-      const result = await response.json() as Verification
-      setVerification(result)
-      setNotice({
-        ok: result.matches && result.balanced,
-        text: result.matches && result.balanced
-          ? t('Otisk souhlasí a předvaha je vyvážená.', 'The evidence hash matches and the trial balance is balanced.')
-          : t('Ověření selhalo — období nesmí být zmrazeno ani použito pro reporting.', 'Verification failed — the period must not be frozen or used for reporting.'),
-      })
-    } catch {
-      setVerification(null)
-      setNotice({ ok: false, text: t('Ověření období se nezdařilo.', 'Period verification failed.') })
-    } finally {
-      setActing(null)
-    }
-  }, [date, t])
+    await flight.run(`regulatory-period:${date}`, async () => {
+      setActing('verify'); setNotice(null); setConfirmed(false)
+      try {
+        const response = await fetch(endpoint(date, '/verify'), { cache: 'no-store', signal: AbortSignal.timeout(15_000) })
+        if (!response.ok) throw new Error(String(response.status))
+        const result = await response.json() as Verification
+        setVerification(result)
+        setNotice({
+          ok: result.matches && result.balanced,
+          text: result.matches && result.balanced
+            ? t('Otisk souhlasí a předvaha je vyvážená.', 'The evidence hash matches and the trial balance is balanced.')
+            : t('Ověření selhalo — období nesmí být zmrazeno ani použito pro reporting.', 'Verification failed — the period must not be frozen or used for reporting.'),
+        })
+      } catch {
+        setVerification(null)
+        setNotice({ ok: false, text: t('Ověření období se nezdařilo.', 'Period verification failed.') })
+      } finally {
+        setActing(null)
+      }
+    })
+  }, [date, flight, t])
 
   return (
     <section aria-labelledby="regulatory-period-title">
@@ -160,15 +166,15 @@ export function RegulatoryPeriodPanel() {
         <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
           <label style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>
             {t('Měsíc', 'Month')}{' '}
-            <input aria-label={t('Datum v měsíci', 'Date within month')} type="date" value={date} max={lastCompletedMonthEnd()} onChange={event => setDate(event.target.value)} className="input" style={{ width: '150px' }} />
+            <input aria-label={t('Datum v měsíci', 'Date within month')} type="date" value={date} max={lastCompletedMonthEnd()} disabled={loading || flight.busy} onChange={event => setDate(event.target.value)} className="input" style={{ width: '150px' }} />
           </label>
-          <button className="btn btn-secondary" onClick={() => void load()} disabled={loading || !date}>
-            <RefreshCw size={13} className={loading ? 'animate-spin' : undefined} /> {t('Obnovit', 'Refresh')}
+          <button type="button" className="btn btn-secondary" onClick={() => void load()} disabled={loading || flight.busy || !date} aria-busy={loading}>
+            <RefreshCw size={13} aria-hidden="true" className={loading ? 'animate-spin' : undefined} /> {t('Obnovit', 'Refresh')}
           </button>
         </div>
       </div>
 
-      {notice && <div role="status" style={{ padding: '10px 14px', marginBottom: '12px', borderRadius: 'var(--r-md)', background: notice.ok ? 'var(--success-bg)' : 'var(--warning-bg)', color: notice.ok ? 'var(--success)' : 'var(--warning)', border: `1px solid ${notice.ok ? 'var(--success-border)' : 'var(--warning-border)'}` }}>{notice.text}</div>}
+      {notice && <div role={notice.ok ? 'status' : 'alert'} style={{ padding: '10px 14px', marginBottom: '12px', borderRadius: 'var(--r-md)', background: notice.ok ? 'var(--success-bg)' : 'var(--warning-bg)', color: notice.ok ? 'var(--success)' : 'var(--warning)', border: `1px solid ${notice.ok ? 'var(--success-border)' : 'var(--warning-border)'}` }}>{notice.text}</div>}
 
       {loading ? <div className="skeleton" style={{ height: '180px' }} /> : unavailable ? (
         <div className="card"><DataUnavailable kind={unavailable} service="Ledger-service" feature={t('regulatorní období', 'regulatory period')} lang={language} /></div>
@@ -177,7 +183,7 @@ export function RegulatoryPeriodPanel() {
           <AlertTriangle size={22} style={{ color: 'var(--warning)', marginBottom: '8px' }} />
           <div style={{ fontWeight: 700 }}>{t('Pro tento měsíc neexistuje regulatorní uzávěrka', 'No regulatory close exists for this month')}</div>
           <p style={{ margin: '6px auto 16px', maxWidth: '560px', fontSize: '12px', color: 'var(--text-secondary)' }}>{t('FINREP/COREP náhled zůstane zablokovaný, dokud maker nevytvoří DRAFT a nezávislý checker jej nezmrazí.', 'FINREP/COREP preview remains blocked until a maker creates a DRAFT and an independent checker freezes it.')}</p>
-          {canManage && <button className="btn btn-primary" onClick={() => void mutate('draft')} disabled={acting !== null}><ShieldCheck size={13} /> {acting === 'draft' ? t('Vytvářím…', 'Creating…') : t('Vytvořit DRAFT (maker)', 'Create DRAFT (maker)')}</button>}
+          {canManage && <button type="button" className="btn btn-primary" onClick={() => void mutate('draft')} disabled={flight.busy} aria-busy={acting === 'draft'}><ShieldCheck size={13} aria-hidden="true" /> {acting === 'draft' ? t('Vytvářím…', 'Creating…') : t('Vytvořit DRAFT (maker)', 'Create DRAFT (maker)')}</button>}
         </div>
       ) : (
         <div className="card" style={{ padding: '18px' }}>
@@ -199,17 +205,17 @@ export function RegulatoryPeriodPanel() {
           {period.status === 'DRAFT' && canManage && (
             <div style={{ marginTop: '18px', paddingTop: '16px', borderTop: '1px solid var(--border)' }}>
               <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                <button className="btn btn-secondary" onClick={() => void mutate('draft')} disabled={acting !== null}>{t('Obnovit DRAFT (maker)', 'Refresh DRAFT (maker)')}</button>
-                <button className="btn btn-secondary" onClick={() => void verify()} disabled={acting !== null}><CheckCircle2 size={13} /> {acting === 'verify' ? t('Ověřuji…', 'Verifying…') : t('Nezávisle ověřit', 'Verify independently')}</button>
+                <button type="button" className="btn btn-secondary" onClick={() => void mutate('draft')} disabled={flight.busy} aria-busy={acting === 'draft'}>{t('Obnovit DRAFT (maker)', 'Refresh DRAFT (maker)')}</button>
+                <button type="button" className="btn btn-secondary" onClick={() => void verify()} disabled={flight.busy} aria-busy={acting === 'verify'}><CheckCircle2 size={13} aria-hidden="true" /> {acting === 'verify' ? t('Ověřuji…', 'Verifying…') : t('Nezávisle ověřit', 'Verify independently')}</button>
               </div>
               {isOwnDraft && <p style={{ marginTop: '10px', fontSize: '12px', color: 'var(--warning)' }}>{t('Jste maker tohoto draftu. Zmrazení musí provést jiný operátor.', 'You are this draft’s maker. A different operator must freeze it.')}</p>}
               {verification?.matches && verification.balanced && !isOwnDraft && (
                 <label style={{ display: 'flex', gap: '8px', alignItems: 'flex-start', marginTop: '12px', fontSize: '12px' }}>
-                  <input type="checkbox" checked={confirmed} onChange={event => setConfirmed(event.target.checked)} />
+                  <input type="checkbox" checked={confirmed} disabled={flight.busy} onChange={event => setConfirmed(event.target.checked)} />
                   {t('Potvrzuji nezávislou kontrolu období a chápu, že zmrazení vytvoří neměnný regulatorní důkaz.', 'I confirm an independent review and understand that freezing creates immutable regulatory evidence.')}
                 </label>
               )}
-              <button className="btn btn-primary" style={{ marginTop: '12px' }} onClick={() => void mutate('freeze')} disabled={!freezeReady || acting !== null}><ShieldCheck size={13} /> {acting === 'freeze' ? t('Zmrazuji…', 'Freezing…') : t('Zmrazit období (checker)', 'Freeze period (checker)')}</button>
+              <button type="button" className="btn btn-primary" style={{ marginTop: '12px' }} onClick={() => void mutate('freeze')} disabled={!freezeReady || flight.busy} aria-busy={acting === 'freeze'}><ShieldCheck size={13} aria-hidden="true" /> {acting === 'freeze' ? t('Zmrazuji…', 'Freezing…') : t('Zmrazit období (checker)', 'Freeze period (checker)')}</button>
             </div>
           )}
         </div>

--- a/openbank-admin-ui/src/test/regulatory-period-panel.test.tsx
+++ b/openbank-admin-ui/src/test/regulatory-period-panel.test.tsx
@@ -3,6 +3,8 @@
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
 import { RegulatoryPeriodPanel } from '@/components/closings/RegulatoryPeriodPanel'
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import { ROLES } from '@/lib/auth/roles'
@@ -30,6 +32,12 @@ afterEach(() => {
 })
 
 describe('Regulatory period maker/checker panel', () => {
+  it('guards every critical action with the same synchronous single-flight key', () => {
+    const source = readFileSync(join(process.cwd(), 'src/components/closings/RegulatoryPeriodPanel.tsx'), 'utf8')
+    expect(source.match(/flight\.run\(`regulatory-period:\$\{date\}`/g)).toHaveLength(2)
+    expect(source).not.toContain('<button className=')
+  })
+
   it('turns a missing period into an explicit maker action without exposing GL values', async () => {
     const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
       if (init?.method === 'POST') return new Response(JSON.stringify(draft), { status: 200 })


### PR DESCRIPTION
## Summary\n\nHarden the FINREP/COREP regulatory-period maker/checker journey against same-turn duplicate actions and add browser-level proof of the complete independent verification flow.\n\n## Type of change\n\n- [x] fix (bug fix)\n\n## Linked issues\n\nCloses #7868\n\n## Changes\n\n- serialize draft, verify and freeze under one synchronous per-period single-flight key\n- lock date/refresh/confirmation controls while a regulatory action is active\n- add explicit button, busy and success/error announcement semantics\n- keep ledger-service four-eyes enforcement and exact ROLE_OPERATOR boundary unchanged\n- add a full-page Playwright verify → acknowledgement → freeze regression\n\n## Verification\n\n- component tests: 6/6 passed\n- Playwright full-page regulatory journey: 1/1 passed\n- npm run type-check\n- focused ESLint\n- git diff --check\n\n## Security checklist\n\n- [x] no secrets, PII, suppressions, unsafe casts or dependencies\n- [x] no endpoint, payload, role or policy change\n- [x] client lock prevents re-entry only; server remains authoritative for cross-operator races and maker/checker separation\n- [x] no successful UI state is shown for a rejected or unreachable operation\n\n## Rollout / rollback\n\n- Deployment: existing admin-ui canary pipeline\n- Rollback: revert this UI-only commit\n- Data migration: N/A\n\n## Reviewer notes\n\nPlease verify that all three actions share the same period-scoped lock, that errors are announced as alerts, and that the browser test proves exactly one freeze request.