### PR TITLE
fix(admin-ui): review audience approvals

### DIFF
--- a/openbank-admin-ui/e2e/audience-approval-review.spec.ts
+++ b/openbank-admin-ui/e2e/audience-approval-review.spec.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const audience = {
+  name: 'actives-tenured-30d',
+  version: 4,
+  rules: ['party status is ACTIVE', 'tenure >= 30 days'],
+  state: 'PENDING_APPROVAL',
+  createdBy: 'maker.operator',
+}
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('reviews exact audience evidence and retains a failed approval for retry', async ({ page }) => {
+  let decisions = 0
+  let items = [audience]
+  await page.route(/\/api\/audiences$/, route => route.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify({ state: 'ok', items }),
+  }))
+  await page.route(`**/api/audiences/${audience.name}/${audience.version}/approve`, async route => {
+    decisions += 1
+    expect(route.request().method()).toBe('POST')
+    if (decisions === 1) {
+      await route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ error: 'temporarily unavailable' }) })
+      return
+    }
+    items = []
+    await route.fulfill({ contentType: 'application/json', body: '{}' })
+  })
+
+  await page.goto('/segments')
+  await page.getByRole('button', { name: /Review and approve|Zkontrolovat a schválit/ }).click()
+  const dialog = page.getByRole('alertdialog')
+  await expect(dialog).toContainText(`${audience.name} · v${audience.version}`)
+  await expect(dialog).toContainText(audience.createdBy)
+  await expect(dialog).toContainText(audience.rules[0])
+  await expect(dialog).toContainText(audience.rules[1])
+
+  const confirm = dialog.getByRole('button', { name: /Confirm approval|Potvrdit schválení/ })
+  await confirm.click()
+  await expect(dialog.getByRole('alert')).toContainText(/state change did not complete|Změna stavu publika se nepodařila/)
+  await expect(dialog).toBeVisible()
+  await confirm.click()
+
+  await expect(dialog).toBeHidden()
+  await expect(page.getByText(/catalogue is empty|Katalog je prázdný/i)).toBeVisible()
+  expect(decisions).toBe(2)
+})

--- a/openbank-admin-ui/src/app/segments/page.tsx
+++ b/openbank-admin-ui/src/app/segments/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { ArrowRight, Clock3, Plus, ShieldCheck, Sparkles, Users } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -12,6 +12,7 @@ import { DataUnavailable, type UnavailableKind } from '@/components/feedback/Dat
 import { PageHeader } from '@/components/ui'
 import { AuthGuard, Can } from '@/components/auth/AuthGuard'
 import { useSingleFlight, wasSkipped } from '@/lib/mutations/singleFlight'
+import { trapDialogFocus } from '@/lib/a11y/trapDialogFocus'
 
 // Read-only by design. ADR-0201 D1: a segment is a versioned artifact defined in code, reviewed and
 // released like anything else — "no free-form SQL from a UI". A marketer picks from this catalogue;
@@ -40,6 +41,8 @@ export default function SegmentsPage() {
   const [previews, setPreviews] = useState<Record<string, Preview | 'loading'>>({})
   const [lifecycleAction, setLifecycleAction] = useState<{ key: string; action: 'submit' | 'approve' } | null>(null)
   const [lifecycleError, setLifecycleError] = useState<string | null>(null)
+  const [approvalIntent, setApprovalIntent] = useState<Segment | null>(null)
+  const approvalTriggerRef = useRef<HTMLButtonElement | null>(null)
   const lifecycleFlight = useSingleFlight()
 
   const loadAudiences = useCallback(async (keepExistingOnFailure = false) => {
@@ -67,11 +70,12 @@ export default function SegmentsPage() {
     loadAudiences()
   }, [loadAudiences])
 
-  const lifecycle = async (s: Segment, action: 'submit' | 'approve') => {
+  const lifecycle = async (s: Segment, action: 'submit' | 'approve'): Promise<boolean> => {
     // Submit/approve are state transitions, not catalogue reads. One in-flight transition keeps
     // a double click or two cards from racing the same maker-checker lifecycle, while a failure
     // remains local to the action and never turns an already loaded catalogue into "unavailable".
     const audienceKey = key(s)
+    let succeeded = false
     const outcome = await lifecycleFlight.run('audience:lifecycle', async () => {
       setLifecycleAction({ key: audienceKey, action })
       setLifecycleError(null)
@@ -81,6 +85,7 @@ export default function SegmentsPage() {
           const body = await response.json().catch(() => null) as { error?: string } | null
           throw new Error(body?.error || 'lifecycle mutation failed')
         }
+        succeeded = true
         if (!await loadAudiences(true)) {
           setLifecycleError(t(
             'Stav se mohl změnit, ale katalog se nepodařilo obnovit. Zkuste načtení znovu.',
@@ -96,7 +101,14 @@ export default function SegmentsPage() {
         setLifecycleAction(null)
       }
     })
-    if (wasSkipped(outcome)) return
+    if (wasSkipped(outcome)) return false
+    return succeeded
+  }
+
+  const closeApprovalReview = () => {
+    if (lifecycleFlight.busy) return
+    setApprovalIntent(null)
+    requestAnimationFrame(() => approvalTriggerRef.current?.focus())
   }
 
   const key = (s: Segment) => `${s.name}@${s.version}`
@@ -193,7 +205,7 @@ export default function SegmentsPage() {
         <DataUnavailable kind={unavailable} service="Campaign-service" feature={t('Segmenty', 'Segments')} />
       )}
 
-      {!loading && !unavailable && lifecycleError && (
+      {!loading && !unavailable && lifecycleError && !approvalIntent && (
         <p role="alert" className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800">
           {lifecycleError}
         </p>
@@ -245,7 +257,7 @@ export default function SegmentsPage() {
                     data-use-audience={key(s)}
                   >
                     {t('Použít v kampani', 'Use in campaign')} <ArrowRight className="h-3.5 w-3.5" />
-                  </Link> : s.state === 'DRAFT' ? <Can permission="campaign:submit" fallback={<span className="text-xs text-muted-foreground">{t('Čeká na oprávněného autora', 'Awaiting an authorized author')}</span>}><button type="button" onClick={() => void lifecycle(s, 'submit')} disabled={lifecycleFlight.busy} aria-busy={lifecycleAction?.key === key(s) && lifecycleAction.action === 'submit'} className="rounded-lg bg-violet-700 px-3 py-2 text-xs font-semibold text-white transition hover:bg-violet-800 disabled:cursor-wait disabled:opacity-60">{lifecycleAction?.key === key(s) && lifecycleAction.action === 'submit' ? t('Odesílám…', 'Submitting…') : t('Odeslat ke schválení', 'Submit for approval')}</button></Can> : <Can permission="campaign:activate" fallback={<span className="text-xs text-muted-foreground">{t('Čeká na oprávněného schvalovatele', 'Awaiting an authorized approver')}</span>}><button type="button" onClick={() => void lifecycle(s, 'approve')} disabled={lifecycleFlight.busy} aria-busy={lifecycleAction?.key === key(s) && lifecycleAction.action === 'approve'} className="rounded-lg bg-emerald-600 px-3 py-2 text-xs font-semibold text-white transition hover:bg-emerald-700 disabled:cursor-wait disabled:opacity-60">{lifecycleAction?.key === key(s) && lifecycleAction.action === 'approve' ? t('Schvaluji…', 'Approving…') : t('Schválit publikum', 'Approve audience')}</button></Can>}
+                  </Link> : s.state === 'DRAFT' ? <Can permission="campaign:submit" fallback={<span className="text-xs text-muted-foreground">{t('Čeká na oprávněného autora', 'Awaiting an authorized author')}</span>}><button type="button" onClick={() => void lifecycle(s, 'submit')} disabled={lifecycleFlight.busy} aria-busy={lifecycleAction?.key === key(s) && lifecycleAction.action === 'submit'} className="rounded-lg bg-violet-700 px-3 py-2 text-xs font-semibold text-white transition hover:bg-violet-800 disabled:cursor-wait disabled:opacity-60">{lifecycleAction?.key === key(s) && lifecycleAction.action === 'submit' ? t('Odesílám…', 'Submitting…') : t('Odeslat ke schválení', 'Submit for approval')}</button></Can> : <Can permission="campaign:activate" fallback={<span className="text-xs text-muted-foreground">{t('Čeká na oprávněného schvalovatele', 'Awaiting an authorized approver')}</span>}><button type="button" onClick={event => { approvalTriggerRef.current = event.currentTarget; setLifecycleError(null); setApprovalIntent(s) }} disabled={lifecycleFlight.busy} className="rounded-lg bg-emerald-600 px-3 py-2 text-xs font-semibold text-white transition hover:bg-emerald-700 disabled:cursor-wait disabled:opacity-60">{t('Zkontrolovat a schválit', 'Review and approve')}</button></Can>}
                 </div>
                 <p className="mt-3 flex items-center gap-1.5 text-[.68rem] text-slate-400"><Clock3 className="h-3 w-3" />{t('Dosah se mění s aktuálním stavem; verze pravidel zůstává stejná.', 'Reach changes with current state; the rule version stays fixed.')}</p>
               </article>
@@ -253,6 +265,65 @@ export default function SegmentsPage() {
           </section>
         </>
       )}
+      {approvalIntent && <AudienceApprovalDialog
+        audience={approvalIntent}
+        busy={lifecycleFlight.busy}
+        error={lifecycleError}
+        onCancel={closeApprovalReview}
+        onConfirm={async () => {
+          if (await lifecycle(approvalIntent, 'approve')) setApprovalIntent(null)
+        }}
+      />}
     </div>
   </AuthGuard>
+}
+
+function AudienceApprovalDialog({ audience, busy, error, onCancel, onConfirm }: {
+  audience: Segment
+  busy: boolean
+  error: string | null
+  onCancel: () => void
+  onConfirm: () => Promise<void>
+}) {
+  const { t } = useLanguage()
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const titleId = `audience-approval-${audience.name}-${audience.version}-title`
+  const impactId = `audience-approval-${audience.name}-${audience.version}-impact`
+
+  return <div
+    ref={dialogRef}
+    role="alertdialog"
+    aria-modal="true"
+    aria-labelledby={titleId}
+    aria-describedby={impactId}
+    aria-busy={busy}
+    onKeyDown={event => {
+      if (event.key === 'Escape' && !busy) onCancel()
+      trapDialogFocus(event, dialogRef.current)
+    }}
+    className="fixed inset-0 z-[1200] grid place-items-center bg-slate-950/70 p-5"
+  >
+    <div className="w-full max-w-xl overflow-y-auto rounded-2xl border border-slate-200 bg-white p-6 shadow-2xl" style={{ maxHeight: 'calc(100dvh - 40px)' }}>
+      <div className="flex items-start gap-3">
+        <span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-emerald-50 text-emerald-700"><ShieldCheck className="h-5 w-5" aria-hidden="true" /></span>
+        <div>
+          <h2 id={titleId} className="text-lg font-semibold text-slate-950">{t('Schválit publikum', 'Approve audience')}</h2>
+          <p id={impactId} className="mt-1 text-sm leading-6 text-slate-600">{t(
+            'Tato verze se stane použitelnou v kampaních. Schválení samo nic neodešle; souhlas a frekvenční ochrany se znovu ověří při odeslání.',
+            'This version will become available to campaigns. Approval sends nothing by itself; consent and frequency protections are checked again at send time.',
+          )}</p>
+        </div>
+      </div>
+      <dl className="mt-5 grid gap-3 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm">
+        <div><dt className="text-xs font-bold uppercase tracking-wide text-slate-400">{t('Publikum', 'Audience')}</dt><dd className="mt-1 font-semibold text-slate-900">{audience.name} · v{audience.version}</dd></div>
+        <div><dt className="text-xs font-bold uppercase tracking-wide text-slate-400">{t('Autor', 'Maker')}</dt><dd className="mt-1 text-slate-700">{audience.createdBy || t('neuvedeno', 'not provided')}</dd></div>
+        <div><dt className="text-xs font-bold uppercase tracking-wide text-slate-400">{t('Pravidla, která schvalujete', 'Rules you are approving')}</dt><dd><ul className="mt-2 space-y-1.5 text-slate-700">{audience.rules.map(rule => <li key={rule} className="flex gap-2"><span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-violet-500" />{rule}</li>)}</ul></dd></div>
+      </dl>
+      {error && <p role="alert" className="mt-4 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800">{error}</p>}
+      <div className="mt-5 flex justify-end gap-2">
+        <button type="button" autoFocus disabled={busy} onClick={onCancel} className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 disabled:opacity-60">{t('Zpět ke kontrole', 'Back to review')}</button>
+        <button type="button" disabled={busy} aria-busy={busy} onClick={() => void onConfirm()} className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white disabled:cursor-wait disabled:opacity-60">{busy ? t('Schvaluji…', 'Approving…') : t('Potvrdit schválení', 'Confirm approval')}</button>
+      </div>
+    </div>
+  </div>
 }

--- a/openbank-admin-ui/src/test/audience-approval-review.guard.test.ts
+++ b/openbank-admin-ui/src/test/audience-approval-review.guard.test.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import path from 'path'
+
+const source = readFileSync(path.resolve(__dirname, '../app/segments/page.tsx'), 'utf8')
+
+describe('audience approval review', () => {
+  it('shows the immutable audience evidence before approval', () => {
+    expect(source).toContain('role="alertdialog"')
+    expect(source).toContain('audience.createdBy')
+    expect(source).toContain('audience.rules.map')
+    expect(source).toContain('audience.name} · v{audience.version')
+  })
+
+  it('preserves the protected endpoint and closes only after success', () => {
+    expect(source).toContain("action: 'submit' | 'approve'")
+    expect(source).toContain("method: 'POST'")
+    expect(source).toContain("if (await lifecycle(approvalIntent, 'approve')) setApprovalIntent(null)")
+    expect(source).toContain('trapDialogFocus(event, dialogRef.current)')
+  })
+})

--- a/openbank-admin-ui/src/test/audience-library.test.tsx
+++ b/openbank-admin-ui/src/test/audience-library.test.tsx
@@ -43,7 +43,7 @@ describe('audience library', () => {
     const session = { user: { roles: ['ROLE_OPERATOR'] }, expires: '2099-01-01' }
     render(React.createElement(SessionProvider, { session }, React.createElement(LanguageProvider, null, React.createElement(SegmentsPage))))
     const submit = await screen.findByRole('button', { name: 'Submit for approval' })
-    const approve = screen.getByRole('button', { name: 'Approve audience' })
+    const approve = screen.getByRole('button', { name: 'Review and approve' })
     await act(async () => {
       // Native activations share one React batch. This is the pre-render race that
       // `disabled` cannot stop; only the hook's synchronous ref claim can.
@@ -57,6 +57,38 @@ describe('audience library', () => {
 
     completeMutation?.({ ok: true, json: async () => ({}) })
     await waitFor(() => expect(screen.getByRole('button', { name: 'Submit for approval' })).toBeTruthy())
+  })
+
+  it('keeps the exact audience approval review open after failure and permits a safe retry', async () => {
+    let decisions = 0
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.endsWith('/approve')) {
+        decisions += 1
+        return decisions === 1
+          ? { ok: false, json: async () => ({ error: 'temporarily unavailable' }) }
+          : { ok: true, json: async () => ({}) }
+      }
+      return { ok: true, json: async () => ({
+        state: 'ok',
+        items: decisions > 1 ? [] : [{ name: 'tenured', version: 3, rules: ['tenure >= 30 days'], state: 'PENDING_APPROVAL', createdBy: 'maker.operator' }],
+      }) }
+    }))
+
+    const session = { user: { roles: ['ROLE_OPERATOR'] }, expires: '2099-01-01' }
+    render(React.createElement(SessionProvider, { session }, React.createElement(LanguageProvider, null, React.createElement(SegmentsPage))))
+    fireEvent.click(await screen.findByRole('button', { name: 'Review and approve' }))
+
+    const dialog = screen.getByRole('alertdialog')
+    expect(dialog).toHaveTextContent('tenured · v3')
+    expect(dialog).toHaveTextContent('maker.operator')
+    expect(dialog).toHaveTextContent('tenure >= 30 days')
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm approval' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('state change did not complete')
+    expect(screen.getByRole('alertdialog')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm approval' }))
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+    expect(decisions).toBe(2)
   })
 
   it('reports lifecycle mutation errors locally without replacing the loaded catalogue', async () => {


### PR DESCRIPTION
## Summary

- add a focused review alert dialog before a pending audience becomes approved
- show the exact audience name, version, maker, and complete selection rules
- explain the operational effect without implying that approval sends a campaign
- retain the dialog on mutation failure and allow a safe retry
- preserve the existing POST endpoint, campaign RBAC, refresh behavior, and maker-checker enforcement

Closes #7882

## Verification

- `npm run pretest`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run src/test/audience-library.test.tsx src/test/audience-approval-review.guard.test.ts src/test/segments-rbac.guard.test.ts` (8 passed)
- `./node_modules/.bin/playwright test e2e/audience-approval-review.spec.ts --project=chromium` (1 passed; first approval returns 503, dialog remains, retry succeeds exactly once)
- `git diff --check`

## Security and operational behavior

- no permission or campaign-service changes
- no audience definition or selection-rule changes
- no request endpoint or payload changes
- service-side four-eyes enforcement remains authoritative
