### PR TITLE
fix(admin-ui): review identity case decisions

### DIFF
--- a/openbank-admin-ui/e2e/identity-decision-review.spec.ts
+++ b/openbank-admin-ui/e2e/identity-decision-review.spec.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const caseId = '019fbe12-1111-7222-8333-444444444444'
+const candidateId = '019fbe12-aaaa-7bbb-8ccc-dddddddddddd'
+const identityCase = {
+  id: caseId,
+  trigger: 'RN_COLLISION',
+  status: 'AWAITING_SECOND_APPROVAL',
+  applicant: {
+    givenName: 'Jana',
+    familyName: 'Nováková',
+    birthdate: '1986-04-12',
+    birthplace: 'Brno',
+    nationalities: ['CZ'],
+  },
+  candidatePartyIds: [candidateId],
+  firstApprover: 'first.reviewer',
+  firstVerdict: 'LINK_TO_EXISTING',
+  firstLinkPartyId: candidateId,
+  firstNotes: 'Registry number and document evidence agree.',
+  firstAt: '2026-08-31T10:00:00Z',
+  secondApprover: null,
+  finalVerdict: null,
+  decidedAt: null,
+  createdAt: '2026-08-31T09:00:00Z',
+}
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('reviews the exact second identity vote and retains a failed decision for retry', async ({ page }) => {
+  let decisions = 0
+  let cases = [identityCase]
+  const base = '/api/svc/pid-service/api/v1/parties/cases'
+  await page.route(new RegExp(`${base}$`), route => route.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify(cases),
+  }))
+  await page.route(`**${base}/${caseId}/decision`, async route => {
+    decisions += 1
+    expect(route.request().method()).toBe('POST')
+    expect(await route.request().postDataJSON()).toEqual({
+      verdict: 'LINK_TO_EXISTING',
+      notes: 'Second reviewer confirmed the same evidence.',
+      linkPartyId: candidateId,
+    })
+    if (decisions === 1) {
+      await route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ message: 'PID temporarily unavailable.' }) })
+      return
+    }
+    cases = []
+    await route.fulfill({ contentType: 'application/json', body: '{}' })
+  })
+
+  await page.goto('/identity-cases')
+  await page.getByLabel(/Decision notes|Poznámka k rozhodnutí/).fill('Second reviewer confirmed the same evidence.')
+  await page.getByRole('button', { name: /Confirm & decide|Potvrdit a rozhodnout/ }).click()
+  const dialog = page.getByRole('alertdialog')
+  await expect(dialog).toContainText('Jana Nováková · 1986-04-12')
+  await expect(dialog).toContainText(caseId)
+  await expect(dialog).toContainText(`LINK_TO_EXISTING → ${candidateId}`)
+  await expect(dialog).toContainText('first.reviewer → LINK_TO_EXISTING')
+  await expect(dialog).toContainText('Second reviewer confirmed the same evidence.')
+
+  const confirm = dialog.getByRole('button', { name: /Confirm vote|Potvrdit hlas/ })
+  await confirm.click()
+  await expect(dialog.getByRole('alert')).toContainText('PID temporarily unavailable.')
+  await expect(dialog).toBeVisible()
+  await confirm.click()
+
+  await expect(dialog).toBeHidden()
+  await expect(page.getByText(/No open cases|Žádné otevřené případy/)).toBeVisible()
+  expect(decisions).toBe(2)
+})

--- a/openbank-admin-ui/src/app/identity-cases/page.tsx
+++ b/openbank-admin-ui/src/app/identity-cases/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useSingleFlight, wasSkipped } from '@/lib/mutations/singleFlight'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
@@ -12,6 +12,7 @@ import { DataUnavailable, type UnavailableKind } from '@/components/feedback/Dat
 import { PageHeader } from '@/components/ui/PageHeader'
 import { AuthGuard, Can } from '@/components/auth/AuthGuard'
 import { Fingerprint, RefreshCw, ShieldAlert, Users, Check } from 'lucide-react'
+import { trapDialogFocus } from '@/lib/a11y/trapDialogFocus'
 
 const SVC = 'pid-service'
 
@@ -76,6 +77,8 @@ function DecisionForm({
   const [notes, setNotes] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [decisionIntent, setDecisionIntent] = useState<'vote' | 'reopen' | null>(null)
+  const decisionTriggerRef = useRef<HTMLButtonElement | null>(null)
 
   const isSecond = c.status === 'AWAITING_SECOND_APPROVAL'
 
@@ -87,6 +90,7 @@ function DecisionForm({
   const flight = useSingleFlight()
 
   const submit = useCallback(async () => {
+    let succeeded = false
     const outcome = await flight.run(`identity-case:${c.id}`, async () => {
     setBusy(true)
     setError(null)
@@ -111,6 +115,7 @@ function DecisionForm({
         )
         return
       }
+      succeeded = true
       onDecided()
     } catch {
       setError(t('Služba je nedostupná.', 'Service unavailable.'))
@@ -118,10 +123,12 @@ function DecisionForm({
       setBusy(false)
     }
     })
-    if (wasSkipped(outcome)) return
+    if (wasSkipped(outcome)) return false
+    return succeeded
   }, [flight, verdict, linkPartyId, notes, c.id, onDecided, t])
 
   const reopen = useCallback(async () => {
+    let succeeded = false
     const outcome = await flight.run(`identity-case:${c.id}`, async () => {
     setBusy(true)
     setError(null)
@@ -134,6 +141,7 @@ function DecisionForm({
         setError(t('Znovuotevření se nezdařilo.', 'Reopen failed.'))
         return
       }
+      succeeded = true
       onDecided()
     } catch {
       setError(t('Služba je nedostupná.', 'Service unavailable.'))
@@ -141,8 +149,21 @@ function DecisionForm({
       setBusy(false)
     }
     })
-    if (wasSkipped(outcome)) return
+    if (wasSkipped(outcome)) return false
+    return succeeded
   }, [flight, c.id, onDecided, t])
+
+  const openDecisionReview = (intent: 'vote' | 'reopen', trigger: HTMLButtonElement) => {
+    decisionTriggerRef.current = trigger
+    setError(null)
+    setDecisionIntent(intent)
+  }
+
+  const closeDecisionReview = () => {
+    if (busy) return
+    setDecisionIntent(null)
+    requestAnimationFrame(() => decisionTriggerRef.current?.focus())
+  }
 
   return (
     <div style={{ marginTop: '12px', paddingTop: '12px', borderTop: '1px solid var(--border)' }}>
@@ -210,21 +231,99 @@ function DecisionForm({
           style={{ fontSize: '13px', padding: '6px 8px', flex: '1 1 160px', minWidth: '140px' }}
         />
 
-        <button type="button" aria-busy={busy} className="btn btn-primary" onClick={submit} disabled={busy} style={{ fontSize: '13px' }}>
+        <button type="button" className="btn btn-primary" onClick={event => openDecisionReview('vote', event.currentTarget)} disabled={busy} style={{ fontSize: '13px' }}>
           <Check size={14} aria-hidden="true" style={{ marginRight: '4px' }} />
           {isSecond ? t('Potvrdit a rozhodnout', 'Confirm & decide') : t('Odeslat hlas', 'Submit vote')}
         </button>
 
         {isSecond && (
-          <button type="button" aria-busy={busy} className="btn btn-secondary" onClick={reopen} disabled={busy} style={{ fontSize: '13px' }}>
+          <button type="button" className="btn btn-secondary" onClick={event => openDecisionReview('reopen', event.currentTarget)} disabled={busy} style={{ fontSize: '13px' }}>
             {t('Znovu otevřít', 'Reopen')}
           </button>
         )}
       </div>
 
-      {error && <div style={{ fontSize: '12px', color: 'var(--danger)', marginTop: '8px' }}>{error}</div>}
+      {error && !decisionIntent && <div role="alert" style={{ fontSize: '12px', color: 'var(--danger)', marginTop: '8px' }}>{error}</div>}
+      {decisionIntent && <IdentityDecisionReviewDialog
+        c={c}
+        intent={decisionIntent}
+        verdict={verdict}
+        linkPartyId={linkPartyId}
+        notes={notes}
+        busy={busy}
+        error={error}
+        onCancel={closeDecisionReview}
+        onConfirm={async () => {
+          const succeeded = decisionIntent === 'vote' ? await submit() : await reopen()
+          if (succeeded) setDecisionIntent(null)
+        }}
+      />}
     </div>
   )
+}
+
+function IdentityDecisionReviewDialog({ c, intent, verdict, linkPartyId, notes, busy, error, onCancel, onConfirm }: {
+  c: VerificationCase
+  intent: 'vote' | 'reopen'
+  verdict: Verdict
+  linkPartyId: string
+  notes: string
+  busy: boolean
+  error: string | null
+  onCancel: () => void
+  onConfirm: () => Promise<void>
+}) {
+  const { t } = useLanguage()
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const titleId = `identity-${c.id}-decision-title`
+  const impactId = `identity-${c.id}-decision-impact`
+  const isReopen = intent === 'reopen'
+
+  return <div
+    ref={dialogRef}
+    role="alertdialog"
+    aria-modal="true"
+    aria-labelledby={titleId}
+    aria-describedby={impactId}
+    aria-busy={busy}
+    onKeyDown={event => {
+      if (event.key === 'Escape' && !busy) onCancel()
+      trapDialogFocus(event, dialogRef.current)
+    }}
+    style={{ position: 'fixed', inset: 0, zIndex: 1200, background: 'rgba(15,23,42,.72)', display: 'grid', placeItems: 'center', padding: 20 }}
+  >
+    <div className="card" style={{ width: 'min(620px, 100%)', maxHeight: 'calc(100dvh - 40px)', overflowY: 'auto', padding: 22 }}>
+      <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+        <Fingerprint size={20} aria-hidden="true" style={{ color: 'var(--accent)', flexShrink: 0, marginTop: 2 }} />
+        <div>
+          <h2 id={titleId} style={{ margin: 0, fontSize: 17, fontWeight: 750 }}>{isReopen ? t('Znovu otevřít případ identity', 'Reopen identity case') : isSecondVote(c) ? t('Potvrdit druhý hlas', 'Confirm second vote') : t('Odeslat první hlas', 'Submit first vote')}</h2>
+          <p id={impactId} style={{ margin: '6px 0 0', fontSize: 12.5, lineHeight: 1.5, color: 'var(--text-secondary)' }}>
+            {isReopen
+              ? t('Neshodný případ vrátíte do otevřeného posouzení. Předchozí hlasy zůstanou v auditní stopě; nový verdikt bude znovu vyžadovat čtyři oči.', 'The disputed case returns to open adjudication. Prior votes remain in the audit trail; a new verdict again requires four-eyes.')
+              : isSecondVote(c)
+                ? t('Stejný verdikt od jiného schvalovatele případ dokončí. Odlišný verdikt služba odmítne a případ lze znovu otevřít.', 'The same verdict from a different approver completes the case. The service rejects a disagreement and the case can be reopened.')
+                : t('Tímto uložíte první hlas. Konečné rozhodnutí vznikne až po stejném hlasu jiného oprávněného schvalovatele.', 'This records the first vote. A final decision exists only after the same vote from another authorized approver.')}
+          </p>
+        </div>
+      </div>
+      <dl style={{ margin: '14px 0 0', padding: 12, borderRadius: 9, border: '1px solid var(--border)', background: 'var(--surface-2)', display: 'grid', gap: 8, fontSize: 12.5 }}>
+        <div><dt style={{ color: 'var(--text-tertiary)', fontSize: 11 }}>{t('Žadatel', 'Applicant')}</dt><dd style={{ margin: '2px 0 0', fontWeight: 650 }}>{c.applicant.givenName} {c.applicant.familyName} · {c.applicant.birthdate}</dd></div>
+        <div><dt style={{ color: 'var(--text-tertiary)', fontSize: 11 }}>{t('Případ a spouštěč', 'Case and trigger')}</dt><dd className="mono" style={{ margin: '2px 0 0', wordBreak: 'break-all' }}>{c.id} · {c.trigger}</dd></div>
+        {!isReopen && <div><dt style={{ color: 'var(--text-tertiary)', fontSize: 11 }}>{t('Verdikt', 'Verdict')}</dt><dd style={{ margin: '2px 0 0', fontWeight: 700, color: VERDICT_COLOR[verdict] }}>{verdict}{verdict === 'LINK_TO_EXISTING' ? ` → ${linkPartyId}` : ''}</dd></div>}
+        {!isReopen && <div><dt style={{ color: 'var(--text-tertiary)', fontSize: 11 }}>{t('Poznámka', 'Notes')}</dt><dd style={{ margin: '2px 0 0' }}>{notes || t('bez poznámky', 'no notes')}</dd></div>}
+        {c.firstApprover && <div><dt style={{ color: 'var(--text-tertiary)', fontSize: 11 }}>{t('První hlas', 'First vote')}</dt><dd style={{ margin: '2px 0 0' }}>{c.firstApprover} → <strong>{c.firstVerdict}</strong>{c.firstLinkPartyId ? ` → ${c.firstLinkPartyId}` : ''}{c.firstNotes ? ` · ${c.firstNotes}` : ''}</dd></div>}
+      </dl>
+      {error && <p role="alert" style={{ margin: '12px 0 0', padding: '10px 12px', borderRadius: 8, color: 'var(--danger-text)', background: 'var(--danger-bg)', border: '1px solid var(--danger-border)', fontSize: 12 }}>{error}</p>}
+      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 18 }}>
+        <button type="button" autoFocus className="btn btn-secondary" disabled={busy} onClick={onCancel}>{t('Zpět ke kontrole', 'Back to review')}</button>
+        <button type="button" className="btn btn-primary" disabled={busy} aria-busy={busy} onClick={() => void onConfirm()}>{busy ? t('Ukládám…', 'Recording…') : isReopen ? t('Potvrdit znovuotevření', 'Confirm reopen') : t('Potvrdit hlas', 'Confirm vote')}</button>
+      </div>
+    </div>
+  </div>
+}
+
+function isSecondVote(c: VerificationCase): boolean {
+  return c.status === 'AWAITING_SECOND_APPROVAL'
 }
 
 // ── Page ────────────────────────────────────────────────────────────────────────

--- a/openbank-admin-ui/src/test/identity-cases-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/identity-cases-a11y.guard.test.ts
@@ -7,8 +7,10 @@ const read = () => fs.readFileSync(path.join(process.cwd(), 'src/app/identity-ca
 describe('identity cases four-eyes accessibility', () => {
   it('keeps decision and refresh controls explicit and stateful', () => {
     const source = read()
-    expect(source).toContain('type="button" aria-busy={busy} className="btn btn-primary"')
-    expect(source).toContain('type="button" aria-busy={busy} className="btn btn-secondary"')
+    expect(source).toContain('role="alertdialog"')
+    expect(source).toContain('aria-busy={busy}')
+    expect(source).toContain('trapDialogFocus(event, dialogRef.current)')
+    expect(source).toContain('if (succeeded) setDecisionIntent(null)')
     expect(source).toContain('type="button"')
     expect(source).toContain('aria-busy={loading}')
     expect(source).toContain('className="btn btn-secondary"')


### PR DESCRIPTION
## Summary

- add a final alert-dialog review for first votes, second votes, and disputed-case reopen
- show exact applicant/case evidence, selected verdict and link target, notes, and prior vote
- explain when a vote is provisional, when a matching second vote completes the case, and what reopen preserves
- retain the review after a refusal or outage and allow a safe retry
- preserve PID endpoints/payloads, RBAC, concurrency arbitration, and service-side four-eyes enforcement

Closes #7888

## Verification

- `npm run pretest`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run src/test/identity-cases-a11y.guard.test.ts src/test/identity-cases-refresh.guard.test.ts src/test/identity-cases-rbac.guard.test.ts` (4 passed)
- `./node_modules/.bin/playwright test e2e/identity-decision-review.spec.ts --project=chromium` (1 passed; exact second-vote payload/evidence, first request 503, retry succeeds)
- `git diff --check`

## Security and operational behavior

- no PID service, identity matching, or authorization changes
- decision and reopen endpoints/payloads are unchanged
- server remains authoritative for distinct approvers, matching verdicts, and conflict handling
