### PR TITLE
fix(admin-ui): review compliance pack decisions

### DIFF
--- a/openbank-admin-ui/e2e/compliance-pack-decision-review.spec.ts
+++ b/openbank-admin-ui/e2e/compliance-pack-decision-review.spec.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const proposal = {
+  id: '019fb939-3e0a-7716-a1ed-7854754c8786',
+  jurisdiction: 'CZ',
+  productType: 'CONSUMER_CREDIT',
+  packVersion: 3,
+  effectiveFrom: '2026-10-01',
+  contentHash: 'b7c4d1e9a0f35286bb1122334455667788990011223344556677889900aabbcc',
+  state: 'PROPOSED',
+  proposedBy: 'maker@openbank.test',
+  decidedBy: null,
+  decidedAt: null,
+  proposedAt: '2026-08-31T20:00:00Z',
+  decisionReason: null,
+  pack: { jurisdiction: 'CZ', productType: 'CONSUMER_CREDIT', version: 3 },
+}
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('checker reviews exact pack, retains a refusal, and retries the unchanged decision', async ({ page }) => {
+  await page.addInitScript(() => window.localStorage.setItem('openbank-admin-lang', 'en'))
+  await page.route('**/api/svc/lending-service/api/v1/lending/compliance-packs/active', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  )
+  await page.route('**/api/svc/lending-service/api/v1/lending/compliance-packs/proposals/pending', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([proposal]) }),
+  )
+
+  let attempts = 0
+  const payloads: unknown[] = []
+  await page.route(`**/api/svc/lending-service/api/v1/lending/compliance-packs/proposals/${proposal.id}/decide`, async route => {
+    attempts += 1
+    payloads.push(route.request().postDataJSON())
+    if (attempts === 1) {
+      return route.fulfill({ status: 422, contentType: 'application/json', body: JSON.stringify({ error: 'Checker must differ from maker' }) })
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+  })
+
+  await page.goto('/lending/compliance-packs')
+  await page.getByRole('textbox', { name: 'Decision reason' }).fill('independent legal review')
+  await page.getByRole('button', { name: 'Approve' }).click()
+
+  const dialog = page.getByRole('alertdialog', { name: 'Review pack activation' })
+  await expect(dialog).toContainText('immediately governs new lending applications')
+  await expect(dialog).toContainText(proposal.contentHash)
+  await expect(dialog).toContainText(proposal.id)
+  await expect(dialog).toContainText('independent legal review')
+  expect(attempts).toBe(0)
+
+  await dialog.getByRole('button', { name: 'Confirm activation' }).click()
+  await expect(dialog.getByTestId('decision-review-error')).toContainText('Checker must differ from maker')
+  await expect(dialog).toBeVisible()
+
+  await dialog.getByRole('button', { name: 'Confirm activation' }).click()
+  await expect(dialog).toBeHidden()
+  expect(attempts).toBe(2)
+  expect(payloads).toEqual([
+    { approve: true, reason: 'independent legal review' },
+    { approve: true, reason: 'independent legal review' },
+  ])
+})

--- a/openbank-admin-ui/src/app/lending/compliance-packs/page.tsx
+++ b/openbank-admin-ui/src/app/lending/compliance-packs/page.tsx
@@ -17,7 +17,7 @@
 
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { CheckCircle2, Clock, RefreshCw, ShieldCheck, ScrollText, AlertTriangle } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -70,6 +70,9 @@ export default function CompliancePacksPage() {
   const [reasons, setReasons] = useState<Record<string, string>>({})
   const [packJson, setPackJson] = useState('')
   const [detail, setDetail] = useState<PackActivationView | null>(null)
+  const [review, setReview] = useState<{ proposal: PackActivationView; approve: boolean } | null>(null)
+  const reviewCancelRef = useRef<HTMLButtonElement>(null)
+  const reviewConfirmRef = useRef<HTMLButtonElement>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -168,6 +171,7 @@ export default function CompliancePacksPage() {
         ? t('Pack aktivován. Guard ho používá okamžitě, bez restartu služby.',
             'Pack activated. The origination guard uses it immediately — no service restart.')
         : t('Návrh zamítnut.', 'Proposal rejected.'))
+      setReview(null)
       await load()
     } catch {
       setError(t('lending-service je nedostupný.', 'lending-service is unreachable.'))
@@ -302,10 +306,10 @@ export default function CompliancePacksPage() {
                 onChange={e => setReasons(r => ({ ...r, [p.id]: e.target.value }))}
                 style={{ fontSize: 12 }}
               />
-              <button type="button" className="btn btn-primary" disabled={busyId === p.id} onClick={() => void decide(p.id, true)} style={{ fontSize: 12 }}>
+              <button type="button" className="btn btn-primary" disabled={busyId === p.id} onClick={() => { setError(null); setReview({ proposal: p, approve: true }) }} style={{ fontSize: 12 }}>
                 {t('Schválit', 'Approve')}
               </button>
-              <button type="button" className="btn btn-secondary" disabled={busyId === p.id} onClick={() => void decide(p.id, false)} style={{ fontSize: 12 }}>
+              <button type="button" className="btn btn-secondary" disabled={busyId === p.id} onClick={() => { setError(null); setReview({ proposal: p, approve: false }) }} style={{ fontSize: 12 }}>
                 {t('Zamítnout', 'Reject')}
               </button>
               </Can>
@@ -318,6 +322,66 @@ export default function CompliancePacksPage() {
           </div>
         )}
       </div>
+
+      {review && (
+        <div
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby="pack-decision-review-title"
+          aria-describedby="pack-decision-review-impact"
+          onKeyDown={event => {
+            if (event.key === 'Escape' && busyId !== review.proposal.id) {
+              setReview(null)
+              setError(null)
+            }
+            if (event.key === 'Tab') {
+              const first = reviewCancelRef.current
+              const last = reviewConfirmRef.current
+              if (event.shiftKey && document.activeElement === first) {
+                event.preventDefault()
+                last?.focus()
+              } else if (!event.shiftKey && document.activeElement === last) {
+                event.preventDefault()
+                first?.focus()
+              }
+            }
+          }}
+          style={{ position: 'fixed', inset: 0, zIndex: 1200, background: 'rgba(15,23,42,.68)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20 }}
+        >
+          <div className="card" style={{ width: 'min(620px, 100%)', maxHeight: '90vh', overflowY: 'auto', padding: 22 }}>
+            <h2 id="pack-decision-review-title" style={{ margin: 0, fontSize: 17 }}>
+              {review.approve ? t('Zkontrolovat aktivaci packu', 'Review pack activation') : t('Zkontrolovat zamítnutí packu', 'Review pack rejection')}
+            </h2>
+            <p id="pack-decision-review-impact" style={{ color: 'var(--text-secondary)', fontSize: 13, lineHeight: 1.55 }}>
+              {review.approve
+                ? t('Po potvrzení začne tento pack okamžitě řídit nové úvěrové žádosti. Není potřeba restart ani release služby.', 'Once confirmed, this pack immediately governs new lending applications. No service restart or release is required.')
+                : t('Po potvrzení bude návrh definitivně zamítnut a nebude ovlivňovat nové úvěrové žádosti.', 'Once confirmed, the proposal is rejected and will not affect new lending applications.')}
+            </p>
+            <dl style={{ display: 'grid', gridTemplateColumns: '150px minmax(0, 1fr)', gap: '8px 12px', padding: 14, borderRadius: 8, background: 'var(--surface-2)', fontSize: 12 }}>
+              <dt>{t('Jurisdikce', 'Jurisdiction')}</dt><dd>{review.proposal.jurisdiction}</dd>
+              <dt>{t('Produkt', 'Product')}</dt><dd>{review.proposal.productType}</dd>
+              <dt>{t('Verze', 'Version')}</dt><dd>v{review.proposal.packVersion}</dd>
+              <dt>{t('Účinnost od', 'Effective from')}</dt><dd>{review.proposal.effectiveFrom}</dd>
+              <dt>{t('Navrhl', 'Proposed by')}</dt><dd>{review.proposal.proposedBy}</dd>
+              <dt>{t('Důvod rozhodnutí', 'Decision reason')}</dt><dd>{reasons[review.proposal.id]?.trim() || t('Neuveden', 'Not provided')}</dd>
+              <dt>{t('Otisk obsahu', 'Content hash')}</dt><dd className="mono" style={{ overflowWrap: 'anywhere' }}>{review.proposal.contentHash}</dd>
+              <dt>{t('ID návrhu', 'Proposal ID')}</dt><dd className="mono" style={{ overflowWrap: 'anywhere' }}>{review.proposal.id}</dd>
+            </dl>
+            <p style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
+              {t('Four-eyes kontrolu vynucuje lending-service: checker musí být jiný principál než maker.', 'The lending service enforces four-eyes: the checker must be a different principal from the maker.')}
+            </p>
+            {error && <div data-testid="decision-review-error" style={{ padding: 10, borderLeft: '3px solid var(--danger)', color: 'var(--danger)', fontSize: 12 }}>{error}</div>}
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 18 }}>
+              <button ref={reviewCancelRef} autoFocus type="button" className="btn btn-secondary" disabled={busyId === review.proposal.id} onClick={() => { setReview(null); setError(null) }}>
+                {t('Zpět', 'Back')}
+              </button>
+              <button ref={reviewConfirmRef} type="button" className={review.approve ? 'btn btn-primary' : 'btn btn-secondary'} aria-busy={busyId === review.proposal.id} disabled={busyId === review.proposal.id} onClick={() => void decide(review.proposal.id, review.approve)}>
+                {busyId === review.proposal.id ? t('Odesílám…', 'Submitting…') : review.approve ? t('Potvrdit aktivaci', 'Confirm activation') : t('Potvrdit zamítnutí', 'Confirm rejection')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {detail && <div onClick={() => setDetail(null)} style={{ position: 'fixed', inset: 0, zIndex: 1000, background: 'rgba(0,0,0,.45)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}>
         <div onClick={e => e.stopPropagation()} className="card" style={{ width: 'min(820px, 100%)', maxHeight: '88vh', overflow: 'auto', padding: 20 }}>

--- a/openbank-admin-ui/src/test/compliance-packs-console.test.tsx
+++ b/openbank-admin-ui/src/test/compliance-packs-console.test.tsx
@@ -156,9 +156,11 @@ describe('compliance pack activation console', () => {
 
     await waitFor(() => expect(screen.getByTestId(`proposal-${PROPOSAL_ID}`)).toBeTruthy())
     fireEvent.click(screen.getByText('Approve'))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm activation' }))
 
-    await waitFor(() => expect(screen.getByTestId('error')).toBeTruthy())
-    expect(screen.getByTestId('error').textContent).toMatch(/must differ from maker/)
+    await waitFor(() => expect(screen.getByTestId('decision-review-error')).toBeTruthy())
+    expect(screen.getByTestId('decision-review-error').textContent).toMatch(/must differ from maker/)
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument()
   })
 
   it('keeps decision controls separate from the pack-detail disclosure', async () => {
@@ -177,19 +179,29 @@ describe('compliance pack activation console', () => {
     expect(screen.getByText('Exact pack content')).toBeInTheDocument()
   })
 
-  it('approving posts approve=true to the proposal decide route', async () => {
+  it('reviews the exact proposal and impact before approving', async () => {
     const f = mockFetch({ pending: { status: 200, body: PENDING } })
     vi.stubGlobal('fetch', f)
     render(React.createElement(Providers, null, React.createElement(CompliancePacksPage)))
 
     await waitFor(() => expect(screen.getByTestId(`proposal-${PROPOSAL_ID}`)).toBeTruthy())
+    fireEvent.change(screen.getByRole('textbox', { name: 'Decision reason' }), { target: { value: 'independent compliance review' } })
     fireEvent.click(screen.getByText('Approve'))
 
+    const dialog = screen.getByRole('alertdialog')
+    expect(dialog).toHaveTextContent('immediately governs new lending applications')
+    expect(dialog).toHaveTextContent(PENDING[0].contentHash)
+    expect(dialog).toHaveTextContent(PROPOSAL_ID)
+    expect(dialog).toHaveTextContent('maker@openbank.local')
+    expect(dialog).toHaveTextContent('independent compliance review')
+    expect(f.mock.calls.some(([u]) => String(u).includes('/decide'))).toBe(false)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm activation' }))
     await waitFor(() => {
       const call = f.mock.calls.find(([u]) => String(u).includes('/decide'))
       expect(call).toBeTruthy()
       expect(String(call?.[0])).toContain(`/proposals/${PROPOSAL_ID}/decide`)
-      expect(JSON.parse(String((call?.[1] as RequestInit)?.body))).toMatchObject({ approve: true })
+      expect(JSON.parse(String((call?.[1] as RequestInit)?.body))).toEqual({ approve: true, reason: 'independent compliance review' })
     })
   })
 


### PR DESCRIPTION
## Summary
- add an accessible final review step before compliance-pack approve/reject mutations
- show the exact proposal ID, full content hash, maker, jurisdiction, product, version, effective date, reason, and action impact
- retain the review and service refusal on failure so the checker can safely retry

## Preserved controls
- unchanged lending-service decide endpoint and JSON payload
- unchanged RBAC and server-enforced maker/checker separation
- unchanged immediate activation semantics and verbatim service error handling

## Verification
- `npm run pretest`
- `npx tsc --noEmit`
- `npx vitest run src/test/compliance-packs-console.test.tsx` (9/9)
- `OPENBANK_E2E_PORT=3117 npx playwright test e2e/compliance-pack-decision-review.spec.ts --project=chromium` (1/1)
- `git diff --check`

Closes #7893