### PR TITLE
fix(admin-ui): review DevOps decisions

### DIFF
--- a/openbank-admin-ui/e2e/devops-decision-review.spec.ts
+++ b/openbank-admin-ui/e2e/devops-decision-review.spec.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const finding = {
+  id: 'finding-deploy-health-42', detector: 'D4_DEPLOY_HEALTH', severity: 'CRITICAL',
+  detectedAt: '2026-08-31T20:00:00Z', title: 'Repeated sandbox rollout failure',
+  rawMetricValue: 4, threshold: 2, affectedResource: 'openbank-admin-ui',
+  doraMetricImpacted: 'CHANGE_FAILURE_RATE', rootCause: 'Readiness probe regressed after rollout',
+  remediationKind: 'PULL_REQUEST', proposalPrUrl: 'https://github.com/JiRaska/open-bank-oss/pull/7000',
+  proposedRemediation: 'Restore the previous readiness timeout and add rollout coverage',
+  status: 'PROPOSED', diagnosedAt: '2026-08-31T20:01:00Z', proposedAt: '2026-08-31T20:02:00Z',
+}
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('operator reviews exact AI remediation, retains failure, and retries unchanged decision', async ({ page }) => {
+  await page.addInitScript(() => window.localStorage.setItem('openbank-admin-lang', 'en'))
+  await page.route('**/api/devops/dora', route => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ overall: null, metrics: { deploymentFrequency: { level: null }, leadTime: { level: null }, changeFailureRate: { level: null }, mttr: { level: null } }, recentDeployments: [], sources: { git: true, prometheus: true }, collectedAt: '2026-08-31T20:00:00Z' }) }))
+  await page.route('**/api/devops/insights', route => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ findings: [finding], available: true }) }))
+
+  let attempts = 0
+  const payloads: unknown[] = []
+  await page.route('**/api/devops/decide', async route => {
+    attempts += 1
+    payloads.push(route.request().postDataJSON())
+    if (attempts === 1) return route.fulfill({ status: 503, contentType: 'application/json', body: '{}' })
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+  })
+
+  await page.goto('/devops')
+  await page.getByRole('button', { name: 'Approve' }).click()
+  const dialog = page.getByRole('alertdialog', { name: 'Review remediation approval' })
+  await expect(dialog).toContainText(finding.title)
+  await expect(dialog).toContainText(finding.rootCause)
+  await expect(dialog).toContainText(finding.proposedRemediation)
+  await expect(dialog.getByRole('link', { name: /Open proposal/ })).toHaveAttribute('href', finding.proposalPrUrl)
+  expect(attempts).toBe(0)
+
+  await dialog.getByRole('button', { name: 'Confirm approval' }).click()
+  await expect(dialog.getByTestId('devops-decision-review-error')).toBeVisible()
+  await expect(dialog).toBeVisible()
+
+  await dialog.getByRole('button', { name: 'Confirm approval' }).click()
+  await expect(dialog).toBeHidden()
+  expect(payloads).toEqual([
+    { id: finding.id, action: 'approve' },
+    { id: finding.id, action: 'approve' },
+  ])
+})

--- a/openbank-admin-ui/src/app/devops/page.tsx
+++ b/openbank-admin-ui/src/app/devops/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import {
   GitBranch, RefreshCw, Rocket, Clock, AlertTriangle, Wrench,
   Info, Zap,
@@ -196,6 +196,9 @@ function DevOpsContent() {
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
   const [deciding, setDeciding] = useState<string | null>(null)
   const [decisionError, setDecisionError] = useState<string | null>(null)
+  const [pendingDecision, setPendingDecision] = useState<{ finding: DevOpsFinding; action: 'approve' | 'reject' } | null>(null)
+  const decisionCancelRef = useRef<HTMLButtonElement>(null)
+  const decisionConfirmRef = useRef<HTMLButtonElement>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -240,6 +243,7 @@ function DevOpsContent() {
         ))
         return
       }
+      setPendingDecision(null)
       await load()
     } catch {
       setDecisionError(t('Služba DevOps neodpovídá. Zkuste to prosím znovu.', 'The DevOps service did not respond. Please try again.'))
@@ -380,14 +384,78 @@ function DevOpsContent() {
             )}
             findings={findings.map(f => toAgentFinding(f, t))}
             emptyMessage={t('Žádné aktivní DevOps nálezy — pipeline v pořádku', 'No active DevOps findings — pipeline healthy')}
-            onApprove={canDecide ? id => decide(id, 'approve') : undefined}
-            onReject={canDecide ? id => decide(id, 'reject') : undefined}
+            onApprove={canDecide ? id => {
+              const finding = findings.find(candidate => candidate.id === id)
+              if (finding) { setDecisionError(null); setPendingDecision({ finding, action: 'approve' }) }
+            } : undefined}
+            onReject={canDecide ? id => {
+              const finding = findings.find(candidate => candidate.id === id)
+              if (finding) { setDecisionError(null); setPendingDecision({ finding, action: 'reject' }) }
+            } : undefined}
             decideLabels={canDecide ? { approve: t('Schválit', 'Approve'), reject: t('Odmítnout', 'Reject') } : undefined}
             decidingId={canDecide ? deciding : null}
           />
           {decisionError && (
             <div role="alert" style={{ marginBottom: '20px', padding: '12px 16px', borderRadius: '8px', background: 'var(--danger-bg)', border: '1px solid var(--danger-border)', color: 'var(--danger-text)', fontSize: '12px' }}>
               {decisionError}
+            </div>
+          )}
+
+          {pendingDecision && (
+            <div
+              role="alertdialog"
+              aria-modal="true"
+              aria-labelledby="devops-decision-review-title"
+              aria-describedby="devops-decision-review-impact"
+              onKeyDown={event => {
+                if (event.key === 'Escape' && deciding !== pendingDecision.finding.id) {
+                  setPendingDecision(null)
+                  setDecisionError(null)
+                }
+                if (event.key === 'Tab') {
+                  const first = decisionCancelRef.current
+                  const last = decisionConfirmRef.current
+                  if (event.shiftKey && document.activeElement === first) {
+                    event.preventDefault()
+                    last?.focus()
+                  } else if (!event.shiftKey && document.activeElement === last) {
+                    event.preventDefault()
+                    first?.focus()
+                  }
+                }
+              }}
+              style={{ position: 'fixed', inset: 0, zIndex: 1200, background: 'rgba(15,23,42,.68)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20 }}
+            >
+              <div className="card" style={{ width: 'min(620px, 100%)', maxHeight: '90vh', overflowY: 'auto', padding: 22 }}>
+                <h2 id="devops-decision-review-title" style={{ margin: 0, fontSize: 17 }}>
+                  {pendingDecision.action === 'approve' ? t('Zkontrolovat schválení remediace', 'Review remediation approval') : t('Zkontrolovat odmítnutí remediace', 'Review remediation rejection')}
+                </h2>
+                <p id="devops-decision-review-impact" style={{ fontSize: 13, lineHeight: 1.55, color: 'var(--text-secondary)' }}>
+                  {pendingDecision.action === 'approve'
+                    ? t('Schválením povolíte navrženou operátorskou remediaci. Samotný nález vytvořil AI agent; rozhodnutí a odpovědnost zůstávají na člověku.', 'Approval authorizes the proposed operator remediation. The finding was produced by an AI agent; the decision and accountability remain human.')
+                    : t('Odmítnutím uzavřete tento návrh bez schválení remediace.', 'Rejection closes this proposal without authorizing the remediation.')}
+                </p>
+                <dl style={{ display: 'grid', gridTemplateColumns: '145px minmax(0, 1fr)', gap: '8px 12px', padding: 14, borderRadius: 8, background: 'var(--surface-2)', fontSize: 12 }}>
+                  <dt>{t('Nález', 'Finding')}</dt><dd>{pendingDecision.finding.title}</dd>
+                  <dt>ID</dt><dd className="mono" style={{ overflowWrap: 'anywhere' }}>{pendingDecision.finding.id}</dd>
+                  <dt>{t('Detektor', 'Detector')}</dt><dd className="mono">{pendingDecision.finding.detector}</dd>
+                  <dt>{t('Závažnost', 'Severity')}</dt><dd>{pendingDecision.finding.severity}</dd>
+                  <dt>{t('Stav', 'Status')}</dt><dd>{pendingDecision.finding.status}</dd>
+                  <dt>{t('Dotčený zdroj', 'Affected resource')}</dt><dd>{pendingDecision.finding.affectedResource}</dd>
+                  <dt>{t('Typ remediace', 'Remediation kind')}</dt><dd>{pendingDecision.finding.remediationKind}</dd>
+                  <dt>{t('DORA dopad', 'DORA impact')}</dt><dd>{pendingDecision.finding.doraMetricImpacted ?? t('Neuveden', 'Not specified')}</dd>
+                  <dt>{t('Kořenová příčina', 'Root cause')}</dt><dd>{pendingDecision.finding.rootCause ?? t('Neuvedena', 'Not specified')}</dd>
+                  <dt>{t('Navržená remediace', 'Proposed remediation')}</dt><dd>{pendingDecision.finding.proposedRemediation ?? t('Neuvedena', 'Not specified')}</dd>
+                </dl>
+                {pendingDecision.finding.proposalPrUrl && <p style={{ fontSize: 12 }}><a href={pendingDecision.finding.proposalPrUrl} target="_blank" rel="noopener noreferrer">{t('Otevřít návrh v novém panelu', 'Open proposal in a new tab')} →</a></p>}
+                {decisionError && <div role="alert" data-testid="devops-decision-review-error" style={{ padding: 10, borderLeft: '3px solid var(--danger)', color: 'var(--danger)', fontSize: 12 }}>{decisionError}</div>}
+                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 18 }}>
+                  <button ref={decisionCancelRef} autoFocus type="button" className="btn btn-secondary" disabled={deciding === pendingDecision.finding.id} onClick={() => { setPendingDecision(null); setDecisionError(null) }}>{t('Zpět', 'Back')}</button>
+                  <button ref={decisionConfirmRef} type="button" className="btn btn-primary" aria-busy={deciding === pendingDecision.finding.id} disabled={deciding === pendingDecision.finding.id} onClick={() => void decide(pendingDecision.finding.id, pendingDecision.action)}>
+                    {deciding === pendingDecision.finding.id ? t('Odesílám…', 'Submitting…') : pendingDecision.action === 'approve' ? t('Potvrdit schválení', 'Confirm approval') : t('Potvrdit odmítnutí', 'Confirm rejection')}
+                  </button>
+                </div>
+              </div>
             </div>
           )}
 

--- a/openbank-admin-ui/src/test/devops-decision-review.guard.test.ts
+++ b/openbank-admin-ui/src/test/devops-decision-review.guard.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('DevOps HITL decision review', () => {
+  it('reviews the exact finding before preserving the existing decision payload', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/devops/page.tsx'), 'utf8')
+    expect(source).toContain('role="alertdialog"')
+    expect(source).toContain('pendingDecision.finding.proposedRemediation')
+    expect(source).toContain('pendingDecision.finding.proposalPrUrl')
+    expect(source).toContain("body: JSON.stringify({ id, action })")
+    expect(source).toContain("setPendingDecision({ finding, action: 'approve' })")
+    expect(source).not.toContain("onApprove={canDecide ? id => decide(id, 'approve')")
+  })
+})

--- a/openbank-admin-ui/src/test/devops-hitl-rbac.guard.test.ts
+++ b/openbank-admin-ui/src/test/devops-hitl-rbac.guard.test.ts
@@ -12,8 +12,11 @@ describe('DevOps HITL authority contract', () => {
     expect(roles).toContain('"devops:decide":             [ROLES.ADMIN]')
     expect(page).toContain("<AuthGuard permission=\"system:view\">")
     expect(page).toContain("hasPermission('devops:decide')")
-    expect(page).toContain("onApprove={canDecide ? id => decide(id, 'approve') : undefined}")
-    expect(page).toContain("onReject={canDecide ? id => decide(id, 'reject') : undefined}")
+    expect(page).toContain('onApprove={canDecide ? id => {')
+    expect(page).toContain("setPendingDecision({ finding, action: 'approve' })")
+    expect(page).toContain('onReject={canDecide ? id => {')
+    expect(page).toContain("setPendingDecision({ finding, action: 'reject' })")
+    expect(page).toContain('onClick={() => void decide(pendingDecision.finding.id, pendingDecision.action)}')
   })
 
   it('reports failed decision writes instead of silently refreshing', () => {


### PR DESCRIPTION
## Summary
- add an accessible final review before DevOps-agent remediation approval or rejection
- show the exact finding, detector, severity, resource, DORA impact, root cause, remediation kind/text, and proposal link
- retain the dialog and error after a failed decision so the operator can safely retry

## Preserved controls
- unchanged `POST /api/devops/decide` payload `{ id, action }`
- unchanged `devops:decide` RBAC and human-in-the-loop semantics
- no devops-agent, remediation execution, or DORA calculation changes

## Verification
- `npm run pretest`
- `npx tsc --noEmit`
- `npx vitest run src/test/devops-decision-review.guard.test.ts` (1/1)
- `OPENBANK_E2E_PORT=3118 npx playwright test e2e/devops-decision-review.spec.ts --project=chromium` (1/1)
- `git diff --check`

Closes #7895