### PR TITLE
feat(admin-ui): review payment orders before submission

### DIFF
--- a/openbank-admin-ui/e2e/payment-create.spec.ts
+++ b/openbank-admin-ui/e2e/payment-create.spec.ts
@@ -8,7 +8,7 @@ test.beforeEach(async ({ context, baseURL }) => {
   await signInAsOperator(context, baseURL!)
 })
 
-test('creates one SEPA payment with one idempotent BFF request under a double submit', async ({ page }) => {
+test('reviews and creates one SEPA payment with one idempotent BFF request under a double confirmation', async ({ page }) => {
   const posts: { key: string | null; body: Record<string, unknown> }[] = []
 
   await page.route('**/api/sepa-payments', async route => {
@@ -39,10 +39,18 @@ test('creates one SEPA payment with one idempotent BFF request under a double su
   await page.getByLabel('Amount (EUR)').fill('100.00')
 
   const form = page.getByLabel('Debtor IBAN').locator('xpath=ancestor::form')
-  await form.evaluate(element => {
-    const paymentForm = element as HTMLFormElement
-    paymentForm.requestSubmit()
-    paymentForm.requestSubmit()
+  await form.evaluate(element => (element as HTMLFormElement).requestSubmit())
+
+  const review = page.getByRole('alertdialog', { name: 'Review payment order' })
+  await expect(review).toBeVisible()
+  await expect(review).toContainText('100.00 EUR')
+  await expect(review).toContainText('Jane Doe')
+  await expect(review).toContainText('DE89370400440532013000')
+  expect(posts).toHaveLength(0)
+
+  await page.getByRole('button', { name: 'Confirm and submit' }).evaluate((button: HTMLButtonElement) => {
+    button.click()
+    button.click()
   })
 
   await expect(page.getByText('SEPA payment created')).toBeVisible()
@@ -55,5 +63,53 @@ test('creates one SEPA payment with one idempotent BFF request under a double su
     amount: 100,
     currency: 'EUR',
     instant: false,
+  })
+})
+
+test('reviews the exact domestic payment before the BFF request leaves the browser', async ({ page }) => {
+  const posts: { key: string | null; body: Record<string, unknown> }[] = []
+  await page.route('**/api/sepa-payments', route => route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }))
+  await page.route('**/api/domestic-payments', async route => {
+    const request = route.request()
+    if (request.method() === 'POST') {
+      posts.push({ key: request.headers()['idempotency-key'] ?? null, body: request.postDataJSON() as Record<string, unknown> })
+      return route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify({ id: 'domestic-e2e-1' }) })
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  })
+
+  await page.goto('/payments')
+  await page.getByRole('button', { name: 'New Payment' }).click()
+  await page.getByRole('button', { name: /Domestic Standard/ }).click()
+  await page.getByLabel('Debtor Account ID').fill('account-42')
+  await page.getByLabel('Debtor Account No.').fill('1234567890')
+  await page.getByLabel('Debtor bank code').fill('0100')
+  await page.getByLabel('Debtor Name').fill('OpenBank Treasury')
+  await page.getByLabel('Creditor Account No.').fill('7654321')
+  await page.getByLabel('Creditor bank code').fill('0800')
+  await page.getByLabel('Creditor Name').fill('Czech Supplier s.r.o.')
+  await page.getByLabel('Amount').fill('1250.50')
+  await page.getByLabel('Variable Symbol').fill('20260901')
+  await page.getByRole('button', { name: 'Create', exact: true }).click()
+
+  const review = page.getByRole('alertdialog', { name: 'Review payment order' })
+  await expect(review).toContainText('1,250.50 CZK')
+  await expect(review).toContainText('OpenBank Treasury')
+  await expect(review).toContainText('7654321/0800')
+  await expect(review).toContainText('20260901')
+  expect(posts).toHaveLength(0)
+
+  await page.getByRole('button', { name: 'Confirm and submit' }).click()
+  await expect(page.getByText('Payment created')).toBeVisible()
+  expect(posts).toHaveLength(1)
+  expect(posts[0].key).toMatch(/^[0-9a-f-]{8,}$/)
+  expect(posts[0].body).toMatchObject({
+    debtorAccountId: 'account-42',
+    creditorAccountNumber: '7654321',
+    creditorBankCode: '0800',
+    creditorName: 'Czech Supplier s.r.o.',
+    amount: 1250.5,
+    currency: 'CZK',
+    variableSymbol: '20260901',
   })
 })

--- a/openbank-admin-ui/e2e/sct-inst-vop.spec.ts
+++ b/openbank-admin-ui/e2e/sct-inst-vop.spec.ts
@@ -63,6 +63,11 @@ test.describe('SCT Inst payee verification', () => {
     await page.getByRole('button', { name: /Verify|Ověřit/ }).click()
     await expect(page.getByText(/MATCH —/)).toBeVisible()
     await page.getByRole('button', { name: /Send instant|Odeslat okamžitě/ }).click()
+    const review = page.getByRole('alertdialog', { name: /Review payment order|Zkontrolovat platební příkaz/ })
+    await expect(review).toContainText('MATCH')
+    await expect(review).toContainText('Verified Supplier GmbH')
+    expect(paymentRequests).toBe(0)
+    await page.getByRole('button', { name: /Confirm and submit|Potvrdit a odeslat/ }).click()
 
     await expect(page.getByText(/SCT Inst payment created|SCT Inst platba vytvořena/)).toBeVisible()
     expect(paymentRequests).toBe(1)

--- a/openbank-admin-ui/src/app/payments/page.tsx
+++ b/openbank-admin-ui/src/app/payments/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState, useEffect, useCallback, Suspense } from 'react'
+import { useState, useEffect, useCallback, useRef, Suspense } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -280,6 +280,18 @@ function PaymentsContent() {
   const [createSuccess, setCreateSuccess] = useState<string | null>(null)
   const [domesticForm, setDomesticForm] = useState<DomesticFormData>(emptyDomestic(false))
   const [sepaForm, setSepaForm] = useState<SepaFormData>(emptySepa(false))
+  const [paymentReview, setPaymentReview] = useState<'domestic' | 'sepa' | null>(null)
+  const reviewBackRef = useRef<HTMLButtonElement>(null)
+  const reviewConfirmRef = useRef<HTMLButtonElement>(null)
+  const domesticSubmitRef = useRef<HTMLButtonElement>(null)
+  const sepaSubmitRef = useRef<HTMLButtonElement>(null)
+
+  const returnToPaymentForm = () => {
+    const submit = paymentReview === 'domestic' ? domesticSubmitRef.current : sepaSubmitRef.current
+    setPaymentReview(null)
+    setCreateError(null)
+    window.requestAnimationFrame(() => submit?.focus())
+  }
 
   // SCT Inst monitoring state
   const [sctPayments, setSctPayments] = useState<SctInstPayment[]>([])
@@ -350,8 +362,8 @@ function PaymentsContent() {
     }
   }
 
-  const handleDomesticCreate = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleDomesticCreate = async (e?: React.FormEvent, confirmed = false) => {
+    e?.preventDefault()
     setCreateError(null); setCreateSuccess(null)
     if (!canCreate) {
       setCreateError(t('Nemáte oprávnění vytvářet platby', 'You do not have permission to create payments'))
@@ -361,6 +373,10 @@ function PaymentsContent() {
     if (!f.debtorAccountId || !f.debtorAccountNumber || !f.debtorBankCode || !f.debtorName ||
         !f.creditorAccountNumber || !f.creditorBankCode || !f.creditorName || !f.amount) {
       setCreateError(t('Vyplňte všechna povinná pole', 'Please fill all required fields'))
+      return
+    }
+    if (!confirmed) {
+      setPaymentReview('domestic')
       return
     }
     const outcome = await flight.run('payment:create:domestic', async () => {
@@ -389,6 +405,7 @@ function PaymentsContent() {
       // submission of an identical payload is then a NEW payment, not a replay.
       domesticIdem.clear()
       setCreateSuccess(t(f.instant ? 'Okamžitá platba vytvořena' : 'Platba vytvořena', f.instant ? 'Instant payment created' : 'Payment created'))
+      setPaymentReview(null)
       setShowCreate(null)
       load()
     } catch (err: unknown) {
@@ -398,8 +415,8 @@ function PaymentsContent() {
     if (wasSkipped(outcome)) return
   }
 
-  const handleSepaCreate = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleSepaCreate = async (e?: React.FormEvent, confirmed = false) => {
+    e?.preventDefault()
     setCreateError(null); setCreateSuccess(null)
     if (!canCreate) {
       setCreateError(t('Nemáte oprávnění vytvářet platby', 'You do not have permission to create payments'))
@@ -423,6 +440,10 @@ function PaymentsContent() {
       setCreateError(t('Jméno příjemce nesouhlasí (VoP NO_MATCH) — platbu nelze odeslat', 'Payee name does not match (VoP NO_MATCH) — payment cannot be sent'))
       return
     }
+    if (!confirmed) {
+      setPaymentReview('sepa')
+      return
+    }
     const outcome = await flight.run('payment:create:sepa', async () => {
     setCreating(true)
     try {
@@ -442,6 +463,7 @@ function PaymentsContent() {
       if (!res.ok) throw new Error(await res.text() || t('Vytvoření platby selhalo', 'Failed to create payment'))
       sepaIdem.clear()
       setCreateSuccess(t(f.instant ? 'SCT Inst platba vytvořena' : 'SEPA platba vytvořena', f.instant ? 'SCT Inst payment created' : 'SEPA payment created'))
+      setPaymentReview(null)
       setShowCreate(null)
       load()
     } catch (err: unknown) {
@@ -834,7 +856,7 @@ function PaymentsContent() {
                 {createError && <div style={{ color: 'var(--red)', fontSize: '13px', marginTop: '4px' }}>{createError}</div>}
                 <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '8px' }}>
                   <button type="button" className="btn btn-secondary" onClick={() => setShowCreate(null)}>{t('Zrušit', 'Cancel')}</button>
-                  <button type="submit" className="btn btn-primary" disabled={creating}>
+                  <button ref={domesticSubmitRef} type="submit" className="btn btn-primary" disabled={creating}>
                     {creating ? t('Odesílám...', 'Sending...') : t(domesticForm.instant ? 'Odeslat okamžitě' : 'Vytvořit', domesticForm.instant ? 'Send instant' : 'Create')}
                   </button>
                 </div>
@@ -916,11 +938,77 @@ function PaymentsContent() {
                 {createError && <div style={{ color: 'var(--red)', fontSize: '13px', marginTop: '4px' }}>{createError}</div>}
                 <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '8px' }}>
                   <button type="button" className="btn btn-secondary" onClick={() => setShowCreate(null)}>{t('Zrušit', 'Cancel')}</button>
-                  <button type="submit" className="btn btn-primary" disabled={creating}>
+                  <button ref={sepaSubmitRef} type="submit" className="btn btn-primary" disabled={creating}>
                     {creating ? t('Odesílám...', 'Sending...') : t(sepaForm.instant ? 'Odeslat okamžitě' : 'Vytvořit', sepaForm.instant ? 'Send instant' : 'Create')}
                   </button>
                 </div>
               </form>
+            </div>
+          )}
+
+          {paymentReview && (
+            <div
+              role="alertdialog"
+              aria-modal="true"
+              aria-labelledby="payment-create-review-title"
+              aria-describedby="payment-create-review-impact"
+              onKeyDown={event => {
+                if (event.key === 'Escape' && !creating) {
+                  returnToPaymentForm()
+                }
+                if (event.key === 'Tab') {
+                  const first = reviewBackRef.current
+                  const last = reviewConfirmRef.current
+                  if (event.shiftKey && document.activeElement === first) {
+                    event.preventDefault()
+                    last?.focus()
+                  } else if (!event.shiftKey && document.activeElement === last) {
+                    event.preventDefault()
+                    first?.focus()
+                  }
+                }
+              }}
+              style={{ position: 'fixed', inset: 0, zIndex: 1200, background: 'rgba(15,23,42,.72)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20 }}
+            >
+              <div className="card" style={{ width: 'min(620px, 100%)', maxHeight: '90vh', overflowY: 'auto', padding: 22 }}>
+                <h2 id="payment-create-review-title" style={{ margin: 0, fontSize: 18 }}>
+                  {t('Zkontrolovat platební příkaz', 'Review payment order')}
+                </h2>
+                <p id="payment-create-review-impact" style={{ color: 'var(--text-secondary)', fontSize: 13, lineHeight: 1.55 }}>
+                  {t('Potvrzením odešlete přesně tento příkaz platební službě. Přijetí příkazu ještě neznamená vypořádání; další stav a případné schválení řídí platební workflow.', 'Confirmation submits this exact order to the payment service. Acceptance is not settlement; subsequent status and any required approval remain controlled by the payment workflow.')}
+                </p>
+                {paymentReview === 'domestic' ? (
+                  <dl style={{ display: 'grid', gridTemplateColumns: '155px minmax(0, 1fr)', gap: '9px 12px', padding: 14, borderRadius: 8, background: 'var(--surface-2)', fontSize: 12 }}>
+                    <dt>{t('Typ', 'Type')}</dt><dd>{domesticForm.instant ? t('Domácí okamžitá', 'Domestic instant') : t('Domácí standardní', 'Domestic standard')}</dd>
+                    <dt>{t('Částka', 'Amount')}</dt><dd style={{ fontSize: 16, fontWeight: 750 }}>{formatAmount(Number(domesticForm.amount), domesticForm.currency, language)}</dd>
+                    <dt>{t('Plátce', 'Debtor')}</dt><dd>{domesticForm.debtorName}<br/><span className="mono">{domesticForm.debtorAccountNumber}/{domesticForm.debtorBankCode}</span></dd>
+                    <dt>{t('Příjemce', 'Beneficiary')}</dt><dd>{domesticForm.creditorName}<br/><span className="mono">{domesticForm.creditorAccountNumber}/{domesticForm.creditorBankCode}</span></dd>
+                    <dt>{t('Rozsah převodu', 'Transfer scope')}</dt><dd>{domesticForm.transferScope}</dd>
+                    <dt>{t('Priorita', 'Priority')}</dt><dd>{domesticForm.priority}</dd>
+                    <dt>{t('Variabilní symbol', 'Variable symbol')}</dt><dd>{domesticForm.variableSymbol || '—'}</dd>
+                    <dt>{t('End-to-End ID', 'End-to-End ID')}</dt><dd className="mono">{domesticForm.endToEndId || '—'}</dd>
+                    <dt>{t('Zpráva', 'Message')}</dt><dd>{domesticForm.messageForPayee || '—'}</dd>
+                  </dl>
+                ) : (
+                  <dl style={{ display: 'grid', gridTemplateColumns: '155px minmax(0, 1fr)', gap: '9px 12px', padding: 14, borderRadius: 8, background: 'var(--surface-2)', fontSize: 12 }}>
+                    <dt>{t('Typ', 'Type')}</dt><dd>{sepaForm.instant ? 'SEPA Instant (SCT Inst)' : 'SEPA Credit Transfer (SCT)'}</dd>
+                    <dt>{t('Částka', 'Amount')}</dt><dd style={{ fontSize: 16, fontWeight: 750 }}>{formatAmount(Number(sepaForm.amount), 'EUR', language)}</dd>
+                    <dt>{t('IBAN plátce', 'Debtor IBAN')}</dt><dd className="mono" style={{ overflowWrap: 'anywhere' }}>{sepaForm.debtorIban}</dd>
+                    <dt>{t('Příjemce', 'Beneficiary')}</dt><dd>{sepaForm.creditorName}<br/><span className="mono" style={{ overflowWrap: 'anywhere' }}>{sepaForm.creditorIban}</span></dd>
+                    <dt>BIC</dt><dd className="mono">{sepaForm.bic || t('Odvozen z IBAN', 'Derived from IBAN')}</dd>
+                    <dt>{t('VoP výsledek', 'VoP result')}</dt><dd>{sepaForm.vopStatus === 'idle' ? t('Nebylo provedeno', 'Not performed') : sepaForm.vopStatus.toUpperCase()}{sepaForm.vopResult && sepaForm.vopResult !== sepaForm.vopStatus ? ` — ${sepaForm.vopResult}` : ''}</dd>
+                    <dt>{t('End-to-End ID', 'End-to-End ID')}</dt><dd className="mono">{sepaForm.endToEndId || '—'}</dd>
+                    <dt>{t('Zpráva', 'Remittance')}</dt><dd>{sepaForm.remittanceInfo || '—'}</dd>
+                  </dl>
+                )}
+                {createError && <div role="alert" data-testid="payment-create-review-error" style={{ marginTop: 14, padding: 10, borderLeft: '3px solid var(--danger)', color: 'var(--danger)', fontSize: 12 }}>{createError}</div>}
+                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 18 }}>
+                  <button ref={reviewBackRef} autoFocus type="button" className="btn btn-secondary" disabled={creating} onClick={returnToPaymentForm}>{t('Zpět k úpravám', 'Back to editing')}</button>
+                  <button ref={reviewConfirmRef} type="button" className="btn btn-primary" aria-busy={creating} disabled={creating} onClick={() => void (paymentReview === 'domestic' ? handleDomesticCreate(undefined, true) : handleSepaCreate(undefined, true))}>
+                    {creating ? t('Odesílám…', 'Submitting…') : t('Potvrdit a odeslat', 'Confirm and submit')}
+                  </button>
+                </div>
+              </div>
             </div>
           )}
 

--- a/openbank-admin-ui/src/test/payments-create-single-flight.test.tsx
+++ b/openbank-admin-ui/src/test/payments-create-single-flight.test.tsx
@@ -100,11 +100,15 @@ describe('payment creation — single-flight (issues #7093, #7172)', () => {
     renderPage()
     const form = await openSepaForm()
 
-    // Both activations before React can re-render `disabled={creating}` — the exact
-    // window a state-only guard cannot cover.
+    fireEvent.submit(form)
+    expect(posted).toHaveLength(0)
+    const confirm = await screen.findByRole('button', { name: 'Confirm and submit' })
+
+    // Both confirmations before React can re-render `disabled={creating}` — the
+    // exact window a state-only guard cannot cover.
     await act(async () => {
-      fireEvent.submit(form)
-      fireEvent.submit(form)
+      fireEvent.click(confirm)
+      fireEvent.click(confirm)
     })
 
     expect(posted.filter(p => p.url.includes('/api/sepa-payments'))).toHaveLength(1)
@@ -120,9 +124,12 @@ describe('payment creation — single-flight (issues #7093, #7172)', () => {
     renderPage()
     const form = await openSepaForm()
 
-    await act(async () => { fireEvent.submit(form) })
+    fireEvent.submit(form)
+    const confirm = await screen.findByRole('button', { name: 'Confirm and submit' })
+    await act(async () => { fireEvent.click(confirm) })
     await waitFor(() => expect(posted).toHaveLength(1))
-    await act(async () => { fireEvent.submit(form) })
+    expect(screen.getByTestId('payment-create-review-error')).toHaveTextContent('upstream unavailable')
+    await act(async () => { fireEvent.click(confirm) })
     await waitFor(() => expect(posted).toHaveLength(2))
 
     expect(posted[0].key).toBeTruthy()
@@ -136,11 +143,14 @@ describe('payment creation — single-flight (issues #7093, #7172)', () => {
     renderPage()
     const form = await openSepaForm('100.00')
 
-    await act(async () => { fireEvent.submit(form) })
+    fireEvent.submit(form)
+    await act(async () => { fireEvent.click(await screen.findByRole('button', { name: 'Confirm and submit' })) })
     await waitFor(() => expect(posted).toHaveLength(1))
 
+    fireEvent.click(screen.getByRole('button', { name: 'Back to editing' }))
     fireEvent.change(document.getElementById('sepa-amount') as HTMLInputElement, { target: { value: '250.00' } })
-    await act(async () => { fireEvent.submit(form) })
+    fireEvent.submit(form)
+    await act(async () => { fireEvent.click(await screen.findByRole('button', { name: 'Confirm and submit' })) })
     await waitFor(() => expect(posted).toHaveLength(2))
 
     expect(posted[1].body).not.toBe(posted[0].body)
@@ -150,7 +160,15 @@ describe('payment creation — single-flight (issues #7093, #7172)', () => {
   it('the healthy path still works: one submit, one POST, a well-formed key and payload', async () => {
     renderPage()
     const form = await openSepaForm()
-    await act(async () => { fireEvent.submit(form) })
+    fireEvent.submit(form)
+
+    expect(posted).toHaveLength(0)
+    const dialog = await screen.findByRole('alertdialog', { name: 'Review payment order' })
+    expect(dialog).toHaveTextContent('100.00 EUR')
+    expect(dialog).toHaveTextContent('Jane Doe')
+    expect(dialog).toHaveTextContent('DE89370400440532013000')
+
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Confirm and submit' })) })
     await waitFor(() => expect(posted).toHaveLength(1))
 
     expect(posted[0].url).toContain('/api/sepa-payments')


### PR DESCRIPTION
Closes #7898

## Summary
- add an accessible final review step for domestic, SEPA and SCT Inst payment initiation
- show the exact amount, source, beneficiary, routing details and VoP result before any money-path POST
- keep failures in the review dialog for a safe retry and restore keyboard focus when returning to edit
- preserve the existing BFF endpoints, payloads, RBAC, VoP gates, single-flight guard and idempotency-key lifecycle

## Verification
- `npm run pretest`
- `npx tsc --noEmit`
- focused ESLint (0 errors; 3 pre-existing warnings in payments page)
- focused Vitest: 6/6
- Playwright: SEPA + SCT Inst 2/2; domestic 1/1
- `git diff --check`

## Safety
No API, approval workflow, RBAC, VoP policy, payload or idempotency semantics changed. The browser now sends zero payment POSTs until the operator confirms the exact review.