### PR TITLE
fix(admin-ui): make FX controls accessible

### DIFF
--- a/openbank-admin-ui/e2e/fx-trend.spec.ts
+++ b/openbank-admin-ui/e2e/fx-trend.spec.ts
@@ -90,3 +90,27 @@ test('does not mislabel an outage as missing fixings and can retry', async ({ pa
   await expect(page.getByText('+2.00 %')).toBeVisible()
   expect(attempts).toBeGreaterThan(attemptsBeforeRetry)
 })
+
+test('meets WCAG A and AA rules across the rendered FX workspace', async ({ page }) => {
+  await page.route('**/api/fx/history/*/CZK', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify([
+      { timestamp: '2026-05-29T00:00:00Z', rate: 25 },
+      { timestamp: '2026-08-29T00:00:00Z', rate: 25.5 },
+    ]),
+  }))
+  await page.goto('/fx')
+  await expect(page.getByRole('img', { name: /EUR\/CZK: (z|from).*2\.00 (procenta|percent change)/ })).toBeVisible({ timeout: 20_000 })
+
+  const scheduleEditor = page.getByRole('button', { name: /Upravit plán CNB|Edit CNB schedule/ })
+  await expect(scheduleEditor).toBeVisible()
+  await expect(scheduleEditor).toHaveAttribute('aria-expanded', 'false')
+
+  const scan = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    .analyze()
+  expect(scan.violations, scan.violations.map(violation =>
+    `${violation.id}: ${violation.nodes.map(node => node.target.join(' ')).join(', ')}`,
+  ).join('\n')).toEqual([])
+})

--- a/openbank-admin-ui/src/app/fx/page.tsx
+++ b/openbank-admin-ui/src/app/fx/page.tsx
@@ -311,10 +311,10 @@ export default function FxPage() {
     fontSize: '12px',
     fontWeight: 600,
     cursor: 'pointer',
-    border: 'none',
+    border: `1px solid ${activeTab === tab ? 'var(--accent-border)' : 'transparent'}`,
     borderRadius: '6px',
-    background: activeTab === tab ? 'var(--accent)' : 'transparent',
-    color: activeTab === tab ? '#fff' : 'var(--text-secondary)',
+    background: activeTab === tab ? 'var(--accent-bg)' : 'transparent',
+    color: activeTab === tab ? 'var(--accent-text)' : 'var(--text-secondary)',
     transition: 'all 0.15s',
   } as React.CSSProperties)
 
@@ -695,10 +695,12 @@ export default function FxPage() {
                       <Play size={11} style={{ animation: isRefreshing(s.source.toLowerCase()) ? 'spin 1s linear infinite' : 'none' }} />
                       {t('Spustit', 'Run')}
                     </button>
-                    <button type="button" disabled={!FX_CONFIGURATION_WRITABLE} onClick={() => { setEditingSchedule(editingSchedule === s.id ? null : s.id); setScheduleDraft({ hour: s.hour, minute: s.minute, days: [...s.days] }) }}
-                      style={{ background: editingSchedule === s.id ? 'var(--accent)' : 'var(--surface-3)', color: editingSchedule === s.id ? '#fff' : 'var(--text-secondary)', border: `1px solid ${editingSchedule === s.id ? 'var(--accent)' : 'var(--border)'}`, padding: '4px 8px', borderRadius: '5px', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '4px', fontSize: '11px' }}>
-                      <Edit3 size={11} />
-                      {editingSchedule === s.id ? <ChevronUp size={11} /> : <ChevronDown size={11} />}
+                    <button type="button" disabled={!FX_CONFIGURATION_WRITABLE} aria-expanded={editingSchedule === s.id}
+                      aria-label={editingSchedule === s.id ? t(`Zavřít úpravu plánu ${s.source}`, `Close ${s.source} schedule editor`) : t(`Upravit plán ${s.source}`, `Edit ${s.source} schedule`)}
+                      onClick={() => { setEditingSchedule(editingSchedule === s.id ? null : s.id); setScheduleDraft({ hour: s.hour, minute: s.minute, days: [...s.days] }) }}
+                      style={{ background: editingSchedule === s.id ? 'var(--accent-bg)' : 'var(--surface-3)', color: editingSchedule === s.id ? 'var(--accent-text)' : 'var(--text-secondary)', border: `1px solid ${editingSchedule === s.id ? 'var(--accent-border)' : 'var(--border)'}`, padding: '4px 8px', borderRadius: '5px', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '4px', fontSize: '11px' }}>
+                      <Edit3 size={11} aria-hidden="true" />
+                      {editingSchedule === s.id ? <ChevronUp size={11} aria-hidden="true" /> : <ChevronDown size={11} aria-hidden="true" />}
                     </button>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- give each FX schedule editor disclosure a localized accessible name and truthful expanded state
- replace the active rate-sheet tab's failing white/accent contrast with semantic accent surface, text and border tokens
- add whole-workspace WCAG A/AA Playwright regression coverage

## Preserved behavior
FX rates, refresh endpoints, schedule editing, configuration write policy, BFF calls and RBAC are unchanged.

## Verification
- npm run build
- npx playwright test e2e/fx-trend.spec.ts --project=chromium (3 passed)
- npx eslint e2e/fx-trend.spec.ts --max-warnings=0
- git diff --check

Whole-file lint for the legacy FX page still reports its two pre-existing warnings at lines 72 and 219; this change introduces no lint errors or new warnings.

Closes #7905