### PR TITLE
fix(admin-ui): hide closed mobile navigation from focus

### DIFF
--- a/openbank-admin-ui/e2e/mobile-shell.spec.ts
+++ b/openbank-admin-ui/e2e/mobile-shell.spec.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+test.beforeEach(async ({ context, baseURL, page }) => {
+  await signInAsOperator(context, baseURL!)
+  await page.route('**/api/services/governance', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ items: [] }),
+  }))
+  await page.route('**/api/services/health', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ services: [] }),
+  }))
+})
+
+test('keeps the mobile navigation keyboard-complete and removes it from focus when closed', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.goto('/dashboard')
+
+  const menu = page.locator('button[aria-controls="admin-sidebar"]')
+  const sidebarControls = page.locator('#admin-sidebar a, #admin-sidebar button:not([disabled])')
+  await expect(menu).toBeVisible()
+  await expect(page.locator('#admin-sidebar')).toBeHidden()
+
+  await menu.click()
+  await expect(menu).toHaveAttribute('aria-expanded', 'true')
+  await expect(sidebarControls.first()).toBeFocused()
+
+  await page.keyboard.press('Shift+Tab')
+  await expect(sidebarControls.last()).toBeFocused()
+  await page.keyboard.press('Tab')
+  await expect(sidebarControls.first()).toBeFocused()
+
+  await page.keyboard.press('Escape')
+  await expect(menu).toHaveAttribute('aria-expanded', 'false')
+  await expect(menu).toBeFocused()
+  await expect(page.locator('#admin-sidebar')).toBeHidden()
+
+  await page.keyboard.press('Shift+Tab')
+  const skipLink = page.getByRole('link', { name: /Skip to main content|Přeskočit na hlavní obsah/ })
+  await expect(skipLink).toBeFocused()
+  await page.keyboard.press('Enter')
+  await expect(page.locator('#main-content')).toBeFocused()
+})

--- a/openbank-admin-ui/src/components/layout/Sidebar.module.css
+++ b/openbank-admin-ui/src/components/layout/Sidebar.module.css
@@ -87,8 +87,9 @@
     z-index: 30;
     inset: 0 auto 0 0;
     transform: translateX(-102%);
-    transition: transform .2s ease;
+    visibility: hidden;
+    transition: transform .2s ease, visibility 0s linear .2s;
     box-shadow: 16px 0 38px rgba(15, 23, 42, .24);
   }
-  .mobileOpen { transform: translateX(0); }
+  .mobileOpen { visibility: visible; transform: translateX(0); transition-delay: 0s; }
 }


### PR DESCRIPTION
## Summary
- remove the translated-off-screen mobile sidebar from focus and accessibility navigation while closed
- preserve the slide animation by delaying visibility only for the closing transition
- add real-browser coverage for focus entry, cyclic Tab/Shift+Tab, Escape, opener restoration, skip-link activation and main-landmark focus

## Preserved behavior
Desktop sidebar visibility, navigation destinations, permissions, routing and mobile animation timing are unchanged.

## Verification
- npm run build
- npx playwright test e2e/mobile-shell.spec.ts --project=chromium (1 passed)
- npx eslint e2e/mobile-shell.spec.ts --max-warnings=0
- git diff --check

Closes #7910