### PR TITLE
fix(governance): move two time-gates whose deadlines passed with their blockers unresolved

### DIFF
--- a/openbank-libs/governance/feature-flags.example.flagd.json
+++ b/openbank-libs/governance/feature-flags.example.flagd.json
@@ -16,7 +16,7 @@
         "classification": "MONEY_PATH",
         "owner": "payments-team",
         "fourEyes": true,
-        "expiresAt": "2026-09-01T00:00:00Z",
+        "expiresAt": "2026-12-01T00:00:00Z",
         "description": "Route SEPA instant payments through the new corridor router."
       }
     },

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1992,8 +1992,13 @@ ci_runners:
     deploy_only_signed_digests: true
   gate: ci-runner-governance
   enforced: planned                     # ADR-0053 Accepted; lint + tofu enable land on rollout
-  target_enforce_date: "2026-08-31"   # ADR-0144
-  blocked_on: "a CI lint enforcing pr_jobs_allowed_pools (build/batch only, never deploy) + the OpenTofu apply for the three scale sets have not both landed yet"
+  target_enforce_date: "2026-11-30"   # ADR-0144. Moved from 2026-08-31, which passed with the
+                                      # blocker unresolved and turned an enforced gate red on every
+                                      # PR regardless of its diff. Extending the horizon is the
+                                      # sanctioned move here; the alternative -- flipping `enforced`
+                                      # to satisfy the date -- would claim a control this repo does
+                                      # not have.
+  blocked_on: "the CI lint enforcing pr_jobs_allowed_pools (build/batch only, never deploy) does not exist: no file under .github/scripts or .github/gates references that key (control: money_path_services is referenced by two, so the probe sees rule keys). The OpenTofu half is less clear than this line used to claim -- arc-runners.tf and arc-runner-reaper.tf are in the tree, but a committed .tf is not an applied one, and that is not checkable from this repository. Corroborating evidence that the pools are not fully provisioned: #6458 records openbank-batch as a declared pool with no capacity and no consumer."
 
 # ---------------------------------------------------------------------------------------
 # Infra apply (ADR-0060). Closes the "as-code without applied" gap: CI applies the


### PR DESCRIPTION
## Two enforced gates are failing every PR right now, independent of its diff

Reproduced from a real PR run today (`33467085326`, 03:41Z):

```
gates (security)      [run-gates]   6/17 FAIL   feature-flag-governance
gates (supplychain)   [run-gates]  18/25 FAIL   gate-graduation-guard
Validate manifests    FAIL (downstream aggregator)
```

Neither is anyone's defect. They are **time-gates whose deadlines arrived while the thing they were waiting for had not landed**. Every PR that runs CI today is red for reasons unrelated to its content, and the queue currently holds ~80 of them.

The exact messages:

```
[feature-flags.example.flagd.json] flag 'sepa-instant-new-router':
  expired at 2026-09-01T00:00:00Z — remove it or extend (ADR-0067 §7)

rules.yaml:1994: target_enforce_date 2026-08-31 has passed and this rule is
  still advisory/planned (ADR-0144).
```

## What changed

**The flag** moves to `2026-12-01`, `MONEY_PATH` and `fourEyes` untouched. Three months, not the `2026-12-31` its two siblings carry — a money-path flag sitting at a 10% fractional rollout should come back for a decision sooner than a cosmetic one, and a generous horizon is precisely how this one reached its own expiry with nobody noticing.

**The graduation date** moves to `2026-11-30`.

## I verified the blocker still holds, and it is half stale

Extending a deadline without checking would hide finished work, so:

- **The CI lint enforcing `pr_jobs_allowed_pools` does not exist.** No file under `.github/scripts` or `.github/gates` references that key. **Control:** the same probe finds `money_path_services` in two files, so it does see rule keys — the empty result is about the lint, not the search.
- **The OpenTofu half is weaker than the old text claimed.** `arc-runners.tf` and `arc-runner-reaper.tf` *are* in the tree. But a committed `.tf` is not an applied one, and that is not checkable from this repository. #6458 records `openbank-batch` as a declared pool with no capacity and no consumer, which corroborates that the pools are not fully provisioned.

So the blocker stands on its first half. The `blocked_on:` text is corrected in place rather than left asserting something no longer true — a stale justification turns a tracked blocker into an unexamined exemption, which this repo has been finding all week.

**Extending the horizon is the sanctioned move.** The alternative — flipping `enforced` to satisfy the date — would claim a control that does not exist, which is the exact failure ADR-0144 built this gate to prevent.

## Proven by what it prevents

| state | validate-flags | gate-graduation |
|---|---|---|
| dates restored to the past | **exit 1** | **exit 1** |
| dates as committed | exit 0 | exit 0 |

Both gates can still fail; they are moved, not muted.

## Scope

`gen-rules-opa-data.py` produces **no change** to the derived subset — `ci-runner-governance` is not in the OPA read set — so no bundle and no `policy-checksum` annotation is restamped. Two files, and it should not conflict with the gitops traffic that usually makes `rules.yaml` changes short-lived.

Closes #7897
