### PR TITLE
fix(governance): extend the expired example feature flag, unblocking every PR

### DIFF
--- a/openbank-libs/governance/feature-flags.example.flagd.json
+++ b/openbank-libs/governance/feature-flags.example.flagd.json
@@ -16,7 +16,7 @@
         "classification": "MONEY_PATH",
         "owner": "payments-team",
         "fourEyes": true,
-        "expiresAt": "2026-09-01T00:00:00Z",
+        "expiresAt": "2027-12-31T00:00:00Z",
         "description": "Route SEPA instant payments through the new corridor router."
       }
     },


### PR DESCRIPTION
## What

`sepa-instant-new-router` in `openbank-libs/governance/feature-flags.example.flagd.json` carried
`expiresAt: 2026-09-01T00:00:00Z`. That lapsed at midnight UTC, and the feature-flag governance gate
(ADR-0067 §7) has failed on **every PR whose CI has run since**:

```
FAIL [security] feature-flag governance (ADR-0067, issue #419)
  flag 'sepa-instant-new-router': expired at 2026-09-01T00:00:00Z — remove it or extend
```

`gates (security)` failing takes `Validate manifests` down with it, so the blast radius is the whole
queue rather than one shard.

## Measured, not inferred

At 2026-09-01T02:xx, **13 consecutive PRs — #7894 through #7917 — were red on exactly these three
contexts**: `Validate manifests`, `gates (supplychain)`, `gates (security)`. Not thirteen defects; one
expired flag. Every future PR and every main push would have followed.

## Why extending is safe here

This is not a live rollout. `validate-flags.py` scans `**/*.flagd.json`, which matches **only** this
governance example. The live configuration is
`openbank-infra/gitops/components/party/feature-flags.yaml` — a ConfigMap with a different extension,
carrying different flags — and `sepa-instant-new-router` appears nowhere in it, nor in any code path
(`git grep` finds no consumer of the example file at all).

So the flag this describes does not exist in any environment. Extending the fixture's horizon changes
no behaviour and removes no coverage. Removing the flag instead would have been wrong for a different
reason: it is the only entry in the example demonstrating `fractional` targeting and a MONEY_PATH
classification with `fourEyes`.

Set to `2027-12-31`, deliberately past its two siblings' `2026-12-31`, so the fixture does not lapse
again the moment those are refreshed.

## The gate is not blunted — falsified both ways

```
expiry set to 2020-01-01   ->  exit 1, names the flag and the file
the fix                    ->  exit 0, "All flags valid"
--self-test                ->  exit 0 (16 cases)
```

## Follow-up that is not mine to decide

A fixture with a fixed expiry is a time bomb by construction, and this is the first time it went off —
the file has not been touched since it was created on 2026-06-26. Either exempt example files from the
expiry rule, or give them an expiry the gate reads as documentation rather than a deadline. Extending
the date fixes today; it does not fix the shape.
