### PR TITLE
fix(governance): move the lapsed ci_runners enforce date, unblocking every PR

### DIFF
--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1992,8 +1992,8 @@ ci_runners:
     deploy_only_signed_digests: true
   gate: ci-runner-governance
   enforced: planned                     # ADR-0053 Accepted; lint + tofu enable land on rollout
-  target_enforce_date: "2026-08-31"   # ADR-0144
-  blocked_on: "a CI lint enforcing pr_jobs_allowed_pools (build/batch only, never deploy) + the OpenTofu apply for the three scale sets have not both landed yet"
+  target_enforce_date: "2026-09-30"   # ADR-0144 — moved 2026-09-01; neither half of blocked_on has landed
+  blocked_on: "a CI lint enforcing pr_jobs_allowed_pools (build/batch only, never deploy) + the OpenTofu apply for the three scale sets have not both landed yet. Measured 2026-09-01: the lint is written and in review (#7598, gate ci-runner-pool-capacity) but not merged, and the scale sets are still TWO — `kubectl get autoscalingrunnersets -n arc-runners` returns openbank-build and openbank-deploy only, openbank-batch does not exist. #7598 own review also found no workflow routes to openbank-batch, so whether the third pool is a real requirement or a stale declaration is the question to settle before the next date."
 
 # ---------------------------------------------------------------------------------------
 # Infra apply (ADR-0060). Closes the "as-code without applied" gap: CI applies the


### PR DESCRIPTION
## What

`ci_runners.target_enforce_date` was `2026-08-31`. It lapsed at midnight UTC and the gate-graduation
guard (ADR-0144) has failed on **every PR whose CI has run since**:

```
FAIL [supplychain] gate graduation guard (ADR-0144, enforced)
  target_enforce_date 2026-08-31 has passed and this rule is still advisory/planned
```

`gates (supplychain)` failing takes `Validate manifests` with it, so the blast radius is the whole
queue rather than one shard.

## This is the second date bomb, not the first

Both went off at the 31 Aug → 1 Sep boundary and together they account for **all 13 consecutive red
PRs (#7894–#7917)**:

| | |
|---|---|
| expired example feature flag | #7922 |
| this lapsed enforce date | this PR |

Fixing only one leaves the queue red, which is what made the first fix look insufficient.

## Moved, not flipped — because flipping would be false

`blocked_on` names two conditions. Neither has landed, measured today:

- the `pr_jobs_allowed_pools` lint is **written and in review** — #7598, gate `ci-runner-pool-capacity`
  — but not merged;
- the scale sets are still **two, not three**:

```
$ kubectl get autoscalingrunnersets -n arc-runners
openbank-build    0   12
openbank-deploy   0    2
```

`openbank-batch` does not exist. So `enforced: planned` is still the truthful state, and moving the
date is what ADR-0144's own message offers for exactly this case.

`blocked_on` is updated to carry that measured status instead of undated prose, and it records the
question #7598's review surfaced: **no workflow routes to `openbank-batch` either**, so whether the
third pool is a real requirement or a stale declaration is worth settling before the next date rather
than rediscovering at it.

## Falsified both ways

```
date set to 2020-01-01  ->  exit 1, names file and line
the fix                 ->  exit 0, "20 advisory/planned rule(s) ... all live"
--self-test             ->  exit 0
```

New horizon `2026-09-30` matches the cluster of other ADR-0144 dates rather than inventing a lone one.

## Worth noting about the shape

Two independent deadlines encoded as fixed dates both fired on the same night and took the entire
queue down. Neither failure says "a deadline passed" anywhere a human sees before CI goes red on
unrelated work. A pre-expiry warning — say, red at T-7 days on the rule's own PRs rather than
everyone's — would turn this from an outage into a reminder.
