### PR TITLE
fix(admin-ui): restore Test Intelligence capability matrix

### DIFF
--- a/openbank-admin-ui/e2e/test-intelligence.spec.ts
+++ b/openbank-admin-ui/e2e/test-intelligence.spec.ts
@@ -36,7 +36,10 @@ test('renders the animated evidence system and consolidates test dimensions', as
   await expect(page.getByRole('region', { name: /Testing assurance map/ })).toBeVisible()
   await expect(page.getByText('Required-control gaps')).toBeVisible()
   await expect(page.getByRole('region', { name: 'Deterministic required controls' })).toContainText('openbank-ledger-service:mutation')
-  await expect(page.getByRole('region', { name: 'Platform capability boundaries' })).toContainText('No separately operated probe fleet is provisioned.')
+  const capabilityMatrix = page.getByRole('region', { name: 'Platform capability boundaries' })
+  await expect(capabilityMatrix).toContainText('Platform capability boundary matrix')
+  await expect(capabilityMatrix).toContainText('No separately operated probe fleet is provisioned.')
+  await expect(capabilityMatrix.getByRole('columnheader', { name: 'Boundary / blocker' })).toBeVisible()
   // The queue must expose absent layers as evidence gaps instead of silently
   // treating the fixture's missing simulation evidence as a pass.
   await expect(page.getByText('Deterministic simulations', { exact: true })).toBeVisible()

--- a/openbank-admin-ui/src/app/system/tests/page.tsx
+++ b/openbank-admin-ui/src/app/system/tests/page.tsx
@@ -201,12 +201,17 @@ function Posture({ report }: { report: TestIntelligenceReport }) {
         </table></div>
       </section>
       <section aria-label={t('Hranice schopností platformy', 'Platform capability boundaries')} style={{ marginBottom: 20 }}>
-        <h2 style={{ fontSize: 16, marginBottom: 8 }}>{t('Hranice schopností platformy', 'Platform capability boundaries')}</h2>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: 10 }}>{(report.platformCapabilities ?? []).map(capability => <div key={capability.id} style={{ border: '1px solid var(--border)', borderRadius: 10, padding: 14, background: 'var(--surface-1)' }}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}><strong>{capability.title}</strong><span style={{ color: capability.state === 'implemented' ? '#16a34a' : '#7c3aed', fontSize: 10, fontWeight: 700 }}>{capability.state}</span></div>
-          {capability.blocker && <p style={{ color: 'var(--text-secondary)', fontSize: 11, margin: '8px 0 0' }}>{capability.blocker}</p>}
-          <code style={{ display: 'block', color: 'var(--text-tertiary)', fontSize: 9, marginTop: 8 }}>{capability.evidence}</code>
-        </div>)}</div>
+        <h2 style={{ fontSize: 16, marginBottom: 4 }}>{t('Matice hranic schopností', 'Platform capability boundary matrix')}</h2>
+        <p style={{ color: 'var(--text-secondary)', fontSize: 12, margin: '0 0 8px' }}>{t('Jedna schopnost na řádek: stav, skutečný blokátor a ověřitelný zdroj jsou vedle sebe. Blokovaný stav není roadmapa ani skrytě hotová funkce.', 'One capability per row: state, actual blocker and verifiable source stay side by side. A blocked state is neither a roadmap nor a silently completed feature.')}</p>
+        <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}><table style={tableStyle}>
+          <thead><tr><th style={thStyle}>{t('Schopnost', 'Capability')}</th><th style={thStyle}>State</th><th style={thStyle}>{t('Hranice / blokátor', 'Boundary / blocker')}</th><th style={thStyle}>Evidence</th></tr></thead>
+          <tbody>{(report.platformCapabilities ?? []).map(capability => <tr key={capability.id}>
+            <td style={{ ...tdStyle, fontWeight: 650, minWidth: 210 }}>{capability.title}<div style={{ color: 'var(--text-tertiary)', fontFamily: 'monospace', fontSize: 10, marginTop: 3 }}>{capability.id}</div></td>
+            <td style={tdStyle}><span style={{ color: capability.state === 'implemented' ? '#16a34a' : '#7c3aed', fontSize: 10, fontWeight: 700 }}>{capability.state}</span></td>
+            <td style={{ ...tdStyle, minWidth: 360, color: 'var(--text-secondary)' }}>{capability.blocker ?? t('Implementováno; podrobnosti v evidenci.', 'Implemented; see the evidence pointer for detail.')}</td>
+            <td style={{ ...tdStyle, minWidth: 250, color: 'var(--text-tertiary)', fontFamily: 'monospace', fontSize: 10, overflowWrap: 'anywhere' }}>{capability.evidence}</td>
+          </tr>)}</tbody>
+        </table></div>
       </section>
     </>
   )

--- a/openbank-admin-ui/src/test/system-tests-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/system-tests-a11y.guard.test.ts
@@ -54,4 +54,13 @@ describe('system code quality accessibility', () => {
     expect(controls).toBeGreaterThan(matrix)
     expect(source).toContain('One row per component: scan across test kinds; money-path components are first.')
   })
+
+  it('keeps platform capability boundaries as a scanable matrix', () => {
+    const source = read()
+
+    expect(source).toContain("t('Matice hranic schopností', 'Platform capability boundary matrix')")
+    expect(source).toContain("t('Hranice / blokátor', 'Boundary / blocker')")
+    expect(source).toContain("<th style={thStyle}>Evidence</th>")
+    expect(source).toContain('One capability per row: state, actual blocker and verifiable source stay side by side.')
+  })
 })


### PR DESCRIPTION
Closes #7926

## What

Renders platform capability boundaries as one accessible, horizontally scrollable matrix so capability, state, real blocker and evidence pointer can be compared row-by-row. The governed source data and all states remain unchanged.

## Proof

- `npm test -- --run src/test/system-tests-a11y.guard.test.ts`
- `npm run lint -- --quiet src/app/system/tests/page.tsx src/test/system-tests-a11y.guard.test.ts e2e/test-intelligence.spec.ts`
- `npm run type-check`
- `git diff --check`