### PR TITLE
fix(admin-ui): split the twelve-route payments:view permission bucket

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -3461,6 +3461,8 @@ gates:
     name: "admin-ui route permissions ⇒ backend @RolesAllowed (issues #7790/#7783/#7788/#7824)"
     group: security
     mode: enforced
+    rationale: "The console's role matrix and the services' @RolesAllowed are written in different languages in different trees, and a divergence produces no failing test, no log line and no metric \u2014 only an operator being shown a link that 403s on click; one permission held twelve routes for five personas, and ROLE_SUPERVISOR was granted on all twelve and admitted by none."
+    review_after: "2027-09-01"
     min_subjects: 10   # 10 route permissions pinned, 28 declared unpinned (2026-09-01)
     selftest: python3 .github/scripts/check-admin-ui-rbac-alignment.py --self-test
     selftest_expect: pass

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -3440,6 +3440,32 @@ gates:
     selftest_expect: pass
     run: |
       python3 .github/scripts/check-roles-allowed-realm.py
+  # The console-side twin of the gate above. That one asks whether the role an endpoint NAMES
+  # can exist; this one asks whether the roles the admin-ui SHOWS a page to are the roles that
+  # endpoint actually admits. Neither is a security control — the service enforces, and OPA sits
+  # behind it — so a divergence leaks nothing. It does something quieter: the console tells an
+  # operator they may do something they may not, and they find out by clicking a link and
+  # getting a 403.
+  # One line held twelve unrelated routes (/payments /product-catalog /standing-orders /sdd
+  # /sepa-instant /clearing /fx /swift /interest /pid /fees /lending) behind a single
+  # `payments:view` with five personas. Measured 2026-09-01: ROLE_SUPERVISOR was granted on all
+  # twelve and admitted by NONE; ROLE_VIEWER and ROLE_PAYMENTS were over-granted on five more;
+  # and /pid's list call targets `/api/v1/pids`, a path no Kotlin resource in the fleet serves.
+  # Nothing could see it — the two sides are different languages in different trees, and the
+  # divergence produces no failing test, no log line and no metric. The pre-existing guard for
+  # the neighbouring party permission asserts the roles LINE AS A STRING, which pins the file
+  # against itself: red when the line is edited, green while the backend moves underneath it.
+  # min_subjects is the known-positive: a subset assertion over an empty corpus is vacuous, so
+  # the gate fails if fewer than 10 permissions are actually pinned rather than reporting OK.
+  - id: admin-ui-rbac-alignment
+    name: "admin-ui route permissions ⇒ backend @RolesAllowed (issues #7790/#7783/#7788/#7824)"
+    group: security
+    mode: enforced
+    min_subjects: 10   # 10 route permissions pinned, 28 declared unpinned (2026-09-01)
+    selftest: python3 .github/scripts/check-admin-ui-rbac-alignment.py --self-test
+    selftest_expect: pass
+    run: |
+      python3 .github/scripts/check-admin-ui-rbac-alignment.py
   # The sibling of the gate above, one layer earlier: that one asks whether the role a caller
   # NEEDS can exist, this one whether the caller can present a token at all. An outbound client
   # annotated @RegisterProvider(OidcClientRequest*Filter) mints from `quarkus.oidc-client`, a

--- a/.github/scripts/check-admin-ui-rbac-alignment.py
+++ b/.github/scripts/check-admin-ui-rbac-alignment.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Guard: an admin-ui route permission may not grant a persona the backing service's
+# `@RolesAllowed` refuses (issues #7790, #7783, #7788, #7824).
+#
+# WHY THIS EXISTS
+#   `roles.ts` decides which nav links and routes a console session may reach. It is NOT a
+#   security control — the service re-checks every call and OPA sits behind that — so a role
+#   listed here that the backend rejects does not leak data. It does something else, and the
+#   distinction is the whole point of this gate: it tells an operator they may do something
+#   they may not. They click the link they were shown and get a 403.
+#
+#   That is exactly what one line did. A single `payments:view` permission mapped TWELVE
+#   unrelated routes (/payments /product-catalog /standing-orders /sdd /sepa-instant /clearing
+#   /fx /swift /interest /pid /fees /lending) to five personas, and the twelve backends do not
+#   agree with each other, let alone with the UI. Measured 2026-09-01 against origin/main:
+#   ROLE_SUPERVISOR was granted on all twelve routes and admitted by NONE of them;
+#   /standing-orders, /pid and /lending each also over-granted ROLE_VIEWER; five routes
+#   over-granted ROLE_PAYMENTS. /pid was the sharpest case — its list call goes to
+#   `/api/v1/pids`, a path that exists in no Kotlin resource in the fleet, so the read that
+#   actually backs the page is PartyResource.search (OPERATOR/ADMIN only).
+#
+#   Nothing could notice. The two sides are written in different languages, in different
+#   trees, reviewed by different people, and the divergence produces no failing test, no log
+#   line and no metric — only a 403 in somebody's browser. The pre-existing guard for the
+#   neighbouring party permission (`party-rbac-alignment.guard.test.ts`) asserts the roles
+#   LINE AS A STRING, which pins the file against itself: it goes red when the line is edited
+#   and stays green while the backend moves underneath it. A test that supplies both sides of
+#   the comparison cannot fail.
+#
+# WHAT IT CHECKS
+#   HARD (exit 1) — a permission granting a role outside its backends' intersection.
+#     The intersection, not the union: where a page's read path fans out to several resources
+#     with different sets (LendingResource is the live example — the two `applications/*`
+#     calls exclude VIEWER/COMPLIANCE while the two `loans/*` calls admit them, and the page
+#     `Promise.all`s them so one 403 blanks the whole page), only the intersection can be
+#     shown without lying.
+#
+#   HARD (exit 1) — a route-gating permission with neither an `@rbac-source` annotation nor an
+#     entry in UNPINNED_BASELINE. This is what stops the bucket being reintroduced: merging
+#     routes back under one permission does not silently pass, it has to survive the
+#     intersection of every backend it just absorbed.
+#
+#   HARD (exit 1) — a STALE declaration in either direction: a baseline entry for a permission
+#     that is now annotated (or no longer gates a route), an `@rbac-source` naming a file or
+#     method that does not exist, or a resolved backend set that is empty. A gate whose scope
+#     is a hand-kept list reads as PASSING when the list is short, never as unchecked, so the
+#     list is only allowed to shrink and every exit from it is verified.
+#
+#   HARD (exit 1) — fewer than --min-pinned permissions actually pinned. An empty corpus makes
+#     every subset assertion vacuously true; this is the known-positive the gate runs on
+#     itself.
+#
+#   ADVISORY — a permission NARROWER than its backend allows. Under-granting hides a page from
+#     someone entitled to it: a usability bug, not a lie to the operator, and sometimes
+#     deliberate. Reported, never blocking.
+#
+# COMMENTS ARE STRIPPED from the Kotlin before matching (nesting-aware — Kotlin block comments
+# NEST, so a KDoc containing `/*` closes early and its tail is scanned as code). Shared
+# rationale with check-roles-allowed-realm.py: a KDoc that QUOTES an annotation to explain a
+# past defect is prose about code, and a scanner that cannot tell the two apart manufactures
+# its own findings.
+#
+# Run:  python3 .github/scripts/check-admin-ui-rbac-alignment.py [--root .] [--min-pinned N]
+#       python3 .github/scripts/check-admin-ui-rbac-alignment.py --self-test
+
+import argparse
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import gatelib
+
+ROLES_TS = "openbank-admin-ui/src/lib/auth/roles.ts"
+ROLES_KT = "openbank-libs-domain/src/main/kotlin/com/openbank/libs/security/Roles.kt"
+CATALOG_ROLES_KT = ("openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/"
+                    "infrastructure/security/CatalogScopeIdentityAugmentor.kt")
+
+# Permissions that gate a route but are not yet pinned to a backend, each with the reason.
+# RATCHET: this may only shrink. An entry that becomes pinned, or stops gating a route, is a
+# STALE DECLARATION and fails the gate — a debt entry cannot quietly become permanent.
+UNPINNED_BASELINE = {
+    "dashboard:view": "aggregates many services; no single backend read path to pin to",
+    "system:config": "proxies telemetry (Prometheus/Holmes/k8s), no service @RolesAllowed",
+    "system:view": "proxies telemetry (Prometheus/Holmes/k8s), no service @RolesAllowed",
+    "catalog:read": "gates /product-studio, whose reads are agent-service /api/agent/* (issue #7824 tail)",
+    "templates:view": "document-service template reads not yet traced",
+    "delegations:view": "delegation-service class-level gate plus OPA delegation.list; OPA half unpinnable here",
+    "feedback:view": "screen-feedback BFF has no upstream service resource",
+    "regulatory:view": "finrep/corep render path, not a single resource read",
+    "audit:view": "audit reads fan out across services",
+    "kyc:view": "kyc-service case endpoints not yet traced",
+    "onboarding:view": "onboarding-service reads not yet traced",
+    "identity-cases:view": "pid-service VerificationCaseResource not yet traced",
+    "parties:create": "party-service POST path, not a read gate",
+    "parties:view": "party-service PartyResource; pinned by party-rbac-alignment.guard.test.ts today",
+    "transactions:view": "transaction-service reads not yet traced",
+    "accounts:create": "account-service POST path, not a read gate",
+    "accounts:view": "spans account/ledger/day-end across three services",
+    "cards:view": "card-issuance reads not yet traced",
+    "sanctions:view": "sanctions-service reads not yet traced",
+    "compliance:view": "spans aml/fraud/disputes/consents/customer-360 across five services",
+    "campaign:view": "campaign-service audience endpoints not yet traced",
+    "campaign:create": "campaign-service POST path, not a read gate",
+    "lending:compliance:view": "CompliancePackResource /active and /proposals/pending DISAGREE "
+                               "(CREDIT_RISK/LENDING_OFFICER 403 on the second); needs a decision, not a pin",
+    "approvals:view": "agent-service ProposalResource not yet traced",
+    "notifications:view": "notification-service @RolesAllowed and rest.rego disagree in both directions",
+    "agent:view": "agent-service MCP endpoint not yet traced",
+    "docs:view": "static docs, no backend",
+    "settings:view": "no backend read path",
+}
+
+# ---------------------------------------------------------------------------- Kotlin reading
+
+ANNOTATION_RE = re.compile(r"@RolesAllowed\s*\(([^)]*)\)", re.S)
+ARG_RE = re.compile(r'"([^"]+)"|(?:(Roles|CatalogRoles)\.(\w+))')
+CONST_RE = re.compile(r'const\s+val\s+(\w+)\s*[:=][^"]*"([^"]+)"')
+FUN_RE = re.compile(r"\bfun\s+(\w+)\s*\(")
+CLASS_RE = re.compile(r"\b(?:class|object|interface)\s+\w+")
+
+
+def strip_comments(src: str) -> str:
+    """Blank // line comments and (NESTING) /* */ blocks, preserving offsets and line numbers."""
+    out, i, depth, n = [], 0, 0, len(src)
+    while i < n:
+        if depth == 0 and src.startswith("//", i):
+            j = src.find("\n", i)
+            j = n if j < 0 else j
+            out.append(" " * (j - i))
+            i = j
+            continue
+        if src.startswith("/*", i):
+            depth += 1
+            out.append("  ")
+            i += 2
+            continue
+        if depth and src.startswith("*/", i):
+            depth -= 1
+            out.append("  ")
+            i += 2
+            continue
+        ch = src[i]
+        out.append(ch if (depth == 0 or ch == "\n") else " ")
+        i += 1
+    return "".join(out)
+
+
+def role_constants(root: pathlib.Path) -> dict:
+    constants = {}
+    for qualifier, rel in (("Roles", ROLES_KT), ("CatalogRoles", CATALOG_ROLES_KT)):
+        src = root / rel
+        if src.is_file():
+            constants.update({f"{qualifier}.{k}": v for k, v in CONST_RE.findall(src.read_text())})
+    return constants
+
+
+def _resolve(arg_blob: str, consts: dict) -> set:
+    names = set()
+    for literal, qualifier, const in ARG_RE.findall(arg_blob):
+        key = f"{qualifier}.{const}" if qualifier else ""
+        names.add(literal or consts.get(key, key))
+    return names
+
+
+def roles_for_method(source: str, method: str, consts: dict):
+    """Roles admitted by `method`, honouring the method-level-overrides-class-level rule.
+
+    JAX-RS/Jakarta semantics: a method-level @RolesAllowed REPLACES the class-level one, it does
+    not add to it. LendingResource is the live proof — its class says
+    LENDING_OFFICER/CREDIT_RISK/COMPLIANCE/ADMIN while every read method overrides, which is the
+    only way OPERATOR and VIEWER get in at all. A reader that unions the two would compute a set
+    no caller actually has, and would have called the over-grant correct.
+
+    Returns (roles, error). Scanning is done on comment-stripped source.
+    """
+    funs = [(m.start(), m.group(1)) for m in FUN_RE.finditer(source)]
+    target = next((i for i, (_, name) in enumerate(funs) if name == method), None)
+    if target is None:
+        return set(), f"method '{method}' not found"
+    start = funs[target - 1][0] if target > 0 else 0
+    end = funs[target][0]
+    # The annotation block belongs to this fun if it sits between the previous fun and this one.
+    method_level = list(ANNOTATION_RE.finditer(source, start, end))
+    if method_level:
+        return _resolve(method_level[-1].group(1), consts), None
+    # Fall back to the class-level annotation: the last one before the type declaration.
+    decl = CLASS_RE.search(source)
+    limit = decl.start() if decl else len(source)
+    class_level = list(ANNOTATION_RE.finditer(source, 0, limit))
+    if class_level:
+        return _resolve(class_level[-1].group(1), consts), None
+    return set(), f"no @RolesAllowed applies to '{method}' (no method-level and no class-level)"
+
+
+# ---------------------------------------------------------------------------- roles.ts reading
+
+ROLES_CONST_RE = re.compile(r"^\s*(\w+):\s*\"([^\"]+)\",", re.M)
+PERM_RE = re.compile(r"^([ \t]*)\"([\w:-]+)\":\s*\[([^\]]*)\]", re.M)
+ROUTE_ENTRY_RE = re.compile(r"\['([\w:-]+)',\s*\[([^\]]*)\]\]", re.S)
+SOURCE_RE = re.compile(r"@rbac-source\s+(\S+)#(\w+)")
+EXCLUDE_RE = re.compile(r"@rbac-exclude\s+([A-Z_]+)")
+
+
+def parse_roles_ts(text: str):
+    """Return (role_consts, permissions{name:(roles,sources,excludes)}, route_permissions)."""
+    block = text.split("export const ROLES", 1)[1].split("} as const", 1)[0]
+    role_consts = {f"ROLES.{k}": v for k, v in ROLES_CONST_RE.findall(block)}
+
+    perms = {}
+    perm_block = text.split("export const PERMISSIONS", 1)[1].split("\n} as const", 1)[0]
+    for m in PERM_RE.finditer(perm_block):
+        name = m.group(2)
+        roles = {role_consts.get(tok.strip(), tok.strip())
+                 for tok in m.group(3).split(",") if tok.strip()}
+        # Directives live in the contiguous comment block immediately above the key.
+        preceding = perm_block[:m.start()].rstrip("\n").split("\n")
+        comment = []
+        for line in reversed(preceding):
+            if line.strip().startswith("//"):
+                comment.append(line)
+            else:
+                break
+        blob = "\n".join(comment)
+        perms[name] = (roles, SOURCE_RE.findall(blob), set(EXCLUDE_RE.findall(blob)))
+
+    route_block = text.split("const ROUTE_PREFIXES", 1)[1].split("\n]\n", 1)[0]
+    route_perms = {m.group(1) for m in ROUTE_ENTRY_RE.finditer(route_block)}
+    return role_consts, perms, route_perms
+
+
+# ---------------------------------------------------------------------------------- the check
+
+def run(root: pathlib.Path, min_pinned: int, baseline: dict | None = None):
+    baseline = UNPINNED_BASELINE if baseline is None else baseline
+    errors, notes = [], []
+    ts_path = root / ROLES_TS
+    if not ts_path.is_file():
+        return [f"{ROLES_TS} not found — the guard cannot run blind"], [], 0
+
+    consts = role_constants(root)
+    _, perms, route_perms = parse_roles_ts(ts_path.read_text())
+    if not perms or not route_perms:
+        return ["parsed zero permissions or zero route entries — the reader is broken"], [], 0
+
+    pinned = 0
+    for name in sorted(route_perms):
+        if name not in perms:
+            errors.append(f"{name}: gates a route but is not defined in PERMISSIONS")
+            continue
+        ui_roles, sources, excludes = perms[name]
+        if not sources:
+            if name not in baseline:
+                errors.append(
+                    f"{name}: gates a route with no @rbac-source annotation and no "
+                    f"UNPINNED_BASELINE entry — pin it to the backing resource's @RolesAllowed, "
+                    f"or declare why it cannot be pinned")
+            continue
+        if name in baseline:
+            errors.append(f"{name}: STALE — now pinned, remove it from UNPINNED_BASELINE")
+            continue
+
+        allowed, failed = None, False
+        for rel, method in sources:
+            kt = root / rel
+            if not kt.is_file():
+                errors.append(f"{name}: @rbac-source file does not exist: {rel}")
+                failed = True
+                continue
+            roles, err = roles_for_method(strip_comments(kt.read_text()), method, consts)
+            if err:
+                errors.append(f"{name}: {rel}: {err}")
+                failed = True
+                continue
+            allowed = roles if allowed is None else (allowed & roles)
+        if failed or allowed is None:
+            continue
+        if not allowed:
+            errors.append(f"{name}: backends intersect to the EMPTY set — no persona can use "
+                          f"this page; the sources are wrong or the pages disagree")
+            continue
+
+        pinned += 1
+        effective = allowed - excludes
+        over = ui_roles - effective
+        if over:
+            errors.append(
+                f"{name}: grants {sorted(over)} which the backend refuses. "
+                f"UI={sorted(ui_roles)} backend-intersection={sorted(allowed)} "
+                f"excluded={sorted(excludes) or '[]'} -> allowed={sorted(effective)}. "
+                f"Sources: {', '.join(f'{r}#{m}' for r, m in sources)}")
+        under = effective - ui_roles
+        if under:
+            notes.append(f"{name}: backend also admits {sorted(under)} — page hidden from a "
+                         f"persona entitled to it (advisory)")
+
+    for name in sorted(baseline):
+        if name not in route_perms:
+            errors.append(f"{name}: STALE — in UNPINNED_BASELINE but gates no route; remove it")
+
+    if pinned < min_pinned:
+        errors.append(f"only {pinned} permissions are pinned, expected at least {min_pinned} — "
+                      f"a subset assertion over an empty corpus is vacuously true")
+    return errors, notes, pinned
+
+
+# ----------------------------------------------------------------------------------- selftest
+
+def self_test() -> int:
+    """Falsify every part that can go quiet: the Kotlin reader, the class/method precedence,
+    the intersection, the comment stripper, and both directions of the stale-declaration rule.
+
+    A guard is not proven by what it prints, only by what it prevents — so each case below is
+    a fixture the gate MUST reject, paired with a near-identical one it must accept.
+    """
+    import tempfile
+    fails = []
+
+    def build(td, perm_body, kt_body, route_perm="x:view"):
+        root = pathlib.Path(td)
+        ts = root / ROLES_TS
+        ts.parent.mkdir(parents=True, exist_ok=True)
+        ts.write_text(
+            'export const ROLES = {\n'
+            '  ADMIN:      "ROLE_ADMIN",\n'
+            '  OPERATOR:   "ROLE_OPERATOR",\n'
+            '  VIEWER:     "ROLE_VIEWER",\n'
+            '  SUPERVISOR: "ROLE_SUPERVISOR",\n'
+            '} as const\n\n'
+            'export const PERMISSIONS = {\n' + perm_body + '\n} as const\n\n'
+            "const ROUTE_PREFIXES = [\n  ['" + route_perm + "', ['/x']],\n]\n"
+        )
+        kt = root / "openbank-x-service/src/main/kotlin/X.kt"
+        kt.parent.mkdir(parents=True, exist_ok=True)
+        kt.write_text(kt_body)
+        rk = root / ROLES_KT
+        rk.parent.mkdir(parents=True, exist_ok=True)
+        rk.write_text('object Roles {\n  const val ADMIN: String = "ROLE_ADMIN"\n'
+                      '  const val OPERATOR: String = "ROLE_OPERATOR"\n}\n')
+        return root
+
+    SRC = "  // @rbac-source openbank-x-service/src/main/kotlin/X.kt#list\n"
+    KT_OK = ('@Path("/x")\nclass X {\n'
+             '  @GET\n  @RolesAllowed("ROLE_ADMIN", "ROLE_OPERATOR", "ROLE_VIEWER")\n'
+             '  fun list() {}\n}\n')
+
+    cases = [
+        # (label, perm_body, kt, must_fail, needle)
+        ("aligned permission passes",
+         SRC + '  "x:view": [ROLES.ADMIN, ROLES.OPERATOR],', KT_OK, False, None),
+        ("THE DEFECT: widened past the backend",
+         SRC + '  "x:view": [ROLES.ADMIN, ROLES.SUPERVISOR],', KT_OK, True, "ROLE_SUPERVISOR"),
+        ("route permission with no annotation and no baseline entry",
+         '  "x:view": [ROLES.ADMIN],', KT_OK, True, "no @rbac-source"),
+        ("@rbac-source naming a missing method",
+         "  // @rbac-source openbank-x-service/src/main/kotlin/X.kt#nope\n"
+         '  "x:view": [ROLES.ADMIN],', KT_OK, True, "not found"),
+        ("@rbac-source naming a missing file",
+         "  // @rbac-source openbank-x-service/src/main/kotlin/Gone.kt#list\n"
+         '  "x:view": [ROLES.ADMIN],', KT_OK, True, "does not exist"),
+        ("@rbac-exclude admits a role the UI correctly drops",
+         SRC + "  // @rbac-exclude ROLE_VIEWER\n"
+         '  "x:view": [ROLES.ADMIN, ROLES.OPERATOR],', KT_OK, False, None),
+        ("exclude does NOT let a role back in",
+         SRC + "  // @rbac-exclude ROLE_VIEWER\n"
+         '  "x:view": [ROLES.ADMIN, ROLES.VIEWER],', KT_OK, True, "ROLE_VIEWER"),
+        # Method-level REPLACES class-level. If the reader unioned them, ROLE_SUPERVISOR
+        # (class-level only) would be admitted and this case would pass — which is the bug.
+        ("method-level annotation replaces class-level, it does not union",
+         SRC + '  "x:view": [ROLES.SUPERVISOR],',
+         '@Path("/x")\n@RolesAllowed("ROLE_SUPERVISOR")\nclass X {\n'
+         '  @GET\n  @RolesAllowed("ROLE_ADMIN")\n  fun list() {}\n}\n', True, "ROLE_SUPERVISOR"),
+        ("class-level applies when the method has none",
+         SRC + '  "x:view": [ROLES.SUPERVISOR],',
+         '@Path("/x")\n@RolesAllowed("ROLE_SUPERVISOR")\nclass X {\n  @GET\n  fun list() {}\n}\n',
+         False, None),
+        # Two sources -> INTERSECTION. Under a union this passes; under intersection it must not.
+        ("two sources intersect rather than union",
+         "  // @rbac-source openbank-x-service/src/main/kotlin/X.kt#list\n"
+         "  // @rbac-source openbank-x-service/src/main/kotlin/X.kt#other\n"
+         '  "x:view": [ROLES.VIEWER],',
+         '@Path("/x")\nclass X {\n'
+         '  @GET\n  @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")\n  fun list() {}\n'
+         '  @GET\n  @RolesAllowed("ROLE_ADMIN")\n  fun other() {}\n}\n', True, "ROLE_VIEWER"),
+        ("a commented-out annotation is prose, not code",
+         SRC + '  "x:view": [ROLES.ADMIN, ROLES.OPERATOR],',
+         '@Path("/x")\nclass X {\n'
+         '  /* historic: @RolesAllowed("ROLE_SUPERVISOR") /* nested */ was wrong */\n'
+         '  @GET\n  @RolesAllowed("ROLE_ADMIN", "ROLE_OPERATOR", "ROLE_VIEWER")\n'
+         '  fun list() {}\n}\n', False, None),
+        ("Roles.X constants resolve",
+         SRC + '  "x:view": [ROLES.ADMIN],',
+         '@Path("/x")\nclass X {\n  @GET\n  @RolesAllowed(Roles.ADMIN, Roles.OPERATOR)\n'
+         '  fun list() {}\n}\n', False, None),
+    ]
+
+    for label, body, kt, must_fail, needle in cases:
+        with tempfile.TemporaryDirectory() as td:
+            root = build(td, body, kt)
+            errs, _, _ = run(root, min_pinned=0, baseline={})
+            got = bool(errs)
+            if got != must_fail:
+                fails.append(f"{label}: expected {'FAIL' if must_fail else 'PASS'}, "
+                             f"got {'FAIL' if got else 'PASS'} ({errs})")
+            elif must_fail and needle and not any(needle in e for e in errs):
+                fails.append(f"{label}: failed for the wrong reason ({errs}), want {needle!r}")
+
+    # Stale-declaration rule, BOTH directions.
+    with tempfile.TemporaryDirectory() as td:
+        root = build(td, SRC + '  "x:view": [ROLES.ADMIN],', KT_OK)
+        errs, _, _ = run(root, min_pinned=0, baseline={"x:view": "test"})
+        if not any("STALE" in e and "remove it from UNPINNED" in e for e in errs):
+            fails.append(f"annotated permission still in baseline must be STALE, got {errs}")
+    with tempfile.TemporaryDirectory() as td:
+        root = build(td, SRC + '  "x:view": [ROLES.ADMIN],', KT_OK)
+        errs, _, _ = run(root, min_pinned=0, baseline={"gone:view": "test"})
+        if not any("gates no route" in e for e in errs):
+            fails.append(f"baseline entry gating no route must be STALE, got {errs}")
+
+    # The min-pinned floor is the gate's own known-positive.
+    with tempfile.TemporaryDirectory() as td:
+        root = build(td, SRC + '  "x:view": [ROLES.ADMIN],', KT_OK)
+        errs, _, n = run(root, min_pinned=99, baseline={})
+        if n != 1 or not any("vacuously true" in e for e in errs):
+            fails.append(f"min-pinned floor did not fire (pinned={n}, errs={errs})")
+
+    for f in fails:
+        print(f"SELF-TEST FAIL: {f}")
+    print(f"self-test: {len(cases) + 3} cases, {len(fails)} failures")
+    return 1 if fails else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--min-pinned", type=int, default=10)
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+
+    errors, notes, pinned = run(pathlib.Path(args.root).resolve(), args.min_pinned)
+    # The subject count is what makes the green meaningful: a subset assertion over an empty
+    # corpus passes. run-gates.py cross-checks this against min_subjects in gates.yaml.
+    gatelib.subjects(pinned, "route permissions pinned to backend @RolesAllowed")
+    for n in notes:
+        print(f"note: {n}")
+    if errors:
+        print(f"\nadmin-ui RBAC alignment: {len(errors)} error(s)\n")
+        for e in errors:
+            print(f"  ERROR {e}")
+        print("\nroles.ts must not grant a persona the backing service's @RolesAllowed refuses:")
+        print("the console would render a link that answers 403 on click.")
+        return 1
+    print(f"admin-ui RBAC alignment OK — {pinned} route permissions pinned to backend "
+          f"@RolesAllowed, {len(UNPINNED_BASELINE)} declared unpinned")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-admin-ui/src/app/clearing/page.tsx
+++ b/openbank-admin-ui/src/app/clearing/page.tsx
@@ -47,7 +47,7 @@ export default function ClearingPage() {
   const totalVolume = batches.reduce((s, b) => s + (b.totalAmount ?? 0), 0)
 
   return (
-    <AuthGuard permission="payments:view">
+    <AuthGuard permission="clearing:view">
       <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
         <PageHeader
           icon={<Layers size={20} aria-hidden="true" />}

--- a/openbank-admin-ui/src/app/fees/page.tsx
+++ b/openbank-admin-ui/src/app/fees/page.tsx
@@ -94,7 +94,7 @@ export default function FeesPage() {
   const activeCount = fees.filter(f => f.status === 'ACTIVE').length
 
   return (
-    <AuthGuard permission="payments:view">
+    <AuthGuard permission="product-catalog:view">
       <div>
         <PageHeader
           icon={<Receipt size={20} aria-hidden="true" />}

--- a/openbank-admin-ui/src/app/interest/page.tsx
+++ b/openbank-admin-ui/src/app/interest/page.tsx
@@ -39,7 +39,7 @@ export default function InterestPage() {
   const totalAccrued = accruals.reduce((s, a) => s + (a.accruedAmount ?? 0), 0)
 
   return (
-    <AuthGuard permission="payments:view">
+    <AuthGuard permission="interest:view">
       <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
         <PageHeader icon={<Percent size={20} aria-hidden="true" />} title={t('Úrokové výpočty', 'Interest Calculations')} subtitle={t('Akruální účetnictví — ACT/365 · ACT/360 · kapitalizace', 'Accrual accounting — ACT/365 · ACT/360 · capitalisation')} actions={<ServiceStatusBadge
             label="interest-service :8125"

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -47,8 +47,8 @@ const coreNav: NavItem[] = [
 ]
 
 const revenueNav: NavItem[] = [
-  { nameCs: 'Úvěry',        nameEn: 'Lending',      href: '/lending',      icon: TrendingUp,    permission: 'payments:view' },
-  { nameCs: 'Poplatky',     nameEn: 'Fees',         href: '/fees',         icon: Receipt,         permission: 'payments:view' },
+  { nameCs: 'Úvěry',        nameEn: 'Lending',      href: '/lending',      icon: TrendingUp,    permission: 'lending:view' },
+  { nameCs: 'Poplatky',     nameEn: 'Fees',         href: '/fees',         icon: Receipt,         permission: 'product-catalog:view' },
 ]
 
 const customerNav: NavItem[] = [
@@ -60,16 +60,16 @@ const customerNav: NavItem[] = [
 ]
 
 const paymentsNav: NavItem[] = [
-  { nameCs: 'Katalog produktů',  nameEn: 'Product Catalog',  href: '/product-catalog',   icon: Package,   permission: 'payments:view' },
+  { nameCs: 'Katalog produktů',  nameEn: 'Product Catalog',  href: '/product-catalog',   icon: Package,   permission: 'product-catalog:view' },
   { nameCs: 'Produktové studio', nameEn: 'Product Studio',   href: '/product-studio',    icon: Boxes,     permission: 'catalog:read' },
   { nameCs: 'Platby',            nameEn: 'Payments',         href: '/payments',          icon: Banknote,  permission: 'payments:view' },
-  { nameCs: 'Trvalé příkazy',    nameEn: 'Standing Orders',  href: '/standing-orders',   icon: Repeat,    permission: 'payments:view' },
-  { nameCs: 'Inkasa (SDD)',      nameEn: 'Direct Debits',    href: '/sdd',               icon: Repeat,    permission: 'payments:view' },
-  { nameCs: 'FX',                nameEn: 'FX',               href: '/fx',                icon: DollarSign,permission: 'payments:view' },
-  { nameCs: 'SWIFT',             nameEn: 'SWIFT',            href: '/swift',             icon: Globe,     permission: 'payments:view' },
+  { nameCs: 'Trvalé příkazy',    nameEn: 'Standing Orders',  href: '/standing-orders',   icon: Repeat,    permission: 'standing-orders:view' },
+  { nameCs: 'Inkasa (SDD)',      nameEn: 'Direct Debits',    href: '/sdd',               icon: Repeat,    permission: 'sdd:view' },
+  { nameCs: 'FX',                nameEn: 'FX',               href: '/fx',                icon: DollarSign,permission: 'fx:view' },
+  { nameCs: 'SWIFT',             nameEn: 'SWIFT',            href: '/swift',             icon: Globe,     permission: 'swift:view' },
   { nameCs: 'Karty',             nameEn: 'Cards',            href: '/cards',             icon: CreditCard,permission: 'cards:view' },
-  { nameCs: 'Clearing',          nameEn: 'Clearing',         href: '/clearing',          icon: Layers,    permission: 'payments:view' },
-  { nameCs: 'Úroky',             nameEn: 'Interest',         href: '/interest',          icon: TrendingUp,permission: 'payments:view' },
+  { nameCs: 'Clearing',          nameEn: 'Clearing',         href: '/clearing',          icon: Layers,    permission: 'clearing:view' },
+  { nameCs: 'Úroky',             nameEn: 'Interest',         href: '/interest',          icon: TrendingUp,permission: 'interest:view' },
   { nameCs: 'Šablony dokumentů', nameEn: 'Document Templates', href: '/document-templates', icon: FileSignature, permission: 'templates:view' },
 
 ]
@@ -90,7 +90,7 @@ const complianceNav: NavItem[] = [
 ]
 
 const opsNav: NavItem[] = [
-  { nameCs: 'PID',                   nameEn: 'PID',              href: '/pid',               icon: Map,          permission: 'payments:view' },
+  { nameCs: 'PID',                   nameEn: 'PID',              href: '/pid',               icon: Map,          permission: 'pid:view' },
   { nameCs: 'Oznámení',              nameEn: 'Notifications',    href: '/notifications',     icon: Bell,         permission: 'notifications:view' },
   { nameCs: 'Bezpečnostní kontrola', nameEn: 'Security Scan',    href: '/security',          icon: ScanLine,     permission: 'system:view' },
 ]

--- a/openbank-admin-ui/src/lib/auth/persona.ts
+++ b/openbank-admin-ui/src/lib/auth/persona.ts
@@ -24,9 +24,14 @@ const WORKSPACES: Record<Persona, WorkspaceLink[]> = {
   ],
   payments: [
     { href: '/payments', nameCs: 'Platby', nameEn: 'Payments', permission: 'payments:view' },
-    { href: '/standing-orders', nameCs: 'Trvalé příkazy', nameEn: 'Standing Orders', permission: 'payments:view' },
-    { href: '/clearing', nameCs: 'Clearing', nameEn: 'Clearing', permission: 'payments:view' },
-    { href: '/fx', nameCs: 'FX', nameEn: 'FX', permission: 'payments:view' },
+    // NOT /standing-orders (#7790): StandingOrderResource admits ROLE_API/OPERATOR/ADMIN and
+    // no ROLE_PAYMENTS on any method, so this persona's own shortcut was a 403 trap. It
+    // passed review only because the old `payments:view` bucket granted twelve routes to
+    // five personas at once. /sdd is the payment-ops queue that sepa-direct-debit really
+    // does admit ROLE_PAYMENTS on.
+    { href: '/sdd', nameCs: 'Inkasa (SDD)', nameEn: 'Direct Debits', permission: 'sdd:view' },
+    { href: '/clearing', nameCs: 'Clearing', nameEn: 'Clearing', permission: 'clearing:view' },
+    { href: '/fx', nameCs: 'FX', nameEn: 'FX', permission: 'fx:view' },
   ],
   compliance: [
     { href: '/kyc', nameCs: 'KYC', nameEn: 'KYC', permission: 'kyc:view' },
@@ -37,7 +42,12 @@ const WORKSPACES: Record<Persona, WorkspaceLink[]> = {
   supervisor: [
     // A supervisor can review, but cannot use the platform-admin approvals queue or the
     // operator-only closing trigger. Keep this workspace aligned to the actual RBAC matrix.
-    { href: '/payments', nameCs: 'Platební dohled', nameEn: 'Payment oversight', permission: 'payments:view' },
+    //
+    // There is deliberately NO payment-oversight link here any more (#7790). ROLE_SUPERVISOR is
+    // admitted by none of the payment read endpoints — not sepa-payment, domestic-payment,
+    // sepa-instant, clearing, sdd, fx or swift — so this shortcut led straight to a 403. The
+    // supervisor's real payment authority is `payments:approve`, which gates an action, not this
+    // page. Restoring the link needs a backend that accepts the role, not a wider UI permission.
     { href: '/aml', nameCs: 'AML dohled', nameEn: 'AML oversight', permission: 'compliance:view' },
     { href: '/sanctions', nameCs: 'Sankční dohled', nameEn: 'Sanctions oversight', permission: 'compliance:view' },
     { href: '/audit', nameCs: 'Audit', nameEn: 'Audit', permission: 'audit:view' },

--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -47,8 +47,72 @@ export const PERMISSIONS = {
   // Closings (EoD/EoM close cockpit, ADR-0069 D3) — the manual catch-up trigger
   // mirrors statement-service's CloseRunResource POST gate (ROLE_OPERATOR/ADMIN)
   "closings:run":             [ROLES.ADMIN, ROLES.OPERATOR],
-  // Payments
-  "payments:view":        [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER, ROLES.PAYMENTS, ROLES.SUPERVISOR],
+  // Payments and the payment-adjacent consoles.
+  //
+  // These ten permissions were ONE (`payments:view`, five personas over twelve routes) until
+  // #7790. The twelve backends never agreed with each other: ROLE_SUPERVISOR was granted on all
+  // twelve and admitted by none, and ROLE_VIEWER/ROLE_PAYMENTS were over-granted on five more.
+  // Nothing failed — the service enforces correctly — so the only symptom was an operator being
+  // shown a link that answered 403 on click. Each permission below is now pinned to the
+  // `@RolesAllowed` of the resource its page actually reads, and
+  // `.github/scripts/check-admin-ui-rbac-alignment.py` fails the build if the two drift apart.
+  //
+  // `@rbac-source <file>#<method>` — a read the page performs on load. Several sources are
+  // INTERSECTED, because a page that Promise.all's its reads is only as usable as its narrowest.
+  // `@rbac-exclude` — a role the backend admits that cannot hold a browser session (ROLE_API is
+  // the M2M service-account identity); listing it here would render a section for a principal
+  // that never logs in.
+  //
+  // @rbac-source openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/rest/SepaPaymentResource.kt#listPayments
+  // @rbac-source openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/rest/DomesticPaymentResource.kt#listPayments
+  // @rbac-source openbank-sepa-instant/src/main/kotlin/com/openbank/sepainstant/infrastructure/rest/SctInstResource.kt#listAll
+  // @rbac-exclude ROLE_API
+  "payments:view":        [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER, ROLES.PAYMENTS],
+  // @rbac-source openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/rest/ClearingResource.kt#listBatches
+  // @rbac-exclude ROLE_API
+  "clearing:view":        [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER, ROLES.PAYMENTS],
+  // @rbac-source openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/rest/SddMandateQueueResource.kt#listRecentMandates
+  "sdd:view":             [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER, ROLES.PAYMENTS],
+  // @rbac-source openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/rest/SwiftResource.kt#listAll
+  "swift:view":           [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER, ROLES.PAYMENTS],
+  // @rbac-source openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/rest/FxResource.kt#getRates
+  // @rbac-source openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/rest/FxResource.kt#getRateHistory
+  "fx:view":              [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER, ROLES.PAYMENTS],
+  // Product catalogue reads (products + the fee schedule) are one service and one role set.
+  // ROLE_PAYMENTS is NOT among them — the old bucket granted it, and it 403s.
+  // CATALOG_SCOPE_READ is minted from an OAuth scope by CatalogScopeIdentityAugmentor; the
+  // AUTHOR/PUBLISH scopes are deliberately absent because the read endpoints require READ
+  // specifically, so listing them would be the same over-grant one layer down.
+  // @rbac-source openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/rest/ProductCatalogResource.kt#list
+  // @rbac-source openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/rest/FeesResource.kt#list
+  // @rbac-exclude ROLE_API
+  "product-catalog:view": [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER, ROLES.CATALOG_READ],
+  // The narrowest of the twelve: StandingOrderResource admits no ROLE_VIEWER on ANY method,
+  // read or write. The bucket showed the page to viewers, payments ops and supervisors alike.
+  // @rbac-source openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/rest/StandingOrderResource.kt#listAll
+  // @rbac-exclude ROLE_API
+  "standing-orders:view": [ROLES.ADMIN, ROLES.OPERATOR],
+  // InterestResource carries no method-level annotation on the accrual list, so its class-level
+  // set applies (#7789).
+  // @rbac-source openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/rest/InterestResource.kt#listAllAccruals
+  // @rbac-exclude ROLE_API
+  "interest:view":        [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER],
+  // The /pid console's list call goes to `/api/v1/pids`, which exists in NO Kotlin resource in
+  // the fleet — it 404s and the page treats that as an empty list. The read that actually backs
+  // the page is pid-service PartyResource.search, OPERATOR/ADMIN only (#7785). ROLE_API appears
+  // on PartyResource's register/resolve POSTs, not on this read path.
+  // @rbac-source openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/rest/PartyResource.kt#search
+  "pid:view":             [ROLES.ADMIN, ROLES.OPERATOR],
+  // INTERSECTION, deliberately. LendingResource disagrees with itself: the two `applications/*`
+  // reads exclude VIEWER/COMPLIANCE while the two `loans/*` reads admit them, and the page
+  // Promise.all's `applications/recent` with `loans/active`, so a VIEWER or COMPLIANCE principal
+  // gets the whole page blanked as "unreachable" rather than a partial view. Showing it to them
+  // is the lie this change removes, so the union is not an option here.
+  // @rbac-source openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/LendingResource.kt#listRecentApplications
+  // @rbac-source openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/LendingResource.kt#listActiveLoans
+  // @rbac-source openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/LendingResource.kt#summariseApplications
+  // @rbac-source openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/LendingResource.kt#summariseLoans
+  "lending:view":         [ROLES.ADMIN, ROLES.OPERATOR, ROLES.LENDING_OFFICER, ROLES.CREDIT_RISK],
   "payments:create":      [ROLES.ADMIN, ROLES.OPERATOR, ROLES.PAYMENTS],
   "payments:approve":     [ROLES.ADMIN, ROLES.PAYMENTS, ROLES.SUPERVISOR],
   // Lending compliance-pack reads include the operational lending roles accepted by
@@ -231,10 +295,20 @@ const ROUTE_PREFIXES: ReadonlyArray<readonly [Permission, readonly string[]]> = 
   ['accounts:create', ['/accounts/new']],
   ['accounts:view', ['/accounts', '/ledger', '/day-end']],
   ['cards:view', ['/cards']],
-  ['payments:view', [
-    '/payments', '/product-catalog', '/standing-orders', '/sdd', '/sepa-instant', '/clearing',
-    '/fx', '/swift', '/interest', '/pid', '/fees', '/lending',
-  ]],
+  // One permission per backing service (#7790). '/sepa-instant' redirects to '/payments' and
+  // reads the same three payment resources, so it belongs with them; '/fees' is served by
+  // product-catalog, so it belongs with '/product-catalog'. '/lending/compliance-packs' keeps
+  // its own stricter permission via the longest-prefix rule.
+  ['payments:view', ['/payments', '/sepa-instant']],
+  ['clearing:view', ['/clearing']],
+  ['sdd:view', ['/sdd']],
+  ['swift:view', ['/swift']],
+  ['fx:view', ['/fx']],
+  ['product-catalog:view', ['/product-catalog', '/fees']],
+  ['standing-orders:view', ['/standing-orders']],
+  ['interest:view', ['/interest']],
+  ['pid:view', ['/pid']],
+  ['lending:view', ['/lending']],
   ['sanctions:view', ['/sanctions']],
   ['compliance:view', [
     '/aml', '/fraud', '/disputes', '/consents', '/customer-360',

--- a/openbank-admin-ui/src/test/payments-permission-bucket.guard.test.ts
+++ b/openbank-admin-ui/src/test/payments-permission-bucket.guard.test.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { ROLES, hasPermission, permissionForPath, type Permission } from '@/lib/auth/roles'
+
+/**
+ * The UI half of the `payments:view` bucket fix (#7790, #7783, #7788, #7824).
+ *
+ * The Kotlin half — "does this persona set match the backing service's @RolesAllowed" — is
+ * NOT tested here and cannot usefully be: parsing Kotlin annotations from vitest would put a
+ * second, weaker parser in a second language next to the real one. That comparison lives in
+ * `.github/scripts/check-admin-ui-rbac-alignment.py`, which reads both sides and is falsified
+ * against a widened permission and a narrowed backend in its own `--self-test`.
+ *
+ * What IS tested here is everything downstream of that pin, which the Python gate cannot see:
+ * that the nav and the route projection agree, and that the specific personas the twelve
+ * backends reject can no longer reach the twelve pages.
+ */
+
+const root = resolve(__dirname, '..')
+const read = (file: string) => readFileSync(resolve(root, file), 'utf8')
+
+const BUCKET_ROUTES = [
+  '/payments', '/product-catalog', '/standing-orders', '/sdd', '/sepa-instant', '/clearing',
+  '/fx', '/swift', '/interest', '/pid', '/fees', '/lending',
+] as const
+
+describe('the twelve-route payments:view bucket is split per backing service', () => {
+  it('no longer maps every payment-adjacent route to one permission', () => {
+    const permissions = BUCKET_ROUTES.map(r => permissionForPath(r))
+    expect(permissions.every(Boolean)).toBe(true)
+    // Before the fix this set had exactly one member. Ten services back these twelve routes.
+    expect(new Set(permissions).size).toBe(10)
+  })
+
+  it('keeps only same-service routes sharing a permission', () => {
+    // /sepa-instant redirects to /payments and reads the same three resources.
+    expect(permissionForPath('/sepa-instant')).toBe(permissionForPath('/payments'))
+    // /fees is served by product-catalog.
+    expect(permissionForPath('/fees')).toBe(permissionForPath('/product-catalog'))
+    // Everything else is its own service, so its own permission.
+    for (const [a, b] of [['/interest', '/payments'], ['/pid', '/payments'],
+                          ['/standing-orders', '/payments'], ['/lending', '/payments'],
+                          ['/swift', '/clearing'], ['/fx', '/sdd']] as const) {
+      expect(permissionForPath(a)).not.toBe(permissionForPath(b))
+    }
+  })
+
+  it('keeps the stricter lending compliance prefix winning over /lending', () => {
+    expect(permissionForPath('/lending')).toBe('lending:view')
+    expect(permissionForPath('/lending/compliance-packs')).toBe('lending:compliance:view')
+  })
+})
+
+describe('personas the backends reject can no longer reach the pages', () => {
+  // ROLE_SUPERVISOR was granted on all twelve routes and is admitted by none of them.
+  it('hides every one of the twelve from a supervisor', () => {
+    for (const route of BUCKET_ROUTES) {
+      const permission = permissionForPath(route) as Permission
+      expect(hasPermission([ROLES.SUPERVISOR], permission),
+        `supervisor must not be shown ${route}`).toBe(false)
+    }
+  })
+
+  // StandingOrderResource admits no ROLE_VIEWER on any method; pid-service's read path and
+  // LendingResource's applications/* reads are OPERATOR/ADMIN-tier.
+  it.each(['/standing-orders', '/pid', '/lending'])('hides %s from a plain viewer', route => {
+    expect(hasPermission([ROLES.VIEWER], permissionForPath(route) as Permission)).toBe(false)
+  })
+
+  // ROLE_PAYMENTS is not admitted by product-catalog, standing-order, interest, pid or lending.
+  it.each(['/product-catalog', '/fees', '/standing-orders', '/interest', '/pid', '/lending'])(
+    'hides %s from payments ops', route => {
+      expect(hasPermission([ROLES.PAYMENTS], permissionForPath(route) as Permission)).toBe(false)
+    })
+
+  // The controls: the personas the backends DO admit must keep their access, or this whole
+  // change is an outage rather than a correction.
+  it('keeps the personas each backend admits', () => {
+    expect(hasPermission([ROLES.PAYMENTS], 'payments:view')).toBe(true)
+    expect(hasPermission([ROLES.VIEWER], 'fx:view')).toBe(true)
+    expect(hasPermission([ROLES.VIEWER], 'swift:view')).toBe(true)
+    expect(hasPermission([ROLES.VIEWER], 'sdd:view')).toBe(true)
+    expect(hasPermission([ROLES.VIEWER], 'interest:view')).toBe(true)
+    expect(hasPermission([ROLES.OPERATOR], 'standing-orders:view')).toBe(true)
+    expect(hasPermission([ROLES.OPERATOR], 'pid:view')).toBe(true)
+    expect(hasPermission([ROLES.CREDIT_RISK], 'lending:view')).toBe(true)
+    expect(hasPermission([ROLES.LENDING_OFFICER], 'lending:view')).toBe(true)
+    expect(hasPermission([ROLES.CATALOG_READ], 'product-catalog:view')).toBe(true)
+    for (const route of BUCKET_ROUTES) {
+      expect(hasPermission([ROLES.ADMIN], permissionForPath(route) as Permission)).toBe(true)
+    }
+  })
+})
+
+describe('nav destinations agree with the route projection', () => {
+  // DERIVED from the nav sources, not a hand-kept list: a nav entry added later is covered
+  // automatically. This is what stops a link being gated by one permission while the route it
+  // points at is gated by another — the shape that let /pid sit behind payments:view.
+  const entries = (file: string) =>
+    [...read(file).matchAll(/href: '(\/[\w/-]+)'[^}]*?permission: '([\w:-]+)'/g)]
+      .map(m => ({ href: m[1], permission: m[2] }))
+
+  // RATCHET, not an allowlist: the mismatch set is asserted EXACTLY, so a new one fails and a
+  // fixed one must be removed from here. The single declared entry is PRE-EXISTING and outside
+  // this change — persona.ts offers /sanctions to the compliance and supervisor workspaces under
+  // `compliance:view`, while the route resolves to `sanctions:view` (ADMIN/OPERATOR/VIEWER), so
+  // the edge gate refuses the link the workspace advertises. It is the same defect class as the
+  // payments bucket and is left alone deliberately: `sanctions:view` has not been verified
+  // against sanctions-service's @RolesAllowed, and guessing which of the two sides is wrong is
+  // how the bucket got its extra personas in the first place. Tracked for follow-up.
+  const DECLARED_NAV_MISMATCHES: Record<string, Array<{ href: string; permission: string }>> = {
+    'components/layout/Sidebar.tsx': [],
+    'lib/auth/persona.ts': [
+      { href: '/sanctions', permission: 'compliance:view' },
+      { href: '/sanctions', permission: 'compliance:view' },
+    ],
+  }
+
+  it.each(['components/layout/Sidebar.tsx', 'lib/auth/persona.ts'])(
+    '%s gates each link with the permission its route resolves to', file => {
+      const mismatched = entries(file)
+        .map(e => ({ ...e, route: permissionForPath(e.href) }))
+        .filter(e => e.route !== undefined && e.route !== e.permission)
+        .map(({ href, permission }) => ({ href, permission }))
+      expect(mismatched).toEqual(DECLARED_NAV_MISMATCHES[file])
+    })
+
+  it('reads a non-empty set of nav entries from both files', () => {
+    // Known-positive: the regex above returning nothing would make the assertion vacuous.
+    expect(entries('components/layout/Sidebar.tsx').length).toBeGreaterThan(20)
+    expect(entries('lib/auth/persona.ts').length).toBeGreaterThan(10)
+  })
+})


### PR DESCRIPTION
## What

`openbank-admin-ui/src/lib/auth/roles.ts` mapped **twelve unrelated routes to one permission**:

```ts
['payments:view', ['/payments','/product-catalog','/standing-orders','/sdd','/sepa-instant',
                   '/clearing','/fx','/swift','/interest','/pid','/fees','/lending']],
"payments:view": [ADMIN, OPERATOR, VIEWER, PAYMENTS, SUPERVISOR],
```

Five personas, twelve routes, ten backing services. **This is not a security hole** — every
service re-checks the call with its own `@RolesAllowed` and OPA sits behind that, so nothing
leaks. It is the console telling an operator they may do something they may not, and them
finding out by clicking a link and getting a 403.

Consolidates #7790 (anchor), #7783, #7788 and the roles.ts half of #7824. They are one PR
because they edit the same two lines: the three open PRs #7789, #7785 and #7791 each rewrite
the same `payments:view` array and would conflict pairwise.

## The measured picture — all twelve routes

Read from `origin/main`; `Roles.X` constants resolved via `libs-domain/security/Roles.kt`,
`CatalogRoles.READ` via `CatalogScopeIdentityAugmentor.kt`.

| route | backing read resource(s) | backend `@RolesAllowed` | UI granted | over-grant |
|---|---|---|---|---|
| `/payments` | `SepaPaymentResource#listPayments`, `DomesticPaymentResource#listPayments`, `SctInstResource#listAll` | VIEWER, OPERATOR, ADMIN, PAYMENTS, API | +SUPERVISOR | SUPERVISOR |
| `/sepa-instant` | redirects to `/payments`, same three | VIEWER, OPERATOR, ADMIN, PAYMENTS, API | +SUPERVISOR | SUPERVISOR |
| `/clearing` | `ClearingResource#listBatches` | API, VIEWER, OPERATOR, PAYMENTS, ADMIN | +SUPERVISOR | SUPERVISOR |
| `/sdd` | `SddMandateQueueResource#listRecentMandates` | VIEWER, OPERATOR, ADMIN, PAYMENTS | +SUPERVISOR | SUPERVISOR |
| `/fx` | `FxResource#getRates`, `#getRateHistory` | VIEWER, OPERATOR, ADMIN, PAYMENTS | +SUPERVISOR | SUPERVISOR |
| `/swift` | `SwiftResource#listAll` | VIEWER, OPERATOR, PAYMENTS, ADMIN | +SUPERVISOR | SUPERVISOR |
| `/product-catalog` | `ProductCatalogResource#list` | API, VIEWER, OPERATOR, ADMIN, CATALOG_SCOPE_READ | +PAYMENTS, +SUPERVISOR | PAYMENTS, SUPERVISOR |
| `/fees` | `FeesResource#list` | API, VIEWER, OPERATOR, ADMIN, CATALOG_SCOPE_READ | +PAYMENTS, +SUPERVISOR | PAYMENTS, SUPERVISOR |
| `/standing-orders` | `StandingOrderResource#listAll` | API, OPERATOR, ADMIN | +VIEWER, +PAYMENTS, +SUPERVISOR | VIEWER, PAYMENTS, SUPERVISOR |
| `/interest` | `InterestResource#listAllAccruals` (class-level) | VIEWER, OPERATOR, ADMIN, API | +PAYMENTS, +SUPERVISOR | PAYMENTS, SUPERVISOR |
| `/pid` | `pid-service PartyResource#search` | OPERATOR, ADMIN | +VIEWER, +PAYMENTS, +SUPERVISOR | VIEWER, PAYMENTS, SUPERVISOR |
| `/lending` | `LendingResource` ×4 (**divergent**, see below) | ∩ = OPERATOR, ADMIN, LENDING_OFFICER, CREDIT_RISK | +VIEWER, +PAYMENTS, +SUPERVISOR, −LENDING_OFFICER, −CREDIT_RISK | VIEWER, PAYMENTS, SUPERVISOR |

**`ROLE_SUPERVISOR` was granted on all twelve and is admitted by none of them.** That single
role is the whole of the defect on six routes, and no issue named it.

The six routes the three issues never mention (`/fees`, `/lending`, `/sdd`, `/standing-orders`,
`/fx`, `/product-catalog`) turned out to hold the **worst** cases: `/standing-orders` and
`/lending` over-grant three roles each, not one.

Two things worth calling out:

- **`/pid`'s list call targets `/api/v1/pids`, which exists in no Kotlin resource in the fleet.**
  It 404s and the page treats that as an empty list, so the read that actually backs the page is
  `PartyResource#search` (OPERATOR/ADMIN). The `ROLE_API` the issue cites is on that resource's
  register/resolve **POSTs**, not on any read.
- **`LendingResource` disagrees with itself.** `listRecentApplications` / `summariseApplications`
  admit OPERATOR/ADMIN/LENDING_OFFICER/CREDIT_RISK; `listActiveLoans` / `summariseLoans` also
  admit VIEWER and COMPLIANCE. The class-level annotation is overridden by every read method
  (method-level *replaces* class-level in Jakarta, it does not union), which is how OPERATOR and
  VIEWER get in at all.

## Where I took an intersection, and why

**`/lending` only.** It is the one route whose read path fans out to resources with different
sets. The page `Promise.all`s `applications/recent` with `loans/active`, so a VIEWER or
COMPLIANCE principal — allowed on the loans call, refused on the applications call — gets the
**whole page** rendered as `unreachable`, not a partial view. Showing it to them is precisely the
lie being removed, so the union was not available. Everywhere else the sets across a page's reads
were identical and the intersection is a no-op.

## The split

Ten permissions, one per backing service. `/sepa-instant` stays with `/payments` (it redirects
there and reads the same three resources); `/fees` stays with `/product-catalog` (same service,
same role set). `/lending/compliance-packs` keeps its own stricter permission via longest-prefix.

| permission | roles | routes |
|---|---|---|
| `payments:view` | ADMIN, OPERATOR, VIEWER, PAYMENTS | `/payments`, `/sepa-instant` |
| `clearing:view` | ADMIN, OPERATOR, VIEWER, PAYMENTS | `/clearing` |
| `sdd:view` | ADMIN, OPERATOR, VIEWER, PAYMENTS | `/sdd` |
| `swift:view` | ADMIN, OPERATOR, VIEWER, PAYMENTS | `/swift` |
| `fx:view` | ADMIN, OPERATOR, VIEWER, PAYMENTS | `/fx` |
| `product-catalog:view` | ADMIN, OPERATOR, VIEWER, CATALOG_READ | `/product-catalog`, `/fees` |
| `standing-orders:view` | ADMIN, OPERATOR | `/standing-orders` |
| `interest:view` | ADMIN, OPERATOR, VIEWER | `/interest` |
| `pid:view` | ADMIN, OPERATOR | `/pid` |
| `lending:view` | ADMIN, OPERATOR, LENDING_OFFICER, CREDIT_RISK | `/lending` |

`ROLE_API` is excluded everywhere via an explicit `@rbac-exclude`: it is the M2M service-account
identity and never holds a browser session, so listing it would render a section for a principal
that cannot log in. `CATALOG_SCOPE_AUTHOR`/`PUBLISH` are deliberately absent from
`product-catalog:view` — the read endpoints require `READ` specifically, so including them would
be the same over-grant one layer down.

The nav is where the lie is actually rendered, so `Sidebar.tsx`, `persona.ts` and the three page
`AuthGuard`s move with it.

### Two more instances the bucket was masking

- The **payments persona's own `/standing-orders` shortcut** was a 403 trap: `StandingOrderResource`
  admits no `ROLE_PAYMENTS` on any method, read or write. It passed review only because
  `payments:view` was broad enough to cover it. Repointed to `/sdd`, which that service does admit
  `ROLE_PAYMENTS` on. **This was caught by the pre-existing `persona.test.ts`**, which went red the
  moment the permission stopped being over-broad — the existing test was right all along and had
  nothing to bite on.
- The **supervisor persona's payment-oversight link** is removed. `ROLE_SUPERVISOR` is admitted by
  none of the payment read endpoints. Its real payment authority is `payments:approve`, which gates
  an action, not this page.

## The durable half

`.github/scripts/check-admin-ui-rbac-alignment.py` (gate `admin-ui-rbac-alignment`, `security`
group, `enforced`). Each permission names the reads it depends on inline:

```ts
// @rbac-source openbank-interest-service/.../InterestResource.kt#listAllAccruals
// @rbac-exclude ROLE_API
"interest:view":        [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER],
```

The gate parses both sides and fails when the UI grants a role the backend's intersection
refuses. It also fails when a route-gating permission has **neither** an annotation **nor** an
entry in `UNPINNED_BASELINE` — that is what stops the bucket being reintroduced, since merging
routes back under one permission must then survive the intersection of every backend it absorbs.
Stale declarations fail in **both** directions (a baseline entry that is now pinned, or that gates
no route; an `@rbac-source` naming a missing file or method), so the debt list can only shrink.

Why a Python gate and not a vitest test: parsing Kotlin annotations from vitest would put a
second, weaker parser in a second language next to the real one. The comparison lives on the
Python side where `check-roles-allowed-realm.py` already reads the same annotations, and it
reuses that script's nesting-aware comment stripper — a KDoc quoting an annotation is prose about
code, and a scanner that cannot tell them apart manufactures its own findings.

**Why not extend the existing pattern:** `party-rbac-alignment.guard.test.ts` asserts the roles
**line as a string**. That pins the file against itself — red when the line is edited, green while
the backend moves underneath it. It is a change-detector, not a pin.

The vitest guard `payments-permission-bucket.guard.test.ts` covers what the Python gate cannot
see: that nav and route projection agree (**derived** from the nav sources by regex, so a link
added later is covered automatically), and that the specific rejected personas can no longer
reach the pages — with positive controls asserting every admitted persona **keeps** its access,
so the change cannot degenerate into an outage.

## Proof by what it prevents

Every exit code read from `$?` immediately after redirecting to a file, never through a pipe.

| check | against | exit |
|---|---|---|
| `check-admin-ui-rbac-alignment.py` | **unmodified `main`** | **1** (`payments:view` unpinned; `only 0 permissions are pinned, expected at least 10`) |
| `check-admin-ui-rbac-alignment.py` | this branch | 0 (`10 pinned, 28 declared unpinned`) |
| `--self-test` | 15 cases incl. must-fail negatives | 0 |
| **regression: re-add SUPERVISOR to `payments:view` + VIEWER to `standing-orders:view`** | this branch | **1**, naming both roles |
| **regression: drop `ROLE_VIEWER` from `InterestResource`'s annotation, UI unchanged** | this branch | **1** (`interest:view` grants ROLE_VIEWER which the backend refuses) |
| restore after each | this branch | 0 |
| `payments-permission-bucket.guard.test.ts` | **unmodified `main` sources** | **1** — 14 failed / 3 passed, first assertion `expected 1 to be 10` |
| `npm test` (full) | this branch | 0 — **399 files, 2045 passed**, 1 skipped |
| `npm test` (full) | baseline `main` | 0 — 398 files, 2028 passed |
| `npx tsc --noEmit` | branch and baseline | 0 / 0 lines both |
| `npx eslint` (touched paths) | this branch | 0 |
| `run-gates.py --only admin-ui-rbac-alignment` | this branch | 0, `SUBJECTS=10` |

The two regression rows are the point: the guard is red when the **UI** widens *and* when the
**backend** narrows underneath an unchanged UI. A pin that only detected one direction would not
prevent drift.

## What I did NOT verify

- **No running service was called.** Every role set is read from `origin/main` sources; the 403s
  are inferred from `@RolesAllowed`, not observed.
- **OPA is not modelled.** `rest.rego`'s `operator-read-any` grants `.read`/`.list` on any
  resource to every operator, so the effective answer for some personas is decided there, not by
  the annotation. This PR aligns the UI with the annotation only, which is the narrower of the two.
- **`payments:approve` / `payments:create` are untouched** — no backend approval path was traced.
  `payments:approve` still lists SUPERVISOR.
- **`lending:compliance:view` is left alone and declared unpinned.** `CompliancePackResource`'s
  `/active` (COMPLIANCE, CREDIT_RISK, LENDING_OFFICER, ADMIN) and `/proposals/pending`
  (class-level COMPLIANCE, ADMIN) disagree, and the page `Promise.all`s them — so a CREDIT_RISK or
  LENDING_OFFICER user gets a broken page today. That needs a decision about which side is wrong,
  not a mechanical pin.
- **A pre-existing `/sanctions` nav mismatch** is declared as a ratchet rather than fixed:
  `persona.ts` offers it under `compliance:view` while the route resolves to `sanctions:view`
  (ADMIN/OPERATOR/VIEWER), so the edge gate refuses the link the workspace advertises. Same defect
  class, but `sanctions:view` has not been verified against sanctions-service, and guessing which
  side is wrong is how the bucket got its extra personas in the first place.
- **`/api/fx/rates` calls fx-service with no `Authorization` header** and swallows the resulting
  401 as an empty array, and `GET /api/v1/fx/conversions` matches no `@Path` in fx-service. So
  those two blocks are structurally always empty regardless of roles. Unrelated to RBAC; not fixed
  here.
- The other 28 route permissions are **declared unpinned with a reason**, not verified.

## Supersedes

#7789, #7785, #7791 — each rewrites the same `payments:view` array. They fix 3 of the 12 routes
and would conflict with each other. Recommend closing them in favour of this; I have commented on
the issues rather than closing anything.

Refs #7790, #7783, #7788, #7824
