### PR TITLE
fix(admin-ui): relay the operator bearer to fx-service, and report a failed read

### DIFF
--- a/openbank-admin-ui/src/app/api/fx/rates/route.ts
+++ b/openbank-admin-ui/src/app/api/fx/rates/route.ts
@@ -3,6 +3,7 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
 import { CURRENCY_META } from '@/lib/currency-meta'
 import { inCluster, discoverServices, resolveInClusterBaseUrl } from '@/lib/discovery'
 
@@ -91,38 +92,62 @@ async function fetchEcbRates() {
   return result
 }
 
-async function fetchFxServiceRates(baseUrl: string) {
+/** Outcome of one fx-service read.
+ *
+ *  Deliberately NOT a bare array. `GET /api/v1/fx/rates` is
+ *  `@RolesAllowed(ROLE_VIEWER, ROLE_OPERATOR, ROLE_ADMIN, ROLE_PAYMENTS)`, and this route used to
+ *  call it with no `Authorization` header at all — so 401 was the expected response, and
+ *  `if (!res.ok) return []` rendered it as "no rates". A missing credential, a 403, a timeout and a
+ *  genuinely empty rate table were four states reduced to one value, with nothing downstream able
+ *  to tell them apart. `cnb` and `ecb` in this same response already carry an `error` field;
+ *  fxService did not. */
+type FxFetch = { rows: unknown[]; error: string | null }
+
+const EMPTY: FxFetch = { rows: [], error: null }
+
+async function fetchFxServiceRates(baseUrl: string, accessToken: string | undefined): Promise<FxFetch> {
+  if (!accessToken) return { rows: [], error: 'unauthenticated: no operator bearer to relay' }
   try {
-    const res = await fetch(`${baseUrl}/api/v1/fx/rates`, { signal: AbortSignal.timeout(5000) })
-    if (!res.ok) return []
+    const res = await fetch(`${baseUrl}/api/v1/fx/rates`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!res.ok) return { rows: [], error: `fx-service responded ${res.status}` }
     const data = await res.json()
-    return Array.isArray(data) ? data : (data?.rates ?? [])
-  } catch {
-    return []
+    return { rows: Array.isArray(data) ? data : (data?.rates ?? []), error: null }
+  } catch (e) {
+    return { rows: [], error: String(e) }
   }
 }
 
-async function fetchFxConversions(baseUrl: string) {
+async function fetchFxConversions(baseUrl: string, accessToken: string | undefined): Promise<FxFetch> {
+  if (!accessToken) return { rows: [], error: 'unauthenticated: no operator bearer to relay' }
   try {
-    const res = await fetch(`${baseUrl}/api/v1/fx/conversions`, { signal: AbortSignal.timeout(5000) })
-    if (!res.ok) return []
+    const res = await fetch(`${baseUrl}/api/v1/fx/conversions`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!res.ok) return { rows: [], error: `fx-service responded ${res.status}` }
     const data = await res.json()
-    return Array.isArray(data) ? data : (data?.conversions ?? [])
-  } catch {
-    return []
+    return { rows: Array.isArray(data) ? data : (data?.conversions ?? []), error: null }
+  } catch (e) {
+    return { rows: [], error: String(e) }
   }
 }
 
 export async function GET() {
   const fx = await resolveFxService()
+  // Relay the operator's own bearer, so fx-service's policy stays authoritative — the same
+  // pattern the agent BFF routes use. Without it every call here was a 401 rendered as "no rates".
+  const accessToken = (await auth())?.user?.accessToken
   // Only reach out to fx-service when it's actually serving; a scaled-to-zero or
   // undeployed service has no reachable pod, so skip the fetch (and its timeout).
   const canFetch = fx.status === 'up' && fx.baseUrl !== null
   const [cnbRates, ecbRates, fxRates, conversions] = await Promise.allSettled([
     fetchCnbRates(),
     fetchEcbRates(),
-    canFetch ? fetchFxServiceRates(fx.baseUrl!) : Promise.resolve([]),
-    canFetch ? fetchFxConversions(fx.baseUrl!) : Promise.resolve([]),
+    canFetch ? fetchFxServiceRates(fx.baseUrl!, accessToken) : Promise.resolve(EMPTY),
+    canFetch ? fetchFxConversions(fx.baseUrl!, accessToken) : Promise.resolve(EMPTY),
   ])
 
   return NextResponse.json({
@@ -140,8 +165,16 @@ export async function GET() {
       status: fx.status,
       // `up` kept for backward-compat with any older client; `status` is authoritative.
       up: fx.status === 'up',
-      rates: fxRates.status === 'fulfilled' ? fxRates.value : [],
-      conversions: conversions.status === 'fulfilled' ? conversions.value : [],
+      rates: fxRates.status === 'fulfilled' ? fxRates.value.rows : [],
+      conversions: conversions.status === 'fulfilled' ? conversions.value.rows : [],
+      // Present so an unauthenticated or failing read is distinguishable from an empty one,
+      // matching the `error` field cnb and ecb already carry above.
+      error: fxRates.status === 'fulfilled'
+        ? fxRates.value.error
+        : String((fxRates as PromiseRejectedResult).reason),
+      conversionsError: conversions.status === 'fulfilled'
+        ? conversions.value.error
+        : String((conversions as PromiseRejectedResult).reason),
     },
     currencyMeta: CURRENCY_META,
     fetchedAt: new Date().toISOString(),

--- a/openbank-admin-ui/src/test/fx-rates-route-auth.guard.test.ts
+++ b/openbank-admin-ui/src/test/fx-rates-route-auth.guard.test.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+/**
+ * `GET /api/v1/fx/rates` on fx-service is
+ * `@RolesAllowed(ROLE_VIEWER, ROLE_OPERATOR, ROLE_ADMIN, ROLE_PAYMENTS)`.
+ * This BFF route used to call it with **no Authorization header at all**, and answered
+ * `if (!res.ok) return []` — so 401 was not an edge case, it was the expected response, and it
+ * rendered as "no rates". A missing credential, a 403, a timeout and a genuinely empty rate table
+ * were four states collapsed into one value.
+ *
+ * Two properties are pinned here, and they fail for different reasons on purpose:
+ *   1. the operator bearer is relayed (so the call can succeed at all);
+ *   2. a failure is REPORTED rather than rendered as emptiness (so nobody has to guess).
+ *
+ * The second is the one that matters longer term: restoring the header without restoring the
+ * error field would give back a working call whose next failure is silent again.
+ */
+
+const mockAuth = vi.fn()
+vi.mock('@/auth', () => ({ auth: () => mockAuth() }))
+vi.mock('@/lib/discovery', () => ({
+  inCluster: () => true,
+  discoverServices: async () => ([{ name: 'fx-service', namespace: 'fx', ready: 1, desired: 1 }]),
+  resolveInClusterBaseUrl: async () => 'http://fx-service.fx.svc:8119',
+}))
+
+async function callRoute() {
+  const mod = await import('@/app/api/fx/rates/route')
+  const res = await mod.GET()
+  return res.json() as Promise<Record<string, any>>
+}
+
+describe('GET /api/fx/rates relays the operator bearer', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.resetModules()
+    fetchSpy = vi.fn(async (url: string) => {
+      if (String(url).includes('/q/health/ready')) return new Response('', { status: 200 })
+      if (String(url).includes('/api/v1/fx/')) return new Response(JSON.stringify([]), { status: 200 })
+      return new Response('[]', { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('sends Authorization on every fx-service call when a session exists', async () => {
+    mockAuth.mockResolvedValue({ user: { accessToken: 'operator-token' } })
+    await callRoute()
+
+    const fxCalls = fetchSpy.mock.calls.filter(c => String(c[0]).includes('/api/v1/fx/'))
+    expect(fxCalls.length).toBeGreaterThan(0)   // if zero, the test proves nothing
+    for (const [, init] of fxCalls) {
+      const headers = (init as RequestInit | undefined)?.headers as Record<string, string> | undefined
+      expect(headers?.Authorization).toBe('Bearer operator-token')
+    }
+  })
+
+  it('reports an unauthenticated read instead of rendering it as an empty table', async () => {
+    mockAuth.mockResolvedValue(null)
+    const body = await callRoute()
+
+    // The distinguishing property: empty rows AND a stated reason.
+    expect(body.fxService.rates).toEqual([])
+    expect(body.fxService.error).toMatch(/unauthenticated/i)
+  })
+
+  it('reports a non-OK upstream status rather than swallowing it', async () => {
+    mockAuth.mockResolvedValue({ user: { accessToken: 'operator-token' } })
+    fetchSpy.mockImplementation(async (url: string) => {
+      if (String(url).includes('/q/health/ready')) return new Response('', { status: 200 })
+      if (String(url).includes('/api/v1/fx/')) return new Response('denied', { status: 403 })
+      return new Response('[]', { status: 200 })
+    })
+    const body = await callRoute()
+
+    expect(body.fxService.rates).toEqual([])
+    expect(body.fxService.error).toContain('403')
+  })
+
+  it('reports no error on a genuinely empty but successful read', async () => {
+    // The control that makes the two assertions above mean something: emptiness on its own
+    // must NOT be reported as a failure, or "error" would just track "rows.length === 0".
+    mockAuth.mockResolvedValue({ user: { accessToken: 'operator-token' } })
+    const body = await callRoute()
+
+    expect(body.fxService.rates).toEqual([])
+    expect(body.fxService.error).toBeNull()
+  })
+})


### PR DESCRIPTION
## The call could not have been succeeding

`GET /api/v1/fx/rates` on fx-service:

```kotlin
@Path("/rates")
@RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS")
suspend fun getRates(): Response = Response.ok(fxUseCase.getAllRates()).build()
```

and this BFF route:

```ts
const res = await fetch(`${baseUrl}/api/v1/fx/rates`, { signal: AbortSignal.timeout(5000) })
if (!res.ok) return []
```

No `headers`, no `Authorization`. So 401 was not an edge case — it was the expected response, and `if (!res.ok) return []` rendered it as *"no rates"*. A missing credential, a 403, a timeout and a genuinely empty rate table were four states reduced to one value, with nothing downstream able to tell them apart.

24 other BFF routes do relay a bearer, so this was an omission rather than a house convention.

## Two changes, and the second is the durable one

**Relay the operator's own bearer**, matching the pattern the agent BFF routes use, so fx-service's policy stays authoritative rather than being bypassed or guessed at.

**Return `{ rows, error }` and surface `error` on the `fxService` block.** This is not a new idea in this file — the `cnb` and `ecb` blocks of the same response already carry an `error` field. `fxService` was the only one of the three that could fail invisibly.

Restoring the header alone would give back a working call whose **next** failure is silent again. That is why both are in one change.

## Proven by what it prevents

| run | exit |
|---|---|
| guard vs **unmodified `main`** | **1** — all four assertions fail |
| guard vs this change | 0 |
| `npm test` | 0 — 399 files, 2034 passed |
| `npm run lint` | 0 — 0 errors |
| `npx tsc --noEmit` | 0 errors in this file (20 pre-existing from missing generated files, unchanged) |

**The fourth test is the control that makes the other three mean something:** a genuinely empty but *successful* read must report `error: null`. Without it, `error` could simply track `rows.length === 0` and the guard would pass while measuring nothing — the failure mode this repo keeps finding in its own checks.

## Scope

Found while sweeping for this shape fleet-wide: **5 of 114** BFF routes turn an upstream failure into an empty collection (#7943). This is the only one that *also* lacks authorization, which makes its failure certain rather than conditional. The other four are left for their own change — each may have a different right answer, and a sweep that flattens them would be the same mistake in the opposite direction.

Refs #7943
