### PR TITLE
ci(governance): warn before a time-gate deadline lands, not on the day it does

### DIFF
--- a/.github/scripts/check-gate-graduation.sh
+++ b/.github/scripts/check-gate-graduation.sh
@@ -25,7 +25,16 @@
 # stdlib-only (awk); no PyYAML/yamllint dependency, matching
 # check-app-version-override.sh / check-outbox-dispatch-enabled.sh.
 # ENFORCED.
+# WARN MODE (--warn-days N, issue #7941). The enforcing comparison above is
+# against TODAY, so the first signal a deadline exists is the day it turns every
+# PR red regardless of its diff — which is exactly how ADR-0144's own
+# ci-runner-governance date reached 2026-08-31 unnoticed and froze a ~80-PR queue
+# (#7897/#7919). `--warn-days N` reports every target_enforce_date falling inside
+# the next N days and ALWAYS exits 0, including for dates already in the past: it
+# is a horizon report, never a second gate. The PR-time behaviour is untouched.
+#
 # Usage: check-gate-graduation.sh [rules.yaml path]   (default: openbank-libs/governance/rules.yaml)
+#        check-gate-graduation.sh --warn-days 30 [rules.yaml path]
 set -euo pipefail
 
 # --- self-test ------------------------------------------------------------------------
@@ -71,16 +80,75 @@ if [ "${1:-}" = "--self-test" ]; then
   # A file with no advisory rules at all must say ZERO rather than read like a clean estate.
   expect "a file with no advisory rules reports 0 checked" "rule_a:\n  enforced: enforce\n" 0 "0 advisory/planned"
 
+  # --- warn mode (#7941) -------------------------------------------------------------
+  # A warner is worth nothing unless it can be shown to DISCRIMINATE. The three cases
+  # below are the discrimination: same rule, three windows, three different answers.
+  # Without them "0 due" is indistinguishable from a scan that walked nothing — the
+  # exact shape that let ci-runner-governance reach its own deadline unnoticed.
+  expect_warn() { local label="$1" body="$2" days="$3" want_sub="$4" out rc
+    printf '%b' "$body" > "$td/rules.yaml"
+    out=$(bash "$0" --warn-days "$days" "$td/rules.yaml" 2>&1); rc=$?
+    if [ "$rc" -ne 0 ]; then echo "::error::self-test: $label — warn mode must always exit 0, got $rc: $out" >&2; fails=$((fails+1))
+    elif ! printf '%s' "$out" | grep -qF -- "$want_sub"; then
+      echo "::error::self-test: $label — no '$want_sub' in: $out" >&2; fails=$((fails+1)); fi; }
+
+  soon=$(date -u -v+10d +%Y-%m-%d 2>/dev/null || date -u -d '+10 days' +%Y-%m-%d)
+
+  # INSIDE the window: reported.
+  expect_warn "a date inside the window is reported" \
+    "rule_a:\n  enforced: advisory\n  target_enforce_date: \"$soon\"\n" 30 "1 of 1 advisory/planned"
+  # OUTSIDE it: the SAME rule, silent. This is the half that proves the window is real
+  # and not a scan that reports everything it sees.
+  expect_warn "the same date outside the window is NOT reported" \
+    "rule_a:\n  enforced: advisory\n  target_enforce_date: \"$soon\"\n" 3 "0 of 1 advisory/planned"
+  # --warn-days 0 is the degenerate window: a future date can never be inside it.
+  expect_warn "--warn-days 0 reports nothing for a future date" \
+    "rule_a:\n  enforced: advisory\n  target_enforce_date: \"$future\"\n" 0 "0 of 1 advisory/planned"
+  # An ALREADY-EXPIRED date is reported by the warner but must NOT fail it — warn mode
+  # is a report, not a second gate. The enforcing lane above already covers this case,
+  # and a warner that can go red is one someone will eventually silence.
+  expect_warn "an expired date is reported and still exits 0" \
+    "rule_a:\n  enforced: advisory\n  target_enforce_date: \"$past\"\n" 30 "ALREADY PASSED"
+  # ...and the enforcing lane on that very same file must still be RED, or warn mode
+  # has quietly replaced the gate instead of preceding it.
+  expect "the enforcing lane is unchanged by the existence of warn mode" \
+    "rule_a:\n  enforced: advisory\n  target_enforce_date: \"$past\"\n" 1 "has passed"
+
   if [ "$fails" -gt 0 ]; then echo "self-test FAILED ($fails case(s))" >&2; exit 1; fi
-  echo "self-test ok: gate-graduation guard is falsifiable (7 cases)"
+  echo "self-test ok: gate-graduation guard is falsifiable (12 cases)"
   exit 0
 fi
-rules="${1:-openbank-libs/governance/rules.yaml}"
+# --- arguments ------------------------------------------------------------------------
+# warn_days = 0 means enforcing mode (the default, and what CI runs on every PR).
+warn_days=""
+rules=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --warn-days)   warn_days="${2:-}"; shift 2 ;;
+    --warn-days=*) warn_days="${1#*=}"; shift ;;
+    -*)            echo "::error::check-gate-graduation: unknown option $1" >&2; exit 1 ;;
+    *)             rules="$1"; shift ;;
+  esac
+done
+rules="${rules:-openbank-libs/governance/rules.yaml}"
 [ -f "$rules" ] || { echo "::error::check-gate-graduation: $rules not found" >&2; exit 1; }
 
+if [ -n "$warn_days" ]; then
+  case "$warn_days" in
+    ''|*[!0-9]*) echo "::error::check-gate-graduation: --warn-days needs a non-negative integer, got '$warn_days'" >&2; exit 1 ;;
+  esac
+fi
+
 today="$(date -u +%Y-%m-%d)"
+# The horizon is only consulted in warn mode. BSD and GNU date disagree on relative
+# arithmetic, so try both — the same shape the self-test above already uses.
+if [ -n "$warn_days" ]; then
+  horizon="$(date -u -v+"${warn_days}"d +%Y-%m-%d 2>/dev/null \
+    || date -u -d "+${warn_days} days" +%Y-%m-%d)"
+fi
 fail=0
 checked=0
+due=0
 
 # Walk the file; whenever a line matches `enforced: advisory` or
 # `enforced: planned`, remember its line number and scan the next few lines
@@ -118,6 +186,22 @@ awk -v today="$today" '
 
 while IFS=: read -r lineno date; do
   checked=$((checked + 1))
+  if [ -n "$warn_days" ]; then
+    # WARN MODE: report, never fail. A missing date is already the enforcing gate's
+    # problem and is reported there; here it is listed so the horizon report is not
+    # silently narrower than the estate it claims to cover.
+    if [ "$date" = "MISSING" ]; then
+      echo "  $rules:$lineno  (no target_enforce_date — see the enforcing run)"
+      due=$((due + 1))
+    elif [[ "$date" < "$today" ]]; then
+      echo "  $rules:$lineno  $date  ALREADY PASSED"
+      due=$((due + 1))
+    elif [[ ! "$date" > "$horizon" ]]; then
+      echo "  $rules:$lineno  $date  due within ${warn_days}d"
+      due=$((due + 1))
+    fi
+    continue
+  fi
   if [ "$date" = "MISSING" ]; then
     echo "::error file=$rules,line=$lineno::advisory/planned rule has no target_enforce_date within 3 lines (ADR-0144: a rule may not be added without one)."
     fail=1
@@ -127,6 +211,13 @@ while IFS=: read -r lineno date; do
   fi
 done < /tmp/.gate-graduation-findings.$$
 rm -f /tmp/.gate-graduation-findings.$$
+
+if [ -n "$warn_days" ]; then
+  # Both numbers, always. "$due due" alone cannot be told apart from a scan that
+  # walked nothing — the failure mode this repo keeps paying for.
+  echo "check-gate-graduation --warn-days $warn_days: $due of $checked advisory/planned rule(s) due on or before $horizon."
+  exit 0
+fi
 
 echo "check-gate-graduation: $checked advisory/planned rule(s) checked, $( [ "$fail" -eq 0 ] && echo "all carry a live target_enforce_date." || echo "VIOLATIONS above." )"
 exit "$fail"

--- a/.github/scripts/validate-flags.py
+++ b/.github/scripts/validate-flags.py
@@ -15,11 +15,19 @@
 #                        via a flag — see OPA rest.rego prohibited rule)
 #
 # Exit 0 = all flags valid. Exit 1 = violations found (CI gate fails).
+#
+# WARN MODE (--warn-days N, issue #7941). Rule 4 compares against NOW, so the first
+# signal a flag has a retirement date is the day it expires and turns every PR red
+# regardless of its diff — which is how `sepa-instant-new-router` reached
+# 2026-09-01T00:00:00Z unnoticed and froze a ~80-PR queue (#7897/#7919).
+# `--warn-days N` lists every flag whose expiresAt falls inside the next N days and
+# ALWAYS exits 0, including for flags already expired: a horizon report, never a
+# second gate. The enforcing path is untouched.
 
 import json
 import re
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 # ── Authoritative constants (mirrors openbank-libs/governance/rules.yaml) ────
@@ -127,6 +135,47 @@ def validate_file(path: Path) -> tuple[int, int, list[str]]:
     return len(flags), len(all_violations), all_violations
 
 
+def _parses(path: Path) -> bool:
+    try:
+        json.loads(path.read_text())
+        return True
+    except json.JSONDecodeError:
+        return False
+
+
+def horizon_findings(files: list[Path], warn_days: int) -> list[tuple[str, str, str, int]]:
+    """Flags whose expiresAt falls on or before now+warn_days.
+
+    Returns (source, key, expiresAt, days_left); days_left is negative for a flag that
+    has already expired. Those are included on purpose — the enforcing lane reports them
+    too, but a horizon report that silently omits the overdue ones is narrower than the
+    estate it claims to cover, and reads as "nothing due".
+
+    Deliberately independent of validate_flag(): a malformed or missing expiresAt is a
+    VIOLATION, not a horizon finding, and must not be smuggled into a report that always
+    exits 0.
+    """
+    now = datetime.now(timezone.utc)
+    cutoff = now + timedelta(days=warn_days)
+    out: list[tuple[str, str, str, int]] = []
+    for path in sorted(files):
+        try:
+            data = json.loads(path.read_text())
+        except json.JSONDecodeError:
+            continue  # the enforcing lane reports this; a warner must not fail on it
+        for key, flag_obj in data.get("flags", {}).items():
+            expires_str = (flag_obj.get("openbank") or {}).get("expiresAt")
+            if not expires_str:
+                continue
+            try:
+                expires = datetime.fromisoformat(expires_str.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            if expires <= cutoff:
+                out.append((str(path), key, expires_str, (expires - now).days))
+    return out
+
+
 # ── Main ──────────────────────────────────────────────────────────────────────
 
 def self_test() -> int:
@@ -221,12 +270,59 @@ def self_test() -> int:
         if count != 1 or not any("invalid JSON" in m for m in msgs):
             fails.append(f"malformed JSON was not reported as a violation: {msgs}")
 
+    # --- warn mode (#7941) -------------------------------------------------------------
+    # A warner is worth nothing unless it can be shown to DISCRIMINATE: the same flag must
+    # be reported under one window and silent under another. Without that, "0 due" and
+    # "the scan walked nothing" are the same output — the shape that let
+    # sepa-instant-new-router reach its own expiry with nobody noticing.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        soon = (datetime.now(timezone.utc) + timedelta(days=10)).isoformat()
+        far = (datetime.now(timezone.utc) + timedelta(days=200)).isoformat()
+        gone = (datetime.now(timezone.utc) - timedelta(days=5)).isoformat()
+        (root / "w.flagd.json").write_text(_json.dumps({"flags": {
+            "soon-flag": {"openbank": {**ok_meta, "expiresAt": soon}},
+            "far-flag": {"openbank": {**ok_meta, "expiresAt": far}},
+        }}))
+        files = find_flagd_files(root)
+
+        keys = {k for _, k, _, _ in horizon_findings(files, 30)}
+        if keys != {"soon-flag"}:
+            fails.append(f"a 30d window must name exactly soon-flag, got {sorted(keys)}")
+        # The SAME flag, a narrower window: silent. This is the half that proves the
+        # window is real rather than a scan reporting everything it sees.
+        if horizon_findings(files, 3):
+            fails.append("a 3d window must report nothing, got {}".format(horizon_findings(files, 3)))
+        # Wide enough and BOTH appear — so "nothing found" was never a broken walker.
+        if len(horizon_findings(files, 365)) != 2:
+            fails.append("a 365d window must name both flags")
+        # The degenerate window: no future date can be inside it.
+        if horizon_findings(files, 0):
+            fails.append("--warn-days 0 must report nothing for future dates")
+
+        # An ALREADY-EXPIRED flag is a horizon finding with a negative days_left, not an
+        # omission — the enforcing lane fails on it, and a report that hides it reads clean.
+        (root / "x.flagd.json").write_text(_json.dumps({"flags": {
+            "gone-flag": {"openbank": {**ok_meta, "expiresAt": gone}}}}))
+        exp = [f for f in horizon_findings(find_flagd_files(root), 0) if f[1] == "gone-flag"]
+        if not exp or exp[0][3] >= 0:
+            fails.append(f"an expired flag must be reported with a negative days_left: {exp}")
+
+        # A malformed or absent expiresAt is a VIOLATION, never a horizon finding — it must
+        # not be smuggled into a lane that always exits 0.
+        (root / "y.flagd.json").write_text(_json.dumps({"flags": {
+            "bad-flag": {"openbank": {**ok_meta, "expiresAt": "soon"}},
+            "no-date-flag": {"openbank": {"owner": "x", "classification": "STANDARD"}}}}))
+        noisy = {k for _, k, _, _ in horizon_findings(find_flagd_files(root), 3650)}
+        if noisy & {"bad-flag", "no-date-flag"}:
+            fails.append(f"warn mode must not report unparseable/missing expiresAt: {sorted(noisy)}")
+
     if fails:
         for f in fails:
             sys.stderr.write(f"::error::self-test: {f}\n")
         sys.stderr.write(f"self-test FAILED ({len(fails)} case(s))\n")
         return 1
-    print("self-test ok: feature-flag governance is falsifiable (16 cases)")
+    print("self-test ok: feature-flag governance is falsifiable (22 cases)")
     return 0
 
 
@@ -234,8 +330,47 @@ def main() -> int:
     if "--self-test" in sys.argv:
         return self_test()
 
-    repo_root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
+    argv = sys.argv[1:]
+    warn_days = None
+    positional: list[str] = []
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--warn-days":
+            if i + 1 >= len(argv):
+                print("validate-flags: --warn-days needs a value", file=sys.stderr)
+                return 1
+            warn_days, i = argv[i + 1], i + 2
+        elif a.startswith("--warn-days="):
+            warn_days, i = a.split("=", 1)[1], i + 1
+        else:
+            positional.append(a)
+            i += 1
+    if warn_days is not None:
+        if not warn_days.isdigit():
+            print(f"validate-flags: --warn-days needs a non-negative integer, got {warn_days!r}",
+                  file=sys.stderr)
+            return 1
+        warn_days = int(warn_days)
+
+    repo_root = Path(positional[0]) if positional else Path(".")
     files = find_flagd_files(repo_root)
+
+    if warn_days is not None:
+        if not files:
+            print("validate-flags --warn-days: no *.flagd.json files found — skipping.")
+            return 0
+        total = sum(len(json.loads(f.read_text()).get("flags", {}))
+                    for f in files if _parses(f))
+        findings = horizon_findings(files, warn_days)
+        for source, key, expires, days_left in findings:
+            when = "ALREADY EXPIRED" if days_left < 0 else f"due in {days_left}d"
+            print(f"  {source}  {key}  {expires}  {when}")
+        # Both numbers, always: "0 due" alone cannot be told apart from a scan that
+        # walked nothing, which is the failure this warner exists to prevent.
+        print(f"validate-flags --warn-days {warn_days}: {len(findings)} of {total} "
+              f"flag(s) expiring within {warn_days} day(s).")
+        return 0
 
     total_flags = 0
     total_violations = 0

--- a/.github/workflows/governance-horizon-watch.yml
+++ b/.github/workflows/governance-horizon-watch.yml
@@ -1,0 +1,189 @@
+# -----------------------------------------------------------------------------
+# Governance deadlines arriving soon (issue #7941).
+#
+# WHAT THIS CLOSES. `check-gate-graduation.sh` and `validate-flags.py` both compare
+# against TODAY, and both run only inside `Validate manifests` on a PR. So the first
+# signal that a governance deadline exists is the day it passes and turns EVERY PR
+# red regardless of its diff. That is not hypothetical: on 2026-09-01 the ADR-0067
+# flag `sepa-instant-new-router` and ADR-0144's `ci_runner_governance` deadline
+# expired within hours of each other and froze a ~80-PR queue (#7897, fixed by
+# #7919). Nothing warned, because there was nothing that could.
+#
+# WHY IT IS A SEPARATE LANE, NOT A LOOSER GATE. The hard fail on an expired date is
+# correct and stays exactly as it is. Warning and enforcing want opposite failure
+# modes — an enforcing gate must be able to go red, a warner must never, or it is
+# one more red check somebody learns to ignore. Both scripts' `--warn-days` lanes
+# therefore exit 0 unconditionally, including for dates already in the past.
+#
+# ESCALATION, not redness (#4019). A red scheduled workflow is addressed to nobody,
+# which is the same blind spot this closes. One issue, refreshed in place, closed
+# when the horizon clears.
+#
+# WHY IT IS NOT A REQUIRED CHECK. Scheduled workflows cannot be required contexts
+# here. The PR lane below is what a PR sees, and it only runs the two self-tests —
+# which is the load-bearing half: a warner that reports "0 due" is indistinguishable
+# from one that walked nothing, so both self-tests assert the window DISCRIMINATES
+# (same input, different windows, different answers) rather than merely runs.
+# -----------------------------------------------------------------------------
+name: governance horizon watch
+
+on:
+  schedule:
+    # Monday morning. The horizon is 30 days, so a weekly tick gives every deadline
+    # at least four notices before it lands.
+    - cron: "23 6 * * 1"
+  pull_request:
+    paths:
+      - ".github/workflows/governance-horizon-watch.yml"
+      - ".github/scripts/check-gate-graduation.sh"
+      - ".github/scripts/validate-flags.py"
+  workflow_dispatch:
+    inputs:
+      warn_days:
+        description: "Horizon in days. Never leave it defaulted when investigating."
+        required: false
+        default: "30"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: governance-horizon-watch
+  cancel-in-progress: false
+
+jobs:
+  # PR lane: offline, seconds, and the only lane a PR sees. It proves the two
+  # warners still discriminate between an in-window and an out-of-window date, and
+  # that adding warn mode did not soften either enforcing lane.
+  declaration:
+    name: governance horizon declaration
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Self-test the graduation guard
+        run: bash .github/scripts/check-gate-graduation.sh --self-test
+
+      - name: Self-test the flag validator
+        run: python3 .github/scripts/validate-flags.py --self-test
+
+      # The enforcing lanes must still be exactly what CI ran before this workflow
+      # existed. Warn mode is additive or it is a regression.
+      - name: The enforcing lanes are unchanged
+        run: |
+          bash .github/scripts/check-gate-graduation.sh
+          python3 .github/scripts/validate-flags.py
+
+  watch:
+    name: governance horizon watch
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # A report that has only ever said "0 due" is indistinguishable from a scan
+      # that walked nothing. This step failing voids the run.
+      - name: Self-test both warners
+        run: |
+          bash .github/scripts/check-gate-graduation.sh --self-test
+          python3 .github/scripts/validate-flags.py --self-test
+
+      - name: Scan the horizon
+        id: scan
+        env:
+          WARN_DAYS: ${{ inputs.warn_days || '30' }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Advisory/planned rules (ADR-0144)"
+            echo
+            echo '```'
+            bash .github/scripts/check-gate-graduation.sh --warn-days "$WARN_DAYS"
+            echo '```'
+            echo
+            echo "### Feature flags (ADR-0067 §7)"
+            echo
+            echo '```'
+            python3 .github/scripts/validate-flags.py --warn-days "$WARN_DAYS"
+            echo '```'
+          } > /tmp/horizon.md
+          cat /tmp/horizon.md
+          # The COUNT decides whether an issue is opened, and it is derived from the
+          # same output the issue body carries — not recomputed, so the two cannot
+          # disagree about what was found.
+          due=$(grep -cE '  (due within|due in|ALREADY (PASSED|EXPIRED))' /tmp/horizon.md || true)
+          echo "due=$due" >> "$GITHUB_OUTPUT"
+          echo "warn_days=$WARN_DAYS" >> "$GITHUB_OUTPUT"
+
+      - name: Escalate or stand down
+        if: ${{ !cancelled() && steps.scan.outcome != 'skipped' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DUE: ${{ steps.scan.outputs.due }}
+          WARN_DAYS: ${{ steps.scan.outputs.warn_days }}
+        with:
+          script: |
+            const fs = require('fs')
+            const LABEL = 'governance'
+            const marker = '<!-- governance-horizon-watch -->'
+            const due = Number(process.env.DUE || '0')
+            const warnDays = process.env.WARN_DAYS
+            const report = fs.readFileSync('/tmp/horizon.md', 'utf8')
+
+            // Find by MARKER, not by title: the title carries a count and moves.
+            const findByMarker = async (state) => {
+              const issues = await github.paginate(github.rest.issues.listForRepo, {
+                ...context.repo, state, labels: LABEL, per_page: 100,
+                sort: 'updated', direction: 'desc',
+              })
+              return issues.find(i => (i.body || '').includes(marker))
+            }
+
+            const open = await findByMarker('open')
+
+            if (due === 0) {
+              if (open) {
+                await github.rest.issues.createComment({
+                  ...context.repo, issue_number: open.number,
+                  body: `Horizon clear: nothing due within ${warnDays} days as of this run. Closing.`,
+                })
+                await github.rest.issues.update({
+                  ...context.repo, issue_number: open.number, state: 'closed',
+                })
+              }
+              core.notice(`Nothing due within ${warnDays} days.`)
+              return
+            }
+
+            const title = `Governance: ${due} deadline(s) due within ${warnDays} days`
+            const body = [
+              marker,
+              `## ${due} governance deadline(s) land within ${warnDays} days`,
+              '',
+              'Each of these fails **every PR in the repository** on the day it passes, regardless',
+              'of the PR\'s diff — that is what happened on 2026-09-01 (#7897, #7919). Either ship',
+              'the producer and flip the rule to `enforce`/`block`, retire the flag, or move the',
+              'date forward with a one-line reason in the commit body (ADR-0144).',
+              '',
+              report,
+              '',
+              `_Refreshed by \`governance-horizon-watch\`. Closes itself when the ${warnDays}-day horizon is clear._`,
+            ].join('\n')
+
+            if (open) {
+              await github.rest.issues.update({
+                ...context.repo, issue_number: open.number, title, body,
+              })
+              core.notice(`Refreshed #${open.number} (${due} due).`)
+            } else {
+              const created = await github.rest.issues.create({
+                ...context.repo, title, body, labels: [LABEL],
+              })
+              core.notice(`Opened #${created.data.number} (${due} due).`)
+            }


### PR DESCRIPTION
## The gates that froze the fleet had no way to warn

`check-gate-graduation.sh` and `validate-flags.py` both compare against **today**, and both run only inside `Validate manifests` on a PR. So the first signal that a governance deadline exists is the day it passes and turns *every* PR red regardless of its diff.

That is what happened on 2026-09-01: the ADR-0067 flag `sepa-instant-new-router` and ADR-0144's `ci_runner_governance` deadline expired hours apart and froze a ~80-PR queue (#7897, fixed by #7919). Nothing warned, because nothing could. #7919 moved one deadline; it did not make the next one visible.

## This is not a November problem

Measured on this branch's base:

```
check-gate-graduation --warn-days 30: 13 of 20 advisory/planned rule(s) due on or before 2026-10-01.
```

**Four of them land on 2026-09-15** — in two weeks.

## What changed

`--warn-days N` on both scripts. They list every deadline inside the window and **always exit 0**, including for dates already in the past.

A separate lane, not a looser gate. Warning and enforcing want opposite failure modes: an enforcing gate must be able to go red, a warner must never — or it becomes one more red check people learn to ignore. The hard fail on an expired date is correct and is untouched.

`governance-horizon-watch.yml` runs both weekly and escalates to a **single issue refreshed in place**, closed when the horizon clears. Escalation rather than a red scheduled run, which is addressed to nobody (#4019) — the same blind spot this closes.

## Proven by what it prevents

A warner that reports `0 due` is indistinguishable from one that walked nothing. So the self-tests assert **discrimination**, not execution — the same fixture, three windows, three answers:

| fixture | window | verdict |
|---|---|---|
| date 10 days out | `--warn-days 30` | reported |
| **the same date** | `--warn-days 3` | **silent** |
| future date | `--warn-days 0` | silent |
| date already past | `--warn-days 30` | reported, **exit 0** |
| date already past | *enforcing lane* | **exit 1** — unchanged |

That last row is deliberate: warn mode must not quietly replace the gate it precedes.

Both counts are always printed (`13 of 20`, `1 of 3`) — a bare `0 due` cannot be told apart from an empty scan. An unparseable or missing date is **excluded** from the horizon report on purpose: that is a violation for the enforcing lane, and must not be smuggled into a lane that always exits 0.

### Falsified

Sabotaging the window comparison in each script turns its self-test red:

| sabotage | result |
|---|---|
| `validate-flags.py`: `if expires <= cutoff:` → `if True:` | self-test **FAILED (3 cases)** |
| `check-gate-graduation.sh`: horizon comparison → `elif true:` | self-test **FAILED (2 cases)** |

Restored, both green: `22 cases` and `12 cases` respectively.

## Scope and verification

- `python3 .github/scripts/run-gates.py --all` — `gate-graduation-guard`, `feature-flag-governance`, `workflow-run-step-size` and `gate-selftest-declaration` all **PASS**.
- 7 gates fail in this local run (`api-contract-gate`, `db-migration-gate`, `threat-model-…`, …). Baselined: they fail **identically on the unmodified base** with my changes stashed, so they are environmental (no PR diff context locally), not caused by this PR.
- `actionlint` and `shellcheck` clean on the new/changed files — each verified against a known-positive first, so the clean result is about the files and not a broken probe.
- Touches only `.github/`, so `gen-rules-opa-data.py` is not involved and no OPA bundle or `policy-checksum` annotation is restamped.

Closes #7941
Refs #7897, #7919, ADR-0144, ADR-0067
