### PR TITLE
fix(test-intelligence): validate capability register structure

### DIFF
--- a/.github/scripts/check-test-intelligence-ecosystem.py
+++ b/.github/scripts/check-test-intelligence-ecosystem.py
@@ -10,9 +10,47 @@ import tempfile
 from pathlib import Path
 from urllib.parse import urlsplit
 
+import yaml
 
 REQUIRED_SCHEMA = {"schemaVersion", "run", "component", "suites", "coverage", "testInfrastructure"}
 TESTCONTAINERS_EVIDENCE_BASELINE = "openbank-libs/governance/testcontainers-evidence-baseline.txt"
+CAPABILITY_REGISTER = "openbank-libs/governance/test-intelligence-capabilities.yaml"
+CAPABILITY_STATES = {
+    "implemented",
+    "external-blocked",
+    "ownership-blocked",
+    "safety-blocked",
+    "intentionally-deferred",
+}
+CAPABILITY_ID = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*\Z")
+
+
+class DuplicateYamlKeyError(yaml.YAMLError):
+    """A YAML mapping whose apparent source and effective value would diverge."""
+
+
+class CapabilityLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects duplicate keys instead of silently keeping the last."""
+
+
+def construct_unique_mapping(loader: yaml.SafeLoader, node: yaml.MappingNode, deep: bool = False) -> dict:
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in mapping
+        except TypeError as exc:
+            raise yaml.YAMLError(f"unhashable mapping key {key!r}") from exc
+        if duplicate:
+            raise DuplicateYamlKeyError(f"duplicate YAML key {key!r}")
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+CapabilityLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    construct_unique_mapping,
+)
 
 
 def text(path: Path) -> str:
@@ -65,6 +103,65 @@ def valid_capability_evidence(root: Path, evidence: str) -> bool:
         normalized_heading(heading) == target
         for heading in re.findall(r"(?m)^#{1,6}\s+(.+?)\s*#*\s*$", text(candidate))
     )
+
+
+def capability_register_errors(root: Path) -> list[str]:
+    """Validate the exact operator contract read by the Admin capability matrix.
+
+    This must parse YAML rather than recognise its indentation.  The collector parses the
+    same file, and ordinary YAML loaders silently retain a duplicate key's final value;
+    accepting the earlier textual value here would let CI certify a different UI state.
+    """
+    register_path = root / CAPABILITY_REGISTER
+    try:
+        register = yaml.load(register_path.read_text(encoding="utf-8"), Loader=CapabilityLoader)
+    except (OSError, yaml.YAMLError) as exc:
+        return [f"test-intelligence capability register unavailable: {exc}"]
+    if not isinstance(register, dict):
+        return ["test-intelligence capability register must be a YAML mapping"]
+
+    errors: list[str] = []
+    if set(register) != {"version", "capabilities"}:
+        errors.append("test-intelligence capability register has unsupported or missing top-level fields")
+    if type(register.get("version")) is not int or register.get("version") != 1:
+        errors.append("test-intelligence capability register must declare integer version 1")
+    capabilities = register.get("capabilities")
+    if not isinstance(capabilities, list) or not capabilities:
+        return errors + ["test-intelligence capability register must declare a non-empty capability list"]
+
+    seen_ids: set[str] = set()
+    for index, capability in enumerate(capabilities, start=1):
+        prefix = f"test-intelligence capability #{index}"
+        if not isinstance(capability, dict):
+            errors.append(f"{prefix} must be a mapping")
+            continue
+        identifier = capability.get("id")
+        title = capability.get("title")
+        state = capability.get("state")
+        evidence = capability.get("evidence")
+        blocker = capability.get("blocker")
+        required = {"id", "title", "state", "evidence"}
+        permitted = required | {"blocker"}
+        if not required.issubset(capability) or not set(capability).issubset(permitted):
+            errors.append(f"{prefix} has unsupported or missing fields")
+        if not isinstance(identifier, str) or not CAPABILITY_ID.fullmatch(identifier):
+            errors.append(f"{prefix} has an invalid id")
+        elif identifier in seen_ids:
+            errors.append(f"test-intelligence capability id is duplicated: {identifier}")
+        else:
+            seen_ids.add(identifier)
+        if not isinstance(title, str) or not title.strip():
+            errors.append(f"{prefix} has an empty or non-string title")
+        if not isinstance(state, str) or state not in CAPABILITY_STATES:
+            errors.append(f"{prefix} has an unsupported state")
+        if not isinstance(evidence, str) or not valid_capability_evidence(root, evidence.strip()):
+            errors.append(f"{prefix} has unresolvable evidence")
+        if state == "implemented":
+            if "blocker" in capability:
+                errors.append(f"implemented test-intelligence capability has a blocker: {identifier}")
+        elif not isinstance(blocker, str) or not blocker.strip():
+            errors.append(f"blocked test-intelligence capability has no non-empty blocker: {identifier}")
+    return errors
 
 
 RECORD_CALL = re.compile(
@@ -282,21 +379,7 @@ def check(root: Path) -> list[str]:
                    "requiredControlGaps: controls.filter"):
         if needle not in collector:
             errors.append(f"admin projection loses an independent required-control denominator: {needle}")
-    capability_text = text(root / "openbank-libs/governance/test-intelligence-capabilities.yaml")
-    capability_blocks = re.split(r"(?m)^  - id: ", capability_text)[1:]
-    ids = [block.splitlines()[0].strip() for block in capability_blocks]
-    allowed = {"implemented", "external-blocked", "ownership-blocked", "safety-blocked", "intentionally-deferred"}
-    if not capability_blocks or len(ids) != len(set(ids)):
-        errors.append("test-intelligence capability register is empty or duplicated")
-    for identifier, block in zip(ids, capability_blocks, strict=True):
-        state = re.search(r"(?m)^    state: ([a-z-]+)$", block)
-        evidence = re.search(r"(?m)^    evidence: (.+)$", block)
-        if not state or state.group(1) not in allowed or "\n    title:" not in block or not evidence:
-            errors.append(f"test-intelligence capability is incomplete: {identifier}")
-        if state and state.group(1) != "implemented" and "\n    blocker:" not in block:
-            errors.append(f"blocked test-intelligence capability has no blocker: {identifier}")
-        if evidence and not valid_capability_evidence(root, evidence.group(1).strip()):
-            errors.append(f"test-intelligence capability has unresolvable evidence: {identifier}")
+    errors.extend(capability_register_errors(root))
     for needle in ("function platformCapabilities()", "platformCapabilities: capabilities"):
         if needle not in collector:
             errors.append(f"admin projection loses operator-visible platform blockers: {needle}")
@@ -510,6 +593,40 @@ def self_test() -> int:
         ):
             if valid_capability_evidence(root, invalid):
                 print(f"self-test failed: invalid capability evidence was accepted: {invalid}")
+                return 1
+        register = root / CAPABILITY_REGISTER
+        register.write_text(
+            "version: 1\ncapabilities:\n"
+            "  - id: verified-capability\n"
+            "    title: Verified capability\n"
+            "    state: implemented\n"
+            "    evidence: docs/adr/test-intelligence.md#d8--capability-boundary\n"
+        )
+        if capability_register_errors(root):
+            print("self-test failed: a valid capability register was rejected")
+            return 1
+        cases = {
+            "duplicate YAML key": register.read_text().replace(
+                "    state: implemented\n", "    state: implemented\n    state: external-blocked\n"
+            ),
+            "duplicate capability id": register.read_text() + (
+                "  - id: verified-capability\n"
+                "    title: Duplicate capability\n"
+                "    state: implemented\n"
+                "    evidence: docs/adr/test-intelligence.md#d8--capability-boundary\n"
+            ),
+            "mapping instead of list": "version: 1\ncapabilities: {}\n",
+            "missing blocked capability reason": register.read_text().replace(
+                "state: implemented", "state: safety-blocked"
+            ),
+            "non-string evidence": register.read_text().replace(
+                "evidence: docs/adr/test-intelligence.md#d8--capability-boundary", "evidence: 42"
+            ),
+        }
+        for label, candidate in cases.items():
+            register.write_text(candidate)
+            if not capability_register_errors(root):
+                print(f"self-test failed: {label} was accepted")
                 return 1
     print("test-intelligence ecosystem self-test: red path proven")
     return 0

--- a/openbank-admin-ui/scripts/collect-test-intelligence.mjs
+++ b/openbank-admin-ui/scripts/collect-test-intelligence.mjs
@@ -6,7 +6,7 @@
 import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { parse as parseYaml } from 'yaml'
+import { parse as parseYaml, parseDocument } from 'yaml'
 import { parseStringPromise } from 'xml2js'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
@@ -407,11 +407,25 @@ function mutationComponents() {
 function platformCapabilities() {
   const file = path.join(repo, 'openbank-libs', 'governance', 'test-intelligence-capabilities.yaml')
   try {
-    const register = parseYaml(fs.readFileSync(file, 'utf8'))
-    return (register?.capabilities ?? []).map(item => ({
-      id: item.id, title: item.title, state: item.state,
-      blocker: item.blocker ?? null, evidence: item.evidence,
-    }))
+    const document = parseDocument(fs.readFileSync(file, 'utf8'), { uniqueKeys: true })
+    if (document.errors.length) throw new Error(document.errors.map(error => error.message).join('; '))
+    const capabilities = document.toJS()?.capabilities
+    if (!Array.isArray(capabilities) || capabilities.length === 0) throw new Error('expected a non-empty capability list')
+    const states = new Set(['implemented', 'external-blocked', 'ownership-blocked', 'safety-blocked', 'intentionally-deferred'])
+    const ids = new Set()
+    return capabilities.map((item, index) => {
+      const prefix = `capability #${index + 1}`
+      if (!item || typeof item !== 'object' || Array.isArray(item)) throw new Error(`${prefix} is not a mapping`)
+      if (typeof item.id !== 'string' || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(item.id)) throw new Error(`${prefix} has an invalid id`)
+      if (ids.has(item.id)) throw new Error(`${prefix} duplicates id ${item.id}`)
+      ids.add(item.id)
+      if (typeof item.title !== 'string' || !item.title.trim()) throw new Error(`${prefix} has an empty title`)
+      if (typeof item.state !== 'string' || !states.has(item.state)) throw new Error(`${prefix} has an unsupported state`)
+      if (typeof item.evidence !== 'string' || !item.evidence.trim()) throw new Error(`${prefix} has no evidence pointer`)
+      if (item.state !== 'implemented' && (typeof item.blocker !== 'string' || !item.blocker.trim())) throw new Error(`${prefix} has no blocker`)
+      if (item.state === 'implemented' && item.blocker !== undefined) throw new Error(`${prefix} has an unexpected blocker`)
+      return { id: item.id, title: item.title, state: item.state, blocker: item.blocker ?? null, evidence: item.evidence }
+    })
   } catch (error) {
     warnings.push(`test-intelligence capability register unavailable: ${error.message}`)
     return []

--- a/openbank-admin-ui/src/app/system/tests/page.tsx
+++ b/openbank-admin-ui/src/app/system/tests/page.tsx
@@ -205,12 +205,12 @@ function Posture({ report }: { report: TestIntelligenceReport }) {
         <p style={{ color: 'var(--text-secondary)', fontSize: 12, margin: '0 0 8px' }}>{t('Jedna schopnost na řádek: stav, skutečný blokátor a ověřitelný zdroj jsou vedle sebe. Blokovaný stav není roadmapa ani skrytě hotová funkce.', 'One capability per row: state, actual blocker and verifiable source stay side by side. A blocked state is neither a roadmap nor a silently completed feature.')}</p>
         <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}><table style={tableStyle}>
           <thead><tr><th style={thStyle}>{t('Schopnost', 'Capability')}</th><th style={thStyle}>State</th><th style={thStyle}>{t('Hranice / blokátor', 'Boundary / blocker')}</th><th style={thStyle}>Evidence</th></tr></thead>
-          <tbody>{(report.platformCapabilities ?? []).map(capability => <tr key={capability.id}>
+          <tbody>{(report.platformCapabilities ?? []).length ? (report.platformCapabilities ?? []).map(capability => <tr key={capability.id}>
             <td style={{ ...tdStyle, fontWeight: 650, minWidth: 210 }}>{capability.title}<div style={{ color: 'var(--text-tertiary)', fontFamily: 'monospace', fontSize: 10, marginTop: 3 }}>{capability.id}</div></td>
             <td style={tdStyle}><span style={{ color: capability.state === 'implemented' ? '#16a34a' : '#7c3aed', fontSize: 10, fontWeight: 700 }}>{capability.state}</span></td>
             <td style={{ ...tdStyle, minWidth: 360, color: 'var(--text-secondary)' }}>{capability.blocker ?? t('Implementováno; podrobnosti v evidenci.', 'Implemented; see the evidence pointer for detail.')}</td>
             <td style={{ ...tdStyle, minWidth: 250, color: 'var(--text-tertiary)', fontFamily: 'monospace', fontSize: 10, overflowWrap: 'anywhere' }}>{capability.evidence}</td>
-          </tr>)}</tbody>
+          </tr>) : <tr><td colSpan={4} style={{ ...tdStyle, color: 'var(--text-secondary)' }}><StateBadge state="unknown" /> {t('Registr schopností není v tomto snapshotu dostupný; přesný důvod je ve varování snapshotu.', 'The capability register is unavailable in this snapshot; the snapshot warning carries the exact reason.')}</td></tr>}</tbody>
         </table></div>
       </section>
     </>

--- a/openbank-admin-ui/src/test/system-tests-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/system-tests-a11y.guard.test.ts
@@ -62,5 +62,7 @@ describe('system code quality accessibility', () => {
     expect(source).toContain("t('Hranice / blokátor', 'Boundary / blocker')")
     expect(source).toContain("<th style={thStyle}>Evidence</th>")
     expect(source).toContain('One capability per row: state, actual blocker and verifiable source stay side by side.')
+    expect(source).toContain('The capability register is unavailable in this snapshot; the snapshot warning carries the exact reason.')
+    expect(source).toContain('<StateBadge state="unknown" />')
   })
 })

--- a/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
@@ -191,6 +191,30 @@ scenarios:
     expect(report.platformCapabilities).toContainEqual(expect.objectContaining({ id: 'probes', state: 'external-blocked' }))
   })
 
+  it('does not project a malformed capability register as a partial platform matrix', () => {
+    const repo = mkdtempSync(path.join(tmpdir(), 'test-intelligence-capability-register-'))
+    dirs.push(repo)
+    write(repo, 'openbank-alpha-service/version.txt', '1.0.0\n')
+    write(repo, 'openbank-libs/governance/rules.yaml', 'money_path_services: []\n')
+    write(repo, 'openbank-libs/governance/journeys.yaml', 'version: 1\njourneys: []\n')
+    write(repo, 'openbank-libs/governance/test-intelligence-capabilities.yaml', `version: 1
+capabilities:
+  - id: probes
+    title: Independent probes
+    state: implemented
+    state: external-blocked
+    evidence: issue-1
+`)
+    const out = path.join(repo, 'report.json')
+    execFileSync('node', [SCRIPT, '--repo', repo, '--out', out, '--stale-after-days', '99999'])
+    const report = JSON.parse(readFileSync(out, 'utf8')) as TestIntelligenceReport
+
+    expect(report.platformCapabilities).toEqual([])
+    expect(report.warnings).toEqual(expect.arrayContaining([
+      expect.stringMatching(/capability register unavailable:.*unique/i),
+    ]))
+  })
+
   it('keeps Vitest and multi-suite Playwright fallback evidence when no CI envelope was retained', () => {
     const repo = mkdtempSync(path.join(tmpdir(), 'test-intelligence-xml-fallback-'))
     dirs.push(repo)


### PR DESCRIPTION
## Summary
- parse the Test Intelligence capability register structurally rather than by indentation/text
- reject duplicate YAML keys, duplicate capability IDs, malformed fields and unsupported operator states
- prove valid and falsifying register cases in the ecosystem self-test

## Verification
- `python3 -m py_compile .github/scripts/check-test-intelligence-ecosystem.py`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py --self-test`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py`
- `python3 .github/scripts/run-gates.py --only test-intelligence-ecosystem --timeout 180`

Refs #7957