### PR TITLE
test(anacredit): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/it/PostgresRedpandaTestResource.kt
+++ b/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/it/PostgresRedpandaTestResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.anacredit.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.redpanda.RedpandaContainer
@@ -27,16 +28,18 @@ class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
     private var redpanda: RedpandaContainer? = null
 
     override fun start(): Map<String, String> {
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withUsername("openbank").withPassword("openbank_secret").withDatabaseName("openbank_anacredit_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
         val rp = RedpandaContainer(
-            DockerImageName.parse("redpandadata/redpanda:v24.1.2")
+            DockerImageName.parse(REDPANDA_IMAGE)
                 .asCompatibleSubstituteFor("docker.redpanda.com/redpandadata/redpanda"),
         )
         rp.start()
         redpanda = rp
+        TestInfrastructureEvidence.record("redpanda", REDPANDA_IMAGE, "started")
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
         val bootstrap = rp.bootstrapServers
@@ -54,11 +57,20 @@ class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        redpanda?.stop()
-        postgres?.stop()
+        redpanda?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("redpanda", REDPANDA_IMAGE, "stopped")
+        }
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
     }
 
     companion object {
+        private const val POSTGRES_IMAGE = "postgres:16.3-alpine"
+        private const val REDPANDA_IMAGE = "redpandadata/redpanda:v24.1.2"
+
         /**
          * Set by [start] and read by test classes that need to talk to the broker directly (e.g.
          * [com.openbank.anacredit.integration.LendingEventsConsumerGroupIdBootIT]'s `AdminClient`). A

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -12,7 +12,6 @@
 # need the two-approval + threat-model process before their topology is touched.
 openbank-account-service/src/test/kotlin/com/openbank/account/it/PostgresRedpandaRedisTestResource.kt
 openbank-aml-service/src/test/kotlin/com/openbank/aml/it/PostgresRedisTestResource.kt
-openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/it/PostgresRedpandaTestResource.kt
 openbank-balance-service/src/test/kotlin/com/openbank/balance/it/PostgresRedpandaTestResource.kt
 openbank-billing-service/src/test/kotlin/com/openbank/billing/it/PostgresRedisTestResource.kt
 openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/it/PostgresRedisTestResource.kt


### PR DESCRIPTION
## Summary
- emit secret-free PostgreSQL and Redpanda lifecycle evidence only after successful start and actual stop
- remove the migrated non-money-path resource from the Test Intelligence ratchet baseline
- preserve the existing Testcontainers topology and all test configuration

## Verification
- `python3 .github/scripts/check-test-intelligence-ecosystem.py --self-test`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py`
- `./gradlew :openbank-anacredit-service:compileTestKotlin`

The actual JSONL lifecycle envelope needs the Docker-enabled service CI runtime; this PR intentionally does not claim local compilation as that proof.

Refs #7246