### PR TITLE
test(aml): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-aml-service/src/test/kotlin/com/openbank/aml/it/PostgresRedisTestResource.kt
+++ b/openbank-aml-service/src/test/kotlin/com/openbank/aml/it/PostgresRedisTestResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.aml.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.PostgreSQLContainer
@@ -22,16 +23,18 @@ class PostgresRedisTestResource : QuarkusTestResourceLifecycleManager {
     private var redis: GenericContainer<*>? = null
 
     override fun start(): Map<String, String> {
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withUsername("openbank")
             .withPassword("openbank_secret")
             .withDatabaseName("openbank_aml_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
 
-        val rd = GenericContainer(DockerImageName.parse("valkey/valkey:7.2-alpine")).withExposedPorts(6379)
+        val rd = GenericContainer(DockerImageName.parse(VALKEY_IMAGE)).withExposedPorts(6379)
         rd.start()
         redis = rd
+        TestInfrastructureEvidence.record("valkey", VALKEY_IMAGE, "started")
 
         val pgHost = pg.host
         val pgPort = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
@@ -46,7 +49,18 @@ class PostgresRedisTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        redis?.stop()
-        postgres?.stop()
+        redis?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("valkey", VALKEY_IMAGE, "stopped")
+        }
+        postgres?.let {
+            it.stop()
+            TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+        }
+    }
+
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:16.3-alpine"
+        const val VALKEY_IMAGE = "valkey/valkey:7.2-alpine"
     }
 }

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -11,7 +11,6 @@
 # clearing, swift, fx, lending, sdd, interest, sca, consent) are tracked separately: they
 # need the two-approval + threat-model process before their topology is touched.
 openbank-account-service/src/test/kotlin/com/openbank/account/it/PostgresRedpandaRedisTestResource.kt
-openbank-aml-service/src/test/kotlin/com/openbank/aml/it/PostgresRedisTestResource.kt
 openbank-balance-service/src/test/kotlin/com/openbank/balance/it/PostgresRedpandaTestResource.kt
 openbank-billing-service/src/test/kotlin/com/openbank/billing/it/PostgresRedisTestResource.kt
 openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/it/PostgresRedisTestResource.kt


### PR DESCRIPTION
Refs #7246

## Scope

Non-money-path AML Testcontainers resource only. Records the existing PostgreSQL and Valkey lifecycle into the shared Test Intelligence evidence helper and removes this resource from the migration ratchet baseline.

No production runtime configuration, credentials, container topology, or test assertion changed. Evidence records only resource kind, public image reference, lifecycle, and timestamp.

## Verification

- `python3 .github/scripts/check-test-intelligence-ecosystem.py --self-test`
- `python3 .github/scripts/check-test-intelligence-ecosystem.py`
- `python3 .github/scripts/run-gates.py --only test-intelligence-ecosystem --timeout 180`
- `git diff --check`
- targeted `:openbank-aml-service:compileTestKotlin` invoked locally; authoritative compilation and immutable runtime envelope remain CI evidence.

The PR must show a real PostgreSQL/Valkey start+stop pair in its immutable CI envelope before it is considered validated.