### PR TITLE
docs(governance): record what the enum-drift gate cannot see, and correct one baseline reason

### DIFF
--- a/.github/scripts/check-openapi-enum-vs-domain.py
+++ b/.github/scripts/check-openapi-enum-vs-domain.py
@@ -25,6 +25,38 @@ and passes, and one that has drifted still overlaps enough to be recognised as t
 An unpaired spec enum is NOT a finding — plenty are free-form vocabularies with no Kotlin type
 (sort orders, filter keywords), and reporting those would bury the real ones.
 
+## What this gate CANNOT see (measured 2026-09-01, #5962)
+
+Two blind spots, both structural. Neither produces a finding, so the gate's silence about them
+is not evidence — they are recorded here so the next reader does not mistake a green run for a
+census.
+
+1. **Pairing is thresholded, so the WORST drift is the most invisible.** The more a spec enum has
+   drifted from its Kotlin enum, the less it overlaps, and below MIN_OVERLAP it is not reported
+   as drift — it is simply not paired, and an unpaired spec enum is not a finding. Measured by
+   re-running this gate with MIN_OVERLAP lowered to 0.10 and changing nothing else: the fleet goes
+   from `17 paired enum(s) drift, all 17 baselined; no new drift` to **six additional pairings**,
+   none of which any run of this gate has ever mentioned — `openbank-account-service` AccountType
+   (spec advertises ESCROW and LOAN, which have never existed, and omits all five GL_*/NOSTRO
+   values), `openbank-dispute-service` DisputeType (three invented names against five real ones —
+   exactly the #5895 shape this gate was built for), `openbank-campaign-service` StepResolution,
+   `openbank-lending-service` CollateralStatus, `openbank-sepa-instant` SctInstStatus and
+   `openbank-swift-service` SwiftStatus. Raising the threshold is NOT the fix: the last two of
+   those six are MIS-pairings against the shared four-eyes vocabulary, see 2.
+
+2. **`kotlin_enums()` walks the SERVICE's own src/main, so a spec enum backed by a shared
+   `openbank-libs-*` enum can never pair, however far it drifts.** 21 spec enums across the fleet
+   are in that state today. The clearest is `[PENDING, APPROVED, REJECTED, EXECUTED]`, which
+   appears in seven service specs as the ADR-0155 four-eyes approval status and is backed by
+   `openbank-libs-domain/.../approval/ApprovalStore.kt: enum class ApprovalStatus`. All seven
+   agree exactly right now — but nothing here is what makes that true. Falsified rather than
+   asserted: feeding `best_match` the swift quartet against the service-only enum map returns
+   `None` both when ApprovalStatus matches and when a value is added to it, while the same call
+   against a service+libs map returns `ApprovalStatus` and reports the added value. Control for
+   that probe: the run asserts the quartet is extracted from the swift spec at all, so a broken
+   extractor cannot masquerade as "no pairing". Consequence: **one value added to a shared libs
+   enum silently drifts seven specs at once, with no signal anywhere.**
+
 ## Ratchet, not a wall
 
 Existing drift is baselined in BASELINE below with the issue that owns it; a NEW drift fails.
@@ -64,8 +96,20 @@ MIN_SHARED = 2
 BASELINE: dict[str, str] = {
     "openbank-account-service:APPROVED,CANCELLED,PENDING,REJECTED":
         "#5962 — WithdrawalProposalStatus: undeclared EXPIRED",
+    # NOT drift — a DELIBERATE SUBSET, kept baselined with the reason corrected (#5962). The
+    # values are the `channel` of the app-interaction attribution response
+    # (GET /api/v1/campaigns/interactions/{interactionRef}/attribution), which resolves ONLY an
+    # attributable app placement. `PanacheSendLogRepository.attributionForAppInteraction` queries
+    #     "id = ?1 and partyId = ?2 and channel in (?3, ?4) and outcome = ?5"
+    # with Channel.PUSH and Channel.BANNER, so EMAIL is unreturnable by construction and
+    # publishing it would advertise a value the endpoint cannot produce. Independent witness, not
+    # the same code re-read: the two DB CHECK constraints disagree ON PURPOSE — V11 constrains the
+    # send log to ('EMAIL','PUSH','BANNER') while V12's engagement projection constrains
+    # `channel` to ('PUSH','BANNER'), the narrower set this enum matches exactly. The gate pairs a
+    # placement-scoped enum with the full Channel enum and cannot see the restriction.
     "openbank-campaign-service:BANNER,PUSH":
-        "#5962 — Channel: undeclared EMAIL",
+        "#5962 — attribution response `channel`: NOT drift. A deliberate subset of Channel; the "
+        "attribution query filters `channel in (PUSH, BANNER)`, so EMAIL is unreturnable.",
     "openbank-campaign-service:DRY_RUN,SENT,SUPPRESSED_CAP,SUPPRESSED_CONSENT,SUPPRESSED_QUIET_HOURS":
         "#5962 — SendOutcome: undeclared CONVERTED/FAILED/SKIPPED_CONDITION/SUPPRESSED_LIST",
     "openbank-card-issuance-service:MASTERCARD,VISA":


### PR DESCRIPTION
## What

No behaviour change to `check-openapi-enum-vs-domain.py`. One baseline reason corrected, and the gate's two structural blind spots written down where the next reader will find them.

Refs #5962. The baseline is unchanged in size: **17 entries / 13 services** on `origin/main`, re-verified by parsing the dict rather than counting lines.

## 1. `campaign-service:BANNER,PUSH` is not drift

Baselined as *"Channel: undeclared EMAIL"*. It is a deliberate subset, the same shape as the `document-service` and `ledger-service` entries directly above it.

The values are the `channel` of the app-interaction attribution response, which resolves only an *attributable app placement*:

```
"id = ?1 and partyId = ?2 and channel in (?3, ?4) and outcome = ?5"   // PUSH, BANNER, SENT
```

EMAIL is unreturnable by construction, so publishing it would advertise a value the endpoint cannot produce.

**Witness independent of that code**, per the rule that a drift "fixed" by editing the spec to match the code proves nothing: the two DB `CHECK` constraints disagree deliberately. `V11__send_log_banner_channel.sql` constrains the send log to `('EMAIL','PUSH','BANNER')`; `V12__campaign_engagement_projection.sql` constrains the projection's `channel` to `('PUSH','BANNER')` — the narrower set this enum matches exactly.

## 2. What the gate cannot see

**The threshold makes the worst drift the most invisible.** The further a spec enum drifts, the less it overlaps, and below `MIN_OVERLAP` it is not reported — it is simply not paired, and an unpaired spec enum is not a finding. Re-running the gate with `MIN_OVERLAP = 0.10` and nothing else changed takes the fleet from `17 paired enum(s) drift, all 17 baselined; no new drift` to **six additional pairings the gate has never mentioned**:

| service | Kotlin enum | what differs |
|---|---|---|
| account | `AccountType` | spec advertises `ESCROW`, `LOAN` (never existed); omits all five `GL_*`/`NOSTRO` |
| dispute | `DisputeType` | three invented names vs five real ones — exactly the #5895 shape |
| campaign | `StepResolution` | seven resolutions unpublished |
| lending | `CollateralStatus` | 17 spec-only values |
| sepa-instant | `SctInstStatus` | mis-pairing, see below |
| swift | `SwiftStatus` | mis-pairing, see below |

**Lowering the threshold is not the fix, and I checked before claiming it was.** The `[PENDING, APPROVED, REJECTED, EXECUTED]` quartet appears in seven service specs and looks like a fleet-wide status defect. It is not: it is the ADR-0155 four-eyes `ApprovalStatus`, and every one of the seven is correct.

**Which exposes the second, threshold-independent blind spot.** `kotlin_enums()` walks the *service's own* `src/main`, and `ApprovalStatus` lives in `openbank-libs-domain/.../approval/ApprovalStore.kt`. So those seven spec enums can never pair, however far they drift. **21 spec enums across the fleet are in that state.** All of them agree with their libs enum today — but nothing in this gate is what makes that true.

Falsified rather than asserted, with a control:

```
scan SERVICE-ONLY (what the gate does): None
scan SERVICE+LIBS                     : ('ApprovalStatus', {PENDING, APPROVED, REJECTED, EXECUTED})
libs gains EXPIRED, service-only      : None          <- still silent
libs gains EXPIRED, service+libs      : reports the added value
```

Control: the probe asserts the quartet is extracted from the swift spec at all, so a broken extractor cannot masquerade as "no pairing". **One value added to a shared libs enum would silently drift seven specs at once, with no signal anywhere.**

## Verification

The gate still enforces. Deleting the corrected `campaign-service` entry makes it report that pairing as a new drift; restoring it returns to green — exit codes read from `$?` after redirecting to a file, not through a pipe:

```
RED_RC=1    ::error ...Channel... spec omits ['EMAIL']
GREEN_RC=0  17 paired enum(s) drift, all 17 baselined; no new drift
```

`--self-test` passes. No `openapi.yaml` is touched, so no `info.version` bump is involved.
