### PR TITLE
fix(admin-ui): report a failed BFF read as a failure, not an empty collection

### DIFF
--- a/openbank-admin-ui/src/app/api/finops/resources/route.ts
+++ b/openbank-admin-ui/src/app/api/finops/resources/route.ts
@@ -11,22 +11,33 @@ function prometheusBase(): string {
   return process.env.PROMETHEUS_URL ?? 'http://localhost:9090'
 }
 
-async function queryRange(query: string, signal: AbortSignal): Promise<Record<string, number>> {
+/** Outcome of one Prometheus read.
+ *
+ *  Deliberately NOT a bare map. This route already distinguishes "Prometheus is unreachable"
+ *  (`available: false`) from a successful read — but only at the `/-/ready` probe. Every
+ *  individual query below then swallowed its own failure into `{}`, so a Prometheus that is ready
+ *  and answering 500 (or timing out, or returning `status: "error"`) rendered as
+ *  `available: true, services: []` — a confident claim that the fleet has no services, which is
+ *  never a true statement about a running cluster. Same asymmetry PR #7945 fixed on fx/rates:
+ *  the honest shape already existed one level up, one layer just lacked it (#7943). */
+type Query = { rows: Record<string, number>; error: string | null }
+
+async function queryRange(query: string, signal: AbortSignal): Promise<Query> {
   try {
     const url = `${prometheusBase()}/api/v1/query?query=${encodeURIComponent(query)}`
     const res = await fetch(url, { signal, headers: { Accept: 'application/json' } })
-    if (!res.ok) return {}
+    if (!res.ok) return { rows: {}, error: `prometheus responded ${res.status}` }
     const json = await res.json() as { status: string; data: { result: { metric: Record<string, string>; value: [number, string] }[] } }
-    if (json.status !== 'success') return {}
+    if (json.status !== 'success') return { rows: {}, error: `prometheus query status ${json.status}` }
     const out: Record<string, number> = {}
     for (const r of json.data.result) {
       const svc = r.metric.container ?? r.metric.application ?? r.metric.job ?? r.metric.service ?? 'unknown'
       const val = parseFloat(r.value[1])
       if (!isNaN(val)) out[svc] = val
     }
-    return out
-  } catch {
-    return {}
+    return { rows: out, error: null }
+  } catch (e) {
+    return { rows: {}, error: String(e) }
   }
 }
 
@@ -46,10 +57,13 @@ export async function GET() {
     }).catch(() => null)
 
     if (!ready?.ok) {
-      return NextResponse.json({ available: false, services: [] }, { headers: { 'Cache-Control': 'no-store' } })
+      return NextResponse.json(
+        { available: false, error: 'prometheus is not ready', services: [] },
+        { headers: { 'Cache-Control': 'no-store' } },
+      )
     }
 
-    const [heapUsed, heapMax, cpuRate, reqRate] = await Promise.all([
+    const [heapUsedQ, heapMaxQ, cpuRateQ, reqRateQ] = await Promise.all([
       // Prometheus scrapes Quarkus pods via ServiceMonitor job "observability/openbank-services".
       // The per-pod identity label is `container`, not `application` — Quarkus Micrometer does
       // not set a common application tag by default. Filter by job to exclude kafka/keycloak JVM.
@@ -58,6 +72,15 @@ export async function GET() {
       queryRange('sum(rate(process_cpu_seconds_total{job="observability/openbank-services"}[5m])) by (container)', controller.signal),
       queryRange('sum(rate(http_server_requests_seconds_count{job="observability/openbank-services"}[5m])) by (container)', controller.signal),
     ])
+
+    const queries = { heapUsed: heapUsedQ, heapMax: heapMaxQ, cpuRate: cpuRateQ, reqRate: reqRateQ }
+    // One failed query is a data GAP, not an empty fleet. Name the queries that failed so the
+    // panel can say "3 of 4 metrics unavailable" instead of silently rendering a shorter list.
+    const failed = Object.entries(queries).flatMap(([name, q]) => (q.error ? [`${name}: ${q.error}`] : []))
+    const heapUsed = heapUsedQ.rows
+    const heapMax = heapMaxQ.rows
+    const cpuRate = cpuRateQ.rows
+    const reqRate = reqRateQ.rows
 
     const allApps = new Set([
       ...Object.keys(heapUsed),
@@ -100,6 +123,10 @@ export async function GET() {
 
     return NextResponse.json({
       available: true,
+      // Present so a failing read is distinguishable from a genuinely empty one. `null` means
+      // every query answered — an empty `services` under a null error really is an empty fleet.
+      error: failed.length ? failed.join('; ') : null,
+      degraded: failed.length > 0,
       fleetHeapPct,
       underutilisedCount: underutilised,
       serviceCount: services.length,

--- a/openbank-admin-ui/src/app/api/finops/right-sizing/route.ts
+++ b/openbank-admin-ui/src/app/api/finops/right-sizing/route.ts
@@ -39,6 +39,10 @@ interface RightSizingReport {
   highSavingsCount: number
   services: ServiceEfficiency[]
   vpaHasData: boolean
+  /** Null when every query answered. Non-null names the queries that did not, so an empty
+   *  `services` under a failing read is not read as "the fleet has no namespaces" (#7943). */
+  error: string | null
+  degraded: boolean
 }
 
 function prometheusBase(): string {
@@ -46,25 +50,33 @@ function prometheusBase(): string {
   return process.env.PROMETHEUS_URL ?? 'http://localhost:9090'
 }
 
+type Vector = { rows: { metric: Record<string, string>; value: number }[]; error: string | null }
+
+/** Deliberately NOT a bare array — see the resources route for the same reasoning. The `/-/ready`
+ *  probe already distinguishes an unreachable Prometheus; a ready Prometheus whose QUERIES fail
+ *  used to render as `available: true, services: []`, i.e. a perfectly efficient fleet. */
 async function queryVector(
   query: string,
   signal: AbortSignal,
-): Promise<{ metric: Record<string, string>; value: number }[]> {
+): Promise<Vector> {
   try {
     const url = `${prometheusBase()}/api/v1/query?query=${encodeURIComponent(query)}`
     const res = await fetch(url, { signal, headers: { Accept: 'application/json' } })
-    if (!res.ok) return []
+    if (!res.ok) return { rows: [], error: `prometheus responded ${res.status}` }
     const json = await res.json() as {
       status: string
       data: { result: { metric: Record<string, string>; value: [number, string] }[] }
     }
-    if (json.status !== 'success') return []
-    return json.data.result.map(r => ({
-      metric: r.metric,
-      value: parseFloat(r.value[1]),
-    })).filter(r => !isNaN(r.value))
-  } catch {
-    return []
+    if (json.status !== 'success') return { rows: [], error: `prometheus query status ${json.status}` }
+    return {
+      rows: json.data.result.map(r => ({
+        metric: r.metric,
+        value: parseFloat(r.value[1]),
+      })).filter(r => !isNaN(r.value)),
+      error: null,
+    }
+  } catch (e) {
+    return { rows: [], error: String(e) }
   }
 }
 
@@ -115,13 +127,15 @@ export async function GET() {
         highSavingsCount: 0,
         services: [],
         vpaHasData: false,
+        error: 'prometheus is not ready',
+        degraded: true,
       }, { headers: { 'Cache-Control': 'no-store' } })
     }
 
     // ── Queries: requested vs actual per namespace ────────────────────────────
     // kube-state-metrics (requests) + cAdvisor (actuals) are both part of
     // kube-prometheus-stack — no extra scrapers needed.
-    const [cpuReq, cpuUsed, memReq, memUsed, vpaCpu, vpaMem] = await Promise.all([
+    const [cpuReqQ, cpuUsedQ, memReqQ, memUsedQ, vpaCpuQ, vpaMemQ] = await Promise.all([
       // CPU requested in millicores per namespace (sum across all containers)
       queryVector(
         'sum by (namespace) (kube_pod_container_resource_requests{resource="cpu",container!=""}) * 1000',
@@ -154,15 +168,24 @@ export async function GET() {
       ),
     ])
 
-    const toMap = (rows: { metric: Record<string, string>; value: number }[]) =>
-      Object.fromEntries(rows.map(r => [r.metric.namespace ?? '', r.value]))
+    const toMap = (v: Vector) =>
+      Object.fromEntries(v.rows.map(r => [r.metric.namespace ?? '', r.value]))
 
-    const cpuReqMap  = toMap(cpuReq)
-    const cpuUsedMap = toMap(cpuUsed)
-    const memReqMap  = toMap(memReq)
-    const memUsedMap = toMap(memUsed)
-    const vpaCpuMap  = toMap(vpaCpu)
-    const vpaMemMap  = toMap(vpaMem)
+    // A failed query yields no rows, which is indistinguishable downstream from a namespace with
+    // no data — so record WHICH queries failed rather than inferring it from the shape.
+    const queries = {
+      cpuRequested: cpuReqQ, cpuUsed: cpuUsedQ,
+      memRequested: memReqQ, memUsed: memUsedQ,
+      vpaCpu: vpaCpuQ, vpaMemory: vpaMemQ,
+    }
+    const failed = Object.entries(queries).flatMap(([n, q]) => (q.error ? [`${n}: ${q.error}`] : []))
+
+    const cpuReqMap  = toMap(cpuReqQ)
+    const cpuUsedMap = toMap(cpuUsedQ)
+    const memReqMap  = toMap(memReqQ)
+    const memUsedMap = toMap(memUsedQ)
+    const vpaCpuMap  = toMap(vpaCpuQ)
+    const vpaMemMap  = toMap(vpaMemQ)
 
     // Build per-namespace report — include all namespaces that have any data
     const allNs = new Set([
@@ -241,7 +264,10 @@ export async function GET() {
       fleetMemEfficiencyPct: fleetMem,
       highSavingsCount: highSavings,
       services,
-      vpaHasData: vpaCpu.length > 0,
+      // Only meaningful when the VPA query actually answered: a failed query has no rows either.
+      vpaHasData: vpaCpuQ.error === null && vpaCpuQ.rows.length > 0,
+      error: failed.length ? failed.join('; ') : null,
+      degraded: failed.length > 0,
     }, { headers: { 'Cache-Control': 'no-store' } })
   } finally {
     clearTimeout(timer)

--- a/openbank-admin-ui/src/app/api/temporal/status/route.ts
+++ b/openbank-admin-ui/src/app/api/temporal/status/route.ts
@@ -11,39 +11,56 @@ function prometheusBase(): string {
   return process.env.PROMETHEUS_URL ?? 'http://localhost:9090'
 }
 
-async function queryInstant(query: string, signal: AbortSignal): Promise<number | null> {
+/** Deliberately NOT a bare `number | null`.
+ *
+ *  `null` had to mean two different things: "the metric genuinely has no samples" (Temporal is not
+ *  emitting it yet — honest, and the UI renders "no data") and "the query FAILED". That mattered
+ *  most for `temporal_restarts`, whose value is the sole input to `temporalDeployed`: a Prometheus
+ *  that is ready but answering 500 produced `temporalDeployed: false`, which the console renders
+ *  as the confident claim that Temporal is not deployed — an outage reported as an architecture
+ *  fact. Splitting the two lets an absent metric stay `null` while a failure is named (#7943). */
+type Instant = { value: number | null; error: string | null }
+
+async function queryInstant(query: string, signal: AbortSignal): Promise<Instant> {
   try {
     const url = `${prometheusBase()}/api/v1/query?query=${encodeURIComponent(query)}`
     const res = await fetch(url, { signal, headers: { Accept: 'application/json' } })
-    if (!res.ok) return null
+    if (!res.ok) return { value: null, error: `prometheus responded ${res.status}` }
     const json = await res.json() as {
       status: string
       data: { result: { metric: Record<string, string>; value: [number, string] }[] }
     }
-    if (json.status !== 'success' || !json.data.result.length) return null
+    if (json.status !== 'success') return { value: null, error: `prometheus query status ${json.status}` }
+    // No samples is a real answer, not a failure: the metric exists and has nothing to report.
+    if (!json.data.result.length) return { value: null, error: null }
     const val = parseFloat(json.data.result[0].value[1])
-    return isNaN(val) ? null : val
-  } catch {
-    return null
+    return { value: isNaN(val) ? null : val, error: null }
+  } catch (e) {
+    return { value: null, error: String(e) }
   }
 }
 
-async function queryVector(query: string, signal: AbortSignal): Promise<{ labels: Record<string, string>; value: number }[]> {
+type LabelVector = { rows: { labels: Record<string, string>; value: number }[]; error: string | null }
+
+async function queryVector(query: string, signal: AbortSignal): Promise<LabelVector> {
   try {
     const url = `${prometheusBase()}/api/v1/query?query=${encodeURIComponent(query)}`
     const res = await fetch(url, { signal, headers: { Accept: 'application/json' } })
-    if (!res.ok) return []
+    if (!res.ok) return { rows: [], error: `prometheus responded ${res.status}` }
     const json = await res.json() as {
       status: string
       data: { result: { metric: Record<string, string>; value: [number, string] }[] }
     }
-    if (json.status !== 'success') return []
-    return json.data.result.flatMap(r => {
-      const val = parseFloat(r.value[1])
-      return isNaN(val) ? [] : [{ labels: r.metric, value: val }]
-    })
-  } catch {
-    return []
+    if (json.status !== 'success') return { rows: [], error: `prometheus query status ${json.status}` }
+    return {
+      rows: json.data.result.flatMap(r => {
+        const val = parseFloat(r.value[1])
+        return isNaN(val) ? [] : [{ labels: r.metric, value: val }]
+      }),
+      error: null,
+    }
+  } catch (e) {
+    return { rows: [], error: String(e) }
   }
 }
 
@@ -61,7 +78,10 @@ export async function GET() {
     if (!prometheusUp) {
       return NextResponse.json({
         available: false,
-        temporalDeployed: false,
+        // `null`, not `false`: with Prometheus unreachable this route has no basis for either
+        // verdict about Temporal, and `false` is the one the console renders as a fact.
+        temporalDeployed: null,
+        error: 'prometheus is not ready',
         metrics: null,
       }, { headers: { 'Cache-Control': 'no-store' } })
     }
@@ -69,19 +89,19 @@ export async function GET() {
     // Detect if Temporal server is scraped by Prometheus at all.
     // Temporal server exposes metrics on port 9090 under the temporal namespace.
     const [
-      temporalUpCount,
-      workflowsScheduled,
-      workflowsCompleted,
-      workflowsFailed,
-      workflowsTimedOut,
-      activityScheduleLatencyP50,
-      workflowTaskLatencyP50,
-      requestLatency,
-      persistenceRequests,
-      workerTaskSlots,
-      workerTaskSlotsUsed,
-      namespaces,
-      workflowTypes,
+      temporalUpCountQ,
+      workflowsScheduledQ,
+      workflowsCompletedQ,
+      workflowsFailedQ,
+      workflowsTimedOutQ,
+      activityScheduleLatencyP50Q,
+      workflowTaskLatencyP50Q,
+      requestLatencyQ,
+      persistenceRequestsQ,
+      workerTaskSlotsQ,
+      workerTaskSlotsUsedQ,
+      namespacesQ,
+      workflowTypesQ,
     ] = await Promise.all([
       // Metric names below are the Temporal SERVER (tally/prometheus) names as
       // scraped by the temporal-server PodMonitor (prefixed temporal_ at scrape
@@ -112,15 +132,46 @@ export async function GET() {
       queryVector('sum by (namespace, workflow_type) (increase(temporal_workflow_success[1h]))', controller.signal),
     ])
 
-    // temporal_restarts is absent (count → vector(0)) only when Temporal is not scraped yet
-    const temporalDeployed = (temporalUpCount ?? 0) > 0
+    const queries = {
+      temporalUp: temporalUpCountQ, workflowsScheduled: workflowsScheduledQ,
+      workflowsCompleted: workflowsCompletedQ, workflowsFailed: workflowsFailedQ,
+      workflowsTimedOut: workflowsTimedOutQ, activityScheduleLatency: activityScheduleLatencyP50Q,
+      workflowTaskLatency: workflowTaskLatencyP50Q, requestLatency: requestLatencyQ,
+      persistenceRequests: persistenceRequestsQ, workerTaskSlots: workerTaskSlotsQ,
+      workerTaskSlotsUsed: workerTaskSlotsUsedQ, namespaces: namespacesQ,
+      workflowTypes: workflowTypesQ,
+    }
+    const failed = Object.entries(queries).flatMap(([n, q]) => (q.error ? [`${n}: ${q.error}`] : []))
+
+    const temporalUpCount = temporalUpCountQ.value
+    const workflowsScheduled = workflowsScheduledQ.value
+    const workflowsCompleted = workflowsCompletedQ.value
+    const workflowsFailed = workflowsFailedQ.value
+    const workflowsTimedOut = workflowsTimedOutQ.value
+    const activityScheduleLatencyP50 = activityScheduleLatencyP50Q.value
+    const workflowTaskLatencyP50 = workflowTaskLatencyP50Q.value
+    const requestLatency = requestLatencyQ.value
+    const persistenceRequests = persistenceRequestsQ.value
+    const workerTaskSlots = workerTaskSlotsQ.value
+    const workerTaskSlotsUsed = workerTaskSlotsUsedQ.value
+    const namespaces = namespacesQ.rows
+    const workflowTypes = workflowTypesQ.rows
+
+    // temporal_restarts is absent (count → vector(0)) only when Temporal is not scraped yet — but
+    // ONLY if the query answered. When it failed we know nothing, and `null` says so rather than
+    // letting an outage render as "Temporal is not deployed".
+    const temporalDeployed = temporalUpCountQ.error !== null ? null : (temporalUpCount ?? 0) > 0
 
     const activeNamespaces = namespaces.map(n => n.labels.namespace ?? 'unknown')
 
     return NextResponse.json({
       available: true,
       temporalDeployed,
-      metrics: temporalDeployed ? {
+      // Null when every query answered — an empty/absent metric set under a null error really is
+      // Temporal having nothing to report, not this route failing to ask.
+      error: failed.length ? failed.join('; ') : null,
+      degraded: failed.length > 0,
+      metrics: temporalDeployed === true ? {
         workflows: {
           scheduled1h: Math.round(workflowsScheduled ?? 0),
           completed1h: Math.round(workflowsCompleted ?? 0),

--- a/openbank-admin-ui/src/test/bff-empty-vs-failure.test.ts
+++ b/openbank-admin-ui/src/test/bff-empty-vs-failure.test.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// #7943 — BFF routes that turn an upstream FAILURE into an empty collection.
+//
+// Each of these routes probes Prometheus `/-/ready` first, and correctly reports `available: false`
+// when that probe fails. The defect is one layer in: a Prometheus that IS ready but answers 500,
+// times out, or returns `status: "error"` had every individual query swallow that into `{}` / `[]`
+// / `null`. The response then read `available: true` with an empty result — a confident claim that
+// the fleet has no services, no namespaces, or that Temporal is not deployed.
+//
+// PR #7945 set the precedent on fx/rates: return a discriminated result and surface the reason.
+//
+// THE CONTROL is the second test in every pair: a query that SUCCEEDS and genuinely returns no
+// samples must report `error: null`. Without it, `error` could simply track `rows.length === 0`
+// and these guards would pass while measuring nothing.
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+const ready = () => new Response('Prometheus Server is Ready.', { status: 200 })
+
+/** Prometheus answers `/-/ready`, then fails every actual query. */
+const readyButQueriesFail = () =>
+  vi.fn(async (input: RequestInfo | URL) =>
+    String(input).includes('/-/ready') ? ready() : json({ status: 'error', error: 'boom' }, 500))
+
+/** Prometheus is healthy and every query legitimately returns no samples. */
+const readyAndGenuinelyEmpty = () =>
+  vi.fn(async (input: RequestInfo | URL) =>
+    String(input).includes('/-/ready') ? ready() : json({ status: 'success', data: { result: [] } }))
+
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); vi.resetModules() })
+
+describe('finops/resources reports a failed read as a failure (#7943)', () => {
+  it('names the failure instead of rendering an empty fleet', async () => {
+    vi.stubGlobal('fetch', readyButQueriesFail())
+    const { GET } = await import('@/app/api/finops/resources/route')
+    const body = await (await GET()).json()
+
+    expect(body.available).toBe(true)      // Prometheus really is up — that part was never wrong
+    expect(body.services).toHaveLength(0)
+    expect(body.error).toBeTruthy()        // ...but the emptiness is NOT a fact about the fleet
+    expect(body.degraded).toBe(true)
+  })
+
+  // CONTROL
+  it('reports NO error when the queries succeed and the fleet is genuinely empty', async () => {
+    vi.stubGlobal('fetch', readyAndGenuinelyEmpty())
+    const { GET } = await import('@/app/api/finops/resources/route')
+    const body = await (await GET()).json()
+
+    expect(body.available).toBe(true)
+    expect(body.services).toHaveLength(0)
+    expect(body.error).toBeNull()
+    expect(body.degraded).toBe(false)
+  })
+})
+
+describe('finops/right-sizing reports a failed read as a failure (#7943)', () => {
+  it('names the failure instead of rendering a perfectly-sized fleet', async () => {
+    vi.stubGlobal('fetch', readyButQueriesFail())
+    const { GET } = await import('@/app/api/finops/right-sizing/route')
+    const body = await (await GET()).json()
+
+    expect(body.available).toBe(true)
+    expect(body.services).toHaveLength(0)
+    expect(body.error).toBeTruthy()
+    expect(body.degraded).toBe(true)
+    // A failed VPA query has no rows either — it must not be reported as "VPA has no data".
+    expect(body.vpaHasData).toBe(false)
+  })
+
+  // CONTROL
+  it('reports NO error when the queries succeed and there is genuinely nothing to size', async () => {
+    vi.stubGlobal('fetch', readyAndGenuinelyEmpty())
+    const { GET } = await import('@/app/api/finops/right-sizing/route')
+    const body = await (await GET()).json()
+
+    expect(body.available).toBe(true)
+    expect(body.services).toHaveLength(0)
+    expect(body.error).toBeNull()
+    expect(body.degraded).toBe(false)
+  })
+})
+
+describe('temporal/status does not report an outage as "not deployed" (#7943)', () => {
+  it('withholds the deployed verdict when the query failed', async () => {
+    vi.stubGlobal('fetch', readyButQueriesFail())
+    const { GET } = await import('@/app/api/temporal/status/route')
+    const body = await (await GET()).json()
+
+    expect(body.available).toBe(true)
+    // The whole defect: `false` here is rendered as "Temporal is not deployed in this environment".
+    expect(body.temporalDeployed).not.toBe(false)
+    expect(body.error).toBeTruthy()
+    expect(body.degraded).toBe(true)
+  })
+
+  // CONTROL. `count(temporal_restarts) or vector(0)` genuinely resolving to 0 IS a real answer:
+  // Temporal is not scraped. That must stay `false` with no error, or the fix is meaningless.
+  it('DOES report not-deployed when the query succeeds and Temporal is absent', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) =>
+      String(input).includes('/-/ready')
+        ? ready()
+        : json({ status: 'success', data: { result: [{ metric: {}, value: [0, '0'] }] } })))
+    const { GET } = await import('@/app/api/temporal/status/route')
+    const body = await (await GET()).json()
+
+    expect(body.available).toBe(true)
+    expect(body.temporalDeployed).toBe(false)
+    expect(body.error).toBeNull()
+    expect(body.degraded).toBe(false)
+  })
+
+  it('still reports prometheus being down as unavailable, without a deployed verdict', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('connection refused') }))
+    const { GET } = await import('@/app/api/temporal/status/route')
+    const body = await (await GET()).json()
+
+    expect(body.available).toBe(false)
+    expect(body.temporalDeployed).not.toBe(false)
+    expect(body.error).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## What

Three of the four routes left by #7943 after #7945 fixed `fx/rates`.

Each route probes Prometheus `/-/ready` first and correctly answers `available: false` when that probe fails — that part was never wrong. **The defect is one layer in.** Every individual query then swallowed its own failure into `{}` / `[]` / `null`, so a Prometheus that is **ready** but answering 500, timing out, or returning `status: "error"` rendered as `available: true` with an empty result:

| route | what an outage rendered as |
|---|---|
| `finops/resources` | "the fleet has no services" |
| `finops/right-sizing` | "no namespace has any savings potential" |
| `temporal/status` | `temporalDeployed: false` — which the console renders as *"Temporal is not deployed in this environment"*, an outage reported as an architecture fact |

That last one is the same downstream shape as the `McpEndpoint` 404 in the repo's own notes: a healthy-but-unreachable service rendering as "not deployed".

## How

The shape PR #7945 established on `fx/rates`, and the asymmetry was already there to copy: `available` distinguished reachability at the outer probe, the inner queries just had no equivalent.

Each helper now returns a **discriminated result** instead of a bare collection:

- `error` is `null` when every query answered, and **names the failing queries** otherwise; `degraded` is the boolean form.
- `temporalDeployed` becomes **`null`** rather than `false` whenever the route has no basis for either verdict — both when Prometheus is unreachable and when the `temporal_restarts` query itself failed.
- `vpaHasData` is true only when the VPA query actually **answered**; a failed query has no rows either, and was reported as "VPA has no data".

An **absent metric stays an honest `null`**: no samples is a real answer, not a failure. Keeping that distinct from a failure is the whole point — collapsing them the other way would just move the lie.

## The control, and its falsification

Every pair carries a test asserting that a query which **succeeds and genuinely returns nothing** reports `error: null`. Without it, `error` could simply track `rows.length === 0` and these guards would pass while measuring nothing — the failure mode this repo keeps finding in its own checks.

That was **falsified, not assumed**. A mutant computing `error` from emptiness rather than from a real failure:

```
MUTANT_RC=1 — Tests 1 failed | 6 passed
× reports NO error when the queries succeed and the fleet is genuinely empty
```

It passes the failure test and fails **only** the control. The control can therefore detect the absence of what it tests.

Exit codes, each read from `$?` immediately after redirecting to a file (never through a pipe):

- 7 new tests against unmodified `main` routes: `RED_RC=1` — 7 failed
- with the fix: `GREEN_RC=0` — 7 passed
- mutant: `MUTANT_RC=1` — only the control fails
- `npx tsc --noEmit`: `TSC_RC=0`, 0 errors
- clean full `npm test`: `SUITE_BFF_CLEAN_RC=1` — 2057 passed, **4 pre-existing failures**

Those 4 (`campaigns-console`, `card-transition-dialog`, `console-summary-wiring`, `iaops-case-thread-page`) reproduce identically with this branch's routes reverted to the base commit — same count, unrelated files, all 5000ms render timeouts. They are not caused by this change. Verified twice, including a same-file-same-base control run.

## Left deliberately

**The fourth route, `test-intelligence`.** Its defect site (`queryPrometheusRuns` returning `[]` on a failed read, line ~131) sits **inside** the hunk range open PR #7049 is rewriting (`@@ -119,34 +142,38 @@`), and three live worktrees plus an in-progress local cherry-pick are on that file. Editing it now buys a conflict rather than a fix. It should be picked up once #7049 lands — the shape is already established here and in #7945, and that route already has a `warnings[]` array to carry the reason.

Refs #7943

🤖 Generated with [Claude Code](https://claude.com/claude-code)
