### PR TITLE
feat(billing): expose pending approvals in the unified inbox

### DIFF
--- a/openbank-admin-ui/src/app/api/approvals/pending/route.ts
+++ b/openbank-admin-ui/src/app/api/approvals/pending/route.ts
@@ -23,13 +23,11 @@ type SourceState = 'ok' | 'forbidden' | 'unavailable' | 'not-configured'
 // the most dangerous state look healthy to an operator.
 const NOT_CONFIGURED_SOURCES = {
   balance: 'not-configured',
-  billing: 'not-configured',
-  consent: 'not-configured',
 } as const satisfies Record<string, SourceState>
 
 type InboxItem = {
   id: string
-  domain: 'lending' | 'sanctions' | 'transaction' | 'domestic-payment' | 'clearing' | 'fx' | 'ledger' | 'swift' | 'sepa-payment' | 'sepa-instant' | 'notification' | 'party' | 'account' | 'agent'
+  domain: 'lending' | 'sanctions' | 'transaction' | 'domestic-payment' | 'clearing' | 'fx' | 'ledger' | 'swift' | 'sepa-payment' | 'sepa-instant' | 'notification' | 'party' | 'account' | 'billing' | 'consent' | 'agent'
   action: string
   resourceId: string | null
   maker: string | null
@@ -101,6 +99,15 @@ type PartyApproval = LendingApproval
 // account-service serves the shared PendingApproval shape for gated account lifecycle actions.
 // Surfacing it here makes a parked freeze or other protected action discoverable before TTL expiry.
 type AccountApproval = LendingApproval
+
+// billing-service serves the same libs `PendingApproval` shape (issue #5679). Before this, a
+// parked `billing.post` / `billing.reverse` four-eyes decision was discoverable only by whoever
+// had been handed its id out of band, and expired silently after the store's 24-hour TTL.
+type BillingApproval = LendingApproval
+
+// consent-service serves the same libs `PendingApproval` shape (issue #5679), for the gated
+// `consent.grant` / `consent.revoke` actions.
+type ConsentApproval = LendingApproval
 
 type AgentProposal = {
   id: string
@@ -327,6 +334,36 @@ async function accountPending(headers: HeadersInit): Promise<SourceResult> {
   }
 }
 
+async function billingPending(headers: HeadersInit): Promise<SourceResult> {
+  const res = await fetch(serverSvcUrl('billing-service', 'billing', 8132, '/api/v1/fees/approvals', { limit: '50' }), {
+    headers, signal: AbortSignal.timeout(4000), cache: 'no-store',
+  })
+  if (!res.ok) return { items: [], state: stateFor(res.status) }
+  const rows = (await res.json()) as BillingApproval[]
+  return {
+    state: 'ok',
+    items: rows.map(r => ({
+      id: r.id, domain: 'billing' as const, action: r.action,
+      resourceId: r.resourceId, maker: r.makerId, proposedAt: r.createdAt,
+    })),
+  }
+}
+
+async function consentPending(headers: HeadersInit): Promise<SourceResult> {
+  const res = await fetch(serverSvcUrl('consent-service', 'consent', 8106, '/api/v1/consents/approvals', { limit: '50' }), {
+    headers, signal: AbortSignal.timeout(4000), cache: 'no-store',
+  })
+  if (!res.ok) return { items: [], state: stateFor(res.status) }
+  const rows = (await res.json()) as ConsentApproval[]
+  return {
+    state: 'ok',
+    items: rows.map(r => ({
+      id: r.id, domain: 'consent' as const, action: r.action,
+      resourceId: r.resourceId, maker: r.makerId, proposedAt: r.createdAt,
+    })),
+  }
+}
+
 function agentBase(): string {
   if (process.env.SERVICES_HOST === 'container') return 'http://openbank-agent-service:8109'
   return (process.env.AGENT_SERVICE_URL ?? 'http://localhost:8109/mcp').replace(/\/mcp$/, '')
@@ -354,7 +391,7 @@ export async function GET() {
   }
   const headers = { authorization: `Bearer ${session.user.accessToken}` }
   const unavailable: SourceResult = { items: [], state: 'unavailable' }
-  const [lending, sanctions, transaction, domesticPayment, clearing, fx, ledger, swift, sepaPayment, sepaInstant, notification, party, account, agent] = await Promise.all([
+  const [lending, sanctions, transaction, domesticPayment, clearing, fx, ledger, swift, sepaPayment, sepaInstant, notification, party, account, billing, consent, agent] = await Promise.all([
     lendingPending(headers).catch(() => unavailable),
     sanctionsPending(headers).catch(() => unavailable),
     transactionPending(headers).catch(() => unavailable),
@@ -368,9 +405,11 @@ export async function GET() {
     notificationPending(headers).catch(() => unavailable),
     partyPending(headers).catch(() => unavailable),
     accountPending(headers).catch(() => unavailable),
+    billingPending(headers).catch(() => unavailable),
+    consentPending(headers).catch(() => unavailable),
     agentPending(headers).catch(() => unavailable),
   ])
-  const items = [...lending.items, ...sanctions.items, ...transaction.items, ...domesticPayment.items, ...clearing.items, ...fx.items, ...ledger.items, ...swift.items, ...sepaPayment.items, ...sepaInstant.items, ...notification.items, ...party.items, ...account.items, ...agent.items]
+  const items = [...lending.items, ...sanctions.items, ...transaction.items, ...domesticPayment.items, ...clearing.items, ...fx.items, ...ledger.items, ...swift.items, ...sepaPayment.items, ...sepaInstant.items, ...notification.items, ...party.items, ...account.items, ...billing.items, ...consent.items, ...agent.items]
     .sort((a, b) => (a.proposedAt ?? '').localeCompare(b.proposedAt ?? ''))
   return NextResponse.json({
     items,
@@ -389,6 +428,8 @@ export async function GET() {
       notification: notification.state,
       party: party.state,
       account: account.state,
+      billing: billing.state,
+      consent: consent.state,
       agent: agent.state,
     },
   })

--- a/openbank-admin-ui/src/test/approvals-inbox.test.ts
+++ b/openbank-admin-ui/src/test/approvals-inbox.test.ts
@@ -106,6 +106,16 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
           { id: 'A-1', action: 'account.freeze', resourceId: 'account-7', makerId: 'operator.h', createdAt: '2026-07-29T11:50:00Z' },
         ]), { status: 200 }))
       }
+      if (url.includes('fees/approvals') || url.includes('billing-service')) {
+        return Promise.resolve(new Response(JSON.stringify([
+          { id: 'B-1', action: 'billing.post', resourceId: 'fee-7', makerId: 'operator.i', createdAt: '2026-07-29T11:55:00Z' },
+        ]), { status: 200 }))
+      }
+      if (url.includes('consents/approvals') || url.includes('consent-service')) {
+        return Promise.resolve(new Response(JSON.stringify([
+          { id: 'CO-1', action: 'consent.revoke', resourceId: 'consent-7', makerId: 'operator.j', createdAt: '2026-07-29T11:57:00Z' },
+        ]), { status: 200 }))
+      }
       return Promise.resolve(new Response(JSON.stringify([
         { id: 'P-1', suggestedAction: 'agent.research', proposedBy: 'ui-assistant', proposedAt: '2026-07-30T08:00:00Z' },
       ]), { status: 200 }))
@@ -118,7 +128,7 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     // sepaPayment); F-1 and I-1 both sit at 11:30 (fx before sepa-instant) — both ties resolved
     // by the stable-sort's concat order in route.ts. N-1 sits at 10:30, between L-1 and the
     // 11:00 tie.
-    expect(body.items.map((i: { id: string }) => i.id)).toEqual(['L-1', 'N-1', 'D-1', 'C-1', 'J-1', 'W-1', 'SP-1', 'F-1', 'I-1', 'PT-1', 'A-1', 'S-1', 'P-1', 'T-1', 'L-2'])
+    expect(body.items.map((i: { id: string }) => i.id)).toEqual(['L-1', 'N-1', 'D-1', 'C-1', 'J-1', 'W-1', 'SP-1', 'F-1', 'I-1', 'PT-1', 'A-1', 'B-1', 'CO-1', 'S-1', 'P-1', 'T-1', 'L-2'])
     expect(body.items[0]).toMatchObject({ domain: 'lending', action: 'lending.writeoff', maker: 'officer.a' })
     expect(body.items[1]).toMatchObject({ domain: 'notification', action: 'opsmessage.compose', maker: 'operator.f' })
     expect(body.items[2]).toMatchObject({ domain: 'domestic-payment', action: 'domestic-payment.transitionStatus', maker: 'operator.d' })
@@ -130,11 +140,15 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(body.items[8]).toMatchObject({ domain: 'sepa-instant', action: 'sctInstPayment.recall', maker: 'operator.e' })
     expect(body.items[9]).toMatchObject({ domain: 'party', action: 'party.merge', maker: 'operator.g' })
     expect(body.items[10]).toMatchObject({ domain: 'account', action: 'account.freeze', maker: 'operator.h' })
-    expect(body.items[11]).toMatchObject({ domain: 'sanctions', action: 'sanctions.clear', maker: 'analyst.c' })
-    expect(body.items[12]).toMatchObject({ domain: 'agent', action: 'agent.research' })
-    expect(body.items[13]).toMatchObject({ domain: 'transaction', action: 'transaction.reverse', maker: 'teller.d' })
+    expect(body.items[11]).toMatchObject({ domain: 'billing', action: 'billing.post', maker: 'operator.i' })
+    expect(body.items[12]).toMatchObject({ domain: 'consent', action: 'consent.revoke', maker: 'operator.j' })
+    expect(body.items[13]).toMatchObject({ domain: 'sanctions', action: 'sanctions.clear', maker: 'analyst.c' })
+    expect(body.items[14]).toMatchObject({ domain: 'agent', action: 'agent.research' })
+    expect(body.items[15]).toMatchObject({ domain: 'transaction', action: 'transaction.reverse', maker: 'teller.d' })
     expect(body.sources.party).toBe('ok')
     expect(body.sources.account).toBe('ok')
+    expect(body.sources.billing).toBe('ok')
+    expect(body.sources.consent).toBe('ok')
   })
 
   // The regression this file exists to prevent, stated as a test for the transaction slice of
@@ -314,6 +328,24 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
 
     expect(seen.some(u => u.includes('/api/v1/parties/approvals'))).toBe(true)
     expect(body.sources.party).toBe('ok')
+  })
+
+  it('reads the billing and consent queues at all — a not-configured source must never linger once the read exists', async () => {
+    const seen: string[] = []
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      seen.push(String(url))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    }))
+
+    const body = await (await (await route()).GET()).json()
+
+    expect(seen.some(u => u.includes('/api/v1/fees/approvals'))).toBe(true)
+    expect(seen.some(u => u.includes('/api/v1/consents/approvals'))).toBe(true)
+    expect(body.sources.billing).toBe('ok')
+    expect(body.sources.consent).toBe('ok')
+    // balance is the one remaining service with a decide endpoint and no pending read (#5679);
+    // it must keep reporting not-configured rather than a healthy-looking empty queue.
+    expect(body.sources.balance).toBe('not-configured')
   })
 
   it('reads the account queue at all — an unread money-path source must never look empty', async () => {

--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/rest/ApprovalResource.kt
@@ -10,11 +10,14 @@ import com.openbank.libs.authz.Authorize
 import io.quarkus.security.identity.SecurityIdentity
 import jakarta.annotation.security.RolesAllowed
 import jakarta.inject.Inject
+import jakarta.ws.rs.DefaultValue
+import jakarta.ws.rs.GET
 import jakarta.ws.rs.NotFoundException
 import jakarta.ws.rs.PATCH
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.openapi.annotations.Operation
@@ -35,6 +38,22 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
 
     @Inject
     lateinit var identity: SecurityIdentity
+
+    /**
+     * FIFO checker queue for gated fee-posting approvals (issue #5679). Without this read a parked
+     * `billing.post` / `billing.reverse` decision is discoverable only by whoever was handed its
+     * approval id out of band, and it silently expires after the shared store's 24-hour TTL. The
+     * read is deliberately separate from disposal: deciding still requires the PATCH below and the
+     * shared store's maker != checker invariant.
+     */
+    @GET
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "billing.approval.read", resource = "")
+    @Operation(summary = "List pending billing approvals, oldest first (ADR-0227 D2)")
+    suspend fun listPending(@QueryParam("limit") @DefaultValue("50") limit: Int): Response {
+        val pending = approvalStore.findPending(limit.coerceIn(1, MAX_PENDING_LIMIT))
+        return Response.ok(pending.map { it.toResponse() }).build()
+    }
 
     @PATCH
     @Path("/{id}")
@@ -59,6 +78,11 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     // their own request. SecurityIdentity (not @Context SecurityContext) since this is a
     // `suspend fun` — see AccountResource.operatorId() for the same workaround.
     private fun checkerId(): String = identity.principal?.name ?: "anonymous"
+
+    private companion object {
+        /** ApprovalStore scans Redis; keep the caller-controlled result bounded. */
+        const val MAX_PENDING_LIMIT = 200
+    }
 }
 
 data class DecideApprovalRequest(val approve: Boolean)
@@ -68,6 +92,8 @@ data class ApprovalResponse(
     val action: String,
     val resourceId: String?,
     val status: String,
+    val makerId: String?,
+    val createdAt: String?,
     val decidedBy: String?,
 )
 
@@ -76,5 +102,7 @@ fun PendingApproval.toResponse() = ApprovalResponse(
     action = action,
     resourceId = resourceId,
     status = status.name,
+    makerId = makerId,
+    createdAt = createdAt.toString(),
     decidedBy = decidedBy,
 )

--- a/openbank-billing-service/src/main/resources/openapi.yaml
+++ b/openbank-billing-service/src/main/resources/openapi.yaml
@@ -6,7 +6,7 @@ info:
   title: Billing Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.2 -> 1.3): additive
   # endpoint only (POST /fees/reverse) — phase 2e, no breaking change.
-  version: 1.4.0
+  version: 1.5.0
   description: >-
     Runtime product fee assessment, posting and reversal (ADR-0143). POST /api/v1/fees/assess
     computes an account's fee assessment from live account/balance/catalog reads and returns it
@@ -137,6 +137,38 @@ paths:
           description: No assessed fee with that idempotencyKey.
         "409":
           description: The fee exists but was never POSTED (waived, zero, still PENDING, or FAILED) — nothing to reverse.
+  /api/v1/fees/approvals:
+    get:
+      summary: List pending fee-posting approvals, oldest first (ADR-0227 D2).
+      description: >-
+        PENDING maker-checker approvals for gated fee actions (billing.post / billing.reverse),
+        oldest first. This is the read side consumed by the unified approval inbox; deciding
+        remains on PATCH /api/v1/fees/approvals/{id}. Requires ROLE_OPERATOR or ROLE_ADMIN.
+      operationId: listPendingApprovals
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+      responses:
+        "200":
+          description: Pending fee-posting approvals, oldest first.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApprovalResponse'
+        "401":
+          description: Unauthenticated.
+        "403":
+          description: Authenticated but denied by the OPA authorization policy (ADR-0034).
   /api/v1/fees/approvals/{id}:
     patch:
       summary: Approve or reject a pending four-eyes approval for a fee posting (ADR-0155).
@@ -163,6 +195,31 @@ paths:
         "404":
           description: No pending approval with that id.
 components:
+  schemas:
+    ApprovalResponse:
+      type: object
+      required: [id, action, status]
+      properties:
+        id:
+          type: string
+        action:
+          type: string
+          description: The gated fee action this approval was raised for.
+        resourceId:
+          type: string
+          nullable: true
+        status:
+          type: string
+        makerId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+          description: Request time; pending approvals expire after 24 hours.
+        decidedBy:
+          type: string
+          nullable: true
   securitySchemes:
     bearerAuth:
       type: http

--- a/openbank-billing-service/src/test/kotlin/com/openbank/billing/ApprovalResourceMappingTest.kt
+++ b/openbank-billing-service/src/test/kotlin/com/openbank/billing/ApprovalResourceMappingTest.kt
@@ -4,9 +4,16 @@
 
 package com.openbank.billing
 
+import com.openbank.billing.infrastructure.rest.ApprovalResource
+import com.openbank.billing.infrastructure.rest.ApprovalResponse
 import com.openbank.billing.infrastructure.rest.toResponse
 import com.openbank.libs.approval.ApprovalStatus
+import com.openbank.libs.approval.ApprovalStore
 import com.openbank.libs.approval.PendingApproval
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.OffsetDateTime
@@ -34,6 +41,8 @@ class ApprovalResourceMappingTest {
         assertThat(response.action).isEqualTo("billing.post")
         assertThat(response.resourceId).isEqualTo("acc-1")
         assertThat(response.status).isEqualTo("APPROVED")
+        assertThat(response.makerId).isEqualTo("maker")
+        assertThat(response.createdAt).isNotNull()
         assertThat(response.decidedBy).isEqualTo("checker")
     }
 
@@ -53,5 +62,46 @@ class ApprovalResourceMappingTest {
         assertThat(response.resourceId).isNull()
         assertThat(response.status).isEqualTo("PENDING")
         assertThat(response.decidedBy).isNull()
+    }
+
+    /**
+     * The read side of the unified approval inbox (issue #5679, ADR-0227 D2). `makerId` and
+     * `createdAt` are the two fields the inbox renders and neither existed on this service's
+     * response shape before, so the assertions on them are what fails if the mapping is dropped.
+     */
+    @Test
+    fun `listPending exposes the mapped checker queue`(): Unit = runBlocking {
+        val store = mockk<ApprovalStore>()
+        coEvery { store.findPending(50) } returns listOf(
+            PendingApproval(
+                id = "appr-3",
+                action = "billing.post",
+                resourceId = "fee-1",
+                makerId = "maker",
+                status = ApprovalStatus.PENDING,
+                createdAt = OffsetDateTime.parse("2026-08-23T00:00:00Z"),
+            ),
+        )
+
+        val response = ApprovalResource(store).listPending(50)
+
+        assertThat(response.status).isEqualTo(200)
+        @Suppress("UNCHECKED_CAST")
+        val body = response.entity as List<ApprovalResponse>
+        assertThat(body).hasSize(1)
+        assertThat(body.single().action).isEqualTo("billing.post")
+        assertThat(body.single().makerId).isEqualTo("maker")
+        assertThat(body.single().createdAt).isEqualTo("2026-08-23T00:00Z")
+    }
+
+    /** The store performs a Redis SCAN; a caller-controlled limit must not decide how big it is. */
+    @Test
+    fun `listPending clamps a caller-controlled limit`(): Unit = runBlocking {
+        val store = mockk<ApprovalStore>()
+        coEvery { store.findPending(200) } returns emptyList()
+
+        ApprovalResource(store).listPending(10_000)
+
+        coVerify(exactly = 1) { store.findPending(200) }
     }
 }

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ApprovalResource.kt
@@ -10,11 +10,14 @@ import com.openbank.libs.authz.Authorize
 import io.quarkus.security.identity.SecurityIdentity
 import jakarta.annotation.security.RolesAllowed
 import jakarta.inject.Inject
+import jakarta.ws.rs.DefaultValue
+import jakarta.ws.rs.GET
 import jakarta.ws.rs.NotFoundException
 import jakarta.ws.rs.PATCH
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.openapi.annotations.Operation
@@ -37,6 +40,22 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
 
     @Inject
     lateinit var identity: SecurityIdentity
+
+    /**
+     * FIFO checker queue for gated consent approvals (issue #5679). Without this read a parked
+     * `consent.grant` / `consent.revoke` decision is discoverable only by whoever was handed its
+     * approval id out of band, and it silently expires after the shared store's 24-hour TTL. The
+     * read is deliberately separate from disposal: deciding still requires the PATCH below and the
+     * shared store's maker != checker invariant.
+     */
+    @GET
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "consent.approval.read", resource = "")
+    @Operation(summary = "List pending consent approvals, oldest first (ADR-0227 D2)")
+    suspend fun listPending(@QueryParam("limit") @DefaultValue("50") limit: Int): Response {
+        val pending = approvalStore.findPending(limit.coerceIn(1, MAX_PENDING_LIMIT))
+        return Response.ok(pending.map { it.toResponse() }).build()
+    }
 
     @PATCH
     @Path("/{id}")
@@ -61,6 +80,11 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     // their own request. SecurityIdentity (not @Context SecurityContext) since this is a
     // `suspend fun` — mirrors billing-service's ApprovalResource.
     private fun checkerId(): String = identity.principal?.name ?: "anonymous"
+
+    private companion object {
+        /** ApprovalStore scans Redis; keep the caller-controlled result bounded. */
+        const val MAX_PENDING_LIMIT = 200
+    }
 }
 
 data class DecideApprovalRequest(val approve: Boolean)
@@ -70,6 +94,8 @@ data class ApprovalResponse(
     val action: String,
     val resourceId: String?,
     val status: String,
+    val makerId: String?,
+    val createdAt: String?,
     val decidedBy: String?,
 )
 
@@ -78,5 +104,7 @@ fun PendingApproval.toResponse() = ApprovalResponse(
     action = action,
     resourceId = resourceId,
     status = status.name,
+    makerId = makerId,
+    createdAt = createdAt.toString(),
     decidedBy = decidedBy,
 )

--- a/openbank-consent-service/src/main/resources/openapi.yaml
+++ b/openbank-consent-service/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Consent Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.0 -> 1.1): additive
   # endpoint only (PATCH /approvals/{id}, ADR-0155 four-eyes) — no breaking change.
-  version: 1.7.0
+  version: 1.8.0
   description: >-
     Data sharing consent lifecycle — create, activate, reject, revoke, validate. PATCH
     /approvals/{id} decides a four-eyes approval paused by the platform's ADR-0155 maker-checker
@@ -253,6 +253,37 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /api/v1/consents/approvals:
+    get:
+      tags: [Consents]
+      summary: List pending consent approvals, oldest first (ADR-0227 D2)
+      description: >-
+        PENDING maker-checker approvals for gated consent actions (consent.grant /
+        consent.revoke), oldest first. This is the read side consumed by the unified approval
+        inbox; deciding remains on PATCH /api/v1/consents/approvals/{id}. Requires ROLE_OPERATOR
+        or ROLE_ADMIN.
+      operationId: listPendingApprovals
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+      responses:
+        '200':
+          description: Pending consent approvals, oldest first
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApprovalResponse'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
   /api/v1/consents/approvals/{id}:
     patch:
       tags: [Consents]
@@ -387,6 +418,31 @@ components:
             $ref: '#/components/schemas/ApiError'
 
   schemas:
+    ApprovalResponse:
+      type: object
+      required: [id, action, status]
+      properties:
+        id:
+          type: string
+        action:
+          type: string
+          description: The gated consent action this approval was raised for.
+        resourceId:
+          type: string
+          nullable: true
+        status:
+          type: string
+        makerId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+          description: Request time; pending approvals expire after 24 hours.
+        decidedBy:
+          type: string
+          nullable: true
+
     CreateConsentRequest:
       type: object
       required: [partyId, granteeId, scopes, expiresAt]

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/ApprovalResourceMappingTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/ApprovalResourceMappingTest.kt
@@ -4,9 +4,16 @@
 
 package com.openbank.consent
 
+import com.openbank.consent.infrastructure.rest.ApprovalResource
+import com.openbank.consent.infrastructure.rest.ApprovalResponse
 import com.openbank.consent.infrastructure.rest.toResponse
 import com.openbank.libs.approval.ApprovalStatus
+import com.openbank.libs.approval.ApprovalStore
 import com.openbank.libs.approval.PendingApproval
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.OffsetDateTime
@@ -34,6 +41,8 @@ class ApprovalResourceMappingTest {
         assertThat(response.action).isEqualTo("consent.grant")
         assertThat(response.resourceId).isEqualTo("consent-1")
         assertThat(response.status).isEqualTo("APPROVED")
+        assertThat(response.makerId).isEqualTo("maker")
+        assertThat(response.createdAt).isNotNull()
         assertThat(response.decidedBy).isEqualTo("checker")
     }
 
@@ -53,5 +62,46 @@ class ApprovalResourceMappingTest {
         assertThat(response.resourceId).isNull()
         assertThat(response.status).isEqualTo("PENDING")
         assertThat(response.decidedBy).isNull()
+    }
+
+    /**
+     * The read side of the unified approval inbox (issue #5679, ADR-0227 D2). `makerId` and
+     * `createdAt` are the two fields the inbox renders and neither existed on this service's
+     * response shape before, so the assertions on them are what fails if the mapping is dropped.
+     */
+    @Test
+    fun `listPending exposes the mapped checker queue`(): Unit = runBlocking {
+        val store = mockk<ApprovalStore>()
+        coEvery { store.findPending(50) } returns listOf(
+            PendingApproval(
+                id = "appr-3",
+                action = "consent.revoke",
+                resourceId = "consent-1",
+                makerId = "maker",
+                status = ApprovalStatus.PENDING,
+                createdAt = OffsetDateTime.parse("2026-08-23T00:00:00Z"),
+            ),
+        )
+
+        val response = ApprovalResource(store).listPending(50)
+
+        assertThat(response.status).isEqualTo(200)
+        @Suppress("UNCHECKED_CAST")
+        val body = response.entity as List<ApprovalResponse>
+        assertThat(body).hasSize(1)
+        assertThat(body.single().action).isEqualTo("consent.revoke")
+        assertThat(body.single().makerId).isEqualTo("maker")
+        assertThat(body.single().createdAt).isEqualTo("2026-08-23T00:00Z")
+    }
+
+    /** The store performs a Redis SCAN; a caller-controlled limit must not decide how big it is. */
+    @Test
+    fun `listPending clamps a caller-controlled limit`(): Unit = runBlocking {
+        val store = mockk<ApprovalStore>()
+        coEvery { store.findPending(200) } returns emptyList()
+
+        ApprovalResource(store).listPending(10_000)
+
+        coVerify(exactly = 1) { store.findPending(200) }
     }
 }


### PR DESCRIPTION
## What

Closes the last two non-money-path gaps in the unified approval inbox (ADR-0227 D2): **billing-service** and **consent-service** now serve their pending maker-checker queue, and the admin-UI BFF federates them for real instead of reporting them `not-configured`.

## Re-verified count (read from `origin/main`, not the working copy)

- 16 services carry `infrastructure/rest/ApprovalResource.kt`.
- **13** call `approvalStore.findPending` — account, clearing, domestic-payment, fx, ledger, lending, notification, party, sanctions, sepa-instant, sepa-payment, swift, transaction.
- **3** did not: `balance`, `billing`, `consent`. This PR does the two non-money-path ones. `balance` is money-path and is a **separate PR** (`feat/approvals-inbox-balance`), so it can be reviewed and held on its own terms.

## `route.ts` source count

| | fetchers (`*Pending`) | keys in `sources` |
|---|---|---|
| before | 14 | 17 (14 read + 3 `not-configured`) |
| after | **16** | 17 (16 read + 1 `not-configured`: `balance`) |

The BFF route is contended — several open PRs add sources to this same list, and two sides adding neighbouring entries to one list **merge clean and keep only one** (the release manifest went 56 -> 55 here that way). The counts above are the check to re-run after any merge. `approvals-inbox.test.ts` asserts the whole ordered id list with `toEqual([...])`, so it changes on every addition.

## Shape

Matched to the 13 existing implementations rather than invented — `openbank-account-service` and `openbank-party-service` were read first and the idiom copied exactly:

- `@GET` + `@RolesAllowed("ROLE_OPERATOR","ROLE_ADMIN")` + `@Authorize(action = "<domain>.approval.read")`, `limit.coerceIn(1, MAX_PENDING_LIMIT=200)`.
- `ApprovalResponse` gains `makerId` and `createdAt` — the two fields the inbox actually renders, and neither existed on these two services' response shape.
- **No OPA change needed**, same as account/party: base `rest.rego`'s `operator-read-any` admits any action ending `.read`, and both services' `*_rest_ext.rego` already grant operators `startswith(input.action, "<domain>.")`.
- `openapi.yaml` additive minor bump (billing 1.4.0 -> 1.5.0, consent 1.7.0 -> 1.8.0) + an `ApprovalResponse` schema.

## Proof by what it prevents

Red first, against **unmodified `origin/main`'s `route.ts`** with the new tests in place:

```
RED_RC=1   Tests  2 failed | 16 passed (18)
```

Green with the change restored:

```
GREEN_RC=0  Test Files 2 passed  Tests 21 passed (21)
```

Full admin-ui suite: `400 passed | 1 failed (401)`, `2053 passed | 1 skipped`. The one failure is `temporal-shipped-claims.guard.test.ts` — a 5s vitest timeout on a guard that walks the whole Kotlin tree, unrelated to this change and reproducible on a contended machine. `npx tsc --noEmit` is clean (0 errors).

Refs #5679
