### PR TITLE
feat(balance): expose pending approvals in the unified inbox

### DIFF
--- a/docs/threat-models/openbank-balance-service.md
+++ b/docs/threat-models/openbank-balance-service.md
@@ -173,6 +173,25 @@ also be deleted (nothing else in balance-service depends on it).
 
 ## 7. Change log
 
+- **2026-09-01** — The operator approval inbox gains a bounded, read-only
+  `GET /api/v1/balances/approvals` edge (issue #5679, ADR-0227 D2). It returns only the pending
+  approval id, action, resource id, maker id and creation time, to callers already holding
+  `ROLE_OPERATOR` or `ROLE_ADMIN`, behind the same OPA boundary as the checker decision endpoint
+  (`balance.approval.read`, admitted by base `rest.rego`'s `operator-read-any` on the `.read`
+  suffix — no policy change). Results are capped at 200 and ordered oldest first; the endpoint
+  cannot approve, reject or execute anything, and `ApprovalStore.decide`'s maker != checker
+  invariant, the random ids, the 24-hour Redis TTL and one-time `EXECUTED` consumption are all
+  untouched. **Risk class:** confidentiality of operator workflow metadata (account ids of parked
+  credit/debit requests become visible to any operator, not only the one holding the id out of
+  band) plus a bounded Redis SCAN load. No new principal, no service-to-service edge, no money
+  mutation. The countervailing risk it removes is the larger one: until now a parked
+  `balance.credit`/`balance.debit` decision was findable only by whoever had been handed its id,
+  and expired silently after 24 hours — a maker-checker control nobody can see is a control that
+  fails open by attrition. Deliberately NOT added: a decide button on the inbox — money-path
+  disposal additionally requires SCA (ADR-0227 D4) and stays on the per-domain flow. Rollback:
+  remove the GET route; the decision path is unaffected and the admin UI reports the balance
+  source unavailable.
+
 - **2026-08-24** — Synthetic-journey taint now propagates over this service's existing internal REST clients through `SyntheticTaintClientFilter` (ADR-0252, #4348). This adds no caller, endpoint, network-policy edge, privilege or control bypass: downstream controls still see the journey. It prevents synthetic activity from becoming indistinguishable before a downstream persistence/event boundary; a fleet gate now requires every new client to choose propagation or a reasoned external boundary.
 
 - **2026-08-05** — Prohibit the customer-edge M2M principal from balance writes (#3734). The

--- a/openbank-admin-ui/src/app/api/approvals/pending/route.ts
+++ b/openbank-admin-ui/src/app/api/approvals/pending/route.ts
@@ -17,17 +17,15 @@ export const dynamic = 'force-dynamic'
 
 type SourceState = 'ok' | 'forbidden' | 'unavailable' | 'not-configured'
 
-// These domains already persist maker-checker decisions, but do not yet expose the
-// pending-list read required by ADR-0227 D2. Keep them in the response explicitly so
-// the inbox can distinguish "not wired" from an empty queue. Omitting them would make
-// the most dangerous state look healthy to an operator.
-const NOT_CONFIGURED_SOURCES = {
-  balance: 'not-configured',
-} as const satisfies Record<string, SourceState>
-
+// Every domain that persists a maker-checker decision now also serves the pending-list read
+// required by ADR-0227 D2, so there is no longer a NOT_CONFIGURED_SOURCES set — balance was the
+// last entry (#5679). The constant is deliberately gone rather than left empty: an empty
+// placeholder invites the next unwired service to be added to a list nothing reads, and
+// "not wired" must stay distinguishable from "empty queue" by being IMPOSSIBLE to omit — a new
+// source without a fetcher fails `approvals-source-truth.guard.test.ts` and the type below.
 type InboxItem = {
   id: string
-  domain: 'lending' | 'sanctions' | 'transaction' | 'domestic-payment' | 'clearing' | 'fx' | 'ledger' | 'swift' | 'sepa-payment' | 'sepa-instant' | 'notification' | 'party' | 'account' | 'billing' | 'consent' | 'agent'
+  domain: 'lending' | 'sanctions' | 'transaction' | 'domestic-payment' | 'clearing' | 'fx' | 'ledger' | 'swift' | 'sepa-payment' | 'sepa-instant' | 'notification' | 'party' | 'account' | 'billing' | 'consent' | 'balance' | 'agent'
   action: string
   resourceId: string | null
   maker: string | null
@@ -108,6 +106,12 @@ type BillingApproval = LendingApproval
 // consent-service serves the same libs `PendingApproval` shape (issue #5679), for the gated
 // `consent.grant` / `consent.revoke` actions.
 type ConsentApproval = LendingApproval
+
+// balance-service serves the same libs `PendingApproval` shape (issue #5679). Both of its gated
+// actions MOVE MONEY (`balance.credit`, `balance.debit`), so this was the most consequential
+// remaining hole in the inbox: a parked credit/debit decision was discoverable only by whoever
+// had been handed its id out of band, and expired silently after 24 hours.
+type BalanceApproval = LendingApproval
 
 type AgentProposal = {
   id: string
@@ -364,6 +368,24 @@ async function consentPending(headers: HeadersInit): Promise<SourceResult> {
   }
 }
 
+async function balancePending(headers: HeadersInit): Promise<SourceResult> {
+  // k8s workload is `balance-service` in the `balances` namespace (plural) — see
+  // openbank-infra/gitops/components/balances/balance-service.yaml. Getting the namespace wrong
+  // here surfaces as a permanently 'unavailable' source, not an error anyone sees.
+  const res = await fetch(serverSvcUrl('balance-service', 'balances', 8103, '/api/v1/balances/approvals', { limit: '50' }), {
+    headers, signal: AbortSignal.timeout(4000), cache: 'no-store',
+  })
+  if (!res.ok) return { items: [], state: stateFor(res.status) }
+  const rows = (await res.json()) as BalanceApproval[]
+  return {
+    state: 'ok',
+    items: rows.map(r => ({
+      id: r.id, domain: 'balance' as const, action: r.action,
+      resourceId: r.resourceId, maker: r.makerId, proposedAt: r.createdAt,
+    })),
+  }
+}
+
 function agentBase(): string {
   if (process.env.SERVICES_HOST === 'container') return 'http://openbank-agent-service:8109'
   return (process.env.AGENT_SERVICE_URL ?? 'http://localhost:8109/mcp').replace(/\/mcp$/, '')
@@ -391,7 +413,7 @@ export async function GET() {
   }
   const headers = { authorization: `Bearer ${session.user.accessToken}` }
   const unavailable: SourceResult = { items: [], state: 'unavailable' }
-  const [lending, sanctions, transaction, domesticPayment, clearing, fx, ledger, swift, sepaPayment, sepaInstant, notification, party, account, billing, consent, agent] = await Promise.all([
+  const [lending, sanctions, transaction, domesticPayment, clearing, fx, ledger, swift, sepaPayment, sepaInstant, notification, party, account, billing, consent, balance, agent] = await Promise.all([
     lendingPending(headers).catch(() => unavailable),
     sanctionsPending(headers).catch(() => unavailable),
     transactionPending(headers).catch(() => unavailable),
@@ -407,14 +429,14 @@ export async function GET() {
     accountPending(headers).catch(() => unavailable),
     billingPending(headers).catch(() => unavailable),
     consentPending(headers).catch(() => unavailable),
+    balancePending(headers).catch(() => unavailable),
     agentPending(headers).catch(() => unavailable),
   ])
-  const items = [...lending.items, ...sanctions.items, ...transaction.items, ...domesticPayment.items, ...clearing.items, ...fx.items, ...ledger.items, ...swift.items, ...sepaPayment.items, ...sepaInstant.items, ...notification.items, ...party.items, ...account.items, ...billing.items, ...consent.items, ...agent.items]
+  const items = [...lending.items, ...sanctions.items, ...transaction.items, ...domesticPayment.items, ...clearing.items, ...fx.items, ...ledger.items, ...swift.items, ...sepaPayment.items, ...sepaInstant.items, ...notification.items, ...party.items, ...account.items, ...billing.items, ...consent.items, ...balance.items, ...agent.items]
     .sort((a, b) => (a.proposedAt ?? '').localeCompare(b.proposedAt ?? ''))
   return NextResponse.json({
     items,
     sources: {
-      ...NOT_CONFIGURED_SOURCES,
       lending: lending.state,
       sanctions: sanctions.state,
       transaction: transaction.state,
@@ -430,6 +452,7 @@ export async function GET() {
       account: account.state,
       billing: billing.state,
       consent: consent.state,
+      balance: balance.state,
       agent: agent.state,
     },
   })

--- a/openbank-admin-ui/src/test/approvals-inbox.test.ts
+++ b/openbank-admin-ui/src/test/approvals-inbox.test.ts
@@ -116,6 +116,11 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
           { id: 'CO-1', action: 'consent.revoke', resourceId: 'consent-7', makerId: 'operator.j', createdAt: '2026-07-29T11:57:00Z' },
         ]), { status: 200 }))
       }
+      if (url.includes('balances/approvals') || url.includes('balance-service')) {
+        return Promise.resolve(new Response(JSON.stringify([
+          { id: 'BA-1', action: 'balance.debit', resourceId: 'account-9', makerId: 'operator.k', createdAt: '2026-07-29T11:58:00Z' },
+        ]), { status: 200 }))
+      }
       return Promise.resolve(new Response(JSON.stringify([
         { id: 'P-1', suggestedAction: 'agent.research', proposedBy: 'ui-assistant', proposedAt: '2026-07-30T08:00:00Z' },
       ]), { status: 200 }))
@@ -128,7 +133,7 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     // sepaPayment); F-1 and I-1 both sit at 11:30 (fx before sepa-instant) — both ties resolved
     // by the stable-sort's concat order in route.ts. N-1 sits at 10:30, between L-1 and the
     // 11:00 tie.
-    expect(body.items.map((i: { id: string }) => i.id)).toEqual(['L-1', 'N-1', 'D-1', 'C-1', 'J-1', 'W-1', 'SP-1', 'F-1', 'I-1', 'PT-1', 'A-1', 'B-1', 'CO-1', 'S-1', 'P-1', 'T-1', 'L-2'])
+    expect(body.items.map((i: { id: string }) => i.id)).toEqual(['L-1', 'N-1', 'D-1', 'C-1', 'J-1', 'W-1', 'SP-1', 'F-1', 'I-1', 'PT-1', 'A-1', 'B-1', 'CO-1', 'BA-1', 'S-1', 'P-1', 'T-1', 'L-2'])
     expect(body.items[0]).toMatchObject({ domain: 'lending', action: 'lending.writeoff', maker: 'officer.a' })
     expect(body.items[1]).toMatchObject({ domain: 'notification', action: 'opsmessage.compose', maker: 'operator.f' })
     expect(body.items[2]).toMatchObject({ domain: 'domestic-payment', action: 'domestic-payment.transitionStatus', maker: 'operator.d' })
@@ -142,13 +147,15 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(body.items[10]).toMatchObject({ domain: 'account', action: 'account.freeze', maker: 'operator.h' })
     expect(body.items[11]).toMatchObject({ domain: 'billing', action: 'billing.post', maker: 'operator.i' })
     expect(body.items[12]).toMatchObject({ domain: 'consent', action: 'consent.revoke', maker: 'operator.j' })
-    expect(body.items[13]).toMatchObject({ domain: 'sanctions', action: 'sanctions.clear', maker: 'analyst.c' })
-    expect(body.items[14]).toMatchObject({ domain: 'agent', action: 'agent.research' })
-    expect(body.items[15]).toMatchObject({ domain: 'transaction', action: 'transaction.reverse', maker: 'teller.d' })
+    expect(body.items[13]).toMatchObject({ domain: 'balance', action: 'balance.debit', maker: 'operator.k' })
+    expect(body.items[14]).toMatchObject({ domain: 'sanctions', action: 'sanctions.clear', maker: 'analyst.c' })
+    expect(body.items[15]).toMatchObject({ domain: 'agent', action: 'agent.research' })
+    expect(body.items[16]).toMatchObject({ domain: 'transaction', action: 'transaction.reverse', maker: 'teller.d' })
     expect(body.sources.party).toBe('ok')
     expect(body.sources.account).toBe('ok')
     expect(body.sources.billing).toBe('ok')
     expect(body.sources.consent).toBe('ok')
+    expect(body.sources.balance).toBe('ok')
   })
 
   // The regression this file exists to prevent, stated as a test for the transaction slice of
@@ -343,9 +350,24 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(seen.some(u => u.includes('/api/v1/consents/approvals'))).toBe(true)
     expect(body.sources.billing).toBe('ok')
     expect(body.sources.consent).toBe('ok')
-    // balance is the one remaining service with a decide endpoint and no pending read (#5679);
-    // it must keep reporting not-configured rather than a healthy-looking empty queue.
-    expect(body.sources.balance).toBe('not-configured')
+    // balance was the last service with a decide endpoint and no pending read (#5679); it now
+    // serves one, so every source in the response is genuinely read and 'not-configured' is no
+    // longer reachable for any of them.
+    expect(body.sources.balance).toBe('ok')
+    expect(Object.values(body.sources)).not.toContain('not-configured')
+  })
+
+  it('reads the balance queue at all — both its gated actions move money', async () => {
+    const seen: string[] = []
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      seen.push(String(url))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    }))
+
+    const body = await (await (await route()).GET()).json()
+
+    expect(seen.some(u => u.includes('/api/v1/balances/approvals'))).toBe(true)
+    expect(body.sources.balance).toBe('ok')
   })
 
   it('reads the account queue at all — an unread money-path source must never look empty', async () => {

--- a/openbank-admin-ui/src/test/approvals-source-truth.guard.test.ts
+++ b/openbank-admin-ui/src/test/approvals-source-truth.guard.test.ts
@@ -9,10 +9,32 @@ const routeSource = fs.readFileSync(path.join(process.cwd(), 'src/app/api/approv
 const pageSource = fs.readFileSync(path.join(process.cwd(), 'src/app/approvals/page.tsx'), 'utf8')
 
 describe('approval inbox source truthfulness', () => {
-  it('exposes known-but-unwired queues instead of treating them as empty', () => {
-    expect(routeSource).toContain("'not-configured'")
-    expect(routeSource).toContain("balance: 'not-configured'")
-    expect(routeSource).toContain('...NOT_CONFIGURED_SOURCES')
+  // Was three `toContain` string assertions naming `balance: 'not-configured'` and the
+  // NOT_CONFIGURED_SOURCES spread. Once balance gained its read (#5679) that set is empty and
+  // gone, and those assertions would have had to be deleted — leaving nothing behind. A guard
+  // that asserts a literal only ever describes the state it was written in; this one asserts the
+  // invariant that state existed to protect: every domain the route can EMIT is a domain the
+  // route actually READS. A source added to the response without a fetcher — the shape that made
+  // an unwired queue render as an empty one — fails here regardless of what it is called.
+  it('reads every source it reports, so no queue can render as empty without being read', () => {
+    const declaredDomains = [...routeSource.matchAll(/domain: '([\w-]+)' as const/g)].map(m => m[1])
+    const fetchers = [...routeSource.matchAll(/^async function (\w+)Pending/gm)].map(m => m[1])
+    const reported = [...routeSource.matchAll(/^ {6}'?([\w-]+)'?: (\w+)\.state,$/gm)].map(m => m[2])
+
+    expect(declaredDomains.length).toBeGreaterThan(15)
+    // Every reported source is backed by a fetcher of the same name...
+    expect([...new Set(reported)].sort()).toEqual([...new Set(fetchers)].sort())
+    // ...and every fetcher is awaited in the fan-out rather than declared and forgotten.
+    for (const f of fetchers) {
+      expect(routeSource).toContain(`${f}Pending(headers).catch(() => unavailable)`)
+    }
+  })
+
+  it('still distinguishes an unreadable source from an empty one', () => {
+    // `stateFor` is the whole reason a 403 does not read as "no approvals pending" — the most
+    // dangerous thing an approvals screen can say wrongly.
+    expect(routeSource).toContain("return status === 401 || status === 403 ? 'forbidden' : 'unavailable'")
+    expect(routeSource).toContain("const unavailable: SourceResult = { items: [], state: 'unavailable' }")
   })
 
   it('does not render an empty-state claim while a source is not configured', () => {

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/rest/ApprovalResource.kt
@@ -11,11 +11,14 @@ import com.openbank.libs.security.Roles
 import io.quarkus.security.identity.SecurityIdentity
 import jakarta.annotation.security.RolesAllowed
 import jakarta.inject.Inject
+import jakarta.ws.rs.DefaultValue
+import jakarta.ws.rs.GET
 import jakarta.ws.rs.NotFoundException
 import jakarta.ws.rs.PATCH
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.openapi.annotations.Operation
@@ -38,6 +41,25 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
 
     @Inject
     lateinit var identity: SecurityIdentity
+
+    /**
+     * FIFO checker queue for gated balance approvals (issue #5679) — the last of the sixteen
+     * services with a decide endpoint to gain the matching read. Both gated actions here MOVE
+     * MONEY (`balance.credit`, `balance.debit`), so a parked decision that nobody can find is the
+     * worst version of this defect in the fleet: it was discoverable only by whoever had been
+     * handed its approval id out of band, and expired silently after the shared store's 24-hour
+     * TTL. The read is strictly separate from disposal — deciding still requires the PATCH below,
+     * and [ApprovalStore.decide]'s maker != checker invariant is untouched. Seeing a request has
+     * never been authority to decide it.
+     */
+    @GET
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "balance.approval.read", resource = "")
+    @Operation(summary = "List pending balance approvals, oldest first (ADR-0227 D2)")
+    suspend fun listPending(@QueryParam("limit") @DefaultValue("50") limit: Int): Response {
+        val pending = approvalStore.findPending(limit.coerceIn(1, MAX_PENDING_LIMIT))
+        return Response.ok(pending.map { it.toResponse() }).build()
+    }
 
     @PATCH
     @Path("/{id}")
@@ -63,6 +85,11 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     // own request. SecurityIdentity (not @Context SecurityContext) because this is
     // a `suspend fun` — see AccountResource.operatorId() for the same workaround.
     private fun checkerId(): String = identity.principal?.name ?: "anonymous"
+
+    private companion object {
+        /** ApprovalStore scans Redis; keep the caller-controlled result bounded. */
+        const val MAX_PENDING_LIMIT = 200
+    }
 }
 
 data class DecideApprovalRequest(val approve: Boolean)
@@ -72,6 +99,8 @@ data class ApprovalResponse(
     val action: String,
     val resourceId: String?,
     val status: String,
+    val makerId: String?,
+    val createdAt: String?,
     val decidedBy: String?,
 )
 
@@ -80,5 +109,7 @@ fun PendingApproval.toResponse() = ApprovalResponse(
     action = action,
     resourceId = resourceId,
     status = status.name,
+    makerId = makerId,
+    createdAt = createdAt.toString(),
     decidedBy = decidedBy,
 )

--- a/openbank-balance-service/src/main/resources/openapi.yaml
+++ b/openbank-balance-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Balance Service API
-  version: 1.8.0
+  version: 1.9.0
   description: >-
     Account balance management — holds, credits, debits, multi-currency. Per ADR-0039 (Phase A) a
     read-only reconciliation ties out, per currency, the ledger deposit-control balance against the
@@ -274,6 +274,37 @@ paths:
         '404':
           description: No reconciliation has been run yet
 
+  /api/v1/balances/approvals:
+    get:
+      tags: [Balances]
+      summary: List pending balance approvals, oldest first (ADR-0227 D2)
+      description: >-
+        PENDING maker-checker approvals for the gated money-moving actions balance.credit and
+        balance.debit, oldest first. This is the read side consumed by the unified approval inbox;
+        deciding remains on PATCH /api/v1/balances/approvals/{id}. Read-only — it cannot approve,
+        reject or execute anything. Requires ROLE_OPERATOR or ROLE_ADMIN.
+      operationId: listPendingApprovals
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+      responses:
+        '200':
+          description: Pending balance approvals, oldest first
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApprovalResponse'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
   /api/v1/balances/approvals/{id}:
     patch:
       tags: [Balances]
@@ -356,6 +387,31 @@ components:
             $ref: '#/components/schemas/ApiError'
 
   schemas:
+    ApprovalResponse:
+      type: object
+      required: [id, action, status]
+      properties:
+        id:
+          type: string
+        action:
+          type: string
+          description: The gated balance action this approval was raised for.
+        resourceId:
+          type: string
+          nullable: true
+        status:
+          type: string
+        makerId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+          description: Request time; pending approvals expire after 24 hours.
+        decidedBy:
+          type: string
+          nullable: true
+
     BalanceResponse:
       type: object
       properties:

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/infrastructure/rest/ApprovalResourceMappingTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/infrastructure/rest/ApprovalResourceMappingTest.kt
@@ -5,7 +5,12 @@
 package com.openbank.balance.infrastructure.rest
 
 import com.openbank.libs.approval.ApprovalStatus
+import com.openbank.libs.approval.ApprovalStore
 import com.openbank.libs.approval.PendingApproval
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.OffsetDateTime
@@ -33,6 +38,8 @@ class ApprovalResourceMappingTest {
         assertThat(response.action).isEqualTo("balance.credit")
         assertThat(response.resourceId).isEqualTo("acc-1")
         assertThat(response.status).isEqualTo("APPROVED")
+        assertThat(response.makerId).isEqualTo("maker")
+        assertThat(response.createdAt).isEqualTo("2026-07-11T23:00Z")
         assertThat(response.decidedBy).isEqualTo("checker")
     }
 
@@ -52,5 +59,46 @@ class ApprovalResourceMappingTest {
         assertThat(response.resourceId).isNull()
         assertThat(response.status).isEqualTo("PENDING")
         assertThat(response.decidedBy).isNull()
+    }
+
+    /**
+     * The read side of the unified approval inbox (issue #5679, ADR-0227 D2). `makerId` and
+     * `createdAt` are the two fields the inbox renders and neither existed on this service's
+     * response shape before, so the assertions on them are what fails if the mapping is dropped.
+     */
+    @Test
+    fun `listPending exposes the mapped checker queue`(): Unit = runBlocking {
+        val store = mockk<ApprovalStore>()
+        coEvery { store.findPending(50) } returns listOf(
+            PendingApproval(
+                id = "appr-3",
+                action = "balance.debit",
+                resourceId = "acc-9",
+                makerId = "maker",
+                status = ApprovalStatus.PENDING,
+                createdAt = OffsetDateTime.parse("2026-07-12T00:00:00Z"),
+            ),
+        )
+
+        val response = ApprovalResource(store).listPending(50)
+
+        assertThat(response.status).isEqualTo(200)
+        @Suppress("UNCHECKED_CAST")
+        val body = response.entity as List<ApprovalResponse>
+        assertThat(body).hasSize(1)
+        assertThat(body.single().action).isEqualTo("balance.debit")
+        assertThat(body.single().makerId).isEqualTo("maker")
+        assertThat(body.single().createdAt).isEqualTo("2026-07-12T00:00Z")
+    }
+
+    /** The store performs a Redis SCAN; a caller-controlled limit must not decide how big it is. */
+    @Test
+    fun `listPending clamps a caller-controlled limit`(): Unit = runBlocking {
+        val store = mockk<ApprovalStore>()
+        coEvery { store.findPending(200) } returns emptyList()
+
+        ApprovalResource(store).listPending(10_000)
+
+        coVerify(exactly = 1) { store.findPending(200) }
     }
 }


### PR DESCRIPTION
## What

The **last** of the sixteen services with a four-eyes decide endpoint to gain the matching read (ADR-0227 D2, #5679), and the one where the hole mattered most: both gated actions here move money (`balance.credit`, `balance.debit`).

**Money-path — 2 approvals + threat model required. Expect this NOT to land quickly, and that is the correct outcome.** It is deliberately split from #7990 (billing + consent) so the non-money-path work is not held behind it.

> **Stacked on `feat/approvals-inbox-billing-consent` (#7990)**, because both PRs edit `route.ts` and `approvals-inbox.test.ts`. The base is that branch, not `main` — a stacked PR reads CLEAN against its base, not against main. Retarget to `main` after #7990 merges; do **not** merge #7990 with `--delete-branch` while this is open, that closes this PR irreversibly.

## The defect

A parked `balance.credit` / `balance.debit` decision was discoverable only by whoever had been handed its approval id out of band, and expired silently after the shared store's 24-hour TTL. A maker-checker control nobody can see is a control that fails open by attrition.

## What it does and does not do

- `GET /api/v1/balances/approvals` — read-only, oldest first, limit clamped to 200.
- `balance.approval.read` needs **no policy change**: base `rest.rego`'s `operator-read-any` admits it on the `.read` suffix — the same path account and party already take. (Checked directly; balance's own `balance_rest_ext.rego` uses explicit action sets, not a prefix, so this was verified rather than assumed.)
- Untouched: `ApprovalStore.decide`'s maker != checker invariant, the random ids, the 24h TTL, one-time `EXECUTED` consumption.
- **Deliberately absent:** a decide button on the inbox. Money-path disposal additionally requires SCA (ADR-0227 D4).
- Threat model updated (ADR-0030) with the risk actually traded: operator-visible workflow metadata plus a bounded Redis SCAN, against a maker-checker control that was effectively invisible.

## `route.ts` source count

| | fetchers | `sources` keys | `not-configured` |
|---|---|---|---|
| on `main` | 14 | 17 | 3 (balance, billing, consent) |
| after #7990 | 16 | 17 | 1 (balance) |
| **after this PR** | **17** | **17** | **0** |

With nothing unread, `NOT_CONFIGURED_SOURCES` is **removed** rather than left as an empty placeholder.

`approvals-source-truth.guard.test.ts` asserted the literal strings `balance: 'not-configured'` and `...NOT_CONFIGURED_SOURCES`. Deleting those would have left nothing behind — a guard that asserts a literal only describes the state it was written in. It is replaced by the invariant it existed to protect: **every domain the route reports is a domain the route reads**, and every fetcher is awaited in the fan-out. A source added without a fetcher now fails regardless of what it is called.

## Proof by what it prevents

Red first, with the new tests against the parent commit's `route.ts`:

```
RED_RC=1   Tests  3 failed | 20 passed (23)
```

Green with the change:

```
GREEN_RC=0  Test Files 2 passed  Tests 23 passed (23)
```

`npx tsc --noEmit`: 0 errors.

The two pre-existing Kotlin tests in `ApprovalResourceMappingTest.kt` are **preserved** and extended (the first draft of this branch overwrote them; caught by reading `git diff --cached --stat` showing `M` where `A` was expected, and restored from `origin/main`).

Refs #5679
