### PR TITLE
fix(psd2,sanctions): a null JSON array element is a 400, not a 500 (#7867)

### DIFF
--- a/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/application/usecase/Psd2Services.kt
+++ b/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/application/usecase/Psd2Services.kt
@@ -92,6 +92,7 @@ class ConsentManagementService(private val consentClient: ConsentServiceClient, 
     ConsentManagementUseCase {
 
     override suspend fun createConsent(command: CreateConsentCommand): ObConsentResponse {
+        requireNoNullAccountRefs(command.request.access)
         val scopes = buildScopes(command.request.access)
         val ibans = collectIbans(command.request.access)
         val validUntil = minOf(command.request.validUntil, LocalDate.now(clock).plusDays(90))
@@ -159,10 +160,28 @@ class ConsentManagementService(private val consentClient: ConsentServiceClient, 
 
     private fun collectIbans(access: ObAccess): List<String>? {
         val ibans = mutableSetOf<String>()
-        access.accounts?.mapNotNull { it.iban }?.let { ibans.addAll(it) }
-        access.balances?.mapNotNull { it.iban }?.let { ibans.addAll(it) }
-        access.transactions?.mapNotNull { it.iban }?.let { ibans.addAll(it) }
+        access.accounts?.mapNotNull { it?.iban }?.let { ibans.addAll(it) }
+        access.balances?.mapNotNull { it?.iban }?.let { ibans.addAll(it) }
+        access.transactions?.mapNotNull { it?.iban }?.let { ibans.addAll(it) }
         return if (ibans.isEmpty()) null else ibans.toList()
+    }
+
+    /**
+     * Reject a `null` JSON array element with a 400 (#7867). Jackson null-checks constructor
+     * parameters but not collection elements, so `[null]` deserialises into a list holding a
+     * null; without this guard the first dereference was an NPE that `GenericExceptionMapper`
+     * rendered as a 500. `IllegalArgumentException` maps to 400 via libs-runtime.
+     */
+    private fun requireNoNullAccountRefs(access: ObAccess) {
+        mapOf(
+            "accounts" to access.accounts,
+            "balances" to access.balances,
+            "transactions" to access.transactions,
+        ).forEach { (field, refs) ->
+            refs?.forEachIndexed { index, ref ->
+                requireNotNull(ref) { "access.$field[$index] must not be null" }
+            }
+        }
     }
 
     private fun mapStatus(s: String): String = when (s) {

--- a/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/domain/model/ObModels.kt
+++ b/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/domain/model/ObModels.kt
@@ -146,10 +146,14 @@ data class ObConsentRequest(
     val combinedServiceIndicator: Boolean = false,
 )
 
+// Element types are nullable ON PURPOSE (#7867): Jackson's Kotlin module null-checks
+// constructor parameters but not collection elements, so `{"accounts": [null]}` arrives
+// as a list holding a null. Only a nullable element type lets the guard in
+// ConsentManagementService reject it with a 400 instead of an NPE-driven 500.
 data class ObAccess(
-    val accounts: List<ObAccountRef>?,
-    val balances: List<ObAccountRef>?,
-    val transactions: List<ObAccountRef>?,
+    val accounts: List<ObAccountRef?>?,
+    val balances: List<ObAccountRef?>?,
+    val transactions: List<ObAccountRef?>?,
     val additionalInformation: ObAdditionalInformation?,
 )
 

--- a/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/application/usecase/Psd2ServicesTest.kt
+++ b/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/application/usecase/Psd2ServicesTest.kt
@@ -202,6 +202,47 @@ class Psd2ServicesTest {
     }
 
     @Test
+    fun `createConsent rejects a null JSON array element with IllegalArgumentException`(): Unit = runBlocking {
+        // #7867: Jackson null-checks constructor parameters but not collection elements, so
+        // `{"accounts": [null]}` arrives as a list holding a null. The guard must reject it
+        // (IllegalArgumentException -> 400) before any dereference turns it into a 500.
+        val request = ObConsentRequest(
+            access = ObAccess(
+                accounts = listOf(sampleAccountRef("acc-iban"), null),
+                balances = null,
+                transactions = null,
+                additionalInformation = null,
+            ),
+            recurringIndicator = true,
+            validUntil = fixedToday.plusDays(30),
+            frequencyPerDay = 4,
+        )
+
+        var thrown: Throwable? = null
+        try {
+            consentManagementService.createConsent(
+                CreateConsentCommand(
+                    tppId = "tpp-1",
+                    tppName = "TPP One",
+                    request = request,
+                    redirectUri = null,
+                    tppTransactionId = null,
+                    ipAddress = null,
+                ),
+            )
+        } catch (e: IllegalArgumentException) {
+            thrown = e
+        }
+
+        assertThat(thrown)
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("access.accounts[1]")
+        coVerify(exactly = 0) {
+            consentClient.createConsent(any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
     fun `createConsent returns consent response with correct links`(): Unit = runBlocking {
         val access = ObAccess(accounts = null, balances = null, transactions = null, additionalInformation = null)
         val request = ObConsentRequest(

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/port/in/SanctionsPorts.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/port/in/SanctionsPorts.kt
@@ -11,7 +11,10 @@ data class ScreenEntityCommand(
     val idempotencyKey: String,
     val entityType: EntityType,
     val name: String,
-    val aliases: List<String> = emptyList(),
+    // Nullable element ON PURPOSE (#7867): Jackson null-checks constructor parameters but not
+    // collection elements, so `{"aliases": [null]}` arrives holding a null. Only a nullable
+    // element type lets SanctionsService reject it with a 400 instead of an NPE-driven 500.
+    val aliases: List<String?> = emptyList(),
     val dateOfBirth: String? = null,
     val nationality: String? = null,
     val identifiers: Map<String, String> = emptyMap(),

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/usecase/SanctionsService.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/usecase/SanctionsService.kt
@@ -35,7 +35,7 @@ class SanctionsService(
         cmd: ScreenEntityCommand,
         targetLists: List<SanctionsListType>,
     ): Pair<SanctionsCheckStatus, List<SanctionsMatch>> {
-        val allNames = listOf(cmd.name) + cmd.aliases
+        val allNames = listOf(cmd.name) + cmd.aliases.filterNotNull()
         val matchMap = mutableMapOf<String, SanctionsEntryMatch>() // key=listType+externalId, keep best
 
         for (name in allNames) {
@@ -78,12 +78,18 @@ class SanctionsService(
     }
 
     override suspend fun screen(cmd: ScreenEntityCommand): SanctionsCheck {
+        // #7867: reject a null JSON array element with a 400 (IllegalArgumentException) before
+        // any dereference turns it into an NPE-driven 500. Jackson does not null-check
+        // collection elements, so `[null]` reaches here despite the Kotlin element type.
+        cmd.aliases.forEachIndexed { index, alias ->
+            requireNotNull(alias) { "aliases[$index] must not be null" }
+        }
         repo.findByIdempotencyKey(cmd.idempotencyKey)?.let { return it }
         val targetLists = resolveTargetLists(cmd)
         val (status, matches) = performScreening(cmd, targetLists)
         val check = SanctionsCheck(
             id = UUID.randomUUID(), idempotencyKey = cmd.idempotencyKey,
-            entityType = cmd.entityType, name = cmd.name, aliases = cmd.aliases,
+            entityType = cmd.entityType, name = cmd.name, aliases = cmd.aliases.filterNotNull(),
             dateOfBirth = cmd.dateOfBirth, nationality = cmd.nationality,
             identifiers = cmd.identifiers, status = status, matches = matches,
             overallScore = matches.maxOfOrNull { it.matchScore } ?: 0.0,

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/application/usecase/SanctionsServiceTest.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/application/usecase/SanctionsServiceTest.kt
@@ -50,6 +50,25 @@ class SanctionsServiceTest {
     }
 
     @Test
+    fun `screen rejects a null JSON array element with IllegalArgumentException`(): Unit = runBlocking {
+        // #7867: Jackson null-checks constructor parameters but not collection elements, so
+        // `{"aliases": [null]}` arrives as a list holding a null. The guard must reject it
+        // (IllegalArgumentException -> 400) before the first dereference turns it into a 500.
+        var thrown: Throwable? = null
+        try {
+            service.screen(sampleScreenCommand(name = "John Doe", aliases = listOf("JD", null)))
+        } catch (e: IllegalArgumentException) {
+            thrown = e
+        }
+
+        assertThat(thrown)
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("aliases[1]")
+        coVerify(exactly = 0) { repo.findByIdempotencyKey(any()) }
+        coVerify(exactly = 0) { repo.saveWithEvent(any(), any()) }
+    }
+
+    @Test
     fun `screen detects HIT when entry repo returns a high-score match`(): Unit = runBlocking {
         coEvery { repo.findByIdempotencyKey(any()) } returns null
         coEvery { repo.saveWithEvent(any(), any()) } answers { firstArg() }
@@ -276,7 +295,7 @@ class SanctionsServiceTest {
     private fun sampleScreenCommand(
         idempotencyKey: String = "idem-1",
         name: String = "John Doe",
-        aliases: List<String> = emptyList(),
+        aliases: List<String?> = emptyList(),
     ) = ScreenEntityCommand(
         idempotencyKey = idempotencyKey,
         entityType = EntityType.INDIVIDUAL,


### PR DESCRIPTION
## Summary

Money-path rows of #7867: a null JSON array element (`{"accounts": [null]}`, `{"aliases": [null]}`) was a **500**, now a **400**.

Jackson's Kotlin module null-checks constructor parameters but **not collection elements**, so a null element arrived despite the non-null Kotlin element type and the first dereference threw an NPE that `GenericExceptionMapper` rendered as a 500 (ADR-0080).

The fix, per the issue's prescribed shape:

- **psd2** (`POST /v1/consents`, money-path): `ObAccess.accounts/balances/transactions` element type declared nullable (`List<ObAccountRef?>?`) so a guard is reachable; `ConsentManagementService.createConsent` rejects a null element via `requireNotNull` naming field and index (`access.accounts[1]`) → `IllegalArgumentException` → 400 via libs-runtime. Covers both the Berlin XS2A and the OB resource, which share the usecase.
- **sanctions** (`POST /api/v1/sanctions/screen`, money-path): `ScreenEntityCommand.aliases` element nullable, same guard at the top of `SanctionsService.screen` (before the idempotency lookup, so no work happens for a malformed body); stored entity keeps `List<String>` via `filterNotNull()`.

**Deliberately not here:** the 18 non-money-path rows and the question whether `check-nonnull-jaxrs-params.py` grows a body-entity arm — issue stays open for those.

Refs #7867

## Test plan

- [x] New red-first tests: `createConsent rejects a null JSON array element with IllegalArgumentException` (psd2), `screen rejects a null JSON array element with IllegalArgumentException` (sanctions) — both assert the index-named message and that no downstream call happens
- [x] `./gradlew :openbank-psd2-service:test :openbank-sanctions-service:test` green
- [x] `ktlintCheck` + `detekt` on both modules green
- [x] Client-side mirror DTOs (`SanctionsServiceClient` in sepa/sepa-instant/fx/domestic/kyc) verified to be separate local classes — unaffected
- [ ] CI gates
