### PR TITLE
fix(admin-ui): restore incentive discovery and matrix access

### DIFF
--- a/openbank-admin-ui/src/app/system/tests/page.tsx
+++ b/openbank-admin-ui/src/app/system/tests/page.tsx
@@ -176,7 +176,7 @@ function Posture({ report }: { report: TestIntelligenceReport }) {
       <section aria-label={t('Matice důkazů komponent', 'Component evidence matrix')} style={{ marginBottom: 20 }}>
         <h2 style={{ fontSize: 16, marginBottom: 4 }}>{t('Matice důkazů komponent', 'Component evidence matrix')}</h2>
         <p style={{ color: 'var(--text-secondary)', fontSize: 12, margin: '0 0 8px' }}>{t('Jeden řádek na komponentu: skenuj napříč druhy testů; peněžní toky jsou nahoře.', 'One row per component: scan across test kinds; money-path components are first.')}</p>
-        <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}>
+        <div tabIndex={0} style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}>
           <table style={tableStyle}>
             <thead><tr><th style={thStyle}>{t('Komponenta', 'Component')}</th>{KINDS.map(kind => <th key={kind} style={thStyle}>{kind}</th>)}<th style={thStyle}>{t('Řádky Kover', 'Kover lines')}</th></tr></thead>
             <tbody>{sorted.map(component => (

--- a/openbank-admin-ui/src/lib/discovery.ts
+++ b/openbank-admin-ui/src/lib/discovery.ts
@@ -80,6 +80,7 @@ const NS_GROUP: Record<string, ServiceGroup> = {
   documents:          'platform',    // document-service (ADR-0161/0162)
   engagement:         'platform',    // engagement-service (ADR-0220 in-app surfaces)
   referral:           'platform',    // referral-service (ADR-0266 MGM attribution)
+  incentive:          'platform',    // incentive/promo service (ADR-0266)
 }
 
 export function inCluster(): boolean {

--- a/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
+++ b/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
@@ -106,7 +106,7 @@ spec:
             #   3. Add a RoleBinding for admin-ui-discovery below.
             # Adding a service *inside* an existing namespace is fully automatic.
             - name: OPENBANK_NAMESPACES
-              value: accounts,payments,compliance,identity,open-banking,platform,ledger,balances,audit,sanctions,security-scanner,onboarding,party,sca,statements,customer-edge,kyc,notifications,aml,consent,dispute,fraud,fx,interest,pid,psd2,documents,campaign,anacredit,billing,finrep,lending,sdd,tpp-registry,delegation,engagement,referral
+              value: accounts,payments,compliance,identity,open-banking,platform,ledger,balances,audit,sanctions,security-scanner,onboarding,party,sca,statements,customer-edge,kyc,notifications,aml,consent,dispute,fraud,fx,interest,pid,psd2,documents,campaign,anacredit,billing,finrep,lending,sdd,tpp-registry,delegation,engagement,referral,incentive
             # agent-service (MCP) is NOT reached via the discovery proxy: the
             # /api/agent/mcp and /api/agent/chat routes resolve it from this env
             # directly. Unset, they fall back to localhost:8109 (the admin-ui pod
@@ -322,6 +322,25 @@ kind: RoleBinding
 metadata:
   name: admin-ui-discovery
   namespace: referral
+  labels:
+    app.kubernetes.io/name: admin-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin-ui-discovery
+subjects:
+  - kind: ServiceAccount
+    name: admin-ui
+    namespace: admin-ui
+---
+# incentive (ADR-0266). This scoped binding and OPENBANK_NAMESPACES above are
+# both required: the former is the least-privilege boundary and the latter is
+# the discovery query scope.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: admin-ui-discovery
+  namespace: incentive
   labels:
     app.kubernetes.io/name: admin-ui
 roleRef:


### PR DESCRIPTION
## Summary

Restores the missing Incentive namespace discovery contract and makes the Test Intelligence evidence matrix keyboard-scrollable. This unblocks the Admin UI test gate without broadening discovery permissions beyond the new namespace.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #8014
Refs #7210, #7553, ADR-0051, ADR-0266

## Changes

- Adds incentive to OPENBANK_NAMESPACES and binds the existing read-only admin-ui-discovery ClusterRole only in namespace incentive.
- Classifies the Incentive/Promo context with the related platform discovery group.
- Makes the horizontally scrollable component-evidence matrix focusable for keyboard users; visual matrix layout is unchanged.

## Verification

- service-registry guard: 13 passed
- targeted Test Intelligence unit/BFF suite: 33 passed
- serial replay of all timeout-only files from the local parallel run: 108 passed, with original timeouts unchanged
- Test Intelligence Chromium E2E including Axe WCAG A/AA: 5 passed
- npm run lint: 0 errors; 91 pre-existing warnings outside this change
- npm run type-check: passed
- npm run build: passed

## Definition of Done

- [x] Hexagonal layering preserved (UI and GitOps-only change).
- [x] Existing deterministic registry guard covers the namespace contract.
- [x] Browser E2E and WCAG gate cover the accessibility change.
- [x] No new lint warnings.
- [x] No public API, database, event schema, or dependency change.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, or logs.
- [x] No new dependency or suppression.
- [ ] Auth / crypto / payment code changed.
- [ ] PII or cardholder-data path changed.

## Compliance impact

- [x] DORA: restores truthful service-health visibility while preserving namespace-scoped least-privilege discovery.

## Rollout / Rollback

- Deployment strategy: standard Admin UI rolling deployment through GitOps.
- Rollback plan: revert this commit; the prior discovery scope and RoleBindings are restored together.
- Data migration reversible: N/A.

## Screenshots / demo

No visual redesign: the existing matrix remains intact. The Playwright E2E proves the matrix, mobile flow, reduced motion and accessibility checks.

## Reviewer notes

Please confirm that the RoleBinding remains namespace-scoped. No ClusterRoleBinding or extra Kubernetes verb is introduced.