### PR TITLE
security(admin-ui): enforce sensitive BFF permissions

### DIFF
--- a/openbank-admin-ui/src/app/api/customer-360/[partyId]/route.ts
+++ b/openbank-admin-ui/src/app/api/customer-360/[partyId]/route.ts
@@ -17,7 +17,7 @@
 // caller can see how stale the view is rather than assuming it is live.
 
 import { NextRequest, NextResponse } from 'next/server'
-import { auth } from '@/auth'
+import { requireApiPermission } from '@/lib/auth/api-permission'
 
 export const dynamic = 'force-dynamic'
 
@@ -25,6 +25,7 @@ const CLICKHOUSE_URL = process.env.CLICKHOUSE_URL || 'http://localhost:8123'
 const CLICKHOUSE_USER = process.env.CLICKHOUSE_USER
 const CLICKHOUSE_PASSWORD = process.env.CLICKHOUSE_PASSWORD
 const DB = 'openbank_analytics'
+const CLICKHOUSE_TIMEOUT_MS = 8_000
 
 // A partyId reaches ClickHouse inside a SQL string, so it is validated as a UUID before it gets
 // anywhere near the query. ClickHouse's HTTP interface takes raw SQL and this route builds it, so
@@ -63,6 +64,7 @@ async function chQuery(sql: string): Promise<Record<string, unknown>[]> {
     headers,
     body: sql,
     cache: 'no-store',
+    signal: AbortSignal.timeout(CLICKHOUSE_TIMEOUT_MS),
   })
   if (!res.ok) throw new Error(`ClickHouse ${res.status}`)
   const body = (await res.json()) as { data?: Record<string, unknown>[] }
@@ -123,8 +125,10 @@ function empty(partyId: string, error?: string): Customer360 {
 }
 
 export async function GET(_req: NextRequest, ctx: { params: Promise<{ partyId: string }> }) {
-  const session = await auth()
-  if (!session) return NextResponse.json(empty('', 'unauthorized'), { status: 401 })
+  const access = await requireApiPermission('compliance:view')
+  if (!access.ok) {
+    return NextResponse.json(empty('', access.error), { status: access.status })
+  }
 
   const { partyId } = await ctx.params
   if (!UUID_RE.test(partyId)) {

--- a/openbank-admin-ui/src/app/api/finops/anomalies/route.ts
+++ b/openbank-admin-ui/src/app/api/finops/anomalies/route.ts
@@ -4,16 +4,28 @@
 
 import { NextResponse } from 'next/server'
 import type { FinOpsAnomaly } from '../ai-costs/route'
+import { requireApiPermission } from '@/lib/auth/api-permission'
 export type { FinOpsAnomaly }
 export const dynamic = 'force-dynamic'
+
+const ALERTMANAGER_TIMEOUT_MS = 5_000
 
 // Returns active FinOps anomalies from Alertmanager (ADR-0112 D1–D5 detectors).
 // When Alertmanager is unreachable, returns empty list (non-blocking).
 export async function GET() {
+  const access = await requireApiPermission('system:view')
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+
   const alertmanagerUrl = process.env.ALERTMANAGER_URL ?? 'http://alertmanager-operated.observability:9093'
 
   try {
-    const res = await fetch(`${alertmanagerUrl}/api/v2/alerts?filter=route%3Dfinops-agent`)
+    const res = await fetch(`${alertmanagerUrl}/api/v2/alerts?filter=route%3Dfinops-agent`, {
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(ALERTMANAGER_TIMEOUT_MS),
+    })
     if (!res.ok) return NextResponse.json({ anomalies: [], available: false })
 
     const raw = await res.json() as Array<{

--- a/openbank-admin-ui/src/lib/auth/api-permission.ts
+++ b/openbank-admin-ui/src/lib/auth/api-permission.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { auth } from '@/auth'
+import { hasPermission, type Permission } from '@/lib/auth/roles'
+
+type ApiPermissionDecision =
+  | { ok: true }
+  | { ok: false; status: 401 | 403; error: 'unauthorized' | 'forbidden' }
+
+/**
+ * Enforce an admin-ui permission at the BFF route boundary.
+ *
+ * Edge middleware and client-side AuthGuard keep navigation truthful, but neither
+ * protects a direct call to an internal `/api/**` route. Routes use this decision
+ * to retain their own established response envelope while sharing one session and
+ * permission check. A denial is returned before any upstream request is made.
+ */
+export async function requireApiPermission(permission: Permission): Promise<ApiPermissionDecision> {
+  const session = await auth()
+  if (!session?.user) return { ok: false, status: 401, error: 'unauthorized' }
+  if (!hasPermission(session.user.roles ?? [], permission)) {
+    return { ok: false, status: 403, error: 'forbidden' }
+  }
+  return { ok: true }
+}

--- a/openbank-admin-ui/src/test/customer-360.test.ts
+++ b/openbank-admin-ui/src/test/customer-360.test.ts
@@ -12,15 +12,16 @@
 // only checked the assembled output against a hand-written row set would pass against a query that
 // leaks, since the fixture would simply not contain the other party's rows.
 
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { readFileSync } from 'fs'
 import path from 'path'
+import { auth } from '@/auth'
 
 const ROUTE = path.join(process.cwd(), 'src/app/api/customer-360/[partyId]/route.ts')
 const PARTY = '11111111-1111-1111-1111-111111111111'
 const OTHER = '22222222-2222-2222-2222-222222222222'
 
-vi.mock('@/auth', () => ({ auth: vi.fn(async () => ({ user: { name: 'op' } })) }))
+vi.mock('@/auth', () => ({ auth: vi.fn() }))
 
 /** Captures the SQL the route sends, so isolation can be asserted on the query itself. */
 function stubClickHouse(rows: Record<string, unknown>[]) {
@@ -34,9 +35,53 @@ function stubClickHouse(rows: Record<string, unknown>[]) {
 
 beforeEach(() => {
   vi.unstubAllGlobals()
+  vi.mocked(auth).mockResolvedValue({ user: { name: 'op', roles: ['ROLE_COMPLIANCE'] } } as never)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
 })
 
 describe('Customer 360 isolation (ADR-0210 D2)', () => {
+  it('rejects an unauthenticated direct BFF call before querying ClickHouse', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const { GET } = await import('@/app/api/customer-360/[partyId]/route')
+
+    const res = await GET({} as never, { params: Promise.resolve({ partyId: PARTY }) })
+
+    expect(res.status).toBe(401)
+    expect((await res.json()).error).toBe('unauthorized')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a session without compliance:view before querying ClickHouse', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { roles: ['ROLE_OPERATOR'] } } as never)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const { GET } = await import('@/app/api/customer-360/[partyId]/route')
+
+    const res = await GET({} as never, { params: Promise.resolve({ partyId: PARTY }) })
+
+    expect(res.status).toBe(403)
+    expect((await res.json()).error).toBe('forbidden')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('bounds the ClickHouse read and degrades a timeout without leaking a 5xx', async () => {
+    const signal = new AbortController().signal
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(signal)
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new DOMException('timed out', 'TimeoutError')))
+    const { GET } = await import('@/app/api/customer-360/[partyId]/route')
+
+    const res = await GET({} as never, { params: Promise.resolve({ partyId: PARTY }) })
+
+    expect(timeout).toHaveBeenCalledWith(8_000)
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toMatchObject({ available: false, partyId: PARTY })
+  })
+
   it('scopes BOTH resolution arms to the requested party', async () => {
     const seen = stubClickHouse([])
     const { GET } = await import('@/app/api/customer-360/[partyId]/route')

--- a/openbank-admin-ui/src/test/finops-anomalies-route.test.ts
+++ b/openbank-admin-ui/src/test/finops-anomalies-route.test.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { auth } from '@/auth'
+
+vi.mock('@/auth', () => ({ auth: vi.fn() }))
+
+describe('GET /api/finops/anomalies', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.mocked(auth).mockResolvedValue({ user: { roles: ['ROLE_OPERATOR'] } } as never)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    delete process.env.ALERTMANAGER_URL
+  })
+
+  it('returns 401 and never contacts Alertmanager without a session', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const { GET } = await import('@/app/api/finops/anomalies/route')
+
+    const res = await GET()
+
+    expect(res.status).toBe(401)
+    await expect(res.json()).resolves.toEqual({ error: 'unauthorized' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 and never contacts Alertmanager without system:view', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { roles: ['ROLE_VIEWER'] } } as never)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const { GET } = await import('@/app/api/finops/anomalies/route')
+
+    const res = await GET()
+
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toEqual({ error: 'forbidden' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns mapped anomalies for an authorized system operator', async () => {
+    const signal = new AbortController().signal
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(signal)
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify([{
+      labels: { alertname: 'IdleService', detector: 'D2', severity: 'warning' },
+      annotations: { summary: 'Idle service detected' },
+      startsAt: '2026-09-01T09:00:00Z',
+      status: { state: 'active' },
+    }]), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { GET } = await import('@/app/api/finops/anomalies/route')
+
+    const res = await GET()
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toMatchObject({
+      available: true,
+      anomalies: [{ detector: 'D2', title: 'Idle service detected', status: 'open' }],
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][1]?.signal).toBe(signal)
+  })
+
+  it('bounds Alertmanager and degrades a timeout to the established calm state', async () => {
+    const signal = new AbortController().signal
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(signal)
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new DOMException('timed out', 'TimeoutError')))
+    const { GET } = await import('@/app/api/finops/anomalies/route')
+
+    const res = await GET()
+
+    expect(timeout).toHaveBeenCalledWith(5_000)
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ anomalies: [], available: false })
+  })
+})


### PR DESCRIPTION
## What

- adds one shared server-side Admin API permission decision helper
- requires `compliance:view` before Customer 360 can query ClickHouse
- requires `system:view` before FinOps anomalies can query Alertmanager
- bounds ClickHouse reads to 8 seconds and Alertmanager reads to 5 seconds
- adds focused 401/403/authorized/timeout tests, including proof that denials make no upstream call

## Why

The authenticated middleware and client-side route guards keep navigation truthful, but they are not a route-local authorization boundary for a direct `/api/**` request. These two BFF routes expose sensitive customer projections or operational alerts and must fail before contacting their upstream when the operator lacks the relevant permission.

Closes #8016

## Verification

- focused Vitest: 16/16 passed
- `npm run type-check`: passed
- ESLint on all five changed files: passed
- `git diff --check`: passed
- full Vitest reached 2071 passes and exposed one unrelated current-main namespace/RoleBinding guard failure; the three sandbox `listen EPERM` cases and the loaded-run console-summary timeout pass in isolated reruns

## Security / compatibility

- no role is widened; the existing `PERMISSIONS` matrix remains the source of truth
- 401 and 403 decisions happen before any ClickHouse or Alertmanager call
- successful response payloads and established calm unavailable/timeout envelopes are unchanged
- backend RBAC, data contracts, and deployment configuration are unchanged

## Checklist

- [x] Signed Conventional Commit
- [x] Focused regression tests added
- [x] Security review requested
