### PR TITLE
fix(governance): drop three NO_OVERLAY_YET entries whose overlays now exist

### DIFF
--- a/.github/scripts/check-vex-overlay-coverage.py
+++ b/.github/scripts/check-vex-overlay-coverage.py
@@ -70,9 +70,6 @@ NO_RELEASE_COMPONENT: dict[str, str] = {
 # component -> issue that tracks writing its overlay. Reason required; stale either direction.
 NO_OVERLAY_YET: dict[str, str] = {
     "admin-ui": "#6719 - released component, no triage overlay written yet",
-    "case-coordinator-agent": "#6719 - released component, no triage overlay written yet",
-    "incentive-service": "#6719 - released component, no triage overlay written yet",
-    "referral-service": "#6719 - missed the whole CVE-2025-14969 fan-out for this reason",
 }
 
 


### PR DESCRIPTION
## The whole PR queue is red behind one stale allowlist entry set

`gates (supplychain)` fails on **31 of the open PRs** right now, and `Validate manifests` on 30,
because it aggregates that shard. The cause is one gate, and it is doing its job correctly:

```
UNFALSIFIED  vex-overlay-coverage                             0.1s  [supplychain]
##[error]self-test verdict wrong — gate is unfalsified: every released component is
         enumerated against the VEX store (#6988, enforced)
```

## What happened

`4ef1e93734` ("write the three JVM VEX overlays") landed today and wrote overlays for
`case-coordinator-agent`, `incentive-service` and `referral-service` — 23 statements each, all three
files present under `openbank-libs/governance/vex/`. It did not remove their `NO_OVERLAY_YET`
entries.

`check-vex-overlay-coverage.py` says of that map: *"Reason required; stale either direction."* So a
declaration that a component has no overlay, made about a component that now has one, is a finding —
which is the design working, not a false positive:

```
NO_OVERLAY_YET declares case-coordinator-agent, which HAS an overlay now
  (openbank-libs/governance/vex/case-coordinator-agent.openvex.json) -- remove the entry
NO_OVERLAY_YET declares incentive-service, which HAS an overlay now ...
NO_OVERLAY_YET declares referral-service, which HAS an overlay now ...
```

Once the gate itself fails, its self-test's "must fail" fixture can no longer be distinguished from
the live failure, so the runner reports **UNFALSIFIED** rather than FAIL — which is why the error text
talks about falsifiability rather than naming the three components.

## The change

Three lines removed. `admin-ui` stays, because it is a released component that genuinely has no
overlay, so its entry still describes something true — and removing it is a finding in the other
direction, which I checked.

## Falsified, not just green

A gate fix that is only ever observed passing proves nothing:

| state | exit |
|---|---|
| a stale entry put back | **1** |
| this fix | **0** |
| `admin-ui`'s live entry removed | **1** |

```
python3 .github/scripts/run-gates.py --only vex-overlay-coverage
  PASS  vex-overlay-coverage  0.4s  [supplychain]
python3 .github/scripts/check-vex-overlay-coverage.py --self-test
  SELF-TEST PASS
```

## Why this is worth merging ahead of other things

Nothing else in the queue can go green until it lands: 31 PRs are failing a required context on a
cause none of them introduced, and the fix touches no behaviour — three entries in a gate's known-gaps
map, in a file whose only purpose is to describe which components lack a VEX overlay.

Refs #6988, #6719
