### PR TITLE
fix(admin-ui): synchronize document language

### DIFF
--- a/openbank-admin-ui/e2e/document-language.spec.ts
+++ b/openbank-admin-ui/e2e/document-language.spec.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+test('server render and language toggle keep the document language synchronized', async ({ page, context, baseURL }) => {
+  if (!baseURL) throw new Error('Playwright baseURL is required')
+  await context.addCookies([{
+    name: 'openbank-admin-lang',
+    value: 'cs',
+    url: baseURL,
+    sameSite: 'Lax',
+  }])
+
+  const serverResponse = await page.request.get('/auth/login')
+  expect(await serverResponse.text()).toMatch(/<html[^>]*lang="cs"/)
+
+  await page.goto('/auth/login')
+
+  await expect(page.locator('html')).toHaveAttribute('lang', 'cs')
+  await expect(page.getByRole('heading', { name: 'Vítejte zpět' })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Switch to English' }).click()
+
+  await expect(page.locator('html')).toHaveAttribute('lang', 'en')
+  await expect(page.getByRole('heading', { name: 'Welcome back' })).toBeVisible()
+
+  await page.reload()
+  await expect(page.locator('html')).toHaveAttribute('lang', 'en')
+})
+
+test('language changes refresh cookie-localized server content', async ({ page, context, baseURL }) => {
+  if (!baseURL) throw new Error('Playwright baseURL is required')
+  await signInAsOperator(context, baseURL)
+  await context.addCookies([{
+    name: 'openbank-admin-lang',
+    value: 'en',
+    url: baseURL,
+    sameSite: 'Lax',
+  }])
+
+  await page.goto('/docs/sensors')
+
+  await expect(page.getByRole('heading', { name: 'Customer-app sensors' })).toBeVisible()
+  await page.getByRole('button', { name: 'Switch to Czech' }).click()
+
+  await expect(page.locator('html')).toHaveAttribute('lang', 'cs')
+  await expect.poll(async () => {
+    const cookie = (await context.cookies()).find(item => item.name === 'openbank-admin-lang')
+    return cookie?.value
+  }).toBe('cs')
+
+  await expect(page.getByRole('heading', { name: 'Senzory zákaznické aplikace' })).toBeVisible()
+
+  await page.reload()
+  await expect(page.locator('html')).toHaveAttribute('lang', 'cs')
+  await expect(page.getByRole('heading', { name: 'Senzory zákaznické aplikace' })).toBeVisible()
+})

--- a/openbank-admin-ui/src/app/layout.tsx
+++ b/openbank-admin-ui/src/app/layout.tsx
@@ -4,8 +4,9 @@
 
 import type { Metadata } from 'next'
 import './globals.css'
-import { headers } from 'next/headers'
+import { cookies, headers } from 'next/headers'
 import { AppProviders } from '@/components/layout/AppProviders'
+import { LANG_COOKIE, parseLanguage } from '@/lib/i18n/language'
 
 export const metadata: Metadata = {
   title: 'OpenBank Admin',
@@ -23,10 +24,13 @@ export const metadata: Metadata = {
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   // Calling headers() opts the layout out of static pre-rendering (side-effect only).
   await headers()
+  const persistedLanguage = parseLanguage((await cookies()).get(LANG_COOKIE)?.value)
+  const initialLanguage = persistedLanguage ?? 'en'
+
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang={initialLanguage} suppressHydrationWarning>
       <body>
-        <AppProviders>{children}</AppProviders>
+        <AppProviders initialLanguage={persistedLanguage}>{children}</AppProviders>
       </body>
     </html>
   )

--- a/openbank-admin-ui/src/components/layout/AppProviders.tsx
+++ b/openbank-admin-ui/src/components/layout/AppProviders.tsx
@@ -4,23 +4,32 @@
 
 'use client'
 
-import { usePathname } from 'next/navigation'
+import { useCallback } from 'react'
+import { usePathname, useRouter } from 'next/navigation'
 import { Toaster } from 'sonner'
 import { AgentDock } from '@/components/agent/AgentDock'
 import { SessionProvider } from '@/components/auth/SessionProvider'
 import { RumScreenTracker } from '@/components/telemetry/RumScreenTracker'
 import { isPublicSurface } from '@/lib/auth/publicSurface'
-import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { LanguageProvider, type Language } from '@/lib/i18n/LanguageContext'
 
 /**
  * Keeps authenticated-only infrastructure off public entry and policy surfaces.
  * Protected operator routes retain session refresh, expiry recovery and AgentDock.
  */
-export function AppProviders({ children }: { children: React.ReactNode }) {
+export function AppProviders({
+  children,
+  initialLanguage = null,
+}: {
+  children: React.ReactNode
+  initialLanguage?: Language | null
+}) {
   const pathname = usePathname()
+  const router = useRouter()
+  const refreshServerContent = useCallback(() => router.refresh(), [router])
   const publicSurface = isPublicSurface(pathname)
   const shared = (
-    <LanguageProvider>
+    <LanguageProvider initialLanguage={initialLanguage} refreshServerContent={refreshServerContent}>
       {children}
       {!publicSurface && <AgentDock />}
       {!publicSurface && <RumScreenTracker />}

--- a/openbank-admin-ui/src/lib/i18n/LanguageContext.tsx
+++ b/openbank-admin-ui/src/lib/i18n/LanguageContext.tsx
@@ -5,8 +5,10 @@
 'use client'
 
 import { createContext, useContext, useEffect, useState } from 'react'
+import { LANG_COOKIE, LANG_STORAGE_KEY, parseLanguage, type Language } from './language'
 
-type Language = 'en' | 'cs'
+export { LANG_COOKIE } from './language'
+export type { Language } from './language'
 
 interface LanguageContextType {
   language: Language
@@ -16,35 +18,68 @@ interface LanguageContextType {
 
 const LanguageContext = createContext<LanguageContextType | undefined>(undefined)
 
-// Cookie mirror so server components (e.g. /services/[name]/docs page) can
-// pick the same language as the client. Cookie expires after a year; same-site
-// Lax is sufficient — this is a cosmetic preference, not a security boundary.
-export const LANG_COOKIE = 'openbank-admin-lang'
-
+// The cookie is the shared server/client preference (server components cannot
+// read localStorage). It expires after a year; SameSite=Lax is sufficient —
+// this is a cosmetic preference, not a security boundary.
 function writeLangCookie(lang: Language) {
   if (typeof document === 'undefined') return
   const maxAge = 60 * 60 * 24 * 365
   document.cookie = `${LANG_COOKIE}=${lang}; path=/; max-age=${maxAge}; SameSite=Lax`
 }
 
-export function LanguageProvider({ children }: { children: React.ReactNode }) {
-  const [language, setLanguageState] = useState<Language>('en')
+export function LanguageProvider({
+  children,
+  initialLanguage = null,
+  refreshServerContent,
+}: {
+  children: React.ReactNode
+  initialLanguage?: Language | null
+  refreshServerContent?: () => void
+}) {
+  const [language, setLanguageState] = useState<Language>(initialLanguage ?? 'en')
 
   useEffect(() => {
-    const saved = localStorage.getItem('openbank-admin-lang') as Language
-    if (saved === 'en' || saved === 'cs') {
-      setLanguageState(saved)
-      writeLangCookie(saved)
+    if (initialLanguage) {
+      // The cookie is visible to both server and client, so it is authoritative
+      // when present. Keep the legacy localStorage mirror in sync instead of
+      // letting a stale browser value replace server-rendered content.
+      localStorage.setItem(LANG_STORAGE_KEY, initialLanguage)
+      return
+    }
+
+    // Migrate browsers that saved the preference before the cookie mirror was
+    // introduced. The first render remains English on both server and client;
+    // the legacy preference is applied only after hydration.
+    const saved = parseLanguage(localStorage.getItem(LANG_STORAGE_KEY))
+    if (saved) {
+      const migration = window.setTimeout(() => {
+        document.documentElement.lang = saved
+        setLanguageState(saved)
+        writeLangCookie(saved)
+        refreshServerContent?.()
+      }, 0)
+      return () => window.clearTimeout(migration)
     } else {
       // Mirror the default to cookie so the first server-rendered page picks it up.
       writeLangCookie('en')
     }
-  }, [])
+  }, [initialLanguage, refreshServerContent])
+
+  useEffect(() => {
+    document.documentElement.lang = language
+  }, [language])
 
   const setLanguage = (lang: Language) => {
+    // Keep the document truthful in the same interaction; the effect below also
+    // covers initial hydration and non-interactive state changes.
+    document.documentElement.lang = lang
     setLanguageState(lang)
-    localStorage.setItem('openbank-admin-lang', lang)
+    localStorage.setItem(LANG_STORAGE_KEY, lang)
     writeLangCookie(lang)
+    // Several documentation pages localize in Server Components by reading the
+    // cookie. Refresh their RSC payload after the synchronous cookie write so
+    // visible copy and the root language never disagree until navigation.
+    refreshServerContent?.()
   }
 
   const t = (csText: string, enText: string) => {

--- a/openbank-admin-ui/src/lib/i18n/language.ts
+++ b/openbank-admin-ui/src/lib/i18n/language.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+export type Language = 'en' | 'cs'
+
+export const LANG_COOKIE = 'openbank-admin-lang'
+export const LANG_STORAGE_KEY = 'openbank-admin-lang'
+
+export function parseLanguage(value: string | null | undefined): Language | null {
+  return value === 'en' || value === 'cs' ? value : null
+}

--- a/openbank-admin-ui/src/test/app-providers.test.tsx
+++ b/openbank-admin-ui/src/test/app-providers.test.tsx
@@ -9,7 +9,10 @@ import { usePathname } from 'next/navigation'
 import { AppProviders } from '@/components/layout/AppProviders'
 import { isPublicSurface } from '@/lib/auth/publicSurface'
 
-vi.mock('next/navigation', () => ({ usePathname: vi.fn() }))
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(),
+  useRouter: vi.fn(() => ({ refresh: vi.fn() })),
+}))
 vi.mock('@/components/auth/SessionProvider', () => ({
   SessionProvider: ({ children }: { children: React.ReactNode }) => <div data-testid="session-provider">{children}</div>,
 }))

--- a/openbank-admin-ui/src/test/document-language.test.tsx
+++ b/openbank-admin-ui/src/test/document-language.test.tsx
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { cookies } from 'next/headers'
+import RootLayout from '@/app/layout'
+import { LanguageProvider, useLanguage } from '@/lib/i18n/LanguageContext'
+import { LANG_COOKIE, LANG_STORAGE_KEY } from '@/lib/i18n/language'
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+  headers: vi.fn(async () => new Headers()),
+}))
+
+function Probe() {
+  const { language, setLanguage } = useLanguage()
+  return (
+    <button type="button" onClick={() => setLanguage(language === 'en' ? 'cs' : 'en')}>
+      {language}
+    </button>
+  )
+}
+
+function cookieStore(value?: string) {
+  return { get: (name: string) => name === LANG_COOKIE && value ? { value } : undefined }
+}
+
+describe('document language', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.cookie = `${LANG_COOKIE}=; path=/; max-age=0`
+    document.documentElement.lang = 'en'
+    vi.mocked(cookies).mockResolvedValue(cookieStore() as never)
+  })
+
+  it('server-renders the persisted cookie language on the root element', async () => {
+    vi.mocked(cookies).mockResolvedValue(cookieStore('cs') as never)
+
+    const root = await RootLayout({ children: <main /> })
+
+    expect(root.props.lang).toBe('cs')
+  })
+
+  it('defaults invalid persisted values to English', async () => {
+    vi.mocked(cookies).mockResolvedValue(cookieStore('de') as never)
+
+    const root = await RootLayout({ children: <main /> })
+
+    expect(root.props.lang).toBe('en')
+  })
+
+  it('keeps the document, cookie and browser mirror synchronized when toggled', async () => {
+    const refreshServerContent = vi.fn()
+    localStorage.setItem(LANG_STORAGE_KEY, 'en')
+    render(<LanguageProvider initialLanguage="cs" refreshServerContent={refreshServerContent}><Probe /></LanguageProvider>)
+
+    await waitFor(() => expect(document.documentElement.lang).toBe('cs'))
+    expect(localStorage.getItem(LANG_STORAGE_KEY)).toBe('cs')
+
+    fireEvent.click(screen.getByRole('button', { name: 'cs' }))
+
+    await waitFor(() => expect(document.documentElement.lang).toBe('en'))
+    expect(localStorage.getItem(LANG_STORAGE_KEY)).toBe('en')
+    expect(document.cookie).toContain(`${LANG_COOKIE}=en`)
+    expect(refreshServerContent).toHaveBeenCalledOnce()
+  })
+
+  it('migrates a legacy localStorage preference only when no cookie language exists', async () => {
+    const refreshServerContent = vi.fn()
+    localStorage.setItem(LANG_STORAGE_KEY, 'cs')
+    render(<LanguageProvider refreshServerContent={refreshServerContent}><Probe /></LanguageProvider>)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'cs' })).toBeVisible()
+      expect(document.documentElement.lang).toBe('cs')
+      expect(document.cookie).toContain(`${LANG_COOKIE}=cs`)
+    })
+    expect(refreshServerContent).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Summary

Keep the server-rendered document language, hydrated Admin UI language, and persisted operator preference in sync. This fixes the root `<html lang>` remaining English after Czech was selected and prevents a hydration-time language mismatch.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #8019

## Changes

- validate the language cookie on the server and render the matching root document language
- hydrate the language provider with the same initial locale, while preserving legacy localStorage migration
- synchronize document, cookie, localStorage, and cookie-localized Server Component content on language changes
- add focused Vitest coverage plus Playwright proof for raw SSR, client toggle, Server Component refresh, and reload persistence

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (Playwright browser scenario).
- [x] Contract tests updated (N/A — no public API change).
- [x] Admin UI type-check, lint, focused Vitest, Playwright, and production build pass.
- [x] No new lint warnings in changed files.
- [x] OpenAPI spec regenerated (N/A — no REST API change).
- [x] Flyway migration added + rollback note (N/A — no DB change).
- [x] Avro schema versioned backward-compatibly (N/A — no event change).
- [x] Docs updated (N/A — behavior is covered by tests).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new suppressions or unsafe casts.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? No.
- [x] PII path changed? No.
- [x] Cardholder data path changed? No.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: rolling through the existing Admin UI GitOps release flow
- Rollback plan: revert this commit and redeploy the preceding Admin UI image
- Data migration reversible: N/A; the existing preference key is retained

## Screenshots / demo (if UI change)

Automated Playwright proof: Czech cookie produces raw server-rendered `lang=cs` and Czech login UI; switching to English updates `lang=en` and survives reload. On an authenticated force-dynamic docs page, switching to Czech updates the cookie, root metadata, and server-rendered heading without a reload, then remains Czech after reload.

## Reviewer notes

Please verify cookie precedence over stale localStorage, the intentional legacy migration only when no valid cookie exists, and the `router.refresh()` bridge for cookie-localized Server Components. The catastrophic global error document remains bilingual-neutral and outside this root-layout context.
