### PR TITLE
fix(admin-ui): bind delegated access to latest party

### DIFF
--- a/openbank-admin-ui/e2e/delegations-console.spec.ts
+++ b/openbank-admin-ui/e2e/delegations-console.spec.ts
@@ -17,6 +17,7 @@ import { test, expect, type Page } from '@playwright/test'
 import { signInAsOperator } from './helpers/auth'
 
 const PARTY = '018f4a3c-1b2d-7e00-9a11-000000000001'
+const PARTY_B = '018f4a3c-1b2d-7e00-9a11-00000000000b'
 const GRANTEE = '018f4a3c-1b2d-7e00-9a11-0000000000ff'
 const GRANT = '018f4a3c-1b2d-7e00-9a11-000000000002'
 const RESOURCE = '018f4a3c-1b2d-7e00-9a11-000000000003'
@@ -80,6 +81,9 @@ async function stubBff(page: Page): Promise<string[]> {
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
+          evaluatedAt: '2026-09-01T12:00:00Z',
+          nextChangeAt: null,
+          refreshAfterMs: null,
           accounts: [{ id: RESOURCE, nickname: 'Provozní účet', accountNumber: 'CZ1234567890', currencyCode: 'CZK', status: 'ACTIVE' }],
           cards: [],
           grants: [],
@@ -169,6 +173,126 @@ test('a refused direction never renders as "no delegations"', async ({ page }) =
   await expect(main.getByText(/nebyl povolen|was refused for your role/)).toBeVisible()
   // The dangerous wrong answer must NOT be on screen for the refused direction.
   await expect(main.getByText(/Žádné delegace\.|No delegations\./)).toHaveCount(1)
+})
+
+test('a slow previous selection can never overwrite the newest customer', async ({ page }) => {
+  await page.route('**/api/entities/resolve**', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      results: [
+        { type: 'party', id: PARTY, label: 'Klient A' },
+        { type: 'party', id: PARTY_B, label: 'Klient B' },
+      ],
+    }),
+  }))
+  await page.route('**/api/delegations/**', async route => {
+    const path = new URL(route.request().url()).pathname
+    if (path.endsWith('/projection-health')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ consumers: [], state: 'ok' }) })
+    }
+    const selectedParty = path.includes(PARTY_B) ? PARTY_B : PARTY
+    if (selectedParty === PARTY) await new Promise(resolve => setTimeout(resolve, 350))
+    if (path.includes('/effective-access/')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          evaluatedAt: '2026-09-01T12:00:00Z',
+          nextChangeAt: null,
+          refreshAfterMs: null,
+          accounts: [{ id: `${selectedParty}-account`, nickname: selectedParty === PARTY_B ? 'Účet klienta B' : 'Účet klienta A' }],
+          cards: [],
+          grants: [],
+          presets: [ROLE_PRESET],
+          resourceDetails: [],
+          sources: { accounts: 'ok', cards: 'ok', grants: 'ok', presets: 'ok' },
+        }),
+      })
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ partyId: selectedParty, granted: [], received: [], sources: { granted: 'ok', received: 'ok' } }),
+    })
+  })
+
+  await page.goto('/delegations')
+  await page.getByRole('textbox', { name: /Hledat stranu|Search party/ }).fill('Klient')
+  await page.getByRole('button', { name: /Vyhledat|Search/ }).click()
+  await page.getByRole('button', { name: /Klient A/ }).click()
+  await page.getByRole('button', { name: /Klient B/ }).click()
+
+  const main = page.locator('main')
+  await expect(main.getByText('Účet klienta B')).toBeVisible()
+  await expect(main.getByText('Účet klienta A')).toHaveCount(0)
+  await expect(page.getByRole('button', { name: /Klient B/ })).toHaveAttribute('aria-pressed', 'true')
+})
+
+test('a newer search stays available and wins over a slower previous query', async ({ page }) => {
+  let slowSearchFinished = false
+  await page.route('**/api/entities/resolve**', async route => {
+    const query = new URL(route.request().url()).searchParams.get('q')
+    if (query === 'alfa') {
+      await new Promise(resolve => setTimeout(resolve, 800))
+      slowSearchFinished = true
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        results: [{ type: 'party', id: query === 'beta' ? PARTY_B : PARTY, label: query === 'beta' ? 'Výsledek Beta' : 'Výsledek Alfa' }],
+      }),
+    })
+  })
+
+  await page.goto('/delegations')
+  const input = page.getByRole('textbox', { name: /Hledat stranu|Search party/ })
+  const button = page.getByRole('button', { name: /Vyhledat|Search/ })
+  await input.fill('alfa')
+  await button.click()
+  await input.fill('beta')
+  await expect(button).toBeEnabled()
+  await button.click()
+
+  await expect(page.getByRole('button', { name: /Výsledek Beta/ })).toBeVisible()
+  await expect.poll(() => slowSearchFinished).toBe(true)
+  await expect(page.getByRole('button', { name: /Výsledek Alfa/ })).toHaveCount(0)
+})
+
+test('a failed effective summary does not hide successfully loaded grants', async ({ page }) => {
+  await stubBff(page)
+  await page.unroute('**/api/delegations/**')
+  let releaseProjection = () => {}
+  const projectionGate = new Promise<void>(resolve => { releaseProjection = resolve })
+  await page.route('**/api/delegations/**', async route => {
+    const path = new URL(route.request().url()).pathname
+    if (path.endsWith('/projection-health')) {
+      await projectionGate
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ consumers: [], state: 'ok' }) })
+    }
+    if (path.includes('/effective-access/')) {
+      return route.fulfill({ status: 502, contentType: 'application/json', body: JSON.stringify({ error: 'upstream_unreachable' }) })
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ partyId: PARTY, granted: [GRANT_ROW], received: [], sources: { granted: 'ok', received: 'ok' } }),
+    })
+  })
+
+  await page.goto('/delegations')
+  await page.getByRole('textbox', { name: /Hledat stranu|Search party/ }).fill('Novák')
+  await page.getByRole('button', { name: /Vyhledat|Search/ }).click()
+  await page.getByRole('button', { name: /Jan Novák/ }).click()
+
+  const main = page.locator('main')
+  await expect(main.getByText(/Souhrn efektivního přístupu je dočasně neúplný|effective-access summary is temporarily incomplete/)).toBeVisible()
+  await expect(main.getByTitle('ACCOUNT_INITIATE_PAYMENT').first()).toBeVisible()
+  await expect(main.getByRole('link', { name: /Detail/ }).first()).toBeVisible()
+  await expect(main.getByText(/Načítám zdraví projekcí|Loading projection health/)).toBeVisible()
+  releaseProjection()
+  await expect(main.getByText(/nemá žádnou konzumentskou skupinu|has no consumer group/)).toBeVisible()
 })
 
 test('role deletion explains impact and recovers from a failed request before removing the preset', async ({ page }) => {
@@ -293,7 +417,7 @@ test('the grant detail offers NO mutation — suspend, reinstate and revoke are 
   ])
 })
 
-test('the coverage probe asks the authority and shows its reason code', async ({ page }) => {
+test('the resource check explains its scope, asks the authority and shows its reason code', async ({ page }) => {
   await stubBff(page)
   await page.unroute('**/api/delegations/**')
 
@@ -313,6 +437,8 @@ test('the coverage probe asks the authority and shows its reason code', async ({
   })
 
   await page.goto(`/delegations/${GRANT}`)
+  await expect(page.getByText(/Nic nerezervuje|reserves nothing/)).toBeVisible()
+  await expect(page.getByText(/konkrétního grantu|specific grant/)).toBeVisible()
   await page.getByRole('textbox', { name: /Částka k ověření|Amount to probe/ }).fill('9000')
   await page.getByRole('button', { name: /^(Ověřit|Probe)$/ }).click()
 

--- a/openbank-admin-ui/src/app/api/delegations/effective-access/[partyId]/route.ts
+++ b/openbank-admin-ui/src/app/api/delegations/effective-access/[partyId]/route.ts
@@ -39,6 +39,29 @@ const object = (value: unknown): Record<string, unknown> | undefined =>
 
 const resourceKey = (resourceType: unknown, resourceId: unknown) => `${String(resourceType)}:${String(resourceId)}`
 
+const time = (value: unknown): number | null => {
+  if (typeof value !== 'string' || value.length === 0) return null
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const effectiveAt = (grant: Record<string, unknown>, now: number): boolean => {
+  if (grant.status !== 'ACTIVE') return false
+  const validFrom = time(grant.validFrom)
+  if (validFrom === null || validFrom > now) return false
+  if (grant.validTo === null || grant.validTo === undefined) return true
+  const validTo = time(grant.validTo)
+  return validTo !== null && now < validTo
+}
+
+const nextBoundary = (grants: Record<string, unknown>[], now: number): string | null => {
+  const candidates = grants.flatMap(grant => {
+    if (grant.status !== 'ACTIVE') return []
+    return [time(grant.validFrom), time(grant.validTo)].filter((value): value is number => value !== null && value > now)
+  })
+  return candidates.length === 0 ? null : new Date(Math.min(...candidates)).toISOString()
+}
+
 export async function GET(_request: Request, { params }: { params: Promise<{ partyId: string }> }) {
   const session = await auth()
   if (!session?.user?.accessToken) return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
@@ -53,8 +76,11 @@ export async function GET(_request: Request, { params }: { params: Promise<{ par
     read(serverSvcUrl('delegation-service', 'delegation', 8126, '/api/v1/delegation-role-presets'), headers),
   ])
   const grantList = list(grants.data)
-  const activeResources = [...new Map(grantList
-    .filter(grant => grant.status === 'ACTIVE' && typeof grant.resourceId === 'string' && UUID_RE.test(grant.resourceId) &&
+  const evaluatedAt = new Date()
+  const nextChangeAt = nextBoundary(grantList, evaluatedAt.getTime())
+  const effectiveGrants = grantList.filter(grant => effectiveAt(grant, evaluatedAt.getTime()))
+  const activeResources = [...new Map(effectiveGrants
+    .filter(grant => typeof grant.resourceId === 'string' && UUID_RE.test(grant.resourceId) &&
       (grant.resourceType === 'ACCOUNT' || grant.resourceType === 'SAVINGS_GOAL' || grant.resourceType === 'CARD'))
     .map(grant => [resourceKey(grant.resourceType, grant.resourceId), grant])).values()]
   const resourcesToResolve = activeResources.slice(0, MAX_RESOURCE_DETAILS)
@@ -68,11 +94,20 @@ export async function GET(_request: Request, { params }: { params: Promise<{ par
     const result = await read(serverSvcUrl(service[0], service[1], service[2], path), headers)
     return { key: resourceKey(resourceType, resourceId), resourceType, resourceId, state: result.state, detail: object(result.data) }
   }))
+  // Detail lookups may consume most of the upstream timeout. Return the remaining server-clock
+  // delay at the instant the response is assembled so the browser never extends a stale snapshot.
+  const nextChangeMs = time(nextChangeAt)
+  const refreshAfterMs = nextChangeMs === null ? null : Math.max(nextChangeMs - Date.now(), 0)
 
   return NextResponse.json({
     partyId,
+    evaluatedAt: evaluatedAt.toISOString(),
+    nextChangeAt,
+    refreshAfterMs,
     accounts: list(accounts.data),
     cards: list(cards.data),
+    // Keep non-effective rows for the explicit "needs attention" explanation, but resolve
+    // concrete resource details only for grants effective at the BFF timestamp above.
     grants: grantList,
     presets: list(presets.data),
     resourceDetails,

--- a/openbank-admin-ui/src/app/delegations/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/delegations/[id]/page.tsx
@@ -2,8 +2,8 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-// ADR-0230 + ADR-0232: single-grant detail — capabilities, ceilings, status timeline, and the
-// coverage probe.
+// ADR-0230 + ADR-0232: single-grant detail — capabilities, ceilings, status timeline, and a
+// side-effect-free resource access eligibility check.
 //
 // The bank-side actions (suspend / reinstate / revoke) are stated as UNAVAILABLE in place rather
 // than rendered as disabled buttons. A greyed-out button says "you lack the right"; the true
@@ -144,9 +144,10 @@ export default function DelegationDetailPage() {
 }
 
 /**
- * Asks delegation-service the same question its enforcement points ask. A grant row shows what
- * exists; only the authority knows how status, ceilings, expiry and capability combine, so an
- * operator answering "could this delegate really have done that?" from the table is guessing.
+ * Asks delegation-service whether any current delegation covers this grantee, resource and
+ * capability. The endpoint does not bind its decision to the grant shown on this page and does
+ * not prove cumulative headroom: only the payment reservation path can atomically consume
+ * daily/monthly capacity without racing another payment.
  */
 function CoverageProbe({ grant }: { grant: Grant }) {
   const { t } = useLanguage()
@@ -186,12 +187,12 @@ function CoverageProbe({ grant }: { grant: Grant }) {
     <div className="card" style={{ padding: '16px', marginTop: '16px' }}>
       <h2 style={{ fontSize: '15px', fontWeight: 700, marginBottom: '2px' }}>
         <ShieldQuestion size={15} color="var(--accent)" style={{ verticalAlign: 'middle', marginRight: '6px' }} />
-        {t('Ověření pokrytí', 'Coverage probe')}
+        {t('Kontrola přístupu ke zdroji', 'Resource access eligibility check')}
       </h2>
       <p style={{ fontSize: '12px', color: 'var(--text-tertiary)', marginBottom: '12px' }}>
         {t(
-          'Zeptá se delegační služby na stejnou otázku, jakou klade vynucovací bod. Nic nemění.',
-          'Asks delegation-service the same question the enforcement point asks. Changes nothing.',
+          'Hledá libovolnou právě účinnou delegaci tohoto příjemce ke stejnému zdroji — výsledek nemusí pocházet z tohoto konkrétního grantu. Ověří oprávnění a strop jedné operace, nic nerezervuje a nepotvrzuje zbývající denní ani měsíční limit.',
+          'Finds any delegation currently effective for this grantee and resource — the result need not come from this specific grant. It checks capability and the per-operation ceiling, reserves nothing, and does not prove remaining daily or monthly headroom.',
         )}
       </p>
 
@@ -225,7 +226,7 @@ function CoverageProbe({ grant }: { grant: Grant }) {
 
       {outcome && (
         <div style={{ marginTop: '12px', fontSize: '13px' }}>
-          <strong>{outcome.granted ? t('Povoleno', 'Allowed') : t('Zamítnuto', 'Denied')}</strong>
+          <strong>{outcome.granted ? t('Aktuální přístup vyhovuje', 'Current access is eligible') : t('Zamítnuto', 'Denied')}</strong>
           {outcome.code && <span style={{ marginLeft: '8px', color: 'var(--text-tertiary)' }}>{outcome.code}</span>}
           {outcome.reason && <div style={{ color: 'var(--text-tertiary)', marginTop: '4px' }}>{outcome.reason}</div>}
         </div>

--- a/openbank-admin-ui/src/app/delegations/page.tsx
+++ b/openbank-admin-ui/src/app/delegations/page.tsx
@@ -18,11 +18,11 @@
 
 'use client'
 
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { Search, Share2, RefreshCw, Activity } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
-import { classifyBffFailure, type BffFailure } from '@/lib/services/bff'
+import { classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { EntityChip } from '@/components/entities/EntityChip'
 import { PageHeader } from '@/components/ui/PageHeader'
@@ -65,75 +65,145 @@ export default function DelegationsPage() {
   const [results, setResults] = useState<EntityRef[]>([])
   const [searched, setSearched] = useState(false)
   const [searchFailed, setSearchFailed] = useState(false)
+  const [searching, setSearching] = useState(false)
 
   const [party, setParty] = useState<EntityRef | null>(null)
   const [grants, setGrants] = useState<GrantsPayload | null>(null)
   const [effectiveAccess, setEffectiveAccess] = useState<EffectiveAccessPayload | null>(null)
   const [grantsUnavail, setGrantsUnavail] = useState<UnavailableKind | null>(null)
+  const [effectiveUnavail, setEffectiveUnavail] = useState<UnavailableKind | null>(null)
   const [loading, setLoading] = useState(false)
 
   const [consumers, setConsumers] = useState<ProjectionConsumer[] | null>(null)
   const [projectionKnown, setProjectionKnown] = useState(true)
+  const [projectionLoading, setProjectionLoading] = useState(false)
+  const searchGeneration = useRef(0)
+  const searchRequest = useRef<AbortController | null>(null)
+  const accessGeneration = useRef(0)
+  const accessRequest = useRef<AbortController | null>(null)
+
+  useEffect(() => () => {
+    searchGeneration.current += 1
+    accessGeneration.current += 1
+    searchRequest.current?.abort()
+    accessRequest.current?.abort()
+  }, [])
 
   const search = useCallback(async () => {
     const q = term.trim()
     if (q.length < SEARCH_MIN) return
+    const generation = ++searchGeneration.current
+    searchRequest.current?.abort()
+    const controller = new AbortController()
+    const timeout = window.setTimeout(() => controller.abort(), 6000)
+    searchRequest.current = controller
     setSearchFailed(false)
     setSearched(true)
+    setSearching(true)
+    setResults([])
     try {
       const res = await fetch(`/api/entities/resolve?q=${encodeURIComponent(q)}`, {
         cache: 'no-store',
-        signal: AbortSignal.timeout(6000),
+        signal: controller.signal,
       })
+      if (generation !== searchGeneration.current) return
       if (!res.ok) { setSearchFailed(true); setResults([]); return }
       const body = (await res.json()) as { results?: EntityRef[] }
+      if (generation !== searchGeneration.current) return
       setResults((body.results ?? []).filter(r => r.type === 'party'))
     } catch {
-      setSearchFailed(true)
-      setResults([])
+      if (generation === searchGeneration.current) {
+        setSearchFailed(true)
+        setResults([])
+      }
+    } finally {
+      window.clearTimeout(timeout)
+      if (searchRequest.current === controller) searchRequest.current = null
+      if (generation === searchGeneration.current) setSearching(false)
     }
   }, [term])
 
   const loadGrants = useCallback(async (target: EntityRef) => {
+    const generation = ++accessGeneration.current
+    accessRequest.current?.abort()
+    const controller = new AbortController()
+    const timeout = window.setTimeout(() => controller.abort(), 8000)
+    accessRequest.current = controller
     setParty(target)
     setLoading(true)
     setGrantsUnavail(null)
+    setEffectiveUnavail(null)
     setGrants(null)
     setEffectiveAccess(null)
-    try {
-      const [res, effectiveRes] = await Promise.all([
-        fetch(`/api/delegations/party/${target.id}`, { cache: 'no-store', signal: AbortSignal.timeout(8000) }),
-        fetch(`/api/delegations/effective-access/${target.id}`, { cache: 'no-store', signal: AbortSignal.timeout(8000) }),
-      ])
-      if (effectiveRes.ok) {
-        const payload: unknown = await effectiveRes.json()
-        if (isEffectiveAccessPayload(payload)) setEffectiveAccess(payload)
-      }
-      if (!res.ok) {
-        setGrantsUnavail((await classifyBffFailure(res)) as BffFailure)
-        return
-      }
-      setGrants((await res.json()) as GrantsPayload)
-    } catch {
-      setGrantsUnavail('unreachable')
-    } finally {
-      setLoading(false)
-    }
+    setConsumers(null)
+    setProjectionKnown(false)
+    setProjectionLoading(true)
+
+    const grantsRequest = fetch(`/api/delegations/party/${target.id}`, {
+      cache: 'no-store',
+      signal: controller.signal,
+    }).then(async res => {
+      if (!res.ok) return { data: null, unavailable: await classifyBffFailure(res) }
+      return { data: (await res.json()) as GrantsPayload, unavailable: null }
+    })
+    const effectiveRequest = fetch(`/api/delegations/effective-access/${target.id}`, {
+      cache: 'no-store',
+      signal: controller.signal,
+    }).then(async res => {
+      if (!res.ok) return { data: null, unavailable: await classifyBffFailure(res) }
+      const payload: unknown = await res.json()
+      return isEffectiveAccessPayload(payload)
+        ? { data: payload, unavailable: null }
+        : { data: null, unavailable: 'error' as const }
+    })
+    const projectionRequest = fetch('/api/delegations/projection-health', {
+      cache: 'no-store',
+      signal: controller.signal,
+    }).then(async res => {
+      if (!res.ok) return null
+      return (await res.json()) as { consumers?: ProjectionConsumer[]; state?: string }
+    }).catch(() => null)
 
     try {
-      const res = await fetch('/api/delegations/projection-health', {
-        cache: 'no-store',
-        signal: AbortSignal.timeout(6000),
-      })
-      if (!res.ok) { setProjectionKnown(false); setConsumers(null); return }
-      const body = (await res.json()) as { consumers?: ProjectionConsumer[]; state?: string }
-      setProjectionKnown(body.state === 'ok')
-      setConsumers(body.consumers ?? [])
-    } catch {
-      setProjectionKnown(false)
-      setConsumers(null)
+      const [grantResult, effectiveResult] = await Promise.allSettled([grantsRequest, effectiveRequest])
+      if (generation === accessGeneration.current) {
+        if (grantResult.status === 'fulfilled') {
+          setGrants(grantResult.value.data)
+          setGrantsUnavail(grantResult.value.unavailable)
+        } else {
+          setGrantsUnavail('unreachable')
+        }
+        if (effectiveResult.status === 'fulfilled') {
+          setEffectiveAccess(effectiveResult.value.data)
+          setEffectiveUnavail(effectiveResult.value.unavailable)
+        } else {
+          setEffectiveUnavail('unreachable')
+        }
+      }
+    } finally {
+      if (generation === accessGeneration.current) setLoading(false)
+    }
+
+    const projection = await projectionRequest
+    if (generation === accessGeneration.current) {
+      setProjectionKnown(projection?.state === 'ok')
+      setConsumers(projection?.consumers ?? null)
+      setProjectionLoading(false)
+    }
+    window.clearTimeout(timeout)
+    if (accessRequest.current === controller) {
+      accessRequest.current = null
     }
   }, [])
+
+  useEffect(() => {
+    if (!party || !effectiveAccess?.nextChangeAt || effectiveAccess.refreshAfterMs === null) return
+    // The BFF computes this remaining duration immediately before returning the snapshot. This
+    // avoids both the workstation clock and extending validity by time spent resolving details.
+    const delay = Math.min(Math.max(effectiveAccess.refreshAfterMs, 0), 2_147_000_000)
+    const timer = window.setTimeout(() => { void loadGrants(party) }, delay)
+    return () => window.clearTimeout(timer)
+  }, [effectiveAccess?.nextChangeAt, effectiveAccess?.refreshAfterMs, loadGrants, party])
 
   return (
     <div>
@@ -167,7 +237,7 @@ export default function DelegationsPage() {
             placeholder={t('Jméno strany…', 'Party name…')}
             aria-label={t('Hledat stranu', 'Search party')}
           />
-          <button type="button" className="btn btn-primary" onClick={search} disabled={term.trim().length < SEARCH_MIN} aria-busy={loading} aria-label={t('Vyhledat delegující stranu', 'Search delegating party')}>
+          <button type="button" className="btn btn-primary" onClick={search} disabled={term.trim().length < SEARCH_MIN} aria-busy={searching} aria-label={t('Vyhledat delegující stranu', 'Search delegating party')}>
             <Search size={14} aria-hidden="true" />
             {t('Vyhledat', 'Search')}
           </button>
@@ -182,7 +252,7 @@ export default function DelegationsPage() {
           </p>
         )}
 
-        {searched && !searchFailed && results.length === 0 && (
+        {searched && !searching && !searchFailed && results.length === 0 && (
           <p style={{ marginTop: '10px', fontSize: '13px', color: 'var(--text-tertiary)' }}>
             {t('Žádná strana neodpovídá dotazu.', 'No party matches that query.')}
           </p>
@@ -225,7 +295,20 @@ export default function DelegationsPage() {
         />
       )}
 
+      {party && loading && (
+        <div role="status" aria-live="polite" className="card" style={{ padding: '20px', marginBottom: '20px', color: 'var(--text-tertiary)', fontSize: '13px' }}>
+          {t(`Načítám přístup klienta ${party.label}…`, `Loading access for ${party.label}…`)}
+        </div>
+      )}
+
       {party && effectiveAccess && <EffectiveAccess data={effectiveAccess} />}
+
+      {party && !loading && effectiveUnavail && grants && (
+        <div role="status" aria-live="polite" style={{ padding: '12px', marginBottom: '20px', borderRadius: '10px', border: '1px solid var(--warning-border)', background: 'var(--warning-bg)', fontSize: '12px' }}>
+          <strong>{t('Souhrn efektivního přístupu je dočasně neúplný.', 'The effective-access summary is temporarily incomplete.')}</strong>{' '}
+          {t('Níže zůstávají zobrazené úspěšně načtené delegace; vlastnictví, názvy rolí nebo detaily zdrojů mohou chybět.', 'Successfully loaded grants remain visible below; ownership, role names, or resource details may be missing.')}
+        </div>
+      )}
 
       {party && !grantsUnavail && grants && (
         <>
@@ -245,7 +328,7 @@ export default function DelegationsPage() {
             direction="received"
             effectiveAccess={effectiveAccess}
           />
-          <ProjectionHealth consumers={consumers} known={projectionKnown} />
+          <ProjectionHealth consumers={consumers} known={projectionKnown} loading={projectionLoading} />
         </>
       )}
     </div>
@@ -322,7 +405,7 @@ function GrantTable({
   )
 }
 
-function ProjectionHealth({ consumers, known }: { consumers: ProjectionConsumer[] | null; known: boolean }) {
+function ProjectionHealth({ consumers, known, loading }: { consumers: ProjectionConsumer[] | null; known: boolean; loading: boolean }) {
   const { t } = useLanguage()
 
   return (
@@ -338,7 +421,11 @@ function ProjectionHealth({ consumers, known }: { consumers: ProjectionConsumer[
         )}
       </p>
 
-      {!known || consumers === null ? (
+      {loading ? (
+        <div role="status" style={{ padding: '12px', fontSize: '13px', color: 'var(--text-tertiary)' }}>
+          {t('Načítám zdraví projekcí…', 'Loading projection health…')}
+        </div>
+      ) : !known || consumers === null ? (
         <div style={{ padding: '12px', fontSize: '13px', color: 'var(--text-tertiary)' }}>
           {t(
             'Zpoždění konzumentů teď není známé — nepovažujte to za nulové zpoždění.',

--- a/openbank-admin-ui/src/components/delegations/EffectiveAccess.tsx
+++ b/openbank-admin-ui/src/components/delegations/EffectiveAccess.tsx
@@ -14,6 +14,9 @@ type Card = { id?: string; maskedPan?: string; cardType?: string; network?: stri
 export type ResourceDetail = { key: string; resourceType: string; resourceId: string; state: SourceState; detail?: Account | Card }
 
 export type EffectiveAccessPayload = {
+  evaluatedAt: string
+  nextChangeAt: string | null
+  refreshAfterMs: number | null
   accounts: Account[]
   cards: Card[]
   grants: Grant[]
@@ -26,7 +29,10 @@ export type EffectiveAccessPayload = {
 export function isEffectiveAccessPayload(value: unknown): value is EffectiveAccessPayload {
   if (!value || typeof value !== 'object') return false
   const candidate = value as Partial<EffectiveAccessPayload>
-  return Array.isArray(candidate.accounts) && Array.isArray(candidate.cards) &&
+  return typeof candidate.evaluatedAt === 'string' && !Number.isNaN(Date.parse(candidate.evaluatedAt)) &&
+    (candidate.nextChangeAt === null || (typeof candidate.nextChangeAt === 'string' && !Number.isNaN(Date.parse(candidate.nextChangeAt)))) &&
+    (candidate.refreshAfterMs === null || (typeof candidate.refreshAfterMs === 'number' && Number.isFinite(candidate.refreshAfterMs) && candidate.refreshAfterMs >= 0)) &&
+    Array.isArray(candidate.accounts) && Array.isArray(candidate.cards) &&
     Array.isArray(candidate.grants) && Array.isArray(candidate.presets) && Array.isArray(candidate.resourceDetails) &&
     !!candidate.sources && typeof candidate.sources === 'object'
 }
@@ -88,6 +94,16 @@ export function grantConditions(grant: Grant, language: 'cs' | 'en') {
   ] as const
   limits.forEach(([label, limit]) => conditions.push({ label, value: limit ? formatCeiling(limit, locale) : t('bez limitu', 'uncapped') }))
   return conditions
+}
+
+/** Matches delegation-service's half-open validity interval: validFrom <= now < validTo. */
+export function isGrantEffectiveAt(grant: Grant, now: Date): boolean {
+  if (grant.status !== 'ACTIVE' || Number.isNaN(now.getTime())) return false
+  const validFrom = new Date(grant.validFrom ?? '').getTime()
+  if (Number.isNaN(validFrom) || now.getTime() < validFrom) return false
+  if (grant.validTo === null || grant.validTo === undefined) return true
+  const validTo = new Date(grant.validTo).getTime()
+  return !Number.isNaN(validTo) && now.getTime() < validTo
 }
 
 export type DelegationAttentionReason = {
@@ -152,8 +168,10 @@ export function delegationAttentionReasons(grant: Grant, now: Date, language: 'c
 export function EffectiveAccess({ data }: { data: EffectiveAccessPayload }) {
   const { t, language } = useLanguage()
   const partial = Object.entries(data.sources).filter(([, state]) => state !== 'ok')
+  const now = new Date(data.evaluatedAt)
+  const effectiveGrants = data.grants.filter(grant => isGrantEffectiveAt(grant, now))
   const attention = data.grants
-    .map(grant => ({ grant, reasons: delegationAttentionReasons(grant, new Date(), language) }))
+    .map(grant => ({ grant, reasons: delegationAttentionReasons(grant, now, language) }))
     .filter(item => item.reasons.length > 0)
 
   return <section className="card" style={{ padding: 16, marginBottom: 20 }} aria-labelledby="effective-access-title">
@@ -191,8 +209,8 @@ export function EffectiveAccess({ data }: { data: EffectiveAccessPayload }) {
       {data.cards.map(card => <AccessCard key={`card-${card.id}`} icon={<Crown size={15} />} role={card.delegated ? t('Držitel dodatkové karty', 'Additional cardholder') : t('Majitel karty', 'Card owner')} resource={card.maskedPan || t('Karta', 'Card')} meta={[card.network, card.cardType, card.status].filter(Boolean).join(' · ')} href={card.id ? `/cards/${card.id}` : undefined} capabilities={card.delegated ? delegatedCardCapabilities(card, data) : [...CAPABILITIES_BY_RESOURCE.CARD]} />)}
     </AccessSection>
 
-    <AccessSection title={t('Delegovaná oprávnění', 'Delegated rights')} empty={!data.grants.some(grant => grant.status === 'ACTIVE')}>
-      {data.grants.filter(grant => grant.status === 'ACTIVE').map(grant => {
+    <AccessSection title={t('Právě účinná delegovaná oprávnění', 'Delegated rights effective now')} empty={effectiveGrants.length === 0}>
+      {effectiveGrants.map(grant => {
         const resource = grantResourcePresentation(grant, data.resourceDetails, language)
         const grantor = grant.grantorName?.trim() || shortId(grant.grantorPartyId)
         return <AccessCard key={`grant-${grant.id}`} icon={<KeyRound size={15} />} role={matchedRoleName(grant, data.presets, language)} resource={resource.label} meta={<div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 7 }}><DelegationStatusBadge status={grant.status} /><span>{t('Udělil', 'Granted by')}: {grantor}</span>{resource.meta && <span>· {resource.meta}</span>}</div>} href={`/delegations/${grant.id}`} capabilities={grant.capabilities} conditions={grantConditions(grant, language)} />

--- a/openbank-admin-ui/src/test/delegation-effective-access.test.ts
+++ b/openbank-admin-ui/src/test/delegation-effective-access.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest'
-import { delegationAttentionReasons, effectiveResourceDetails, grantConditions, grantResourcePresentation, isEffectiveAccessPayload, matchedRoleName } from '@/components/delegations/EffectiveAccess'
+import { delegationAttentionReasons, effectiveResourceDetails, grantConditions, grantResourcePresentation, isEffectiveAccessPayload, isGrantEffectiveAt, matchedRoleName } from '@/components/delegations/EffectiveAccess'
 import type { Grant } from '@/components/delegations/GrantView'
 import type { RolePreset } from '@/lib/delegations/rolePresets'
 
@@ -16,9 +16,10 @@ describe('effective access role matching', () => {
     expect(matchedRoleName({ ...grant, capabilities: ['ACCOUNT_READ_BALANCES'] }, presets, 'cs')).toBe('Vlastní kombinace práv')
   })
 
-  it('rejects a legacy grant payload instead of crashing the customer console', () => {
+  it('requires a server evaluation timestamp instead of trusting the browser clock', () => {
     expect(isEffectiveAccessPayload({ ...grant, id: 'g1' })).toBe(false)
-    expect(isEffectiveAccessPayload({ accounts: [], cards: [], grants: [], presets: [], resourceDetails: [], sources: { accounts: 'ok' } })).toBe(true)
+    expect(isEffectiveAccessPayload({ evaluatedAt: '2026-09-01T12:00:00Z', nextChangeAt: null, refreshAfterMs: null, accounts: [], cards: [], grants: [], presets: [], resourceDetails: [], sources: { accounts: 'ok' } })).toBe(true)
+    expect(isEffectiveAccessPayload({ evaluatedAt: 'not-a-time', nextChangeAt: null, refreshAfterMs: null, accounts: [], cards: [], grants: [], presets: [], resourceDetails: [], sources: {} })).toBe(false)
   })
 
   it('explains the concrete account behind a delegation instead of showing only its UUID', () => {
@@ -31,6 +32,9 @@ describe('effective access role matching', () => {
 
   it('uses owned resources to explain grants made by the selected customer', () => {
     const details = effectiveResourceDetails({
+      evaluatedAt: '2026-09-01T12:00:00Z',
+      nextChangeAt: null,
+      refreshAfterMs: null,
       accounts: [{ id: 'account-1', accountNumber: 'CZ1234567890', nickname: 'Provozní účet', currencyCode: 'CZK' }],
       cards: [{ id: 'card-1', maskedPan: '•••• 4321', network: 'VISA' }],
       grants: [],
@@ -51,6 +55,9 @@ describe('effective access role matching', () => {
 
   it('prefers an explicitly resolved detail over an ownership-list fallback', () => {
     const details = effectiveResourceDetails({
+      evaluatedAt: '2026-09-01T12:00:00Z',
+      nextChangeAt: null,
+      refreshAfterMs: null,
       accounts: [{ id: 'account-1', nickname: 'Old label' }],
       cards: [],
       grants: [],
@@ -137,5 +144,27 @@ describe('effective access role matching', () => {
   it('does not flag read-only access without an end date or inactive grants', () => {
     expect(delegationAttentionReasons({ ...grant, status: 'ACTIVE', validTo: null }, new Date('2026-09-01T12:00:00Z'), 'en')).toEqual([])
     expect(delegationAttentionReasons({ ...grant, status: 'REVOKED', validTo: '2026-09-02T12:00:00Z' }, new Date('2026-09-01T12:00:00Z'), 'en')).toEqual([])
+  })
+
+  it('uses the authority half-open validity interval for effective-now access', () => {
+    const timedGrant = {
+      ...grant,
+      status: 'ACTIVE',
+      validFrom: '2026-09-01T10:00:00Z',
+      validTo: '2026-09-01T11:00:00Z',
+    }
+
+    expect(isGrantEffectiveAt(timedGrant, new Date('2026-09-01T09:59:59.999Z'))).toBe(false)
+    expect(isGrantEffectiveAt(timedGrant, new Date('2026-09-01T10:00:00Z'))).toBe(true)
+    expect(isGrantEffectiveAt(timedGrant, new Date('2026-09-01T10:59:59.999Z'))).toBe(true)
+    expect(isGrantEffectiveAt(timedGrant, new Date('2026-09-01T11:00:00Z'))).toBe(false)
+  })
+
+  it('fails closed for malformed validity and non-active status', () => {
+    const now = new Date('2026-09-01T10:00:00Z')
+    expect(isGrantEffectiveAt({ ...grant, status: 'ACTIVE', validFrom: null }, now)).toBe(false)
+    expect(isGrantEffectiveAt({ ...grant, status: 'ACTIVE', validFrom: 'invalid' }, now)).toBe(false)
+    expect(isGrantEffectiveAt({ ...grant, status: 'ACTIVE', validFrom: '2026-01-01T00:00:00Z', validTo: '' }, now)).toBe(false)
+    expect(isGrantEffectiveAt({ ...grant, status: 'REVOKED', validFrom: '2026-01-01T00:00:00Z' }, now)).toBe(false)
   })
 })

--- a/openbank-admin-ui/src/test/delegations-routes.test.ts
+++ b/openbank-admin-ui/src/test/delegations-routes.test.ts
@@ -23,6 +23,8 @@ function grant(id: string, status = 'ACTIVE') {
     resourceType: 'ACCOUNT',
     resourceId: RESOURCE,
     capabilities: ['ACCOUNT_READ_BALANCES'],
+    validFrom: '2026-01-01T00:00:00Z',
+    validTo: null,
     status,
   }
 }
@@ -36,6 +38,7 @@ beforeEach(() => {
   vi.mocked(auth).mockResolvedValue(SESSION as never)
 })
 afterEach(() => {
+  vi.useRealTimers()
   vi.restoreAllMocks()
 })
 
@@ -143,10 +146,59 @@ describe('GET /api/delegations/effective-access/[partyId]', () => {
     expect(body.accounts[0].id).toBe('a1')
     expect(body.cards[0].id).toBe('c1')
     expect(body.grants[0].id).toBe('r1')
+    expect(Number.isNaN(Date.parse(body.evaluatedAt))).toBe(false)
+    expect(body.nextChangeAt).toBeNull()
+    expect(body.refreshAfterMs).toBeNull()
     expect(body.presets[0].name).toBe('Účetní')
     expect(body.resourceDetails[0]).toMatchObject({ key: `ACCOUNT:${RESOURCE}`, state: 'ok', detail: { accountNumber: 'CZ1234567890' } })
     expect(body.sources).toEqual({ accounts: 'ok', cards: 'ok', grants: 'ok', presets: 'ok' })
     expect(fetchCalls()).toHaveLength(5)
+  })
+
+  it('uses the BFF clock and resolves details only inside a valid interval', async () => {
+    const futureResource = '018f4a3c-1b2d-7e00-9a11-000000000004'
+    const expiredResource = '018f4a3c-1b2d-7e00-9a11-000000000005'
+    const malformedResource = '018f4a3c-1b2d-7e00-9a11-000000000006'
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+      const url = String(input)
+      if (url.includes('/delegations/grantee/')) {
+        return new Response(JSON.stringify([
+          grant('effective'),
+          { ...grant('future'), resourceId: futureResource, validFrom: '2099-01-01T00:00:00Z' },
+          { ...grant('expired'), resourceId: expiredResource, validFrom: '2000-01-01T00:00:00Z', validTo: '2001-01-01T00:00:00Z' },
+          { ...grant('malformed'), resourceId: malformedResource, validFrom: '' },
+        ]), { status: 200 })
+      }
+      return new Response('[]', { status: 200 })
+    }))
+
+    const body = await (await call(PARTY)).json()
+    expect(body.grants.map((item: { id: string }) => item.id)).toEqual(['effective', 'future', 'expired', 'malformed'])
+    expect(body.nextChangeAt).toBe('2099-01-01T00:00:00.000Z')
+    expect(body.refreshAfterMs).toBeGreaterThan(0)
+    const resolvedResources = fetchCalls().map(([url]) => String(url)).filter(url => /\/api\/v1\/accounts\/[0-9a-f-]+$/.test(url))
+    expect(resolvedResources).toEqual([expect.stringContaining(`/api/v1/accounts/${RESOURCE}`)])
+  })
+
+  it('requests an immediate refresh when a validity boundary passes during detail resolution', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime('2026-09-01T12:00:00Z')
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+      const url = String(input)
+      if (url.includes('/delegations/grantee/')) {
+        return new Response(JSON.stringify([{ ...grant('ending'), validTo: '2026-09-01T12:00:01Z' }]), { status: 200 })
+      }
+      if (url.includes(`/accounts/${RESOURCE}`)) {
+        vi.setSystemTime('2026-09-01T12:00:02Z')
+        return new Response(JSON.stringify({ id: RESOURCE }), { status: 200 })
+      }
+      return new Response('[]', { status: 200 })
+    }))
+
+    const body = await (await call(PARTY)).json()
+    expect(body.evaluatedAt).toBe('2026-09-01T12:00:00.000Z')
+    expect(body.nextChangeAt).toBe('2026-09-01T12:00:01.000Z')
+    expect(body.refreshAfterMs).toBe(0)
   })
 
   it('keeps successful ownership visible when another source is forbidden', async () => {

--- a/openbank-admin-ui/src/test/delegations-search.guard.test.ts
+++ b/openbank-admin-ui/src/test/delegations-search.guard.test.ts
@@ -7,7 +7,7 @@ describe('delegations search contract', () => {
   it('keeps party search and selection explicit', () => {
     const source = readFileSync(path.resolve(__dirname, '../app/delegations/page.tsx'), 'utf8')
     expect(source).toContain('type="button" className="btn btn-primary" onClick={search}')
-    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain('aria-busy={searching}')
     expect(source).toContain("aria-label={t('Vyhledat delegující stranu', 'Search delegating party')}")
     expect(source).toContain('aria-pressed={party?.id === r.id}')
     expect(source).toContain('onClick={() => loadGrants(r)}')


### PR DESCRIPTION
## Summary

Makes the delegated-access console bind every asynchronous result to the latest selected party and render time-bound access from an authoritative server snapshot. It also keeps successful partial data visible, separates projection-health loading, and describes the resource eligibility check without implying that it validates this specific grant or reserves cumulative limit capacity.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #8018

## Changes

- Abort and generation-bind party searches and access fan-out so stale A responses cannot overwrite selected party B.
- Evaluate half-open grant validity on the BFF clock, refresh at the next validity boundary, and account for time consumed by resource-detail resolution.
- Preserve successful grants when the effective-access source fails; represent projection loading, forbidden sources, and unknown lag distinctly.
- Make the resource check's scope explicit and add deterministic browser regressions for races, partial failures, role retries, read-only detail, and authority reason codes.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [x] Contract tests updated (N/A: internal same-release BFF response only; strict runtime validator and route integration test updated together).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes (N/A for admin UI; targeted ESLint, TypeScript, Vitest, Playwright, and production Next.js build pass).
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (N/A: no public REST contract changed).
- [x] Flyway migration added + rollback note (N/A: no database change).
- [x] Avro schema versioned backward-compatibly (N/A: no event change).
- [x] Docs updated (truthful operator guidance is inline on the affected screen).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? No.
- [x] PII path changed? No new collection or disclosure; the fix prevents cross-party stale rendering.
- [x] Cardholder data path changed? No.

## Compliance impact

- [ ] PCI DSS
- [x] DORA
- [x] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

The change improves operational truthfulness and prevents a stale response for one party from being rendered after another party was selected. It introduces no new data, retention, or downstream processing.

## Rollout / Rollback

- Deployment strategy: rolling admin-ui image deployment through the existing GitOps workflow.
- Rollback plan: revert the squash commit and roll back to the prior admin-ui image; no persistent state changes are involved.
- Data migration reversible: N/A

## Screenshots / demo (if UI change)

The existing `/delegations` and `/delegations/[id]` layouts are retained; the change is covered by nine Playwright scenarios rather than a static screenshot of timing-dependent behavior.

## Reviewer notes

Please focus on the request-generation guards in `delegations/page.tsx`, the server-clock `refreshAfterMs` boundary contract, and the explicit caveat that `/check` may be satisfied by an overlapping grant rather than the grant displayed on the detail page.
