### PR TITLE
fix(admin-ui): require observed execution evidence

### DIFF
--- a/openbank-admin-ui/scripts/collect-test-intelligence.mjs
+++ b/openbank-admin-ui/scripts/collect-test-intelligence.mjs
@@ -8,6 +8,7 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 import { parse as parseYaml, parseDocument } from 'yaml'
 import { parseStringPromise } from 'xml2js'
+import { executionEvidenceTotals } from '../src/lib/test-intelligence-execution-evidence.mjs'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 const args = process.argv.slice(2)
@@ -849,14 +850,29 @@ async function main() {
   const unknownEvidence = components.flatMap(item => item.evidence).filter(item => item.state === 'unknown').length
   const unresolvedEvidence = components.flatMap(item => item.evidence)
     .filter(item => ['unknown', 'not-run', 'blocked'].includes(item.state)).length
-  const missingEvidence = components.filter(item => item.evidence.length === 0).length
+  // A Pact declaration can add an unresolved row without a provider replay. Conversely, an
+  // observed suite that skipped every test is still a real zero-execution result.
+  const { componentsWithExecutionEvidence, missingEvidence } = executionEvidenceTotals(components)
   const historyDir = path.join(repo, 'openbank-admin-ui', 'test-intelligence-history')
   const historicalSnapshots = allFiles(historyDir, file => file.endsWith('.json'))
     .map(readJson).filter(item => item?.collectedAt && item?.totals)
-  const historicalReports = historicalSnapshots
-    .map(item => ({ collectedAt: item.collectedAt, ...item.totals }))
+  const historicalEvidenceStates = new Set(['passed', 'failed', 'skipped', 'not-run', 'stale', 'blocked', 'unknown'])
+  const historicalReports = historicalSnapshots.map(item => {
+    const historicalComponents = Array.isArray(item.components)
+      && item.components.every(component => Array.isArray(component?.evidence)
+        && component.evidence.every(evidence => evidence && typeof evidence === 'object'
+          && !Array.isArray(evidence) && historicalEvidenceStates.has(evidence.state)
+          && (evidence.observedAt === undefined || evidence.observedAt === null
+            || typeof evidence.observedAt === 'string')))
+      ? item.components
+      : null
+    const correctedExecutionTotals = historicalComponents
+      ? { components: historicalComponents.length, ...executionEvidenceTotals(historicalComponents) }
+      : {}
+    return { collectedAt: item.collectedAt, ...item.totals, ...correctedExecutionTotals }
+  })
   const currentPoint = { collectedAt: collectedAt.toISOString(), components: components.length,
-    componentsWithExecutionEvidence: components.filter(item => item.evidence.length > 0).length,
+    componentsWithExecutionEvidence,
     failingEvidence, missingEvidence, staleEvidence, unknownEvidence, unresolvedEvidence }
   const history = [...historicalReports, currentPoint]
     .sort((a, b) => Date.parse(a.collectedAt) - Date.parse(b.collectedAt))
@@ -925,7 +941,7 @@ async function main() {
     clientExperiences: clientExperience, requiredControls: controls, platformCapabilities: capabilities,
     totals: {
       components: components.length,
-      componentsWithExecutionEvidence: components.filter(item => item.evidence.length > 0).length,
+      componentsWithExecutionEvidence,
       moneyPathComponents: components.filter(item => item.moneyPath).length,
       failingEvidence, missingEvidence, staleEvidence, unknownEvidence, unresolvedEvidence,
       requiredControls: controls.length,

--- a/openbank-admin-ui/src/lib/test-intelligence-execution-evidence.mjs
+++ b/openbank-admin-ui/src/lib/test-intelligence-execution-evidence.mjs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @param {Array<{evidence: Array<{observedAt?: string | null, state: string}>}>} components
+ */
+export function executionEvidenceTotals(components) {
+  const componentsWithExecutionEvidence = components.filter(component =>
+    component.evidence.some(item => {
+      const observed = Date.parse(item.observedAt ?? '')
+      return Number.isFinite(observed) && item.state !== 'not-run' && item.state !== 'blocked'
+    }),
+  ).length
+
+  return {
+    componentsWithExecutionEvidence,
+    missingEvidence: components.length - componentsWithExecutionEvidence,
+  }
+}

--- a/openbank-admin-ui/src/lib/test-intelligence-freshness.ts
+++ b/openbank-admin-ui/src/lib/test-intelligence-freshness.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { EvidenceState, TestIntelligenceReport } from '@/lib/types/test-intelligence'
+import { executionEvidenceTotals } from '@/lib/test-intelligence-execution-evidence.mjs'
 
 const evidenceFreshnessMs = () => {
   const days = Number(process.env.OPENBANK_TEST_INTELLIGENCE_STALE_AFTER_DAYS ?? 14)
@@ -30,6 +31,7 @@ export function enforceRuntimeFreshness(report: TestIntelligenceReport): TestInt
     },
   }))
   const evidence = components.flatMap(component => component.evidence)
+  const { componentsWithExecutionEvidence, missingEvidence } = executionEvidenceTotals(components)
   return {
     ...report,
     components,
@@ -61,10 +63,10 @@ export function enforceRuntimeFreshness(report: TestIntelligenceReport): TestInt
     totals: {
       ...report.totals,
       components: components.length,
-      componentsWithExecutionEvidence: components.filter(component => component.evidence.length > 0).length,
+      componentsWithExecutionEvidence,
       moneyPathComponents: components.filter(component => component.moneyPath).length,
       failingEvidence: evidence.filter(item => item.state === 'failed').length,
-      missingEvidence: components.filter(component => component.evidence.length === 0).length,
+      missingEvidence,
       staleEvidence: evidence.filter(item => item.state === 'stale').length,
       unknownEvidence: evidence.filter(item => item.state === 'unknown').length,
       unresolvedEvidence: evidence.filter(item => ['unknown', 'not-run', 'blocked'].includes(item.state)).length,

--- a/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
@@ -171,6 +171,78 @@ scenarios:
     ]))
   })
 
+  it('does not count an unobserved contract declaration as execution evidence', () => {
+    const repo = mkdtempSync(path.join(tmpdir(), 'test-intelligence-execution-evidence-'))
+    dirs.push(repo)
+    write(repo, 'openbank-alpha-service/version.txt', '1.0.0\n')
+    write(repo, 'openbank-beta-service/version.txt', '1.0.0\n')
+    write(repo, 'openbank-libs/governance/rules.yaml', 'money_path_services: []\n')
+    write(repo, 'openbank-libs/governance/journeys.yaml', 'version: 1\njourneys: []\n')
+    write(repo, 'pacts/alpha-external.json', JSON.stringify({
+      consumer: { name: 'openbank-alpha-service' },
+      provider: { name: 'external-provider' },
+      interactions: [{ description: 'declared but not verified' }],
+    }))
+    write(
+      repo,
+      'openbank-beta-service/build/test-results/test/TEST-com.openbank.beta.AllSkippedTest.xml',
+      '<testsuite name="com.openbank.beta.AllSkippedTest" tests="1" failures="0" errors="0" skipped="1" time="0"><testcase classname="com.openbank.beta.AllSkippedTest"><skipped/></testcase></testsuite>',
+    )
+    write(repo, 'openbank-admin-ui/test-intelligence-history/previous.json', JSON.stringify({
+      schemaVersion: 1, collectedAt: '2026-08-01T00:00:00.000Z',
+      components: [
+        { component: 'openbank-alpha-service', evidence: [{ state: 'unknown', observedAt: null }] },
+        { component: 'openbank-beta-service', evidence: [{ state: 'skipped', observedAt: '2026-08-01T00:00:00.000Z' }] },
+      ],
+      totals: { components: 2, componentsWithExecutionEvidence: 2, missingEvidence: 0 },
+    }))
+    write(repo, 'openbank-admin-ui/test-intelligence-history/malformed-null.json', JSON.stringify({
+      schemaVersion: 1, collectedAt: '2026-07-30T00:00:00.000Z',
+      components: [{ component: 'openbank-legacy-service', evidence: [null] }],
+      totals: { components: 7, componentsWithExecutionEvidence: 6, missingEvidence: 1 },
+    }))
+    write(repo, 'openbank-admin-ui/test-intelligence-history/malformed-shape.json', JSON.stringify({
+      schemaVersion: 1, collectedAt: '2026-07-31T00:00:00.000Z',
+      components: [
+        { component: 'openbank-invalid-state', evidence: [{ state: 'invented', observedAt: '2026-07-31T00:00:00.000Z' }] },
+        { component: 'openbank-invalid-time', evidence: [{ state: 'passed', observedAt: 123 }] },
+      ],
+      totals: { components: 9, componentsWithExecutionEvidence: 8, missingEvidence: 1 },
+    }))
+
+    const out = path.join(repo, 'report.json')
+    execFileSync('node', [SCRIPT, '--repo', repo, '--out', out, '--stale-after-days', '99999'])
+    const report = JSON.parse(readFileSync(out, 'utf8')) as TestIntelligenceReport
+
+    expect(report.components.find(item => item.component === 'openbank-alpha-service')?.evidence).toEqual([
+      expect.objectContaining({ kind: 'contract', state: 'unknown', observedAt: null }),
+    ])
+    expect(report.components.find(item => item.component === 'openbank-beta-service')?.evidence).toEqual([
+      expect.objectContaining({
+        kind: 'unit', state: 'skipped', observedAt: expect.any(String),
+        counts: expect.objectContaining({ discovered: 1, executed: 0, skipped: 1 }),
+      }),
+    ])
+    expect(report.totals).toMatchObject({
+      components: 2, componentsWithExecutionEvidence: 1, missingEvidence: 1,
+    })
+    expect(report.history[0]).toMatchObject({
+      collectedAt: '2026-07-30T00:00:00.000Z',
+      components: 7, componentsWithExecutionEvidence: 6, missingEvidence: 1,
+    })
+    expect(report.history[1]).toMatchObject({
+      collectedAt: '2026-07-31T00:00:00.000Z',
+      components: 9, componentsWithExecutionEvidence: 8, missingEvidence: 1,
+    })
+    expect(report.history[2]).toMatchObject({
+      collectedAt: '2026-08-01T00:00:00.000Z',
+      components: 2, componentsWithExecutionEvidence: 1, missingEvidence: 1,
+    })
+    expect(report.history.at(-1)).toMatchObject({
+      components: 2, componentsWithExecutionEvidence: 1, missingEvidence: 1,
+    })
+  })
+
   it('derives required mutation controls from the full commented Pitest matrix', () => {
     const repo = mkdtempSync(path.join(tmpdir(), 'test-intelligence-required-mutation-'))
     dirs.push(repo)

--- a/openbank-admin-ui/src/test/test-intelligence-route.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-route.test.ts
@@ -46,6 +46,52 @@ describe('GET /api/test-intelligence', () => {
     expect(body.warnings[0]).toMatch(/not bundled/i)
   })
 
+  it('does not promote an unobserved contract declaration into runtime execution evidence', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'test-intelligence-runtime-evidence-'))
+    dirs.push(dir)
+    const file = path.join(dir, 'report.json')
+    writeFileSync(file, JSON.stringify({
+      schemaVersion: 1, collectedAt: new Date().toISOString(),
+      components: [
+        {
+          component: 'openbank-alpha-service', released: true, moneyPath: false,
+          evidence: [{ kind: 'contract', state: 'unknown', observedAt: null, source: 'pacts/alpha.json', environment: 'ci' }],
+          coverage: { state: 'not-run' },
+        },
+        {
+          component: 'openbank-beta-service', released: true, moneyPath: false,
+          evidence: [{
+            kind: 'unit', state: 'skipped', observedAt: new Date().toISOString(), source: 'junit', environment: 'ci',
+            counts: { discovered: 1, executed: 0, passed: 0, failed: 0, skipped: 1, errors: 0 },
+          }],
+          coverage: { state: 'not-run' },
+        },
+        {
+          component: 'openbank-gamma-service', released: true, moneyPath: false,
+          evidence: [{ kind: 'integration', state: 'not-run', observedAt: new Date().toISOString(), source: 'junit', environment: 'ci' }],
+          coverage: { state: 'not-run' },
+        },
+        {
+          component: 'openbank-delta-service', released: true, moneyPath: false,
+          evidence: [{ kind: 'integration', state: 'blocked', observedAt: new Date().toISOString(), source: 'junit', environment: 'ci' }],
+          coverage: { state: 'not-run' },
+        },
+      ],
+      contracts: [], mutations: [], performance: [], syntheticJourneys: [], history: [],
+      totals: { components: 4, componentsWithExecutionEvidence: 1, moneyPathComponents: 0, failingEvidence: 0, missingEvidence: 3, staleEvidence: 0 },
+      warnings: [],
+    }))
+    process.env.OPENBANK_TEST_INTELLIGENCE = file
+    const { GET } = await import('@/app/api/test-intelligence/route')
+    const body = await (await GET()).json()
+
+    expect(body.components.map((component: { evidence: Array<{ state: string }> }) => component.evidence[0].state))
+      .toEqual(['unknown', 'skipped', 'not-run', 'blocked'])
+    expect(body.totals).toMatchObject({
+      components: 4, componentsWithExecutionEvidence: 1, missingEvidence: 3,
+    })
+  })
+
   it('ages a deployed successful snapshot at request time while preserving failures and recomputing totals', async () => {
     const dir = mkdtempSync(path.join(tmpdir(), 'test-intelligence-runtime-freshness-'))
     dirs.push(dir)


### PR DESCRIPTION
## Summary

Make the Test Intelligence execution-evidence denominator describe observed runs rather than static evidence rows. A declared but unverified Pact can no longer make a component look executed, while a timestamped suite with zero executed and all skipped tests remains an honest observed-zero result.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #8023
Refs #8015

## Changes

- Use one pure execution-evidence classifier in the build-time collector and request-time freshness projection.
- Require a parseable observation timestamp and exclude explicit `not-run` and `blocked` states from the denominator.
- Correct current totals and structurally valid retained history without changing historical verdicts or timestamps; malformed/legacy snapshots retain their stored totals instead of crashing collection.
- Add regression coverage for an unobserved Pact, observed zero-execution/skipped suite, timestamped `not-run`/`blocked`, BFF recomputation, corrected history, and malformed history fallback.

## Verification

- Red proof: collector, retained-history and BFF fixtures returned `2 evidenced / 0 missing` instead of `1 / 1`; a null historical evidence row crashed collection.
- `npx vitest run src/test/test-intelligence-collector.test.ts src/test/test-intelligence-route.test.ts src/test/test-intelligence-agent-route.test.ts --maxWorkers=1 --no-file-parallelism` — 35/35 passed on the rebased branch.
- `npm test -- --reporter=dot --silent` in an isolated merge worktree containing merged #8015 — 406/406 files, 2073 passed, 1 explicit skip, 0 failures.
- `npx playwright test e2e/test-intelligence.spec.ts --project=chromium --workers=1` on the same warm isolated server — 5/5 passed, including the component matrix, mobile layout and WCAG scan.
- `npm run type-check` — passed.
- `npm run lint` — 0 errors (91 pre-existing warnings); targeted ESLint over all changed files produced no output.
- `npm run build` — passed; 91 static pages generated.
- `python3 .github/scripts/check-test-intelligence-ecosystem.py` — passed, 60 subjects.
- `git diff --check` and independent diff review — passed with no remaining findings.

## Definition of Done

- [x] Layering preserved; the classifier is a pure module shared by collector and BFF.
- [x] Unit and route-boundary regression tests added.
- [x] No public REST, OpenAPI, database or event-contract change.
- [x] No new lint warning or suppression.
- [x] No derived repository artifact hand-edited.

## Security checklist

- [x] No secrets, tokens, passwords, PII, hosts, ports or container identities added.
- [x] No new suppression or unsafe cast.
- [x] No third-party dependency added.
- [x] Auth, crypto, payment and cardholder-data paths are unchanged.

## Compliance impact

- [x] None

This makes an assurance KPI fail honest; it does not relax or promote any gate verdict.

## Rollout / Rollback

- Deployment strategy: ordinary rolling Admin UI deployment after required CI/review.
- Rollback plan: revert the single commit; no stored data is mutated.
- Data migration reversible: N/A.

## Screenshots / demo

No visual layout change. The existing capability/evidence matrix remains the operator surface; only its derived current and history counts become truthful.

## Reviewer notes

Please focus on the definition of execution evidence: timestamped `skipped`, `stale` and `unknown` observations count as observed; `not-run`, `blocked`, missing or invalid timestamps do not. Unresolved evidence remains reported independently and is never promoted to a passing verdict.
