### PR TITLE
fix(admin-ui): make PID sync retries recoverable

### DIFF
--- a/openbank-admin-ui/e2e/pid-quick-create-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/pid-quick-create-recovery.spec.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const PARTY_ID = '77777777-7777-4777-8777-777777777777'
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('resumes BankID sync without creating the party again', async ({ page }) => {
+  let createAttempts = 0
+  let syncAttempts = 0
+
+  await page.route('**/api/svc/pid-service/api/v1/pids', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  )
+  await page.route('**/api/svc/pid-service/api/v1/parties', route => {
+    createAttempts += 1
+    return route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: PARTY_ID }),
+    })
+  })
+  await page.route(`**/api/svc/pid-service/api/v1/parties/${PARTY_ID}/sync/bankid`, route => {
+    syncAttempts += 1
+    return route.fulfill({
+      status: syncAttempts === 1 ? 503 : 200,
+      contentType: 'application/json',
+      body: JSON.stringify(syncAttempts === 1 ? { code: 'UPSTREAM_UNAVAILABLE' } : { id: PARTY_ID }),
+    })
+  })
+
+  await page.goto('/pid')
+  await page.getByRole('button', { name: 'Open PID quick create' }).click()
+  await page.locator('#pid-given-name').fill('Ada')
+  await page.locator('#pid-family-name').fill('Lovelace')
+  await page.locator('#pid-birthdate').fill('1985-04-12')
+  await page.locator('#pid-gender').selectOption('FEMALE')
+  await page.locator('#pid-birthplace').fill('Praha')
+  await page.locator('#pid-bankid-sub').fill('bankid|recoverable-subject')
+  await page.locator('#pid-document-number').fill('ID-123456')
+  await page.locator('#pid-document-issued-at').fill('2024-01-02')
+  await page.locator('#pid-document-expires-at').fill('2034-01-02')
+
+  await page.getByRole('button', { name: 'Create', exact: true }).click()
+  await expect(page.getByText(`Record created (ID: ${PARTY_ID})`, { exact: false })).toBeVisible()
+  await expect(page.locator('#pid-bankid-sub')).toBeDisabled()
+
+  await page.getByRole('button', { name: 'Retry BankID sync' }).click()
+  await expect(page.getByText('Record created and synchronized successfully.')).toBeVisible()
+  expect(createAttempts).toBe(1)
+  expect(syncAttempts).toBe(2)
+})

--- a/openbank-admin-ui/src/app/pid/page.tsx
+++ b/openbank-admin-ui/src/app/pid/page.tsx
@@ -27,6 +27,30 @@ interface PidRecord {
   validUntil?: string
 }
 
+interface BankIdSyncPayload {
+  readonly bankIdSub: string
+  readonly givenName: string
+  readonly familyName: string
+  readonly birthdate: string
+  readonly gender: string
+  readonly birthplace: string
+  readonly nationalities: readonly string[]
+  readonly idDocuments: readonly {
+    readonly type: string
+    readonly number: string
+    readonly issuingCountry: string
+    readonly issuedAt: string
+    readonly expiresAt: string
+  }[]
+  readonly email?: string
+  readonly phone?: string
+}
+
+interface PendingBankIdSync {
+  readonly partyId: string
+  readonly payload: BankIdSyncPayload
+}
+
 // PID lifecycle deliberately treats expired credentials as renewal work and a
 // revoked credential as a security concern. Those meanings are stricter than
 // the shared consent-oriented defaults for the same words.
@@ -65,6 +89,10 @@ export default function PidPage() {
     idDocExpiresAt: ''
   })
   const [formSubmitting, setFormSubmitting] = useState(false)
+  // Party creation and BankID enrichment are two separate writes. Bind the confirmed party ID
+  // to the immutable payload submitted for that party, so recovery cannot enrich it with form
+  // values edited after the non-idempotent POST /parties began.
+  const [pendingBankIdSync, setPendingBankIdSync] = useState<PendingBankIdSync | null>(null)
   const [successMsg, setSuccessMsg] = useState<string | null>(null)
 
   const load = useCallback(async () => {
@@ -104,66 +132,76 @@ export default function PidPage() {
     setFormSubmitting(true)
     setError(null)
     setSuccessMsg(null)
-    
+
+    const checkpoint = pendingBankIdSync
     const requiredFields = [
       'givenName', 'familyName', 'birthdate', 'bankIdSub', 'nationalities', 
       'gender', 'birthplace', 'idDocType', 'idDocNumber', 'idDocCountry', 
       'idDocIssuedAt', 'idDocExpiresAt'
     ];
-    
-    for (const field of requiredFields) {
-      if (!formData[field as keyof typeof formData]) {
-        setError(t(`Prosím vyplňte všechna povinná pole (${field}).`, `Please fill all required fields (${field}).`));
-        setFormSubmitting(false);
-        return;
+
+    if (!checkpoint) {
+      for (const field of requiredFields) {
+        if (!formData[field as keyof typeof formData]) {
+          setError(t(`Prosím vyplňte všechna povinná pole (${field}).`, `Please fill all required fields (${field}).`));
+          setFormSubmitting(false);
+          return;
+        }
       }
     }
-    
+
     try {
       const nationalitiesArray = formData.nationalities.split(',').map(s => s.trim()).filter(Boolean)
-      
-      const createPayload = {
-        partyType: 'NATURAL_PERSON',
+      const syncPayload: BankIdSyncPayload = checkpoint?.payload ?? {
+        bankIdSub: formData.bankIdSub,
         givenName: formData.givenName,
         familyName: formData.familyName,
         birthdate: formData.birthdate,
-        bankIdSub: formData.bankIdSub,
-        nationalities: nationalitiesArray.length > 0 ? nationalitiesArray : ['CZ'],
-        verificationSource: 'BANKID',
-        initialRole: 'CUSTOMER',
-        onboardingChannel: 'BANKID'
+        gender: formData.gender,
+        birthplace: formData.birthplace,
+        nationalities: nationalitiesArray,
+        idDocuments: [{
+          type: formData.idDocType,
+          number: formData.idDocNumber,
+          issuingCountry: formData.idDocCountry,
+          issuedAt: formData.idDocIssuedAt,
+          expiresAt: formData.idDocExpiresAt
+        }],
+        email: formData.email || undefined,
+        phone: formData.phone || undefined
       }
-      
-      const res = await fetch(`${PID_SERVICE}/api/v1/parties`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(createPayload)
-      })
-      if (!res.ok) throw new Error(t('Vytvoření strany selhalo. Zkuste to prosím znovu.', 'Failed to create party. Please try again.'))
 
-      const party = await res.json()
-      const partyId = party.id || party.partyId
-
-      if (formData.bankIdSub) {
-        const syncPayload = {
-          bankIdSub: formData.bankIdSub,
+      let partyId = checkpoint?.partyId
+      if (!partyId) {
+        const createPayload = {
+          partyType: 'NATURAL_PERSON',
           givenName: formData.givenName,
           familyName: formData.familyName,
           birthdate: formData.birthdate,
-          gender: formData.gender,
-          birthplace: formData.birthplace,
-          nationalities: nationalitiesArray,
-          idDocuments: [{
-            type: formData.idDocType,
-            number: formData.idDocNumber,
-            issuingCountry: formData.idDocCountry,
-            issuedAt: formData.idDocIssuedAt,
-            expiresAt: formData.idDocExpiresAt
-          }],
-          email: formData.email || undefined,
-          phone: formData.phone || undefined
+          bankIdSub: formData.bankIdSub,
+          nationalities: nationalitiesArray.length > 0 ? nationalitiesArray : ['CZ'],
+          verificationSource: 'BANKID',
+          initialRole: 'CUSTOMER',
+          onboardingChannel: 'BANKID'
         }
 
+        const res = await fetch(`${PID_SERVICE}/api/v1/parties`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(createPayload)
+        })
+        if (!res.ok) throw new Error(t('Vytvoření strany selhalo. Zkuste to prosím znovu.', 'Failed to create party. Please try again.'))
+
+        const party = await res.json() as { id?: unknown; partyId?: unknown }
+        const createdPartyId = party.id || party.partyId
+        if (typeof createdPartyId !== 'string' || !createdPartyId) {
+          throw new Error(t('Služba nevrátila ID vytvořené strany.', 'The service did not return the created party ID.'))
+        }
+        partyId = createdPartyId
+        setPendingBankIdSync({ partyId: createdPartyId, payload: syncPayload })
+      }
+
+      if (syncPayload.bankIdSub) {
         const syncRes = await fetch(`${PID_SERVICE}/api/v1/parties/${partyId}/sync/bankid`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -171,10 +209,14 @@ export default function PidPage() {
         })
 
         if (!syncRes.ok) {
-          throw new Error(t(`Záznam vytvořen (ID: ${partyId}), ale synchronizace BankID selhala. Zkuste to prosím znovu.`, `Record created (ID: ${partyId}), but BankID sync failed. Please try again.`))
+          const retryable = syncRes.status === 408 || syncRes.status === 425 || syncRes.status === 429 || syncRes.status >= 500
+          throw new Error(retryable
+            ? t(`Záznam vytvořen (ID: ${partyId}), ale synchronizace BankID dočasně selhala. Zopakujte pouze synchronizaci BankID.`, `Record created (ID: ${partyId}), but BankID sync failed temporarily. Retry BankID sync only.`)
+            : t(`Záznam vytvořen (ID: ${partyId}), ale synchronizace BankID byla odmítnuta (HTTP ${syncRes.status}). Nevytvářejte další stranu; před opakováním synchronizace vyřešte chybu služby nebo dat.`, `Record created (ID: ${partyId}), but BankID sync was rejected (HTTP ${syncRes.status}). Do not create another party; resolve the service or data error before retrying sync.`))
         }
       }
-      
+
+      setPendingBankIdSync(null)
       setShowNewForm(false)
       setFormData({ 
         givenName: '', familyName: '', birthdate: '', bankIdSub: '', nationalities: 'CZ', 
@@ -183,7 +225,7 @@ export default function PidPage() {
       load()
       setSuccessMsg(t('Záznam úspěšně vytvořen a synchronizován.', 'Record created and synchronized successfully.'))
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : 'Failed to create record'
+      const msg = e instanceof Error ? e.message : t('Vytvoření záznamu selhalo.', 'Failed to create record.')
       setError(msg)
     } finally {
       setFormSubmitting(false)
@@ -270,6 +312,15 @@ export default function PidPage() {
               <strong>{t('Rychlé vytvoření je pouze předvyplnění. Právně závazná AML identifikace vyžaduje plný onboarding a ověření.', 'Quick create is only pre-filling. Legally binding AML identification requires full onboarding and verification.')}</strong>
             </div>
             <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+              {pendingBankIdSync && (
+                <div role="status" style={{ padding: '12px', background: 'var(--info-bg)', color: 'var(--info-text)', border: '1px solid var(--info-border)', borderRadius: '6px', fontSize: '13px' }}>
+                  {t(
+                    `Strana ${pendingBankIdSync.partyId} už byla vytvořena. Údaje jsou uzamčené; další pokus zopakuje pouze synchronizaci BankID se stejnou stranou a původně odeslanou identitou.`,
+                    `Party ${pendingBankIdSync.partyId} was already created. The fields are locked; the next attempt retries BankID sync against the same party and originally submitted identity only.`,
+                  )}
+                </div>
+              )}
+              <fieldset disabled={formSubmitting || pendingBankIdSync !== null} style={{ border: 0, padding: 0, margin: 0, minWidth: 0 }}>
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px' }}>
                 <div style={{ gridColumn: '1 / -1' }}>
                   <h4 style={{ fontSize: '13px', margin: '0 0 8px 0', borderBottom: '1px solid var(--border-color)', paddingBottom: '4px' }}>{t('Základní údaje', 'Basic Info')}</h4>
@@ -448,12 +499,19 @@ export default function PidPage() {
                   />
                 </div>
               </div>
+              </fieldset>
               <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end', marginTop: '8px' }}>
                 <button type="button" className="btn btn-secondary" onClick={() => setShowNewForm(false)} disabled={formSubmitting}>
                   {t('Zrušit', 'Cancel')}
                 </button>
                 <button type="submit" className="btn btn-primary" disabled={formSubmitting}>
-                  {formSubmitting ? t('Vytvářím...', 'Creating...') : t('Vytvořit', 'Create')}
+                  {formSubmitting
+                    ? pendingBankIdSync
+                      ? t('Synchronizuji...', 'Syncing...')
+                      : t('Vytvářím...', 'Creating...')
+                    : pendingBankIdSync
+                      ? t('Znovu synchronizovat BankID', 'Retry BankID sync')
+                      : t('Vytvořit', 'Create')}
                 </button>
               </div>
             </form>

--- a/openbank-admin-ui/src/test/pid-quick-create-recovery.test.tsx
+++ b/openbank-admin-ui/src/test/pid-quick-create-recovery.test.tsx
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// PID quick-create is a two-step write: create the party, then enrich that SAME party from BankID.
+// Once create succeeds, retrying the whole flow cannot recover: pid-service has no Idempotency-Key
+// support and rejects the already-bound bankIdSub with 409. Drive the page like an operator and pin
+// the only safe browser transition: a failed sync retry skips create and targets the retained party.
+
+import React from 'react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import PidPage from '@/app/pid/page'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { user: { name: 'Operator', roles: ['ROLE_OPERATOR', 'ROLE_ADMIN'] } },
+    status: 'authenticated',
+  }),
+  signIn: vi.fn(),
+}))
+
+const PARTY_ID = '77777777-7777-4777-8777-777777777777'
+
+const ORIGINAL_SYNC_PAYLOAD = {
+  bankIdSub: 'bankid|recoverable-subject',
+  givenName: 'Ada',
+  familyName: 'Lovelace',
+  birthdate: '1985-04-12',
+  gender: 'FEMALE',
+  birthplace: 'Praha',
+  nationalities: ['CZ'],
+  idDocuments: [{
+    type: 'NATIONAL_ID',
+    number: 'ID-123456',
+    issuingCountry: 'CZ',
+    issuedAt: '2024-01-02',
+    expiresAt: '2034-01-02',
+  }],
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>(settle => { resolve = settle })
+  return { promise, resolve }
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function fill(id: string, value: string) {
+  const field = document.getElementById(id)
+  expect(field, `missing #${id}`).toBeTruthy()
+  fireEvent.change(field!, { target: { value } })
+}
+
+async function openAndFillQuickCreate() {
+  fireEvent.click(await screen.findByRole('button', { name: 'Open PID quick create' }))
+  fill('pid-given-name', 'Ada')
+  fill('pid-family-name', 'Lovelace')
+  fill('pid-birthdate', '1985-04-12')
+  fill('pid-gender', 'FEMALE')
+  fill('pid-birthplace', 'Praha')
+  fill('pid-bankid-sub', 'bankid|recoverable-subject')
+  fill('pid-document-number', 'ID-123456')
+  fill('pid-document-issued-at', '2024-01-02')
+  fill('pid-document-expires-at', '2034-01-02')
+  const form = document.getElementById('pid-given-name')?.closest('form')
+  expect(form).toBeTruthy()
+  return form as HTMLFormElement
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe('PID quick-create recovery', () => {
+  it('retries only BankID sync against the already-created party', async () => {
+    const requests: string[] = []
+    let syncAttempts = 0
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (init?.method !== 'POST') return json([])
+      requests.push(url)
+      if (url.endsWith('/api/v1/parties')) return json({ id: PARTY_ID }, 201)
+      if (url.endsWith(`/api/v1/parties/${PARTY_ID}/sync/bankid`)) {
+        syncAttempts += 1
+        return syncAttempts === 1 ? json({ code: 'UPSTREAM_UNAVAILABLE' }, 503) : json({ id: PARTY_ID })
+      }
+      return json({ code: 'UNEXPECTED_REQUEST' }, 500)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await act(async () => {
+      render(<LanguageProvider><PidPage /></LanguageProvider>)
+    })
+    const form = await openAndFillQuickCreate()
+
+    await act(async () => { fireEvent.submit(form) })
+    await waitFor(() => expect(screen.getByText(new RegExp(`Record created \\(ID: ${PARTY_ID}\\)`))).toBeInTheDocument())
+
+    const retry = screen.getByRole('button', { name: 'Retry BankID sync' })
+    expect(document.getElementById('pid-bankid-sub')).toBeDisabled()
+    await act(async () => { fireEvent.click(retry) })
+
+    await waitFor(() => expect(screen.getByText('Record created and synchronized successfully.')).toBeInTheDocument())
+    expect(requests.filter(url => url.endsWith('/api/v1/parties'))).toHaveLength(1)
+    expect(requests.filter(url => url.endsWith(`/api/v1/parties/${PARTY_ID}/sync/bankid`))).toHaveLength(2)
+  })
+
+  it('binds retries to the submitted identity while party creation is pending', async () => {
+    const createResponse = deferred<Response>()
+    const syncBodies: unknown[] = []
+    let syncAttempts = 0
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (init?.method !== 'POST') return json([])
+      if (url.endsWith('/api/v1/parties')) return createResponse.promise
+      if (url.endsWith(`/api/v1/parties/${PARTY_ID}/sync/bankid`)) {
+        syncBodies.push(JSON.parse(String(init.body)))
+        syncAttempts += 1
+        return syncAttempts === 1 ? json({ code: 'UPSTREAM_UNAVAILABLE' }, 503) : json({ id: PARTY_ID })
+      }
+      return json({ code: 'UNEXPECTED_REQUEST' }, 500)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await act(async () => {
+      render(<LanguageProvider><PidPage /></LanguageProvider>)
+    })
+    const form = await openAndFillQuickCreate()
+
+    fireEvent.submit(form)
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/v1\/parties$/),
+      expect.objectContaining({ method: 'POST' }),
+    ))
+
+    const bankIdSub = document.getElementById('pid-bankid-sub') as HTMLInputElement
+    const givenName = document.getElementById('pid-given-name') as HTMLInputElement
+    expect(bankIdSub).toBeDisabled()
+    expect(givenName).toBeDisabled()
+    fireEvent.change(bankIdSub, { target: { value: 'bankid|mutated-subject' } })
+    fireEvent.change(givenName, { target: { value: 'Mutated' } })
+
+    await act(async () => { createResponse.resolve(json({ id: PARTY_ID }, 201)) })
+    const retry = await screen.findByRole('button', { name: 'Retry BankID sync' })
+    await act(async () => { fireEvent.click(retry) })
+
+    await waitFor(() => expect(screen.getByText('Record created and synchronized successfully.')).toBeInTheDocument())
+    expect(syncBodies).toEqual([ORIGINAL_SYNC_PAYLOAD, ORIGINAL_SYNC_PAYLOAD])
+  })
+})


### PR DESCRIPTION
## Summary

Make Admin PID Quick Create recover safely when party creation succeeds but BankID synchronization fails. The page now checkpoints the confirmed party ID together with the immutable submitted identity and retries only the synchronization step, preventing duplicate party creation or cross-identity enrichment.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #8025

## Changes

- Retain the created party ID and a read-only snapshot of the submitted BankID identity after synchronization failure.
- Lock identity inputs while the recovery checkpoint exists and make retry skip the non-idempotent party-creation request.
- Distinguish transient retry-only failures from permanent service/data rejection in operator copy.
- Add focused component coverage, including a deferred-create mutation attempt, plus a browser E2E proving one create and two sync attempts.

## Definition of Done

- [x] Hexagonal layering preserved (Admin UI state only; no domain/framework boundary changed).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (Playwright browser E2E).
- [x] Contract tests updated (N/A: no public API contract changed).
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes (N/A for this Admin UI-only slice; CI remains authoritative).
- [x] No new lint warnings (changed-file ESLint has zero errors; the existing `react-hooks/set-state-in-effect` warning is outside this diff).
- [x] OpenAPI spec regenerated (N/A: no REST API changed).
- [x] Flyway migration added + rollback note (N/A: no database change).
- [x] Avro schema versioned backward-compatibly (N/A: no event change).
- [x] Docs updated (issue and this PR document recovery and privacy behavior; no architecture change).

## Security checklist

- [x] No secrets, tokens, passwords, or real PII in code, config, tests, logs. Test identities and identifiers are synthetic.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? No; no security-review label required.
- [x] PII path changed? Yes; `gdpr-review-required` is applied.
- [x] Cardholder data path changed? No; no PCI-review label required.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [x] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

The page already handles PID identity data. This change keeps a recovery checkpoint only in current browser memory; it is not persisted, logged, or exported to telemetry, and it is cleared after a successful synchronization. Locking the submitted identity prevents an operator from attaching edited PII to an already-created party. The `compliance:gdpr` and `gdpr-review-required` labels make the review requirement explicit.

## Verification

- `npm test -- src/test/pid-*.test.ts src/test/pid-*.test.tsx` — 8 files / 11 tests passed.
- `OPENBANK_E2E_PORT=32118 npm run test:e2e -- e2e/pid-quick-create-recovery.spec.ts --workers=1` — 1/1 passed on a unique local port.
- `npm run type-check` — passed.
- Changed-file ESLint — zero errors; one pre-existing warning on the unchanged initial-load effect.
- `git diff --check origin/main...HEAD` — passed.

## Rollout / Rollback

- Deployment strategy: normal Admin UI rolling deployment after required review and green CI.
- Rollback plan: revert the squash commit; the previous full-flow retry behavior is restored without data migration.
- Data migration reversible: N/A.

## Screenshots / demo

No static screenshot: the safety property is a request sequence and immutable retry state, covered by focused component and browser tests.

## Reviewer notes

Please focus on the checkpoint boundary: the party ID and identity snapshot must be captured before the first asynchronous create result is consumed, fields must stay locked while recovery is pending, and retries must never issue another `POST /api/v1/parties`. An independent exact-diff review found no blocker before this PR was opened.

