### PR TITLE
fix(admin-ui): keep staged namespaces outside discovery

### DIFF
--- a/openbank-admin-ui/src/lib/discovery.ts
+++ b/openbank-admin-ui/src/lib/discovery.ts
@@ -80,7 +80,6 @@ const NS_GROUP: Record<string, ServiceGroup> = {
   documents:          'platform',    // document-service (ADR-0161/0162)
   engagement:         'platform',    // engagement-service (ADR-0220 in-app surfaces)
   referral:           'platform',    // referral-service (ADR-0266 MGM attribution)
-  incentive:          'platform',    // incentive/promo service (ADR-0266)
 }
 
 export function inCluster(): boolean {

--- a/openbank-admin-ui/src/test/service-registry.guard.test.ts
+++ b/openbank-admin-ui/src/test/service-registry.guard.test.ts
@@ -43,6 +43,7 @@ import { SERVICE_REGISTRY, k8sNameOf } from '@/lib/services/registry'
 const ADMIN_UI = path.resolve(__dirname, '../..')
 const REPO = path.resolve(ADMIN_UI, '..')
 const GITOPS = path.join(REPO, 'openbank-infra', 'gitops')
+const GITOPS_APPS = path.join(GITOPS, 'apps')
 
 const BFF_ROUTE = path.join(ADMIN_UI, 'src/app/api/svc/[service]/[...path]/route.ts')
 const SERVICES_PAGE = path.join(ADMIN_UI, 'src/app/services/page.tsx')
@@ -140,6 +141,50 @@ function gitopsWorkloadNamespaces(): Set<string> {
     }
   }
   return namespaces
+}
+
+interface ApplicationDiscoveryState {
+  file: string
+  namespace: string
+  staged: boolean
+  automated: boolean
+}
+
+/**
+ * Deployment lifecycle comes from the Argo Application, not merely from manifests under its
+ * component path. A staged Application may describe a complete workload while deliberately
+ * withholding sync; binding discovery RBAC into that absent namespace blocks the Admin UI's own
+ * Argo reconciliation before its Deployment can roll out.
+ */
+function applicationDiscoveryStates(): ApplicationDiscoveryState[] {
+  const states: ApplicationDiscoveryState[] = []
+  for (const file of walkYaml(GITOPS_APPS)) {
+    const src = readFileSync(file, 'utf8')
+    for (const doc of src.split(/^---$/m)) {
+      if (!/^kind:\s*Application\s*$/m.test(doc)) continue
+      const lines = doc.split('\n')
+      const destinationLine = lines.findIndex(line => line === '  destination:')
+      let namespace: string | undefined
+      if (destinationLine !== -1) {
+        for (let i = destinationLine + 1; i < lines.length; i++) {
+          if (/^  \S/.test(lines[i])) break
+          const match = /^ {4}namespace:\s*(\S+)\s*$/.exec(lines[i])
+          if (match) {
+            namespace = match[1]
+            break
+          }
+        }
+      }
+      if (!namespace) continue
+      states.push({
+        file: path.relative(REPO, file),
+        namespace,
+        staged: lines.some(line => /^ {4}openbank\.io\/discovery-state:\s*staged\s*$/.test(line)),
+        automated: lines.some(line => /^ {4}automated:\s*$/.test(line)),
+      })
+    }
+  }
+  return states
 }
 
 /**
@@ -298,11 +343,15 @@ describe('service registry drift guard', () => {
 
     // Namespaces that actually run an openbank service, derived from the gitops tree rather than
     // from a second hand-kept list — the whole point is that the set cannot drift.
+    const stagedNamespaces = new Set(
+      applicationDiscoveryStates().filter(app => app.staged).map(app => app.namespace),
+    )
     const serviceNamespaces = new Set<string>()
     for (const ns of gitopsWorkloadNamespaces()) serviceNamespaces.add(ns)
 
     const missing = [...serviceNamespaces]
       .filter(ns => !DISCOVERY_EXEMPT_NAMESPACES.has(ns))
+      .filter(ns => !stagedNamespaces.has(ns))
       .filter(ns => !listed.has(ns) || !bound.has(ns))
       .map(ns => `${ns}${listed.has(ns) ? '' : ' (not in OPENBANK_NAMESPACES)'}${bound.has(ns) ? '' : ' (no RoleBinding)'}`)
 
@@ -310,6 +359,37 @@ describe('service registry drift guard', () => {
       missing,
       'namespaces running an openbank service that admin-ui discovery cannot see. The console '
       + 'will render "not responding" for every service in them, against healthy pods.',
+    ).toEqual([])
+  })
+
+  it('keeps staged Applications outside live discovery until activation', () => {
+    const manifest = readFileSync(
+      path.join(GITOPS, 'components/admin-ui/admin-ui.yaml'), 'utf8',
+    )
+    const listed = new Set(
+      (manifest.match(/name: OPENBANK_NAMESPACES\s*\n\s*value:\s*(.+)/)?.[1] ?? '')
+        .split(',').map(n => n.trim()).filter(Boolean),
+    )
+    const bound = new Set(
+      [...manifest.matchAll(/name: admin-ui-discovery\s*\n\s*namespace:\s*(\S+)/g)].map(m => m[1]),
+    )
+    const staged = applicationDiscoveryStates().filter(app => app.staged)
+    const staleMarkers = staged
+      .filter(app => app.automated)
+      .map(app => `${app.namespace} (${app.file} is automated)`)
+    const activatedTooEarly = staged
+      .filter(app => listed.has(app.namespace) || bound.has(app.namespace))
+      .map(app => `${app.namespace}${listed.has(app.namespace) ? ' (queried)' : ''}${bound.has(app.namespace) ? ' (RBAC bound)' : ''}`)
+
+    expect(
+      staleMarkers,
+      'an automated Application cannot remain marked discovery-state=staged; remove the marker '
+      + 'and complete its OPENBANK_NAMESPACES + RoleBinding activation together.',
+    ).toEqual([])
+    expect(
+      activatedTooEarly,
+      'staged Applications are desired state, not live namespaces. Querying or binding them makes '
+      + `the Admin UI Argo sync fail before its own rollout: ${activatedTooEarly.join(', ')}`,
     ).toEqual([])
   })
 

--- a/openbank-infra/gitops/apps/incentive.yaml
+++ b/openbank-infra/gitops/apps/incentive.yaml
@@ -8,6 +8,10 @@ kind: Application
 metadata:
   name: incentive
   namespace: argocd
+  annotations:
+    # Machine-readable counterpart to the rollout boundary above. Admin UI discovery must not
+    # create cross-namespace RBAC until this Application is activated and observed healthy.
+    openbank.io/discovery-state: staged
   finalizers: [resources-finalizer.argocd.argoproj.io]
 spec:
   project: default

--- a/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
+++ b/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
@@ -106,7 +106,7 @@ spec:
             #   3. Add a RoleBinding for admin-ui-discovery below.
             # Adding a service *inside* an existing namespace is fully automatic.
             - name: OPENBANK_NAMESPACES
-              value: accounts,payments,compliance,identity,open-banking,platform,ledger,balances,audit,sanctions,security-scanner,onboarding,party,sca,statements,customer-edge,kyc,notifications,aml,consent,dispute,fraud,fx,interest,pid,psd2,documents,campaign,anacredit,billing,finrep,lending,sdd,tpp-registry,delegation,engagement,referral,incentive
+              value: accounts,payments,compliance,identity,open-banking,platform,ledger,balances,audit,sanctions,security-scanner,onboarding,party,sca,statements,customer-edge,kyc,notifications,aml,consent,dispute,fraud,fx,interest,pid,psd2,documents,campaign,anacredit,billing,finrep,lending,sdd,tpp-registry,delegation,engagement,referral
             # agent-service (MCP) is NOT reached via the discovery proxy: the
             # /api/agent/mcp and /api/agent/chat routes resolve it from this env
             # directly. Unset, they fall back to localhost:8109 (the admin-ui pod
@@ -322,25 +322,6 @@ kind: RoleBinding
 metadata:
   name: admin-ui-discovery
   namespace: referral
-  labels:
-    app.kubernetes.io/name: admin-ui
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: admin-ui-discovery
-subjects:
-  - kind: ServiceAccount
-    name: admin-ui
-    namespace: admin-ui
----
-# incentive (ADR-0266). This scoped binding and OPENBANK_NAMESPACES above are
-# both required: the former is the least-privilege boundary and the latter is
-# the discovery query scope.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: admin-ui-discovery
-  namespace: incentive
   labels:
     app.kubernetes.io/name: admin-ui
 roleRef:


### PR DESCRIPTION
## Summary

Prevents the automatically synced Admin UI Application from creating discovery RBAC in an Incentive namespace that is deliberately staged and not provisioned yet. This removes the current Argo reconciliation blocker and makes the drift guard distinguish desired manifests from activated runtime namespaces.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #8030
Refs #8014, #7554, ADR-0051, ADR-0266

## Changes

- Marks the manual Incentive Application with a machine-readable `openbank.io/discovery-state: staged` lifecycle signal.
- Keeps explicitly staged namespaces out of the live discovery completeness set and rejects stale markers once an Application becomes automated.
- Removes `incentive` from `OPENBANK_NAMESPACES`, its namespace-scoped discovery RoleBinding, and `NS_GROUP` until activation is independently reviewed.
- Preserves the unrelated keyboard-scroll accessibility fix from #8015.

## Verification

- Live read-only check before the fix: Admin UI Application `OutOfSync/Healthy`, Incentive Application `OutOfSync/Missing`, and the `incentive` namespace absent.
- Regression-first: the new guard failed on `incentive (queried) (RBAC bound)` before the discovery entries were removed.
- Service-registry guard: 14/14 passed after the fix and again on the final base.
- `npm run type-check`: passed.
- Changed-file ESLint: passed with no output.
- `git diff --check`: passed.
- Independent exact-diff review: NO BLOCKER.

## Definition of Done

- [x] Hexagonal layering preserved (Admin UI/GitOps guard only).
- [x] Unit guard added and regression-first behavior demonstrated.
- [x] No new lint warnings.
- [x] No public API, database, event schema, dependency, or generated-data change.
- [x] No OpenAPI, Flyway, Avro, or threat-model update required.

## Security checklist

- [x] No secrets, tokens, passwords, PII, private endpoints, or cloud-account details added.
- [x] No suppression or unsafe cast added.
- [x] No new dependency.
- [ ] Auth / crypto / payment code changed.
- [ ] PII or cardholder-data path changed.
- [x] Kubernetes permissions are narrowed: one premature RoleBinding is removed; no verb or cluster-wide binding is added.

## Compliance impact

- [x] DORA

Restores deterministic GitOps reconciliation and preserves namespace-scoped least privilege. The staged marker is fail-safe: activation must remove it and add group/query/RBAC in one reviewed change.

## Rollout / Rollback

- Deployment strategy: standard Admin UI rolling deployment through GitOps.
- Rollback plan: revert this commit only if the Incentive namespace has been activated and observed healthy; in that case replace the staged marker with the complete three-part discovery activation.
- Data migration reversible: N/A.
- Post-merge proof: verify Admin UI Argo `Synced/Healthy`, desired image applied, Deployment ready, and public login smoke.

## Screenshots / demo

No visual change.

## Reviewer notes

Please verify that the staged marker, query scope, and RoleBinding remain one lifecycle contract. The matrix `tabIndex={0}` change from #8015 is intentionally not reverted.
