### PR TITLE
fix(admin-ui): cancel superseded BFF resource reads

### DIFF
--- a/openbank-admin-ui/src/lib/services/useServiceResource.ts
+++ b/openbank-admin-ui/src/lib/services/useServiceResource.ts
@@ -89,6 +89,7 @@ export function useServiceResource<T = unknown>(
     const { select, maxWakeRetries = 3, retryDelayMs = 4000, timeoutMs = 10_000 } = optsRef.current
     let cancelled = false
     let timer: ReturnType<typeof setTimeout> | null = null
+    let activeController: AbortController | null = null
     let attempt = 0
 
     const scheduleRetry = (kind: BffFailure) => {
@@ -100,8 +101,11 @@ export function useServiceResource<T = unknown>(
     }
 
     async function run() {
+      const controller = new AbortController()
+      activeController = controller
+      const deadline = setTimeout(() => controller.abort(), timeoutMs)
       try {
-        const res = await fetch(url!, { signal: AbortSignal.timeout(timeoutMs), cache: 'no-store' })
+        const res = await fetch(url!, { signal: controller.signal, cache: 'no-store' })
         if (cancelled) return
         if (!res.ok) {
           const kind = await classifyBffFailure(res)
@@ -131,6 +135,9 @@ export function useServiceResource<T = unknown>(
         setUnavailable({ kind: 'unreachable' })
         setWaking(false)
         setLoading(false)
+      } finally {
+        clearTimeout(deadline)
+        if (activeController === controller) activeController = null
       }
     }
 
@@ -142,6 +149,7 @@ export function useServiceResource<T = unknown>(
     return () => {
       cancelled = true
       if (timer) clearTimeout(timer)
+      activeController?.abort()
     }
     // `url` + `nonce` are the only real inputs; options are read via ref.
   }, [url, nonce])

--- a/openbank-admin-ui/src/test/use-service-resource.test.ts
+++ b/openbank-admin-ui/src/test/use-service-resource.test.ts
@@ -76,6 +76,23 @@ describe('useServiceResource', () => {
     expect(fetchMock).toHaveBeenCalledTimes(3)
   })
 
+  it('retains a per-attempt deadline when wake retries are disabled', async () => {
+    let signal: AbortSignal | null = null
+    vi.stubGlobal('fetch', vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+      signal = init?.signal as AbortSignal
+      return new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')))
+      })
+    }))
+
+    const { result } = renderHook(() =>
+      useServiceResource('/api/svc/x/api/v1/items', { timeoutMs: 10, maxWakeRetries: 0 }),
+    )
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(signal?.aborted).toBe(true)
+    expect(result.current.unavailable).toEqual({ kind: 'unreachable' })
+  })
+
   it('does nothing when url is null', async () => {
     const fetchMock = vi.fn(async () => jsonRes(200, []))
     vi.stubGlobal('fetch', fetchMock)
@@ -83,5 +100,32 @@ describe('useServiceResource', () => {
     await waitFor(() => expect(result.current.loading).toBe(false))
     expect(fetchMock).not.toHaveBeenCalled()
     expect(result.current.data).toBeNull()
+  })
+
+  it('aborts an obsolete request when the URL changes and on unmount', async () => {
+    const signals: AbortSignal[] = []
+    const fetchMock = vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+      const signal = init?.signal
+      expect(signal).toBeInstanceOf(AbortSignal)
+      signals.push(signal as AbortSignal)
+      return new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')))
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { rerender, unmount } = renderHook(
+      ({ url }) => useServiceResource(url, { timeoutMs: 60_000 }),
+      { initialProps: { url: '/api/svc/x/api/v1/items/first' } },
+    )
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    rerender({ url: '/api/svc/x/api/v1/items/second' })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    expect(signals[0]?.aborted).toBe(true)
+    expect(signals[1]?.aborted).toBe(false)
+
+    unmount()
+    expect(signals[1]?.aborted).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

Cancel the active shared BFF resource request when its URL changes, a reload supersedes it, or the consuming screen unmounts. This prevents obsolete reads from retaining connections or waking scaled-to-zero services after an operator navigates away, while preserving the existing per-attempt deadline, wake retries, authentication relay, and status classification.

## Type of change

- [x] fix (bug fix)
- [ ] feat (new functionality)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #8037

## Changes

- Give every useServiceResource attempt an owned AbortController and clear its deadline on settle.
- Abort the active attempt during React effect cleanup and cover URL replacement, unmount, and timeout behavior with focused tests.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (N/A: client hook lifecycle only; no service boundary changed).
- [x] Contract tests updated (N/A: no public API changed).
- [ ] ./gradlew detekt ktlintCheck koverVerify build passes (N/A: Admin UI only).
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (N/A: no REST API changed).
- [x] Flyway migration added + rollback note (N/A: no DB change).
- [x] Avro schema versioned backward-compatibly (N/A: no event change).
- [x] Docs updated (N/A: behavior is documented in the shared hook and regression tests).

## Verification

- npm test -- --run src/test/use-service-resource.test.ts — 8/8 passed
- npm run type-check — passed
- npx eslint src/lib/services/useServiceResource.ts src/test/use-service-resource.test.ts — 0 errors; one pre-existing warning outside changed lines
- git diff --check — passed
- Signed commit and sign-off verified

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new suppressions or unsafe casts without justification.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? No.
- [x] PII path changed? No.
- [x] Cardholder data path changed? No.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: normal rolling Admin UI deployment.
- Rollback plan: revert this PR to restore the previous timeout-only signal behavior.
- Data migration reversible: N/A

## Screenshots / demo

N/A — request lifecycle behavior only; no visual change.

## Reviewer notes

Please verify that intentional cleanup cannot be classified as unreachable and that timeout and KEDA wake retry semantics remain unchanged. The exact pre-commit blobs received an independent read-only NO BLOCKER review; repository approval and green CI remain required before merge.