### PR TITLE
test(tpp-registry): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -32,5 +32,4 @@ openbank-settlement-service/src/test/kotlin/com/openbank/settlement/it/PostgresT
 openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/it/PostgresRedisTestResource.kt
 openbank-statement-service/src/test/kotlin/com/openbank/statement/it/PostgresTestResource.kt
 openbank-swift-service/src/test/kotlin/com/openbank/swift/it/PostgresRedisTestResource.kt
-openbank-tpp-registry-service/src/test/kotlin/com/openbank/tppregistry/it/PostgresRedisTestResource.kt
 openbank-vop-service/src/test/kotlin/com/openbank/vop/PostgresTestResource.kt

--- a/openbank-tpp-registry-service/build.gradle.kts
+++ b/openbank-tpp-registry-service/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.junit.jupiter)
+    testImplementation(project(":openbank-libs-testing"))
     // Boot smoke-test (TppRegistryBootSmokeIT): per-job Testcontainers Postgres + Valkey and the
     // in-memory Kafka connector, so a real Quarkus boot + Flyway runs in CI (issue #578).
     testImplementation(libs.smallrye.reactive.messaging.inmemory)

--- a/openbank-tpp-registry-service/src/test/kotlin/com/openbank/tppregistry/it/PostgresRedisTestResource.kt
+++ b/openbank-tpp-registry-service/src/test/kotlin/com/openbank/tppregistry/it/PostgresRedisTestResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.tppregistry.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.PostgreSQLContainer
@@ -29,16 +30,18 @@ class PostgresRedisTestResource : QuarkusTestResourceLifecycleManager {
     private var redis: GenericContainer<*>? = null
 
     override fun start(): Map<String, String> {
-        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+        val pg = PostgreSQLContainer(DockerImageName.parse(POSTGRES_IMAGE))
             .withUsername("openbank")
             .withPassword("openbank_secret")
             .withDatabaseName("openbank_tpp_registry_it")
         pg.start()
         postgres = pg
+        TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "started")
 
-        val rd = GenericContainer(DockerImageName.parse("valkey/valkey:7.2-alpine")).withExposedPorts(6379)
+        val rd = GenericContainer(DockerImageName.parse(VALKEY_IMAGE)).withExposedPorts(6379)
         rd.start()
         redis = rd
+        TestInfrastructureEvidence.record("valkey", VALKEY_IMAGE, "started")
 
         val pgHost = pg.host
         val pgPort = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
@@ -53,7 +56,21 @@ class PostgresRedisTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        redis?.stop()
-        postgres?.stop()
+        try {
+            redis?.let {
+                it.stop()
+                TestInfrastructureEvidence.record("valkey", VALKEY_IMAGE, "stopped")
+            }
+        } finally {
+            postgres?.let {
+                it.stop()
+                TestInfrastructureEvidence.record("postgres", POSTGRES_IMAGE, "stopped")
+            }
+        }
+    }
+
+    private companion object {
+        const val POSTGRES_IMAGE = "postgres:16.3-alpine"
+        const val VALKEY_IMAGE = "valkey/valkey:7.2-alpine"
     }
 }


### PR DESCRIPTION
## Summary

Migrate the TPP Registry integration-test runtime from a governance baseline exception to observed Testcontainers lifecycle evidence. The shared envelope can now prove that its PostgreSQL and Valkey resources both started and stopped in the same run.

## Type of change

- [x] test (test infrastructure and evidence)

## Linked issues

Refs #7246

## Changes

- Record PostgreSQL and Valkey `started` only after successful container startup.
- Record each `stopped` only after successful teardown; PostgreSQL teardown remains attempted in `finally` even if Valkey teardown fails.
- Reuse constants for the existing public pinned image references.
- Add the shared evidence recorder as a test-only project dependency.
- Remove only the now-covered TPP Registry entry from the governed Testcontainers evidence baseline.

## Verification

- Red proof: removing the TPP baseline entry before instrumentation produced the single expected `new service-owned Testcontainers resource lacks lifecycle evidence` failure.
- Test Intelligence ecosystem self-test, direct checker and manifest gate — passed, 60 subjects.
- `compileTestKotlin`, `ktlintCheck` and `detekt` — passed.
- `TppRegistryBootSmokeIT` — 2/2 passed, 0 skipped.
- Full TPP Registry build — successful; 28 passed, 2 expected broker-only skips, 0 failures/errors.
- Collected envelope — 30 test observations and four runtime events; PostgreSQL and Valkey each have one `started` and one `stopped` event.
- Forbidden evidence-key scan — no host, port, credential, secret or container identifier.
- `git diff --check` and independent diff review — passed with no findings.

## Definition of Done

- [x] Real container lifecycle is observed at the owning test resource.
- [x] Start/stop records are emitted only after successful operations.
- [x] Existing images, topology, credentials and application configuration are unchanged.
- [x] Baseline debt is reduced only for the now-covered resource.
- [x] No production dependency or public API/schema change.

## Security checklist

- [x] Evidence contains only resource kind, public image reference, lifecycle and timestamp.
- [x] No secrets, credentials, hostnames, ports, container IDs or private registry details are recorded.
- [x] Shared redaction and bounded evidence infrastructure is reused.
- [x] No suppression or unsafe cast added.

## Compliance impact

- [x] None

This strengthens test-runtime provenance; it does not promote a verdict without a completed lifecycle.

## Rollout / Rollback

- Deployment strategy: no production runtime change; evidence appears after the required CI/main publication chain.
- Rollback plan: revert the single commit and restore the exact baseline entry.
- Data migration reversible: N/A.

## Screenshots / demo

No UI layout change. After a successful default-branch Services CI publication and Admin UI deployment, the existing Test Intelligence runtime view will consume the new TPP Registry evidence.

## Reviewer notes

Please focus on operation ordering: recorder calls intentionally follow successful `start()`/`stop()`, and PostgreSQL cleanup is protected by `finally`.
