### PR TITLE
fix(admin-ui): prevent deploy source starvation

### DIFF
--- a/.github/scripts/authorize-admin-ui-deploy-source.sh
+++ b/.github/scripts/authorize-admin-ui-deploy-source.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+#
+# Prints exactly `true` when an Admin UI deploy source may enter the privileged build job.
+# A source that is no longer the main tip is normally stale. The sole exception is when every
+# newer commit is this workflow's own GitOps image bump: those commits change no build input, and
+# rejecting the waiting source would leave its Admin UI changes permanently undeployed.
+set -euo pipefail
+
+SOURCE_SHA="${1:?source SHA is required}"
+MAIN_SHA="${2:?main SHA is required}"
+ADMIN_UI_MANIFEST="openbank-infra/gitops/components/admin-ui/admin-ui.yaml"
+DEPLOY_SUBJECT_PREFIX="chore(admin-ui): deploy "
+
+reject() {
+  echo "$1" >&2
+  echo false
+  exit 0
+}
+
+git cat-file -e "${SOURCE_SHA}^{commit}" 2>/dev/null \
+  || reject "Skipping unknown deploy source ${SOURCE_SHA}."
+git cat-file -e "${MAIN_SHA}^{commit}" 2>/dev/null \
+  || reject "Skipping deploy because current main ${MAIN_SHA} is unavailable locally."
+
+source_subject="$(git log -1 --format=%s "$SOURCE_SHA")"
+if [[ "$source_subject" == "${DEPLOY_SUBJECT_PREFIX}"* ]]; then
+  reject "Skipping self-generated GitOps commit; its image is already built, signed and attested."
+fi
+
+if [ "$SOURCE_SHA" = "$MAIN_SHA" ]; then
+  echo true
+  exit 0
+fi
+
+git merge-base --is-ancestor "$SOURCE_SHA" "$MAIN_SHA" 2>/dev/null \
+  || reject "Skipping stale source ${SOURCE_SHA}; it is not an ancestor of main ${MAIN_SHA}."
+
+while IFS= read -r commit_sha; do
+  subject="$(git log -1 --format=%s "$commit_sha")"
+  if [[ "$subject" != "${DEPLOY_SUBJECT_PREFIX}"* ]]; then
+    reject "Skipping stale source ${SOURCE_SHA}; newer build-relevant main commit ${commit_sha} owns deployment."
+  fi
+
+  changed_paths="$(git diff-tree --first-parent --no-commit-id --name-only -r "$commit_sha")"
+  if [ "$changed_paths" != "$ADMIN_UI_MANIFEST" ]; then
+    reject "Skipping stale source ${SOURCE_SHA}; deploy-looking commit ${commit_sha} changed more than the Admin UI image pin."
+  fi
+done < <(git rev-list --reverse "${SOURCE_SHA}..${MAIN_SHA}")
+
+echo "Allowing ${SOURCE_SHA}; main advanced only through self-generated Admin UI image bumps." >&2
+echo true

--- a/.github/scripts/check-test-intelligence-ecosystem.py
+++ b/.github/scripts/check-test-intelligence-ecosystem.py
@@ -316,8 +316,7 @@ def check(root: Path) -> list[str]:
         ("workflow_run.conclusion == 'success'", "admin deployment accepts unsuccessful Services CI evidence"),
         ("workflow_run.head_branch == 'main'", "admin deployment accepts non-main Services CI evidence"),
         ("github.event.workflow_run.head_sha", "admin deployment cannot inspect the exact workflow-run source commit"),
-        ('subject="$(git log -1 --format=%s)"', "admin deployment does not inspect the workflow-run commit subject"),
-        ('proceed=false', "admin deployment cannot reject its own GitOps commit"),
+        ("authorize-admin-ui-deploy-source.sh", "admin deployment bypasses its source-ancestry guard"),
         ("needs.deploy-source.outputs.proceed == 'true'", "privileged admin image build bypasses the deploy-source guard"),
         ("latest_main_artifact", "admin deployment cannot select main-only service evidence"),
         ("per_page=100&page=${page}",
@@ -328,13 +327,31 @@ def check(root: Path) -> list[str]:
         ("github.event_name }}\" = \"workflow_run\"", "event-driven snapshot refresh does not use a unique immutable image tag"),
         ("github.event.workflow_run.head_sha || 'eligible'", "workflow-run events can evict the current push/dispatch Admin UI deploy queue"),
         ("git ls-remote origin refs/heads/main", "admin deployment does not reject a source commit that is stale before privileged build"),
-        ("Skipping stale source", "admin deployment does not make stale-source rejection observable"),
+        ('git fetch --no-tags --depth=64 origin "$main_sha"',
+         "admin deployment cannot inspect current main after checking out a waiting source"),
         ('"openbank-libs/governance/journeys.yaml"', "admin deployment does not rebuild the Test Intelligence snapshot when the journey catalog changes"),
         ('"perf/scenarios.yaml"', "admin deployment does not rebuild the Test Intelligence snapshot when the performance catalog changes"),
         ('"perf/k6/**"', "admin deployment does not rebuild the Test Intelligence snapshot when a performance definition changes"),
         ('"openbank-infra/gitops/components/observability/cronjob-journey-*.yaml"', "admin deployment does not rebuild the Test Intelligence snapshot when a synthetic runtime manifest changes"),
     ):
         if needle not in deploy:
+            errors.append(message)
+    deploy_source_guard = text(root / ".github/scripts/authorize-admin-ui-deploy-source.sh")
+    for needle, message in (
+        ('source_subject="$(git log -1 --format=%s "$SOURCE_SHA")"',
+         "admin deployment does not inspect the source commit subject"),
+        ('git merge-base --is-ancestor "$SOURCE_SHA" "$MAIN_SHA"',
+         "admin deployment accepts a stale source outside main ancestry"),
+        ('git rev-list --reverse "${SOURCE_SHA}..${MAIN_SHA}"',
+         "admin deployment cannot inspect every commit that overtook a waiting source"),
+        ('git diff-tree --first-parent --no-commit-id --name-only -r "$commit_sha"',
+         "admin deployment trusts a deploy-looking commit without verifying its changed paths"),
+        ('openbank-infra/gitops/components/admin-ui/admin-ui.yaml',
+         "admin deployment does not restrict the harmless-advance exception to its image manifest"),
+        ("Skipping stale source", "admin deployment does not make stale-source rejection observable"),
+        ("echo false", "admin deployment cannot reject its own GitOps commit"),
+    ):
+        if needle not in deploy_source_guard:
             errors.append(message)
     history_stage = deploy.partition("Stage immutable per-attempt Test Intelligence history")[2].partition(
         "Stage pitest mutation results"

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -105,8 +105,11 @@ concurrency:
   # pending deploy for a newer push, and only then discover that it must skip. That exact race
   # cancelled the pending Test Intelligence deploy for 29dc20e2 in favour of a stale evidence
   # refresh (#7211). Keep workflow-run events in a SHA-scoped queue; deploy-source independently
-  # rejects a source SHA that is no longer main before the privileged build. Push, dispatch and
-  # schedule retain one queue, so the newest operator/source-triggered deploy still wins normally.
+  # rejects a source SHA that has been superseded by build-relevant work before the privileged
+  # build. Push, dispatch and schedule retain one queue, so the newest operator/source-triggered
+  # deploy still wins normally. A waiting source remains eligible when main advanced solely through
+  # this workflow's own image-pin commit; otherwise that harmless commit can starve the source that
+  # produced it and leave newer UI code undeployed.
   group: >-
     admin-ui-deploy-${{
       github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || 'eligible'
@@ -146,19 +149,13 @@ jobs:
             echo "::error::could not resolve origin/main; refusing a privileged build from an unverified source"
             exit 1
           fi
-          if [ "$source_sha" != "$main_sha" ]; then
-            echo "proceed=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping stale source $source_sha; main is now $main_sha. A newer push/workflow run owns deployment."
-            exit 0
+          if ! git cat-file -e "${main_sha}^{commit}" 2>/dev/null; then
+            # A waiting run checked out its own (now older) SHA. Fetch a bounded current-main
+            # ancestry window for the image-pin-only proof; a longer gap safely remains stale.
+            git fetch --no-tags --depth=64 origin "$main_sha"
           fi
-
-          subject="$(git log -1 --format=%s)"
-          if [[ "$subject" == "chore(admin-ui): deploy "* ]]; then
-            echo "proceed=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping self-generated GitOps commit; its image is already built, signed and attested."
-          else
-            echo "proceed=true" >> "$GITHUB_OUTPUT"
-          fi
+          proceed="$(bash .github/scripts/authorize-admin-ui-deploy-source.sh "$source_sha" "$main_sha")"
+          echo "proceed=$proceed" >> "$GITHUB_OUTPUT"
 
   build-push:
     name: Build + push admin-ui

--- a/openbank-admin-ui/src/test/admin-ui-deploy-source.guard.test.ts
+++ b/openbank-admin-ui/src/test/admin-ui-deploy-source.guard.test.ts
@@ -1,0 +1,103 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const repoRoot = join(__dirname, '../../..')
+const guard = join(repoRoot, '.github/scripts/authorize-admin-ui-deploy-source.sh')
+const manifest = 'openbank-infra/gitops/components/admin-ui/admin-ui.yaml'
+const temporaryRepositories: string[] = []
+
+function git(repository: string, ...args: string[]) {
+  return execFileSync('git', args, { cwd: repository, encoding: 'utf8' }).trim()
+}
+
+function createRepository() {
+  const repository = mkdtempSync(join(tmpdir(), 'admin-ui-deploy-source-'))
+  temporaryRepositories.push(repository)
+  git(repository, 'init', '-q')
+  git(repository, 'config', 'user.email', 'test@example.com')
+  git(repository, 'config', 'user.name', 'Admin UI deploy guard test')
+  git(repository, 'config', 'commit.gpgsign', 'false')
+  commitFile(repository, 'openbank-admin-ui/src/app/page.tsx', 'initial\n', 'feat(admin-ui): seed source')
+  return repository
+}
+
+function commitFile(repository: string, path: string, content: string, subject: string) {
+  const target = join(repository, path)
+  mkdirSync(dirname(target), { recursive: true })
+  writeFileSync(target, content)
+  git(repository, 'add', '--', path)
+  git(repository, 'commit', '-qm', subject)
+  return git(repository, 'rev-parse', 'HEAD')
+}
+
+function authorize(repository: string, source: string, main: string) {
+  return execFileSync('bash', [guard, source, main], {
+    cwd: repository,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}
+
+afterEach(() => {
+  for (const repository of temporaryRepositories.splice(0)) {
+    rmSync(repository, { recursive: true, force: true })
+  }
+})
+
+describe('Admin UI deploy source authorization', () => {
+  it('keeps a waiting source eligible when main advanced only by its generated image pin', () => {
+    const repository = createRepository()
+    const source = git(repository, 'rev-parse', 'HEAD')
+    const main = commitFile(
+      repository,
+      manifest,
+      'image: admin-ui:sandbox-source\n',
+      'chore(admin-ui): deploy sandbox-source (#1)',
+    )
+
+    expect(authorize(repository, source, main)).toBe('true')
+  })
+
+  it('rejects a source overtaken by build-relevant work', () => {
+    const repository = createRepository()
+    const source = git(repository, 'rev-parse', 'HEAD')
+    const main = commitFile(
+      repository,
+      'openbank-admin-ui/src/app/page.tsx',
+      'newer source\n',
+      'fix(admin-ui): change newer source',
+    )
+
+    expect(authorize(repository, source, main)).toBe('false')
+  })
+
+  it('rejects a deploy-looking commit that changes anything beyond the image pin', () => {
+    const repository = createRepository()
+    const source = git(repository, 'rev-parse', 'HEAD')
+    mkdirSync(join(repository, 'openbank-infra/gitops/components/admin-ui'), { recursive: true })
+    writeFileSync(join(repository, manifest), 'image: admin-ui:sandbox-source\n')
+    writeFileSync(join(repository, 'openbank-admin-ui/README.md'), 'unexpected\n')
+    git(repository, 'add', '--', manifest, 'openbank-admin-ui/README.md')
+    git(repository, 'commit', '-qm', 'chore(admin-ui): deploy spoofed')
+    const main = git(repository, 'rev-parse', 'HEAD')
+
+    expect(authorize(repository, source, main)).toBe('false')
+  })
+
+  it('rejects the generated deploy commit itself and accepts an ordinary current source', () => {
+    const repository = createRepository()
+    const ordinary = git(repository, 'rev-parse', 'HEAD')
+    expect(authorize(repository, ordinary, ordinary)).toBe('true')
+
+    const generated = commitFile(
+      repository,
+      manifest,
+      'image: admin-ui:sandbox-source\n',
+      'chore(admin-ui): deploy sandbox-source',
+    )
+    expect(authorize(repository, generated, generated)).toBe('false')
+  })
+})


### PR DESCRIPTION
## Summary

- keep a queued Admin UI source eligible when `main` advanced only through generated image-pin commits
- keep rejecting a source overtaken by any build-relevant commit, any non-ancestor, and the generated deploy commit itself
- verify every harmless successor changes exactly the Admin UI GitOps manifest
- make the authorization seam part of the Test Intelligence ecosystem guard

## Why

The source run containing the delegated-access UI fix was queued behind an older deployment. That deployment's generated GitOps PR moved `main`, so the exact-SHA authorizer skipped the queued source as stale. The new main commit was itself correctly ineligible, leaving no run able to deploy the newer UI.

The guard now distinguishes an image-pin-only advance from a genuinely newer source. The real observed source/main pair is accepted; an older source separated by a build-relevant Admin UI commit is rejected.

Closes #8049

## Verification

- `npm test -- --run src/test/admin-ui-deploy-source.guard.test.ts` — 4/4 passed
- `npm run type-check` — passed
- targeted ESLint — passed
- `check-test-intelligence-ecosystem.py` and its red-path self-test — passed
- shell syntax/static analysis and YAML parse — passed
- real commit-pair reproduction — expected `true` for image-pin-only advance and `false` for genuinely superseded source

## Risk / rollback

The exception is intentionally narrow: linear ancestry, generated deploy subject, and exactly one allowed path for every intervening commit. Any ambiguity fails closed. Rollback is a single workflow/script revert; no runtime or data migration is involved.
