### PR TITLE
feat(admin-ui): add truthful approval inbox triage

### DIFF
--- a/openbank-admin-ui/e2e/approvals-decision.spec.ts
+++ b/openbank-admin-ui/e2e/approvals-decision.spec.ts
@@ -109,4 +109,91 @@ test.describe('approval workbench', () => {
     await expect(page.getByRole('cell', { name: 'Evidence independently checked.' })).toBeVisible()
     expect(decisionRequests).toBe(2)
   })
+
+  test('filters domain work and hands a sanctions item to its governed checker', async ({ page }) => {
+    const sanctionsApproval = {
+      id: 'sanctions-approval / 42', domain: 'sanctions', action: 'sanctions.clear',
+      resourceId: 'check-42', maker: 'maker.sanctions', proposedAt: '2026-08-31T08:00:00Z',
+    }
+    const notificationApproval = {
+      id: 'notification-approval-7', domain: 'notification', action: 'opsmessage.compose',
+      resourceId: null, maker: 'maker.notifications', proposedAt: '2026-08-31T09:00:00Z',
+    }
+    const balanceApproval = {
+      id: 'balance-approval-3', domain: 'balance', action: 'balance.debit',
+      resourceId: 'account-3', maker: 'maker.balance', proposedAt: '2026-08-31T10:00:00Z',
+    }
+    const billingApproval = {
+      id: 'billing-approval-4', domain: 'billing', action: 'fee.post',
+      resourceId: 'fee-4', maker: 'maker.billing', proposedAt: '2026-08-31T11:00:00Z',
+    }
+
+    await page.route('**/api/agent/proposals*', route =>
+      route.fulfill({ contentType: 'application/json', body: '[]' }),
+    )
+    await page.route('**/api/approvals/pending', route => route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        items: [billingApproval, balanceApproval, sanctionsApproval, notificationApproval],
+        sources: { sanctions: 'ok', notification: 'ok', balance: 'ok', billing: 'ok' },
+      }),
+    }))
+    await page.route('**/api/governance/agent-identities', route => route.fulfill({
+      contentType: 'application/json', body: JSON.stringify({ available: true, agents: [] }),
+    }))
+    await page.route('**/api/sanctions/checks', route =>
+      route.fulfill({ contentType: 'application/json', body: '[]' }),
+    )
+    await page.route('**/api/sanctions/lists', route =>
+      route.fulfill({ contentType: 'application/json', body: '[]' }),
+    )
+    await page.route('**/api/sanctions/approvals', route =>
+      route.fulfill({ contentType: 'application/json', body: JSON.stringify([{
+        id: sanctionsApproval.id,
+        action: sanctionsApproval.action,
+        resourceId: sanctionsApproval.resourceId,
+        status: 'PENDING',
+        makerId: sanctionsApproval.maker,
+        createdAt: sanctionsApproval.proposedAt,
+      }]) }),
+    )
+
+    await page.goto('/approvals')
+
+    const rows = page.locator('[data-testid^="domain-approval-"]')
+    await expect(rows).toHaveCount(4)
+    await expect(rows.nth(0)).toContainText(sanctionsApproval.action)
+    await page.getByLabel(/^(Order|Pořadí)$/).selectOption('newest')
+    await expect(rows.nth(0)).toContainText(billingApproval.action)
+
+    await page.getByLabel(/^(Domain|Doména)$/).selectOption('sanctions')
+    await expect(rows).toHaveCount(1)
+    await expect(rows.first()).toContainText(sanctionsApproval.action)
+    await page.getByLabel(/Search queue|Hledat ve frontě/).fill('maker.sanctions')
+    await expect(rows).toHaveCount(1)
+
+    const handoff = page.getByRole('link', { name: new RegExp(`Open governed review for approval ${sanctionsApproval.id}|Otevřít řízenou kontrolu žádosti ${sanctionsApproval.id}`) })
+    await expect(handoff).toHaveAttribute('href', '/sanctions?approvalId=sanctions-approval%20%2F%2042#sanctions-approval-id')
+    await handoff.click()
+
+    await expect(page).toHaveURL(/\/sanctions\?approvalId=sanctions-approval%20%2F%2042#sanctions-approval-id$/)
+    await expect(page.getByLabel(/Approval id|ID žádosti/)).toHaveValue(sanctionsApproval.id)
+  })
+
+  test('never reports an empty domain queue when the federated read itself failed', async ({ page }) => {
+    await page.route('**/api/agent/proposals*', route =>
+      route.fulfill({ contentType: 'application/json', body: '[]' }),
+    )
+    await page.route('**/api/approvals/pending', route =>
+      route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ error: 'aggregator unavailable' }) }),
+    )
+    await page.route('**/api/governance/agent-identities', route => route.fulfill({
+      contentType: 'application/json', body: JSON.stringify({ available: true, agents: [] }),
+    }))
+
+    await page.goto('/approvals')
+
+    await expect(page.getByText(/Domain approval inbox could not be loaded|Doménovou schvalovací frontu se nepodařilo načíst/)).toBeVisible()
+    await expect(page.getByText(/No domain approvals pending|Žádná doménová schvalování nečekají/)).toHaveCount(0)
+  })
 })

--- a/openbank-admin-ui/src/app/approvals/page.tsx
+++ b/openbank-admin-ui/src/app/approvals/page.tsx
@@ -11,15 +11,23 @@
 // author) is enforced by the agent.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import Link from 'next/link'
 import { useSingleFlight, wasSkipped } from '@/lib/mutations/singleFlight'
 import { useSession } from 'next-auth/react'
-import { CheckCircle2, XCircle, Clock, ClipboardCheck, RefreshCw, ShieldCheck, AlertTriangle, Bot, UserRound } from 'lucide-react'
+import { CheckCircle2, XCircle, Clock, ClipboardCheck, RefreshCw, ShieldCheck, AlertTriangle, Bot, UserRound, ExternalLink, Search } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader } from '@/components/ui/PageHeader'
 import { AgentIdentityBadge } from '@/components/approvals/AgentIdentityBadge'
 import { resolveAgentIdentity, type AgentIdentityRegistry } from '@/lib/governance/agentIdentity'
 import { AuthGuard, Can } from '@/components/auth/AuthGuard'
 import { trapDialogFocus } from '@/lib/a11y/trapDialogFocus'
+import {
+  approvalWorkbenchHref,
+  filterAndSortDomainApprovals,
+  type ApprovalDomain,
+  type ApprovalSortOrder,
+  type DomainApprovalItem,
+} from '@/lib/approvals/triage'
 
 interface Proposal {
   id: string
@@ -36,9 +44,9 @@ interface Proposal {
   agent?: { id: string; displayName: string; icon: 'bot' | 'user'; charterKnown: boolean }
 }
 
-interface InboxItem {
+interface InboxItem extends Omit<DomainApprovalItem, 'domain'> {
   id: string
-  domain: 'lending' | 'agent'
+  domain: ApprovalDomain | 'agent'
   action: string
   resourceId: string | null
   maker: string | null
@@ -62,6 +70,7 @@ export default function ApprovalsPage() {
   const [rows, setRows] = useState<Proposal[]>([])
   const [domainItems, setDomainItems] = useState<InboxItem[]>([])
   const [domainSources, setDomainSources] = useState<Record<string, string>>({})
+  const [domainLoadFailed, setDomainLoadFailed] = useState(false)
   const [loading, setLoading] = useState(true)
   const flight = useSingleFlight()
   const [decisionIntent, setDecisionIntent] = useState<DecisionIntent | null>(null)
@@ -72,27 +81,44 @@ export default function ApprovalsPage() {
   // `registryLoading` keeps the two apart in the UI (#5904).
   const [registry, setRegistry] = useState<AgentIdentityRegistry | null>(null)
   const [registryLoading, setRegistryLoading] = useState(true)
+  const [domainFilter, setDomainFilter] = useState<ApprovalDomain | 'all'>('all')
+  const [domainQuery, setDomainQuery] = useState('')
+  const [domainSort, setDomainSort] = useState<ApprovalSortOrder>('oldest')
 
   const load = useCallback(async () => {
     setLoading(true)
-    try {
-      const [proposalsRes, inboxRes] = await Promise.all([
-        fetch('/api/agent/proposals?state=all', { cache: 'no-store' }),
-        fetch('/api/approvals/pending', { cache: 'no-store' }),
-      ])
-      const data = await proposalsRes.json()
-      setRows(Array.isArray(data) ? data : [])
-      if (inboxRes.ok) {
-        const inbox = await inboxRes.json()
-        setDomainItems(Array.isArray(inbox.items) ? inbox.items : [])
-        setDomainSources(inbox.sources ?? {})
-      }
+    const [proposalsResult, inboxResult] = await Promise.allSettled([
+      fetch('/api/agent/proposals?state=all', { cache: 'no-store' }).then(async response => {
+        if (!response.ok) throw new Error('agent proposals unavailable')
+        const data = await response.json()
+        return Array.isArray(data) ? data as Proposal[] : []
+      }),
+      fetch('/api/approvals/pending', { cache: 'no-store' }).then(async response => {
+        if (!response.ok) throw new Error('domain approvals unavailable')
+        const inbox = await response.json()
+        return {
+          items: Array.isArray(inbox.items) ? inbox.items as InboxItem[] : [],
+          sources: inbox.sources && typeof inbox.sources === 'object' ? inbox.sources as Record<string, string> : {},
+        }
+      }),
+    ])
+
+    if (proposalsResult.status === 'fulfilled') {
+      setRows(proposalsResult.value)
       setError(null)
-    } catch {
+    } else {
       setError('unreachable')
-    } finally {
-      setLoading(false)
     }
+
+    if (inboxResult.status === 'fulfilled') {
+      setDomainItems(inboxResult.value.items)
+      setDomainSources(inboxResult.value.sources)
+      setDomainLoadFailed(false)
+    } else {
+      // Retain any last successful snapshot, but never let it look current or empty.
+      setDomainLoadFailed(true)
+    }
+    setLoading(false)
   }, [])
 
   useEffect(() => { void load() }, [load])
@@ -169,6 +195,18 @@ export default function ApprovalsPage() {
     () => Object.entries(domainSources).filter(([, v]) => v === 'not-configured').map(([k]) => k),
     [domainSources],
   )
+  const domainApprovalItems = useMemo(
+    () => domainItems.filter((item): item is DomainApprovalItem => item.domain !== 'agent'),
+    [domainItems],
+  )
+  const domainOptions = useMemo(
+    () => [...new Set(domainApprovalItems.map(item => item.domain))].sort(),
+    [domainApprovalItems],
+  )
+  const visibleDomainItems = useMemo(
+    () => filterAndSortDomainApprovals(domainApprovalItems, domainFilter, domainSort, domainQuery),
+    [domainApprovalItems, domainFilter, domainQuery, domainSort],
+  )
 
   return (
     <AuthGuard permission="approvals:view">
@@ -193,8 +231,19 @@ export default function ApprovalsPage() {
       {/* ADR-0227 D2/D4: domain maker-checker queues, federated. Read-only here — disposal
           belongs to the governed per-domain flows (money-path adds SCA). */}
       <div style={{ fontSize: 12, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-secondary)', margin: '4px 0 10px' }}>
-        {t('Doménová schvalování (money-path)', 'Domain approvals (money-path)')} ({domainItems.filter(i => i.domain !== 'agent').length})
+        {t('Doménová schvalování (money-path)', 'Domain approvals (money-path)')} ({domainApprovalItems.length})
       </div>
+      {domainLoadFailed && (
+        <div className="card" role="alert" style={{
+          padding: 14, marginBottom: 16, fontSize: 13,
+          color: '#92400e', background: '#fffbeb', border: '1px solid #fcd34d',
+        }}>
+          {t(
+            'Doménovou schvalovací frontu se nepodařilo načíst. Případná zobrazená data jsou z posledního úspěšného načtení; prázdný seznam neznamená, že nic nečeká.',
+            'Domain approval inbox could not be loaded. Any displayed data is from the last successful read; an empty list does not mean nothing is pending.',
+          )}
+        </div>
+      )}
       {unavailableSources.length > 0 && (
         <div className="card" style={{
           padding: 14, marginBottom: 16, fontSize: 13,
@@ -217,14 +266,48 @@ export default function ApprovalsPage() {
           )}
         </div>
       )}
-      {!loading && unavailableSources.length === 0 && notConfiguredSources.length === 0 && domainItems.filter(i => i.domain !== 'agent').length === 0 && (
+      {!loading && !domainLoadFailed && unavailableSources.length === 0 && notConfiguredSources.length === 0 && domainApprovalItems.length === 0 && (
         <div className="card" style={{ padding: 16, marginBottom: 16, color: 'var(--text-secondary)', fontSize: 13 }}>
           {t('Žádná doménová schvalování nečekají.', 'No domain approvals pending.')}
         </div>
       )}
+      {domainApprovalItems.length > 0 && (
+        <div className="card" role="group" aria-label={t('Filtry doménové fronty', 'Domain queue filters')} style={{ padding: 14, marginBottom: 12, display: 'flex', gap: 12, alignItems: 'end', flexWrap: 'wrap' }}>
+          <div style={{ flex: '2 1 240px' }}>
+            <label htmlFor="approval-domain-search" style={{ display: 'block', marginBottom: 5, fontSize: 11, fontWeight: 700, color: 'var(--text-secondary)' }}>{t('Hledat ve frontě', 'Search queue')}</label>
+            <div style={{ position: 'relative' }}>
+              <Search aria-hidden="true" size={14} style={{ position: 'absolute', left: 10, top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
+              <input id="approval-domain-search" className="input" type="search" value={domainQuery} onChange={event => setDomainQuery(event.target.value)} placeholder={t('ID, akce, zdroj nebo maker', 'ID, action, resource or maker')} style={{ width: '100%', paddingLeft: 32 }} />
+            </div>
+          </div>
+          <div style={{ flex: '1 1 180px' }}>
+            <label htmlFor="approval-domain-filter" style={{ display: 'block', marginBottom: 5, fontSize: 11, fontWeight: 700, color: 'var(--text-secondary)' }}>{t('Doména', 'Domain')}</label>
+            <select id="approval-domain-filter" className="input" value={domainFilter} onChange={event => setDomainFilter(event.target.value as ApprovalDomain | 'all')} style={{ width: '100%' }}>
+              <option value="all">{t('Všechny domény', 'All domains')}</option>
+              {domainOptions.map(domain => <option key={domain} value={domain}>{domain}</option>)}
+            </select>
+          </div>
+          <div style={{ flex: '1 1 180px' }}>
+            <label htmlFor="approval-domain-sort" style={{ display: 'block', marginBottom: 5, fontSize: 11, fontWeight: 700, color: 'var(--text-secondary)' }}>{t('Pořadí', 'Order')}</label>
+            <select id="approval-domain-sort" className="input" value={domainSort} onChange={event => setDomainSort(event.target.value as ApprovalSortOrder)} style={{ width: '100%' }}>
+              <option value="oldest">{t('Nejstarší první', 'Oldest first')}</option>
+              <option value="newest">{t('Nejnovější první', 'Newest first')}</option>
+            </select>
+          </div>
+          <span role="status" aria-live="polite" style={{ flex: '0 0 auto', paddingBottom: 9, fontSize: 11, color: 'var(--text-tertiary)' }}>
+            {t(`Zobrazeno ${visibleDomainItems.length} z ${domainApprovalItems.length}`, `Showing ${visibleDomainItems.length} of ${domainApprovalItems.length}`)}
+          </span>
+        </div>
+      )}
+      {!loading && domainApprovalItems.length > 0 && visibleDomainItems.length === 0 && (
+        <div className="card" style={{ padding: 16, marginBottom: 12, color: 'var(--text-secondary)', fontSize: 13 }}>
+          {t('Žádné čekající žádosti neodpovídají vybraným filtrům.', 'No pending approvals match the selected filters.')}
+        </div>
+      )}
       <div style={{ display: 'grid', gap: 10, marginBottom: 24 }}>
-        {domainItems.filter(i => i.domain !== 'agent').map(item => (
-          <div key={`${item.domain}:${item.id}`} className="card" style={{ padding: 14, display: 'flex', alignItems: 'center', gap: 12 }}>
+        {visibleDomainItems.map(item => {
+          const workbenchHref = approvalWorkbenchHref(item)
+          return <div key={`${item.domain}:${item.id}`} data-testid={`domain-approval-${item.domain}:${item.id}`} className="card" style={{ padding: 14, display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
             <span style={{
               fontSize: 10, fontWeight: 800, padding: '2px 8px', borderRadius: 10, textTransform: 'uppercase',
               color: '#1d4ed8', background: '#eff6ff', border: '1px solid #bfdbfe', flexShrink: 0,
@@ -242,8 +325,11 @@ export default function ApprovalsPage() {
             <span style={{ fontSize: 10, fontWeight: 700, color: '#d97706', background: '#fffbeb', border: '1px solid #fcd34d', padding: '2px 7px', borderRadius: 20, textTransform: 'uppercase', flexShrink: 0 }}>
               {t('Čeká', 'Pending')}
             </span>
+            {workbenchHref && <Link href={workbenchHref} className="btn btn-secondary" aria-label={t(`Otevřít řízenou kontrolu žádosti ${item.id}`, `Open governed review for approval ${item.id}`)} style={{ fontSize: 11, textDecoration: 'none' }}>
+              {t('Otevřít řízenou kontrolu', 'Open governed review')} <ExternalLink aria-hidden="true" size={12} />
+            </Link>}
           </div>
-        ))}
+        })}
       </div>
 
       <div style={{ fontSize: 12, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-secondary)', margin: '4px 0 10px' }}>

--- a/openbank-admin-ui/src/app/notifications/page.tsx
+++ b/openbank-admin-ui/src/app/notifications/page.tsx
@@ -14,6 +14,7 @@ import { DataUnavailable, type UnavailableKind } from '@/components/feedback/Dat
 import { opsMessageApi } from '@/lib/api'
 import { PageHeader, StatusBadge } from '@/components/ui'
 import { AuthGuard } from '@/components/auth/AuthGuard'
+import { readApprovalId } from '@/lib/approvals/triage'
 
 const NOTIFICATION_SERVICE = '/api/svc/notification-service'
 
@@ -173,16 +174,22 @@ export default function NotificationsPage() {
  * `PATCH /api/v1/notifications/approvals/{id}` endpoint. SelfApprovalNotAllowedException refuses
  * a maker deciding their own request server-side (403).
  *
- * Deliberately NOT an auto-loaded queue: the shipped backend (ApprovalStore) exposes no query to
- * enumerate pending approvals — there is no list endpoint — so the checker acts on the approval
- * id the maker relays out of band (shown on the maker's party-page banner). A backend list
- * endpoint would let this become a real queue; that is remaining ADR-0176 work.
+ * The unified /approvals inbox owns the auto-loaded queue. This domain workbench accepts the
+ * selected opaque id by deep link, but keeps the actual decision on the existing endpoint where
+ * backend self-approval and maker-checker enforcement remain authoritative.
  */
 function OperatorMessageApprovals() {
   const { t } = useLanguage()
   const [approvalId, setApprovalId] = useState('')
   const [busy, setBusy] = useState(false)
   const [result, setResult] = useState<{ ok: boolean; text: string } | null>(null)
+
+  useEffect(() => {
+    const linkedApprovalId = readApprovalId(window.location.search)
+    if (!linkedApprovalId) return
+    const frame = requestAnimationFrame(() => setApprovalId(linkedApprovalId))
+    return () => cancelAnimationFrame(frame)
+  }, [])
 
   const decide = async (approve: boolean) => {
     const id = approvalId.trim()
@@ -221,6 +228,7 @@ function OperatorMessageApprovals() {
         </span>
         <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
           <input
+            id="notification-approval-id"
             aria-label={t('ID schválení notifikace', 'Notification approval ID')}
             className="input"
             style={{ flex: 1, minWidth: '240px', fontFamily: 'var(--font-mono)' }}

--- a/openbank-admin-ui/src/app/sanctions/page.tsx
+++ b/openbank-admin-ui/src/app/sanctions/page.tsx
@@ -18,6 +18,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader, StatCard, StatusBadge, type Tone } from '@/components/ui'
 import { statusTone } from '@/components/ui/tone'
 import { trapDialogFocus } from '@/lib/a11y/trapDialogFocus'
+import { readApprovalId } from '@/lib/approvals/triage'
 
 interface SanctionCheck {
   id: string; name: string; entityType: string; status: string
@@ -239,6 +240,13 @@ export default function SanctionsPage() {
   const [decideMsg, setDecideMsg] = useState('')
   const [decisionIntent, setDecisionIntent] = useState<ApprovalDecisionIntent | null>(null)
   const decisionTriggerRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    const linkedApprovalId = readApprovalId(window.location.search)
+    if (!linkedApprovalId) return
+    const frame = requestAnimationFrame(() => setDecideId(linkedApprovalId))
+    return () => cancelAnimationFrame(frame)
+  }, [])
 
   const loadChecks = useCallback(async () => {
     setLoading(true)

--- a/openbank-admin-ui/src/lib/approvals/triage.ts
+++ b/openbank-admin-ui/src/lib/approvals/triage.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+export type ApprovalDomain =
+  | 'lending'
+  | 'sanctions'
+  | 'transaction'
+  | 'domestic-payment'
+  | 'clearing'
+  | 'fx'
+  | 'ledger'
+  | 'swift'
+  | 'sepa-payment'
+  | 'sepa-instant'
+  | 'notification'
+  | 'party'
+  | 'account'
+  | 'consent'
+  | 'balance'
+  | 'billing'
+
+export type DomainApprovalItem = {
+  id: string
+  domain: ApprovalDomain
+  action: string
+  resourceId: string | null
+  maker: string | null
+  proposedAt: string | null
+}
+
+export type ApprovalSortOrder = 'oldest' | 'newest'
+
+export function filterAndSortDomainApprovals(
+  items: readonly DomainApprovalItem[],
+  domain: ApprovalDomain | 'all',
+  order: ApprovalSortOrder,
+  query = '',
+): DomainApprovalItem[] {
+  const needle = query.trim().toLocaleLowerCase()
+  const filtered = items.filter(item => {
+    if (domain !== 'all' && item.domain !== domain) return false
+    if (!needle) return true
+    return [item.id, item.domain, item.action, item.resourceId, item.maker]
+      .filter((value): value is string => Boolean(value))
+      .some(value => value.toLocaleLowerCase().includes(needle))
+  })
+
+  return [...filtered].sort((left, right) => {
+    const comparison = (left.proposedAt ?? '').localeCompare(right.proposedAt ?? '')
+    return order === 'oldest' ? comparison : -comparison
+  })
+}
+
+/**
+ * Only return routes backed by a real checker UI. The unified inbox remains read-only: these
+ * links hand the opaque approval id to the domain that already owns RBAC, self-approval and
+ * maker-checker enforcement.
+ */
+export function approvalWorkbenchHref(item: DomainApprovalItem): string | null {
+  if (item.domain === 'sanctions') {
+    return `/sanctions?approvalId=${encodeURIComponent(item.id)}#sanctions-approval-id`
+  }
+  if (item.domain === 'notification') {
+    return `/notifications?approvalId=${encodeURIComponent(item.id)}#notification-approval-id`
+  }
+  return null
+}
+
+export function readApprovalId(search: string): string | null {
+  const approvalId = new URLSearchParams(search).get('approvalId')?.trim()
+  return approvalId || null
+}

--- a/openbank-admin-ui/src/test/approval-triage.test.ts
+++ b/openbank-admin-ui/src/test/approval-triage.test.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it } from 'vitest'
+import {
+  approvalWorkbenchHref,
+  filterAndSortDomainApprovals,
+  readApprovalId,
+  type DomainApprovalItem,
+} from '@/lib/approvals/triage'
+
+const rows: DomainApprovalItem[] = [
+  { id: 'balance-old', domain: 'balance', action: 'balance.debit', resourceId: 'account-7', maker: 'maker-a', proposedAt: '2026-08-31T08:00:00Z' },
+  { id: 'sanctions-new', domain: 'sanctions', action: 'sanctions.clear', resourceId: 'check-7', maker: 'maker-b', proposedAt: '2026-08-31T10:00:00Z' },
+  { id: 'notification-mid', domain: 'notification', action: 'opsmessage.compose', resourceId: null, maker: 'maker-c', proposedAt: '2026-08-31T09:00:00Z' },
+  { id: 'billing-newest', domain: 'billing', action: 'fee.post', resourceId: 'fee-7', maker: 'maker-d', proposedAt: '2026-08-31T11:00:00Z' },
+]
+
+describe('approval inbox triage', () => {
+  it('filters by domain and makes queue ordering explicit', () => {
+    expect(filterAndSortDomainApprovals(rows, 'all', 'oldest').map(row => row.id)).toEqual([
+      'balance-old', 'notification-mid', 'sanctions-new', 'billing-newest',
+    ])
+    expect(filterAndSortDomainApprovals(rows, 'all', 'newest').map(row => row.id)).toEqual([
+      'billing-newest', 'sanctions-new', 'notification-mid', 'balance-old',
+    ])
+    expect(filterAndSortDomainApprovals(rows, 'sanctions', 'oldest').map(row => row.id)).toEqual(['sanctions-new'])
+    expect(filterAndSortDomainApprovals(rows, 'all', 'oldest', 'MAKER-C').map(row => row.id)).toEqual(['notification-mid'])
+    expect(rows.map(row => row.id)).toEqual(['balance-old', 'sanctions-new', 'notification-mid', 'billing-newest'])
+  })
+
+  it('routes only to checker workbenches that preserve domain governance', () => {
+    expect(approvalWorkbenchHref(rows[1])).toBe('/sanctions?approvalId=sanctions-new#sanctions-approval-id')
+    expect(approvalWorkbenchHref(rows[2])).toBe('/notifications?approvalId=notification-mid#notification-approval-id')
+    expect(approvalWorkbenchHref(rows[0])).toBeNull()
+    expect(approvalWorkbenchHref(rows[3])).toBeNull()
+  })
+
+  it('round-trips opaque approval ids and ignores absent deep links', () => {
+    const opaque = { ...rows[1], id: 'approval / with?reserved&chars' }
+    expect(approvalWorkbenchHref(opaque)).toBe('/sanctions?approvalId=approval%20%2F%20with%3Freserved%26chars#sanctions-approval-id')
+    expect(readApprovalId('?approvalId=approval%20%2F%20with%3Freserved%26chars')).toBe('approval / with?reserved&chars')
+    expect(readApprovalId('?tab=checks')).toBeNull()
+    expect(readApprovalId('?approvalId=%20%20')).toBeNull()
+  })
+})

--- a/openbank-admin-ui/src/test/approvals-source-truth.guard.test.ts
+++ b/openbank-admin-ui/src/test/approvals-source-truth.guard.test.ts
@@ -21,7 +21,8 @@ describe('approval inbox source truthfulness', () => {
 
   it('does not render an empty-state claim while a source is not configured', () => {
     expect(pageSource).toContain('const notConfiguredSources = useMemo(')
-    expect(pageSource).toContain('notConfiguredSources.length === 0 && domainItems.filter')
+    expect(pageSource).toContain('!domainLoadFailed && unavailableSources.length === 0')
+    expect(pageSource).toContain('notConfiguredSources.length === 0 && domainApprovalItems.length === 0')
     expect(pageSource).toContain('Decisions from these domains will not appear here until their read endpoint is available.')
   })
 


### PR DESCRIPTION
## Summary

Turn the unified approval inbox into a truthful triage surface with search, domain filters, deterministic age ordering, and governed handoffs only where a real checker workbench exists. Preserve partial-source failures instead of rendering a false empty queue.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #8042

## Changes

- Add non-mutating search, domain filtering, result counts, and oldest/newest ordering across sanctions, notification, and billing domain approval records; agent proposals remain a separate queue.
- Link only sanctions and notification records to their existing governed checker workbenches; opaque identifiers are encoded and only prefill the existing form.
- Keep failed federated sources visible and block false empty-state claims on upstream 503 responses.
- Cover billing without inventing a decision route or bypassing its existing control boundary.

## Definition of Done

- [x] Hexagonal layering preserved (UI-only change; no domain/framework boundary changed).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (authenticated browser coverage for triage and source failure).
- [x] Contract tests updated (N/A: no public API change).
- [x] Relevant local gate passes: 26 focused tests plus the reviewed 34-test suite, type-check, changed-file ESLint, and diff-check.
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (N/A).
- [x] Flyway migration added + rollback note (N/A).
- [x] Avro schema versioned backward-compatibly (N/A).
- [x] Docs updated (N/A: behavior is self-contained in the existing inbox).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, or logs.
- [x] No new suppressions; boundary assertions remain scoped to the existing validated response shapes.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? No.
- [x] PII path changed? No; existing opaque approval identifiers remain opaque.
- [x] Cardholder data path changed? No.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

No decision endpoint, authorization rule, SCA flow, or maker-checker contract changes. Destination permissions and backend enforcement remain authoritative.

## Rollout / Rollback

- Deployment strategy: rolling with the normal Admin UI image promotion.
- Rollback plan: revert this single commit; the prior read-only inbox behavior returns.
- Data migration reversible: N/A.

## Screenshots / demo

Covered by authenticated Playwright scenarios for filter/sort/handoff and truthful 503 behavior.

## Reviewer notes

Please verify that agent proposals remain separate, billing intentionally has no decision link, only sanctions/notification use real checker workbenches, and upstream failures cannot collapse into the empty state. The independent exact-blob review found no blocker.
