### PR TITLE
test(customer-edge): record Testcontainers lifecycle evidence

### DIFF
--- a/openbank-customer-edge/build.gradle.kts
+++ b/openbank-customer-edge/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.quarkus.junit5)
+    testImplementation(project(":openbank-libs-testing"))
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.testcontainers)

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/it/RedpandaRedisTestResource.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/it/RedpandaRedisTestResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.customeredge.it
 
+import com.openbank.libs.testing.evidence.TestInfrastructureEvidence
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.opentest4j.TestAbortedException
 import org.testcontainers.DockerClientFactory
@@ -36,18 +37,20 @@ class RedpandaRedisTestResource : QuarkusTestResourceLifecycleManager {
             throw TestAbortedException("Docker not available — skipping Testcontainers IT")
         }
         val rp = RedpandaContainer(
-            DockerImageName.parse("redpandadata/redpanda:v24.1.2")
+            DockerImageName.parse(REDPANDA_IMAGE)
                 .asCompatibleSubstituteFor("docker.redpanda.com/redpandadata/redpanda"),
         )
         rp.start()
         redpanda = rp
         lastBootstrapServers = rp.bootstrapServers
+        TestInfrastructureEvidence.record("redpanda", REDPANDA_IMAGE, "started")
 
-        val rd = GenericContainer(DockerImageName.parse("docker.io/valkey/valkey:7.2-alpine")).withExposedPorts(
+        val rd = GenericContainer(DockerImageName.parse(VALKEY_IMAGE)).withExposedPorts(
             REDIS_PORT,
         )
         rd.start()
         redis = rd
+        TestInfrastructureEvidence.record("valkey", VALKEY_IMAGE, "started")
 
         return mapOf(
             "kafka.bootstrap.servers" to rp.bootstrapServers,
@@ -71,11 +74,22 @@ class RedpandaRedisTestResource : QuarkusTestResourceLifecycleManager {
     }
 
     override fun stop() {
-        redpanda?.stop()
-        redis?.stop()
+        try {
+            redpanda?.let {
+                it.stop()
+                TestInfrastructureEvidence.record("redpanda", REDPANDA_IMAGE, "stopped")
+            }
+        } finally {
+            redis?.let {
+                it.stop()
+                TestInfrastructureEvidence.record("valkey", VALKEY_IMAGE, "stopped")
+            }
+        }
     }
 
     companion object {
+        private const val REDPANDA_IMAGE = "redpandadata/redpanda:v24.1.2"
+        private const val VALKEY_IMAGE = "docker.io/valkey/valkey:7.2-alpine"
         private const val REDIS_PORT = 6379
 
         /** Matches [com.openbank.customeredge.integration.PartyEventsConsumerGroupIdBootIT]'s expectation. */

--- a/openbank-libs/governance/testcontainers-evidence-baseline.txt
+++ b/openbank-libs/governance/testcontainers-evidence-baseline.txt
@@ -16,7 +16,6 @@ openbank-billing-service/src/test/kotlin/com/openbank/billing/it/PostgresRedisTe
 openbank-clearing-service/src/test/kotlin/com/openbank/clearing/it/PostgresRedpandaRedisTestResource.kt
 openbank-consent-service/src/test/kotlin/com/openbank/consent/it/ConsentPostgresRedisTestResource.kt
 openbank-consent-service/src/test/kotlin/com/openbank/consent/it/PostgresTestResource.kt
-openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/it/RedpandaRedisTestResource.kt
 openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/it/PostgresRedisTestResource.kt
 openbank-fraud-service/src/test/kotlin/com/openbank/fraud/it/PostgresRedisRedpandaTestResource.kt
 openbank-fraud-service/src/test/kotlin/com/openbank/fraud/it/PostgresRedisTestResource.kt


### PR DESCRIPTION
## Summary

- record honest Redpanda and Valkey Testcontainers lifecycle evidence from the existing customer-edge test resource
- add the shared evidence recorder on the test classpath only
- remove the now-covered customer-edge entry from the governance ratchet baseline

No production runtime, image, topology, credential, host, port, or service configuration changes.

## Verification

- RED proof: removing only the baseline entry made `check-test-intelligence-ecosystem.py` fail on `RedpandaRedisTestResource.kt`
- ecosystem self-test: PASS (red path proven)
- direct ecosystem check: PASS (`SUBJECTS=60`)
- `run-gates.py --only test-intelligence-ecosystem`: PASS
- post-rebase `compileTestKotlin`, `ktlintCheck`, and `detekt`: PASS
- `PartyEventsConsumerGroupIdBootIT --rerun-tasks`: 1/1 passed, 0 skipped/failures/errors
- full `:openbank-customer-edge:build`: PASS
- collected envelope: 425 discovered, 423 executed/passed, 2 expected broker-only skips, 0 failures/errors, 0 diagnostics
- runtime envelope: exactly one balanced `started`/`stopped` pair for both Redpanda and Valkey; no host, port, credential, token, secret, bootstrap server, or container identifier fields

## Coordination

- #7997 changes a different line in the shared baseline; no current content conflict
- #8011 changes disjoint production customer-edge files; rebase and repeat the module proof if it lands first
- independent CODEOWNER review remains required before merge

Refs #7246
