### PR TITLE
test(synthetic): prove public-edge falsification path

### DIFF
--- a/.github/workflows/synthetic-journeys.yml
+++ b/.github/workflows/synthetic-journeys.yml
@@ -75,6 +75,32 @@ jobs:
           python3 .github/scripts/check-journey-catalog.py \
             --root . --extract public-edge --out synthetic-evidence/journey.js
 
+      - name: Prove the exact public-edge monitor fails closed
+        run: |
+          set +e
+          docker run --rm \
+            --network none \
+            --user "$(id -u):$(id -g)" \
+            --volume "$PWD/synthetic-evidence:/evidence" \
+            --env API_BASE=http://127.0.0.1:9 \
+            --env CUSTOMER_BASE=http://127.0.0.1:9 \
+            --env ADMIN_BASE=http://127.0.0.1:9 \
+            docker.io/grafana/k6:1.2.0@sha256:5301215b669b3758b1b3b1f43a25a91378c2bbb8cbb6b29d5b4a44be8064dedc \
+            run --quiet \
+            --summary-export /evidence/public-edge-negative-summary.json \
+            /evidence/journey.js
+          negative_exit=$?
+          set -e
+          if [[ "$negative_exit" -ne 99 ]]; then
+            echo "::error::public-edge negative control returned ${negative_exit}; expected k6 threshold exit 99"
+            exit 1
+          fi
+          jq -e '
+            .metrics.checks.fails == 3 and
+            .metrics.checks.passes == 0 and
+            .metrics.checks.thresholds["rate==1.0"] == true
+          ' synthetic-evidence/public-edge-negative-summary.json >/dev/null
+
       - name: Run the exact sandbox journey
         run: |
           docker run --rm \


### PR DESCRIPTION
## Summary

- execute the exact ConfigMap-derived `public-edge` k6 program as a deterministic negative control before its live positive run
- disable container networking and point all three targets at an unused loopback port
- require the documented k6 threshold exit (`99`) plus exactly 3 failed / 0 passed checks and a crossed `checks` threshold
- retain the negative summary alongside the existing immutable synthetic artifacts

The live sandbox journey remains unchanged and authoritative for the Test Intelligence `run.json`. This change adds no identity, secret, deployment, manifest, or production topology.

## Verification

- exact digest-pinned k6 reproduction with `--network none`: exit `99`, 3 failed / 0 passed, `rate==1.0` crossed
- `actionlint .github/workflows/synthetic-journeys.yml`: PASS
- fleet `yamllint`: PASS (`SUBJECTS=804`)
- workflow run-step size gate: PASS
- journey catalog self-test: 19/19 PASS
- journey catalog enforced gate: PASS (`SUBJECTS=15`)
- journey coverage self-test: 9/9 PASS
- journey coverage enforce: PASS (`SUBJECTS=23`)
- independent diff review: no P1/P2 findings

## Safety

- the negative container is non-root, has no network, and receives no credentials
- loopback avoids DNS, public endpoint, and sandbox availability dependencies
- the expected failing command is scoped under `set +e`; fail-fast mode is restored before exact assertions
- the existing positive-control step and positive `summary.json` are unchanged

Independent review remains required before merge.

Refs #7284
