### PR TITLE
fix(admin-ui): make sanctions list changes recoverable

### DIFF
--- a/openbank-admin-ui/e2e/sanctions-list-change-review.spec.ts
+++ b/openbank-admin-ui/e2e/sanctions-list-change-review.spec.ts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const SANCTIONS_LIST = {
+  id: 'eu-consolidated',
+  listType: 'EU',
+  displayName: 'EU Consolidated Financial Sanctions List',
+  sourceUrl: 'https://example.test/eu-sanctions',
+  enabled: true,
+  lastUpdatedAt: '2026-08-31T12:00:00Z',
+  lastEntryCount: 1248,
+  cronHour: 3,
+  cronMinute: 0,
+  cronDays: 'MON,TUE,WED,THU,FRI,SAT,SUN',
+}
+
+const OTHER_SANCTIONS_LIST = {
+  ...SANCTIONS_LIST,
+  id: 'ofac-sdn',
+  listType: 'OFAC_SDN',
+  displayName: 'OFAC Specially Designated Nationals',
+}
+
+test.beforeEach(async ({ context, baseURL, page }) => {
+  await signInAsOperator(context, baseURL!)
+  await page.route('**/api/auth/session', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      user: {
+        name: 'E2E Operator',
+        email: 'e2e-operator@openbank.test',
+        roles: ['ROLE_ADMIN', 'ROLE_OPERATOR', 'ROLE_AUDITOR', 'ROLE_COMPLIANCE', 'ROLE_PAYMENTS'],
+        accessToken: 'e2e-fake-access-token',
+      },
+      expires: '2099-01-01T00:00:00.000Z',
+    }),
+  }))
+})
+
+test('reviews the real disable impact, suppresses duplicate PUTs, and recovers from an unconfirmed response', async ({ page }) => {
+  let list = { ...SANCTIONS_LIST }
+  let putRequests = 0
+
+  await page.route('**/api/sanctions/checks', route =>
+    route.fulfill({ contentType: 'application/json', body: '[]' }),
+  )
+  await page.route('**/api/sanctions/approvals', route =>
+    route.fulfill({ contentType: 'application/json', body: '[]' }),
+  )
+  await page.route('**/api/sanctions/lists', route =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify([list]) }),
+  )
+  await page.route(`**/api/sanctions/lists/${SANCTIONS_LIST.id}`, async route => {
+    putRequests += 1
+    expect(route.request().method()).toBe('PUT')
+    expect(await route.request().postDataJSON()).toEqual({ enabled: false })
+    if (putRequests === 1) {
+      await route.fulfill({ status: 503, contentType: 'application/json', body: '{"error":"upstream_error"}' })
+      return
+    }
+    list = { ...list, enabled: false }
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify(list) })
+  })
+
+  await page.goto('/sanctions')
+  await page.getByRole('button', { name: /Správa listů|List Management/ }).click()
+  await page.getByRole('button', { name: `Review pausing automatic updates for ${SANCTIONS_LIST.displayName}` }).click()
+  expect(putRequests).toBe(0)
+
+  const dialog = page.getByRole('alertdialog')
+  await expect(dialog).toContainText('API screenings outside this console are not excluded by this setting')
+  await expect(dialog).toContainText('does not enter the four-eyes approval queue')
+
+  const confirm = dialog.getByRole('button', { name: 'Pause automatic updates' })
+  await confirm.evaluate(button => {
+    const control = button as HTMLButtonElement
+    control.click()
+    control.click()
+  })
+  await expect(dialog.getByRole('alert')).toContainText('The service did not confirm the change')
+  await expect(dialog.getByRole('button', { name: 'Close and refresh status' })).toBeVisible()
+  expect(putRequests).toBe(1)
+
+  await confirm.click()
+  await expect(dialog).toBeHidden()
+  expect(putRequests).toBe(2)
+
+  const resumedToggle = page.getByRole('button', { name: `Review resuming automatic updates for ${SANCTIONS_LIST.displayName}` })
+  await expect(resumedToggle).toBeVisible()
+  await expect(resumedToggle).toBeFocused()
+  await page.getByRole('button', { name: /Manuální vyhledávání|Manual Search/ }).click()
+  const scope = page.getByRole('checkbox', { name: SANCTIONS_LIST.displayName })
+  await expect(scope).toBeDisabled()
+  await expect(scope).not.toBeChecked()
+})
+
+for (const status of [401, 403]) {
+  test(`reconciles status after a ${status} authorization rejection instead of promising the previous state`, async ({ page }) => {
+    let listReads = 0
+
+    await page.route('**/api/sanctions/checks', route =>
+      route.fulfill({ contentType: 'application/json', body: '[]' }),
+    )
+    await page.route('**/api/sanctions/approvals', route =>
+      route.fulfill({ contentType: 'application/json', body: '[]' }),
+    )
+    await page.route('**/api/sanctions/lists', route => {
+      listReads += 1
+      return route.fulfill({ contentType: 'application/json', body: JSON.stringify([SANCTIONS_LIST]) })
+    })
+    await page.route(`**/api/sanctions/lists/${SANCTIONS_LIST.id}`, route =>
+      route.fulfill({ status, contentType: 'application/json', body: '{"error":"forbidden"}' }),
+    )
+
+    await page.goto('/sanctions')
+    await page.getByRole('button', { name: /Správa listů|List Management/ }).click()
+    const toggle = page.getByRole('button', { name: `Review pausing automatic updates for ${SANCTIONS_LIST.displayName}` })
+    await toggle.click()
+    const readsBeforeReconcile = listReads
+    const dialog = page.getByRole('alertdialog')
+    await dialog.getByRole('button', { name: 'Pause automatic updates' }).click()
+    await expect(dialog.getByRole('alert')).toContainText('This session is not authorised to make the change')
+    await dialog.getByRole('button', { name: 'Close and refresh status' }).click()
+
+    await expect(dialog).toBeHidden()
+    await expect.poll(() => listReads).toBeGreaterThan(readsBeforeReconcile)
+    await expect(toggle).toBeFocused()
+  })
+}
+
+test('prunes an ambiguously applied disable from the reconciled manual-screening scope', async ({ page }) => {
+  let list = { ...SANCTIONS_LIST }
+
+  await page.route('**/api/sanctions/checks', route =>
+    route.fulfill({ contentType: 'application/json', body: '[]' }),
+  )
+  await page.route('**/api/sanctions/approvals', route =>
+    route.fulfill({ contentType: 'application/json', body: '[]' }),
+  )
+  await page.route('**/api/sanctions/lists', route =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify([list, OTHER_SANCTIONS_LIST]) }),
+  )
+  await page.route(`**/api/sanctions/lists/${SANCTIONS_LIST.id}`, route => {
+    list = { ...list, enabled: false }
+    return route.abort('failed')
+  })
+  await page.route('**/api/sanctions/screen', route =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'manual-check-1',
+        name: 'Acme Ltd',
+        entityType: 'INDIVIDUAL',
+        status: 'CLEAR',
+        overallScore: 0,
+        checkedLists: [OTHER_SANCTIONS_LIST.listType],
+        matches: [],
+        checkedAt: '2026-09-01T12:00:00Z',
+      }),
+    }),
+  )
+
+  await page.goto('/sanctions')
+  await page.getByRole('button', { name: /Správa listů|List Management/ }).click()
+  await page.getByRole('button', { name: `Review pausing automatic updates for ${SANCTIONS_LIST.displayName}` }).click()
+  const dialog = page.getByRole('alertdialog')
+  await dialog.getByRole('button', { name: 'Pause automatic updates' }).click()
+  await expect(dialog.getByRole('alert')).toContainText('The service did not confirm the change')
+  await dialog.getByRole('button', { name: 'Close and refresh status' }).click()
+  await expect(dialog).toBeHidden()
+
+  await page.getByRole('button', { name: /Manuální vyhledávání|Manual Search/ }).click()
+  const disabledScope = page.getByRole('checkbox', { name: SANCTIONS_LIST.displayName })
+  await expect(disabledScope).toBeDisabled()
+  await expect(disabledScope).not.toBeChecked()
+  await expect(page.getByRole('checkbox', { name: OTHER_SANCTIONS_LIST.displayName })).toBeChecked()
+
+  await page.getByLabel(/Jméno \/ Název|Name \/ Entity/).fill('Acme Ltd')
+  const screenRequestPromise = page.waitForRequest('**/api/sanctions/screen')
+  await page.getByRole('button', { name: /Spustit prověření sankcí|Run sanctions screening/ }).click()
+  const screenPayload = await (await screenRequestPromise).postDataJSON()
+  expect(screenPayload.listTypes).toEqual([OTHER_SANCTIONS_LIST.listType])
+})

--- a/openbank-admin-ui/src/app/sanctions/page.tsx
+++ b/openbank-admin-ui/src/app/sanctions/page.tsx
@@ -11,6 +11,12 @@ import {
   ToggleLeft, ToggleRight, ExternalLink, Download, Loader2
 } from 'lucide-react'
 import { AuthGuard, Can } from '@/components/auth/AuthGuard'
+import {
+  SanctionsListChangeDialog,
+  retainEnabledSelectedListTypes,
+  type SanctionsList,
+  type SanctionsListChangeError,
+} from '@/components/sanctions/SanctionsListChangeDialog'
 import { classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
@@ -28,10 +34,9 @@ interface SanctionMatch {
   listType: string; matchType: string; matchScore: number
   matchedName: string; programs: string[]
 }
-interface SanctionsList {
-  id: string; listType: string; displayName: string; sourceUrl: string
-  enabled: boolean; lastUpdatedAt?: string; lastEntryCount?: number
-  cronHour: number; cronMinute: number; cronDays: string
+interface SanctionsListChangeIntent {
+  list: SanctionsList
+  enabled: boolean
 }
 
 interface ApiError {
@@ -68,6 +73,7 @@ interface ApprovalDecisionIntent {
 const DAYS = ['MON','TUE','WED','THU','FRI','SAT','SUN']
 const DAY_LABELS_CS: Record<string,string> = { MON:'Po', TUE:'Út', WED:'St', THU:'Čt', FRI:'Pá', SAT:'So', SUN:'Ne' }
 const DAY_LABELS_EN: Record<string,string> = { MON:'Mon', TUE:'Tue', WED:'Wed', THU:'Thu', FRI:'Fri', SAT:'Sat', SUN:'Sun' }
+const listToggleControlId = (listId: string) => `sanctions-list-${listId}-toggle`
 
 function CronEditor({ list, onSave }: { list: SanctionsList; onSave: (id: string, patch: Partial<SanctionsList>) => void }) {
   const { t } = useLanguage()
@@ -129,7 +135,7 @@ function CronEditor({ list, onSave }: { list: SanctionsList; onSave: (id: string
 
 function ListCard({ list, onToggle, onRefresh, onSave }: {
   list: SanctionsList
-  onToggle: (id: string, enabled: boolean) => void
+  onToggle: (list: SanctionsList, enabled: boolean, trigger: HTMLButtonElement) => void
   onRefresh: (listType: string) => void
   onSave: (id: string, patch: Partial<SanctionsList>) => void
 }) {
@@ -149,7 +155,17 @@ function ListCard({ list, onToggle, onRefresh, onSave }: {
     <div style={{ border: '1px solid var(--border)', borderRadius: '8px', overflow: 'hidden', opacity: list.enabled ? 1 : 0.6, transition: 'opacity 0.2s' }}>
       <div style={{ padding: '12px 16px', display: 'flex', alignItems: 'center', gap: '10px', background: 'var(--surface)' }}>
         <Can permission="sanctions:manage">
-          <button type="button" onClick={() => onToggle(list.id, !list.enabled)} aria-label={list.enabled ? t('Deaktivovat sankční seznam', 'Disable sanctions list') : t('Aktivovat sankční seznam', 'Enable sanctions list')} style={{ background: 'none', border: 'none', cursor: 'pointer', color: list.enabled ? 'var(--success)' : 'var(--text-tertiary)', padding: 0, display: 'flex' }}>
+          <button
+            id={listToggleControlId(list.id)}
+            type="button"
+            aria-pressed={list.enabled}
+            aria-haspopup="dialog"
+            onClick={event => onToggle(list, !list.enabled, event.currentTarget)}
+            aria-label={list.enabled
+              ? t(`Zkontrolovat pozastavení automatických aktualizací seznamu ${list.displayName}`, `Review pausing automatic updates for ${list.displayName}`)
+              : t(`Zkontrolovat obnovení automatických aktualizací seznamu ${list.displayName}`, `Review resuming automatic updates for ${list.displayName}`)}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', color: list.enabled ? 'var(--success)' : 'var(--text-tertiary)', padding: 0, display: 'flex' }}
+          >
             {list.enabled ? <ToggleRight size={20} aria-hidden="true" /> : <ToggleLeft size={20} aria-hidden="true" />}
           </button>
         </Can>
@@ -218,6 +234,10 @@ export default function SanctionsPage() {
   // Selected list types for manual screening — initialised to all enabled lists once loaded
   const [selectedListTypes, setSelectedListTypes] = useState<string[]>([])
   const [listScopeInitialised, setListScopeInitialised] = useState(false)
+  const [pendingListChange, setPendingListChange] = useState<SanctionsListChangeIntent | null>(null)
+  const [listChangeBusy, setListChangeBusy] = useState(false)
+  const [listChangeError, setListChangeError] = useState<SanctionsListChangeError>(null)
+  const listChangeTriggerRef = useRef<HTMLButtonElement | null>(null)
 
   // Manual disposition of a hit (issue #3334). POST /api/v1/sanctions/review existed, was
   // publicly routed and had no caller anywhere in the product — so this queue could only grow.
@@ -272,7 +292,11 @@ export default function SanctionsPage() {
         setListsError(errorPayload.error ?? t(`Načtení listů selhalo (HTTP ${res.status})`, `Failed to load lists (HTTP ${res.status})`))
         return
       }
-      setLists(Array.isArray(data) ? data : [])
+      const nextLists = Array.isArray(data) ? data as SanctionsList[] : []
+      setLists(nextLists)
+      // Reconciliation may reveal that an ambiguous PUT actually disabled a list. Remove only
+      // types that are no longer enabled; never add back a list the operator deliberately omitted.
+      setSelectedListTypes(current => retainEnabledSelectedListTypes(current, nextLists))
     } catch (error) {
       setListsError(error instanceof Error ? error.message : 'Spojení se službou selhalo')
     }
@@ -338,15 +362,28 @@ export default function SanctionsPage() {
     setScreening(false)
   }
 
-  const handleToggleList = async (id: string, enabled: boolean) => {
-    setListsError('')
-    const res = await fetch(`/api/sanctions/lists/${id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ enabled }) })
-    if (!res.ok) {
-      const errorPayload = await res.json().catch(() => ({ error: 'Update failed' })) as ApiError
-      setListsError(errorPayload.error ?? `Aktualizace listu selhala (HTTP ${res.status})`)
-      return
-    }
-    loadLists()
+  const requestListChange = (list: SanctionsList, enabled: boolean, trigger: HTMLButtonElement) => {
+    listChangeTriggerRef.current = trigger
+    setListChangeError(null)
+    setPendingListChange({ list, enabled })
+  }
+
+  const restoreListChangeFocus = (listId: string) => {
+    requestAnimationFrame(() => {
+      const stableControl = document.getElementById(listToggleControlId(listId))
+      if (stableControl instanceof HTMLButtonElement) stableControl.focus()
+      else listChangeTriggerRef.current?.focus()
+    })
+  }
+
+  const closeListChange = async () => {
+    if (listChangeBusy) return
+    const intent = pendingListChange
+    const mustReconcile = listChangeError !== null
+    setPendingListChange(null)
+    setListChangeError(null)
+    if (mustReconcile) await loadLists()
+    if (intent) restoreListChangeFocus(intent.list.id)
   }
 
   const handleRefreshList = async (listType: string) => {
@@ -396,12 +433,56 @@ export default function SanctionsPage() {
     setPendingApproval(null)
   }
 
-  // SEPARATE locks for the maker and checker halves (#7098): a maker disposition and a
-  // checker decision are different operations and must not block each other. Neither
-  // lock addresses the cross-operator four-eyes race — that is arbitrated upstream
-  // (403 on self-approval, below) and no client-side lock could ever see it.
+  // These are separate operations and must not block each other. The list-change lock prevents
+  // same-tick duplicate PUTs; the upstream endpoint is idempotent because it sets an explicit
+  // boolean target state. It does NOT create a maker-checker approval — sanctions.update is an
+  // immediate operation, unlike sanctions.clear below.
+  const listChangeFlight = useSingleFlight()
   const reviewFlight = useSingleFlight()
   const decideFlight = useSingleFlight()
+
+  const confirmListChange = async () => {
+    const intent = pendingListChange
+    if (!intent) return
+
+    const outcome = await listChangeFlight.run(`sanctions:list:${intent.list.id}`, async () => {
+      setListChangeBusy(true)
+      setListChangeError(null)
+      setListsError('')
+      try {
+        const res = await fetch(`/api/sanctions/lists/${intent.list.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ enabled: intent.enabled }),
+        })
+        if (!res.ok) {
+          setListChangeError(res.status === 401 || res.status === 403 ? 'unauthorized' : 'unconfirmed')
+          return
+        }
+
+        // A confirmed target-state PUT is safe to reflect immediately. Keep stale-list recovery:
+        // loadLists() reconciles with the service, but a failed follow-up GET must not undo the
+        // state the successful PUT already confirmed.
+        setLists(current => current.map(list => list.id === intent.list.id ? { ...list, enabled: intent.enabled } : list))
+        if (!intent.enabled) {
+          // The list scope is initialised only once, so a list disabled later would otherwise stay
+          // selected and the next manual check would still send it explicitly.
+          setSelectedListTypes(current => current.filter(listType => listType !== intent.list.listType))
+        }
+        setPendingListChange(null)
+        setListChangeError(null)
+        await loadLists()
+        restoreListChangeFocus(intent.list.id)
+      } catch {
+        // A dropped response is ambiguous: the server may have applied the idempotent target state.
+        // Keep the dialog open and never claim that nothing changed.
+        setListChangeError('unconfirmed')
+      } finally {
+        setListChangeBusy(false)
+      }
+    })
+    if (wasSkipped(outcome)) return
+  }
 
   /** Submit a disposition. `approvalId` is set only on the post-approval retry. */
   const submitReview = async (checkId: string, approvalId?: string) => {
@@ -860,7 +941,7 @@ export default function SanctionsPage() {
                       {t('Rozsah prověření', 'Search scope')}
                     </label>
                     <div role="group" aria-label={t('Výběr všech sankčních listů', 'Select sanctions lists')} style={{ display: 'flex', gap: '8px' }}>
-                      <button type="button" onClick={() => setSelectedListTypes(lists.map(lst => lst.listType))}
+                      <button type="button" onClick={() => setSelectedListTypes(lists.filter(lst => lst.enabled).map(lst => lst.listType))}
                         style={{ fontSize: '11px', fontWeight: 600, color: 'var(--accent)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}>
                         {t('Vše', 'All')}
                       </button>
@@ -881,17 +962,18 @@ export default function SanctionsPage() {
                         const checked = selectedListTypes.includes(lst.listType)
                         const isPep = lst.displayName.toLowerCase().includes('pep') || lst.listType.toLowerCase().includes('pep')
                         return (
-                          <label key={lst.listType} style={{ display: 'flex', alignItems: 'flex-start', gap: '8px', cursor: 'pointer', padding: '6px 8px', borderRadius: '5px',
+                          <label key={lst.listType} style={{ display: 'flex', alignItems: 'flex-start', gap: '8px', cursor: lst.enabled ? 'pointer' : 'not-allowed', padding: '6px 8px', borderRadius: '5px',
                             background: checked ? (isPep ? 'rgba(168,85,247,0.07)' : 'rgba(99,102,241,0.07)') : 'transparent',
                             border: `1px solid ${checked ? (isPep ? 'rgba(168,85,247,0.25)' : 'rgba(99,102,241,0.25)') : 'transparent'}`,
                             transition: 'all 0.15s', opacity: lst.enabled ? 1 : 0.5 }}>
                             <input
                               type="checkbox"
                               checked={checked}
+                              disabled={!lst.enabled}
                               onChange={e => setSelectedListTypes(prev =>
                                 e.target.checked ? [...prev, lst.listType] : prev.filter(x => x !== lst.listType)
                               )}
-                              style={{ width: '13px', height: '13px', marginTop: '1px', accentColor: isPep ? 'rgb(168,85,247)' : 'var(--accent)', cursor: 'pointer', flexShrink: 0 }}
+                              style={{ width: '13px', height: '13px', marginTop: '1px', accentColor: isPep ? 'rgb(168,85,247)' : 'var(--accent)', cursor: lst.enabled ? 'pointer' : 'not-allowed', flexShrink: 0 }}
                             />
                             <div style={{ minWidth: 0 }}>
                               <div style={{ fontSize: '12px', fontWeight: 600, color: checked ? 'var(--text-primary)' : 'var(--text-secondary)',
@@ -995,7 +1077,7 @@ export default function SanctionsPage() {
             <div style={{ padding: '16px' }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '14px' }}>
                 <div style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
-                  {lists.filter(l => l.enabled).length} {t('z', 'of')} {lists.length} {t('listů aktivních', 'lists active')}
+                  {lists.filter(l => l.enabled).length} {t('z', 'of')} {lists.length} {t('listů s automatickou aktualizací', 'lists with automatic updates')}
                 </div>
                 <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                   <button type="button" aria-busy={listsLoading} aria-label={t('Obnovit stav sankčních listů', 'Refresh sanctions-list status')} onClick={() => void loadLists()} disabled={listsLoading}
@@ -1046,7 +1128,7 @@ export default function SanctionsPage() {
                   <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
                     {lists.map(list => (
                       <ListCard key={list.id} list={list}
-                        onToggle={handleToggleList}
+                        onToggle={requestListChange}
                         onRefresh={handleRefreshList}
                         onSave={handleSaveCron} />
                     ))}
@@ -1057,6 +1139,14 @@ export default function SanctionsPage() {
           )}
         </div>
       </div>
+      {pendingListChange && <SanctionsListChangeDialog
+        list={pendingListChange.list}
+        enabled={pendingListChange.enabled}
+        busy={listChangeBusy}
+        error={listChangeError}
+        onCancel={() => void closeListChange()}
+        onConfirm={() => void confirmListChange()}
+      />}
       {decisionIntent && <SanctionsApprovalDecisionDialog
         intent={decisionIntent}
         busy={decideBusy}

--- a/openbank-admin-ui/src/components/sanctions/SanctionsListChangeDialog.tsx
+++ b/openbank-admin-ui/src/components/sanctions/SanctionsListChangeDialog.tsx
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useRef } from 'react'
+import { AlertTriangle } from 'lucide-react'
+import { trapDialogFocus } from '@/lib/a11y/trapDialogFocus'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+
+export interface SanctionsList {
+  id: string; listType: string; displayName: string; sourceUrl: string
+  enabled: boolean; lastUpdatedAt?: string; lastEntryCount?: number
+  cronHour: number; cronMinute: number; cronDays: string
+}
+
+export type SanctionsListChangeError = 'unauthorized' | 'unconfirmed' | null
+
+export function retainEnabledSelectedListTypes(selectedListTypes: string[], lists: SanctionsList[]) {
+  const enabledListTypes = new Set(lists.filter(list => list.enabled).map(list => list.listType))
+  const retained = selectedListTypes.filter(listType => enabledListTypes.has(listType))
+  return retained.length === selectedListTypes.length ? selectedListTypes : retained
+}
+
+export function SanctionsListChangeDialog({ list, enabled, busy, error, onCancel, onConfirm }: {
+  list: SanctionsList
+  enabled: boolean
+  busy: boolean
+  error: SanctionsListChangeError | boolean
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  const { t, language } = useLanguage()
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const titleId = `sanctions-list-${list.id}-change-title`
+  const impactId = `sanctions-list-${list.id}-change-impact`
+  const governanceId = `sanctions-list-${list.id}-change-governance`
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
+  const failedUnauthorized = error === 'unauthorized'
+
+  return <div
+    ref={dialogRef}
+    role="alertdialog"
+    aria-modal="true"
+    aria-labelledby={titleId}
+    aria-describedby={`${impactId} ${governanceId}`}
+    aria-busy={busy}
+    onKeyDown={event => {
+      if (event.key === 'Escape' && !busy) onCancel()
+      trapDialogFocus(event, dialogRef.current)
+    }}
+    style={{ position: 'fixed', inset: 0, zIndex: 1200, background: 'rgba(15,23,42,.68)', display: 'grid', placeItems: 'center', padding: 20 }}
+  ><div className="card" style={{ width: 'min(580px, 100%)', maxHeight: 'calc(100dvh - 40px)', overflowY: 'auto', padding: 22 }}>
+    <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+      <AlertTriangle aria-hidden="true" size={19} style={{ color: enabled ? 'var(--success)' : 'var(--danger)', flexShrink: 0, marginTop: 2 }} />
+      <div>
+        <h2 id={titleId} style={{ margin: 0, fontSize: 17, fontWeight: 750 }}>
+          {enabled
+            ? t(`Obnovit automatické aktualizace pro „${list.displayName}“?`, `Resume automatic updates for “${list.displayName}”?`)
+            : t(`Pozastavit automatické aktualizace pro „${list.displayName}“?`, `Pause automatic updates for “${list.displayName}”?`)}
+        </h2>
+        <p id={impactId} style={{ margin: '6px 0 0', fontSize: 12.5, lineHeight: 1.55, color: 'var(--text-secondary)' }}>
+          {enabled
+            ? t('Plánované stahování a funkce „stáhnout vše“ se obnoví. Seznam bude znovu dostupný pro výběr v nových manuálních kontrolách z této konzole; do aktuálního rozsahu ho ale nepřidáme bez vašeho výběru.', 'Scheduled and refresh-all downloads resume. The list becomes available for selection in new manual checks from this console, but it is not added to the current scope without your choice.')
+            : t('Budoucí plánovaná stahování a spuštění „stáhnout vše“ tento seznam přeskočí; již probíhající stahování může doběhnout. Tato konzole odebere seznam z nových manuálních kontrol. Importované záznamy a dosavadní kontroly zůstanou uložené. API kontroly mimo tuto konzoli toto nastavení nevyloučí.', 'Future scheduled and refresh-all runs will skip this list; a download already in progress may finish. This console will remove the list from new manual checks. Imported entries and existing checks stay stored. API screenings outside this console are not excluded by this setting.')}
+        </p>
+      </div>
+    </div>
+
+    <div style={{ marginTop: 14, padding: '11px 12px', borderRadius: 8, background: 'var(--surface-2)', border: '1px solid var(--border)', fontSize: 12.5 }}>
+      <div style={{ fontWeight: 750 }}>{list.displayName}</div>
+      <div style={{ marginTop: 4, fontFamily: 'var(--font-mono)', color: 'var(--text-tertiary)' }}>{list.listType}</div>
+      <div style={{ marginTop: 7 }}>
+        {typeof list.lastEntryCount === 'number'
+          ? `${list.lastEntryCount.toLocaleString(numberLocale)} ${t('záznamů', 'entries')}`
+          : t('Počet záznamů není synchronizován', 'Entry count not synced')}
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 10, fontWeight: 750 }}>
+        <span>{list.enabled ? t('POVOLENO', 'ENABLED') : t('POZASTAVENO', 'PAUSED')}</span>
+        <span aria-hidden="true" style={{ color: 'var(--text-tertiary)' }}>→</span>
+        <span>{enabled ? t('POVOLENO', 'ENABLED') : t('POZASTAVENO', 'PAUSED')}</span>
+      </div>
+    </div>
+
+    <p id={governanceId} style={{ margin: '12px 0 0', padding: '10px 12px', borderRadius: 8, color: 'var(--warning-text)', background: 'var(--warning-bg)', border: '1px solid var(--warning-border)', fontSize: 12, lineHeight: 1.5 }}>
+      {t('Služba provede změnu ihned po potvrzení; požadavek nevstupuje do čtyřokého schvalování a současné API neukládá důvod změny.', 'The service applies this change immediately after confirmation; it does not enter the four-eyes approval queue, and the current API does not store a change reason.')}
+    </p>
+
+    {error && <p role="alert" style={{ margin: '12px 0 0', padding: '10px 12px', borderRadius: 8, color: 'var(--danger-text)', background: 'var(--danger-bg)', border: '1px solid var(--danger-border)', fontSize: 12, lineHeight: 1.5 }}>
+      {failedUnauthorized
+        ? t('Tato relace nemá oprávnění ke změně. Služba nový stav nepotvrdila; obnovte stav listů.', 'This session is not authorised to make the change. The service did not confirm a new state; refresh the list status.')
+        : t('Služba změnu nepotvrdila. Zobrazený stav může být zastaralý; zopakovat stejný cílový stav je bezpečné.', 'The service did not confirm the change. The displayed state may be stale; retrying the same target state is safe.')}
+    </p>}
+
+    <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 18 }}>
+      <button type="button" autoFocus className="btn btn-secondary" disabled={busy} onClick={onCancel}>
+        {error
+          ? t('Zavřít a obnovit stav', 'Close and refresh status')
+          : enabled
+            ? t('Ponechat pozastavené', 'Keep updates paused')
+            : t('Ponechat automatické aktualizace', 'Keep automatic updates')}
+      </button>
+      <button type="button" className={enabled ? 'btn btn-primary' : 'btn btn-danger'} disabled={busy} aria-busy={busy} onClick={onConfirm}>
+        {busy
+          ? t('Provádím změnu…', 'Applying change…')
+          : enabled
+            ? t('Obnovit automatické aktualizace', 'Resume automatic updates')
+            : t('Pozastavit automatické aktualizace', 'Pause automatic updates')}
+      </button>
+    </div>
+  </div></div>
+}

--- a/openbank-admin-ui/src/test/sanctions-list-change-dialog.test.tsx
+++ b/openbank-admin-ui/src/test/sanctions-list-change-dialog.test.tsx
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  retainEnabledSelectedListTypes,
+  SanctionsListChangeDialog,
+  type SanctionsList,
+} from '@/components/sanctions/SanctionsListChangeDialog'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+const LIST = {
+  id: 'eu-consolidated',
+  listType: 'EU',
+  displayName: 'EU Consolidated Financial Sanctions List',
+  sourceUrl: 'https://example.test/eu-sanctions',
+  enabled: true,
+  lastUpdatedAt: '2026-08-31T12:00:00Z',
+  lastEntryCount: 1248,
+  cronHour: 3,
+  cronMinute: 0,
+  cronDays: 'MON,TUE,WED,THU,FRI,SAT,SUN',
+} satisfies SanctionsList
+
+afterEach(cleanup)
+
+describe('sanctions-list enablement review', () => {
+  it('prunes disabled types after reconciliation without restoring user deselections', () => {
+    const reconciledLists = [
+      { ...LIST, enabled: false },
+      { ...LIST, id: 'ofac-sdn', listType: 'OFAC_SDN', displayName: 'OFAC SDN' },
+    ]
+
+    expect(retainEnabledSelectedListTypes(['EU', 'OFAC_SDN'], reconciledLists)).toEqual(['OFAC_SDN'])
+    expect(retainEnabledSelectedListTypes(['EU'], reconciledLists)).toEqual([])
+  })
+
+  it('explains the exact disable impact without claiming a global screening exclusion', () => {
+    render(
+      <LanguageProvider>
+        <SanctionsListChangeDialog
+          list={LIST}
+          enabled={false}
+          busy={false}
+          error={false}
+          onCancel={vi.fn()}
+          onConfirm={vi.fn()}
+        />
+      </LanguageProvider>,
+    )
+
+    const dialog = screen.getByRole('alertdialog', { name: `Pause automatic updates for “${LIST.displayName}”?` })
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(dialog).toHaveTextContent('Future scheduled and refresh-all runs will skip this list')
+    expect(dialog).toHaveTextContent('a download already in progress may finish')
+    expect(dialog).toHaveTextContent('API screenings outside this console are not excluded by this setting')
+    expect(dialog).toHaveTextContent('1,248 entries')
+    expect(dialog).toHaveTextContent('ENABLED')
+    expect(dialog).toHaveTextContent('PAUSED')
+    expect(dialog).toHaveTextContent('does not enter the four-eyes approval queue')
+  })
+
+  it('contains keyboard focus and supports escape dismissal before submission', () => {
+    const cancel = vi.fn()
+    const confirm = vi.fn()
+    render(
+      <LanguageProvider>
+        <SanctionsListChangeDialog
+          list={LIST}
+          enabled={false}
+          busy={false}
+          error={false}
+          onCancel={cancel}
+          onConfirm={confirm}
+        />
+      </LanguageProvider>,
+    )
+
+    const dialog = screen.getByRole('alertdialog')
+    const keep = screen.getByRole('button', { name: 'Keep automatic updates' })
+    const apply = screen.getByRole('button', { name: 'Pause automatic updates' })
+    keep.focus()
+    fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(apply)
+    fireEvent.keyDown(dialog, { key: 'Tab' })
+    expect(document.activeElement).toBe(keep)
+    fireEvent.keyDown(dialog, { key: 'Escape' })
+    expect(cancel).toHaveBeenCalledOnce()
+  })
+
+  it('locks duplicate submission and leaves a failed change retryable', () => {
+    const cancel = vi.fn()
+    const confirm = vi.fn()
+    const { rerender } = render(
+      <LanguageProvider>
+        <SanctionsListChangeDialog
+          list={LIST}
+          enabled={false}
+          busy
+          error={false}
+          onCancel={cancel}
+          onConfirm={confirm}
+        />
+      </LanguageProvider>,
+    )
+
+    const dialog = screen.getByRole('alertdialog')
+    expect(dialog).toHaveAttribute('aria-busy', 'true')
+    expect(screen.getByRole('button', { name: 'Applying change…' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Keep automatic updates' })).toBeDisabled()
+    fireEvent.keyDown(dialog, { key: 'Escape' })
+    expect(cancel).not.toHaveBeenCalled()
+    expect(confirm).not.toHaveBeenCalled()
+
+    rerender(
+      <LanguageProvider>
+        <SanctionsListChangeDialog
+          list={LIST}
+          enabled={false}
+          busy={false}
+          error
+          onCancel={cancel}
+          onConfirm={confirm}
+        />
+      </LanguageProvider>,
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent('The service did not confirm the change')
+    expect(screen.getByRole('alert')).toHaveTextContent('retrying the same target state is safe')
+    expect(screen.getByRole('button', { name: 'Close and refresh status' })).toBeEnabled()
+    fireEvent.click(screen.getByRole('button', { name: 'Pause automatic updates' }))
+    expect(confirm).toHaveBeenCalledOnce()
+  })
+
+  it('renders an unknown entry count truthfully', () => {
+    render(
+      <LanguageProvider>
+        <SanctionsListChangeDialog
+          list={{ ...LIST, lastEntryCount: undefined }}
+          enabled={false}
+          busy={false}
+          error={false}
+          onCancel={vi.fn()}
+          onConfirm={vi.fn()}
+        />
+      </LanguageProvider>,
+    )
+
+    expect(screen.getByRole('alertdialog')).toHaveTextContent('Entry count not synced')
+    expect(screen.getByRole('alertdialog')).not.toHaveTextContent('0 entries')
+  })
+
+  it('shows the authorization-specific failure and offers status reconciliation', () => {
+    const reconcile = vi.fn()
+    render(
+      <LanguageProvider>
+        <SanctionsListChangeDialog
+          list={LIST}
+          enabled={false}
+          busy={false}
+          error="unauthorized"
+          onCancel={reconcile}
+          onConfirm={vi.fn()}
+        />
+      </LanguageProvider>,
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent('This session is not authorised to make the change')
+    fireEvent.click(screen.getByRole('button', { name: 'Close and refresh status' }))
+    expect(reconcile).toHaveBeenCalledOnce()
+  })
+
+  it('describes re-enablement as resuming refresh and console selection', () => {
+    render(
+      <LanguageProvider>
+        <SanctionsListChangeDialog
+          list={{ ...LIST, enabled: false }}
+          enabled
+          busy={false}
+          error={false}
+          onCancel={vi.fn()}
+          onConfirm={vi.fn()}
+        />
+      </LanguageProvider>,
+    )
+
+    expect(screen.getByRole('alertdialog', { name: `Resume automatic updates for “${LIST.displayName}”?` }))
+      .toHaveTextContent('Scheduled and refresh-all downloads resume')
+    expect(screen.getByRole('alertdialog')).toHaveTextContent('new manual checks from this console')
+  })
+})


### PR DESCRIPTION
## Summary

Require an explicit, truthful review before enabling or pausing sanctions-list refreshes. Reconcile ambiguous and authorization outcomes, preserve focus, and keep manual screening scope aligned with the service state returned after the change.

## Type of change

- [x] fix (bug fix)
- [ ] feat (new functionality)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #8034

## Changes

- Add a single-flight confirmation dialog with exact list scope, truthful scheduler/in-flight impact, unknown-count handling, and honest error/retry states.
- Reconcile 401, 403, ambiguous, and successful outcomes before restoring focus to a stable control.
- Prune disabled or removed lists from manual-screening scope without re-adding operator deselections.
- Add focused component guards and four Chromium flows, including a server-applied change with a lost response and the subsequent screening payload.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [x] Contract tests updated (if public API changed) — no public API changed.
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed) — no REST API changed.
- [x] Flyway migration added + rollback note (if DB changed) — no DB change.
- [x] Avro schema versioned backward-compatibly (if event changed) — no event change.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, or `@Suppress` escape hatch.
- [x] No new third-party dependency.
- [x] Auth, backend RBAC, maker-checker, and screening API contracts are unchanged.
- [x] No cardholder-data or PII data path changed.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [x] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

This changes only the operator UX around the existing sanctions-list update permission. The service remains authoritative; no approval control, persisted reason, or API screening behavior is fabricated or bypassed.

## Verification

- Focused Vitest: 4 files / 11 tests passed.
- Chromium on a unique local port: 4 / 4 passed.
- Native TypeScript type-check passed.
- Changed-file ESLint: 0 errors; only five pre-existing warnings in the legacy page.
- `git diff --check` passed.

## Rollout / Rollback

- Deployment strategy: normal rolling Admin UI release.
- Rollback plan: revert the single squash commit and redeploy the previous Admin UI image.
- Data migration reversible: N/A

## Reviewer notes

The E2E suite keeps the signed operator cookie for middleware and uses the repository-standard session route fixture for the client provider. Sanctions service calls are route-mocked; no live BFF/OPA behavior is changed.