### PR TITLE
fix(admin-ui): load payment details by ID

### DIFF
--- a/openbank-admin-ui/src/app/payments/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/payments/[id]/page.tsx
@@ -4,12 +4,12 @@
 
 'use client'
 
-import { Suspense, useEffect, useState } from 'react'
+import { Suspense, useEffect, useRef, useState } from 'react'
 import { useParams, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { ArrowLeft, RefreshCw, ChevronDown, ChevronRight } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
-import { classifyBffFailure } from '@/lib/services/bff'
+import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { readStashedRow } from '@/lib/services/rowHandoff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader, StatusBadge, statusTone, type Tone } from '@/components/ui'
@@ -43,11 +43,12 @@ function paymentStatusTone(status: string | undefined): Tone {
   return statusTone(status)
 }
 
-// The list route is the source of truth (no by-id backend endpoint exists);
-// refresh re-fetches the list and picks this id out of it.
-const LIST_ROUTE: Record<string, string> = {
-  SEPA: '/api/sepa-payments',
-  DOMESTIC: '/api/domestic-payments',
+// Both payment rails expose an authorized by-id resource. Use the generic BFF so
+// the browser keeps the session→bearer relay and the backend enforces read RBAC
+// for this exact payment instead of broadening the request to the whole list.
+const DETAIL_ROUTE: Record<string, { service: string; path: string }> = {
+  SEPA: { service: 'sepa-payment', path: '/api/v1/sepa-payments' },
+  DOMESTIC: { service: 'domestic-payment', path: '/api/v1/domestic-payments' },
 }
 
 export default function PaymentDetailPage() {
@@ -64,47 +65,80 @@ function PaymentDetailContent() {
   const type = (params.get('type') ?? '').toUpperCase()
   const { t, language } = useLanguage()
   const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
+  const routeKey = `${type}:${id}`
 
-  const [payment, setPayment] = useState<Payment | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
+  const [paymentSnapshot, setPaymentSnapshot] = useState<{ key: string; payment: Payment } | null>(null)
+  const [loadingState, setLoadingState] = useState<{ key: string; active: boolean }>({ key: routeKey, active: true })
+  const [unavailableSnapshot, setUnavailableSnapshot] = useState<{ key: string; kind: UnavailableKind } | null>(null)
   const [showRaw, setShowRaw] = useState(false)
+  const requestGeneration = useRef(0)
 
-  async function load() {
-    setLoading(true)
-    // Show the handed-off row immediately (no round-trip); refresh in the background.
-    const stashed = readStashedRow<Payment>('payments', id)
-    if (stashed) { setPayment(stashed); setUnavailable(null) }
+  // Key every rendered state to the current route. A param/rail change must not
+  // flash the previous payment or its failure before the new effect starts.
+  const payment = paymentSnapshot?.key === routeKey ? paymentSnapshot.payment : null
+  const unavailable = unavailableSnapshot?.key === routeKey
+    ? { kind: unavailableSnapshot.kind }
+    : null
+  const loading = loadingState.key !== routeKey || loadingState.active
 
-    const route = LIST_ROUTE[type]
-    if (!route) {
-      // Direct URL with no/unknown type and no stash — we can't know which service to ask.
-      if (!stashed) setUnavailable({ kind: 'not_found' })
-      setLoading(false)
+  async function load(resetForRoute = false) {
+    const generation = ++requestGeneration.current
+    const stillCurrent = () => requestGeneration.current === generation
+    setLoadingState({ key: routeKey, active: true })
+
+    // Show the handed-off row immediately on navigation (no round-trip); a
+    // manual refresh retains the freshest currently displayed snapshot.
+    const handedOff = resetForRoute ? readStashedRow<Payment>('payments', id) : null
+    const stashed = handedOff?.id === id && handedOff.type === type ? handedOff : null
+    if (resetForRoute) {
+      setPaymentSnapshot(stashed ? { key: routeKey, payment: stashed } : null)
+    }
+
+    const target = DETAIL_ROUTE[type]
+    if (!target) {
+      // A missing/unknown rail cannot be refreshed truthfully. Keep a handed-off
+      // preview if present, but mark it unavailable rather than presenting it as live.
+      if (stillCurrent()) {
+        setUnavailableSnapshot({ key: routeKey, kind: 'not_found' })
+        setLoadingState({ key: routeKey, active: false })
+      }
       return
     }
     try {
+      const route = svcUrl(target.service, `${target.path}/${encodeURIComponent(id)}`)
       const res = await fetch(route, { signal: AbortSignal.timeout(10_000), cache: 'no-store' })
       if (!res.ok) {
-        if (!stashed) setUnavailable({ kind: await classifyBffFailure(res) })
-        setLoading(false)
+        const kind = await classifyBffFailure(res)
+        if (stillCurrent()) setUnavailableSnapshot({ key: routeKey, kind })
         return
       }
-      const body = (await res.json()) as unknown
-      const items = (Array.isArray(body) ? body : ((body as { items?: unknown[] }).items ?? [])) as Payment[]
-      const found = items.find(p => p.id === id)
-      if (found) { setPayment({ ...found, type: type as Payment['type'] }); setUnavailable(null) }
-      else if (!stashed) setUnavailable({ kind: 'not_found' })
+      const fresh = (await res.json()) as Payment
+      if (!stillCurrent()) return
+      setPaymentSnapshot({ key: routeKey, payment: { ...fresh, type: type as Payment['type'] } })
+      setUnavailableSnapshot(null)
     } catch {
-      if (!stashed) setUnavailable({ kind: 'unreachable' })
+      if (stillCurrent()) setUnavailableSnapshot({ key: routeKey, kind: 'unreachable' })
     } finally {
-      setLoading(false)
+      if (stillCurrent()) setLoadingState({ key: routeKey, active: false })
     }
   }
 
-  useEffect(() => { load() /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [id, type])
+  useEffect(() => {
+    void load(true)
+    return () => { requestGeneration.current += 1 }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, type])
 
   const svcLabel = type === 'SEPA' ? t('SEPA-payment', 'SEPA-payment') : t('Domestic-payment', 'Domestic-payment')
+  const stalePreviewCopy = unavailable?.kind === 'unauthorized'
+    ? {
+        title: t('Relace vypršela — zobrazuji uložený náhled', 'Session expired — showing saved preview'),
+        detail: t('Uložený náhled může být zastaralý. Pro načtení živých dat se znovu přihlaste.', 'This saved preview may be stale. Sign in again to load live data.'),
+      }
+    : {
+        title: t('Živá platba není dostupná — zobrazuji uložený náhled', 'Live payment unavailable — showing saved preview'),
+        detail: t('Obnovení živých dat selhalo. Uložený náhled může být zastaralý; zkuste platbu obnovit znovu.', 'The live refresh failed. This saved preview may be stale; try refreshing the payment again.'),
+      }
 
   return (
     <div>
@@ -116,7 +150,7 @@ function PaymentDetailContent() {
           {payment?.status && <StatusBadge status={payment.status} tone={paymentStatusTone(payment.status)} />}
           {payment?.type && <span className="tag">{payment.type}</span>}
           <Link href="/payments" className="btn btn-secondary"><ArrowLeft size={13} aria-hidden="true" /> {t('Zpět', 'Back')}</Link>
-          <button type="button" className="btn btn-secondary" onClick={load} disabled={loading} aria-busy={loading} aria-label={t('Obnovit platbu', 'Refresh payment')}>
+          <button type="button" className="btn btn-secondary" onClick={() => { void load() }} disabled={loading} aria-busy={loading} aria-label={t('Obnovit platbu', 'Refresh payment')}>
             <RefreshCw size={13} aria-hidden="true" className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
           </button>
         </div>}
@@ -129,7 +163,21 @@ function PaymentDetailContent() {
       ) : !payment && unavailable ? (
         <div className="card"><DataUnavailable kind={unavailable.kind} service={svcLabel} feature={t('Platba', 'Payment')} lang={language} /></div>
       ) : payment ? (
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '14px' }}>
+        <>
+          {unavailable && (
+            <div className="card" style={{ marginBottom: '14px' }}>
+              <DataUnavailable
+                kind={unavailable.kind}
+                service={svcLabel}
+                feature={t('Platba', 'Payment')}
+                lang={language}
+                dense
+                title={stalePreviewCopy.title}
+                detail={stalePreviewCopy.detail}
+              />
+            </div>
+          )}
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '14px' }}>
           <div className="card">
             <div className="card-header"><span className="card-header-title">{t('Platba', 'Payment')}</span></div>
             <DetailRows rows={[
@@ -165,7 +213,8 @@ function PaymentDetailContent() {
               </div>
             )}
           </div>
-        </div>
+          </div>
+        </>
       ) : null}
     </div>
   )

--- a/openbank-admin-ui/src/test/payment-detail-by-id.test.tsx
+++ b/openbank-admin-ui/src/test/payment-detail-by-id.test.tsx
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import React from 'react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import PaymentDetailPage from '@/app/payments/[id]/page'
+
+const PAYMENT_ID = 'payment/id 42'
+const BY_ID_URL = '/api/svc/sepa-payment/api/v1/sepa-payments/payment%2Fid%2042'
+const DOMESTIC_BY_ID_URL = '/api/svc/domestic-payment/api/v1/domestic-payments/payment%2Fid%2042'
+let paymentId = PAYMENT_ID
+let paymentType = 'SEPA'
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: paymentId }),
+  useSearchParams: () => new URLSearchParams(`type=${paymentType}`),
+}))
+
+vi.mock('@/lib/i18n/LanguageContext', () => ({
+  useLanguage: () => ({ language: 'en', t: (_cs: string, en: string) => en }),
+}))
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+beforeEach(() => {
+  paymentId = PAYMENT_ID
+  paymentType = 'SEPA'
+  window.sessionStorage.clear()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('payment detail by-id loading', () => {
+  it('loads the selected SEPA payment from its encoded by-id BFF URL without listing the collection', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === BY_ID_URL) {
+        return json({
+          id: PAYMENT_ID,
+          status: 'COMPLETED',
+          amount: 125,
+          currency: 'EUR',
+          creditorName: 'By-ID creditor',
+        })
+      }
+      if (url === '/api/sepa-payments') throw new Error('collection URL must not be used')
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await act(async () => { render(<PaymentDetailPage />) })
+
+    expect(await screen.findByText('By-ID creditor')).toBeInTheDocument()
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(BY_ID_URL)
+  })
+
+  it('keeps a handed-off preview visible but marks it stale when the by-id refresh is unavailable', async () => {
+    window.sessionStorage.setItem(`ob:row:payments:${PAYMENT_ID}`, JSON.stringify({
+      id: PAYMENT_ID,
+      type: 'SEPA',
+      status: 'RECEIVED',
+      amount: 99,
+      currency: 'EUR',
+      creditorName: 'Saved preview creditor',
+    }))
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe(BY_ID_URL)
+      return json({ error: 'scaled_to_zero' }, 503)
+    }))
+
+    await act(async () => { render(<PaymentDetailPage />) })
+
+    expect(await screen.findByText('Saved preview creditor')).toBeInTheDocument()
+    expect(await screen.findByText('Live payment unavailable — showing saved preview')).toBeInTheDocument()
+    expect(screen.getByText(/may be stale/i)).toBeInTheDocument()
+  })
+
+  it('keeps re-authentication guidance visible when an expired session leaves only a saved preview', async () => {
+    window.sessionStorage.setItem(`ob:row:payments:${PAYMENT_ID}`, JSON.stringify({
+      id: PAYMENT_ID,
+      type: 'SEPA',
+      status: 'RECEIVED',
+      creditorName: 'Preview requiring sign-in',
+    }))
+    vi.stubGlobal('fetch', vi.fn(async () => json({ error: 'unauthorized' }, 401)))
+
+    await act(async () => { render(<PaymentDetailPage />) })
+
+    expect(await screen.findByText('Preview requiring sign-in')).toBeInTheDocument()
+    expect(await screen.findByText('Session expired — showing saved preview')).toBeInTheDocument()
+    expect(screen.getByText(/may be stale\. Sign in again/i)).toBeInTheDocument()
+  })
+
+  it('keeps domestic rail selection on the domestic by-id service and path', async () => {
+    paymentType = 'DOMESTIC'
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe(DOMESTIC_BY_ID_URL)
+      return json({ id: PAYMENT_ID, status: 'SETTLED', creditorName: 'Domestic creditor' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await act(async () => { render(<PaymentDetailPage />) })
+
+    expect(await screen.findByText('Domestic creditor')).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a superseded rail response that resolves after the current request', async () => {
+    let resolveSepa: ((response: Response) => void) | undefined
+    let resolveDomestic: ((response: Response) => void) | undefined
+    const sepaResponse = new Promise<Response>(resolve => { resolveSepa = resolve })
+    const domesticResponse = new Promise<Response>(resolve => { resolveDomestic = resolve })
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === BY_ID_URL) return sepaResponse
+      if (url === DOMESTIC_BY_ID_URL) return domesticResponse
+      return Promise.reject(new Error(`unexpected request: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    let view!: ReturnType<typeof render>
+    await act(async () => { view = render(<PaymentDetailPage />) })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    paymentType = 'DOMESTIC'
+    await act(async () => { view.rerender(<PaymentDetailPage />) })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      resolveDomestic?.(json({ id: PAYMENT_ID, status: 'SETTLED', creditorName: 'Current domestic payment' }))
+      await domesticResponse
+    })
+    expect(await screen.findByText('Current domestic payment')).toBeInTheDocument()
+
+    await act(async () => {
+      resolveSepa?.(json({ id: PAYMENT_ID, status: 'COMPLETED', creditorName: 'Superseded SEPA payment' }))
+      await sepaResponse
+    })
+    expect(screen.queryByText('Superseded SEPA payment')).not.toBeInTheDocument()
+    expect(screen.getByText('Current domestic payment')).toBeInTheDocument()
+  })
+
+  it('never carries the previous payment or a mismatched stash across a failed route change', async () => {
+    const nextId = 'domestic/id 77'
+    const nextUrl = '/api/svc/domestic-payment/api/v1/domestic-payments/domestic%2Fid%2077'
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === BY_ID_URL) return json({ id: PAYMENT_ID, status: 'COMPLETED', creditorName: 'Previous SEPA payment' })
+      if (url === nextUrl) return json({ error: 'scaled_to_zero' }, 503)
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    let view!: ReturnType<typeof render>
+    await act(async () => { view = render(<PaymentDetailPage />) })
+    expect(await screen.findByText('Previous SEPA payment')).toBeInTheDocument()
+
+    window.sessionStorage.setItem(`ob:row:payments:${nextId}`, JSON.stringify({
+      id: nextId,
+      type: 'SEPA',
+      creditorName: 'Wrong-rail saved row',
+    }))
+    paymentId = nextId
+    paymentType = 'DOMESTIC'
+    await act(async () => { view.rerender(<PaymentDetailPage />) })
+
+    expect(await screen.findByText('Domestic-payment is idle (scaled to zero)')).toBeInTheDocument()
+    expect(screen.queryByText('Previous SEPA payment')).not.toBeInTheDocument()
+    expect(screen.queryByText('Wrong-rail saved row')).not.toBeInTheDocument()
+    expect(screen.queryByText('Live payment unavailable — showing saved preview')).not.toBeInTheDocument()
+  })
+})

--- a/openbank-admin-ui/src/test/payment-detail-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/payment-detail-refresh.guard.test.ts
@@ -4,12 +4,13 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
 describe('payment detail refresh contract', () => {
-  it('exposes localized busy semantics without changing list-source refresh', () => {
+  it('exposes localized busy semantics while refreshing the selected payment by id', () => {
     const source = readFileSync(path.resolve(__dirname, '../app/payments/[id]/page.tsx'), 'utf8')
     expect(source).toContain('type="button"')
     expect(source).toContain('aria-busy={loading}')
     expect(source).toContain("aria-label={t('Obnovit platbu', 'Refresh payment')}")
-    expect(source).toContain('onClick={load}')
-    expect(source).toContain('refresh re-fetches the list')
+    expect(source).toContain('onClick={() => { void load() }}')
+    expect(source).toContain("svcUrl(target.service, `${target.path}/${encodeURIComponent(id)}`)")
+    expect(source).not.toContain('items.find')
   })
 })


### PR DESCRIPTION
## Summary

Load Admin UI payment details from the authoritative rail-specific by-ID endpoint instead of scanning a paginated collection. Preserve a matching saved preview during a live-read failure, but label it explicitly as unavailable and potentially stale.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #8079

## Changes

- Use encoded SEPA and domestic by-ID service routes through the existing authenticated BFF.
- Key state by route and request generation so stale responses cannot overwrite a newer payment or rail.
- Accept stash only for the same payment ID and type; keep failed previews visible with truthful stale and re-auth guidance.
- Replace the obsolete collection-scan guard with behavioral coverage for both rails, 503/401, refresh, route changes, and out-of-order responses.

## Definition of Done

- [x] Hexagonal layering preserved; no domain or backend code changed.
- [x] Unit tests added/updated: exact-final focused Vitest 9/9.
- [x] Integration tests N/A; the existing BFF contract and auth path are unchanged.
- [x] Contract tests N/A; no public API changed.
- [x] Admin UI type-check passes on the exact final snapshot.
- [x] No new lint warnings; changed-file ESLint has 0 errors and one pre-existing hook warning.
- [x] OpenAPI, Flyway, event schemas, and architecture docs N/A.

## Security checklist

- [x] No secrets, tokens, passwords, or PII added to code, config, tests, or logs.
- [x] No new suppressions or unsafe casts.
- [x] No new third-party dependency.
- [x] Existing session-to-bearer BFF and read RBAC are preserved; security review requested because payment UI code changed.
- [x] No new PII or cardholder-data surface.

## Compliance impact

- [x] None

This is a read-only freshness and correctness fix. It does not change payment initiation, SCA, authorization, monetary values, or backend contracts.

## Rollout / Rollback

- Deployment strategy: rolling with the normal Admin UI release.
- Rollback plan: revert this single commit to restore the previous collection lookup.
- Data migration reversible: N/A

## Screenshots / demo

Not applicable; the visible change is limited to truthful stale/unavailable feedback when the live detail read fails.

## Reviewer notes

The old implementation is behaviorally RED against an exact by-ID-only mock. Please focus on route-key/request-generation handling, stash identity matching, and preservation of unauthorized sign-in guidance.