### PR TITLE
fix(admin-ui): reject thresholdless test evidence

### DIFF
--- a/openbank-admin-ui/scripts/collect-test-intelligence.mjs
+++ b/openbank-admin-ui/scripts/collect-test-intelligence.mjs
@@ -78,6 +78,69 @@ const freshnessAwareState = (state, at) => {
   return state
 }
 
+const thresholdObservation = summary => {
+  if (!summary || typeof summary !== 'object' || Array.isArray(summary)
+      || !summary.metrics || typeof summary.metrics !== 'object' || Array.isArray(summary.metrics)) {
+    return { valid: false, count: 0, failed: 0 }
+  }
+  const results = []
+  let malformed = false
+  for (const metric of Object.values(summary.metrics)) {
+    if (!metric || typeof metric !== 'object' || Array.isArray(metric)
+        || !Object.hasOwn(metric, 'thresholds')) continue
+    if (!metric.thresholds || typeof metric.thresholds !== 'object' || Array.isArray(metric.thresholds)) {
+      malformed = true
+      continue
+    }
+    const metricResults = Object.values(metric.thresholds)
+    if (metricResults.length === 0) malformed = true
+    results.push(...metricResults)
+  }
+  const valid = !malformed && results.length > 0 && results.every(result =>
+    typeof result === 'boolean'
+      || (result && typeof result === 'object' && !Array.isArray(result) && typeof result.ok === 'boolean'))
+  // Never let one malformed sibling erase a concrete breached threshold.
+  const failed = results.filter(result =>
+    result === true || (result && typeof result === 'object' && !Array.isArray(result) && result.ok === false)).length
+  return { valid, count: results.length, failed }
+}
+
+const retainedThresholdObservation = value => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)
+      || !Number.isSafeInteger(value.evaluated) || value.evaluated <= 0
+      || !Number.isSafeInteger(value.breached) || value.breached < 0
+      || value.breached > value.evaluated) return undefined
+  return { valid: true, count: value.evaluated, failed: value.breached }
+}
+
+const thresholdBackedState = (claimedState, rawObservation, retainedObservation) => {
+  // Recorded failures remain actionable even if the optional summary artifact was lost.
+  // A pass is different: prose cannot prove that the producer saw typed outcomes (the legacy
+  // producer rendered malformed objects as "0 breached"), so it needs the raw summary until
+  // the versioned envelope carries a structured denominator.
+  const retained = retainedThresholdObservation(retainedObservation)
+  if (rawObservation?.failed > 0 || retained?.failed > 0) return 'failed'
+  if (claimedState === 'failed') return 'failed'
+  if (!['passed', 'stale'].includes(claimedState)) return claimedState
+  const observation = rawObservation ?? retained
+  if (!observation?.valid) return 'unknown'
+  return claimedState
+}
+
+const retainActionableFailure = (previous, next, validRecovery) =>
+  previous?.state === 'failed' && next.state !== 'failed' && !validRecovery ? previous : next
+
+const normalizeThresholdEvidence = evidence => {
+  if (evidence.kind !== 'performance' && (evidence.kind !== 'synthetic' || evidence.variant)) return evidence
+  const retained = retainedThresholdObservation(evidence.thresholdResults)
+  const { thresholdResults: _untrustedThresholdResults, ...rest } = evidence
+  return {
+    ...rest,
+    state: thresholdBackedState(evidence.state, undefined, evidence.thresholdResults),
+    ...(retained ? { thresholdResults: { evaluated: retained.count, breached: retained.failed } } : {}),
+  }
+}
+
 function releasedComponents() {
   return fs.readdirSync(repo, { withFileTypes: true })
     .filter(entry => entry.isDirectory() && entry.name.startsWith('openbank-'))
@@ -183,10 +246,17 @@ function runEnvelope(component) {
         kind: item.kind, name: item.name, url: item.url, retentionDays: item.retentionDays,
         access: item.access, mayContainSensitiveData: item.mayContainSensitiveData,
       })),
-    })), ...(run.specializedEvidence ?? []).map(item => ({
-      kind: item.kind, state: freshnessAwareState(item.state, run.run?.observedAt ?? observedAt(file)), observedAt: run.run?.observedAt ?? observedAt(file),
-      source: item.source, environment: 'ci', detail: item.detail, run: provenance,
-    }))],
+    })), ...(run.specializedEvidence ?? []).map(item => {
+      const normalized = normalizeThresholdEvidence(item)
+      return {
+        kind: normalized.kind,
+        state: freshnessAwareState(normalized.state, run.run?.observedAt ?? observedAt(file)),
+        observedAt: run.run?.observedAt ?? observedAt(file),
+        source: item.source, environment: 'ci', detail: item.detail, run: provenance,
+        ...(normalized.variant ? { variant: normalized.variant } : {}),
+        ...(normalized.thresholdResults ? { thresholdResults: normalized.thresholdResults } : {}),
+      }
+    })],
     coverage: run.coverage ? {
       state: stateFrom(0, 1, run.run?.observedAt ?? observedAt(file)),
       observedAt: run.run?.observedAt ?? observedAt(file), lines: run.coverage.lines,
@@ -550,12 +620,7 @@ function performance() {
       ? readJson(summaryFile.replace(/-summary\.json$/, '-run.json')) ?? readJson(`${summaryFile}.run.json`)
       : readJson(runSidecar)
     const specialized = performanceRun?.specializedEvidence?.find(item => item.kind === 'performance')
-    const thresholdResults = summary
-      ? Object.values(summary.metrics ?? {}).flatMap(metric => Object.values(metric?.thresholds ?? {}))
-      : []
-    // k6 summary-export uses bare booleans with inverted-looking polarity: true means
-    // crossed/breached, false means passed. The object form is kept for compatible fixtures.
-    const failed = thresholdResults.filter(result => result === true || result?.ok === false).length
+    const summaryThresholds = summaryFile ? thresholdObservation(summary) : undefined
     const number = value => typeof value === 'number' && Number.isFinite(value) ? value : null
     const ratePercent = value => {
       const rate = number(value)
@@ -569,13 +634,44 @@ function performance() {
     } : undefined
     const at = summaryFile ? observedAt(summaryFile) : null
     const provenance = safeRun(performanceRun?.run ?? summaryMeta?.run, `performance:${id}`)
+    const specializedState = specialized
+      ? thresholdBackedState(
+          freshnessAwareState(specialized.state, performanceRun?.run?.observedAt ?? at),
+          summaryThresholds,
+          specialized.thresholdResults,
+        )
+      : null
+    if (specialized?.state === 'passed' && specializedState === 'unknown') {
+      warnings.push(`thresholdless performance pass downgraded: ${id}`)
+    } else if (!specialized && summaryThresholds && !summaryThresholds.valid) {
+      warnings.push(`performance summary has no valid threshold denominator: ${id}`)
+    }
+    const summaryDetail = summaryThresholds
+      ? (summaryThresholds.failed > 0
+          ? `${summaryThresholds.count} threshold result(s), ${summaryThresholds.failed} breached${summaryThresholds.valid ? '' : '; additional invalid threshold outcome(s)'}`
+          : summaryThresholds.count === 0 || summaryThresholds.valid
+          ? `${summaryThresholds.count} threshold result(s), 0 breached`
+          : 'k6 summary contains invalid threshold outcomes')
+      : 'Scenario is declared; the latest k6 run artifact is not bundled into this image.'
+    const retainedThresholds = retainedThresholdObservation(specialized?.thresholdResults)
+    const authoritativeThresholds = summaryThresholds?.valid
+      ? summaryThresholds
+      : summaryFile ? undefined : retainedThresholds
     return {
       id, component,
       state: specialized
-        ? freshnessAwareState(specialized.state, performanceRun?.run?.observedAt ?? at)
-        : (summary ? stateFrom(failed, 1, at) : 'not-run'),
+        ? specializedState
+        : (summaryThresholds?.failed > 0
+            ? stateFrom(summaryThresholds.failed, Math.max(summaryThresholds.count, 1), at)
+            : summaryThresholds?.valid
+            ? stateFrom(summaryThresholds.failed, summaryThresholds.count, at)
+            : summaryFile ? 'unknown' : 'not-run'),
       observedAt: performanceRun?.run?.observedAt ?? at,
       source: path.relative(repo, file), thresholds,
+      ...(authoritativeThresholds ? { thresholdResults: {
+        evaluated: authoritativeThresholds.count,
+        breached: authoritativeThresholds.failed,
+      } } : {}),
       ...(plan ? { plan: {
         executionMode: plan.execution_mode,
         safetyBoundary: plan.safety_boundary,
@@ -584,9 +680,9 @@ function performance() {
         blocker: plan.blocker ?? null,
       } } : {}),
       ...(metrics ? { metrics } : {}),
-      detail: specialized?.detail ?? (summary
-        ? `${thresholdResults.length} threshold result(s), ${failed} breached`
-        : 'Scenario is declared; the latest k6 run artifact is not bundled into this image.'),
+      detail: summaryThresholds?.failed > 0 || (summaryThresholds && !summaryThresholds.valid)
+        ? summaryDetail
+        : specialized?.detail ?? summaryDetail,
       ...(provenance ? { run: provenance } : {}),
     }
   })
@@ -614,17 +710,29 @@ function syntheticJourneys() {
           warnings.push(`synthetic evidence workflow mismatch omitted: ${journeyId}`)
           continue
         }
+        const freshnessState = freshnessAwareState(evidence.state, envelope.run.observedAt)
+        const evidenceState = evidence.variant
+          ? freshnessState
+          : thresholdBackedState(freshnessState, undefined, evidence.thresholdResults)
+        const validRecovery = ['passed', 'stale'].includes(evidenceState)
+          && (Boolean(evidence.variant) || Boolean(retainedThresholdObservation(evidence.thresholdResults)))
+        if (!evidence.variant && evidence.state === 'passed' && evidenceState === 'unknown') {
+          warnings.push(`thresholdless synthetic pass downgraded: ${journeyId}`)
+        }
         const observation = {
-          state: freshnessAwareState(evidence.state, envelope.run.observedAt), observedAt: envelope.run.observedAt,
+          state: evidenceState, observedAt: envelope.run.observedAt,
           detail: evidence.detail ?? 'Synthetic run retained without detail.',
+          ...(retainedThresholdObservation(evidence.thresholdResults) ? {
+            thresholdResults: evidence.thresholdResults,
+          } : {}),
           ...(provenance ? { run: provenance } : {}),
         }
         if (evidence.variant) {
           const variants = latestVariants.get(journeyId) ?? new Map()
-          variants.set(evidence.variant, observation)
+          variants.set(evidence.variant, retainActionableFailure(variants.get(evidence.variant), observation, validRecovery))
           latestVariants.set(journeyId, variants)
         } else {
-          latestCi.set(journeyId, observation)
+          latestCi.set(journeyId, retainActionableFailure(latestCi.get(journeyId), observation, validRecovery))
         }
       }
     }
@@ -836,6 +944,7 @@ async function main() {
       kind: 'performance', state: item.state, observedAt: item.observedAt,
       source: `k6:${item.source}`, environment: item.id === 'money-path-smoke' ? 'sandbox' : 'ci',
       detail: item.detail,
+      ...(item.thresholdResults ? { thresholdResults: item.thresholdResults } : {}),
     })
   }
   const synthetic = syntheticJourneys()

--- a/openbank-admin-ui/src/lib/types/test-intelligence.ts
+++ b/openbank-admin-ui/src/lib/types/test-intelligence.ts
@@ -31,6 +31,12 @@ export interface TestCounts {
   errors: number
 }
 
+/** Typed k6 threshold outcomes. A prose detail is not evidence of this denominator. */
+export interface ThresholdResults {
+  evaluated: number
+  breached: number
+}
+
 export interface CoverageObservation {
   state: EvidenceState
   observedAt: string | null
@@ -50,6 +56,10 @@ export interface EvidenceObservation {
   detail?: string
   run?: TestRunProvenance
   diagnostics?: TestDiagnosticArtifact[]
+  /** Present only when typed k6 threshold outcomes were retained. */
+  thresholdResults?: ThresholdResults
+  /** Browser synthetics prove execution without a k6 threshold denominator. */
+  variant?: 'chromium' | 'firefox' | 'webkit'
 }
 
 export interface TestDiagnosticArtifact {
@@ -145,6 +155,8 @@ export interface PerformanceEvidence {
   observedAt: string | null
   source: string
   thresholds: number
+  /** Present only when typed k6 threshold outcomes were observed. */
+  thresholdResults?: ThresholdResults
   metrics?: {
     p95Ms: number | null
     errorRatePercent: number | null
@@ -172,6 +184,7 @@ export interface PerformanceHistoryPoint {
   state: EvidenceState
   observedAt: string | null
   metrics: NonNullable<PerformanceEvidence['metrics']>
+  thresholdResults?: ThresholdResults
   run?: TestRunProvenance
 }
 
@@ -195,6 +208,7 @@ export interface SyntheticJourneyEvidence {
     observedAt: string
     detail: string
     run: TestRunProvenance
+    thresholdResults?: ThresholdResults
     /** Browser engines declared by the journey. Missing evidence remains explicitly not-run. */
     variants?: Array<{
       browser: 'chromium' | 'firefox' | 'webkit'

--- a/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
@@ -62,6 +62,7 @@ journeys:
     money_moving: false
     workflow: .github/workflows/admin-ui-browser-synthetic.yml
     workflow_name: Admin UI browser synthetic
+    browser_variants: [chromium]
     schedule: "13 */2 * * *"
     capability: proves the public SSO hand-off
     falsification: remove the SSO boundary
@@ -117,13 +118,15 @@ scenarios:
       schemaVersion: 1,
       run: { id: 'browser-10', attempt: 1, commit: '123456789abc', branch: 'main', workflow: 'Admin UI browser synthetic', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/browser-10', observedAt: '2026-08-25T08:10:00Z' },
       component: 'openbank-admin-ui', suites: [], coverage: null, testInfrastructure: { declared: [], observed: [] },
-      specializedEvidence: [{ kind: 'synthetic', state: 'passed', source: 'journey:admin-ui-sso-boundary', detail: '1/1 browser E2E checks executed' }],
+      specializedEvidence: [{ kind: 'synthetic', state: 'passed', source: 'journey:admin-ui-sso-boundary', detail: '1/1 browser E2E checks executed', variant: 'chromium' }],
     }))
     write(repo, 'openbank-admin-ui/test-intelligence-history/previous-snapshot.json', JSON.stringify({
       schemaVersion: 1, collectedAt: '2026-08-24T06:00:00Z', totals: { components: 2 },
-      performance: [{ id: 'openbank-alpha-service-alpha-smoke', state: 'passed', observedAt: '2026-08-24T05:59:00Z', metrics: {
-        p95Ms: 280, errorRatePercent: 0, checkPassRatePercent: 100, requests: 75,
-      }, run: { id: 'perf-previous', attempt: 1, commit: 'abcdef012345', branch: 'main', workflow: 'Performance gate', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/perf-previous' } }],
+      performance: [{
+        id: 'openbank-alpha-service-alpha-smoke', state: 'passed', observedAt: '2026-08-24T05:59:00Z',
+        metrics: { p95Ms: 280, errorRatePercent: 0, checkPassRatePercent: 100, requests: 75 },
+        run: { id: 'perf-previous', attempt: 1, commit: 'abcdef012345', branch: 'main', workflow: 'Performance gate', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/perf-previous' },
+      }],
     }))
     const out = path.join(repo, 'report.json')
     execFileSync('node', [SCRIPT, '--repo', repo, '--out', out, '--stale-after-days', '99999'])
@@ -142,11 +145,15 @@ scenarios:
       verificationDetail: expect.stringMatching(/not a passing result/i),
     })])
     expect(report.syntheticJourneys[0]).toMatchObject({ id: 'edge', state: 'unknown', schedule: '*/5 * * * *', runtimeNote: 'requires a dedicated synthetic identity', ci: {
-      state: 'passed', detail: '2 threshold result(s), 0 breached', run: { id: 'synthetic-9', workflow: 'Synthetic journeys' },
+      state: 'unknown', detail: '2 threshold result(s), 0 breached',
+      run: { id: 'synthetic-9', workflow: 'Synthetic journeys' },
     } })
     expect(report.syntheticJourneys[1]).toMatchObject({ id: 'mobile', state: 'blocked', schedule: '0 * * * *', blocker: 'needs canary devices' })
     expect(report.syntheticJourneys.find(item => item.id === 'admin-ui-sso-boundary')).toMatchObject({
-      status: 'active', executor: 'github-actions', ci: { state: 'passed', detail: '1/1 browser E2E checks executed' },
+      status: 'active', executor: 'github-actions', ci: {
+        state: 'passed', detail: '1/1 declared browser variants passed.',
+        variants: [expect.objectContaining({ browser: 'chromium', state: 'passed' })],
+      },
     })
     expect(report.journeyCoverage).toMatchObject({ moneyPathTotal: 2, activelyCovered: 1, explicitlyUnwatched: 1 })
     expect(report.journeyCoverage?.services).toEqual([
@@ -155,7 +162,7 @@ scenarios:
     ])
     expect(report.performance.find(item => item.id === 'openbank-alpha-service-alpha-smoke')).toMatchObject({ state: 'passed', metrics: {
       p95Ms: 321.4, errorRatePercent: 1.25, checkPassRatePercent: 98.75, requests: 80,
-    }, run: { id: 'perf-42', workflow: 'Performance gate' } })
+    }, thresholdResults: { evaluated: 3, breached: 0 }, run: { id: 'perf-42', workflow: 'Performance gate' } })
     expect(report.performanceHistory.filter(item => item.id === 'openbank-alpha-service-alpha-smoke')).toEqual(expect.arrayContaining([
       expect.objectContaining({ collectedAt: '2026-08-24T06:00:00Z', metrics: expect.objectContaining({ p95Ms: 280 }), run: { id: 'perf-previous', attempt: 1, commit: 'abcdef012345', branch: 'main', workflow: 'Performance gate', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/perf-previous' } }),
       expect.objectContaining({ metrics: expect.objectContaining({ p95Ms: 321.4 }), run: expect.objectContaining({ id: 'perf-42' }) }),
@@ -169,6 +176,131 @@ scenarios:
       expect.objectContaining({ id: 'admin-ui', rum: expect.objectContaining({ policy: 'authenticated', state: 'unknown' }) }),
       expect.objectContaining({ id: 'openbank-app', evidence: [], blocker: expect.stringMatching(/artifact/i) }),
     ]))
+  })
+
+  it('refuses thresholdless performance and synthetic passes in current and retained evidence', () => {
+    const repo = mkdtempSync(path.join(tmpdir(), 'test-intelligence-thresholdless-'))
+    dirs.push(repo)
+    write(repo, 'openbank-alpha-service/version.txt', '1.0.0\n')
+    write(repo, 'openbank-libs/governance/rules.yaml', 'money_path_services: []\n')
+    write(repo, 'openbank-libs/governance/journeys.yaml', `version: 1
+journeys:
+  - id: edge
+    title: Edge
+    status: active
+    severity: page
+    capability: proves the public edge
+    covers: [openbank-alpha-service]
+    schedule: "*/5 * * * *"
+    falsification: break it
+`)
+    write(repo, 'perf/k6/empty.js', 'export const options = { thresholds: { checks: ["rate==1.0"] } }')
+    write(repo, 'openbank-admin-ui/perf-artifacts/empty-summary.json', JSON.stringify({ metrics: {} }))
+    write(repo, 'openbank-admin-ui/perf-artifacts/empty-run.json', JSON.stringify({
+      schemaVersion: 1,
+      run: { id: 'perf-empty', attempt: 1, commit: 'abcdef012345', branch: 'main', workflow: 'Performance gate', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/perf-empty', observedAt: '2026-09-01T10:00:00Z' },
+      component: 'openbank-alpha-service', suites: [], coverage: null,
+      testInfrastructure: { declared: [], observed: [] },
+      specializedEvidence: [{ kind: 'performance', state: 'passed', source: 'summary.json', detail: '0 threshold result(s), 0 breached' }],
+    }))
+    write(repo, 'perf/k6/malformed.js', 'export const options = { thresholds: { checks: ["rate==1.0"] } }')
+    write(repo, 'openbank-admin-ui/perf-artifacts/malformed-summary.json', JSON.stringify({
+      metrics: { checks: { thresholds: { 'rate==1.0': {} } } },
+    }))
+    write(repo, 'perf/k6/object-valid.js', 'export const options = { thresholds: { checks: ["rate==1.0"] } }')
+    write(repo, 'openbank-admin-ui/perf-artifacts/object-valid-summary.json', JSON.stringify({
+      metrics: { checks: { thresholds: { 'rate==1.0': { ok: true } } } },
+    }))
+    write(repo, 'perf/k6/mixed.js', 'export const options = { thresholds: { checks: ["rate==1.0"] } }')
+    write(repo, 'openbank-admin-ui/perf-artifacts/mixed-summary.json', JSON.stringify({
+      metrics: { checks: { thresholds: { breached: true, malformed: {} } } },
+    }))
+    write(repo, 'openbank-admin-ui/perf-artifacts/mixed-run.json', JSON.stringify({
+      schemaVersion: 1,
+      run: { id: 'perf-mixed', attempt: 1, commit: 'abcdef012345', branch: 'main', workflow: 'Performance gate', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/perf-mixed', observedAt: '2026-09-01T10:00:30Z' },
+      component: 'openbank-alpha-service', suites: [], coverage: null,
+      testInfrastructure: { declared: [], observed: [] },
+      specializedEvidence: [{ kind: 'performance', state: 'not-run', source: 'summary.json', detail: 'producer did not classify the summary' }],
+    }))
+    write(repo, 'perf/k6/retained.js', 'export const options = { thresholds: { checks: ["rate==1.0"] } }')
+    write(repo, 'openbank-admin-ui/perf-artifacts/retained-summary.json.run.json', JSON.stringify({
+      schemaVersion: 1,
+      run: { id: 'perf-retained', attempt: 1, commit: 'abcdef012345', branch: 'main', workflow: 'Performance gate', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/perf-retained', observedAt: '2026-09-01T10:01:00Z' },
+      component: 'openbank-alpha-service', suites: [], coverage: null,
+      testInfrastructure: { declared: [], observed: [] },
+      specializedEvidence: [{ kind: 'performance', state: 'passed', source: 'summary.json', detail: '1 threshold result(s), 0 breached' }],
+    }))
+    write(repo, 'openbank-admin-ui/test-run-history/synthetic-failed.json', JSON.stringify({
+      schemaVersion: 1,
+      run: { id: 'synthetic-failed', attempt: 1, commit: '123456789abc', branch: 'main', workflow: 'Synthetic journeys', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/synthetic-failed', observedAt: '2026-09-01T10:01:30Z' },
+      component: 'openbank-platform', suites: [], coverage: null,
+      testInfrastructure: { declared: [], observed: [] },
+      specializedEvidence: [{ kind: 'synthetic', state: 'failed', source: 'journey:edge', detail: '1 threshold result(s), 1 breached' }],
+    }))
+    write(repo, 'openbank-admin-ui/test-run-history/synthetic-empty.json', JSON.stringify({
+      schemaVersion: 1,
+      run: { id: 'synthetic-empty', attempt: 1, commit: '123456789abc', branch: 'main', workflow: 'Synthetic journeys', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/synthetic-empty', observedAt: '2026-09-01T10:02:00Z' },
+      component: 'openbank-platform', suites: [], coverage: null,
+      testInfrastructure: { declared: [], observed: [] },
+      specializedEvidence: [{ kind: 'synthetic', state: 'passed', source: 'journey:edge', detail: '0 threshold result(s), 0 breached' }],
+    }))
+    write(repo, 'openbank-admin-ui/test-run-history/performance-empty.json', JSON.stringify({
+      schemaVersion: 1,
+      run: { id: 'performance-empty', attempt: 1, commit: '123456789abc', branch: 'main', workflow: 'Performance gate', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/performance-empty', observedAt: '2026-09-01T10:03:00Z' },
+      component: 'openbank-alpha-service', suites: [], coverage: null,
+      testInfrastructure: { declared: [], observed: [] },
+      specializedEvidence: [{ kind: 'performance', state: 'passed', source: 'summary.json', detail: '0 threshold result(s), 0 breached' }],
+    }))
+    write(repo, 'openbank-admin-ui/test-intelligence-history/thresholdless-snapshot.json', JSON.stringify({
+      schemaVersion: 1,
+      collectedAt: '2026-08-31T10:00:00Z',
+      totals: {
+        components: 1, componentsWithExecutionEvidence: 1, missingEvidence: 0,
+        failingEvidence: 0, staleEvidence: 0, unknownEvidence: 0, unresolvedEvidence: 0,
+      },
+      components: [{
+        component: 'openbank-alpha-service',
+        evidence: [{
+          kind: 'performance', state: 'passed', observedAt: '2026-08-31T09:59:00Z',
+          source: 'k6:legacy.js', environment: 'ci', detail: '1 threshold result(s), 0 breached',
+        }],
+      }],
+      performance: [{
+        id: 'legacy', state: 'passed', observedAt: '2026-08-31T09:59:00Z',
+        detail: '1 threshold result(s), 0 breached',
+        metrics: { p95Ms: 50, errorRatePercent: 0, checkPassRatePercent: 100, requests: 1 },
+      }],
+    }))
+
+    const out = path.join(repo, 'report.json')
+    execFileSync('node', [SCRIPT, '--repo', repo, '--out', out, '--stale-after-days', '99999'])
+    const report = JSON.parse(readFileSync(out, 'utf8')) as TestIntelligenceReport
+
+    expect(report.performance.find(item => item.id === 'empty')).toMatchObject({
+      state: 'unknown', detail: '0 threshold result(s), 0 breached',
+    })
+    expect(report.performance.find(item => item.id === 'retained')).toMatchObject({
+      state: 'unknown', detail: '1 threshold result(s), 0 breached',
+    })
+    expect(report.performance.find(item => item.id === 'malformed')).toMatchObject({
+      state: 'unknown', detail: 'k6 summary contains invalid threshold outcomes',
+    })
+    expect(report.performance.find(item => item.id === 'object-valid')).toMatchObject({
+      state: 'passed', thresholdResults: { evaluated: 1, breached: 0 },
+    })
+    expect(report.performance.find(item => item.id === 'mixed')).toMatchObject({
+      state: 'failed', detail: '2 threshold result(s), 1 breached; additional invalid threshold outcome(s)',
+    })
+    expect(report.syntheticJourneys.find(item => item.id === 'edge')?.ci).toMatchObject({
+      state: 'failed', detail: '1 threshold result(s), 1 breached', run: { id: 'synthetic-failed' },
+    })
+    // ADR-0273 keeps immutable history as originally recorded; only the current projection is corrected.
+    expect(report.runHistory.find(item => item.run.id === 'synthetic-empty')?.states.synthetic).toBe('passed')
+    expect(report.runHistory.find(item => item.run.id === 'performance-empty')?.states.performance).toBe('passed')
+    expect(report.performanceHistory.find(item => item.id === 'legacy')).toMatchObject({ state: 'passed' })
+    expect(report.history.find(item => item.collectedAt === '2026-08-31T10:00:00Z')).toMatchObject({
+      failingEvidence: 0, unknownEvidence: 0, unresolvedEvidence: 0,
+    })
   })
 
   it('does not count an unobserved contract declaration as execution evidence', () => {
@@ -579,7 +711,7 @@ journeys:
     write(repo, 'openbank-admin-ui/test-run-history/synthetic-old.json', JSON.stringify({
       schemaVersion: 1, run: oldRun, component: 'openbank-platform', suites: [], coverage: null,
       testInfrastructure: { declared: [], observed: [] },
-      specializedEvidence: [{ kind: 'synthetic', state: 'passed', source: 'journey:old-journey' }],
+      specializedEvidence: [{ kind: 'synthetic', state: 'passed', source: 'journey:old-journey', detail: '1 threshold result(s), 0 breached' }],
     }))
     write(repo, 'openbank-admin-ui/quality-report.json', JSON.stringify({ contracts: [{
       consumer: 'openbank-alpha-service', provider: 'openbank-provider', pactFile: 'alpha-provider.json',
@@ -599,7 +731,7 @@ journeys:
     expect(report.mutations[0]).toMatchObject({ state: 'stale' })
     expect(report.performance.find(item => item.id === 'openbank-alpha-service-alpha-smoke')).toMatchObject({ state: 'stale' })
     expect(report.performance.find(item => item.id === 'future')).toMatchObject({ state: 'unknown' })
-    expect(report.syntheticJourneys[0].ci).toMatchObject({ state: 'stale' })
+    expect(report.syntheticJourneys[0].ci).toMatchObject({ state: 'unknown' })
     expect(report.contracts[0]).toMatchObject({ state: 'stale' })
     expect(report.totals).toMatchObject({ failingEvidence: 1, staleEvidence: 5 })
   })


### PR DESCRIPTION
## Summary

Fail closed when k6 evidence contains no typed threshold outcomes instead of turning an empty or malformed summary into a green verdict. Current operator projections now distinguish a proved pass from a prose-only retained claim while preserving concrete failures and ADR-0273 immutable history.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #6613
Refs #7284

## Changes

- validate raw k6 boolean and object threshold outcomes with a non-zero denominator
- keep any observed breach red even when a sibling outcome or retained sidecar is malformed
- downgrade unproved current performance and non-browser synthetic passes to unknown without rewriting historical verdicts
- retain an actionable synthetic failure until a later proved recovery, while preserving browser-variant evidence
- expose the typed threshold denominator in the Admin report and cover empty, malformed, mixed, retained and immutable-history cases

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [x] Contract tests updated (if public API changed).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. (N/A: Admin UI-only change.)
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed).
- [x] Flyway migration added + rollback note (if DB changed).
- [x] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural). (Existing ADR-0273 contract preserved.)

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? No.
- [x] PII path changed? No.
- [x] Cardholder data path changed? No.

## Compliance impact

- [x] DORA

The change prevents missing or malformed test evidence from being represented as a successful control. It does not change production transaction behavior or customer data.

## Rollout / Rollback

- Deployment strategy: standard Admin UI rolling image deployment
- Rollback plan: revert this commit; no persisted data or schema migration
- Data migration reversible: N/A

## Screenshots / demo (if UI change)

No layout change. This changes evidence classification only.

## Reviewer notes

Local proof on the rebased head:

- Test Intelligence collector: 17/17 passed
- Test Intelligence ecosystem enforced gate: 1/1 passed, SUBJECTS=60
- ESLint for all three changed files: passed
- TypeScript: passed
- production Next.js build: passed, 91/91 static pages generated
- independent read-only review: no P1/P2 findings

The fleet producer and v1 run schema do not yet emit the structured threshold denominator. Until the review-blocked #8068 lands and that follow-up is implemented, legacy prose-only retained k6 successes intentionally render unknown. This PR does not claim that external producer/schema leg complete.
