### PR TITLE
fix(admin-ui): age required test controls

### DIFF
--- a/openbank-admin-ui/src/app/api/test-intelligence/agents/route.ts
+++ b/openbank-admin-ui/src/app/api/test-intelligence/agents/route.ts
@@ -71,9 +71,12 @@ const safeEvidence = (items: ReadonlyArray<{ kind: string; state: string; observ
       : 'unknown',
   }))
 
-const safeRequiredControls = (items: ReadonlyArray<{ kind: string; state: string }> | undefined) =>
+const safeRequiredControls = (items: ReadonlyArray<{ kind: string; state: string; observedAt?: string | null }> | undefined) =>
   (items ?? []).filter(item => REQUIRED_CONTROL_KINDS.has(item.kind) && EVIDENCE_STATES.has(item.state))
-    .map(item => ({ kind: item.kind, state: item.state }))
+    .map(item => ({
+      kind: item.kind,
+      state: runtimeFreshnessState(item.state as EvidenceState, item.observedAt),
+    }))
 
 const boundedText = (value: unknown): string | null => {
   if (typeof value !== 'string') return null

--- a/openbank-admin-ui/src/lib/test-intelligence-freshness.ts
+++ b/openbank-admin-ui/src/lib/test-intelligence-freshness.ts
@@ -31,10 +31,14 @@ export function enforceRuntimeFreshness(report: TestIntelligenceReport): TestInt
     },
   }))
   const evidence = components.flatMap(component => component.evidence)
+  const requiredControls = report.requiredControls?.map(control => ({
+    ...control, state: runtimeFreshnessState(control.state, control.observedAt),
+  }))
   const { componentsWithExecutionEvidence, missingEvidence } = executionEvidenceTotals(components)
   return {
     ...report,
     components,
+    ...(requiredControls ? { requiredControls } : {}),
     contracts: (report.contracts ?? []).map(item => ({
       ...item, state: runtimeFreshnessState(item.state, item.observedAt),
     })),
@@ -70,6 +74,10 @@ export function enforceRuntimeFreshness(report: TestIntelligenceReport): TestInt
       staleEvidence: evidence.filter(item => item.state === 'stale').length,
       unknownEvidence: evidence.filter(item => item.state === 'unknown').length,
       unresolvedEvidence: evidence.filter(item => ['unknown', 'not-run', 'blocked'].includes(item.state)).length,
+      ...(requiredControls ? {
+        requiredControls: requiredControls.length,
+        requiredControlGaps: requiredControls.filter(control => control.state !== 'passed').length,
+      } : {}),
     },
   }
 }

--- a/openbank-admin-ui/src/test/test-intelligence-agent-route.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-agent-route.test.ts
@@ -57,7 +57,10 @@ describe('Test Intelligence agent BFF', () => {
         { component: 'openbank-ledger-service', state: 'flaky', sameCommitTransitions: 2, wastedDurationMs: 1250, name: 'private test name', fingerprint: 'private-fingerprint' },
         { component: 'openbank-ledger-service', state: 'failing', sameCommitTransitions: 0, wastedDurationMs: 500, name: 'another private test', fingerprint: 'private-fingerprint-2' },
       ],
-      requiredControls: [{ component: 'openbank-ledger-service', kind: 'coverage', state: 'not-run' }],
+      requiredControls: [
+        { component: 'openbank-ledger-service', kind: 'coverage', state: 'not-run' },
+        { component: 'openbank-ledger-service', kind: 'integration', state: 'passed', observedAt: '2020-01-01T00:00:00Z' },
+      ],
     }))
     process.env.OPENBANK_TEST_INTELLIGENCE = file
     const agentFinding = { id: 'diagnosed-1', component: 'openbank-ledger-service', title: 'Investigate stale integration', severity: 'WARNING' }
@@ -69,7 +72,7 @@ describe('Test Intelligence agent BFF', () => {
     const outbound = JSON.parse(fetchMock.mock.calls[0][1].body as string)
     expect(outbound.components[0]).toEqual({ component: 'openbank-ledger-service', moneyPath: true,
       evidence: [{ kind: 'integration', state: 'stale' }], declaredInfrastructure: ['postgres'], observedInfrastructureStarts: 1, observedInfrastructureStops: 0,
-      requiredControls: [{ kind: 'coverage', state: 'not-run' }],
+      requiredControls: [{ kind: 'coverage', state: 'not-run' }, { kind: 'integration', state: 'stale' }],
       flakyTests: 1, failingTests: 1, sameCommitTransitions: 2, wastedDurationMs: 1750 })
     expect(outbound.components[1]).toEqual({ component: 'openbank-app', moneyPath: true,
       evidence: [{ kind: 'visual', state: 'passed' }], declaredInfrastructure: [], observedInfrastructureStarts: 0, observedInfrastructureStops: 0,

--- a/openbank-admin-ui/src/test/test-intelligence-freshness.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-freshness.test.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { enforceRuntimeFreshness } from '@/lib/test-intelligence-freshness'
+import type { EvidenceState, RequiredTestControl, TestIntelligenceReport } from '@/lib/types/test-intelligence'
+
+const NOW = '2026-09-02T12:00:00.000Z'
+const OLD = '2026-08-01T12:00:00.000Z'
+const FRESH = '2026-09-01T12:00:00.000Z'
+
+function control(state: EvidenceState, observedAt: string): RequiredTestControl {
+  return {
+    id: `openbank-ledger-service:unit:${state}`,
+    component: 'openbank-ledger-service',
+    kind: 'unit',
+    state,
+    reason: 'Unit execution is required.',
+    source: 'run:v1',
+    observedAt,
+  }
+}
+
+function report(
+  requiredControls?: RequiredTestControl[],
+  componentState: EvidenceState = 'passed',
+  observedAt = FRESH,
+): TestIntelligenceReport {
+  return {
+    schemaVersion: 1,
+    collectedAt: observedAt,
+    components: [{
+      component: 'openbank-ledger-service',
+      released: true,
+      moneyPath: true,
+      evidence: [{ kind: 'unit', state: componentState, observedAt, source: 'run:v1', environment: 'ci' }],
+      coverage: {
+        state: 'not-run',
+        observedAt: null,
+        source: null,
+        lines: { covered: 0, missed: 0, percentage: null },
+        branches: { covered: 0, missed: 0, percentage: null },
+      },
+      testInfrastructure: { declared: [], observed: [] },
+    }],
+    contracts: [],
+    mutations: [],
+    performance: [],
+    performanceHistory: [],
+    syntheticJourneys: [],
+    clientExperiences: [],
+    ...(requiredControls ? { requiredControls } : {}),
+    history: [],
+    runHistory: [],
+    testCases: [],
+    totals: {
+      components: 1,
+      componentsWithExecutionEvidence: 1,
+      moneyPathComponents: 1,
+      failingEvidence: 0,
+      missingEvidence: 0,
+      staleEvidence: 0,
+      ...(requiredControls ? {
+        requiredControls: requiredControls.length,
+        requiredControlGaps: requiredControls.filter(item => item.state !== 'passed').length,
+      } : {}),
+    },
+    warnings: [],
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+  process.env.OPENBANK_TEST_INTELLIGENCE_STALE_AFTER_DAYS = '14'
+})
+
+afterEach(() => {
+  delete process.env.OPENBANK_TEST_INTELLIGENCE_STALE_AFTER_DAYS
+  vi.useRealTimers()
+})
+
+describe('test-intelligence runtime required-control freshness', () => {
+  it('ages old passing component and required-control evidence and recomputes the gap', () => {
+    const freshened = enforceRuntimeFreshness(report([control('passed', OLD)], 'passed', OLD))
+
+    expect(freshened.components[0].evidence[0].state).toBe('stale')
+    expect(freshened.requiredControls?.[0].state).toBe('stale')
+    expect(freshened.totals).toMatchObject({ requiredControls: 1, requiredControlGaps: 1 })
+  })
+
+  it('keeps a fresh required-control pass out of the gap total', () => {
+    const freshened = enforceRuntimeFreshness(report([control('passed', FRESH)]))
+
+    expect(freshened.requiredControls?.[0].state).toBe('passed')
+    expect(freshened.totals).toMatchObject({ requiredControls: 1, requiredControlGaps: 0 })
+  })
+
+  it('never promotes failed or blocked required controls', () => {
+    const freshened = enforceRuntimeFreshness(report([
+      control('failed', OLD),
+      control('blocked', FRESH),
+    ]))
+
+    expect(freshened.requiredControls?.map(item => item.state)).toEqual(['failed', 'blocked'])
+    expect(freshened.totals).toMatchObject({ requiredControls: 2, requiredControlGaps: 2 })
+  })
+
+  it('preserves reports that predate required controls', () => {
+    const freshened = enforceRuntimeFreshness(report())
+
+    expect(freshened).not.toHaveProperty('requiredControls')
+    expect(freshened.totals).not.toHaveProperty('requiredControls')
+    expect(freshened.totals).not.toHaveProperty('requiredControlGaps')
+  })
+})


### PR DESCRIPTION
## Summary

- age derived required Test Intelligence controls with the same runtime freshness policy as their source evidence
- recompute required-control totals and gaps from the freshened controls while preserving legacy reports that have no control projection
- keep the bounded flaky-test-hunter payload consistent, so an old control cannot reach the AI agent as a current pass

## Why

The runtime API already aged component evidence after the configured freshness budget, but left the matching required control and `requiredControlGaps` untouched. An old passing run could therefore render as stale in the evidence matrix while the deterministic-control table and KPI stayed green. The AI analysis payload repeated that false-green state.

## Verification

- red regression reproduced: old control was `passed` while its source evidence was `stale`
- focused API/freshness/agent tests: 23/23 passed
- remaining focused Test Intelligence tests: 39/39 passed
- collector suite outside the bind-restricted sandbox: 16/16 passed
- focused ESLint: passed
- `npm run type-check`: passed
- production `npm run build`: passed; 91/91 pages generated
- Test Intelligence ecosystem self-test and direct check: passed (`SUBJECTS=60`)
- `git diff --check`: passed

## Compatibility

Reports without `requiredControls` keep their optional legacy shape and totals. Existing failed, blocked, unknown, not-run and stale controls are never promoted. Immutable history is not rewritten; only the current runtime projection is aged.

Refs #6613
