### PR TITLE
fix(admin-ui): prioritize critical test findings

### DIFF
--- a/openbank-admin-ui/src/components/testing/TestAgentPanel.tsx
+++ b/openbank-admin-ui/src/components/testing/TestAgentPanel.tsx
@@ -16,6 +16,8 @@ type AgentGovernance = {
 }
 
 const FLAKY_HUNTER_EVAL_BACKLOG_URL = 'https://github.com/JiRaska/open-bank-oss/issues/7040'
+const FINDINGS_DISPLAY_LIMIT = 5
+const FINDING_SEVERITY_ORDER: Record<TestAgentFinding['severity'], number> = { CRITICAL: 0, WARNING: 1 }
 
 function evalEvidenceDetail(state: AgentGovernance['evalEvidence'], t: (cs: string, en: string) => string): string {
   switch (state) {
@@ -35,6 +37,9 @@ export function TestAgentPanel() {
   const [available, setAvailable] = useState<boolean | null>(null)
   const [analyzing, setAnalyzing] = useState(false)
   const [governance, setGovernance] = useState<AgentGovernance | null>(null)
+  const visibleFindings = [...findings]
+    .sort((left, right) => FINDING_SEVERITY_ORDER[left.severity] - FINDING_SEVERITY_ORDER[right.severity])
+    .slice(0, FINDINGS_DISPLAY_LIMIT)
   useEffect(() => { void fetch('/api/test-intelligence/agents', { cache: 'no-store' }).then(async response => {
     if (!response.ok) { setAvailable(false); return }
     const body = await response.json() as { findings: TestAgentFinding[]; available: boolean; governance?: AgentGovernance }
@@ -62,7 +67,7 @@ export function TestAgentPanel() {
       {available === null ? <span style={{ color: 'var(--text-tertiary)', fontSize: 12 }}>{t('Načítám agentní nálezy…', 'Loading agent findings…')}</span>
         : !available ? <span style={{ color: 'var(--text-tertiary)', fontSize: 12 }}>{t('Agent v tomto prostředí není dostupný. Měřená evidence výše zůstává úplná a beze změny.', 'The agent is unavailable in this environment. Measured evidence above remains complete and unchanged.')}</span>
           : findings.length === 0 ? <span style={{ color: 'var(--text-secondary)', fontSize: 12 }}>{t('Žádné aktivní nálezy. To není důkaz bezchybnosti; jen aktuální výstup agentova omezeného charteru.', 'No active findings. This is not proof of correctness; only the current output of the agent’s bounded charter.')}</span>
-            : <div style={{ display: 'grid', gap: 8 }}>{findings.slice(0, 5).map(finding => <div key={finding.id} style={{ display: 'grid', gridTemplateColumns: '90px 1fr auto', gap: 10, alignItems: 'center', fontSize: 12 }}><span style={{ color: finding.severity === 'CRITICAL' ? '#dc2626' : '#d97706', fontWeight: 700 }}>{finding.severity}</span><span><strong>{finding.component}</strong> · {finding.title}{finding.rootCause && <small style={{ display: 'block', color: 'var(--text-tertiary)', marginTop: 3 }}>{finding.rootCause}</small>}</span>{finding.proposalUrl && <a href={finding.proposalUrl} target="_blank" rel="noreferrer" aria-label={t('Otevřít návrh agenta', 'Open agent proposal')}><ExternalLink size={14}/></a>}</div>)}</div>}
+            : <div style={{ display: 'grid', gap: 8 }}>{visibleFindings.map(finding => <div key={finding.id} style={{ display: 'grid', gridTemplateColumns: '90px 1fr auto', gap: 10, alignItems: 'center', fontSize: 12 }}><span style={{ color: finding.severity === 'CRITICAL' ? '#dc2626' : '#d97706', fontWeight: 700 }}>{finding.severity}</span><span><strong>{finding.component}</strong> · {finding.title}{finding.rootCause && <small style={{ display: 'block', color: 'var(--text-tertiary)', marginTop: 3 }}>{finding.rootCause}</small>}</span>{finding.proposalUrl && <a href={finding.proposalUrl} target="_blank" rel="noreferrer" aria-label={t('Otevřít návrh agenta', 'Open agent proposal')}><ExternalLink size={14}/></a>}</div>)}{findings.length > FINDINGS_DISPLAY_LIMIT && <span role="status" style={{ color: 'var(--text-tertiary)', fontSize: 11 }}>{t(`Zobrazeno ${visibleFindings.length} z ${findings.length} nálezů.`, `Showing ${visibleFindings.length} of ${findings.length} findings.`)}</span>}</div>}
     </div>
   </section>
 }

--- a/openbank-admin-ui/src/test/test-agent-panel-governance.test.tsx
+++ b/openbank-admin-ui/src/test/test-agent-panel-governance.test.tsx
@@ -33,4 +33,46 @@ describe('Test Agent governance evidence', () => {
     expect(screen.getByRole('link', { name: /Open evaluation backlog/ })).toHaveAttribute('href', 'https://github.com/JiRaska/open-bank-oss/issues/7040')
     expect(screen.getByText(/agent is unavailable/i)).toBeVisible()
   })
+
+  it('prioritizes critical findings before limiting the visible list', async () => {
+    const newerWarnings = Array.from({ length: 5 }, (_, index) => ({
+      id: `warning-${index + 1}`,
+      checkType: 'flaky-test',
+      severity: 'WARNING',
+      detectedAt: `2026-08-0${6 - index}T10:00:00Z`,
+      title: `Newer warning ${index + 1}`,
+      component: 'openbank-test-service',
+      rootCause: null,
+      proposalUrl: null,
+      status: 'OPEN',
+    }))
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      findings: [
+        ...newerWarnings,
+        {
+          id: 'critical-older',
+          checkType: 'flaky-test',
+          severity: 'CRITICAL',
+          detectedAt: '2026-08-01T10:00:00Z',
+          title: 'Older critical finding',
+          component: 'openbank-critical-service',
+          rootCause: null,
+          proposalUrl: null,
+          status: 'OPEN',
+        },
+      ],
+      available: true,
+    }), { status: 200, headers: { 'content-type': 'application/json' } })))
+
+    render(<TestAgentPanel />)
+
+    expect(await screen.findByText(/Older critical finding/)).toBeVisible()
+    expect(screen.getAllByText(/^(CRITICAL|WARNING)$/).map(item => item.textContent)).toEqual([
+      'CRITICAL', 'WARNING', 'WARNING', 'WARNING', 'WARNING',
+    ])
+    expect(screen.queryByText(/Newer warning 5/)).not.toBeInTheDocument()
+    const truncationStatus = screen.getByRole('status')
+    expect(truncationStatus).toHaveTextContent('Showing 5 of 6 findings.')
+    expect(truncationStatus).toBeVisible()
+  })
 })


### PR DESCRIPTION
## Summary

- prioritize active `CRITICAL` Test Intelligence agent findings before the five-item display cap
- preserve backend order within each severity without mutating the response
- disclose visible and total finding counts whenever the panel truncates results

## Why

The backend returns active findings by detection time. The Admin UI previously rendered the first five unchanged, so five newer warnings could silently hide an older active critical finding. Operators were also given no indication that the list was truncated.

## Verification

- red regression reproduced with five newer warnings plus one older critical finding
- focused panel and agent-route tests: 8/8 passed
- regression asserts exact rendered severity order/count and that the sixth warning is omitted
- focused ESLint: passed
- `npm run type-check`: passed on the rebased `0.232.0` Admin UI
- production `npm run build`: passed; 91/91 pages generated
- independent diff review: no remaining findings
- `git diff --check`: passed

## Safety

This changes only the bounded advisory presentation. It does not promote agent output to test evidence, alter finding lifecycle, mutate the API response, or trigger remediation.

Refs #6613
