### PR TITLE
fix(admin-ui): make interest refresh failures recoverable

### DIFF
--- a/openbank-admin-ui/src/app/interest/page.tsx
+++ b/openbank-admin-ui/src/app/interest/page.tsx
@@ -3,8 +3,8 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 'use client'
-import { useState } from 'react'
-import { TrendingUp, Search, CheckCircle2, RefreshCw, Percent, Calendar } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { AlertTriangle, ShieldAlert, TrendingUp, Search, CheckCircle2, RefreshCw, Percent, Calendar } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { svcUrl } from '@/lib/services/bff'
@@ -18,15 +18,72 @@ interface AccrualRecord {
   currency: string; rate: number; dayCount: string; status: string
 }
 
+type AccessBlock = 'unauthorized' | 'forbidden'
+
+function InterestAccessDenied({ language }: { language: 'cs' | 'en' }) {
+  const cs = language === 'cs'
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      style={{
+        padding: '40px', textAlign: 'center', display: 'flex', flexDirection: 'column',
+        alignItems: 'center', gap: '10px',
+      }}
+    >
+      <ShieldAlert size={28} aria-hidden="true" style={{ color: 'var(--danger)' }} />
+      <div style={{ fontSize: '14px', fontWeight: 600, color: 'var(--text-primary)' }}>
+        {cs ? 'Přístup odepřen' : 'Access denied'}
+      </div>
+      <div style={{ fontSize: '12px', color: 'var(--text-tertiary)', maxWidth: '460px', lineHeight: 1.5 }}>
+        {cs
+          ? 'Vaše aktuální role nemá oprávnění zobrazit tato data. Žádná dříve načtená data se nezobrazují.'
+          : 'Your current role does not have permission to view this data. No previously loaded data is shown.'}
+      </div>
+    </div>
+  )
+}
+
 export default function InterestPage() {
   const { t, language } = useLanguage()
   const [search, setSearch] = useState('')
+  const [lastSuccessfulAt, setLastSuccessfulAt] = useState<Date | null>(null)
+  const [retainedAccessBlock, setRetainedAccessBlock] = useState<{
+    kind: AccessBlock
+    snapshot: AccrualRecord[] | null
+  } | null>(null)
+  const reloadInFlight = useRef(false)
   const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
-  const { data, loading, unavailable, waking } = useServiceResource<AccrualRecord[]>(
+  const { data, loading, unavailable, waking, reload } = useServiceResource<AccrualRecord[]>(
     svcUrl('interest-service', '/api/v1/interest/accruals'),
-    { select: (raw) => (Array.isArray(raw) ? (raw as AccrualRecord[]) : ((raw as { accruals?: AccrualRecord[] }).accruals ?? [])) },
+    { select: (raw) => {
+      setLastSuccessfulAt(new Date())
+      return Array.isArray(raw) ? (raw as AccrualRecord[]) : ((raw as { accruals?: AccrualRecord[] }).accruals ?? [])
+    } },
   )
   const accruals = data ?? []
+  const hasSnapshot = data !== null
+  const currentAccessBlock: AccessBlock | null = unavailable?.kind === 'unauthorized'
+    ? 'unauthorized'
+    : unavailable?.status === 403 ? 'forbidden' : null
+  const persistedAccessBlock = retainedAccessBlock?.snapshot === data ? retainedAccessBlock.kind : null
+  const accessBlock = currentAccessBlock ?? persistedAccessBlock
+  const visibleSnapshot = hasSnapshot && accessBlock === null
+  const settledFailure = unavailable !== null && !loading && !waking
+  const showingRetainedSnapshot = settledFailure && visibleSnapshot
+
+  useEffect(() => {
+    if (!loading) reloadInFlight.current = false
+  }, [data, loading, unavailable])
+
+  const requestReload = useCallback(() => {
+    if (loading || reloadInFlight.current) return
+    setRetainedAccessBlock(currentAccessBlock
+      ? { kind: currentAccessBlock, snapshot: data }
+      : null)
+    reloadInFlight.current = true
+    reload()
+  }, [currentAccessBlock, data, loading, reload])
 
   const filtered = accruals.filter(a =>
     a.accountId?.toLowerCase().includes(search.toLowerCase()) ||
@@ -41,20 +98,83 @@ export default function InterestPage() {
   return (
     <AuthGuard permission="payments:view">
       <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
-        <PageHeader icon={<Percent size={20} aria-hidden="true" />} title={t('Úrokové výpočty', 'Interest Calculations')} subtitle={t('Akruální účetnictví — ACT/365 · ACT/360 · kapitalizace', 'Accrual accounting — ACT/365 · ACT/360 · capitalisation')} actions={<ServiceStatusBadge
-            label="interest-service :8125"
-            loading={loading}
-            waking={waking}
-            unavailable={unavailable}
-            copy={{
-              up: t('interest-service běží', 'interest-service is up'),
-              idle: t('interest-service spí (scale-to-zero), probouzí se…', 'interest-service idle (scaled to zero), waking…'),
-              down: t('interest-service neodpovídá', 'interest-service is not responding'),
-              checking: t('Zjišťuji stav služby…', 'Checking service…'),
-            }}
-          />} />
+        <PageHeader
+          icon={<Percent size={20} aria-hidden="true" />}
+          title={t('Úrokové výpočty', 'Interest Calculations')}
+          subtitle={t('Akruální účetnictví — ACT/365 · ACT/360 · kapitalizace', 'Accrual accounting — ACT/365 · ACT/360 · capitalisation')}
+          actions={<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            {accessBlock === null && (
+              <ServiceStatusBadge
+                label="interest-service :8125"
+                loading={loading}
+                waking={waking}
+                unavailable={unavailable}
+                copy={{
+                  up: t('interest-service běží', 'interest-service is up'),
+                  idle: t('interest-service spí (scale-to-zero), probouzí se…', 'interest-service idle (scaled to zero), waking…'),
+                  down: t('interest-service neodpovídá', 'interest-service is not responding'),
+                  checking: t('Zjišťuji stav služby…', 'Checking service…'),
+                }}
+              />
+            )}
+            <button
+              type="button"
+              onClick={requestReload}
+              disabled={loading}
+              aria-busy={loading}
+              aria-label={settledFailure
+                ? t('Zkusit znovu načíst úrokové záznamy', 'Retry loading interest records')
+                : t('Obnovit úrokové záznamy', 'Refresh interest records')}
+              className="btn btn-secondary btn-sm"
+            >
+              <RefreshCw size={14} aria-hidden="true" className={loading ? 'animate-spin' : ''} />
+              {settledFailure ? t('Zkusit znovu', 'Try again') : t('Obnovit', 'Refresh')}
+            </button>
+          </div>}
+        />
 
-        <div className="grid-4" style={{ marginBottom: '24px' }}>
+        {showingRetainedSnapshot && (
+          <div
+            role="status"
+            aria-live="polite"
+            aria-label={t('Aktuálnost úrokových dat', 'Interest data freshness')}
+            style={{
+              marginBottom: 20, padding: '14px 16px', borderRadius: 10,
+              border: '1px solid var(--warning-border)', background: 'var(--warning-bg)',
+              color: 'var(--text-primary)', display: 'flex', alignItems: 'flex-start', gap: 10,
+            }}
+          >
+            <AlertTriangle size={18} aria-hidden="true" style={{ color: 'var(--warning)', flexShrink: 0, marginTop: 1 }} />
+            <div>
+              <div style={{ fontSize: 13, fontWeight: 700 }}>
+                {t(
+                  'Obnovení selhalo — zobrazuji poslední úspěšný snapshot.',
+                  'Refresh failed — showing the last successful snapshot.',
+                )}
+              </div>
+              <div style={{ marginTop: 3, fontSize: 12, color: 'var(--text-secondary)' }}>
+                {lastSuccessfulAt && <>
+                  {t('Poslední úspěšné načtení', 'Last successful load')}: {lastSuccessfulAt.toLocaleString(numberLocale)}.{' '}
+                </>}
+                {t(
+                  'Naakruované částky i stavy se od té doby mohly změnit.',
+                  'Accrued amounts and statuses may have changed since then.',
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {loading && visibleSnapshot && (
+          <p role="status" aria-live="polite" style={{ margin: '0 0 12px', color: 'var(--text-tertiary)', fontSize: 11 }}>
+            {t(
+              'Aktualizuji úrokové záznamy; poslední snapshot zůstává dostupný.',
+              'Refreshing interest records; the last snapshot remains available.',
+            )}
+          </p>
+        )}
+
+        {visibleSnapshot && <div className="grid-4" style={{ marginBottom: '24px' }}>
           {[
             { label: t('Záznamy celkem', 'Total records'), value: accruals.length, icon: <TrendingUp size={16} aria-hidden="true" />, color: 'var(--accent)' },
             { label: t('Akruuje', 'Accruing'), value: accruing.length, icon: <Percent size={16} aria-hidden="true" />, color: 'var(--warning)' },
@@ -68,7 +188,7 @@ export default function InterestPage() {
               <div style={{ fontSize: '12px', color: 'var(--text-secondary)', fontWeight: 500 }}>{k.label}</div>
             </div>
           ))}
-        </div>
+        </div>}
 
         <div className="card">
           <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--border)', display: 'flex', gap: '10px', alignItems: 'center' }}>
@@ -80,16 +200,22 @@ export default function InterestPage() {
                   border: '1px solid var(--border)', fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)', outline: 'none' }} />
             </div>
           </div>
-          {loading ? (
+          {accessBlock === 'forbidden' ? (
+            <InterestAccessDenied language={language} />
+          ) : accessBlock === 'unauthorized' ? (
+            <DataUnavailable kind="unauthorized" service={t('Interest-service', 'Interest-service')} feature={t('Úrokové záznamy', 'Interest records')} lang={language} />
+          ) : loading && !visibleSnapshot ? (
             <div role="status" aria-live="polite" style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
               <RefreshCw size={20} aria-hidden="true" style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} /><div>{t('Načítám…', 'Loading…')}</div>
             </div>
-          ) : unavailable ? (
+          ) : unavailable && !visibleSnapshot ? (
             <DataUnavailable kind={unavailable.kind} service={t('Interest-service', 'Interest-service')} feature={t('Úrokové záznamy', 'Interest records')} lang={language} />
           ) : filtered.length === 0 ? (
             <DataUnavailable kind="no_data" feature={t('Úrokové záznamy', 'Interest records')} lang={language}
               detail={accruals.length === 0
-                ? t('Služba běží, zatím žádné úrokové záznamy.', 'The service is running; no interest records yet.')
+                ? showingRetainedSnapshot
+                  ? t('Poslední úspěšný snapshot neobsahoval žádné úrokové záznamy.', 'The last successful snapshot contained no interest records.')
+                  : t('Služba běží, zatím žádné úrokové záznamy.', 'The service is running; no interest records yet.')
                 : t('Žádné výsledky pro zadaný filtr.', 'No results for the applied filter.')} />
           ) : (
             <table style={{ width: '100%', borderCollapse: 'collapse' }}>

--- a/openbank-admin-ui/src/lib/services/useServiceResource.ts
+++ b/openbank-admin-ui/src/lib/services/useServiceResource.ts
@@ -28,7 +28,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { classifyBffFailure, type BffFailure } from './bff'
 
-export type ServiceUnavailable = { kind: BffFailure | 'no_data' }
+export type ServiceUnavailable = {
+  kind: BffFailure | 'no_data'
+  /** Upstream HTTP status when this failure came from a response. */
+  status?: number
+}
 
 export interface ServiceResource<T> {
   data: T | null
@@ -82,25 +86,27 @@ export function useServiceResource<T = unknown>(
   const reload = useCallback(() => setNonce(n => n + 1), [])
 
   useEffect(() => {
-    if (!url) {
-      setLoading(false)
-      return
-    }
+    if (!url) return
     const { select, maxWakeRetries = 3, retryDelayMs = 4000, timeoutMs = 10_000 } = optsRef.current
     let cancelled = false
     let timer: ReturnType<typeof setTimeout> | null = null
     let activeController: AbortController | null = null
     let attempt = 0
 
-    const scheduleRetry = (kind: BffFailure) => {
+    const scheduleRetry = (kind: BffFailure, status?: number) => {
       attempt += 1
       setWaking(true)
       // Show the calm "idle / waking" panel while we keep polling.
-      setUnavailable({ kind })
+      setUnavailable({ kind, status })
       timer = setTimeout(run, retryDelayMs)
     }
 
     async function run() {
+      if (attempt === 0) {
+        setLoading(true)
+        setUnavailable(null)
+        setWaking(false)
+      }
       const controller = new AbortController()
       activeController = controller
       const deadline = setTimeout(() => controller.abort(), timeoutMs)
@@ -111,10 +117,10 @@ export function useServiceResource<T = unknown>(
           const kind = await classifyBffFailure(res)
           if (cancelled) return
           if (WAKE_KINDS.has(kind) && attempt < maxWakeRetries) {
-            scheduleRetry(kind)
+            scheduleRetry(kind, res.status)
             return
           }
-          setUnavailable({ kind })
+          setUnavailable({ kind, status: res.status })
           setWaking(false)
           setLoading(false)
           return
@@ -141,9 +147,6 @@ export function useServiceResource<T = unknown>(
       }
     }
 
-    setLoading(true)
-    setUnavailable(null)
-    setWaking(false)
     run()
 
     return () => {
@@ -154,5 +157,5 @@ export function useServiceResource<T = unknown>(
     // `url` + `nonce` are the only real inputs; options are read via ref.
   }, [url, nonce])
 
-  return { data, loading, unavailable, waking, reload }
+  return { data, loading: url ? loading : false, unavailable, waking, reload }
 }

--- a/openbank-admin-ui/src/test/interest-recovery.test.tsx
+++ b/openbank-admin-ui/src/test/interest-recovery.test.tsx
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import InterestPage from '@/app/interest/page'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+vi.mock('@/components/auth/AuthGuard', () => ({
+  AuthGuard: ({ children }: { children: ReactNode }) => children,
+}))
+
+const FIRST_ACCRUAL = {
+  id: 'accrual-1',
+  accountId: 'CZ6508000000001234567899',
+  accrualDate: '2026-08-31',
+  accruedAmount: 10.25,
+  currency: 'CZK',
+  rate: 0.0325,
+  dayCount: 'ACT_365',
+  status: 'ACCRUING',
+}
+
+const REFRESHED_ACCRUAL = {
+  ...FIRST_ACCRUAL,
+  id: 'accrual-2',
+  accountId: 'CZ6508000000009876543210',
+  accruedAmount: 11.5,
+}
+
+const FINAL_ACCRUAL = {
+  ...REFRESHED_ACCRUAL,
+  id: 'accrual-3',
+  accountId: 'CZ6508000000001111222233',
+  accruedAmount: 12.75,
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+async function renderPage() {
+  await act(async () => {
+    render(<LanguageProvider initialLanguage="en"><InterestPage /></LanguageProvider>)
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('interest snapshot recovery', () => {
+  it('keeps the last successful rows visible after a failed refresh and releases single-flight after success', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(200, [FIRST_ACCRUAL]))
+      .mockResolvedValueOnce(jsonResponse(500, { error: 'temporarily unavailable' }))
+      .mockResolvedValueOnce(jsonResponse(200, [REFRESHED_ACCRUAL]))
+      .mockResolvedValueOnce(jsonResponse(200, [FINAL_ACCRUAL]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await renderPage()
+    expect(await screen.findByText(FIRST_ACCRUAL.accountId)).toBeVisible()
+
+    const refresh = screen.getByRole('button', { name: 'Refresh interest records' })
+    fireEvent.click(refresh)
+    fireEvent.click(refresh)
+
+    const stale = await screen.findByRole('status', { name: 'Interest data freshness' })
+    expect(stale).toHaveTextContent('showing the last successful snapshot')
+    expect(stale).toHaveTextContent('Last successful load')
+    expect(screen.getByText(FIRST_ACCRUAL.accountId)).toBeVisible()
+    expect(screen.getByText('10.2500')).toBeVisible()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry loading interest records' }))
+
+    expect(await screen.findByText(REFRESHED_ACCRUAL.accountId)).toBeVisible()
+    await waitFor(() => expect(screen.queryByRole('status', { name: 'Interest data freshness' })).not.toBeInTheDocument())
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh interest records' }))
+
+    expect(await screen.findByText(FINAL_ACCRUAL.accountId)).toBeVisible()
+    expect(screen.queryByText(REFRESHED_ACCRUAL.accountId)).not.toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('shows an initial failure without synthetic zero statistics or rows', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      jsonResponse(500, { error: 'temporarily unavailable' }),
+    ))
+
+    await renderPage()
+
+    expect(await screen.findByRole('button', { name: 'Retry loading interest records' })).toBeVisible()
+    expect(screen.getByRole('status')).toHaveTextContent('Failed to load: Interest records')
+    expect(screen.queryByText('Total records')).not.toBeInTheDocument()
+    expect(screen.queryByText(FIRST_ACCRUAL.accountId)).not.toBeInTheDocument()
+  })
+
+  it.each([
+    { status: 401, body: { error: 'unauthorized' }, title: 'Session expired' },
+    { status: 403, body: { error: 'forbidden' }, title: 'Access denied' },
+  ])('keeps a retained privileged snapshot blocked through an HTTP $status retry', async ({ status, body, title }) => {
+    let resolveRetry!: (response: Response) => void
+    const retryResponse = new Promise<Response>(resolve => { resolveRetry = resolve })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(200, [FIRST_ACCRUAL]))
+      .mockResolvedValueOnce(jsonResponse(status, body))
+      .mockReturnValueOnce(retryResponse)
+    vi.stubGlobal('fetch', fetchMock)
+
+    await renderPage()
+    expect(await screen.findByText(FIRST_ACCRUAL.accountId)).toBeVisible()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh interest records' }))
+
+    const blocked = await screen.findByRole('alert')
+    expect(blocked).toHaveTextContent(title)
+    expect(blocked.querySelector('[role="status"], [role="alert"]')).toBeNull()
+    expect(screen.queryByText('interest-service :8125')).not.toBeInTheDocument()
+    expect(screen.queryByTitle('interest-service is not responding')).not.toBeInTheDocument()
+    expect(screen.queryByTitle('interest-service is up')).not.toBeInTheDocument()
+    expect(screen.queryByText(FIRST_ACCRUAL.accountId)).not.toBeInTheDocument()
+    expect(screen.queryByText('Total records')).not.toBeInTheDocument()
+    expect(screen.queryByRole('status', { name: 'Interest data freshness' })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry loading interest records' }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    expect(screen.getByRole('alert')).toHaveTextContent(title)
+    expect(screen.queryByText(FIRST_ACCRUAL.accountId)).not.toBeInTheDocument()
+    expect(screen.queryByText(REFRESHED_ACCRUAL.accountId)).not.toBeInTheDocument()
+    expect(screen.queryByText('Total records')).not.toBeInTheDocument()
+
+    await act(async () => { resolveRetry(jsonResponse(200, [REFRESHED_ACCRUAL])) })
+
+    expect(await screen.findByText(REFRESHED_ACCRUAL.accountId)).toBeVisible()
+    expect(screen.getByText('Total records')).toBeVisible()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByTitle('interest-service is up')).toHaveTextContent('interest-service :8125')
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('announces one refreshing state during a wake retry and replaces the snapshot on success', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(200, [FIRST_ACCRUAL]))
+      .mockResolvedValueOnce(jsonResponse(503, { error: 'scaled_to_zero' }))
+      .mockResolvedValueOnce(jsonResponse(200, [REFRESHED_ACCRUAL]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await renderPage()
+    expect(await screen.findByText(FIRST_ACCRUAL.accountId)).toBeVisible()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh interest records' }))
+
+    expect(await screen.findByText('Refreshing interest records; the last snapshot remains available.')).toBeVisible()
+    expect(screen.queryByRole('status', { name: 'Interest data freshness' })).not.toBeInTheDocument()
+    expect(screen.getAllByRole('status')).toHaveLength(1)
+
+    expect(await screen.findByText(REFRESHED_ACCRUAL.accountId, {}, { timeout: 6_000 })).toBeVisible()
+    expect(screen.queryByText(FIRST_ACCRUAL.accountId)).not.toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  }, 10_000)
+})

--- a/openbank-admin-ui/src/test/use-service-resource.test.ts
+++ b/openbank-admin-ui/src/test/use-service-resource.test.ts
@@ -40,7 +40,7 @@ describe('useServiceResource', () => {
     vi.stubGlobal('fetch', fetchMock)
     const { result } = renderHook(() => useServiceResource('/api/svc/x/api/v1/items'))
     await waitFor(() => expect(result.current.loading).toBe(false))
-    expect(result.current.unavailable).toEqual({ kind: 'not_deployed' })
+    expect(result.current.unavailable).toEqual({ kind: 'not_deployed', status: 404 })
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
@@ -56,7 +56,7 @@ describe('useServiceResource', () => {
     )
     // While waking, it shows the calm scaled_to_zero panel, not a hard failure.
     await waitFor(() => expect(result.current.waking).toBe(true))
-    expect(result.current.unavailable).toEqual({ kind: 'scaled_to_zero' })
+    expect(result.current.unavailable).toEqual({ kind: 'scaled_to_zero', status: 503 })
     // Then the retry succeeds and the data lands.
     await waitFor(() => expect(result.current.data).toEqual([{ id: 'woke' }]))
     expect(result.current.unavailable).toBeNull()
@@ -71,7 +71,7 @@ describe('useServiceResource', () => {
       useServiceResource('/api/svc/x/api/v1/items', { retryDelayMs: 5, maxWakeRetries: 2 }),
     )
     await waitFor(() => expect(result.current.loading).toBe(false))
-    expect(result.current.unavailable).toEqual({ kind: 'scaled_to_zero' })
+    expect(result.current.unavailable).toEqual({ kind: 'scaled_to_zero', status: 503 })
     // initial attempt + 2 retries
     expect(fetchMock).toHaveBeenCalledTimes(3)
   })
@@ -91,6 +91,14 @@ describe('useServiceResource', () => {
     await waitFor(() => expect(result.current.loading).toBe(false))
     expect(signal?.aborted).toBe(true)
     expect(result.current.unavailable).toEqual({ kind: 'unreachable' })
+  })
+
+  it('exposes HTTP status metadata without changing the shared failure classification', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonRes(403, { error: 'forbidden' })))
+    const { result } = renderHook(() => useServiceResource('/api/svc/x/api/v1/items'))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.unavailable).toEqual({ kind: 'error', status: 403 })
   })
 
   it('does nothing when url is null', async () => {


### PR DESCRIPTION
## Summary

Keep the last successful interest snapshot visible and explicitly stale after an ordinary refresh failure, while treating authorization loss as non-retainable. Add truthful recovery controls and prevent stale privileged rows from reappearing during 401/403 retries.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #8091

## Changes

- Preserve rows and statistics after a settled non-auth refresh failure with a prominent stale notice and local last-success time.
- Distinguish initial hard failure from stale-data recovery and remove fake zero statistics.
- Keep 401/403 access blocking sticky through delayed retries; release only after a newly committed successful snapshot.
- Suppress the service-outage badge for access failures so a responding service is not called down.
- Harden useServiceResource terminal status metadata and single-flight release without changing global BFF classification.
- Add regressions for initial failure, stale recovery, wake retry, delayed 401/403, instant success, and a subsequent fourth refresh.

## Definition of Done

- [x] Hexagonal layering preserved; no backend or domain code changed.
- [x] Unit tests added/updated: exact focused suite 25/25.
- [x] Integration tests N/A; BFF and service contracts are unchanged.
- [x] Contract tests N/A; no public API changed.
- [x] Canonical Admin UI type-check passes.
- [x] Changed-file ESLint passes with zero warnings and diff-check is clean.
- [x] Production route build N/A; no App Router export or route boundary changed.
- [x] OpenAPI, Flyway, event schemas, and architecture docs N/A.

## Security checklist

- [x] No secrets, tokens, passwords, or real PII in code, config, tests, or logs.
- [x] No new suppressions or unsafe casts.
- [x] No new third-party dependency.
- [x] Existing session forwarding, BFF classification, interest:view permission, and backend read roles are unchanged.
- [x] Security and GDPR review requested because retained financial data is hidden after access loss.

## Compliance impact

- [x] GDPR

The patch reduces exposure: a previously loaded financial snapshot cannot reappear while authorization is unresolved. It adds no fields, roles, storage, exports, or logging.

## Rollout / Rollback

- Deployment strategy: rolling with the normal Admin UI release.
- Rollback plan: revert this single commit to restore the previous hard-error rendering.
- Data migration reversible: N/A

## Screenshots / demo

Not attached; states are covered by focused render and hook tests.

## Reviewer notes

Review sticky 401/403 semantics across Retry, the local-only 403 handling, waking-state live regions, and the terminal single-flight release. Shared BFF classifiers and generic unavailable components are intentionally unchanged.