### PR TITLE
fix(admin-ui): refuse healthy unavailable test evidence

### DIFF
--- a/openbank-admin-ui/e2e/test-intelligence.spec.ts
+++ b/openbank-admin-ui/e2e/test-intelligence.spec.ts
@@ -105,6 +105,34 @@ test('renders the animated evidence system and consolidates test dimensions', as
   await expect(page.getByText(/AI AGENT/)).toBeVisible()
 })
 
+test('never paints an unavailable evidence bundle healthy', async ({ page }) => {
+  await page.unroute('**/api/test-intelligence')
+  await page.route('**/api/test-intelligence', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      schemaVersion: 1,
+      collectedAt: '1970-01-01T00:00:00.000Z',
+      components: [], contracts: [], mutations: [], performance: [], performanceHistory: [],
+      syntheticJourneys: [], clientExperiences: [], history: [], runHistory: [], testCases: [],
+      totals: {
+        components: 0, componentsWithExecutionEvidence: 0, moneyPathComponents: 0,
+        failingEvidence: 0, missingEvidence: 0, staleEvidence: 0,
+      },
+      warnings: ['test-intelligence.json is not bundled'],
+    }),
+  }))
+
+  await page.goto('/system/tests')
+
+  await expect(page.locator('.ti-health')).toContainText(/NEEDS ATTENTION\s*1\s*signal to inspect/)
+  await expect(page.getByText('EVIDENCE HEALTHY', { exact: true })).not.toBeVisible()
+  const assurance = page.getByRole('region', { name: 'Testing assurance map' })
+  await expect(assurance.getByRole('button', { name: /CI evidence/ })).toContainText('unknown')
+  await expect(assurance.getByRole('button', { name: /Testcontainers runtime/ })).toContainText('unknown')
+  await expect(assurance).not.toContainText('passed')
+})
+
 test('keeps the evidence flow usable at the mobile breakpoint', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 })
   await page.goto('/system/tests')

--- a/openbank-admin-ui/src/app/system/tests/page.tsx
+++ b/openbank-admin-ui/src/app/system/tests/page.tsx
@@ -14,7 +14,9 @@ import { filterTestCases, type TestTriageFilter } from '@/lib/test-intelligence-
 import type {
   ComponentTestPosture, EvidenceKind, EvidenceState, TestIntelligenceReport,
 } from '@/lib/types/test-intelligence'
-import { TestIntelligenceFlow } from '@/components/testing/TestIntelligenceFlow'
+import {
+  TestIntelligenceFlow, testIntelligenceCollectionUnavailable,
+} from '@/components/testing/TestIntelligenceFlow'
 import { TestAgentPanel } from '@/components/testing/TestAgentPanel'
 import { PageHeader, StatusBadge as SharedStatusBadge, TONE_TEXT_CLASS, type Tone } from '@/components/ui'
 
@@ -53,10 +55,11 @@ function Stat({ label, value, tone }: { label: string; value: number | string; t
  */
 function AssuranceBoard({ report, selectTab }: { report: TestIntelligenceReport; selectTab: (tab: Tab) => void }) {
   const { t } = useLanguage()
+  const collectionUnavailable = testIntelligenceCollectionUnavailable(report)
   const syntheticActive = report.syntheticJourneys.filter(item => item.status === 'active')
   const syntheticState = aggregateEvidenceState(syntheticActive.map(item => item.state))
   const runtimeRows = report.components.filter(component => component.testInfrastructure.declared.length > 0)
-  const runtimeState: EvidenceState = runtimeRows.some(component => {
+  const runtimeState: EvidenceState = collectionUnavailable ? 'unknown' : runtimeRows.length === 0 ? 'not-run' : runtimeRows.some(component => {
     const observed = component.testInfrastructure.observed
     return observed.filter(item => item.lifecycle === 'stopped').length < observed.filter(item => item.lifecycle === 'started').length
   }) ? 'unknown' : runtimeRows.some(component => component.testInfrastructure.observed.length === 0) ? 'unknown' : 'passed'
@@ -65,7 +68,8 @@ function AssuranceBoard({ report, selectTab }: { report: TestIntelligenceReport;
     clientEvidence.flatMap(client => [...client.evidence.map(item => item.state), client.rum.state]),
     'not-run',
   )
-  const ciState: EvidenceState = report.totals.failingEvidence > 0 ? 'failed'
+  const ciState: EvidenceState = collectionUnavailable ? 'unknown'
+    : report.totals.failingEvidence > 0 ? 'failed'
     : (report.totals.unresolvedEvidence ?? report.totals.unknownEvidence ?? 0) > 0 ? 'unknown'
       : report.totals.missingEvidence > 0 || report.totals.staleEvidence > 0 ? 'stale' : 'passed'
   const cards: { tab: Tab; title: string; eyebrow: string; state: EvidenceState; detail: string }[] = [

--- a/openbank-admin-ui/src/components/testing/TestIntelligenceFlow.tsx
+++ b/openbank-admin-ui/src/components/testing/TestIntelligenceFlow.tsx
@@ -25,6 +25,18 @@ type Stage = {
   tone: string
 }
 
+export function testIntelligenceCollectionUnavailable(
+  report?: Pick<TestIntelligenceReport, 'totals'> | null,
+): boolean {
+  return Boolean(report && report.totals.components === 0)
+}
+
+export function testIntelligenceCollectionNeedsAttention(
+  report?: Pick<TestIntelligenceReport, 'totals' | 'warnings'> | null,
+): boolean {
+  return testIntelligenceCollectionUnavailable(report) || Boolean(report?.warnings.length)
+}
+
 export function TestIntelligenceFlow({ report }: { report?: TestIntelligenceReport | null }) {
   const { t } = useLanguage()
   const [selected, setSelected] = useState<StageId>('prove')
@@ -95,7 +107,8 @@ export function TestIntelligenceFlow({ report }: { report?: TestIntelligenceRepo
   const crossLayerAttention = (report?.performance ?? []).filter(item => item.state !== 'passed' || item.plan?.blocker).length
     + (report?.syntheticJourneys ?? []).filter(item => item.status === 'planned' || item.state !== 'passed').length
     + (report?.clientExperiences ?? []).reduce((sum, client) => sum + (client.rum.platforms?.filter(platform => platform.runtime !== 'passed').length ?? 0), 0)
-  const attention = componentAttention + crossLayerAttention
+  const collectionAttention = testIntelligenceCollectionNeedsAttention(report) ? 1 : 0
+  const attention = componentAttention + crossLayerAttention + collectionAttention
   const activeJourneys = report?.syntheticJourneys.filter(item => item.status === 'active').length ?? 0
   const runtimeProofs = report?.components.reduce((sum, component) => sum + component.testInfrastructure.observed.filter(event => event.lifecycle === 'started').length, 0) ?? 0
   const traceProofs = report?.components.filter(component => component.evidence.some(evidence => evidence.kind === 'trace' && evidence.state === 'passed')).length ?? 0
@@ -112,7 +125,9 @@ export function TestIntelligenceFlow({ report }: { report?: TestIntelligenceRepo
       </div>
       <div className={`ti-health ${attention ? 'attention' : ''}`}><i />
         <span>{report ? (attention ? t('VYŽADUJE POZORNOST', 'NEEDS ATTENTION') : t('DŮKAZY ZDRAVÉ', 'EVIDENCE HEALTHY')) : t('ČEKÁM NA DATA', 'AWAITING DATA')}</span>
-        <strong>{report ? `${attention}` : '—'}</strong><small>{t('signálů k prověření', 'signals to inspect')}</small>
+        <strong>{report ? `${attention}` : '—'}</strong><small>{attention === 1
+          ? t('signál k prověření', 'signal to inspect')
+          : t('signálů k prověření', 'signals to inspect')}</small>
       </div>
     </header>
 

--- a/openbank-admin-ui/src/test/test-intelligence-flow-attention.test.tsx
+++ b/openbank-admin-ui/src/test/test-intelligence-flow-attention.test.tsx
@@ -3,42 +3,114 @@
 
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
-import { TestIntelligenceFlow } from '@/components/testing/TestIntelligenceFlow'
-import type { TestIntelligenceReport } from '@/lib/types/test-intelligence'
+import {
+  TestIntelligenceFlow, testIntelligenceCollectionNeedsAttention,
+  testIntelligenceCollectionUnavailable,
+} from '@/components/testing/TestIntelligenceFlow'
+import type { ComponentTestPosture, TestIntelligenceReport } from '@/lib/types/test-intelligence'
 
 vi.mock('@/lib/i18n/LanguageContext', () => ({
   useLanguage: () => ({ language: 'en', t: (_cs: string, en: string) => en }),
 }))
 
+const healthyComponent: ComponentTestPosture = {
+  component: 'openbank-example-service',
+  released: true,
+  moneyPath: false,
+  evidence: [{
+    kind: 'unit', state: 'passed', observedAt: '2026-09-01T00:00:00.000Z',
+    source: 'JUnit:example', environment: 'ci',
+  }],
+  coverage: {
+    state: 'passed', observedAt: '2026-09-01T00:00:00.000Z', source: 'kover.xml',
+    lines: { covered: 1, missed: 0, percentage: 100 },
+    branches: { covered: 1, missed: 0, percentage: 100 },
+  },
+  testInfrastructure: { declared: [], observed: [] },
+}
+
+function reportFixture({
+  componentCount = 1,
+  warnings = [],
+  totals = {},
+  syntheticJourneys = [],
+}: {
+  componentCount?: number
+  warnings?: string[]
+  totals?: Partial<TestIntelligenceReport['totals']>
+  syntheticJourneys?: TestIntelligenceReport['syntheticJourneys']
+} = {}): TestIntelligenceReport {
+  return {
+    schemaVersion: 1,
+    collectedAt: '2026-09-01T00:00:00.000Z',
+    components: componentCount === 0 ? [] : [healthyComponent],
+    contracts: [], mutations: [], performance: [], performanceHistory: [],
+    syntheticJourneys, clientExperiences: [], history: [], runHistory: [], testCases: [],
+    totals: {
+      components: componentCount, componentsWithExecutionEvidence: componentCount,
+      moneyPathComponents: 0, failingEvidence: 0, missingEvidence: 0, staleEvidence: 0,
+      ...totals,
+    },
+    warnings,
+  }
+}
+
 describe('Test Intelligence flow attention', () => {
-  it('never paints unresolved evidence healthy', () => {
-    const report = {
-      components: [], syntheticJourneys: [], clientExperiences: [],
-      totals: {
-        components: 0, componentsWithExecutionEvidence: 0, moneyPathComponents: 0,
-        failingEvidence: 0, missingEvidence: 0, staleEvidence: 0,
-        unknownEvidence: 1, unresolvedEvidence: 1,
-      },
-    } as TestIntelligenceReport
+  it('classifies zero inventory as unavailable without relying on a warning', () => {
+    const report = reportFixture({ componentCount: 0 })
+
+    expect(testIntelligenceCollectionUnavailable(report)).toBe(true)
+    expect(testIntelligenceCollectionNeedsAttention(report)).toBe(true)
+  })
+
+  it('classifies a collector warning as attention without relying on zero inventory', () => {
+    const report = reportFixture({ warnings: ['Tempo projection unavailable'] })
+
+    expect(testIntelligenceCollectionUnavailable(report)).toBe(false)
+    expect(testIntelligenceCollectionNeedsAttention(report)).toBe(true)
+  })
+
+  it('leaves a populated warning-free collection clear', () => {
+    const report = reportFixture()
+
+    expect(testIntelligenceCollectionUnavailable(report)).toBe(false)
+    expect(testIntelligenceCollectionNeedsAttention(report)).toBe(false)
+  })
+
+  it('never paints the real unavailable-report shape healthy', () => {
+    const report = reportFixture({
+      componentCount: 0,
+      warnings: ['test-intelligence.json is not bundled'],
+    })
 
     render(<TestIntelligenceFlow report={report} />)
 
-    expect(screen.getByText('NEEDS ATTENTION')).toBeVisible()
-    expect(screen.getByText('signals to inspect')).toBeVisible()
+    const health = screen.getByText('NEEDS ATTENTION').closest('.ti-health')
+    expect(health).toHaveTextContent(/NEEDS ATTENTION\s*1\s*signal to inspect/)
+    expect(screen.queryByText('EVIDENCE HEALTHY')).not.toBeInTheDocument()
+  })
+
+  it('never paints unresolved evidence healthy', () => {
+    const report = reportFixture({
+      totals: { unknownEvidence: 1, unresolvedEvidence: 1 },
+    })
+
+    render(<TestIntelligenceFlow report={report} />)
+
+    const health = screen.getByText('NEEDS ATTENTION').closest('.ti-health')
+    expect(health).toHaveTextContent(/NEEDS ATTENTION\s*1\s*signal to inspect/)
   })
 
   it('does not hide a declared but unexecuted synthetic journey behind green component totals', () => {
-    const report = {
-      components: [], performance: [], clientExperiences: [],
-      syntheticJourneys: [{ id: 'admin-operator-access', title: 'Admin access', status: 'planned', state: 'blocked' }],
-      totals: {
-        components: 0, componentsWithExecutionEvidence: 0, moneyPathComponents: 0,
-        failingEvidence: 0, missingEvidence: 0, staleEvidence: 0,
-      },
-    } as TestIntelligenceReport
+    const report = reportFixture({
+      syntheticJourneys: [{
+        id: 'admin-operator-access', title: 'Admin access', status: 'planned', state: 'blocked',
+      }] as TestIntelligenceReport['syntheticJourneys'],
+    })
 
     render(<TestIntelligenceFlow report={report} />)
 
-    expect(screen.getByText('NEEDS ATTENTION')).toBeVisible()
+    const health = screen.getByText('NEEDS ATTENTION').closest('.ti-health')
+    expect(health).toHaveTextContent(/NEEDS ATTENTION\s*1\s*signal to inspect/)
   })
 })


### PR DESCRIPTION
## Summary

- treat zero-inventory and warning-bearing Test Intelligence collections as operator attention instead of `EVIDENCE HEALTHY`
- make CI and Testcontainers assurance fail closed when the report-shaped unavailable fallback has no inventory
- keep warning-only and zero-inventory classification independently testable, and use the correct singular signal label
- exercise the real `/system/tests` page so an unavailable bundle cannot leave any assurance card in `passed`

## Verification

- `npm test -- --reporter=dot`: 412/412 files; 2,120 passed; 1 explicit skip; 0 failures
- `OPENBANK_E2E_PORT=41833 playwright test e2e/test-intelligence.spec.ts --project=chromium --workers=1`: 6/6 passed (matrix, unavailable fallback, mobile, WCAG, reduced motion, navigation)
- focused route + flow Vitest: 19/19 passed
- ESLint and TypeScript checks passed
- production Next.js build passed; 91/91 pages generated
- `test-intelligence-ecosystem` self-test, direct check and enforced gate passed (`SUBJECTS=60`)
- independent local diff review found no P1/P2 issue

Refs #6613
