### PR TITLE
fix(admin-ui): honor notification page contract

### DIFF
--- a/openbank-admin-ui/e2e/notification-log-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/notification-log-recovery.spec.ts
@@ -7,7 +7,7 @@ import { signInAsOperator } from './helpers/auth'
 
 const NOTIFICATION = {
   id: 'notification-42',
-  type: 'EMAIL',
+  template: 'PAYMENT_COMPLETED',
   channel: 'EMAIL',
   recipient: 'customer-42@example.test',
   subject: 'Payment received',
@@ -16,19 +16,33 @@ const NOTIFICATION = {
   createdAt: '2026-08-31T08:00:00Z',
 }
 
+const RECOVERED_NOTIFICATION = {
+  ...NOTIFICATION,
+  recipient: 'customer-42-recovered@example.test',
+  subject: 'Payment notification recovered',
+  sentAt: '2026-08-31T08:02:00Z',
+}
+
 test.beforeEach(async ({ context, baseURL }) => {
   await signInAsOperator(context, baseURL!)
 })
 
 test('keeps the last notification log during an outage and recovers', async ({ page }) => {
   let available = true
+  let currentNotification = NOTIFICATION
   let requests = 0
-  await page.route('**/api/svc/notification-service/api/v1/notifications', route => {
+  const requestedPages: string[] = []
+  await page.route(url => url.pathname === '/api/svc/notification-service/api/v1/notifications', route => {
     requests += 1
+    const requestUrl = new URL(route.request().url())
+    requestedPages.push(`${requestUrl.searchParams.get('page')}:${requestUrl.searchParams.get('size')}`)
     if (!available) {
       return route.fulfill({ status: 503, contentType: 'application/json', body: '{"error":"unavailable"}' })
     }
-    return route.fulfill({ contentType: 'application/json', body: JSON.stringify([NOTIFICATION]) })
+    return route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [currentNotification], total: 1, page: 0, size: 20 }),
+    })
   })
 
   await page.goto('/notifications')
@@ -42,8 +56,11 @@ test('keeps the last notification log during an outage and recovers', async ({ p
   await expect(page.getByText(/Žádné notifikace nenalezeny|No notifications found/)).toHaveCount(0)
 
   available = true
+  currentNotification = RECOVERED_NOTIFICATION
   await page.getByRole('button', { name: /Obnovit oznámení|Refresh notifications/ }).click()
   await expect(page.getByText(/stav doručení se mohl změnit|delivery status may have changed/)).toBeHidden()
-  await expect(page.getByText(NOTIFICATION.recipient, { exact: true })).toBeVisible()
+  await expect(page.getByText(RECOVERED_NOTIFICATION.recipient, { exact: true })).toBeVisible()
+  await expect(page.getByText(NOTIFICATION.recipient, { exact: true })).toHaveCount(0)
   expect(requests).toBeGreaterThanOrEqual(3)
+  expect(requestedPages).toEqual(Array(requests).fill('0:20'))
 })

--- a/openbank-admin-ui/src/app/notifications/page.tsx
+++ b/openbank-admin-ui/src/app/notifications/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { Bell, RefreshCw, Mail, AlertTriangle, CheckCircle2, Info, Clock, Check, X } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { useAuth } from '@/lib/auth/useAuth'
@@ -19,14 +19,64 @@ import { readApprovalId } from '@/lib/approvals/triage'
 const NOTIFICATION_SERVICE = '/api/svc/notification-service'
 
 interface Notification {
-  id: string; type: string; channel: string; recipient: string
-  subject?: string; status: string; sentAt?: string; createdAt: string
-  payload?: Record<string, unknown>
+  id: string; template: string; channel: string; recipient: string
+  subject?: string | null; status: string; sentAt?: string | null; createdAt: string
 }
 
-const TYPE_ICON: Record<string, React.ElementType> = {
-  EMAIL: Mail, ALERT: AlertTriangle, SUCCESS: CheckCircle2, INFO: Info,
+interface NotificationPage {
+  items: Notification[]
+  total: number
+  page: number
+  size: number
 }
+
+const PAGE_SIZE = 20
+
+const TEMPLATE_ICON: Record<string, React.ElementType> = {
+  ACCOUNT_OPENED: CheckCircle2,
+  TRANSACTION_COMPLETED: CheckCircle2,
+  KYC_APPROVED: CheckCircle2,
+  TRANSACTION_FAILED: AlertTriangle,
+  KYC_REJECTED: AlertTriangle,
+  ACCOUNT_FROZEN: AlertTriangle,
+  GENERIC_NOTICE: Info,
+  SUPPORT_FOLLOWUP: Mail,
+}
+
+interface NotificationsUnavailable {
+  kind: UnavailableKind
+  forbidden?: boolean
+}
+
+function isNotificationPage(value: unknown): value is NotificationPage {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<NotificationPage>
+  if (!Array.isArray(candidate.items)
+    || typeof candidate.total !== 'number'
+    || !Number.isInteger(candidate.total)
+    || candidate.total < 0
+    || typeof candidate.page !== 'number'
+    || !Number.isInteger(candidate.page)
+    || candidate.page < 0
+    || typeof candidate.size !== 'number'
+    || !Number.isInteger(candidate.size)
+    || candidate.size <= 0
+    || candidate.items.length > candidate.size
+    || (candidate.items.length > 0
+      && candidate.page * candidate.size + candidate.items.length > candidate.total)) return false
+
+  return candidate.items.every(item => Boolean(item)
+      && typeof item === 'object'
+      && typeof item.id === 'string'
+      && typeof item.template === 'string'
+      && typeof item.channel === 'string'
+      && typeof item.recipient === 'string'
+      && (item.subject == null || typeof item.subject === 'string')
+      && typeof item.status === 'string'
+      && (item.sentAt == null || typeof item.sentAt === 'string')
+      && typeof item.createdAt === 'string')
+}
+
 function NotificationsContent() {
   const { t, language } = useLanguage()
   const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
@@ -34,34 +84,125 @@ function NotificationsContent() {
   const canApprove = hasPermission(roles, 'opsmessage:approve')
   const [items, setItems]     = useState<Notification[]>([])
   const [loading, setLoading] = useState(true)
+  const [page, setPage] = useState(0)
+  const [pagination, setPagination] = useState<{ total: number; page: number; size: number } | null>(null)
+  const requestSequenceRef = useRef(0)
+  const activeRequestRef = useRef<AbortController | null>(null)
   // Typed unavailable reason → renders the calm <DataUnavailable> panel instead
   // of leaking a raw "HTTP 404" string (admin-ui graceful-state rule).
-  const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
+  const [unavailable, setUnavailable] = useState<NotificationsUnavailable | null>(null)
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (requestedPage: number) => {
+    const requestSequence = ++requestSequenceRef.current
+    activeRequestRef.current?.abort()
+    const controller = new AbortController()
+    activeRequestRef.current = controller
+    let timedOut = false
+    const timeout = window.setTimeout(() => {
+      timedOut = true
+      controller.abort()
+    }, 5000)
+
     setLoading(true); setUnavailable(null)
     try {
-      const res = await fetch(`${NOTIFICATION_SERVICE}/api/v1/notifications`, { signal: AbortSignal.timeout(5000) })
+      const res = await fetch(
+        `${NOTIFICATION_SERVICE}/api/v1/notifications?page=${requestedPage}&size=${PAGE_SIZE}`,
+        { signal: controller.signal },
+      )
+      if (requestSequence !== requestSequenceRef.current) return
       if (!res.ok) {
         const kind = await classifyBffFailure(res)
-        // A genuine 404/405 on the log endpoint means "no notifications yet",
-        // not a broken app — degrade to the calm empty state.
-        setUnavailable({ kind: res.status === 405 || kind === 'not_found' ? 'no_data' : kind })
+        if (requestSequence !== requestSequenceRef.current) return
+        const authRefused = res.status === 401 || res.status === 403
+        if (authRefused) {
+          // Notification recipients and subjects are protected operational data. Once the
+          // current session is refused, do not retain a previously authorized page in the DOM.
+          setItems([])
+          setPagination(null)
+        }
+        setUnavailable({
+          kind: res.status === 403 ? 'unauthorized' : kind === 'not_found' ? 'error' : kind,
+          forbidden: res.status === 403,
+        })
         return
       }
-      const data = await res.json()
-      setItems(Array.isArray(data) ? data : data.items ?? [])
+      let data: unknown
+      try {
+        data = await res.json()
+      } catch {
+        if (requestSequence !== requestSequenceRef.current) return
+        if (controller.signal.aborted) {
+          if (timedOut) setUnavailable({ kind: 'unreachable' })
+          return
+        }
+        setUnavailable({ kind: 'error' })
+        return
+      }
+      if (requestSequence !== requestSequenceRef.current) return
+      if (!isNotificationPage(data)) {
+        setUnavailable({ kind: 'error' })
+        return
+      }
+      if (data.page !== requestedPage || data.size !== PAGE_SIZE) {
+        setUnavailable({ kind: 'error' })
+        return
+      }
+
+      const lastPage = data.total === 0 ? 0 : Math.floor((data.total - 1) / data.size)
+      if (requestedPage > lastPage) {
+        setPage(lastPage)
+        return
+      }
+      // Count and page reads are separate backend statements. A concurrent delete can leave an
+      // otherwise in-range non-zero page empty; walk back once and obtain an authoritative page.
+      if (data.total > 0 && data.items.length === 0) {
+        if (requestedPage > 0) setPage(requestedPage - 1)
+        else setUnavailable({ kind: 'error' })
+        return
+      }
+
+      setItems(data.items)
+      setPagination({ total: data.total, page: data.page, size: data.size })
     } catch {
-      // Timeout / abort / network — the BFF or notification-service didn't answer.
+      if (requestSequence !== requestSequenceRef.current) return
+      // An effect cleanup or newer request deliberately aborts this read. Only a real
+      // timeout/network failure should replace the last successful page with an error panel.
+      if (controller.signal.aborted && !timedOut) return
       setUnavailable({ kind: 'unreachable' })
-    } finally { setLoading(false) }
+    } finally {
+      window.clearTimeout(timeout)
+      if (requestSequence === requestSequenceRef.current) {
+        activeRequestRef.current = null
+        setLoading(false)
+      }
+    }
   }, [])
 
-  useEffect(() => { load() }, [load])
+  useEffect(() => {
+    void load(page)
+    return () => {
+      requestSequenceRef.current += 1
+      activeRequestRef.current?.abort()
+    }
+  }, [load, page])
+
+  const refresh = useCallback(() => {
+    if (page === 0) void load(0)
+    else setPage(0)
+  }, [load, page])
 
   const sentCount   = items.filter(n => n.status === 'SENT').length
   const failedCount = items.filter(n => n.status === 'FAILED').length
   const pendingCount = items.filter(n => n.status === 'PENDING' || n.status === 'QUEUED').length
+  const rangeStart = !pagination || pagination.total === 0 || items.length === 0
+    ? 0
+    : pagination.page * pagination.size + 1
+  const rangeEnd = !pagination || pagination.total === 0 || items.length === 0
+    ? 0
+    : Math.min(pagination.page * pagination.size + items.length, pagination.total)
+  const hasNextPage = pagination
+    ? (pagination.page + 1) * pagination.size < pagination.total
+    : false
 
   return (
     <div>
@@ -73,7 +214,7 @@ function NotificationsContent() {
         actions={<button
           className="btn btn-secondary"
           type="button"
-          onClick={load}
+          onClick={refresh}
           disabled={loading}
           aria-busy={loading}
           aria-label={t('Obnovit oznámení', 'Refresh notifications')}
@@ -86,12 +227,12 @@ function NotificationsContent() {
       {/* Stats */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '12px', marginBottom: '20px' }}>
         {[
-          { label: t('Odesláno', 'Sent'), value: sentCount, color: 'var(--green)' },
-          { label: t('Selhalo', 'Failed'), value: failedCount, color: 'var(--red)' },
-          { label: t('Čeká / Ve frontě', 'Pending / Queued'), value: pendingCount, color: 'var(--yellow)' },
+          { label: t('Odesláno na této stránce', 'Sent on this page'), value: sentCount, color: 'var(--green)' },
+          { label: t('Selhalo na této stránce', 'Failed on this page'), value: failedCount, color: 'var(--red)' },
+          { label: t('Čeká / Ve frontě na této stránce', 'Pending / Queued on this page'), value: pendingCount, color: 'var(--yellow)' },
         ].map(s => (
           <div key={s.label} className="stat-card">
-            <div className="stat-value" style={{ color: s.color }}>{loading ? '—' : s.value}</div>
+            <div className="stat-value" style={{ color: s.color }}>{loading || !pagination ? '—' : s.value}</div>
             <div className="stat-label">{s.label}</div>
           </div>
         ))}
@@ -106,9 +247,15 @@ function NotificationsContent() {
             service={t('Notification-service', 'Notification-service')}
             feature={t('Notifikace', 'Notifications')}
             lang={language}
-            detail={items.length > 0
-              ? t('Zobrazen je poslední úspěšně načtený log; stav doručení se mohl změnit.', 'The last successfully loaded log is shown; delivery status may have changed.')
-              : undefined}
+            title={unavailable.forbidden ? t('Přístup odepřen', 'Access denied') : undefined}
+            detail={unavailable.forbidden
+              ? t(
+                'Jste přihlášeni, ale vaše role nemá oprávnění číst log oznámení. Požádejte správce o potřebný přístup.',
+                'You are signed in, but your role cannot read the notification log. Ask an administrator for the required access.',
+              )
+              : items.length > 0
+                ? t('Zobrazen je poslední úspěšně načtený log; stav doručení se mohl změnit.', 'The last successfully loaded log is shown; delivery status may have changed.')
+                : undefined}
             dense
           />
         </div>
@@ -118,7 +265,7 @@ function NotificationsContent() {
         <table className="data-table">
           <thead>
             <tr>
-              <th>{t('Typ', 'Type')}</th>
+              <th>{t('Šablona', 'Template')}</th>
               <th>{t('Kanál', 'Channel')}</th>
               <th>{t('Příjemce', 'Recipient')}</th>
               <th>{t('Předmět', 'Subject')}</th>
@@ -142,10 +289,10 @@ function NotificationsContent() {
               </td></tr>
             )}
             {!loading && items.map(n => {
-              const Icon = TYPE_ICON[n.type] ?? Bell
+              const Icon = TEMPLATE_ICON[n.template] ?? Bell
               return (
                 <tr key={n.id}>
-                  <td><div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}><Icon aria-hidden="true" size={13} style={{ color: 'var(--accent)' }} /><span className="tag">{n.type}</span></div></td>
+                  <td><div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}><Icon aria-hidden="true" size={13} style={{ color: 'var(--accent)' }} /><span className="tag">{n.template}</span></div></td>
                   <td><span className="tag">{n.channel}</span></td>
                   <td style={{ fontSize: '12px', fontFamily: 'var(--font-mono)' }}>{n.recipient}</td>
                   <td style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>{n.subject ?? '—'}</td>
@@ -158,6 +305,37 @@ function NotificationsContent() {
             })}
           </tbody>
         </table>
+        {pagination && pagination.total > 0 && !unavailable && (
+          <nav
+            aria-label={t('Stránkování oznámení', 'Notifications pagination')}
+            style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '12px', padding: '12px 16px', borderTop: '1px solid var(--border)' }}
+          >
+            <button
+              className="btn btn-secondary"
+              type="button"
+              aria-label={t('Předchozí stránka oznámení', 'Previous notifications page')}
+              disabled={page === 0}
+              onClick={() => setPage(current => Math.max(0, current - 1))}
+            >
+              {t('← Předchozí', '← Previous')}
+            </button>
+            <span role="status" aria-live="polite" style={{ fontSize: '12px', color: 'var(--text-muted)' }}>
+              {t(
+                `Zobrazeno ${rangeStart}–${rangeEnd} z ${pagination.total} oznámení`,
+                `Showing ${rangeStart}–${rangeEnd} of ${pagination.total} ${pagination.total === 1 ? 'notification' : 'notifications'}`,
+              )}
+            </span>
+            <button
+              className="btn btn-secondary"
+              type="button"
+              aria-label={t('Další stránka oznámení', 'Next notifications page')}
+              disabled={loading || !hasNextPage}
+              onClick={() => setPage(current => current + 1)}
+            >
+              {t('Další →', 'Next →')}
+            </button>
+          </nav>
+        )}
       </div>
     </div>
   )

--- a/openbank-admin-ui/src/test/notifications-pagination.test.tsx
+++ b/openbank-admin-ui/src/test/notifications-pagination.test.tsx
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import NotificationsPage from '@/app/notifications/page'
+
+vi.mock('@/components/auth/AuthGuard', () => ({
+  AuthGuard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+const authState = vi.hoisted(() => ({ roles: [] as string[] }))
+
+vi.mock('@/lib/auth/useAuth', () => ({
+  useAuth: () => ({ roles: authState.roles }),
+}))
+
+type NotificationPage = {
+  items: Array<Record<string, unknown>>
+  total: number
+  page: number
+  size: number
+}
+
+function item(index: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id: `notification-${index}`,
+    partyId: '10000000-0000-0000-0000-000000000001',
+    channel: 'EMAIL',
+    template: 'PAYMENT_COMPLETED',
+    recipient: `recipient-${index}`,
+    subject: `Message ${index}`,
+    status: index <= 10 ? 'SENT' : index <= 15 ? 'FAILED' : 'PENDING',
+    sentAt: index <= 10 ? '2026-09-01T10:00:00Z' : null,
+    readAt: null,
+    createdAt: '2026-09-01T09:00:00Z',
+    ...overrides,
+  }
+}
+
+function page(items: Array<Record<string, unknown>>, total: number, pageIndex: number): NotificationPage {
+  return { items, total, page: pageIndex, size: 20 }
+}
+
+function response(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(done => { resolve = done })
+  return { promise, resolve }
+}
+
+function renderPage() {
+  return render(
+    React.createElement(LanguageProvider, null, React.createElement(NotificationsPage)),
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  authState.roles = []
+  window.history.replaceState(null, '', '/notifications')
+  vi.unstubAllGlobals()
+})
+
+describe('Notifications contract pagination', () => {
+  it('renders the documented template and authoritative range, then requests the next page', async () => {
+    const firstItems = Array.from({ length: 20 }, (_, index) => item(index + 1))
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response(page(firstItems, 21, 0)))
+      .mockResolvedValueOnce(response(page([item(21, { template: 'ACCOUNT_OPENED' })], 21, 1)))
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+
+    await screen.findByText('Message 1')
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      '/api/svc/notification-service/api/v1/notifications?page=0&size=20',
+    )
+    expect(screen.getAllByText('PAYMENT_COMPLETED')).toHaveLength(20)
+    expect(screen.getByText('Showing 1–20 of 21 notifications')).toBeInTheDocument()
+    expect(screen.getByText('Sent on this page').parentElement).toHaveTextContent('10')
+    expect(screen.getByRole('button', { name: 'Previous notifications page' })).toBeDisabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next notifications page' }))
+
+    await screen.findByText('Message 21')
+    expect(String(fetchMock.mock.calls[1]?.[0])).toBe(
+      '/api/svc/notification-service/api/v1/notifications?page=1&size=20',
+    )
+    expect(screen.getByText('ACCOUNT_OPENED')).toBeInTheDocument()
+    expect(screen.getByText('Showing 21–21 of 21 notifications')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Next notifications page' })).toBeDisabled()
+  })
+
+  it('resets an operator refresh to the first page', async () => {
+    const firstItems = Array.from({ length: 20 }, (_, index) => item(index + 1))
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response(page(firstItems, 21, 0)))
+      .mockResolvedValueOnce(response(page([item(21)], 21, 1)))
+      .mockResolvedValueOnce(response(page([item(1, { subject: 'Refreshed first message' })], 1, 0)))
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await screen.findByText('Message 1')
+    fireEvent.click(screen.getByRole('button', { name: 'Next notifications page' }))
+    await screen.findByText('Message 21')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh notifications' }))
+
+    await screen.findByText('Refreshed first message')
+    expect(String(fetchMock.mock.calls[2]?.[0])).toBe(
+      '/api/svc/notification-service/api/v1/notifications?page=0&size=20',
+    )
+    expect(screen.getByText('Showing 1–1 of 1 notification')).toBeInTheDocument()
+  })
+
+  it('aborts and ignores a superseded next-page response', async () => {
+    const firstItems = Array.from({ length: 20 }, (_, index) => item(index + 1))
+    const lateSecondPage = deferred<Response>()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response(page(firstItems, 21, 0)))
+      .mockReturnValueOnce(lateSecondPage.promise)
+      .mockResolvedValueOnce(response(page([item(1, { subject: 'Current first page' })], 1, 0)))
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await screen.findByText('Message 1')
+    fireEvent.click(screen.getByRole('button', { name: 'Next notifications page' }))
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    const supersededSignal = (fetchMock.mock.calls[1]?.[1] as RequestInit | undefined)?.signal
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous notifications page' }))
+
+    await screen.findByText('Current first page')
+    expect(supersededSignal?.aborted).toBe(true)
+    const staleBody = vi.fn().mockResolvedValue(page([item(21, { subject: 'Late stale page' })], 21, 1))
+    await act(async () => {
+      lateSecondPage.resolve({ ok: true, status: 200, json: staleBody } as Response)
+      await lateSecondPage.promise
+      await new Promise(resolve => window.setTimeout(resolve, 0))
+    })
+    expect(staleBody).not.toHaveBeenCalled()
+    expect(screen.queryByText('Late stale page')).not.toBeInTheDocument()
+    expect(screen.getByText('Current first page')).toBeInTheDocument()
+  })
+
+  it('ignores a superseded response whose JSON body resolves after navigation', async () => {
+    const firstItems = Array.from({ length: 20 }, (_, index) => item(index + 1))
+    const lateBody = deferred<NotificationPage>()
+    const readLateBody = vi.fn(() => lateBody.promise)
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response(page(firstItems, 21, 0)))
+      .mockResolvedValueOnce({ ok: true, status: 200, json: readLateBody } as Response)
+      .mockResolvedValueOnce(response(page([item(1, { subject: 'Body-race winner' })], 1, 0)))
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await screen.findByText('Message 1')
+    fireEvent.click(screen.getByRole('button', { name: 'Next notifications page' }))
+    await waitFor(() => expect(readLateBody).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous notifications page' }))
+    expect(await screen.findByText('Body-race winner')).toBeInTheDocument()
+
+    await act(async () => {
+      lateBody.resolve(page([item(21, { subject: 'Late parsed body' })], 21, 1))
+      await lateBody.promise
+      await new Promise(resolve => window.setTimeout(resolve, 0))
+    })
+    expect(screen.queryByText('Late parsed body')).not.toBeInTheDocument()
+    expect(screen.getByText('Body-race winner')).toBeInTheDocument()
+  })
+
+  it('returns to the last valid page when the total shrinks', async () => {
+    const firstItems = Array.from({ length: 20 }, (_, index) => item(index + 1))
+    const shrunkenItems = Array.from({ length: 5 }, (_, index) => item(index + 1))
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response(page(firstItems, 21, 0)))
+      .mockResolvedValueOnce(response(page([], 5, 1)))
+      .mockResolvedValueOnce(response(page(shrunkenItems, 5, 0)))
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await screen.findByText('Message 1')
+    fireEvent.click(screen.getByRole('button', { name: 'Next notifications page' }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    expect(String(fetchMock.mock.calls[2]?.[0])).toContain('page=0&size=20')
+    expect(await screen.findByText('Showing 1–5 of 5 notifications')).toBeInTheDocument()
+  })
+
+  it('walks back from an empty in-range page produced by a concurrent total change', async () => {
+    const firstItems = Array.from({ length: 20 }, (_, index) => item(index + 1))
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response(page(firstItems, 21, 0)))
+      .mockResolvedValueOnce(response(page([], 21, 1)))
+      .mockResolvedValueOnce(response(page([item(1, { subject: 'Stable first page' })], 1, 0)))
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await screen.findByText('Message 1')
+    fireEvent.click(screen.getByRole('button', { name: 'Next notifications page' }))
+
+    expect(await screen.findByText('Stable first page')).toBeInTheDocument()
+    expect(String(fetchMock.mock.calls[2]?.[0])).toContain('page=0&size=20')
+    expect(screen.getByText('Showing 1–1 of 1 notification')).toBeInTheDocument()
+  })
+
+  it('keeps an approval deep link while starting the notification log on page zero', async () => {
+    authState.roles = ['ROLE_OPERATOR']
+    window.history.replaceState(null, '', '/notifications?approvalId=approval%2Fone#notification-approval-id')
+    const fetchMock = vi.fn().mockResolvedValueOnce(response(page([], 0, 0)))
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+
+    expect(await screen.findByDisplayValue('approval/one')).toHaveAttribute('id', 'notification-approval-id')
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain('page=0&size=20')
+  })
+
+  it('renders an expired-session state for a 401 response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response({ error: 'unauthorized' }, 401)))
+
+    renderPage()
+
+    expect(await screen.findByText('Session expired')).toBeInTheDocument()
+    expect(screen.queryByText('Access denied')).not.toBeInTheDocument()
+    expect(screen.queryByText(/No data yet/)).not.toBeInTheDocument()
+  })
+
+  it('renders access denied without telling an authenticated operator to sign in again', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response({ error: 'forbidden' }, 403)))
+
+    renderPage()
+
+    expect(await screen.findByText('Access denied')).toBeInTheDocument()
+    expect(screen.getByText(/You are signed in, but your role cannot read/)).toBeInTheDocument()
+    expect(screen.queryByText('Session expired')).not.toBeInTheDocument()
+    expect(screen.queryByText(/No data yet/)).not.toBeInTheDocument()
+    expect(screen.queryByRole('navigation', { name: 'Notifications pagination' })).not.toBeInTheDocument()
+  })
+
+  it.each([
+    { status: 401, title: 'Session expired' },
+    { status: 403, title: 'Access denied' },
+  ])('removes protected cached rows when a refresh is refused with $status', async ({ status, title }) => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response(page([item(1, { subject: 'Protected subject' })], 1, 0)))
+      .mockResolvedValueOnce(response({ error: 'refused' }, status))
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    expect(await screen.findByText('Protected subject')).toBeInTheDocument()
+    expect(screen.getByText('recipient-1')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh notifications' }))
+
+    expect(await screen.findByText(title)).toBeInTheDocument()
+    expect(screen.queryByText('Protected subject')).not.toBeInTheDocument()
+    expect(screen.queryByText('recipient-1')).not.toBeInTheDocument()
+    expect(screen.getByText('Sent on this page').parentElement).toHaveTextContent('—')
+  })
+
+  it('keeps the committed page but hides stale navigation after a page request fails', async () => {
+    const firstItems = Array.from({ length: 20 }, (_, index) => item(index + 1))
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response(page(firstItems, 21, 0)))
+      .mockResolvedValueOnce(response({ error: 'failed' }, 500))
+      .mockResolvedValueOnce(response(page([item(1, { subject: 'Recovered first page' })], 1, 0)))
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await screen.findByText('Message 1')
+    fireEvent.click(screen.getByRole('button', { name: 'Next notifications page' }))
+
+    expect(await screen.findByText('Failed to load: Notifications')).toBeInTheDocument()
+    expect(screen.getByText('Message 1')).toBeInTheDocument()
+    expect(screen.queryByRole('navigation', { name: 'Notifications pagination' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh notifications' }))
+    expect(await screen.findByText('Recovered first page')).toBeInTheDocument()
+    expect(String(fetchMock.mock.calls[2]?.[0])).toContain('page=0&size=20')
+  })
+
+  it('reports malformed JSON and rendered fields as response errors, not unreachable service', async () => {
+    const malformedSubject = page([item(1, { subject: { unsafe: true } })], 1, 0)
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response('{', { status: 200 }))
+      .mockResolvedValueOnce(response(malformedSubject))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const view = renderPage()
+    expect(await screen.findByText('Failed to load: Notifications')).toBeInTheDocument()
+    expect(screen.queryByText('Notification-service is not responding')).not.toBeInTheDocument()
+
+    view.unmount()
+    renderPage()
+    expect(await screen.findByText('Failed to load: Notifications')).toBeInTheDocument()
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument()
+  })
+
+  it('rejects a nonempty page whose authoritative total cannot contain its items', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response(page([item(1)], 0, 0))))
+
+    renderPage()
+
+    expect(await screen.findByText('Failed to load: Notifications')).toBeInTheDocument()
+    expect(screen.queryByText('Message 1')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Showing/)).not.toBeInTheDocument()
+  })
+
+  it('shows a genuine empty state only for a successful empty page', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response(page([], 0, 0))))
+
+    renderPage()
+
+    expect(await screen.findByText('No data yet: Notifications')).toBeInTheDocument()
+    expect(screen.getByText('Sent on this page').parentElement).toHaveTextContent('0')
+    expect(screen.queryByRole('navigation', { name: 'Notifications pagination' })).not.toBeInTheDocument()
+  })
+})

--- a/openbank-admin-ui/src/test/notifications-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/notifications-refresh.guard.test.ts
@@ -12,6 +12,6 @@ describe('Notifications refresh contract', () => {
     expect(source).toContain('aria-busy={loading}')
     expect(source).toContain("aria-label={t('Obnovit oznámení', 'Refresh notifications')}")
     expect(source).toContain('<RefreshCw aria-hidden="true"')
-    expect(source).toContain('onClick={load}')
+    expect(source).toContain('onClick={refresh}')
   })
 })


### PR DESCRIPTION
## Summary

Align the Admin Notifications log with the notification-service's documented paginated response. The UI now renders `template`, reports page-scoped counts and an authoritative localized range, and safely handles pagination races, authorization changes, malformed responses, and concurrent total changes while preserving the governed approval deep link.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #8097

## Changes

- Consume the `{ items, total, page, size }` contract with explicit `page` / `size=20`, runtime validation, truthful current-page statistics, and accessible Previous/Next navigation.
- Abort and ignore superseded reads, recover from out-of-range or concurrently emptied pages, distinguish session expiry from access denial, and remove cached recipient/subject data after a 401/403.
- Add behavior tests for the 20-of-21 boundary, template rendering, deep-link preservation, refresh/reset, stale responses before and after headers, authorization states, malformed envelopes, total shrinkage, and an end-to-end outage/recovery with distinguishable refreshed data.

## Definition of Done

- [x] Hexagonal layering preserved (Admin UI-only change; no domain/framework boundary change).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (the existing Admin UI outage/recovery E2E now exercises the paginated contract and proves the recovered response replaces stale data).
- [x] Contract tests updated (N/A: existing backend/OpenAPI contract is consumed, not changed).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes (N/A for Admin UI; focused Vitest, canonical typecheck, changed-file ESLint, diff-check, targeted Playwright E2E, and production Next build pass).
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (N/A: no REST API change).
- [x] Flyway migration added + rollback note (N/A: no DB change).
- [x] Avro schema versioned backward-compatibly (N/A: no event change).
- [x] Docs updated (N/A: behavior is covered by the linked issue and regression tests).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? → tag `security-review-required` (authorization-failure retention behavior changed).
- [x] PII path changed? → tag `gdpr-review-required` (recipient/subject display and removal on authorization loss).
- [ ] Cardholder data path changed? → tag `pci-review-required` (N/A).

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [x] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

The UI displays notification recipients and subjects only after an authorized response. If a current request returns 401 or 403, previously loaded protected rows and page metadata are removed from the DOM. No data is persisted or newly logged.

## Rollout / Rollback

- Deployment strategy: rolling Admin UI release through the existing GitOps path.
- Rollback plan: revert this PR and roll back the Admin UI image; the backend and API contract are unchanged.
- Data migration reversible: N/A

## Screenshots / demo (if UI change)

No screenshot attached; deterministic component tests cover both pages, accessible controls, localized range copy, and graceful states. The targeted Playwright scenario covers stale-data retention during an outage and replacement after recovery.

## Reviewer notes

- Review the runtime contract invariants and requested-vs-committed page behavior under failed or superseded reads.
- Focused tests: `npm test -- src/test/notifications-pagination.test.tsx src/test/notifications-refresh.guard.test.ts src/test/approval-triage.test.ts` (19/19 passed) and `npx playwright test e2e/notification-log-recovery.spec.ts --project=chromium` (1/1 passed after a genuine distinguishable-response RED).
- `npm run type-check`, changed-file ESLint (0 errors; only the pre-existing `set-state-in-effect` warning), `git diff --check`, and `npm run build` (91/91 static pages) passed on the rebased head.
- Independent exact-diff review and the follow-up exact E2E fixture rereview both returned NO BLOCKER before their respective commits.
