### PR TITLE
ci(governance): declare ArgoCD gate runtime budget

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -4569,6 +4569,7 @@ gates:
     name: "the ArgoCD Synced-but-applying-nothing detector still classifies, and is still wired (#6371, enforced)"
     group: gitops
     mode: enforced
+    budget_seconds: 15  # 1.2s in PR CI; 3.5s standalone locally over all 19 unit cases
     rationale: "ArgoCD reported Synced/Healthy on an app it had applied nothing to for three weeks, and no metric exposes the condition that recorded it; the replacement detector runs in-cluster, so only this gate can notice it being unwired or its comparison being broken."
     review_after: "2027-02-23"
     selftest: python3 .github/scripts/check-argocd-sync-integrity.py --self-test


### PR DESCRIPTION
## Summary

Restore the gate-observability ratchet after `argocd-sync-integrity-unit-test` reached `main` without a runtime budget. Declare a bounded 15-second ceiling on the gate itself instead of weakening the derived debt baseline.

This unblocks the current consolidated fleet shard and generated Admin UI GitOps PR #8153 once independently reviewed and merged.

## Type of change

- [ ] feat
- [ ] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [x] chore / CI tooling
- [ ] security
- [ ] breaking change

## Linked issues

Closes #8156

## Changes

- Add `budget_seconds: 15` to `argocd-sync-integrity-unit-test`.
- Preserve `.github/gates/observability-baseline.json` unchanged; new debt is not baselined.

## Definition of Done

- [x] Gate-manifest layering and ownership preserved.
- [x] No application or public API behavior changed.
- [x] No generated/derived baseline edited.
- [x] No new lint warnings introduced.

## Security checklist

- [x] No secrets, tokens, passwords, PII, dependencies, suppressions, or permission changes.
- [x] Auth, crypto, payment, and cardholder-data paths unchanged.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: merge through the normal governance PR gate, then update/re-run blocked descendants from `main`.
- Rollback plan: revert this one-line declaration; doing so deliberately restores the fail-closed observability blocker.
- Data migration reversible: N/A

## Reviewer notes

RED on current `main` before the change:

- `gate-observability-declarations` failed with `missing_budget_seconds: 160 gates, baseline allows 159`; the only new undeclared gate was `argocd-sync-integrity-unit-test`.

GREEN after the change:

- `gate-observability-declarations`: PASS, debt returns to 159;
- `argocd-sync-integrity-unit-test`: PASS, all 19 cases and wiring proof;
- `gate-lifecycle-metadata`: PASS;
- `gate-subject-floor`: PASS;
- `yamllint`: PASS (only pre-existing advisory comment warnings);
- `git diff --check`: PASS.

Budget evidence: immutable PR #6610 gate artifact recorded 1.213 seconds in CI; standalone local proof was 3.5 seconds. The 15-second ceiling leaves fail-closed headroom without accepting an unbounded gate.

Independent review is required; do not self-merge.