### PR TITLE
perf(ci): narrow loki-rule-load-test's selftest_inputs to what its falsification reads

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -852,8 +852,16 @@ gates:
     # gate unconditionally. `selftest_inputs` below is the same input set (check-loki-rules.py's
     # own RULE_INPUTS) driven by the shared mechanism, which runs off a pull request always.
     selftest: python3 .github/scripts/check-loki-rules.py --self-test
+    # NARROWED, and measured both ways rather than reasoned about. The self-test's load-test
+    # half builds its OWN synthetic rule files (`good`/`bad` inside self_test()); the only repo
+    # file it reads is apps/loki.yaml, via check_ruler_wiring(). So the rule ConfigMaps under
+    # gitops/components are an input to the GATE, not to its falsification, and listing them
+    # charged this 101s self-test to the 62% of pull requests that touch that tree for entirely
+    # unrelated reasons -- every admin-ui and gitops deploy PR. Proven by experiment: corrupting
+    # the LogQL in a real rule ConfigMap leaves the self-test verdict byte-identical, while
+    # mutating apps/loki.yaml (rulerConfig -> ruler, the #5734 defect) turns it red. The gate's
+    # own --since scoping over RULE_INPUTS is untouched and still covers the ConfigMaps.
     selftest_inputs:
-      - "openbank-infra/gitops/components"
       - "openbank-infra/gitops/apps/loki.yaml"
       - ".github/scripts/check-loki-rules.py"
     run: |


### PR DESCRIPTION
## The symptom

After #8143 and #8147 the estate skips **97% of self-tests** on a pull request — and measured self-test CPU per run went **up**, 70.3 s → 105.6 s across two post-#8147 runs. One gate explains all of it: `loki-rule-load-test`'s self-test costs ~101 s and ran on both.

It ran **correctly, by its declaration**. The declaration was too wide.

## The cause

`selftest_inputs` listed `openbank-infra/gitops/components` — the rule ConfigMaps — carried over verbatim from `check-loki-rules.py`'s `RULE_INPUTS`. But that is the **gate's** input set. The **self-test's** is smaller: its load-test half builds its own synthetic rule files (`good` / `bad`, constructed inside `self_test()`), and the only repo file it reads is `apps/loki.yaml`, via `check_ruler_wiring()`.

That distinction is worth 101 s on **62% of pull requests**:

```
last 40 PRs touching openbank-infra/gitops/components   25  (62%)
last 40 PRs touching openbank-infra/gitops/apps/loki.yaml 0  ( 0%)
```

Every admin-ui and gitops deploy PR edits that tree for reasons with nothing to do with Loki rules.

## Measured both ways, not argued

| experiment | result |
|---|---|
| corrupt the LogQL in a real rule ConfigMap (`loki-rules-silent-failures.yaml`) | self-test verdict **byte-identical** → the ConfigMaps cannot break it |
| mutate `apps/loki.yaml` with the #5734 defect (`rulerConfig` → `ruler`) | self-test goes **red, rc=1** → the narrowed set is not vacuous |

The second control is the one that matters. A narrowing that made the self-test unfalsifiable would look exactly like a saving — that is the whole failure mode this mechanism has to be defended against, so it is measured rather than reasoned about.

## Scope

The gate's own `--since` scoping over the full `RULE_INPUTS` is **untouched**. The rule ConfigMaps are still covered by the check itself, which is where they belong. Only the falsification's input set narrows.

Refs #4339

🤖 Generated with [Claude Code](https://claude.com/claude-code)
