### PR TITLE
feat(admin-ui): triage identity verification cases

### DIFF
--- a/openbank-admin-ui/e2e/identity-cases-triage.spec.ts
+++ b/openbank-admin-ui/e2e/identity-cases-triage.spec.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const cases = [
+  {
+    id: '019fbe12-1111-7222-8333-444444444444',
+    trigger: 'NAMESAKE_CANDIDATE',
+    status: 'OPEN',
+    applicant: { givenName: 'Adam', familyName: 'Novák', birthdate: '1990-01-02', birthplace: 'Praha', nationalities: ['CZ'] },
+    candidatePartyIds: ['019fbe12-aaaa-7bbb-8ccc-dddddddddddd'],
+    firstApprover: null,
+    firstVerdict: null,
+    firstLinkPartyId: null,
+    firstNotes: null,
+    firstAt: null,
+    secondApprover: null,
+    finalVerdict: null,
+    decidedAt: null,
+    createdAt: '2026-09-02T09:00:00Z',
+  },
+  {
+    id: '019fbe12-2222-7333-8444-555555555555',
+    trigger: 'RN_COLLISION',
+    status: 'AWAITING_SECOND_APPROVAL',
+    applicant: { givenName: 'Beáta', familyName: 'Svobodová', birthdate: '1984-03-04', birthplace: 'Brno', nationalities: ['CZ'] },
+    candidatePartyIds: ['019fbe12-bbbb-7ccc-8ddd-eeeeeeeeeeee'],
+    firstApprover: 'first.reviewer',
+    firstVerdict: 'DISTINCT_NEW',
+    firstLinkPartyId: null,
+    firstNotes: null,
+    firstAt: '2026-09-02T08:30:00Z',
+    secondApprover: null,
+    finalVerdict: null,
+    decidedAt: null,
+    createdAt: '2026-09-01T09:00:00Z',
+  },
+]
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('prioritizes second votes and keeps triage understandable on a narrow screen', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.route('**/api/svc/pid-service/api/v1/parties/cases', route => route.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify(cases),
+  }))
+
+  await page.goto('/identity-cases')
+
+  await expect(page.getByText('2 active cases')).toBeVisible()
+  await expect(page.getByText(/1 awaits an independent second vote/)).toBeVisible()
+  await expect(page.getByText('Beáta Svobodová')).toBeVisible()
+  await expect(page.getByText('Adam Novák')).toBeVisible()
+  const secondVoteY = (await page.getByText('Beáta Svobodová').boundingBox())?.y
+  const openY = (await page.getByText('Adam Novák').boundingBox())?.y
+  expect(secondVoteY).toBeLessThan(openY!)
+  await page.getByLabel('Review stage').selectOption('OPEN')
+  await expect(page.getByText('Adam Novák')).toBeVisible()
+  await expect(page.getByText('Beáta Svobodová')).toBeHidden()
+
+  await page.getByLabel('Find a person or case').fill('nobody matches')
+  await expect(page.getByRole('status')).toContainText('No cases match these filters')
+  await expect(page.getByText('The active queue is unchanged.')).toBeVisible()
+})

--- a/openbank-admin-ui/src/app/identity-cases/page.tsx
+++ b/openbank-admin-ui/src/app/identity-cases/page.tsx
@@ -4,14 +4,14 @@
 
 'use client'
 
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useSingleFlight, wasSkipped } from '@/lib/mutations/singleFlight'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader } from '@/components/ui/PageHeader'
 import { AuthGuard, Can } from '@/components/auth/AuthGuard'
-import { Fingerprint, RefreshCw, ShieldAlert, Users, Check } from 'lucide-react'
+import { Fingerprint, RefreshCw, ShieldAlert, Users, Check, Search } from 'lucide-react'
 import { trapDialogFocus } from '@/lib/a11y/trapDialogFocus'
 
 const SVC = 'pid-service'
@@ -333,29 +333,73 @@ export default function IdentityCasesPage() {
   const [cases, setCases] = useState<VerificationCase[]>([])
   const [unavail, setUnavail] = useState<UnavailableKind | null>(null)
   const [loading, setLoading] = useState(true)
+  const [query, setQuery] = useState('')
+  const [statusFilter, setStatusFilter] = useState<'ALL' | 'OPEN' | 'AWAITING_SECOND_APPROVAL'>('ALL')
+  const [triggerFilter, setTriggerFilter] = useState<'ALL' | Trigger>('ALL')
+  const loadGeneration = useRef(0)
 
   const load = useCallback(async () => {
+    const generation = ++loadGeneration.current
     setLoading(true)
     setUnavail(null)
     try {
       const res = await fetch(svcUrl(SVC, '/api/v1/parties/cases'), { signal: AbortSignal.timeout(6000) })
+      if (generation !== loadGeneration.current) return
       if (!res.ok) {
-        setUnavail(await classifyBffFailure(res))
+        const failure = await classifyBffFailure(res)
+        if (generation !== loadGeneration.current) return
+        setUnavail(failure)
         setCases([])
         return
       }
-      setCases(await res.json())
+      const nextCases = await res.json()
+      if (generation !== loadGeneration.current) return
+      setCases(nextCases)
     } catch {
+      if (generation !== loadGeneration.current) return
       setUnavail('unreachable')
       setCases([])
     } finally {
-      setLoading(false)
+      if (generation === loadGeneration.current) setLoading(false)
     }
   }, [])
 
   useEffect(() => {
     load()
+    return () => { loadGeneration.current += 1 }
   }, [load])
+
+  const awaitingCount = cases.filter(c => c.status === 'AWAITING_SECOND_APPROVAL').length
+  const visibleCases = useMemo(() => {
+    const normalizedQuery = query.trim().toLocaleLowerCase(language === 'cs' ? 'cs-CZ' : 'en-US')
+    return cases
+      .filter(c => statusFilter === 'ALL' || c.status === statusFilter)
+      .filter(c => triggerFilter === 'ALL' || c.trigger === triggerFilter)
+      .filter(c => {
+        if (!normalizedQuery) return true
+        return [c.applicant.givenName, c.applicant.familyName, c.id, ...c.candidatePartyIds]
+          .some(value => value.toLocaleLowerCase(language === 'cs' ? 'cs-CZ' : 'en-US').includes(normalizedQuery))
+      })
+      .sort((a, b) => {
+        const priority = Number(b.status === 'AWAITING_SECOND_APPROVAL') - Number(a.status === 'AWAITING_SECOND_APPROVAL')
+        return priority || b.createdAt.localeCompare(a.createdAt) || a.id.localeCompare(b.id)
+      })
+  }, [cases, language, query, statusFilter, triggerFilter])
+
+  const triggerLabel = (trigger: Trigger) => ({
+    RN_COLLISION: t('Kolize rodného čísla', 'National-ID collision'),
+    NAMESAKE_CANDIDATE: t('Možný jmenovec', 'Possible namesake'),
+    PROBABILISTIC_CANDIDATE: t('Pravděpodobná shoda', 'Probable match'),
+  })[trigger]
+  const activeCaseLabel = (count: number) => language === 'cs'
+    ? `${count} ${count === 1 ? 'aktivní případ' : count >= 2 && count <= 4 ? 'aktivní případy' : 'aktivních případů'}`
+    : `${count} active ${count === 1 ? 'case' : 'cases'}`
+  const awaitingLabel = (count: number) => language === 'cs'
+    ? `${count} ${count === 1 ? 'čeká' : 'čekají'} na nezávislý druhý hlas`
+    : `${count} ${count === 1 ? 'awaits' : 'await'} an independent second vote`
+  const candidateLabel = (count: number) => language === 'cs'
+    ? `${count} ${count === 1 ? 'kandidát' : count >= 2 && count <= 4 ? 'kandidáti' : 'kandidátů'}`
+    : `${count} ${count === 1 ? 'candidate' : 'candidates'}`
 
   return <AuthGuard permission="identity-cases:view">
     <div>
@@ -367,7 +411,15 @@ export default function IdentityCasesPage() {
           <RefreshCw size={14} aria-hidden="true" style={{ marginRight: '4px' }} />{t('Obnovit', 'Refresh')}
         </button>}
       />
-      {unavail ? (
+      {loading && cases.length === 0 ? (
+        <div className="card" role="status" aria-live="polite" style={{ padding: '28px', display: 'flex', gap: 12, alignItems: 'center' }}>
+          <RefreshCw size={18} aria-hidden="true" className="animate-spin" />
+          <div>
+            <div style={{ fontWeight: 650 }}>{t('Načítám frontu případů…', 'Loading the case queue…')}</div>
+            <div style={{ marginTop: 3, fontSize: 12, color: 'var(--text-secondary)' }}>{t('Ověřuji otevřené případy a pořadí druhých hlasů.', 'Checking active cases and second-vote priority.')}</div>
+          </div>
+        </div>
+      ) : unavail ? (
         <DataUnavailable kind={unavail} service="pid-service" feature={t('ověření identity', 'identity verification')} lang={language} />
       ) : cases.length === 0 && !loading ? (
         <div className="card" style={{ padding: '40px', textAlign: 'center' }}>
@@ -381,7 +433,45 @@ export default function IdentityCasesPage() {
         </div>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
-          {cases.map(c => (
+          <section className="card" aria-label={t('Třídění fronty případů', 'Case queue triage')} style={{ padding: 14 }}>
+            <div aria-live="polite" style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 12, fontSize: 12 }}>
+              <strong>{activeCaseLabel(cases.length)}</strong>
+              <span style={{ color: 'var(--text-secondary)' }}>· {awaitingLabel(awaitingCount)}</span>
+            </div>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))', gap: 10 }}>
+              <label style={{ display: 'grid', gap: 5, fontSize: 12, color: 'var(--text-secondary)' }}>
+                {t('Hledat osobu nebo případ', 'Find a person or case')}
+                <span style={{ position: 'relative' }}>
+                  <Search size={14} aria-hidden="true" style={{ position: 'absolute', left: 10, top: 10, color: 'var(--text-tertiary)' }} />
+                  <input className="input" value={query} onChange={event => setQuery(event.target.value)} placeholder={t('Jméno, ID případu nebo party', 'Name, case ID, or party ID')} autoComplete="off" spellCheck={false} style={{ width: '100%', paddingLeft: 30 }} />
+                </span>
+              </label>
+              <label style={{ display: 'grid', gap: 5, fontSize: 12, color: 'var(--text-secondary)' }}>
+                {t('Fáze kontroly', 'Review stage')}
+                <select className="input" value={statusFilter} onChange={event => setStatusFilter(event.target.value as typeof statusFilter)}>
+                  <option value="ALL">{t('Všechny aktivní', 'All active')}</option>
+                  <option value="AWAITING_SECOND_APPROVAL">{t('Čeká na druhý hlas', 'Awaiting second vote')}</option>
+                  <option value="OPEN">{t('Čeká na první hlas', 'Awaiting first vote')}</option>
+                </select>
+              </label>
+              <label style={{ display: 'grid', gap: 5, fontSize: 12, color: 'var(--text-secondary)' }}>
+                {t('Důvod kontroly', 'Review reason')}
+                <select className="input" value={triggerFilter} onChange={event => setTriggerFilter(event.target.value as typeof triggerFilter)}>
+                  <option value="ALL">{t('Všechny důvody', 'All reasons')}</option>
+                  <option value="RN_COLLISION">{triggerLabel('RN_COLLISION')}</option>
+                  <option value="NAMESAKE_CANDIDATE">{triggerLabel('NAMESAKE_CANDIDATE')}</option>
+                  <option value="PROBABILISTIC_CANDIDATE">{triggerLabel('PROBABILISTIC_CANDIDATE')}</option>
+                </select>
+              </label>
+            </div>
+          </section>
+          {visibleCases.length === 0 && (
+            <div className="card" role="status" style={{ padding: 28, textAlign: 'center' }}>
+              <strong>{t('Filtrům neodpovídá žádný případ', 'No cases match these filters')}</strong>
+              <div style={{ marginTop: 5, fontSize: 12, color: 'var(--text-secondary)' }}>{t('Změňte hledaný text nebo některý filtr. Aktivní fronta zůstává beze změny.', 'Change the search text or a filter. The active queue is unchanged.')}</div>
+            </div>
+          )}
+          {visibleCases.map(c => (
             <div key={c.id} className="card" style={{ padding: '18px' }}>
               <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '12px' }}>
                 <div>
@@ -397,7 +487,7 @@ export default function IdentityCasesPage() {
                         border: `1px solid ${TRIGGER_COLOR[c.trigger]}30`,
                       }}
                     >
-                      {c.trigger}
+                      {triggerLabel(c.trigger)}
                     </span>
                     <span className="mono" style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>
                       {t('případ', 'case')} {shortId(c.id)}
@@ -428,7 +518,7 @@ export default function IdentityCasesPage() {
                   }}
                 >
                   <Users size={14} />
-                  {c.candidatePartyIds.length} {t('kandidát(ů)', 'candidate(s)')}
+                  {candidateLabel(c.candidatePartyIds.length)}
                 </div>
               </div>
 

--- a/openbank-admin-ui/src/test/identity-cases-triage.test.tsx
+++ b/openbank-admin-ui/src/test/identity-cases-triage.test.tsx
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import IdentityCasesPage from '@/app/identity-cases/page'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+vi.mock('@/components/auth/AuthGuard', () => ({
+  AuthGuard: ({ children }: { children: ReactNode }) => children,
+  Can: ({ children }: { children: ReactNode }) => children,
+}))
+
+const openCase = {
+  id: '019fbe12-1111-7222-8333-444444444444',
+  trigger: 'NAMESAKE_CANDIDATE',
+  status: 'OPEN',
+  applicant: { givenName: 'Adam', familyName: 'Novák', birthdate: '1990-01-02', birthplace: 'Praha', nationalities: ['CZ'] },
+  candidatePartyIds: ['019fbe12-aaaa-7bbb-8ccc-dddddddddddd'],
+  firstApprover: null,
+  firstVerdict: null,
+  firstLinkPartyId: null,
+  firstNotes: null,
+  firstAt: null,
+  secondApprover: null,
+  finalVerdict: null,
+  decidedAt: null,
+  createdAt: '2026-09-02T09:00:00Z',
+}
+
+const secondVoteCase = {
+  ...openCase,
+  id: '019fbe12-2222-7333-8444-555555555555',
+  trigger: 'RN_COLLISION',
+  status: 'AWAITING_SECOND_APPROVAL',
+  applicant: { givenName: 'Beáta', familyName: 'Svobodová', birthdate: '1984-03-04', birthplace: 'Brno', nationalities: ['CZ'] },
+  candidatePartyIds: ['019fbe12-bbbb-7ccc-8ddd-eeeeeeeeeeee'],
+  firstApprover: 'first.reviewer',
+  firstVerdict: 'DISTINCT_NEW',
+  firstAt: '2026-09-02T08:30:00Z',
+  createdAt: '2026-09-01T09:00:00Z',
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  return { promise: new Promise<T>(settle => { resolve = settle }), resolve }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('identity case queue triage', () => {
+  it('announces initial loading, prioritizes the second vote, and filters without changing the queue', async () => {
+    const response = deferred<Response>()
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(response.promise))
+
+    await act(async () => {
+      render(<LanguageProvider initialLanguage="en"><IdentityCasesPage /></LanguageProvider>)
+    })
+
+    expect(screen.getByRole('status')).toHaveTextContent('Loading the case queue')
+    expect(screen.queryByText('No open cases')).not.toBeInTheDocument()
+
+    await act(async () => {
+      response.resolve(new Response(JSON.stringify([openCase, secondVoteCase]), { status: 200 }))
+    })
+
+    expect(await screen.findByText('2 active cases')).toBeVisible()
+    expect(screen.getByText(/1 awaits an independent second vote/)).toBeVisible()
+    const secondVoteName = screen.getByText('Beáta Svobodová')
+    const openName = screen.getByText('Adam Novák')
+    expect(secondVoteName.compareDocumentPosition(openName) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(screen.getAllByText('National-ID collision')).toHaveLength(2)
+    expect(screen.getAllByText('Possible namesake')).toHaveLength(2)
+
+    fireEvent.change(screen.getByLabelText('Review stage'), { target: { value: 'OPEN' } })
+    expect(screen.getByText('Adam Novák')).toBeVisible()
+    expect(screen.queryByText('Beáta Svobodová')).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Find a person or case'), { target: { value: 'missing person' } })
+    expect(screen.getByRole('status')).toHaveTextContent('No cases match these filters')
+    expect(screen.queryByText('No open cases')).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Find a person or case'), { target: { value: '' } })
+    fireEvent.change(screen.getByLabelText('Review stage'), { target: { value: 'ALL' } })
+    await waitFor(() => expect(screen.getByText('Beáta Svobodová')).toBeVisible())
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

Turn the active identity-verification list into an understandable operator queue: second votes are prioritized, loading is explicit, and localized search/filter controls explain why each case needs review. The browser keeps all filtering local to the already-authorized response and preserves the server-enforced four-eyes decision path.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #8159

## Changes

- Add an accessible initial loading state and truthful filtered-empty state.
- Prioritize cases awaiting an independent second vote, with deterministic ordering.
- Add responsive local search plus stage/reason filters and localized human labels/plurals.
- Prevent late list responses from overwriting a newer load or updating an unmounted page.
- Add focused render coverage and a 390px Chromium triage journey.

## Definition of Done

- [x] Hexagonal layering preserved (UI-only; no domain or service change).
- [x] Unit tests added/updated (5/5 focused tests pass).
- [x] Integration tests added/updated (Chromium 1/1 pass).
- [x] Contract tests updated (N/A — no API change).
- [x] Admin UI type-check, changed-file ESLint, diff-check, and production build pass.
- [x] No new lint warnings (the one page warning is pre-existing).
- [x] OpenAPI/Flyway/Avro changes are N/A.
- [x] Docs impact is captured in the operator-facing educational copy and issue.

## Security checklist

- [x] No secrets, tokens, passwords, or real PII in code, config, tests, or logs; fixtures are synthetic.
- [x] No new suppression or unsafe cast beyond select values constrained by their options.
- [x] No new third-party dependency.
- [x] Auth, decision payload, and server-side four-eyes enforcement are unchanged.
- [x] PII path changed: GDPR review requested; search is in-memory only, autocomplete is off, and terms are not persisted.

## Compliance impact

- [x] GDPR
- [ ] PCI DSS
- [ ] DORA
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

The page already displays identity-case PII to authorized roles. This change only filters the authorized in-memory snapshot and does not add storage, telemetry, URL parameters, or network queries for search terms.

## Rollout / Rollback

- Deployment strategy: rolling with the normal Admin UI release.
- Rollback plan: revert the single UI commit; backend and stored data are unchanged.
- Data migration reversible: N/A

## Reviewer notes

Verify that awaiting-second-vote cases appear first, filters never trigger network calls, narrow-screen controls remain usable, and no decision/RBAC payload changed.