### PR TITLE
fix(kyc): publish actual case page response

### DIFF
--- a/openbank-kyc-service/src/main/resources/openapi.yaml
+++ b/openbank-kyc-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: KYC Service API
-  version: 1.7.0
+  version: 1.8.0
   description: Know Your Customer case management — open cases, run checks, approve/reject.
   license:
     name: Apache-2.0
@@ -41,13 +41,11 @@ paths:
             enum: [OPEN, DOCUMENTS_REQUIRED, UNDER_REVIEW, APPROVED, REJECTED, EXPIRED]
       responses:
         '200':
-          description: List of KYC cases with optional statusFilter echo
+          description: Paginated KYC cases with the applied status filter echoed when present.
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/KycCaseResponse'
+                $ref: '#/components/schemas/KycCasePage'
     post:
       tags: [KYC]
       summary: Open a KYC case
@@ -104,6 +102,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KycCaseResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
   /api/v1/kyc/cases/{id}/checks/{checkType}:
     put:
@@ -330,8 +330,29 @@ components:
         partyName:
           type: string
 
+    KycCasePage:
+      type: object
+      required: [items, total, page, size, statusFilter]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/KycCaseResponse'
+        total:
+          type: integer
+          format: int64
+          minimum: 0
+        page:
+          type: integer
+        size:
+          type: integer
+        statusFilter:
+          type: [string, 'null']
+          enum: [OPEN, DOCUMENTS_REQUIRED, UNDER_REVIEW, APPROVED, REJECTED, EXPIRED, null]
+
     KycCaseResponse:
       type: object
+      required: [id, partyId, status, riskLevel, assignedTo, checks, notes, reviewedBy, reviewedAt, expiresAt, createdAt, updatedAt]
       properties:
         id:
           type: string
@@ -339,20 +360,59 @@ components:
         partyId:
           type: string
           format: uuid
-        caseType:
-          type: string
         status:
           type: string
+          enum: [OPEN, DOCUMENTS_REQUIRED, UNDER_REVIEW, APPROVED, REJECTED, EXPIRED]
         riskLevel:
           type: string
+          enum: [LOW, MEDIUM, HIGH, VERY_HIGH]
+        assignedTo:
+          type: [string, 'null']
         checks:
-          type: object
-          additionalProperties:
-            type: string
+          type: array
+          items:
+            $ref: '#/components/schemas/KycCheckResponse'
+        notes:
+          type: [string, 'null']
+        reviewedBy:
+          type: [string, 'null']
+        reviewedAt:
+          type: [string, 'null']
+          format: date-time
+        expiresAt:
+          type: [string, 'null']
+          format: date-time
         createdAt:
           type: string
           format: date-time
         updatedAt:
+          type: string
+          format: date-time
+
+    KycCheckResponse:
+      type: object
+      required: [id, caseId, checkType, status, result, provider, performedAt, createdAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        caseId:
+          type: string
+          format: uuid
+        checkType:
+          type: string
+          enum: [IDENTITY, ADDRESS, PEP_SCREENING, SANCTIONS_SCREENING, ADVERSE_MEDIA]
+        status:
+          type: string
+          enum: [PENDING, PASSED, FAILED, MANUAL_REVIEW]
+        result:
+          type: [string, 'null']
+        provider:
+          type: [string, 'null']
+        performedAt:
+          type: [string, 'null']
+          format: date-time
+        createdAt:
           type: string
           format: date-time
 


### PR DESCRIPTION
## Summary

Correct the published KYC API document to describe the response the running service already returns. This is the contract-first prerequisite for truthful server-backed pagination in the Admin UI; it changes no runtime code or stored data.

## Type of change

- [ ] feat
- [x] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore
- [ ] security
- [ ] breaking runtime change

## Linked issues

Refs #8163

## Changes

- Declare the implemented `{items,total,page,size,statusFilter}` case-list envelope.
- Replace the phantom `caseType` and object-shaped checks with the actual `KycCase`/`KycCheck` wire fields, enums, arrays, and nullable values.
- Publish the implemented 404 response for party lookup.
- Bump the independent API-contract version from 1.7.0 to 1.8.0.

## Definition of Done

- [x] Runtime/domain code unchanged; this is a spec-only correction.
- [x] YAML parses and pinned oasdiff reads the document.
- [x] API contract gate classifies the seven document-breaking corrections as CORRECTION and accepts the required MINOR bump.
- [x] KYC route-conformance gate reports zero findings.
- [x] `git diff --check` passes.
- [x] Runtime integration test is deliberately deferred to the follow-up consumer PR so this PR remains mechanically spec-only; #8163 requires it before UI pagination ships.

## Security checklist

- [x] No secrets, tokens, passwords, fixtures, or personal records added.
- [x] No suppression, unsafe cast, or dependency added.
- [x] Auth, RBAC, KYC state transitions, and four-eyes controls are unchanged.
- [x] The document now truthfully enumerates already-returned KYC fields; GDPR review requested.

## Compliance impact

- [x] GDPR
- [x] AML / 5AMLD
- [ ] PCI DSS
- [ ] DORA
- [ ] PSD2 / SCA / RTS
- [ ] CNB reporting
- [ ] None

This corrects documentation of an existing authorized response. It neither adds data to the wire nor expands who can read it.

## Rollout / Rollback

- Deployment strategy: normal KYC release; runtime bytecode is unchanged.
- Rollback plan: revert this single OpenAPI commit, though that restores a known false document.
- Data migration reversible: N/A

## Reviewer notes

Compare the schemas directly with `KycResource.listCases`, `KycCase`, and `KycCheck`. This PR must remain spec-only so the governance correction path applies; runtime contract coverage and Admin UI pagination follow in #8163.