### PR TITLE
fix(admin-ui): let visible interest retries run

### DIFF
--- a/openbank-admin-ui/src/app/interest/page.tsx
+++ b/openbank-admin-ui/src/app/interest/page.tsx
@@ -3,7 +3,7 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 'use client'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { AlertTriangle, ShieldAlert, TrendingUp, Search, CheckCircle2, RefreshCw, Percent, Calendar } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -52,7 +52,6 @@ export default function InterestPage() {
     kind: AccessBlock
     snapshot: AccrualRecord[] | null
   } | null>(null)
-  const reloadInFlight = useRef(false)
   const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const { data, loading, unavailable, waking, reload } = useServiceResource<AccrualRecord[]>(
     svcUrl('interest-service', '/api/v1/interest/accruals'),
@@ -72,16 +71,11 @@ export default function InterestPage() {
   const settledFailure = unavailable !== null && !loading && !waking
   const showingRetainedSnapshot = settledFailure && visibleSnapshot
 
-  useEffect(() => {
-    if (!loading) reloadInFlight.current = false
-  }, [data, loading, unavailable])
-
   const requestReload = useCallback(() => {
-    if (loading || reloadInFlight.current) return
+    if (loading) return
     setRetainedAccessBlock(currentAccessBlock
       ? { kind: currentAccessBlock, snapshot: data }
       : null)
-    reloadInFlight.current = true
     reload()
   }, [currentAccessBlock, data, loading, reload])
 

--- a/openbank-admin-ui/src/test/interest-loading.guard.test.ts
+++ b/openbank-admin-ui/src/test/interest-loading.guard.test.ts
@@ -10,4 +10,9 @@ describe('interest loading contract', () => {
     expect(source).toContain('<RefreshCw size={20} aria-hidden="true"')
     expect(source).toContain("t('Načítám…', 'Loading…')")
   })
+
+  it('never hides a visible retry behind a passive-effect single-flight latch', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/interest/page.tsx'), 'utf8')
+    expect(source).not.toContain('reloadInFlight')
+  })
 })


### PR DESCRIPTION
## Summary

Make the visible Interest retry action reliable after a terminal refresh or authorization failure. Two independent main-CI runs proved that the page-local passive-effect latch could outlive the failure render and silently swallow the operator's click.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #8168

## Changes

- Remove the redundant page-local `reloadInFlight` ref and its passive-effect release.
- Keep `loading` as the rendered request boundary; the hook nonce coalesces same-turn updates and cancelled requests cannot commit stale data.
- Add a deterministic guard against restoring the lagging second source of truth.

## Definition of Done

- [x] Hexagonal layering preserved; this is an Admin UI-only change.
- [x] Unit tests added/updated.
- [x] Integration tests N/A; no service boundary changed.
- [x] Contract tests N/A; no public API changed.
- [x] Focused recovery/hook/guard suite: 16/16 passed on the rebased head.
- [x] Full Admin UI unit/integration suite: 422/422 files, 2,235 passed + 1 explicit skip, 0 failures.
- [x] TypeScript and changed-file ESLint passed with no warnings.
- [x] Production Next build passed; 91/91 static pages generated.
- [x] OpenAPI, Flyway, event schemas, and architecture docs N/A.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, or logs.
- [x] No new suppressions or unsafe casts.
- [x] No new third-party dependency.
- [x] Auth, permissions, crypto, and payment semantics are unchanged.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: rolling with the normal Admin UI release.
- Rollback plan: revert this single commit to restore the former page-local latch.
- Data migration reversible: N/A.

## Screenshots / demo

Not applicable; this fixes a timing window with no intended visual change.

## Reviewer notes

- External red evidence: [run 33613627289](https://github.com/JiRaska/open-bank-oss/actions/runs/33613627289) and [run 33606501913](https://github.com/JiRaska/open-bank-oss/actions/runs/33606501913) each rendered Retry but observed no third fetch in different recovery cases.
- Existing PR #7789 overlaps only the `AuthGuard` permission line in the same page; the hunks and semantics are independent.
- Review the rapid-click behavior and sticky 401/403 snapshot block. An independent read-only review found no P1/P2.
