### PR TITLE
feat(notification): complete delegation lifecycle alerts

### DIFF
--- a/docs/threat-models/openbank-notification-service.md
+++ b/docs/threat-models/openbank-notification-service.md
@@ -1,0 +1,35 @@
+# Notification service threat model
+
+## Scope
+
+This lightweight STRIDE review covers customer notification ingestion, persistence and delivery,
+including delegated-access lifecycle notifications consumed from `openbank.delegation.events`.
+Notification-service does not authorize delegated access: the product service remains the final
+authority and the app must re-fetch the authenticated grant after a notification tap.
+
+## Trust boundaries and controls
+
+| Threat | Control |
+|---|---|
+| A producer injects an arbitrary mobile URL | `MobileDeepLink` admits only closed bank routes. Delegation detail routes require a canonical UUID and reject query strings, fragments, traversal and non-bank schemes. |
+| A lock-screen notification discloses customer or account data | Push data contains only template id, notification id, the allow-listed app route and an opaque correlation reference. Lifecycle copy carries only the resource type; no party name, balance, account number or capability set is placed on the wire. |
+| A forged or stale notification becomes authorization | A deep link is navigation metadata only. The destination must authenticate the party and load the grant from customer-edge; notification content never grants access or supplies an authority decision. |
+| A lifecycle change is invisible to one affected party | Offered, activated, declined, revoked and renounced transitions notify the party that did not initiate the action. Bank suspension/reinstatement and expiry notify both parties because authority changes independently of either customer. Security-category preferences cannot mute these messages. |
+| An unknown future event is routed to the wrong customer | Event types use a closed reviewed recipient map. Unknown types are acknowledged without notification until recipient semantics are explicitly added and tested. Malformed identifiers are rejected before dispatch. |
+| Event redelivery creates duplicate messages | Delivery remains at-least-once and duplicates are possible. `aggregateId` is retained as correlation evidence; the app must render notification state idempotently. A durable producer-event deduplication key is a residual improvement and must not be simulated with an in-memory cache. |
+
+## Rollout and rollback
+
+The change is additive: deploy notification-service after the delegation event contract is present.
+No producer rollout or database migration is required. Rollback restores the previous consumer and
+stops the three newly handled event types; it does not alter grants or authorization state. Before
+rollback, confirm the consumer group has no lag so an old image cannot silently acknowledge queued
+suspend, reinstate or renounce events without notifying customers.
+
+## Residual risks
+
+- The customer mobile application lives in a separate repository. Its `openbank://delegations/{id}`
+  route must authenticate, handle a missing/revoked grant without an existence oracle, and show a
+  safe generic state until that client contract is available and verified end to end.
+- At-least-once delivery may create duplicate notification rows. This is visible but not an
+  authorization or money-movement defect; durable deduplication remains preferable for UX quality.

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -1101,6 +1101,18 @@ class NotificationConsumer @Inject constructor(
                 "Your delegated access was revoked" to
                     "<h2>Access Revoked</h2><p>Delegated access to a <b>${vars.v("resourceType")}</b> " +
                     "granted to you has been revoked. You can no longer act on it.</p>"
+            NotificationTemplate.DELEGATION_SUSPENDED ->
+                "Delegated access was suspended" to
+                    "<h2>Access Suspended</h2><p>Delegated access for a <b>${vars.v("resourceType")}</b> " +
+                    "was temporarily suspended by the bank. It cannot be used while suspended.</p>"
+            NotificationTemplate.DELEGATION_REINSTATED ->
+                "Delegated access was restored" to
+                    "<h2>Access Restored</h2><p>Delegated access for a <b>${vars.v("resourceType")}</b> " +
+                    "was restored by the bank and may be used again within its existing scope and conditions.</p>"
+            NotificationTemplate.DELEGATION_RENOUNCED ->
+                "Delegated access was renounced" to
+                    "<h2>Access Renounced</h2><p>The person who held delegated access to your " +
+                    "<b>${vars.v("resourceType")}</b> ended that access. It is no longer active.</p>"
             NotificationTemplate.DELEGATION_EXPIRED ->
                 "A delegated access grant has expired" to
                     "<h2>Grant Expired</h2><p>A delegated access grant for a <b>${vars.v("resourceType")}</b> " +

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
@@ -76,6 +76,15 @@ enum class NotificationTemplate(val variables: Set<String>) {
     /** The grantor revoked an active grant; the grantee's access ends now (DelegationRevoked). */
     DELEGATION_REVOKED(setOf("resourceType")),
 
+    /** The bank temporarily removed delegated authority (DelegationSuspended). */
+    DELEGATION_SUSPENDED(setOf("resourceType")),
+
+    /** The bank restored previously suspended delegated authority (DelegationReinstated). */
+    DELEGATION_REINSTATED(setOf("resourceType")),
+
+    /** The grantee gave up delegated authority (DelegationRenounced). */
+    DELEGATION_RENOUNCED(setOf("resourceType")),
+
     /** A grant's validity window ended on its own; sent to both parties (DelegationExpired). */
     DELEGATION_EXPIRED(setOf("resourceType")),
     ;
@@ -115,6 +124,9 @@ enum class NotificationTemplate(val variables: Set<String>) {
             DELEGATION_ACCEPTED,
             DELEGATION_DECLINED,
             DELEGATION_REVOKED,
+            DELEGATION_SUSPENDED,
+            DELEGATION_REINSTATED,
+            DELEGATION_RENOUNCED,
             DELEGATION_EXPIRED,
             -> null
         }
@@ -130,7 +142,8 @@ enum class NotificationTemplate(val variables: Set<String>) {
             KYC_APPROVED, KYC_REJECTED, KYC_DOCUMENT_REQUIRED,
             CONSENT_GRANTED, CONSENT_REVOKED,
             DELEGATION_OFFERED, DELEGATION_ACCEPTED, DELEGATION_DECLINED,
-            DELEGATION_REVOKED, DELEGATION_EXPIRED,
+            DELEGATION_REVOKED, DELEGATION_SUSPENDED, DELEGATION_REINSTATED,
+            DELEGATION_RENOUNCED, DELEGATION_EXPIRED,
             -> NotificationCategory.SECURITY
             TRANSACTION_COMPLETED, TRANSACTION_FAILED -> NotificationCategory.PAYMENTS
             ACCOUNT_OPENED, ACCOUNT_CLOSED, WELCOME -> NotificationCategory.PRODUCT
@@ -184,6 +197,8 @@ data class NotificationRequest(
 
 /** Closed allow-list for navigation metadata sent through FCM/APNs. */
 object MobileDeepLink {
+    private const val DELEGATION_DETAIL_PREFIX = "openbank://delegations/"
+
     private val allowed = setOf(
         "openbank://home",
         "openbank://savings",
@@ -192,5 +207,11 @@ object MobileDeepLink {
         "openbank://products",
     )
 
-    fun isAllowed(value: String?): Boolean = value == null || value in allowed
+    fun isAllowed(value: String?): Boolean = value == null || value in allowed || isCanonicalDelegationDetail(value)
+
+    private fun isCanonicalDelegationDetail(value: String): Boolean {
+        if (!value.startsWith(DELEGATION_DETAIL_PREFIX)) return false
+        val id = value.removePrefix(DELEGATION_DETAIL_PREFIX)
+        return runCatching { UUID.fromString(id).toString() == id }.getOrDefault(false)
+    }
 }

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/kafka/DelegationNotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/kafka/DelegationNotificationConsumer.kt
@@ -31,10 +31,10 @@ import java.util.UUID
  *  - `DelegationActivated` -> the **grantor**: their offer was accepted.
  *  - `DelegationDeclined` -> the **grantor**: their offer was turned down.
  *  - `DelegationRevoked` -> the **grantee**: their access just ended.
+ *  - `DelegationSuspended` / `DelegationReinstated` -> **both**: authority changed at the bank.
+ *  - `DelegationRenounced` -> the **grantor**: the grantee ended their access.
  *  - `DelegationExpired` -> **both**: the grant is gone either way.
- *  - Everything else (`DelegationSuspended`, `DelegationReinstated`, `DelegationRenounced`, and any
- *    future/unknown type) is deliberately not notified here — out of this fan-out's stated scope,
- *    not silently dropped by accident; add it as its own reviewed branch when it is in scope.
+ *  - Any future/unknown type is deliberately not notified until its recipient semantics are reviewed.
  *
  * **Delivery reuses the real pipeline, in-process.** Rather than re-implement rendering, the
  * consent gate, push/email preference checks, persistence and the outcome-event write, this builds
@@ -103,8 +103,8 @@ class DelegationNotificationConsumer @Inject constructor(
         val eventType = node.path("eventType").asText("")
         val template = TEMPLATE_BY_EVENT_TYPE[eventType]
         if (template == null) {
-            // Not an error: DelegationSuspended/Reinstated/Renounced and any future type are
-            // in-scope for other consumers of this topic, just not for this fan-out (see class KDoc).
+            // Not an error: future event types stay out until their customer recipient semantics
+            // are deliberately reviewed (see class KDoc).
             log.debugf("delegation event %s not in notification scope, skipping", eventType.ifBlank { "?" })
             return emptyList()
         }
@@ -128,6 +128,7 @@ class DelegationNotificationConsumer @Inject constructor(
                 template = template,
                 recipient = partyId.toString(),
                 variables = mapOf("resourceType" to resourceType),
+                deepLink = "openbank://delegations/$grantId",
                 // The grant id, not a freshly minted one: it is the stable identifier a producer
                 // owns for this business event (ADR-0239 D1), letting a later outcome event be
                 // joined back to the delegation grant that caused it.
@@ -145,6 +146,9 @@ class DelegationNotificationConsumer @Inject constructor(
             "DelegationActivated" to NotificationTemplate.DELEGATION_ACCEPTED,
             "DelegationDeclined" to NotificationTemplate.DELEGATION_DECLINED,
             "DelegationRevoked" to NotificationTemplate.DELEGATION_REVOKED,
+            "DelegationSuspended" to NotificationTemplate.DELEGATION_SUSPENDED,
+            "DelegationReinstated" to NotificationTemplate.DELEGATION_REINSTATED,
+            "DelegationRenounced" to NotificationTemplate.DELEGATION_RENOUNCED,
             "DelegationExpired" to NotificationTemplate.DELEGATION_EXPIRED,
         )
 
@@ -154,6 +158,9 @@ class DelegationNotificationConsumer @Inject constructor(
             "DelegationActivated" to { grantor, _ -> listOf(grantor) },
             "DelegationDeclined" to { grantor, _ -> listOf(grantor) },
             "DelegationRevoked" to { _, grantee -> listOf(grantee) },
+            "DelegationSuspended" to { grantor, grantee -> listOf(grantor, grantee) },
+            "DelegationReinstated" to { grantor, grantee -> listOf(grantor, grantee) },
+            "DelegationRenounced" to { grantor, _ -> listOf(grantor) },
             "DelegationExpired" to { grantor, grantee -> listOf(grantor, grantee) },
         )
     }

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/contract/DelegationLifecycleNotificationContractTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/contract/DelegationLifecycleNotificationContractTest.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.contract
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+/** Pins the producer-owned lifecycle vocabulary consumed by the notification fan-out. */
+class DelegationLifecycleNotificationContractTest {
+
+    @Test
+    fun `delegation contract declares every customer-notified lifecycle event`() {
+        val contract = Files.readString(
+            Path.of("../openbank-contracts/openbank-delegation-service/asyncapi.yaml"),
+        )
+
+        assertThat(contract).contains(
+            "DelegationOffered:",
+            "DelegationActivated:",
+            "DelegationDeclined:",
+            "DelegationRevoked:",
+            "DelegationSuspended:",
+            "DelegationReinstated:",
+            "DelegationRenounced:",
+            "DelegationExpired:",
+        )
+        assertThat(contract).contains("grantorPartyId:", "granteePartyId:", "resourceType:")
+    }
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
@@ -31,7 +31,7 @@ class NotificationModelTest {
 
     @Test
     fun `NotificationTemplate has all expected templates`() {
-        assertThat(NotificationTemplate.values()).hasSize(20)
+        assertThat(NotificationTemplate.values()).hasSize(23)
         assertThat(NotificationTemplate.values()).contains(
             NotificationTemplate.ACCOUNT_OPENED,
             NotificationTemplate.OTP_CODE,
@@ -42,6 +42,9 @@ class NotificationModelTest {
             NotificationTemplate.DELEGATION_ACCEPTED,
             NotificationTemplate.DELEGATION_DECLINED,
             NotificationTemplate.DELEGATION_REVOKED,
+            NotificationTemplate.DELEGATION_SUSPENDED,
+            NotificationTemplate.DELEGATION_REINSTATED,
+            NotificationTemplate.DELEGATION_RENOUNCED,
             NotificationTemplate.DELEGATION_EXPIRED,
         )
         // SCA_APPROVAL is SECURITY so the #2 push-preference gate never suppresses it.
@@ -56,6 +59,9 @@ class NotificationModelTest {
                 NotificationTemplate.DELEGATION_ACCEPTED,
                 NotificationTemplate.DELEGATION_DECLINED,
                 NotificationTemplate.DELEGATION_REVOKED,
+                NotificationTemplate.DELEGATION_SUSPENDED,
+                NotificationTemplate.DELEGATION_REINSTATED,
+                NotificationTemplate.DELEGATION_RENOUNCED,
                 NotificationTemplate.DELEGATION_EXPIRED,
             ),
         ).allSatisfy { assertThat(it.category).isEqualTo(NotificationCategory.SECURITY) }
@@ -102,6 +108,14 @@ class NotificationModelTest {
         assertThat(MobileDeepLink.isAllowed("openbank://savings")).isTrue()
         assertThat(MobileDeepLink.isAllowed("https://example.invalid/redirect")).isFalse()
         assertThat(MobileDeepLink.isAllowed("openbank://savings?next=https://evil.invalid")).isFalse()
+        assertThat(MobileDeepLink.isAllowed("openbank://delegations/123e4567-e89b-42d3-a456-426614174000")).isTrue()
+        assertThat(MobileDeepLink.isAllowed("openbank://delegations/01995e74-19c7-7d79-9b22-63076d7fd321")).isTrue()
+        assertThat(MobileDeepLink.isAllowed("openbank://delegations/not-a-uuid")).isFalse()
+        assertThat(
+            MobileDeepLink.isAllowed(
+                "openbank://delegations/123e4567-e89b-42d3-a456-426614174000?next=https://evil.invalid",
+            ),
+        ).isFalse()
     }
 
     @Test

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/kafka/DelegationNotificationConsumerTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/kafka/DelegationNotificationConsumerTest.kt
@@ -75,6 +75,7 @@ class DelegationNotificationConsumerTest {
         assertThat(req.channel).isEqualTo(NotificationChannel.PUSH)
         assertThat(req.variables).isEqualTo(mapOf("resourceType" to "CARD"))
         assertThat(req.correlationId).isEqualTo(grantId)
+        assertThat(req.deepLink).isEqualTo("openbank://delegations/$grantId")
     }
 
     @Test
@@ -115,10 +116,37 @@ class DelegationNotificationConsumerTest {
     }
 
     @Test
-    fun `out-of-scope lifecycle types are not notified`() {
-        for (type in listOf("DelegationSuspended", "DelegationReinstated", "DelegationRenounced", "SomethingElse")) {
+    fun `bank suspension and reinstatement notify both parties`() {
+        for (type in listOf("DelegationSuspended", "DelegationReinstated")) {
             consumer.consume(eventPayload(type)).subscribe().with({}, {})
         }
+
+        val requests = capturedRequests()
+        assertThat(requests).hasSize(4)
+        assertThat(requests.groupingBy { it.template }.eachCount()).containsExactlyInAnyOrderEntriesOf(
+            mapOf(
+                NotificationTemplate.DELEGATION_SUSPENDED to 2,
+                NotificationTemplate.DELEGATION_REINSTATED to 2,
+            ),
+        )
+        assertThat(requests).allSatisfy {
+            assertThat(it.partyId).isIn(grantorPartyId, granteePartyId)
+            assertThat(it.deepLink).isEqualTo("openbank://delegations/$grantId")
+        }
+    }
+
+    @Test
+    fun `renunciation notifies the grantor`() {
+        consumer.consume(eventPayload("DelegationRenounced")).subscribe().with({}, {})
+
+        val request = capturedRequests().single()
+        assertThat(request.partyId).isEqualTo(grantorPartyId)
+        assertThat(request.template).isEqualTo(NotificationTemplate.DELEGATION_RENOUNCED)
+    }
+
+    @Test
+    fun `unknown lifecycle types are not notified`() {
+        consumer.consume(eventPayload("SomethingElse")).subscribe().with({}, {})
 
         verify(exactly = 0) { notificationConsumer.consume(any()) }
     }


### PR DESCRIPTION
## Summary

- notify both parties when the bank suspends or reinstates delegated authority
- notify the grantor when a grantee renounces access
- route every delegated-access push through a closed canonical UUIDv4/v7 app deep link
- document navigation-vs-authorization boundaries and residual client-app work

## Security

- lifecycle templates remain unmutable `SECURITY` notifications
- push metadata carries no party name, account number, balance or capability set
- malformed, query-bearing and non-bank routes are rejected
- unknown future lifecycle events remain outside the recipient map until reviewed
- the mobile destination must authenticate and re-fetch the current grant

## Verification

- `:openbank-notification-service:ktlintCheck` — green
- `:openbank-notification-service:detekt` — green
- `:openbank-notification-service:quarkusBuild` — green
- focused domain, consumer and producer-contract tests — 18/18 green, 0 skipped
- `git diff --check` — green

Closes #8183
Refs #8172
