### PR TITLE
fix(admin-ui): pin Pact verification to provider main

### DIFF
--- a/openbank-admin-ui/scripts/collect-quality-report.mjs
+++ b/openbank-admin-ui/scripts/collect-quality-report.mjs
@@ -163,13 +163,14 @@ export async function providerHasMainVersion(baseUrl, auth, provider) {
 export async function fetchPairVerification(baseUrl, auth, consumer, consumerVersion, provider) {
   if (!consumerVersion) return { status: 'pending', verifiedAt: null, providerVersion: null }
   // Matrix API — pin the consumer to the commit that authored this exact pact
-  // file. The provider remains latest because it is the provider replay asked
-  // to validate that consumer version. Pact Broker documents `version` as a
-  // pacticipant build/version selector, normally a Git SHA.
+  // file. Pin the provider to its latest main-branch version so a newer feature
+  // verification cannot mask the verdict operators will deploy. Pact Broker
+  // documents `version` as a pacticipant build/version selector, normally a Git SHA.
   const qs = new URLSearchParams()
   qs.append('q[][pacticipant]', consumer)
   qs.append('q[][version]', consumerVersion)
   qs.append('q[][pacticipant]', provider)
+  qs.append('q[][branch]', 'main')
   qs.append('q[][latest]', 'true')
   qs.append('latestby', 'cvpv')
   const url = `${baseUrl.replace(/\/$/, '')}/matrix?${qs.toString()}`

--- a/openbank-admin-ui/src/test/collect-quality-report.test.ts
+++ b/openbank-admin-ui/src/test/collect-quality-report.test.ts
@@ -61,6 +61,44 @@ describe('collect-quality-report contract classification (#7544)', () => {
     expect(failed).not.toHaveProperty('reasonCode')
   })
 
+  it('pins the provider selector to main so a newer feature pass cannot mask a main failure', async () => {
+    let selector: [string, string][] = []
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      const parsed = new URL(url)
+      selector = [...parsed.searchParams.entries()]
+      const selectsMain = parsed.searchParams.getAll('q[][branch]').at(-1) === 'main'
+      return jsonResponse(200, {
+        matrix: selectsMain
+          ? [{
+              providerVersion: { number: 'main-red' },
+              verificationResult: { success: false, verifiedAt: '2026-08-31T00:00:00Z' },
+            }]
+          : [{
+              providerVersion: { number: 'feature-green' },
+              verificationResult: { success: true, verifiedAt: '2026-09-01T00:00:00Z' },
+            }],
+      })
+    }))
+
+    const v = await fetchPairVerification(
+      'http://broker.example',
+      null,
+      'openbank-alpha-service',
+      'sha-consumer',
+      'openbank-real-provider',
+    )
+
+    expect(v).toEqual({ status: 'failed', verifiedAt: '2026-08-31T00:00:00Z', providerVersion: 'main-red' })
+    expect(selector).toEqual([
+      ['q[][pacticipant]', 'openbank-alpha-service'],
+      ['q[][version]', 'sha-consumer'],
+      ['q[][pacticipant]', 'openbank-real-provider'],
+      ['q[][branch]', 'main'],
+      ['q[][latest]', 'true'],
+      ['latestby', 'cvpv'],
+    ])
+  })
+
   it('classifies a network/timeout exception as query-error, and never turns it into a pass', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => { throw new DOMException('The operation was aborted', 'TimeoutError') }))
     const contracts = [{ consumer: 'openbank-alpha-service', provider: 'openbank-real-provider', pactFile: 'x.json', consumerVersion: 'sha-consumer', status: 'pending', verifiedAt: null, interactions: [] }]


### PR DESCRIPTION
## Summary

Keep Test Intelligence contract evidence on the provider main branch. The previous Pact Matrix query used latest=true without a branch, so a newer green feature-branch verification could mask a red latest-main verification and falsely satisfy the required contract control.

Official selector semantics: https://docs.pact.io/pact_broker/advanced_topics/matrix_selectors

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #8185.
Refs ADR-0273.

## Changes

- Add provider branch=main to the exact-consumer Pact Matrix selector.
- Add a behavior regression that returns feature-green without the branch and main-red with it, then asserts the complete ordered selector and failed main verdict.

## Validation

- Red before product fix: 1 failed / 5 passed; feature-green was incorrectly reported passed.
- Focused post-fix suite on current main: 6/6 passed.
- Full Admin UI unit/integration suite on the same two-file patch before a non-overlapping main fast-forward: 422/422 files, 2,235 passed, 1 explicit skip.
- TypeScript gate on current main: passed.
- Targeted ESLint and Node syntax check: passed.
- Production Next build: compiled, 91/91 static pages.
- Test Intelligence ecosystem self-test and enforced gate: 1/1 passed, SUBJECTS=60.
- git diff --check: passed.
- Independent review: no P1/P2.

## Definition of Done

- [x] Hexagonal layering preserved.
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (no service boundary changed).
- [ ] Contract files updated (the Broker read selector changed, not a public API/Pact interaction).
- [ ] Gradle fleet build (no Kotlin/Gradle scope).
- [x] No new lint warnings.
- [ ] OpenAPI, Flyway and Avro changes (not applicable).
- [x] Behavior and operator-facing provenance documented in code and test.

## Security checklist

- [x] No secrets, tokens, passwords, PII or private Broker coordinates added.
- [x] No new suppressions or unsafe casts.
- [x] No new third-party dependency.
- [x] No auth, crypto, payment or cardholder-data path changed.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: normal Admin UI release/deploy.
- Rollback plan: revert this commit; no stored evidence or Broker data is mutated.
- Data migration reversible: N/A.

## Reviewer notes

The consumer remains pinned to the exact pact-producing commit. Only the provider selector changes from latest across all branches to latest main. The repository reconciler already uses main as the canonical provider branch. Current open PRs have no file overlap with either changed file.