### PR TITLE
fix(admin-ui): enforce core workflow contrast

### DIFF
--- a/openbank-admin-ui/e2e/core-workflow-accessibility.spec.ts
+++ b/openbank-admin-ui/e2e/core-workflow-accessibility.spec.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, test } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+import { signInAsOperator } from './helpers/auth'
+
+const CORE_WORKFLOWS = [
+  '/dashboard',
+  '/accounts',
+  '/payments',
+  '/parties',
+  '/approvals',
+  '/audit',
+  '/consents',
+  '/kyc',
+  '/sanctions',
+  '/sdd',
+] as const
+
+test.beforeEach(async ({ context, baseURL, page }) => {
+  await signInAsOperator(context, baseURL!)
+  await page.route('**/api/**', route => {
+    if (new URL(route.request().url()).pathname.startsWith('/api/auth/')) return route.continue()
+    return route.fulfill({
+      status: 503,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'temporarily unavailable' }),
+    })
+  })
+})
+
+for (const route of CORE_WORKFLOWS) {
+  test(`${route} has no automated WCAG A/AA violations in its default state`, async ({ page }) => {
+    await page.goto(route)
+    await expect(page.locator('#main-content')).toBeVisible()
+    // Several legacy consoles still use a short entry transition. Axe samples computed colours,
+    // so scan the settled UI rather than a deliberately translucent animation frame.
+    await page.waitForTimeout(300)
+    const scan = await new AxeBuilder({ page })
+      .include('#main-content')
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])
+      .analyze()
+    expect(scan.violations, scan.violations.map(violation =>
+      `${violation.id}: ${violation.nodes.map(node => node.target.join(' ')).join(', ')}`,
+    ).join('\n')).toEqual([])
+  })
+}

--- a/openbank-admin-ui/src/app/sanctions/page.tsx
+++ b/openbank-admin-ui/src/app/sanctions/page.tsx
@@ -667,7 +667,7 @@ export default function SanctionsPage() {
             {TABS.map(t => (
               <button key={t.id} type="button" aria-pressed={tab === t.id} aria-label={t.label} onClick={() => setTab(t.id)}
                 style={{ padding: '12px 16px', fontSize: '13px', fontWeight: tab === t.id ? 700 : 500,
-                  color: tab === t.id ? 'var(--accent)' : 'var(--text-secondary)',
+                  color: tab === t.id ? 'var(--accent-text)' : 'var(--text-secondary)',
                   background: 'none', border: 'none', borderBottom: tab === t.id ? '2px solid var(--accent)' : '2px solid transparent',
                   cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '-1px' }}>
                 {t.icon}{t.label}

--- a/openbank-admin-ui/src/components/party/PartySearch.tsx
+++ b/openbank-admin-ui/src/components/party/PartySearch.tsx
@@ -151,7 +151,7 @@ export function PartySearch({ onSelect, selectedId, busy = false, placeholder, l
             <Search size={15} aria-hidden="true" /> {searching ? t('Hledám…', 'Searching…') : t('Vyhledat', 'Search')}
           </button>
         </div>
-        <p style={{ margin: '10px 0 0', fontSize: '11px', color: 'var(--text-tertiary)' }}>
+        <p style={{ margin: '10px 0 0', fontSize: '11px', color: 'var(--text-secondary)' }}>
           {t(
             'Začněte jménem klienta nebo názvem firmy. Pokud už máte Party ID, můžete ho vložit přímo.',
             'Start with the customer or company name. If you already have a Party ID, paste it directly.',


### PR DESCRIPTION
## Summary
- add an authenticated Axe sweep across ten core operator workflow default states
- cover automated WCAG 2.0, 2.1, and 2.2 A/AA rules inside the main landmark
- correct measured Party Search hint and active Sanctions tab contrast failures

## Verification
- Chromium cross-route accessibility suite: 10/10 passed
- TypeScript: passed
- changed-file ESLint: 0 errors (5 pre-existing Sanctions warnings)
- diff check: passed
- independent exact-diff review: no blocker

No API, RBAC, persistence, or workflow behavior changes.

Closes #8201