### PR TITLE
fix(admin-ui): enforce dark workflow contrast

### DIFF
--- a/openbank-admin-ui/e2e/core-workflow-dark-accessibility.spec.ts
+++ b/openbank-admin-ui/e2e/core-workflow-dark-accessibility.spec.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, test } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+import { signInAsOperator } from './helpers/auth'
+
+const CORE_WORKFLOWS = [
+  { route: '/dashboard', heading: /Můj pracovní prostor|My workspace/ },
+  { route: '/accounts', heading: /Účty zákazníků|Customer Accounts/ },
+  { route: '/payments', heading: /Platby|Payments/ },
+  { route: '/parties', heading: /Subjekty|Parties/ },
+  { route: '/approvals', heading: /Fronta schvalování \(AI agent\)|Approval queue \(AI agent\)/ },
+  { route: '/audit', heading: /Auditní log|Audit Log/ },
+  { route: '/consents', heading: /Souhlasy|Consents/ },
+  { route: '/kyc', heading: /KYC Případy|KYC Cases/ },
+  { route: '/sanctions', heading: /Prověření sankcí|Sanctions Screening/ },
+  { route: '/sdd', heading: /Mandáty inkas|Direct debit mandates/ },
+] as const
+
+test.beforeEach(async ({ context, baseURL, page }) => {
+  await signInAsOperator(context, baseURL!)
+  await page.route('**/api/**', route => {
+    if (new URL(route.request().url()).pathname.startsWith('/api/auth/')) return route.continue()
+    return route.fulfill({
+      status: 503,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'temporarily unavailable' }),
+    })
+  })
+})
+
+for (const { route, heading } of CORE_WORKFLOWS) {
+  test(`${route} has no automated WCAG A/AA violations in its controlled dark state`, async ({ page }) => {
+    await page.goto(route)
+    await expect(page.locator('#main-content')).toBeVisible()
+    await expect(page.getByRole('heading', { level: 1, name: heading })).toBeVisible()
+    await page.locator('html').evaluate(element => element.classList.add('dark'))
+    await expect(page.locator('html')).toHaveCSS('color-scheme', 'dark')
+    if (route === '/approvals') {
+      await expect(page.getByRole('alert').filter({ hasText: /Agent (je nedostupný|unreachable)/ })).toBeVisible()
+    }
+    await page.waitForTimeout(300)
+    const scan = await new AxeBuilder({ page })
+      .include('#main-content')
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])
+      .analyze()
+    expect(scan.violations, scan.violations.map(violation =>
+      `${violation.id}: ${violation.nodes.map(node => node.target.join(' ')).join(', ')}`,
+    ).join('\n')).toEqual([])
+  })
+}

--- a/openbank-admin-ui/src/app/approvals/page.tsx
+++ b/openbank-admin-ui/src/app/approvals/page.tsx
@@ -223,8 +223,8 @@ export default function ApprovalsPage() {
       />
 
       {error && (
-        <div className="card" style={{ padding: 12, marginBottom: 16, borderLeft: '3px solid #dc2626', display: 'flex', gap: 8, alignItems: 'center', color: '#dc2626', fontSize: 13 }}>
-          <AlertTriangle size={15} /> {error === 'unreachable' ? t('Agent je nedostupný.', 'Agent unreachable.') : error}
+        <div role="alert" className="card" style={{ padding: 12, marginBottom: 16, borderLeft: '3px solid var(--danger)', display: 'flex', gap: 8, alignItems: 'center', color: 'var(--danger-text)', background: 'var(--danger-bg)', fontSize: 13 }}>
+          <AlertTriangle aria-hidden="true" size={15} /> {error === 'unreachable' ? t('Agent je nedostupný.', 'Agent unreachable.') : error}
         </div>
       )}
 

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -1135,9 +1135,9 @@ main {
 
 .input {
   min-height: 40px;
-  border-color: #cbd5e1;
+  border-color: var(--border-strong);
   border-radius: 9px;
-  background: rgba(255, 255, 255, .94);
+  background: var(--surface);
 }
 .input:focus { border-color: var(--accent); box-shadow: 0 0 0 4px rgba(99, 102, 241, .13); }
 


### PR DESCRIPTION
## Summary

- keep the shared Admin UI input primitive on semantic surface and border tokens in both themes
- render the Approvals failure panel with dark-safe danger tokens and assertive alert semantics
- add an authenticated WCAG 2.0/2.1/2.2 A/AA sweep for ten core workflows in a controlled dark state

## Evidence

- genuine pre-fix Chromium/Axe run: 3/10 failed
  - Accounts and Audit inputs: 1.07:1 contrast
  - Approvals failure panel: 3.67:1 contrast
- exact final Chromium/Axe run: 10/10 passed
- focused token/approval Vitest: 8/8 passed
- canonical `npm run type-check`: passed
- changed-file ESLint: 0 errors; one inherited effect warning
- production `npm run build`: passed, including 91/91 static pages
- `git diff --check`: passed
- independent exact-blob review: no blocker

## Safety

- no API, RBAC, workflow, or payload changes
- light-theme input border remains the same token value; its surface becomes the existing opaque shared surface
- the test proves each route H1, computed dark color scheme, and the Approvals asynchronous alert

Closes #8208
