### PR TITLE
fix(admin-ui): restore sanctions toggle focus after refresh

### DIFF
--- a/openbank-admin-ui/src/app/sanctions/page.tsx
+++ b/openbank-admin-ui/src/app/sanctions/page.tsx
@@ -40,6 +40,10 @@ interface SanctionsListChangeIntent {
   enabled: boolean
 }
 
+interface ListChangeFocusRequest {
+  listId: string
+}
+
 interface ApiError {
   error?: string
 }
@@ -238,6 +242,8 @@ export default function SanctionsPage() {
   const [pendingListChange, setPendingListChange] = useState<SanctionsListChangeIntent | null>(null)
   const [listChangeBusy, setListChangeBusy] = useState(false)
   const [listChangeError, setListChangeError] = useState<SanctionsListChangeError>(null)
+  const [listChangeFocusRequest, setListChangeFocusRequest] = useState<ListChangeFocusRequest | null>(null)
+  const handledListChangeFocusRef = useRef<ListChangeFocusRequest | null>(null)
   const listChangeTriggerRef = useRef<HTMLButtonElement | null>(null)
 
   // Manual disposition of a hit (issue #3334). POST /api/v1/sanctions/review existed, was
@@ -340,6 +346,23 @@ export default function SanctionsPage() {
     }
   }, [lists, listScopeInitialised])
 
+  // Restore focus only after React commits both dialog removal and the reconciled list controls.
+  // A one-shot animation frame can run while the loading branch still owns the panel, leaving only
+  // the detached initiating button to focus. A fresh request object also supports the same list
+  // being changed repeatedly without refocusing it on unrelated later renders.
+  useEffect(() => {
+    const request = listChangeFocusRequest
+    if (!request || handledListChangeFocusRef.current === request || pendingListChange || listsLoading) return
+
+    const stableControl = document.getElementById(listToggleControlId(request.listId))
+    const originalTrigger = listChangeTriggerRef.current
+    const target = stableControl instanceof HTMLButtonElement
+      ? stableControl
+      : originalTrigger?.isConnected ? originalTrigger : null
+    target?.focus()
+    handledListChangeFocusRef.current = request
+  }, [listChangeFocusRequest, listsLoading, pendingListChange])
+
   const handleScreen = async () => {
     if (!searchName.trim()) return
     setScreening(true); setScreenResult(null); setScreenError('')
@@ -377,11 +400,7 @@ export default function SanctionsPage() {
   }
 
   const restoreListChangeFocus = (listId: string) => {
-    requestAnimationFrame(() => {
-      const stableControl = document.getElementById(listToggleControlId(listId))
-      if (stableControl instanceof HTMLButtonElement) stableControl.focus()
-      else listChangeTriggerRef.current?.focus()
-    })
+    setListChangeFocusRequest({ listId })
   }
 
   const closeListChange = async () => {


### PR DESCRIPTION
## Summary

Restore keyboard focus to the sanctions-list toggle only after the refreshed list state has committed to the DOM. This removes the race where the previous one-frame callback could focus a detached pre-refresh button and leave focus on `<body>`.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #8216

## Changes

- Queue a fresh focus-restoration request when a sanctions-list review dialog closes.
- Fulfil it from a render-commit-coupled effect after reconciliation has finished, preferring the stable current control and using the initiating element only while it remains connected.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Existing unit and E2E coverage exercises the changed behavior; the strong focus assertions remain unchanged.
- [x] Integration tests added/updated (if service boundary involved) — N/A, no service boundary changed.
- [x] Contract tests updated (if public API changed) — N/A, no public API changed.
- [x] Relevant admin-UI Vitest, Playwright, ESLint, and TypeScript checks pass.
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed) — N/A.
- [x] Flyway migration added + rollback note (if DB changed) — N/A.
- [x] Avro schema versioned backward-compatibly (if event changed) — N/A.
- [x] Docs updated (README, ADR if architectural) — N/A, narrow bug fix documented by #8216.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, or `@Suppress("...")`.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? No.
- [x] PII path changed? No.
- [x] Cardholder data path changed? No.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

## Rollout / Rollback

- Deployment strategy: rolling (normal admin-UI deployment)
- Rollback plan: revert `e27b211f2`
- Data migration reversible: N/A

## Screenshots / demo (if UI change)

No visual change. Deterministic pre-fix probe leaves `activeElement` on `BODY`; the same forced ordering with this fix focuses the connected replacement toggle.

## Reviewer notes

- Exact scope: `openbank-admin-ui/src/app/sanctions/page.tsx` only.
- Deterministic forced race: red on the old code (`targetPresent=false`, detached fallback, `activeElement=BODY`); green with this commit (`activeElement=BUTTON`, stable toggle id).
- Focused Playwright repeat: 20/20 passes, `--repeat-each=20 --retries=0 --workers=1`.
- Full sanctions list-change spec: 4/4 passes with retries disabled, including success and 401/403 reconciliation paths.
- Relevant Vitest: 12 files / 44 tests pass.
- ESLint: 0 errors and the same 5 pre-existing warnings as `main`; TypeScript type-check and `git diff --check` pass.
- Open PRs #8214 and #8215 have no sanctions page/spec file overlap.
