### PR TITLE
security(delegation): reject stale lifecycle projections

### DIFF
--- a/docs/threat-models/openbank-account-service.md
+++ b/docs/threat-models/openbank-account-service.md
@@ -521,3 +521,10 @@ not change any existing request's outcome until explicitly flipped.
   the stamp is taken when the error object is built, not measured against request start, so it
   does not expose per-request processing duration. Rollback: revert; the field is
   serialisation-only and nothing persists it.
+## Delegation lifecycle ordering
+
+The local enforcement projection accepts authority-opening events only with a positive,
+monotonically increasing `lifecycleRevision`. A revisionless close remains accepted and installs a
+permanent legacy tombstone; a revisionless activate/reinstate is ignored. This deliberately favors
+temporary unavailability during a consumer-first rolling upgrade over resurrecting revoked access.
+Recovery from a legacy tombstone is a newly issued grant, never replaying the same grant id.

--- a/docs/threat-models/openbank-card-issuance-service.md
+++ b/docs/threat-models/openbank-card-issuance-service.md
@@ -211,3 +211,10 @@ retiring the corresponding KEK version in Transit, not after.
   DLQ so a close event is never destroyed, idempotent upsert per grant id. Residual: seconds-level
   revoke propagation per ADR-0232; customer-edge adoption of the check endpoint is its own slice.
   Rollback: revert; the projection tables are droppable without touching `cards`.
+## Delegation lifecycle ordering
+
+The card enforcement projection uses a durable monotonic cursor before changing access or blocking
+a supplementary card. Revisionless opens are ignored and revisionless closes install permanent
+legacy tombstones. A delayed lower revision cannot reopen a closed grant or trigger irreversible
+card blocking after a newer lifecycle decision. Consumers must be deployed and verified before the
+revisioned delegation producer.

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/application/port/out/DelegationProjectionRepository.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/application/port/out/DelegationProjectionRepository.kt
@@ -16,6 +16,10 @@ interface DelegationProjectionRepository {
     /** Close the row (revoke/suspend/renounce/expire). Returns false when unknown — still a no-op. */
     suspend fun closeById(grantId: UUID): Boolean
 
+    suspend fun applyActive(grant: DelegatedAccessGrant, lifecycleRevision: Long) = upsertActive(grant)
+
+    suspend fun applyClosed(grantId: UUID, lifecycleRevision: Long?): Boolean = closeById(grantId)
+
     suspend fun findActiveByAccountAndParty(accountId: UUID, partyId: UUID): List<DelegatedAccessGrant>
 
     /** Same lookup restricted to one resource type (ACCOUNT guard vs SAVINGS_GOAL guard). */

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/kafka/DelegationEventConsumer.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/kafka/DelegationEventConsumer.kt
@@ -26,6 +26,7 @@ private data class DelegationEvent(
     val perTxLimitCurrency: String?,
     val validFrom: OffsetDateTime?,
     val validTo: OffsetDateTime?,
+    val lifecycleRevision: Long?,
 )
 
 /**
@@ -81,22 +82,24 @@ class DelegationEventConsumer(
                 runCatching { OffsetDateTime.parse(it) }.getOrNull()
             },
             validTo = node.path("validTo").asText(null)?.let { runCatching { OffsetDateTime.parse(it) }.getOrNull() },
+            lifecycleRevision = node.path("lifecycleRevision").takeIf { it.isIntegralNumber }?.longValue(),
         )
     }
 
     private suspend fun dispatch(event: DelegationEvent) {
         if (event.resourceType !in PROJECTED_RESOURCE_TYPES && event.type in LIFECYCLE_TYPES) return
         when (event.type) {
-            "DelegationActivated", "DelegationReinstated" -> upsert(event)
+            "DelegationActivated", "DelegationReinstated" ->
+                if (event.lifecycleRevision != null) upsert(event) else Unit
             "DelegationRevoked", "DelegationSuspended", "DelegationRenounced", "DelegationExpired" ->
-                projectionRepository.closeById(event.grantId)
+                projectionRepository.applyClosed(event.grantId, event.lifecycleRevision)
             else -> Unit // OFFERED/DECLINED/unknown: nothing enforceable to do, ack.
         }
     }
 
     private suspend fun upsert(event: DelegationEvent) {
         val accountId = event.resourceId ?: return
-        projectionRepository.upsertActive(
+        projectionRepository.applyActive(
             DelegatedAccessGrant(
                 id = event.grantId,
                 accountId = accountId,
@@ -110,6 +113,7 @@ class DelegationEventConsumer(
                 validTo = event.validTo,
                 active = true,
             ),
+            requireNotNull(event.lifecycleRevision),
         )
     }
 

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/DelegationProjectionRepositoryImpl.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/DelegationProjectionRepositoryImpl.kt
@@ -11,6 +11,7 @@ import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.PanacheRepository
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
+import org.hibernate.reactive.mutiny.Mutiny
 import java.time.Clock
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -34,6 +35,45 @@ class DelegationProjectionRepositoryImpl(private val clock: Clock) :
         update("active = false, updatedAt = ?1 where id = ?2 and active = true", OffsetDateTime.now(clock), grantId)
     }.awaitSuspending() > 0L
 
+    override suspend fun applyActive(grant: DelegatedAccessGrant, lifecycleRevision: Long) {
+        Panache.withTransaction {
+            Panache.getSession().chain { session ->
+                claim(session, grant.id, lifecycleRevision, opening = true).chain { accepted ->
+                    if (accepted == true) {
+                        session.merge(DelegationProjectionEntity.fromDomain(grant, OffsetDateTime.now(clock)))
+                            .replaceWithVoid()
+                    } else {
+                        io.smallrye.mutiny.Uni.createFrom().voidItem()
+                    }
+                }
+            }
+        }.awaitSuspending()
+    }
+
+    override suspend fun applyClosed(grantId: UUID, lifecycleRevision: Long?): Boolean = Panache.withTransaction {
+        Panache.getSession().chain { session ->
+            claim(session, grantId, lifecycleRevision, opening = false).chain { accepted ->
+                if (accepted == true) {
+                    update(
+                        "active = false, updatedAt = ?1 where id = ?2 and active = true",
+                        OffsetDateTime.now(clock),
+                        grantId,
+                    )
+                        .replaceWith(true)
+                } else {
+                    io.smallrye.mutiny.Uni.createFrom().item(false)
+                }
+            }
+        }
+    }.awaitSuspending()
+
+    private fun claim(session: Mutiny.Session, grantId: UUID, revision: Long?, opening: Boolean) = session
+        .createNativeQuery(CLAIM_SQL, java.lang.Boolean::class.java)
+        .setParameter("grantId", grantId)
+        .setParameter("revision", revision)
+        .setParameter("opening", opening)
+        .singleResult
+
     override suspend fun findActiveByAccountAndParty(accountId: UUID, partyId: UUID): List<DelegatedAccessGrant> =
         findActiveByAccountPartyAndType(accountId, partyId, DelegatedAccessGrant.RESOURCE_TYPE_ACCOUNT)
 
@@ -49,4 +89,8 @@ class DelegationProjectionRepositoryImpl(private val clock: Clock) :
             resourceType,
         ).list<DelegationProjectionEntity>()
     }.awaitSuspending().map { it.toDomain() }
+
+    private companion object {
+        const val CLAIM_SQL = "SELECT account_claim_delegation_lifecycle(:grantId, :revision, :opening)"
+    }
 }

--- a/openbank-account-service/src/main/resources/db/migration/V23__delegation_lifecycle_cursor.sql
+++ b/openbank-account-service/src/main/resources/db/migration/V23__delegation_lifecycle_cursor.sql
@@ -1,0 +1,46 @@
+-- Monotonic consumer cursor. Revisionless closes become permanent tombstones; revisionless opens
+-- are rejected by the consumer.
+-- Rollback: first stop account-service consumers, prove all retained legacy events are drained and
+-- every producer emits lifecycleRevision, then DROP FUNCTION account_claim_delegation_lifecycle
+-- and DROP TABLE account_delegation_lifecycle_cursor. Keep both objects on ordinary code rollback.
+CREATE TABLE account_delegation_lifecycle_cursor (
+    grant_id UUID PRIMARY KEY,
+    lifecycle_revision BIGINT,
+    legacy_closed BOOLEAN NOT NULL DEFAULT FALSE,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT account_delegation_cursor_revision_positive
+        CHECK (lifecycle_revision IS NULL OR lifecycle_revision > 0)
+);
+
+CREATE OR REPLACE FUNCTION account_claim_delegation_lifecycle(
+    p_grant_id UUID,
+    p_revision BIGINT,
+    p_opening BOOLEAN
+) RETURNS BOOLEAN LANGUAGE plpgsql AS $$
+DECLARE
+    current_row account_delegation_lifecycle_cursor%ROWTYPE;
+BEGIN
+    IF p_opening AND p_revision IS NULL THEN RETURN FALSE; END IF;
+    INSERT INTO account_delegation_lifecycle_cursor(grant_id, lifecycle_revision, legacy_closed)
+    VALUES (p_grant_id, p_revision, NOT p_opening AND p_revision IS NULL)
+    ON CONFLICT DO NOTHING;
+    IF FOUND THEN RETURN TRUE; END IF;
+
+    SELECT * INTO current_row FROM account_delegation_lifecycle_cursor
+      WHERE grant_id = p_grant_id FOR UPDATE;
+    IF p_opening THEN
+        IF current_row.legacy_closed OR current_row.lifecycle_revision >= p_revision THEN RETURN FALSE; END IF;
+    ELSE
+        IF p_revision IS NULL THEN
+            UPDATE account_delegation_lifecycle_cursor
+              SET legacy_closed = TRUE, updated_at = now() WHERE grant_id = p_grant_id;
+            RETURN TRUE;
+        END IF;
+        IF current_row.legacy_closed THEN RETURN TRUE; END IF;
+        IF current_row.lifecycle_revision > p_revision THEN RETURN FALSE; END IF;
+        IF current_row.lifecycle_revision = p_revision THEN RETURN TRUE; END IF;
+    END IF;
+    UPDATE account_delegation_lifecycle_cursor
+      SET lifecycle_revision = p_revision, updated_at = now() WHERE grant_id = p_grant_id;
+    RETURN TRUE;
+END $$;

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/contract/DelegationEventMessagePactConsumerTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/contract/DelegationEventMessagePactConsumerTest.kt
@@ -106,6 +106,7 @@ class DelegationEventMessagePactConsumerTest {
             newJsonBody { o ->
                 o.stringValue("eventType", "DelegationActivated")
                 o.uuid("aggregateId")
+                o.integerType("lifecycleRevision", 1)
                 o.uuid("grantorPartyId")
                 o.uuid("granteePartyId")
                 o.stringValue("resourceType", "ACCOUNT")
@@ -128,6 +129,7 @@ class DelegationEventMessagePactConsumerTest {
         // Mirrors parseEnvelope + upsert, at the exact paths the consumer reads.
         assertThat(node.path("eventType").asText()).isEqualTo("DelegationActivated")
         assertThat(UUID.fromString(node.path("aggregateId").asText())).isNotNull()
+        assertThat(node.path("lifecycleRevision").asLong()).isEqualTo(1)
         assertThat(UUID.fromString(node.path("grantorPartyId").asText())).isNotNull()
         assertThat(UUID.fromString(node.path("granteePartyId").asText())).isNotNull()
         assertThat(node.path("resourceType").asText()).isEqualTo("ACCOUNT")
@@ -150,6 +152,7 @@ class DelegationEventMessagePactConsumerTest {
             newJsonBody { o ->
                 o.stringValue("eventType", "DelegationRevoked")
                 o.uuid("aggregateId")
+                o.integerType("lifecycleRevision", 2)
                 o.uuid("grantorPartyId")
                 o.uuid("granteePartyId")
                 o.stringValue("resourceType", "ACCOUNT")
@@ -165,6 +168,7 @@ class DelegationEventMessagePactConsumerTest {
         val node = objectMapper.readTree(messages.first().contentsAsBytes())
 
         assertThat(node.path("eventType").asText()).isEqualTo("DelegationRevoked")
+        assertThat(node.path("lifecycleRevision").asLong()).isEqualTo(2)
         // closeById(grantId) is keyed on aggregateId alone — if that field ever moved, every
         // revoke would be a no-op and the grant would stay enforceable.
         assertThat(UUID.fromString(node.path("aggregateId").asText())).isNotNull()

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/kafka/DelegationEventConsumerTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/kafka/DelegationEventConsumerTest.kt
@@ -34,28 +34,33 @@ class DelegationEventConsumerTest {
         consumer = DelegationEventConsumer(repository, objectMapper)
     }
 
-    private fun event(type: String, resourceType: String = "ACCOUNT", resourceId: UUID? = accountId): String =
-        objectMapper.writeValueAsString(
-            mapOf(
-                "eventType" to type,
-                "aggregateId" to grantId,
-                "grantorPartyId" to grantor,
-                "granteePartyId" to grantee,
-                "resourceType" to resourceType,
-                "resourceId" to resourceId,
-                "capabilities" to listOf("ACCOUNT_READ_BALANCES", "ACCOUNT_INITIATE_PAYMENT"),
-                "perTransactionLimit" to mapOf("amount" to "5000.00", "currency" to "CZK"),
-                "validFrom" to "2026-07-31T12:00:00Z",
-                "validTo" to "2027-07-31T12:00:00Z",
-                "occurredAt" to "2026-08-01T12:00:00Z",
-            ),
-        )
+    private fun event(
+        type: String,
+        resourceType: String = "ACCOUNT",
+        resourceId: UUID? = accountId,
+        revision: Long? = 1,
+    ): String = objectMapper.writeValueAsString(
+        mapOf(
+            "eventType" to type,
+            "aggregateId" to grantId,
+            "grantorPartyId" to grantor,
+            "granteePartyId" to grantee,
+            "resourceType" to resourceType,
+            "resourceId" to resourceId,
+            "capabilities" to listOf("ACCOUNT_READ_BALANCES", "ACCOUNT_INITIATE_PAYMENT"),
+            "perTransactionLimit" to mapOf("amount" to "5000.00", "currency" to "CZK"),
+            "validFrom" to "2026-07-31T12:00:00Z",
+            "validTo" to "2027-07-31T12:00:00Z",
+            "occurredAt" to "2026-08-01T12:00:00Z",
+            "lifecycleRevision" to revision,
+        ),
+    )
 
     @Test
     fun `DelegationActivated upserts an active projection row`(): Unit = runBlocking {
         consumer.consume(event("DelegationActivated"))
         coVerify {
-            repository.upsertActive(
+            repository.applyActive(
                 match<DelegatedAccessGrant> {
                     it.id == grantId &&
                         it.accountId == accountId &&
@@ -66,6 +71,7 @@ class DelegationEventConsumerTest {
                         "ACCOUNT_READ_BALANCES" in it.capabilities &&
                         it.perTransactionLimitAmount?.compareTo("5000.00".toBigDecimal()) == 0
                 },
+                1,
             )
         }
     }
@@ -95,7 +101,7 @@ class DelegationEventConsumerTest {
         for (type in listOf("DelegationRevoked", "DelegationSuspended", "DelegationRenounced", "DelegationExpired")) {
             consumer.consume(event(type))
         }
-        coVerify(exactly = 4) { repository.closeById(grantId) }
+        coVerify(exactly = 4) { repository.applyClosed(grantId, 1) }
     }
 
     @Test
@@ -110,10 +116,11 @@ class DelegationEventConsumerTest {
     fun `SAVINGS_GOAL events are projected with their resource type`(): Unit = runBlocking {
         consumer.consume(event("DelegationActivated", resourceType = "SAVINGS_GOAL"))
         coVerify {
-            repository.upsertActive(
+            repository.applyActive(
                 match<DelegatedAccessGrant> {
                     it.id == grantId && it.resourceType == "SAVINGS_GOAL" && it.active
                 },
+                1,
             )
         }
     }
@@ -140,9 +147,18 @@ class DelegationEventConsumerTest {
 
     @Test
     fun `transient failure is retried then escapes to the DLQ`(): Unit = runBlocking {
-        coEvery { repository.upsertActive(any()) } throws IllegalStateException("db blip")
+        coEvery { repository.applyActive(any(), any()) } throws IllegalStateException("db blip")
         assertThatThrownBy { runBlocking { consumer.consume(event("DelegationActivated")) } }
             .isInstanceOf(IllegalStateException::class.java)
-        coVerify(exactly = 4) { repository.upsertActive(any()) }
+        coVerify(exactly = 4) { repository.applyActive(any(), 1) }
+    }
+
+    @Test
+    fun `revisionless opening is ignored but revisionless close installs a tombstone`(): Unit = runBlocking {
+        consumer.consume(event("DelegationActivated", revision = null))
+        consumer.consume(event("DelegationRevoked", revision = null))
+
+        coVerify(exactly = 0) { repository.applyActive(any(), any()) }
+        coVerify(exactly = 1) { repository.applyClosed(grantId, null) }
     }
 }

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/integration/DelegationProjectionIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/integration/DelegationProjectionIT.kt
@@ -58,11 +58,16 @@ class DelegationProjectionIT {
             connector.source("delegation-events-in")
         source.runOnVertxContext(true)
 
-        source.send(delegationEvent("DelegationActivated", accountId))
+        source.send(delegationEvent("DelegationActivated", accountId, lifecycleRevision = 1))
         assertThat(awaitAuthorized(accountId, expected = true)).isTrue()
 
-        source.send(delegationEvent("DelegationRevoked", accountId))
+        source.send(delegationEvent("DelegationRevoked", accountId, lifecycleRevision = 2))
         assertThat(awaitAuthorized(accountId, expected = false)).isTrue()
+
+        source.send(delegationEvent("DelegationReinstated", accountId, lifecycleRevision = 1))
+        assertThat(awaitAuthorized(accountId, expected = false))
+            .describedAs("a delayed older opening must not resurrect revoked authority")
+            .isTrue()
     }
 
     /**
@@ -148,6 +153,7 @@ class DelegationProjectionIT {
         grantId: UUID = this.grantId,
         grantorPartyId: UUID = ownerParty,
         capabilities: String = """"ACCOUNT_READ_BALANCES"""",
+        lifecycleRevision: Long = 1,
     ): String =
         """
         {
@@ -160,6 +166,7 @@ class DelegationProjectionIT {
           "capabilities": [$capabilities],
           "validFrom": "2026-01-01T00:00:00Z",
           "occurredAt": "2026-08-01T12:00:00Z"
+          ,"lifecycleRevision": $lifecycleRevision
         }
         """.trimIndent()
 }

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/integration/LegacyArmOmitsGrantorIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/integration/LegacyArmOmitsGrantorIT.kt
@@ -231,6 +231,7 @@ class LegacyArmOmitsGrantorIT {
         """
         {
           "eventType": "DelegationActivated",
+          "lifecycleRevision": 1,
           "aggregateId": "$grantId",
           "grantorPartyId": "$ownerParty",
           "granteePartyId": "$delegateParty",

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/integration/SavingsGoalDelegationIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/integration/SavingsGoalDelegationIT.kt
@@ -116,6 +116,7 @@ class SavingsGoalDelegationIT {
         """
         {
           "eventType": "$type",
+          "lifecycleRevision": ${if (type == "DelegationActivated") 1 else 2},
           "aggregateId": "$grantId",
           "grantorPartyId": "$ownerParty",
           "granteePartyId": "$delegateParty",

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/integration/SavingsProposalIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/integration/SavingsProposalIT.kt
@@ -181,6 +181,7 @@ class SavingsProposalIT {
         """
         {
           "eventType": "$type",
+          "lifecycleRevision": 1,
           "aggregateId": "$grantId",
           "grantorPartyId": "$ownerParty",
           "granteePartyId": "$delegateParty",

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/port/out/CardDelegationProjectionRepository.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/port/out/CardDelegationProjectionRepository.kt
@@ -16,5 +16,9 @@ interface CardDelegationProjectionRepository {
     /** Close the row (revoke/suspend/renounce/expire). Returns false when unknown — still a no-op. */
     suspend fun closeById(grantId: UUID): Boolean
 
+    suspend fun applyActive(grant: DelegatedCardGrant, lifecycleRevision: Long) = upsertActive(grant)
+
+    suspend fun applyClosed(grantId: UUID, lifecycleRevision: Long?): Boolean = closeById(grantId)
+
     suspend fun findActiveByCardAndParty(cardId: UUID, partyId: UUID): List<DelegatedCardGrant>
 }

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/kafka/CardDelegationEventConsumer.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/kafka/CardDelegationEventConsumer.kt
@@ -25,6 +25,7 @@ private data class DelegationEvent(
     val capabilities: Set<String>,
     val validFrom: OffsetDateTime?,
     val validTo: OffsetDateTime?,
+    val lifecycleRevision: Long?,
 )
 
 /**
@@ -75,6 +76,7 @@ class CardDelegationEventConsumer(
                 runCatching { OffsetDateTime.parse(it) }.getOrNull()
             },
             validTo = node.path("validTo").asText(null)?.let { runCatching { OffsetDateTime.parse(it) }.getOrNull() },
+            lifecycleRevision = node.path("lifecycleRevision").takeIf { it.isIntegralNumber }?.longValue(),
         )
     }
 
@@ -86,20 +88,24 @@ class CardDelegationEventConsumer(
         // filter below drops every non-CARD lifecycle event, so putting this after it would mean
         // the exact revocation that has to kill the card is the one event we never see. The card is
         // found by its own stored delegation_grant_id, which is why no resourceType is needed here.
-        if (event.type in ENDING_TYPES) {
-            cardUseCase.blockCardsForRevokedGrant(event.grantId, "$REVOCATION_REASON_PREFIX${event.type}")
+        if (event.type in CLOSING_TYPES) {
+            val accepted = projectionRepository.applyClosed(event.grantId, event.lifecycleRevision)
+            if (accepted && event.type in ENDING_TYPES) {
+                cardUseCase.blockCardsForRevokedGrant(event.grantId, "$REVOCATION_REASON_PREFIX${event.type}")
+            }
         }
         if (event.resourceType != RESOURCE_CARD && event.type in LIFECYCLE_TYPES) return
         when (event.type) {
-            "DelegationActivated", "DelegationReinstated" -> upsert(event)
-            in CLOSING_TYPES -> projectionRepository.closeById(event.grantId)
+            "DelegationActivated", "DelegationReinstated" ->
+                if (event.lifecycleRevision != null) upsert(event) else Unit
+            in CLOSING_TYPES -> Unit
             else -> Unit
         }
     }
 
     private suspend fun upsert(event: DelegationEvent) {
         val cardId = event.resourceId ?: return
-        projectionRepository.upsertActive(
+        projectionRepository.applyActive(
             DelegatedCardGrant(
                 id = event.grantId,
                 cardId = cardId,
@@ -110,6 +116,7 @@ class CardDelegationEventConsumer(
                 validTo = event.validTo,
                 active = true,
             ),
+            requireNotNull(event.lifecycleRevision),
         )
     }
 

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/repository/CardDelegationProjectionRepositoryImpl.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/repository/CardDelegationProjectionRepositoryImpl.kt
@@ -11,6 +11,7 @@ import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.PanacheRepository
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
+import org.hibernate.reactive.mutiny.Mutiny
 import java.time.Clock
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -33,9 +34,52 @@ class CardDelegationProjectionRepositoryImpl(private val clock: Clock) :
         update("active = false, updatedAt = ?1 where id = ?2 and active = true", OffsetDateTime.now(clock), grantId)
     }.awaitSuspending() > 0L
 
+    override suspend fun applyActive(grant: DelegatedCardGrant, lifecycleRevision: Long) {
+        Panache.withTransaction {
+            Panache.getSession().chain { session ->
+                claim(session, grant.id, lifecycleRevision, opening = true).chain { accepted ->
+                    if (accepted == true) {
+                        session.merge(CardDelegationProjectionEntity.fromDomain(grant, OffsetDateTime.now(clock)))
+                            .replaceWithVoid()
+                    } else {
+                        io.smallrye.mutiny.Uni.createFrom().voidItem()
+                    }
+                }
+            }
+        }.awaitSuspending()
+    }
+
+    override suspend fun applyClosed(grantId: UUID, lifecycleRevision: Long?): Boolean = Panache.withTransaction {
+        Panache.getSession().chain { session ->
+            claim(session, grantId, lifecycleRevision, opening = false).chain { accepted ->
+                if (accepted == true) {
+                    update(
+                        "active = false, updatedAt = ?1 where id = ?2 and active = true",
+                        OffsetDateTime.now(clock),
+                        grantId,
+                    )
+                        .replaceWith(true)
+                } else {
+                    io.smallrye.mutiny.Uni.createFrom().item(false)
+                }
+            }
+        }
+    }.awaitSuspending()
+
+    private fun claim(session: Mutiny.Session, grantId: UUID, revision: Long?, opening: Boolean) = session
+        .createNativeQuery(CLAIM_SQL, java.lang.Boolean::class.java)
+        .setParameter("grantId", grantId)
+        .setParameter("revision", revision)
+        .setParameter("opening", opening)
+        .singleResult
+
     override suspend fun findActiveByCardAndParty(cardId: UUID, partyId: UUID): List<DelegatedCardGrant> =
         Panache.withSession {
             find("cardId = ?1 and granteePartyId = ?2 and active = true", cardId, partyId)
                 .list<CardDelegationProjectionEntity>()
         }.awaitSuspending().map { it.toDomain() }
+
+    private companion object {
+        const val CLAIM_SQL = "SELECT card_claim_delegation_lifecycle(:grantId, :revision, :opening)"
+    }
 }

--- a/openbank-card-issuance-service/src/main/resources/db/migration/V12__delegation_lifecycle_cursor.sql
+++ b/openbank-card-issuance-service/src/main/resources/db/migration/V12__delegation_lifecycle_cursor.sql
@@ -1,0 +1,42 @@
+-- Rollback: first stop card-issuance consumers, prove all retained legacy events are drained and
+-- every producer emits lifecycleRevision, then DROP FUNCTION card_claim_delegation_lifecycle and
+-- DROP TABLE card_delegation_lifecycle_cursor. Keep both objects on ordinary code rollback.
+CREATE TABLE card_delegation_lifecycle_cursor (
+    grant_id UUID PRIMARY KEY,
+    lifecycle_revision BIGINT,
+    legacy_closed BOOLEAN NOT NULL DEFAULT FALSE,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT card_delegation_cursor_revision_positive
+        CHECK (lifecycle_revision IS NULL OR lifecycle_revision > 0)
+);
+
+CREATE OR REPLACE FUNCTION card_claim_delegation_lifecycle(
+    p_grant_id UUID,
+    p_revision BIGINT,
+    p_opening BOOLEAN
+) RETURNS BOOLEAN LANGUAGE plpgsql AS $$
+DECLARE current_row card_delegation_lifecycle_cursor%ROWTYPE;
+BEGIN
+    IF p_opening AND p_revision IS NULL THEN RETURN FALSE; END IF;
+    INSERT INTO card_delegation_lifecycle_cursor(grant_id, lifecycle_revision, legacy_closed)
+    VALUES (p_grant_id, p_revision, NOT p_opening AND p_revision IS NULL)
+    ON CONFLICT DO NOTHING;
+    IF FOUND THEN RETURN TRUE; END IF;
+    SELECT * INTO current_row FROM card_delegation_lifecycle_cursor
+      WHERE grant_id = p_grant_id FOR UPDATE;
+    IF p_opening THEN
+        IF current_row.legacy_closed OR current_row.lifecycle_revision >= p_revision THEN RETURN FALSE; END IF;
+    ELSE
+        IF p_revision IS NULL THEN
+            UPDATE card_delegation_lifecycle_cursor SET legacy_closed = TRUE, updated_at = now()
+              WHERE grant_id = p_grant_id;
+            RETURN TRUE;
+        END IF;
+        IF current_row.legacy_closed THEN RETURN TRUE; END IF;
+        IF current_row.lifecycle_revision > p_revision THEN RETURN FALSE; END IF;
+        IF current_row.lifecycle_revision = p_revision THEN RETURN TRUE; END IF;
+    END IF;
+    UPDATE card_delegation_lifecycle_cursor SET lifecycle_revision = p_revision, updated_at = now()
+      WHERE grant_id = p_grant_id;
+    RETURN TRUE;
+END $$;

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/contract/CardDelegationEventMessagePactConsumerTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/contract/CardDelegationEventMessagePactConsumerTest.kt
@@ -95,6 +95,7 @@ class CardDelegationEventMessagePactConsumerTest {
             newJsonBody { o ->
                 o.stringValue("eventType", "DelegationActivated")
                 o.uuid("aggregateId")
+                o.integerType("lifecycleRevision", 1)
                 o.uuid("grantorPartyId")
                 o.uuid("granteePartyId")
                 o.stringValue("resourceType", "CARD")
@@ -112,6 +113,7 @@ class CardDelegationEventMessagePactConsumerTest {
 
         assertThat(node.path("eventType").asText()).isEqualTo("DelegationActivated")
         assertThat(UUID.fromString(node.path("aggregateId").asText())).isNotNull()
+        assertThat(node.path("lifecycleRevision").asLong()).isEqualTo(1)
         assertThat(UUID.fromString(node.path("grantorPartyId").asText())).isNotNull()
         assertThat(UUID.fromString(node.path("granteePartyId").asText())).isNotNull()
         assertThat(node.path("resourceType").asText()).isEqualTo("CARD")
@@ -131,6 +133,7 @@ class CardDelegationEventMessagePactConsumerTest {
             newJsonBody { o ->
                 o.stringValue("eventType", "DelegationRevoked")
                 o.uuid("aggregateId")
+                o.integerType("lifecycleRevision", 2)
                 o.uuid("grantorPartyId")
                 o.uuid("granteePartyId")
                 o.stringValue("resourceType", "CARD")
@@ -146,6 +149,7 @@ class CardDelegationEventMessagePactConsumerTest {
         val node = objectMapper.readTree(messages.first().contentsAsBytes())
 
         assertThat(node.path("eventType").asText()).isEqualTo("DelegationRevoked")
+        assertThat(node.path("lifecycleRevision").asLong()).isEqualTo(2)
         assertThat(UUID.fromString(node.path("aggregateId").asText())).isNotNull()
         assertThat(node.path("resourceType").asText()).isEqualTo("CARD")
     }

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/infrastructure/kafka/CardDelegationEventConsumerTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/infrastructure/kafka/CardDelegationEventConsumerTest.kt
@@ -33,32 +33,39 @@ class CardDelegationEventConsumerTest {
     @BeforeEach
     fun setUp() {
         consumer = CardDelegationEventConsumer(repository, cardUseCase, objectMapper)
+        coEvery { repository.applyClosed(any(), any()) } returns true
     }
 
-    private fun event(type: String, resourceType: String = "CARD", resourceId: UUID? = cardId): String =
-        objectMapper.writeValueAsString(
-            mapOf(
-                "eventType" to type,
-                "aggregateId" to grantId,
-                "grantorPartyId" to UUID.randomUUID(),
-                "granteePartyId" to grantee,
-                "resourceType" to resourceType,
-                "resourceId" to resourceId,
-                "capabilities" to listOf("CARD_VIEW", "CARD_MANAGE_LIMITS"),
-                "validFrom" to "2026-07-31T12:00:00Z",
-                "validTo" to "2027-07-31T12:00:00Z",
-                "occurredAt" to "2026-08-01T12:00:00Z",
-            ),
-        )
+    private fun event(
+        type: String,
+        resourceType: String = "CARD",
+        resourceId: UUID? = cardId,
+        revision: Long? = 1,
+    ): String = objectMapper.writeValueAsString(
+        mapOf(
+            "eventType" to type,
+            "aggregateId" to grantId,
+            "grantorPartyId" to UUID.randomUUID(),
+            "granteePartyId" to grantee,
+            "resourceType" to resourceType,
+            "resourceId" to resourceId,
+            "capabilities" to listOf("CARD_VIEW", "CARD_MANAGE_LIMITS"),
+            "validFrom" to "2026-07-31T12:00:00Z",
+            "validTo" to "2027-07-31T12:00:00Z",
+            "occurredAt" to "2026-08-01T12:00:00Z",
+            "lifecycleRevision" to revision,
+        ),
+    )
 
     @Test
     fun `DelegationActivated upserts an active projection row`(): Unit = runBlocking {
         consumer.consume(event("DelegationActivated"))
         coVerify {
-            repository.upsertActive(
+            repository.applyActive(
                 match<DelegatedCardGrant> {
                     it.id == grantId && it.cardId == cardId && it.active && "CARD_VIEW" in it.capabilities
                 },
+                1,
             )
         }
     }
@@ -68,7 +75,7 @@ class CardDelegationEventConsumerTest {
         for (type in listOf("DelegationRevoked", "DelegationSuspended", "DelegationRenounced", "DelegationExpired")) {
             consumer.consume(event(type))
         }
-        coVerify(exactly = 4) { repository.closeById(grantId) }
+        coVerify(exactly = 4) { repository.applyClosed(grantId, 1) }
     }
 
     @Test
@@ -114,7 +121,7 @@ class CardDelegationEventConsumerTest {
         // Suspension is reversible; a block is not, and nothing here could tell a bank-frozen card
         // from a customer-frozen one on reinstatement. The delegate's controls still stop at once,
         // because the projection row closes and the edge asks delegation-service on every request.
-        coVerify(exactly = 1) { repository.closeById(grantId) }
+        coVerify(exactly = 1) { repository.applyClosed(grantId, 1) }
         coVerify(exactly = 0) { cardUseCase.blockCardsForRevokedGrant(any(), any()) }
     }
 
@@ -133,9 +140,18 @@ class CardDelegationEventConsumerTest {
 
     @Test
     fun `transient failure is retried then escapes to the DLQ`(): Unit = runBlocking {
-        coEvery { repository.upsertActive(any()) } throws IllegalStateException("db blip")
+        coEvery { repository.applyActive(any(), any()) } throws IllegalStateException("db blip")
         assertThatThrownBy { runBlocking { consumer.consume(event("DelegationActivated")) } }
             .isInstanceOf(IllegalStateException::class.java)
-        coVerify(exactly = 4) { repository.upsertActive(any()) }
+        coVerify(exactly = 4) { repository.applyActive(any(), 1) }
+    }
+
+    @Test
+    fun `stale close does not trigger irreversible card blocking`(): Unit = runBlocking {
+        coEvery { repository.applyClosed(grantId, 1) } returns false
+
+        consumer.consume(event("DelegationRevoked", resourceType = "ACCOUNT"))
+
+        coVerify(exactly = 0) { cardUseCase.blockCardsForRevokedGrant(any(), any()) }
     }
 }

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/integration/CardDelegationProjectionIT.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/integration/CardDelegationProjectionIT.kt
@@ -62,11 +62,16 @@ class CardDelegationProjectionIT {
         val source: InMemorySource<String> = connector.source("delegation-events-in")
         source.runOnVertxContext(true)
 
-        source.send(delegationEvent("DelegationActivated", cardId))
+        source.send(delegationEvent("DelegationActivated", cardId, lifecycleRevision = 1))
         assertThat(awaitAuthorized(cardId, expected = true)).isTrue()
 
-        source.send(delegationEvent("DelegationRevoked", cardId))
+        source.send(delegationEvent("DelegationRevoked", cardId, lifecycleRevision = 2))
         assertThat(awaitAuthorized(cardId, expected = false)).isTrue()
+
+        source.send(delegationEvent("DelegationReinstated", cardId, lifecycleRevision = 1))
+        assertThat(awaitAuthorized(cardId, expected = false))
+            .describedAs("a delayed older opening must not resurrect revoked card authority")
+            .isTrue()
     }
 
     private fun seedCard(): UUID {
@@ -111,7 +116,7 @@ class CardDelegationProjectionIT {
         return false
     }
 
-    private fun delegationEvent(type: String, cardId: UUID): String =
+    private fun delegationEvent(type: String, cardId: UUID, lifecycleRevision: Long): String =
         """
         {
           "eventType": "$type",
@@ -123,6 +128,7 @@ class CardDelegationProjectionIT {
           "capabilities": ["CARD_VIEW"],
           "validFrom": "2026-01-01T00:00:00Z",
           "occurredAt": "2026-08-01T12:00:00Z"
+          ,"lifecycleRevision": $lifecycleRevision
         }
         """.trimIndent()
 }

--- a/pacts/openbank-account-service-openbank-delegation-service.json
+++ b/pacts/openbank-account-service-openbank-delegation-service.json
@@ -12,6 +12,7 @@
         "eventType": "DelegationActivated",
         "granteePartyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
         "grantorPartyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "lifecycleRevision": 1,
         "perTransactionLimit": {
           "amount": 1500.0,
           "currency": "CZK"
@@ -74,6 +75,14 @@
               }
             ]
           },
+          "$.lifecycleRevision": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "integer"
+              }
+            ]
+          },
           "$.perTransactionLimit.amount": {
             "combine": "AND",
             "matchers": [
@@ -128,6 +137,7 @@
         "eventType": "DelegationRevoked",
         "granteePartyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
         "grantorPartyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "lifecycleRevision": 2,
         "resourceId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
         "resourceType": "ACCOUNT"
       },
@@ -182,6 +192,14 @@
               {
                 "match": "regex",
                 "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.lifecycleRevision": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "integer"
               }
             ]
           },

--- a/pacts/openbank-card-issuance-service-openbank-delegation-service.json
+++ b/pacts/openbank-card-issuance-service-openbank-delegation-service.json
@@ -12,6 +12,7 @@
         "eventType": "DelegationActivated",
         "granteePartyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
         "grantorPartyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "lifecycleRevision": 1,
         "resourceId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
         "resourceType": "CARD",
         "validFrom": "2026-01-01T00:00:00Z"
@@ -70,6 +71,14 @@
               }
             ]
           },
+          "$.lifecycleRevision": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "integer"
+              }
+            ]
+          },
           "$.resourceId": {
             "combine": "AND",
             "matchers": [
@@ -108,6 +117,7 @@
         "eventType": "DelegationRevoked",
         "granteePartyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
         "grantorPartyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "lifecycleRevision": 2,
         "resourceId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
         "resourceType": "CARD"
       },
@@ -162,6 +172,14 @@
               {
                 "match": "regex",
                 "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.lifecycleRevision": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "integer"
               }
             ]
           },


### PR DESCRIPTION
## Summary\n- add durable monotonic lifecycle cursors to account and card projections\n- ignore revisionless authority-opening events and retain legacy close tombstones\n- require lifecycle revisions in both consumer-driven message contracts\n\n## Rollout\nConsumer-first. Deploy and verify account/card before the delegation producer starts emitting authoritative revisions. Revisionless ACTIVE/REINSTATED events fail closed during overlap; revisionless closes remain permanent tombstones until explicit reissue/reconciliation.\n\n## Verification\n- account consumer unit + real PostgreSQL delayed-reinstatement projection tests green\n- card consumer unit + real PostgreSQL projection tests green\n- account/card compile, ktlint and detekt green\n- account message Pact 2/2 green and regenerated\n- card message Pact 2/2 green and regenerated\n\nCloses #8199