### PR TITLE
feat(admin-ui): capture Core Web Vitals

### DIFF
--- a/openbank-admin-ui/src/components/layout/AppProviders.tsx
+++ b/openbank-admin-ui/src/components/layout/AppProviders.tsx
@@ -32,10 +32,14 @@ export function AppProviders({
     <LanguageProvider initialLanguage={initialLanguage} refreshServerContent={refreshServerContent}>
       {children}
       {!publicSurface && <AgentDock />}
-      {!publicSurface && <RumScreenTracker />}
       <Toaster richColors position="top-right" />
     </LanguageProvider>
   )
 
-  return publicSurface ? shared : <SessionProvider>{shared}</SessionProvider>
+  return (
+    <>
+      <RumScreenTracker enabled={!publicSurface} />
+      {publicSurface ? shared : <SessionProvider>{shared}</SessionProvider>}
+    </>
+  )
 }

--- a/openbank-admin-ui/src/components/telemetry/RumScreenTracker.tsx
+++ b/openbank-admin-ui/src/components/telemetry/RumScreenTracker.tsx
@@ -5,20 +5,34 @@
 'use client'
 
 import { usePathname } from 'next/navigation'
-import { useEffect } from 'react'
-import { initRum, recordScreenView } from '@/lib/telemetry/rum'
+import { useReportWebVitals } from 'next/web-vitals'
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react'
+import { initRum, recordScreenView, recordWebVital } from '@/lib/telemetry/rum'
 
 /** Emits one authenticated App-Router screen-view span per navigation; renders nothing. */
-export function RumScreenTracker() {
+export function RumScreenTracker({ enabled = true }: { enabled?: boolean }) {
   const pathname = usePathname()
+  const initialDocumentPath = useRef(pathname)
+  const initialDocumentEligible = useRef(enabled)
+  const enabledRef = useRef(enabled)
+
+  useLayoutEffect(() => {
+    enabledRef.current = enabled
+  }, [enabled])
 
   useEffect(() => {
+    if (!enabled) return
     initRum({
       userAgent: window.navigator.userAgent,
       appVersion: process.env.NEXT_PUBLIC_BUILD_VERSION ?? 'dev',
     })
     recordScreenView(pathname)
-  }, [pathname])
+  }, [enabled, pathname])
+
+  useReportWebVitals(useCallback(metric => {
+    if (!initialDocumentEligible.current || !enabledRef.current) return
+    recordWebVital(metric, initialDocumentPath.current)
+  }, []))
 
   return null
 }

--- a/openbank-admin-ui/src/lib/telemetry/rum.ts
+++ b/openbank-admin-ui/src/lib/telemetry/rum.ts
@@ -17,6 +17,21 @@ export const ATTR_APP_VERSION = 'app.version'
 export const ATTR_DEVICE_MODEL = 'device.model'
 export const ATTR_OS_TYPE = 'os.type'
 export const ATTR_OS_VERSION = 'os.version'
+export const ATTR_WEB_VITAL_NAME = 'web_vital.name'
+export const ATTR_WEB_VITAL_VALUE = 'web_vital.value'
+export const ATTR_WEB_VITAL_DELTA = 'web_vital.delta'
+export const ATTR_WEB_VITAL_RATING = 'web_vital.rating'
+export const ATTR_WEB_VITAL_UNIT = 'web_vital.unit'
+
+const CORE_WEB_VITAL_NAMES = new Set(['CLS', 'INP', 'LCP'])
+const WEB_VITAL_RATINGS = new Set(['good', 'needs-improvement', 'poor'])
+
+export interface CoreWebVitalInput {
+  name: string
+  value: number
+  delta: number
+  rating: string
+}
 
 /** Conservative redaction: screen names must never contain operator, customer or case identifiers. */
 export function looksLikeIdentifier(segment: string): boolean {
@@ -99,6 +114,27 @@ export function recordScreenView(pathname: string, tracer: Tracer = rumTracer())
   const screen = toScreenName(pathname)
   const span = tracer.startSpan(`screen.${screen}`, {
     attributes: { [ATTR_SCREEN_NAME]: screen, [ATTR_HTTP_ROUTE]: screen },
+  })
+  context.with(trace.setSpan(context.active(), span), () => span.end())
+}
+
+/** Emits only the three stable Core Web Vitals and deliberately drops IDs and attribution entries. */
+export function recordWebVital(metric: CoreWebVitalInput, pathname: string, tracer: Tracer = rumTracer()): void {
+  if (!CORE_WEB_VITAL_NAMES.has(metric.name) || !WEB_VITAL_RATINGS.has(metric.rating)) return
+  if (!Number.isFinite(metric.value) || !Number.isFinite(metric.delta) || metric.value < 0 || metric.delta < 0) return
+
+  const screen = toScreenName(pathname)
+  const unit = metric.name === 'CLS' ? '1' : 'ms'
+  const span = tracer.startSpan(`web-vital.${metric.name.toLowerCase()}`, {
+    attributes: {
+      [ATTR_WEB_VITAL_NAME]: metric.name,
+      [ATTR_WEB_VITAL_VALUE]: metric.value,
+      [ATTR_WEB_VITAL_DELTA]: metric.delta,
+      [ATTR_WEB_VITAL_RATING]: metric.rating,
+      [ATTR_WEB_VITAL_UNIT]: unit,
+      [ATTR_SCREEN_NAME]: screen,
+      [ATTR_HTTP_ROUTE]: screen,
+    },
   })
   context.with(trace.setSpan(context.active(), span), () => span.end())
 }

--- a/openbank-admin-ui/src/test/app-providers.test.tsx
+++ b/openbank-admin-ui/src/test/app-providers.test.tsx
@@ -9,6 +9,8 @@ import { usePathname } from 'next/navigation'
 import { AppProviders } from '@/components/layout/AppProviders'
 import { isPublicSurface } from '@/lib/auth/publicSurface'
 
+const trackerLifecycle = vi.hoisted(() => ({ mounts: 0, unmounts: 0 }))
+
 vi.mock('next/navigation', () => ({
   usePathname: vi.fn(),
   useRouter: vi.fn(() => ({ refresh: vi.fn() })),
@@ -17,13 +19,29 @@ vi.mock('@/components/auth/SessionProvider', () => ({
   SessionProvider: ({ children }: { children: React.ReactNode }) => <div data-testid="session-provider">{children}</div>,
 }))
 vi.mock('@/components/agent/AgentDock', () => ({ AgentDock: () => <div data-testid="agent-dock" /> }))
+vi.mock('@/components/telemetry/RumScreenTracker', async () => {
+  const React = await import('react')
+  return {
+    RumScreenTracker: ({ enabled }: { enabled?: boolean }) => {
+      React.useEffect(() => {
+        trackerLifecycle.mounts += 1
+        return () => { trackerLifecycle.unmounts += 1 }
+      }, [])
+      return <div data-enabled={String(enabled)} data-testid="rum-tracker" />
+    },
+  }
+})
 vi.mock('@/lib/i18n/LanguageContext', () => ({
   LanguageProvider: ({ children }: { children: React.ReactNode }) => <div data-testid="language-provider">{children}</div>,
 }))
 vi.mock('sonner', () => ({ Toaster: () => <div data-testid="toaster" /> }))
 
 describe('AppProviders', () => {
-  beforeEach(() => vi.mocked(usePathname).mockReturnValue('/dashboard'))
+  beforeEach(() => {
+    vi.mocked(usePathname).mockReturnValue('/dashboard')
+    trackerLifecycle.mounts = 0
+    trackerLifecycle.unmounts = 0
+  })
 
   it.each(['/auth/login', '/auth/error', '/auth/forbidden', '/privacy'])('keeps %s session-free', pathname => {
     vi.mocked(usePathname).mockReturnValue(pathname)
@@ -42,6 +60,17 @@ describe('AppProviders', () => {
     expect(screen.getByTestId('session-provider')).toBeVisible()
     expect(screen.getByTestId('agent-dock')).toBeVisible()
     expect(screen.getByText('Operator content')).toBeVisible()
+  })
+
+  it('keeps one RUM observer owner mounted across protected and public surfaces', () => {
+    const view = render(<AppProviders><main>Content</main></AppProviders>)
+    expect(screen.getByTestId('rum-tracker')).toHaveAttribute('data-enabled', 'true')
+
+    vi.mocked(usePathname).mockReturnValue('/auth/login')
+    view.rerender(<AppProviders><main>Content</main></AppProviders>)
+
+    expect(screen.getByTestId('rum-tracker')).toHaveAttribute('data-enabled', 'false')
+    expect(trackerLifecycle).toEqual({ mounts: 1, unmounts: 0 })
   })
 
   it('does not classify similarly named protected routes as public', () => {

--- a/openbank-admin-ui/src/test/rum-instrumentation.test.ts
+++ b/openbank-admin-ui/src/test/rum-instrumentation.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   createRumProvider,
   looksLikeIdentifier,
+  recordWebVital,
   recordScreenView,
   resetRumForTests,
   RUM_INGEST_PATH,
@@ -22,6 +23,27 @@ function exportScreen(pathname: string) {
     new SimpleSpanProcessor(exporter),
   )
   recordScreenView(pathname, provider.getTracer(RUM_SERVICE_NAME))
+  return exporter.getFinishedSpans() as ReadableSpan[]
+}
+
+function exportWebVital(
+  name: 'CLS' | 'INP' | 'LCP',
+  value: number,
+  pathname = '/parties/9f3c1e2a-77b1-4d0e-9a55-000000000001?customer=secret',
+) {
+  const exporter = new InMemorySpanExporter()
+  const provider = createRumProvider(
+    { userAgent: IPHONE_UA, appVersion: '1.2.3' },
+    new SimpleSpanProcessor(exporter),
+  )
+  recordWebVital({
+    name,
+    value,
+    delta: value,
+    rating: 'good',
+    id: 'v4-sensitive-session-shaped-id',
+    entries: [{ name: 'https://bank.example/payments/sepa?customer=secret' }],
+  }, pathname, provider.getTracer(RUM_SERVICE_NAME))
   return exporter.getFinishedSpans() as ReadableSpan[]
 }
 
@@ -54,6 +76,33 @@ describe('authenticated Admin UI browser RUM', () => {
 
   it('uses the authenticated same-origin relay, never an external browser collector', () => {
     expect(RUM_INGEST_PATH).toBe('/api/telemetry/traces')
+  })
+
+  it.each([
+    ['CLS', 0.04, '1'],
+    ['INP', 130, 'ms'],
+    ['LCP', 1_800, 'ms'],
+  ] as const)('exports low-cardinality %s without metric IDs, URLs or attribution', (name, value, unit) => {
+    const [span] = exportWebVital(name, value)
+    expect(span.name).toBe(`web-vital.${name.toLowerCase()}`)
+    expect(span.attributes).toMatchObject({
+      'web_vital.name': name,
+      'web_vital.value': value,
+      'web_vital.delta': value,
+      'web_vital.rating': 'good',
+      'web_vital.unit': unit,
+      'screen.name': '/parties/:id',
+      'http.route': '/parties/:id',
+    })
+    expect(JSON.stringify(span.attributes)).not.toContain('sensitive-session')
+    expect(JSON.stringify(span.attributes)).not.toContain('customer=secret')
+    expect(JSON.stringify(span.attributes)).not.toContain('9f3c1e2a')
+  })
+
+  it('drops malformed or non-Core Web Vital measurements', () => {
+    expect(exportWebVital('LCP', Number.POSITIVE_INFINITY)).toHaveLength(0)
+    expect(exportWebVital('INP', -1)).toHaveLength(0)
+    expect(exportWebVital('FCP' as 'LCP', 100)).toHaveLength(0)
   })
 
   it('relays to the runtime-only collector endpoint and exposes disabled state distinctly', async () => {

--- a/openbank-admin-ui/src/test/rum-web-vitals-tracker.test.tsx
+++ b/openbank-admin-ui/src/test/rum-web-vitals-tracker.test.tsx
@@ -1,0 +1,73 @@
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const telemetry = vi.hoisted(() => ({
+  initRum: vi.fn(),
+  recordScreenView: vi.fn(),
+  recordWebVital: vi.fn(),
+}))
+const navigation = vi.hoisted(() => ({ pathname: '/payments/party-123456' }))
+const vitals = vi.hoisted(() => ({
+  callbacks: [] as Array<(metric: { id: string; name: string; value: number; delta: number; rating: string }) => void>,
+  fireDuringLayout: undefined as { id: string; name: string; value: number; delta: number; rating: string } | undefined,
+}))
+
+vi.mock('next/navigation', () => ({ usePathname: () => navigation.pathname }))
+vi.mock('next/web-vitals', async () => {
+  const React = await import('react')
+  return {
+    useReportWebVitals: (callback: (metric: typeof vitals.fireDuringLayout) => void) => {
+      React.useLayoutEffect(() => {
+        if (vitals.fireDuringLayout) callback(vitals.fireDuringLayout)
+      })
+      React.useEffect(() => { vitals.callbacks.push(callback) }, [callback])
+    },
+  }
+})
+vi.mock('@/lib/telemetry/rum', () => telemetry)
+
+import { RumScreenTracker } from '@/components/telemetry/RumScreenTracker'
+
+describe('RUM Web Vitals tracker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vitals.callbacks = []
+    vitals.fireDuringLayout = undefined
+    navigation.pathname = '/payments/party-123456'
+  })
+
+  it('wires the built-in Next.js reporter to the initial document route', () => {
+    const view = render(<RumScreenTracker enabled />)
+    navigation.pathname = '/dashboard'
+    view.rerender(<RumScreenTracker enabled />)
+    const metric = { id: 'vital-a', name: 'LCP', value: 1_200, delta: 1_200, rating: 'good' }
+    vitals.callbacks.at(-1)?.(metric)
+
+    expect(telemetry.initRum).toHaveBeenCalledTimes(2)
+    expect(telemetry.recordScreenView).toHaveBeenLastCalledWith('/dashboard')
+    expect(telemetry.recordWebVital).toHaveBeenCalledWith(metric, '/payments/party-123456')
+    expect(new Set(vitals.callbacks).size).toBe(1)
+  })
+
+  it('keeps one observer owner and suppresses metrics after moving to a public surface', () => {
+    const view = render(<RumScreenTracker enabled />)
+    vitals.fireDuringLayout = { id: 'vital-b', name: 'CLS', value: 0.01, delta: 0.01, rating: 'good' }
+    view.rerender(<RumScreenTracker enabled={false} />)
+
+    expect(telemetry.recordWebVital).not.toHaveBeenCalled()
+    expect(new Set(vitals.callbacks).size).toBe(1)
+  })
+
+  it('does not relabel a public document vital after client navigation to a protected route', () => {
+    navigation.pathname = '/auth/login'
+    const view = render(<RumScreenTracker enabled={false} />)
+    navigation.pathname = '/dashboard'
+    view.rerender(<RumScreenTracker enabled />)
+    vitals.callbacks.at(-1)?.({ id: 'vital-c', name: 'LCP', value: 900, delta: 900, rating: 'good' })
+
+    expect(telemetry.recordScreenView).toHaveBeenCalledWith('/dashboard')
+    expect(telemetry.recordWebVital).not.toHaveBeenCalled()
+    expect(new Set(vitals.callbacks).size).toBe(1)
+  })
+
+})


### PR DESCRIPTION
## Summary

- capture LCP, INP, and CLS with the built-in Next.js Web Vitals reporter
- export only validated low-cardinality measurements through the existing authenticated same-origin OTLP relay
- keep one tracker owner across public/protected provider transitions and suppress public-document or public-surface metrics
- redact dynamic route identifiers and omit metric IDs, raw URLs, query strings, and DOM attribution

## Verification

- genuine RED: new instrumentation assertions failed 4/9 because recordWebVital did not exist
- focused Vitest: 3 files, 19 tests passed
- canonical npm run type-check passed
- changed-file ESLint passed
- production Next build passed, including 91/91 pages
- git diff --check passed
- independent exact-blob review: no blocker

## Privacy and security

No customer/operator identity correlation or raw attribution is added. Metric names and ratings are closed vocabularies; routes pass through the existing identifier redaction. Existing authenticated relay byte budget and collector boundary remain unchanged.

Closes #8218