### PR TITLE
fix(admin-ui): retain onboarding analytics context

### DIFF
--- a/openbank-admin-ui/src/app/onboarding/analytics/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/analytics/page.tsx
@@ -10,7 +10,7 @@
 // range: step funnel + drop-off, median dwell per step, daily signature conversion, why signatures
 // fail, and the KYC-method split.
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import { TrendingUp, RefreshCw, ArrowLeft } from 'lucide-react'
@@ -60,47 +60,94 @@ export default function OnboardingAnalyticsPage() {
   )
 
   const [to, setTo] = useState(() => isoDay(new Date()))
-  // eslint-disable-next-line react-hooks/purity -- time-relative display; timestamps are stable server data.
   const [from, setFrom] = useState(() => isoDay(new Date(Date.now() - 30 * 864e5)))
 
   const [data, setData] = useState<FunnelAnalytics | null>(null)
   const [loading, setLoading] = useState(true)
-  const [unreachable, setUnreachable] = useState(false)
+  const [failure, setFailure] = useState<'operational' | 'unauthorized' | 'forbidden' | null>(null)
+  const [lastSuccessfulLoad, setLastSuccessfulLoad] = useState<Date | null>(null)
+  const [renderedRange, setRenderedRange] = useState<string | null>(null)
+  const generation = useRef(0)
+  const loadedRange = useRef<string | null>(null)
+  const activeRequest = useRef<AbortController | null>(null)
+  const mounted = useRef(false)
 
   const load = useCallback(async () => {
-    setLoading(true); setUnreachable(false)
+    const requestGeneration = ++generation.current
+    const requestedRange = `${from}:${to}`
+    activeRequest.current?.abort()
+    const controller = new AbortController()
+    activeRequest.current = controller
+    setLoading(true)
+    setFailure(null)
+    if (loadedRange.current !== requestedRange) setData(null)
     try {
       const res = await fetch(`/api/onboarding/funnel-analytics?from=${from}&to=${to}`, {
-        signal: AbortSignal.timeout(12000),
+        signal: AbortSignal.any([controller.signal, AbortSignal.timeout(12000)]),
       })
-      if (!res.ok) { setUnreachable(true); setData(null); return }
-      setData(await res.json())
+      if (res.status === 401 || res.status === 403) {
+        if (!mounted.current) return
+        generation.current += 1
+        activeRequest.current?.abort()
+        setData(null)
+        loadedRange.current = null
+        setRenderedRange(null)
+        setFailure(res.status === 401 ? 'unauthorized' : 'forbidden')
+        setLoading(false)
+        return
+      }
+      if (requestGeneration !== generation.current) return
+      if (!res.ok) {
+        setFailure('operational')
+        return
+      }
+      const next = await res.json() as FunnelAnalytics
+      if (requestGeneration !== generation.current) return
+      if (next.error || next.from !== from || next.to !== to) {
+        setFailure('operational')
+        return
+      }
+      setData(next)
+      loadedRange.current = requestedRange
+      setRenderedRange(requestedRange)
+      setLastSuccessfulLoad(new Date())
     } catch {
-      setUnreachable(true); setData(null)
+      if (requestGeneration === generation.current) setFailure('operational')
     } finally {
-      setLoading(false)
+      if (requestGeneration === generation.current) setLoading(false)
     }
   }, [from, to])
 
-  useEffect(() => { load() }, [load])
+  useEffect(() => {
+    mounted.current = true
+    void load()
+    return () => {
+      mounted.current = false
+      generation.current += 1
+      activeRequest.current?.abort()
+    }
+  }, [load])
+
+  const currentRange = `${from}:${to}`
+  const visibleData = renderedRange === currentRange ? data : null
 
   // Derived KPI: overall funnel conversion (SIGN completed / WELCOME viewed).
-  const welcome = data?.steps.find(s => s.step === 'WELCOME')?.viewed ?? 0
-  const signed = data?.steps.find(s => s.step === 'SIGN')?.completed ?? 0
+  const welcome = visibleData?.steps.find(s => s.step === 'WELCOME')?.viewed ?? 0
+  const signed = visibleData?.steps.find(s => s.step === 'SIGN')?.completed ?? 0
   const overallPct = welcome > 0 ? (signed / welcome) * 100 : 0
-  const totalSigns = (data?.signOutcomes ?? []).reduce((a, o) => a + o.attempts, 0)
-  const totalOk = (data?.signOutcomes ?? []).reduce((a, o) => a + o.successes, 0)
+  const totalSigns = (visibleData?.signOutcomes ?? []).reduce((a, o) => a + o.attempts, 0)
+  const totalOk = (visibleData?.signOutcomes ?? []).reduce((a, o) => a + o.successes, 0)
   const signRate = totalSigns > 0 ? (totalOk / totalSigns) * 100 : 0
 
-  const funnelChart = (data?.steps ?? []).map(s => ({
+  const funnelChart = (visibleData?.steps ?? []).map(s => ({
     ...s, label: stepLabel(s.step),
   }))
-  const rateChart = (data?.signOutcomes ?? []).map(o => ({
+  const rateChart = (visibleData?.signOutcomes ?? []).map(o => ({
     day: o.day.slice(5), // MM-DD
     rate: o.attempts > 0 ? Math.round((o.successes / o.attempts) * 1000) / 10 : 0,
   }))
-  const kycChart = (data?.kycMethods ?? []).map(k => ({ name: k.method, value: k.sessions }))
-  const maxReasonFailures = Math.max(1, ...(data?.failReasons ?? []).map(r => r.failures))
+  const kycChart = (visibleData?.kycMethods ?? []).map(k => ({ name: k.method, value: k.sessions }))
+  const maxReasonFailures = Math.max(1, ...(visibleData?.failReasons ?? []).map(r => r.failures))
 
   const tooltipStyle = {
     background: 'var(--surface)',
@@ -121,12 +168,20 @@ export default function OnboardingAnalyticsPage() {
         actions={<div style={{ display: 'flex', alignItems: 'flex-end', gap: '8px' }}>
           <label style={{ display: 'flex', flexDirection: 'column', gap: '2px', fontSize: '11px', color: 'var(--text-muted)' }}>
             {t('Od', 'From')}
-            <input type="date" value={from} max={to} onChange={e => setFrom(e.target.value)}
+            <input type="date" value={from} max={to} onChange={e => {
+              setLoading(true)
+              setFailure(null)
+              setFrom(e.target.value)
+            }}
               className="input" style={{ padding: '5px 8px', fontSize: '12px' }} />
           </label>
           <label style={{ display: 'flex', flexDirection: 'column', gap: '2px', fontSize: '11px', color: 'var(--text-muted)' }}>
             {t('Do', 'To')}
-            <input type="date" value={to} min={from} max={isoDay(new Date())} onChange={e => setTo(e.target.value)}
+            <input type="date" value={to} min={from} max={isoDay(new Date())} onChange={e => {
+              setLoading(true)
+              setFailure(null)
+              setTo(e.target.value)
+            }}
               className="input" style={{ padding: '5px 8px', fontSize: '12px' }} />
           </label>
           <button
@@ -149,28 +204,65 @@ export default function OnboardingAnalyticsPage() {
         </Link>
       </div>
 
-      {/* Unreachable / loading / no-data gates */}
-      {unreachable ? (
+      {failure === 'unauthorized' || failure === 'forbidden' ? (
         <div className="card" style={{ padding: 0 }}>
-          <DataUnavailable kind="unreachable" service="Analytics-sink (ClickHouse)"
-            feature={t('Konverze onboardingu', 'Onboarding conversion')} lang={language} />
+          <DataUnavailable
+            kind="unauthorized"
+            feature={t('Konverze onboardingu', 'Onboarding conversion')}
+            lang={language}
+            title={failure === 'forbidden' ? t('Přístup zamítnut', 'Access denied') : undefined}
+            detail={failure === 'forbidden'
+              ? t('Vaše aktuální role nemá oprávnění zobrazit tuto analytiku.', 'Your current role is not permitted to view this analytics data.')
+              : t('Vaše přihlášení vypršelo. Přihlaste se prosím znovu.', 'Your session has expired. Please sign in again.')}
+          />
         </div>
-      ) : loading && !data ? (
+      ) : loading && !visibleData ? (
         <div role="status" aria-live="polite" className="card" style={{ padding: '48px', textAlign: 'center', color: 'var(--text-muted)' }}>
           <RefreshCw size={20} aria-hidden="true" style={{ animation: 'spin 1s linear infinite' }} />
+          <span className="sr-only">{t('Načítám analytiku onboardingu', 'Loading onboarding analytics')}</span>
         </div>
-      ) : !data || data.available === false ? (
+      ) : !visibleData || visibleData.available === false ? (
         <div className="card" style={{ padding: 0 }}>
-          <DataUnavailable kind={data?.error ? 'unreachable' : 'no_data'}
+          <DataUnavailable kind={failure === 'operational' || visibleData?.error ? 'unreachable' : 'no_data'}
             service="Analytics-sink (ClickHouse)"
             feature={t('Konverze onboardingu', 'Onboarding conversion')}
             lang={language}
-            detail={data?.error
+            detail={failure === 'operational' || visibleData?.error
               ? t('ClickHouse gold marty nejsou dostupné.', 'ClickHouse gold marts are unavailable.')
-              : t('V tomto období nejsou žádná data funnelu.', 'No funnel data in this period.')} />
+              : t('V tomto období nejsou žádná data funnelu.', 'No funnel data in this period.')}>
+            {failure === 'operational' && (
+              <button type="button" className="btn btn-secondary" onClick={load} disabled={loading}>
+                <RefreshCw size={13} aria-hidden="true" /> {t('Zkusit znovu', 'Retry')}
+              </button>
+            )}
+          </DataUnavailable>
         </div>
       ) : (
         <>
+          {(failure === 'operational' || loading) && (
+            <div
+              role="status"
+              aria-label={t('Aktuálnost analytiky onboardingu', 'Onboarding analytics freshness')}
+              className="card"
+              style={{ padding: '12px 16px', marginBottom: '16px', borderColor: 'var(--warning)' }}
+            >
+              <div style={{ fontSize: '13px', fontWeight: 600 }}>
+                {loading
+                  ? t('Obnovuji analytiku; poslední úspěšný snímek zůstává zobrazený.', 'Refreshing analytics; the last successful snapshot remains visible.')
+                  : t('Živá analytika není dostupná — zobrazuji poslední úspěšný snímek.', 'Live analytics is unavailable — showing the last successful snapshot.')}
+              </div>
+              {lastSuccessfulLoad && (
+                <div style={{ marginTop: '3px', fontSize: '11px', color: 'var(--text-muted)' }}>
+                  {t('Naposledy úspěšně načteno', 'Last successful load')}: {lastSuccessfulLoad.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}
+                </div>
+              )}
+              {failure === 'operational' && (
+                <button type="button" className="btn btn-secondary" onClick={load} disabled={loading} aria-label={t('Zkusit znovu načíst analytiku onboardingu', 'Retry onboarding analytics')} style={{ marginTop: '8px' }}>
+                  <RefreshCw size={13} aria-hidden="true" /> {t('Zkusit znovu', 'Retry')}
+                </button>
+              )}
+            </div>
+          )}
           {/* KPI stat row */}
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '10px', marginBottom: '20px' }}>
             <StatTile label={t('Celková konverze', 'Overall conversion')} value={`${overallPct.toFixed(1)} %`}
@@ -284,11 +376,11 @@ export default function OnboardingAnalyticsPage() {
             <p style={{ margin: '0 0 12px', fontSize: '12px', color: 'var(--text-muted)' }}>
               {t('Seřazeno podle počtu selhání', 'Ranked by failure count')}
             </p>
-            {(data.failReasons ?? []).length === 0 ? (
+            {(visibleData.failReasons ?? []).length === 0 ? (
               <DataUnavailable kind="no_data" feature={t('Důvody selhání podpisu', 'Signature failure reasons')} lang={language} dense />
             ) : (
               <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-                {data.failReasons.map(r => (
+                {visibleData.failReasons.map(r => (
                   <div key={r.reason} style={{ display: 'grid', gridTemplateColumns: '180px 1fr 48px', gap: '10px', alignItems: 'center' }}>
                     <span style={{ fontSize: '12px', fontFamily: 'var(--font-mono)', color: 'var(--text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={r.reason}>
                       {r.reason}

--- a/openbank-admin-ui/src/test/onboarding-analytics-recovery.test.tsx
+++ b/openbank-admin-ui/src/test/onboarding-analytics-recovery.test.tsx
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import OnboardingAnalyticsPage from '@/app/onboarding/analytics/page'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => children,
+  BarChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Bar: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Cell: () => null,
+  LabelList: () => null,
+  LineChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Line: () => null,
+  PieChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Pie: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Legend: () => null,
+}))
+
+const SNAPSHOT = {
+  available: true,
+  from: '2026-08-03',
+  to: '2026-09-02',
+  steps: [
+    { step: 'WELCOME', stepOrdinal: 1, viewed: 40, completed: 30, holdAbandons: 0, dropOffPct: 25, medianSeconds: 12 },
+    { step: 'SIGN', stepOrdinal: 6, viewed: 20, completed: 18, holdAbandons: 0, dropOffPct: 10, medianSeconds: 45 },
+  ],
+  signOutcomes: [{ day: '2026-08-31', attempts: 20, successes: 18, failures: 2 }],
+  failReasons: [{ reason: 'OTP_EXPIRED', failures: 2 }],
+  kycMethods: [{ method: 'BANK_ID', sessions: 30 }],
+}
+
+function response(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(done => { resolve = done })
+  return { promise, resolve }
+}
+
+function renderPage() {
+  return render(<LanguageProvider initialLanguage="en"><OnboardingAnalyticsPage /></LanguageProvider>)
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  vi.setSystemTime(new Date('2026-09-02T12:00:00Z'))
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('onboarding analytics recovery', () => {
+  it('retains the last successful funnel during an operational outage and replaces it after retry', async () => {
+    const recovered = { ...SNAPSHOT, steps: SNAPSHOT.steps.map(step => step.step === 'WELCOME' ? { ...step, viewed: 50 } : step) }
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response(200, SNAPSHOT))
+      .mockResolvedValueOnce(response(200, { ...SNAPSHOT, available: false, error: 'ClickHouse timeout', steps: [] }))
+      .mockResolvedValueOnce(response(200, recovered))
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    expect(await screen.findByText('40')).toBeVisible()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh onboarding analytics' }))
+
+    expect(await screen.findByRole('status', { name: 'Onboarding analytics freshness' })).toHaveTextContent('last successful snapshot')
+    expect(screen.getByText('40')).toBeVisible()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry onboarding analytics' }))
+
+    expect(await screen.findByText('50')).toBeVisible()
+    await waitFor(() => expect(screen.queryByRole('status', { name: 'Onboarding analytics freshness' })).not.toBeInTheDocument())
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it.each([401, 403])('purges the retained funnel after HTTP %s', async status => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(response(200, SNAPSHOT))
+      .mockResolvedValueOnce(response(status, { error: status === 401 ? 'unauthorized' : 'forbidden' })))
+
+    renderPage()
+    expect(await screen.findByText('40')).toBeVisible()
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh onboarding analytics' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(status === 401 ? 'Session expired' : 'Access denied')
+    expect(screen.queryByText('40')).not.toBeInTheDocument()
+    expect(screen.queryByText('OTP_EXPIRED')).not.toBeInTheDocument()
+  })
+
+  it('never renders a previous range while a new range is loading', async () => {
+    const nextRange = deferred<Response>()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response(200, SNAPSHOT))
+      .mockReturnValueOnce(nextRange.promise)
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    expect(await screen.findByText('40')).toBeVisible()
+    fireEvent.change(screen.getByLabelText('From'), { target: { value: '2026-08-10' } })
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    expect(screen.queryByText('40')).not.toBeInTheDocument()
+    expect(screen.getByRole('status')).toBeVisible()
+  })
+
+  it('rejects a successful response whose range does not match the request', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response(200, {
+      ...SNAPSHOT,
+      from: '2026-07-01',
+      to: '2026-07-31',
+    })))
+
+    renderPage()
+
+    expect(await screen.findByText('ClickHouse gold marts are unavailable.')).toBeVisible()
+    expect(screen.queryByText('40')).not.toBeInTheDocument()
+  })
+
+  it('treats an older access denial as stronger than a newer pending success', async () => {
+    const denied = deferred<Response>()
+    const newer = deferred<Response>()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response(200, SNAPSHOT))
+      .mockReturnValueOnce(denied.promise)
+      .mockReturnValueOnce(newer.promise)
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    expect(await screen.findByText('40')).toBeVisible()
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh onboarding analytics' }))
+    fireEvent.change(screen.getByLabelText('From'), { target: { value: '2026-08-10' } })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    await act(async () => { denied.resolve(response(403, { error: 'forbidden' })) })
+    expect(await screen.findByRole('alert')).toHaveTextContent('Access denied')
+    const newerSignal = (fetchMock.mock.calls[2]?.[1] as RequestInit | undefined)?.signal
+    expect(newerSignal?.aborted).toBe(true)
+    await act(async () => {
+      newer.resolve(response(200, {
+        ...SNAPSHOT,
+        from: '2026-08-10',
+        steps: SNAPSHOT.steps.map(step => ({ ...step, viewed: 99 })),
+      }))
+      await newer.promise
+      await new Promise(resolve => window.setTimeout(resolve, 0))
+    })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Access denied')
+    expect(screen.queryByText('99')).not.toBeInTheDocument()
+    expect(screen.queryByText('40')).not.toBeInTheDocument()
+  })
+
+  it('gives the initial loading status an accessible message', () => {
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => undefined)))
+
+    renderPage()
+
+    expect(screen.getByRole('status')).toHaveTextContent('Loading onboarding analytics')
+  })
+
+  it('aborts and ignores a late response after unmount', async () => {
+    const late = deferred<Response>()
+    const readBody = vi.fn().mockResolvedValue(SNAPSHOT)
+    const fetchMock = vi.fn().mockReturnValue(late.promise)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const view = renderPage()
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    const signal = (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.signal
+    view.unmount()
+    expect(signal?.aborted).toBe(true)
+
+    await act(async () => {
+      late.resolve({ ok: true, status: 200, json: readBody } as Response)
+      await late.promise
+      await new Promise(resolve => window.setTimeout(resolve, 0))
+    })
+    expect(readBody).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- retain the last successful onboarding funnel only for the exact selected date range during transient ClickHouse outages
- label retained values as stale with last-success time and a single-flight retry
- validate response range, abort superseded requests, and reject late stale responses
- purge all analytics on 401/403, including an older denial racing a newer pending response
- give initial loading and access-loss states explicit localized assistive semantics

## Verification

- genuine RED: initial recovery/access suite failed 3/3 on the previous implementation
- additional strongest-signal race test failed before the auth-denial fix
- focused Vitest: 3 files, 10 tests passed after final rebase
- canonical npm run type-check passed
- changed-file ESLint: 0 errors; one pre-existing auto-load warning
- production Next build passed, including 91/91 pages
- git diff --check passed
- independent exact-blob review: no blocker

## Privacy and security

Aggregated funnel data is retained in memory only for the same date range during operational failures. HTTP 401/403 is a fail-closed strongest signal: it aborts newer work, purges the snapshot, and renders a blocking localized alert. No RBAC, BFF contract, ClickHouse query, or analytics calculation changes.

Closes #8227