### PR TITLE
test(admin-ui): await origination KPI readiness

### DIFF
--- a/openbank-admin-ui/src/test/origination-pipeline.test.tsx
+++ b/openbank-admin-ui/src/test/origination-pipeline.test.tsx
@@ -121,8 +121,14 @@ describe('lending console', () => {
     return vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
       if (url.includes('/api/auth/session')) return new Response('null', { status: 200, headers: { 'content-type': 'application/json' } })
-      if (url.includes('/loans/active')) return json(LOANS)
-      if (url.includes('/applications/recent')) return json(APPS)
+      if (url.includes('/loans/active')) {
+        await new Promise(resolve => setTimeout(resolve, 50))
+        return json(LOANS)
+      }
+      if (url.includes('/applications/recent')) {
+        await new Promise(resolve => setTimeout(resolve, 50))
+        return json(APPS)
+      }
       return json({})
     })
   }
@@ -134,11 +140,9 @@ describe('lending console', () => {
     vi.stubGlobal('fetch', mockFetch())
     render(React.createElement(Providers, null, React.createElement(LendingPage)))
 
-    await waitFor(() => expect(screen.getByText('Applications in flight')).toBeTruthy())
-
     // 3 applications, one DISBURSED — "in flight" is 2, not 3. Counting the finished one would
     // inflate the desk's own workload figure.
-    expect(screen.getByText('Applications in flight').closest('.stat-card')?.textContent).toMatch(/2/)
+    await waitFor(() => expect(screen.getByText('Applications in flight').closest('.stat-card')?.textContent).toMatch(/2/))
     expect(screen.getByText('Loans in trouble').closest('.stat-card')?.textContent).toMatch(/1/)
 
     // A credit officer reads "Four-eyes review"; the enum stays as the title so the screen and the


### PR DESCRIPTION
## Summary

Hardens the lending-console KPI test so it waits for the loaded stat-card value instead of a label that is present synchronously. Delayed list mocks make the prior vacuous readiness wait fail deterministically while preserving every product assertion and leaving product code unchanged.

## Type of change

- [x] test (test-only hardening)
- [ ] feat (new functionality)
- [ ] fix (shipped product bug)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #8237

## Changes

- Delay the mocked active-loan and recent-application list responses by 50 ms to expose premature KPI assertions.
- Wait for the unchanged `/2/` Applications in flight stat-card assertion rather than the synchronously rendered label.

## Definition of Done

- [x] Hexagonal layering preserved; no product code changed.
- [x] Unit tests updated.
- [ ] Integration tests added/updated (no service boundary changed).
- [ ] Contract tests updated (no public API changed).
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes (admin-ui-only test change).
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (no REST API change).
- [ ] Flyway migration added + rollback note (no DB change).
- [ ] Avro schema versioned backward-compatibly (no event change).
- [ ] Docs updated (no documentation change required).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, or `@Suppress`.
- [x] No new third-party dependency.
- [x] No auth, crypto, or payment code changed.
- [x] No PII path changed.
- [x] No cardholder data path changed.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A — test-only change.
- Rollback plan: revert commit `500031611c`.
- Data migration reversible: N/A.

## Verification

- Deterministic pre-fix proof with delayed mocks: 1 failed, 8 passed; expected `/2/`, received `Applications in flight—loading…`.
- Post-rebase full target file: 9/9 passed.
- Post-rebase race-sensitive test: 5/5 independent runs passed.
- `npm run type-check`: passed.
- `npx eslint src/test/origination-pipeline.test.tsx`: passed.
- `git diff --check origin/main...HEAD`: passed.
- Single bounded `npm test -- --maxWorkers=4`: 424/426 files passed; 2,260 passed, 3 failed, 1 skipped, 1 unhandled error. The three unrelated failures are local sandbox blockers: two Product Catalog client tests cannot `listen` on `127.0.0.1` (`EPERM`), and the collector test times out while the same forbidden-listen error is reported unhandled. CI is authoritative for the full suite; the broad local suite was not rerun.

## Screenshots / demo

N/A — test-only change.

## Reviewer notes

Please verify that the delayed producers retain the intended assertions and that the readiness wait is now tied to the KPI value. An independent read-only diff review found no P1/P2 issue. This PR must receive external review; it must not be self-approved or merged by its author.