### PR TITLE
fix(admin-ui): render unknown observability metrics neutrally

### DIFF
--- a/openbank-admin-ui/src/app/observability/page.tsx
+++ b/openbank-admin-ui/src/app/observability/page.tsx
@@ -27,6 +27,17 @@ interface MetricsData {
   prometheusUp: boolean
 }
 
+function metricColor(
+  value: number | null | undefined,
+  good: (value: number) => boolean,
+  warning?: (value: number) => boolean,
+) {
+  if (value === null || value === undefined) return 'var(--text-muted)'
+  if (good(value)) return 'var(--success)'
+  if (warning?.(value)) return 'var(--warning)'
+  return 'var(--danger)'
+}
+
 export default function ObservabilityPage() {
   const { t, language } = useLanguage()
   const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
@@ -194,29 +205,33 @@ export default function ObservabilityPage() {
           icon={<Server size={18} />}
           label={t('Dostupnost služeb', 'Service Availability')}
           value={formatValue(metrics?.availability.value, '%', 1)}
+          known={metrics?.availability.value != null}
           sub={t('Dostupnost celé platformy', 'Platform-wide uptime')}
-          color={(metrics?.availability.value ?? 0) >= 99 ? 'var(--success)' : (metrics?.availability.value ?? 0) >= 95 ? 'var(--warning)' : 'var(--danger)'}
+          color={metricColor(metrics?.availability.value, value => value >= 99, value => value >= 95)}
         />
         <KpiCard
           icon={<AlertTriangle size={18} />}
           label={t('Chybovost služeb', 'Service Error Rate')}
           value={formatValue(metrics?.errorRate.value, '%', 2)}
+          known={metrics?.errorRate.value != null}
           sub={t('Aplikační 5xx / požadavky (1h)', 'App-recorded 5xx / requests (1h)')}
-          color={(metrics?.errorRate.value ?? 0) < 1 ? 'var(--success)' : (metrics?.errorRate.value ?? 0) < 5 ? 'var(--warning)' : 'var(--danger)'}
+          color={metricColor(metrics?.errorRate.value, value => value < 1, value => value < 5)}
         />
         <KpiCard
           icon={<Clock size={18} />}
           label={t('p99 Latence', 'p99 Latency')}
           value={formatValue(metrics?.p99Latency.value, 'ms', 0)}
+          known={metrics?.p99Latency.value != null}
           sub={t('99. percentil doby odezvy', '99th percentile response time')}
-          color={(metrics?.p99Latency.value ?? 0) < 200 ? 'var(--success)' : (metrics?.p99Latency.value ?? 0) < 500 ? 'var(--warning)' : 'var(--danger)'}
+          color={metricColor(metrics?.p99Latency.value, value => value < 200, value => value < 500)}
         />
         <KpiCard
           icon={<Activity size={18} />}
           label={t('Propustnost', 'Throughput')}
           value={formatValue(metrics?.throughput.value, ' req/s', 1)}
+          known={metrics?.throughput.value != null}
           sub={t('Globální rychlost požadavků', 'Global request rate')}
-          color="var(--info)"
+          color={metrics?.throughput.value == null ? 'var(--text-muted)' : 'var(--info)'}
         />
       </div>
 
@@ -225,15 +240,17 @@ export default function ObservabilityPage() {
           icon={<Globe size={18} />}
           label={t('Chybovost na edge', 'Edge Error Rate')}
           value={formatValue(metrics?.edgeErrorRate.value, '%', 2)}
+          known={metrics?.edgeErrorRate.value != null}
           sub={t('Co vidí klient: nginx 5xx / 1h', 'Customer-facing: nginx 5xx / total (1h)')}
-          color={(metrics?.edgeErrorRate.value ?? 0) < 1 ? 'var(--success)' : (metrics?.edgeErrorRate.value ?? 0) < 5 ? 'var(--warning)' : 'var(--danger)'}
+          color={metricColor(metrics?.edgeErrorRate.value, value => value < 1, value => value < 5)}
         />
         <KpiCard
           icon={<Zap size={18} />}
           label={t('Neúspěšné platby', 'Failed Payments')}
           value={formatValue(metrics?.failedPayments.value, '', 0)}
+          known={metrics?.failedPayments.value != null}
           sub={t('Selhání za posledních 5 minut', 'Failures in last 5 minutes')}
-          color={(metrics?.failedPayments.value ?? 0) === 0 ? 'var(--success)' : 'var(--danger)'}
+          color={metricColor(metrics?.failedPayments.value, value => value === 0)}
         />
       </div>
     </div>
@@ -241,13 +258,13 @@ export default function ObservabilityPage() {
   )
 }
 
-function KpiCard({ icon, label, value, sub, color }: {
-  icon: React.ReactNode; label: string; value: string; sub: string; color: string;
+function KpiCard({ icon, label, value, sub, color, known }: {
+  icon: React.ReactNode; label: string; value: string; sub: string; color: string; known: boolean;
 }) {
   return (
-    <div className="stat-card">
+    <div className="stat-card" data-metric-state={known ? 'available' : 'unknown'}>
       <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: '12px' }}>
-        <div style={{ width: '36px', height: '36px', borderRadius: '10px',
+        <div data-metric-icon style={{ width: '36px', height: '36px', borderRadius: '10px',
           background: `${color}18`, display: 'flex', alignItems: 'center', justifyContent: 'center', color }}>
           {icon}
         </div>

--- a/openbank-admin-ui/src/test/observability-unknown-metrics.test.tsx
+++ b/openbank-admin-ui/src/test/observability-unknown-metrics.test.tsx
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import ObservabilityPage from '@/app/observability/page'
+
+vi.mock('@/components/auth/AuthGuard', () => ({
+  AuthGuard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('Business observability unknown metric states', () => {
+  it('never presents missing values with healthy or unhealthy severity colors', async () => {
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => {
+      if (String(input).endsWith('/-/ready')) return Promise.resolve(new Response('ready'))
+      return Promise.resolve(new Response(JSON.stringify({ status: 'success', data: { result: [] } })))
+    }))
+
+    render(<LanguageProvider><ObservabilityPage /></LanguageProvider>)
+
+    await screen.findByText('Prometheus Connected')
+    for (const label of ['Service Availability', 'Service Error Rate', 'p99 Latency', 'Edge Error Rate', 'Failed Payments']) {
+      const card = screen.getByText(label).closest('.stat-card')
+      expect(card).toHaveAttribute('data-metric-state', 'unknown')
+      expect(card?.querySelector('[data-metric-icon]')).toHaveStyle({ color: 'var(--text-muted)' })
+      expect(card).toHaveTextContent('N/A')
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- render missing Business Observability values with a neutral tone instead of deriving false health from zero
- expose an explicit machine-testable unknown/available state on every KPI card
- preserve all existing success, warning, and danger thresholds for measured values

## Verification

- genuine behavior RED on the previous code: missing metrics had no unknown state and inherited green/red zero fallbacks
- focused Vitest: 1/1 pass after the fix and after rebase
- canonical TypeScript check: pass
- changed-file ESLint: 0 errors (1 inherited auto-load warning)
- diff check: pass
- independent exact-diff review: no blocker

Closes #8242