### PR TITLE
fix(admin-ui): retain Playwright retry evidence

### DIFF
--- a/.github/scripts/check-test-intelligence-ecosystem.py
+++ b/.github/scripts/check-test-intelligence-ecosystem.py
@@ -231,6 +231,31 @@ def check(root: Path) -> list[str]:
         if (not diagnostic_url_pattern or re.fullmatch(diagnostic_url_pattern, trusted_diagnostic) is None
                 or re.fullmatch(diagnostic_url_pattern, f"{hostile_run}#artifacts") is not None):
             errors.append("run schema permits diagnostic links outside canonical GitHub run artifacts")
+        test_case = schema.get("$defs", {}).get("testCase", {})
+        test_case_properties = test_case.get("properties", {})
+        if set(test_case_properties.get("state", {}).get("enum", [])) != {"passed", "failed", "skipped"}:
+            errors.append("retry-flaky evidence changed the authoritative testcase state vocabulary")
+        retry_contract = {
+            "retryFlaky": {"const": True},
+            "failedAttemptCount": {"type": "integer", "minimum": 1, "maximum": 9007199254740991},
+            "failedAttemptDurationMs": {"type": "integer", "minimum": 0, "maximum": 9007199254740991},
+        }
+        for field, expected in retry_contract.items():
+            actual = test_case_properties.get(field, {})
+            if any(actual.get(key) != value for key, value in expected.items()):
+                errors.append(f"run schema cannot represent safe optional retry-flaky metadata: {field}")
+            if field in test_case.get("required", []):
+                errors.append(f"legacy testcase envelopes now require additive retry metadata: {field}")
+        retry_fields = set(retry_contract)
+        dependencies = test_case.get("dependentRequired", {})
+        if any(set(dependencies.get(field, [])) != retry_fields - {field} for field in retry_fields):
+            errors.append("retry-flaky testcase metadata is not an all-or-nothing optional group")
+        retry_state_rule = {
+            "if": {"properties": {"retryFlaky": {"const": True}}, "required": ["retryFlaky"]},
+            "then": {"properties": {"state": {"const": "passed"}}},
+        }
+        if retry_state_rule not in test_case.get("allOf", []):
+            errors.append("run schema allows retry-flaky metadata to change a testcase verdict")
     except (OSError, json.JSONDecodeError) as exc:
         errors.append(f"run schema unavailable: {exc}")
 
@@ -448,6 +473,9 @@ def check(root: Path) -> list[str]:
                    "--browser-report-dir", "playwright-report-${{ github.run_id }}-a${{ github.run_attempt }}"):
         if needle not in ui_workflow:
             errors.append(f"Admin UI test producer is incomplete: {needle}")
+    playwright_config = text(root / "openbank-admin-ui/playwright.config.ts")
+    if "includeRetries: true" not in playwright_config:
+        errors.append("Playwright JUnit omits intra-run retry failures from Test Intelligence evidence")
     deploy_workflow = text(root / ".github/workflows/admin-ui-deploy.yml")
     for needle in ('snapshot_count}" -lt 30', "admin-ui-deploy.yml/runs?branch=main&status=success&per_page=100", "runs/${deploy_run_id}/artifacts?per_page=100", "awk '!seen[$0]++'"):
         if needle not in deploy_workflow:
@@ -456,6 +484,12 @@ def check(root: Path) -> list[str]:
     for needle in ("def browser_diagnostics(", "def trusted_run_url(", '"mayContainSensitiveData": True', '"github-run-authenticated"'):
         if needle not in producer:
             errors.append(f"test producer loses the browser diagnostic privacy contract: {needle}")
+    for needle in ("flakyFailure", "flakyError", "rerunFailure", "rerunError", "def junit_duration_ms(",
+                   "JSON_SAFE_INTEGER_MAX", "def safe_sum_duration_ms(", "total_duration_ms",
+                   '"retryFlaky": True', '"failedAttemptCount"',
+                   '"failedAttemptDurationMs"'):
+        if needle not in producer:
+            errors.append(f"test producer loses bounded Playwright retry-flaky evidence: {needle}")
     for needle in ("const trustedRunUrl =", "const safeRun =", "diagnostics: (run.diagnostics ?? [])", "mayContainSensitiveData: item.mayContainSensitiveData"):
         if needle not in collector:
             errors.append(f"Admin projection loses browser diagnostic metadata: {needle}")
@@ -465,6 +499,22 @@ def check(root: Path) -> list[str]:
         errors.append("Admin UI has no typed Playwright diagnostic artifact")
     if "may contain sensitive browser data" not in tests_page:
         errors.append("Admin UI does not expose the diagnostic privacy warning")
+    for needle in ("function retryFlakyMetadata(item)", "function safeAddNonNegativeIntegers(left, right)",
+                   "function mergeSameRunTestCase(previous, next)", "delete merged.retryFlaky",
+                   "mergedDurationMs !== null", "const latestRunRows =", "const lastState =",
+                   "retryFlakyRows.length > 0",
+                   "failedAttemptCount", "failedAttemptDurationMs", "retryRun"):
+        if needle not in collector:
+            errors.append(f"Admin projection loses direct retry-flaky history: {needle}")
+    if "state: sameCommitTransitions > 0 ? 'flaky' : lastState === 'failed' ? 'failing'" not in collector:
+        errors.append("Admin projection loses deterministic same-commit flake and latest-run failure precedence")
+    for needle in ('status="flaky"', "failed retry attempt(s)", "retryRun"):
+        if needle not in tests_page:
+            errors.append(f"Admin UI does not render direct retry-flaky provenance: {needle}")
+    if "retryRun?:" not in types:
+        errors.append("Admin UI has no typed retry-flaky run provenance")
+    if "item.state === 'skipped' ? 'skipped' : 'stale'" in tests_page:
+        errors.append("Admin UI still mislabels an observed flaky testcase as stale evidence")
     synthetic_route = text(root / "openbank-admin-ui/src/app/api/test-intelligence/route.ts")
     freshness = text(root / "openbank-admin-ui/src/lib/test-intelligence-freshness.ts")
     for needle in ("function enforceRuntimeFreshness", "MAX_FUTURE_SKEW_MS", "observed - Date.now() > MAX_FUTURE_SKEW_MS", "runtimeFreshnessState(item.state, item.observedAt)", "staleEvidence: evidence.filter"):

--- a/.github/scripts/collect-test-run-evidence.py
+++ b/.github/scripts/collect-test-run-evidence.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import os
 import re
 from datetime import datetime, timedelta, timezone
@@ -22,6 +23,7 @@ SPECIALIZED_STATES = SUITE_STATES | {"blocked", "unknown"}
 INFRASTRUCTURE = {"postgres", "redpanda", "valkey"}
 DIAGNOSTIC_KINDS = {"playwright-report"}
 MAX_FUTURE_SKEW = timedelta(minutes=5)
+JSON_SAFE_INTEGER_MAX = 2**53 - 1
 # Shared resources write their readiness-aware lifecycle directly while the CI
 # Docker event stream sees the same container at daemon start/stop time. Keep
 # one observation when the two sources describe that same lifecycle, without
@@ -127,12 +129,26 @@ def validate_envelope(envelope: dict) -> None:
             raise ValueError("synthetic evidence variant is invalid")
     for item in envelope.get("testCases", []):
         required_case_fields = {"fingerprint", "kind", "classname", "name", "state", "durationMs"}
-        if set(item) - (required_case_fields | {"testDefinitionPath"}) or not required_case_fields.issubset(item):
+        retry_fields = {"retryFlaky", "failedAttemptCount", "failedAttemptDurationMs"}
+        if set(item) - (required_case_fields | {"testDefinitionPath"} | retry_fields) or not required_case_fields.issubset(item):
             raise ValueError("test case fields are invalid")
         if (not re.fullmatch(r"[0-9a-f]{24}", item["fingerprint"]) or item["kind"] not in SUITE_KINDS
                 or item["state"] not in {"passed", "failed", "skipped"}
                 or not item["classname"] or not item["name"] or item["durationMs"] < 0):
             raise ValueError("test case values are invalid")
+        present_retry_fields = retry_fields.intersection(item)
+        if present_retry_fields and present_retry_fields != retry_fields:
+            raise ValueError("retry-flaky test case metadata must be complete")
+        if present_retry_fields:
+            failed_attempt_count = item["failedAttemptCount"]
+            failed_attempt_duration = item["failedAttemptDurationMs"]
+            if (item["retryFlaky"] is not True or item["state"] != "passed"
+                    or not isinstance(failed_attempt_count, int) or isinstance(failed_attempt_count, bool)
+                    or failed_attempt_count < 1 or failed_attempt_count > JSON_SAFE_INTEGER_MAX
+                    or not isinstance(failed_attempt_duration, int) or isinstance(failed_attempt_duration, bool)
+                    or failed_attempt_duration < 0 or failed_attempt_duration > JSON_SAFE_INTEGER_MAX
+                    or failed_attempt_duration > item["durationMs"]):
+                raise ValueError("retry-flaky test case metadata is invalid")
         path = item.get("testDefinitionPath")
         if (path is not None and (
                 not re.fullmatch(r"src/test/(?:kotlin|java)/[A-Za-z0-9_./-]+\.(?:kt|java)", path)
@@ -283,6 +299,32 @@ def source_declared_kind(service: Path, classname: str) -> str | None:
     return "integration" if re.search(r"@Quarkus(?:Integration)?Test\b", source) else None
 
 
+def junit_duration_ms(value: str | None, *, required: bool = False) -> int | None:
+    """Parse a non-negative finite JUnit duration without converting invalid evidence to zero."""
+    if value is None:
+        return None if required else 0
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    milliseconds = seconds * 1000
+    if not math.isfinite(milliseconds) or milliseconds > JSON_SAFE_INTEGER_MAX:
+        return None
+    return round(milliseconds)
+
+
+def safe_sum_duration_ms(values: list[int | None]) -> int | None:
+    """Sum parsed durations only while their aggregate remains JSON/JavaScript-safe."""
+    total = 0
+    for value in values:
+        if value is None or value < 0 or value > JSON_SAFE_INTEGER_MAX - total:
+            return None
+        total += value
+    return total
+
+
 def test_cases(component: str, service: Path) -> list[dict]:
     """Emit secret-free observations with stable identity and verified test-source provenance."""
     result = []
@@ -297,11 +339,39 @@ def test_cases(component: str, service: Path) -> list[dict]:
             state = "skipped" if case.find("skipped") is not None else "failed" if (
                 case.find("failure") is not None or case.find("error") is not None
             ) else "passed"
+            # Playwright's JUnit `includeRetries` format nests prior failed attempts under an
+            # eventually passing testcase, and later terminal failures under a failed testcase.
+            # Read only the element kind and numeric duration:
+            # message/type, stackTrace, stdout/stderr and attachments can contain fixtures,
+            # endpoints or tokens and never enter canonical evidence.
+            retry_failures = [
+                child for child in case
+                if child.tag in {"flakyFailure", "flakyError"}
+            ] if state == "passed" else []
+            terminal_reruns = [
+                child for child in case
+                if child.tag in {"rerunFailure", "rerunError"}
+            ] if state == "failed" else []
+            nested_attempts = retry_failures or terminal_reruns
+            nested_durations = [junit_duration_ms(child.attrib.get("time"), required=True) for child in nested_attempts]
+            nested_duration_ms = safe_sum_duration_ms(nested_durations)
+            testcase_duration_ms = junit_duration_ms(case.attrib.get("time"))
+            testcase_duration_valid = testcase_duration_ms is not None
+            base_duration_ms = testcase_duration_ms if testcase_duration_ms is not None else 0
+            total_duration_ms = safe_sum_duration_ms([testcase_duration_ms, nested_duration_ms])
             item = {
                 "fingerprint": hashlib.sha256(identity.encode()).hexdigest()[:24],
                 "kind": kind, "classname": classname, "name": definition, "state": state,
-                "durationMs": max(0, round(float(case.attrib.get("time", 0)) * 1000)),
+                # The testcase attribute is the final pass or first terminal failure. Add valid
+                # nested attempts so duration remains the total cost of this observation.
+                "durationMs": total_duration_ms if total_duration_ms is not None else base_duration_ms,
             }
+            if retry_failures and testcase_duration_valid and nested_duration_ms is not None and total_duration_ms is not None:
+                item.update({
+                    "retryFlaky": True,
+                    "failedAttemptCount": len(retry_failures),
+                    "failedAttemptDurationMs": nested_duration_ms,
+                })
             source_path = test_definition_path(service, classname)
             if source_path is not None:
                 item["testDefinitionPath"] = source_path
@@ -699,9 +769,15 @@ def main() -> None:
                           '<system-out>OPENBANK_TRACE_CONTRACT_V1:failed-contract\n'
                           'OPENBANK_TRACE_CONTRACT_V1:customer supplied trace id</system-out>'
                           '</testsuite></testsuites>'),
-                ("e2e", '<testsuites name="playwright" tests="1" failures="0" errors="0" skipped="0" time="2">'
-                        '<testsuite name="nav" tests="1" failures="0" errors="0" skipped="0" time="2">'
-                        '<testcase classname="nav.spec.ts" name="loads" time="2"/>'
+                ("e2e", '<testsuites name="playwright" tests="1" failures="0" errors="0" skipped="0" time="3.25">'
+                        '<testsuite name="nav" tests="1" failures="0" errors="0" skipped="0" time="3.25">'
+                        '<testcase classname="nav.spec.ts" name="loads" time="2">'
+                        '<flakyFailure message="customer fixture leaked" type="FAILURE" time="0.75">'
+                        '<stackTrace>PRIVATE_STACK_TOKEN</stackTrace><system-out>PRIVATE_STDOUT_TOKEN</system-out>'
+                        '</flakyFailure>'
+                        '<flakyError message="internal endpoint leaked" type="ERROR" time="0.5">'
+                        '<stackTrace>PRIVATE_ERROR_TOKEN</stackTrace><system-err>PRIVATE_STDERR_TOKEN</system-err>'
+                        '</flakyError></testcase>'
                         '<system-out>OPENBANK_TRACE_CONTRACT_V1:public-edge</system-out>'
                         '</testsuite></testsuites>'),
             ):
@@ -717,9 +793,73 @@ def main() -> None:
             assert set(discovered) == {"unit", "e2e"}, discovered
             assert (discovered["unit"]["discovered"], discovered["unit"]["failed"]) == (2, 1), discovered
             assert discovered["unit"]["state"] == "failed" and discovered["e2e"]["state"] == "passed"
+            assert discovered["e2e"]["durationMs"] == 3250
             cases = test_cases("openbank-admin-ui", service)
             assert len(cases) == 3
             assert {item.get("testDefinitionPath") for item in cases} == {"src/test/kotlin/com/openbank/GuardTest.kt", None}
+            retry_flaky = next(item for item in cases if item["kind"] == "e2e")
+            assert retry_flaky == {
+                "fingerprint": retry_flaky["fingerprint"],
+                "kind": "e2e",
+                "classname": "nav.spec.ts",
+                "name": "loads",
+                "state": "passed",
+                "durationMs": 3250,
+                "retryFlaky": True,
+                "failedAttemptCount": 2,
+                "failedAttemptDurationMs": 1250,
+            }
+            serialized_retry_flaky = json.dumps(retry_flaky)
+            assert all(secret not in serialized_retry_flaky for secret in (
+                "customer fixture leaked", "internal endpoint leaked", "PRIVATE_STACK_TOKEN",
+                "PRIVATE_STDOUT_TOKEN", "PRIVATE_ERROR_TOKEN", "PRIVATE_STDERR_TOKEN",
+            ))
+            retry_edge_service = service / "retry-edge-cases"
+            retry_edge_report = retry_edge_service / "build/test-results/e2e/playwright.xml"
+            retry_edge_report.parent.mkdir(parents=True)
+            retry_edge_report.write_text(
+                '<testsuite name="retry edges" tests="7" failures="1" errors="0" skipped="0" time="3.1">'
+                '<testcase classname="terminal.spec.ts" name="exhausts retries" time="0.5">'
+                '<failure message="PRIVATE_FIRST_FAILURE"><stackTrace>PRIVATE_FIRST_STACK</stackTrace></failure>'
+                '<rerunFailure message="PRIVATE_RERUN_FAILURE" time="0.7"><stackTrace>PRIVATE_RERUN_STACK</stackTrace></rerunFailure>'
+                '<rerunError message="PRIVATE_RERUN_ERROR" time="0.3"><system-err>PRIVATE_RERUN_STDERR</system-err></rerunError>'
+                '</testcase>'
+                '<testcase classname="malformed.spec.ts" name="rejects NaN retry time" time="0.4">'
+                '<flakyFailure message="PRIVATE_NAN_FAILURE" time="NaN"/></testcase>'
+                '<testcase classname="malformed.spec.ts" name="rejects negative retry time" time="0.4">'
+                '<flakyError message="PRIVATE_NEGATIVE_ERROR" time="-0.2"/></testcase>'
+                '<testcase classname="malformed.spec.ts" name="rejects malformed retry time" time="0.4">'
+                '<flakyFailure message="PRIVATE_VALID_FAILURE" time="0.1"/>'
+                '<flakyError message="PRIVATE_GARBAGE_ERROR" time="garbage"/></testcase>'
+                '<testcase classname="malformed.spec.ts" name="rejects overflowing retry time" time="0.4">'
+                '<flakyFailure message="PRIVATE_OVERFLOW_FAILURE" time="1e308"/></testcase>'
+                '<testcase classname="aggregate.spec.ts" name="rejects total retry duration overflow" time="5000000000000">'
+                '<flakyFailure message="PRIVATE_TOTAL_OVERFLOW" time="5000000000000"/></testcase>'
+                '<testcase classname="aggregate.spec.ts" name="rejects failed attempt duration overflow" time="0.4">'
+                '<flakyFailure message="PRIVATE_SUM_OVERFLOW_ONE" time="5000000000000"/>'
+                '<flakyError message="PRIVATE_SUM_OVERFLOW_TWO" time="5000000000000"/></testcase>'
+                '</testsuite>'
+            )
+            retry_edge_cases = test_cases("openbank-admin-ui", retry_edge_service)
+            terminal_failure = next(item for item in retry_edge_cases if item["name"] == "exhausts retries")
+            assert terminal_failure["state"] == "failed" and terminal_failure["durationMs"] == 1500
+            assert "retryFlaky" not in terminal_failure
+            malformed_retry_cases = [item for item in retry_edge_cases if item["classname"] == "malformed.spec.ts"]
+            assert len(malformed_retry_cases) == 4
+            assert all(item["state"] == "passed" and item["durationMs"] == 400 for item in malformed_retry_cases)
+            assert all("retryFlaky" not in item for item in malformed_retry_cases)
+            aggregate_retry_cases = {item["name"]: item for item in retry_edge_cases if item["classname"] == "aggregate.spec.ts"}
+            assert aggregate_retry_cases["rejects total retry duration overflow"]["durationMs"] == 5_000_000_000_000_000
+            assert aggregate_retry_cases["rejects failed attempt duration overflow"]["durationMs"] == 400
+            assert all("retryFlaky" not in item for item in aggregate_retry_cases.values())
+            serialized_retry_edges = json.dumps(retry_edge_cases)
+            assert all(secret not in serialized_retry_edges for secret in (
+                "PRIVATE_FIRST_FAILURE", "PRIVATE_FIRST_STACK", "PRIVATE_RERUN_FAILURE",
+                "PRIVATE_RERUN_STACK", "PRIVATE_RERUN_ERROR", "PRIVATE_RERUN_STDERR",
+                "PRIVATE_NAN_FAILURE", "PRIVATE_NEGATIVE_ERROR", "PRIVATE_VALID_FAILURE",
+                "PRIVATE_GARBAGE_ERROR", "PRIVATE_OVERFLOW_FAILURE", "PRIVATE_TOTAL_OVERFLOW",
+                "PRIVATE_SUM_OVERFLOW_ONE", "PRIVATE_SUM_OVERFLOW_TWO",
+            ))
             suite_rows = list(discovered.values())
             failing_fingerprint = next(item["fingerprint"] for item in cases if item["state"] == "failed")
             no_candidates = escaped_failure_recall(suite_rows, cases, [], full_suite_complete=True)
@@ -922,6 +1062,37 @@ def main() -> None:
                 "testCases": [],
                 "testImpact": {"schemaVersion": 1, "mode": "shadow", "mappingState": "unknown", "selectionState": "unavailable"},
             }
+            retry_envelope = json.loads(json.dumps(valid))
+            retry_envelope["testCases"] = [retry_flaky]
+            validate_envelope(retry_envelope)
+            rejected_retry_cases = []
+            missing_retry_duration = dict(retry_flaky)
+            del missing_retry_duration["failedAttemptDurationMs"]
+            rejected_retry_cases.append(missing_retry_duration)
+            for field, value in (
+                ("retryFlaky", False),
+                ("failedAttemptCount", 0),
+                ("failedAttemptCount", True),
+                ("failedAttemptCount", JSON_SAFE_INTEGER_MAX + 1),
+                ("failedAttemptDurationMs", -1),
+                ("failedAttemptDurationMs", retry_flaky["durationMs"] + 1),
+                ("state", "failed"),
+            ):
+                rejected_retry_cases.append({**retry_flaky, field: value})
+            rejected_retry_cases.append({
+                **retry_flaky,
+                "durationMs": JSON_SAFE_INTEGER_MAX + 1,
+                "failedAttemptDurationMs": JSON_SAFE_INTEGER_MAX + 1,
+            })
+            for rejected_case in rejected_retry_cases:
+                rejected_retry_envelope = json.loads(json.dumps(valid))
+                rejected_retry_envelope["testCases"] = [rejected_case]
+                try:
+                    validate_envelope(rejected_retry_envelope)
+                except ValueError:
+                    pass
+                else:
+                    raise AssertionError(f"invalid retry-flaky metadata was accepted: {rejected_case}")
             traversal = {**valid, "testCases": [{
                 "fingerprint": "0123456789abcdef01234567", "kind": "integration",
                 "classname": "com.openbank.GuardTest", "name": "guards", "state": "passed",

--- a/openbank-admin-ui/e2e/test-intelligence.spec.ts
+++ b/openbank-admin-ui/e2e/test-intelligence.spec.ts
@@ -16,7 +16,7 @@ test.beforeEach(async ({ context, baseURL, page }) => {
     clientExperiences: [{ id: 'openbank-app', title: 'OpenBank customer app', surface: 'mobile', platforms: ['android', 'ios'], evidence: [{ kind: 'visual', state: 'passed', observedAt: '2026-08-22T11:00:00.000Z', source: 'openbank-app CI', environment: 'ci', counts: { discovered: 1, executed: 1, passed: 1, failed: 0, skipped: 0, errors: 0 }, detail: 'Roborazzi committed-golden verification' }], rum: { state: 'passed', policy: 'consent-gated', detail: 'Mobile RUM is opt-in and its runtime signal is independent of CI.', observedAt: '2026-08-22T12:00:00.000Z', source: 'tempo', sampledSpansLast7d: 12, errorSpansLast7d: 2 }, blocker: null }],
     history: [{ collectedAt: '2026-08-22T12:00:00.000Z', components: 1, componentsWithExecutionEvidence: 1, failingEvidence: 0, missingEvidence: 0, staleEvidence: 0 }],
     runHistory: [{ component: 'openbank-ledger-service', run: { id: '4242', attempt: 1, commit: '1234567890abcdef', branch: 'main', workflow: 'Services CI', url: 'https://example.test/run/4242', observedAt: '2026-08-22T11:00:00.000Z' }, states: { integration: 'passed' }, infrastructureStarted: 1, infrastructureStopped: 1 }],
-    testCases: [{ fingerprint: '0123456789abcdef01234567', component: 'openbank-ledger-service', kind: 'integration', classname: 'com.openbank.LedgerApiIT', name: 'posts balanced journal', owner: '@JiRaska', state: 'flaky', lastState: 'passed', observations: 3, failureRate: 33.33, averageDurationMs: 400, wastedDurationMs: 420, sameCommitTransitions: 1, lastObservedAt: '2026-08-22T11:00:00.000Z' }],
+    testCases: [{ fingerprint: '0123456789abcdef01234567', component: 'openbank-ledger-service', kind: 'integration', classname: 'com.openbank.LedgerApiIT', name: 'posts balanced journal', owner: '@JiRaska', state: 'flaky', lastState: 'passed', observations: 1, failureRate: 0, averageDurationMs: 820, wastedDurationMs: 420, sameCommitTransitions: 0, lastObservedAt: '2026-08-22T11:00:00.000Z', retryFlaky: true, failedAttemptCount: 1, failedAttemptDurationMs: 420, retryRun: { id: '4242', attempt: 1, commit: '1234567890abcdef', branch: 'main', workflow: 'Admin UI CI', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/4242', observedAt: '2026-08-22T11:00:00.000Z' } }],
     testImpact: { schemaVersion: 1, mode: 'shadow', mappingState: 'unknown', selectionState: 'unavailable', declaredByAllRetainedRuns: true, detail: 'Every retained run explicitly reports that no verified test-to-production mapping was collected. Full suites remain authoritative.' },
     totals: { components: 1, componentsWithExecutionEvidence: 1, moneyPathComponents: 1, failingEvidence: 0, missingEvidence: 0, staleEvidence: 0, requiredControls: 1, requiredControlGaps: 1 }, warnings: [],
   }) }))
@@ -66,8 +66,11 @@ test('renders the animated evidence system and consolidates test dimensions', as
   await page.getByRole('button', { name: /Client & RUM/ }).click()
   await expect(page.getByText('OpenBank customer app')).toBeVisible()
   await page.getByRole('button', { name: /Testy a flaky|Tests & flaky/ }).click()
-  await expect(page.getByText('posts balanced journal')).toBeVisible()
-  await expect(page.getByText('1 same-commit pass/fail transition(s)')).toBeVisible()
+  const retryFlakyRow = page.getByRole('row').filter({ hasText: 'posts balanced journal' })
+  await expect(retryFlakyRow).toContainText('flaky')
+  await expect(retryFlakyRow).not.toContainText('stale')
+  await expect(retryFlakyRow).toContainText('1 failed retry attempt(s) · 420 ms')
+  await expect(retryFlakyRow.getByRole('link', { name: /Admin UI CI · 4242 \/ 1 · 1234567/ })).toHaveAttribute('href', 'https://github.com/JiRaska/open-bank-oss/actions/runs/4242')
   await expect(page.getByLabel('Test impact mapping state')).toContainText('Test impact selection: shadow only')
   await expect(page.getByText('AI must not infer it or select a required gate.')).toBeVisible()
   await page.getByRole('button', { name: /Testovací runtime|Test runtime/ }).click()

--- a/openbank-admin-ui/playwright.config.ts
+++ b/openbank-admin-ui/playwright.config.ts
@@ -24,7 +24,12 @@ export default defineConfig({
   reporter: process.env.CI ? [
     ['github'],
     ['html', { open: 'never' }],
-    ['junit', { outputFile: process.env.PLAYWRIGHT_JUNIT_OUTPUT_FILE ?? 'build/test-results/e2e/playwright.xml' }],
+    ['junit', {
+      outputFile: process.env.PLAYWRIGHT_JUNIT_OUTPUT_FILE ?? 'build/test-results/e2e/playwright.xml',
+      // Preserve failed attempts when a retry passes. The collector retains only bounded
+      // counts/durations from these entries; suite and testcase verdicts remain passed.
+      includeRetries: true,
+    }],
   ] : 'list',
 
   use: {

--- a/openbank-admin-ui/scripts/collect-test-intelligence.mjs
+++ b/openbank-admin-ui/scripts/collect-test-intelligence.mjs
@@ -283,6 +283,65 @@ function componentOwners() {
   return { owners, fallback }
 }
 
+function retryFlakyMetadata(item) {
+  if (item?.state !== 'passed' || item.retryFlaky !== true
+      || !Number.isSafeInteger(item.failedAttemptCount) || item.failedAttemptCount < 1
+      || !Number.isSafeInteger(item.failedAttemptDurationMs) || item.failedAttemptDurationMs < 0
+      || !Number.isSafeInteger(item.durationMs) || item.failedAttemptDurationMs > item.durationMs) return null
+  return {
+    retryFlaky: true,
+    failedAttemptCount: item.failedAttemptCount,
+    failedAttemptDurationMs: item.failedAttemptDurationMs,
+  }
+}
+
+function safeAddNonNegativeIntegers(left, right) {
+  if (!Number.isSafeInteger(left) || left < 0 || !Number.isSafeInteger(right) || right < 0
+      || left > Number.MAX_SAFE_INTEGER - right) return null
+  return left + right
+}
+
+function saturatingSumNonNegativeIntegers(values) {
+  let total = 0
+  for (const value of values) {
+    const next = safeAddNonNegativeIntegers(total, value)
+    if (next === null) return Number.MAX_SAFE_INTEGER
+    total = next
+  }
+  return total
+}
+
+function mergeSameRunTestCase(previous, next) {
+  const retryRows = [previous, next].filter(item => item.retryFlaky === true)
+  const mergedDurationMs = safeAddNonNegativeIntegers(previous.durationMs, next.durationMs)
+  const failedAttemptCount = retryRows.reduce(
+    (sum, item) => sum === null ? null : safeAddNonNegativeIntegers(sum, item.failedAttemptCount), 0,
+  )
+  const failedAttemptDurationMs = retryRows.reduce(
+    (sum, item) => sum === null ? null : safeAddNonNegativeIntegers(sum, item.failedAttemptDurationMs), 0,
+  )
+  const merged = {
+    ...previous,
+    ...next,
+    durationMs: mergedDurationMs ?? Math.max(
+      Number.isSafeInteger(previous.durationMs) && previous.durationMs >= 0 ? previous.durationMs : 0,
+      Number.isSafeInteger(next.durationMs) && next.durationMs >= 0 ? next.durationMs : 0,
+    ),
+  }
+  delete merged.retryFlaky
+  delete merged.failedAttemptCount
+  delete merged.failedAttemptDurationMs
+  if (retryRows.length > 0 && mergedDurationMs !== null && failedAttemptCount !== null
+      && failedAttemptDurationMs !== null && failedAttemptDurationMs <= mergedDurationMs) {
+    Object.assign(merged, {
+      retryFlaky: true,
+      failedAttemptCount,
+      failedAttemptDurationMs,
+    })
+  }
+  return merged
+}
+
 function testCaseHistory(currentEnvelopes) {
   const historical = allFiles(path.join(repo, 'openbank-admin-ui', 'test-run-history'), file => file.endsWith('.json'))
     .map(readJson)
@@ -290,9 +349,27 @@ function testCaseHistory(currentEnvelopes) {
     .filter(item => item?.schemaVersion === 1 && item?.run && item?.component && Array.isArray(item.testCases))
   const unique = new Map()
   for (const envelope of envelopes) {
+    const envelopeRows = new Map()
     for (const item of envelope.testCases) {
       const key = `${envelope.component}:${envelope.run.id}:${envelope.run.attempt}:${item.fingerprint}:${item.state}`
-      unique.set(key, { ...item, component: envelope.component, run: envelope.run })
+      const normalized = { ...item }
+      delete normalized.retryFlaky
+      delete normalized.failedAttemptCount
+      delete normalized.failedAttemptDurationMs
+      const retryMetadata = retryFlakyMetadata(item)
+      const observation = {
+        ...normalized,
+        ...(retryMetadata ?? {}),
+        component: envelope.component,
+        run: envelope.run,
+      }
+      const previous = envelopeRows.get(key)
+      envelopeRows.set(key, previous ? mergeSameRunTestCase(previous, observation) : observation)
+    }
+    // A retained snapshot can be the same immutable run as the current envelope. Keep one
+    // observation per run/state after aggregating distinct parameter/project invocations within it.
+    for (const [key, observation] of envelopeRows) {
+      unique.set(key, observation)
     }
   }
   const grouped = new Map()
@@ -303,7 +380,9 @@ function testCaseHistory(currentEnvelopes) {
   }
   const ownership = componentOwners()
   return [...grouped.entries()].map(([fingerprint, rows]) => {
-    rows.sort((a, b) => Date.parse(a.run.observedAt) - Date.parse(b.run.observedAt))
+    rows.sort((a, b) => Date.parse(a.run.observedAt) - Date.parse(b.run.observedAt)
+      || String(a.run.id).localeCompare(String(b.run.id))
+      || Number(a.run.attempt) - Number(b.run.attempt))
     const executed = rows.filter(item => item.state !== 'skipped')
     const failures = executed.filter(item => item.state === 'failed')
     const commitStates = new Map()
@@ -314,18 +393,41 @@ function testCaseHistory(currentEnvelopes) {
     }
     const sameCommitTransitions = [...commitStates.values()].filter(states => states.has('passed') && states.has('failed')).length
     const last = rows.at(-1)
+    const latestRunRows = rows.filter(item => item.component === last.component
+      && String(item.run.id) === String(last.run.id) && Number(item.run.attempt) === Number(last.run.attempt))
+    const latestRunStates = new Set(latestRunRows.map(item => item.state))
+    const lastState = latestRunStates.has('failed') ? 'failed'
+      : latestRunStates.has('passed') ? 'passed' : 'skipped'
+    const latest = latestRunRows.find(item => item.state === lastState) ?? last
+    const retryFlakyRows = executed.filter(item => item.retryFlaky === true)
+    const latestRetryFlaky = retryFlakyRows.at(-1)
+    const wastedDurationMs = saturatingSumNonNegativeIntegers([
+      ...failures.map(item => item.durationMs),
+      ...retryFlakyRows.map(item => item.failedAttemptDurationMs),
+    ])
+    const retryRun = latestRetryFlaky
+      ? safeRun(latestRetryFlaky.run, `retry-flaky:${latest.component}:${fingerprint}`)
+      : undefined
     return {
-      fingerprint, component: last.component, kind: last.kind, classname: last.classname, name: last.name,
+      fingerprint, component: latest.component, kind: latest.kind, classname: latest.classname, name: latest.name,
       // This is a verified path to the test definition, when a JVM report can provide one. It
       // is intentionally not a claimed production dependency or a test-selection recommendation.
-      testDefinitionPath: last.testDefinitionPath ?? null,
-      owner: ownership.owners.get(last.component) ?? ownership.fallback,
-      state: sameCommitTransitions > 0 ? 'flaky' : last.state === 'failed' ? 'failing' : last.state === 'skipped' ? 'skipped' : 'stable',
-      lastState: last.state, observations: rows.length,
+      testDefinitionPath: latest.testDefinitionPath ?? null,
+      owner: ownership.owners.get(latest.component) ?? ownership.fallback,
+      // Preserve the established same-commit transition signal, then let the newest run group
+      // decide terminal precedence independently of testcase array order.
+      state: sameCommitTransitions > 0 ? 'flaky' : lastState === 'failed' ? 'failing' : lastState === 'skipped' ? 'skipped' : retryFlakyRows.length > 0 ? 'flaky' : 'stable',
+      lastState, observations: rows.length,
       failureRate: executed.length ? Math.round(failures.length * 10_000 / executed.length) / 100 : null,
       averageDurationMs: Math.round(rows.reduce((sum, item) => sum + item.durationMs, 0) / rows.length),
-      wastedDurationMs: failures.reduce((sum, item) => sum + item.durationMs, 0),
-      sameCommitTransitions, lastObservedAt: last.run.observedAt,
+      wastedDurationMs,
+      sameCommitTransitions, lastObservedAt: latest.run.observedAt,
+      ...(retryFlakyRows.length > 0 ? {
+        retryFlaky: true,
+        failedAttemptCount: latestRetryFlaky.failedAttemptCount,
+        failedAttemptDurationMs: latestRetryFlaky.failedAttemptDurationMs,
+        ...(retryRun ? { retryRun } : {}),
+      } : {}),
     }
   }).sort((a, b) => {
     const priority = { flaky: 0, failing: 1, skipped: 2, stable: 3 }

--- a/openbank-admin-ui/src/app/system/tests/page.tsx
+++ b/openbank-admin-ui/src/app/system/tests/page.tsx
@@ -12,7 +12,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { aggregateEvidenceState } from '@/lib/test-intelligence-state'
 import { filterTestCases, type TestTriageFilter } from '@/lib/test-intelligence-triage'
 import type {
-  ComponentTestPosture, EvidenceKind, EvidenceState, TestIntelligenceReport,
+  ComponentTestPosture, EvidenceKind, EvidenceState, TestCaseHistory, TestIntelligenceReport,
 } from '@/lib/types/test-intelligence'
 import {
   TestIntelligenceFlow, testIntelligenceCollectionUnavailable,
@@ -38,6 +38,11 @@ function evidenceTone(state: EvidenceState): Tone {
 
 function StateBadge({ state }: { state: EvidenceState }) {
   return <SharedStatusBadge status={state} tone={evidenceTone(state)} label={state} withDot />
+}
+
+function TestCaseStateBadge({ state }: { state: TestCaseHistory['state'] }) {
+  if (state === 'flaky') return <SharedStatusBadge status="flaky" tone="warning" label="flaky" withDot />
+  return <StateBadge state={state === 'stable' ? 'passed' : state === 'failing' ? 'failed' : 'skipped'} />
 }
 
 function Stat({ label, value, tone }: { label: string; value: number | string; tone?: Tone }) {
@@ -264,7 +269,7 @@ function TestCases({ report }: { report: TestIntelligenceReport }) {
       <Stat label="Failed runtime" value={`${Math.round(wasted / 1000)} s`} tone={wasted ? 'warning' : undefined} />
     </div>
     <div style={{ padding: 12, border: '1px solid color-mix(in srgb, #16a34a 35%, var(--border))', borderRadius: 9, color: 'var(--text-secondary)', fontSize: 12 }}>
-      {t('Test je označen jako flaky až po úspěšném i neúspěšném pozorování stejného commitu. Vlastnictví vychází z CODEOWNERS. Triage nikdy nemění deterministický verdikt CI ani nepřeskakuje peněžní kontroly.', 'A test is marked flaky only after pass and fail observations on the same commit. Ownership comes from CODEOWNERS. Triage never changes the deterministic CI verdict or skips money-path controls.')}
+      {t('Test je označen jako flaky po neúspěšném Playwright pokusu následovaném úspěšným retry ve stejném běhu nebo po úspěšném i neúspěšném pozorování stejného commitu. Vlastnictví vychází z CODEOWNERS. Triage nikdy nemění deterministický verdikt CI ani nepřeskakuje peněžní kontroly.', 'A test is marked flaky after a failed Playwright attempt followed by a passing retry in the same run, or after pass and fail observations on the same commit. Ownership comes from CODEOWNERS. Triage never changes the deterministic CI verdict or skips money-path controls.')}
     </div>
     {impact && <div aria-label={t('Stav mapování test impactu', 'Test impact mapping state')} style={{ padding: 12, border: '1px solid color-mix(in srgb, #64748b 42%, var(--border))', borderRadius: 9, color: 'var(--text-secondary)', fontSize: 12, background: 'var(--surface-2)' }}>
       <strong>{t('Test impact selection: shadow only', 'Test impact selection: shadow only')}</strong><span style={{ marginLeft: 8 }}><StateBadge state="unknown" /></span><div style={{ marginTop: 5 }}>{impact.detail}</div><div style={{ marginTop: 5, color: 'var(--text-tertiary)' }}>{t('Cesta k testu není mapa závislostí do produkce. AI ji nesmí domýšlet ani vybírat povinné gate.', 'A test source path is not a production dependency map. AI must not infer it or select a required gate.')}</div>
@@ -282,8 +287,8 @@ function TestCases({ report }: { report: TestIntelligenceReport }) {
     <div style={{ overflowX: 'auto', border: '1px solid var(--border)', borderRadius: 10 }}><table style={tableStyle}>
       <thead><tr>{['State', 'Test definition', 'Test source', 'Component', 'Kind', 'Owner', 'Runs', 'Failure rate', 'Avg duration', 'Failed runtime', 'Fingerprint'].map(label => <th key={label} style={thStyle}>{label}</th>)}</tr></thead>
       <tbody>{visibleTests.map(item => <tr key={item.fingerprint}>
-        <td style={tdStyle}><StateBadge state={item.state === 'stable' ? 'passed' : item.state === 'failing' ? 'failed' : item.state === 'skipped' ? 'skipped' : 'stale'} /></td>
-        <td style={{ ...tdStyle, minWidth: 230 }}><strong>{item.name}</strong><div style={{ color: 'var(--text-tertiary)', fontSize: 10, marginTop: 3 }}>{item.classname}</div>{item.sameCommitTransitions > 0 && <div style={{ color: '#d97706', fontSize: 10, marginTop: 3 }}>{item.sameCommitTransitions} same-commit pass/fail transition(s)</div>}</td>
+        <td style={tdStyle}><TestCaseStateBadge state={item.state} /></td>
+        <td style={{ ...tdStyle, minWidth: 230 }}><strong>{item.name}</strong><div style={{ color: 'var(--text-tertiary)', fontSize: 10, marginTop: 3 }}>{item.classname}</div>{item.retryFlaky && item.failedAttemptCount !== undefined && item.failedAttemptDurationMs !== undefined && <div style={{ color: '#d97706', fontSize: 10, marginTop: 3 }}><div>{t(`${item.failedAttemptCount} neúspěšných retry pokusů · ${item.failedAttemptDurationMs} ms`, `${item.failedAttemptCount} failed retry attempt(s) · ${item.failedAttemptDurationMs} ms`)}</div>{item.retryRun && <a href={item.retryRun.url} target="_blank" rel="noreferrer" style={{ color: '#d97706', fontWeight: 650 }}>{item.retryRun.workflow} · {item.retryRun.id} / {item.retryRun.attempt} · {item.retryRun.commit.slice(0, 7)}</a>}</div>}{item.sameCommitTransitions > 0 && <div style={{ color: '#d97706', fontSize: 10, marginTop: 3 }}>{item.sameCommitTransitions} same-commit pass/fail transition(s)</div>}</td>
         <td style={{ ...tdStyle, fontFamily: 'monospace', fontSize: 10, maxWidth: 260, overflowWrap: 'anywhere' }}>{item.testDefinitionPath ?? 'not reported'}</td>
         <td style={tdStyle}>{item.component}</td><td style={tdStyle}>{item.kind}</td><td style={tdStyle}>{item.owner}</td><td style={tdStyle}>{item.observations}</td>
         <td style={tdStyle}>{item.failureRate === null ? '—' : `${item.failureRate}%`}</td><td style={tdStyle}>{item.averageDurationMs} ms</td><td style={tdStyle}>{item.wastedDurationMs} ms</td>

--- a/openbank-admin-ui/src/lib/types/test-intelligence.ts
+++ b/openbank-admin-ui/src/lib/types/test-intelligence.ts
@@ -404,6 +404,13 @@ export interface TestCaseHistory {
   wastedDurationMs: number
   sameCommitTransitions: number
   lastObservedAt: string
+  /** Direct evidence that a passed Playwright testcase needed retry attempts. */
+  retryFlaky?: true
+  /** Latest typed retry observation; failure text and stack output are never retained. */
+  failedAttemptCount?: number
+  failedAttemptDurationMs?: number
+  /** Latest trusted run carrying direct retry-flaky evidence. */
+  retryRun?: TestRunProvenance & { observedAt: string }
 }
 
 export interface TestRunHistoryPoint {

--- a/openbank-admin-ui/src/test/playwright-test-intelligence-evidence.guard.test.ts
+++ b/openbank-admin-ui/src/test/playwright-test-intelligence-evidence.guard.test.ts
@@ -9,7 +9,9 @@ const config = () => readFileSync(path.resolve(process.cwd(), 'playwright.config
 describe('Playwright Test Intelligence evidence', () => {
   it('writes a JUnit report to the workflow-controlled E2E evidence path', () => {
     const source = config()
-    expect(source).toContain("['junit', { outputFile: process.env.PLAYWRIGHT_JUNIT_OUTPUT_FILE")
+    expect(source).toContain("['junit', {")
+    expect(source).toContain('outputFile: process.env.PLAYWRIGHT_JUNIT_OUTPUT_FILE')
     expect(source).toContain("'build/test-results/e2e/playwright.xml'")
+    expect(source).toContain('includeRetries: true')
   })
 })

--- a/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
+++ b/openbank-admin-ui/src/test/test-intelligence-collector.test.ts
@@ -517,6 +517,192 @@ capabilities:
     })
   })
 
+  it('projects a direct Playwright retry flake from one passed envelope without changing its verdict', () => {
+    const repo = mkdtempSync(path.join(tmpdir(), 'test-intelligence-retry-flaky-'))
+    dirs.push(repo)
+    write(repo, 'openbank-admin-ui/version.txt', '1.0.0\n')
+    write(repo, 'openbank-libs/governance/rules.yaml', 'money_path_services: []\n')
+    write(repo, 'openbank-libs/governance/journeys.yaml', 'version: 1\njourneys: []\n')
+    write(repo, 'openbank-admin-ui/build/test-intelligence/run.json', JSON.stringify({
+      schemaVersion: 1,
+      run: { id: 'retry-42', attempt: 1, commit: 'abcdef012345', branch: 'main', workflow: 'CI', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/retry-42', observedAt: '2026-08-22T10:00:00Z' },
+      component: 'openbank-admin-ui',
+      suites: [{ kind: 'e2e', state: 'passed', discovered: 5, executed: 5, passed: 5, failed: 0, skipped: 0, errors: 0, durationMs: 5000 }],
+      testCases: [
+        { fingerprint: '0123456789abcdef01234567', kind: 'e2e', classname: 'flaky.spec.ts', name: 'recovers on retry', state: 'passed', durationMs: 1700, retryFlaky: true, failedAttemptCount: 1, failedAttemptDurationMs: 700 },
+        // A second project/parameter invocation can normalize to the same logical fingerprint.
+        { fingerprint: '0123456789abcdef01234567', kind: 'e2e', classname: 'flaky.spec.ts', name: 'recovers on retry', state: 'passed', durationMs: 300 },
+        // The merge must be order-independent when the stable invocation is emitted first.
+        { fingerprint: 'aaaaaaaaaaaaaaaaaaaaaaaa', kind: 'e2e', classname: 'flaky.spec.ts', name: 'also recovers on retry', state: 'passed', durationMs: 300 },
+        { fingerprint: 'aaaaaaaaaaaaaaaaaaaaaaaa', kind: 'e2e', classname: 'flaky.spec.ts', name: 'also recovers on retry', state: 'passed', durationMs: 1700, retryFlaky: true, failedAttemptCount: 1, failedAttemptDurationMs: 700 },
+        { fingerprint: 'fedcba9876543210fedcba98', kind: 'e2e', classname: 'malformed.spec.ts', name: 'must not invent a flake', state: 'passed', durationMs: 1000, retryFlaky: true, failedAttemptCount: 0, failedAttemptDurationMs: 900 },
+      ],
+      coverage: null,
+      testInfrastructure: { declared: [], observed: [] },
+    }))
+    const out = path.join(repo, 'report.json')
+    execFileSync('node', [SCRIPT, '--repo', repo, '--out', out, '--stale-after-days', '99999'])
+    const report = JSON.parse(readFileSync(out, 'utf8')) as TestIntelligenceReport
+
+    expect(report.components[0].evidence[0]).toMatchObject({ kind: 'e2e', state: 'passed', counts: { passed: 5, failed: 0 } })
+    expect(report.testCases.find(item => item.fingerprint === '0123456789abcdef01234567')).toMatchObject({
+      state: 'flaky', lastState: 'passed', observations: 1, failureRate: 0,
+      averageDurationMs: 2000, wastedDurationMs: 700, sameCommitTransitions: 0, retryFlaky: true,
+      failedAttemptCount: 1, failedAttemptDurationMs: 700,
+      retryRun: { id: 'retry-42', attempt: 1, commit: 'abcdef012345', workflow: 'CI' },
+    })
+    expect(report.testCases.find(item => item.fingerprint === 'aaaaaaaaaaaaaaaaaaaaaaaa')).toMatchObject({
+      state: 'flaky', lastState: 'passed', observations: 1, failureRate: 0,
+      averageDurationMs: 2000, wastedDurationMs: 700, retryFlaky: true,
+      failedAttemptCount: 1, failedAttemptDurationMs: 700,
+    })
+    expect(report.testCases.find(item => item.fingerprint === 'fedcba9876543210fedcba98')).toMatchObject({
+      state: 'stable', lastState: 'passed', observations: 1, wastedDurationMs: 0,
+    })
+    expect(report.testCases.find(item => item.fingerprint === 'fedcba9876543210fedcba98')).not.toHaveProperty('retryFlaky')
+  })
+
+  it('keeps a newer terminal failure authoritative over older direct retry-flaky evidence', () => {
+    const repo = mkdtempSync(path.join(tmpdir(), 'test-intelligence-retry-then-failed-'))
+    dirs.push(repo)
+    write(repo, 'openbank-admin-ui/version.txt', '1.0.0\n')
+    write(repo, 'openbank-libs/governance/rules.yaml', 'money_path_services: []\n')
+    write(repo, 'openbank-libs/governance/journeys.yaml', 'version: 1\njourneys: []\n')
+    write(repo, 'openbank-admin-ui/test-run-history/retry-pass.json', JSON.stringify({
+      schemaVersion: 1,
+      run: { id: 'retry-pass', attempt: 1, commit: 'abcdef012345', branch: 'main', workflow: 'CI', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/retry-pass', observedAt: '2026-08-22T09:00:00Z' },
+      component: 'openbank-admin-ui', suites: [], coverage: null,
+      testCases: [{ fingerprint: '0123456789abcdef01234567', kind: 'e2e', classname: 'flaky.spec.ts', name: 'fails after an earlier retry pass', state: 'passed', durationMs: 900, retryFlaky: true, failedAttemptCount: 1, failedAttemptDurationMs: 300 }],
+      testInfrastructure: { declared: [], observed: [] },
+    }))
+    write(repo, 'openbank-admin-ui/build/test-intelligence/run.json', JSON.stringify({
+      schemaVersion: 1,
+      run: { id: 'terminal-fail', attempt: 1, commit: 'fedcba987654', branch: 'main', workflow: 'CI', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/terminal-fail', observedAt: '2026-08-22T10:00:00Z' },
+      component: 'openbank-admin-ui',
+      suites: [{ kind: 'e2e', state: 'failed', discovered: 1, executed: 1, passed: 0, failed: 1, skipped: 0, errors: 0, durationMs: 1000 }],
+      testCases: [{ fingerprint: '0123456789abcdef01234567', kind: 'e2e', classname: 'flaky.spec.ts', name: 'fails after an earlier retry pass', state: 'failed', durationMs: 1000 }],
+      coverage: null,
+      testInfrastructure: { declared: [], observed: [] },
+    }))
+    const out = path.join(repo, 'report.json')
+    execFileSync('node', [SCRIPT, '--repo', repo, '--out', out, '--stale-after-days', '99999'])
+    const report = JSON.parse(readFileSync(out, 'utf8')) as TestIntelligenceReport
+
+    expect(report.testCases[0]).toMatchObject({
+      state: 'failing', lastState: 'failed', observations: 2, failureRate: 50,
+      wastedDurationMs: 1300, sameCommitTransitions: 0, retryFlaky: true,
+      failedAttemptCount: 1, failedAttemptDurationMs: 300,
+      retryRun: { id: 'retry-pass', attempt: 1, commit: 'abcdef012345', workflow: 'CI' },
+    })
+  })
+
+  it('classifies same-run pass/fail transitions independently of testcase array order', () => {
+    const repo = mkdtempSync(path.join(tmpdir(), 'test-intelligence-transition-order-'))
+    dirs.push(repo)
+    write(repo, 'openbank-admin-ui/version.txt', '1.0.0\n')
+    write(repo, 'openbank-libs/governance/rules.yaml', 'money_path_services: []\n')
+    write(repo, 'openbank-libs/governance/journeys.yaml', 'version: 1\njourneys: []\n')
+    const failed = (fingerprint: string, name: string) => ({ fingerprint, kind: 'e2e', classname: 'matrix.spec.ts', name, state: 'failed', durationMs: 600 })
+    const passed = (fingerprint: string, name: string) => ({ fingerprint, kind: 'e2e', classname: 'matrix.spec.ts', name, state: 'passed', durationMs: 400 })
+    write(repo, 'openbank-admin-ui/build/test-intelligence/run.json', JSON.stringify({
+      schemaVersion: 1,
+      run: { id: 'matrix-42', attempt: 1, commit: 'abcdef012345', branch: 'main', workflow: 'CI', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/matrix-42', observedAt: '2026-08-22T10:00:00Z' },
+      component: 'openbank-admin-ui',
+      suites: [{ kind: 'e2e', state: 'failed', discovered: 4, executed: 4, passed: 2, failed: 2, skipped: 0, errors: 0, durationMs: 2000 }],
+      testCases: [
+        failed('0123456789abcdef01234567', 'failed then passed'),
+        passed('0123456789abcdef01234567', 'failed then passed'),
+        passed('aaaaaaaaaaaaaaaaaaaaaaaa', 'passed then failed'),
+        failed('aaaaaaaaaaaaaaaaaaaaaaaa', 'passed then failed'),
+      ],
+      coverage: null,
+      testInfrastructure: { declared: [], observed: [] },
+    }))
+    const out = path.join(repo, 'report.json')
+    execFileSync('node', [SCRIPT, '--repo', repo, '--out', out, '--stale-after-days', '99999'])
+    const report = JSON.parse(readFileSync(out, 'utf8')) as TestIntelligenceReport
+
+    for (const fingerprint of ['0123456789abcdef01234567', 'aaaaaaaaaaaaaaaaaaaaaaaa']) {
+      expect(report.testCases.find(item => item.fingerprint === fingerprint)).toMatchObject({
+        state: 'flaky', lastState: 'failed', observations: 2, failureRate: 50,
+        wastedDurationMs: 600, sameCommitTransitions: 1,
+      })
+    }
+  })
+
+  it('drops duplicate retry metadata when its same-run aggregate exceeds the safe integer boundary', () => {
+    const repo = mkdtempSync(path.join(tmpdir(), 'test-intelligence-retry-overflow-'))
+    dirs.push(repo)
+    write(repo, 'openbank-admin-ui/version.txt', '1.0.0\n')
+    write(repo, 'openbank-libs/governance/rules.yaml', 'money_path_services: []\n')
+    write(repo, 'openbank-libs/governance/journeys.yaml', 'version: 1\njourneys: []\n')
+    const retryObservation = {
+      fingerprint: '0123456789abcdef01234567', kind: 'e2e', classname: 'overflow.spec.ts',
+      name: 'keeps aggregates representable', state: 'passed', durationMs: Number.MAX_SAFE_INTEGER,
+      retryFlaky: true, failedAttemptCount: Number.MAX_SAFE_INTEGER,
+      failedAttemptDurationMs: Number.MAX_SAFE_INTEGER,
+    }
+    write(repo, 'openbank-admin-ui/build/test-intelligence/run.json', JSON.stringify({
+      schemaVersion: 1,
+      run: { id: 'retry-overflow', attempt: 1, commit: 'abcdef012345', branch: 'main', workflow: 'CI', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/retry-overflow', observedAt: '2026-08-22T10:00:00Z' },
+      component: 'openbank-admin-ui',
+      suites: [{ kind: 'e2e', state: 'passed', discovered: 2, executed: 2, passed: 2, failed: 0, skipped: 0, errors: 0, durationMs: Number.MAX_SAFE_INTEGER }],
+      testCases: [retryObservation, retryObservation],
+      coverage: null,
+      testInfrastructure: { declared: [], observed: [] },
+    }))
+    const out = path.join(repo, 'report.json')
+    execFileSync('node', [SCRIPT, '--repo', repo, '--out', out, '--stale-after-days', '99999'])
+    const report = JSON.parse(readFileSync(out, 'utf8')) as TestIntelligenceReport
+
+    expect(report.testCases[0]).toMatchObject({
+      state: 'stable', observations: 1, averageDurationMs: Number.MAX_SAFE_INTEGER, wastedDurationMs: 0,
+    })
+    expect(Number.isSafeInteger(report.testCases[0].averageDurationMs)).toBe(true)
+    expect(report.testCases[0]).not.toHaveProperty('retryFlaky')
+    expect(report.testCases[0]).not.toHaveProperty('failedAttemptCount')
+    expect(report.testCases[0]).not.toHaveProperty('failedAttemptDurationMs')
+  })
+
+  it('saturates cross-run retry waste while retaining the latest valid retry evidence', () => {
+    const repo = mkdtempSync(path.join(tmpdir(), 'test-intelligence-retry-history-overflow-'))
+    dirs.push(repo)
+    write(repo, 'openbank-admin-ui/version.txt', '1.0.0\n')
+    write(repo, 'openbank-libs/governance/rules.yaml', 'money_path_services: []\n')
+    write(repo, 'openbank-libs/governance/journeys.yaml', 'version: 1\njourneys: []\n')
+    const retryCase = (durationMs: number) => ({
+      fingerprint: '0123456789abcdef01234567', kind: 'e2e', classname: 'overflow.spec.ts',
+      name: 'keeps historical waste representable', state: 'passed', durationMs,
+      retryFlaky: true, failedAttemptCount: 1, failedAttemptDurationMs: durationMs,
+    })
+    write(repo, 'openbank-admin-ui/test-run-history/retry-max.json', JSON.stringify({
+      schemaVersion: 1,
+      run: { id: 'retry-max', attempt: 1, commit: 'abcdef012345', branch: 'main', workflow: 'CI', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/retry-max', observedAt: '2026-08-22T09:00:00Z' },
+      component: 'openbank-admin-ui', suites: [], coverage: null,
+      testCases: [retryCase(Number.MAX_SAFE_INTEGER)],
+      testInfrastructure: { declared: [], observed: [] },
+    }))
+    write(repo, 'openbank-admin-ui/build/test-intelligence/run.json', JSON.stringify({
+      schemaVersion: 1,
+      run: { id: 'retry-latest', attempt: 1, commit: 'fedcba987654', branch: 'main', workflow: 'CI', url: 'https://github.com/JiRaska/open-bank-oss/actions/runs/retry-latest', observedAt: '2026-08-22T10:00:00Z' },
+      component: 'openbank-admin-ui',
+      suites: [{ kind: 'e2e', state: 'passed', discovered: 1, executed: 1, passed: 1, failed: 0, skipped: 0, errors: 0, durationMs: Number.MAX_SAFE_INTEGER - 1 }],
+      testCases: [retryCase(Number.MAX_SAFE_INTEGER - 1)], coverage: null,
+      testInfrastructure: { declared: [], observed: [] },
+    }))
+    const out = path.join(repo, 'report.json')
+    execFileSync('node', [SCRIPT, '--repo', repo, '--out', out, '--stale-after-days', '99999'])
+    const report = JSON.parse(readFileSync(out, 'utf8')) as TestIntelligenceReport
+
+    expect(report.testCases[0]).toMatchObject({
+      state: 'flaky', lastState: 'passed', observations: 2,
+      wastedDurationMs: Number.MAX_SAFE_INTEGER, retryFlaky: true,
+      failedAttemptCount: 1, failedAttemptDurationMs: Number.MAX_SAFE_INTEGER - 1,
+      retryRun: { id: 'retry-latest', attempt: 1, commit: 'fedcba987654', workflow: 'CI' },
+    })
+    expect(Number.isSafeInteger(report.testCases[0].wastedDurationMs)).toBe(true)
+  })
+
   it('projects the unreleased simulation tooling envelope instead of reporting missing evidence', () => {
     const repo = mkdtempSync(path.join(tmpdir(), 'test-intelligence-simulation-'))
     dirs.push(repo)

--- a/openbank-libs/governance/test-intelligence-run.schema.json
+++ b/openbank-libs/governance/test-intelligence-run.schema.json
@@ -87,8 +87,23 @@
         "name": { "type": "string", "minLength": 1 },
         "state": { "enum": ["passed", "failed", "skipped"] },
         "durationMs": { "type": "integer", "minimum": 0 },
+        "retryFlaky": {
+          "const": true,
+          "description": "The testcase passed only after one or more failed attempts in this run."
+        },
+        "failedAttemptCount": { "type": "integer", "minimum": 1, "maximum": 9007199254740991 },
+        "failedAttemptDurationMs": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 },
         "testDefinitionPath": { "type": "string", "pattern": "^(?!.*\\/(?:\\.|\\.\\.)\\/)src/test/(?:kotlin|java)/[A-Za-z0-9_./-]+\\.(?:kt|java)$" }
       },
+      "dependentRequired": {
+        "retryFlaky": ["failedAttemptCount", "failedAttemptDurationMs"],
+        "failedAttemptCount": ["retryFlaky", "failedAttemptDurationMs"],
+        "failedAttemptDurationMs": ["retryFlaky", "failedAttemptCount"]
+      },
+      "allOf": [{
+        "if": { "properties": { "retryFlaky": { "const": true } }, "required": ["retryFlaky"] },
+        "then": { "properties": { "state": { "const": "passed" } } }
+      }],
       "additionalProperties": false
     },
     "testImpact": {


### PR DESCRIPTION
## Summary

Captures Playwright intra-run retry failures as bounded, secret-free evidence while keeping the authoritative suite and testcase verdict passed. Projects that direct observation as a real flaky warning with trusted run provenance in Test Intelligence.

## Type of change

- [x] fix (bug fix)
- [ ] feat (new functionality)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #8222
Refs #6613

## Changes

- Enable Playwright JUnit includeRetries and parse flakyFailure, flakyError, rerunFailure, and rerunError durations without retaining messages, stacks, stdout, stderr, or attachments.
- Add an optional exact retryFlaky metadata group while preserving the passed/failed/skipped state vocabulary and legacy envelopes.
- Aggregate same-run duplicate observations deterministically, preserve terminal failure precedence, bound all new numeric evidence, and saturate derived cumulative waste safely.
- Render direct retry flakes as warning-state flaky evidence with failed-attempt duration/count and trusted GitHub run provenance, never as stale.
- Add collector self-tests, schema/ecosystem guards, unit regressions, and rendered UI coverage for malformed input, terminal failures, ordering, deduplication, and overflow boundaries.

## Definition of Done

- [x] Hexagonal layering preserved (no domain code changed).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated for collector and rendered UI boundaries.
- [x] Contract tests updated for the additive envelope schema.
- [x] No new lint warnings.
- [x] OpenAPI spec not applicable; no REST API changed.
- [x] Flyway migration not applicable.
- [x] Event schema migration not applicable.
- [x] User-facing Test Intelligence explanation updated.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, or logs. Synthetic PRIVATE markers prove diagnostics are discarded.
- [x] No new suppressions or unsafe casts.
- [x] No new third-party dependency.
- [x] Auth, crypto, and payment code unchanged.
- [x] PII paths unchanged.
- [x] Cardholder-data paths unchanged.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: rolling Admin UI deployment after normal CI gates.
- Rollback plan: revert this commit; legacy envelopes remain accepted and the testcase state enum is unchanged.
- Data migration reversible: N/A. This is additive optional evidence.

## Verification

- Collector Python self-test and py_compile: passed.
- Test Intelligence ecosystem gate: 60 subjects passed; ecosystem red-path self-test passed.
- Strict Ajv schema compile: legacy and new envelopes accepted; malformed, incomplete, failed-state, and unsafe-number cases rejected.
- Focused Vitest: 2 files, 23 tests passed.
- Rendered Playwright Test Intelligence spec: 6 tests passed, including flaky warning, no stale label, and provenance.
- TypeScript type-check: passed.
- ESLint: 0 errors; 84 pre-existing warnings.
- Production build: compiled, TypeScript passed, 91 of 91 static pages generated, traces collected.
- Bounded full Vitest: npm test -- --maxWorkers=4; 424 files passed, 2251 tests passed, 1 skipped.
- Diff and explicit-stage checks: passed; exactly 10 intended files.

## Reviewer notes

This is an expand-only migration. Old Admin collectors ignore the optional fields; the new collector still accepts legacy envelopes. Malformed or unsafe retry metadata fails closed without inventing a flake. Terminal rerun durations contribute to total runtime but never set retryFlaky.

Two default-parallel full-suite attempts hit different existing five-second resource-contention failures; each isolated test passed, and the bounded four-worker full suite passed. The final overflow hardening touched only the collector and its test; the focused suite, type/lint/build, rendered Playwright, Python, ecosystem, Ajv, and diff gates were rerun afterward.

The final branch base was five release/deploy commits behind main with zero touched-path overlap; git merge-tree was clean. Filename-based classification and HTML/trace retention remain separate follow-ups. Live overlap checks found no duplicate retry-evidence PR; #7049 and #8176 cover distinct diagnostics/performance work, while #8212 and #8219 are merged and unrelated.

No self-review or merge is requested.