### PR TITLE
fix(admin-ui): make regulatory preview an accessible dialog

### DIFF
--- a/openbank-admin-ui/src/app/regulatory/page.tsx
+++ b/openbank-admin-ui/src/app/regulatory/page.tsx
@@ -5,7 +5,8 @@
 'use client'
 
 import Link from 'next/link'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
+import * as Dialog from '@radix-ui/react-dialog'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl, type BffFailure } from '@/lib/services/bff'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
@@ -293,6 +294,7 @@ export default function RegulatoryPage() {
   // table before committing to a download) — `preview` holds the report whose
   // export is being inspected.
   const [preview, setPreview] = useState<Report | null>(null)
+  const previewTriggerRef = useRef<HTMLElement | null>(null)
   const [previewData, setPreviewData] = useState<PreviewData>({ status: 'idle' })
   const [reportingDate, setReportingDate] = useState('')
   const [reportingPeriods, setReportingPeriods] = useState<string[]>([])
@@ -359,6 +361,7 @@ export default function RegulatoryPage() {
 
   function openPreview(id: string, e: React.MouseEvent) {
     e.stopPropagation()
+    previewTriggerRef.current = e.currentTarget as HTMLElement
     const report = REPORTS.find(r => r.id === id)
     if (report) {
       setPreview(report)
@@ -612,20 +615,25 @@ export default function RegulatoryPage() {
 
       {/* Export preview — visual control before download. Shows the exact
           field/value table that will be serialised, plus JSON and CSV export. */}
+      <Dialog.Root open={preview !== null} onOpenChange={open => { if (!open) setPreview(null) }}>
       {preview && (
-        <div
-          onClick={() => setPreview(null)}
+        <Dialog.Portal>
+        <Dialog.Overlay
           style={{
             position: 'fixed', inset: 0, zIndex: 1000,
-            background: 'rgba(0,0,0,0.45)', display: 'flex',
-            alignItems: 'center', justifyContent: 'center', padding: '24px',
+            background: 'rgba(0,0,0,0.45)',
           }}
-        >
-          <div
-            onClick={e => e.stopPropagation()}
+        />
+          <Dialog.Content
             className="card"
+            aria-modal="true"
+            onCloseAutoFocus={event => {
+              event.preventDefault()
+              if (previewTriggerRef.current?.isConnected) previewTriggerRef.current.focus()
+            }}
             style={{
-              width: '100%', maxWidth: '680px', maxHeight: '86vh',
+              position: 'fixed', zIndex: 1001, top: '50%', left: '50%', transform: 'translate(-50%, -50%)',
+              width: 'calc(100% - 48px)', maxWidth: '680px', maxHeight: '86vh',
               display: 'flex', flexDirection: 'column', overflow: 'hidden', padding: 0,
             }}
           >
@@ -634,15 +642,17 @@ export default function RegulatoryPage() {
               <div style={{ display: 'flex', alignItems: 'center', gap: '10px', minWidth: 0 }}>
                 <TableIcon size={16} style={{ color: 'var(--accent)', flexShrink: 0 }} />
                 <div style={{ minWidth: 0 }}>
-                  <div style={{ fontSize: '14px', fontWeight: 700, color: 'var(--text-primary)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  <Dialog.Title style={{ fontSize: '14px', fontWeight: 700, color: 'var(--text-primary)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                     {t('Náhled exportu', 'Export preview')} · {preview.sdatCode}
-                  </div>
-                  <div style={{ fontSize: '12px', color: 'var(--text-tertiary)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{preview.name}</div>
+                  </Dialog.Title>
+                  <Dialog.Description style={{ fontSize: '12px', color: 'var(--text-tertiary)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{preview.name}</Dialog.Description>
                 </div>
               </div>
-              <button type="button" className="btn btn-secondary" style={{ padding: '5px', flexShrink: 0 }} onClick={() => setPreview(null)} aria-label={t('Zavřít náhled exportu', 'Close export preview')}>
-                <X size={15} aria-hidden="true" />
-              </button>
+              <Dialog.Close asChild>
+                <button type="button" className="btn btn-secondary" style={{ padding: '5px', flexShrink: 0 }} aria-label={t('Zavřít náhled exportu', 'Close export preview')}>
+                  <X size={15} aria-hidden="true" />
+                </button>
+              </Dialog.Close>
             </div>
 
             {TEMPLATE_PATHS[preview.id] && (
@@ -748,9 +758,10 @@ export default function RegulatoryPage() {
                 </button>
               </div>
             </div>
-          </div>
-        </div>
+          </Dialog.Content>
+        </Dialog.Portal>
       )}
+      </Dialog.Root>
     </div>
   )
 }

--- a/openbank-admin-ui/src/test/regulatory-preview-close.guard.test.ts
+++ b/openbank-admin-ui/src/test/regulatory-preview-close.guard.test.ts
@@ -9,6 +9,7 @@ describe('regulatory export preview close contract', () => {
     expect(source).toContain('type="button" className="btn btn-secondary"')
     expect(source).toContain("aria-label={t('Zavřít náhled exportu', 'Close export preview')}")
     expect(source).toContain('<X size={15} aria-hidden="true" />')
-    expect(source).toContain('onClick={() => setPreview(null)}')
+    expect(source).toContain('<Dialog.Close asChild>')
+    expect(source).toContain('onOpenChange={open => { if (!open) setPreview(null) }}')
   })
 })

--- a/openbank-admin-ui/src/test/regulatory-report-preview.test.tsx
+++ b/openbank-admin-ui/src/test/regulatory-report-preview.test.tsx
@@ -24,6 +24,23 @@ function finrepResponse(templateId: string) {
 afterEach(() => vi.unstubAllGlobals())
 
 describe('Regulatory report preview', () => {
+  it('opens as a labelled modal and restores the trigger after Escape', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('unavailable', { status: 502 })))
+    render(<LanguageProvider><RegulatoryPage /></LanguageProvider>)
+
+    const finrepCard = screen.getByText('CNB — Finanční výkazy (FINREP)').closest('.card')
+    const trigger = within(finrepCard as HTMLElement).getByRole('button', { name: 'Preview export' })
+    fireEvent.click(trigger)
+
+    const dialog = await screen.findByRole('dialog', { name: /Export preview.*FINREP/i })
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(screen.getByRole('button', { name: 'Close export preview' })).toHaveFocus()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    expect(trigger).toHaveFocus()
+  })
+
   it('does not offer a fake export preview for catalogue-only reports', () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)


### PR DESCRIPTION
## Summary

- replace the hand-rolled regulatory export overlay with the existing Radix modal-dialog primitive
- expose a labelled title and report description while preserving all preview/export logic
- restore keyboard focus to the exact initiating report after Escape, close, or outside dismissal

## Verification

- focused regulatory Vitest suite: 4 files / 9 tests passed on the exact rebased head
- `npm run type-check`: passed
- changed-file ESLint: passed
- `git diff --check`: passed
- independent exact-blob review: NO BLOCKER

## Risk and scope

Admin UI only. No API, RBAC, calculation, reporting-period, readiness, JSON, or CSV payload changes. Radix is already a production dependency used by another Admin UI confirmation dialog.

Closes #8249
