### PR TITLE
test(admin-ui): exercise product lifecycle confirmation

### DIFF
--- a/openbank-admin-ui/e2e/product-lifecycle.spec.ts
+++ b/openbank-admin-ui/e2e/product-lifecycle.spec.ts
@@ -24,23 +24,73 @@ test.describe('product lifecycle', () => {
   })
 
   test('an operator can deactivate a product and reach governed add-on management', async ({ page }) => {
+    let deactivationRequests = 0
+    let activationRequests = 0
+    let currentProduct = product
+    const catalogueReads: Array<{ status: string; revision: number }> = []
     await page.route('**/api/svc/product-catalog/api/v1/products', route => {
       if (route.request().method() === 'GET') {
-        return route.fulfill({ contentType: 'application/json', body: JSON.stringify([product]) })
+        catalogueReads.push({ status: currentProduct.status, revision: currentProduct.revision })
+        return route.fulfill({ contentType: 'application/json', body: JSON.stringify([currentProduct]) })
       }
       return route.fallback()
     })
     await page.route(`**/api/svc/product-catalog/api/v1/products/${product.id}/deactivate`, async route => {
+      deactivationRequests += 1
       expect(route.request().method()).toBe('POST')
       expect(route.request().headers()['if-match']).toBe('"4"')
-      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ...product, status: 'INACTIVE', revision: 5 }) })
+      currentProduct = { ...product, status: 'INACTIVE', revision: 5 }
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify(currentProduct) })
+    })
+    await page.route(`**/api/svc/product-catalog/api/v1/products/${product.id}/activate`, async route => {
+      activationRequests += 1
+      expect(route.request().method()).toBe('POST')
+      expect(route.request().headers()['if-match']).toBe('"5"')
+      currentProduct = { ...currentProduct, status: 'ACTIVE', revision: 6 }
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify(currentProduct) })
     })
 
     await page.goto('/product-catalog')
     await expect(page.getByText('TERM_DEPOSIT_6M_CZK')).toBeVisible()
     await expect(page.locator('a.btn[href="/product-studio"]')).toBeVisible()
 
-    page.once('dialog', dialog => dialog.accept())
-    await page.locator('button[title="Deactivate"]').click()
+    await page.getByRole('button', { name: 'Deactivate product', exact: true }).click()
+
+    const dialog = page.getByRole('dialog', { name: 'Deactivate product?' })
+    await expect(dialog).toBeVisible()
+    await expect(dialog).toContainText(product.name)
+    await expect(dialog).toContainText(product.code)
+    await expect(dialog.getByText('ACTIVE', { exact: true })).toBeVisible()
+    await expect(dialog.getByText('INACTIVE', { exact: true })).toBeVisible()
+    await expect(dialog).toContainText('History and existing accounts remain available. The product stops being offered for new accounts.')
+    expect(deactivationRequests).toBe(0)
+
+    await dialog.getByRole('button', { name: `Confirm deactivation of ${product.name}`, exact: true }).click()
+
+    await expect.poll(() => deactivationRequests).toBe(1)
+    await expect.poll(() => catalogueReads[catalogueReads.length - 1]).toEqual({ status: 'INACTIVE', revision: 5 })
+    await expect(dialog).toBeHidden()
+    const productRow = page.getByRole('row').filter({ hasText: product.code })
+    await expect(productRow.getByText('INACTIVE', { exact: true })).toBeVisible()
+    const activate = productRow.getByRole('button', { name: 'Activate product', exact: true })
+    await expect(activate).toBeVisible()
+    expect(deactivationRequests).toBe(1)
+
+    await activate.click()
+    const activationDialog = page.getByRole('dialog', { name: 'Activate product?' })
+    await expect(activationDialog).toBeVisible()
+    await expect(activationDialog.getByText('INACTIVE', { exact: true })).toBeVisible()
+    await expect(activationDialog.getByText('ACTIVE', { exact: true })).toBeVisible()
+    expect(activationRequests).toBe(0)
+
+    await activationDialog.getByRole('button', { name: `Confirm activation of ${product.name}`, exact: true }).click()
+
+    await expect.poll(() => activationRequests).toBe(1)
+    await expect.poll(() => catalogueReads[catalogueReads.length - 1]).toEqual({ status: 'ACTIVE', revision: 6 })
+    await expect(activationDialog).toBeHidden()
+    await expect(productRow.getByText('ACTIVE', { exact: true })).toBeVisible()
+    await expect(productRow.getByRole('button', { name: 'Deactivate product', exact: true })).toBeVisible()
+    expect(deactivationRequests).toBe(1)
+    expect(activationRequests).toBe(1)
   })
 })


### PR DESCRIPTION
## Summary

- replace the obsolete native-dialog lifecycle flow with the current in-product confirmation dialog
- prove deactivation sends exactly one POST with If-Match "4" only after confirmation
- prove the refreshed product becomes INACTIVE at revision 5
- prove reactivation sends exactly one POST with If-Match "5" and returns to ACTIVE revision 6
- use exact status assertions so ACTIVE cannot pass against INACTIVE by substring

## Type of change

- [x] test
- [ ] product behavior
- [ ] API/schema/config change

## Linked issue

Closes #8257

## Verification

- deterministic red on the old flow: expected one deactivation request, received zero
- targeted Playwright on current main with retries disabled and one worker: 1/1 passed
- Admin UI type-check: passed
- changed-file ESLint: passed
- production Next build: passed
- git diff --check: passed
- independent frozen-diff review: no P1/P2

## Safety

- one E2E file only; no production code, API, auth, data, config, or dependency change
- no self-review or merge requested