### PR TITLE
fix(admin-ui): single-flight delegation role saves

### DIFF
--- a/openbank-admin-ui/src/components/delegations/RoleCatalog.tsx
+++ b/openbank-admin-ui/src/components/delegations/RoleCatalog.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { useAuth } from '@/lib/auth/useAuth'
 import { trapDialogFocus } from '@/lib/a11y/trapDialogFocus'
 import { CAPABILITIES_BY_RESOURCE, assignablePresetCapabilities, capabilityIntent, capabilityLabel, isAssignablePresetCapability, isReservedOwnershipPresetName, truthfulPresetName, type CapabilityIntent, type DelegationResource, type RolePreset } from '@/lib/delegations/rolePresets'
+import { useSingleFlight } from '@/lib/mutations/singleFlight'
 import { LegacyCapabilityEvidence } from '@/components/delegations/LegacyCapabilityEvidence'
 
 const emptyRole = (): RolePreset => ({ id: '', name: '', description: '', resourceType: 'ACCOUNT', capabilities: [] })
@@ -14,6 +15,7 @@ const emptyRole = (): RolePreset => ({ id: '', name: '', description: '', resour
 export function RoleCatalog() {
   const { t } = useLanguage()
   const { hasRole } = useAuth()
+  const saveFlight = useSingleFlight()
   const canManage = hasRole('ROLE_ADMIN')
   const [roles, setRoles] = useState<RolePreset[]>([])
   const [resource, setResource] = useState<DelegationResource>('ACCOUNT')
@@ -53,24 +55,27 @@ export function RoleCatalog() {
     setSaveError(false)
   }
   const save = async (role: RolePreset) => {
-    const payload = { name: truthfulPresetName(role).trim(), description: role.description.trim(), resourceType: role.resourceType, capabilities: role.capabilities.filter(isAssignablePresetCapability) }
-    setSaving(true)
-    setSaveError(false)
-    try {
-      const response = await fetch(role.id ? `/api/delegation-role-presets/${role.id}` : '/api/delegation-role-presets', {
-        method: role.id ? 'PUT' : 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payload),
-      })
-      if (!response.ok) {
+    const operationKey = role.id ? `delegation-role:update:${role.id}` : 'delegation-role:create'
+    await saveFlight.run(operationKey, async () => {
+      const payload = { name: truthfulPresetName(role).trim(), description: role.description.trim(), resourceType: role.resourceType, capabilities: role.capabilities.filter(isAssignablePresetCapability) }
+      setSaving(true)
+      setSaveError(false)
+      try {
+        const response = await fetch(role.id ? `/api/delegation-role-presets/${role.id}` : '/api/delegation-role-presets', {
+          method: role.id ? 'PUT' : 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payload),
+        })
+        if (!response.ok) {
+          setSaveError(true)
+          return
+        }
+        setEditing(null)
+        await load()
+      } catch {
         setSaveError(true)
-        return
+      } finally {
+        setSaving(false)
       }
-      setEditing(null)
-      await load()
-    } catch {
-      setSaveError(true)
-    } finally {
-      setSaving(false)
-    }
+    })
   }
   const requestRemoval = (role: RolePreset, trigger: HTMLButtonElement) => {
     removeReturnFocusRef.current = trigger

--- a/openbank-admin-ui/src/test/delegation-role-delete-dialog.test.tsx
+++ b/openbank-admin-ui/src/test/delegation-role-delete-dialog.test.tsx
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { readFileSync } from 'fs'
 import { join } from 'path'
-import { DeleteRoleDialog, OwnershipRoleNotice, RoleEditor, RoleOverview } from '@/components/delegations/RoleCatalog'
+import { DeleteRoleDialog, OwnershipRoleNotice, RoleCatalog, RoleEditor, RoleOverview } from '@/components/delegations/RoleCatalog'
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import type { RolePreset } from '@/lib/delegations/rolePresets'
+
+vi.mock('@/lib/auth/useAuth', () => ({
+  useAuth: () => ({ hasRole: (role: string) => role === 'ROLE_ADMIN' }),
+}))
 
 const ROLE = {
   id: 'treasury-operator',
@@ -38,7 +42,10 @@ const LEGACY_ONLY_ROLE = {
   capabilities: ['DELEGATION_MANAGE'],
 } satisfies RolePreset
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
 
 describe('delegation role deletion', () => {
   it('never falls back to a native browser confirmation', () => {
@@ -111,22 +118,61 @@ describe('delegation role editor recovery', () => {
     expect(save).toHaveBeenCalledWith(expect.objectContaining({ name: 'Treasury reviewer' }))
   })
 
-  it('locks dismissal and duplicate submission while saving', () => {
-    const cancel = vi.fn()
-    const save = vi.fn(async () => undefined)
+  it('locks dismissal and duplicate submission while saving, then releases the lock for retry', async () => {
+    let releaseFirstResponse!: (response: Response) => void
+    const firstResponse = new Promise<Response>(resolve => { releaseFirstResponse = resolve })
+    let postRequests = 0
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const method = init?.method ?? 'GET'
+      if (method === 'GET') {
+        return Promise.resolve(new Response('[]', { status: 200, headers: { 'content-type': 'application/json' } }))
+      }
+      if (method === 'POST' && String(input) === '/api/delegation-role-presets') {
+        postRequests += 1
+        if (postRequests === 1) return firstResponse
+        return Promise.resolve(new Response('{}', { status: 201, headers: { 'content-type': 'application/json' } }))
+      }
+      return Promise.reject(new Error(`unexpected ${method} ${String(input)}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
     render(
       <LanguageProvider>
-        <RoleEditor value={ROLE} busy failed={false} cancel={cancel} save={save} />
+        <RoleCatalog />
       </LanguageProvider>,
     )
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      '/api/delegation-role-presets',
+      expect.objectContaining({ cache: 'no-store' }),
+    ))
+    fireEvent.click(screen.getByRole('button', { name: 'Add role' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Name' }), { target: { value: 'Payments reviewer' } })
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Account details' }))
+
+    const save = screen.getByRole('button', { name: 'Save' })
+    expect(save).toBeEnabled()
+    act(() => {
+      save.click()
+      save.click()
+    })
 
     const dialog = screen.getByRole('dialog')
     expect(dialog).toHaveAttribute('aria-busy', 'true')
     expect(screen.getByRole('button', { name: 'Saving…' })).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
     fireEvent.keyDown(dialog, { key: 'Escape' })
-    expect(cancel).not.toHaveBeenCalled()
-    expect(save).not.toHaveBeenCalled()
+    expect(dialog).toBeInTheDocument()
+    expect(postRequests).toBe(1)
+
+    releaseFirstResponse(new Response('{}', { status: 503, headers: { 'content-type': 'application/json' } }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Nothing changed; check the details and try again.')
+    const retry = screen.getByRole('button', { name: 'Save' })
+    expect(retry).toBeEnabled()
+    fireEvent.click(retry)
+
+    await waitFor(() => expect(postRequests).toBe(2))
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
   })
 
   it('does not offer recursive delegation and removes it only on an explicit save', () => {


### PR DESCRIPTION
## Summary

Prevents same-tick re-entry in the delegation role editor from sending duplicate create or update mutations. Replaces the prior prop-only busy-state test with a real `RoleCatalog` regression that proves exact request counts across a deferred failure and one later retry.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #8279

## Changes

- Claim the existing synchronous `useSingleFlight` lock under a stable create/update operation key before a delegation role request begins.
- Exercise two same-tick Save activations against the real catalog, retain busy/disabled/Escape behavior, and prove a controlled 503 releases the lock for one successful retry.

## Definition of Done

- [x] Hexagonal layering preserved; Admin UI only.
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (no service boundary changed).
- [ ] Contract tests updated (no public API changed).
- [x] Relevant Admin UI tests, typecheck, lint, and production build pass.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (no REST API change).
- [ ] Flyway migration added + rollback note (no DB change).
- [ ] Avro schema versioned backward-compatibly (no event change).
- [ ] Docs updated (no documentation change required).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, or logs.
- [x] No new suppressions or unsafe casts.
- [x] No new third-party dependency.
- [x] Auth, crypto, and payment code unchanged.
- [x] PII paths unchanged.
- [x] Cardholder data paths unchanged.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: rolling Admin UI deployment through the normal pipeline.
- Rollback plan: revert commit `92b618a8a5`.
- Data migration reversible: N/A.

## Verification

- Deterministic pre-fix RED: 1 failed, 9 passed; two same-tick Save activations produced 2 POSTs where 1 was expected.
- Post-fix focused regression plus nearest single-flight suite: 22/22 passed.
- Admin UI typecheck: passed.
- Changed-file ESLint: passed.
- Production `next build --webpack`: passed; 91/91 static pages generated.
- `git diff --check`: passed.
- After the single main refresh, neither scoped path had changed; the focused tests, typecheck, lint, and diff check were repeated on the final base.

## Screenshots / demo

N/A; the visible busy, disabled, and Escape behavior is intentionally unchanged.

## Reviewer notes

The lock is client-side re-entry protection only; it does not claim server-side replay idempotency. Please review the stable create/update key and the regression release path. A frozen independent diff review found no blocking issue. No self-review or merge is requested.