### PR TITLE
test(admin-ui): scan healthy SDD workflow accessibility

### DIFF
--- a/openbank-admin-ui/e2e/core-workflow-accessibility.spec.ts
+++ b/openbank-admin-ui/e2e/core-workflow-accessibility.spec.ts
@@ -4,7 +4,7 @@ import { expect, test } from '@playwright/test'
 import AxeBuilder from '@axe-core/playwright'
 import { signInAsOperator } from './helpers/auth'
 
-const CORE_WORKFLOWS = [
+const OUTAGE_WORKFLOWS = [
   '/dashboard',
   '/accounts',
   '/payments',
@@ -14,7 +14,6 @@ const CORE_WORKFLOWS = [
   '/consents',
   '/kyc',
   '/sanctions',
-  '/sdd',
 ] as const
 
 test.beforeEach(async ({ context, baseURL, page }) => {
@@ -29,8 +28,8 @@ test.beforeEach(async ({ context, baseURL, page }) => {
   })
 })
 
-for (const route of CORE_WORKFLOWS) {
-  test(`${route} has no automated WCAG A/AA violations in its default state`, async ({ page }) => {
+for (const route of OUTAGE_WORKFLOWS) {
+  test(`${route} has no automated WCAG A/AA violations with non-auth APIs forced unavailable`, async ({ page }) => {
     await page.goto(route)
     await expect(page.locator('#main-content')).toBeVisible()
     // Several legacy consoles still use a short entry transition. Axe samples computed colours,
@@ -45,3 +44,41 @@ for (const route of CORE_WORKFLOWS) {
     ).join('\n')).toEqual([])
   })
 }
+
+test('/sdd has no automated WCAG A/AA violations in its healthy default state', async ({ page }) => {
+  await page.route('**/api/svc/sdd-service/api/v1/sdd/mandates/recent**', async route => {
+    expect(route.request().url()).toContain('limit=50')
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([{
+        id: '11111111-1111-1111-1111-111111111111',
+        umr: 'UMR-EVIDENCE-42',
+        creditorName: 'Verified Utilities SE',
+        debtorIban: 'CZ6508000000192000145399',
+        status: 'ACTIVE',
+        scheme: 'CORE',
+        createdAt: '2026-08-31T08:00:00Z',
+      }]),
+    })
+  })
+
+  await page.goto('/sdd')
+
+  const mandateTable = page.getByRole('table')
+  await expect(page.getByText('UMR-EVIDENCE-42', { exact: true })).toBeVisible()
+  await expect(page.getByText('Verified Utilities SE', { exact: true })).toBeVisible()
+  await expect(mandateTable).toBeVisible()
+  await expect(mandateTable.getByRole('columnheader', { name: 'UMR', exact: true })).toBeVisible()
+  await expect(mandateTable.getByRole('columnheader')).toHaveCount(6)
+
+  // Several legacy consoles still use a short entry transition. Axe samples computed colours,
+  // so scan the settled UI rather than a deliberately translucent animation frame.
+  await page.waitForTimeout(300)
+  const scan = await new AxeBuilder({ page })
+    .include('#main-content')
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])
+    .analyze()
+  expect(scan.violations, scan.violations.map(violation =>
+    `${violation.id}: ${violation.nodes.map(node => node.target.join(' ')).join(', ')}`,
+  ).join('\n')).toEqual([])
+})


### PR DESCRIPTION
## Summary

- split `/sdd` out of the catch-all 503 accessibility loop and scan its healthy default state
- reuse the proven mandate response and require the unique UMR, creditor, and semantic six-column table before Axe runs
- describe the remaining generic scans truthfully as running with non-auth APIs forced unavailable

## Type of change

- [x] test
- [ ] product behavior
- [ ] API/schema/config change

## Linked issue

Closes #8286

## Verification

- deterministic RED on the old 503 harness: exact `UMR-EVIDENCE-42` locator absent after five seconds
- focused Playwright on latest main, one worker and retries disabled: 1/1 passed
- full changed Playwright spec on latest main, one worker and retries disabled: 10/10 passed
- Admin UI type-check: passed
- changed-file ESLint: passed
- production Next build: passed on the frozen patch before a disjoint main advance; the candidate file was unchanged
- `git diff --check`: passed
- independent frozen-diff review: clean

## Safety

- one E2E file only; no production code, API, auth, data, config, dependency, or release change
- no self-review or merge requested
