### PR TITLE
test(admin-ui): scope campaign conversion assertion

### DIFF
--- a/openbank-admin-ui/e2e/campaign-visual-contract.spec.ts
+++ b/openbank-admin-ui/e2e/campaign-visual-contract.spec.ts
@@ -165,7 +165,7 @@ test('keeps campaign outcome and app attention as distinct, readable decision su
   await expect(outcome).toBeVisible()
   await expect(attention).toBeVisible()
   await expect(outcome).toContainText(/18/)
-  await expect(outcome).toContainText(/4/)
+  await expect(outcome.locator('[data-conversion="measured"] > strong')).toHaveText('4')
   await expect(attention).toContainText(/1,200/)
   await expect(attention).toContainText(/186/)
 


### PR DESCRIPTION
## Summary

Tighten the campaign outcome browser assertion to read the exact measured-conversion value. This prevents the audience count `24` from satisfying an expected conversion count of `4`.

## Type of change

- [x] test (test-only assertion hardening)

## Linked issues

Closes #8289

## Changes

- Scope the conversion assertion to the existing `data-conversion="measured"` metric.
- Preserve the production component, fixture, and surrounding visual checks.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Browser test updated.
- [x] No service boundary or public API changed.
- [x] No new lint warnings.
- [x] Type-check passes.
- [x] Production Admin UI build passes.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new suppressions or unsafe casts.
- [x] No new third-party dependency.
- [x] No auth, crypto, payment, PII, or cardholder-data path changed.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A (test-only)
- Rollback plan: revert the assertion-only commit
- Data migration reversible: N/A

## Screenshots / demo

N/A (test-only).

## Reviewer notes

Counterexample on the real spec with retries disabled: changing only `CONVERTED` from `4` to `0` left the old card-wide `/4/` assertion green (2/2 tests passed). The scoped assertion then failed with expected `4`, received `0`; restoring the fixture returned 2/2 green.

Validation: targeted Playwright (`--retries=0`), type-check, changed-file ESLint, `git diff --check`, and production build.