### PR TITLE
test(admin-ui): cover account opening single-flight

### DIFF
--- a/openbank-admin-ui/e2e/term-deposit-account-opening.spec.ts
+++ b/openbank-admin-ui/e2e/term-deposit-account-opening.spec.ts
@@ -14,7 +14,8 @@ test.describe('term-deposit account opening', () => {
     await signInAsOperator(context, baseURL!)
   })
 
-  test('selecting an active term-deposit product fills the account and opens it', async ({ page }) => {
+  test('selecting an active term-deposit product fills the account and opens it once', async ({ page }) => {
+    const accountOpeningPosts: Array<{ idempotencyKey: string; body: Record<string, unknown> }> = []
     await page.route('**/api/svc/product-catalog/api/v1/products?status=ACTIVE', route => route.fulfill({
       contentType: 'application/json',
       body: JSON.stringify([
@@ -29,13 +30,11 @@ test.describe('term-deposit account opening', () => {
       ]),
     }))
     await page.route('**/api/svc/account-service/api/v1/accounts', async route => {
-      expect(route.request().method()).toBe('POST')
-      expect(route.request().postDataJSON()).toMatchObject({
-        partyId,
-        productId,
-        accountType: 'TERM_DEPOSIT',
-        currencyCode: 'CZK',
-        legalName: 'Test Customer',
+      const request = route.request()
+      expect(request.method()).toBe('POST')
+      accountOpeningPosts.push({
+        idempotencyKey: request.headers()['idempotency-key'] ?? '',
+        body: request.postDataJSON() as Record<string, unknown>,
       })
       await route.fulfill({
         status: 201,
@@ -52,8 +51,21 @@ test.describe('term-deposit account opening', () => {
     await expect(page.locator('#account-currency')).toHaveValue('CZK')
 
     await page.locator('#account-legal-name').fill('Test Customer')
-    await page.locator('button[type="submit"]').click()
+    await page.locator('form').evaluate(form => {
+      const accountForm = form as HTMLFormElement
+      accountForm.requestSubmit()
+      accountForm.requestSubmit()
+    })
 
     await expect(page).toHaveURL(`/accounts/${accountId}`)
+    expect(accountOpeningPosts).toHaveLength(1)
+    expect(accountOpeningPosts[0].idempotencyKey).toMatch(/^[0-9a-f-]{36}$/)
+    expect(accountOpeningPosts[0].body).toMatchObject({
+      partyId,
+      productId,
+      accountType: 'TERM_DEPOSIT',
+      currencyCode: 'CZK',
+      legalName: 'Test Customer',
+    })
   })
 })


### PR DESCRIPTION
## Summary

Exercise the term-deposit account form with two synchronous submit activations and prove that the Admin UI sends exactly one account-opening POST. This adds behavior-level regression coverage for the existing single-flight guard.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [x] test (regression coverage only)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #8295

## Changes

- Activate the valid account-opening form twice in the same browser turn and record every matching POST.
- Assert exactly one POST after redirect while retaining stable idempotency-key and request-body checks.

## Definition of Done

- [x] Hexagonal layering preserved (test-only change).
- [x] Unit tests added/updated (N/A; focused browser regression is the responsible layer).
- [x] Integration tests added/updated (Playwright E2E updated).
- [x] Contract tests updated (N/A; no API change).
- [x] Relevant Admin UI gates pass.
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (N/A; no REST API change).
- [x] Flyway migration added + rollback note (N/A; no DB change).
- [x] Avro schema versioned backward-compatibly (N/A; no event change).
- [x] Docs updated (N/A; no documentation impact).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, or `@Suppress(...)`.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment production code changed? No.
- [x] PII path changed? No.
- [x] Cardholder data path changed? No.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

## Rollout / Rollback

- Deployment strategy: N/A (E2E-only change)
- Rollback plan: revert this commit
- Data migration reversible: N/A

## Screenshots / demo

N/A (test-only change)

## Reviewer notes

- Controlled mutation: removing `if (openingInFlight.current) return` produced two POSTs and failed `expected 1, received 2` with retries disabled.
- Restored guard: focused Chromium Playwright passed 1/1 with `--retries=0 --workers=1`.
- `npm run type-check`, changed-file ESLint, and `git diff --check` passed.
- `npm run build` passed on the reviewed base. The one refresh to latest `main` contained deployment-only commits and changed neither Admin UI nor the guarded production page, so it was not repeated.
- Independent frozen-diff review: clean.