### PR TITLE
fix(admin-ui): make template lifecycle dialogs focus-safe

### DIFF
--- a/openbank-admin-ui/src/app/document-templates/page.tsx
+++ b/openbank-admin-ui/src/app/document-templates/page.tsx
@@ -5,6 +5,7 @@
 'use client'
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import * as Dialog from '@radix-ui/react-dialog'
 import { useSingleFlight, wasSkipped } from '@/lib/mutations/singleFlight'
 import { useSession } from 'next-auth/react'
 import {
@@ -243,6 +244,20 @@ export default function DocumentTemplatesPage() {
   // so this bar is modelled on the app's own modal-overlay convention instead.
   const [pendingAction, setPendingAction] = useState<{ id: string; kind: 'publish' | 'retire' } | null>(null)
   const [actioning, setActioning] = useState(false)
+  const [lifecycleError, setLifecycleError] = useState<string | null>(null)
+  const actionCancelRef = useRef<HTMLButtonElement>(null)
+  const actionReturnFocusRef = useRef<HTMLElement | null>(null)
+  const actionReturnIdRef = useRef<string | null>(null)
+
+  const openLifecycleDialog = (
+    event: React.MouseEvent<HTMLButtonElement>,
+    action: { id: string; kind: 'publish' | 'retire' },
+  ) => {
+    actionReturnFocusRef.current = event.currentTarget
+    actionReturnIdRef.current = `template-row-primary-${action.id}`
+    setLifecycleError(null)
+    setPendingAction(action)
+  }
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -431,13 +446,13 @@ export default function DocumentTemplatesPage() {
   const runAction = async (id: string, kind: 'publish' | 'retire') => {
     const outcome = await flight.run('template:write', async () => {
     setActioning(true)
-    setActionError(null)
+    setLifecycleError(null)
     try {
       await apiFetch(`${TEMPLATES_PATH}/${id}/${kind}`, { method: 'POST' })
       await load()
       setPendingAction(null)
     } catch (err) {
-      setActionError(err instanceof Error ? err.message : t('Akci se nepodařilo provést', 'The action could not be completed'))
+      setLifecycleError(err instanceof Error ? err.message : t('Akci se nepodařilo provést', 'The action could not be completed'))
     } finally {
       setActioning(false)
     }
@@ -559,16 +574,16 @@ export default function DocumentTemplatesPage() {
                       <td style={{ fontFamily: 'var(--font-mono)', fontSize: '11px', color: 'var(--text-tertiary)' }}>{tpl.productRef ?? '—'}</td>
                       <td style={{ textAlign: 'right' }}>
                         <div style={{ display: 'flex', gap: '3px', justifyContent: 'flex-end' }}>
-                          <button type="button" className="btn btn-secondary btn-sm" style={{ padding: '4px' }} title={canEdit ? t('Upravit', 'Edit') : t('Zobrazit', 'View')} aria-label={canEdit ? t('Upravit šablonu', 'Edit template') : t('Zobrazit šablonu', 'View template')} onClick={() => openEditModal(tpl)}>
+                          <button id={`template-row-primary-${tpl.id}`} type="button" className="btn btn-secondary btn-sm" style={{ padding: '4px' }} title={canEdit ? t('Upravit', 'Edit') : t('Zobrazit', 'View')} aria-label={canEdit ? t('Upravit šablonu', 'Edit template') : t('Zobrazit šablonu', 'View template')} onClick={() => openEditModal(tpl)}>
                             {canEdit ? <Edit size={13} /> : <Eye size={13} />}
                           </button>
                           {canEdit && (tpl.status ?? 'DRAFT') === 'DRAFT' && (
-                            <button type="button" className="btn btn-secondary btn-sm" style={{ padding: '4px', color: 'var(--success-text)' }} title={t('Publikovat', 'Publish')} aria-label={t('Publikovat šablonu', 'Publish template')} onClick={() => setPendingAction({ id: tpl.id, kind: 'publish' })}>
+                            <button type="button" className="btn btn-secondary btn-sm" style={{ padding: '4px', color: 'var(--success-text)' }} title={t('Publikovat', 'Publish')} aria-label={t('Publikovat šablonu', 'Publish template')} onClick={event => openLifecycleDialog(event, { id: tpl.id, kind: 'publish' })}>
                               <Send size={13} />
                             </button>
                           )}
                           {canEdit && tpl.status === 'PUBLISHED' && (
-                            <button type="button" className="btn btn-secondary btn-sm" style={{ padding: '4px', color: 'var(--warning-text)' }} title={t('Vyřadit', 'Retire')} aria-label={t('Vyřadit šablonu', 'Retire template')} onClick={() => setPendingAction({ id: tpl.id, kind: 'retire' })}>
+                            <button type="button" className="btn btn-secondary btn-sm" style={{ padding: '4px', color: 'var(--warning-text)' }} title={t('Vyřadit', 'Retire')} aria-label={t('Vyřadit šablonu', 'Retire template')} onClick={event => openLifecycleDialog(event, { id: tpl.id, kind: 'retire' })}>
                               <Archive size={13} />
                             </button>
                           )}
@@ -794,24 +809,58 @@ export default function DocumentTemplatesPage() {
 
       {/* Inline confirm for publish/retire — never a raw browser confirm()/alert() */}
       {pendingAction && (
-        <div style={{ position: 'fixed', top: 0, left: 0, width: '100%', height: '100%', background: 'rgba(15,23,42,0.65)', zIndex: 1100, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '20px' }}>
-          <div className="card" style={{ width: '400px', maxWidth: '100%', padding: '20px' }}>
-            <div style={{ fontSize: '14px', fontWeight: 700, marginBottom: '8px', color: 'var(--text-primary)' }}>
+        <Dialog.Root open onOpenChange={open => {
+          if (!open && !actioning) {
+            setLifecycleError(null)
+            setPendingAction(null)
+          }
+        }}>
+          <Dialog.Portal>
+            <Dialog.Overlay style={{ position: 'fixed', inset: 0, zIndex: 1100, background: 'rgba(15,23,42,0.65)' }} />
+            <Dialog.Content
+              className="card"
+              aria-modal="true"
+              aria-busy={actioning}
+              onOpenAutoFocus={event => {
+                event.preventDefault()
+                actionCancelRef.current?.focus()
+              }}
+              onCloseAutoFocus={event => {
+                event.preventDefault()
+                const original = actionReturnFocusRef.current
+                const rowFallback = actionReturnIdRef.current ? document.getElementById(actionReturnIdRef.current) : null
+                const pageFallback = document.getElementById('template-status-filter')
+                const target = original?.isConnected ? original : rowFallback ?? pageFallback
+                target?.focus()
+              }}
+              onEscapeKeyDown={event => { if (actioning) event.preventDefault() }}
+              onInteractOutside={event => { if (actioning) event.preventDefault() }}
+              style={{ position: 'fixed', zIndex: 1101, top: '50%', left: '50%', transform: 'translate(-50%, -50%)', width: 'calc(100% - 40px)', maxWidth: '400px', padding: '20px' }}
+            >
+            <Dialog.Title style={{ fontSize: '14px', fontWeight: 700, marginBottom: '8px', color: 'var(--text-primary)' }}>
               {pendingAction.kind === 'publish' ? t('Publikovat šablonu?', 'Publish this template?') : t('Vyřadit šablonu?', 'Retire this template?')}
-            </div>
-            <div style={{ fontSize: '12.5px', color: 'var(--text-secondary)', marginBottom: '16px', lineHeight: 1.5 }}>
+            </Dialog.Title>
+            <Dialog.Description style={{ fontSize: '12.5px', color: 'var(--text-secondary)', marginBottom: '16px', lineHeight: 1.5 }}>
               {pendingAction.kind === 'publish'
                 ? t('Publikovaná verze je neměnná — další úprava vytvoří novou verzi.', 'A published version is immutable — a further edit creates a new version.')
                 : t('Vyřazená šablona se přestane nabízet pro generování nových dokumentů.', 'A retired template stops being offered for new document generation.')}
-            </div>
+            </Dialog.Description>
+            {lifecycleError && (
+              <div role="alert" style={{ padding: '10px 12px', marginBottom: '16px', background: 'var(--danger-bg)', color: 'var(--danger-text)', borderRadius: '6px', fontSize: '12px', border: '1px solid var(--danger-border)' }}>
+                {lifecycleError}
+              </div>
+            )}
             <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
-              <button className="btn btn-secondary" type="button" onClick={() => setPendingAction(null)} disabled={actioning}>{t('Zrušit', 'Cancel')}</button>
+              <Dialog.Close asChild>
+                <button ref={actionCancelRef} className="btn btn-secondary" type="button" disabled={actioning}>{t('Zrušit', 'Cancel')}</button>
+              </Dialog.Close>
               <button className="btn btn-primary" type="button" onClick={() => runAction(pendingAction.id, pendingAction.kind)} disabled={actioning} aria-busy={actioning}>
                 {actioning ? t('Provádím…', 'Working…') : t('Potvrdit', 'Confirm')}
               </button>
             </div>
-          </div>
-        </div>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog.Root>
       )}
     </AuthGuard>
   )

--- a/openbank-admin-ui/src/test/document-template-controls.guard.test.ts
+++ b/openbank-admin-ui/src/test/document-template-controls.guard.test.ts
@@ -7,7 +7,9 @@ describe('document template workflow controls contract', () => {
   it('keeps action and lookup controls explicit and truthful', () => {
     const source = readFileSync(path.resolve(__dirname, '../app/document-templates/page.tsx'), 'utf8')
     expect(source).toContain('type="button" onClick={openCreateModal} disabled={loading}')
-    expect(source).toContain('type="button" onClick={() => setPendingAction(null)} disabled={actioning}')
+    expect(source).toContain('<Dialog.Close asChild>')
+    expect(source).toContain('ref={actionCancelRef} className="btn btn-secondary" type="button" disabled={actioning}')
+    expect(source).toContain('onEscapeKeyDown={event => { if (actioning) event.preventDefault() }}')
     expect(source).toContain('aria-busy={actioning}')
     expect(source).toContain('aria-busy={loading}')
     expect(source).toContain("aria-label={t('Vyhledat dokument podle ID', 'Look up document by ID')}")

--- a/openbank-admin-ui/src/test/document-template-lifecycle-dialog.test.tsx
+++ b/openbank-admin-ui/src/test/document-template-lifecycle-dialog.test.tsx
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import React from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SessionProvider } from 'next-auth/react'
+import DocumentTemplatesPage from '@/app/document-templates/page'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+const TEMPLATE = {
+  id: 'template-42', code: 'LOAN_AGREEMENT', version: '1.0.0', name: 'Loan agreement',
+  engine: 'HANDLEBARS', bodyHtml: '<p>Hello</p>', locale: 'en', status: 'DRAFT',
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(res => { resolve = res })
+  return { promise, resolve }
+}
+
+function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <SessionProvider session={{ user: { roles: ['ROLE_ADMIN'], email: 'admin@openbank.local' } } as never}>
+      <LanguageProvider>{children}</LanguageProvider>
+    </SessionProvider>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('document template lifecycle dialog', () => {
+  it('is named, traps dismissal in a modal, and restores focus to its trigger', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/preview')) {
+        return new Response(JSON.stringify({ renderedHtml: '' }), { status: 200, headers: { 'content-type': 'application/json' } })
+      }
+      return new Response(JSON.stringify([TEMPLATE]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }))
+    render(<Providers><DocumentTemplatesPage /></Providers>)
+
+    const trigger = await screen.findByRole('button', { name: 'Publish template' })
+    trigger.focus()
+    fireEvent.click(trigger)
+
+    const dialog = screen.getByRole('dialog', { name: 'Publish this template?' })
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(screen.getByText('A published version is immutable — a further edit creates a new version.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus()
+
+    fireEvent.keyDown(dialog, { key: 'Escape' })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    await waitFor(() => expect(trigger).toHaveFocus())
+  })
+
+  it('cannot dismiss an in-flight transition and focuses a stable row action after success', async () => {
+    const publish = deferred<Response>()
+    let calls = 0
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).includes('/preview')) {
+        return new Response(JSON.stringify({ renderedHtml: '' }), { status: 200, headers: { 'content-type': 'application/json' } })
+      }
+      calls += 1
+      if (init?.method === 'POST') return publish.promise
+      const status = calls >= 3 ? 'PUBLISHED' : 'DRAFT'
+      return new Response(JSON.stringify([{ ...TEMPLATE, status }]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }))
+    render(<Providers><DocumentTemplatesPage /></Providers>)
+
+    fireEvent.change(await screen.findByLabelText('Status:'), { target: { value: 'DRAFT' } })
+    fireEvent.click(await screen.findByRole('button', { name: 'Publish template' }))
+    const dialog = screen.getByRole('dialog', { name: 'Publish this template?' })
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    await waitFor(() => expect(dialog).toHaveAttribute('aria-busy', 'true'))
+
+    fireEvent.keyDown(dialog, { key: 'Escape' })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    publish.resolve(new Response('', { status: 200 }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    expect(screen.queryByText('PUBLISHED', { exact: true })).not.toBeInTheDocument()
+    await waitFor(() => expect(screen.getByLabelText('Status:')).toHaveFocus())
+  })
+
+  it('announces a rejected transition inside the dialog and permits an explicit retry', async () => {
+    let publishAttempts = 0
+    let published = false
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).includes('/preview')) {
+        return new Response(JSON.stringify({ renderedHtml: '' }), { status: 200, headers: { 'content-type': 'application/json' } })
+      }
+      if (init?.method === 'POST') {
+        publishAttempts += 1
+        if (publishAttempts === 1) {
+          return new Response(JSON.stringify({ error: 'Document policy rejected this transition' }), {
+            status: 503,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        published = true
+        return new Response('', { status: 200 })
+      }
+      return new Response(JSON.stringify([{ ...TEMPLATE, status: published ? 'PUBLISHED' : 'DRAFT' }]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }))
+    render(<Providers><DocumentTemplatesPage /></Providers>)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Publish template' }))
+    const dialog = screen.getByRole('dialog', { name: 'Publish this template?' })
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(dialog).toContainElement(alert)
+    expect(alert).toHaveTextContent('Document policy rejected this transition')
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    expect(publishAttempts).toBe(2)
+    expect(screen.getByText('PUBLISHED', { exact: true })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes #8294

## What changed

- replaces the visual publish/retire overlay with the established Radix modal primitive
- gives the confirmation a programmatic title and impact description
- focuses Cancel first, restores the exact trigger on dismissal, and uses stable row/page fallbacks after a successful transition
- blocks Escape/outside dismissal while the mutation is in flight
- announces lifecycle failures inside the dialog and supports an explicit retry

## Verification

- genuine RED on the old overlay: no named dialog
- focused Vitest: 5 files / 10 tests passed
- canonical `npm run type-check` passed
- changed-file ESLint: 0 errors (1 inherited initial-load warning)
- `git diff --check` passed
- independent exact-diff review: NO BLOCKER

API endpoints, authorization, request payloads, and the existing single-flight mutation lock are unchanged.