### PR TITLE
fix(admin-ui): stop onboarding funnel from rendering fabricated zeros while loading

### DIFF
--- a/openbank-admin-ui/src/app/onboarding/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/page.tsx
@@ -92,8 +92,10 @@ export default function OnboardingPage() {
   const { t, language } = useLanguage()
   const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
 
-  // funnel KPI
-  const [counts, setCounts] = useState<FunnelCounts>({})
+  // funnel KPI — `counts` stays null until the first response lands, so an in-flight or
+  // failed fetch is never rendered as an authoritative zero (issue #8233).
+  const [counts, setCounts] = useState<FunnelCounts | null>(null)
+  const [countsLoading, setCountsLoading] = useState(true)
   const [countsUnavail, setCountsUnavail] = useState<{ kind: UnavailableKind } | null>(null)
 
   // list
@@ -117,14 +119,14 @@ export default function OnboardingPage() {
   // ── Load funnel counts ──────────────────────────────────────────────────────
 
   const loadCounts = useCallback(async () => {
-    setCountsUnavail(null)
+    setCountsLoading(true); setCountsUnavail(null)
     try {
       const res = await fetch(svcUrl(SVC, '/api/v1/onboarding/funnel'), { signal: AbortSignal.timeout(5000) })
       if (!res.ok) { setCountsUnavail({ kind: await classifyBffFailure(res) }); return }
       setCounts(await res.json())
     } catch {
       setCountsUnavail({ kind: 'unreachable' })
-    }
+    } finally { setCountsLoading(false) }
   }, [])
 
   // ── Load records list ───────────────────────────────────────────────────────
@@ -172,23 +174,41 @@ export default function OnboardingPage() {
             <TrendingUp size={13} style={{ color: 'var(--accent)' }} />
             {t('Konverze', 'Conversion')}
           </Link>
-          <button className="btn btn-secondary" type="button" onClick={refresh} disabled={loading}
-            aria-busy={loading} aria-label={t('Obnovit onboarding', 'Refresh onboarding')}>
-            <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
+          <button className="btn btn-secondary" type="button" onClick={refresh} disabled={loading || countsLoading}
+            aria-busy={loading || countsLoading} aria-label={t('Obnovit onboarding', 'Refresh onboarding')}>
+            <RefreshCw size={13} aria-hidden="true" style={{ animation: (loading || countsLoading) ? 'spin 1s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
         </div>}
       />
 
-      {/* KPI funnel tiles */}
-      {countsUnavail ? (
+      {/* KPI funnel tiles — never render a fabricated 0 while the count is unknown (#8233) */}
+      {countsLoading ? (
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          aria-label={t('Načítání počtů funnelu…', 'Loading funnel counts…')}
+          style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: '10px', marginBottom: '20px' }}
+        >
+          {STAGES.map(s => (
+            <div key={s} style={{ border: '1px solid var(--border)', borderRadius: '8px', padding: '12px 8px', textAlign: 'center' }}>
+              <div className="skeleton" style={{ height: '22px', width: '32px', margin: '0 auto' }} />
+              <div style={{ fontSize: '10px', color: 'var(--text-muted)', marginTop: '8px', lineHeight: 1.3 }}>
+                {stageLabel(s)}
+              </div>
+            </div>
+          ))}
+          <span className="sr-only">{t('Načítání počtů funnelu…', 'Loading funnel counts…')}</span>
+        </div>
+      ) : countsUnavail ? (
         <div className="card" style={{ padding: 0, marginBottom: '20px' }}>
           <DataUnavailable kind={countsUnavail.kind} service={t('Onboarding-service', 'Onboarding-service')} feature={t('Funnel počty', 'Funnel counts')} lang={language} dense />
         </div>
       ) : (
         <div role="group" aria-label={t('Filtr fází onboardingu', 'Onboarding stage filters')} style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: '10px', marginBottom: '20px' }}>
           {STAGES.map(s => {
-            const count = counts[s] ?? 0
+            const count = counts?.[s] ?? 0
             const isActive = stage === s
             const color = STAGE_COLOR[s]
             return (

--- a/openbank-admin-ui/src/test/onboarding-funnel-loading.test.tsx
+++ b/openbank-admin-ui/src/test/onboarding-funnel-loading.test.tsx
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import OnboardingPage from '@/app/onboarding/page'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+const FUNNEL = { REGISTERED: 12, KYC_OPEN: 4, KYC_DOCUMENTS_REQUIRED: 2, KYC_UNDER_REVIEW: 1, SCA_PENDING: 3, ACTIVE: 40, BLOCKED: 1 }
+const RECORDS = { items: [], total: 0, page: 0, size: 20 }
+
+function response(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(done => { resolve = done })
+  return { promise, resolve }
+}
+
+function renderPage() {
+  return render(<LanguageProvider initialLanguage="en"><OnboardingPage /></LanguageProvider>)
+}
+
+function routedFetch(handlers: { funnel: () => Promise<Response>; records: () => Promise<Response> }) {
+  return vi.fn((input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.includes('/onboarding/funnel')) return handlers.funnel()
+    if (url.includes('/onboarding/records')) return handlers.records()
+    throw new Error(`unexpected fetch: ${url}`)
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('onboarding funnel loading (issue #8233)', () => {
+  it('never renders a fabricated 0 for the funnel tiles while the request is in flight', async () => {
+    const funnelDeferred = deferred<Response>()
+    vi.stubGlobal('fetch', routedFetch({
+      funnel: () => funnelDeferred.promise,
+      records: () => Promise.resolve(response(200, RECORDS)),
+    }))
+
+    renderPage()
+
+    // Explicit, accessible loading announcement — not a silent zero.
+    expect(await screen.findByRole('status', { name: 'Loading funnel counts…' })).toBeInTheDocument()
+    expect(screen.queryByText('0')).not.toBeInTheDocument()
+
+    await act(async () => {
+      funnelDeferred.resolve(response(200, FUNNEL))
+      await funnelDeferred.promise
+    })
+
+    expect(await screen.findByText('12')).toBeVisible()
+    expect(screen.queryByRole('status', { name: 'Loading funnel counts…' })).not.toBeInTheDocument()
+  })
+
+  it('keeps stage tiles unclickable-as-zero and shows real counts once the funnel resolves', async () => {
+    vi.stubGlobal('fetch', routedFetch({
+      funnel: () => Promise.resolve(response(200, FUNNEL)),
+      records: () => Promise.resolve(response(200, RECORDS)),
+    }))
+
+    renderPage()
+
+    const group = await screen.findByRole('group', { name: 'Onboarding stage filters' })
+    expect(within(group).getByText('12')).toBeVisible()
+    expect(within(group).getByText('40')).toBeVisible()
+    fireEvent.click(within(group).getByRole('button', { name: /Registered/ }))
+    expect(within(group).getByRole('button', { name: /Registered/ })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('keeps Refresh busy until BOTH the records and the funnel requests resolve', async () => {
+    const funnelDeferred = deferred<Response>()
+    const recordsDeferred = deferred<Response>()
+    vi.stubGlobal('fetch', routedFetch({
+      funnel: () => Promise.resolve(response(200, FUNNEL)),
+      records: () => Promise.resolve(response(200, RECORDS)),
+    }))
+
+    renderPage()
+    await screen.findByText('12')
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Refresh onboarding' })).not.toBeDisabled())
+
+    // Re-arm fetch: funnel resolves quickly, records stays pending.
+    vi.stubGlobal('fetch', routedFetch({
+      funnel: () => funnelDeferred.promise,
+      records: () => recordsDeferred.promise,
+    }))
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh onboarding' }))
+
+    expect(screen.getByRole('button', { name: 'Refresh onboarding' })).toBeDisabled()
+
+    await act(async () => {
+      funnelDeferred.resolve(response(200, FUNNEL))
+      await funnelDeferred.promise
+    })
+    // Funnel alone resolved — records is still pending, so Refresh must stay busy.
+    expect(screen.getByRole('button', { name: 'Refresh onboarding' })).toBeDisabled()
+
+    await act(async () => {
+      recordsDeferred.resolve(response(200, RECORDS))
+      await recordsDeferred.promise
+    })
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Refresh onboarding' })).not.toBeDisabled())
+  })
+
+  it('does not fabricate a zero when the funnel request fails', async () => {
+    vi.stubGlobal('fetch', routedFetch({
+      funnel: () => Promise.reject(new Error('network down')),
+      records: () => Promise.resolve(response(200, RECORDS)),
+    }))
+
+    renderPage()
+
+    expect(await screen.findByText(/onboarding-service/i)).toBeVisible()
+    expect(screen.queryByRole('group', { name: 'Onboarding stage filters' })).not.toBeInTheDocument()
+    expect(screen.queryByText('0')).not.toBeInTheDocument()
+  })
+})

--- a/openbank-admin-ui/src/test/onboarding-refresh.guard.test.ts
+++ b/openbank-admin-ui/src/test/onboarding-refresh.guard.test.ts
@@ -7,8 +7,8 @@ describe('Onboarding refresh contract', () => {
   it('exposes localized busy semantics without changing onboarding loading', () => {
     const source = readFileSync(path.resolve(__dirname, '../app/onboarding/page.tsx'), 'utf8')
     expect(source).toContain('type="button"')
-    expect(source).toContain('disabled={loading}')
-    expect(source).toContain('aria-busy={loading}')
+    expect(source).toContain('disabled={loading || countsLoading}')
+    expect(source).toContain('aria-busy={loading || countsLoading}')
     expect(source).toContain("aria-label={t('Obnovit onboarding', 'Refresh onboarding')}")
     expect(source).toContain('<RefreshCw size={13} aria-hidden="true"')
     expect(source).toContain('onClick={refresh}')


### PR DESCRIPTION
## Problem

The Admin UI onboarding cockpit (`/onboarding`) initialized funnel counts to `{}` and read
`counts[s] ?? 0`, so every funnel-stage tile rendered an authoritative-looking `0` before the
first `/api/v1/onboarding/funnel` response arrived — or if it failed. That presents unknown data
as a real zero, which can mislead an operator into thinking a stage is genuinely empty. The shared
Refresh action also tracked only the records request's busy state, so it could report "ready"
while the funnel counts were still loading.

## Fix

`openbank-admin-ui/src/app/onboarding/page.tsx`:
- `counts` is now `FunnelCounts | null` (never a fabricated default), with a dedicated
  `countsLoading` flag driving a three-way render: loading → unavailable → real data — the same
  shape `src/app/day-end/page.tsx` already uses for its own "distinguish absent/loading from zero"
  fix.
- While loading, the KPI row renders an accessible skeleton (`role="status"`,
  `aria-live="polite"`, `aria-busy="true"`, plus an `sr-only` label) sized to match the final
  7-tile grid, so the layout does not jump once real counts arrive.
- The Refresh button is now `disabled`/`aria-busy` while **either** the records request or the
  funnel request is in flight (`loading || countsLoading`), not records alone.
- On success, the funnel tiles are the same interactive stage-filter buttons as before, now fed
  real counts.
- All new/changed UI text goes through the existing inline `t('cs', 'en')` convention this page
  already uses — there is no separate locale JSON in this codebase, so Czech strings are added
  in place, not lost.

## Tests

- `openbank-admin-ui/src/test/onboarding-funnel-loading.test.tsx` (new, React Testing Library):
  - initial render shows the accessible loading status, never a `0`
  - a failed funnel fetch still never renders a `0`
  - Refresh stays disabled until **both** the funnel and records requests resolve
  - a successful funnel response renders real counts and working stage filters
- `openbank-admin-ui/src/test/onboarding-refresh.guard.test.ts` updated for the new
  `disabled={loading || countsLoading}` / `aria-busy={loading || countsLoading}` contract.
- Verified with `npm test -- src/test/onboarding` (this repo's documented convention — `npm test`,
  not bare `npx vitest run`, because the `pretest` hook bakes generated catalog/governance
  artifacts the suite depends on): 9 test files, 19 tests, all green.

## Scope

Admin UI presentation/loading orchestration only — no API, RBAC, or onboarding-service behavior
changes.

Closes #8233
