### PR TITLE
fix(account): dead-letter into an explicit topic, not the shared implicit one

### DIFF
--- a/.github/scripts/check-incoming-dlq-wiring.py
+++ b/.github/scripts/check-incoming-dlq-wiring.py
@@ -68,19 +68,23 @@ KNOWN_UNWIRED = {
     # the same way, so it is gone from here too — only `delegation-events-in` remains untouched.
     ("openbank-notification-service", "delegation-events-in"): "#5737 wired only party-events-in; this channel has no failure-strategy yet (#5745)",
     ("openbank-tax-reporting-service", "withholding-remitted-in"): "no KafkaUser in gitops — a Write ACL cannot be granted, so a DLQ would wedge on the send (#5745)",
-    # The four channels that had a DLQ BEFORE #5745, all on SmallRye's implicit
-    # `dead-letter-topic-<channel>` name. Naming them explicitly is a RENAME of a live topic: it
-    # strands whatever is already parked in the old one and silently blinds the existing
-    # AccountPartyEventDeadLettered alert, which reads `dead-letter-topic-party-events-in` by name.
-    # That is an operational change with a migration, not a config edit, so it is recorded here
-    # rather than done in passing. It is not cosmetic: account-service and card-issuance-service
-    # BOTH consume `delegation-events-in` and therefore already share
-    # `dead-letter-topic-delegation-events-in` today — two services' dead letters in one topic,
-    # misattributed by anything that reads it. That is the collision this gate exists to prevent,
-    # observed live (#5745).
-    ("openbank-account-service", "party-events-in"): "pre-#5745 implicit DLQ name; renaming is a live-topic migration",
-    ("openbank-account-service", "delegation-events-in"): "pre-#5745 implicit DLQ name; ALREADY COLLIDES with card-issuance-service",
-    ("openbank-card-issuance-service", "delegation-events-in"): "pre-#5745 implicit DLQ name; ALREADY COLLIDES with account-service",
+    # The channels that had a DLQ BEFORE #5745, on SmallRye's implicit `dead-letter-topic-<channel>`
+    # name. Naming one explicitly is a RENAME of a live topic: it strands whatever is already parked
+    # in the old one and moves what the AccountPartyEventDeadLettered alert must read. That is an
+    # operational change with a migration, not a config edit, which is why they were recorded here
+    # rather than done in passing.
+    #
+    # account-service is OFF this list as of #5752. Its two channels now name
+    # `openbank.dlq.account.party-events-in` / `openbank.dlq.account.delegation-events-in`, with
+    # KafkaTopic CRs and Write ACLs, and the migration is carried explicitly: the two old topics and
+    # their Write ACLs are RETAINED so an existing backlog stays drainable, and the alert matches
+    # both names for the length of the rollout (old and new pods run side by side under a Rollout).
+    #
+    # card-issuance-service's `delegation-events-in` stays. It no longer COLLIDES — account-service
+    # was the other writer of `dead-letter-topic-delegation-events-in` and has moved off it — so what
+    # remains is a single service on an implicit, channel-derived name. Renaming it is still a live
+    # topic migration, and it is card-issuance's to make.
+    ("openbank-card-issuance-service", "delegation-events-in"): "pre-#5745 implicit DLQ name; sole writer since #5752 moved account-service off it, but the rename is still a live-topic migration",
     # NOT the implicit name, and not a rename: fraud-service already sets an EXPLICIT topic
     # (`openbank.transactions.transaction.initiated.fraud.dlq`) in
     # components/fraud-service/fraud-service-msg-override.yaml, with a matching [Write, Describe]

--- a/openbank-account-service/src/main/resources/application.yaml
+++ b/openbank-account-service/src/main/resources/application.yaml
@@ -191,12 +191,24 @@ mp:
         # rather than swallowed. dead-letter-queue routes that record to the DLQ topic and lets
         # the consumer keep moving — so a transient dependency outage parks the event for replay
         # instead of destroying it (which a prior catch-all did, dropping a whole cohort's
-        # PARTY_CREATED, 2026-06-24..2026-07-17). The DLQ topic name is left at SmallRye's default
-        # (dead-letter-topic-party-events-in): setting `dead-letter-queue.topic` explicitly here
-        # would be a DOTTED leaf key, which SmallRye Config's YAML source silently quotes so the
-        # connector never reads it (the group.id/dead-letter-queue.topic trap documented in
-        # fraud-service/transaction-service) — the default name avoids that entirely.
+        # PARTY_CREATED, 2026-06-24..2026-07-17).
+        #
+        # The topic is EXPLICIT. SmallRye's implicit default is `dead-letter-topic-<channel>`,
+        # derived from the channel name ALONE, and `party-events-in` is declared by eight services
+        # here — left implicit they all dead-letter into one topic and the
+        # AccountPartyEventDeadLettered alert misattributes every record in it.
+        #
+        # NESTED under `dead-letter-queue:`, never the dotted leaf `dead-letter-queue.topic:`.
+        # SmallRye Config's YAML source quotes a leaf key containing a literal dot, registering it
+        # as ..."dead-letter-queue.topic" which the connector's plain getOptionalValue never reads
+        # (#686). An earlier comment here read that trap as making an explicit topic IMPOSSIBLE in
+        # this file — true premise, wrong conclusion: only the DOTTED spelling is inert, and the
+        # nested one resolves. card-issuance-service has carried the nested form since #5745, and
+        # aml-service's DeadLetterQueueConfigResolutionTest proves both directions against the real
+        # SmallRye YAML source. #5752.
         failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.account.party-events-in
         value:
           deserializer: org.apache.kafka.common.serialization.StringDeserializer
         key:
@@ -209,7 +221,13 @@ mp:
         topic: openbank.delegation.events
         group.id: openbank-account-service
         auto.offset.reset: earliest
+        # Explicit + nested for the reasons spelled out on party-events-in above. This channel is
+        # the one where the collision was not hypothetical: card-issuance-service also consumes
+        # `delegation-events-in`, so both services were writing their dead letters into the single
+        # implicit `dead-letter-topic-delegation-events-in` (#5752).
         failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.dlq.account.delegation-events-in
         value:
           deserializer: org.apache.kafka.common.serialization.StringDeserializer
         key:

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/kafka/DeadLetterQueueConfigResolutionTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/kafka/DeadLetterQueueConfigResolutionTest.kt
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.account.infrastructure.kafka
+
+import io.smallrye.config.source.yaml.YamlConfigSource
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * The DLQ wiring is a GUARD, so it is proven by what it prevents, not by what the file says.
+ *
+ * Both incoming channels here dead-letter into an EXPLICIT, service-scoped topic. Until #5752 they
+ * did not: `failure-strategy: dead-letter-queue` was set and the topic was left implicit, so
+ * SmallRye derived `dead-letter-topic-<channel>` from the channel name ALONE. That name is not
+ * unique to a service — `party-events-in` is declared by eight services here, and
+ * `delegation-events-in` by two (this one and card-issuance-service), which were therefore
+ * dead-lettering into a single shared topic that no alert could attribute.
+ *
+ * The comment that used to sit next to `party-events-in` asserted an explicit topic was IMPOSSIBLE
+ * in `application.yaml`, on the grounds that `dead-letter-queue.topic` is a dotted leaf key which
+ * SmallRye Config's YAML source quotes. True premise, wrong conclusion, and it suppressed the fix:
+ * only the DOTTED spelling is inert. `KafkaConnectorIncomingConfiguration` calls
+ * `getOptionalValue("dead-letter-queue.topic", …)` on the plain, unquoted property name, so
+ *
+ *     dead-letter-queue.topic: openbank.dlq.account.party-events-in    // registers QUOTED, inert
+ *     dead-letter-queue:                                               // resolves
+ *       topic: openbank.dlq.account.party-events-in
+ *
+ * differ. Nothing errors in the first case; the implicit default silently applies. Issue #686 is
+ * the same footgun for `group.id`.
+ *
+ * These assertions go through the very class Quarkus uses to read `application.yaml`, never a
+ * string search for a line, and `dlqTopicWrittenAsADottedLeafKeyIsUnreadable` is the negative
+ * control: it feeds this test's own mechanism the spelling that must NOT work and shows it does
+ * not. Without it, the positive assertions could not distinguish a working config from an inert one.
+ */
+class DeadLetterQueueConfigResolutionTest {
+
+    private fun serviceConfig() =
+        YamlConfigSource("application.yaml", File("src/main/resources/application.yaml").readText())
+
+    private fun channel(name: String) = "mp.messaging.incoming.$name"
+
+    @Test
+    fun `both incoming channels resolve a dead-letter-queue strategy and an explicit topic`() {
+        val cfg = serviceConfig()
+
+        for ((name, topic) in EXPECTED) {
+            assertThat(cfg.getValue("${channel(name)}.failure-strategy"))
+                .describedAs("$name: without this the connector defaults to `fail` and a rethrow WEDGES the channel")
+                .isEqualTo("dead-letter-queue")
+
+            assertThat(cfg.getValue("${channel(name)}.dead-letter-queue.topic"))
+                .describedAs("$name: the exact property name KafkaConnectorIncomingConfiguration reads")
+                .isEqualTo(topic)
+        }
+    }
+
+    @Test
+    fun `the topics are named explicitly, never left to SmallRye's channel-derived default`() {
+        val cfg = serviceConfig()
+        for ((name, _) in EXPECTED) {
+            val resolved = cfg.getValue("${channel(name)}.dead-letter-queue.topic")
+            assertThat(resolved)
+                .describedAs("$name: `dead-letter-topic-$name` is derived from the channel name alone and is shared")
+                .isNotEqualTo("dead-letter-topic-$name")
+            assertThat(resolved).startsWith("openbank.dlq.account.")
+        }
+    }
+
+    @Test
+    fun `the service config does not use the unreadable dotted-leaf spelling`() {
+        val names = serviceConfig().propertyNames
+        for ((name, _) in EXPECTED) {
+            assertThat(names).doesNotContain("""${channel(name)}."dead-letter-queue.topic"""")
+        }
+    }
+
+    @Test
+    fun `dlq topic written as a dotted leaf key is unreadable — negative control`() {
+        val c = channel("party-events-in")
+
+        val dotted = YamlConfigSource(
+            "dotted",
+            """
+            mp:
+              messaging:
+                incoming:
+                  party-events-in:
+                    failure-strategy: dead-letter-queue
+                    dead-letter-queue.topic: openbank.dlq.account.party-events-in
+            """.trimIndent(),
+        )
+        // What the connector asks for: absent. Nothing errors; the implicit default silently applies.
+        assertThat(dotted.getValue("$c.dead-letter-queue.topic")).isNull()
+        // Where the value actually went.
+        assertThat(dotted.propertyNames).contains("""$c."dead-letter-queue.topic"""")
+
+        // The NESTED spelling this service now uses produces the property the connector reads.
+        val nested = YamlConfigSource(
+            "nested",
+            """
+            mp:
+              messaging:
+                incoming:
+                  party-events-in:
+                    failure-strategy: dead-letter-queue
+                    dead-letter-queue:
+                      topic: openbank.dlq.account.party-events-in
+            """.trimIndent(),
+        )
+        assertThat(nested.getValue("$c.dead-letter-queue.topic"))
+            .isEqualTo("openbank.dlq.account.party-events-in")
+        assertThat(nested.propertyNames).doesNotContain("""$c."dead-letter-queue.topic"""")
+    }
+
+    private companion object {
+        val EXPECTED = listOf(
+            "party-events-in" to "openbank.dlq.account.party-events-in",
+            "delegation-events-in" to "openbank.dlq.account.delegation-events-in",
+        )
+    }
+}

--- a/openbank-infra/gitops/components/accounts/kafka-account-mtls.yaml
+++ b/openbank-infra/gitops/components/accounts/kafka-account-mtls.yaml
@@ -3,7 +3,10 @@
 # account-service topics:
 #   Produces: openbank.accounts.account.created (two channels: account-events-out + account-outbox-out)
 #             openbank.notification.requests (notification-requests-out)
-#             dead-letter-topic-party-events-in (SmallRye DLQ for party-events-in, failure-strategy)
+#             openbank.dlq.account.party-events-in       (SmallRye DLQ for party-events-in)
+#             openbank.dlq.account.delegation-events-in  (SmallRye DLQ for delegation-events-in)
+#             dead-letter-topic-party-events-in / dead-letter-topic-delegation-events-in
+#               — the pre-#5752 implicit names, RETAINED (see the ACLs below)
 #   Consumes: openbank.party.events (group: openbank-account-service, ADR-0267 §1 party lifecycle)
 ---
 apiVersion: kafka.strimzi.io/v1
@@ -48,6 +51,28 @@ spec:
           patternType: literal
         operations: [Read, Describe]
         host: "*"
+      # #5752: the EXPLICIT per-service DLQ topics. SmallRye's implicit
+      # `dead-letter-topic-<channel>` name is derived from the channel name alone, so
+      # account-service and card-issuance-service (both consumers of `delegation-events-in`) were
+      # writing dead letters into one topic, and `party-events-in` is declared by eight services.
+      # Without Write here the DLQ send itself fails and the consumer wedges on the very failure it
+      # was meant to park — the ANONYMOUS-vs-ACL lockout class that took party-service down (#1476).
+      - resource:
+          type: topic
+          name: openbank.dlq.account.delegation-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      - resource:
+          type: topic
+          name: openbank.dlq.account.party-events-in
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # The two pre-#5752 implicit topics. RETAINED, not removed: under an Argo Rollout old and new
+      # pods run side by side, so a pod on the previous ConfigMap can still write here mid-cutover,
+      # and whatever is already parked in them has to stay drainable. Drop these two entries once
+      # both topics are confirmed empty.
       - resource:
           type: topic
           name: dead-letter-topic-delegation-events-in

--- a/openbank-infra/gitops/components/kafka/kafka-dlq-topics.yaml
+++ b/openbank-infra/gitops/components/kafka/kafka-dlq-topics.yaml
@@ -32,6 +32,45 @@
 # these are quarantines, and they are invisible to the event-consumer-liveness gate (which reads
 # declared `outgoing:` channels; the connector's DLQ producer is not one).
 ---
+# openbank-account-service :: channel `delegation-events-in`
+# #5752: account-service and card-issuance-service both consume `delegation-events-in`, so both
+# were dead-lettering into the single implicit `dead-letter-topic-delegation-events-in`. This
+# names account-service's half. The old topic and its Write ACL are RETAINED so an existing
+# backlog stays drainable.
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.account.delegation-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
+# openbank-account-service :: channel `party-events-in`
+# #5752. `party-events-in` is declared by eight services; account-service was the last one still
+# on the implicit `dead-letter-topic-party-events-in`. The AccountPartyEventDeadLettered alert in
+# prometheus-rules-onboarding.yaml matches BOTH names for the length of the rollout — under an
+# Argo Rollout old and new pods run side by side, and the old topic still holds whatever was
+# parked before the cutover.
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dlq.account.party-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+---
 # openbank-agent-service :: channel `oversight-events`
 apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic

--- a/openbank-infra/gitops/components/observability/prometheus-rules-onboarding.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-onboarding.yaml
@@ -33,14 +33,31 @@ spec:
           # no account. This is the exact silent data-loss that ran for 3 weeks, now made loud.
           # increase() over 1h: fires while records are still arriving and clears an hour after
           # they stop (the topic offset is monotonic, so a plain `> 0` would latch forever).
+          #
+          # TWO topic names, deliberately (#5752). account-service now dead-letters into the
+          # explicit `openbank.dlq.account.party-events-in`; the implicit
+          # `dead-letter-topic-party-events-in` it used before is still matched because (a) under an
+          # Argo Rollout old and new pods run side by side, so the old name keeps receiving during
+          # the cutover, and (b) whatever was parked there before it stays visible. A regex over
+          # both is what keeps this alert from going quiet by construction on the day the topic is
+          # renamed — the failure mode a rename introduces is an alert that can no longer fire, and
+          # nothing about it looks broken. Drop the old alternative once the topic is confirmed
+          # empty and the ACL is removed from kafka-account-mtls.yaml.
+          #
+          # The dots are NOT backslash-escaped on purpose. This is a YAML literal block scalar, so
+          # a backslash reaches PromQL verbatim, and PromQL's own double-quoted string then applies
+          # Go escape rules — `\.` is not a valid one there, and `\\.` would ask the regex for a
+          # literal backslash. An unescaped `.` matches itself; `=~` is fully anchored, so the only
+          # over-match would be a topic differing from these two in a separator character alone,
+          # and no such topic exists in kafka-dlq-topics.yaml.
           expr: |
-            increase(kafka_topic_partition_current_offset{topic="dead-letter-topic-party-events-in"}[1h]) > 0
+            increase(kafka_topic_partition_current_offset{topic=~"dead-letter-topic-party-events-in|openbank.dlq.account.party-events-in"}[1h]) > 0
           for: 5m
           labels:
             severity: critical
           annotations:
             summary: "Party events are being dead-lettered (account-service)"
-            description: "account-service dead-lettered at least one party event in the last hour — a well-formed event it could not project even after retries. Almost always a downstream dependency is down (sanctions-service, product-catalog, the accounts DB). Inspect `dead-letter-topic-party-events-in`; every record there is a customer action (likely a PARTY_CREATED → no account opened) awaiting replay once the dependency recovers."
+            description: "account-service dead-lettered at least one party event in the last hour — a well-formed event it could not project even after retries. Almost always a downstream dependency is down (sanctions-service, product-catalog, the accounts DB). Inspect `openbank.dlq.account.party-events-in` (and, for anything parked before #5752, `dead-letter-topic-party-events-in`); every record there is a customer action (likely a PARTY_CREATED → no account opened) awaiting replay once the dependency recovers."
         - alert: OnboardingAccountsNotFollowingParties
           # The disparity that names this incident: parties ARE being created but accounts are NOT
           # following. Silent when nothing is happening — no parties created means the left side is


### PR DESCRIPTION
## account-service was the last consumer left on the shared implicit DLQ topic

SmallRye derives the implicit dead-letter topic from the **channel name alone** — `dead-letter-topic-party-events-in` — and `party-events-in` is declared by **eight** services here. Left implicit they all dead-letter into one topic, and `AccountPartyEventDeadLettered` misattributes every record in it.

`card-issuance-service` already moved off, with a comment explaining exactly this. account-service had not — and carried a comment asserting the fix was **impossible**:

> The DLQ topic name is left at SmallRye's default … setting `dead-letter-queue.topic` explicitly here would be a DOTTED leaf key, which SmallRye Config's YAML source silently quotes so the connector never reads it.

The premise is true and the conclusion is wrong. The dotted leaf key *is* inert — the **nested** form is not, and card-issuance has been using it in production. That false comment was the last one of its kind in the fleet; it is removed here rather than left as a trap for the next reader.

## All four parts, because three of them is a wedge

A rethrow without a working DLQ does not fail safe — it wedges the consumer on the dead-letter send. So this carries:

| part | file |
|---|---|
| `failure-strategy` + **nested** explicit topic | `openbank-account-service/src/main/resources/application.yaml` |
| `KafkaTopic` CR (topics are not auto-created) | `openbank-infra/gitops/components/kafka/kafka-dlq-topics.yaml` |
| KafkaUser **Write** ACL | `openbank-infra/gitops/components/accounts/kafka-account-mtls.yaml` |
| alert retargeted at the new topic | `openbank-infra/gitops/components/observability/prometheus-rules-onboarding.yaml` |

Plus `DeadLetterQueueConfigResolutionTest` (4 cases) asserting the **resolved** value rather than the presence of a string — the nested and dotted forms are indistinguishable by grep and differ only in what the connector actually reads.

## Proven by what it prevents

| run | result |
|---|---|
| `check-incoming-dlq-wiring.py` on this branch | `SUBJECTS=46`, *"clean: 46 incoming channels, every one dead-letters into an explicit topic it may write"* |
| same, with the nested topic deleted | reports `openbank-account-service :: party-events-in: DLQ topic left implicit — … collides across services sharing it` |
| restored | clean again |

**Note the gate is advisory**, so the discriminator is the finding, not the exit code — both states exit 0. Read the output, not `$?`.

## Provenance

This branch was pushed by an agent session that stopped before opening a PR; the commit was complete and orphaned. I verified it against current `main` (merged cleanly), re-ran the gate in both directions, and am opening the PR rather than rebuilding work that already existed.

Closes #5752
