### PR TITLE
fix(admin-ui): server-backed KYC pagination, contract test, and 404/405 truthfulness

### DIFF
--- a/openbank-admin-ui/src/app/kyc/page.tsx
+++ b/openbank-admin-ui/src/app/kyc/page.tsx
@@ -15,11 +15,21 @@ import { Can } from '@/components/auth/AuthGuard'
 import { PartySearch, type PartyHit } from '@/components/party/PartySearch'
 
 const KYC_SERVICE = '/api/svc/kyc-service'
+const PAGE_SIZE = 20
 
 interface KycCase {
   id: string; partyId: string; status: string
   checks: { checkType: string; status: string }[]
   reviewedBy?: string; createdAt: string; updatedAt: string
+}
+
+/** Envelope returned by GET /api/v1/kyc/cases (KycResource.listCases, openapi.yaml KycCasePage). */
+interface KycCasePage {
+  items: KycCase[]
+  total: number
+  page: number
+  size: number
+  statusFilter: string | null
 }
 
 export default function KycPage() {
@@ -36,22 +46,34 @@ export default function KycPage() {
   const [loadedPartyId, setLoadedPartyId] = useState<string | null>(null)
   const loadedPartyIdRef = useRef<string | null>(null)
   const [selectedParty, setSelectedParty] = useState<PartyHit | null>(null)
+  // Server-backed pagination against the declared KycCasePage envelope (issue #8163) —
+  // `page`/`total` are only meaningful in list mode; the party-scoped lookup returns a single case.
+  const [page, setPage] = useState(0)
+  const [total, setTotal] = useState<number | null>(null)
+  // Requests can race (e.g. a slow page-1 response landing after a page-2 click) — only the
+  // most recently ISSUED request may commit state, never whichever happens to resolve first.
+  const requestSeq = useRef(0)
 
-  const load = useCallback(async (requestedPartyId = partyId) => {
+  const load = useCallback(async (requestedPartyId = partyId, requestedPage = page) => {
     const scope = requestedPartyId || null
+    const seq = ++requestSeq.current
     setLoading(true); setUnavailable(null)
     try {
       const url = requestedPartyId
         ? `${KYC_SERVICE}/api/v1/kyc/cases/party/${requestedPartyId}`
-        : `${KYC_SERVICE}/api/v1/kyc/cases`
+        : `${KYC_SERVICE}/api/v1/kyc/cases?page=${requestedPage}&size=${PAGE_SIZE}`
       const res = await fetch(url, { signal: AbortSignal.timeout(5000) })
+      if (seq !== requestSeq.current) return // superseded by a newer request — drop this response
       if (!res.ok) {
         const kind = await classifyBffFailure(res)
-        // A genuine 404/405 on the cases endpoint means "no case for this party",
-        // not a broken app — degrade to the calm empty state rather than an error.
-        const unavailableKind = res.status === 405 || kind === 'not_found' ? 'no_data' : kind
+        // Only a genuine 404 on the PARTY-SCOPED lookup means "no case exists for this party".
+        // A 405 (or a 404 on the unscoped list route) is a route-contract failure — surfacing it
+        // as an empty result would tell an operator the KYC queue is empty when it is actually
+        // unavailable (issue #8163).
+        const isPartyLookupMiss = Boolean(scope) && res.status === 404
+        const unavailableKind = isPartyLookupMiss ? 'no_data' : kind
         if (unavailableKind === 'no_data' || loadedPartyIdRef.current !== scope) {
-          setCases([])
+          setCases([]); setTotal(null)
           loadedPartyIdRef.current = unavailableKind === 'no_data' ? scope : null
           setLoadedPartyId(unavailableKind === 'no_data' ? scope : null)
         }
@@ -59,21 +81,37 @@ export default function KycPage() {
         return
       }
       const data = await res.json()
-      setCases(Array.isArray(data) ? data : data.items ?? [data].filter(Boolean))
+      if (requestedPartyId) {
+        // Single-case response (KycResource.getCaseByParty) — not paginated.
+        setCases(Array.isArray(data) ? data : [data].filter(Boolean))
+        setTotal(null)
+      } else {
+        const envelope = data as Partial<KycCasePage>
+        setCases(Array.isArray(envelope.items) ? envelope.items : [])
+        setTotal(typeof envelope.total === 'number' ? envelope.total : null)
+      }
       loadedPartyIdRef.current = scope
       setLoadedPartyId(scope)
     } catch {
+      if (seq !== requestSeq.current) return
       // Timeout / abort / network — the BFF or kyc-service didn't answer.
       if (loadedPartyIdRef.current !== scope) {
-        setCases([])
+        setCases([]); setTotal(null)
         loadedPartyIdRef.current = null
         setLoadedPartyId(null)
       }
       setUnavailable({ kind: 'unreachable' })
-    } finally { setLoading(false) }
-  }, [partyId])
+    } finally {
+      if (seq === requestSeq.current) setLoading(false)
+    }
+  }, [partyId, page])
 
-  useEffect(() => { load() }, [load])
+  useEffect(() => { load(partyId, page) }, [load, partyId, page])
+
+  const canPrev = !partyId && page > 0
+  const canNext = !partyId && total !== null && (page + 1) * PAGE_SIZE < total
+  const rangeStart = total !== null && total > 0 ? page * PAGE_SIZE + 1 : 0
+  const rangeEnd = total !== null ? Math.min((page + 1) * PAGE_SIZE, total) : cases.length
 
   const filtered = cases.filter(c =>
     !search || c.id.includes(search) || c.partyId.includes(search) || c.status.includes(search.toUpperCase())
@@ -88,7 +126,7 @@ export default function KycPage() {
         actions={<button
           type="button"
           className="btn btn-secondary"
-          onClick={() => void load()}
+          onClick={() => void load(partyId, page)}
           disabled={loading}
           aria-busy={loading}
           aria-label={t('Obnovit KYC případy', 'Refresh KYC cases')}
@@ -101,7 +139,7 @@ export default function KycPage() {
       <PartySearch
         selectedId={selectedParty?.id}
         busy={loading}
-        onSelect={party => { setSelectedParty(party); setPartyIdInput(party.id); setPartyId(party.id) }}
+        onSelect={party => { setSelectedParty(party); setPartyIdInput(party.id); setPartyId(party.id); setPage(0) }}
         placeholder={t('Jméno, příjmení, firma nebo Party UUID', 'Name, company, or Party UUID')}
       />
 
@@ -119,14 +157,15 @@ export default function KycPage() {
           className="btn btn-secondary"
           onClick={() => {
             const nextPartyId = partyIdInput.trim()
-            if (nextPartyId === partyId) void load(nextPartyId)
+            if (nextPartyId === partyId) void load(nextPartyId, 0)
             else setPartyId(nextPartyId)
+            setPage(0)
           }}
           disabled={loading || partyIdInput.trim() === ''}
           aria-busy={loading}
           aria-label={t('Vyhledat KYC případy', 'Search KYC cases')}
         >{t('Hledat', 'Search')}</button>
-        {(selectedParty || partyId) && <button type="button" className="btn btn-secondary" onClick={() => { setSelectedParty(null); setPartyIdInput(''); setPartyId('') }}>{t('Všechny případy', 'All cases')}</button>}
+        {(selectedParty || partyId) && <button type="button" className="btn btn-secondary" onClick={() => { setSelectedParty(null); setPartyIdInput(''); setPartyId(''); setPage(0) }}>{t('Všechny případy', 'All cases')}</button>}
       </div>
 
       {unavailable && (
@@ -204,6 +243,32 @@ export default function KycPage() {
           </tbody>
         </table>
       </div>
+
+      {!partyId && (
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: '10px' }}>
+          <span style={{ fontSize: '12px', color: 'var(--text-muted)' }}>
+            {total !== null
+              ? t(`Zobrazeno ${rangeStart}–${rangeEnd} z ${total}`, `Showing ${rangeStart}-${rangeEnd} of ${total}`)
+              : t('Celkový počet není znám', 'Total unknown')}
+          </span>
+          <div style={{ display: 'flex', gap: '8px' }}>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => setPage(p => Math.max(0, p - 1))}
+              disabled={loading || !canPrev}
+              aria-label={t('Předchozí strana', 'Previous page')}
+            >{t('Předchozí', 'Previous')}</button>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => setPage(p => p + 1)}
+              disabled={loading || !canNext}
+              aria-label={t('Další strana', 'Next page')}
+            >{t('Další', 'Next')}</button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/openbank-admin-ui/src/test/kyc-pagination-and-error-mapping.test.tsx
+++ b/openbank-admin-ui/src/test/kyc-pagination-and-error-mapping.test.tsx
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import React from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import KycPage from '@/app/kyc/page'
+
+vi.mock('@/components/auth/AuthGuard', () => ({ Can: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
+
+const PARTY = '66666666-6666-6666-6666-666666666666'
+const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+const kycCase = (id: string) => ({ id, partyId: PARTY, status: 'OPEN', checks: [], updatedAt: '2026-09-01T00:00:00Z', createdAt: '2026-09-01T00:00:00Z' })
+
+afterEach(() => { cleanup(); vi.restoreAllMocks(); vi.unstubAllGlobals() })
+
+/**
+ * Issue #8163: two truthfulness defects in this page — (1) it requested no page/size and
+ * silently showed the default first 20 records as the whole KYC queue, and (2) it converted an
+ * HTTP 405 from either list route into `no_data`, though only a genuine party-lookup 404 means
+ * "no case exists". This file drives the real page against the corrected
+ * `{items,total,page,size,statusFilter}` envelope (openapi.yaml 1.8.0, #8164).
+ */
+describe('KYC case list — server-backed pagination', () => {
+  it('requests page 0 explicitly and advances to page 1 on Next, without losing the total', async () => {
+    const calls: string[] = []
+    const f = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      calls.push(url)
+      if (url.includes('page=1')) {
+        return json({ items: [kycCase('case-page1')], total: 25, page: 1, size: 20, statusFilter: null })
+      }
+      if (url.includes('/api/v1/kyc/cases?')) {
+        return json({ items: Array.from({ length: 20 }, (_, i) => kycCase(`case-${i}`)), total: 25, page: 0, size: 20, statusFilter: null })
+      }
+      return json({}, 404)
+    })
+    vi.stubGlobal('fetch', f)
+    render(<LanguageProvider><KycPage /></LanguageProvider>)
+
+    await waitFor(() => expect(screen.getByText(/25/)).toBeInTheDocument())
+    expect(calls.some(u => u.includes('page=0') && u.includes('size=20'))).toBe(true)
+
+    const next = screen.getByRole('button', { name: 'Next page' })
+    expect(next).toBeEnabled()
+    fireEvent.click(next)
+
+    await waitFor(() => expect(calls.some(u => u.includes('page=1'))).toBe(true))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Previous page' })).toBeEnabled())
+  })
+
+  it('disables Next on the last page instead of implying more records exist', async () => {
+    const f = vi.fn(async () => json({ items: [kycCase('only-case')], total: 1, page: 0, size: 20, statusFilter: null }))
+    vi.stubGlobal('fetch', f)
+    render(<LanguageProvider><KycPage /></LanguageProvider>)
+
+    await waitFor(() => expect(screen.getByText('only-case'.slice(0, 8), { exact: false })).toBeTruthy())
+    expect(screen.getByRole('button', { name: 'Next page' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Previous page' })).toBeDisabled()
+  })
+
+  it('drops a stale party-scoped response that resolves after "All cases" was clicked (out-of-order network)', async () => {
+    // "All cases" is the one control in this page that stays enabled while a request is in
+    // flight (it must, so an operator can always escape a stuck filter) — which makes it the
+    // reachable path for issue #8163's stale/out-of-order requirement: a slow response for the
+    // OLD scope must not clobber the state of the NEW scope once it lands late.
+    let resolvePartyLookup: ((r: Response) => void) | null = null
+    const f = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/api/v1/parties/search')) {
+        return json({ data: [{ id: PARTY, legalName: 'Stale Party', status: 'ACTIVE', kycStatus: 'PENDING' }] })
+      }
+      if (url.endsWith(`/api/v1/kyc/cases/party/${PARTY}`)) {
+        // Deliberately held open past the "All cases" click below.
+        return new Promise<Response>(resolve => { resolvePartyLookup = resolve })
+      }
+      if (url.includes('/api/v1/kyc/cases?')) {
+        return json({ items: [kycCase('fresh-list-case')], total: 1, page: 0, size: 20, statusFilter: null })
+      }
+      return json({}, 404)
+    })
+    vi.stubGlobal('fetch', f)
+    render(<LanguageProvider><KycPage /></LanguageProvider>)
+
+    await waitFor(() => expect(screen.getByLabelText('Search parties')).toBeEnabled())
+    fireEvent.change(screen.getByLabelText('Search parties'), { target: { value: 'Stale Party' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+    await waitFor(() => expect(screen.getByText('Stale Party')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Select Stale Party' }))
+
+    // The party-scoped request is now in flight and held. Escape it via "All cases" (not
+    // disabled while loading) before it resolves.
+    await waitFor(() => expect(screen.getByText('All cases')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('All cases'))
+
+    await waitFor(() => expect(screen.getByText('fresh-li', { exact: false })).toBeInTheDocument())
+
+    // Now let the superseded party-scoped response resolve — it must NOT overwrite the list.
+    resolvePartyLookup?.(json([kycCase('stale-party-case')]))
+    await new Promise(r => setTimeout(r, 0))
+
+    expect(screen.getByText('fresh-li', { exact: false })).toBeInTheDocument()
+    expect(screen.queryByText('stale-pa', { exact: false })).not.toBeInTheDocument()
+  })
+})
+
+describe('KYC case list — 404 vs 405 truthfulness', () => {
+  it('maps a genuine party-lookup 404 to the no-data empty state', async () => {
+    const f = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/api/v1/parties/search')) return json({ data: [{ id: PARTY, legalName: 'Petr Novák', status: 'ACTIVE', kycStatus: 'PENDING' }] })
+      if (url.endsWith(`/api/v1/kyc/cases/party/${PARTY}`)) return json({}, 404)
+      return json({}, 404)
+    })
+    vi.stubGlobal('fetch', f)
+    render(<LanguageProvider><KycPage /></LanguageProvider>)
+
+    await waitFor(() => expect(screen.getByLabelText('Search parties')).toBeEnabled())
+    fireEvent.change(screen.getByLabelText('Search parties'), { target: { value: 'Petr Novak' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+    await waitFor(() => expect(screen.getByText('Petr Novák')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Select Petr Novák' }))
+
+    await waitFor(() => expect(screen.getByText('No KYC case was found for this party.')).toBeInTheDocument())
+  })
+
+  it('does NOT map a 405 route-contract failure to no-data — it must read as unavailable', async () => {
+    const f = vi.fn(async () => json({ error: 'method not allowed' }, 405))
+    vi.stubGlobal('fetch', f)
+    render(<LanguageProvider><KycPage /></LanguageProvider>)
+
+    await waitFor(() => expect(screen.queryByText(/^No KYC cases found\.$/)).not.toBeInTheDocument())
+  })
+
+  it('does NOT map an unscoped 404 on the list route to no-data (only party-lookup 404 qualifies)', async () => {
+    const f = vi.fn(async () => json({}, 404))
+    vi.stubGlobal('fetch', f)
+    render(<LanguageProvider><KycPage /></LanguageProvider>)
+
+    await waitFor(() => expect(screen.queryByText(/^No KYC cases found\.$/)).not.toBeInTheDocument())
+  })
+})

--- a/openbank-admin-ui/src/test/kyc-party-search.test.tsx
+++ b/openbank-admin-ui/src/test/kyc-party-search.test.tsx
@@ -19,7 +19,7 @@ describe('KYC party search', () => {
       const url = String(input)
       if (url.includes('/api/v1/parties/search')) return json({ data: [{ id: PARTY, legalName: 'Oldřich Vaněk', status: 'ACTIVE', kycStatus: 'APPROVED' }] })
       if (url.endsWith(`/api/v1/kyc/cases/party/${PARTY}`)) return json([{ id: 'case-1', partyId: PARTY, status: 'APPROVED', checks: [], updatedAt: '2026-08-20T10:00:00Z', createdAt: '2026-08-20T09:00:00Z' }])
-      if (url.endsWith('/api/v1/kyc/cases')) return json([])
+      if (url.includes('/api/v1/kyc/cases?')) return json({ items: [], total: 0, page: 0, size: 20, statusFilter: null })
       return json({}, 404)
     })
     vi.stubGlobal('fetch', f)

--- a/openbank-kyc-service/src/main/resources/openapi.yaml
+++ b/openbank-kyc-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: KYC Service API
-  version: 1.7.0
+  version: 1.8.0
   description: Know Your Customer case management — open cases, run checks, approve/reject.
   license:
     name: Apache-2.0
@@ -41,13 +41,11 @@ paths:
             enum: [OPEN, DOCUMENTS_REQUIRED, UNDER_REVIEW, APPROVED, REJECTED, EXPIRED]
       responses:
         '200':
-          description: List of KYC cases with optional statusFilter echo
+          description: Paginated KYC cases with the applied status filter echoed when present.
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/KycCaseResponse'
+                $ref: '#/components/schemas/KycCasePage'
     post:
       tags: [KYC]
       summary: Open a KYC case
@@ -104,6 +102,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KycCaseResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
   /api/v1/kyc/cases/{id}/checks/{checkType}:
     put:
@@ -330,8 +330,29 @@ components:
         partyName:
           type: string
 
+    KycCasePage:
+      type: object
+      required: [items, total, page, size, statusFilter]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/KycCaseResponse'
+        total:
+          type: integer
+          format: int64
+          minimum: 0
+        page:
+          type: integer
+        size:
+          type: integer
+        statusFilter:
+          type: [string, 'null']
+          enum: [OPEN, DOCUMENTS_REQUIRED, UNDER_REVIEW, APPROVED, REJECTED, EXPIRED, null]
+
     KycCaseResponse:
       type: object
+      required: [id, partyId, status, riskLevel, assignedTo, checks, notes, reviewedBy, reviewedAt, expiresAt, createdAt, updatedAt]
       properties:
         id:
           type: string
@@ -339,20 +360,59 @@ components:
         partyId:
           type: string
           format: uuid
-        caseType:
-          type: string
         status:
           type: string
+          enum: [OPEN, DOCUMENTS_REQUIRED, UNDER_REVIEW, APPROVED, REJECTED, EXPIRED]
         riskLevel:
           type: string
+          enum: [LOW, MEDIUM, HIGH, VERY_HIGH]
+        assignedTo:
+          type: [string, 'null']
         checks:
-          type: object
-          additionalProperties:
-            type: string
+          type: array
+          items:
+            $ref: '#/components/schemas/KycCheckResponse'
+        notes:
+          type: [string, 'null']
+        reviewedBy:
+          type: [string, 'null']
+        reviewedAt:
+          type: [string, 'null']
+          format: date-time
+        expiresAt:
+          type: [string, 'null']
+          format: date-time
         createdAt:
           type: string
           format: date-time
         updatedAt:
+          type: string
+          format: date-time
+
+    KycCheckResponse:
+      type: object
+      required: [id, caseId, checkType, status, result, provider, performedAt, createdAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        caseId:
+          type: string
+          format: uuid
+        checkType:
+          type: string
+          enum: [IDENTITY, ADDRESS, PEP_SCREENING, SANCTIONS_SCREENING, ADVERSE_MEDIA]
+        status:
+          type: string
+          enum: [PENDING, PASSED, FAILED, MANUAL_REVIEW]
+        result:
+          type: [string, 'null']
+        provider:
+          type: [string, 'null']
+        performedAt:
+          type: [string, 'null']
+          format: date-time
+        createdAt:
           type: string
           format: date-time
 

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/contract/KycCaseListPageContractIT.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/contract/KycCaseListPageContractIT.kt
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyc.contract
+
+import com.openbank.kyc.it.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Extract
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * Issue #8163: the committed `openapi.yaml` (1.7.0) declared `GET /api/v1/kyc/cases` as a raw
+ * array while `KycResource.listCases` has always returned the envelope
+ * `{items,total,page,size,statusFilter}`. #8164 corrected the DOCUMENT (bumped to 1.8.0) — this
+ * test is the runtime half that PR deliberately deferred: it proves the corrected document
+ * actually matches what the live endpoint returns, for both the first page and a later page, so
+ * the Admin UI's server-backed pagination (this same PR) can rely on the declared contract
+ * instead of the implementation shape "opportunistically".
+ */
+@QuarkusTest
+@QuarkusTestResource(KycCaseListPageContractIT.NoAuthzResource::class)
+@QuarkusTestResource(PostgresTestResource::class)
+class KycCaseListPageContractIT {
+
+    class NoAuthzResource : QuarkusTestResourceLifecycleManager {
+        // No OPA sidecar in a test JVM — see KycOutboxWriteIT for the same rationale. The subject
+        // here is the response envelope, not the authz decision.
+        override fun start(): Map<String, String> = mapOf("authz.enforce" to "false")
+        override fun stop() = Unit
+    }
+
+    private fun openCase(partyId: UUID = UUID.randomUUID()): UUID {
+        val id = Given {
+            contentType("application/json")
+            body("""{"partyId":"$partyId"}""")
+        } When {
+            post("/api/v1/kyc/cases")
+        } Then {
+            statusCode(201)
+        } Extract {
+            jsonPath().getString("id")
+        }
+        assertThat(id).isNotBlank()
+        return UUID.fromString(id)
+    }
+
+    @Test
+    @TestSecurity(user = "contract-it", roles = ["ROLE_ADMIN"])
+    fun `page 0 returns the declared envelope shape with size respected and no filter echoed`() {
+        repeat(3) { openCase() }
+
+        Given {
+            queryParam("page", 0)
+            queryParam("size", 2)
+        } When {
+            get("/api/v1/kyc/cases")
+        } Then {
+            statusCode(200)
+            body("page", org.hamcrest.Matchers.equalTo(0))
+            body("size", org.hamcrest.Matchers.equalTo(2))
+            body("items", org.hamcrest.Matchers.hasSize<Any>(2))
+            body("total", org.hamcrest.Matchers.greaterThanOrEqualTo(3))
+            body("statusFilter", org.hamcrest.Matchers.nullValue())
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "contract-it", roles = ["ROLE_ADMIN"])
+    fun `a later page echoes its own page number and total stays consistent across pages`() {
+        repeat(5) { openCase() }
+
+        val page0Total = Given {
+            queryParam("page", 0)
+            queryParam("size", 2)
+        } When {
+            get("/api/v1/kyc/cases")
+        } Then {
+            statusCode(200)
+        } Extract {
+            jsonPath().getLong("total")
+        }
+
+        Given {
+            queryParam("page", 1)
+            queryParam("size", 2)
+        } When {
+            get("/api/v1/kyc/cases")
+        } Then {
+            statusCode(200)
+            body("page", org.hamcrest.Matchers.equalTo(1))
+            body("total", org.hamcrest.Matchers.equalTo(page0Total.toInt()))
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "contract-it", roles = ["ROLE_ADMIN"])
+    fun `status filter is echoed back as statusFilter, matching the declared enum`() {
+        Given {
+            queryParam("status", "OPEN")
+        } When {
+            get("/api/v1/kyc/cases")
+        } Then {
+            statusCode(200)
+            body("statusFilter", org.hamcrest.Matchers.equalTo("OPEN"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #8164 (the OpenAPI-only correction). This PR is the runtime + Admin UI half of #8163:

1. **Contract test** — `KycCaseListPageContractIT` proves the corrected `openapi.yaml` (1.8.0,
   `{items,total,page,size,statusFilter}`) actually matches what `KycResource.listCases` returns,
   for page 0 and a later page, and that `statusFilter` echoes the applied filter. #8164 deliberately
   deferred this so it could stay a mechanical spec-only correction; this PR supplies it before the
   Admin UI is allowed to depend on the contract.
2. **Admin UI server-backed pagination** — `openbank-admin-ui/src/app/kyc/page.tsx` now requests
   `?page=&size=20` explicitly against the declared `KycCasePage` envelope instead of silently
   rendering the implementation's default first page as if it were the whole KYC queue. Adds
   Previous/Next controls, a truthful "Showing X-Y of N" range, and a stale/out-of-order response
   guard (`requestSeq` ref) so a superseded request can never clobber a newer one's state — the
   escape hatch is the "All cases" button, which stays enabled while a request is in flight so an
   operator is never stuck behind a slow filter.
3. **404-vs-405 truthfulness fix** — only a genuine 404 from the **party-scoped** lookup
   (`GET /api/v1/kyc/cases/party/{partyId}`, `KycResource.getCaseByParty`) now maps to the `no_data`
   empty state. A 405, or a 404 on the unscoped list route, is a route-contract failure and now
   surfaces through the normal `classifyBffFailure` path (`not_found`/`error`) instead of reading as
   "no cases exist."

## Type of change

- [x] fix

## Linked issues

Closes #8163
Builds on #8164

## Changes

- `openbank-kyc-service/src/test/kotlin/com/openbank/kyc/contract/KycCaseListPageContractIT.kt` — new
  `@QuarkusTest` + Testcontainers-Postgres IT (pattern from `KycOutboxWriteIT`), 3 cases: page 0 shape
  + size respected, page 1 echoes its own page number with total consistent across pages, and
  `statusFilter` echo.
- `openbank-admin-ui/src/app/kyc/page.tsx` — pagination state (`page`, `total`), `requestSeq` staleness
  guard, corrected 404-vs-405 mapping, pager UI.
- `openbank-admin-ui/src/test/kyc-pagination-and-error-mapping.test.tsx` — new regression coverage:
  page-0 request shape, Next/Previous transitions, Next disabled on the last page, a real
  out-of-order-response race (party lookup superseded by "All cases"), party-404 → `no_data`, and
  405 / unscoped-404 must NOT become `no_data`.
- `openbank-admin-ui/src/test/kyc-party-search.test.tsx` — updated its list-route mock to the
  envelope shape (was asserting against the old raw-array response).

## Definition of Done

- [x] `./gradlew :openbank-kyc-service:compileTestKotlin` and the new `KycCaseListPageContractIT`
      pass locally (Testcontainers Postgres).
- [x] `npm test -- kyc-` (admin-ui, via the `pretest` hook) — 9/9 passing, 4 files.
- [x] RBAC, party lookup semantics for the single-case response, and four-eyes approve/reject are
      untouched — this PR is read/pagination/error-mapping only.
- [x] No secrets, tokens, or personal data added.

## Security checklist

- [x] No secrets, tokens, passwords, fixtures, or personal records added.
- [x] No suppression, unsafe cast, or dependency added.
- [x] Auth, RBAC, KYC state transitions, and four-eyes controls are unchanged.
- [x] `check-agent-pr-guard.py --paths <files>` flags this PR as touching `openbank-kyc-service`
      (kyc is an `extra_protected_tokens` entry — high blast radius though not money-path) — flagging
      it for human review, as intended; it is not asking anyone to bypass anything.

## Compliance impact

- [x] GDPR
- [x] AML / 5AMLD
- [ ] PCI DSS
- [ ] DORA
- [ ] PSD2 / SCA / RTS
- [ ] CNB reporting
- [ ] None

This removes an operational risk where an operator could believe they were viewing the complete KYC
queue while only seeing its default first page, and a route-contract failure (405) could read as "no
cases" instead of "unavailable."

## Rollout / Rollback

- Deployment strategy: normal kyc-service + admin-ui release; contract test only, no schema/migration
  changes.
- Rollback plan: revert this PR; #8164's spec correction can stand alone.
- Data migration reversible: N/A

## Reviewer notes

Compare `KycCaseListPageContractIT` against `KycResource.listCases` and the `KycCasePage` schema in
`openapi.yaml` (1.8.0, landed in #8164). The Admin UI diff is confined to `src/app/kyc/page.tsx`; no
other KYC-adjacent screens were touched.
