### PR TITLE
fix(governance): a mode:enforced gate that runs its checker advisory, and a rule record that graduated without saying so

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1095,7 +1095,13 @@ gates:
     selftest: python3 openbank-infra/scripts/check-cnpg-backup-declared.py --self-test
     selftest_expect: pass
     run: |
-      python3 openbank-infra/scripts/check-cnpg-backup-declared.py
+      # --enforce is REQUIRED alongside `mode: enforced`, and neither alone does anything
+      # (#2392, the same trap threat-model-updated-on-trust-boundary-change documents in
+      # place): check-cnpg-backup-declared.py ends `return 1 if args.enforce else 0`, so
+      # without the flag a finding prints ::error and still exits 0 — the runner sees rc=0
+      # and reports a permanently green gate. Measured 2026-09-02: 0 findings today, so this
+      # was latent rather than actively hiding one, which is exactly when it is cheap to fix.
+      python3 openbank-infra/scripts/check-cnpg-backup-declared.py --enforce
 
   # A probed or scraped port must be a port the service opens (issue #2872, item 1).
   #

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -277,9 +277,17 @@ change_requirements:
     requires:
       - "spec.backup.barmanObjectStore.destinationPath is set, OR the cluster carries
          openbank.io/backup-exempt-reason with a non-empty reason"
-    gate: cnpg-backup-declared
-    enforced: advisory
-    target_enforce_date: "2026-09-15"
+    gate: cnpg-backup-declared-gate
+    # GRADUATED EARLY, 13 days before its 2026-09-15 date, because the same PR made the gate
+    # able to fail at all. It carried `mode: enforced` from the day it was added (#4993) while
+    # invoking its checker without --enforce, so a finding exited 0 and the gate was green by
+    # construction. Leaving this record on `advisory` after fixing that would have reproduced,
+    # in the very PR that reports it, the drift the sibling entry below documents.
+    #
+    # The graduation condition is met and was measured, not assumed: 0 findings across all 61
+    # CNPG Cluster manifests on 2026-09-02, and the gate is falsifiable — stripping the
+    # `backup:` block from a real cluster manifest takes it red.
+    enforced: enforced
     ci_producer: "openbank-infra/scripts/check-cnpg-backup-declared.py"
     # The sibling of db_backup_association, for the case that rule CANNOT see. Its producer
     # scans for clusters that DECLARE a barmanObjectStore and skips the rest (`if not dest:

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -538,13 +538,16 @@ change_requirements:
     detect: ["money-path <service> trust-boundary paths in the PR diff"]
     require:
       - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
-    gate: threat-model-diff
-    enforced: advisory
-    target_enforce_date: "2026-09-15"   # ADR-0144
-    # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
-    # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
-    # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
-    # pass --enforce to the script in ci.yml (one-line change).
+    gate: threat-model-updated-on-trust-boundary-change
+    enforced: enforced
+    # GRADUATED in #3431, after the #3438 scope fix took the false-positive rate from 7-of-60
+    # to 2-of-60 (both survivors real). This block said `advisory` with a target_enforce_date
+    # of 2026-09-15 and described findings as "::warning annotations" with the flip still to
+    # come — all three were already untrue. The gate runs `mode: enforced` AND passes
+    # --enforce (both are required, #2392), so findings are ::error and fail the build.
+    # Corrected 2026-09-02, found by reading gates.yaml against this file rather than either
+    # alone: nothing cross-checks a rule's `enforced:` against the mode of the gate that
+    # implements it, so this record could drift for as long as it did.
     ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
   mp_messaging_dotted_keys:
     # SmallRye reactive-messaging config written as a DOTTED key


### PR DESCRIPTION
## What

Two findings from reading `gates.yaml` **against** `rules.yaml`. Neither is visible from either file alone, and nothing in the estate cross-checks the pair.

## 1. A `mode: enforced` gate that runs its checker in advisory mode

`cnpg-backup-declared-gate` declares `mode: enforced` and invokes the script **without** `--enforce`. That script ends `return 1 if args.enforce else 0`, so a finding prints `::error` and still exits 0 — the runner sees `rc=0` and reports a permanently green gate.

This is precisely the trap **#2392** documented, and which the sibling gate `threat-model-updated-on-trust-boundary-change` carries a comment about *in place*: "BOTH the mode above and `--enforce` below are required, and neither alone does anything." One sibling got it right; this one did not.

**Falsified with a known-positive, not argued.** Strip the `backup:` block from a real cluster manifest (`temporal-helmrelease.yaml`):

| invocation | output | exit | gate |
|---|---|---|---|
| without `--enforce` (main today) | `::error` printed | **0** | **GREEN** |
| with `--enforce` (this PR) | `::error` printed | **1** | RED |

Measured 2026-09-02 the gate has **0 findings**, so this was latent rather than actively hiding one — which is exactly when it is cheap to fix.

## 2. A rule that graduated without its record saying so

`rules.yaml: change_requirements.trust_boundary_diff_change` said `enforced: advisory`, `target_enforce_date: 2026-09-15`, and carried a comment describing findings as "`::warning` annotations" with the flip still to come.

All three were untrue. The rule **graduated in #3431** (after the #3438 scope fix took the false-positive rate from 7-of-60 to 2-of-60, both survivors real), and its gate has run `mode: enforced` **with** `--enforce` ever since.

Corrected, with the `gate:` label pointed at the real gate id. This also removes one deadline from the 2026-09-15 cluster that was never going to need action — `check-gate-graduation.sh` goes 20 → 19 advisory rules, still all with live dates.

## Deliberately NOT done: a gate for the class

The obvious follow-up is a check that `mode: enforced` implies the run passes `--enforce`. **I measured it and it is not decidable from the manifest.** A naive predicate flags 3 of 66 enforced single-script gates; reading them shows only 1 is real, because `--enforce` carries three incompatible meanings across this estate:

| script | what `--enforce` means | correct as-is? |
|---|---|---|
| `check-cnpg-backup-declared.py` | on/off switch — findings return 0 without it | **no** (this PR) |
| `check-scheduler-liveness.py` | *stricter* mode: also fail on baselined violations | yes |
| `check-raw-colour-literal-ratchet.py` | explicit no-op — "enforcement is the default" | yes |

Such a gate would cry wolf about two correct gates out of three. CLAUDE.md's own `entity-column-names` lesson is that a gate which does that is worth less than nothing. It stays a review question.

## Verification

- Known-positive above, both directions.
- `check-gate-graduation.sh` and `check-advisory-gate-registration.py` both pass after the `rules.yaml` edit.
- `gen-rules-opa-data.py` produces no diff — `enforced:` and `gate:` are not in the OPA read set, so no bundle restamp.
- `lint` shard 26/26 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Follow-up commit: the same drift, caught in this PR's own change

Adding `--enforce` makes `cnpg-backup-declared-gate` able to fail **for the first time**. Leaving `enforced: advisory` on its `rules.yaml` record would then have reproduced — inside the very PR that reports that drift — the same disagreement it reports for `trust_boundary_diff_change`.

So the cnpg record is graduated too, **13 days ahead of its 2026-09-15 date**. The condition is met and was measured rather than assumed:

- **0 findings** across all 61 CNPG Cluster manifests (2026-09-02);
- the gate is **falsifiable** — stripping the `backup:` block from a real cluster manifest takes it red;
- the gate has carried `mode: enforced` since #4993, so enforcement was always the intent. What was missing was the flag that made it true.

`check-gate-graduation` now goes **20 → 18** advisory rules, all still with live dates, clearing **two** entries from the 2026-09-15 cluster rather than one.
