### PR TITLE
docs(governance): re-measure money_path_depth's blocked_on against the actual weekly run

### DIFF
--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1144,7 +1144,23 @@ coverage:
     # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
     # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
     # transaction 46%, balance 55%, ledger 65%, fx 73%.
-    blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+    # Re-measured 2026-09-03 against the last weekly run (33289385445, 2026-08-30). The previous
+    # text named account/transaction/balance/ledger and was wrong in BOTH directions: account
+    # (49 -> 70) and transaction (46 -> 76) have since cleared, while interest, sanctions and
+    # sepa-payment were never named and are below. ledger has gone the wrong way, 65 -> 63.
+    #
+    #     balance   60%  (46/76)      account     70%  (103/146)
+    #     interest  60%  (36/60)      fx          72%  (62/85)
+    #     ledger    63%  (180/283)    domestic    74%  (49/66)
+    #     sanctions 69%  (34/49)      sdd         75%  (46/61)
+    #     sepa-pay  69%  (44/63)      transaction 76%  (80/104)
+    #                                 sepa-instant 77% (35/45)
+    #                                 fraud       89%  (41/46)
+    #
+    # So the flip is blocked by FIVE services, not four, and the two the record has been
+    # pointing at for a month are no longer among them. Read the weekly run before quoting a
+    # number here; these move.
+    blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; balance 60, interest 60, ledger 63, sanctions 69 and sepa-payment 69 are below it as of run 33289385445 (2026-08-30)"
   dast:
     tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
     enforced: advisory                  # report-only first cut; no fail_action, no PR gate


### PR DESCRIPTION
## What

`rules.yaml: coverage.money_path_depth` said the mutation flip was blocked by *"account/transaction/balance/ledger"*. Measured against the last weekly pitest run (**33289385445**, 2026-08-30), that is wrong **in both directions**.

| below 70% | | at or above | |
|---|---|---|---|
| balance | 60% (46/76) | account | 70% (103/146) |
| interest | 60% (36/60) | fx | 72% (62/85) |
| ledger | 63% (180/283) | domestic-payment | 74% (49/66) |
| sanctions | 69% (34/49) | sdd | 75% (46/61) |
| sepa-payment | 69% (44/63) | transaction | 76% (80/104) |
| | | sepa-instant | 77% (35/45) |
| | | fraud | 89% (41/46) |

- **account 49 → 70** and **transaction 46 → 76** have cleared the bar the record still says they fail.
- **interest, sanctions and sepa-payment** are below it and were never named — interest and sanctions joined the pitest matrix *after* the text was written (#3675, #265), and nobody re-read it.
- **ledger has moved the wrong way, 65 → 63.**

So the flip is blocked by **five** services, not four, and the two the record has pointed at for a month are not among them.

## Why it matters now

`target_enforce_date: 2026-09-30` is **27 days away**. This is the number that decision gets made on, and until now it named the wrong services.

## Scope

No behaviour change — `blocked_on` is prose read by humans, not by a checker. `check-gate-graduation.sh` still reports 20 advisory rules, all with live dates; `gen-rules-opa-data.py` produces no diff. `lint` shard 26/26 PASS.

## Context

Third stale governance record found today by the same method — reading a record against the thing it describes rather than trusting either alone. The other two are in #8309. The common shape: a record written once, correct at the time, describing a moving quantity, with nothing that re-checks it. The comment now says so in place: *"Read the weekly run before quoting a number here; these move."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
