### PR TITLE
test(admin-ui): require exact fraud amount evidence

### DIFF
--- a/openbank-admin-ui/e2e/fraud-review-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/fraud-review-recovery.spec.ts
@@ -39,7 +39,7 @@ test('retains the bounded fraud evidence snapshot when refresh fails', async ({ 
 
   await page.goto('/fraud')
 
-  await expect(page.getByText('125,000 CZK')).toBeVisible({ timeout: 20_000 })
+  await expect(page.getByText('125,000 CZK', { exact: true })).toBeVisible({ timeout: 20_000 })
   await expect(page.getByText('fraud-rules-2026.08')).toBeVisible()
   await expect(page.getByText('91', { exact: true })).toBeVisible()
 
@@ -47,7 +47,7 @@ test('retains the bounded fraud evidence snapshot when refresh fails', async ({ 
   await page.getByRole('button', { name: /Obnovit frontu podvodů|Refresh fraud queue/ }).click()
 
   await expect(page.getByText(/Zobrazen je poslední úspěšný snapshot|Showing the last successful snapshot/)).toBeVisible()
-  await expect(page.getByText('125,000 CZK')).toBeVisible()
+  await expect(page.getByText('125,000 CZK', { exact: true })).toBeVisible()
   await expect(page.getByText('fraud-rules-2026.08')).toBeVisible()
   await expect(page.getByText(/Fronta je prázdná|Queue is empty/)).toHaveCount(0)
 })


### PR DESCRIPTION
## Summary

- scope fraud recovery amount checks to the complete displayed money value
- reject larger amounts that merely contain the expected digits
- preserve both the initial evidence and failed-refresh recovery assertions

## Verification

- counterexample: `1,125,000 CZK` passed the old broad locator and fails the exact locator
- targeted Playwright: 1/1 passed, Chromium, one worker, retries disabled
- `npm run type-check`
- changed-file ESLint
- `npm run build` (91/91 static pages)
- `git diff --check`
- independent diff review: clean

Closes #8313
