### PR TITLE
test(admin-ui): synchronize quick-search readiness

### DIFF
--- a/openbank-admin-ui/e2e/command-palette.spec.ts
+++ b/openbank-admin-ui/e2e/command-palette.spec.ts
@@ -39,12 +39,19 @@ test('keeps quick search truthful through an outage and retry', async ({ page })
     })
   })
 
-  const sessionReady = page.waitForResponse(response =>
-    response.url().endsWith('/api/auth/session') && response.ok(),
-  )
   await page.goto('/dashboard')
-  await sessionReady
-  await page.keyboard.press('Control+K')
+  // A session response can beat Header's passive-effect listener. Missed probes have no
+  // side effect; the first cancelled event is handled and toggles the palette exactly once.
+  await expect.poll(() => page.evaluate(() => {
+    const event = new KeyboardEvent('keydown', {
+      key: 'k',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    })
+    window.dispatchEvent(event)
+    return event.defaultPrevented
+  })).toBe(true)
 
   const dialog = page.getByRole('dialog', { name: /Rychlé hledání|Quick search/ })
   const input = dialog.getByRole('textbox')


### PR DESCRIPTION
## Summary

- synchronize the command-palette test with Header's actual keyboard-listener contract
- make pre-listener probes side-effect free and stop on the first handled shortcut
- preserve the real Ctrl+K transition, dialog focus, outage retry, and destination assertions

## Verification

- before fix: a successful session response still preceded the Header listener in 8/40 fresh-page probes
- patched stress: 40/40 passed with one Chromium worker and Playwright retries disabled
- latest-base targeted Playwright: 1/1 passed with retries disabled
- `npm run type-check`
- changed-file ESLint
- `npm run build` (91/91 static pages)
- `git diff --check`
- independent diff review: clean

Closes #8316
