### PR TITLE
test(admin-ui): bind readiness verdict to ledger row

### DIFF
--- a/openbank-admin-ui/e2e/prod-readiness-recovery.spec.ts
+++ b/openbank-admin-ui/e2e/prod-readiness-recovery.spec.ts
@@ -34,19 +34,24 @@ test('preserves the last verified readiness report through an outage and retry',
   })
 
   await page.goto('/system/readiness')
-  await expect(page.getByText('ledger', { exact: true })).toBeVisible()
-  await expect(page.getByText('GO', { exact: true }).first()).toBeVisible()
+  const ledgerRow = page.getByRole('row').filter({
+    has: page.getByText('ledger', { exact: true }),
+  })
+  const ledgerGate = ledgerRow.getByText('GO', { exact: true })
+  await expect(ledgerRow).toBeVisible()
+  await expect(ledgerGate).toBeVisible()
 
   failNextRequest = true
   await page.getByRole('button', { name: /Obnovit připravenost na produkci|Refresh production readiness/ }).click()
 
   const stale = page.getByRole('status')
   await expect(stale).toContainText(/zobrazuji poslední dostupný report|showing the last available report/)
-  await expect(page.getByText('ledger', { exact: true })).toBeVisible()
-  await expect(page.getByText('GO', { exact: true }).first()).toBeVisible()
+  await expect(ledgerRow).toBeVisible()
+  await expect(ledgerGate).toBeVisible()
 
   await page.getByRole('button', { name: /Zkusit znovu načíst report připravenosti|Retry loading the readiness report/ }).click()
   await expect(stale).toBeHidden()
-  await expect(page.getByText('ledger', { exact: true })).toBeVisible()
+  await expect(ledgerRow).toBeVisible()
+  await expect(ledgerGate).toBeVisible()
   expect(request).toBeGreaterThanOrEqual(3)
 })


### PR DESCRIPTION
## Summary

- scope the production-readiness verdict to the ledger table row
- verify the same row-specific gate before refresh, during retained outage evidence, and after retry
- prevent the unconditional summary-card `GO` label from satisfying service-level assertions

## Verification

- old global selector + ledger `NO-GO`: false-green 1/1
- corrected row selector + ledger `NO-GO`: expected red at missing ledger `GO`
- restored `GO`: targeted Playwright 1/1 passed, Chromium, one worker, retries disabled
- latest-base targeted Playwright: 1/1 passed
- `npm run type-check`
- changed-file ESLint
- `npm run build` (91/91 static pages)
- `git diff --check`
- independent frozen-diff review: clean

Closes #8319
