### PR TITLE
docs(customer-edge): publish the sharedWithMe flag /accounts already sends

### DIFF
--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.47.0
+  version: 1.48.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -3798,6 +3798,16 @@ components:
         nickname:
           type: string
           nullable: true
+        sharedWithMe:
+          type: boolean
+          default: false
+          description: >-
+            True for an account GET /accounts APPENDS because an ACTIVE delegation grant covers it,
+            not because the caller owns it (ADR-0232 D6). The edge sets it on every shared entry
+            and never on an owned one, so absent means "mine" — that asymmetry is the whole point,
+            and a client that cannot see the flag presents someone else's account as the customer's
+            own. Served since #4021; published here because it was not, and a field the edge sends
+            but does not declare is one no client can rely on.
         incentiveReservation:
           allOf:
             - {$ref: '#/components/schemas/IncentiveReservation'}


### PR DESCRIPTION
## What

`sharedAccountsFor` has marked every appended entry with `"sharedWithMe": true` since #4021 — it is what lets a client say "shared with you" instead of presenting someone else's account as the customer's own. The `Account` schema never declared it.

One field, plus the `info.version` minor bump the api-contract gate requires. No behaviour change.

## Why it matters

Found while writing the app client for delegated accounts. The customer app's contract test fails a DTO field the edge schema does not define, as a **phantom** — on the grounds that the app would decode it as a default forever and any UI built on it would be quietly dead. That rule is right, and here it bites on a field that is real: the edge sends it, the spec was simply silent, so the app could not model the one thing that distinguishes borrowed money from its own without failing its own gate.

`default: false` states the asymmetry the code already relies on: the flag is set on every shared entry and never on an owned one, so absent means "mine".

## Note for whoever merges second

open-bank-oss#8321 also bumps `info.version` 1.47.0 → 1.48.0. Whichever of the two lands second needs a re-bump to 1.49.0; there is no other overlap between them.

## Linked issues
N/A — publishing an already-served field found while wiring the app client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
