### PR TITLE
ci(governance): gate Instant.EPOCH defaults and Temporal worker switch naming

### DIFF
--- a/.github/gates/epoch-instant-default-baseline.txt
+++ b/.github/gates/epoch-instant-default-baseline.txt
@@ -1,0 +1,61 @@
+# Baseline for check-no-epoch-instant-default.py — the occurrences present when the
+# gate was introduced (2026-09-03, audit Top-50 B-gates). Format: path::line-text#n.
+# Ratchet: new occurrences fail; remove an entry in the same PR that fixes it.
+openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/AccountEntities.kt::var createdAt: Instant = Instant.EPOCH#1
+openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/AccountEntities.kt::var createdAt: Instant = Instant.EPOCH#2
+openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/AccountEntities.kt::var createdAt: Instant = Instant.EPOCH#3
+openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/AccountEntities.kt::var updatedAt: Instant = Instant.EPOCH#1
+openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/AccountEntities.kt::var updatedAt: Instant = Instant.EPOCH#2
+openbank-aml-service/src/main/kotlin/com/openbank/aml/domain/event/AmlCaseEvents.kt::fun AmlCase.toCreatedEvent(now: Instant = Instant.EPOCH) = AmlCaseCreatedEvent(#1
+openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun activate(now: Instant = Instant.EPOCH) = also {#1
+openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun block(reason: String, now: Instant = Instant.EPOCH) = also {#1
+openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun cancel(reason: String?, now: Instant = Instant.EPOCH) = also {#1
+openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun consume(now: Instant = Instant.EPOCH) = also {#1
+openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun expireUnused(now: Instant = Instant.EPOCH) = also {#1
+openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun resume(now: Instant = Instant.EPOCH) = also {#1
+openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun suspend(now: Instant = Instant.EPOCH) = also {#1
+openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun withLimits(dailyMinor: Long, monthlyMinor: Long, now: Instant = Instant.EPOCH) = also {#1
+openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::now: Instant = Instant.EPOCH,#1
+openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/entity/CardCategoryRuleEntity.kt::var updatedAt: Instant = Instant.EPOCH#1
+openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/entity/DocumentEntity.kt::var createdAt: Instant = Instant.EPOCH#1
+openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/entity/DocumentTemplateEntity.kt::var createdAt: Instant = Instant.EPOCH#1
+openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/entity/SignatureCeremonyEntity.kt::var createdAt: Instant = Instant.EPOCH#1
+openbank-fx-service/src/main/kotlin/com/openbank/fx/domain/event/FxEvents.kt::override val occurredAt: Instant = Instant.EPOCH,#1
+openbank-fx-service/src/main/kotlin/com/openbank/fx/domain/event/FxEvents.kt::override val occurredAt: Instant = Instant.EPOCH,#2
+openbank-fx-service/src/main/kotlin/com/openbank/fx/domain/model/FxRate.kt::fun isValid(at: Instant = Instant.EPOCH) = at.isAfter(validFrom) && at.isBefore(validTo)#1
+openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/persistence/entity/FxRateEntity.kt::var createdAt: Instant = Instant.EPOCH#1
+openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/persistence/entity/FxRateEntity.kt::var createdAt: Instant = Instant.EPOCH#2
+openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/persistence/entity/FxRateEntity.kt::var validFrom: Instant = Instant.EPOCH#1
+openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/persistence/entity/FxRateEntity.kt::var validTo: Instant = Instant.EPOCH#1
+openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/AccountingDayEntity.kt::var createdAt: Instant = Instant.EPOCH#1
+openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/AccountingDayEntity.kt::var openedAt: Instant = Instant.EPOCH#1
+openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/AccountingDayEntity.kt::var updatedAt: Instant = Instant.EPOCH#1
+openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/ClosedPeriodEntity.kt::var computedAt: Instant = Instant.EPOCH#1
+openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/ClosedPeriodEntity.kt::var createdAt: Instant = Instant.EPOCH#1
+openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/ClosedPeriodEntity.kt::var updatedAt: Instant = Instant.EPOCH#1
+openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/JournalEntities.kt::var createdAt: Instant = Instant.EPOCH#1
+openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/JournalEntities.kt::var createdAt: Instant = Instant.EPOCH#2
+openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/JournalEntities.kt::var createdAt: Instant = Instant.EPOCH#3
+openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/TieOutRunEntity.kt::var runAt: Instant = Instant.EPOCH#1
+openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/YearCloseEntity.kt::var computedAt: Instant = Instant.EPOCH#1
+openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/YearCloseEntity.kt::var createdAt: Instant = Instant.EPOCH#1
+openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/YearCloseEntity.kt::var updatedAt: Instant = Instant.EPOCH#1
+openbank-libs-domain/src/main/kotlin/com/openbank/libs/analytics/AnalyticsEnvelope.kt::val ingestedAt: Instant = Instant.EPOCH,#1
+openbank-libs-domain/src/main/kotlin/com/openbank/libs/flags/FlagDefinition.kt::fun isExpired(asOf: Instant = Instant.EPOCH): Boolean = expiresAt != null && asOf.isAfter(expiresAt)#1
+openbank-libs-domain/src/main/kotlin/com/openbank/libs/flags/FlagDefinition.kt::fun validate(asOf: Instant = Instant.EPOCH): List<String> = buildList {#1
+openbank-libs-domain/src/main/kotlin/com/openbank/libs/foureyes/ApprovalPorts.kt::asOf: Instant = Instant.EPOCH,#1
+openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/domain/Product.kt::val createdAt: Instant = Instant.EPOCH,#1
+openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/domain/Product.kt::val createdAt: Instant = Instant.EPOCH,#2
+openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/domain/Product.kt::val updatedAt: Instant = Instant.EPOCH,#1
+openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/domain/model/SanctionsEntry.kt::val createdAt: Instant = Instant.EPOCH,#1
+openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/domain/model/SanctionsEntry.kt::val updatedAt: Instant = Instant.EPOCH,#1
+openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/entity/SanctionsCheckEntity.kt::var checkedAt: Instant = Instant.EPOCH#1
+openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/entity/SanctionsListEntity.kt::var createdAt: Instant = Instant.EPOCH#1
+openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/entity/SanctionsListEntity.kt::var updatedAt: Instant = Instant.EPOCH#1
+openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/persistence/entity/StandingOrderEntity.kt::var createdAt: Instant = Instant.EPOCH#1
+openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/persistence/entity/StandingOrderEntity.kt::var updatedAt: Instant = Instant.EPOCH#1
+openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/persistence/entity/SwiftMessageEntity.kt::var createdAt: Instant = Instant.EPOCH#1
+openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/persistence/entity/SwiftMessageEntity.kt::var updatedAt: Instant = Instant.EPOCH#1
+openbank-tax-reporting-service/src/main/kotlin/com/openbank/tax/infrastructure/persistence/Persistence.kt::var observedAt: Instant = Instant.EPOCH#1
+openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/persistence/entity/MerchantCatalogEntity.kt::var updatedAt: Instant = Instant.EPOCH#1
+openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/persistence/entity/TransactionEntity.kt::var initiatedAt: Instant = Instant.EPOCH#1

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -4680,6 +4680,7 @@ gates:
     group: kotlin
     mode: enforced
     rationale: "A defaulted EPOCH timestamp is invisible to every assertion that discriminates by non-nullity, and fixing it later vacuums every test that discriminated by the defect's magnitude; the convention (caller supplies the time, or Clock injection) is fully decidable."
+    budget_seconds: 15   # 1.5s locally via run-gates.py --only; generous first setting
     review_after: "2027-03-03"
     selftest: python3 .github/scripts/check-no-epoch-instant-default.py --self-test
     selftest_expect: pass
@@ -4698,6 +4699,7 @@ gates:
     group: kotlin
     mode: enforced
     rationale: "A disable switch whose name cannot be derived from the service name forces every consumer (fuzz harness, DR manifests, runbooks) to carry a drifting per-service list; the convention makes it computable."
+    budget_seconds: 10   # 0.5s locally via run-gates.py --only; generous first setting
     review_after: "2027-03-03"
     selftest: python3 .github/scripts/check-temporal-worker-switch-naming.py --self-test
     selftest_expect: pass

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -4667,3 +4667,41 @@ gates:
     run: |
       python3 -m unittest openbank-infra/scripts/check_argocd_sync_integrity_test.py
       python3 .github/scripts/check-argocd-sync-integrity.py --check-wiring
+
+  # Audit Top-50 follow-ups (2026-09-03, docs/audit-2026-09-03-top50.md).
+  # no-epoch-instant-default: an `Instant = Instant.EPOCH` default on a field meaning "when did
+  # this happen" is a lie every test agrees with — isNotNull() passes against 1970-01-01 (#3882),
+  # and the same sentinel seeded an age gauge that fired WorkflowLivenessStale 15 minutes after
+  # every deploy for every daily workflow (#2239 Gap 2, #4208). 58 occurrences baselined at
+  # introduction; the ratchet only tightens, and a baseline entry that disappears fails too, so
+  # the list cannot rot.
+  - id: no-epoch-instant-default
+    name: "no `Instant = Instant.EPOCH` default in production sources (#3882/#4208 class, enforced)"
+    group: kotlin
+    mode: enforced
+    rationale: "A defaulted EPOCH timestamp is invisible to every assertion that discriminates by non-nullity, and fixing it later vacuums every test that discriminated by the defect's magnitude; the convention (caller supplies the time, or Clock injection) is fully decidable."
+    review_after: "2027-03-03"
+    selftest: python3 .github/scripts/check-no-epoch-instant-default.py --self-test
+    selftest_expect: pass
+    selftest_inputs: [".github/scripts/check-no-epoch-instant-default.py"]
+    min_subjects: 116   # 58 occurrences + 58 baseline entries today (2026-09-03)
+    run: |
+      python3 .github/scripts/check-no-epoch-instant-default.py --root .
+
+  # temporal-worker-switch-naming: six Temporal-worker services, six disable switches, five
+  # under `openbank.<service>.worker.enabled` and lending's under `lending.origination…` — an
+  # underivable name is why the fuzz harness needs a hard-coded name list, and a drifted list is
+  # how a fuzz job reports a failure that never sent a request (2026-08-18 run). Convention and
+  # the one allowlisted exception live in rules.yaml: temporal_worker_switch_naming.
+  - id: temporal-worker-switch-naming
+    name: "Temporal worker disable switches follow openbank.<service>.worker.enabled (enforced)"
+    group: kotlin
+    mode: enforced
+    rationale: "A disable switch whose name cannot be derived from the service name forces every consumer (fuzz harness, DR manifests, runbooks) to carry a drifting per-service list; the convention makes it computable."
+    review_after: "2027-03-03"
+    selftest: python3 .github/scripts/check-temporal-worker-switch-naming.py --self-test
+    selftest_expect: pass
+    selftest_inputs: [".github/scripts/check-temporal-worker-switch-naming.py"]
+    min_subjects: 6   # 6 worker.enabled switches today (2026-09-03)
+    run: |
+      python3 .github/scripts/check-temporal-worker-switch-naming.py --root .

--- a/.github/scripts/check-no-epoch-instant-default.py
+++ b/.github/scripts/check-no-epoch-instant-default.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Guard: no `Instant = Instant.EPOCH` default in production Kotlin sources.
+
+WHY THIS EXISTS: an `Instant.EPOCH` default on a field meaning "when did this happen" is a lie
+every test agrees with. `AuditEvent.timestamp` and `FlagExposure.timestamp` both defaulted to it;
+23 of the 25 fleet `AuditEvent(` sites took the default, and `isNotNull()` passes against
+1970-01-01 — so nothing caught it until #3882. The companion defect, one step later, is a
+sentinel that is right for a REPORT and wrong the day something ALERTS on it:
+`DomainMetrics.registerWorkflowLiveness` seeded its age gauge from `Instant.EPOCH`, and
+ADR-0237's `WorkflowLivenessStale` then fired 15 minutes after every deploy, for every daily
+workflow, until that workflow's next success (#2239 Gap 2, fixed by #4208).
+
+WHAT IT CHECKS: every `openbank-*/src/main/kotlin/**.kt`, comments stripped (a fix comment
+explaining why EPOCH is wrong must not trip the guard, and a violation must not be hideable in a
+comment). Any `… : Instant = Instant.EPOCH` default — field, constructor parameter, or function
+parameter — is flagged. A default of EPOCH is never the right answer in production code: the
+correct shapes are a required parameter (caller supplies the time), a `Clock` injection, or
+`Instant.now()` at the call site that owns the meaning.
+
+BASELINE RATCHET: the fleet carried 58 occurrences when this guard was written (2026-09-03,
+audit follow-up #8344 family). They are baselined in
+`.github/gates/epoch-instant-default-baseline.txt` as `path::trimmed-declaration#<n>`
+(`#<n>` disambiguates identical lines in one file), so:
+  - a NEW occurrence fails the gate (the ratchet only tightens), and
+  - a baseline entry whose occurrence DISAPPEARS also fails — the list cannot rot, and the fix
+    PR removes the line as part of the fix (same idiom as check-kafka-dotted-keys.py, #2945).
+Line numbers are deliberately NOT in the baseline: they drift under every unrelated edit.
+
+ENFORCED: findings are ::error:: annotations and exit 1.
+
+stdlib only. Usage: check-no-epoch-instant-default.py [--root .] [--enforce] [--self-test]
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+import gatelib
+
+EPOCH_DEFAULT_RE = re.compile(r":\s*Instant\s*=\s*Instant\.EPOCH\b")
+BASELINE = ".github/gates/epoch-instant-default-baseline.txt"
+
+
+def strip_comments(lines: list[str]) -> list[str]:
+    """Blank `//` comments and (possibly nested) `/* … */` blocks, keeping line numbering.
+
+    Kotlin block comments NEST, so depth is counted, not boolean — with a boolean a KDoc
+    explaining the rule becomes a violation of the rule it documents (#2450 precedent in
+    check-no-runblocking-in-scheduled.py).
+    """
+    out: list[str] = []
+    depth = 0
+    for line in lines:
+        buf: list[str] = []
+        i = 0
+        while i < len(line):
+            two = line[i:i + 2]
+            if depth > 0:
+                if two == "*/":
+                    depth -= 1
+                    i += 2
+                    continue
+                if two == "/*":
+                    depth += 1
+                    i += 2
+                    continue
+                i += 1
+                continue
+            if two == "/*":
+                depth += 1
+                i += 2
+                continue
+            if two == "//":
+                break
+            buf.append(line[i])
+            i += 1
+        out.append("".join(buf))
+    return out
+
+
+def find_occurrences(root: pathlib.Path) -> dict[str, tuple[int, str]]:
+    """All occurrences as {"<path>::<trimmed line>#<n>": (line_no, trimmed)} over src/main only.
+
+    `#<n>` is the 1-based index of this occurrence among IDENTICAL lines in the same file.
+    Without it, a file carrying the same default twelve times (Card.kt's `now:` parameters)
+    collapses to one baseline key — and the ratchet then cannot tell "one of the twelve was
+    fixed" from "a thirteenth was added".
+    """
+    found: dict[str, tuple[int, str]] = {}
+    for kt in gatelib.rglob(root, "openbank-*/src/main/**/*.kt"):
+        code = strip_comments(gatelib.read_text(kt).splitlines())
+        seen: dict[str, int] = {}
+        for idx, line in enumerate(code, start=1):
+            if EPOCH_DEFAULT_RE.search(line):
+                rel = kt.relative_to(root).as_posix()
+                text = line.strip()
+                seen[text] = seen.get(text, 0) + 1
+                found[f"{rel}::{text}#{seen[text]}"] = (idx, text)
+    return found
+
+
+def load_baseline(root: pathlib.Path) -> set[str]:
+    path = root / BASELINE
+    if not path.exists():
+        return set()
+    return {
+        ln.strip()
+        for ln in gatelib.read_text(path).splitlines()
+        if ln.strip() and not ln.startswith("#")
+    }
+
+
+def self_test() -> int:
+    """Falsify the detector against fixtures whose answer is known."""
+    fails: list[str] = []
+
+    def flagged(src: str) -> bool:
+        code = strip_comments(src.splitlines())
+        return any(EPOCH_DEFAULT_RE.search(line) for line in code)
+
+    def case(label: str, src: str, want: bool) -> None:
+        got = flagged(src)
+        if got != want:
+            fails.append(f"{label}: expected flagged={want}, got {got}")
+
+    case("a data-class timestamp default must be FLAGGED", """
+        data class AuditEvent(val timestamp: Instant = Instant.EPOCH)
+    """, True)
+
+    case("a var entity default must be FLAGGED", """
+        var createdAt: Instant = Instant.EPOCH
+    """, True)
+
+    case("a function parameter default must be FLAGGED", """
+        fun activate(now: Instant = Instant.EPOCH) = also { }
+    """, True)
+
+    case("the fix — a required parameter — is CLEAN", """
+        data class AuditEvent(val timestamp: Instant)
+    """, False)
+
+    case("Instant.now() is CLEAN (the call site owns the meaning)", """
+        var createdAt: Instant = Instant.now()
+    """, False)
+
+    case("a comment mentioning the pattern is CLEAN", """
+        // never write: val timestamp: Instant = Instant.EPOCH — see #3882
+        val timestamp: Instant
+    """, False)
+
+    case("a NESTED block comment mentioning the pattern is CLEAN", """
+        /* outer /* val x: Instant = Instant.EPOCH */ still comment */
+        val timestamp: Instant
+    """, False)
+
+    case("a different default instant constant is out of scope (CLEAN)", """
+        val cutoff: Instant = Instant.MAX
+    """, False)
+
+    if fails:
+        for f in fails:
+            print(f"SELF-TEST FAILURE: {f}")
+        return 1
+    print(f"self-test OK ({8} cases)")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--enforce", action="store_true",
+                    help="exit 1 on findings (default in this script; kept for flag parity)")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    root = pathlib.Path(args.root)
+    found = find_occurrences(root)
+    baseline = load_baseline(root)
+
+    gatelib.subjects(len(found) + len(baseline), "epoch-default occurrences + baseline entries")
+
+    rc = 0
+    for key, (line_no, text) in sorted(found.items()):
+        if key not in baseline:
+            path = key.split("::", 1)[0]
+            print(f"::error file={path},line={line_no}::new `Instant = Instant.EPOCH` default "
+                  f"({text}) — make the caller supply the time, inject a Clock, or use "
+                  f"Instant.now() at the owning call site (#3882, #4208). If this is genuinely "
+                  f"not event time, baseline it in {BASELINE} with the reason in the PR.")
+            rc = 1
+    for entry in sorted(baseline - set(found)):
+        print(f"::error::baseline entry no longer present in the tree: {entry} — remove it from "
+              f"{BASELINE} in the same PR that removes the occurrence (the list cannot rot).")
+        rc = 1
+
+    if rc == 0:
+        print(f"OK: {len(found)} occurrence(s), all baselined; no new `Instant.EPOCH` defaults.")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check-temporal-worker-switch-naming.py
+++ b/.github/scripts/check-temporal-worker-switch-naming.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Guard: every Temporal worker disable switch is named `openbank.<service>.worker.enabled`.
+
+WHY THIS EXISTS: six services register a Temporal worker at `StartupEvent`, and every registrar
+carries a disable switch so `@QuarkusTest` runs (and the API-fuzz harness) can boot the service
+with no Temporal present. But the property name was invented per service:
+`openbank.transaction.worker.enabled`, `openbank.sepa.worker.enabled`, `openbank.campaign…`,
+`openbank.domestic…`, `openbank.settlement…` — and lending's `lending.origination.worker.enabled`,
+not even under `openbank.`. The fuzz harness therefore cannot derive the switch from the service
+name and must hard-code a per-service name list; a name list drifts, and a drifted list means the
+service under test never booted and its fuzz job reported a failure that was never a finding
+(2026-08-18 run: 6 of 7 "failures" never sent a request).
+
+One convention — `openbank.<service>.worker.enabled` — makes the switch derivable from the
+artifact name everywhere it is needed: the fuzz harness, local dev, the DR manifest, runbooks.
+
+WHAT IT CHECKS: every `@ConfigProperty(name = "…")` in `openbank-*/src/main/kotlin/**.kt` whose
+name ends in `worker.enabled`. The name must match `^openbank\\.[a-z0-9-]+\\.worker\\.enabled$`.
+A genuine exception lives in `rules.yaml: temporal_worker_switch_naming.allowlist` with a
+one-line reason; the allowlist fails on a stale entry in either direction, so an exception
+cannot quietly outlive its reason (same idiom as scheduled_methods.runblocking_allowlist).
+
+The one known exception at introduction (2026-09-03) is lending's
+`lending.origination.worker.enabled`, allowlisted with its rename tracked as an issue: renaming
+a live config property is a coordinated change across registrar, application.yaml, tests and
+deployment config, not a drive-by in a gate PR.
+
+ENFORCED: findings are ::error:: annotations and exit 1.
+
+stdlib + PyYAML + gatelib (both already used by sibling gates in the same CI job).
+Usage: check-temporal-worker-switch-naming.py [--root .] [--rules openbank-libs/governance/rules.yaml] [--self-test]
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+import yaml
+
+import gatelib
+
+CONFIG_PROPERTY_RE = re.compile(r'@(?:param:)?ConfigProperty\(name\s*=\s*"([^"]*worker\.enabled)"')
+CANONICAL_RE = re.compile(r"^openbank\.[a-z0-9-]+\.worker\.enabled$")
+ALLOWLIST_KEY = "temporal_worker_switch_naming"
+
+
+def find_switches(root: pathlib.Path) -> dict[str, tuple[str, int]]:
+    """All worker.enabled switch properties as {name: (path, line_no)}."""
+    found: dict[str, tuple[str, int]] = {}
+    for kt in gatelib.rglob(root, "openbank-*/src/main/**/*.kt"):
+        for idx, line in enumerate(gatelib.read_text(kt).splitlines(), start=1):
+            m = CONFIG_PROPERTY_RE.search(line)
+            if m:
+                found[m.group(1)] = (kt.relative_to(root).as_posix(), idx)
+    return found
+
+
+def load_allowlist(rules_path: pathlib.Path) -> dict[str, str]:
+    data = yaml.safe_load(gatelib.read_text(rules_path)) or {}
+    entries = (data.get(ALLOWLIST_KEY) or {}).get("allowlist") or []
+    return {str(e["property"]): str(e.get("reason", "")) for e in entries if isinstance(e, dict)}
+
+
+def self_test() -> int:
+    fails: list[str] = []
+
+    def case(label: str, name: str, want_canonical: bool) -> None:
+        got = bool(CANONICAL_RE.match(name))
+        if got != want_canonical:
+            fails.append(f"{label}: {name!r} canonical={got}, want {want_canonical}")
+
+    case("canonical", "openbank.transaction.worker.enabled", True)
+    case("canonical with digit", "openbank.ap2.worker.enabled", True)
+    case("the lending exception is NOT canonical", "lending.origination.worker.enabled", False)
+    case("missing openbank prefix is NOT canonical", "campaign.worker.enabled", False)
+    case("extra segment is NOT canonical", "openbank.lending.origination.worker.enabled", False)
+    case("uppercase is NOT canonical", "openbank.SEPA.worker.enabled", False)
+
+    m = CONFIG_PROPERTY_RE.search('@ConfigProperty(name = "openbank.sepa.worker.enabled", defaultValue = "true")')
+    if not m or m.group(1) != "openbank.sepa.worker.enabled":
+        fails.append("plain @ConfigProperty declaration not matched")
+    m = CONFIG_PROPERTY_RE.search('@param:ConfigProperty(name = "lending.origination.worker.enabled", defaultValue = "true")')
+    if not m or m.group(1) != "lending.origination.worker.enabled":
+        fails.append("@param:ConfigProperty use-site form not matched")
+    if CONFIG_PROPERTY_RE.search('@ConfigProperty(name = "openbank.worker.enabledness")'):
+        fails.append("non-worker.enabled property falsely matched")
+
+    if fails:
+        for f in fails:
+            print(f"SELF-TEST FAILURE: {f}")
+        return 1
+    print("self-test OK (9 assertions)")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--rules", default="openbank-libs/governance/rules.yaml")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    root = pathlib.Path(args.root)
+    found = find_switches(root)
+    allowlist = load_allowlist(root / args.rules)
+
+    gatelib.subjects(len(found), "worker.enabled switch properties")
+
+    rc = 0
+    for name, (path, line_no) in sorted(found.items()):
+        if CANONICAL_RE.match(name):
+            continue
+        if name in allowlist:
+            print(f"::notice::{name} ({path}:{line_no}) is non-canonical but allowlisted: "
+                  f"{allowlist[name]}")
+            continue
+        print(f"::error file={path},line={line_no}::Temporal worker disable switch {name!r} does "
+              f"not follow the convention `openbank.<service>.worker.enabled` — an underivable "
+              f"name forces every consumer (fuzz harness, DR manifests, runbooks) to hard-code a "
+              f"drifting name list. Rename it, or allowlist it in rules.yaml: "
+              f"{ALLOWLIST_KEY}.allowlist with the reason.")
+        rc = 1
+    for name in sorted(set(allowlist) - set(found)):
+        print(f"::error::stale allowlist entry {name!r} in rules.yaml: {ALLOWLIST_KEY}.allowlist "
+              f"— no such @ConfigProperty exists; remove the entry in the same PR.")
+        rc = 1
+
+    if rc == 0:
+        canonical = sum(1 for n in found if CANONICAL_RE.match(n))
+        print(f"OK: {len(found)} worker.enabled switches, {canonical} canonical, "
+              f"{len(found) - canonical} allowlisted.")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/audit-2026-09-03-top50.md
+++ b/docs/audit-2026-09-03-top50.md
@@ -1,0 +1,161 @@
+# OpenBank — korporátní audit & Top 50 priorit (2026-09-03)
+
+> Vypracováno analýzou repozitáře: `docs/ROADMAP.md`, `openbank-libs/governance/rules.yaml`,
+> `SECURITY.md`, `docs/openssf-silver-assessment.md`, `docs/threat-models/`, `.github/workflows/`,
+> `pacts/`, `AGENTS.md` (fleet gotchas). Audit je evidence-based na stavu repozitáře k 2026-09-03.
+
+---
+
+## 1. Executive summary
+
+OpenBank je nezvykle disciplinovaný monorepo projekt (~73 modulů, ~34 mikroslužeb, 44 threat modelů,
+70 CI workflow, 270+ ADR). Governance-as-code (`rules.yaml`, 3 137 řádků) je úroveň, kterou většina
+korporátních bankovních platform nemá. Projekt je ale stále **beta, single-maintainer**, a největší
+rizika nejsou technická — jsou organizační (bus factor = 1) a dokazní (coverage 58,7 %, tenké Pact,
+neprokázané DR). Roadmapa M2/M3/M5 běží paralelně; M6/M7 (multi-region) nezačaly.
+
+**Verdikt:** architektura a engineering procesy = korporátní třída. Produktová zralost = referenční
+implementace, ne produkční banka. Největší dluh: dokladní (testy, kontrakty, DR cvičení) a provozní
+reálnost (živé clearing sítě, KYC vendori, regulator submission chybí).
+
+## 2. Technologický stack (hodnocení)
+
+| Vrstva | Volba | Hodnocení |
+|---|---|---|
+| Backend | Quarkus + Kotlin, hexagonal arch (ADR-0002), domain bez framework importů | ✅ Silné, moderní, enforceované |
+| Build | Gradle + convention plugins, JDK 25, lockfiles, digest-pinned images | ✅ Reproducibility téměř, bit-for-bit ne |
+| Data | PostgreSQL 18 (CNPG), Flyway, Panache reactive | ✅ Dobré; non-money-path bez HA |
+| Messaging | Kafka/Redpanda, SmallRye, outbox fleet-wide (31 služeb) | ✅ Outbox OK; DLQ jen 4/44 kanálů |
+| Orchestrace | Temporal (ADR-0101/0120, nahradil custom saga) | ✅ Správné rozhodnutí |
+| AuthN/Z | Keycloak, OPA deny-by-default (enforce jen customer-edge), passkeys/SCA | 🟡 Enforce režim OPA limitovaný |
+| Observability | OTel, Pyrra SLO-as-code, GoAlert, GlitchTip, Grafana | ✅ Velmi silné |
+| Security | gitleaks, CodeQL, Trivy, SBOM+cosign+SLSA+VEX, Kyverno, NetworkPolicy (34 svc), pen-test P0–P2 remediated | ✅ Silné; SLSA L3 formální atestace pending |
+| Frontend | Next.js admin-ui, RUM (ADR-0274) | 🟡 Zralost neznámá, e2e mimo release paths |
+| Customer app | Kotlin Multiplatform/Compose (repo `openbank-app`, mimo tento monorepo). Stav F1: `useFakeData=false`, živý customer edge `customer.open-bank.tech`, reálná data účtů/transakcí. Živý plan-vs-reality dossier v admin-ui `/docs/customer-app` (ADR-0074), derivovaný z `app-status.json` publikovaného app CI | 🟡 Existuje a běží; ne GA v app stores, placeholder credential store, cert pinning neaktivní |
+| AI | copilot/agent-service, sandbox-only LLM | 🟡 Experiment, ne hardenované |
+
+## 3. Silné stránky (co stojí za zachování)
+
+1. Governance-as-code (`rules.yaml`) jako single source of truth, CI-enforced — výjimečné.
+2. ADR kultura (270+ rozhodnutí) + poctivý "known gaps" seznam v roadmapě — vzácná transparentnost.
+3. Incident-driven učení: AGENTS.md gotchas jsou proměněny v CI gaty (check-*.py skripty) — modelový postup.
+4. Release engineering: release-please, per-service SemVer, oasdiff API-contract verzování, merge queue (ADR-0272).
+5. Supply chain: SBOM, cosign, SLSA evidence bundle, VEX, verify-release-evidence workflow.
+6. Money-path disciplína: 2 approvals, threat modely CI-gated, SLO registry jako governed data.
+7. Resilience: transakční outbox fleet-wide, Temporal, idempotence, CNPG HA s live-verified switchover.
+8. **As-built dokumentace derivovaná z kódu, ne z prose**: customer-app dossier v admin-ui (`/docs/customer-app`, ADR-0074) čte stav z `AppConfig.kt` + `app-status.json` publikovaného app CI, s live ADR statusy — drift README-vs-kód je CI signál, ne lidská povinnost. Vzor, který stojí za zobecnění.
+
+## 4. Klíčová rizika (korporátní pohled)
+
+- **Bus factor = 1.** OpenSSF `bus_factor` a `two_person_review` jsou poctivě Unmet. Pro korporátní adopci je to dealbreaker #1.
+- **Coverage 58,7 % fleet-wide** (Silver blocker); pitest jen na 9 money-path službách.
+- **Důkazní mezery:** DR restore-verify je dispatch-only, ne naplánovaný; SLO targets jsou "reference defaults, not calibrated"; fuzz harness u 6/7 failing jobů nikdy neposlal request (testy, které netestují).
+- **Provozní nerealita:** žádné živé SEPA/SWIFT/CERTIS připojení, KYC/AML vendori jsou stubby, FINREP/AnaCredit neposílají regulátorovi, SCA bez FIDO2 attestation. Customer app existuje a běží (F1, reálná data), ale není GA v app stores a SCA/credential-store v ní je placeholder.
+- **ML/PD-LGD placeholdery** v lending — samo přiznané.
+- **DLQ pokrytí 4/44** při současném sweepu retry-then-rethrow → riziko zaseknutých consumerů na money path.
+
+## 5. Top 50 prioritních návrhů
+
+Skupiny: **A** = existenční/organizační, **B** = dokladní kvalita, **C** = bezpečnost,
+**D** = produktová zralost, **E** = provoz/infra, **F** = hygiena/dluh.
+
+### A. Organizace & governance (korporace to řeší první)
+
+1. **Bus factor → 2+**: onboarduj druhého maintainera s merge právy; bez toho je cokoli níže korporátně nedozrává. (OpenSSF Silver/Gold blocker.)
+2. **Fleet-wide two-person review**: rozšiř 2-approval pravidlo z money-path na celý fleet (nebo aspoň vše s `version.txt`).
+3. **Formalizuj governance přechod** maintainer → council (je v workstreams; dodej termíny a kritéria).
+4. **Funding/sustainability plán**: SPONSORS.md existuje — korporátní adopter potřebuje vidět 2-letou udržitelnost.
+5. **Public launch dokončit**: M1 hotovo; chybí doc polish + veřejně přístupný security disclosure workflow — to je gating podmínka, dotačněte.
+6. **Backup maintainer access test**: `access_continuity` je "Met" na papíře — proveď jednou ročně reálné předání-klíčů cvičení a zdokumentuj ho.
+7. **SLA tightening plán**: SECURITY.md SLA jsou "best-effort single maintainer" — definuj, co se změní při příchodu maintainera #2.
+
+### B. Dokladní kvalita (testy, kontrakty, důkazy)
+
+8. **Coverage 58,7 % → 70 % fleet-wide**: Silver blocker; ratchet roadmap #321 zrychlit, kvartální milníky s deadliny.
+9. **Pact pokrytí rozšířit**: Pact Broker žije, ale coverage je "thin" — povinný pact pro každý cross-service HTTP call na money path.
+10. **DLQ pro všech 44 incoming kanálů**: při retry-then-rethrow sweepu (#5698) je to bezpečnostní nutnost; explicitní per-service DLQ topics + KafkaTopic CR + Write ACL (všechny 4 části).
+11. **DR restore-verify na quarterly schedule**: workflow existuje, ale je dispatch-only — RTO/RPO jsou "stated, not demonstrated". Naplánovat a reportovat výsledky.
+12. **Fuzz harness opravit**: 6/7 failing fuzz jobů nikdy neposlalo request (config-expression username, Temporal registrars). Fuzz, který nefuzzuje, je horší než žádný — falešný pocit pokrytí.
+13. **Mutation testing rozšířit** z 9 money-path služeb na všechny money-path (14) + security-critical (sca, consent, authz).
+14. **Kalibrovat SLO targets**: rules.yaml přiznává, že jsou to nekaliброванé defaulty — i bez provozu lze kalibrovat z perf-baseline/perf-gate běhů.
+15. **Idempotency coverage audit (M2 gap)**: změřit a reportovat pokrytí idempotency klíčů napříč POST endpointy; roadmapa to zmiňuje jako remaining gap.
+16. **Schemathesis fuzz na všech nasazených službách**: vop a settlement nikdy nebyly fuzznuty; temporal-worker služby padaly na boot — vyřešeno harness fixem? Ověřit a zavřít.
+17. **Audit-trail `occurredAt` vs ingest-time sweep dokončit**: 7/21 topiců bez event time → řádek tvrdí business time, který nikdy nezměřil (#3883/#3907; ověřit zbytek fleetu).
+18. **Integration-test depth (M2 gap)**: kvartální cíl — každá money-path služba má aspoň 1 real-DB outbox atomicity IT (vzor `LendingOutboxWriteIT`).
+19. **E2E admin-ui zahrnout do release paths** nebo vědomě zdokumentovat, proč ne — dnes e2e nevyvolá release.
+20. **Reproducible builds**: `preserveFileTimestamps=false` + rebuild-and-compare job (OpenSSF `build_reproducible` Unmet).
+21. **Vyplnit OpenSSF Silver formulář**: Silver je na 13 % jen proto, že formulář není vyplněný — assessment doc má paste-ready zdůvodnění. Náklad: hodiny. Výtěžek: důvěryhodnost.
+
+### C. Bezpečnost
+
+22. **OPA enforce režim rozšířit** za customer-edge — dnes deny-by-default enforce běží jen tam; definovat rollout plán na další edge služby.
+23. **SLSA L3 formální atestace** dokončit (M5 remaining).
+24. **OWASP ASVS L3 self-assessment** dokončit (M5 remaining) — máte assurance-case jako základ.
+25. **mTLS in-cluster migration (ADR-0137)** dokončit a reportovat stav.
+26. **Four-eyes na sdd-service a interest-service**: rules.yaml výslovně říká "not yet assessed" (#1478) — tyto služby hýbou penězi.
+27. **Four-eyes wiring pro sca-service**: posouzeno, ale NE zapojeno, protože by to bricklo automation — vyřešit přes dedikovaný service-account model, ne nechat otevřené.
+28. **SCA dokončit**: FIDO2 attestation + reálné OTP delivery (roadmapa gap).
+29. **AI copilot hardening**: model gateway, rate-limiting, abuse guardrails před jakýmkoli public traffic — dnes sandbox-only a tak to má zůstat, dokud není hardening.
+30. **Kafka dotted-keys baselined 6 služeb (#2945)**: dotáhnout sweep; hrozba mass-replay při rename consumer groupy na money-path.
+31. ~~**Závislostní verifikace dokončit**~~ — ✅ OVĚŘENO JAKO HOTOVÉ (2026-09-03): `gradle/verification-metadata.xml` existuje, SHA-256 pinning všech resolvnutých závislostí, `dependabot-verification-metadata.yml` udržuje metadata automaticky. Audit se opíral o zastaralý záznam v OpenSSF assessmentu — doplnit tam "Met".
+32. **Keycloak/Vault/Postgres hardening runbooky pro deployery**: SECURITY.md deleguje, ale korporátní adopter ocení referenční hardening guide v docs/.
+33. **Pen-test #2 (opakovací)**: první pen-test remediated; M5 chce "independent pen-test" jako gate — naplánovat druhý na M5 exit.
+34. **security.txt expiry & disclosure dry-run**: ověřit, že security@open-bank.tech mailbox je monitorovaný a security.txt neexpiruje.
+
+### D. Produktová zralost (z pohledu adopce)
+
+35. **Live SEPA/CERTIS sandbox připojení**: alespoň jedna reálná testovací síť (např. bankovní sandbox), jinak "banking platform" zůstává simulace.
+36. **Net-settlement ledger leg**: chybějící část clearing pipeline (roadmapa gap).
+37. **KYC/AML vendor integrace**: aspoň jeden reálný provider adapter (ComplyAdvantage/EBA feed) místo seed listů; interface už existuje.
+38. **Regulator submission pro FINREP/AnaCredit**: i jen ČNB testovací endpoint; jinak služby generují PDF do prázdna.
+39. **Customer app: GA příprava, ne existence**: appka je F1 a běží proti živému edge — priority jsou app-store release checklist, náhrada placeholder credential store za hardware-backed (ADR-0073), aktivace cert pinningu (dossier ukazuje `certPinningConfigured`/`certPinningActive`), FIDO2 attestation navazující na #28. Zdroj pravdy je dossier `/docs/customer-app`, ne README appky (ADR-0074 dokládá, že README driftuje).
+40. **PD/LGD placeholdery v lending nahradit** kalibrovatelným modelem + poctivou dokumentací limitů (už částečně disclosed).
+41. **Developer onboarding UX**: Codespaces je; přidej 15-minutový "first contribution" path a změř ho (issue-hygiene ukazatele).
+42. **Reference deployment guide pro korporace**: DEPLOYMENT.md + doporučené sizing, HA topologie, odhadované náklady — to korporátní evaluator hledá jako první.
+
+### E. Provoz & infra
+
+43. **HA pro non-money-path DB**: dnes `instances: 1`; definovat, které služby jsou Tier-B, a dát jim aspoň PITR + dokumentovaný restore runbook.
+44. **M6 start: multi-region active-passive design**: DR cvičení (bod 11) je prerekvizita; začít design ADR pro RTO ≤ 30 min.
+45. **PostgreSQL 16→18 v local Docker dev**: drift proti CNPG fleetu (PG18) — sjednotit, jinak lokální testy netestují produkční dialect.
+46. **Temporal worker disable-switch naming**: 5+ různých property jmen pro totéž (`openbank.X.worker.enabled` vs `lending.origination.worker.enabled`) — sjednotit konvenci, harness na to doplul bolestivě.
+47. **Auto-deploy drift watch**: `deploy-drift-watch.yml` existuje — reportovat drift metriku do README/dashboardu, ať je vidět.
+
+### F. Hygiena & tech dluh
+
+48. **Consumer-group rename riziko**: 6 služeb má `group.id` správně jen náhodou (== application name) — explicitní group.id všude, dokumentované rename-riziko.
+49. **AGENTS.md gotchas → machine-checks parity audit**: několik gotchas (např. `Instant.EPOCH` defaulty, `enabled=false` + `success=true` shape) má grep-able pattern, ale ne CI gate — doplnit check skripty tam, kde je to decidable.
+50. **Licence/trademark připravenost pro public**: REUSE/NOTICE/TRADEMARKS existují — finální právní review před public-launch triggerem.
+
+## 6. Navrhované pořadí (90 dní)
+
+| Týdny | Fokus |
+|---|---|
+| 1–2 | #21 (OpenSSF formulář), #5 (public launch gates), #12 (fuzz harness) — levné, vysoká výtěžnost |
+| 3–6 | #10 (DLQ sweep), #8 (coverage push), #9 (Pact money-path), #26–27 (four-eyes mezery) |
+| 7–10 | #11 (DR cvičení naplánovat + první běh), #22 (OPA rollout), #37–38 (jedna reálná vendor/regulator integrace) |
+| 11–13 | #1–2 (maintainer #2 onboarding), #23–24 (SLSA L3 + ASVS L3), #43 (Tier-B DB ochrana) |
+
+## 7. Co NEDĚLAT (stejně důležité)
+
+- Nezačínat M7 (active-active) před prokázaným M6.
+- Neotevírat AI copilot public traffic před #29.
+- Nepřidávat nové služby, dokud coverage/DLQ/Pact mezery na existujících nejsou uzavřené.
+- Neměnit release/governance mechaniku ručně — vždy přes `rules.yaml` + ADR.
+
+---
+
+## 8. Stav zpracování (2026-09-03)
+
+**Pull requesty**
+- PR [#8358](https://github.com/JiRaska/open-bank-oss/pull/8358) — CI gates: `no-epoch-instant-default` (58 výskytů baselined, ratchet) + `temporal-worker-switch-naming` (konvence + 1 allowlist výjimka v rules.yaml). Body F49/E46.
+- PR [#8369](https://github.com/JiRaska/open-bank-oss/pull/8369) — e2e release-exclusion zdokumentováno v CONTRIBUTING.md (B19) + deploy-drift badge v README (E47).
+
+**Issues (ADR-0052 backlog)**
+- B: #8344 coverage→70 %, #8345 Pact money-path, #8346 DLQ 44 kanálů, #8347 DR quarterly, #8348 fuzz harness, #8349 pitest rozšíření, #8350 SLO kalibrace, #8351 idempotence inventář, #8352 audit event-time, #8353 outbox IT sweep, #8354 e2e exclusion (uzavřeno PR #8369), #8355 reproducible builds
+- C: #8359 four-eyes sdd+interest, #8360 sca four-eyes stalemate; C31 ověřeno jako hotové (verification-metadata.xml existuje)
+- D: #8361 net-settlement leg, #8362 KYC/AML adapter, #8363 customer app GA, #8364 PD/LGD kalibrace, #8365 onboarding path, #8366 deployment guide
+- E/F: #8357 (gates tracker), #8370 (11 auto.offset.reset baseline položek — owner decisions)
+- Již existující, převzato do trackingu: #7867, #7376, #5913, #5752, #4757, #6568
+
+**Poznámka k provedení:** hlavní pracovní strom měl ~2 500 necommitnutých změn z paralelních sezení — veškerá git práce proto proběhla v izolovaném worktree `tmp/wt-audit` z `origin/main`, aby se nepřimíchala cizí rozpracovanost.

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1502,6 +1502,24 @@ authz_policy:
 # ---------------------------------------------------------------------------------------
 # Scheduled-method invariants (issue #2148, fleet sweep #2187).
 # ---------------------------------------------------------------------------------------
+# ---------------------------------------------------------------------------------------
+# Temporal worker disable-switch naming (audit Top-50 E46). Every service that registers a
+# Temporal worker at StartupEvent carries a switch so tests / the fuzz harness / DR manifests
+# can boot without Temporal. The name MUST be derivable: `openbank.<service>.worker.enabled`.
+# An invented-per-service name forces every consumer to hard-code a drifting name list — the
+# 2026-08-18 fuzz run shipped 6 "failures" that never sent a request, partly on this.
+# Enforced by .github/scripts/check-temporal-worker-switch-naming.py (gate
+# temporal-worker-switch-naming). Allowlist entries fail stale in either direction.
+# ---------------------------------------------------------------------------------------
+temporal_worker_switch_naming:
+  convention: "openbank.<service>.worker.enabled"
+  allowlist:
+    - property: "lending.origination.worker.enabled"
+      reason: >-
+        Pre-dates the convention; renaming a live config property is a coordinated change
+        across registrar, application.yaml, tests and deployment config — tracked as a
+        follow-up issue, not a drive-by in the gate PR.
+
 scheduled_methods:
   no_runblocking_in_scheduled_body: true
   # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,


### PR DESCRIPTION
## Summary

Two audit Top-50 follow-ups convert documented AGENTS.md gotchas into enforced CI gates — prose is not a control. Both gates run self-test-first under `run-gates.py`, are registered in `gates.yaml` (kotlin group, enforced), and were verified locally via `run-gates.py --only` plus the registration/graduation meta-gates.

## Type of change

- [x] chore (build / tooling)

## Linked issues

Refs #8357

## Changes

- `check-no-epoch-instant-default.py` — no `Instant = Instant.EPOCH` default in `src/main` (#3882/#4208 defect class: passes `isNotNull()`, seeds lies into metrics and audit envelopes). The 58 existing occurrences are baselined in `.github/gates/epoch-instant-default-baseline.txt`; the ratchet fails on new occurrences **and** on stale baseline entries, so the list cannot rot. Baseline keys are `path::line-text#n` — the `#n` disambiguates identical lines in one file (Card.kt alone carries 12), without which the ratchet could not tell "one fixed" from "one added".
- `check-temporal-worker-switch-naming.py` — every Temporal worker disable switch follows `openbank.<service>.worker.enabled` so the fuzz harness, DR manifests and runbooks can derive it (the 2026-08-18 fuzz run shipped 6 "failures" that never sent a request, partly on underivable switch names). Convention + the single pre-existing exception recorded in `rules.yaml: temporal_worker_switch_naming.allowlist` (`lending.origination.worker.enabled`; its rename is a coordinated config change tracked in #8357, not a drive-by here). Allowlist fails stale in both directions.

## Definition of Done

- [x] Hexagonal layering preserved (no service code touched).
- [x] Unit tests added/updated — both scripts carry `--self-test` fixtures (8 + 9 assertions), run by the gate runner before the gate itself.
- [x] `./gradlew detekt ktlintCheck koverVerify build` — N/A: no Kotlin source changed; gates verified through `run-gates.py` (the runner these gates execute under).
- [x] No new lint warnings.
- [x] Docs updated — gate rationale comments in gates.yaml + rules.yaml section.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new third-party dependency (stdlib + PyYAML + gatelib, same as sibling gates).

## Compliance impact

- [x] None (CI tooling only; DORA-relevant as change-control evidence, no product surface changed).
