### PR TITLE
docs(customer-edge): publish the surface fields the proxy already forwards

### DIFF
--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.48.0
+  version: 1.49.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -4244,6 +4244,33 @@ components:
         variables:
           type: array
           items: {type: string}
+          description: >-
+            The presentation variable KEYS a catalogue item declares. Names, never values — copy
+            for a catalogue item lives in the app, which is what keeps this a typed server decision
+            rather than remote UI markup.
+        values:
+          type: object
+          additionalProperties: {type: string}
+          description: >-
+            Resolved values, present ONLY for a trusted campaign assignment; a catalogue item
+            declares keys and sends no values. A client that cannot see this renders a campaign
+            banner with its variables unfilled.
+        deepLink:
+          type: string
+          nullable: true
+          description: >-
+            Where a tap should go, as a closed `openbank://` app route. engagement-service enforces
+            the SCHEME only (`CampaignBannerPlacement` requires the `openbank://` prefix); it does
+            not constrain the destination, so a client must resolve this through its own allowlist
+            of known routes and ignore anything it does not recognise. Absent for content with no
+            tap target.
+        interactionRef:
+          type: string
+          format: uuid
+          nullable: true
+          description: >-
+            Opaque reference tying this content to a campaign send. Copy it back verbatim on the
+            engagement event so attribution can be resolved server-side; the app never interprets it.
 
     EngagementSurfaceEvent:
       type: object


### PR DESCRIPTION
## What

`getSurface` returns engagement-service's response **verbatim** (`upstream.get(...)`), and that response carries `values`, `deepLink` and `interactionRef` — see the service's own `SurfaceContent`. The edge's `EngagementSurfaceContent` declared only `id`/`slot`/`type`/`variables`.

Three fields the edge serves were invisible to any client reading the contract. No behaviour change here; they are already on the wire.

## Why each one matters

- **`values`** — catalogue items declare variable *keys* only; a trusted campaign assignment is the one case that carries resolved copy. Without it a campaign banner renders with its variables unfilled.
- **`deepLink`** — without it a banner tap has nowhere to go, which is most of what a banner is for.
- **`interactionRef`** — without it the engagement event cannot carry attribution back, so the campaign feedback loop silently measures nothing.

## The part worth reading

I also wrote down where the deep-link trust boundary actually sits, because the schema is the only place a client would look.

engagement-service enforces the **scheme** and nothing else — `CampaignBannerPlacement` does `require(deepLink.startsWith("openbank://"))`, with no constraint on the destination. So a campaign author can emit `openbank://` anything, and **a client must resolve the route through its own allowlist and ignore what it does not recognise.**

That was already true and undocumented. A client written against the old schema could not have known to do it — which is exactly the kind of gap that produces a client that "works" until a campaign points somewhere it shouldn't.

## Note on ordering

Bumps `info.version` 1.48.0 → 1.49.0. If open-bank-oss#8321 (still open, money-path) merges after this, it needs a re-bump to 1.50.0 — it currently claims 1.48.0.

## Linked issues
N/A — publishing already-served fields found while wiring the app client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
