### PR TITLE
docs(contributing): record e2e release-exclusion decision; deploy-drift badge on README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,15 @@ issue → fork → branch → commit -s -S → push → PR → review → CI gre
 
 `<scope>` = service name without `openbank-` prefix (e.g. `ledger`, `psd2`, `sepa`).
 
+> **Why admin-ui `e2e/` does not trigger a release** (recorded decision, #8354): release-please
+> releases on commit type × touched path, and `openbank-admin-ui/e2e` sits in `exclude-paths`
+> next to `src/test`. That is deliberate: e2e specs verify the *deployed* system (the browser
+> synthetic lane attests the deployed build), they ship no runtime artifact, and releasing the
+> npm package for a test-only change would cut a version whose bits are identical to the
+> previous one. If an e2e change ever ships a behavioural fix to the harness users run locally,
+> say so in the PR and use a `fix(admin-ui)` commit touching a non-excluded path. Do not
+> "fix" the exclusion without reading this note.
+
 ### Commit messages (Conventional Commits)
 
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/JiRaska/open-bank-oss/badge)](https://scorecard.dev/viewer/?uri=github.com/JiRaska/open-bank-oss)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13505/badge)](https://www.bestpractices.dev/projects/13505)
 [![codecov](https://codecov.io/gh/JiRaska/open-bank-oss/graph/badge.svg)](https://codecov.io/gh/JiRaska/open-bank-oss)
+[![Deploy drift](https://img.shields.io/github/issues-search/JiRaska/open-bank-oss?query=label%3Adeploy-drift%20state%3Aopen&label=deploy%20drift)](https://github.com/JiRaska/open-bank-oss/issues?q=label%3Adeploy-drift+state%3Aopen)
 [![Open in GitHub Codespaces](https://img.shields.io/badge/Codespaces-Open-181717?logo=github)](https://codespaces.new/JiRaska/open-bank-oss)
 [![Platform: Apache 2.0](https://img.shields.io/badge/Platform-Apache_2.0-brightgreen.svg)](https://opensource.org/licenses/Apache-2.0)
 [![AI agents: AGPL-3.0 + commercial](https://img.shields.io/badge/AI_agents-AGPL--3.0--only_%2B_commercial-blue.svg)](docs/adr/0136-agent-services-agpl-in-repo-open-core.md)


### PR DESCRIPTION
## Summary

Two small audit Top-50 items: record the admin-ui e2e release-exclusion decision where a contributor will find it, and make deploy drift visible without opening CI logs.

## Type of change

- [x] docs

## Linked issues

Refs #8354

## Changes

- `CONTRIBUTING.md` — the release-please `exclude-paths` entry for `openbank-admin-ui/e2e` is now a recorded decision: deliberate (e2e verifies the *deployed* system via the browser synthetic lane and ships no runtime artifact), with guidance for the day an e2e change does carry a behavioural fix. Decision recorded, exclusion kept — closes the "undocumented WHY" gap.
- `README.md` — a shields `issues-search` badge counting open `deploy-drift`-labelled issues. The drift watch already escalates one issue per drifted service (#3344 design); the badge puts the count on the front page.

## Definition of Done

- [x] Docs-only change; no code, config, or API touched.
- [x] Badge URL verified against the shields issues-search endpoint format used for GitHub label+state queries.

## Security checklist

- [x] No secrets, no PII, no new dependency.

## Compliance impact

- [x] None
