### PR TITLE
fix(lending): rename worker switch to openbank.lending.worker.enabled

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -4689,11 +4689,12 @@ gates:
     run: |
       python3 .github/scripts/check-no-epoch-instant-default.py --root .
 
-  # temporal-worker-switch-naming: six Temporal-worker services, six disable switches, five
-  # under `openbank.<service>.worker.enabled` and lending's under `lending.origination…` — an
-  # underivable name is why the fuzz harness needs a hard-coded name list, and a drifted list is
-  # how a fuzz job reports a failure that never sent a request (2026-08-18 run). Convention and
-  # the one allowlisted exception live in rules.yaml: temporal_worker_switch_naming.
+  # temporal-worker-switch-naming: six Temporal-worker services once carried six invented names
+  # for the same switch — an underivable name is why the fuzz harness needed a hard-coded list,
+  # and a drifted list is how a fuzz job reports a failure that never sent a request
+  # (2026-08-18 run). The one pre-convention name (lending.origination.worker.enabled) was
+  # renamed in the same follow-up; the convention and the (now empty) allowlist live in
+  # rules.yaml: temporal_worker_switch_naming.
   - id: temporal-worker-switch-naming
     name: "Temporal worker disable switches follow openbank.<service>.worker.enabled (enforced)"
     group: kotlin

--- a/.github/scripts/check-temporal-worker-switch-naming.py
+++ b/.github/scripts/check-temporal-worker-switch-naming.py
@@ -6,10 +6,11 @@ carries a disable switch so `@QuarkusTest` runs (and the API-fuzz harness) can b
 with no Temporal present. But the property name was invented per service:
 `openbank.transaction.worker.enabled`, `openbank.sepa.worker.enabled`, `openbank.campaign…`,
 `openbank.domestic…`, `openbank.settlement…` — and lending's `lending.origination.worker.enabled`,
-not even under `openbank.`. The fuzz harness therefore cannot derive the switch from the service
-name and must hard-code a per-service name list; a name list drifts, and a drifted list means the
-service under test never booted and its fuzz job reported a failure that was never a finding
-(2026-08-18 run: 6 of 7 "failures" never sent a request).
+not even under `openbank.` (since renamed; see below). The fuzz harness therefore could not
+derive the switch from the service name and had to hard-code a per-service name list; a name
+list drifts, and a drifted list means the service under test never booted and its fuzz job
+reported a failure that was never a finding (2026-08-18 run: 6 of 7 "failures" never sent a
+request).
 
 One convention — `openbank.<service>.worker.enabled` — makes the switch derivable from the
 artifact name everywhere it is needed: the fuzz harness, local dev, the DR manifest, runbooks.
@@ -20,10 +21,11 @@ A genuine exception lives in `rules.yaml: temporal_worker_switch_naming.allowlis
 one-line reason; the allowlist fails on a stale entry in either direction, so an exception
 cannot quietly outlive its reason (same idiom as scheduled_methods.runblocking_allowlist).
 
-The one known exception at introduction (2026-09-03) is lending's
-`lending.origination.worker.enabled`, allowlisted with its rename tracked as an issue: renaming
-a live config property is a coordinated change across registrar, application.yaml, tests and
-deployment config, not a drive-by in a gate PR.
+The fleet's one pre-convention name — lending's `lending.origination.worker.enabled` — was
+renamed to `openbank.lending.worker.enabled` in the same follow-up that introduced this guard;
+the allowlist (`rules.yaml: temporal_worker_switch_naming.allowlist`) stays armed, and fails on
+a stale entry in either direction, so the next exception must be named and justified rather than
+absorbed.
 
 ENFORCED: findings are ::error:: annotations and exit 1.
 

--- a/.github/scripts/fuzz-services.sh
+++ b/.github/scripts/fuzz-services.sh
@@ -44,11 +44,13 @@
 # retried past the boot deadline. Four money-path services were once reported as fuzz failures for
 # an absent dependency, which is not a finding about their HTTP surface, and it drowned the one
 # real finding in the same run (consent-service, #5711). Every registrar already has the switch
-# (because @QuarkusTest needs it too); what they do not share is a name for it —
-# openbank.transaction.worker.enabled, openbank.domestic.worker.enabled,
-# openbank.sepa.worker.enabled, openbank.campaign.worker.enabled,
-# openbank.settlement.worker.enabled, and lending's `lending.origination.worker.enabled` (not even
-# under `openbank.`).
+# (because @QuarkusTest needs it too). Since the `temporal-worker-switch-naming` gate the names
+# also follow one convention — `openbank.<service>.worker.enabled` — so this derivation is now
+# uniform rather than a per-service list: openbank.transaction.worker.enabled,
+# openbank.domestic.worker.enabled, openbank.sepa.worker.enabled,
+# openbank.campaign.worker.enabled, openbank.settlement.worker.enabled,
+# openbank.lending.worker.enabled (lending renamed from `lending.origination.worker.enabled`,
+# the one pre-convention name).
 #
 # ── Two passes, both must pass ─────────────────────────────────────────────────────────────────
 # Pass 1 (auth ON) is what this lane has always done: every endpoint behind @RolesAllowed must

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,10 +376,9 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
   settlement had therefore NEVER been fuzzed; and six services register a Temporal worker at
   `StartupEvent`, so with no Temporal present transaction-service failed to boot outright while
   lending, sepa-payment and domestic-payment retried past the deadline. Every registrar carries a
-  disable switch but under a DIFFERENT name each (`openbank.transaction.worker.enabled`,
-  `openbank.sepa.worker.enabled`, … and lending's `lending.origination.worker.enabled`, not even
-  under `openbank.`), so the harness derives the property from each registrar's own
-  `@ConfigProperty` rather than listing six names. This matters beyond the lane: the `pentest`
+  disable switch, and since the `temporal-worker-switch-naming` gate (2026-09) all of them follow
+  one convention — `openbank.<service>.worker.enabled` — so the harness derives the property from
+  each registrar's own `@ConfigProperty` rather than listing names. This matters beyond the lane: the `pentest`
   attestation is earned by this workflow with its run URL as `ref`, so while a service could not be
   fuzzed, C7=Bank-grade was blocked on an event that could not happen for it.
 

--- a/docs/threat-models/openbank-lending-service.md
+++ b/docs/threat-models/openbank-lending-service.md
@@ -154,7 +154,8 @@
     environment.** The bound no-op logged at `debug` and returned `Uni<Unit>`, the Temporal
     adapter's exact success value, so nothing disagreed. Two details make this a distinct entry
     rather than a footnote to the above. First, the *worker* half is not build-time gated
-    (`lending.origination.worker.enabled`), so the deployed pod registered the timers worker and
+    (switched by `openbank.lending.worker.enabled`; named `lending.origination.worker.enabled`
+    at the time of the incident), so the deployed pod registered the timers worker and
     polled the task queue normally the whole time — every observable that a reviewer would reach
     for (worker started, queue exists, pollers healthy, no errors) was green, and the client that
     starts a workflow was simply not in the image. Second, the no-op here reports a distinct

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/workflow/OriginationTimersWorkerRegistrar.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/workflow/OriginationTimersWorkerRegistrar.kt
@@ -15,12 +15,12 @@ import org.jboss.logging.Logger
 /**
  * Registers the origination-timers worker (ADR-0211 D2), mirroring the
  * domestic-payment registrar: gated separately from dispatch by
- * `lending.origination.worker.enabled` (default true) so `@QuarkusTest` runs with no
+ * `openbank.lending.worker.enabled` (default true) so `@QuarkusTest` runs with no
  * real Temporal frontend can set it false and boot clean.
  */
 @ApplicationScoped
 class OriginationTimersWorkerRegistrar(
-    @param:ConfigProperty(name = "lending.origination.worker.enabled", defaultValue = "true")
+    @param:ConfigProperty(name = "openbank.lending.worker.enabled", defaultValue = "true")
     private val workerEnabled: Boolean,
     @param:ConfigProperty(name = "openbank.temporal.task-queue", defaultValue = "openbank-lending-origination")
     private val taskQueue: String,
@@ -33,7 +33,7 @@ class OriginationTimersWorkerRegistrar(
     @Suppress("UnusedParameter")
     fun onStart(@Observes event: StartupEvent) {
         if (!workerEnabled) {
-            log.info("Temporal origination worker disabled (lending.origination.worker.enabled=false)")
+            log.info("Temporal origination worker disabled (openbank.lending.worker.enabled=false)")
             return
         }
         log.infof("Registering Temporal worker on task queue '%s'", taskQueue)

--- a/openbank-lending-service/src/main/resources/application.yaml
+++ b/openbank-lending-service/src/main/resources/application.yaml
@@ -134,8 +134,8 @@ quarkus:
     # so the management interface (default :8086) must be folded back in (else /q/health/* 404s).
     management:
       enabled: false
-  lending:
-    origination:
+  openbank:
+    lending:
       # No real Temporal frontend in @QuarkusTest: don't register the timers worker (it would
       # fail boot on Connection refused). Workflow tests drive their own TestWorkflowEnvironment.
       worker:
@@ -169,6 +169,11 @@ openbank:
     server-url: ${TEMPORAL_FRONTEND_URL:temporal-frontend.temporal.svc.cluster.local:7233}
     namespace: ${OPENBANK_TEMPORAL_NAMESPACE:openbank-lending}
     task-queue: ${OPENBANK_TEMPORAL_TASK_QUEUE:openbank-lending-origination}
+  lending:
+    # Temporal timers-worker switch (temporal-worker-switch-naming convention,
+    # rules.yaml: temporal_worker_switch_naming). Env var name unchanged.
+    worker:
+      enabled: ${LENDING_ORIGINATION_WORKER_ENABLED:true}
 
 # Ledger posting (ADR-0028 D3). `backend=rest` build-time-activates RestLedgerPostingAdapter against
 # ledger-service; left as `none` the @Default no-op stays bound and the service builds/boots offline.
@@ -227,8 +232,6 @@ lending:
     # READY_TO_DISBURSE by the 'sandbox-auto-approval' actor so sandbox e2e runs without an operator.
     # Restart-required. MUST stay false in production — it bypasses the four-eyes gate entirely.
     auto-approve: ${LENDING_ORIGINATION_AUTO_APPROVE:false}
-    worker:
-      enabled: ${LENDING_ORIGINATION_WORKER_ENABLED:true}
     timers:
       offer-validity-days: ${LENDING_OFFER_VALIDITY_DAYS:30}
       docs-sla-days: ${LENDING_DOCS_SLA_DAYS:14}

--- a/openbank-lending-service/src/main/resources/application.yaml
+++ b/openbank-lending-service/src/main/resources/application.yaml
@@ -163,7 +163,7 @@ openbank:
     # LendingAdapterBindingVerifier refuses to boot if the two ever disagree again.
     #
     # Note this gates only the CLIENT half. OriginationTimersWorkerRegistrar is not build-time
-    # gated (it is switched by lending.origination.worker.enabled), so the deployed pod has been
+    # gated (it is switched by openbank.lending.worker.enabled), so the deployed pod has been
     # polling the task queue all along with nothing ever starting a workflow on it.
     enabled: ${OPENBANK_TEMPORAL_ENABLED:false}
     server-url: ${TEMPORAL_FRONTEND_URL:temporal-frontend.temporal.svc.cluster.local:7233}

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/integration/OriginationWorkflowAdapterBindingIT.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/integration/OriginationWorkflowAdapterBindingIT.kt
@@ -97,7 +97,7 @@ class InertOriginationWorkflowAdapterBindingIT {
 class TemporalEnabledProfile : QuarkusTestProfile {
     override fun getConfigOverrides(): Map<String, String> = mapOf(
         "openbank.temporal.enabled" to "true",
-        "lending.origination.worker.enabled" to "false",
+        "openbank.lending.worker.enabled" to "false",
     )
 }
 
@@ -105,6 +105,6 @@ class TemporalEnabledProfile : QuarkusTestProfile {
 class TemporalDisabledProfile : QuarkusTestProfile {
     override fun getConfigOverrides(): Map<String, String> = mapOf(
         "openbank.temporal.enabled" to "false",
-        "lending.origination.worker.enabled" to "false",
+        "openbank.lending.worker.enabled" to "false",
     )
 }

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1513,12 +1513,11 @@ authz_policy:
 # ---------------------------------------------------------------------------------------
 temporal_worker_switch_naming:
   convention: "openbank.<service>.worker.enabled"
-  allowlist:
-    - property: "lending.origination.worker.enabled"
-      reason: >-
-        Pre-dates the convention; renaming a live config property is a coordinated change
-        across registrar, application.yaml, tests and deployment config — tracked as a
-        follow-up issue, not a drive-by in the gate PR.
+  allowlist: []
+  # The one pre-convention name, lending's `lending.origination.worker.enabled`, was renamed
+  # to `openbank.lending.worker.enabled` in the same audit follow-up that introduced the gate;
+  # the allowlist mechanism stays (and fails stale in either direction) for the next exception
+  # that genuinely cannot be renamed.
 
 scheduled_methods:
   no_runblocking_in_scheduled_body: true


### PR DESCRIPTION
## Summary

Renames the fleet's one pre-convention Temporal worker disable switch — `lending.origination.worker.enabled` (not even under `openbank.`) — to `openbank.lending.worker.enabled`, the convention enforced by the `temporal-worker-switch-naming` gate. Stacked on #8358 (the gate this satisfies); the rules.yaml allowlist goes back to empty and stays armed.

## Type of change

- [x] fix (config-property rename; no behavioural change — no deployment sets the property)

## Linked issues

Refs #8357

## Changes

- `OriginationTimersWorkerRegistrar.kt` — `@param:ConfigProperty` name + KDoc + log line.
- `OriginationWorkflowAdapterBindingIT.kt` — both test overrides.
- `application.yaml` comment; `fuzz-services.sh` header (the harness derives the switch by grep, so it needs no logic change).
- `docs/threat-models/openbank-lending-service.md` — mechanism updated, incident-time name preserved in the historical narrative.
- `CLAUDE.md` — gotcha updated to the post-convention state.
- `rules.yaml: temporal_worker_switch_naming.allowlist` — emptied; the mechanism fails stale in either direction for the next genuine exception.

## Blast radius

Checked: no gitops manifest or deployment config sets the property (the switch exists for `@QuarkusTest` and the fuzz harness). Local dev/tests using the old name would silently run the worker — no such usage found in the tree.

## Definition of Done

- [x] `:openbank-lending-service:compileKotlin` + `compileTestKotlin` BUILD SUCCESSFUL locally.
- [x] Both gates green via `run-gates.py --only` (6/6 canonical, 0 allowlisted).
- [x] Threat model updated (money-path requirement).

## Security checklist

- [x] No secrets/PII; no new dependency; auth/crypto/payment logic untouched.

## Compliance impact

- [x] None (config-property rename; threat model updated per money-path rule).
