### PR TITLE
fix(fuzz): fail loudly when a fuzz pass drives zero operations

### DIFF
--- a/.github/scripts/fuzz-services.sh
+++ b/.github/scripts/fuzz-services.sh
@@ -389,6 +389,17 @@ for svc in $SERVICES; do
       blocked="$(grep -aoE 'Authentication failed: [0-9]+ operation' "fuzz-reports/${svc}-fuzz${logsuffix}.log" | grep -oE '[0-9]+' | head -1 || true)"
       echo "==> [${svc}] ${label}: ${sel:-Selected: ?} auth-blocked=${blocked:-0}"
 
+      # A pass that drove ZERO operations tested nothing, and its green reads exactly like a
+      # finding-free run — the 2026-08-18 run reported 7 failures of 23 where six had never
+      # sent a request, and the job list rendered both kinds identically. Fail LOUDLY, worded
+      # as a harness error so triage does not read it as an HTTP-surface finding.
+      local selected_n
+      selected_n="$(printf '%s' "${sel}" | grep -oE 'Selected: [0-9]+' | grep -oE '[0-9]+' | head -1 || true)"
+      if [ -z "${selected_n}" ] || [ "${selected_n}" -eq 0 ]; then
+        echo "::error::[${svc}] ${label}: HARNESS ERROR — schemathesis drove ${selected_n:-no} operations (Selected: ${sel:-?}). The service likely never booted or its OpenAPI was unreachable; this pass is not evidence about the HTTP surface."
+        OVERALL=1
+      fi
+
       # A census of causes, printed next to the count (triage aid, not a verdict — see header).
       local census
       census="$(sed 's/\x1b\[[0-9;]*m//g' "fuzz-reports/${svc}-boot${logsuffix}.log" 2>/dev/null \


### PR DESCRIPTION
## Summary

Closes the last missing acceptance criterion of #8348 that is harness-side: a fuzz pass whose schemathesis drove **zero operations** now fails loudly, worded as a HARNESS ERROR — so a service that never booted can never again render in the job list identically to a real HTTP-surface finding (2026-08-18 run: 6 of 7 "failures" had never sent a request).

## Type of change

- [x] fix (CI harness)

## Linked issues

Refs #8348

## Changes

- `fuzz-services.sh` — after the existing `Selected: N/M` census, a missing or zero selection is `::error:: ... HARNESS ERROR` + `OVERALL=1`, for both the authz-ON and authz-OFF passes.

The other two criteria are already in the tree: datasource config expressions (`${POSTGRES_USER:openbank}`) are resolved to their default before `docker run`/`pg_isready`, and the Temporal worker switch is derived from each registrar's `@ConfigProperty` by grep — uniform since the `openbank.<service>.worker.enabled` convention (#8357). What remains in #8348 after this PR is the live rerun: vop + settlement completing a real fuzz run.

## Note on stacking

Based on `fix/lending-worker-switch-rename` (#8374) because it touches the same header comment block; merge that one first, GitHub will retarget automatically.

## Definition of Done

- [x] `bash -n` + `shellcheck -S error` clean.
- [x] No service code changed; harness-only.

## Security checklist

- [x] No secrets/PII; no new dependency.

## Compliance impact

- [x] None (the pentest attestation's evidence quality improves — a zero-request run can no longer pass silently).
