### PR TITLE
fix(aml): toCreatedEvent requires the caller's clock, not an EPOCH default

### DIFF
--- a/.github/gates/epoch-instant-default-baseline.txt
+++ b/.github/gates/epoch-instant-default-baseline.txt
@@ -6,7 +6,6 @@ openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/per
 openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/AccountEntities.kt::var createdAt: Instant = Instant.EPOCH#3
 openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/AccountEntities.kt::var updatedAt: Instant = Instant.EPOCH#1
 openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/AccountEntities.kt::var updatedAt: Instant = Instant.EPOCH#2
-openbank-aml-service/src/main/kotlin/com/openbank/aml/domain/event/AmlCaseEvents.kt::fun AmlCase.toCreatedEvent(now: Instant = Instant.EPOCH) = AmlCaseCreatedEvent(#1
 openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun activate(now: Instant = Instant.EPOCH) = also {#1
 openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun block(reason: String, now: Instant = Instant.EPOCH) = also {#1
 openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun cancel(reason: String?, now: Instant = Instant.EPOCH) = also {#1

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -4685,7 +4685,7 @@ gates:
     selftest: python3 .github/scripts/check-no-epoch-instant-default.py --self-test
     selftest_expect: pass
     selftest_inputs: [".github/scripts/check-no-epoch-instant-default.py"]
-    min_subjects: 116   # 58 occurrences + 58 baseline entries today (2026-09-03)
+    min_subjects: 114   # 57+57 after the aml-service burn-down (#8357); lower this in each burn-down PR
     run: |
       python3 .github/scripts/check-no-epoch-instant-default.py --root .
 

--- a/openbank-aml-service/src/main/kotlin/com/openbank/aml/domain/event/AmlCaseEvents.kt
+++ b/openbank-aml-service/src/main/kotlin/com/openbank/aml/domain/event/AmlCaseEvents.kt
@@ -37,7 +37,7 @@ data class AmlCaseStatusChangedEvent(
     val occurredAt: Instant,
 )
 
-fun AmlCase.toCreatedEvent(now: Instant = Instant.EPOCH) = AmlCaseCreatedEvent(
+fun AmlCase.toCreatedEvent(now: Instant) = AmlCaseCreatedEvent(
     caseId = id,
     idempotencyKey = idempotencyKey,
     partyId = partyId,


### PR DESCRIPTION
## Summary

First burn-down of the 58-entry EPOCH baseline (#8357): `AmlCase.toCreatedEvent(now: Instant = Instant.EPOCH)` loses its default — the sole production caller already passes `Instant.now(clock)` and no test used the default. Baseline entry and the gate's `min_subjects` floor (116 → 114) move in the same commit; the floor is the ratchet's vanished-corpus detector, so a burn-down PR adjusts it deliberately.

## Type of change

- [x] fix (dead default removal; no caller-visible behaviour change)

## Linked issues

Refs #8357

## Definition of Done

- [x] `:openbank-aml-service:compileKotlin + compileTestKotlin` BUILD SUCCESSFUL.
- [x] `run-gates.py --only no-epoch-instant-default` PASS (57+57).

## Security checklist

- [x] No secrets/PII; no new dependency.

## Compliance impact

- [x] None