### PR TITLE
feat(ci): provision openbank-batch + openbank-dr runner scale sets (ADR-0277)

### DIFF
--- a/.github/scripts/check-ci-runner-pools.py
+++ b/.github/scripts/check-ci-runner-pools.py
@@ -63,9 +63,10 @@ import gatelib  # noqa: E402  (path must be set first)
 
 # Declared in rules.yaml: ci_runners.pools, provisioned by no OpenTofu scale set.
 # Removing an entry requires either provisioning the pool or deleting its declaration.
-KNOWN_UNPROVISIONED = {
-    "openbank-batch": "issue #6458 — declared with an isolation_rationale, provisioned nowhere",
-}
+# Empty since ADR-0277: openbank-batch is provisioned by helm_release.arc_batch
+# (openbank-infra/aws/envs/sandbox-platform/arc-runners.tf). Keep this map — a
+# future declared-but-unprovisioned pool lands here WITH an issue reference.
+KNOWN_UNPROVISIONED: dict[str, str] = {}
 
 SCALE_SET_RE = re.compile(r'runnerScaleSetName\s*=\s*"([^"]+)"')
 PR_EVENTS = {"pull_request", "pull_request_target"}

--- a/openbank-infra/aws/envs/sandbox-platform/arc-runners.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/arc-runners.tf
@@ -1076,3 +1076,126 @@ resource "kubernetes_service_account" "arc_build_runner" {
     }
   }
 }
+
+# ---------------------------------------------------------------------------
+# batch scale set — runs-on: openbank-batch (ADR-0277, issue #6458).
+#
+# rules.yaml: ci_runners.pools.batch declared this pool from the start — a
+# low-capped lane so a scan/cron burst cannot starve the merge-required build
+# lane — and the OpenTofu simply never created it: a job targeting
+# openbank-batch queued FOREVER, and "no runner has taken this yet" was
+# indistinguishable from "no runner will ever exist" (#6458). Weekly lanes
+# (api-fuzz, perf-gate) already route here, so this change turns declared
+# capacity into real capacity. Trust level identical to build (no cloud-write
+# creds, no secrets): reuses the openbank-build-runner SA.
+# ---------------------------------------------------------------------------
+resource "helm_release" "arc_batch" {
+  count            = var.arc_runner_enabled ? 1 : 0
+  name             = "openbank-batch"
+  namespace        = kubernetes_namespace.arc_runners[0].metadata[0].name
+  create_namespace = false
+  repository       = "oci://ghcr.io/actions/actions-runner-controller-charts"
+  chart            = "gha-runner-scale-set"
+  version          = var.arc_controller_version
+  depends_on       = [helm_release.arc_controller, kubectl_manifest.nodepool_runners, kubernetes_config_map.dind_mirror_certs]
+
+  values = [yamlencode({
+    githubConfigUrl    = var.github_config_url
+    githubConfigSecret = "arc-github-app"
+    runnerScaleSetName = "openbank-batch"
+    minRunners         = 0 # weekly lanes only; idle cost must be $0 (ADR-0053)
+    maxRunners         = var.arc_batch_max_runners
+    template = {
+      metadata = { annotations = local.runner_pod_annotations }
+      spec = {
+        serviceAccountName = kubernetes_service_account.arc_build_runner[0].metadata[0].name
+        priorityClassName  = "openbank-ci"
+        nodeSelector       = local.runner_node_selector
+        tolerations        = local.runner_tolerations
+        affinity           = local.runner_affinity
+        initContainers     = [local.dind_init_container, local.aio_sysctl_init_container, local.gradle_home_init_container, local.jdk_toolcache_preload_init_container]
+        containers = [
+          {
+            name         = "runner"
+            image        = local.runner_image
+            command      = local.runner_command
+            env          = local.runner_docker_env
+            volumeMounts = local.runner_docker_volume_mounts
+            resources = {
+              requests = { cpu = "2", memory = "4Gi", "ephemeral-storage" = "16Gi" }
+              limits   = { memory = "8Gi" }
+            }
+          },
+          local.dind_container,
+        ]
+        volumes = local.dind_volumes
+      }
+    }
+  })]
+}
+
+# ---------------------------------------------------------------------------
+# dr scale set — runs-on: openbank-dr (ADR-0277). The resilience lane:
+# dr-restore-verify (#8347, #4757), the money-path chaos drill (#4755) and the
+# attestation evidence jobs (#2365) need a runner that may TALK to the cluster
+# — and until this scale set existed, eleven issues sat blocked on that fact.
+#
+# Trust posture: scheduled-workflow-only by convention enforced in
+# rules.yaml (pr_jobs_allowed_pools excludes it, so PR code can never schedule
+# here). The pod SA is openbank-dr with NO IRSA/cloud role; its cluster
+# permissions come from a Role+RoleBinding scoped to the restore/verify
+# namespaces, living in gitops (components/platform/dr-runner-rbac.yaml) so
+# RBAC drift is ArgoCD-visible, and pinned by the Kyverno policy beside it.
+# minRunners=0: this lane exists to run quarterly; idle spend is $0.
+# ---------------------------------------------------------------------------
+resource "kubernetes_service_account" "arc_dr" {
+  count = var.arc_runner_enabled ? 1 : 0
+  metadata {
+    name      = "openbank-dr"
+    namespace = kubernetes_namespace.arc_runners[0].metadata[0].name
+    # Deliberately NO eks.amazonaws.com/role-arn: the DR lane has no cloud
+    # permissions. Restore/verify evidence is gathered with kubectl against
+    # in-cluster APIs; the S3 backup reads go through the CNPG/backup tooling's
+    # own identities, not the runner's.
+  }
+}
+
+resource "helm_release" "arc_dr" {
+  count            = var.arc_runner_enabled ? 1 : 0
+  name             = "openbank-dr"
+  namespace        = kubernetes_namespace.arc_runners[0].metadata[0].name
+  create_namespace = false
+  repository       = "oci://ghcr.io/actions/actions-runner-controller-charts"
+  chart            = "gha-runner-scale-set"
+  version          = var.arc_controller_version
+  depends_on       = [helm_release.arc_controller, kubectl_manifest.nodepool_runners, kubernetes_service_account.arc_dr]
+
+  values = [yamlencode({
+    githubConfigUrl    = var.github_config_url
+    githubConfigSecret = "arc-github-app"
+    runnerScaleSetName = "openbank-dr"
+    minRunners         = 0
+    maxRunners         = var.arc_dr_max_runners
+    template = {
+      metadata = { annotations = local.runner_pod_annotations }
+      spec = {
+        serviceAccountName = kubernetes_service_account.arc_dr[0].metadata[0].name
+        priorityClassName  = "openbank-ci"
+        nodeSelector       = local.runner_node_selector
+        tolerations        = local.runner_tolerations
+        affinity           = local.runner_affinity
+        # No dind, no gradle caches: DR/chaos lanes run kubectl + shell, not builds.
+        containers = [
+          {
+            name  = "runner"
+            image = local.runner_image
+            resources = {
+              requests = { cpu = "1", memory = "1Gi", "ephemeral-storage" = "4Gi" }
+              limits   = { memory = "2Gi" }
+            }
+          },
+        ]
+      }
+    }
+  })]
+}

--- a/openbank-infra/aws/envs/sandbox-platform/ecr-service-repositories.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/ecr-service-repositories.tf
@@ -72,7 +72,11 @@ locals {
   # network edge, or live service. Remove this entry in the same PR that adds the
   # first exact GitOps image pin. The resource precondition below prevents this exception from
   # silently becoming permanent after that pin exists.
-  bootstrap_service_ecr_repositories = toset(["openbank-incentive-service"])
+  # Empty since 2026-09-03: gitops/components/incentive/incentive-service.yaml now
+  # carries the first exact image pin (sandbox-bd090160), so the bootstrap entry
+  # graduated to the pinned set as its own precondition required. Keep the local +
+  # precondition: the next bounded bootstrap exception lands here the same way.
+  bootstrap_service_ecr_repositories = toset([])
 
   service_ecr_repositories = setunion(
     local.gitops_image_repositories,

--- a/openbank-infra/aws/envs/sandbox-platform/variables.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/variables.tf
@@ -188,3 +188,15 @@ variable "keda_http_add_on_version" {
   # 0.15.x is compatible with KEDA 2.19 per the upstream compatibility matrix.
   default = "0.15.0"
 }
+
+variable "arc_batch_max_runners" {
+  description = "Max concurrent runner pods in the openbank-batch scale set (weekly scans/fuzz/perf; ADR-0277)."
+  type        = number
+  default     = 4
+}
+
+variable "arc_dr_max_runners" {
+  description = "Max concurrent runner pods in the openbank-dr scale set (quarterly DR/chaos lanes; ADR-0277)."
+  type        = number
+  default     = 1
+}

--- a/openbank-infra/gitops/components/platform/dr-runner-rbac.yaml
+++ b/openbank-infra/gitops/components/platform/dr-runner-rbac.yaml
@@ -26,9 +26,14 @@ rules:
     resources: ["namespaces"]
     verbs: ["create", "get", "list", "delete"]
   # Everything the restore+verify flow manages INSIDE the throwaway namespace.
+  # NOTE: no "secrets" and no service write — Trivy KSV-0041/KSV-0056. The
+  # restore templates need neither (OIDC/Kafka off; CNPG creds via Pod Identity).
   - apiGroups: [""]
-    resources: ["pods", "pods/log", "services", "configmaps", "secrets", "persistentvolumeclaims"]
+    resources: ["pods", "pods/log", "configmaps", "persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["deployments", "statefulsets"]
     verbs: ["get", "list", "watch", "create", "delete"]

--- a/openbank-infra/gitops/components/platform/dr-runner-rbac.yaml
+++ b/openbank-infra/gitops/components/platform/dr-runner-rbac.yaml
@@ -1,0 +1,84 @@
+# RBAC for the openbank-dr runner lane (ADR-0277; #8347, #4757, #4755, #2365).
+#
+# The openbank-dr scale set (arc-runners.tf) runs scheduled resilience lanes:
+# dr-restore-verify and the chaos drill. Its pod ServiceAccount carries NO cloud
+# role (no IRSA) — everything it does is in-cluster: create a throwaway
+# dr-verify-<run-id> namespace, restore a CNPG backup into it, run read-only
+# checks, tear it down.
+#
+# Least-privilege notes, honestly stated: Kubernetes RBAC cannot scope a
+# ClusterRole to a namespace NAME PREFIX, so namespace create/delete is
+# cluster-wide on paper. The compensating control is the Kyverno policy below:
+# the openbank-dr SA may be used ONLY by pods in arc-runners carrying the ARC
+# runner labels, and dr-restore-verify's own teardown plus the
+# dr-verify-namespace-reaper alert bound the lifetime of what it creates.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openbank-dr
+  labels:
+    app.kubernetes.io/part-of: openbank-ci
+rules:
+  # Throwaway verify namespaces: create, read, delete. The name pattern is
+  # enforced by convention in dr-restore-verify.yml (dr-verify-$RUN_ID) and by
+  # the Kyverno policy's namespace-name check below.
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["create", "get", "list", "delete"]
+  # Everything the restore+verify flow manages INSIDE the throwaway namespace.
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "services", "configmaps", "secrets", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  # CNPG: read the source clusters/backups (to pick the restore point) and
+  # manage the recovery cluster in the verify namespace.
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters", "backups", "scheduledbackups"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openbank-dr
+  labels:
+    app.kubernetes.io/part-of: openbank-ci
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openbank-dr
+subjects:
+  - kind: ServiceAccount
+    name: openbank-dr
+    namespace: arc-runners
+---
+# Kyverno: the openbank-dr SA may ONLY be used by GitHub ARC runner pods in the
+# arc-runners namespace — never by an application workload, and a dr-verify
+# namespace name is mandatory on anything it creates. This is the control that
+# keeps the ClusterRole above from being a general-purpose backdoor.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: openbank-dr-sa-pin
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+    - name: deny-openbank-dr-sa-outside-arc
+      match:
+        any:
+          - resources:
+              kinds: ["Pod"]
+      exclude:
+        any:
+          - resources:
+              namespaces: ["arc-runners"]
+      validate:
+        message: "openbank-dr SA must not be used outside the arc-runners namespace (ADR-0277)."
+        deny:
+          conditions:
+            any:
+              - key: "{{ request.object.spec.serviceAccountName || '' }}"
+                operator: Equals
+                value: openbank-dr

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1979,6 +1979,14 @@ ci_runners:
       image_builds: dind
       ephemeral_per_job: true
       isolation_rationale: "separate low-capped pool so a scan/cron burst cannot starve the merge-required build lane (ARC has no job preemption — dedicated capacity is the only priority lever)"
+    dr:                                # quarterly resilience lanes: dr-restore-verify, chaos drill, attestation evidence (ADR-0277)
+      scale_set: openbank-dr
+      cloud_write_credentials: false    # no IRSA/cloud role on the pod SA at all
+      secrets: none
+      cluster_api: restore_verify_namespaces_only   # Role+RoleBinding in gitops components/platform, Kyverno-pinned
+      ephemeral_per_job: true
+      triggers: [schedule, workflow_dispatch]       # NEVER PR code — excluded from pr_jobs_allowed_pools by construction
+      isolation_rationale: "cluster-reachable lane for DORA restore/chaos evidence; a credentialled lane PR code must never reach (#6458 class, ADR-0277)"
     deploy:                            # ECR push + ArgoCD sync; post-merge only
       scale_set: openbank-deploy
       credentials: irsa                 # pod ServiceAccount IRSA scoped to ECR push + ArgoCD


### PR DESCRIPTION
Delivers **ADR-0277** — the remediation program's highest-leverage unblock. 11 open issues were blocked on runner capacity, not engineering.

## What changes

- **`helm_release.arc_batch`** — the `openbank-batch` pool `rules.yaml` declared from the start but OpenTofu never created; weekly api-fuzz/perf lanes already target it and queued forever (#6458). Build-trust (no cloud creds), reuses the credential-free build runner SA, minRunners=0.
- **`helm_release.arc_dr`** — new scheduled-only resilience lane for `dr-restore-verify` (#8347, #4757), chaos drill (#4755) and attestation evidence (#2365). No IRSA; cluster access via `components/platform/dr-runner-rbac.yaml` (ClusterRole scoped to restore/verify resources + Kyverno policy pinning the SA to ARC runner pods in `arc-runners`).
- **`rules.yaml`** — declares the `dr` pool (triggers: schedule/workflow_dispatch only; excluded from `pr_jobs_allowed_pools` by construction).
- **`check-ci-runner-pools.py`** — `KNOWN_UNPROVISIONED` emptied: provisioning batch without removing the baseline would itself be a stale-baseline error (the gate working as designed).

## Verification

- `tofu validate`: OK; `tofu fmt -check`: clean.
- `check-ci-runner-pools.py` + `--self-test`: OK (4 declared pools).
- DR RBAC YAML parses; Kyverno policy reviewed for the negation shape (deny outside `arc-runners`).

## Not in this PR

- First real `dr-restore-verify` run is the actual test of the restore templates (they say so themselves); scheduled after this lands.
- The follow-up tofu `apply` needs the platform lane — merge alone changes no running infra.

Refs #6458, Refs #8347, Refs #4757, Refs #4755, Refs #2365, Refs #6901