### PR TITLE
fix(card-issuance): Card lifecycle functions and category-rule entity drop EPOCH defaults

### DIFF
--- a/.github/gates/epoch-instant-default-baseline.txt
+++ b/.github/gates/epoch-instant-default-baseline.txt
@@ -6,16 +6,6 @@ openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/per
 openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/AccountEntities.kt::var createdAt: Instant = Instant.EPOCH#3
 openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/AccountEntities.kt::var updatedAt: Instant = Instant.EPOCH#1
 openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/AccountEntities.kt::var updatedAt: Instant = Instant.EPOCH#2
-openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun activate(now: Instant = Instant.EPOCH) = also {#1
-openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun block(reason: String, now: Instant = Instant.EPOCH) = also {#1
-openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun cancel(reason: String?, now: Instant = Instant.EPOCH) = also {#1
-openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun consume(now: Instant = Instant.EPOCH) = also {#1
-openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun expireUnused(now: Instant = Instant.EPOCH) = also {#1
-openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun resume(now: Instant = Instant.EPOCH) = also {#1
-openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun suspend(now: Instant = Instant.EPOCH) = also {#1
-openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::fun withLimits(dailyMinor: Long, monthlyMinor: Long, now: Instant = Instant.EPOCH) = also {#1
-openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt::now: Instant = Instant.EPOCH,#1
-openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/entity/CardCategoryRuleEntity.kt::var updatedAt: Instant = Instant.EPOCH#1
 openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/entity/DocumentEntity.kt::var createdAt: Instant = Instant.EPOCH#1
 openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/entity/DocumentTemplateEntity.kt::var createdAt: Instant = Instant.EPOCH#1
 openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/entity/SignatureCeremonyEntity.kt::var createdAt: Instant = Instant.EPOCH#1

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -4685,7 +4685,7 @@ gates:
     selftest: python3 .github/scripts/check-no-epoch-instant-default.py --self-test
     selftest_expect: pass
     selftest_inputs: [".github/scripts/check-no-epoch-instant-default.py"]
-    min_subjects: 114   # 57+57 after the aml-service burn-down (#8357); lower this in each burn-down PR
+    min_subjects: 94    # 47+47 after aml + card-issuance burn-downs; lower this in each burn-down PR
     run: |
       python3 .github/scripts/check-no-epoch-instant-default.py --root .
 

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt
@@ -115,11 +115,11 @@ data class Card(
      */
     val isDelegated: Boolean get() = delegationGrantId != null
 
-    fun activate(now: Instant = Instant.EPOCH) = also {
+    fun activate(now: Instant) = also {
         require(status == CardStatus.PENDING) { "Only PENDING cards can be activated, current: $status" }
     }.copy(status = CardStatus.ACTIVE, activatedAt = now, updatedAt = now)
 
-    fun block(reason: String, now: Instant = Instant.EPOCH) = also {
+    fun block(reason: String, now: Instant) = also {
         require(status in setOf(CardStatus.ACTIVE, CardStatus.SUSPENDED)) { "Cannot block card in status $status" }
         require(reason.isNotBlank()) { "Block reason required" }
     }.copy(status = CardStatus.BLOCKED, blockedAt = now, blockedReason = reason, updatedAt = now)
@@ -131,7 +131,7 @@ data class Card(
      * the processor, and this records the outcome so the customer can see it. Only SINGLE_USE
      * reaches it — marking any other card CONSUMED would be a lie about why it stopped working.
      */
-    fun consume(now: Instant = Instant.EPOCH) = also {
+    fun consume(now: Instant) = also {
         require(cardType == CardType.SINGLE_USE) { "Only SINGLE_USE cards can be consumed, this is $cardType" }
         require(status == CardStatus.ACTIVE) { "Only ACTIVE cards can be consumed, current: $status" }
     }.copy(
@@ -144,7 +144,7 @@ data class Card(
      * The card's validity window ran out before it was ever used. EXPIRED rather than CONSUMED:
      * nothing was spent, and the difference is what the customer is told.
      */
-    fun expireUnused(now: Instant = Instant.EPOCH) = also {
+    fun expireUnused(now: Instant) = also {
         require(status in LIVE_STATUSES) { "Cannot expire card in status $status" }
     }.copy(
         status = CardStatus.EXPIRED,
@@ -152,11 +152,11 @@ data class Card(
         updatedAt = now,
     )
 
-    fun suspend(now: Instant = Instant.EPOCH) = also {
+    fun suspend(now: Instant) = also {
         require(status == CardStatus.ACTIVE) { "Only ACTIVE cards can be suspended" }
     }.copy(status = CardStatus.SUSPENDED, updatedAt = now)
 
-    fun resume(now: Instant = Instant.EPOCH) = also {
+    fun resume(now: Instant) = also {
         require(status == CardStatus.SUSPENDED) { "Only SUSPENDED cards can be resumed" }
     }.copy(status = CardStatus.ACTIVE, updatedAt = now)
 
@@ -172,7 +172,7 @@ data class Card(
      * [blockedReason], the aggregate's single "why is this card not usable" note. Cancelling a
      * BLOCKED card with no reason therefore preserves the original block reason.
      */
-    fun cancel(reason: String?, now: Instant = Instant.EPOCH) = also {
+    fun cancel(reason: String?, now: Instant) = also {
         require(status in CANCELLABLE_STATUSES) { "Cannot cancel card in status $status" }
     }.copy(status = CardStatus.CANCELLED, blockedReason = reason ?: blockedReason, updatedAt = now)
 
@@ -180,7 +180,7 @@ data class Card(
      * Customer-set spending limits. Only a live card may be re-limited (a BLOCKED/CANCELLED/EXPIRED
      * card has no spend to cap). Limits are non-negative and daily must not exceed monthly.
      */
-    fun withLimits(dailyMinor: Long, monthlyMinor: Long, now: Instant = Instant.EPOCH) = also {
+    fun withLimits(dailyMinor: Long, monthlyMinor: Long, now: Instant) = also {
         require(status in setOf(CardStatus.ACTIVE, CardStatus.SUSPENDED, CardStatus.PENDING)) {
             "Cannot change limits on a card in status $status"
         }
@@ -192,13 +192,7 @@ data class Card(
      * Customer channel controls (#1): turn contactless / online (e-commerce) / ATM / abroad usage
      * on or off. Only a live card may be re-controlled — a terminal card has no usage to gate.
      */
-    fun withControls(
-        contactless: Boolean,
-        online: Boolean,
-        atm: Boolean,
-        abroad: Boolean,
-        now: Instant = Instant.EPOCH,
-    ) = also {
+    fun withControls(contactless: Boolean, online: Boolean, atm: Boolean, abroad: Boolean, now: Instant) = also {
         require(status in setOf(CardStatus.ACTIVE, CardStatus.SUSPENDED, CardStatus.PENDING)) {
             "Cannot change controls on a card in status $status"
         }

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/entity/CardCategoryRuleEntity.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/entity/CardCategoryRuleEntity.kt
@@ -41,5 +41,5 @@ class CardCategoryRuleEntity : PanacheEntityBase {
     var monthlyLimitMinorUnits: Long? = null
 
     @Column(name = "updated_at", nullable = false)
-    var updatedAt: Instant = Instant.EPOCH
+    var updatedAt: Instant = Instant.now()
 }

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/domain/model/CardTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/domain/model/CardTest.kt
@@ -110,13 +110,21 @@ class CardTest {
 
     @Test fun `withControls is allowed on a suspended card`() {
         val updated = card(status = CardStatus.SUSPENDED)
-            .withControls(contactless = true, online = false, atm = true, abroad = false)
+            .withControls(
+                contactless = true,
+                online = false,
+                atm = true,
+                abroad = false,
+                now = Instant.parse("2026-01-01T10:15:30Z"),
+            )
         assertThat(updated.onlineEnabled).isFalse()
     }
 
     @Test fun `withControls rejects a terminal card`() {
         assertThatThrownBy {
-            card(status = CardStatus.BLOCKED).withControls(true, true, true, true)
+            card(
+                status = CardStatus.BLOCKED,
+            ).withControls(true, true, true, true, Instant.parse("2026-01-01T10:15:30Z"))
         }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("Cannot change controls")
@@ -141,11 +149,16 @@ class CardTest {
     @Test fun `cancel is allowed from BLOCKED - a lost card the customer then closes`() {
         val blocked = card(status = CardStatus.BLOCKED)
 
-        assertThat(blocked.cancel(null).status).isEqualTo(CardStatus.CANCELLED)
+        assertThat(blocked.cancel(null, Instant.parse("2026-01-01T10:15:30Z")).status).isEqualTo(CardStatus.CANCELLED)
     }
 
     @Test fun `cancel without a reason keeps the original block reason`() {
-        val lost = card(status = CardStatus.ACTIVE).block("Reported lost").cancel(null)
+        val lost = card(
+            status = CardStatus.ACTIVE,
+        ).block(
+            "Reported lost",
+            Instant.parse("2026-01-01T10:15:30Z"),
+        ).cancel(null, Instant.parse("2026-01-01T10:15:30Z"))
 
         assertThat(lost.status).isEqualTo(CardStatus.CANCELLED)
         assertThat(lost.blockedReason).isEqualTo("Reported lost")
@@ -154,20 +167,33 @@ class CardTest {
     @Test fun `cancel is terminal - a cancelled card can never transition again`() {
         val cancelled = card(status = CardStatus.CANCELLED)
 
-        assertThatThrownBy { cancelled.cancel("again") }
+        assertThatThrownBy { cancelled.cancel("again", Instant.parse("2026-01-01T10:15:30Z")) }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("Cannot cancel card in status CANCELLED")
-        assertThatThrownBy { cancelled.activate() }.isInstanceOf(IllegalArgumentException::class.java)
-        assertThatThrownBy { cancelled.block("fraud") }.isInstanceOf(IllegalArgumentException::class.java)
-        assertThatThrownBy { cancelled.suspend() }.isInstanceOf(IllegalArgumentException::class.java)
-        assertThatThrownBy { cancelled.resume() }.isInstanceOf(IllegalArgumentException::class.java)
-        assertThatThrownBy { cancelled.withLimits(1, 2) }.isInstanceOf(IllegalArgumentException::class.java)
-        assertThatThrownBy { cancelled.withControls(true, true, true, true) }
+        assertThatThrownBy {
+            cancelled.activate(Instant.parse("2026-01-01T10:15:30Z"))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy {
+            cancelled.block("fraud", Instant.parse("2026-01-01T10:15:30Z"))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy {
+            cancelled.suspend(Instant.parse("2026-01-01T10:15:30Z"))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy {
+            cancelled.resume(Instant.parse("2026-01-01T10:15:30Z"))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy {
+            cancelled.withLimits(1, 2, Instant.parse("2026-01-01T10:15:30Z"))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy { cancelled.withControls(true, true, true, true, Instant.parse("2026-01-01T10:15:30Z")) }
             .isInstanceOf(IllegalArgumentException::class.java)
     }
 
     @Test fun `cancel rejects an expired card`() {
-        assertThatThrownBy { card(status = CardStatus.EXPIRED).cancel("closing") }
+        assertThatThrownBy {
+            card(status = CardStatus.EXPIRED)
+                .cancel("closing", Instant.parse("2026-01-01T10:15:30Z"))
+        }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("Cannot cancel card in status EXPIRED")
     }


### PR DESCRIPTION
## Summary

Burn-down of the 10 card-issuance entries in the `no-epoch-instant-default` baseline: the 9 `Card` lifecycle functions now require the caller's time (all production callers already pass `Instant.now(clock)`; 12 test call sites moved to an explicit fixed instant), and `CardCategoryRuleEntity.updatedAt` defaults to `Instant.now()` instead of a 1970 lie (its only construction site always overwrites from the injected Clock). Gate floor `min_subjects` 114 → 94 in the same commit.

## Type of change

- [x] fix (dead default removal; no production behaviour change)

## Linked issues

Refs #8357

## Definition of Done

- [x] `ktlintCheck`, `detekt`, full `:openbank-card-issuance-service:test` BUILD SUCCESSFUL.
- [x] `run-gates.py --only no-epoch-instant-default` PASS.

## Security checklist

- [x] No secrets/PII; no new dependency.

## Compliance impact

- [x] None