### PR TITLE
ci(governance): pentest attestation needs the exercised-operations count (#5769)

### DIFF
--- a/.github/scripts/check-readiness-attestations.py
+++ b/.github/scripts/check-readiness-attestations.py
@@ -96,6 +96,28 @@ DRILL_LOGS = ("docs/bcp/dr-test-log.md", "docs/bcp/chaos-test-log.md")
 # cannot rot into a permanent exemption. Key: "<service>.<attestation key>".
 EXERCISE_REF_DEBT: dict[str, str] = {}
 
+# R8 (issue #5769) -- a pentest attestation minted by a CI lane must say what the
+# green is WORTH. A green api-fuzz/dast run is not interchangeable across services:
+# measured on the two ends of the range, consent's run drove 13/13 operations while
+# settlement's drove 1 and that one answered only auth errors. TTL renewal makes it
+# worse: a lane that exercises nothing renews the attestation forever. So a
+# `pentest` entry whose `by` is a CI lane (`ci-*`) must carry `ops: N` -- the number
+# of operations the run actually EXERCISED (schemathesis `Selected` minus the
+# auth-blocked ones, recorded machine-readably by the lane in
+# fuzz-reports/<svc>-ops*.json since #5769) -- and N must clear the floor, or the
+# entry must say `not_fuzzable: "<reason>"` so the matrix reads "not meaningfully
+# testable at v1 scope" instead of a silent pass.
+PENTEST_OPS_FLOOR = 5
+CI_BY_RE = re.compile(r"^ci-")
+
+# CI-minted pentest attestations that predate R8. Shrink-only, checked BOTH WAYS:
+# a new ci-* pentest entry without ops fails, and a baselined entry that gains ops
+# (or leaves the file) is reported so the exemption cannot rot into permanence.
+PENTEST_OPS_DEBT: dict[str, str] = {
+    "ledger.pentest": "predates R8 (#5769): ci-zap-baseline run 32173390301; add ops from the run artifact on next renewal",
+    "consent.pentest": "predates R8 (#5769): ci-schemathesis run 30340495749 measured 13/13 exercised — add ops: 13 on next renewal",
+}
+
 DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 ISSUE_RE = re.compile(r"^#\d+$")
 RUNBOOK_RE = re.compile(r"^runbook-(\d+)$")
@@ -325,6 +347,35 @@ def check(
                 )
                 continue
 
+        # R8 -- a CI-minted pentest attestation must record the exercised surface
+        # (#5769). A bare green is a lane that RAN, not a surface that was TESTED.
+        if key == "pentest" and CI_BY_RE.match(f.get("by", "")):
+            debt_key = f"{svc}.{key}"
+            ops_raw = f.get("ops")
+            if ops_raw is None and "not_fuzzable" not in f and debt_key not in PENTEST_OPS_DEBT:
+                errors.append(
+                    f"{where}: `{debt_key}` is minted by `{f['by']}` but records no `ops: N` "
+                    f"-- the exercised-operations count from the run (Selected minus "
+                    f"auth-blocked, fuzz-reports/<svc>-ops*.json). A pentest attestation "
+                    f"without it reads 'adversarial test passed' while asserting 'a lane "
+                    f"ran' (#5769). Below-floor services belong in `not_fuzzable: <reason>`."
+                )
+                continue
+            if ops_raw is not None:
+                try:
+                    ops = int(ops_raw)
+                except ValueError:
+                    errors.append(f"{where}: `{debt_key}` ops {ops_raw!r} is not an integer")
+                    continue
+                if ops < PENTEST_OPS_FLOOR and "not_fuzzable" not in f:
+                    errors.append(
+                        f"{where}: `{debt_key}` records ops={ops}, below the floor "
+                        f"({PENTEST_OPS_FLOOR}) -- that run tested too little surface to "
+                        f"mint a pentest attestation; use `not_fuzzable: <reason>` or fuzz "
+                        f"a meaningfully larger surface first"
+                    )
+                    continue
+
         # Freshness. Exact calendar arithmetic, deliberately: the collector approximates a
         # month as 30 days, which lets a TTL run a day or two past its own expiry.
         age = (today - date).days
@@ -363,6 +414,19 @@ def check(
             f"{file_rel}: `{stale}` is in EXERCISE_REF_DEBT but no longer cites a runbook "
             f"-- remove the entry from check-readiness-attestations.py"
         )
+
+    if file_rel == FILE_REL:
+        live_debt = {
+            f"{r['service']}.{r['key']}"
+            for r in records
+            if r["key"] == "pentest" and CI_BY_RE.match(r["fields"].get("by", ""))
+            and "ops" not in r["fields"] and "not_fuzzable" not in r["fields"]
+        }
+        for stale in sorted(set(PENTEST_OPS_DEBT) - live_debt):
+            errors.append(
+                f"{file_rel}: `{stale}` is in PENTEST_OPS_DEBT but now carries ops "
+                f"(or left the file) -- remove the entry from check-readiness-attestations.py"
+            )
 
     return (errors, warnings, len(records))
 
@@ -512,6 +576,36 @@ def _self_test(stale_fail_days: int = DEFAULT_STALE_FAIL_DAYS) -> int:
             "error",
             False,
         ),
+        (
+            "R8: CI-minted pentest without ops fails (#5769)",
+            f"audit:\n  pentest: {{ date: 2026-08-01, ttl_days: 365, by: ci-schemathesis, ref: {good_ref} }}\n",
+            "error",
+            True,
+        ),
+        (
+            "R8 TRUE ENTRY: CI-minted pentest with ops at the floor",
+            f"audit:\n  pentest: {{ date: 2026-08-01, ttl_days: 365, by: ci-schemathesis, ref: {good_ref}, ops: 13 }}\n",
+            "clean",
+            True,
+        ),
+        (
+            "R8: ops below the floor is not a pentest",
+            f"audit:\n  pentest: {{ date: 2026-08-01, ttl_days: 365, by: ci-zap-baseline, ref: {good_ref}, ops: 1 }}\n",
+            "error",
+            True,
+        ),
+        (
+            "R8 TRUE ENTRY: below-floor surface says so explicitly",
+            f"audit:\n  pentest: {{ date: 2026-08-01, ttl_days: 365, by: ci-zap-baseline, ref: {good_ref}, ops: 1, not_fuzzable: 'entire API behind auth at v1 scope' }}\n",
+            "clean",
+            True,
+        ),
+        (
+            "R8: a human pentest engagement needs no ops field",
+            f"ledger:\n  pentest: {{ date: 2026-08-01, ttl_days: 365, by: ext, ref: {good_ref} }}\n",
+            "clean",
+            True,
+        ),
     ]
 
     failures = 0
@@ -520,6 +614,7 @@ def _self_test(stale_fail_days: int = DEFAULT_STALE_FAIL_DAYS) -> int:
         # The sandbox needs the artefacts the "true entry" cases cite.
         (tmp / "openbank-ledger-service").mkdir()
         (tmp / "openbank-consent-service").mkdir()
+        (tmp / "openbank-audit-service").mkdir()
         (tmp / "docs/runbooks").mkdir(parents=True)
         (tmp / "docs/runbooks/0003-postgresql-16-to-18-major-upgrade.md").write_text("x")
         (tmp / "docs/bcp").mkdir(parents=True)

--- a/.github/scripts/fuzz-services.sh
+++ b/.github/scripts/fuzz-services.sh
@@ -389,6 +389,26 @@ for svc in $SERVICES; do
       blocked="$(grep -aoE 'Authentication failed: [0-9]+ operation' "fuzz-reports/${svc}-fuzz${logsuffix}.log" | grep -oE '[0-9]+' | head -1 || true)"
       echo "==> [${svc}] ${label}: ${sel:-Selected: ?} auth-blocked=${blocked:-0}"
 
+      # Machine-readable exercised-surface record (#5769): the number a pentest
+      # attestation's `ops:` field cites. Logs age out with retention; this JSON
+      # is the durable artifact check-readiness-attestations.py's R8 refers to.
+      # exercised = selected - auth-blocked: operations that only ever answered
+      # 401/403 tested NO handler logic and must not inflate the count.
+      local sel_n
+      sel_n="$(printf '%s' "${sel}" | grep -oE 'Selected: [0-9]+' | grep -oE '[0-9]+' | head -1 || true)"
+      cat > "fuzz-reports/${svc}-ops${logsuffix}.json" <<OPSJSON
+{
+  "service": "${svc}",
+  "lane": "${label}",
+  "selected": ${sel_n:-0},
+  "auth_blocked": ${blocked:-0},
+  "exercised": $(( ${sel_n:-0} - ${blocked:-0} )),
+  "max_examples": "${MAX_EXAMPLES}",
+  "run": "${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-?}/actions/runs/${GITHUB_RUN_ID:-?}",
+  "date": "$(date -u +%F)"
+}
+OPSJSON
+
       # A pass that drove ZERO operations tested nothing, and its green reads exactly like a
       # finding-free run — the 2026-08-18 run reported 7 failures of 23 where six had never
       # sent a request, and the job list rendered both kinds identically. Fail LOUDLY, worded

--- a/openbank-libs/governance/attestations.yaml
+++ b/openbank-libs/governance/attestations.yaml
@@ -19,6 +19,13 @@
 #   <service>:
 #     <key>: { date: YYYY-MM-DD, ttl_days: N, by: <kdo>, ref: <PR/runbook> }
 #
+# Pentest atestace vydaná CI lanou (`by: ci-*`) NESÍ navíc `ops: N` — počet
+# skutečně otestovaných operací z běhu (Selected minus auth-blocked; lane ho od
+# #5769 zapisuje strojově do fuzz-reports/<svc>-ops*.json). Pod prahem
+# (5 operací) patří místo toho `not_fuzzable: "<důvod>"` — jinak zelená lane,
+# která otestovala jednu operaci, obnovuje atestaci donekonečna, aniž by
+# cokoli testovala (#5769). Gate `readiness-attestation-format` to vynucuje.
+#
 # <service> je KRÁTKÉ jméno (`consent`, ne `consent-service`) — collector hledá pod
 # `openbank-<service>-service`. Špatné jméno = atestace neplatí pro nic a nikde to
 # nekřičí; přesně tak byla `consent-service:` mrtvá od svého vzniku (#2365).


### PR DESCRIPTION
Implements the #5769 shape exactly: **a bare green must not mint the attestation.**

## Change

1. **Lane records the evidence** — `fuzz-services.sh` writes `fuzz-reports/<svc>-ops*.json` per run: `selected`, `auth_blocked`, `exercised` (= selected − auth-blocked; auth-only operations tested no handler logic), run URL, date. Logs age out with retention; this JSON is the durable artifact.
2. **Gate enforces the floor** — new rule R8 in `check-readiness-attestations.py` (gate `readiness-attestation-format`, enforced): a `pentest` attestation with `by: ci-*` must carry `ops: N` at/above the floor (5), or an explicit `not_fuzzable: "<reason>"` — so a below-floor service reads "not meaningfully fuzzable at v1 scope" instead of a silent pass. The TTL then decays the right way again: a lane that exercises nothing can no longer renew forever.
3. **No retroactive red** — the two pre-existing CI-minted entries (`ledger.pentest`, `consent.pentest`) are baselined shrink-only in `PENTEST_OPS_DEBT`, checked both ways like `EXERCISE_REF_DEBT`; consent's renewal can cite ops: 13 straight from the run measured in the issue.
4. `attestations.yaml` header documents the `ops` field.

## Verification

- `--self-test`: 32/32 cases, both directions (new: ci-pentest without ops → red; ops at floor → green; ops below floor → red; `not_fuzzable` → green; human engagement `by: ext` unaffected).
- Gate run against the real file: green (2 pre-existing freshness warnings only).
- `bash -n` on the edited lane.

Refs #5769