### PR TITLE
docs(transaction): say which half of the merge-sweep mitigation the tests hold

### DIFF
--- a/docs/threat-models/openbank-transaction-service.md
+++ b/docs/threat-models/openbank-transaction-service.md
@@ -266,10 +266,14 @@ what the catalogue may hold.
   defect (§4) that had to be fixed before any payment rail settles through the engine. (2) **Dual-write
   removed:** the saga drops `balanceCoverPort.debit/credit` (and the compensation refund); booked balance
   is the ledger projection's sole mover, the cover hold released by the projection. Risk class =
-  **integrity** (money direction + single booked source of truth), mitigated by `PaymentJournalFactoryTest`,
-  `PaymentSagaOrchestratorTest`, and — as written at the time — a `PaymentSagaLedgerIT` that was
-  never committed (noted 2026-08-20; left in place because a change log records what was claimed
-  on the day, and correcting it silently would erase the evidence that it was). Coupled
+  **integrity** (money direction + single booked source of truth), mitigated by `PaymentJournalFactoryTest`
+  (real, still present) and — as written at the time — two classes that are not in the tree:
+  `PaymentSagaOrchestratorTest` and a `PaymentSagaLedgerIT` that was never committed (the IT noted
+  2026-08-20, the orchestrator test noted 2026-09-03; both left in place because a change log
+  records what was claimed on the day, and correcting them silently would erase the evidence that
+  they were). `PaymentSagaOrchestratorTest` went away with its subject: ADR-0120 Phase 5 made
+  Temporal the sole orchestrator and removed `PaymentSagaOrchestrator` itself, so the surviving
+  coverage of that path is `PaymentWorkflowImplTest`. Coupled
   balance-service change:
   `openbank.balance.projection.enabled=true`.
 - **2026-05-30** — K7/ADR-0018: role-gated the previously `@PermitAll` read endpoints; raw-string

--- a/docs/threat-models/openbank-transaction-service.md
+++ b/docs/threat-models/openbank-transaction-service.md
@@ -290,9 +290,17 @@ what the catalogue may hold.
   Touches the **E — elevation of privilege** and **T — tampering** rows (§4b): the action is
   deliberately distinct from `transaction.create` so it can be four-eyes gated without pausing the
   M2M payment rails, and so the resulting journal is distinguishable from a customer payment.
-  Risk class = **integrity** (segregation of duties + auditability of a correction), mitigated by
-  `MergeSweepDescriptionTest` and `TransactionResourceMergeSweepTest`. `authz.four-eyes.enforce`
-  remains `false`; the verb is inert until that flip.
+  Risk class = **integrity** (segregation of duties + auditability of a correction). The
+  **auditability** half is mitigated by `MergeSweepDescriptionTest`, which pins the server-minted
+  description's prefix, its merge reference and both party ids in survivor-last order, and asserts
+  it names no PII — that string is the only thing distinguishing a merge correction from an ordinary
+  transfer in the trial balance. The **segregation-of-duties** half has no endpoint test: a
+  `TransactionResourceMergeSweepTest` was named here but is in no Kotlin source, and no other test
+  references the sweep endpoint. What gates it today is declarative only —
+  `@RolesAllowed(Roles.OPERATOR, Roles.ADMIN)` plus `@Authorize(action = "transaction.sweep")` on
+  `TransactionResource.mergeSweep`. `authz.four-eyes.enforce` remains `false`
+  (`AUTHZ_FOUR_EYES_ENFORCE:false`); the verb is inert until that flip, so the four-eyes leg of the
+  segregation-of-duties claim is not enforced in any environment today.
 - **2026-08-27** — Transaction-initiation trace contract. `TransactionService` emits the internal
   `transaction.initiate` span only with the terminal transaction status. It deliberately excludes
   amount, account/party identifiers, description, idempotency key and payment metadata. Risk class

--- a/docs/threat-models/openbank-transaction-service.md
+++ b/docs/threat-models/openbank-transaction-service.md
@@ -294,13 +294,24 @@ what the catalogue may hold.
   **auditability** half is mitigated by `MergeSweepDescriptionTest`, which pins the server-minted
   description's prefix, its merge reference and both party ids in survivor-last order, and asserts
   it names no PII — that string is the only thing distinguishing a merge correction from an ordinary
-  transfer in the trial balance. The **segregation-of-duties** half has no endpoint test: a
-  `TransactionResourceMergeSweepTest` was named here but is in no Kotlin source, and no other test
-  references the sweep endpoint. What gates it today is declarative only —
-  `@RolesAllowed(Roles.OPERATOR, Roles.ADMIN)` plus `@Authorize(action = "transaction.sweep")` on
-  `TransactionResource.mergeSweep`. `authz.four-eyes.enforce` remains `false`
-  (`AUTHZ_FOUR_EYES_ENFORCE:false`); the verb is inert until that flip, so the four-eyes leg of the
-  segregation-of-duties claim is not enforced in any environment today.
+  transfer in the trial balance. The
+  **segregation-of-duties** half is weaker than this entry claimed, in three separable ways, and
+  only the first is a missing artifact. (1) `TransactionResourceMergeSweepTest`, named here as the
+  mitigation, is in **no** file of any kind — `git grep -n TransactionResourceMergeSweepTest` finds
+  nothing on any path, so the name resolves to nothing rather than to a renamed class. (2) What does
+  cover `mergeSweep` is `TransactionSecurityContractTest`'s sweep-all assertion, which walks every
+  HTTP endpoint on `TransactionResource` by reflection and requires each to be `@RolesAllowed` and
+  never `@PermitAll` — so the endpoint cannot silently become permit-all, and that much of the claim
+  does hold. Its **specific** role set is not pinned, unlike `listTransactions`, `searchTransactions`,
+  `getTransaction` and `initiateTransaction`, which the same class pins by name: widening
+  `mergeSweep` from OPERATOR/ADMIN to any other non-empty role set would pass every test in the
+  module. (3) No test exercises the sweep endpoint over HTTP at all. What gates it today is therefore
+  declarative — `@RolesAllowed(Roles.OPERATOR, Roles.ADMIN)` plus
+  `@Authorize(action = "transaction.sweep")` on `TransactionResource.mergeSweep` — with the
+  never-permit-all half locked by test and the exact role set not.
+  `authz.four-eyes.enforce` remains `false` (`AUTHZ_FOUR_EYES_ENFORCE:false`); the verb is inert
+  until that flip, so the four-eyes leg of the segregation-of-duties claim is not enforced in any
+  environment today.
 - **2026-08-27** — Transaction-initiation trace contract. `TransactionService` emits the internal
   `transaction.initiate` span only with the terminal transaction status. It deliberately excludes
   amount, account/party identifiers, description, idempotency key and payment metadata. Risk class


### PR DESCRIPTION
## Summary

The 2026-07-19 merge-sweep entry in `docs/threat-models/openbank-transaction-service.md` credits its
segregation-of-duties mitigation to `TransactionResourceMergeSweepTest`, which is in **no file of any
kind** in this repository. This splits the entry into the half the tests genuinely hold and the half
they do not, and says exactly where the boundary is. Documentation only: no source, schema, endpoint,
role or policy change.

## Type of change

- [x] docs

## Linked issues

Refs #8407

## Changes

**The missing artifact.** Unlike the sibling corrections in #8408 and #8409, this name is not a
rename — it resolves to nothing at all, on any path:

```
git grep -n "TransactionResourceMergeSweepTest" origin/main             # no output, any path
git grep -l "class ServiceInfoResource" origin/main -- '*.kt'           # a hit (control)
```

The control is what makes the silence evidence rather than a broken probe.

**What still holds, and is now stated.** The entry's risk class is "segregation of duties +
auditability", and the auditability half is genuinely mitigated: `MergeSweepDescriptionTest` pins the
server-minted description's prefix, its merge reference and both party ids in survivor-last order,
and asserts it names no PII. That string is the only thing distinguishing a merge correction from an
ordinary transfer in the trial balance, so this is the load-bearing half and it is covered.

**What does not hold — narrower than my first pass said.** An earlier draft of this change replaced
the false name with "the segregation-of-duties half has no endpoint test". That overstates in the
other direction, so it is not what this PR says. `TransactionSecurityContractTest` walks *every* HTTP
endpoint on `TransactionResource` by reflection and requires each to be `@RolesAllowed` and never
`@PermitAll` — `mergeSweep` is inside that sweep, so it cannot silently become permit-all, and that
much of the original claim is true.

What is genuinely unpinned is the **specific role set**. That class pins `listTransactions`,
`searchTransactions`, `getTransaction` and `initiateTransaction` by name to exact role lists;
`mergeSweep` is not in any of those lists. So widening `mergeSweep` from `OPERATOR`/`ADMIN` to any
other non-empty role set passes every test in the module. Beyond that: no test drives the endpoint
over HTTP, and `authz.four-eyes.enforce` is `false`, so the four-eyes leg of the SoD claim is inert
in every environment today — which the entry already said and this PR keeps.

## Reviewer notes

- **Not fixed by deletion.** The entry now records what it used to claim, what is true now, and
  which half changed, so a later reader can distinguish a correction from a control quietly dropped.
- **#5043 is open against the same file** (`fix/four-eyes-resource-binding-4754`) and adds
  `MergeSweepApprovalBindingIT`, real-HTTP coverage of the sweep approval binding. It inserts at a
  different point in the same change log (~line 222 vs ~line 293 here), so the two should merge
  cleanly, but whichever lands second is worth a re-read: once #5043 is in, point (3) above — "no
  test exercises the sweep endpoint over HTTP" — stops being true and should be updated in the same
  spirit rather than left to rot.
- Everything the entry says about the money mechanics, the saga path, the `ADJUSTMENT` type and the
  §4b STRIDE rows is untouched.

## Definition of Done

- [x] Docs updated.
- [x] No source change at all in this PR.

## Compliance impact

- [x] None — corrects the description of existing controls; no control changed.

## Rollout / Rollback

- Deployment strategy: n/a (docs)
- Rollback plan: revert
- Data migration reversible: N/A
