### PR TITLE
docs(sanctions): publish the event names the service actually emits

### DIFF
--- a/openbank-sanctions-service/src/main/resources/docs/01-overview.cs.md
+++ b/openbank-sanctions-service/src/main/resources/docs/01-overview.cs.md
@@ -40,8 +40,8 @@ Při zahájení převodu volá platební služba `POST /api/v1/sanctions/screen`
 
 | Use case | API | Event |
 |---|---|---|
-| Prověřit stranu před platbou | `POST /api/v1/sanctions/screen` | `SanctionsCheckCompleted` |
-| Přezkoumat potenciální hit | `POST /api/v1/sanctions/review` | `SanctionsReviewSubmitted` |
+| Prověřit stranu před platbou | `POST /api/v1/sanctions/screen` | `SanctionChecked` |
+| Přezkoumat potenciální hit | `POST /api/v1/sanctions/review` | `SanctionReviewed` |
 | Zobrazit potvrzené hity | `GET /api/v1/sanctions/hits` | — |
 | Zobrazit hity čekající na přezkum | `GET /api/v1/sanctions/pending` | — |
 | Povolit / nakonfigurovat listinu | `PUT /api/v1/sanctions/lists/{id}` | — |

--- a/openbank-sanctions-service/src/main/resources/docs/01-overview.en.md
+++ b/openbank-sanctions-service/src/main/resources/docs/01-overview.en.md
@@ -40,8 +40,8 @@ When a payment service initiates a transfer, it calls `POST /api/v1/sanctions/sc
 
 | Use case | API | Event |
 |---|---|---|
-| Screen a party before payment | `POST /api/v1/sanctions/screen` | `SanctionsCheckCompleted` |
-| Review a potential hit | `POST /api/v1/sanctions/review` | `SanctionsReviewSubmitted` |
+| Screen a party before payment | `POST /api/v1/sanctions/screen` | `SanctionChecked` |
+| Review a potential hit | `POST /api/v1/sanctions/review` | `SanctionReviewed` |
 | List all confirmed hits | `GET /api/v1/sanctions/hits` | — |
 | List hits awaiting review | `GET /api/v1/sanctions/pending` | — |
 | Enable / configure a list | `PUT /api/v1/sanctions/lists/{id}` | — |


### PR DESCRIPTION
## Summary
`openbank-sanctions-service`'s operator-facing use-case table names the screen and review events
`SanctionsCheckCompleted` and `SanctionsReviewSubmitted`. Neither string exists in any Kotlin source.
The service emits `SanctionChecked` and `SanctionReviewed`. Documentation only, Czech and English
corrected together.

## Type of change
- [x] docs

## Linked issues
Refs #8407

## Changes
```
git grep -l "SanctionsCheckCompleted" origin/main -- '*.kt'   # 0
git grep -l "SanctionsReviewSubmitted" origin/main -- '*.kt'  # 0
git grep -l "SanctionChecked"          origin/main -- '*.kt'  # 5 (control: the probe finds names)
```
Read from the constants rather than from a grep for the quoted table values —
`SanctionsService.kt:108` `const val EVENT_SCREENED = "SanctionChecked"` and `:129`
`const val EVENT_REVIEWED = "SanctionReviewed"`, used at `saveWithEvent(check, EVENT_SCREENED)` and
`updateWithEvent(updated, EVENT_REVIEWED)`.

- `01-overview.cs.md:43,44`
- `01-overview.en.md:43,44`

## Reviewer notes
This table is what a downstream consumer builds its `eventType` discriminator from, so a wrong name
is not cosmetic: it is a filter that silently matches nothing, on a 5AMLD Art. 13 screening path —
and a filter matching nothing looks exactly like "no hits to review".

Both languages changed in one commit; correcting one alone would have left a fresh inconsistency
between the pair.

## Compliance impact
- [x] AML / 5AMLD — documentation of the screening event contract only; no code, event or control changed.

## Rollout / Rollback
- Deployment strategy: n/a (docs)
- Rollback plan: revert
