### PR TITLE
docs(security-scanner): publish the ICT incident event names actually emitted

### DIFF
--- a/openbank-security-scanner/src/main/resources/docs/01-overview.cs.md
+++ b/openbank-security-scanner/src/main/resources/docs/01-overview.cs.md
@@ -46,9 +46,9 @@
 | Spustit on-demand úplný sken | `POST /api/v1/security/scan` | — (žádný event; report jen přes REST) |
 | Získat nejnovější platformový report | `GET /api/v1/security/report` | — |
 | Získat výsledky pro konkrétní službu | `GET /api/v1/security/services/{name}` | — |
-| Nahlásit nový ICT incident | `POST /api/v1/ict-incidents` | `IctIncidentReported` |
-| Aktualizovat stav incidentu | `PATCH /api/v1/ict-incidents/{id}/status` | `IctIncidentUpdated` |
-| Označit incident jako nahlášený regulátorovi | `POST /api/v1/ict-incidents/{id}/regulatory-report` | `IctIncidentRegulatoryReported` |
+| Nahlásit nový ICT incident | `POST /api/v1/ict-incidents` | `ICT_INCIDENT_REPORTED` |
+| Aktualizovat stav incidentu | `PATCH /api/v1/ict-incidents/{id}/status` | `ICT_INCIDENT_STATUS_CHANGED` |
+| Označit incident jako nahlášený regulátorovi | `POST /api/v1/ict-incidents/{id}/regulatory-report` | `ICT_INCIDENT_REPORTED_TO_REGULATOR` |
 
 ## Kontroly skenu na službu
 

--- a/openbank-security-scanner/src/main/resources/docs/01-overview.en.md
+++ b/openbank-security-scanner/src/main/resources/docs/01-overview.en.md
@@ -46,9 +46,9 @@
 | Trigger an on-demand full scan | `POST /api/v1/security/scan` | — (no event; report is REST-only) |
 | Get the latest platform report | `GET /api/v1/security/report` | — |
 | Get results for a specific service | `GET /api/v1/security/services/{name}` | — |
-| Report a new ICT incident | `POST /api/v1/ict-incidents` | `IctIncidentReported` |
-| Update incident status | `PATCH /api/v1/ict-incidents/{id}/status` | `IctIncidentUpdated` |
-| Mark incident as reported to regulator | `POST /api/v1/ict-incidents/{id}/regulatory-report` | `IctIncidentRegulatoryReported` |
+| Report a new ICT incident | `POST /api/v1/ict-incidents` | `ICT_INCIDENT_REPORTED` |
+| Update incident status | `PATCH /api/v1/ict-incidents/{id}/status` | `ICT_INCIDENT_STATUS_CHANGED` |
+| Mark incident as reported to regulator | `POST /api/v1/ict-incidents/{id}/regulatory-report` | `ICT_INCIDENT_REPORTED_TO_REGULATOR` |
 
 ## Scan checks per service
 


### PR DESCRIPTION
## Summary
The DORA ICT incident register's use-case table names its three events `IctIncidentReported`,
`IctIncidentUpdated` and `IctIncidentRegulatoryReported`. None of those strings exists in any Kotlin
source. `IctIncidentService` emits `ICT_INCIDENT_REPORTED`, `ICT_INCIDENT_STATUS_CHANGED` and
`ICT_INCIDENT_REPORTED_TO_REGULATOR`. Documentation only, Czech and English corrected together.

## Type of change
- [x] docs

## Linked issues
Refs #8407

## Changes
Read from the emitting call sites, not by grepping the quoted names — a serialised payload carries no
literal key anywhere, so a grep for the table's values is a false clean by construction:
```
grep -n "publishEvent(" openbank-security-scanner/.../application/IctIncidentService.kt
# 74:  publishEvent("ICT_INCIDENT_REPORTED", saved)
# 97:  publishEvent("ICT_INCIDENT_STATUS_CHANGED", updated)
# 120: publishEvent("ICT_INCIDENT_REPORTED_TO_REGULATOR", updated)
git grep -l "IctIncidentReported" origin/main -- '*.kt'   # 0  (likewise the other two)
```
- `01-overview.cs.md:49,50,51`
- `01-overview.en.md:49,50,51`

## Reviewer notes
Note this is not three typos but a **different naming convention** — CamelCase in the document,
SCREAMING_SNAKE on the wire — so a consumer transcribing the table gets three filters that each match
nothing, and the middle one is not even a renaming of the same idea (`Updated` vs `STATUS_CHANGED`).

Same subsystem as the already-fixed cloud-architecture persistence line (#7954), different assertion:
that one was about whether the register persists, this one about what it publishes.

## Compliance impact
- [x] DORA — documentation of the ICT incident event contract only; no code, event or control changed.

## Rollout / Rollback
- Deployment strategy: n/a (docs)
- Rollback plan: revert
