### PR TITLE
security(interest): enforce authorization by default, not by manifest

### DIFF
--- a/docs/threat-models/openbank-interest-service.md
+++ b/docs/threat-models/openbank-interest-service.md
@@ -39,6 +39,10 @@ money-path service, not adjacent.
 - Operator-facing REST endpoints: `@RolesAllowed` (ROLE_OPERATOR/ADMIN).
 - Capitalization and remittance runs are triggered internally (scheduled job), not by an external caller — no unauthenticated inbound trigger surface.
 - Calls to `ledger-service` and `transaction-service` are service-to-service (OIDC client credentials, OPA policy, four-eyes verbs per `rules.yaml`).
+- OPA enforcement is a property of the **service**, not of a manifest: `authz.enforce` defaults to
+  `${AUTHZ_ENFORCE:true}` in `application.yaml` (#3679). The `%test` profile is the single
+  documented exception — no OPA sidecar runs in the test JVM, and the interceptor fails closed
+  (503) on an unreachable PDP.
 
 ## 4. STRIDE
 
@@ -59,6 +63,26 @@ money-path service, not adjacent.
 - **Settlement ack consumer** (`WithholdingRemittanceSettlementConsumer`) trusts the Kafka topic's mTLS/ACL boundary as its authentication; no additional payload-level signature.
 
 ## 6. Change log
+
+- **2026-09-03** — `authz.enforce` now defaults to **true** in `application.yaml` (#3679). Until
+  now it read `${AUTHZ_ENFORCE:false}`, so enforcement was a property of one gitops manifest
+  rather than of the service: the deployed Rollout sets the variable to `"true"` (since #3695), so
+  the cluster was enforcing, but **any environment that does not set the variable ran this
+  money-path service in advisory mode** — a new cluster, a local run, an ad-hoc container, a
+  restored namespace. In advisory mode `AuthorizeInterceptor` evaluates every `@Authorize`
+  decision, logs the deny at WARN and lets the request through, so the failure is silent: the
+  `prohibition` on service-account writes recorded in the 2026-08-03 entry below is **inert** in
+  any such environment, and so is every other reason in the bundle. This closes that gap at the
+  source. **No new caller, endpoint, network edge or grant** — the change can only ever move a
+  request from allowed-while-denied to denied. Grantability was measured before flipping, since
+  enforcing an action that no reason grants turns it into a 403: all five gated actions
+  (`interest.create/.trigger/.delete/.read/.list`) were evaluated with `opa eval` against the
+  deployed bundle ConfigMap, each probe carrying a must-DENY and a must-ALLOW control, and every
+  one resolves `allow=true` for at least one real principal. `four_eyes_required` is false for all
+  five. Residual: an operator running this service with no OPA sidecar reachable now gets 503
+  rather than an unauthorized success — the intended fail-closed direction, but it makes a missing
+  sidecar a hard outage instead of a silent control bypass. Rollback: set `AUTHZ_ENFORCE=false` in
+  the environment, which needs no code change.
 
 - **2026-08-24** — Synthetic-journey taint now propagates over this service's existing internal REST clients through `SyntheticTaintClientFilter` (ADR-0252, #4348). This adds no caller, endpoint, network-policy edge, privilege or control bypass. It preserves the marker before a downstream persistence/event boundary; a fleet gate requires every new client to choose propagation or a reasoned external boundary.
 

--- a/openbank-interest-service/src/main/resources/application.yaml
+++ b/openbank-interest-service/src/main/resources/application.yaml
@@ -115,7 +115,16 @@ opa:
   path: "${OPA_PATH:/v1/data/openbank/rest/allow}"
   timeout-ms: "${OPA_TIMEOUT_MS:500}"
 authz:
-  enforce: "${AUTHZ_ENFORCE:false}"
+  # Enforcing by DEFAULT (#3679). interest-service is money-path — it posts real GL
+  # journals (#1478) — and while this read `${AUTHZ_ENFORCE:false}` enforcement was a
+  # property of one gitops manifest rather than of the service: the deployed Rollout sets
+  # the variable to "true", so the cluster was correct, but a new cluster, a local run or
+  # an ad-hoc container silently ran ADVISORY — every @Authorize decision evaluated,
+  # every deny logged, every request allowed through. Fail-safe belongs in the default,
+  # not in whichever manifest remembers the variable. Every action this service gates
+  # (interest.create/.trigger/.delete/.read/.list) was confirmed grantable against the
+  # deployed bundle before this flip, so no endpoint 403s as a result of it.
+  enforce: "${AUTHZ_ENFORCE:true}"
 
 "%dev":
   quarkus:
@@ -149,6 +158,12 @@ authz:
     # dispatchScheduledBatch() explicitly and never races the assertions.
     scheduler:
       enabled: false
+  # OPA is not present in CI integration tests — keep advisory so @Authorize methods proceed
+  # instead of 503ing on the absent sidecar (the interceptor fails CLOSED on an unreachable
+  # PDP, by design). Scoped and explicit, which is the point: the fleet default above is now
+  # enforce, and this is the one environment that opts out. Same shape as aml/pid/party.
+  authz:
+    enforce: "false"
 # ADR-0033 §D — the GL accounts the capitalization split posts against (InterestLedgerConfig).
 # Defaults are the stable `a0000000-…` rows seeded by the ledger's
 # V17__interest_capitalization_accounts.sql; operators repoint them at the real chart per

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/authz/AuthzEnforceDefaultTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/authz/AuthzEnforceDefaultTest.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.interest.infrastructure.authz
+
+import io.smallrye.config.SmallRyeConfigBuilder
+import io.smallrye.config.source.yaml.YamlConfigSource
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * `authz.enforce` must not depend on a deployment manifest remembering to set `AUTHZ_ENFORCE`
+ * (issue #3679).
+ *
+ * interest-service is money-path (it posts real GL journals, #1478). While `application.yaml` read
+ * `${AUTHZ_ENFORCE:false}`, enforcement was a property of ONE gitops manifest rather than of the
+ * service: the deployed Rollout sets the variable to `"true"`, so the cluster was fine, but every
+ * environment that does not set it — a new cluster, a local run, an ad-hoc container, a restored
+ * namespace — silently ran a money-path service in ADVISORY mode, where `AuthorizeInterceptor`
+ * evaluates every `@Authorize` decision, logs the denies and lets the request through anyway.
+ * Nothing failed; the only symptom was a WARN line nobody was reading.
+ *
+ * WHY THIS TEST RESOLVES RATHER THAN GREPS. Asserting the literal string `${AUTHZ_ENFORCE:true}`
+ * would pass in both worlds this test has to tell apart: the value that reaches the interceptor is
+ * produced by SmallRye's expression expansion and profile merging, not by the characters in the
+ * file, so a `%prod` override or a second `authz:` mapping key later in the document would change
+ * the answer without changing the string. So the config is actually built and the value read back.
+ *
+ * The sources are deliberately ONLY the YAML file — no env, no system properties. That is what
+ * makes the assertion mean "with `AUTHZ_ENFORCE` unset", and it keeps the test deterministic on a
+ * workstation that happens to export the variable.
+ */
+class AuthzEnforceDefaultTest {
+
+    private fun resolveAuthzEnforce(profile: String): Boolean = SmallRyeConfigBuilder()
+        .addDefaultInterceptors()
+        .withSources(YamlConfigSource(applicationYaml(), YAML_ORDINAL))
+        .withProfile(profile)
+        .build()
+        .getValue("authz.enforce", Boolean::class.java)
+
+    private fun applicationYaml() = requireNotNull(javaClass.classLoader.getResource("application.yaml")) {
+        "application.yaml is not on the test classpath"
+    }
+
+    @Test
+    fun `enforces authorization by default when AUTHZ_ENFORCE is unset`() {
+        assertThat(resolveAuthzEnforce("prod"))
+            .describedAs(
+                "authz.enforce must resolve to true with AUTHZ_ENFORCE unset — otherwise any " +
+                    "environment that forgets the variable runs this money-path service in advisory mode",
+            )
+            .isTrue()
+    }
+
+    /**
+     * The one deliberate exception, asserted so it stays deliberate: no OPA sidecar exists in the
+     * test JVM, and with `authz.enforce=true` a `@Authorize` method whose PDP is unreachable raises
+     * `PolicyDecisionException` -> HTTP 503 (the interceptor fails CLOSED, by design). The
+     * integration tests that drive authorized endpoints — `InterestMissingParamStatusIT` — would
+     * turn into 503s. Same shape aml-service and pid-service already carry.
+     */
+    @Test
+    fun `runs advisory under the test profile because no OPA sidecar exists there`() {
+        assertThat(resolveAuthzEnforce("test"))
+            .describedAs("the %test profile must keep advisory mode; the exception is scoped and explicit")
+            .isFalse()
+    }
+
+    private companion object {
+        const val YAML_ORDINAL = 100
+    }
+}


### PR DESCRIPTION
## Summary

`openbank-interest-service` defaulted `authz.enforce` to `${AUTHZ_ENFORCE:false}`, so authorization
enforcement was a property of **one gitops manifest** rather than of the service. The deployed
Rollout sets the variable to `"true"`, so the cluster is correct — but any environment that does not
set it (a new cluster, a local run, an ad-hoc container, a restored namespace) silently ran a
money-path service in **advisory** mode: every `@Authorize` decision evaluated, every deny logged at
WARN, every request allowed through anyway. This flips the default to `true` and scopes the one real
exception to the `%test` profile. Half of #3679; `sdd-service` is the model.

## Type of change

- [x] security (private until disclosed)

## Linked issues

Refs #3679

## Changes

- `application.yaml`: `authz.enforce` default `${AUTHZ_ENFORCE:false}` → `${AUTHZ_ENFORCE:true}`.
- `application.yaml`: explicit `%test` override `authz.enforce: "false"` — no OPA sidecar exists in
  the test JVM and the interceptor **fails closed** on an unreachable PDP
  (`PolicyDecisionException` → 503), which would turn `InterestMissingParamStatusIT` into 503s. This
  is the shape `aml-service`, `pid-service` and `party-service` already carry.
- New `AuthzEnforceDefaultTest` locking both halves.

## Verified before flipping — grantability

Flipping enforcement on an action with **no allow reason** turns it into a 403. Three money-path
actions were found declared four-eyes and granted nowhere this week, so this was measured rather
than assumed. Every action was evaluated with `opa eval` against the **deployed bundle ConfigMap**
(`interest-opa-bundle.yaml`, checksum `fbbc9c7d0985cf82`), materialised to the sidecar's own layout
(`rules-data.yaml` → `rules/data.yaml`) — reading the rego is not enough, since several reasons can
match and only evaluation says which fires.

Every probe carried a **must-DENY and a must-ALLOW control in the same invocation**
(`anonymous/interest.create` → deny, `staff-operator/bogus.nonexistent` → deny,
`staff-operator/party.read` → allow); all controls valid.

| Action | Verdict | Reason that fires |
|---|---|---|
| `interest.create` | GRANTABLE | `operator-interest-write`, `matrix-allows` |
| `interest.trigger` | GRANTABLE | `operator-interest-write`, `matrix-allows` |
| `interest.delete` | GRANTABLE | `operator-interest-write`, `matrix-allows` |
| `interest.read` | GRANTABLE | `interest-oversight-read`, `compliance-read-any`, `operator-read-any` |
| `interest.list` | GRANTABLE | `interest-oversight-read`, `matrix-allows` |

**No action is ungrantable, so no endpoint 403s as a result of this change.** The two service
accounts remain correctly denied on the writes — the `prohibited` rule in `interest_rest_ext.rego`
vetoes them — which is existing intent, unchanged here. `four_eyes_required` is `false` for all five
actions (control: `ledger.post` → true, `bogus.nothing` → false), so nothing here depends on
four-eyes.

## Proof by what it prevents

The test **resolves** the value through SmallRye rather than asserting the literal string: the string
would pass in both worlds this has to tell apart, because profile merging and expression expansion
decide what actually reaches the interceptor. Sources are the YAML file only — no env, no system
properties — which is what makes it mean "with `AUTHZ_ENFORCE` unset" and keeps it deterministic on a
workstation that exports the variable.

- Against **unmodified `main`**: exit `1`, `tests="2" skipped="0" failures="1" errors="0"` —
  `Expecting value to be true but was false`.
- After the change: exit `0`, `tests="2" skipped="0" failures="0" errors="0"`.
- `ktlintCheck` + `detekt`: exit `0`.

Skip counts read explicitly and are zero in both runs (a service that cannot boot reports tests as
SKIPPED, so the skip count is the number that matters).

## Definition of Done

- [x] Hexagonal layering preserved (config + test only).
- [x] Unit tests added.
- [ ] Integration tests — unchanged by construction: the `%test` profile resolves `authz.enforce` to
      `false` exactly as it did before, so existing ITs see no behavioural delta.
- [x] No public API change, no DB change, no event change.
- [x] `ktlintCheck` / `detekt` pass.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new suppressions.
- [x] No new third-party dependency (`smallrye-config-source-yaml` already on the classpath via
      `quarkus-config-yaml`).
- [x] Auth code changed → **`security-review-required`**. Money-path: 2 approvals + threat model.

## Compliance impact

- [x] DORA
- [x] PSD2 / SCA / RTS
