### PR TITLE
security(delegation): enforce authorization by default, not by manifest

### DIFF
--- a/docs/threat-models/openbank-delegation-service.md
+++ b/docs/threat-models/openbank-delegation-service.md
@@ -130,6 +130,42 @@ gap closes only with a consumer pact or a run against a deployed stack.
 
 ## Change log
 
+- **2026-09-03** — `authz.enforce` now defaults to **true** in `application.yaml` (#3679). Until
+  now it read `${AUTHZ_ENFORCE:false}`, so enforcement was a property of one gitops manifest
+  rather than of the service: the deployed Rollout sets the variable to `"true"`, so the cluster
+  was enforcing, but **any environment that does not set the variable ran this money-path service
+  in advisory mode** — a new cluster, a local run, an ad-hoc container, a restored namespace. In
+  advisory mode `AuthorizeInterceptor` evaluates every `@Authorize` decision, logs the deny at
+  WARN and lets the request through, so the failure is silent — and for this service that means
+  the boundary in row 1 above degrades from a checked door to an observed one: every scoping rule
+  that keeps `edge-service-delegation` off the bank-side `suspend`/`reinstate` actions, and
+  `service-delegation-check` down to a single read-only action, is **inert** there. This closes
+  that gap at the source. **No new caller, endpoint, network edge or grant** — the change can only
+  ever move a request from allowed-while-denied to denied. Grantability was measured before
+  flipping, since enforcing an action that no reason grants turns it into a 403: all 14 gated
+  actions were evaluated with `opa eval` against the deployed bundle ConfigMap, each probe
+  carrying a must-DENY and a must-ALLOW control, and every one resolves `allow=true` for at least
+  one real principal. Residual: an operator running this service with no OPA sidecar reachable now
+  gets 503 rather than an unauthorized success — the intended fail-closed direction, but it makes
+  a missing sidecar a hard outage instead of a silent control bypass. Rollback: set
+  `AUTHZ_ENFORCE=false` in the environment, which needs no code change.
+
+- **2026-09-03** — Four-eyes remains **off**, recorded here because it is a different control from
+  the one above and was verified rather than assumed (#3679). Measured against the deployed
+  bundle, `delegation.revoke` and `delegation.reserve.release` DO evaluate
+  `four_eyes_required=true` — both end in a verb listed in `rules.yaml: four_eyes.verbs`
+  (`revoke`, `release`) and this service is in `money_path_services`; the other twelve actions are
+  false. But **no `ApprovalStore` bean is wired in this service**, so
+  `AuthorizeInterceptor.requireFourEyesOrProceed` takes its `no_approval_store` branch: it logs an
+  error and **proceeds** (ADR-0155 D3 keeps it a no-op rather than failing closed). Flipping
+  `AUTHZ_FOUR_EYES_ENFORCE` today would therefore gate nothing while appearing to gate two
+  money-path actions, which is a worse state than being visibly off. Prerequisite: an
+  `ApprovalStore` of the kind account-, balance- and billing-service carry
+  (`infrastructure/approval/ApprovalConfig.kt`). One decision to take deliberately at that point:
+  `delegation.reserve.release` is a routine customer spending action that matches the `release`
+  verb by accident of naming, so inheriting the money-path default would put a second approver in
+  front of ordinary customer traffic.
+
 - **2026-09-01** — Lifecycle transitions gained database-authoritative monotonic revisions (T17). The migration is expand-compatible with an old producer for acyclic transitions; legacy reinstatement fails closed because only a revision-aware writer can distinguish a repeated SUSPENDED state. The database state machine supplies the revision and the deferred outbox trigger stamps the committed value. Rollout is consumer-first and quiesces writers while immutable V8–V10 apply; producer deployment before revision-aware account/card cursors would publish an ordering fact nobody enforces. Rollback retains the lifecycle migrations when reverting the producer image, because their triggers are the compatibility layer for that old image.
 
 - **2026-08-24** — Synthetic-journey taint now propagates over this service's existing internal REST clients through `SyntheticTaintClientFilter` (ADR-0252, #4348). This adds no caller, endpoint, network-policy edge, privilege or authorization bypass. It preserves the marker before a downstream persistence/event boundary; a fleet gate requires every new client to choose propagation or a reasoned external boundary.

--- a/openbank-delegation-service/src/main/resources/application.yaml
+++ b/openbank-delegation-service/src/main/resources/application.yaml
@@ -183,6 +183,13 @@ mp:
     # the test JVM try to reach a Keycloak that is not there. Same as party-service's test profile.
     oidc-client:
       enabled: false
+  # OPA is not present in CI integration tests — keep advisory so @Authorize methods proceed
+  # instead of 503ing on the absent sidecar (the interceptor fails CLOSED on an unreachable
+  # PDP, by design; SpendReservationConcurrencyIT and SpendReservationStateOutboxIT drive the
+  # authorized reservation endpoints). Scoped and explicit, which is the point: the fleet
+  # default above is now enforce, and this is the one environment that opts out.
+  authz:
+    enforce: "false"
 
 openbank:
   delegation:
@@ -208,12 +215,30 @@ openbank:
   git:
     commit: "${GIT_COMMIT:unknown}"
 
-# OPA sidecar (ADR-0034). Advisory mode by default.
+# OPA sidecar (ADR-0034). ENFORCING by default since #3679 — see the authz block below.
 opa:
   url: "${OPA_URL:http://localhost:8181}"
   path: "${OPA_PATH:/v1/data/openbank/rest/allow}"
   timeout-ms: "${OPA_TIMEOUT_MS:500}"
 authz:
-  enforce: "${AUTHZ_ENFORCE:false}"
+  # Enforcing by DEFAULT (#3679). delegation-service is money-path — it mints the
+  # capabilities that let one party spend another's money — and while this read
+  # `${AUTHZ_ENFORCE:false}` enforcement was a property of one gitops manifest rather than
+  # of the service: the deployed Rollout sets the variable to "true", so the cluster was
+  # correct, but a new cluster, a local run or an ad-hoc container silently ran ADVISORY —
+  # every @Authorize decision evaluated, every deny logged, every request allowed through.
+  # Fail-safe belongs in the default, not in whichever manifest remembers the variable.
+  # All 14 actions this service gates were confirmed grantable against the deployed bundle
+  # before this flip, so no endpoint 403s as a result of it.
+  enforce: "${AUTHZ_ENFORCE:true}"
+  # Four-eyes stays OFF, deliberately and separately from the flip above. `delegation.revoke`
+  # and `delegation.reserve.release` DO evaluate four_eyes_required=true against the deployed
+  # bundle (both end in a `rules.yaml: four_eyes.verbs` verb, and this service is money-path),
+  # but no ApprovalStore bean is wired here, and AuthorizeInterceptor treats that as
+  # "no_approval_store": it logs an error and PROCEEDS (ADR-0155 D3 keeps it a no-op rather
+  # than failing closed). Flipping this today would gate nothing while looking like it did.
+  # Wire an ApprovalStore first, then flip — and note that `delegation.reserve.release` is a
+  # routine customer action that matches the `release` verb, so it needs a deliberate
+  # decision rather than inheriting the money-path default.
   four-eyes:
     enforce: "${AUTHZ_FOUR_EYES_ENFORCE:false}"

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/infrastructure/authz/AuthzEnforceDefaultTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/infrastructure/authz/AuthzEnforceDefaultTest.kt
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.delegation.infrastructure.authz
+
+import io.smallrye.config.SmallRyeConfigBuilder
+import io.smallrye.config.source.yaml.YamlConfigSource
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * `authz.enforce` must not depend on a deployment manifest remembering to set `AUTHZ_ENFORCE`
+ * (issue #3679).
+ *
+ * delegation-service is money-path and mints capabilities to spend other people's money. While
+ * `application.yaml` read `${AUTHZ_ENFORCE:false}`, enforcement was a property of ONE gitops
+ * manifest rather than of the service: the deployed Rollout sets the variable to `"true"`, so the
+ * cluster was fine, but every environment that does not set it — a new cluster, a local run, an
+ * ad-hoc container, a restored namespace — silently ran in ADVISORY mode, where
+ * `AuthorizeInterceptor` evaluates every `@Authorize` decision, logs the denies and lets the
+ * request through anyway. Nothing failed; `AuthzModeAnnouncer` logged one WARN nobody was reading.
+ *
+ * WHY THIS TEST RESOLVES RATHER THAN GREPS. Asserting the literal string `${AUTHZ_ENFORCE:true}`
+ * would pass in both worlds this test has to tell apart: the value that reaches the interceptor is
+ * produced by SmallRye's expression expansion and profile merging, not by the characters in the
+ * file, so a `%prod` override or a second `authz:` mapping key later in the document would change
+ * the answer without changing the string. So the config is actually built and the value read back.
+ *
+ * The sources are deliberately ONLY the YAML file — no env, no system properties. That is what
+ * makes the assertion mean "with `AUTHZ_ENFORCE` unset", and it keeps the test deterministic on a
+ * workstation that happens to export the variable.
+ */
+class AuthzEnforceDefaultTest {
+
+    private fun resolve(property: String, profile: String): Boolean = SmallRyeConfigBuilder()
+        .addDefaultInterceptors()
+        .withSources(YamlConfigSource(applicationYaml(), YAML_ORDINAL))
+        .withProfile(profile)
+        .build()
+        .getValue(property, Boolean::class.java)
+
+    private fun applicationYaml() = requireNotNull(javaClass.classLoader.getResource("application.yaml")) {
+        "application.yaml is not on the test classpath"
+    }
+
+    @Test
+    fun `enforces authorization by default when AUTHZ_ENFORCE is unset`() {
+        assertThat(resolve("authz.enforce", "prod"))
+            .describedAs(
+                "authz.enforce must resolve to true with AUTHZ_ENFORCE unset — otherwise any " +
+                    "environment that forgets the variable runs this money-path service in advisory mode",
+            )
+            .isTrue()
+    }
+
+    /**
+     * The one deliberate exception, asserted so it stays deliberate: no OPA sidecar exists in the
+     * test JVM, and with `authz.enforce=true` a `@Authorize` method whose PDP is unreachable raises
+     * `PolicyDecisionException` -> HTTP 503 (the interceptor fails CLOSED, by design). The
+     * integration tests that drive authorized endpoints — `SpendReservationConcurrencyIT` and
+     * `SpendReservationStateOutboxIT`, which POST the reservation trio — would turn into 503s.
+     * Same shape aml-service and pid-service already carry.
+     */
+    @Test
+    fun `runs advisory under the test profile because no OPA sidecar exists there`() {
+        assertThat(resolve("authz.enforce", "test"))
+            .describedAs("the %test profile must keep advisory mode; the exception is scoped and explicit")
+            .isFalse()
+    }
+
+    /**
+     * Four-eyes stays OFF, and that is deliberate rather than an oversight this change forgot.
+     *
+     * `delegation.revoke` and `delegation.reserve.release` do evaluate `four_eyes_required=true`
+     * against the deployed bundle (both end in a verb listed in `rules.yaml: four_eyes.verbs`, and
+     * delegation-service is in `money_path_services`). But this service wires no `ApprovalStore`
+     * bean, and `AuthorizeInterceptor.requireFourEyesOrProceed` treats that case as
+     * "no_approval_store": it logs an error and PROCEEDS — ADR-0155 D3 deliberately keeps it a
+     * no-op rather than failing closed. So flipping `AUTHZ_FOUR_EYES_ENFORCE` here would gate
+     * nothing while looking like it did, which is worse than leaving it visibly off. It is a
+     * separate piece of work (wire the store, then flip), not a rider on this change.
+     */
+    @Test
+    fun `leaves four-eyes enforcement off until an ApprovalStore is wired`() {
+        assertThat(resolve("authz.four-eyes.enforce", "prod"))
+            .describedAs("four-eyes must stay off while no ApprovalStore bean exists to gate on")
+            .isFalse()
+    }
+
+    private companion object {
+        const val YAML_ORDINAL = 100
+    }
+}


### PR DESCRIPTION
## Summary

`openbank-delegation-service` defaulted `authz.enforce` to `${AUTHZ_ENFORCE:false}`, so authorization
enforcement was a property of **one gitops manifest** rather than of the service. The deployed
Rollout sets the variable to `"true"`, so the cluster is correct — but any environment that does not
set it (a new cluster, a local run, an ad-hoc container, a restored namespace) silently ran in
**advisory** mode: every `@Authorize` decision evaluated, every deny logged, every request allowed
through anyway. This service mints the capabilities that let one party spend another's money, so
advisory-by-accident is the wrong failure mode. Half of #3679; `sdd-service` is the model.

## Type of change

- [x] security (private until disclosed)

## Linked issues

Refs #3679

## Changes

- `application.yaml`: `authz.enforce` default `${AUTHZ_ENFORCE:false}` → `${AUTHZ_ENFORCE:true}`.
- `application.yaml`: explicit `%test` override `authz.enforce: "false"` — no OPA sidecar exists in
  the test JVM and the interceptor **fails closed** on an unreachable PDP
  (`PolicyDecisionException` → 503), which would turn `SpendReservationConcurrencyIT` and
  `SpendReservationStateOutboxIT` into 503s. Shape already carried by `aml`/`pid`/`party`.
- `AUTHZ_FOUR_EYES_ENFORCE` **deliberately left `false`** — see below; the reason is now recorded in
  the file and locked by a test.
- New `AuthzEnforceDefaultTest`.

## Verified before flipping — grantability

Flipping enforcement on an action with **no allow reason** turns it into a 403. Every one of the 14
actions was evaluated with `opa eval` against the **deployed bundle ConfigMap**
(`delegation-opa-bundle.yaml`, checksum `97b8daa0e97c48a3`), materialised to the sidecar's own layout
(`rules-data.yaml` → `rules/data.yaml`) — reading the rego is not enough, since several reasons can
match and only evaluation says which fires.

Every probe carried a **must-DENY and a must-ALLOW control in the same invocation**
(`anonymous/delegation.offer` → deny, `staff-operator/bogus.nonexistent` → deny,
`staff-operator/party.read` → allow); all controls valid.

| Action | Verdict | Reason that fires |
|---|---|---|
| `delegation.offer` | GRANTABLE | `operator-delegation-write`, `edge-service-delegation` |
| `delegation.preview` | GRANTABLE | `operator-delegation-write`, `edge-service-delegation` |
| `delegation.read` | GRANTABLE | `operator-delegation-write`, `edge-service-delegation`, `operator-read-any`, `compliance-read-any` |
| `delegation.list` | GRANTABLE | `operator-delegation-write`, `edge-service-delegation`, `operator-read-any` |
| `delegation.accept` | GRANTABLE | `operator-delegation-write`, `edge-service-delegation` |
| `delegation.decline` | GRANTABLE | `operator-delegation-write`, `edge-service-delegation` |
| `delegation.renounce` | GRANTABLE | `operator-delegation-write`, `edge-service-delegation` |
| `delegation.revoke` | GRANTABLE | `operator-delegation-write`, `edge-service-delegation` |
| `delegation.suspend` | GRANTABLE | `operator-delegation-write` (bank-side; edge correctly excluded) |
| `delegation.reinstate` | GRANTABLE | `operator-delegation-write` (bank-side; edge correctly excluded) |
| `delegation.check` | GRANTABLE | `service-delegation-check` (the one action open to backend callers) |
| `delegation.reserve` | GRANTABLE | `operator-delegation-write`, `edge-service-delegation` |
| `delegation.reserve.confirm` | GRANTABLE | `operator-delegation-write`, `edge-service-delegation` |
| `delegation.reserve.release` | GRANTABLE | `operator-delegation-write`, `edge-service-delegation` |

**No action is ungrantable, so no endpoint 403s as a result of this change.**

## Four-eyes is NOT flipped, and that is the finding

`AUTHZ_FOUR_EYES_ENFORCE` also defaults to `false` here. That is a **different** risk from advisory
authz and it is **not** fixed in this PR, because the four-eyes path is not wired end to end:

- Measured against the deployed bundle (control: `ledger.post` → true, `bogus.nothing` → false),
  **`delegation.revoke` and `delegation.reserve.release` do evaluate `four_eyes_required=true`** —
  both end in a verb listed in `rules.yaml: four_eyes.verbs` (`revoke`, `release`) and this service
  is in `money_path_services`. The other 12 actions are `false`.
- But **this service wires no `ApprovalStore` bean.** `AuthorizeInterceptor.requireFourEyesOrProceed`
  hits the `no_approval_store` branch, logs an error and **proceeds** — ADR-0155 D3 deliberately
  keeps it a no-op rather than failing closed.

So flipping `AUTHZ_FOUR_EYES_ENFORCE` today would **gate nothing while looking like it did**, which
is worse than leaving it visibly off. The prerequisite is an `ApprovalStore` of the kind
`account-service`, `balance-service` and `billing-service` already carry
(`infrastructure/approval/ApprovalConfig.kt`). Worth a deliberate decision when it is wired:
**`delegation.reserve.release` is a routine customer spending action that matches the `release` verb
by accident of naming**, so inheriting the money-path default would put a second approver in front of
ordinary customer traffic.

## Proof by what it prevents

The test **resolves** the value through SmallRye rather than asserting the literal string: the string
would pass in both worlds this has to tell apart, because profile merging and expression expansion
decide what actually reaches the interceptor. Sources are the YAML file only — no env, no system
properties.

- Against **unmodified `main`**: exit `1`, `tests="3" skipped="0" failures="1" errors="0"` —
  `Expecting value to be true but was false`.
- After the change: exit `0`, `tests="3" skipped="0" failures="0" errors="0"`.
- `ktlintCheck` + `detekt`: exit `0`.

Skip counts read explicitly and are zero in both runs.

## Definition of Done

- [x] Hexagonal layering preserved (config + test only).
- [x] Unit tests added.
- [ ] Integration tests — unchanged by construction: the `%test` profile resolves `authz.enforce` to
      `false` exactly as it did before, so existing ITs see no behavioural delta.
- [x] No public API change, no DB change, no event change.
- [x] `ktlintCheck` / `detekt` pass.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new suppressions.
- [x] No new third-party dependency (`smallrye-config-source-yaml` already on the classpath via
      `quarkus-config-yaml`).
- [x] Auth code changed → **`security-review-required`**. Money-path: 2 approvals + threat model.

## Compliance impact

- [x] DORA
- [x] PSD2 / SCA / RTS
