### PR TITLE
fix(observability): alert on a rollout stuck Progressing — the one-replica canary deadlock (#3806)

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-tier1.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-tier1.yaml
@@ -193,6 +193,28 @@ spec:
               the 10-minute progress deadline — canary pods did not become healthy.
               Likely cause: OOMKilled, CrashLoopBackOff, missing secret/configmap, or
               image pull error. Traffic reverted to stable.
+        # The complement the deadline alert cannot see (#3806): all 21 fleet Rollouts
+        # are replicas: 1 with default canary maxSurge, so on a FULL cluster the canary
+        # pod never schedules and the Rollout sits in Progressing indefinitely — never
+        # Degraded (no deadline fires while nothing ever started), never failed, stable
+        # pod serving happily. GitOps says Synced, the service says healthy, and the
+        # new revision simply never rolls. "gitops pin != running image" is that state,
+        # read through the one signal that exposes it.
+        - alert: RolloutStuckProgressing
+          expr: |
+            rollout_phase{phase="Progressing"} == 1
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Rollout {{ $labels.name }} stuck Progressing for 30m in {{ $labels.namespace }}"
+            description: >-
+              {{ $labels.name }} (namespace {{ $labels.namespace }}) has been Progressing
+              for 30 minutes without completing. On this fleet's one-replica canaries the
+              standing cause is capacity: the canary pod cannot schedule on a full
+              nodepool, so the new revision never rolls and nothing else reports it
+              (#3806). Check KarpenterNodePoolAtLimit and the pending canary pod first;
+              the replica-floor decision is ADR material, tracked in #3806.
     - name: openbank.tier1.slo_burn
       rules:
         # Fast burn: budget exhausted in ~2 days → page.


### PR DESCRIPTION
## Summary

Adds a tier-1 alert `RolloutStuckProgressing` (`rollout_phase{phase="Progressing"} == 1`, `for: 30m`) next to the existing `RolloutProgressDeadlineExceeded`.

**Why (#3806):** on this fleet's one-replica canaries, a canary pod that cannot schedule (full nodepool) leaves the Rollout in `Progressing` indefinitely. `RolloutProgressDeadlineExceeded` only fires on `phase="Degraded"`, and with one replica there is no healthy new pod whose absence anything else notices — so the rollout deadlocks silently while every existing control reports green. The gap was invisible by construction; this alert makes the state itself page-worthy after 30 minutes.

**Deliberately not in this PR:** the per-service replica bump to ≥2 and PDBs (acceptance criteria 1–2 of #3806). Replicas are a per-service decision requiring proof of statelessness (the lending counter-example from #3467/#3644) and a capacity call (~+9.6 % CPU) — that is ADR material, not an autonomous code change. The issue stays open for that track.

Refs #3806

## Test plan

- [x] YAML parses (`yaml.safe_load`)
- [x] Same metric family as the existing sibling alert (`rollout_phase`), which the helm-values gate (#4584) already proved is scraped
- [ ] CI gates
