### PR TITLE
perf(ci): drop the dead API request main-red-watch makes on every firing

### DIFF
--- a/.github/scripts/check-main-red-watch.py
+++ b/.github/scripts/check-main-red-watch.py
@@ -725,10 +725,21 @@ def main() -> int:
         if not args.run_id:
             ap.error("--inspect-run needs --run-id")
         try:
-            meta = gh_api(f"repos/{args.repo}/actions/runs/{args.run_id}")[0]
-            attempt = args.attempt or meta.get("run_attempt") or 1
-            # Re-read the run AT THAT ATTEMPT: the top-level object describes the latest one, so
-            # its `conclusion` can disagree with the attempt the event fired for.
+            # The unscoped run object is fetched ONLY to derive the attempt, and the caller
+            # usually knows it: main-red-watch.yml always passes --attempt from
+            # `github.event.workflow_run.run_attempt`. When it does, this call's result was
+            # overwritten on the next line and never read — one dead API request on the
+            # highest-frequency consumer in the estate. Measured 2026-09-03 with a `gh` shim:
+            # 3 requests per --inspect-run, ~129 firings/hour, so ~387 of the 1000/hour
+            # INSTALLATION quota. That quota was exhausted at 08:01 the same morning and took
+            # Trivy's SARIF upload and dependency-review down fleet-wide, including on main.
+            attempt = args.attempt
+            if not attempt:
+                attempt = gh_api(f"repos/{args.repo}/actions/runs/{args.run_id}")[0].get(
+                    "run_attempt") or 1
+            # Read the run AT THAT ATTEMPT: the top-level object describes the LATEST attempt, so
+            # its `conclusion` can disagree with the attempt the event fired for. This one is
+            # load-bearing and stays.
             meta = gh_api(f"repos/{args.repo}/actions/runs/{args.run_id}/attempts/{attempt}")[0]
             jobs = fetch_jobs_scoped(args.repo, args.run_id, attempt)
         except Exception as exc:  # noqa: BLE001 -- any failure here is "could not answer"


### PR DESCRIPTION
## What

`--inspect-run` fetched the unscoped run object **solely to derive the attempt**, then overwrote `meta` with the attempt-scoped read on the very next line. When the caller already knows the attempt, that first result is never read — and `main-red-watch.yml` **always** passes it, from `github.event.workflow_run.run_attempt`.

So the estate's highest-frequency API consumer has been making one dead request per firing.

## Measured with a shim, because the obvious probe cannot see it

`gh api rate_limit` reported **zero** consumption across five distinct runs — `gh` served them from its HTTP cache, and GitHub does not charge `304 Not Modified`. A known-positive (10 uncached calls → delta 11) proved the probe worked and the script genuinely wasn't spending. Counting `gh` invocations directly settles it:

```
with --attempt (the workflow's own path)   3 -> 2 requests
without --attempt (fallback preserved)     3 -> 3 requests
```

## Why it is worth a PR

`main red watch` fired **129 times in the hour before 2026-09-03 08:01**, so roughly **387 of the 1000/hour INSTALLATION quota** came from this one workflow.

At 08:01 that quota was exhausted. Trivy's SARIF upload and `dependency-review` began failing on every branch **including main** — 33 successes before the transition, 13 failures after, and `dependency-review` reporting it as the misleading *"Dependency graph is not enabled"*. Neither check is required and `all-green` does not gate on them, so nothing was blocked; what was lost is that **Code Scanning silently stopped being updated**. Reruns went green on unchanged commits once the hourly window reset.

## What this does not claim

**It does not make the watch cheap, and it is not meant to.** The fan-out *is* the control: each of the ~10 watched workflows has to be classified separately, because a later workflow going red after an earlier one went green is exactly the case `main-red-watch` exists for. Deduplicating it to one firing per SHA would remove the thing it detects.

What this removes is a request that bought nothing — about **129 calls/hour, ~13 points of the installation budget**. The remaining ~258/hour is the control doing its job.

## Linked issues

Refs #6853 — the same mechanism, seen from the other side. That issue records
`auto-retry-cancelled.yml` failing on an **installation rate-limit 403** from the jobs API, so a
spot-killed CI run silently stopped being re-run. This PR removes ~129 requests/hour from the same
installation budget. It does not close #6853: that issue is about the retry not surviving a 403,
which remains true whatever the budget headroom is.

## Verification

- Fallback kept and exercised: without `--attempt` the script still derives it from the unscoped object, so nothing outside the workflow changes behaviour.
- `--self-test`: all cases behaved as required. `--check-declaration`: green.
- `lint` shard 26/26 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

