### PR TITLE
fix(fraud): declare quarkus.redis.hosts so the service can boot without out-of-band config

### DIFF
--- a/openbank-fraud-service/src/main/resources/application.yaml
+++ b/openbank-fraud-service/src/main/resources/application.yaml
@@ -46,6 +46,22 @@ quarkus:
       secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
     tls:
       verification: none
+
+  # ADR-0140 online feature store: FeatureStoreConfig @Produces an OnlineFeatureStore from
+  # ReactiveRedisDataSource. Quarkus DEACTIVATES that synthetic bean at build time when neither
+  # `quarkus.redis.hosts` nor `hosts-provider-name` is set, and boot then dies with
+  # `InactiveBeanException: Bean is not active` — not a config warning, a hard start failure.
+  # It was reaching this service from two places OUTSIDE this file and nowhere inside it: the
+  # gitops env (`QUARKUS_REDIS_HOSTS`) and PostgresRedisTestResource's Testcontainers override.
+  # Every environment that worked supplied it out-of-band, so nothing that reads this repo could
+  # tell the service needs Redis at all — which is exactly how the api-fuzz harness, whose Redis
+  # provisioning is derived from this file, ran fraud-service twice without it and never sent a
+  # single request (run 33720692606). The expression form keeps the deployed value authoritative:
+  # QUARKUS_REDIS_HOSTS still wins, and the fallback is the fleet default the other 30 services
+  # declare literally.
+  redis:
+    hosts: ${QUARKUS_REDIS_HOSTS:redis://localhost:6379}
+
   shutdown:
     timeout: 30S
   log:


### PR DESCRIPTION
## Summary

`openbank-fraud-service` injects a `ReactiveRedisDataSource` but never declared `quarkus.redis.hosts` in `application.yaml`, so the bean deactivates at build time and boot fails with `InactiveBeanException`. The value was reaching the service only from the gitops env and a Testcontainers test resource — never from the repo's own config — which is why the api-fuzz harness ran fraud-service twice and sent **zero** requests. One key added, matching the fleet convention.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #8348

## Changes

- `openbank-fraud-service/src/main/resources/application.yaml`: add `quarkus.redis.hosts: ${QUARKUS_REDIS_HOSTS:redis://localhost:6379}` with a comment recording why the key must exist here even though every working environment supplies it out-of-band.

## Why this is a bug, and what it broke

`FeatureStoreConfig` `@Produces` the ADR-0140 `OnlineFeatureStore` from a `ReactiveRedisDataSource`. Quarkus deactivates that synthetic bean at build time when neither `quarkus.redis.hosts` nor `hosts-provider-name` is set, so startup dies:

```
io.quarkus.arc.InactiveBeanException: Bean is not active: SYNTHETIC bean
  [class=io.quarkus.redis.datasource.ReactiveRedisDataSource, id=9JEfLbZPzdeLaQiWTMDNa7jdfrI]
Reason: Redis Client '<default>' was deactivated automatically because neither the hosts
nor the hostsProviderName is set.
This bean is injected into:
	- parameter 'redis' of com.openbank.fraud.infrastructure.feature.FeatureStoreConfig#onlineFeatureStore()
```

`quarkus.redis.hosts` was arriving from two places, **both outside this file**:

- deploy — `QUARKUS_REDIS_HOSTS: redis://redis.fraud.svc:6379` in `openbank-infra/gitops/components/fraud-service/fraud-service.yaml`, whose in-place comment already documents this same `InactiveBeanException`;
- test — `PostgresRedisTestResource.kt` sets `"quarkus.redis.hosts" to "redis://${rd.host}:${rd.getMappedPort(REDIS_PORT)}"` from Testcontainers.

So every environment that worked supplied it out-of-band and the file asserted nothing. Anything that reads the file to decide what the service needs was structurally blind to Redis — which is exactly what `fuzz-services.sh` does:

```
if grep -qi "redis" "$APP_YAML"; then
  echo "==> [${svc}] config references redis — starting one"
```

No match, no container, and the harness additionally passes `-Dquarkus.devservices.enabled=false`, removing the Dev Services fallback that masks this locally. In [run 33720692606](https://github.com/JiRaska/open-bank-oss/actions/runs/33720692606) fraud-service crashed on **both** the authz-ON and authz-OFF passes: its `api-fuzz-reports-openbank-fraud-service` artifact contains the build log and the two boot logs and **no fuzz log and no junit XML at all**. The harness annotated it `this is a finding about the service, not the harness` — the wrong verdict, since a boot crash cannot distinguish a broken app from an unprovisioned dependency.

fraud-service was the sole outlier: **31 services declare `quarkus.redis.hosts` in `application.yaml`** (29 literally as `redis://localhost:6379`; customer-edge and vop-service use the `${QUARKUS_REDIS_HOSTS:...}` expression adopted here). fraud-service declared none.

## Verified by effect, both directions

The harness's decision predicate is `grep -qi redis "$APP_YAML"`:

```
BEFORE (origin/main): NO MATCH -> no redis container -> InactiveBeanException (the observed failure)
AFTER  (this branch): MATCH (redis container started)
```

- `bash .github/scripts/check-duplicate-yaml-keys.sh` passes (79 files checked).
- The parsed document keeps every sibling key under `quarkus:` (`oidc`, `shutdown`, … all present) — a YAML insert is exactly where a mapping key gets silently swallowed, so this was checked rather than assumed.
- The fallback matches the container the harness starts (`redis:7-alpine`, no password, port 6379).

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports) — config-only change.
- [ ] Unit tests added/updated — n/a, no code change. The existing suite cannot see this defect by construction: `PostgresRedisTestResource` supplies `quarkus.redis.hosts` at test time, so `@QuarkusTest` boots green against the missing key. That blindness is the defect's cause, not an omission in this PR.
- [ ] Integration tests added/updated — n/a.
- [ ] Contract tests updated — n/a, no public API change.
- [x] No new lint warnings.
- [x] OpenAPI spec unchanged.
- [x] No Flyway migration (no DB change).
- [x] No event-schema change.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. The added value is a hostname expression with a localhost fallback; no credential is introduced (the fleet default for this key is unauthenticated on 6379).
- [x] No new `@Suppress`.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? — no.
- [ ] PII path changed? — no.
- [ ] Cardholder data path changed? — no.

## Compliance impact

- [x] None. No deployed, test or CI value changes: `QUARKUS_REDIS_HOSTS` sits above `application.yaml` in SmallRye's ordinal chain and still wins everywhere it is set. Only the previously-unset case gains a default.

Note for reviewers: fraud-service is money-path (`rules.yaml: money_path_services`), so this carries the 2-approval requirement even though the diff is one config key.

## Rollout / Rollback

- Deployment strategy: rolling (no behavioral change in any environment that already sets `QUARKUS_REDIS_HOSTS`).
- Rollback plan: revert the commit; the service returns to depending entirely on out-of-band config.
- Data migration reversible: N/A.

## Reviewer notes

This PR fixes **only** the class-B (harness) cause in fraud-service. The same run carried five genuine class-A findings — 500s in account, balance, ledger and lending, and a never-answering `POST /api/v1/sanctions/lists/refresh-all` that logs `HR000090: Live transaction dropped` — which are **not** touched here and are itemised in the classification comment on #8348.
