### PR TITLE
fix(gates): clear four stale threat-model claim exclusions that have main red

### DIFF
--- a/.github/scripts/check-threat-model-claims.py
+++ b/.github/scripts/check-threat-model-claims.py
@@ -126,8 +126,6 @@ ALLOWED_UNRESOLVED: dict[str, str] = {
     #
     # Eight entries name an OPEN PR. Those are the sweep's own corrections; they retire themselves
     # the day each PR lands, and re-editing the same rows here would conflict with a live branch.
-    'document-service|Trust boundaries|openbank.billing.billing.event':
-        'open PR #8415 — no such topic; the real ingress is `openbank.billing.fee.event`',
     'onboarding-service|5. AML / sanctions override — special controls|kyc.check.override':
         'an ADR-0068 planned control; absent from `rules.yaml` and from every resource',
     'onboarding-service|5. AML / sanctions override — special controls|confirmedBy':
@@ -152,8 +150,6 @@ ALLOWED_UNRESOLVED: dict[str, str] = {
         'removed by #4221; `application.yaml:174` records the removal in a comment',
     'openbank-fraud-service|6. Change log|fraudServiceUrl':
         'occurs only inside a comment in `fraud_rest_ext.rego`; not a policy input',
-    'openbank-fx-service|6. Change log|FxConversionService':
-        'open PR #8414 — the wrapper is real and is `FxService.scoreFraudShadow()`',
     'openbank-ledger-service|8. Change log|ledgerServiceUrl':
         'occurs only inside a comment in `ledger_rest_ext.rego`; not a policy input',
     'openbank-lending-service|3. Controls in place (this slice)|lending.origination.worker.enabled':
@@ -168,8 +164,11 @@ ALLOWED_UNRESOLVED: dict[str, str] = {
         'previous repository contract, replaced by `upsertAll`; only the port KDoc names it',
     'openbank-security-scanner|1. Scope & purpose|openbank.security.scan.event':
         'topic named in CHANGELOGs only; no producer, consumer, contract or KafkaTopic CR',
-    'openbank-security-scanner|5. Residual risks|SecurityContractTest':
-        'open PR #8418 — no fleet-wide class; nine per-service variants cover 8 of 61 modules',
+    # Retargeted 2026-09-03: #8418 merged and rewrote §5 to say the test is per-service, so the
+    # claim no longer parses there. It survives in the change log, which necessarily names the
+    # thing it is recording the absence of — a phantom by construction, not a defect.
+    'openbank-security-scanner|6. Change log|SecurityContractTest':
+        'no fleet-wide class; nine per-service variants cover 8 of 61 modules (#8418 corrected §5)',
     'openbank-sepa-instant|6. Change log|SctInstOutboxBacklogGaugeTest':
         'test for the outbox dropped by `V4__drop_sct_inst_outbox.sql` (#5126); no such class',
     'openbank-sepa-instant|6. Change log|KafkaSctInstOutboxEventPublisher':
@@ -182,8 +181,6 @@ ALLOWED_UNRESOLVED: dict[str, str] = {
         'names the StAX API; `Pacs004Reader` IS XXE-hardened, via `DocumentBuilderFactory` (`disallow-doctype-decl`, external entities off). Control real, API name wrong',
     'openbank-sepa-payment|5a. Return path (pacs.004) — STRIDE supplement|XMLInputFactory':
         'names the StAX API; `Pacs004Reader` IS XXE-hardened, via `DocumentBuilderFactory` (`disallow-doctype-decl`, external entities off). Control real, API name wrong',
-    'openbank-sepa-payment|5a. Return path (pacs.004) — STRIDE supplement|openbank.sepa.returns.enabled':
-        'open PR #8416 — no such property; `/returns` reads no config at all',
     'openbank-sepa-payment|6. Change log|settleProcessingPayment':
         'no such function in the tree',
     'openbank-settlement-service|T1|workflowRunId':


### PR DESCRIPTION
## What

`threat-model-claims-resolve` is **failing on `origin/main`** — reproduced on a clean checkout of `7d3bcf902f` with no local diff, so this is main's own state, not any PR's. It is blocking the `gates (lint-supplychain-security)` shard on every open PR.

Four `ALLOWED_UNRESOLVED` entries no longer match any claim. That is a failure **by design** — the gate's own docstring:

> a stale entry fails in BOTH directions … because a gate whose scope is a hand-kept list reads as PASSING when the list is short

Same shape as `gate-subject-floor`, which caught me the same way earlier today.

## Cause

Threat-model documents are being corrected, and a corrected claim moves out of the section its exclusion key names — usually into the change log, which records the absence. #8418 (merged 09:17Z) is one such rewrite.

## Three deleted, one retargeted — and the difference matters

| entry | verdict |
|---|---|
| `document-service \| Trust boundaries \| openbank.billing.billing.event` | gone → **delete** |
| `openbank-fx-service \| 6. Change log \| FxConversionService` | gone → **delete** |
| `openbank-sepa-payment \| 5a. Return path… \| openbank.sepa.returns.enabled` | gone → **delete** |
| `openbank-security-scanner \| 5. Residual risks \| SecurityContractTest` | **moved → retarget** |

Deleting the fourth would have been wrong. Removing it surfaced a **live PHANTOM finding** for the same identifier under `6. Change log`: #8418 rewrote §5 to say the test is per-service, and the claim survives in the change log, which necessarily names the thing whose absence it records — a phantom by construction, not a defect. Retargeted, with its reason updated (it still cited #8418 as *open*).

## Method, because a grep gets two of four wrong

Classifying by searching the `.md` for the identifier reports *"key still correct"* for fx-service and security-scanner — **a mention in prose is not a claim.** The gate's own parser is the authority on what counts, so the classification comes from `--report`, not from `grep`. My first pass used grep and disagreed with the gate on half the entries.

## Falsification

```
security-scanner key back on the WRONG section  -> exit 1, 2 stale + 1 phantom
restored                                        -> exit 0
```

`--self-test`: ok (0 failures). Gate through the runner: PASS.

## Overlap

**#8439 is open and edits `openbank-security-scanner.md`.** This change is in the `.py`, so there is no textual conflict — and if that PR moves the claim again the gate will say so, which is the gate working. I did not touch the document.

## Linked issues

Refs #8418 — the merged rewrite that made the security-scanner entry stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
