### PR TITLE
fix(ci): unblock main — retire four ALLOWED_UNRESOLVED entries their own PRs made stale

### DIFF
--- a/.github/scripts/check-threat-model-claims.py
+++ b/.github/scripts/check-threat-model-claims.py
@@ -126,8 +126,6 @@ ALLOWED_UNRESOLVED: dict[str, str] = {
     #
     # Eight entries name an OPEN PR. Those are the sweep's own corrections; they retire themselves
     # the day each PR lands, and re-editing the same rows here would conflict with a live branch.
-    'document-service|Trust boundaries|openbank.billing.billing.event':
-        'open PR #8415 — no such topic; the real ingress is `openbank.billing.fee.event`',
     'onboarding-service|5. AML / sanctions override — special controls|kyc.check.override':
         'an ADR-0068 planned control; absent from `rules.yaml` and from every resource',
     'onboarding-service|5. AML / sanctions override — special controls|confirmedBy':
@@ -152,8 +150,6 @@ ALLOWED_UNRESOLVED: dict[str, str] = {
         'removed by #4221; `application.yaml:174` records the removal in a comment',
     'openbank-fraud-service|6. Change log|fraudServiceUrl':
         'occurs only inside a comment in `fraud_rest_ext.rego`; not a policy input',
-    'openbank-fx-service|6. Change log|FxConversionService':
-        'open PR #8414 — the wrapper is real and is `FxService.scoreFraudShadow()`',
     'openbank-ledger-service|8. Change log|ledgerServiceUrl':
         'occurs only inside a comment in `ledger_rest_ext.rego`; not a policy input',
     'openbank-lending-service|3. Controls in place (this slice)|lending.origination.worker.enabled':
@@ -168,8 +164,8 @@ ALLOWED_UNRESOLVED: dict[str, str] = {
         'previous repository contract, replaced by `upsertAll`; only the port KDoc names it',
     'openbank-security-scanner|1. Scope & purpose|openbank.security.scan.event':
         'topic named in CHANGELOGs only; no producer, consumer, contract or KafkaTopic CR',
-    'openbank-security-scanner|5. Residual risks|SecurityContractTest':
-        'open PR #8418 — no fleet-wide class; nine per-service variants cover 8 of 61 modules',
+    'openbank-security-scanner|6. Change log|SecurityContractTest':
+        '#8418 landed and moved this into the change log, where the mention IS the correction: the document now states no class of that name exists and names the nine per-service variants covering 8 of 61 modules. Re-keyed, not deleted — the text is still there to be parsed',
     'openbank-sepa-instant|6. Change log|SctInstOutboxBacklogGaugeTest':
         'test for the outbox dropped by `V4__drop_sct_inst_outbox.sql` (#5126); no such class',
     'openbank-sepa-instant|6. Change log|KafkaSctInstOutboxEventPublisher':
@@ -182,8 +178,6 @@ ALLOWED_UNRESOLVED: dict[str, str] = {
         'names the StAX API; `Pacs004Reader` IS XXE-hardened, via `DocumentBuilderFactory` (`disallow-doctype-decl`, external entities off). Control real, API name wrong',
     'openbank-sepa-payment|5a. Return path (pacs.004) — STRIDE supplement|XMLInputFactory':
         'names the StAX API; `Pacs004Reader` IS XXE-hardened, via `DocumentBuilderFactory` (`disallow-doctype-decl`, external entities off). Control real, API name wrong',
-    'openbank-sepa-payment|5a. Return path (pacs.004) — STRIDE supplement|openbank.sepa.returns.enabled':
-        'open PR #8416 — no such property; `/returns` reads no config at all',
     'openbank-sepa-payment|6. Change log|settleProcessingPayment':
         'no such function in the tree',
     'openbank-settlement-service|T1|workflowRunId':


### PR DESCRIPTION
## main is red, and this is why

`threat-model-claims-resolve` is **enforced**. It has been failing on `main` since **2026-09-03T09:24Z** — the last four main pushes all show `gates (lint-supplychain-security)` red — so **every open PR inherits the failure regardless of its own diff**. Four of my own PRs today show exactly one failing check, and it is this one.

Reproduced on a clean detached worktree of `origin/main` before touching anything:

```
FAIL: 1 false/self-referential claim(s), 4 stale exclusion(s)
```

## Cause

#8429 (mine, merged 09:23:15Z) widened the gate. Its own `ALLOWED_UNRESOLVED` header says:

> Eight entries name an OPEN PR. Those are the sweep's own corrections; **they retire themselves the day each PR lands**, and re-editing the same rows here would conflict with a live branch.

Four of those PRs landed between 09:17 and 09:42 — #8414, #8415, #8416, #8418. The rows did not get deleted. The check fails in both directions by design, so it went red on its own author, which is the design working. This is the same shape as #7981/#8012 earlier today.

## What changed

**Three deleted** — the claims they excused are gone:

| entry | retired by |
|---|---|
| `document-service\|Trust boundaries\|openbank.billing.billing.event` | #8415 |
| `openbank-fx-service\|6. Change log\|FxConversionService` | #8414 |
| `openbank-sepa-payment\|5a. …\|openbank.sepa.returns.enabled` | #8416 |

**One re-keyed, not deleted.** #8418 rewrote `openbank-security-scanner`'s threat model and moved the `SecurityContractTest` mention from `5. Residual risks` into `6. Change log`. One move produced two findings: the old key matched nothing (stale exclusion) while the identical text at the new location was reported as a phantom claim. The text still deserves excusing — it *is* the correction, stating that no class of that name exists and naming the nine per-service variants that cover 8 of 61 modules. Deleting it would have re-flagged the document for saying something true.

## Verification — and a first attempt that proved nothing

My first pass ran the script bare and got **exit 0 on both the fixed tree and a deliberately sabotaged one**. The script ends `return 1 if a.enforce else 0`, and `gates.yaml` invokes it with `--enforce`; without that flag every finding downgrades to a warning. Re-run with the invocation CI actually uses:

| state | exit |
|---|---|
| `--enforce`, fixed tree | **0** |
| `--enforce`, one stale entry restored | **1** |
| `--enforce`, restored again | **0** |
| `--self-test` | **0** |

`SUBJECTS=45` in every state, so the green is not bought by the corpus collapsing.

## Note on the other gate in this shard

A local run also shows `threat-model-updated-on-trust-boundary-change` failing with `PR_DIFF_BASE is empty but this gate requires it — refusing to run vacuously`. That is an artifact of running detached with no PR base, not a defect — the gate is refusing to run vacuously, which is correct behaviour. It is not addressed here, and this PR's own CI will show whether it is satisfied in a real PR context.

Refs #6059
