### PR TITLE
fix(account): revoking an unknown authorization answers 404, not 500

### DIFF
--- a/docs/threat-models/openbank-account-service.md
+++ b/docs/threat-models/openbank-account-service.md
@@ -51,6 +51,7 @@ that is balance-service).
 | **I**nfo disclosure | IBAN / account enumeration via `/iban/{iban}` | AuthZ on lookup; rate limiting at gateway; no PII in IBAN response beyond need |
 | **I**nfo disclosure / **IDOR** | Customer reads another party's account/balance via a guessed id (reads are gated by role, not ownership; the edge calls with a ROLE_OPERATOR M2M token) | Primary control is at the customer-edge (resolves ownership before proxying, finding A1). **Defense-in-depth here:** when a call carries `X-Customer-Party-Id` the read must belong to that party, else 404 (no existence oracle) — catches an edge bug/new route that forwards the header but skips its own check. Operator/service reads (no header) unaffected. |
 | **I**nfo disclosure | Domain metrics leak PII / enable per-customer inference via high-cardinality labels | `DomainMetrics` low-cardinality contract (ADR-0077): `openbank.accounts.created` tagged only by `product_type` (closed `AccountType` enum) + `currency`; `openbank.accounts.closed` adds a `reason` **normalized to a closed set** (`customer_request`/`regulatory`/`fraud`/`inactivity`/`unspecified`/`other`) — the operator-supplied free-text reason never becomes a label; outbox-backlog gauge tagged only by `service`. Never an account id, IBAN, party id, or balance. Counters increment only after the commit + publish. `/q/metrics` is cluster-internal |
+| **I**nfo disclosure | Authorization-id enumeration via the revoke route: `DELETE /api/v1/accounts/{accountId}/authorizations/{authorizationId}` distinguishing "this id exists on another account" from "this id does not exist" | `AuthorizationNotFoundExceptionMapper` and `AuthorizationNotOnAccountExceptionMapper` both answer 404 with a byte-identical `AUTHORIZATION_NOT_FOUND` body, so an operator scoped to one account gets no existence oracle over ids on accounts they do not hold. The distinction is kept in a WARN log, not on the wire. Same posture as the `X-Customer-Party-Id` row above. |
 | **D**oS | Mass open/close churn | Gateway rate limits; outbox decouples event load |
 | **E**oP | Viewer escalates to freeze/close | Distinct roles; OPA enforce; deny-by-default |
 | **S**poofing / **E**oP (M2M) | Compromise of the `oidc-client` secret → mint a ROLE_OPERATOR token → inject arbitrary transactions via transaction-service `POST /api/v1/transactions` | Secret held only in a K8s Secret (ExternalSecret from Vault), never in image/git; rotatable; least-privilege client (`openbank-services`); welcome-bonus call is **flag-gated default-OFF** and **sandbox-only**. Residual: transaction-service does not currently distinguish caller identity beyond the role — accepted residual risk in sandbox (see §5) |
@@ -94,6 +95,20 @@ not change any existing request's outcome until explicitly flipped.
   it is a strict improvement over the prior state of no guard at all.
 
 ## 6. Change log
+
+- **2026-09-03** — **Inbound REST error surface on the authorization routes**, no new route, caller,
+  edge or privilege. Revoking an authorization that does not exist answered 500 INTERNAL_ERROR; it now
+  answers 404, via two service-local mappers (`AuthorizationNotFoundExceptionMapper`,
+  `AuthorizationNotOnAccountExceptionMapper`) added to the existing
+  `com.openbank.account.infrastructure.rest.ExceptionMappers` file. RBAC, OPA action
+  (`account.authorize`) and the revoke logic are untouched — only the status and body of an
+  already-refused request change. **Security-relevant half:** the cross-account case
+  (`AuthorizationNotOnAccountException`) previously leaked through the generic 500 and now returns a
+  body byte-identical to the unknown-id case, closing an authorization-id existence oracle for an
+  operator scoped to a different account; a unit test asserts the two bodies match field for field.
+  **Risk class:** availability/observability (a client fault stops consuming this money-path service's
+  5xx error budget) plus the enumeration hardening above; no money mutation and no new principal.
+  Rollback: delete the two mappers and both types fall back to the generic 500 mapper. (#5913)
 
 - **2026-08-27** — **New tightly scoped inbound diagnostic edge:** the sandbox's
   `journey-product-catalog-read` k6 CronJob may make one read-only request to

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/ExceptionMappers.kt
@@ -7,11 +7,14 @@ package com.openbank.account.infrastructure.rest
 import com.openbank.account.application.usecase.AccountNotEmptyException
 import com.openbank.account.application.usecase.AccountNotFoundException
 import com.openbank.account.application.usecase.AccountUpdateConflictException
+import com.openbank.account.application.usecase.AuthorizationNotFoundException
+import com.openbank.account.application.usecase.AuthorizationNotOnAccountException
 import com.openbank.libs.api.error.ApiError
 import com.openbank.libs.domain.identifiers.Ids
 import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.ext.ExceptionMapper
 import jakarta.ws.rs.ext.Provider
+import org.jboss.logging.Logger
 import java.time.Instant
 import java.util.UUID
 
@@ -68,6 +71,68 @@ class AccountNotEmptyExceptionMapper : ExceptionMapper<AccountNotEmptyException>
             ),
         )
         .build()
+}
+
+// 404 — revoking an authorization that does not exist, or that exists on a DIFFERENT account.
+//
+// Both types previously had no mapper at all, so they fell through to libs-runtime's
+// GenericExceptionMapper and every miss answered 500 INTERNAL_ERROR. Measured on the
+// authenticated-fuzz lane (#5913, run 33720692606, traceId 0466cbbc-17c8-4dee-b40a-94c5bfdcd5d9):
+//
+//     DELETE /api/v1/accounts/{accountId}/authorizations/{authorizationId}
+//     ERROR [GenericExceptionMapper] Unhandled exception:
+//       AuthorizationNotFoundException: Authorization not found: e3e70682-...
+//
+// A "not found" is the caller's fact, not a server fault. account-service is money-path, so
+// reporting it as 5xx inflates the error budget and buries real faults in the same bucket.
+//
+// A service-local @Provider on the service's own domain type is the pattern libs-runtime's
+// CommonExceptionMappers header sanctions (it names AccountNotFoundExceptionMapper as the
+// example) and the shape the three mappers above and ProposalExceptionMappers already use.
+// Issue #526 forbids the opposite case — a second mapper for a type libs-runtime ALREADY
+// registers (IllegalArgumentException / IllegalStateException / Exception), where the two
+// @Providers collide non-deterministically per request. Neither type here is one of those.
+
+/**
+ * Both mappers answer with a byte-identical body ON PURPOSE.
+ *
+ * `AuthorizationNotOnAccountException` means the id resolves to a real row owned by some other
+ * account. Echoing that — the exception's own message names both ids — would turn this endpoint
+ * into an existence oracle: an operator scoped to account A could tell "this authorization id
+ * exists somewhere" from "this id does not exist" by reading the status or the message. So the
+ * distinction stays in the log, where it is diagnosable, and never reaches the wire. Same
+ * reasoning the sibling account-access endpoint applies to an ownership mismatch.
+ */
+private const val AUTHORIZATION_NOT_FOUND_MESSAGE = "Authorization not found on this account"
+
+private fun authorizationNotFound() = Response.status(Response.Status.NOT_FOUND)
+    .entity(
+        ApiError(
+            traceId = Ids.randomId().toString(),
+            status = 404,
+            code = "AUTHORIZATION_NOT_FOUND",
+            message = AUTHORIZATION_NOT_FOUND_MESSAGE,
+            timestamp = Instant.now(),
+        ),
+    )
+    .build()
+
+@Provider
+class AuthorizationNotFoundExceptionMapper : ExceptionMapper<AuthorizationNotFoundException> {
+    override fun toResponse(exception: AuthorizationNotFoundException): Response = authorizationNotFound()
+}
+
+@Provider
+class AuthorizationNotOnAccountExceptionMapper : ExceptionMapper<AuthorizationNotOnAccountException> {
+    private val log = Logger.getLogger(AuthorizationNotOnAccountExceptionMapper::class.java)
+
+    override fun toResponse(exception: AuthorizationNotOnAccountException): Response {
+        // WARN, not silence: a caller walking authorization ids against an account they hold is
+        // the shape this 404 deliberately hides from them, and the log is the only place left
+        // where the two cases are still distinguishable.
+        log.warnf("authorization/account mismatch on revoke: %s", exception.message)
+        return authorizationNotFound()
+    }
 }
 
 // SelfApprovalNotAllowedMapper / InvalidApprovalStateMapper (403/409) moved to

--- a/openbank-account-service/src/main/resources/openapi.yaml
+++ b/openbank-account-service/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Account Service API
   # API-contract axis (ADR-0048) — bumps are classified from the OpenAPI diff,
   # independently of the release version in version.txt.
-  version: 1.12.0
+  version: 1.13.0
   description: BIAN-aligned account lifecycle management — open, query, freeze, close accounts.
   contact:
     name: OpenBank Platform
@@ -726,6 +726,16 @@ paths:
                 $ref: '#/components/schemas/AuthorizationResponse'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          description: >
+            No such authorization on this account. Returned both when the authorization id does
+            not exist and when it exists on a DIFFERENT account, with an identical body, so the
+            endpoint cannot be used to probe which authorization ids exist (#5913). Before this
+            was documented the same two cases answered 500.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
 
   /api/v1/accounts/{accountId}/pockets:
     get:

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/rest/AuthorizationNotFoundExceptionMapperTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/rest/AuthorizationNotFoundExceptionMapperTest.kt
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.account.infrastructure.rest
+
+import com.openbank.account.application.usecase.AuthorizationNotFoundException
+import com.openbank.account.application.usecase.AuthorizationNotOnAccountException
+import com.openbank.libs.api.error.ApiError
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * Unit cover for the two mappers added in #5913. This asserts the SHAPE; that the shape is
+ * actually reached over HTTP — the half a mocked test cannot see — is asserted by
+ * `AccountAuthorizationLifecycleIT`, which drives the real endpoint and reads the status code.
+ */
+class AuthorizationNotFoundExceptionMapperTest {
+
+    @Test
+    fun `maps AuthorizationNotFoundException to a 404 AUTHORIZATION_NOT_FOUND ApiError`() {
+        val response = AuthorizationNotFoundExceptionMapper()
+            .toResponse(AuthorizationNotFoundException(UUID.randomUUID()))
+
+        assertThat(response.status).isEqualTo(404)
+        val error = response.entity as ApiError
+        assertThat(error.status).isEqualTo(404)
+        assertThat(error.code).isEqualTo("AUTHORIZATION_NOT_FOUND")
+        assertThat(error.traceId).isNotBlank()
+    }
+
+    @Test
+    fun `maps AuthorizationNotOnAccountException to a 404 too`() {
+        val response = AuthorizationNotOnAccountExceptionMapper()
+            .toResponse(AuthorizationNotOnAccountException(UUID.randomUUID(), UUID.randomUUID()))
+
+        assertThat(response.status).isEqualTo(404)
+        assertThat((response.entity as ApiError).code).isEqualTo("AUTHORIZATION_NOT_FOUND")
+    }
+
+    /**
+     * The two responses must be indistinguishable, or the endpoint is an existence oracle: a
+     * caller scoped to one account could otherwise tell "this authorization id exists elsewhere"
+     * from "this id does not exist". Compares every field except the per-request traceId.
+     */
+    @Test
+    fun `an unknown id and an id on another account are indistinguishable on the wire`() {
+        val unknown = AuthorizationNotFoundExceptionMapper()
+            .toResponse(AuthorizationNotFoundException(UUID.randomUUID())).entity as ApiError
+        val otherAccount = AuthorizationNotOnAccountExceptionMapper()
+            .toResponse(AuthorizationNotOnAccountException(UUID.randomUUID(), UUID.randomUUID())).entity as ApiError
+
+        assertThat(otherAccount.status).isEqualTo(unknown.status)
+        assertThat(otherAccount.code).isEqualTo(unknown.code)
+        assertThat(otherAccount.message).isEqualTo(unknown.message)
+        assertThat(otherAccount.details).isEqualTo(unknown.details)
+    }
+}

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/integration/AccountAuthorizationLifecycleIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/integration/AccountAuthorizationLifecycleIT.kt
@@ -101,4 +101,56 @@ class AccountAuthorizationLifecycleIT {
 
         assertThat(authStatus(authId)).describedAs("account_authorizations.status after revoke").isEqualTo("REVOKED")
     }
+
+    /**
+     * #5913. `AuthorizationNotFoundException` had no mapper, so it fell through to libs-runtime's
+     * `GenericExceptionMapper` and a miss answered **500 INTERNAL_ERROR** — measured on the
+     * authenticated-fuzz lane, run 33720692606, traceId 0466cbbc-17c8-4dee-b40a-94c5bfdcd5d9.
+     *
+     * `AuthorizationServiceTest` already asserts the exception TYPE against a mocked repository
+     * and passes against the broken code: the type was never in doubt, the STATUS was. Only a
+     * request through the real endpoint can tell a 404 from a 500, which is why this lives here.
+     */
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-0000000000aa", roles = ["ROLE_OPERATOR"])
+    fun `revoking an authorization that does not exist answers 404, not 500`() {
+        val accountId = openAccount()
+
+        Given {
+            contentType("application/json")
+            body("""{"revokedBy":"$operator","reason":"customer request"}""")
+        } When {
+            delete("/api/v1/accounts/$accountId/authorizations/${UUID.randomUUID()}")
+        } Then {
+            statusCode(404)
+            body("code", org.hamcrest.Matchers.equalTo("AUTHORIZATION_NOT_FOUND"))
+        }
+    }
+
+    /**
+     * The sibling case: the id resolves to a real row, on somebody else's account. It must answer
+     * 404 with the SAME body as the unknown-id case above — a different status or message here
+     * would make the endpoint an existence oracle for authorization ids.
+     */
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-0000000000aa", roles = ["ROLE_OPERATOR"])
+    fun `revoking an authorization that belongs to another account answers 404`() {
+        val ownerAccount = openAccount()
+        val otherAccount = openAccount()
+        val authId = grant(ownerAccount)
+
+        Given {
+            contentType("application/json")
+            body("""{"revokedBy":"$operator","reason":"customer request"}""")
+        } When {
+            delete("/api/v1/accounts/$otherAccount/authorizations/$authId")
+        } Then {
+            statusCode(404)
+            body("code", org.hamcrest.Matchers.equalTo("AUTHORIZATION_NOT_FOUND"))
+        }
+
+        assertThat(authStatus(authId))
+            .describedAs("a refused cross-account revoke must not have transitioned the row")
+            .isEqualTo("ACTIVE")
+    }
 }


### PR DESCRIPTION
## The defect

`DELETE /api/v1/accounts/{accountId}/authorizations/{authorizationId}` answered **500 INTERNAL_ERROR**
for an authorization id that does not exist. Verified from the boot log of the authenticated-fuzz lane
(#5913), run 33720692606, traceId `0466cbbc-17c8-4dee-b40a-94c5bfdcd5d9`:

```
ERROR [co.op.li.ap.er.GenericExceptionMapper] Unhandled exception (traceId=0466cbbc-...):
com.openbank.account.application.usecase.AuthorizationNotFoundException: Authorization not found: e3e70682-c209-1cac-a29f-6fbed82c07cd
```

A not-found is the caller's fact, not a server fault. account-service is money-path, so reporting it
as 5xx inflates the error budget and buries real faults in the same bucket.

## Why a service-local mapper, not `NoSuchElementException`

libs-runtime already maps `NoSuchElementException` to 404, so re-parenting the exception was the
alternative. I went with a service-local `@Provider` because that is what this repo already does —
not a guess:

| type | mapper | status |
|---|---|---|
| `AccountNotFoundException` | `AccountNotFoundExceptionMapper` (service-local) | 404 |
| `ProposalNotFoundException` | `ProposalNotFoundExceptionMapper` (service-local) | 404 |
| `AuthorizationNotFoundException` | **none** | **500** |

Every other not-found type in this service is a service-local `@Provider` with its own error code.
`CommonExceptionMappers`' own header sanctions the pattern and literally names this service's mapper
as the example ("adding `AccountNotFoundExceptionMapper` ... still wins over the generic
`NoSuchElementExceptionMapper`").

**On #526** — that rule forbids the *opposite* case: a second mapper for a type libs-runtime already
registers (`IllegalArgumentException` / `IllegalStateException` / `Exception`), where the two
`@Provider`s collide non-deterministically per request. Neither type here is one of those, so #526
does not apply. Re-parenting to `NoSuchElementException` would also have flattened the specific
`AUTHORIZATION_NOT_FOUND` code into the generic `NOT_FOUND` and left this service the only one whose
not-found types are handled differently from its four siblings.

## The set fixed, and how I enumerated it

`git grep -n "class .*Exception" origin/main -- 'openbank-account-service/src/main/kotlin/**'` — 10
exception types, then cross-referenced against the two mapper files:

| type | verdict |
|---|---|
| `AuthorizationNotFoundException` | **fixed → 404** (the measured defect) |
| `AuthorizationNotOnAccountException` | **fixed → 404** (same family, see below) |
| `AccountNotFound` / `AccountUpdateConflict` / `AccountNotEmpty` / `ProposalNotFound` / `ProposalForbidden` / `ProposalExpired` / `ProposalSca` | already mapped (404/409/422/404/403/409/400) |
| `ProductNotEligibleException` | already 422 — extends `IllegalStateException` deliberately |
| `AccountScreeningUnavailableException` | **not touched** — availability failure, not not-found |
| `AccountOpeningBlockedByScreeningException` | **not touched** — policy refusal, not not-found |

`AuthorizationNotOnAccountException` is included because the request addresses the composite resource
`/accounts/{A}/authorizations/{B}`; when B exists on another account, *that* resource does not exist.
The IT confirms it had the identical 500.

The last two also render as 500 today and are arguably wrong (503 / 422), but neither is not-found
semantics, so they are out of scope here rather than fixed on a hunch. Worth a follow-up issue.

## Both cases answer an identical body, on purpose

`AuthorizationNotOnAccountException`'s message names both ids. Echoing it — or answering a different
status — would make the endpoint an existence oracle: an operator scoped to account A could tell
"this authorization id exists somewhere" from "this id does not exist". The distinction stays in a
WARN log, where it is diagnosable. A unit test asserts the two bodies are field-for-field identical.
Same reasoning #8011 applies to the sibling account-access endpoint.

## Verified by effect, not by appearance

A unit test that mocks the repository cannot see this — `AuthorizationServiceTest` already asserts the
exception *type* and passes against the broken code. The type was never in doubt; the status was. So
the assertion is the HTTP status, driven through the real endpoint (RestAssured + `@TestSecurity`,
real Postgres) in `AccountAuthorizationLifecycleIT`.

**Before** (mapper reverted to `origin/main`, everything else identical):

```
AccountAuthorizationLifecycleIT > revoking an authorization that does not exist answers 404, not 500 FAILED
    Expected status code <404> but was <500>.
    JSON path code doesn't match. Expected: AUTHORIZATION_NOT_FOUND  Actual: INTERNAL_ERROR
AccountAuthorizationLifecycleIT > revoking an authorization that belongs to another account answers 404 FAILED
    Expected status code <404> but was <500>.
3 tests completed, 2 failed          (tests="3" skipped="0" failures="2")
```

That run independently reproduces the reported defect *and* establishes the second one.

**After**: `268 tests, 0 failures, 1 skipped` — the single skip is the pre-existing broker-gated
`AccountEventPactProviderVerificationTest` (`@EnabledIfSystemProperty(pactbroker.url)`), unrelated.

```
:openbank-account-service:test          BUILD SUCCESSFUL   268 tests / 0 failures / 1 skipped
:openbank-account-service:ktlintCheck   BUILD SUCCESSFUL   (Main + Test + ProviderPactTest source sets)
:openbank-account-service:detekt        BUILD SUCCESSFUL
```

Lint was run as a separate invocation after the test run, since Gradle stops at the first failing task.

## API contract

`openapi.yaml` documents the 404 on the revoke operation; `info.version` 1.12.0 -> 1.13.0. Classified
by the gate, not by me, and the version was re-read off live `origin/main` immediately before commit:

```
$ python3 .github/scripts/check-api-contract.py --base $(git merge-base HEAD origin/main) --enforce
api-contract gate: openbank-account-service: additive change, info.version 1.12.0 -> 1.13.0 — OK (required >= MINOR).
```

`version.txt` is untouched — release-please derives it from the `fix(account)` type.

## Overlap check

Open PRs were scanned by changed **file**, not title (`gh api --paginate .../pulls?state=open`, 55 open,
497 changed files). Three others touch this service: #8011 (`feat/account-access-transparency`) adds a new
`/access` endpoint and edits `AuthorizationService.kt` / `AuthorizationResource.kt` — different concern,
no overlap with the mapper files, but it **also moves `openapi.yaml`**, as does #5986. Whichever of the
three lands first takes 1.13.0; the other two need a re-bump. No pushed branch without a PR and no live
worktree claims these files.

Refs #5913
