### PR TITLE
fix(governance): retire 4 stale ALLOWED_UNRESOLVED entries now that their PRs merged

### DIFF
--- a/.github/scripts/check-threat-model-claims.py
+++ b/.github/scripts/check-threat-model-claims.py
@@ -126,8 +126,6 @@ ALLOWED_UNRESOLVED: dict[str, str] = {
     #
     # Eight entries name an OPEN PR. Those are the sweep's own corrections; they retire themselves
     # the day each PR lands, and re-editing the same rows here would conflict with a live branch.
-    'document-service|Trust boundaries|openbank.billing.billing.event':
-        'open PR #8415 — no such topic; the real ingress is `openbank.billing.fee.event`',
     'onboarding-service|5. AML / sanctions override — special controls|kyc.check.override':
         'an ADR-0068 planned control; absent from `rules.yaml` and from every resource',
     'onboarding-service|5. AML / sanctions override — special controls|confirmedBy':
@@ -152,8 +150,6 @@ ALLOWED_UNRESOLVED: dict[str, str] = {
         'removed by #4221; `application.yaml:174` records the removal in a comment',
     'openbank-fraud-service|6. Change log|fraudServiceUrl':
         'occurs only inside a comment in `fraud_rest_ext.rego`; not a policy input',
-    'openbank-fx-service|6. Change log|FxConversionService':
-        'open PR #8414 — the wrapper is real and is `FxService.scoreFraudShadow()`',
     'openbank-ledger-service|8. Change log|ledgerServiceUrl':
         'occurs only inside a comment in `ledger_rest_ext.rego`; not a policy input',
     'openbank-lending-service|3. Controls in place (this slice)|lending.origination.worker.enabled':
@@ -168,8 +164,6 @@ ALLOWED_UNRESOLVED: dict[str, str] = {
         'previous repository contract, replaced by `upsertAll`; only the port KDoc names it',
     'openbank-security-scanner|1. Scope & purpose|openbank.security.scan.event':
         'topic named in CHANGELOGs only; no producer, consumer, contract or KafkaTopic CR',
-    'openbank-security-scanner|5. Residual risks|SecurityContractTest':
-        'open PR #8418 — no fleet-wide class; nine per-service variants cover 8 of 61 modules',
     'openbank-sepa-instant|6. Change log|SctInstOutboxBacklogGaugeTest':
         'test for the outbox dropped by `V4__drop_sct_inst_outbox.sql` (#5126); no such class',
     'openbank-sepa-instant|6. Change log|KafkaSctInstOutboxEventPublisher':
@@ -182,8 +176,6 @@ ALLOWED_UNRESOLVED: dict[str, str] = {
         'names the StAX API; `Pacs004Reader` IS XXE-hardened, via `DocumentBuilderFactory` (`disallow-doctype-decl`, external entities off). Control real, API name wrong',
     'openbank-sepa-payment|5a. Return path (pacs.004) — STRIDE supplement|XMLInputFactory':
         'names the StAX API; `Pacs004Reader` IS XXE-hardened, via `DocumentBuilderFactory` (`disallow-doctype-decl`, external entities off). Control real, API name wrong',
-    'openbank-sepa-payment|5a. Return path (pacs.004) — STRIDE supplement|openbank.sepa.returns.enabled':
-        'open PR #8416 — no such property; `/returns` reads no config at all',
     'openbank-sepa-payment|6. Change log|settleProcessingPayment':
         'no such function in the tree',
     'openbank-settlement-service|T1|workflowRunId':

--- a/.github/scripts/check-threat-model-claims.py
+++ b/.github/scripts/check-threat-model-claims.py
@@ -164,11 +164,6 @@ ALLOWED_UNRESOLVED: dict[str, str] = {
         'previous repository contract, replaced by `upsertAll`; only the port KDoc names it',
     'openbank-security-scanner|1. Scope & purpose|openbank.security.scan.event':
         'topic named in CHANGELOGs only; no producer, consumer, contract or KafkaTopic CR',
-    # Retargeted 2026-09-03: #8418 merged and rewrote §5 to say the test is per-service, so the
-    # claim no longer parses there. It survives in the change log, which necessarily names the
-    # thing it is recording the absence of — a phantom by construction, not a defect.
-    'openbank-security-scanner|6. Change log|SecurityContractTest':
-        'no fleet-wide class; nine per-service variants cover 8 of 61 modules (#8418 corrected §5)',
     'openbank-sepa-instant|6. Change log|SctInstOutboxBacklogGaugeTest':
         'test for the outbox dropped by `V4__drop_sct_inst_outbox.sql` (#5126); no such class',
     'openbank-sepa-instant|6. Change log|KafkaSctInstOutboxEventPublisher':

--- a/docs/threat-models/openbank-security-scanner.md
+++ b/docs/threat-models/openbank-security-scanner.md
@@ -106,7 +106,7 @@ caller for every production service's API and management ports within the cluste
 
 - **2026-09-03** — Doc correction, no behavior change: §5.2 credited its mitigation to "the
   security-contract test (`SecurityContractTest`)" enforcing that "**every** JAX-RS endpoint is
-  annotated", and called it "the primary defence". No class named `SecurityContractTest` exists —
+  annotated", and called it "the primary defence". `SecurityContractTest` does not exist as a class —
   `git grep -nE 'class SecurityContractTest\b' -- '*.kt'` returns nothing — and the name is not a
   rename of one thing but a family label for nine per-service variants. Measured against the tree:
   61 modules declare a JAX-RS resource, 8 of them carry such a test. security-scanner is not one of


### PR DESCRIPTION
check-threat-model-claims.py's own comment says its ALLOWED_UNRESOLVED
entries self-retire the day the referenced PR lands, and a stale entry
is a hard FAIL by design ("fails in BOTH directions"). #8415, #8414,
#8418, #8416 are all merged, so their four entries matched nothing and
were failing `gates (lint-supplychain-security)` fleet-wide, on every
open PR, including ones that never touch these files.

Also rewords the openbank-security-scanner disclaimer so the gate's
DISCLAIMED regex matches it (same fix as #8439, reapplied here since
main doesn't have it yet — otherwise this PR would fail its own gate).

Verified locally: `python3 .github/scripts/check-threat-model-claims.py`
now reports 0 stale exclusions, 0 phantom claims, self-test OK.