### PR TITLE
docs(libs): mark BootstrapVerifier not shipped in the DORA/NIS2 control map

### DIFF
--- a/openbank-libs/docs/06-compliance.cs.md
+++ b/openbank-libs/docs/06-compliance.cs.md
@@ -8,7 +8,7 @@ openbank-libs **není compliance hraniční kontrolou**, ale **kanálem pro impl
 |---|---|---|---|
 | `BuildInfo` + `ServiceInfoResource` | DORA | Art. 8 (asset register) | Per-service runtime tech stack (Kotlin/Quarkus/JDK verze) je machine-readable přes `/api/v1/info` |
 | `BuildInfo` + per-service SBOM | DORA | Art. 28 (ICT third-party register) | CycloneDX SBOM per service v `build/reports/bom.json`, CI artefakty + admin UI download |
-| `BootstrapVerifier` | DORA, NIS2 | DORA Art. 9 (ICT security controls), NIS2 čl. 21 | Fail-fast guard proti dev-default secrets v prod (closes K1 z audit 2026-05-28) |
+| `BootstrapVerifier` — ⬜ **není dodáno** | DORA, NIS2 | DORA Art. 9 (ICT security controls), NIS2 čl. 21 | **Nic — třída neexistuje.** V `openbank-libs` není žádný `BootstrapVerifier` (`git grep BootstrapVerifier -- '*.kt'` vrací 0); fail-fast guard proti dev placeholderům, který předepisuje ADR-0017, nebyl nikdy zapojen — uvádí to i delivery note téže ADR. K1 je místo toho mitigováno ESO/OpenBao env-var indirekcí (ADR-0007): nasazené manifesty berou credentials přes `secretKeyRef`, takže dev placeholder se dnes do prod nedostává — ale žádný boot-time guard to nekontroluje (#8426) |
 | `PiiMasking` (`PiiMask`) | GDPR | Art. 25 (privacy by design), Art. 32 (security of processing) | Single audit-grade implementation, PCI-DSS compliant card masking (first 4 + last 4). Maskování aplikuje **explicitně** volající — deklarativní anotace neexistuje a neexistuje ani serializační filtr, který by ji ctil (#4011) |
 | `AuditEvent` + `AuditEventPublisher` | GDPR, DORA | GDPR Art. 30 (Records of Processing), DORA Art. 17 (incident reconstruction 24h) | Canonical envelope (actor, op, resource, ts, ip, result, traceId), pluggable publisher |
 | `Roles` (canonical constants) | PSD2, CNB | PSD2 RTS § technický standard, CNB vyhláška 163/2014 § přístupová oprávnění | Eliminuje string-typo bezpečnostní díry, audit ví, jaké role existují |
@@ -35,7 +35,7 @@ graph LR
   end
 
   subgraph LibsContrib["openbank-libs contribution"]
-    BV[BootstrapVerifier]
+    BV["BootstrapVerifier — není dodáno"]
     Roles[Roles canonical enum]
     PiiMask[PiiMask deterministic masking]
     AuditEvent[AuditEvent envelope]
@@ -60,7 +60,7 @@ graph LR
   K7 --> OPA
   K7 --> AuditEvent
 
-  style BV fill:#e8f5e9
+  style BV fill:#ffcdd2
   style PiiMask fill:#e8f5e9
   style Roles fill:#e8f5e9
   style AuditEvent fill:#e8f5e9
@@ -70,6 +70,10 @@ graph LR
   style NetPol fill:#fff9c4
   style OPA fill:#fff9c4
 ```
+
+Legenda: zelená = dodáno v libs · žlutá = uzavřeno mimo libs · červená = **předepsáno, ale nikdy nedodáno**.
+`BootstrapVerifier` je jediný červený uzel. K1 dnes drží pouze injektáž secrets přes ESO/OpenBao — žádný
+boot-time guard za tím není, takže hrana `K1 --> BV` zaznamenává záměr, ne kontrolu (#8426).
 
 ## Skóre regulací před / po libs
 

--- a/openbank-libs/docs/06-compliance.en.md
+++ b/openbank-libs/docs/06-compliance.en.md
@@ -8,7 +8,7 @@ openbank-libs is **not a compliance boundary control**, but **a channel for impl
 |---|---|---|---|
 | `BuildInfo` + `ServiceInfoResource` | DORA | Art. 8 (asset register) | Per-service runtime tech stack (Kotlin/Quarkus/JDK versions) is machine-readable via `/api/v1/info` |
 | `BuildInfo` + per-service SBOM | DORA | Art. 28 (ICT third-party register) | CycloneDX SBOM per service in `build/reports/bom.json`, CI artifacts + admin UI download |
-| `BootstrapVerifier` | DORA, NIS2 | DORA Art. 9 (ICT security controls), NIS2 Art. 21 | Fail-fast guard against dev-default secrets in prod (closes K1 from the 2026-05-28 audit) |
+| `BootstrapVerifier` — ⬜ **not shipped** | DORA, NIS2 | DORA Art. 9 (ICT security controls), NIS2 Art. 21 | **Nothing — the class does not exist.** There is no `BootstrapVerifier` anywhere in `openbank-libs` (`git grep BootstrapVerifier -- '*.kt'` returns 0); the fail-fast placeholder guard ADR-0017 prescribes was never wired, as that ADR's own delivery note records. K1 is mitigated instead by ESO/OpenBao env-var indirection (ADR-0007): deployed manifests take credentials through `secretKeyRef`, so no dev placeholder reaches prod today — but no boot-time guard checks that (#8426) |
 | `PiiMasking` (`PiiMask`) | GDPR | Art. 25 (privacy by design), Art. 32 (security of processing) | Single audit-grade implementation, PCI-DSS compliant card masking (first 4 + last 4). Applied **explicitly** by the caller — there is no declarative masking annotation, and no serialization filter that would honour one (#4011) |
 | `AuditEvent` + `AuditEventPublisher` | GDPR, DORA | GDPR Art. 30 (Records of Processing), DORA Art. 17 (incident reconstruction 24 h) | Canonical envelope (actor, op, resource, ts, ip, result, traceId), pluggable publisher |
 | `Roles` (canonical constants) | PSD2, CNB | PSD2 RTS § technical standard, CNB decree 163/2014 § access permissions | Eliminates string-typo security holes; audit knows which roles exist |
@@ -35,7 +35,7 @@ graph LR
   end
 
   subgraph LibsContrib["openbank-libs contribution"]
-    BV[BootstrapVerifier]
+    BV["BootstrapVerifier — not shipped"]
     Roles[Roles canonical enum]
     PiiMask[PiiMask deterministic masking]
     AuditEvent[AuditEvent envelope]
@@ -60,7 +60,7 @@ graph LR
   K7 --> OPA
   K7 --> AuditEvent
 
-  style BV fill:#e8f5e9
+  style BV fill:#ffcdd2
   style PiiMask fill:#e8f5e9
   style Roles fill:#e8f5e9
   style AuditEvent fill:#e8f5e9
@@ -70,6 +70,10 @@ graph LR
   style NetPol fill:#fff9c4
   style OPA fill:#fff9c4
 ```
+
+Legend: green = delivered in libs · yellow = closed outside libs · red = **prescribed but never delivered**.
+`BootstrapVerifier` is the only red node. K1 is held today by ESO/OpenBao secret injection alone — there is no
+boot-time guard behind it, so the `K1 --> BV` edge records an intent, not a control (#8426).
 
 ## Regulatory score before / after libs
 

--- a/openbank-libs/docs/06-compliance.md
+++ b/openbank-libs/docs/06-compliance.md
@@ -8,7 +8,7 @@ openbank-libs **není compliance hraniční kontrolou**, ale **kanálem pro impl
 |---|---|---|---|
 | `BuildInfo` + `ServiceInfoResource` | DORA | Art. 8 (asset register) | Per-service runtime tech stack (Kotlin/Quarkus/JDK verze) je machine-readable přes `/api/v1/info` |
 | `BuildInfo` + per-service SBOM | DORA | Art. 28 (ICT third-party register) | CycloneDX SBOM per service v `build/reports/bom.json`, CI artefakty + admin UI download |
-| `BootstrapVerifier` | DORA, NIS2 | DORA Art. 9 (ICT security controls), NIS2 čl. 21 | Fail-fast guard proti dev-default secrets v prod (closes K1 z audit 2026-05-28) |
+| `BootstrapVerifier` — ⬜ **není dodáno** | DORA, NIS2 | DORA Art. 9 (ICT security controls), NIS2 čl. 21 | **Nic — třída neexistuje.** V `openbank-libs` není žádný `BootstrapVerifier` (`git grep BootstrapVerifier -- '*.kt'` vrací 0); fail-fast guard proti dev placeholderům, který předepisuje ADR-0017, nebyl nikdy zapojen — uvádí to i delivery note téže ADR. K1 je místo toho mitigováno ESO/OpenBao env-var indirekcí (ADR-0007): nasazené manifesty berou credentials přes `secretKeyRef`, takže dev placeholder se dnes do prod nedostává — ale žádný boot-time guard to nekontroluje (#8426) |
 | `PiiMasking` (`PiiMask`) | GDPR | Art. 25 (privacy by design), Art. 32 (security of processing) | Single audit-grade implementation, PCI-DSS compliant card masking (first 4 + last 4). Applied **explicitly** by the caller — there is no declarative masking annotation, and no serialization filter that would honour one (#4011) |
 | `AuditEvent` + `AuditEventPublisher` | GDPR, DORA | GDPR Art. 30 (Records of Processing), DORA Art. 17 (incident reconstruction 24h) | Canonical envelope (actor, op, resource, ts, ip, result, traceId), pluggable publisher |
 | `Roles` (canonical constants) | PSD2, CNB | PSD2 RTS § technický standard, CNB vyhláška 163/2014 § přístupová oprávnění | Eliminuje string-typo bezpečnostní díry, audit ví, jaké role existují |
@@ -35,7 +35,7 @@ graph LR
   end
 
   subgraph LibsContrib["openbank-libs contribution"]
-    BV[BootstrapVerifier]
+    BV["BootstrapVerifier — není dodáno"]
     Roles[Roles canonical enum]
     PiiMask[PiiMask deterministic masking]
     AuditEvent[AuditEvent envelope]
@@ -60,7 +60,7 @@ graph LR
   K7 --> OPA
   K7 --> AuditEvent
 
-  style BV fill:#e8f5e9
+  style BV fill:#ffcdd2
   style PiiMask fill:#e8f5e9
   style Roles fill:#e8f5e9
   style AuditEvent fill:#e8f5e9
@@ -70,6 +70,10 @@ graph LR
   style NetPol fill:#fff9c4
   style OPA fill:#fff9c4
 ```
+
+Legenda: zelená = dodáno v libs · žlutá = uzavřeno mimo libs · červená = **předepsáno, ale nikdy nedodáno**.
+`BootstrapVerifier` je jediný červený uzel. K1 dnes drží pouze injektáž secrets přes ESO/OpenBao — žádný
+boot-time guard za tím není, takže hrana `K1 --> BV` zaznamenává záměr, ne kontrolu (#8426).
 
 ## Skóre regulací před / po libs
 


### PR DESCRIPTION
## What this corrects

`openbank-libs/docs/06-compliance.{md,cs.md,en.md}` — the libs control-to-regulation
register — carried this row:

```
| `BootstrapVerifier` | DORA, NIS2 | DORA Art. 9 (ICT security controls), NIS2 Art. 21 | Fail-fast guard against dev-default secrets in prod (closes K1 from the 2026-05-28 audit) |
```

and a mermaid node `BV[BootstrapVerifier]` styled green (`fill:#e8f5e9`, this
document's "delivered in libs" colour) with a `K1 --> BV` edge.

**The class does not exist.** This is the strongest of the three shapes the issue
allows for — not "exists but nothing calls it", and not "runs but checks less than
claimed".

## Evidence

```
$ git grep -l 'BootstrapVerifier' origin/main -- '*.kt' '*.java' | wc -l
0
$ git grep -l 'class ServiceInfoResource' origin/main -- '*.kt' | wc -l
1
```

The second is a **known-positive control**: a libs class that does exist returns 1
through the identical probe, so the zero is a fact about the tree and not about the
search.

`openbank-libs*/src/main/kotlin/com/openbank/libs/security/` contains exactly
`PiiMasking`, `Roles`, `ServiceTokenProvider`, `BearerTokenClientHeadersFactory` and
`SecurityContextExtensions` — every name the libs README lists except this one. No
equivalent control ships under another name either: one Kotlin file fleet-wide
mentions a dev placeholder token (`AnchorSignerProducer`, a `defaultValue` for a
signing key), and it is not a startup guard.

`docs/adr/0017-secrets-via-vault.md` has recorded this since 2026-07-17 — *"⬜ Not
shipped: no `BootstrapVerifier` class exists in code … Service docs asserting it
exists are stale."* This PR fixes the first of those stale documents.

## Why the row is corrected rather than deleted

A red row that is true beats a green one that is not. An assessor reading a DORA
Art. 9 / NIS2 Art. 21 control register needs to see the gap; a row that simply
vanishes tells them nothing. So the row stays, restated as ⬜ **not shipped** with
what actually mitigates K1. The mermaid node keeps its `K1 --> BV` edge — that edge
records the intent — but is relabelled and restyled red, and a new legend states what
the three fill colours mean (they were undocumented).

## Nothing is exposed

Deployed manifests take credentials through `secretKeyRef` (ESO/OpenBao env-var
indirection, ADR-0007), so the defended-against condition does not occur today. What
is missing is the boot-time guard behind that — defence in depth, not an open door.
This PR does not invent the control; it corrects the claim. Building it remains
option 1 in #8426 and is a deliberate decision, not a doc edit.

## Verification

| Check | Result |
|---|---|
| `python3 .github/scripts/check-threat-model-claims.py --enforce` | rc=0, 45/45 models |
| same script `--self-test` | rc=0 |
| `BootstrapVerifier` in `ALLOWED_UNRESOLVED` | **absent** — this change retires no exclusion, so there is no stale row to delete |
| threat models mentioning `BootstrapVerifier` | 0 |
| `check-compliance-evidence.py --enforce` | rc=0 |
| `check-compliance-matrix.py --enforce` | rc=0 |
| all 3 edited mermaid blocks, under admin-ui's own mermaid 11.17.2 | parse |

`--enforce` is used deliberately: bare, the claims script ends `return 1 if a.enforce
else 0` and returns 0 even against a sabotaged tree. The mermaid green was checked
against known-bad controls the same parser rejects (garbage diagram type, unbalanced
bracket, `;` in a sequenceDiagram Note), so it is not a parser that says yes to
everything.

Branched from `origin/main` at 78fd54fd0d, which already contains #8460 — so the
`gates (lint-supplychain-security)` red on main from the stale exclusions is not
inherited here.

## Scope

`openbank-libs` has no `version.txt`, and `docs` is a hidden type, so this releases
nothing.

**34 documents still assert the control** (38 files mention it: 1 is ADR-0017's own
correction, 3 are corrected here). Counted with:

```
git grep -l 'BootstrapVerifier' HEAD | grep -v 'docs/adr/0017' | grep -v 'openbank-libs/docs/06-compliance' | wc -l
```

They span account, balance, lending, sanctions and security-scanner service docs plus
the remaining libs docs (`01-overview`, `02-architecture`, `05-operations`, `README`),
in both languages. Per the issue's one-PR-per-document request, this is the
highest-stakes one first: it is the only place the control is mapped to named
regulatory articles and declared to close an audit finding.

Refs #8426
