### PR TITLE
docs(libs): correct the BootstrapVerifier claim across the libs doc set

### DIFF
--- a/openbank-libs/docs/01-overview.cs.md
+++ b/openbank-libs/docs/01-overview.cs.md
@@ -24,7 +24,7 @@ Audit napočítal **~4 500 řádků duplikovaného Kotlinu** a několik regulato
 | Per-service `BigDecimal + String` páry pro peníze | `Money` value object s `CurrencyCode` (ISO 4217), `add/subtract/multiply` operacemi |
 | Žádný unifikovaný audit log | `AuditEvent` envelope s GDPR Art. 30 poli + `AuditEventPublisher` port |
 | Service-to-service volání bez `Authorization` header | `BearerTokenClientHeadersFactory` automatická injekce + correlation ID propagace |
-| Hardcoded `CHANGE_ME_LOCAL_DEV_ONLY` v prod profilu (K1) | `BootstrapVerifier` fail-fast při startupu |
+| Hardcoded `CHANGE_ME_LOCAL_DEV_ONLY` v prod profilu (K1) | ⬜ **Není dodáno.** `BootstrapVerifier` v libs neexistuje (`git grep BootstrapVerifier -- '*.kt'` vrací 0) — uvádí to i delivery note ADR-0017. K1 dnes drží injektáž secrets přes ESO/OpenBao (ADR-0007): nasazené manifesty berou credentials přes `secretKeyRef` a žádný dev placeholder v nich není, ale žádný startup guard to nekontroluje (#8426) |
 | Žádný runtime přehled o tech stacku | `BuildInfo` singleton → `/api/v1/info` ukazuje Kotlin/Quarkus/JDK verze, LTS flag, support date |
 
 ## Klíčové schopnosti (per balíček)
@@ -52,7 +52,7 @@ mindmap
     security
       PiiMask deterministic masking
       Roles canonical enum
-      BootstrapVerifier
+      BootstrapVerifier NENI DODANO
       BearerTokenClientHeadersFactory
     util
       BuildInfo runtime stack
@@ -87,7 +87,7 @@ Když vznikne nový OpenBank service `openbank-foo-service`:
 |---|---|---|
 | F1 — house cleaning | ✅ done | Unified dep declaration, Jandex plugin, smazaný InfoResource/Redis duplicates |
 | F2 — domain primitives | ✅ done | Outbox, typesafe IDs, common exception mappers |
-| F3 — security foundation | ✅ done | PiiMask, Roles, AuditEvent, S2S auth, BootstrapVerifier |
+| F3 — security foundation | ⚠️ partial | PiiMask, Roles, AuditEvent, S2S auth. `BootstrapVerifier` byl do F3 naplánován a nikdy nedodán (#8426) |
 | F4 — convention plugin | planned | `build-logic/openbank.quarkus-service` Gradle convention plugin |
 | F5 — Quarkus platform extension | planned | Baseline `application.yaml` jako Quarkus extension |
 

--- a/openbank-libs/docs/01-overview.en.md
+++ b/openbank-libs/docs/01-overview.en.md
@@ -24,7 +24,7 @@ The audit counted **~4 500 lines of duplicated Kotlin** and several regulatory g
 | Per-service `BigDecimal + String` pairs for money | `Money` value object with `CurrencyCode` (ISO 4217) and `add/subtract/multiply` operations |
 | No unified audit log | `AuditEvent` envelope with GDPR Art. 30 fields + `AuditEventPublisher` port |
 | Service-to-service calls with no `Authorization` header | `BearerTokenClientHeadersFactory` automatic injection + correlation ID propagation |
-| Hardcoded `CHANGE_ME_LOCAL_DEV_ONLY` in the prod profile (K1) | `BootstrapVerifier` fail-fast at startup |
+| Hardcoded `CHANGE_ME_LOCAL_DEV_ONLY` in the prod profile (K1) | ⬜ **Not shipped.** No `BootstrapVerifier` exists in libs (`git grep BootstrapVerifier -- '*.kt'` returns 0), as ADR-0017's own delivery note records. K1 is held today by ESO/OpenBao secret injection (ADR-0007): deployed manifests take credentials through `secretKeyRef` and carry no dev placeholder, but no startup guard checks that (#8426) |
 | No runtime view of the tech stack | `BuildInfo` singleton → `/api/v1/info` shows Kotlin/Quarkus/JDK versions, LTS flag, support date |
 
 ## Key capabilities (per package)
@@ -52,7 +52,7 @@ mindmap
     security
       PiiMask deterministic masking
       Roles canonical enum
-      BootstrapVerifier
+      BootstrapVerifier NOT SHIPPED
       BearerTokenClientHeadersFactory
     util
       BuildInfo runtime stack
@@ -87,7 +87,7 @@ When a new OpenBank service `openbank-foo-service` is created:
 |---|---|---|
 | F1 — house cleaning | ✅ done | Unified dep declaration, Jandex plugin, deleted InfoResource/Redis duplicates |
 | F2 — domain primitives | ✅ done | Outbox, typesafe IDs, common exception mappers |
-| F3 — security foundation | ✅ done | PiiMask, Roles, AuditEvent, S2S auth, BootstrapVerifier |
+| F3 — security foundation | ⚠️ partial | PiiMask, Roles, AuditEvent, S2S auth. `BootstrapVerifier` was scoped into F3 and never shipped (#8426) |
 | F4 — convention plugin | planned | `build-logic/openbank.quarkus-service` Gradle convention plugin |
 | F5 — Quarkus platform extension | planned | Baseline `application.yaml` as a Quarkus extension |
 

--- a/openbank-libs/docs/01-overview.md
+++ b/openbank-libs/docs/01-overview.md
@@ -24,7 +24,7 @@ Audit napočítal **~4 500 řádků duplikovaného Kotlinu** a několik regulato
 | Per-service `BigDecimal + String` páry pro peníze | `Money` value object s `CurrencyCode` (ISO 4217), `add/subtract/multiply` operacemi |
 | Žádný unifikovaný audit log | `AuditEvent` envelope s GDPR Art. 30 poli + `AuditEventPublisher` port |
 | Service-to-service volání bez `Authorization` header | `BearerTokenClientHeadersFactory` automatická injekce + correlation ID propagace |
-| Hardcoded `CHANGE_ME_LOCAL_DEV_ONLY` v prod profilu (K1) | `BootstrapVerifier` fail-fast při startupu |
+| Hardcoded `CHANGE_ME_LOCAL_DEV_ONLY` v prod profilu (K1) | ⬜ **Není dodáno.** `BootstrapVerifier` v libs neexistuje (`git grep BootstrapVerifier -- '*.kt'` vrací 0) — uvádí to i delivery note ADR-0017. K1 dnes drží injektáž secrets přes ESO/OpenBao (ADR-0007): nasazené manifesty berou credentials přes `secretKeyRef` a žádný dev placeholder v nich není, ale žádný startup guard to nekontroluje (#8426) |
 | Žádný runtime přehled o tech stacku | `BuildInfo` singleton → `/api/v1/info` ukazuje Kotlin/Quarkus/JDK verze, LTS flag, support date |
 
 ## Klíčové schopnosti (per balíček)
@@ -52,7 +52,7 @@ mindmap
     security
       PiiMask deterministic masking
       Roles canonical enum
-      BootstrapVerifier
+      BootstrapVerifier NENI DODANO
       BearerTokenClientHeadersFactory
     util
       BuildInfo runtime stack
@@ -87,7 +87,7 @@ Když vznikne nový OpenBank service `openbank-foo-service`:
 |---|---|---|
 | F1 — house cleaning | ✅ done | Unified dep declaration, Jandex plugin, smazaný InfoResource/Redis duplicates |
 | F2 — domain primitives | ✅ done | Outbox, typesafe IDs, common exception mappers |
-| F3 — security foundation | ✅ done | PiiMask, Roles, AuditEvent, S2S auth, BootstrapVerifier |
+| F3 — security foundation | ⚠️ partial | PiiMask, Roles, AuditEvent, S2S auth. `BootstrapVerifier` byl do F3 naplánován a nikdy nedodán (#8426) |
 | F4 — convention plugin | planned | `build-logic/openbank.quarkus-service` Gradle convention plugin |
 | F5 — Quarkus platform extension | planned | Baseline `application.yaml` jako Quarkus extension |
 

--- a/openbank-libs/docs/02-architecture.cs.md
+++ b/openbank-libs/docs/02-architecture.cs.md
@@ -55,7 +55,7 @@ graph TB
     subgraph security[security/]
       PiiMask
       Roles
-      BootstrapVerifier
+      BV["BootstrapVerifier — není dodáno"]
       BearerHeaders[BearerTokenClientHeadersFactory]
     end
     subgraph audit[audit/]
@@ -212,7 +212,7 @@ Audit-grade security primitives — viz [ADR 0017](../../docs/adr/0017-secrets-v
 | `SecurityContextExtensions.kt` | Kotlin extensions: `securityContext.currentUserId`, `actorName`, `actorType`, `requireAnyRole(...)` |
 | `ServiceTokenProvider.kt` | Port pro S2S Bearer tokens; doporučená prod impl: `quarkus-oidc-client-reactive-filter` |
 | `BearerTokenClientHeadersFactory.kt` | `@RegisterClientHeaders(…)` — automatická Bearer + correlation injection do REST clients |
-| `BootstrapVerifier.kt` | Startup `@Observes StartupEvent` — fail-fast pokud config v prod profile obsahuje dev placeholders |
+| `BootstrapVerifier.kt` — ⬜ **soubor neexistuje** | **Nic.** Startup fail-fast guard proti dev placeholderům, který předepisuje ADR-0017, nebyl nikdy napsán (`git grep BootstrapVerifier -- '*.kt'` vrací 0) — uvádí to i delivery note téže ADR. Secrets dnes drží ESO/OpenBao `secretKeyRef` injektáž (ADR-0007), bez jakékoli boot-time kontroly (#8426) |
 
 ### `util/`
 | Soubor | Účel |
@@ -247,10 +247,10 @@ sequenceDiagram
   Libs->>SvcCfg: needs IdempotencyStore?
   SvcCfg-->>ArC: @Produces fun idempotencyStore(...): IdempotencyStore
   ArC-->>Quarkus: container ready
-  Quarkus->>Libs: BootstrapVerifier.onStart(StartupEvent)
-  alt prod profile & dev placeholders found
-    Libs-->>Quarkus: throw IllegalStateException, fail-fast
-  else clean config
-    Libs-->>Quarkus: log "0 placeholders found"
-  end
+  Note over Quarkus,Libs: Žádný BootstrapVerifier krok se nekoná — třída neexistuje
 ```
+
+Diagram dříve uváděl `BootstrapVerifier.onStart(StartupEvent)` jako poslední krok startupu. Ten krok se
+nikdy nekonal: v `openbank-libs` žádný `BootstrapVerifier` není a nikdy nebyl. Startup končí tím, že je
+kontejner připraven — nic v libs nekontroluje, zda config v prod profilu obsahuje dev placeholdery.
+Tu vlastnost dnes drží ESO/OpenBao `secretKeyRef` injektáž mimo tuto knihovnu (ADR-0007, #8426).

--- a/openbank-libs/docs/02-architecture.en.md
+++ b/openbank-libs/docs/02-architecture.en.md
@@ -55,7 +55,7 @@ graph TB
     subgraph security[security/]
       PiiMask
       Roles
-      BootstrapVerifier
+      BV["BootstrapVerifier — not shipped"]
       BearerHeaders[BearerTokenClientHeadersFactory]
     end
     subgraph audit[audit/]
@@ -212,7 +212,7 @@ Audit-grade security primitives — see [ADR 0017](../../docs/adr/0017-secrets-v
 | `SecurityContextExtensions.kt` | Kotlin extensions: `securityContext.currentUserId`, `actorName`, `actorType`, `requireAnyRole(...)` |
 | `ServiceTokenProvider.kt` | Port for S2S Bearer tokens; recommended prod impl: `quarkus-oidc-client-reactive-filter` |
 | `BearerTokenClientHeadersFactory.kt` | `@RegisterClientHeaders(…)` — automatic Bearer + correlation injection into REST clients |
-| `BootstrapVerifier.kt` | Startup `@Observes StartupEvent` — fail-fast when config in the prod profile contains dev placeholders |
+| `BootstrapVerifier.kt` — ⬜ **the file does not exist** | **Nothing.** The startup fail-fast guard against dev placeholders that ADR-0017 prescribes was never written (`git grep BootstrapVerifier -- '*.kt'` returns 0), as that ADR's own delivery note records. Secrets are held today by ESO/OpenBao `secretKeyRef` injection (ADR-0007), with no boot-time check at all (#8426) |
 
 ### `util/`
 | File | Purpose |
@@ -247,10 +247,10 @@ sequenceDiagram
   Libs->>SvcCfg: needs IdempotencyStore?
   SvcCfg-->>ArC: @Produces fun idempotencyStore(...): IdempotencyStore
   ArC-->>Quarkus: container ready
-  Quarkus->>Libs: BootstrapVerifier.onStart(StartupEvent)
-  alt prod profile & dev placeholders found
-    Libs-->>Quarkus: throw IllegalStateException, fail-fast
-  else clean config
-    Libs-->>Quarkus: log "0 placeholders found"
-  end
+  Note over Quarkus,Libs: No BootstrapVerifier step happens — the class does not exist
 ```
+
+This diagram used to show `BootstrapVerifier.onStart(StartupEvent)` as the last startup step. That step
+never happened: there is no `BootstrapVerifier` in `openbank-libs` and there never was. Startup ends when
+the container is ready — nothing in libs checks whether the prod-profile config contains dev placeholders.
+That property is held today by ESO/OpenBao `secretKeyRef` injection outside this library (ADR-0007, #8426).

--- a/openbank-libs/docs/02-architecture.md
+++ b/openbank-libs/docs/02-architecture.md
@@ -55,7 +55,7 @@ graph TB
     subgraph security[security/]
       PiiMask
       Roles
-      BootstrapVerifier
+      BV["BootstrapVerifier — není dodáno"]
       BearerHeaders[BearerTokenClientHeadersFactory]
     end
     subgraph audit[audit/]
@@ -212,7 +212,7 @@ Audit-grade security primitives — viz [ADR 0017](../../docs/adr/0017-secrets-v
 | `SecurityContextExtensions.kt` | Kotlin extensions: `securityContext.currentUserId`, `actorName`, `actorType`, `requireAnyRole(...)` |
 | `ServiceTokenProvider.kt` | Port pro S2S Bearer tokens; doporučená prod impl: `quarkus-oidc-client-reactive-filter` |
 | `BearerTokenClientHeadersFactory.kt` | `@RegisterClientHeaders(…)` — automatická Bearer + correlation injection do REST clients |
-| `BootstrapVerifier.kt` | Startup `@Observes StartupEvent` — fail-fast pokud config v prod profile obsahuje dev placeholders |
+| `BootstrapVerifier.kt` — ⬜ **soubor neexistuje** | **Nic.** Startup fail-fast guard proti dev placeholderům, který předepisuje ADR-0017, nebyl nikdy napsán (`git grep BootstrapVerifier -- '*.kt'` vrací 0) — uvádí to i delivery note téže ADR. Secrets dnes drží ESO/OpenBao `secretKeyRef` injektáž (ADR-0007), bez jakékoli boot-time kontroly (#8426) |
 
 ### `util/`
 | Soubor | Účel |
@@ -247,10 +247,10 @@ sequenceDiagram
   Libs->>SvcCfg: needs IdempotencyStore?
   SvcCfg-->>ArC: @Produces fun idempotencyStore(...): IdempotencyStore
   ArC-->>Quarkus: container ready
-  Quarkus->>Libs: BootstrapVerifier.onStart(StartupEvent)
-  alt prod profile & dev placeholders found
-    Libs-->>Quarkus: throw IllegalStateException, fail-fast
-  else clean config
-    Libs-->>Quarkus: log "0 placeholders found"
-  end
+  Note over Quarkus,Libs: Žádný BootstrapVerifier krok se nekoná — třída neexistuje
 ```
+
+Diagram dříve uváděl `BootstrapVerifier.onStart(StartupEvent)` jako poslední krok startupu. Ten krok se
+nikdy nekonal: v `openbank-libs` žádný `BootstrapVerifier` není a nikdy nebyl. Startup končí tím, že je
+kontejner připraven — nic v libs nekontroluje, zda config v prod profilu obsahuje dev placeholdery.
+Tu vlastnost dnes drží ESO/OpenBao `secretKeyRef` injektáž mimo tuto knihovnu (ADR-0007, #8426).

--- a/openbank-libs/docs/05-operations.cs.md
+++ b/openbank-libs/docs/05-operations.cs.md
@@ -110,7 +110,7 @@ Vše ostatní (Quarkus types, jakarta APIs, Redis client, Persistence API, Micro
 | Service `/api/v1/info` vrací `stack: null` | Service běží se starým libs JAR (před SBOM-2) nebo image není rebuiltlý | `docker compose build --no-cache <service>` + `up -d --force-recreate <service>` |
 | Build padá s `ClassNotFoundException: jakarta.validation.ConstraintViolationException` | Service nemá `quarkus-hibernate-validator` extension ale libs původně auto-registroval ConstraintViolationExceptionMapper (deleted v `62b312b`) | Pull latest libs |
 | `Circular dependency: :classes → :compileJava → :compileKotlin → :quarkusGenerateCode → :jar → :classes` | Per-service `settings.gradle.kts` s `includeBuild("../openbank-libs")` + Quarkus 3.33 + Gradle 9 | Build z root: `./gradlew :openbank-<svc>:quarkusBuild` (commit `62b312b`) |
-| `BootstrapVerifier` failuje s "looks like development defaults" | Property v prod profile obsahuje `CHANGE_ME_LOCAL_DEV_ONLY` nebo `_local_dev_only` | Provázat na Vault (ADR 0017) |
+| `BootstrapVerifier` failuje s "looks like development defaults" — ⬜ **tento symptom nemůže nastat** | `BootstrapVerifier` neexistuje, takže tuto hlášku nikdy nic nevypíše. Řádek popisoval kontrolu, která nebyla nikdy dodána (#8426) | Nic k řešení zde. Dev placeholder se do prod nedostane přes ESO/OpenBao `secretKeyRef` injektáž (ADR-0007) — ne přes boot-time kontrolu, takže selhání startu, které byste čekali, nepřijde |
 
 ## Audit & support
 

--- a/openbank-libs/docs/05-operations.en.md
+++ b/openbank-libs/docs/05-operations.en.md
@@ -110,7 +110,7 @@ Everything else (Quarkus types, jakarta APIs, Redis client, Persistence API, Mic
 | Service `/api/v1/info` returns `stack: null` | Service runs an old libs JAR (pre-SBOM-2) or the image was not rebuilt | `docker compose build --no-cache <service>` + `up -d --force-recreate <service>` |
 | Build fails with `ClassNotFoundException: jakarta.validation.ConstraintViolationException` | Service lacks `quarkus-hibernate-validator` extension but libs used to auto-register ConstraintViolationExceptionMapper (deleted in `62b312b`) | Pull latest libs |
 | `Circular dependency: :classes → :compileJava → :compileKotlin → :quarkusGenerateCode → :jar → :classes` | Per-service `settings.gradle.kts` using `includeBuild("../openbank-libs")` + Quarkus 3.33 + Gradle 9 | Build from root: `./gradlew :openbank-<svc>:quarkusBuild` (commit `62b312b`) |
-| `BootstrapVerifier` fails with "looks like development defaults" | A property in the prod profile contains `CHANGE_ME_LOCAL_DEV_ONLY` or `_local_dev_only` | Wire to Vault (ADR 0017) |
+| `BootstrapVerifier` fails with "looks like development defaults" — ⬜ **this symptom cannot occur** | There is no `BootstrapVerifier`, so nothing ever emits that message. The row described a check that was never shipped (#8426) | Nothing to fix here. A dev placeholder is kept out of prod by ESO/OpenBao `secretKeyRef` injection (ADR-0007) — not by a boot-time check, so the startup failure you would expect never arrives |
 
 ## Audit & support
 

--- a/openbank-libs/docs/05-operations.md
+++ b/openbank-libs/docs/05-operations.md
@@ -110,7 +110,7 @@ Vše ostatní (Quarkus types, jakarta APIs, Redis client, Persistence API, Micro
 | Service `/api/v1/info` vrací `stack: null` | Service běží se starým libs JAR (před SBOM-2) nebo image není rebuiltlý | `docker compose build --no-cache <service>` + `up -d --force-recreate <service>` |
 | Build padá s `ClassNotFoundException: jakarta.validation.ConstraintViolationException` | Service nemá `quarkus-hibernate-validator` extension ale libs původně auto-registroval ConstraintViolationExceptionMapper (deleted v `62b312b`) | Pull latest libs |
 | `Circular dependency: :classes → :compileJava → :compileKotlin → :quarkusGenerateCode → :jar → :classes` | Per-service `settings.gradle.kts` s `includeBuild("../openbank-libs")` + Quarkus 3.33 + Gradle 9 | Build z root: `./gradlew :openbank-<svc>:quarkusBuild` (commit `62b312b`) |
-| `BootstrapVerifier` failuje s "looks like development defaults" | Property v prod profile obsahuje `CHANGE_ME_LOCAL_DEV_ONLY` nebo `_local_dev_only` | Provázat na Vault (ADR 0017) |
+| `BootstrapVerifier` failuje s "looks like development defaults" — ⬜ **tento symptom nemůže nastat** | `BootstrapVerifier` neexistuje, takže tuto hlášku nikdy nic nevypíše. Řádek popisoval kontrolu, která nebyla nikdy dodána (#8426) | Nic k řešení zde. Dev placeholder se do prod nedostane přes ESO/OpenBao `secretKeyRef` injektáž (ADR-0007) — ne přes boot-time kontrolu, takže selhání startu, které byste čekali, nepřijde |
 
 ## Audit & support
 

--- a/openbank-libs/docs/README.cs.md
+++ b/openbank-libs/docs/README.cs.md
@@ -30,10 +30,15 @@ com.openbank.libs/
 ├── idempotency/       IdempotencyStore port + Redis-backed implementation
 ├── persistence/
 │   └── outbox/        Generic transactional outbox primitives (entity, dispatcher, ports)
-├── security/          PiiMask, Roles, SecurityContext extensions, BearerTokenClientHeadersFactory, BootstrapVerifier
+├── security/          PiiMask, Roles, SecurityContext extensions, BearerTokenClientHeadersFactory
 ├── util/              BuildInfo (runtime tech-stack snapshot via Gradle stamping)
 └── web/               JAX-RS filters: CorrelationIdFilter, RateLimitFilter, ApiVersionResponseFilter, ServiceInfoResource, ServiceConfigResource
 ```
+
+`security/` **neobsahuje** `BootstrapVerifier` — tento řádek ho dříve uváděl a byl to omyl. ADR-0017
+předepisuje startup fail-fast guard proti dev-placeholder secrets, ten ale nebyl nikdy napsán
+(`git grep BootstrapVerifier -- '*.kt'` vrací 0) a delivery note téže ADR to uvádí. Dev placeholdery
+drží mimo prod injektáž secrets přes ESO/OpenBao `secretKeyRef` (ADR-0007), ne cokoli v této knihovně (#8426).
 
 ## Související dokumenty
 

--- a/openbank-libs/docs/README.en.md
+++ b/openbank-libs/docs/README.en.md
@@ -30,10 +30,16 @@ com.openbank.libs/
 ├── idempotency/       IdempotencyStore port + Redis-backed implementation
 ├── persistence/
 │   └── outbox/        Generic transactional outbox primitives (entity, dispatcher, ports)
-├── security/          PiiMask, Roles, SecurityContext extensions, BearerTokenClientHeadersFactory, BootstrapVerifier
+├── security/          PiiMask, Roles, SecurityContext extensions, BearerTokenClientHeadersFactory
 ├── util/              BuildInfo (runtime tech-stack snapshot via Gradle stamping)
 └── web/               JAX-RS filters: CorrelationIdFilter, RateLimitFilter, ApiVersionResponseFilter, ServiceInfoResource, ServiceConfigResource
 ```
+
+`security/` does **not** contain a `BootstrapVerifier` — this line used to list one, and that was wrong.
+ADR-0017 prescribes a startup fail-fast guard against dev-placeholder secrets, but it was never written
+(`git grep BootstrapVerifier -- '*.kt'` returns 0), and that ADR's own delivery note says so. Dev
+placeholders are kept out of prod by ESO/OpenBao `secretKeyRef` secret injection (ADR-0007), not by
+anything in this library (#8426).
 
 ## Related documents
 

--- a/openbank-libs/docs/README.md
+++ b/openbank-libs/docs/README.md
@@ -30,10 +30,15 @@ com.openbank.libs/
 ├── idempotency/       IdempotencyStore port + Redis-backed implementation
 ├── persistence/
 │   └── outbox/        Generic transactional outbox primitives (entity, dispatcher, ports)
-├── security/          PiiMask, Roles, SecurityContext extensions, BearerTokenClientHeadersFactory, BootstrapVerifier
+├── security/          PiiMask, Roles, SecurityContext extensions, BearerTokenClientHeadersFactory
 ├── util/              BuildInfo (runtime tech-stack snapshot via Gradle stamping)
 └── web/               JAX-RS filters: CorrelationIdFilter, RateLimitFilter, ApiVersionResponseFilter, ServiceInfoResource, ServiceConfigResource
 ```
+
+`security/` **neobsahuje** `BootstrapVerifier` — tento řádek ho dříve uváděl a byl to omyl. ADR-0017
+předepisuje startup fail-fast guard proti dev-placeholder secrets, ten ale nebyl nikdy napsán
+(`git grep BootstrapVerifier -- '*.kt'` vrací 0) a delivery note téže ADR to uvádí. Dev placeholdery
+drží mimo prod injektáž secrets přes ESO/OpenBao `secretKeyRef` (ADR-0007), ne cokoli v této knihovně (#8426).
 
 ## Související dokumenty
 


### PR DESCRIPTION
## What

`BootstrapVerifier` does not exist in tracked source. `git grep BootstrapVerifier -- '*.kt' '*.java'` returns **0** on `origin/main` (control: `class ServiceInfoResource` returns 1), and [ADR-0017](https://github.com/JiRaska/open-bank-oss/blob/main/docs/adr/0017-secrets-via-vault.md) has recorded it as ⬜ Not shipped since 2026-07-17 — saying in as many words that the service docs asserting it are stale.

38 files mention it. One (ADR-0017) is the correction. Three were fixed by **#8468** (`openbank-libs/docs/06-compliance.{md,cs.md,en.md}`, the DORA Art. 9 / NIS2 Art. 21 control map that closed audit finding K1). **34 still assert the control.** This PR corrects the 12 that live in `openbank-libs/docs/`; the 22 per-service documents follow in a sibling PR.

## How each claim was corrected

Corrected, never deleted — a red row that is true beats a green one that is not. Shape follows #8468 so the fleet reads consistently.

| Document | What it claimed | What it says now |
|---|---|---|
| `01-overview` | K1 row: "`BootstrapVerifier` fail-fast at startup" | ⬜ Not shipped; K1 is held by ESO/OpenBao `secretKeyRef` injection (ADR-0007), not a startup guard |
| `01-overview` | `security/` mindmap node | node reads `BootstrapVerifier NOT SHIPPED` |
| `01-overview` | F3 roadmap row `✅ done` | `⚠️ partial` — the phase's last named deliverable was never built |
| `02-architecture` | package graph node | `BV["BootstrapVerifier — not shipped"]` |
| `02-architecture` | `security/` file table row for `BootstrapVerifier.kt` | ⬜ the file does not exist; mitigation column says **Nothing** |
| `02-architecture` | startup sequence: `BootstrapVerifier.onStart(StartupEvent)` + its whole `alt` branch | replaced by a `Note` that no such step happens, plus prose explaining what the diagram used to assert |
| `05-operations` | troubleshooting row: `BootstrapVerifier` fails with "looks like development defaults" | ⬜ this symptom cannot occur — nothing emits that message, so a reader would wait for a startup failure that never arrives |
| `README` | package tree listed `BootstrapVerifier` under `security/` | removed from the tree (the tree describes real files) **with an explicit note below it** recording the absence rather than tidying it away |

Both language variants of every document move in this PR so they cannot drift apart. `06-compliance.*` is deliberately untouched — that is #8468's live diff.

## The honest replacement, measured not assumed

The documents now name what actually mitigates the risk. Verified against the gitops manifests on `origin/main`:

| Service manifest | `secretKeyRef` | `CHANGE_ME` / `_local_dev_only` literals |
|---|---|---|
| `accounts/account-service.yaml` | 4 | 0 |
| `balances/balance-service.yaml` | 4 | 0 |
| `lending/lending-service.yaml` | 4 | 0 |
| `sanctions-service/sanctions-service.yaml` | 7 | 0 |
| `security-scanner/security-scanner-service.yaml` | 6 | 0 |

So ESO/OpenBao injection (ADR-0007) is what keeps dev placeholders out of prod today. **No boot-time guard checks it**, and every corrected document says exactly that rather than implying a control exists.

## Verification

**`mermaid-parses`** — three diagrams changed (mindmap node, graph node, sequence diagram). Run with admin-ui's own mermaid 11.17.2 via `check-mermaid-parses.sh` with `MERMAID_SCAN_ROOT` pointed at these files: **0 failing / 18 diagrams**.

Falsified rather than trusted: reintroducing a bare `@` in an unquoted node label and a literal `;` in the `Note` I added turns the same run **red (exit 1)**. The green is about the diagrams, not about the gate being inert.

**`threat-model-claims-resolve`** — run the way `gates.yaml` runs it, `python3 .github/scripts/check-threat-model-claims.py --enforce`, exit 0, `SUBJECTS=23`, 23/23 money-path models. Nothing to retire: no threat model mentions `BootstrapVerifier` and no `ALLOWED_UNRESOLVED` entry excuses it — verified, not assumed, because that table fails on a stale entry in both directions.

**No release impact.** Type `docs` is a hidden type, so release-please cuts nothing regardless of path.

## Claim check before writing

- Open PRs scanned by changed **file** (`gh api --paginate .../pulls?state=open&per_page=100`, 58 PRs, 541 files). Only **#8468** overlaps, on the three `06-compliance.*` files this PR does not touch. #8274 touches `openbank-domestic-payment` docs, which carry no such claim.
- `git ls-remote --heads origin` — one related branch, #8468's.
- `git worktree list` — `/private/tmp/ob-bootstrap-10707` is #8468's live worktree; left alone.

Every one of the 34 remaining mentions was read in context before rewriting. All 34 are claims — none turned out to be a correction already. Worth noting: `openbank-security-scanner/src/main/resources/docs/06-compliance.*` (in the sibling PR) has a nearby "this is where the documentation previously overclaimed" section, so the file reads as self-correcting while line 66 still asserts the control.

Refs #8426
