### PR TITLE
docs(adr): correct ADR-0264's followup — phases C and E are built, and E is inert

### DIFF
--- a/docs/adr/0264-loan-products-in-the-industry-neutral-catalog-kernel.md
+++ b/docs/adr/0264-loan-products-in-the-industry-neutral-catalog-kernel.md
@@ -8,7 +8,7 @@ superseded-by: []
 delivery-repos: []
 tags: [product-catalog, lending, governance, api-contract]
 summary: "Loan products join the ADR-0257/0258 catalog kernel via a banking.loan-v1 schema pack, no parallel versioning; lending-service will pin a resolved revision fail-closed, diverging from account-service's fail-open precedent."
-followup: "#668 — phases C (money-path wiring), D (repayment allocation), E (interest resolution), F (restructuring re-pin) are unbuilt; phase C needs its own ADR before any lending-service code changes"
+followup: "#668 — phase C (money-path wiring) is built: lending resolves a published offering via ProductCatalogLoanProfileAdapter. Phase E (interest resolution) is built but INERT — CatalogInterestProfileSynchronizer is gated by INTEREST_CATALOG_SYNC_ENABLED, which defaults false and is set by no manifest, pending a catalog read grant for the openbank-services principal (#8481). Phases D (repayment allocation) and F (restructuring re-pin) remain unbuilt: zero allocation logic in lending src/main, and no restructuring path touches a catalog revision"
 ---
 
 # ADR-0264 — Loan Products in the Industry-Neutral Catalog Kernel


### PR DESCRIPTION
ADR-0264's front-matter `followup:` still called phases C, D, E and F unbuilt. Two of the four have shipped since, and one of those shipped into a state that neither reading of the old line describes.

| phase | old `followup:` | measured on `origin/main` |
|---|---|---|
| C — money-path wiring | unbuilt | **BUILT** — lending references the catalog in 4 files, including `ProductCatalogLoanProfileAdapter` |
| D — repayment allocation | unbuilt | unbuilt — zero `allocat` hits across `openbank-lending-service/src/main` |
| E — interest resolution | unbuilt | **BUILT BUT INERT** — `CatalogInterestProfileSynchronizer` + `CatalogInterestProfile` exist, gated by `${INTEREST_CATALOG_SYNC_ENABLED:false}` |
| F — restructuring re-pin | unbuilt | unbuilt — restructuring exists (ADR-0028 forbearance, `LendingService.kt:904`) but no restructuring path references a revision, catalog or pin |

**Phase E is why this is more than bookkeeping.** No gitops manifest names `INTEREST_CATALOG_SYNC_ENABLED`, so the synchronizer runs in no environment. Read the old `followup:` and phase E looks like work not started; read only the code and it looks done. Both are wrong in the direction that matters. Its own comment states the precondition honestly — a catalog read grant for the `openbank-services` principal, plus an explicit opt-in per environment — and the corrected line now says that instead of implying either extreme.

That is one of the twelve cases swept in **#8481**: features off in every environment, eleven of them with nothing recording whether that is intended.

The ADR **body** also carries a now-false sentence — *"`openbank-lending-service` has zero references to `productId`, `ProductCatalog`, or any revision concept anywhere in `src/main`"*. I deliberately left it: an ADR body is a record of what was true on its date (2026-08-16) and rewriting it would destroy that. The `followup:` field is the part that is supposed to describe the present, and it is the part corrected here.

Derived files (`README.md`, `DIGEST.md`, `index.json`) regenerated with `docs/adr/gen-index.sh` **before** committing, per the mandatory order — a failing checker restores them to HEAD on exit, so running the check first would have staged the restored content. `check-adr-registry.sh` after the commit: exit 0, *"268 ADRs: unique numbers, headings match filenames, front-matter valid, supersession bidirectional, derived artefacts fresh."*

Refs #668, #8481
