### PR TITLE
docs(threat-models): stop crediting service-to-service mTLS that is not deployed

### DIFF
--- a/docs/threat-models/openbank-domestic-payment.md
+++ b/docs/threat-models/openbank-domestic-payment.md
@@ -317,7 +317,7 @@ not change any existing request's outcome until explicitly flipped.
   true; `%test` false) so @QuarkusTest boot does not connect to an absent Temporal frontend; a test
   `WorkflowClientTestProducer` backs the CDI `WorkflowClient` with an in-process `TestWorkflowEnvironment`.
   **No new trust boundary or external caller** — the same screening/fraud/scheme/settlement steps now run
-  inside Temporal activities (each already OIDC/mTLS-bounded), with the workflow adding durable retries +
+  inside Temporal activities (each already OIDC-bounded; mTLS is NOT deployed for service-to-service HTTP — the only PeerAuthentication/DestinationRule in the tree is `openbank-infra/k8s/base/istio.yaml`, which no ArgoCD application applies, #1914. Kafka mTLS is real and separate), with the workflow adding durable retries +
   reverse compensation. The prerequisite that the Temporal path was missing shadow fraud scoring was
   fixed in the same change (the `shadowFraudScore` activity is now invoked between validation and scheme
   submission, matching the retired flow). Rollback: revert the commit (the flag + in-service flow return).

--- a/docs/threat-models/openbank-sepa-payment.md
+++ b/docs/threat-models/openbank-sepa-payment.md
@@ -237,7 +237,7 @@ simply stops existing).
   (default true; `%test` false) so @QuarkusTest boot does not connect to an absent Temporal frontend;
   a test `WorkflowClientTestProducer` backs the CDI `WorkflowClient` with an in-process
   `TestWorkflowEnvironment`. **No new trust boundary or external caller** — the same screening/fraud/
-  scheme/settlement steps now run inside Temporal activities (each already OIDC/mTLS-bounded), with the
+  scheme/settlement steps now run inside Temporal activities (each already OIDC-bounded; mTLS is NOT deployed for service-to-service HTTP — the only PeerAuthentication/DestinationRule in the tree is `openbank-infra/k8s/base/istio.yaml`, which no ArgoCD application applies, #1914. Kafka mTLS is real and separate), with the
   workflow adding durable retries + reverse compensation. The prerequisite that the Temporal path was
   missing shadow fraud scoring was fixed first (#2068). Rollback: revert the commit (the flag +
   in-service flow return). Risk class = **availability/correctness** (durable orchestration replaces a


### PR DESCRIPTION
Two money-path threat models credit a control that is not deployed.

Both `openbank-domestic-payment.md` and `openbank-sepa-payment.md` describe the Temporal migration as:

> the same screening/fraud/scheme/settlement steps now run inside Temporal activities (**each already OIDC/mTLS-bounded**)

The OIDC half is true. The mTLS half is not.

| probe | result |
|---|---|
| `kind: PeerAuthentication` / `DestinationRule` anywhere in `openbank-infra/` | exactly one file — `k8s/base/istio.yaml` |
| any ArgoCD application applying it | none (#1914) |
| `istio` under `openbank-infra/gitops/` | one hit, a comment in `apps/argo-rollouts.yaml`: *"native k8s, no Istio/Linkerd"* |
| control — `kind: KafkaUser` | **37** |

So the fleet does have mTLS, on Kafka, via Strimzi. It does not have it on service-to-service HTTP. That is part of why the sentence reads plausibly.

## What this is not

**It is not #6066.** I read the full paragraph before touching it: the parenthetical attaches to the *steps* — the activities' own outbound calls — not to the worker↔frontend edge. #6066 is about Temporal transport authentication, which I confirmed separately (`TemporalClientProducer.kt` contains zero occurrences of `ssl`/`tls`/`cert`), and settlement-service's threat model was already corrected for that on 2026-08-20 by #6055. This is the neighbouring claim, and it is wrong for a different reason.

## The gate could not have caught this, and that is worth knowing

`check-threat-model-claims.py --enforce` exits **0 both before and after**, `SUBJECTS=45`. That is not reassurance — it is the gate's own accounting: of 3029 mitigation claims it reports **2086 as naming "no mechanism at all (unfalsifiable as written)"**. A prose claim like "mTLS-bounded" resolves no symbol, so it lives in that bucket by construction. The gate catches a claim that names a class or config key and gets it wrong; it is structurally blind to a claim that names a *property*.

Two-thirds of the fleet's mitigation claims are in that bucket. This one was found by reading.

## Merge note

PR #8274 also touches `openbank-domestic-payment.md`, in a different hunk. Its `DelegatedSpendActivationContractTest` asserts three literal strings from that file — *"Account authority proof is an activation gate"*, *"canonical-IBAN-to-account-id and account-id-to-owner checks are green"*, *"must produce no payment, outbox event or workflow start"* — and none of them is the sentence changed here, so the two compose. Worth re-checking after the merge rather than assuming, since a test that reads a document is exactly what a careless edit breaks.

Refs #1914, #6066
