### PR TITLE
fix: send occurredAt on the last four audit-consumed producers that omit it (#8352)

### DIFF
--- a/openbank-audit-service/CLAUDE.md
+++ b/openbank-audit-service/CLAUDE.md
@@ -43,6 +43,32 @@
   replaces. `TopicAttribution` is a verified table whose COVERAGE (not values) is derived from
   `application.yaml`, so a newly subscribed topic fails `TopicAttributionCoverageTest` instead of
   silently defaulting again.
+- **Event time vs ingest time: the per-topic disposition, and why it is HERE and not in the
+  consumer's KDoc** (#8352, sweeping #3883). `AuditConsumer.eventTime` reads `occurredAt` and only
+  `occurredAt`; absent or unparseable ⇒ the row stores the consumer's clock, flagged
+  `occurred_at_source = INGEST`. As of 2026-09-03 the channel subscribes to **27** topics (not the
+  21 of #3883) and every one of them carries a top-level `occurredAt` on every production-reachable
+  event type. Four event types did not until this sweep, and all four had the instant already in
+  hand and simply never projected it onto the wire: `dispute.opened` (had it as `openedAt`),
+  `PARTY_ERASED` (as `erasedAt`, while `PartyEvent.occurredAt` held the same value and fed the
+  outbox row's `createdAt`), and interest-service's `interest.withholding.recorded.v1` /
+  `interest.withholding.remitted.v1` (nothing on the wire; the values are the withholding row's and
+  the remittance batch's own `createdAt`). **No topic on this channel genuinely lacks a business
+  time** — the honest-INGEST case the issue allowed for did not turn out to exist here.
+  Two things about that sweep are the reusable part:
+  - **Enumerate the producing TYPE, never grep the key.** Payloads are built four ways on this
+    channel — a serialised `DomainEvent` subclass (cards, delegation, ledger, consent, account,
+    transaction, balance, domestic-payment, fx, document), a `mapOf`/`ObjectNode` envelope (party,
+    kyc, clearing, sca, swift, sepa-instant, customer-edge, ICT), a raw JSON string template
+    (dispute, statement, lending, sdd, interest, fraud, sepa-payment's Temporal activities), and
+    sanctions' hybrid (serialise the aggregate, then `put` the per-event instant). A grep for
+    `"occurredAt"` sees only the last two families and reports a confident false gap over the first.
+  - **A `has(key)` assertion cannot see the wire form.** `PartyEventEnvelopeContractTest` built its
+    mapper with `findAndRegisterModules()` alone, which leaves `WRITE_DATES_AS_TIMESTAMPS` ON, so
+    every `Instant` in it serialised as the number `1.7866E9` — a shape no consumer of that topic
+    receives, since Quarkus defaults the property to false. Nothing failed, because every time
+    assertion in the file was `json.has(...)`, true of a number as readily as of an ISO-8601 string.
+    Assert the VALUE. The same trap cost #3926 a red run on document-service.
 - **Asking the audit DATABASE which fields producers send measures traffic, not the wire contract —
   and it answers "nothing to recover" with total confidence.** Chasing the actor half of #3994, the
   obvious probe was to enumerate the payload keys of every actor-less row

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
@@ -306,12 +306,23 @@ class AuditConsumer {
      * second silent path, and a silent path is exactly how the gap below survived unnoticed.
      *
      * Two ways to have no event time, both previously invisible:
-     *  - the key is absent. 7 of the 21 consumed topics are in this state today (clearing,
+     *  - the key is absent. The old code substituted `Instant.now(clock)` and the row then
+     *    asserted, indistinguishably from a real one, that the operation happened when the consumer
+     *    got round to it. Under consumer lag or a replay that is arbitrarily wrong, and it is the
+     *    GDPR Art. 30 "when" dimension and DORA Art. 17 evidence.
+     *
+     *    **This paragraph used to name the topics in that state, and the list went stale within
+     *    hours of being written** (#8352). It said "7 of the 21 consumed topics — clearing,
      *    dispute, statement, sanctions, six of lending's payloads, sepa-payment's Temporal path,
-     *    and document-service which names it `at`). The old code substituted `Instant.now(clock)`
-     *    and the row then asserted, indistinguishably from a real one, that the operation happened
-     *    when the consumer got round to it. Under consumer lag or a replay that is arbitrarily
-     *    wrong, and it is the GDPR Art. 30 "when" dimension and DORA Art. 17 evidence.
+     *    and document-service which names it `at`", and by the time anyone read it the #3914/#3926
+     *    sweep had fixed every one of those except a `dispute.opened` builder that had landed three
+     *    hours earlier and so was invisible to that sweep's branch. Meanwhile the subscription grew
+     *    from 21 topics to 27 and the list could not know. A comment naming other services' current
+     *    payload shapes is a claim with a shelf life and nothing re-checks it — the same trap this
+     *    repo already records for comments asserting current CONFIGURATION. So this one now names
+     *    the MECHANISM only. What the state is today is answered by things that cannot go stale:
+     *    `openbank.audit.event.time.missing{source_service}` as a series, `occurred_at_source` per
+     *    row, and the per-topic disposition in `openbank-audit-service/CLAUDE.md`.
      *  - the key is present but unparseable. That threw out of the constructor into consume()'s
      *    catch, so the WHOLE audit entry was dropped — one malformed field lost the record of the
      *    operation entirely. It is now an INGEST-sourced row: a degraded entry beats no entry.

--- a/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/application/usecase/DisputeService.kt
+++ b/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/application/usecase/DisputeService.kt
@@ -256,6 +256,20 @@ class DisputeService(
      * where that lookup is exactly what the ADR-0220 eligibility snapshot exists to avoid. Paired
      * with the existing `dispute.resolved`, the two bracket the window during which a customer is
      * in dispute, so a consumer can both apply and lift the exclusion.
+     *
+     * `occurredAt` is the OPENING instant — `dispute.createdAt`, the same value `openedAt` already
+     * carries — converted with `.toInstant()` (#8352). Two separate points, and the second is the
+     * one a rename alone would have missed:
+     *  - `openedAt` is not a spelling `AuditConsumer.eventTime` accepts. It reads `occurredAt` and
+     *    only `occurredAt`, so every `dispute.opened` row in the ten-year audit trail recorded the
+     *    consumer's ingest clock as the moment a customer disputed a payment.
+     *  - `createdAt` is an `OffsetDateTime`, and this file's two sibling builders both spell
+     *    `.toInstant()` for that reason. `openedAt` is left exactly as it was — additive, no
+     *    existing field changes name, place or form.
+     *
+     * Why this one builder was missed by the #3914/#3926 sweep that patched its two siblings:
+     * `dispute.opened` was introduced by #4087, which merged about three hours BEFORE that sweep
+     * did — so the sweep's branch, cut earlier, could not see the sibling it was about to acquire.
      */
     private fun openedOutboxMessage(dispute: Dispute): OutboxMessage = OutboxMessage(
         aggregateId = dispute.id,
@@ -263,7 +277,9 @@ class DisputeService(
         payload = """{"eventType":"dispute.opened","disputeId":"${dispute.id}",""" +
             """"reference":"${dispute.reference}","partyId":"${dispute.partyId}",""" +
             """"disputeType":"${dispute.disputeType}","status":"${dispute.status}",""" +
-            """"openedAt":"${dispute.createdAt}","sourceService":"$SOURCE_SERVICE"}""",
+            """"openedAt":"${dispute.createdAt}",""" +
+            """"occurredAt":"${dispute.createdAt.toInstant()}",""" +
+            """"sourceService":"$SOURCE_SERVICE"}""",
         createdAt = Instant.now(clock),
     )
 

--- a/openbank-dispute-service/src/test/kotlin/com/openbank/dispute/application/usecase/DisputeServiceTest.kt
+++ b/openbank-dispute-service/src/test/kotlin/com/openbank/dispute/application/usecase/DisputeServiceTest.kt
@@ -329,6 +329,44 @@ class DisputeServiceTest {
         messagesSlot.captured.forEach { AuditEventTime.assertRecordedAsEventTime(it.payload, resolvedAt) }
     }
 
+    /**
+     * #8352: red against `origin/main`, where `dispute.opened` carried `openedAt` and no
+     * `occurredAt` — so every audit row for the moment a customer disputed a payment recorded the
+     * audit consumer's ingest clock instead.
+     *
+     * Both halves are asserted, and the second is the one a rename alone would not have satisfied:
+     * `Dispute.createdAt` is an `OffsetDateTime`, so interpolating it directly renders an offset
+     * form rather than the `Z`-normalised instant the two sibling builders in the same file emit.
+     * `assertRecordedAsEventTime` compares the parsed value, so a payload carrying the right key
+     * with the wrong form fails here rather than downstream.
+     *
+     * The sibling assertion on `openedAt` is not decoration: this change had to be additive, and a
+     * test that only looked at the new key could not tell an addition from a rename.
+     */
+    @Test
+    fun `the opened outbox payload carries the opening instant as the audit event time`() {
+        val request = OpenDisputeRequest(
+            transactionId = UUID.randomUUID(),
+            accountId = UUID.randomUUID(),
+            partyId = UUID.randomUUID(),
+            disputeType = DisputeType.UNAUTHORIZED,
+            amount = BigDecimal("25.00"),
+            transactionDate = today,
+            description = "Unauthorized card payment",
+        )
+        val outbox = slot<List<OutboxMessage>>()
+        every { disputeRepo.save(any(), capture(outbox)) } answers { Uni.createFrom().item(firstArg<Dispute>()) }
+        every { timelineRepo.save(any()) } answers { Uni.createFrom().item(firstArg<DisputeTimelineEvent>()) }
+
+        service.open(request).await().indefinitely()
+
+        val payload = outbox.captured.single().payload
+        AuditEventTime.assertRecordedAsEventTime(payload, now.toInstant())
+        assertThat(payload)
+            .describedAs("occurredAt is ADDITIVE — openedAt keeps its name, place and form")
+            .contains(""""openedAt":"$now"""")
+    }
+
     private fun <T> requireNonNull(value: T?): T = requireNotNull(value) { "resolvedAt must be set by resolve()" }
 
     @Test

--- a/openbank-interest-service/build.gradle.kts
+++ b/openbank-interest-service/build.gradle.kts
@@ -45,6 +45,12 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.smallrye.reactive.messaging.inmemory)
+    // #8352: AuditEventTime — the ONE shared copy of the rule `AuditConsumer.eventTime` applies to
+    // a payload, so this service's own test can assert what its outbox event becomes in the audit
+    // trail (EVENT vs INGEST). Restating the rule locally is what let the two withholding events
+    // ship with no event time at all: a hand-kept second copy of an agreement between modules
+    // moves with the first and keeps passing against a contract neither side honours.
+    testImplementation(project(":openbank-libs-testing"))
 
     // CI infra sweep (#578): isolated PostgreSQL + Valkey(Redis) per test JVM
     // via Testcontainers. Kafka is already in-memory in the IT (no broker).

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/InterestService.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/InterestService.kt
@@ -463,7 +463,25 @@ class InterestService(
         )
     }
 
-    /** Builds the versioned `interest.withholding.recorded` outbox event (ADR-0033 §F). */
+    /**
+     * Builds the versioned `interest.withholding.recorded` outbox event (ADR-0033 §F).
+     *
+     * `occurredAt` is [WithholdingTax.createdAt] — the instant this withholding was decided and
+     * recorded, stamped from the injected clock in the very transaction this event announces
+     * (#8352). Two things about it are worth stating rather than leaving to a reader:
+     *
+     *  - It was already in hand and simply not projected. The payload's only temporal fields are
+     *    `periodFrom`/`periodTo`, which are `LocalDate` ACCRUAL-PERIOD bounds, not an instant —
+     *    so `AuditConsumer.eventTime` (which reads `occurredAt` and only `occurredAt`) found no
+     *    event time and every audit row for a withholding decision recorded the audit consumer's
+     *    ingest clock as the moment tax was withheld from a customer.
+     *  - `.toInstant()` is load-bearing, not tidiness: `createdAt` is an `OffsetDateTime`, and
+     *    while `Instant.parse` does accept a non-`Z` offset, the ISO-8601 form this service's
+     *    `BANK_TIME`-zoned clock would render is not the one the rest of the fleet puts on the
+     *    wire. Normalise once here rather than rely on the consumer's tolerance.
+     *
+     * Additive: every existing field keeps its name, place and form.
+     */
     private fun withholdingRecordedEvent(cap: InterestCapitalization, withholding: WithholdingTax): OutboxMessage {
         val payload = "{\"schemaVersion\":1," +
             "\"capitalizationId\":\"${cap.id}\",\"withholdingId\":\"${withholding.id}\"," +
@@ -472,7 +490,8 @@ class InterestService(
             "\"currency\":\"${cap.currency}\",\"grossAmount\":\"${cap.grossAmount}\"," +
             "\"taxableBase\":\"${withholding.taxableBase}\",\"rate\":\"${withholding.rate}\"," +
             "\"taxAmount\":\"${withholding.taxAmount}\",\"netAmount\":\"${cap.netAmount}\"," +
-            "\"treatment\":\"${withholding.treatment}\",\"status\":\"${withholding.status}\"}"
+            "\"treatment\":\"${withholding.treatment}\",\"status\":\"${withholding.status}\"," +
+            "\"occurredAt\":\"${withholding.createdAt.toInstant()}\"}"
         return OutboxMessage(
             eventId = UUID.randomUUID(),
             aggregateId = cap.id,

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/WithholdingRemittanceService.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/WithholdingRemittanceService.kt
@@ -90,13 +90,27 @@ class WithholdingRemittanceService(
             "assembly or reversed rows; the batch was not emitted.",
     )
 
-    /** Builds the versioned `interest.withholding.remitted` outbox event (ADR-0038). */
+    /**
+     * Builds the versioned `interest.withholding.remitted` outbox event (ADR-0038).
+     *
+     * `occurredAt` is [WithholdingRemittance.createdAt] — the instant [assembleRemittance] built
+     * this batch, which is the event (#8352). `dueDate` cannot serve: it is a `LocalDate`
+     * regulatory deadline, a date the obligation must be met BY, not a moment anything happened.
+     * With neither on the wire under a name `AuditConsumer.eventTime` accepts, every audit row for
+     * a tax remittance recorded the audit consumer's ingest clock as the assembly time.
+     *
+     * `.toInstant()` normalises the `OffsetDateTime` to the `Z` form the rest of the fleet emits,
+     * rather than relying on `Instant.parse`'s tolerance of an offset.
+     *
+     * Additive: every existing field keeps its name, place and form.
+     */
     private fun remittedEvent(r: WithholdingRemittance): OutboxMessage {
         val payload = "{\"schemaVersion\":1," +
             "\"remittanceId\":\"${r.id}\",\"periodYear\":${r.periodYear},\"periodMonth\":${r.periodMonth}," +
             "\"authority\":\"${r.authority}\",\"currency\":\"${r.currency}\"," +
             "\"totalTaxAmount\":\"${r.totalTaxAmount}\",\"itemCount\":${r.itemCount}," +
-            "\"dueDate\":\"${r.dueDate}\",\"status\":\"${r.status}\"}"
+            "\"dueDate\":\"${r.dueDate}\",\"status\":\"${r.status}\"," +
+            "\"occurredAt\":\"${r.createdAt.toInstant()}\"}"
         return OutboxMessage(
             eventId = UUID.randomUUID(),
             aggregateId = r.id,

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/application/usecase/InterestAuditEventTimeTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/application/usecase/InterestAuditEventTimeTest.kt
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.interest.application.usecase
+
+import com.openbank.interest.application.port.out.AccountDirectoryPort
+import com.openbank.interest.application.port.out.CapitalizationPosting
+import com.openbank.interest.application.port.out.InterestAccrualRepository
+import com.openbank.interest.application.port.out.InterestCapitalizationRepository
+import com.openbank.interest.application.port.out.InterestRateConfigRepository
+import com.openbank.interest.application.port.out.LedgerPostingPort
+import com.openbank.interest.application.port.out.TaxProfilePort
+import com.openbank.interest.domain.model.AccrualStatus
+import com.openbank.interest.domain.model.InterestAccrual
+import com.openbank.interest.domain.model.InterestCapitalization
+import com.openbank.interest.domain.tax.TaxProfile
+import com.openbank.interest.domain.tax.WithholdingTax
+import com.openbank.libs.persistence.outbox.OutboxMessage
+import com.openbank.libs.testing.audit.AuditEventTime
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.smallrye.mutiny.Uni
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * What `interest.withholding.recorded.v1` becomes in the audit trail (#8352).
+ *
+ * A file of its own rather than another method on `InterestServiceTest`: that class is already at
+ * detekt's `LargeClass` threshold, so the honest place for a new concern is a new class, and the
+ * concern here IS distinct — every other test in that file is about the arithmetic and the
+ * transaction boundary, none about what the payload asserts to a consumer.
+ */
+class InterestAuditEventTimeTest {
+
+    private val clock = Clock.fixed(Instant.parse("2026-02-01T11:30:00Z"), ZoneOffset.UTC)
+    private val configRepo = mockk<InterestRateConfigRepository>()
+    private val accrualRepo = mockk<InterestAccrualRepository>()
+    private val capitalizationRepo = mockk<InterestCapitalizationRepository>()
+    private val taxProfilePort = mockk<TaxProfilePort>()
+    private val ledgerPostingPort = mockk<LedgerPostingPort>()
+    private val accountDirectoryPort = mockk<AccountDirectoryPort>()
+    private val service = InterestService(
+        configRepo,
+        accrualRepo,
+        capitalizationRepo,
+        taxProfilePort,
+        ledgerPostingPort,
+        accountDirectoryPort,
+        "ACT_365",
+        "SAVINGS",
+        clock,
+    )
+
+    private val whtSlot: CapturingSlot<WithholdingTax> = slot()
+    private val eventSlot: CapturingSlot<OutboxMessage> = slot()
+
+    /**
+     * #8352: red against `origin/main`, where this payload carried no event time of any name.
+     *
+     * `periodFrom`/`periodTo` look like the answer and are not — they are `LocalDate` accrual-period
+     * bounds, the range the tax was computed OVER, not a moment anything happened. So
+     * `AuditConsumer.eventTime` (which reads `occurredAt` and only `occurredAt`) found nothing, and
+     * every audit row for a withholding decision recorded the audit consumer's ingest clock as the
+     * moment tax was withheld from a customer.
+     *
+     * The instant asserted is the withholding row's own `createdAt` — the value this use case
+     * already stamps from the injected clock inside the very transaction the event announces, and
+     * the same one it hands `saveWithOutbox` as `capitalizedAt`. Asserting THAT, and not merely
+     * that some event time is present, is the point: a fresh `Instant.now()` taken at serialisation
+     * would satisfy presence while asserting a business time nothing measured — indistinguishable
+     * in the trail from a real one, and so worse than an honest INGEST row.
+     */
+    @Test
+    fun `the withholding-recorded payload carries the recording instant as the audit event time`() {
+        val accountId = UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+        val productId = "SAVINGS_CZK"
+        val toDate = LocalDate.of(2026, 1, 20)
+
+        every { accrualRepo.findClaimedForCapitalization(any(), any()) } returns Uni.createFrom().item(emptyList())
+        every { accrualRepo.claimForCapitalization(any(), any(), any()) } returns Uni.createFrom().item(Unit)
+        every { taxProfilePort.resolve(any()) } returns Uni.createFrom().item(TaxProfile.FAIL_SAFE_DEFAULT)
+        every { ledgerPostingPort.post(any<CapitalizationPosting>()) } returns Uni.createFrom().item(Unit)
+        every {
+            capitalizationRepo.saveWithOutbox(any(), capture(whtSlot), capture(eventSlot), any(), any())
+        } answers { Uni.createFrom().item(firstArg<InterestCapitalization>()) }
+        every { accrualRepo.findPendingCapitalization(accountId, productId, toDate) } returns
+            Uni.createFrom().item(listOf(accrual(accountId, productId)))
+
+        service.capitalize(accountId, productId, toDate).await().indefinitely()
+
+        AuditEventTime.assertRecordedAsEventTime(
+            eventSlot.captured.payload,
+            whtSlot.captured.createdAt.toInstant(),
+        )
+    }
+
+    private fun accrual(accountId: UUID, productId: String) = InterestAccrual(
+        id = UUID.randomUUID(),
+        accountId = accountId,
+        productId = productId,
+        configId = UUID.randomUUID(),
+        accrualDate = LocalDate.of(2026, 1, 18),
+        balance = BigDecimal("1000.00"),
+        dailyRate = BigDecimal("0.0010000000"),
+        accruedAmount = BigDecimal("60.00"),
+        currency = "CZK",
+        status = AccrualStatus.ACCRUING,
+        capitalizedAt = null,
+        createdAt = OffsetDateTime.parse("2026-01-01T00:00:00Z"),
+    )
+}

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/application/usecase/WithholdingRemittanceServiceTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/application/usecase/WithholdingRemittanceServiceTest.kt
@@ -12,6 +12,7 @@ import com.openbank.interest.domain.tax.WithholdingTax
 import com.openbank.interest.domain.tax.WithholdingTaxStatus
 import com.openbank.interest.domain.tax.WithholdingTreatment
 import com.openbank.libs.persistence.outbox.OutboxMessage
+import com.openbank.libs.testing.audit.AuditEventTime
 import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
@@ -22,8 +23,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 
 class WithholdingRemittanceServiceTest {
@@ -32,6 +36,15 @@ class WithholdingRemittanceServiceTest {
     private val remittanceRepo = mockk<WithholdingRemittanceRepository>()
     private val eventOutbox = mockk<InterestEventOutbox>()
     private val service = WithholdingRemittanceService(withholdingTaxRepo, remittanceRepo, eventOutbox)
+
+    /**
+     * A FIXED clock, and the service built on its four-arg constructor so the assembly instant is
+     * knowable (#8352). The other tests in this file use the `@Inject` three-arg constructor, which
+     * takes `Clock.systemUTC()` — fine while nothing asserts a time, useless the moment one does.
+     */
+    private val fixedClock = Clock.fixed(Instant.parse("2026-02-03T09:15:00Z"), ZoneOffset.UTC)
+    private val clockedService =
+        WithholdingRemittanceService(withholdingTaxRepo, remittanceRepo, eventOutbox, fixedClock)
 
     private fun withheld(taxAmount: BigDecimal, periodTo: LocalDate = LocalDate.of(2026, 1, 31)) = WithholdingTax(
         id = UUID.randomUUID(),
@@ -151,5 +164,48 @@ class WithholdingRemittanceServiceTest {
         assertThat(result.totalTaxAmount).isEqualByComparingTo("0")
         verify(exactly = 1) { remittanceRepo.save(any()) }
         verify(exactly = 1) { eventOutbox.append(any()) }
+    }
+
+    /**
+     * #8352: red against `origin/main`, where this payload carried no event time of any name.
+     *
+     * `dueDate` is the field that looks like an answer and is not: a `LocalDate` regulatory
+     * deadline is the date the obligation must be met BY, not a moment anything happened. So
+     * `AuditConsumer.eventTime` found nothing and every audit row for a tax remittance recorded
+     * the audit consumer's ingest clock as the assembly time.
+     *
+     * The instant asserted is the batch's own `createdAt` — stamped by [assembleRemittance] from
+     * the injected clock as it built this batch, which IS the event. Asserting the exact value
+     * rather than mere presence is what separates the fix from a fresh `Instant.now()` at
+     * serialisation, which would look identical in the audit trail and measure nothing.
+     */
+    @Test
+    fun `the remitted payload carries the assembly instant as the audit event time`() {
+        val records = listOf(withheld(BigDecimal("15")))
+        val savedSlot: CapturingSlot<WithholdingRemittance> = slot()
+        val eventSlot: CapturingSlot<OutboxMessage> = slot()
+
+        every { remittanceRepo.findByPeriod(2026, 1) } returns Uni.createFrom().nullItem()
+        every {
+            withholdingTaxRepo.findRecordedForPeriod(
+                LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 1, 31),
+            )
+        } returns Uni.createFrom().item(records)
+        every { remittanceRepo.save(capture(savedSlot)) } answers {
+            Uni.createFrom().item(firstArg<WithholdingRemittance>())
+        }
+        every { withholdingTaxRepo.markRemitted(any(), any()) } returns Uni.createFrom().item(1)
+        every { eventOutbox.append(capture(eventSlot)) } returns Uni.createFrom().nullItem()
+
+        clockedService.assembleRemittance(2026, 1).await().indefinitely()
+
+        // Not `fixedClock.instant()` directly: the assertion has to be the instant the batch
+        // actually recorded, or it would still pass against a payload that read a second clock.
+        AuditEventTime.assertRecordedAsEventTime(
+            eventSlot.captured.payload,
+            savedSlot.captured.createdAt.toInstant(),
+        )
+        assertThat(savedSlot.captured.createdAt.toInstant()).isEqualTo(fixedClock.instant())
     }
 }

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/PartyEvent.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/PartyEvent.kt
@@ -105,6 +105,15 @@ object PartyEvents {
      * self-service erasure is the data subject's own Keycloak subject — putting that on a
      * broadcast topic would re-publish an identifier for the person the event exists to erase.
      * Zero rows of the live unattributed set are `PARTY_ERASED`, so nothing is lost by leaving it.
+     *
+     * The narrowing is about IDENTIFIERS, and `occurredAt` is not one (#8352). Every sibling
+     * builder projects the event instant into the envelope under that key; this one projected the
+     * same value under `erasedAt` instead, and `AuditConsumer.eventTime` reads `occurredAt` and
+     * only `occurredAt` — so the audit row for a GDPR Art. 17 erasure recorded the audit
+     * consumer's ingest clock as the moment the subject's data was erased. That is the one row in
+     * this service where "when did this happen" is itself the regulatory artefact. `erasedAt`
+     * stays exactly where it is: additive, no existing key changes name, place or form, and a
+     * consumer reading `erasedAt` is unaffected.
      */
     fun erased(partyId: UUID, at: Instant): PartyEvent = PartyEvent(
         eventType = "PARTY_ERASED",
@@ -114,6 +123,7 @@ object PartyEvents {
             "eventType" to "PARTY_ERASED",
             "partyId" to partyId,
             "erasedAt" to at,
+            "occurredAt" to at,
             "sourceService" to SOURCE_SERVICE,
         ),
     )

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/domain/model/PartyEventEnvelopeContractTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/domain/model/PartyEventEnvelopeContractTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.party.domain.model
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.libs.testing.audit.AuditEventTime
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Instant
@@ -32,9 +33,16 @@ import java.util.UUID
  */
 class PartyEventEnvelopeContractTest {
 
-    // Mirror the Quarkus-configured ObjectMapper (JSR-310 registered) so this test serializes
-    // Instant exactly as the running producer does.
+    // Mirrors the RUNNING producer's mapper. `findAndRegisterModules()` ALONE is not that mapper
+    // and this file claimed it was until #8352: the feature it leaves ON, WRITE_DATES_AS_TIMESTAMPS,
+    // renders an `Instant` as the number `1.7866E9`, a wire shape no consumer of this topic ever
+    // receives (Quarkus defaults `quarkus.jackson.write-dates-as-timestamps` to false). Nothing
+    // here noticed, because every time assertion in this file was `json.has(...)` — true of a
+    // number just as much as of the ISO-8601 string, so the assertion could not fail either way.
+    // `PartyChangeMaterialityContractTest` in this same package already had the correct mapper and
+    // says why; this is the copy that drifted.
     private val mapper = ObjectMapper().findAndRegisterModules()
+        .disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
     private val at = Instant.parse("2026-06-11T08:00:00Z")
 
@@ -129,11 +137,52 @@ class PartyEventEnvelopeContractTest {
 
         assertThat(json.get("eventType").asText()).isEqualTo("PARTY_ERASED")
         assertThat(json.get("partyId").asText()).isEqualTo(id.toString())
-        assertThat(json.has("erasedAt")).isTrue()
+        // The VALUE, not `has`: an epoch number satisfies `has("erasedAt")` and is unreadable by
+        // any consumer parsing a timestamp. Same reason the mapper above had to be corrected.
+        assertThat(json.get("erasedAt").asText()).isEqualTo(at.toString())
         assertThat(json.get("sourceService").asText()).isEqualTo("party-service")
         listOf("legalName", "email", "partyType", "status", "kycStatus").forEach {
             assertThat(json.has(it)).describedAs("PARTY_ERASED must not carry %s", it).isFalse()
         }
+    }
+
+    /**
+     * #8352: red against `origin/main`, where the `PARTY_ERASED` envelope projected the erasure
+     * instant as `erasedAt` and nothing else. `AuditConsumer.eventTime` reads `occurredAt` and only
+     * `occurredAt`, so the audit row for a GDPR Art. 17 erasure recorded the audit consumer's
+     * ingest clock as the moment the subject's data was erased — on the one event in this service
+     * where "when did this happen" is itself the regulatory artefact.
+     *
+     * The value was never missing: `PartyEvent.occurredAt` already held it and fed the outbox row's
+     * `createdAt`. Only the projection into the envelope — the part that goes on the wire — was
+     * absent, which is why the fix cannot invent a time and the assertion can name the exact one.
+     *
+     * `erasedAt` is asserted alongside on purpose: the change had to be ADDITIVE, and a test that
+     * looked only at the new key could not tell an addition from a rename.
+     */
+    @Test
+    fun `PARTY_ERASED carries the erasure instant as the audit event time`() {
+        val envelope = PartyEvents.erased(UUID.randomUUID(), at).envelope
+
+        AuditEventTime.assertRecordedAsEventTime(mapper.writeValueAsString(envelope), at)
+
+        val json = mapper.readTree(mapper.writeValueAsString(envelope))
+        assertThat(json.get("erasedAt").asText())
+            .describedAs("occurredAt is ADDITIVE — erasedAt keeps its name, place and form")
+            .isEqualTo(at.toString())
+    }
+
+    /**
+     * The narrowing PARTY_ERASED exists for is about IDENTIFIERS, and this pins that adding a time
+     * did not widen it. Without this, "the envelope is narrow" is only asserted by the PII list
+     * above, which cannot see a future key that is neither PII nor expected.
+     */
+    @Test
+    fun `PARTY_ERASED carries exactly five keys - a time, not an identifier, was added`() {
+        val envelope = PartyEvents.erased(UUID.randomUUID(), at).envelope
+
+        assertThat(envelope.keys)
+            .containsExactly("eventType", "partyId", "erasedAt", "occurredAt", "sourceService")
     }
 
     /**


### PR DESCRIPTION
## What this is

The `#8352` deliverable: the topic-by-topic disposition of event time vs ingest time on
audit-service's `audit-events-in` channel, plus the four bounded producer fixes it turned up.

The full 27-topic table, with the method used per row, is [in a comment on #8352](https://github.com/JiRaska/open-bank-oss/issues/8352).

## The four fixes

`AuditConsumer.eventTime` reads `occurredAt` and **only** `occurredAt`; absent or unparseable ⇒ the
row stores the consumer's clock and is flagged `occurred_at_source = INGEST`. Four event types had
no such key, and **every one of them already had the instant in hand and simply never projected it
onto the wire** — which is what makes these bounded rather than a design call:

| event type | what it carried | what it now sends as `occurredAt` |
|---|---|---|
| `dispute.opened` | `openedAt` (an `OffsetDateTime`) | `dispute.createdAt.toInstant()` |
| `PARTY_ERASED` | `erasedAt`, while `PartyEvent.occurredAt` held the same value and fed the outbox row's `createdAt` | the same instant, projected into the envelope |
| `interest.withholding.recorded.v1` | nothing temporal but `LocalDate` period bounds | `WithholdingTax.createdAt.toInstant()` |
| `interest.withholding.remitted.v1` | nothing temporal but a `LocalDate` `dueDate` | `WithholdingRemittance.createdAt.toInstant()` |

**Nothing was invented, and nothing was left as an honest INGEST.** The issue allowed for a topic
that genuinely has only an ingest moment; on this channel that case does not exist — all 27 topics
now carry a real business instant on every production-reachable event type.

The two fields that *look* like an answer on the interest events are not: `periodFrom`/`periodTo`
are the range the tax was computed **over**, and `dueDate` is the date the obligation must be met
**by**. Neither is a moment anything happened.

All four changes are **additive** — every existing field keeps its name, place and form, and each
test asserts that too, because a test looking only at the new key cannot tell an addition from a
rename. `.toInstant()` is load-bearing rather than tidiness in three of the four: those fields are
`OffsetDateTime`, and a bare rename would put an offset form on the wire.

## Falsification

Every new assertion was run red against the unfixed producer first, and the failure text is the
real payload:

```
the opened outbox payload carries the opening instant as the audit event time
  [audit occurred_at_source for payload {"eventType":"dispute.opened",...,"openedAt":"2025-01-15T10:00Z","sourceService":"dispute-service"}]
  expected: EVENT but was: INGEST

PARTY_ERASED carries the erasure instant as the audit event time
  [... {"eventType":"PARTY_ERASED","partyId":"...","erasedAt":"2026-06-11T08:00:00Z","sourceService":"party-service"}]
  expected: EVENT but was: INGEST

PARTY_ERASED carries exactly five keys - a time, not an identifier, was added
  actual ["eventType","partyId","erasedAt","sourceService"] — could not find ["occurredAt"]

the withholding-recorded payload carries the recording instant as the audit event time
  [... "periodFrom":"2026-01-18","periodTo":"2026-01-20",...,"status":"RECORDED"}]
  expected: EVENT but was: INGEST

the remitted payload carries the assembly instant as the audit event time
  [... "dueDate":"2026-02-28","status":"PENDING"}]
  expected: EVENT but was: INGEST
```

Green after the fix. Each test asserts the **exact** instant, not merely that an event time is
present: a blanket `Instant.now()` at serialisation would satisfy presence while asserting a
business time nothing measured — indistinguishable in the ten-year trail from a real one, and so
worse than an honest INGEST row.

The assertions go through `AuditEventTime` (`openbank-libs-testing`), the one shared copy of the
rule the consumer applies. interest-service gains that test dependency rather than restating the
rule locally; a hand-kept second copy of an agreement between modules moves with the first and keeps
passing against a contract neither side honours.

## A test that could not see the defect

`PartyEventEnvelopeContractTest` built its mapper with `findAndRegisterModules()` alone, which
leaves `WRITE_DATES_AS_TIMESTAMPS` **on**, so every `Instant` in it serialised as the number
`1.7866E9` — a wire shape no consumer of that topic ever receives, since Quarkus defaults
`quarkus.jackson.write-dates-as-timestamps` to false. The file's own comment claimed it mirrored the
running producer. Nothing failed, because every time assertion in it was `json.has(...)`, true of a
number as readily as of an ISO-8601 string. `PartyChangeMaterialityContractTest`, in the same
package, already had the correct mapper and says why. Corrected here, and the `erasedAt` assertion
upgraded from `has` to the value — this is the same trap that cost #3926 a red run on
document-service.

## The stale comment

`AuditConsumer.eventTime`'s KDoc named the seven topics without an event time. That list was wrong
within hours of being written: it said clearing, dispute, statement, sanctions, six of lending's
payloads, sepa-payment's Temporal path and document-service, and the #3914/#3926 sweep had already
fixed all of those except a `dispute.opened` builder introduced by #4087 **three hours before that
sweep merged** — so the sweep's branch could not see the sibling it was about to acquire. Meanwhile
the subscription grew from 21 topics to 27 and the comment could not know.

A comment naming other services' current payload shapes is a claim with a shelf life and nothing
re-checks it. The KDoc now states the mechanism only and points at the three things that cannot go
stale: `openbank.audit.event.time.missing{source_service}` as a series, the per-row
`occurred_at_source` flag, and the disposition now written down in
`openbank-audit-service/CLAUDE.md`.

## Method, and why a grep would have lied

Producers were enumerated by reading the **serialised type** or the construction site, never by
grepping the quoted key. This channel carries **four** payload idioms:

- a serialised `DomainEvent` subclass — cards, delegation, ledger, consent, account, transaction,
  balance, domestic-payment, fx, document. `occurredAt` is on the wire with **no literal anywhere**;
- a `mapOf` / `ObjectNode` envelope — party, kyc, clearing, sca, swift, sepa-instant, customer-edge,
  security-scanner;
- a raw JSON string template — dispute, statement, lending, sdd, interest, fraud, and
  sepa-payment's Temporal activities;
- sanctions' hybrid: serialise the aggregate, then `put` the per-event instant.

`grep '"occurredAt"'` sees only the last two families, so it reports a confident false gap over the
first — the #3883 lesson, applied.

## Contracts and compatibility

- No new topic and no new contract file, so `event-contract-coverage-ratchet` is unmoved in both
  directions. None of dispute-, party- or interest-service has an `asyncapi.yaml`; all three pairs
  stay grandfathered in `.github/event-contract-baseline.txt`.
- Additive JSON keys only; no constructor changes. `check-event-schema-compat.py --base origin/main`
  is clean, and a consumer that ignores the new key is unaffected during rollout.

## Verification

```
:openbank-dispute-service:test   58 tests, 0 failed, 0 skipped
:openbank-party-service:test    183 tests, 0 failed, 1 skipped (the broker-gated pact class)
:openbank-interest-service:test 114 tests, 0 failed, 0 skipped
:openbank-audit-service:test --tests '*AuditConsumerTest*'  green
ktlintCheck + detekt on all four modules: green
check-event-contract-coverage.py            OK: 46 producer topics, 0 new undocumented
check-event-contract-code-agreement.py      OK: 13 contracts agree with their code
check-audit-money-path-subscription.py      clean (22 topics, 9 known gaps, unchanged)
check-domain-event-occuredat.sh             clean (3695 .kt)
check-event-schema-compat.py --base origin/main   no backward-incompatible change
```

Two `@QuarkusTest` classes failed on the first full run with `Unable to start HTTP server` and took
their siblings to SKIPPED with them — the documented parallel-build port collision, not this change.
Re-run serially: `PartyApiIT`, `PartyOutboxWriteIT`, `PartyOutboxClaimIT`,
`PartyOutboxDispatcherCdiIT`, `PartySequenceAllocationIT`, `PartyPactFolderProviderVerificationTest`
and `DisputeMissingParamStatusIT` are all green with zero skips. The skipped counts above are read
from the serial runs, not the parallel one.

## Review notes

- `openbank-interest-service` is money-path (`rules.yaml: money_path_services`) ⇒ two approvals. Its
  threat model is unchanged: this adds a timestamp the service already computes to a payload it
  already publishes, and introduces no new trust boundary, actor or data class.
- `openbank-audit-service/CLAUDE.md` is also touched by #5967, which appends at the end of the file
  while this inserts mid-file. Expected to merge cleanly; worth a look if both land close together.
- The interest test is a new class because `InterestServiceTest` is at detekt's `LargeClass`
  threshold — measured, the inline version failed the gate.

Closes #8352
Refs #3883, #3907, #3914, #3926, #4087
