### PR TITLE
fix(ci): reconcile probe must treat a version.txt release as build-relevant (#8127)

### DIFF
--- a/.github/scripts/auto-deploy-reconcile-lag.sh
+++ b/.github/scripts/auto-deploy-reconcile-lag.sh
@@ -101,8 +101,15 @@ while IFS= read -r pin; do
   fi
 
   # Any build-relevant commit on this checkout's HEAD since the pinned image was built?
+  # The path set must match the auto-deploy push trigger EXACTLY — including version.txt:
+  # a release-please commit touches only version.txt, and the push path rebuilds+deploys on
+  # it ("that release marker must rebuild/deploy the component"). When this probe omitted
+  # version.txt, a release-triggered deploy blocked at can-i-deploy stayed stranded FOREVER:
+  # no src/main delta, so no reconcile tick ever re-offered it — clearing-simulator ran 0.5.0
+  # for 9 days after 0.6.0 was cut (#8127). Dockerfile is in for the same reason.
   if [ -n "$(git log --format=%H "${commit}..HEAD" -- \
-              "${svc}/src/main" "${svc}/build.gradle.kts" 2>/dev/null)" ]; then
+              "${svc}/src/main" "${svc}/build.gradle.kts" \
+              "${svc}/version.txt" "${svc}/Dockerfile" 2>/dev/null)" ]; then
     epoch="$(git log -1 --format=%ct "${commit}^{commit}" 2>/dev/null || echo 0)"
     lagging+=("${epoch}	$svc")
   fi

--- a/.github/scripts/test-auto-deploy-reconcile-lag.sh
+++ b/.github/scripts/test-auto-deploy-reconcile-lag.sh
@@ -28,7 +28,7 @@ short() { git rev-parse --short=8 "$1"; }
 
 # --- history -----------------------------------------------------------------------------
 # c0: fresh source for four services.
-for s in current-svc stale-svc placeholder-svc testonly-svc; do
+for s in current-svc stale-svc placeholder-svc testonly-svc release-svc; do
   mkdir -p "openbank-${s}/src/main/kotlin" "openbank-${s}/src/test/kotlin"
   echo "v1" > "openbank-${s}/src/main/kotlin/App.kt"
 done
@@ -42,6 +42,12 @@ commit "c1: change stale-svc main"
 # c2: bump ONLY testonly-svc's TEST source — must NOT count as build-relevant.
 echo "v2" > openbank-testonly-svc/src/test/kotlin/App.kt
 commit "c2: change testonly-svc test only"
+
+# c3: bump ONLY release-svc's version.txt — the release-please shape. The push trigger
+# rebuilds+deploys on it, so the reconcile probe must see it too (#8127: a release-triggered
+# deploy blocked at can-i-deploy was invisible to reconcile forever without it).
+echo "0.2.0" > openbank-release-svc/version.txt
+commit "c3: release-please bump of release-svc version.txt"
 TIP="$(short HEAD)"
 
 # --- gitops manifest ---------------------------------------------------------------------
@@ -49,18 +55,20 @@ TIP="$(short HEAD)"
 # stale-svc    : pinned at c0 (before c1)     -> main changed since -> LAGGING
 # placeholder  : pinned at a non-commit tag   -> never deployed     -> LAGGING
 # testonly-svc : pinned at c0, only test moved -> not build-relevant -> NOT lagging
+# release-svc  : pinned at c0, only version.txt moved -> release must deploy -> LAGGING
 # foreign-svc  : stale pin BUT built by another pipeline (not in allowlist) -> NOT lagging
 cat > gitops/deploy.yaml <<EOF
 image: repo/openbank-current-svc:sandbox-${TIP}
 image: repo/openbank-stale-svc:sandbox-${C0}
 image: repo/openbank-placeholder-svc:sandbox-pending
 image: repo/openbank-testonly-svc:sandbox-${C0}
+image: repo/openbank-release-svc:sandbox-${C0}
 image: repo/openbank-foreign-svc:sandbox-pending
 EOF
 
 # --- run + assert (no allowlist: every manifest service is a candidate) -------------------
 GOT="$(RECONCILE_SERVICES='' bash "$PROBE" "$WORK/gitops")"
-WANT='["openbank-foreign-svc","openbank-placeholder-svc","openbank-stale-svc"]'
+WANT='["openbank-foreign-svc","openbank-placeholder-svc","openbank-release-svc","openbank-stale-svc"]'
 
 # Normalise ordering (probe already sorts via jq unique, but compare defensively).
 GOT_N="$(echo "$GOT"  | jq -S .)"


### PR DESCRIPTION
## Summary

The systemic hole under #8127: **a release-only deploy drift is invisible to the reconcile loop forever.**

- The auto-deploy push trigger treats `version.txt` as build-relevant ("release-please changes only version.txt, and that release marker must rebuild/deploy the component").
- The reconcile staleness probe (`auto-deploy-reconcile-lag.sh`, the every-3h self-heal from #2020) diffed only `src/main` + `build.gradle.kts` — despite its own comment claiming it "mirrors the auto-deploy.yml push-trigger globs".
- So a release-triggered deploy that got blocked at can-i-deploy (transient pact lag) was never re-offered: no src delta, no reconcile staleness, no signal except the drift watch. clearing-simulator ran 0.5.0 for 9 days after 0.6.0 was cut with zero code delta — exactly this shape.

Fix: the probe's path set now mirrors the push trigger exactly — `src/main`, `build.gradle.kts`, **`version.txt`, `Dockerfile`**. Stable by construction: a re-driven service is pinned at tip, and nothing is newer than tip.

**Test:** the unit test gains a release-only commit (`version.txt` bump only) that must classify the service as lagging — verified **red first** against the pre-fix probe (`got` lacked `release-svc`), green with the fix. The existing test-only-commit negative (must NOT be build-relevant) still passes.

Once merged, the next reconcile tick (or the one I already triggered) re-drives clearing-simulator and the drift watch closes #8127 itself — no hand-edit of the gitops pin.

Refs #8127

## Test plan

- [x] `test-auto-deploy-reconcile-lag.sh` red first (old probe) then green (fixed probe)
- [x] `bash -n` on the probe
- [ ] CI gates
