### PR TITLE
feat(customer-edge): the product catalogue a customer may open from

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -428,6 +428,45 @@ class CustomerEdgeResource(
      * this edge has an M2M credential. This projection is therefore also the single source for
      * the product eligibility check at [openTermDeposit].
      */
+    /**
+     * The customer-facing product catalogue: what this customer may open today.
+     *
+     * Generalises the projection [listTermDepositOffers] already applies to term deposits, for the
+     * same reason and with the same filters — the operator catalogue holds draft, private,
+     * withdrawn and future-dated products, and none of them may become discoverable merely
+     * because this edge holds an M2M credential.
+     *
+     * **Rates are read, never derived.** A savings product prices by balance tier and a term
+     * deposit by its own fixed term, so this endpoint reports the catalogue's numbers and the
+     * shape they came in. It does not flatten tiers into one "from" rate or interpolate a term
+     * curve: the app would then be quoting a price the bank never set. Where a product carries no
+     * rate at all — a current account — the field is absent rather than zero, because 0 % is a
+     * price and "not priced" is not.
+     *
+     * `type` narrows the list; omitted, every discoverable type comes back.
+     */
+    @GET
+    @Path("/products")
+    @Authorize(action = "customer.products.read")
+    @Blocking
+    fun listProductOffers(@QueryParam("type") type: String?): Response {
+        val customer = customer()
+        val requested = type?.takeIf { it.isNotBlank() }?.uppercase()
+        if (requested != null && requested !in CUSTOMER_PRODUCT_TYPES) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(mapOf("error" to "Unsupported product type"))
+                .build()
+        }
+        val query = requested?.let { "?type=$it&status=ACTIVE" } ?: "?status=ACTIVE"
+        val catalog = upstream.get("$productCatalogUrl/api/v1/products$query", customer.partyId.toString())
+        if (catalog.status != 200) return productCatalogueUnavailable()
+        val products = parseJson(catalog)?.takeIf { it.isArray } ?: return productCatalogueUnavailable()
+        val today = LocalDate.now(clock)
+        val offers = objectMapper.createArrayNode()
+        products.forEach { product -> productOffer(product, today)?.let(offers::add) }
+        return Response.ok(objectMapper.createObjectNode().set<ArrayNode>("items", offers)).build()
+    }
+
     @GET
     @Path("/products/term-deposits")
     @Authorize(action = "customer.products.read")
@@ -4864,6 +4903,60 @@ class CustomerEdgeResource(
         }
     }
 
+    /**
+     * Customer-safe projection of one catalogue product, or null when it is not discoverable.
+     *
+     * Carries only what a customer needs to choose: identity, copy, currency, limits, and the
+     * price IN THE SHAPE THE CATALOGUE PRICES IT — `annualRate` for a term deposit (which has one
+     * fixed rate for one fixed term), `interestTiers` for savings (which prices by balance), and
+     * neither for a current account. Internal fields — version history, eligibility segments,
+     * draft state, operator notes — never cross.
+     */
+    private fun productOffer(product: JsonNode, today: LocalDate): ObjectNode? {
+        if (!isDiscoverableProduct(product) || !isCurrentlyValid(product, today)) return null
+        val type = product.path("type").asText()
+        return objectMapper.createObjectNode().apply {
+            put("id", product.path("id").asText())
+            put("code", product.path("code").asText())
+            put("name", product.path("name").asText())
+            put("type", type)
+            put("currency", product.path("currency").asText())
+            product.get("shortDescription")?.takeIf { !it.isNull }?.let { set<JsonNode>("shortDescription", it) }
+            product.get("description")?.takeIf { !it.isNull }?.let { set<JsonNode>("description", it) }
+            product.get("minBalance")?.takeIf { !it.isNull }?.let { set<JsonNode>("minBalance", it) }
+            product.get("maxBalance")?.takeIf { !it.isNull }?.let { set<JsonNode>("maxBalance", it) }
+            // The monthly account fee, when the catalogue states one. Zero IS a price here — "no
+            // fee, forever" is the current account's whole pitch — so unlike a rate it is copied
+            // even when it is 0.
+            product.get("fee")?.takeIf { !it.isNull }?.let { set<JsonNode>("fee", it) }
+            // Price, in the catalogue's own shape. Never flattened, never interpolated.
+            product.get("termDepositConfig")?.takeIf { it.isObject }?.let { configuration ->
+                put("annualRate", configuration.path("interestRateAnnual").asDouble())
+                set<JsonNode>("term", configuration)
+            }
+            product.get("savingsConfig")?.takeIf { it.isObject }?.let { configuration ->
+                set<JsonNode>("savings", configuration)
+            }
+            set<JsonNode>("termsAndConditions", product.path("termsAndConditions"))
+        }
+    }
+
+    /**
+     * Discoverability, deliberately identical to [isDiscoverableTermDeposit] apart from the type
+     * gate: ACTIVE, public, identifiable, priced in a currency. A product failing any of these is
+     * invisible rather than greyed out — an offer the customer cannot take is not an offer.
+     */
+    private fun isDiscoverableProduct(product: JsonNode): Boolean =
+        product.path("type").asText() in CUSTOMER_PRODUCT_TYPES &&
+            product.path("status").asText() == "ACTIVE" &&
+            product.path("isPublic").asBoolean(false) &&
+            product.path("id").asText().isNotBlank() &&
+            product.path("currency").asText().isNotBlank()
+
+    private fun productCatalogueUnavailable(): Response = Response.status(Response.Status.SERVICE_UNAVAILABLE)
+        .entity(mapOf("error" to "Product catalogue unavailable"))
+        .build()
+
     private fun isDiscoverableTermDeposit(product: JsonNode): Boolean =
         product.path("type").asText() == "TERM_DEPOSIT" &&
             product.path("status").asText() == "ACTIVE" &&
@@ -4901,6 +4994,17 @@ class CustomerEdgeResource(
         parseCreditorAccount(raw) ?: czechIbanToBban(raw)
 
     companion object {
+
+        /**
+         * The product types a customer may discover and open from the app.
+         *
+         * An allow-list, not a deny-list: MORTGAGE, CREDIT_CARD, OVERDRAFT and INVESTMENT exist in
+         * the catalogue and are deliberately absent — each needs its own suitability and disclosure
+         * journey, and surfacing one here would let the app offer a regulated product with no path
+         * to take it. A new type becomes customer-visible by being added here, on purpose.
+         */
+        internal val CUSTOMER_PRODUCT_TYPES = setOf("CURRENT", "SAVINGS", "TERM_DEPOSIT")
+
         /**
          * The ADR-0269 credit consents, as the app's field name → the consent-service scope.
          *

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.49.0
+  version: 1.50.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -53,6 +53,60 @@ tags:
   - name: Complaints
 
 paths:
+  /products:
+    get:
+      tags: [Products]
+      summary: The product catalogue this customer may open from
+      description: >-
+        Generalises the term-deposit projection to the whole customer-facing catalogue, with the
+        same filters and for the same reason: the operator catalogue holds draft, private,
+        withdrawn and future-dated products, and none of them may become discoverable merely
+        because the edge holds an M2M credential.
+
+
+        Types are allow-listed to CURRENT, SAVINGS and TERM_DEPOSIT. MORTGAGE, CREDIT_CARD,
+        OVERDRAFT and INVESTMENT exist in the catalogue and are deliberately absent — each needs
+        its own suitability and disclosure journey, and surfacing one here would let the app offer
+        a regulated product with no path to take it.
+
+
+        Rates are reported in the shape the catalogue prices them and are never derived: a term
+        deposit carries `annualRate` plus its own fixed `term`, savings carries `savings` with its
+        balance tiers, and a current account carries neither. A product with no rate omits the
+        field rather than sending zero — 0 % is a price, "not priced" is not. `fee` IS sent at
+        zero, because "no fee, forever" is a current account's whole pitch.
+
+
+        A catalogue outage answers 503, never an empty list: an empty list reads as "we offer
+        nothing", which is a claim about the bank.
+      operationId: listProductOffers
+      security:
+        - customerOidc: [products:read]
+      parameters:
+        - name: type
+          in: query
+          required: false
+          description: Narrows the list. Rejected with 400 when outside the allow-list.
+          schema:
+            type: string
+            enum: [CURRENT, SAVINGS, TERM_DEPOSIT]
+      responses:
+        '200':
+          description: Discoverable product offers
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ProductOffer'
+        '400':
+          description: Unsupported product type
+        '503':
+          description: Product catalogue unavailable
+
   /products/term-deposits:
     get:
       tags: [Term deposits]
@@ -4610,6 +4664,55 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TermDepositOffer'
+
+    ProductOffer:
+      type: object
+      description: >-
+        One discoverable product. Carries only what a customer needs in order to choose, priced in
+        the shape the catalogue prices it. Internal fields — version history, eligibility segments,
+        draft state — never cross this boundary.
+      required: [id, code, name, type, currency]
+      properties:
+        id:
+          type: string
+        code:
+          type: string
+          description: Semantic product code, e.g. SAVINGS_STANDARD (ADR-0105).
+        name:
+          type: string
+        type:
+          type: string
+          enum: [CURRENT, SAVINGS, TERM_DEPOSIT]
+        currency:
+          type: string
+        shortDescription:
+          type: string
+        description:
+          type: string
+        minBalance:
+          type: number
+        maxBalance:
+          type: number
+        fee:
+          type: number
+          description: Monthly account fee as the catalogue states it. Sent even when zero.
+        annualRate:
+          type: number
+          description: >-
+            Term deposits only — one fixed rate for one fixed term. Absent for every other type;
+            absence means "not priced here", not 0 %.
+        term:
+          type: object
+          description: The term deposit's own TermDepositConfig, verbatim.
+        savings:
+          type: object
+          description: >-
+            Savings only — the SavingsConfig with its balance tiers, verbatim. Not flattened into
+            a single "from" rate: that would quote a price the bank never set for this balance.
+        termsAndConditions:
+          type: array
+          items:
+            type: object
 
     TermDepositOffer:
       type: object

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
@@ -1669,4 +1669,156 @@ class CustomerEdgeResourceTest {
         assertThat(urlSlot.captured).contains("from=")
         assertThat(urlSlot.captured).contains("to=")
     }
+
+    // ── customer product catalogue (/products) ────────────────────────────────
+    // Every case here is a product the OPERATOR catalogue legitimately holds and the
+    // CUSTOMER must never see. The endpoint's whole job is that gap, so its tests are
+    // the negative ones.
+
+    private fun catalogueProduct(
+        id: UUID,
+        type: String = "SAVINGS",
+        status: String = "ACTIVE",
+        public: Boolean = true,
+        extra: String = "",
+    ): String = """{
+        "id":"$id", "code":"${type}_STANDARD", "name":"Product $type", "type":"$type",
+        "currency":"CZK", "status":"$status", "isPublic":$public, "fee":0.0,
+        "versionHistory":[{"version":"0.9.0"}], "eligibilitySegments":["ALL"]$extra
+    }"""
+
+    private fun offersFrom(upstream: UpstreamClient, party: UUID): com.fasterxml.jackson.databind.JsonNode {
+        val response = resourceFor(upstream, party).listProductOffers(null)
+        assertThat(response.status).isEqualTo(200)
+        return ObjectMapper().readTree(ObjectMapper().writeValueAsString(response.entity)).path("items")
+    }
+
+    @Test
+    fun `a draft product is not discoverable`() {
+        val party = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(any(), any()) } returns
+            Response.ok("[${catalogueProduct(UUID.randomUUID(), status = "DRAFT")}]").build()
+        assertThat(offersFrom(upstream, party)).isEmpty()
+    }
+
+    @Test
+    fun `a private product is not discoverable`() {
+        val party = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(any(), any()) } returns
+            Response.ok("[${catalogueProduct(UUID.randomUUID(), public = false)}]").build()
+        assertThat(offersFrom(upstream, party)).isEmpty()
+    }
+
+    @Test
+    fun `a withdrawn product is not discoverable`() {
+        val party = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(any(), any()) } returns Response.ok(
+            "[${catalogueProduct(UUID.randomUUID(), extra = ""","validTo":"2020-01-01"""")}]",
+        ).build()
+        assertThat(offersFrom(upstream, party)).isEmpty()
+    }
+
+    @Test
+    fun `a future-dated product is not discoverable`() {
+        val party = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(any(), any()) } returns Response.ok(
+            "[${catalogueProduct(UUID.randomUUID(), extra = ""","validFrom":"2999-01-01"""")}]",
+        ).build()
+        assertThat(offersFrom(upstream, party)).isEmpty()
+    }
+
+    @Test
+    fun `a regulated type outside the allow-list is not discoverable`() {
+        // MORTGAGE and CREDIT_CARD exist in the catalogue and each needs its own suitability
+        // journey. Surfacing one here would let the app offer it with no path to take it.
+        val party = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(any(), any()) } returns Response.ok(
+            "[${catalogueProduct(UUID.randomUUID(), type = "MORTGAGE")}," +
+                "${catalogueProduct(UUID.randomUUID(), type = "CREDIT_CARD")}]",
+        ).build()
+        assertThat(offersFrom(upstream, party)).isEmpty()
+    }
+
+    @Test
+    fun `internal fields never cross the boundary`() {
+        val party = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(any(), any()) } returns
+            Response.ok("[${catalogueProduct(UUID.randomUUID())}]").build()
+        val offer = offersFrom(upstream, party).first()
+        assertThat(offer.has("versionHistory")).isFalse()
+        assertThat(offer.has("eligibilitySegments")).isFalse()
+        assertThat(offer.has("status")).isFalse()
+        assertThat(offer.has("isPublic")).isFalse()
+    }
+
+    @Test
+    fun `a term deposit reports its own fixed rate and term`() {
+        val party = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(any(), any()) } returns Response.ok(
+            "[${catalogueProduct(
+                UUID.randomUUID(),
+                type = "TERM_DEPOSIT",
+                extra = ""","termDepositConfig":{"termMonths":12,"interestRateAnnual":4.8}""",
+            )}]",
+        ).build()
+        val offer = offersFrom(upstream, party).first()
+        assertThat(offer.path("annualRate").asDouble()).isEqualTo(4.8)
+        assertThat(offer.path("term").path("termMonths").asInt()).isEqualTo(12)
+    }
+
+    @Test
+    fun `savings keeps its tiers rather than being flattened to one rate`() {
+        // Savings prices by balance tier. Collapsing that into a single "from" number would be
+        // the app quoting a rate the bank never set for the customer's actual balance.
+        val party = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(any(), any()) } returns Response.ok(
+            "[${catalogueProduct(
+                UUID.randomUUID(),
+                extra = ""","savingsConfig":{"interestTiers":[{"upTo":100000,"rateAnnual":3.5}]}""",
+            )}]",
+        ).build()
+        val offer = offersFrom(upstream, party).first()
+        assertThat(offer.path("savings").path("interestTiers")).hasSize(1)
+        assertThat(offer.has("annualRate")).isFalse()
+    }
+
+    @Test
+    fun `a current account carries no rate at all`() {
+        // Absent, not zero: 0 % is a price, "not priced" is not.
+        val party = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(any(), any()) } returns
+            Response.ok("[${catalogueProduct(UUID.randomUUID(), type = "CURRENT")}]").build()
+        val offer = offersFrom(upstream, party).first()
+        assertThat(offer.has("annualRate")).isFalse()
+        assertThat(offer.has("savings")).isFalse()
+        // The monthly fee IS copied even at zero — "no fee, forever" is the product's pitch.
+        assertThat(offer.path("fee").asDouble()).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `an unknown type is refused rather than silently listing everything`() {
+        val party = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        val response = resourceFor(upstream, party).listProductOffers("MORTGAGE")
+        assertThat(response.status).isEqualTo(400)
+        verify(exactly = 0) { upstream.get(any(), any()) }
+    }
+
+    @Test
+    fun `a catalogue outage is a 503, never an empty catalogue`() {
+        // An empty list reads as "we offer nothing", which is a claim about the bank.
+        val party = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(any(), any()) } returns Response.status(500).build()
+        assertThat(resourceFor(upstream, party).listProductOffers(null).status).isEqualTo(503)
+    }
 }


### PR DESCRIPTION
The app has no way to ask what products it may offer. `/products/term-deposits` projects one type; everything else — current account, savings — is invisible, so a products screen would have to **hardcode its prices**. In a banking app a hardcoded rate is not a design shortcut, it is a price the bank never quoted.

`GET /customer/v1/products` generalises the term-deposit projection, with the same filters and for the reason its own comment already gives:

> the operator catalogue deliberately contains draft, private and historical products too; none of those must become discoverable merely because this edge has an M2M credential

## Types are allow-listed, not deny-listed

`CURRENT`, `SAVINGS`, `TERM_DEPOSIT`.

`MORTGAGE`, `CREDIT_CARD`, `OVERDRAFT` and `INVESTMENT` exist in the catalogue and are **deliberately absent** — each needs its own suitability and disclosure journey, and surfacing one here would let the app offer a regulated product with no path to take it. A new type becomes customer-visible by being added to that set on purpose, not by being added to the catalogue.

## Rates are read, never derived

This is the architectural point of the endpoint:

| type | how the catalogue prices it | what the edge sends |
|---|---|---|
| `TERM_DEPOSIT` | one fixed rate for one fixed term | `annualRate` + its own `term` config |
| `SAVINGS` | by **balance tier** | the tiers, verbatim |
| `CURRENT` | not priced | **neither field** |

Four term lengths are **four products**, not one product with a curve — so the edge does not interpolate one. Flattening savings tiers into a single "from" rate would quote a price the bank never set for the customer's actual balance.

A product with no rate **omits** the field rather than sending zero: 0 % is a price, "not priced" is not. `fee` is the deliberate exception — sent even at zero, because *"no fee, forever"* is a current account's whole pitch.

## Failure is not emptiness

A catalogue outage answers **503, never an empty list**. An empty list reads as "we offer nothing", which is a claim about the bank rather than about the request.

## Verification

- `:openbank-customer-edge:test` — 106 tests, 0 failures
- `ktlintCheck` + `detekt` clean
- OpenAPI bumped 1.49.0 → 1.50.0, YAML validated

Eleven new tests, **ten of them negative** — the endpoint's whole job is the gap between what the operator catalogue holds and what a customer may see, so that gap is what they cover: draft, private, withdrawn, future-dated, regulated-type, internal-field leakage, tier flattening, zero-vs-absent rate, bad type, outage.

Falsified: dropping the discoverability filter fails five of them.

## Client side

Consumed by the app's new Products screen (design-system handoff 6, `products5.jsx`), which until now had no way to show a rate it had not invented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)