### PR TITLE
docs(kyc): mark DOCUMENTS_REQUIRED unreachable instead of removing it

### DIFF
--- a/docs/adr/0068-onboarding-operations-cockpit.md
+++ b/docs/adr/0068-onboarding-operations-cockpit.md
@@ -35,8 +35,10 @@ choreographed across three services, each owning one slice of the truth:
 > `KYC_DOCUMENTS_REQUIRED` funnel column in §4.2, were never implemented: no kyc-service operation
 > ever set that status, so the cockpit column could only ever read zero — which reads as "nobody is
 > stuck on documents" rather than "this is not built". The column has been removed from the cockpit.
-> The status itself is still declared in the enums and contracts: removing it there is blocked by
-> two mutually exclusive CI gates (#8618). The decision recorded below is preserved as written;
+> The status itself stays declared in the enums and contracts, deliberately: dropping a value from
+> a published enum is a breaking contract narrowing, and it is not worth a MAJOR for a value no
+> client can ever receive (#8618). The service docs and the lifecycle diagram now say it is
+> unreachable rather than describing transitions that do not exist. The decision recorded below is preserved as written;
 > collecting documents from a customer needs an operator endpoint, an upload path and storage, and
 > would be a new ADR.
 

--- a/docs/adr/0116-kyc-engine-risk-checks-and-four-eyes-gate.md
+++ b/docs/adr/0116-kyc-engine-risk-checks-and-four-eyes-gate.md
@@ -67,9 +67,10 @@ OPEN / DOCUMENTS_REQUIRED / UNDER_REVIEW → EXPIRED   (terminal, time-driven)
 > **Correction, 2026-09-05.** Three gaps between this lifecycle and the code, found together:
 >
 > - **`DOCUMENTS_REQUIRED` was never implemented** (#8535). No operation in `KycService` sets it,
->   and the service has no concept of a document type or any upload path. Removing it from the
->   enums and contracts is blocked by two mutually exclusive CI gates (#8618); the dead cockpit
->   column it fed has been removed, and the `KYC_DOCUMENT_REQUIRED` notification template with it.
+>   and the service has no concept of a document type or any upload path. The dead cockpit column
+>   it fed and the `KYC_DOCUMENT_REQUIRED` notification template are gone. The status itself stays
+>   declared: removing it from a published enum is a breaking narrowing, not worth a MAJOR for a
+>   value no client can receive (#8618). The docs and the diagram above now mark it unreachable.
 > - **`ESCALATED` was never a KYC case status at all.** The lifecycle diagram drew it with four
 >   transitions; it is not in `KycCaseStatus`. Escalation here is a check in `MANUAL_REVIEW` plus
 >   `due_diligence_level = EDD`, with the case staying `UNDER_REVIEW`; MLRO escalation is a state

--- a/openbank-kyc-service/src/main/resources/diagrams/03-kyc-status-lifecycle.mmd
+++ b/openbank-kyc-service/src/main/resources/diagrams/03-kyc-status-lifecycle.mmd
@@ -2,20 +2,11 @@
 stateDiagram-v2
   [*] --> OPEN: case created (PARTY_CREATED event or POST /kyc/cases)
 
-  OPEN --> DOCUMENTS_REQUIRED: operator marks docs missing
   OPEN --> UNDER_REVIEW: all mandatory checks recorded
   OPEN --> EXPIRED: expires_at passed without decision
 
-  DOCUMENTS_REQUIRED --> OPEN: documents submitted
-  DOCUMENTS_REQUIRED --> EXPIRED: expires_at passed
-
   UNDER_REVIEW --> APPROVED: POST /approve (four-eyes, authorised reviewer)
   UNDER_REVIEW --> REJECTED: POST /reject (four-eyes, authorised reviewer)
-  UNDER_REVIEW --> ESCALATED: escalation required (EDD / PEP)
-
-  ESCALATED --> UNDER_REVIEW: escalation resolved
-  ESCALATED --> APPROVED: escalation cleared, four-eyes approve
-  ESCALATED --> REJECTED: escalation rejected
 
   APPROVED --> [*]: terminal — emits KYC_CASE_APPROVED → party activation
   REJECTED --> [*]: terminal — emits KYC_CASE_REJECTED → party SUSPENDED
@@ -30,4 +21,22 @@ stateDiagram-v2
   note right of UNDER_REVIEW
     due_diligence_level: SDD / CDD / EDD
     risk_level: LOW / MEDIUM / HIGH / VERY_HIGH
+
+    A KYC case has no ESCALATED status. Escalation
+    shows up here as a check in MANUAL_REVIEW and
+    due_diligence_level EDD, while the case stays
+    UNDER_REVIEW. MLRO escalation is a state of the
+    AML case in aml-service (AmlCaseStatus.ESCALATED,
+    aml_cases.escalated_to_mlro), a different
+    aggregate in a different service.
+  end note
+
+  note right of OPEN
+    DOCUMENTS_REQUIRED is declared by KycCaseStatus
+    and published by the OpenAPI contracts, and is
+    drawn nowhere here on purpose: no operation in
+    KycService sets it, so no case can reach it
+    (#8535). It stays declared rather than removed
+    because dropping a value from a published enum
+    is a breaking contract narrowing (#8618).
   end note

--- a/openbank-kyc-service/src/main/resources/docs/01-overview.cs.md
+++ b/openbank-kyc-service/src/main/resources/docs/01-overview.cs.md
@@ -4,7 +4,7 @@
 
 `openbank-kyc-service` je **systém pravdy pro správu případů Know Your Customer (KYC) / Customer Due Diligence (CDD)** na platformě OpenBank. Drží:
 
-- **Agregát KycCase** — `partyId`, stav případu (OPEN / DOCUMENTS_REQUIRED / UNDER_REVIEW / APPROVED / REJECTED / EXPIRED), úroveň rizika (LOW / MEDIUM / HIGH / VERY_HIGH), úroveň hloubkové prověrky (SDD / CDD / EDD), revizora, expiraci a seznam kontrol.
+- **Agregát KycCase** — `partyId`, stav případu (OPEN / DOCUMENTS_REQUIRED / UNDER_REVIEW / APPROVED / REJECTED / EXPIRED) (`DOCUMENTS_REQUIRED` je deklarovaný, ale nedosažitelný — žádná operace `KycService` ho nenastavuje, viz #8535; ponechán, protože odebrání hodnoty z publikovaného enumu je rozbíjející zúžení kontraktu, #8618), úroveň rizika (LOW / MEDIUM / HIGH / VERY_HIGH), úroveň hloubkové prověrky (SDD / CDD / EDD), revizora, expiraci a seznam kontrol.
 - **KycCheck** — výsledek jednotlivé kontroly uvnitř případu: IDENTITY, ADDRESS, PEP_SCREENING, SANCTIONS_SCREENING, ADVERSE_MEDIA, každá se stavem (PENDING / PASSED / FAILED / MANUAL_REVIEW), volitelnou poznámkou k výsledku a referencí poskytovatele.
 - **Compliance obohacující pole** (V2) — zdroj prostředků / majetku, účel obchodního vztahu, očekávaný obrat, PEP samoprohlášení, skutečný majitel, poskytovatel/reference screeningu, datum příští periodické revize a metadata eskalace.
 

--- a/openbank-kyc-service/src/main/resources/docs/01-overview.en.md
+++ b/openbank-kyc-service/src/main/resources/docs/01-overview.en.md
@@ -4,7 +4,7 @@
 
 `openbank-kyc-service` is the **case-management system of record for Know Your Customer (KYC) / Customer Due Diligence (CDD)** in the OpenBank platform. It holds:
 
-- **KycCase aggregate** — `partyId`, case status (OPEN / DOCUMENTS_REQUIRED / UNDER_REVIEW / APPROVED / REJECTED / EXPIRED), risk level (LOW / MEDIUM / HIGH / VERY_HIGH), due-diligence level (SDD / CDD / EDD), reviewer, expiry, and a list of checks.
+- **KycCase aggregate** — `partyId`, case status (OPEN / DOCUMENTS_REQUIRED / UNDER_REVIEW / APPROVED / REJECTED / EXPIRED) (`DOCUMENTS_REQUIRED` is declared but unreachable — no `KycService` operation sets it, see #8535; kept because dropping a value from a published enum is a breaking contract narrowing, #8618), risk level (LOW / MEDIUM / HIGH / VERY_HIGH), due-diligence level (SDD / CDD / EDD), reviewer, expiry, and a list of checks.
 - **KycCheck** — the per-check result inside a case: IDENTITY, ADDRESS, PEP_SCREENING, SANCTIONS_SCREENING, ADVERSE_MEDIA, each with a status (PENDING / PASSED / FAILED / MANUAL_REVIEW), an optional result note and provider reference.
 - **Compliance enrichment fields** (V2) — source of funds / wealth, business purpose, expected turnover, PEP self-declaration, beneficial owner, screening provider/reference, periodic next-review date and escalation metadata.
 

--- a/openbank-kyc-service/src/main/resources/docs/04-data.cs.md
+++ b/openbank-kyc-service/src/main/resources/docs/04-data.cs.md
@@ -15,7 +15,7 @@ PostgreSQL 16, databáze **`openbank_kyc`** (reaktivní PG klient + JDBC pro Fly
 | `id` | BIGSERIAL PK | interní id; sekvence `kyc_cases_seq` (V4) |
 | `case_id` | UUID UNIQUE | business id (agregát `KycCase.id`) |
 | `party_id` | UUID | prověřovaná party — viz PII níže |
-| `status` | VARCHAR(30) | OPEN / DOCUMENTS_REQUIRED / UNDER_REVIEW / APPROVED / REJECTED / EXPIRED |
+| `status` | VARCHAR(30) | OPEN / DOCUMENTS_REQUIRED / UNDER_REVIEW / APPROVED / REJECTED / EXPIRED — DOCUMENTS_REQUIRED nedosažitelný (#8535) |
 | `risk_level` | VARCHAR(20) | LOW / MEDIUM / HIGH / VERY_HIGH |
 | `assigned_to` | VARCHAR(100) | přiřazení revizora |
 | `checks_json` | TEXT | serializovaný seznam `KycCheck` |

--- a/openbank-kyc-service/src/main/resources/docs/04-data.en.md
+++ b/openbank-kyc-service/src/main/resources/docs/04-data.en.md
@@ -15,7 +15,7 @@ PostgreSQL 16, database **`openbank_kyc`** (reactive PG client + JDBC for Flyway
 | `id` | BIGSERIAL PK | internal id; sequence `kyc_cases_seq` (V4) |
 | `case_id` | UUID UNIQUE | business id (the aggregate `KycCase.id`) |
 | `party_id` | UUID | the party under review — see PII below |
-| `status` | VARCHAR(30) | OPEN / DOCUMENTS_REQUIRED / UNDER_REVIEW / APPROVED / REJECTED / EXPIRED |
+| `status` | VARCHAR(30) | OPEN / DOCUMENTS_REQUIRED / UNDER_REVIEW / APPROVED / REJECTED / EXPIRED — DOCUMENTS_REQUIRED is unreachable (#8535) |
 | `risk_level` | VARCHAR(20) | LOW / MEDIUM / HIGH / VERY_HIGH |
 | `assigned_to` | VARCHAR(100) | reviewer assignment |
 | `checks_json` | TEXT | serialized list of `KycCheck` |

--- a/openbank-onboarding-service/src/main/resources/docs/02-architecture.cs.md
+++ b/openbank-onboarding-service/src/main/resources/docs/02-architecture.cs.md
@@ -118,7 +118,7 @@ sequenceDiagram
 | party `ACTIVE` a `scaEnrolled` | `ACTIVE` |
 | party `ACTIVE` a neenrollnuto | `SCA_PENDING` |
 | kyc `UNDER_REVIEW` | `KYC_UNDER_REVIEW` |
-| kyc `DOCUMENTS_REQUIRED` | `KYC_DOCUMENTS_REQUIRED` |
+| kyc `DOCUMENTS_REQUIRED` | `KYC_DOCUMENTS_REQUIRED` | <!-- nedosažitelné: kyc tento stav nikdy nenastaví (#8535) -->
 | kyc `OPEN` nebo null | `KYC_OPEN` |
 | kyc `REJECTED` nebo `EXPIRED` | `BLOCKED` |
 | jinak | `REGISTERED` |

--- a/openbank-onboarding-service/src/main/resources/docs/02-architecture.en.md
+++ b/openbank-onboarding-service/src/main/resources/docs/02-architecture.en.md
@@ -118,7 +118,7 @@ sequenceDiagram
 | party `ACTIVE` and `scaEnrolled` | `ACTIVE` |
 | party `ACTIVE` and not enrolled | `SCA_PENDING` |
 | kyc `UNDER_REVIEW` | `KYC_UNDER_REVIEW` |
-| kyc `DOCUMENTS_REQUIRED` | `KYC_DOCUMENTS_REQUIRED` |
+| kyc `DOCUMENTS_REQUIRED` | `KYC_DOCUMENTS_REQUIRED` | <!-- unreachable: kyc never sets this status (#8535) -->
 | kyc `OPEN` or null | `KYC_OPEN` |
 | kyc `REJECTED` or `EXPIRED` | `BLOCKED` |
 | otherwise | `REGISTERED` |


### PR DESCRIPTION
Closes #8535 and #8618. **The decision on #8618, taken rather than deferred: do not narrow the contract.**

## Why not my own earlier preference

I had preferred teaching `api-contract-gate`'s `correction` class to recognise a narrowing that brings a spec into line with its implementation. **That does not survive contact with the code.** The discriminator would have to be *"the server cannot emit this value"* — and it can: `DOCUMENTS_REQUIRED` **is** in `KycCaseStatus`, so statically the value is producible. That nothing constructs it is a reachability property I established by hand, not something a gate can see. The gate's own KDoc also rules out the fallback: *"the discriminator is the diff itself, never a declared marker."*

**Baselining the drift does not help either**, which I had assumed it might. The baseline lives in `openapi-enum-domain-drift`; the blocker for the combined change is `api-contract-gate`. Buying the removal that way costs a split, a deliberately parked drift, and three follow-up PRs.

So **both gates are right and the removal is genuinely breaking by their standard.** It is not worth a MAJOR — which ADR-0048 D2 requires, moving the service to `/api/v2` — for a value no client can ever receive.

## What this means

The harm that mattered is already fixed. #8834 removed the `KYC_DOCUMENT_REQUIRED` notification template, the cockpit column that could only ever read zero, and the alert regex naming it. What remained was tidiness, at the price of a breaking contract change.

This PR makes the remaining documentation honest **without touching a contract**:

- the **lifecycle diagram** stops drawing transitions into `DOCUMENTS_REQUIRED`, and a note says the state is declared, unreachable, and deliberately kept;
- the **kyc and onboarding service docs** mark the value unreachable where they list it;
- **ADR-0068 and ADR-0116** notes record the decision.

`ESCALATED` **does** come out of the diagram: it was never in `KycCaseStatus` and appears in no spec enum, so removing it narrows nothing. The note explains where escalation actually lives — a check in `MANUAL_REVIEW` plus `due_diligence_level = EDD`, with MLRO escalation belonging to the *AML* case in aml-service (ADR-0032).

## Gate status

Documentation only. No enum, no OpenAPI, no Kotlin — so neither `api-contract-gate` nor `openapi-enum-domain-drift` has anything to object to. The red that made this PR interesting is gone because the change that caused it is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)