### PR TITLE
fix(notification): KYC outcome notifications get a producer (#8432)

### DIFF
--- a/openbank-infra/gitops/components/notifications/kafka-notification-mtls.yaml
+++ b/openbank-infra/gitops/components/notifications/kafka-notification-mtls.yaml
@@ -3,7 +3,7 @@
 # secret is projected into `notifications` via ExternalSecret (kafka-messaging-certs
 # ClusterSecretStore). The cluster-CA truststore is shared and also projected.
 #
-# ACLs: notification-service reads from three topics using three separate consumer
+# ACLs: notification-service reads from four topics using four separate consumer
 # groups, and — since ADR-0239 D2 — WRITES delivery outcomes onto one topic. That
 # Write grant is the whole of its producer surface; it is not a general producer.
 ---
@@ -46,6 +46,23 @@ spec:
           patternType: literal
         operations: [Read, Describe]
         host: "*"
+      # #8432: KYC outcome notifications (KycNotificationConsumer) — a further consumer of the
+      # topic kyc-service already publishes via its transactional outbox.
+      - resource:
+          type: topic
+          name: openbank.kyc.events
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      # #8432: SmallRye dead-letter topic for the kyc-events-in channel (failure-strategy:
+      # dead-letter-queue, set in application.yaml in nested form). Without Write here the DLQ
+      # send itself fails and the consumer wedges on the very failure it was meant to park.
+      - resource:
+          type: topic
+          name: openbank.kyc.events.notification.dlq
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
       # ADR-0232 delegated-access lifecycle notifications (DelegationNotificationConsumer) — a
       # second consumer of the topic account-service and audit-service already read.
       - resource:
@@ -83,6 +100,12 @@ spec:
       - resource:
           type: group
           name: notification-service-party
+          patternType: literal
+        operations: [Read]
+        host: "*"
+      - resource:
+          type: group
+          name: notification-service-kyc
           patternType: literal
         operations: [Read]
         host: "*"

--- a/openbank-infra/gitops/components/notifications/kafka-topic.yaml
+++ b/openbank-infra/gitops/components/notifications/kafka-topic.yaml
@@ -110,3 +110,31 @@ spec:
   config:
     retention.ms: 2592000000
     cleanup.policy: delete
+---
+# #8432: dead-letter topic for notification-service's kyc-events-in channel (SmallRye
+# failure-strategy: dead-letter-queue, set in the service's application.yaml in nested form).
+# A KYC outcome event that survives the consumer's own poison-pill handling and still fails
+# (a delivery-pipeline failure further down) is parked here instead of stopping the channel.
+#
+# Explicitly named (openbank.kyc.events.notification.dlq) rather than left to SmallRye's
+# implicit `dead-letter-topic-kyc-events-in`: channel names repeat across services, so the
+# fleet convention is an explicit per-service name any alert can attribute unambiguously.
+#
+# A CR is required, not optional: this cluster does not auto-create topics, so without it the
+# DLQ send itself fails and the consumer wedges on the failure it was meant to park.
+#
+# Longer retention than the source topic, mirroring the sibling DLQs above: a dead-lettered
+# SECURITY-category notification is worth triaging, not merely replaying within a week.
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.kyc.events.notification.dlq
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/kafka/KycNotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/kafka/KycNotificationConsumer.kt
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.notification.application.NotificationConsumer
+import com.openbank.notification.domain.model.NotificationChannel
+import com.openbank.notification.domain.model.NotificationRequest
+import com.openbank.notification.domain.model.NotificationTemplate
+import io.smallrye.mutiny.Uni
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.jboss.logging.Logger
+import java.util.UUID
+
+/**
+ * Closes #8432's sharpest gap: the KYC outcome notifications existed end-to-end — templates
+ * rendered, SECURITY-classified, allow-listed — and had NO producer. `openbank-kyc-service`
+ * already publishes `KYC_CASE_APPROVED` / `KYC_CASE_REJECTED` onto `openbank.kyc.events` via its
+ * transactional outbox (`KycEvents`, since #4007 the ONLY publisher on that topic); this is a
+ * further consumer of that already-live topic, not a new event contract and not a second
+ * emitter inside kyc-service (the bare post-commit emitter shape #4007 removed there).
+ *
+ * Recipient is always the data subject: the envelope's `partyId` is the person whose identity
+ * verification concluded, and they are exactly who must be told.
+ *
+ * **The rejection reason is NOT taken from the event — deliberately.** `KYC_REJECTED`'s closed
+ * variable schema (ADR-0176 D1) requires a `reason`, and the KycEvents envelope carries none:
+ * the reviewer's reason lives in `KycCase.notes`, a ČNB-audited internal field that was never
+ * meant for the customer. Copying internal review notes into a customer push would be a PII
+ * and process leak, so the notification sends a fixed customer-safe reason and points at
+ * support; the template's own copy already ends with "Please contact support."
+ *
+ * **No deep link.** `MobileDeepLink` is a closed allow-list and has no KYC entry; rather than
+ * grow the allow-list for an app route this service cannot verify, the notification carries
+ * none (null is allowed).
+ *
+ * Delivery reuses the real pipeline in-process (same as [DelegationNotificationConsumer]): the
+ * exact [NotificationRequest] wire shape handed to [NotificationConsumer.consume], so the
+ * closed variable-schema check, the SECURITY classification and the outcome-event write all run
+ * unchanged.
+ *
+ * **Idempotency / failure handling**: identical to [DelegationNotificationConsumer] — delivery
+ * is at-least-once and a redelivery re-persists a fresh row (acceptable for notifications, no
+ * money path); a malformed record is a poison pill, logged and swallowed, never wedging the
+ * partition.
+ */
+@ApplicationScoped
+class KycNotificationConsumer @Inject constructor(
+    private val notificationConsumer: NotificationConsumer,
+    private val objectMapper: ObjectMapper,
+) {
+    private val log = Logger.getLogger(KycNotificationConsumer::class.java)
+
+    /**
+     * Reactive `Uni`, not `suspend` — same reasoning as [DelegationNotificationConsumer]:
+     * delegating into a `Uni`-returning method, and a `suspend` wrapper would reintroduce the
+     * Vert.x-context hazard documented on [NotificationConsumer.consume].
+     */
+    @Incoming("kyc-events-in")
+    // Mirrors the sibling consumers: any malformed record is a poison pill and must be
+    // swallowed, not just the JsonProcessingException Jackson usually throws.
+    @Suppress("TooGenericExceptionCaught")
+    fun consume(payload: String): Uni<Void> {
+        val node = try {
+            objectMapper.readTree(payload)
+        } catch (e: Exception) {
+            log.warnf(
+                e,
+                "Dropping unprocessable KYC event (poison pill): %s",
+                payload.take(MAX_LOGGED_PAYLOAD_CHARS),
+            )
+            return Uni.createFrom().voidItem()
+        }
+        val request = requestFor(node, payload) ?: return Uni.createFrom().voidItem()
+        return notificationConsumer.consume(objectMapper.writeValueAsString(request))
+    }
+
+    /** The [NotificationRequest] this event should raise, or null when out of scope. */
+    private fun requestFor(node: JsonNode, payload: String): NotificationRequest? {
+        val eventType = node.path("eventType").asText("")
+        val template = TEMPLATE_BY_EVENT_TYPE[eventType]
+        if (template == null) {
+            // Not an error: KYC_CASE_OPENED / STATUS_CHANGED and any future type stay
+            // un-notified until their customer recipient semantics are deliberately reviewed.
+            log.debugf("KYC event %s not in notification scope, skipping", eventType.ifBlank { "?" })
+            return null
+        }
+        val partyId = node.path("partyId").asText(null)?.let {
+            runCatching { UUID.fromString(it) }.getOrNull()
+        }
+        // `kycCaseId`, not `aggregateId`: the flat envelope on the wire (KycEvents, pinned by
+        // the provider pacts) names the case id `kycCaseId`; `aggregateId` exists only on the
+        // typed KycEvent object inside kyc-service, never on the topic.
+        val caseId = node.path("kycCaseId").asText(null)?.let {
+            runCatching { UUID.fromString(it) }.getOrNull()
+        }
+        if (partyId == null || caseId == null) {
+            log.warnf(
+                "Dropping KYC event %s with missing/unparseable identifiers: %s",
+                eventType,
+                payload.take(MAX_LOGGED_PAYLOAD_CHARS),
+            )
+            return null
+        }
+        return NotificationRequest(
+            partyId = partyId,
+            channel = NotificationChannel.PUSH,
+            template = template,
+            recipient = partyId.toString(),
+            variables = VARIABLES_BY_EVENT_TYPE.getValue(eventType),
+            deepLink = null, // no KYC entry in MobileDeepLink's closed allow-list — see KDoc
+            // The KYC case id, not a freshly minted one: the stable identifier of the business
+            // event (ADR-0239 D1), so a later outcome event joins back to this case.
+            correlationId = caseId,
+        )
+    }
+
+    private companion object {
+        /** Cap on the producer-supplied payload echoed into a poison-pill warning (untrusted input). */
+        const val MAX_LOGGED_PAYLOAD_CHARS = 300
+
+        val TEMPLATE_BY_EVENT_TYPE: Map<String, NotificationTemplate> = mapOf(
+            "KYC_CASE_APPROVED" to NotificationTemplate.KYC_APPROVED,
+            "KYC_CASE_REJECTED" to NotificationTemplate.KYC_REJECTED,
+        )
+
+        val VARIABLES_BY_EVENT_TYPE: Map<String, Map<String, String>> = mapOf(
+            "KYC_CASE_APPROVED" to emptyMap(),
+            // Customer-safe, fixed — the internal reviewer reason (KycCase.notes) must not
+            // leave the bank; see the class KDoc.
+            "KYC_CASE_REJECTED" to mapOf(
+                "reason" to "the submitted information could not be verified",
+            ),
+        )
+    }
+}

--- a/openbank-notification-service/src/main/resources/application.yaml
+++ b/openbank-notification-service/src/main/resources/application.yaml
@@ -189,6 +189,25 @@ mp:
         # set via the gitops ConfigMap instead (issue #686).
         topic: openbank.delegation.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      # #8432: KYC outcome notifications (KycNotificationConsumer) — a further consumer of the
+      # topic kyc-service's transactional outbox already publishes (openbank.kyc.events).
+      kyc-events-in:
+        connector: smallrye-kafka
+        # client.id / group.id / auto.offset.reset: same dotted-key YAML bug as above —
+        # set via the gitops ConfigMap instead (issue #686).
+        topic: openbank.kyc.events
+        value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        # Poison pills are swallowed in the consumer itself, but a failure further down the
+        # pipeline rethrows — and SmallRye's DEFAULT failure-strategy is `fail`, which STOPS the
+        # channel (#5698/#5745). The DLQ topic name is written in NESTED form, which resolves
+        # correctly through SmallRye's YAML source (the dotted leaf key `dead-letter-queue.topic:`
+        # would be quoted and never read — #686). The matching KafkaTopic CR and the KafkaUser
+        # Write ACL ship in the same change (openbank-infra/gitops/components/notifications);
+        # without them the DLQ send itself fails and the consumer wedges on the very failure the
+        # DLQ was meant to park.
+        failure-strategy: dead-letter-queue
+        dead-letter-queue:
+          topic: openbank.kyc.events.notification.dlq
 
 # ADR-0155 four-eyes, opted into by opsmessage.compose (ADR-0176 D5). Default false, matching
 # every other four-eyes-wired service (lending, balance, sepa-payment, sepa-instant, account) —

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/kafka/KycNotificationConsumerTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/kafka/KycNotificationConsumerTest.kt
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.notification.application.NotificationConsumer
+import com.openbank.notification.domain.model.NotificationChannel
+import com.openbank.notification.domain.model.NotificationRequest
+import com.openbank.notification.domain.model.NotificationTemplate
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.smallrye.mutiny.Uni
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class KycNotificationConsumerTest {
+
+    private val notificationConsumer = mockk<NotificationConsumer>()
+    private val objectMapper: ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    private lateinit var consumer: KycNotificationConsumer
+
+    private val caseId = UUID.randomUUID()
+    private val partyId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        consumer = KycNotificationConsumer(notificationConsumer, objectMapper)
+        every { notificationConsumer.consume(any()) } returns Uni.createFrom().voidItem()
+    }
+
+    /** Captures the [NotificationRequest] JSON(s) handed to [NotificationConsumer.consume]. */
+    private fun capturedRequests(): List<NotificationRequest> {
+        val slot = mutableListOf<String>()
+        verify { notificationConsumer.consume(capture(slot)) }
+        return slot.map { objectMapper.readValue(it, NotificationRequest::class.java) }
+    }
+
+    /** The exact flat envelope `KycEvents` puts on `openbank.kyc.events` (pinned by the pacts). */
+    private fun eventPayload(
+        eventType: String,
+        kycCaseId: String? = caseId.toString(),
+        party: String? = partyId.toString(),
+    ): String {
+        val fields = mutableListOf(
+            "\"eventType\":\"$eventType\"",
+            "\"status\":\"VERIFIED\"",
+            "\"riskLevel\":\"LOW\"",
+            "\"occurredAt\":\"${Instant.parse("2026-09-03T10:00:00Z")}\"",
+        )
+        kycCaseId?.let { fields += "\"kycCaseId\":\"$it\"" }
+        party?.let { fields += "\"partyId\":\"$it\"" }
+        return "{${fields.joinToString(",")}}"
+    }
+
+    @Test
+    fun `case approved notifies the data subject with KYC_APPROVED`() {
+        consumer.consume(eventPayload("KYC_CASE_APPROVED")).subscribe().with({}, {})
+
+        val req = capturedRequests().single()
+        assertThat(req.partyId).isEqualTo(partyId)
+        assertThat(req.recipient).isEqualTo(partyId.toString())
+        assertThat(req.template).isEqualTo(NotificationTemplate.KYC_APPROVED)
+        assertThat(req.channel).isEqualTo(NotificationChannel.PUSH)
+        assertThat(req.variables).isEmpty()
+        assertThat(req.correlationId).isEqualTo(caseId)
+        assertThat(req.deepLink).isNull()
+    }
+
+    @Test
+    fun `case rejected notifies with a fixed customer-safe reason, never internal notes`() {
+        consumer.consume(eventPayload("KYC_CASE_REJECTED")).subscribe().with({}, {})
+
+        val req = capturedRequests().single()
+        assertThat(req.template).isEqualTo(NotificationTemplate.KYC_REJECTED)
+        assertThat(req.variables).containsKey("reason")
+        // Deliberately fixed text: the reviewer's internal reason (KycCase.notes) is not on the
+        // wire and must not be — see the consumer's KDoc.
+        assertThat(req.variables["reason"]).isEqualTo("the submitted information could not be verified")
+        assertThat(req.correlationId).isEqualTo(caseId)
+    }
+
+    @Test
+    fun `opened and status-changed events are not notified`() {
+        consumer.consume(eventPayload("KYC_CASE_OPENED")).subscribe().with({}, {})
+        consumer.consume(eventPayload("KYC_CASE_STATUS_CHANGED")).subscribe().with({}, {})
+
+        verify(exactly = 0) { notificationConsumer.consume(any()) }
+    }
+
+    @Test
+    fun `malformed JSON is a poison pill, swallowed without throwing`() {
+        consumer.consume("not json").subscribe().with({}, {})
+
+        verify(exactly = 0) { notificationConsumer.consume(any()) }
+    }
+
+    @Test
+    fun `missing or unparseable identifiers are dropped rather than notified with a bad target`() {
+        consumer.consume(eventPayload("KYC_CASE_APPROVED", party = null)).subscribe().with({}, {})
+        consumer.consume(eventPayload("KYC_CASE_REJECTED", kycCaseId = null)).subscribe().with({}, {})
+        consumer.consume(eventPayload("KYC_CASE_APPROVED", kycCaseId = "not-a-uuid")).subscribe().with({}, {})
+
+        verify(exactly = 0) { notificationConsumer.consume(any()) }
+    }
+}


### PR DESCRIPTION
## Summary

Refs #8432

The KYC outcome notifications existed end-to-end — templates rendered, SECURITY-classified, allow-listed — and had **no producer**. kyc-service already publishes `KYC_CASE_APPROVED` / `KYC_CASE_REJECTED` onto `openbank.kyc.events` via its transactional outbox (the only publisher on that topic since #4007). This PR adds a further **consumer** of that already-live topic inside notification-service — no change to kyc-service, no new event contract, and no reintroduction of the bare post-commit emitter shape #4007 removed there.

## What changed

- **`KycNotificationConsumer`** — `@Incoming("kyc-events-in")`, maps `KYC_CASE_APPROVED` → `KYC_APPROVED` and `KYC_CASE_REJECTED` → `KYC_REJECTED`, delivered to the data subject (`partyId`) over PUSH, reusing the exact `NotificationRequest` wire shape handed to `NotificationConsumer.consume` (same pattern as `DelegationNotificationConsumer`), so the closed variable-schema check, SECURITY classification and outcome-event write all run unchanged. `correlationId` = the KYC case id (ADR-0239 D1). Poison pills are logged and swallowed, never wedging the partition.
- **Rejection reason is deliberately fixed text** — `KYC_REJECTED`'s closed variable schema (ADR-0176 D1) requires a `reason`, but the envelope carries none: the reviewer's reason lives in `KycCase.notes`, a ČNB-audited internal field never meant for the customer. Copying internal review notes into a customer push would be a PII/process leak, so the notification sends a fixed customer-safe reason ("the submitted information could not be verified") and the template's own copy points at support.
- **No deep link** — `MobileDeepLink` is a closed allow-list with no KYC entry; rather than grow it for an unverifiable app route, the notification carries none (null is allowed).
- **`application.yaml`** — new `kyc-events-in` channel with `failure-strategy: dead-letter-queue` and the DLQ topic in NESTED form (`openbank.kyc.events.notification.dlq`) — the `incoming-dlq-wiring` gate (#5745) requires explicit dead-lettering for every new incoming channel, and the dotted leaf key would be quoted and never read (#686).
- **GitOps (channel-agnostic parts only)** — Strimzi ACL: Read/Describe on `openbank.kyc.events`, Read on new group `notification-service-kyc`, Write/Describe on the DLQ topic; plus the `KafkaTopic` CR for the DLQ (this cluster does not auto-create topics).

## Two-phase rollout (msg-channel-image-parity gate)

The `mp.messaging.incoming.kyc-events-in.*` **ConfigMap override keys are deliberately NOT in this PR**: the `msg-channel-image-parity` gate (SRMSG00071 guard) requires the deployed image to declare the channel's `connector:` before any GitOps config names it. This PR ships the image half (consumer + application.yaml + ACL/topic). Once the sandbox deploy carries this commit, a follow-up PR adds the `group.id` / `client.id` / `auto.offset.reset` overrides to `notification-service-msg-override.yaml`. Between the two, the channel polls with the fallback group and is unauthorized — degraded consumer, not a boot failure; the window is minutes, not days.

## Wire-contract note

The consumer reads `kycCaseId` (not `aggregateId`) — the flat envelope pinned by the provider pacts (`KycEvents`) names the case id `kycCaseId` on the wire.

## Deliberately out of scope

`KYC_DOCUMENT_REQUIRED` stays un-notified — its customer-recipient semantics need ADR-0256 before a producer is wired. The issue stays open for that.

One side effect to note: the `PushFallbackConfiguredButInert` alert may now legitimately fire for `KYC_REJECTED` in environments without APNs credentials — that is the alert doing its job for the first time on this template.

## Testing

- `KycNotificationConsumerTest` — approved/rejected mapping, partyId recipient, fixed reason, correlation id, out-of-scope event types skipped, poison-pill swallow, missing/unparseable identifiers dropped.
- `./gradlew :openbank-notification-service:test :openbank-notification-service:ktlintCheck :openbank-notification-service:detekt` — green locally.
