### PR TITLE
feat(libs): add SecurityTelemetry and HoneytokenFilter security primitives

### DIFF
--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/security/HoneytokenFilter.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/security/HoneytokenFilter.kt
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.security
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import jakarta.annotation.Priority
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+import jakarta.ws.rs.Priorities
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.container.ContainerRequestFilter
+import jakarta.ws.rs.core.Response
+import jakarta.ws.rs.ext.Provider
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.jboss.logging.Logger
+import java.util.Optional
+
+/**
+ * Fleet-wide **honey endpoints** (ADR-0279 WS2): configured URL paths that no legitimate
+ * caller can ever reach — any hit is, by construction, reconnaissance or a confused client —
+ * counted, logged, and answered with a plain 404.
+ *
+ * ## Why this is worth having
+ *
+ * A honeytoken is the cheapest detection that exists: it needs no baseline, no model, and
+ * has effectively zero false positives, because the paths are never linked, never routed,
+ * and never documented. One hit says "someone is enumerating this service" — the signal the
+ * security-observability gap (no span/log/alert answers "are we being probed") was missing.
+ *
+ * ## Configuration
+ *
+ * ```
+ * openbank.security.honey.paths=/api/v1/internal/debug,/api/v1/admin/export
+ * ```
+ *
+ * Comma-separated, exact path match against the request path (relative, no leading-slash
+ * sensitivity). **Empty/absent property disables the filter entirely** — services opt in by
+ * listing their honey paths. The paths themselves must NOT be committed per service in a way
+ * that documents them to an attacker reading the repo: prefer environment-specific config
+ * (ConfigMap/secret) over application.yaml.
+ *
+ * ## Response shape
+ *
+ * 404 with no body — deliberately indistinguishable from "route does not exist". A 403 or a
+ * clever error would confirm to the prober that the path is special, which is the one thing
+ * a honeypot must never do. The detection happens out-of-band: [SecurityTelemetry.HONEYTOKEN_HITS]
+ * counter (tag `path` = the **configured** honey path, low cardinality) plus a WARN log line
+ * with a sanitized path and the remote address when available.
+ */
+@Provider
+@ApplicationScoped
+@Priority(HoneytokenFilter.PRIORITY)
+class HoneytokenFilter @Inject constructor(
+    @ConfigProperty(name = "openbank.security.honey.paths")
+    private val honeyPaths: Optional<String>,
+) : ContainerRequestFilter {
+
+    @Inject
+    lateinit var registryInstance: Instance<MeterRegistry>
+
+    private val configured: List<String> by lazy {
+        honeyPaths.orElse("")
+            .split(',')
+            .map { it.trim().removePrefix("/") }
+            .filter { it.isNotEmpty() }
+    }
+
+    override fun filter(requestContext: ContainerRequestContext) {
+        if (configured.isEmpty()) return
+        val requestPath = requestContext.uriInfo.path.trimStart('/')
+        val matched = configured.firstOrNull { it == requestPath } ?: return
+
+        if (registryInstance.isResolvable) {
+            Counter.builder(SecurityTelemetry.HONEYTOKEN_HITS)
+                .description("Hits on configured honey endpoints — any hit is reconnaissance by construction")
+                .tags("path", matched)
+                .register(registryInstance.get())
+                .increment()
+        }
+        log.warnf(
+            "honey endpoint hit: path=%s remote=%s",
+            sanitizeForLog(matched),
+            sanitizeForLog(requestContext.getHeaderString("X-Forwarded-For") ?: "unknown"),
+        )
+        requestContext.abortWith(Response.status(Response.Status.NOT_FOUND).build())
+    }
+
+    companion object {
+        private val log = Logger.getLogger(HoneytokenFilter::class.java)
+
+        /** Runs just before authentication: a prober must not need credentials to be counted. */
+        const val PRIORITY: Int = Priorities.AUTHENTICATION - 100
+
+        /** Cap on the log-rendered value — long enough to be useful, short enough to bound a log line. */
+        private const val LOG_VALUE_MAX = 128
+
+        /**
+         * A config value is operator-controlled, but it is rendered into logs on an
+         * attacker-triggered path — strip anything non-printable so a crafted value (or a
+         * crafted X-Forwarded-For) cannot inject log lines (CRLF) or terminal escapes.
+         */
+        internal fun sanitizeForLog(value: String): String =
+            value.filter { it.isLetterOrDigit() || it in "/-_.:@[]" }.take(LOG_VALUE_MAX)
+    }
+}

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/security/SecurityTelemetry.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/security/SecurityTelemetry.kt
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.security
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+
+/**
+ * Security-native telemetry for every service (ADR-0279 WS2): authorization decisions and
+ * honeytoken hits as **metrics**, and the same facts as **span attributes** on the current
+ * trace — so a denied request can be followed from the alert to the exact trace that produced
+ * it, without shipping PII (attribute keys carry identifiers and decisions, never payloads;
+ * the same bound as ADR-0274 RUM).
+ *
+ * ## Why a lib primitive and not per-service counters
+ *
+ * The security-observability gap this closes is that the observability stack (Tempo/Loki)
+ * had no security signal to correlate. If each service invented its own metric name for
+ * "authz denied", the Loki/Prometheus rule pack would watch series nothing emits — the exact
+ * failure mode (#5733) that metric-name constants in libs exist to prevent. Alert rules name
+ * [AUTHZ_DECISIONS] / [HONEYTOKEN_HITS]; only this class may emit them.
+ *
+ * ## Safety
+ *
+ * Safe to load in services without `quarkus-micrometer` (registry is an [Instance] guard —
+ * silent no-op, the [com.openbank.libs.observability.DomainMetrics] precedent) and without
+ * `quarkus-opentelemetry` (span writes go through [OtelSpanAttributeWriter], reflection, the
+ * [com.openbank.libs.llm.OtelTraceIdProvider] precedent — an absent OTel is one more no-op,
+ * never a `NoClassDefFoundError` on the request path).
+ */
+@ApplicationScoped
+class SecurityTelemetry {
+
+    @Inject
+    lateinit var registryInstance: Instance<MeterRegistry>
+
+    private fun reg(): MeterRegistry? = if (registryInstance.isResolvable) registryInstance.get() else null
+
+    /** Authorization outcome. The tag value is the enum name lowercased — low cardinality by construction. */
+    enum class AuthzDecision {
+        ALLOW,
+        DENY,
+        ;
+
+        val tag: String get() = name.lowercase()
+    }
+
+    /**
+     * Record an authorization decision: increments [AUTHZ_DECISIONS] tagged
+     * `decision=allow|deny, reason=<reason>` and stamps the current span with
+     * [ATTR_AUTHZ_DECISION] / [ATTR_AUTHZ_REASON].
+     *
+     * [reason] MUST be a low-cardinality code (e.g. `"role-missing"`, `"delegation-expired"`),
+     * never a party id, token, or message — the cardinality contract of
+     * [com.openbank.libs.observability.DomainMetrics] applies here unchanged.
+     */
+    fun recordAuthorizationDecision(decision: AuthzDecision, reason: String) {
+        reg()?.let {
+            Counter.builder(AUTHZ_DECISIONS)
+                .description("Authorization decisions by outcome and reason code")
+                .tags("decision", decision.tag, "reason", reason)
+                .register(it)
+                .increment()
+        }
+        OtelSpanAttributeWriter.set(ATTR_AUTHZ_DECISION, decision.tag)
+        OtelSpanAttributeWriter.set(ATTR_AUTHZ_REASON, reason)
+    }
+
+    /**
+     * Record a delegation chain depth on the current span (no metric — depth is a trace
+     * concern; a gauge of it would be noise). Used by delegation-aware services so a trace
+     * shows how many hops the acting identity traversed.
+     */
+    fun recordDelegationDepth(depth: Int) {
+        OtelSpanAttributeWriter.setLong(ATTR_DELEGATION_DEPTH, depth.toLong())
+    }
+
+    companion object {
+        /** Counter name for authorization decisions. Alert rules reference this constant's value. */
+        const val AUTHZ_DECISIONS = "openbank.security.authz.decisions"
+
+        /** Counter name for honeytoken hits. Alert rules reference this constant's value. */
+        const val HONEYTOKEN_HITS = "openbank.security.honeytoken.hits"
+
+        /** Span attribute key carrying the authz decision (`allow`/`deny`). */
+        const val ATTR_AUTHZ_DECISION = "openbank.authz.decision"
+
+        /** Span attribute key carrying the low-cardinality authz reason code. */
+        const val ATTR_AUTHZ_REASON = "openbank.authz.reason"
+
+        /** Span attribute key carrying the delegation chain depth. */
+        const val ATTR_DELEGATION_DEPTH = "openbank.delegation.depth"
+    }
+}
+
+/**
+ * Writes an attribute to the ambient OpenTelemetry span, by reflection, returning silently
+ * wherever OTel is not there to ask. See [com.openbank.libs.llm.OtelTraceIdProvider] for why
+ * reflection and not a compile-time reference: several services do not carry
+ * `quarkus-opentelemetry`, and a security signal must never be able to fail a request.
+ */
+internal object OtelSpanAttributeWriter {
+
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
+    fun set(key: String, value: String) {
+        try {
+            val spanClass = Class.forName("io.opentelemetry.api.trace.Span")
+            val span = spanClass.getMethod("current").invoke(null)
+            spanClass.getMethod("setAttribute", String::class.java, String::class.java)
+                .invoke(span, key, value)
+        } catch (ex: Exception) {
+            // OTel absent or API drift — the attribute is best-effort by construction.
+        } catch (ex: LinkageError) {
+            // NoClassDefFoundError is an Error, not an Exception (#3376).
+        }
+    }
+
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
+    fun setLong(key: String, value: Long) {
+        try {
+            val spanClass = Class.forName("io.opentelemetry.api.trace.Span")
+            val span = spanClass.getMethod("current").invoke(null)
+            spanClass.getMethod("setAttribute", String::class.java, Long::class.javaPrimitiveType)
+                .invoke(span, key, value)
+        } catch (ex: Exception) {
+            // as above
+        } catch (ex: LinkageError) {
+            // as above
+        }
+    }
+}

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/security/HoneytokenFilterTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/security/HoneytokenFilterTest.kt
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.security
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import jakarta.enterprise.inject.Instance
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.core.Response
+import jakarta.ws.rs.core.UriInfo
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.Optional
+
+class HoneytokenFilterTest {
+
+    private fun filter(config: String?, reg: MeterRegistry? = SimpleMeterRegistry()): HoneytokenFilter {
+        val inst = mockk<Instance<MeterRegistry>>()
+        if (reg == null) {
+            every { inst.isResolvable } returns false
+        } else {
+            every { inst.isResolvable } returns true
+            every { inst.get() } returns reg
+        }
+        return HoneytokenFilter(Optional.ofNullable(config)).apply { registryInstance = inst }
+    }
+
+    private fun request(path: String): ContainerRequestContext {
+        val uriInfo = mockk<UriInfo>()
+        every { uriInfo.path } returns path
+        val ctx = mockk<ContainerRequestContext>(relaxed = true)
+        every { ctx.uriInfo } returns uriInfo
+        every { ctx.getHeaderString("X-Forwarded-For") } returns "10.0.0.9"
+        return ctx
+    }
+
+    @Test
+    fun `disabled when the property is absent`() {
+        val ctx = request("api/v1/internal/debug")
+
+        filter(null).filter(ctx)
+
+        verify(exactly = 0) { ctx.abortWith(any()) }
+    }
+
+    @Test
+    fun `disabled when the property is empty`() {
+        val ctx = request("api/v1/internal/debug")
+
+        filter("").filter(ctx)
+
+        verify(exactly = 0) { ctx.abortWith(any()) }
+    }
+
+    @Test
+    fun `a honey path hit aborts with 404 and counts the configured path`() {
+        val reg = SimpleMeterRegistry()
+        val ctx = request("api/v1/internal/debug")
+        val aborted = slot<Response>()
+
+        filter("/api/v1/internal/debug,/api/v1/admin/export", reg).filter(ctx)
+
+        verify { ctx.abortWith(capture(aborted)) }
+        assertThat(aborted.captured.status).isEqualTo(404)
+        val counter = reg.find(SecurityTelemetry.HONEYTOKEN_HITS)
+            .tags("path", "api/v1/internal/debug").counter()
+        assertThat(counter).isNotNull
+        assertThat(counter!!.count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `leading slash in config or request is insignificant`() {
+        val ctx = request("api/v1/admin/export")
+
+        filter("api/v1/admin/export").filter(ctx)
+
+        verify { ctx.abortWith(any()) }
+    }
+
+    @Test
+    fun `a normal business path passes through untouched`() {
+        val ctx = request("api/v1/payments")
+
+        filter("/api/v1/internal/debug").filter(ctx)
+
+        verify(exactly = 0) { ctx.abortWith(any()) }
+    }
+
+    @Test
+    fun `a prefix of a honey path is not a hit`() {
+        val ctx = request("api/v1/internal")
+
+        filter("/api/v1/internal/debug").filter(ctx)
+
+        verify(exactly = 0) { ctx.abortWith(any()) }
+    }
+
+    @Test
+    fun `no micrometer registry still aborts with 404`() {
+        val ctx = request("api/v1/internal/debug")
+
+        filter("/api/v1/internal/debug", reg = null).filter(ctx)
+
+        verify { ctx.abortWith(any()) }
+    }
+
+    @Test
+    fun `log sanitization strips control characters and caps length`() {
+        assertThat(HoneytokenFilter.sanitizeForLog("ok/path-1_2.x:@[a]")).isEqualTo("ok/path-1_2.x:@[a]")
+        assertThat(HoneytokenFilter.sanitizeForLog("a\r\nb\tc\"'; DROP")).isEqualTo("abcDROP")
+        assertThat(HoneytokenFilter.sanitizeForLog("x".repeat(500))).hasSize(128)
+    }
+}

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/security/SecurityTelemetryTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/security/SecurityTelemetryTest.kt
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.security
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.enterprise.inject.Instance
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.Test
+
+class SecurityTelemetryTest {
+
+    private fun withRegistry(reg: MeterRegistry?): SecurityTelemetry {
+        val inst = mockk<Instance<MeterRegistry>>()
+        if (reg == null) {
+            every { inst.isResolvable } returns false
+        } else {
+            every { inst.isResolvable } returns true
+            every { inst.get() } returns reg
+        }
+        return SecurityTelemetry().apply { registryInstance = inst }
+    }
+
+    @Test
+    fun `authz decisions are counted with low-cardinality tags`() {
+        val reg = SimpleMeterRegistry()
+        val telemetry = withRegistry(reg)
+
+        telemetry.recordAuthorizationDecision(SecurityTelemetry.AuthzDecision.DENY, "role-missing")
+        telemetry.recordAuthorizationDecision(SecurityTelemetry.AuthzDecision.DENY, "role-missing")
+        telemetry.recordAuthorizationDecision(SecurityTelemetry.AuthzDecision.ALLOW, "role-present")
+
+        val denied = reg.find(SecurityTelemetry.AUTHZ_DECISIONS)
+            .tags("decision", "deny", "reason", "role-missing").counter()
+        val allowed = reg.find(SecurityTelemetry.AUTHZ_DECISIONS)
+            .tags("decision", "allow", "reason", "role-present").counter()
+        assertThat(denied).isNotNull
+        assertThat(denied!!.count()).isEqualTo(2.0)
+        assertThat(allowed).isNotNull
+        assertThat(allowed!!.count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `no micrometer registry means a silent no-op, never an exception`() {
+        val telemetry = withRegistry(null)
+
+        assertThatCode {
+            telemetry.recordAuthorizationDecision(SecurityTelemetry.AuthzDecision.DENY, "delegation-expired")
+            telemetry.recordDelegationDepth(3)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `span attribute writes are best-effort and never throw, with or without OTel`() {
+        assertThatCode {
+            OtelSpanAttributeWriter.set("openbank.authz.decision", "deny")
+            OtelSpanAttributeWriter.setLong("openbank.delegation.depth", 2L)
+        }.doesNotThrowAnyException()
+    }
+}


### PR DESCRIPTION
## Summary
First code slice of **ADR-0279 WS2** (security observability), placed in `openbank-libs-runtime/com.openbank.libs.security` so every consumer service picks it up automatically (beans.xml + jandex, zero service-side changes):

- **SecurityTelemetry** — authorization decisions as a fleet-standard counter `openbank.security.authz.decisions` (tags `decision=allow|deny`, `reason` low-cardinality code) + span attributes (`openbank.authz.decision/reason`, `openbank.delegation.depth`) on the current trace. Metric names are constants so alert rules and emitters cannot drift apart (#5733 lesson). Reflection-guarded OTel writes and `Instance<MeterRegistry>` guard — silent no-op in services without those extensions, never a request-path failure (#3376 lesson).
- **HoneytokenFilter** — fleet-wide honey endpoints: any hit on a configured path (`openbank.security.honey.paths`) is reconnaissance by construction → counted (`openbank.security.honeytoken.hits`, tag = configured path), logged (sanitized, CRLF-safe), answered with a plain 404 indistinguishable from "route does not exist". Disabled when the property is absent.

This is the emit-side for the Loki/Prometheus security rule pack (follow-up PR) and gives the Security Excellence hub its first offensive-detection signal.

Refs #8488 (ADR-0279 merged as #8549)

## Test plan
- [x] 11 new unit tests (counters, tags, no-op modes, disabled filter, 404 shape, prefix non-match, log sanitization)
- [x] `:openbank-libs-runtime:ktlintCheck detekt koverVerify` green locally
- [ ] CI