### PR TITLE
chore(gitops): wire kyc-events-in consumer group override (#8432 phase 2)

### DIFF
--- a/openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml
@@ -70,3 +70,10 @@ data:
     mp.messaging.incoming.delegation-events-in.client.id=notification-service-delegation-${quarkus.uuid}
     mp.messaging.incoming.delegation-events-in.group.id=notification-service-delegation
     mp.messaging.incoming.delegation-events-in.auto.offset.reset=earliest
+    # #8432 (phase 2 of #8547): KYC outcome notifications. Same dotted-key constraint (issue
+    # #686) as above — these keys can only live in a properties source. Phase 1 shipped the
+    # connector + consumer in the image (deployed as sandbox-c754eabb or later), so naming the
+    # channel here no longer risks the SRMSG00071 boot failure the parity gate guards.
+    mp.messaging.incoming.kyc-events-in.client.id=notification-service-kyc-${quarkus.uuid}
+    mp.messaging.incoming.kyc-events-in.group.id=notification-service-kyc
+    mp.messaging.incoming.kyc-events-in.auto.offset.reset=earliest


### PR DESCRIPTION
Refs #8432

Phase 2 of #8547. Phase 1 shipped the `kyc-events-in` channel (connector + `KycNotificationConsumer`) in the notification-service image, now deployed in the sandbox as `sandbox-c754eabb` — so the `msg-channel-image-parity` gate's precondition (image declares the channel before config names it) is satisfied.

This adds the dotted-leaf keys that cannot live in `application.yaml` (issue #686):

- `client.id=notification-service-kyc-${quarkus.uuid}`
- `group.id=notification-service-kyc` (ACL-granted in phase 1)
- `auto.offset.reset=earliest`

Until this lands, the channel polls under the fallback group id and is unauthorized — degraded consumer, not a boot failure, exactly the window the two-phase rollout accepted.

No service code changes; notification-service `version.txt` untouched deliberately (gitops-only change).