### PR TITLE
feat(observability): security signal rule pack — honey endpoint + authz deny ratio

### DIFF
--- a/openbank-infra/gitops/components/observability/loki-rules-security-signals.yaml
+++ b/openbank-infra/gitops/components/observability/loki-rules-security-signals.yaml
@@ -1,0 +1,70 @@
+# Security-signal log alerting (ADR-0279 WS2 — security observability).
+#
+# THE GAP THIS CLOSES. The observability stack (Alloy -> Loki -> ruler -> Alertmanager) was
+# built for liveness and workflow staleness (ADR-0237), and Falco runtime detections got their
+# alerts in loki-rules-falco-runtime.yaml — but no rule answered "is someone PROBING us right
+# now". The HoneytokenFilter in openbank-libs-runtime (com.openbank.libs.security, #8554) now
+# emits exactly one log line for exactly one condition, and this file turns it into an alert.
+#
+# WHY A HONEY ENDPOINT ALERT CAN BE TRUSTED. A honey path is never routed, never linked and
+# never documented, so a hit cannot be a confused-but-legitimate user — it is reconnaissance
+# by construction. That makes this the rare alert whose false-positive rate is ~0 by design,
+# not by tuning. The one deliberate exception is our OWN synthetic/fuzz tooling, which is why
+# the rule excludes the namespaces those run in; add exclusions only for tooling that provably
+# crawls every route, never for "it was noisy".
+#
+# SEVERITY. Starts at `warning` per the estate's documented convention (a new rule that pages
+# is a regression even when it is correct — see loki-rules-falco-runtime.yaml). PROMOTION
+# CRITERION: flip to `critical` the day a known-positive (a manual curl against a sandbox honey
+# path) has been shown to reach Slack end-to-end — that proof is part of the runbook-0018
+# purple-team tabletop, which is exactly the drill this alert exists to make observable.
+#
+# MECHANISM. ConfigMap labelled loki_rule=1, picked up by the Loki chart's sidecar into the
+# ruler — the same, and only, log-alerting mechanism this repo operates (see the header of
+# loki-rules-falco-runtime.yaml for why no other). A separate file, not an appended document,
+# per the #3450/#3460 clean-merge-that-kept-one-side lesson.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-rules-security-signals
+  namespace: observability
+  labels:
+    loki_rule: "1"
+    app.kubernetes.io/part-of: observability
+data:
+  security-signals.yaml: |
+    groups:
+      - name: openbank.logs.security-signals
+        interval: 1m
+        rules:
+          # Any hit on a configured honey endpoint. The HoneytokenFilter logs
+          # `honey endpoint hit: path=... remote=...` at WARN in the hitting service's pod and
+          # answers the caller a plain 404 — the caller learns nothing, we learn everything.
+          # The match string is emitted by exactly one class in the estate, so the filter
+          # cannot collide with an unrelated log line.
+          #
+          # No `for:` — a probe is a point event; see the Falco alert for why `for` on a bursty
+          # log signal can drop the notification entirely.
+          - alert: HoneyEndpointHit
+            expr: |
+              sum by (namespace) (
+                count_over_time(
+                  {namespace=~".+", namespace!~"observability|falco|kube-system|monitoring"}
+                    |= "honey endpoint hit"
+                  [10m]
+                )
+              ) > 0
+            labels:
+              severity: warning
+              team: security
+            annotations:
+              summary: "Honey endpoint hit in {{ $labels.namespace }}: {{ $value | printf \"%.0f\" }}x in 10m"
+              description: >-
+                A request reached a configured honey endpoint — a path no legitimate caller can
+                know, so this is reconnaissance by construction. Read the full line in Loki:
+                {namespace="{{ $labels.namespace }}"} |= "honey endpoint hit"
+                — it carries the sanitized honey path and the X-Forwarded-For value. Correlate
+                with the openbank.security.honeytoken.hits counter (Prometheus) and with Falco
+                events in the same window; a honey hit plus a runtime detection is an incident,
+                not an alert. Tuning: only exclude a source that provably crawls every route
+                (our own fuzz/synthetic jobs); never silence the rule.

--- a/openbank-infra/gitops/components/observability/prometheus-rules-security-signals.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-security-signals.yaml
@@ -1,0 +1,73 @@
+# Security-signal metric alerting (ADR-0279 WS2 — security observability).
+#
+# THE GAP THIS CLOSES. Authorization decisions were a silent control: services decided
+# allow/deny on every request and nothing aggregated the answer. An attacker working through
+# endpoint enumeration produces a rising deny ratio that no liveness, workflow or Falco rule
+# can see. SecurityTelemetry (openbank-libs-runtime com.openbank.libs.security, #8554) now
+# emits `openbank.security.authz.decisions` on every service with micrometer, and this rule
+# watches the SHAPE of that series, not its existence.
+#
+# WHY A RATIO, NOT A THRESHOLD. An absolute deny count cannot distinguish "attacker probing"
+# from "Tuesday": traffic growth moves it, a misconfigured client moves it, and the estate's
+# documented failure mode is alerts tuned to a magnitude that later legitimately changes
+# (WorkflowLivenessStale / FalcoAgentSilent lessons). The DENY SHARE of decisions is what an
+# enumeration attack moves and normal business does not; the floor on total rate keeps the
+# ratio from judging a service with three requests an hour.
+#
+# METRIC EMITTED-BY-CODE. openbank.security.authz.decisions is emitted by
+# openbank-libs-runtime/src/main/kotlin/com/openbank/libs/security/SecurityTelemetry.kt —
+# the name lives there as a constant (AUTHZ_DECISIONS) so this rule and the emitter cannot
+# drift apart (#5733). The alert-metric-emitted gate enforces it.
+#
+# SEVERITY. `warning` per the estate convention (a new rule that pages is a regression even
+# when it is correct). Promotion criterion: flip to `critical` once the rule has fired on a
+# real anomaly or a purple-team drill (runbook 0018) has proven the end-to-end path.
+#
+# Picked up automatically (ruleSelectorNilUsesHelmValues=false).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-security-signal-alerts
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: observability
+spec:
+  groups:
+    - name: openbank.security-signals
+      rules:
+        # Deny share of authorization decisions above 30% for 15m, on services with enough
+        # traffic for the share to mean something (> 0.05 decisions/s ≈ 180/h). Normal
+        # operation is overwhelmingly allow (authenticated staff doing their jobs); a
+        # sustained deny-heavy mix on a busy service is enumeration, a broken client
+        # hammering with stale credentials, or a delegation misconfiguration — all three
+        # worth a human's eyes, none of them pageable.
+        - alert: AuthzDenyRatioElevated
+          expr: |
+            (
+              sum by (namespace, service) (
+                rate(openbank_security_authz_decisions_total{decision="deny"}[10m])
+              )
+              /
+              sum by (namespace, service) (
+                rate(openbank_security_authz_decisions_total[10m])
+              )
+            ) > 0.3
+            and
+            sum by (namespace, service) (
+              rate(openbank_security_authz_decisions_total[10m])
+            ) > 0.05
+          for: 15m
+          labels:
+            severity: warning
+            team: security
+          annotations:
+            summary: "Authz deny share on {{ $labels.service }}: {{ $value | humanizePercentage }} for 15m"
+            description: >-
+              More than 30% of authorization decisions on this service have been denies for
+              15 minutes at meaningful traffic. First look at the reason tag — Loki:
+              {namespace="{{ $labels.namespace }}"} | json | ... the deny reason code is on
+              the metric (openbank_security_authz_decisions_total{decision="deny"}) and on
+              the span attributes openbank.authz.decision / openbank.authz.reason in Tempo.
+              A single dominant reason like "delegation-expired" is usually a broken client;
+              a spread of reasons across endpoints is enumeration — correlate with
+              HoneyEndpointHit and Falco events in the same window before deciding.

--- a/openbank-infra/gitops/components/observability/prometheus-rules-security-signals.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-security-signals.yaml
@@ -61,6 +61,7 @@ spec:
             severity: warning
             team: security
           annotations:
+            subject_period: continuous
             summary: "Authz deny share on {{ $labels.service }}: {{ $value | humanizePercentage }} for 15m"
             description: >-
               More than 30% of authorization decisions on this service have been denies for


### PR DESCRIPTION
## Summary
Alerting half of ADR-0279 WS2, consuming the primitives merged in #8554:

- **HoneyEndpointHit** (Loki ruler, `loki-rules-security-signals.yaml`) — any hit on a configured honey endpoint is reconnaissance by construction (~0 false positives by design). Starts at `warning` per the estate convention; promotion criterion documented (known-positive in the runbook-0018 drill).
- **AuthzDenyRatioElevated** (PrometheusRule, `prometheus-rules-security-signals.yaml`) — deny share > 30% for 15m at meaningful traffic (>0.05 decisions/s). Ratio, not magnitude, per the FalcoAgentSilent lesson; metric ties to `SecurityTelemetry.AUTHZ_DECISIONS` constant.

Both picked up automatically by the `observability-components` ArgoCD app (whole-directory apply).

## Test plan
- [x] `check-loki-rules.py` — real Loki ruler accepted the group (caught and fixed a negative-only matcher, exactly what the gate exists for)
- [x] `promtool check rules` — 1 rule, SUCCESS
- [x] `check-alert-metric-emitted.py` — clean (154 rules scanned incl. new one)
- [ ] CI