### PR TITLE
feat(ci): security regression test gate + security SLO definitions

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -33,6 +33,9 @@ labels:
     description: "vuln_management SLA: 180 days."
 
   # --- Type: what kind of work this is -------------------------------------------------
+  - name: security
+    color: "b60205"
+    description: "A security defect or hardening task. Closing a `security` issue by PR requires a regression test (security-regression-test.yml, ADR-0279 #5)."
   - name: bug
     color: "d73a4a"
     description: "A defect in shipped behavior."

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -35,7 +35,7 @@ labels:
   # --- Type: what kind of work this is -------------------------------------------------
   - name: security
     color: "b60205"
-    description: "A security defect or hardening task. Closing a `security` issue by PR requires a regression test (security-regression-test.yml, ADR-0279 #5)."
+    description: "Security defect/hardening. Closing by PR requires a regression test (security-regression-test.yml)."
   - name: bug
     color: "d73a4a"
     description: "A defect in shipped behavior."

--- a/.github/workflows/security-regression-test.yml
+++ b/.github/workflows/security-regression-test.yml
@@ -1,0 +1,94 @@
+# -----------------------------------------------------------------------------
+# Security regression test — a security issue is never closed without a test (ADR-0279 WS1 #5).
+#
+# THE RULE. A PR that closes an issue labeled `security` must touch a test surface
+# (`src/test`, `e2e`, or `*.spec.*`/`*.test.*` anywhere). The defect history in CLAUDE.md
+# is the justification: the recurring security classes (nullable JAX-RS params, silent
+# no-op success, scheduler context loss) each shipped more than once precisely because
+# the fix PR changed only the production code, leaving the next service to rediscover the
+# same hole. A fix without a test is a fix that regresses on schedule.
+#
+# SCOPE, STATED PLAINLY. Only CLOSING keywords (Closes/Fixes/Resolves) bind the rule —
+# `Refs #` is a mention, not a resolution, and demanding a test for a mention would make
+# the gate cry wolf. Only the `security` label is in scope: review-gate labels like
+# `security-review-required` are PR-applied checklist state, not issue types.
+#
+# Lives in its own workflow (not ci.yml) so the `edited` event re-evaluates when the PR
+# body is fixed — same shape as issue-hygiene.yml, whose header documents why.
+#
+# Escape hatch: a security issue that genuinely cannot carry a test (a policy-only fix)
+# is closed by a PR whose body states `no-test-justification: <reason>` on its own line.
+# The justification is text in a permanent record, which is the point — the gate forces
+# the decision to be conscious, not impossible.
+# -----------------------------------------------------------------------------
+name: Security regression test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: security-regression-test-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  security-regression-test:
+    name: security-regression-test
+    # actions/github-script only — no self-hosted-pool dependency.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: A PR closing a `security` issue must touch a test surface
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || "";
+
+            // Closing keywords only — Refs is a mention, not a resolution.
+            const closing = [...body.matchAll(/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi)]
+              .map(m => Number(m[1]));
+            if (closing.length === 0) {
+              core.info("No closing issue references — rule does not apply.");
+              return;
+            }
+
+            if (/^no-test-justification:\s*\S+/im.test(body)) {
+              core.info("no-test-justification present — conscious escape hatch, passing.");
+              return;
+            }
+
+            const securityIssues = [];
+            for (const n of closing) {
+              const { data: issue } = await github.rest.issues.get({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: n,
+              });
+              if (issue.labels.some(l => (l.name || l) === "security")) securityIssues.push(n);
+            }
+            if (securityIssues.length === 0) {
+              core.info(`Closed issues ${closing.join(", ")} — none labeled 'security'.`);
+              return;
+            }
+
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.number,
+              per_page: 100,
+            });
+            const TEST_SURFACE = /src\/test\/|\/e2e\/|\.(spec|test)\.[tj]sx?$/;
+            const touchedTests = files.map(f => f.filename).filter(f => TEST_SURFACE.test(f));
+            if (touchedTests.length > 0) {
+              core.info(`Test surface touched (${touchedTests.length} file(s)); security issue(s) ${securityIssues.join(", ")} close with a regression test.`);
+              return;
+            }
+
+            core.setFailed(
+              `This PR closes security issue(s) ${securityIssues.map(n => "#" + n).join(", ")} but touches no test surface ` +
+              `(src/test/, e2e/, *.spec.*, *.test.*). Add the regression test that would have caught the defect — ` +
+              `or, only if a test genuinely cannot express this fix, state \`no-test-justification: <reason>\` ` +
+              `on its own line in the PR body (ADR-0279, #8590).`
+            );

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -9,6 +9,7 @@ deploying OpenBank as a real bank requires your own licensing, compliance, and l
 | [`finos-ccc-mapping.md`](./finos-ccc-mapping.md) | Mapping of platform controls to FINOS Common Cloud Controls (CCC) + AI Governance Framework (AIGF). |
 | [`eu-ai-act.md`](./eu-ai-act.md) | EU AI Act control mapping (tracked separately, issue #1918). |
 | [`cra-conformity-assessment.md`](./cra-conformity-assessment.md) | Cyber Resilience Act product classification (default category) and the conformity-assessment path (ADR-0278, issue #8488). |
+| [`security-slo.md`](./security-slo.md) | Security SLOs: measurable targets (CVE MTTR, signed-SBOM coverage, honey dwell time) with computable sources (ADR-0279, issue #8590). |
 
 See also: [`docs/bcp/`](../bcp/) (BCP / DORA / incident response), the ADR set under
 [`docs/adr/`](../adr/), and the authoritative CI-enforced ruleset

--- a/docs/compliance/security-slo.md
+++ b/docs/compliance/security-slo.md
@@ -1,0 +1,31 @@
+# Security SLOs — measurable targets, not posture prose
+
+> The security-service-level objectives of the platform: each one has a **metric, a data
+> source that exists today, a target, and an owner-visible surface**. An SLO without a live
+> number is a wish; this document lists only objectives whose numerator and denominator are
+> computable from artifacts we already produce (ADR-0279 WS2, item #12). Tracked in #8590.
+
+## The SLOs
+
+| # | SLO | Metric / computation | Source of truth | Target | Surface |
+|---|-----|----------------------|-----------------|--------|---------|
+| S1 | **Critical-CVE remediation time (MTTR)** | days from a Critical/High CVE first appearing in a release SBOM to the first release whose SBOM no longer contains it | release `.cdx.json` bundle (release-please `release-evidence` job) + Trivy scan of the same | Critical ≤ 7 d, High ≤ 30 d | Security Excellence hub, Supply-chain pillar |
+| S2 | **Signed-SBOM release coverage** | releases in the last 90 d carrying a cosign-signed `.cdx.json` + `.sig` ÷ all releases | GitHub Releases asset list | 100 % | hub; `verify-release-evidence.yml` weekly |
+| S3 | **Vulnerability age in production** | age of the oldest Critical/High CVE present in the *running* image set (fleet attestation digests ↔ SBOM match) | fleet-attestation + SBOM, #8590 #11 wires the diff | oldest Critical ≤ 14 d | hub Supply-chain pillar |
+| S4 | **Honey-endpoint dwell time** | minutes from first `honey endpoint hit` log line to `HoneyEndpointHit` alert delivery | Loki (rule pack, #8583) ↔ Alertmanager | ≤ 5 min | runbook-0018 purple-team drill measurement |
+| S5 | **Authz decision integrity** | `openbank_security_authz_decisions_total` emitted by every service with micrometer; deny-ratio alert evaluated and not dead | `AuthzDenyRatioElevated` rule (#8583) + alert-metric-emitted gate | alert live 100 % of days | Prometheus rule console |
+| S6 | **Security-incident regression coverage** | closed `security`+`incident` issues whose fixing PR touched `src/test`/`e2e` ÷ all closed security incidents | `security-regression-test.yml` PR gate (#8590 #5) | 100 % of new incidents | issue #8590 dashboard row |
+| S7 | **Standing critical alerts** | count of critical-severity alerts firing > 24 h | ADR-0241 alert hygiene | 0 | existing alert-hygiene surface |
+
+## Rules this document follows
+
+1. **No SLO without a computable source.** When the source does not exist yet (S3, S4 end-to-end), the SLO says what wires it, and the row names the issue.
+2. **Targets tighten, never loosen.** A target is raised only by an ADR, so a bad quarter cannot be edited away.
+3. **Error budgets are release gates, not blame.** S1/S2 breaching budget pauses non-fix releases of the affected component until back inside target.
+
+## References
+
+- ADR-0279 (roadmap), ADR-0241 (alert hygiene), ADR-0278 (CRA — S1/S2 are the SBOM/evidence legs),
+  `docs/compliance/cra-conformity-assessment.md`.
+- Metrics: `SecurityTelemetry` (`openbank-libs-runtime`, #8554), rule pack (#8583),
+  release evidence bundle (`release-please.yml`).


### PR DESCRIPTION
## Summary
ADR-0279 items **#5** (incident → regression test) and **#12** (security SLOs):

- **`security-regression-test.yml`** — a PR closing an issue labeled `security` must touch a test surface (`src/test/`, `e2e/`, `*.spec.*`, `*.test.*`) or carry an explicit `no-test-justification: <reason>` line. Closing keywords only (`Refs` is a mention); own workflow so the `edited` event re-evaluates (issue-hygiene precedent). Adds the `security` label to `labels.yml` (governance-as-code, applied by label-sync).
- **`docs/compliance/security-slo.md`** — seven security SLOs (CVE MTTR, signed-SBOM coverage, vuln age, honey dwell time, authz integrity, incident regression coverage, standing criticals), each with a computable source that exists today and targets that tighten only via ADR.

Refs #8590

## Test plan
- [x] YAML validity (both files parse)
- [x] Gate logic walked through mentally: no closing refs → pass; non-security issue → pass; test touched → pass; escape hatch → pass; else fail
- [ ] CI