### PR TITLE
ci(governance): four-eyes assessment for sdd/interest — wire sdd.approve, interest.create, interest.trigger

### DIFF
--- a/docs/threat-models/openbank-interest-service.md
+++ b/docs/threat-models/openbank-interest-service.md
@@ -64,6 +64,21 @@ money-path service, not adjacent.
 
 ## 6. Change log
 
+- **2026-09-03** — Four-eyes assessment (#8359, ADR-0034 D-criteria as applied in the #938 sweep).
+  Per-verb caller audit: **`interest.create` and `interest.trigger` are now four-eyes-gated** via
+  `rules.yaml: four_eyes.actions`. `interest.create` bundles every operator write on the money path
+  (manual accrue, capitalize → real GL journals, rate-config create → shapes all future accrual
+  amounts, withholding remittance assemble → triggers the real cash leg to the finanční úřad);
+  `interest.trigger` (accrueAll) is the manual mass accrual. Both caller sets are human-only, twice
+  over: `operator-interest-write` excludes `service-account-*` and the `interest_rest_ext.rego`
+  prohibition vetoes the write set for any service account at the allow head; the fleet audit found
+  no M2M writer (agent-service's client is read-only). The accrual/capitalization schedulers and the
+  remittance settlement consumer call the use cases in-process, so the HTTP-layer gate can never
+  pause automation. **`interest.delete` (deactivateRateConfig) NOT gated:** it stops future accrual
+  — reduces money movement (standing-order pause/cancel precedent). `interest.read/list` are reads.
+  Four-eyes enforcement itself remains off fleet-wide (`authz.four-eyes.enforce`, ADR-0155) — the
+  wiring sets the decision flag, nothing pauses yet.
+
 - **2026-09-03** — `authz.enforce` now defaults to **true** in `application.yaml` (#3679). Until
   now it read `${AUTHZ_ENFORCE:false}`, so enforcement was a property of one gitops manifest
   rather than of the service: the deployed Rollout sets the variable to `"true"` (since #3695), so

--- a/docs/threat-models/openbank-sdd-service.md
+++ b/docs/threat-models/openbank-sdd-service.md
@@ -74,6 +74,23 @@ instruction, but the irreversible debit lives downstream.
 
 ## 6. Change log
 
+- **2026-09-03** — Four-eyes assessment (#8359, ADR-0034 D-criteria as applied in the #938 sweep).
+  Per-verb caller audit over all seven actions: **`sdd.approve` (B2B mandate confirmation) is now
+  four-eyes-gated** via `rules.yaml: four_eyes.actions` — the confirmation authorises every future
+  collection against the debtor, and its caller set is human-only (the edge grant deliberately
+  excludes it; `operator-sdd-write` excludes every `service-account-*`). Exact action, not the
+  `approve` verb: the verb would also flag `lending.approve` (already maker-checker in-app) and pull
+  non-money-path `dispatch.approve` into the grantable gate. **`sdd.authorise` assessed,
+  NOT gated:** it is the bulk authorisation of inbound collections whose designed caller is clearing
+  automation (not built yet — `sdd_rest_ext.rego` header), so gating it today covers no real caller
+  and plants the trap the `four_eyes.verbs` guardrail describes. When that caller ships, the operator
+  authorise-by-hand path gets its own distinct action and that is gated instead.
+  `sdd.create/update/delete` are edge-reachable customer self-service with effect on future debits
+  only — ungateable per the guardrail. Four-eyes enforcement itself remains off fleet-wide
+  (`authz.four-eyes.enforce`, ADR-0155) — the wiring sets the decision flag, nothing pauses yet.
+  Correction: §3's "`AUTHZ_ENFORCE` is `false` — advisory" was stale — flipped to `true` on
+  2026-08-10 (#4427); the `@Authorize` layer is an enforcing control today.
+
 - **2026-08-24** — Synthetic-journey taint now propagates over this service's existing internal transaction REST edge through `SyntheticTaintClientFilter` (ADR-0252, #4348). This adds no caller, endpoint, network-policy edge, privilege or payment-control bypass. It preserves the marker before a downstream persistence/event boundary; a fleet gate requires every new client to choose propagation or a reasoned external boundary.
 
 - **2026-08-03** — Missing required query/header parameter answered 500, not 400 (#3104). A required `@QueryParam`/`@HeaderParam` declared with a non-nullable Kotlin type was fed `null` by JAX-RS when the caller omitted it, and answered **500** rather than 400 (#3104). Kotlin's null-safety is compile-time only, so the declared type only decided where the failure landed: a non-suspend handler threw `Intrinsics.checkNotNullParameter` at the method boundary, and a **suspend** handler got no intrinsic at all, so the null flowed into the body. `accountId` on listMandates and `debitDate` on assessRefund. Both handlers are non-suspend and threw at the method boundary. `debitDate` is the input to the refund-window arithmetic (8-week / 13-month), so a request missing it must be rejected rather than defaulted — an UNPARSEABLE date is a different class and already 400 via `DateTimeExceptionMapper`. No new caller or boundary. Rollback: revert.

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "21cb426620a70a58"
+    openbank.tech/policy-checksum: "5357a7b0efa42e0a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1127,13 +1127,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1298,6 +1328,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "21cb426620a70a58"
+        openbank.tech/policy-checksum: "5357a7b0efa42e0a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "a090d4c63d680f6e"
+    openbank.tech/policy-checksum: "1caa746dc936e9e3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1078,13 +1078,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1249,6 +1279,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a090d4c63d680f6e"
+        openbank.tech/policy-checksum: "1caa746dc936e9e3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "b5e1c1c8d9010398"
+    openbank.tech/policy-checksum: "502b4145288e28e5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1061,13 +1061,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1232,6 +1262,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b5e1c1c8d9010398"
+        openbank.tech/policy-checksum: "502b4145288e28e5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "355c3f9e3043443a"
+    openbank.tech/policy-checksum: "587b73b1900ce5ab"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1016,13 +1016,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1187,6 +1217,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "355c3f9e3043443a"
+        openbank.tech/policy-checksum: "587b73b1900ce5ab"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "1803ec97f1dbb79e"
+    openbank.tech/policy-checksum: "ea0d946660414f47"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1060,13 +1060,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1231,6 +1261,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1803ec97f1dbb79e"
+        openbank.tech/policy-checksum: "ea0d946660414f47"
     spec:
       serviceAccountName: audit-service
       securityContext:

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "a496968f7d089aee"
+    openbank.tech/policy-checksum: "9ae73774acf085c7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1203,13 +1203,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1374,6 +1404,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a496968f7d089aee"
+        openbank.tech/policy-checksum: "9ae73774acf085c7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "3deb0b360583661d"
+    openbank.tech/policy-checksum: "631e20e5ddcea7a8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1083,13 +1083,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1254,6 +1284,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -36,7 +36,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3deb0b360583661d"
+        openbank.tech/policy-checksum: "631e20e5ddcea7a8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: campaign-service
     app.kubernetes.io/part-of: campaign
   annotations:
-    openbank.tech/policy-checksum: "038aab487844adb0"
+    openbank.tech/policy-checksum: "cd4868dd9ddbd6aa"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1085,13 +1085,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1256,6 +1286,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-campaign-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "038aab487844adb0"
+        openbank.tech/policy-checksum: "cd4868dd9ddbd6aa"
       labels:
         app.kubernetes.io/name: campaign-service
         app.kubernetes.io/part-of: campaign

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "6711cce884ba095a"
+    openbank.tech/policy-checksum: "10bac0c087ec16d6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1161,13 +1161,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1332,6 +1362,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6711cce884ba095a"
+        openbank.tech/policy-checksum: "10bac0c087ec16d6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "6faa4fe735a507c5"
+    openbank.tech/policy-checksum: "4d72b5ad37c6bf4b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1140,13 +1140,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1311,6 +1341,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6faa4fe735a507c5"
+        openbank.tech/policy-checksum: "4d72b5ad37c6bf4b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "8db63577c74178a4"
+    openbank.tech/policy-checksum: "949dd0eab194bd46"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -733,13 +733,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -904,6 +934,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8db63577c74178a4"
+        openbank.tech/policy-checksum: "949dd0eab194bd46"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: delegation-service
     app.kubernetes.io/part-of: delegation
   annotations:
-    openbank.tech/policy-checksum: "97b8daa0e97c48a3"
+    openbank.tech/policy-checksum: "00f87c29a259c97e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1106,13 +1106,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1277,6 +1307,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/delegation/delegation-service.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-delegation-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "97b8daa0e97c48a3"
+        openbank.tech/policy-checksum: "00f87c29a259c97e"
       labels:
         app.kubernetes.io/name: delegation-service
         app.kubernetes.io/part-of: delegation

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "4c9af284bc43bb1a"
+    openbank.tech/policy-checksum: "40bec93dd61f61ff"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1190,13 +1190,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1361,6 +1391,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -24,7 +24,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4c9af284bc43bb1a"
+        openbank.tech/policy-checksum: "40bec93dd61f61ff"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "8db63577c74178a4"
+    openbank.tech/policy-checksum: "949dd0eab194bd46"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -733,13 +733,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -904,6 +934,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -52,7 +52,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8db63577c74178a4"
+        openbank.tech/policy-checksum: "949dd0eab194bd46"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/engagement/engagement-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/engagement/engagement-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: engagement-service
     app.kubernetes.io/part-of: engagement
   annotations:
-    openbank.tech/policy-checksum: "8db63577c74178a4"
+    openbank.tech/policy-checksum: "949dd0eab194bd46"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -733,13 +733,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -904,6 +934,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/engagement/engagement-service.yaml
+++ b/openbank-infra/gitops/components/engagement/engagement-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-engagement-opa-bundle.sh.
-        openbank.tech/policy-checksum: "8db63577c74178a4"
+        openbank.tech/policy-checksum: "949dd0eab194bd46"
       labels:
         app.kubernetes.io/name: engagement-service
         app.kubernetes.io/part-of: engagement

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "0d7216cda1279981"
+    openbank.tech/policy-checksum: "6d65868619d5d3f3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1097,13 +1097,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1268,6 +1298,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0d7216cda1279981"
+        openbank.tech/policy-checksum: "6d65868619d5d3f3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "435f20d77779c0bc"
+    openbank.tech/policy-checksum: "530c83a8459dde3e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1133,13 +1133,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1304,6 +1334,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "435f20d77779c0bc"
+        openbank.tech/policy-checksum: "530c83a8459dde3e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "fbbc9c7d0985cf82"
+    openbank.tech/policy-checksum: "81261a3e159af6c4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1112,13 +1112,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1283,6 +1313,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fbbc9c7d0985cf82"
+        openbank.tech/policy-checksum: "81261a3e159af6c4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "a10ac4b220dcc91c"
+    openbank.tech/policy-checksum: "134bcc8d19d23722"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1078,13 +1078,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1249,6 +1279,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a10ac4b220dcc91c"
+        openbank.tech/policy-checksum: "134bcc8d19d23722"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "cd40dc718702c60d"
+    openbank.tech/policy-checksum: "065373518bfa358d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1202,13 +1202,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1373,6 +1403,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cd40dc718702c60d"
+        openbank.tech/policy-checksum: "065373518bfa358d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "39adb28b0be5d9ac"
+    openbank.tech/policy-checksum: "7f2d7d270678fd43"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1183,13 +1183,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1354,6 +1384,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "39adb28b0be5d9ac"
+        openbank.tech/policy-checksum: "7f2d7d270678fd43"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "355c3f9e3043443a"
+    openbank.tech/policy-checksum: "587b73b1900ce5ab"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1016,13 +1016,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1187,6 +1217,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "355c3f9e3043443a"
+        openbank.tech/policy-checksum: "587b73b1900ce5ab"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "8db63577c74178a4"
+    openbank.tech/policy-checksum: "949dd0eab194bd46"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -733,13 +733,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -904,6 +934,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "8db63577c74178a4"
+        openbank.tech/policy-checksum: "949dd0eab194bd46"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "aff6166cd4db828d"
+    openbank.tech/policy-checksum: "df13387fa9216888"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1087,13 +1087,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1258,6 +1288,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "aff6166cd4db828d"
+        openbank.tech/policy-checksum: "df13387fa9216888"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5969f0e88f7e2a6c"
+    openbank.tech/policy-checksum: "0f3205054e762902"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1087,13 +1087,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1258,6 +1288,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c132038da74a56bd"
+    openbank.tech/policy-checksum: "4e8d9ff1f8feeb30"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1108,13 +1108,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1279,6 +1309,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ab29dba4c689a033"
+    openbank.tech/policy-checksum: "379e288c417635aa"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1093,13 +1093,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1264,6 +1294,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "2e8e9aa7bae6a3c1" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "b3a8485a282a5a15" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -378,7 +378,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "de74339ecdcbe4af"
+        openbank.tech/policy-checksum: "07f58393032b92cb"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -741,7 +741,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "ab29dba4c689a033" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "379e288c417635aa" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1078,7 +1078,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "66dc0d77375df158"
+        openbank.tech/policy-checksum: "a1fdd4d3d414ab68"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1399,7 +1399,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "c132038da74a56bd" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "4e8d9ff1f8feeb30" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1697,7 +1697,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "18c764931d43bee8" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "b49505fad160d662" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1974,7 +1974,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5969f0e88f7e2a6c"
+        openbank.tech/policy-checksum: "0f3205054e762902"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2252,7 +2252,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "420119a441890741" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "07a0215e10a18d04" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2678,7 +2678,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2df6e23f35756a46"
+        openbank.tech/policy-checksum: "542123a7ca821642"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2992,7 +2992,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "37f3171c44d7e74c"
+        openbank.tech/policy-checksum: "4f40990e3b50a41d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "66dc0d77375df158"
+    openbank.tech/policy-checksum: "a1fdd4d3d414ab68"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1066,13 +1066,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1237,6 +1267,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "de74339ecdcbe4af"
+    openbank.tech/policy-checksum: "07f58393032b92cb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1112,13 +1112,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1283,6 +1313,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "420119a441890741"
+    openbank.tech/policy-checksum: "07a0215e10a18d04"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1067,13 +1067,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1238,6 +1268,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "18c764931d43bee8"
+    openbank.tech/policy-checksum: "b49505fad160d662"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1088,13 +1088,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1259,6 +1289,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "2df6e23f35756a46"
+    openbank.tech/policy-checksum: "542123a7ca821642"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1070,13 +1070,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1241,6 +1271,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "2e8e9aa7bae6a3c1"
+    openbank.tech/policy-checksum: "b3a8485a282a5a15"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1123,13 +1123,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1294,6 +1324,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "37f3171c44d7e74c"
+    openbank.tech/policy-checksum: "4f40990e3b50a41d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1088,13 +1088,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1259,6 +1289,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "b97149f1f7e02c17"
+    openbank.tech/policy-checksum: "3d9997d7c491d4ab"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1104,13 +1104,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1275,6 +1305,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b97149f1f7e02c17"
+        openbank.tech/policy-checksum: "3d9997d7c491d4ab"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "9f58e8c857de6d51"
+    openbank.tech/policy-checksum: "5c08659cf507f205"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1149,13 +1149,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1320,6 +1350,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9f58e8c857de6d51"
+        openbank.tech/policy-checksum: "5c08659cf507f205"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "b209a318d0fea3ce"
+    openbank.tech/policy-checksum: "fb87f34da2c823bf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1054,13 +1054,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1225,6 +1255,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b209a318d0fea3ce"
+        openbank.tech/policy-checksum: "fb87f34da2c823bf"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "72bab9e7e66cef19"
+    openbank.tech/policy-checksum: "5441402fe6fc4f60"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1109,13 +1109,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1280,6 +1310,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "72bab9e7e66cef19"
+        openbank.tech/policy-checksum: "5441402fe6fc4f60"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sdd/sdd-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sdd/sdd-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sdd-service
     app.kubernetes.io/part-of: sdd
   annotations:
-    openbank.tech/policy-checksum: "248abf0c0827ba45"
+    openbank.tech/policy-checksum: "ad1ea80e4b3f6839"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1134,13 +1134,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1305,6 +1335,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/sdd/sdd-service.yaml
+++ b/openbank-infra/gitops/components/sdd/sdd-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sdd-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "248abf0c0827ba45"
+        openbank.tech/policy-checksum: "ad1ea80e4b3f6839"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "a7795567c226d22f"
+    openbank.tech/policy-checksum: "d1dbfdb46f6360c2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1120,13 +1120,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1291,6 +1321,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -35,7 +35,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a7795567c226d22f"
+        openbank.tech/policy-checksum: "d1dbfdb46f6360c2"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "61cd39ceb157abcf"
+    openbank.tech/policy-checksum: "1e66abcb6706a24d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1057,13 +1057,43 @@ data:
       - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                                # TransactionServiceClient for every authorised direct-debit collection
                                                # (#1027, merged) — moves funds directly, not adjacent to it like
-                                               # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                               # revisit under issue #938's follow-up sweep.
+                                               # sca/consent/vop below. Threat model:
+                                               # docs/threat-models/openbank-sdd-service.md.
+                                               # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                               # the act that authorises all future debits on a mandate) WIRED via
+                                               # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                               # the bulk authorisation of inbound collections whose DESIGNED caller
+                                               # is clearing automation (sdd_rest_ext.rego header documents that
+                                               # caller is simply not built yet — the consent.activate "plausibly
+                                               # could" case), so gating it today buys nothing (no caller exists)
+                                               # and plants the exact trap the four_eyes.verbs guardrail describes
+                                               # for the day that caller ships. When it does, the operator
+                                               # authorise-by-hand path gets its OWN distinct action and THAT is
+                                               # gated. sdd.create/update/delete are edge-reachable customer
+                                               # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                               # debits only — ungateable per the guardrail, same shape as
+                                               # standing-order order CRUD. The debit itself is event-driven
+                                               # (SddCollectionDebitConsumer), no HTTP PEP on that path.
       - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                                # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                               # (#999, in progress) will book a cash leg via transaction-service.
-                                               # Four-eyes not yet assessed for this service; revisit under issue
-                                               # #938's follow-up sweep.
+                                               # (#999, merged) books a cash leg via transaction-service.
+                                               # Threat model: docs/threat-models/openbank-interest-service.md.
+                                               # four-eyes assessed (#8359): interest.create (manual accrue,
+                                               # capitalize — posts real GL journals, rate-config create — shapes
+                                               # all future accrual amounts, withholding remittance assemble —
+                                               # triggers the real cash leg) and interest.trigger (manual mass
+                                               # accrual) WIRED via four_eyes.actions below; both are human-only
+                                               # (operator-interest-write excludes service accounts outright AND
+                                               # the interest_rest_ext prohibition vetoes them at the allow head;
+                                               # fleet audit found no M2M writer — agent-service's client is
+                                               # read-only). The daily accrual / monthly capitalization schedulers
+                                               # and the remittance settlement consumer call the use cases
+                                               # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                               # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                               # accrual — reduces money movement, standing-order pause precedent.
+                                               # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                               # #3695); four-eyes enforcement stays off fleet-wide
+                                               # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
       - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                                # scaChallenge.consume are both real-payment/self-service actions with a
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1228,6 +1258,57 @@ data:
                                              # (maker != checker), same mechanism as opsmessage.compose.
                                              # m2m-sanctions-screening uses for the opposite carve-out.
         - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
+        - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                             # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                             # point: a wrongly-confirmed mandate authorises every future
+                                             # collection against the debtor. Exact action, not the `approve`
+                                             # verb: the verb would ALSO flag lending.approve (already
+                                             # maker-checker in-app — an OPA second-approver pause on top
+                                             # would stall the designed checker flow the day enforcement
+                                             # flips) and pull non-money-path dispatch.approve into the
+                                             # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                             # the edge rule (edge-service-sdd) deliberately excludes
+                                             # sdd.approve ("a bank-side verification act, the edge exposes
+                                             # no route for it"), operator-sdd-write excludes every
+                                             # service-account-* principal, and the role_action_matrix
+                                             # grants no sdd write at all. The money-moving sdd.authorise
+                                             # is deliberately NOT gated — see the money_path_services
+                                             # entry for the reasoning.
+        - interest.create                   # #8359: bundles every operator write on the interest money
+                                             # path — manual accrue, capitalize (posts real GL journals),
+                                             # rate-config create (a mis-set rate moves money at scale on
+                                             # every future accrual — the runtime analogue of vop's
+                                             # max-edit-distance), and withholding remittance assemble
+                                             # (triggers the real cash leg to the finanční úřad via the
+                                             # settlement consumer). GUARDRAIL check: human-only, twice
+                                             # over — operator-interest-write excludes service-account-*
+                                             # and the interest_rest_ext prohibition vetoes the write set
+                                             # for ANY service account at the allow head; fleet audit found
+                                             # no M2M writer (agent-service's InterestServiceClient is
+                                             # read-only). The accrual/capitalization SCHEDULERS call the
+                                             # use cases in-process — they never pass the HTTP PEP, so this
+                                             # gate cannot pause them.
+        - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
     feature_flags:
       # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "61cd39ceb157abcf"
+        openbank.tech/policy-checksum: "1e66abcb6706a24d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules-opa-data.yaml
+++ b/openbank-libs/governance/rules-opa-data.yaml
@@ -22,13 +22,43 @@ money_path_services:
   - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                            # TransactionServiceClient for every authorised direct-debit collection
                                            # (#1027, merged) — moves funds directly, not adjacent to it like
-                                           # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                           # revisit under issue #938's follow-up sweep.
+                                           # sca/consent/vop below. Threat model:
+                                           # docs/threat-models/openbank-sdd-service.md.
+                                           # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                           # the act that authorises all future debits on a mandate) WIRED via
+                                           # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                           # the bulk authorisation of inbound collections whose DESIGNED caller
+                                           # is clearing automation (sdd_rest_ext.rego header documents that
+                                           # caller is simply not built yet — the consent.activate "plausibly
+                                           # could" case), so gating it today buys nothing (no caller exists)
+                                           # and plants the exact trap the four_eyes.verbs guardrail describes
+                                           # for the day that caller ships. When it does, the operator
+                                           # authorise-by-hand path gets its OWN distinct action and THAT is
+                                           # gated. sdd.create/update/delete are edge-reachable customer
+                                           # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                           # debits only — ungateable per the guardrail, same shape as
+                                           # standing-order order CRUD. The debit itself is event-driven
+                                           # (SddCollectionDebitConsumer), no HTTP PEP on that path.
   - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                            # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                           # (#999, in progress) will book a cash leg via transaction-service.
-                                           # Four-eyes not yet assessed for this service; revisit under issue
-                                           # #938's follow-up sweep.
+                                           # (#999, merged) books a cash leg via transaction-service.
+                                           # Threat model: docs/threat-models/openbank-interest-service.md.
+                                           # four-eyes assessed (#8359): interest.create (manual accrue,
+                                           # capitalize — posts real GL journals, rate-config create — shapes
+                                           # all future accrual amounts, withholding remittance assemble —
+                                           # triggers the real cash leg) and interest.trigger (manual mass
+                                           # accrual) WIRED via four_eyes.actions below; both are human-only
+                                           # (operator-interest-write excludes service accounts outright AND
+                                           # the interest_rest_ext prohibition vetoes them at the allow head;
+                                           # fleet audit found no M2M writer — agent-service's client is
+                                           # read-only). The daily accrual / monthly capitalization schedulers
+                                           # and the remittance settlement consumer call the use cases
+                                           # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                           # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                           # accrual — reduces money movement, standing-order pause precedent.
+                                           # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                           # #3695); four-eyes enforcement stays off fleet-wide
+                                           # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
   - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                            # scaChallenge.consume are both real-payment/self-service actions with a
                                            # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -193,6 +223,57 @@ four_eyes:
                                          # (maker != checker), same mechanism as opsmessage.compose.
                                          # m2m-sanctions-screening uses for the opposite carve-out.
     - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                         # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                         # `verbs` for the same structural reason opsmessage.compose
+                                         # is: party-service is not, and should not become, a
+                                         # money_path_services entry (it moves no value), so the
+                                         # verb clause can never derive a `party` scope and no verb
+                                         # addition could ever reach this action.
+                                         # Why it needs the gate at all: a merge is destructive OF
+                                         # IDENTITY and irreversible in practice — one operator can
+                                         # retire a real customer behind another party id, and every
+                                         # downstream consumer follows `merged_into`. It carried only
+                                         # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                         # which records who did it but stops nobody.
+                                         # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                         # caller. party-service's own rego states party.merge "has NO
+                                         # in-repo M2M caller today"; the edge M2M identity is granted
+                                         # only {party.consent.update, party:resolve} by the rule that
+                                         # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                         # counterpart transaction.merge-sweep is already gated by the
+                                         # `sweep` verb — so both halves of the merge flow now pause
+                                         # for a second approver, or neither does.
+    - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                         # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                         # point: a wrongly-confirmed mandate authorises every future
+                                         # collection against the debtor. Exact action, not the `approve`
+                                         # verb: the verb would ALSO flag lending.approve (already
+                                         # maker-checker in-app — an OPA second-approver pause on top
+                                         # would stall the designed checker flow the day enforcement
+                                         # flips) and pull non-money-path dispatch.approve into the
+                                         # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                         # the edge rule (edge-service-sdd) deliberately excludes
+                                         # sdd.approve ("a bank-side verification act, the edge exposes
+                                         # no route for it"), operator-sdd-write excludes every
+                                         # service-account-* principal, and the role_action_matrix
+                                         # grants no sdd write at all. The money-moving sdd.authorise
+                                         # is deliberately NOT gated — see the money_path_services
+                                         # entry for the reasoning.
+    - interest.create                   # #8359: bundles every operator write on the interest money
+                                         # path — manual accrue, capitalize (posts real GL journals),
+                                         # rate-config create (a mis-set rate moves money at scale on
+                                         # every future accrual — the runtime analogue of vop's
+                                         # max-edit-distance), and withholding remittance assemble
+                                         # (triggers the real cash leg to the finanční úřad via the
+                                         # settlement consumer). GUARDRAIL check: human-only, twice
+                                         # over — operator-interest-write excludes service-account-*
+                                         # and the interest_rest_ext prohibition vetoes the write set
+                                         # for ANY service account at the allow head; fleet audit found
+                                         # no M2M writer (agent-service's InterestServiceClient is
+                                         # read-only). The accrual/capitalization SCHEDULERS call the
+                                         # use cases in-process — they never pass the HTTP PEP, so this
+                                         # gate cannot pause them.
+    - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
 
 feature_flags:
   # Disabling any of these via a flag flip is never permitted — they guard SCA (ADR-0021),

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -736,13 +736,43 @@ money_path_services:
   - openbank-sdd-service                  # issue #1478: SddCollectionDebitConsumer posts a real debit via
                                            # TransactionServiceClient for every authorised direct-debit collection
                                            # (#1027, merged) — moves funds directly, not adjacent to it like
-                                           # sca/consent/vop below. Four-eyes not yet assessed for this service;
-                                           # revisit under issue #938's follow-up sweep.
+                                           # sca/consent/vop below. Threat model:
+                                           # docs/threat-models/openbank-sdd-service.md.
+                                           # four-eyes assessed (#8359): sdd.approve (B2B mandate confirmation —
+                                           # the act that authorises all future debits on a mandate) WIRED via
+                                           # four_eyes.actions below. sdd.authorise assessed, NOT wired: it is
+                                           # the bulk authorisation of inbound collections whose DESIGNED caller
+                                           # is clearing automation (sdd_rest_ext.rego header documents that
+                                           # caller is simply not built yet — the consent.activate "plausibly
+                                           # could" case), so gating it today buys nothing (no caller exists)
+                                           # and plants the exact trap the four_eyes.verbs guardrail describes
+                                           # for the day that caller ships. When it does, the operator
+                                           # authorise-by-hand path gets its OWN distinct action and THAT is
+                                           # gated. sdd.create/update/delete are edge-reachable customer
+                                           # self-service (M2M grant in edge-service-sdd) with effect on FUTURE
+                                           # debits only — ungateable per the guardrail, same shape as
+                                           # standing-order order CRUD. The debit itself is event-driven
+                                           # (SddCollectionDebitConsumer), no HTTP PEP on that path.
   - openbank-interest-service              # issue #1478: capitalize()/write-off post real GL journals
                                            # (LendingJournalFactory-equivalent), and withholding-tax remittance
-                                           # (#999, in progress) will book a cash leg via transaction-service.
-                                           # Four-eyes not yet assessed for this service; revisit under issue
-                                           # #938's follow-up sweep.
+                                           # (#999, merged) books a cash leg via transaction-service.
+                                           # Threat model: docs/threat-models/openbank-interest-service.md.
+                                           # four-eyes assessed (#8359): interest.create (manual accrue,
+                                           # capitalize — posts real GL journals, rate-config create — shapes
+                                           # all future accrual amounts, withholding remittance assemble —
+                                           # triggers the real cash leg) and interest.trigger (manual mass
+                                           # accrual) WIRED via four_eyes.actions below; both are human-only
+                                           # (operator-interest-write excludes service accounts outright AND
+                                           # the interest_rest_ext prohibition vetoes them at the allow head;
+                                           # fleet audit found no M2M writer — agent-service's client is
+                                           # read-only). The daily accrual / monthly capitalization schedulers
+                                           # and the remittance settlement consumer call the use cases
+                                           # IN-PROCESS, so the HTTP-layer gate never touches automation.
+                                           # interest.delete (deactivateRateConfig) NOT wired: it stops future
+                                           # accrual — reduces money movement, standing-order pause precedent.
+                                           # interest.read/list are reads. Runs AUTHZ_ENFORCE=true (flipped in
+                                           # #3695); four-eyes enforcement stays off fleet-wide
+                                           # (authz.four-eyes.enforce, ADR-0155) — wiring sets the flag only.
   - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
                                            # scaChallenge.consume are both real-payment/self-service actions with a
                                            # confirmed M2M automated caller (customer-edge) — gating either would brick
@@ -1066,6 +1096,41 @@ four_eyes:
                                          # counterpart transaction.merge-sweep is already gated by the
                                          # `sweep` verb — so both halves of the merge flow now pause
                                          # for a second approver, or neither does.
+    - sdd.approve                       # #8359: confirm a B2B direct-debit mandate
+                                         # (POST /api/v1/sdd/mandates/{id}/confirm) — the SDD B2B control
+                                         # point: a wrongly-confirmed mandate authorises every future
+                                         # collection against the debtor. Exact action, not the `approve`
+                                         # verb: the verb would ALSO flag lending.approve (already
+                                         # maker-checker in-app — an OPA second-approver pause on top
+                                         # would stall the designed checker flow the day enforcement
+                                         # flips) and pull non-money-path dispatch.approve into the
+                                         # four-eyes-verb-grantable gate. GUARDRAIL check: human-only —
+                                         # the edge rule (edge-service-sdd) deliberately excludes
+                                         # sdd.approve ("a bank-side verification act, the edge exposes
+                                         # no route for it"), operator-sdd-write excludes every
+                                         # service-account-* principal, and the role_action_matrix
+                                         # grants no sdd write at all. The money-moving sdd.authorise
+                                         # is deliberately NOT gated — see the money_path_services
+                                         # entry for the reasoning.
+    - interest.create                   # #8359: bundles every operator write on the interest money
+                                         # path — manual accrue, capitalize (posts real GL journals),
+                                         # rate-config create (a mis-set rate moves money at scale on
+                                         # every future accrual — the runtime analogue of vop's
+                                         # max-edit-distance), and withholding remittance assemble
+                                         # (triggers the real cash leg to the finanční úřad via the
+                                         # settlement consumer). GUARDRAIL check: human-only, twice
+                                         # over — operator-interest-write excludes service-account-*
+                                         # and the interest_rest_ext prohibition vetoes the write set
+                                         # for ANY service account at the allow head; fleet audit found
+                                         # no M2M writer (agent-service's InterestServiceClient is
+                                         # read-only). The accrual/capitalization SCHEDULERS call the
+                                         # use cases in-process — they never pass the HTTP PEP, so this
+                                         # gate cannot pause them.
+    - interest.trigger                  # #8359: accrueAll (POST /api/v1/interest/accrue/all) — manual
+                                         # mass accrual posting GL journals en masse. Same human-only
+                                         # caller set as interest.create above (same allow rule, same
+                                         # prohibition). The daily accrual scheduler is in-process and
+                                         # unaffected.
 
 # ---------------------------------------------------------------------------------------
 # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)


### PR DESCRIPTION
Closes #8359. Refs #938, #1478, #999.

## Four-eyes assessment: sdd-service + interest-service

Per-verb caller audit per the ADR-0034 D-criteria as applied in the #938 sweep. Both services were
in `money_path_services` since #1478 with "four-eyes not yet assessed".

### sdd-service

| Action | Surface | Caller set | Decision |
|---|---|---|---|
| `sdd.approve` | POST /mandates/{id}/confirm (B2B confirmation) | **human-only** — edge grant excludes it deliberately; `operator-sdd-write` excludes `service-account-*`; matrix grants no sdd write | **WIRED** via `four_eyes.actions` |
| `sdd.authorise` | POST /collections/authorise — the decision that books the debit | none today; designed caller is clearing **bulk automation** (not built yet, documented in `sdd_rest_ext.rego`) | **NOT wired** — consent.activate "plausibly could" precedent; when the clearing caller ships, the operator by-hand path gets its own distinct action and THAT is gated |
| `sdd.create/update/delete` | mandate CRUD | edge M2M (customer self-service) | ungateable per guardrail; effect is future debits (standing-order precedent) |
| `sdd.read/list` | reads | — | n/a |

Verb `approve` was rejected in favour of the exact action: it would also flag `lending.approve`
(already maker-checker in-app — an OPA pause on top would stall the designed checker flow) and pull
non-money-path `dispatch.approve` into the four-eyes-verb-grantable gate.

### interest-service

| Action | Surface | Caller set | Decision |
|---|---|---|---|
| `interest.create` | manual accrue / **capitalize (real GL journals)** / rate-config create / **remittance assemble (real cash leg)** | **human-only, twice over** — allow rule excludes service accounts AND `interest_rest_ext` prohibition vetoes them at the allow head; no M2M writer (agent-service client read-only) | **WIRED** via `four_eyes.actions` |
| `interest.trigger` | accrueAll — manual mass accrual | same | **WIRED** via `four_eyes.actions` |
| `interest.delete` | deactivateRateConfig | human-only | NOT wired — stops future accrual, reduces money movement (standing-order pause precedent) |

The accrual/capitalization **schedulers and the remittance settlement consumer call the use cases
in-process** — they never pass the HTTP PEP, so the gate cannot pause automation.

### Scope of change

- `rules.yaml`: assessment comments on both `money_path_services` entries (replacing the stale
  "not yet assessed" notes); three new `four_eyes.actions` entries with guardrail justifications.
- `rules-opa-data.yaml`: regenerated (`gen-rules-opa-data.py --check` green).
- Threat models: dated change-log entries in both; the sdd one also corrects the stale
  "AUTHZ_ENFORCE is false — advisory" claim (flipped to `true` 2026-08-10 in #4427).

### Verification

- `opa eval` over rest.rego + regenerated rules-opa-data: `four_eyes_required` = **true** for
  `sdd.approve`, `interest.create`, `interest.trigger`; **undefined** for `sdd.authorise`,
  `interest.delete`; unchanged for existing verbs (`ledger.post` still true).
- `check-four-eyes-verb-grantable.py --enforce` PASS (SUBJECTS=25, no new ungranted).
- `check-opa-bundle-parses.py` PASS (43 bundles). `opa test policies/` 103/106 — the 3 failures are
  agent-bridge tests that fail identically on a clean tree (pre-existing, unrelated).
- No runtime effect today: four-eyes enforcement stays off fleet-wide (`authz.four-eyes.enforce`,
  ADR-0155) — the wiring sets the decision flag only.

### Rollback

Revert this commit (removes the three flags; no data, no schema, no deployed-state change).
