### PR TITLE
feat(ci): Semgrep IaC security lane — Dockerfile + manifest rules

### DIFF
--- a/.github/workflows/main-red-watch.yml
+++ b/.github/workflows/main-red-watch.yml
@@ -55,6 +55,9 @@ on:
       - "Dependency submission"
       - "Gradle wrapper validation"
       - "Release Please"
+      # ADR-0279 #16/#20: the Semgrep IaC lane is a security gate; its red on main is a
+      # container/manifest regression and must not stay silent.
+      - "Semgrep IaC security"
       # Pushes to main unconditionally (issue #4240). Its red is meaningful in a way worth
       # naming: it means the watch could NOT read the ruleset bypass log — a permission-shaped
       # absence, not "nothing was bypassed". Exactly the state that must not stay silent.

--- a/.github/workflows/semgrep-iac.yml
+++ b/.github/workflows/semgrep-iac.yml
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# Semgrep IaC security lane (ADR-0279 #16/#20, issue #8590).
+#
+# Scans the container and manifest surface — every Dockerfile and every YAML manifest —
+# with the repo-local rules in .semgrep/rules/. The engine is GA-strong on
+# Dockerfile/YAML; Kotlin fleet patterns deliberately stay with the Python gates
+# (Semgrep's Kotlin support is experimental and lost the annotation-context bake-off,
+# measured 2026-09-03 — that is recorded in .semgrep/rules/openbank-iac.yml's header).
+#
+# The gate is ENFORCED from day one: the measured corpus was 1,108 files with exactly one
+# finding, and that one (the CI runner image's build-time USER root) carries a documented
+# in-place nosemgrep exception. A finding from here on is a real defect, not noise.
+#
+# Engine pinned by digest (the K6_IMAGE precedent): a version tag alone is mutable.
+name: Semgrep IaC security
+
+on:
+  pull_request:
+    paths:
+      - "**/Dockerfile"
+      - "**/*.yaml"
+      - "**/*.yml"
+      - ".semgrep/**"
+      - ".github/workflows/semgrep-iac.yml"
+  push:
+    branches: [main]
+    paths:
+      - "**/Dockerfile"
+      - "**/*.yaml"
+      - "**/*.yml"
+      - ".semgrep/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: semgrep-iac-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep-iac:
+    name: semgrep-iac
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # semgrep/semgrep:1.99.0 @ 2026-09-03 linux/amd64.
+      - name: Semgrep scan (Dockerfile + YAML manifests)
+        run: |
+          set -euo pipefail
+          docker run --rm -v "$PWD:/src" \
+            semgrep/semgrep@sha256:ae27024c16f7848cdbfd49c24ed0b78b13f13b85fcd7b87c679aaa8b0c0dce98 \
+            semgrep scan --config /src/.semgrep/rules/openbank-iac.yml \
+              --include="Dockerfile" --include="*.yaml" --include="*.yml" \
+              --exclude="node_modules" --exclude="**/build/**" \
+              --metrics=off --error /src

--- a/.semgrep/rules/openbank-iac.yml
+++ b/.semgrep/rules/openbank-iac.yml
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# OpenBank IaC security rules (ADR-0279 #16/#20) — Semgrep, pinned engine in CI.
+#
+# WHY SEMGREP HERE AND NOT THE PYTHON GATES: the fleet-pattern Python gates own
+# Kotlin/Quarkus source conventions (Semgrep's Kotlin support is experimental and lost
+# the annotation-context bake-off — measured 2026-09-03 on the scheduled-runBlocking and
+# Instant.EPOCH shapes, 0 findings on known-bad samples). Semgrep is GA-strong on
+# Dockerfile and YAML, which is exactly where no gate looked before: the container and
+# manifest surface (#16 container audit, #20 policy-as-code on IaC).
+#
+# Positive-detection rules only: Semgrep YAML cannot express "key X is missing", so
+# requirements like runAsNonRoot stay with the Kyverno admission policies that enforce
+# them at deploy time. These rules catch the shapes that must NEVER appear.
+rules:
+  - id: dockerfile-add-not-copy
+    languages: [dockerfile]
+    severity: WARNING
+    pattern: ADD $SRC $DST
+    message: >-
+      Use COPY, not ADD. ADD silently unpacks archives and fetches URLs — an implicit
+      behavior a supply-chain review should never have to rule out (ADR-0279 #16).
+
+  - id: dockerfile-latest-tag
+    languages: [dockerfile]
+    severity: ERROR
+    pattern-regex: 'FROM\s+\S+:latest(\s|$)'
+    message: >-
+      Never FROM :latest — the base image is part of the build's identity; pin by digest
+      like every other image reference in this estate.
+
+  - id: dockerfile-root-user
+    languages: [dockerfile]
+    severity: ERROR
+    pattern-regex: '^\s*USER\s+root\s*$'
+    message: >-
+      USER root in a service image. Runtime policies require non-root; a root USER line is
+      a defect that ships.
+
+  - id: k8s-latest-tag
+    languages: [yaml]
+    severity: ERROR
+    pattern-regex: 'image:\s*\S+:latest\s*$'
+    message: >-
+      Never deploy :latest — images are digest-pinned (ADR-0088). A mutable tag makes the
+      deployed bytes unauditable after the fact.
+
+  - id: k8s-privileged
+    languages: [yaml]
+    severity: ERROR
+    pattern: "privileged: true"
+    message: >-
+      privileged: true is never allowed in this estate — Kyverno rejects it at admission;
+      it must not reach the cluster in the first place (ADR-0279 #20).
+
+  - id: k8s-host-namespace
+    languages: [yaml]
+    severity: ERROR
+    pattern-either:
+      - pattern: "hostNetwork: true"
+      - pattern: "hostPID: true"
+      - pattern: "hostIPC: true"
+    message: >-
+      Host namespace sharing (hostNetwork/hostPID/hostIPC) breaks the pod isolation model;
+      nothing in this estate is allowed to need it.

--- a/openbank-infra/aws/envs/sandbox-platform/runner-image/Dockerfile
+++ b/openbank-infra/aws/envs/sandbox-platform/runner-image/Dockerfile
@@ -66,6 +66,10 @@
 # ghcr.io/actions/actions-runner:latest @ 2026-06-01 (multi-arch index digest).
 FROM ghcr.io/actions/actions-runner@sha256:e5496277be5d09bc968b3d64911b74e219ac4a3f2edce956a3ecf9271bea1ef4
 
+# Build-time tool installation; the actions-runner entrypoint drops to the runner user.
+# Service images are held to the no-root rule; this is the one documented exception,
+# visible at the site rather than in a CI exclude list.
+# nosemgrep: dockerfile-root-user
 USER root
 
 # --- pinned tool versions + arm64 sha256 ----------------------------------


### PR DESCRIPTION
## Summary
ADR-0279 **#16/#20** (first Semgrep adoption, approved): an enforced CI lane over the container + manifest surface:

- **`.semgrep/rules/openbank-iac.yml`** — 6 rules: `ADD`-not-`COPY`, `FROM :latest`, `USER root`, K8s `:latest` image, `privileged: true`, host namespaces
- **`.github/workflows/semgrep-iac.yml`** — PR/push gate, engine pinned by digest, `--error` enforced from day one
- **Honest scope decision** (documented in the rules header): Semgrep Kotlin is experimental and lost the bake-off on our two target patterns (`@Scheduled`+runBlocking, `Instant.EPOCH` default — 0 findings on known-bad samples), so Kotlin fleet patterns stay with the Python gates; Semgrep owns Dockerfile/YAML where it's GA-strong
- One measured finding in the whole repo: runner image's build-time `USER root` — legitimate, now carrying a documented in-place `# nosemgrep` exception

Refs #8590

## Test plan
- [x] All rules fired on known-bad samples (local docker, pinned engine)
- [x] Full-repo scan: 1,109 files, 1 finding (the documented exception), exit 0 after exception
- [ ] CI