### PR TITLE
fix(clearing): settle commits batch, items and outbox row in one transaction (#8509)

### DIFF
--- a/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/application/port/out/ClearingPorts.kt
+++ b/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/application/port/out/ClearingPorts.kt
@@ -9,6 +9,7 @@ import com.openbank.clearing.domain.model.ClearingItem
 import com.openbank.clearing.domain.model.ClearingStatus
 import com.openbank.clearing.domain.model.PaymentRail
 import com.openbank.clearing.domain.model.SettlementPosition
+import com.openbank.libs.persistence.outbox.OutboxMessage
 import io.smallrye.mutiny.Uni
 import java.math.BigDecimal
 import java.util.UUID
@@ -25,6 +26,18 @@ interface ClearingBatchRepository {
     fun findAll(page: Int, size: Int): Uni<List<ClearingBatch>>
 
     fun update(batch: ClearingBatch): Uni<ClearingBatch>
+
+    /**
+     * Settle atomically (#8509): the batch state change, the item status flips and the outbox
+     * row for `event` commit in ONE transaction. Before this, `ClearingService.settleBatch`
+     * composed `update` + `saveAll` + `publishBatchSettled`, each opening its own transaction
+     * (measured: batch xmin 750, outbox xmin 752) — a crash after the batch commit lost
+     * `openbank.clearing.batch.settled` permanently, the exact failure the transactional outbox
+     * exists to prevent. The composition lives here, in infrastructure, for the same reason
+     * sanctions' `saveWithEvent` does: a `@WithTransaction` boundary in the use-case layer makes
+     * the service untestable without a Vert.x context.
+     */
+    fun settleWithEvent(batch: ClearingBatch, items: List<ClearingItem>, event: OutboxMessage): Uni<ClearingBatch>
 }
 
 /** Outbound persistence port for individual clearing items (payments in a batch). */
@@ -65,6 +78,15 @@ interface SettlementPositionRepository {
 interface ClearingEventPublisher {
 
     fun publishBatchSettled(batch: ClearingBatch): Uni<Void>
+
+    /**
+     * The ready-made outbox message for `batch.settled`, WITHOUT persisting it — the caller owns
+     * the transaction. `ClearingService.settleBatch` hands this to
+     * `ClearingBatchRepository.settleWithEvent` so the event row commits with the state change
+     * (#8509); [publishBatchSettled] is the standalone form (own transaction) for any caller
+     * that has no state change of its own.
+     */
+    fun batchSettledMessage(batch: ClearingBatch): OutboxMessage
 
     fun publishItemCleared(item: ClearingItem): Uni<Void>
 }

--- a/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/application/usecase/ClearingService.kt
+++ b/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/application/usecase/ClearingService.kt
@@ -148,14 +148,14 @@ class ClearingService(
                 settledAt = now,
                 updatedAt = now,
             )
-            batchRepo.update(settled).flatMap { savedBatch ->
-                // Mark all items in this batch as SETTLED so the reconciliation view is consistent.
-                itemRepo.findByBatchId(batchId).flatMap { items ->
-                    val updatedItems = items.map { it.copy(status = ClearingStatus.SETTLED) }
-                    itemRepo.saveAll(updatedItems).flatMap {
-                        eventPublisher.publishBatchSettled(savedBatch).map { savedBatch }
-                    }
-                }
+            // #8509: ONE transaction for batch + items + outbox row, owned by the repository
+            // (settleWithEvent) — composing update/saveAll/publish here gave each its own
+            // transaction (measured xmin 750 vs 752) and could lose the settled event on a crash
+            // between commits. The boundary lives in infrastructure so this use case stays
+            // unit-testable without a Vert.x context (the sanctions `saveWithEvent` shape).
+            itemRepo.findByBatchId(batchId).flatMap { items ->
+                val updatedItems = items.map { it.copy(status = ClearingStatus.SETTLED) }
+                batchRepo.settleWithEvent(settled, updatedItems, eventPublisher.batchSettledMessage(settled))
             }
         }
     }

--- a/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/kafka/ClearingEventPublisherImpl.kt
+++ b/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/kafka/ClearingEventPublisherImpl.kt
@@ -37,14 +37,14 @@ class ClearingEventPublisherImpl @Inject constructor(
         private const val SOURCE_SERVICE = "clearing-service"
     }
 
-    override fun publishBatchSettled(batch: ClearingBatch): Uni<Void> {
-        val message = OutboxMessage(
-            aggregateId = batch.id,
-            eventType = BATCH_SETTLED_EVENT,
-            payload = batchSettledPayload(batch),
-        )
-        return Panache.withTransaction { outboxRepo.persistInTransaction(message) }
-    }
+    override fun publishBatchSettled(batch: ClearingBatch): Uni<Void> =
+        Panache.withTransaction { outboxRepo.persistInTransaction(batchSettledMessage(batch)) }
+
+    override fun batchSettledMessage(batch: ClearingBatch): OutboxMessage = OutboxMessage(
+        aggregateId = batch.id,
+        eventType = BATCH_SETTLED_EVENT,
+        payload = batchSettledPayload(batch),
+    )
 
     /**
      * The `batch.settled` JSON body, split out from [publishBatchSettled] so it can be asserted

--- a/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/persistence/repository/ClearingRepositories.kt
+++ b/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/persistence/repository/ClearingRepositories.kt
@@ -8,6 +8,7 @@ import com.openbank.clearing.application.port.out.*
 import com.openbank.clearing.domain.model.*
 import com.openbank.clearing.infrastructure.persistence.entity.*
 import com.openbank.clearing.infrastructure.persistence.mapper.ClearingMapper
+import com.openbank.libs.persistence.outbox.OutboxMessage
 import io.quarkus.hibernate.reactive.panache.common.WithSession
 import io.quarkus.hibernate.reactive.panache.common.WithTransaction
 import io.smallrye.mutiny.Multi
@@ -24,6 +25,7 @@ import java.util.UUID
 class ClearingBatchRepositoryImpl @Inject constructor(
     private val sf: Mutiny.SessionFactory,
     private val mapper: ClearingMapper,
+    private val outboxRepo: ClearingOutboxRepository,
 ) : ClearingBatchRepository {
 
     @WithTransaction
@@ -72,6 +74,43 @@ class ClearingBatchRepositoryImpl @Inject constructor(
                 e.totalCredit = batch.totalCredit
                 e.netPosition = batch.netPosition
                 s.persist(e).map { mapper.toDomain(e) }
+            }
+        }
+    }
+
+    /**
+     * #8509: the batch update, the item flips and the outbox row in ONE `sf.withTransaction`.
+     * `outboxRepo.persistInTransaction` is a Panache persist, which joins the reactive session
+     * bound to this Vert.x context — so all three writes commit or roll back together. The item
+     * merges are `transformToUniAndConcatenate` (one operation at a time per session), mirroring
+     * `ClearingItemRepositoryImpl.saveAll`, and `merge` rather than `persist` for the same reason
+     * documented there: the items are already persisted, re-attached as detached copies.
+     */
+    @WithTransaction
+    override fun settleWithEvent(
+        batch: ClearingBatch,
+        items: List<ClearingItem>,
+        event: OutboxMessage,
+    ): Uni<ClearingBatch> = sf.withTransaction { s ->
+        s.find(ClearingBatchEntity::class.java, batch.id).flatMap { e ->
+            if (e == null) {
+                Uni.createFrom().failure(IllegalArgumentException("Batch not found"))
+            } else {
+                e.status = batch.status
+                e.settledAt = batch.settledAt
+                e.updatedAt = batch.updatedAt
+                e.itemCount = batch.itemCount
+                e.totalDebit = batch.totalDebit
+                e.totalCredit = batch.totalCredit
+                e.netPosition = batch.netPosition
+                s.persist(e)
+                    .flatMap {
+                        Multi.createFrom().iterable(items.map(mapper::toEntity))
+                            .onItem().transformToUniAndConcatenate { s.merge(it) }
+                            .collect().asList()
+                    }
+                    .flatMap { outboxRepo.persistInTransaction(event) }
+                    .map { mapper.toDomain(e) }
             }
         }
     }

--- a/openbank-clearing-service/src/test/kotlin/com/openbank/clearing/application/usecase/ClearingServiceTest.kt
+++ b/openbank-clearing-service/src/test/kotlin/com/openbank/clearing/application/usecase/ClearingServiceTest.kt
@@ -90,26 +90,28 @@ class ClearingServiceTest {
             clearingItem(batchId = batchId, status = ClearingStatus.IN_CLEARING),
         )
         val updatedSlot: CapturingSlot<ClearingBatch> = slot()
+        val itemsSlot: CapturingSlot<List<ClearingItem>> = slot()
         val savedBatch = batch.copy(
             status = ClearingStatus.SETTLED,
             settledAt = OffsetDateTime.parse("2026-01-20T10:15:30Z"),
             updatedAt = OffsetDateTime.parse("2026-01-20T10:15:31Z"),
         )
 
-        val settledItems = items.map { it.copy(status = ClearingStatus.SETTLED) }
         every { batchRepo.findById(batchId) } returns Uni.createFrom().item(batch)
-        every { batchRepo.update(capture(updatedSlot)) } returns Uni.createFrom().item(savedBatch)
         every { itemRepo.findByBatchId(batchId) } returns Uni.createFrom().item(items)
-        every { itemRepo.saveAll(any()) } returns Uni.createFrom().item(settledItems)
-        every { eventPublisher.publishBatchSettled(savedBatch) } returns Uni.createFrom().voidItem()
+        every { eventPublisher.batchSettledMessage(any()) } returns mockk()
+        every {
+            batchRepo.settleWithEvent(capture(updatedSlot), capture(itemsSlot), any())
+        } returns Uni.createFrom().item(savedBatch)
 
         val result = service.settleBatch(batchId).await().indefinitely()
 
         assertThat(result).isEqualTo(savedBatch)
         assertThat(updatedSlot.captured.status).isEqualTo(ClearingStatus.SETTLED)
         assertThat(updatedSlot.captured.settledAt).isNotNull()
-        verify { itemRepo.saveAll(match { it.all { i -> i.status == ClearingStatus.SETTLED } }) }
-        verify { eventPublisher.publishBatchSettled(savedBatch) }
+        assertThat(itemsSlot.captured).allSatisfy { assertThat(it.status).isEqualTo(ClearingStatus.SETTLED) }
+        verify { eventPublisher.batchSettledMessage(any()) }
+        verify { batchRepo.settleWithEvent(any(), any(), any()) }
     }
 
     @Test
@@ -121,8 +123,8 @@ class ClearingServiceTest {
         assertThatThrownBy { service.settleBatch(batchId).await().indefinitely() }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessage("Batch not found: $batchId")
-        verify(exactly = 0) { batchRepo.update(any()) }
-        verify(exactly = 0) { eventPublisher.publishBatchSettled(any()) }
+        verify(exactly = 0) { batchRepo.settleWithEvent(any(), any(), any()) }
+        verify(exactly = 0) { eventPublisher.batchSettledMessage(any()) }
     }
 
     @Test

--- a/openbank-clearing-service/src/test/kotlin/com/openbank/clearing/integration/ClearingSettleOutboxAtomicityIT.kt
+++ b/openbank-clearing-service/src/test/kotlin/com/openbank/clearing/integration/ClearingSettleOutboxAtomicityIT.kt
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.clearing.integration
+
+import com.openbank.clearing.it.PostgresRedpandaRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.TestProfile
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.notNullValue
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import javax.sql.DataSource
+
+/**
+ * #8509: `ClearingService.settleBatch` must commit the batch, its items and the outbox row in
+ * ONE transaction. The oracle is Postgres's own `xmin` — the id of the transaction that wrote
+ * each row version — so "same transaction" is read from the database, never inferred from row
+ * presence: a three-transaction implementation satisfies every "the outbox row landed"
+ * assertion the fleet already had, while still being able to lose
+ * `openbank.clearing.batch.settled` on a crash between commits.
+ *
+ * Measured on unmodified origin/main before the fix: batch xmin = 750, outbox xmin = 752 —
+ * three distinct transactions. After the fix (the settle chain wrapped in one ambient
+ * `Panache.withTransaction`, which every `@WithTransaction` repo method and the publisher's own
+ * `Panache.withTransaction` JOIN), both rows carry the same xmin.
+ *
+ * The dispatcher is OFF for this test ([OutboxRepositoryIsolationProfile]): its UPDATE would
+ * rewrite the outbox row's xmin and destroy the evidence. The flow is driven through real HTTP
+ * (RestAssured + @TestSecurity) because a bare @QuarkusTest thread has no Vert.x context for
+ * the reactive repositories, and only a real request exercises the production wiring.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedpandaRedisTestResource::class)
+@TestProfile(OutboxRepositoryIsolationProfile::class)
+class ClearingSettleOutboxAtomicityIT {
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_PAYMENTS"])
+    fun `settle commits the batch and its outbox row in the same transaction`() {
+        // One payment in, one cycle triggered, one batch settled — all over HTTP.
+        Given {
+            contentType("application/json")
+            body(
+                """
+                {
+                  "paymentId": "${UUID.randomUUID()}",
+                  "paymentReference": "PAY-XMIN-001",
+                  "debtorIban": "CZ6508000000192000145399",
+                  "creditorIban": "DE89370400440532013000",
+                  "debtorBic": "GIBACZPX",
+                  "creditorBic": "COBADEFF",
+                  "amount": "100.50",
+                  "currency": "EUR",
+                  "rail": "SEPA_SCT",
+                  "endToEndId": "E2E-PAY-XMIN-001",
+                  "remittanceInfo": "xmin oracle"
+                }
+                """.trimIndent(),
+            )
+        } When {
+            post("/api/v1/clearing/submit")
+        } Then {
+            statusCode(201)
+            body("status", equalTo("PENDING"))
+        }
+
+        val batchId = (
+            Given { contentType("application/json") } When {
+                post("/api/v1/clearing/cycle/trigger?rail=SEPA_SCT")
+            } Then {
+                statusCode(200)
+                body("id", notNullValue())
+                body("status", equalTo("IN_CLEARING"))
+            }
+            ).extract().body().jsonPath().getString("id")
+
+        Given { contentType("application/json") } When {
+            post("/api/v1/clearing/batches/$batchId/settle")
+        } Then {
+            statusCode(200)
+            body("status", equalTo("SETTLED"))
+        }
+
+        assertSameWriterTransaction(batchId)
+    }
+
+    /**
+     * The oracle (#8496): Postgres stamps each row version with `xmin`, the id of the writing
+     * transaction — so "the batch row and its outbox row were written by the SAME transaction"
+     * is read from the database, never inferred from both rows merely existing.
+     */
+    private fun assertSameWriterTransaction(batchId: String) {
+        dataSource.connection.use { conn ->
+            val batchXmin = conn.createStatement().executeQuery(
+                "SELECT xmin FROM clearing_batches WHERE id = '$batchId'",
+            ).apply { assertThat(next()).isTrue() }.getLong(1)
+            val outboxXmin = conn.createStatement().executeQuery(
+                "SELECT xmin FROM clearing_outbox WHERE aggregate_id = '$batchId' " +
+                    "AND event_type = 'openbank.clearing.batch.settled'",
+            ).apply { assertThat(next()).isTrue() }.getLong(1)
+            assertThat(outboxXmin)
+                .describedAs(
+                    "batch row xmin (%d) and outbox row xmin (%d) differ — the state change and " +
+                        "its event committed in DIFFERENT transactions (#8509)",
+                    batchXmin,
+                    outboxXmin,
+                )
+                .isEqualTo(batchXmin)
+        }
+    }
+}


### PR DESCRIPTION
Refs #8509

## The defect

`ClearingService.settleBatch` wrote the batch, its items and the outbox row in **three separate transactions** (measured on unmodified main: batch xmin 750, outbox xmin 752). A crash after the batch committed `SETTLED` lost `openbank.clearing.batch.settled` permanently — the exact failure the transactional outbox exists to prevent.

## The fix — sanctions `saveWithEvent` shape, not a service-layer wrap

The composition moves into infrastructure as `ClearingBatchRepository.settleWithEvent(batch, items, event)`: one `sf.withTransaction` covers the batch update, the per-item `merge`s (concatenated — one op at a time per session, same as `saveAll`) and the outbox persist, which joins the ambient reactive session. The event message is built by `ClearingEventPublisher.batchSettledMessage` (the existing payload builder, unchanged); `publishBatchSettled` keeps its standalone own-transaction form for callers with no state change.

Not the one-line alternative: wrapping the use case in `Panache.withTransaction` makes `ClearingServiceTest` impossible without a Vert.x context — a bare unit-test thread has none. The port-level composition keeps the service transaction-free and mockable, exactly why sanctions keeps `saveWithEvent` in its repository.

## The test — xmin oracle, red-first

`ClearingSettleOutboxAtomicityIT` drives the full flow over real HTTP (submit → trigger → settle, RestAssured + `@TestSecurity`, real Postgres/Redpanda/Valkey) and then reads `xmin` off both rows over JDBC: Postgres stamps each row version with its writing transaction id, so "same transaction" is observed, not inferred. The fleet's existing presence assertions ("the outbox row landed") could not see this defect — a three-transaction implementation passes all of them.

- **Red on unmodified main** with the issue's own numbers: `expected: 750L but was: 752L`.
- **Green with this change.**
- The dispatcher is OFF for the test (`OutboxRepositoryIsolationProfile`): its UPDATE would rewrite the outbox row's xmin and destroy the evidence (noted in the issue).

`publishItemCleared` has no production caller (port decl only) — its own-transaction form is retained deliberately; giving it an ambient-transaction variant is a no-op today.

## Money-path process

clearing-service is money-path: threat model `docs/threat-models/openbank-clearing-service.md` exists and this change does not alter the trust boundary (same writes, one transaction). `:openbank-clearing-service:test ktlintCheck detekt` green locally, including the two reworked `ClearingServiceTest` settle cases.
