### PR TITLE
docs(security): operational runbooks 0019-0022 + maintainer WebAuthn hardening

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -113,6 +113,16 @@ This repository enforces:
 - Pre-commit hooks blocking common secret patterns.
 - No `.env` files, private keys, certificates, or PII in repository (enforced by `.gitignore` + `.gitleaks.toml`).
 
+### Maintainer Authentication Hardening (ADR-0279 #19)
+
+The repository's strongest control is only as strong as the weakest maintainer login, so maintainer-facing authentication is held to a higher bar than the code:
+
+- **Phishing-resistant MFA required.** Maintainers and org admins authenticate with WebAuthn/passkeys (hardware security keys) as the primary second factor. TOTP is an accepted fallback only during onboarding; SMS is never acceptable.
+- **Two keys per maintainer.** Every maintainer registers a primary and a backup hardware key, so a lost key is a rotation event, not an account-recovery event. Recovery codes are stored offline.
+- **Privileged actions re-authenticate.** Releases (release-please merge), ruleset changes, and Security Advisory publication are performed in a fresh, recently-authenticated session — a stolen long-lived cookie must not be enough to ship code to `main`.
+- **Quarterly attestation.** The maintainer list, key registrations, and org admin roster are reviewed quarterly against HR/engagement records; departed maintainers lose access the same day (recorded in the review notes).
+- **Signed commits are identity, not formality.** The GPG/SSH signing requirement above exists so that a compromised GitHub session alone cannot forge a maintainer's authorship; treat unsigned commits on `main` as an incident signal.
+
 ## Hardening Guidance for Deployers
 
 If you are deploying OpenBank in any non-development environment, **you are responsible for**:

--- a/docs/runbooks/0019-internal-pentest-cadence.md
+++ b/docs/runbooks/0019-internal-pentest-cadence.md
@@ -1,0 +1,56 @@
+# Runbook 0019: Interní penetrační test — čtvrtletní kadence
+
+> ADR-0279 workstream 1, bod #1. Majitel: security lead. Kadence: **každé Q**,
+> money-path scénář **každý měsíc** (rotuje se službou). Cíl není „projít pentest",
+> ale **každý finding proměnit v trvalý gate** — jinak se za rok testuje totéž.
+
+## Rozsah a rotace
+
+| Cyklus | Cíl | Východisko |
+|---|---|---|
+| Q1 | authn/authz hrana (Keycloak, delegation, customer-edge) | threat model `docs/threat-models/` |
+| Q2 | money-path (ledger, sepa-payment, domestic-payment, card-issuance) | `rules.yaml: money_path_services` |
+| Q3 | supply chain & CI/CD (runnery, release-evidence, cosign) | ADR-0279 WS3 |
+| Q4 | multi-tenant izolace + audit/audit-anchor integrita | ADR-0031 |
+
+Měsíční mini-lov: jedna money-path služba, jeden den, focus = poslední změny
+od minulého lovu (`git log --since` nad službou).
+
+## Postup (jedna iterace)
+
+1. **Příprava (T-7 dní).** Vyber scénáře z threat modelu příslušné služby.
+   Zakaž na dobu testu paging na testovaném prostředí (sandbox), ale **nech
+   alert pipeline zapnutou** — detekce je součást skóre (bod 6).
+2. **Provedení.** Manuální test nad sandboxem. Nástroje: schemathesis (fuzz
+   existuje ve fleet CI — vrať se k jeho artifactům), Burp/ZAP pro authz
+   matice, vlastní skripty pro business-logic zneužití (limit bypass,
+   delegační eskalace, idempotence replay).
+3. **Záznam.** Každý finding = issue s labely `security`, `pentest-finding`,
+   severitou a reprodukčním krokem. Žádný finding nežije jen v reportu.
+4. **Triage do 5 pracovních dnů.** critical/high → hotfix PR; medium/low →
+   plánovaný sweep.
+5. **Uzávěrka findingů (tvrdé pravidlo).** Finding není „fixed" opravou —
+   je fixed **gate nebo testem**, který by ho chytil příště: contract test,
+   fuzz pravidlo, `check-*.py` gate, OPA politika. Finding bez trvalé
+   kontroly zůstává otevřený s labelem `needs-permanent-control`.
+6. **Detekční skóre.** Pro každý finding zapiš, zda ho security rule pack
+   (`loki-rules-security-signals.yaml`, `prometheus-rules-security-signals.yaml`)
+   nebo Falco **viděl během testu**. Neviděl = souběžný observability finding
+   (viz runbook 0021 pro purple-team návaznost).
+7. **Report.** Čtvrtletní souhrn do `docs/security/pentest/YYYY-Qn.md`:
+   scénáře, findings, detekční skóre, splaněné trvalé kontroly. Tento soubor
+   je evidence pro CRA (runbook 0017/0018) a SOC 2.
+
+## Co pentest NENÍ
+
+- Není to DAST scan — ten běží v CI průběžně (schemathesis lane, ADR-0279 #2).
+- Není to tabletop — krizová procedura se cvičí v runbooku 0018.
+- Produktový pentest třetí stranou supluje externí audit (1× ročně), nikoli
+  tuto interní kadenci.
+
+## Kritéria úspěchu
+
+- 100 % critical/high findingů má trvalou kontrolu do 30 dnů.
+- Detekční skóre roste kvartál od kvartálu; baseline se zapisuje do prvního reportu.
+- Žádný scénář se neopakuje dvě Q po sobě beze změny (jinak se testuje naučená
+  odpověď, ne systém).

--- a/docs/runbooks/0020-security-chaos-drill.md
+++ b/docs/runbooks/0020-security-chaos-drill.md
@@ -1,0 +1,51 @@
+# Runbook 0020: Security chaos drill — odolnost detekce a degradace
+
+> ADR-0279 workstream 2, bod #21. Navazuje na ADR-0242 (quarterly DR & chaos
+> drill s měřeným RTO/RPO) — **toto je jeho security rameno**: ne „přežije
+> služba výpadek", ale „přežije detekce útok a degraduje se bezpečně".
+> Kadence: 2× ročně, vždy na sandboxu, vždy mimo money-path business hours.
+
+## Proč zvlášť od DR drillu
+
+DR drill měří RTO/RPO při výpadku infrastruktury. Security chaos měří něco
+jiného: **zda bezpečnostní kontroly fungují, když je část systému mrtvá nebo
+lže** — a zda služba při selhání bezpečnostní závislosti degraduje *bezpečně*
+(fail-closed), ne *pohodlně* (fail-open).
+
+## Scénářová matice (rotují se, min. 3 za drill)
+
+| # | Chaos injekce | Co se měří | Očekávané chování |
+|---|---|---|---|
+| C1 | Zabij Keycloak pod na sandboxu | authz hrana | API odpovídá 401/503, NIKDY 200; alert `KeycloakDown` + `AuthzDenySpike` do 5 min |
+| C2 | Zabij Falco daemonset | runtime detekce | alert na absence Falco heartbeatu; security rule pack stále detekuje Loki-signály (vrstvy jsou nezávislé) |
+| C3 | Zabij Loki / Prometheus ruler | alert pipeline | `Watchdog`+ absent-alert detekce; on-call ví z dead-man switch, ne z náhodného ticha |
+| C4 | Utni NetworkPolicy na jednom namespace | mTLS/izolace drift | Kyverno/NetPol gate zahlásí drift; služby v namespace fail-closed |
+| C5 | Vraž outbox dispatcher (dispatch-enabled=false simulace) | event integrita | `WorkflowLiveness`-style alert na nedisponující outbox; žádný tichý `attempt_count=0` stav |
+| C6 | Simuluj pomalý audit-anchor backend | evidentní integrita | audit píše dál, anchor lag roste → alert; NIKDY se neskipne anchoring potichu |
+
+## Postup
+
+1. **T-7 dní:** vyber 3 scénáře, zapiš očekávané chování (tabulka výše) do
+   drill záznamu — *před* injekcí. Hodnotí se předpověď, ne improvizace.
+2. **Game day:** injekce přes existující chaos nástroje DR drillu
+   (ADR-0242). Scribe zapisuje čas injekce, čas prvního alertu, čas
+   lidské reakce — stejná disciplína jako runbook 0018.
+3. **Měření:** pro každý scénář: (a) detekováno alertem? čas; (b) fail-closed?
+   důkaz z API odpovědí/logů; (c) recovery čistá? (žádný ruční zásah, který
+   by nešel zdokumentovat jako runbook krok).
+4. **Fail-open finding = critical.** Služba, která při mrtvém IdP/PDP
+   odpovídá 200, má issue s `security` + `fail-open` a je blokována z release
+   do opravy + gate (typicky contract/IT test na absent-PDP chování).
+5. **Report** do `docs/security/chaos/YYYY-Hn.md` vč. porovnání detekčních
+   časů s minulým drillem. Časy se mají zlepšovat; zhoršení je finding.
+
+## Vazby
+
+- ADR-0242 — společná chaos infrastruktura a kalendář (security drill běží
+  vždy v týdnu po DR drillu, aby se nespojovaly vlivy).
+- Runbook 0021 — purple-team drill; chaos drill testuje *degradaci*,
+  purple-team testuje *detekci útoku*. Jeden rok: Q1 purple, Q2 chaos,
+  Q3 purple, Q4 chaos.
+- Honeytoken/HoneyEndpointHit (`loki-rules-security-signals.yaml`) je
+  known-positive kontrola, že alert pipeline během drillu žije — pokud ani
+  honeytoken zásah nez alerting, drill se STOPUJE a řeší se pipeline, ne scénáře.

--- a/docs/runbooks/0021-purple-team-simulated-incident.md
+++ b/docs/runbooks/0021-purple-team-simulated-incident.md
@@ -1,0 +1,60 @@
+# Runbook 0021: Purple-team cvičení — simulovaný incident přes reálnou alert pipeline
+
+> ADR-0279 workstream 2, bod #22. Rozšiřuje runbook 0018 (CRA Art. 14
+> tabletop) o **technickou polovinu**: tabletop cvičí lidi a procedury,
+> purple-team cvičí detekci. Kadence: 2× ročně (střídá se s runbookem 0020).
+> Tvrdé pravidlo: **útok musí projít reálnou alert pipeline end-to-end**
+> (Loki/Prometheus rule pack → Alertmanager → on-call), jinak se nic neměří.
+
+## Promotion criterion — known-positive
+
+Před každým cvičením se ověří, že pipeline žije, **živou kontrolou, ne
+předpokladem**:
+
+1. Na sandboxu navštiv honeytoken endpoint (viz `HoneyEndpointHit` v
+   `openbank-infra/gitops/components/observability/loki-rules-security-signals.yaml`)
+   z testovací identity.
+2. Alert MUSÍ dorazit na on-call kanál do 5 minut.
+3. Nedorazí-li: cvičení se ruší, zakládá se incident na alert pipeline samotnou
+   (pipeline mrtvá = banka slepá). Teprve po opravě se cvičení opakuje.
+
+Teprve potom se spouští scénář. Known-positive se zapisuje do reportu
+s časem — je to důkaz, že „nedetekováno" znamená opravdu nedetekováno.
+
+## Scénáře (red hraje, blue sleduje; facilitator zná obě strany)
+
+| # | Simulovaný útok | Detekce, která má zareagovat |
+|---|---|---|
+| P1 | Credential stuffing na login (burst z jedné /24) | Loki `AuthFailureBurst` / WAF signál |
+| P2 | Enumerace party/IBAN přes IDOR probing | `AuthzDenySpike`, příp. 404-pattern rule |
+| P3 | Zásah do honeytoken endpointu z běžné service identity | `HoneyEndpointHit` |
+| P4 | Podezřelý proces v podu (simulace přes test container) | Falco → `prometheus-rules-security-signals.yaml` |
+| P5 | Exfiltrace pattern: nezvyklý egress objem z reporting služby | Prometheus egress/bytes anomálie + NetPol audit |
+| P6 | Replay idempotency-key / outbox manipulace na sandboxu | audit-anchor verifier (`verify-audit-anchors.py`) + outbox liveness |
+
+Scénář se nikdy nehlásí blue týmu předem. Facilitátor má STOP slovo
+(„kinetická událost na sandboxu" končí okamžitě, ne dotažením scénáře).
+
+## Postup
+
+1. **T-7 dní:** red tým vybere 2–3 scénáře, připraví payloady mimo sdílené
+   kanály. Blue tým ví jen „v tomto týdnu bude okno".
+2. **Provedení:** red útočí na sandbox; scribe (neutrální) zapisuje čas
+   každé red akce. Blue reaguje dle běžného on-call — nikdo mu nepomáhá.
+3. **Skóre na scénář:** čas injekce → čas alertu → čas lidského uznání
+   (ack) → čas správné klasifikace. Správná klasifikace = blue pozná, *co*
+   se děje, ne jen že „něco křičí".
+4. **Debrief do 48 h:** pro každý scénář jeden z výstupů:
+   (a) detekce fungovala → zapsat čas do baseline;
+   (b) detekce pozdě → tuning PR na rule pack (window/threshold);
+   (c) detekce chyběla → nový rule + gate `check-alert-metric-emitted.py`
+       zajistí, že má emitter; finding nese label `detection-gap`.
+5. **Report** do `docs/security/purple-team/YYYY-Hn.md` — vstup pro
+   ADR-0279 review a pro CRA evidenci průběžného testování.
+
+## Vazby
+
+- Runbook 0018 — tabletop (procedura/lidé); tento runbook je strojová polovina.
+- Runbook 0020 — chaos drill (degradace kontrol); střídání Q: purple/chaos/purple/chaos.
+- Detekční skóre z runbooku 0019 (pentest) a z tohoto cvičení se sjednocuje
+  do security excellence dashboardu v admin-ui (bod ADR-0279 WS4).

--- a/docs/runbooks/0022-vdp-bug-bounty-readiness.md
+++ b/docs/runbooks/0022-vdp-bug-bounty-readiness.md
@@ -1,0 +1,60 @@
+# Runbook 0022: Vulnerability Disclosure Program — provozní readiness
+
+> ADR-0279 workstream 4, bod #25. SECURITY.md (veřejný reporting kanál) je
+> *právní a komunikační* polovina VDP; tento runbook je *provozní* polovina —
+> co se děje s reportem po přijetí, jaké SLA platí, a kdy se VDP stane
+> bug bounty. Dokud tento runbook není projetý tabletop cvičením, VDP je
+> „publikováno, neprovozováno".
+
+## SLA a tok reportu
+
+| Krok | SLA | Majitel |
+|---|---|---|
+| Přijetí + potvrzení reportérovi | 3 pracovní dny | security on-call |
+| Triage + severita (CVSS 4.0) | 5 pracovních dnů | security lead |
+| Hotfix na main (critical/high) | dle SECURITY.md safe-harbor okna | vedení služby |
+| Veřejné zveřejnění (GHSA) | po fixu + 14 dnů grace, koordinovaně s reportérem | security lead |
+
+Tok: report (security.txt kanál / GitHub Security Advisory) → **privátní**
+Security Advisory (nikdy veřejný issue — AGENTS.md to vynucuje a toto je
+provozní kontrola téhož) → triage → fix PR (linkuje advisory, ne veřejné
+issue) → GHSA publish → credit reportérovi.
+
+## Kontroly před spuštěním (checklist readiness)
+
+- [ ] Security.txt kanál je monitorovaný — testovací zpráva dostane odpověď
+      do SLA (měřit kvartálně, zapsat čas).
+- [ ] Privátní advisory workflow projet tabletop style: jeden cvičný report
+      ročně projde celý tok vč. GHSA draftu (publikuje se jen „credit"
+      cvičného reportéra, draft se smaže).
+- [ ] Duplicita s interním chytrostí: reportérův finding se porovná s
+      backlogem — pokud ho interní kontrola (gate/fuzz/pentest) už zná,
+      zapisuje se, *proč* ho gate nechytil dřív. To je zpětná vazba do
+      ADR-0279, ne ostuda.
+- [ ] Safe-harbor formulace v SECURITY.md odpovídá právnímu review
+      (aktualizace při změně jurisdikce nasazení).
+
+## Bug bounty — aktivační kritéria
+
+Bounty program se zapíná, teprve když platí VŠECHNO:
+
+1. VDP běží ≥ 2 kvartály se splněnými SLA (měřeno z advisory časosběrných dat).
+2. Median time-to-triage ≤ 3 dny za poslední 2 kvartály.
+3. Trvalé kontroly z runbooku 0019 pokrývají poslední 4 kvartály findingů
+   (žádný otevřený `needs-permanent-control` starší 30 dnů).
+4. Vyhrazený rozpočet + právní rámec (scope, safe harbor, payout tabulka)
+   schválen vedením.
+
+Do té doby: kredit a thanks, ne peníze. Bounty bez provozní zralosti kupuje
+šum, ne signál — duplicitní reporty známých dluhů by stály víc než samotné
+zranitelnosti.
+
+## Vazby
+
+- SECURITY.md — veřejná fasáda; tento runbook ji nesmí rozporovat (při změně
+  SLA měnit obojí v jednom PR).
+- Runbook 0019 — interní pentest; externí reporty se řadí do stejné
+  `pentest-finding` evidence s origin labelem `external-report`.
+- CRA Art. 14 (runbooky 0017/0018) — aktivně zneužívaná zranitelnost z VDP
+  reportu spouští Art. 14 hodiny; to je důvod, proč triage SLA je v dnech,
+  ne týdnech.


### PR DESCRIPTION
## What

Operational half of ADR-0279 that cannot be merged as code — the runbooks and policy that make the controls *operated*, not just present:

- **Runbook 0019 — internal pentest cadence (#1):** quarterly rotation over authn/authz edge, money-path, supply chain, tenant isolation; monthly money-path mini-hunt. Hard rule: a finding is "fixed" only when a permanent control (gate/test/policy) would catch it next time. Detection scored against the Loki/Prometheus security rule pack — an undetected finding is also an observability finding.
- **Runbook 0020 — security chaos drill (#21):** the security arm of the ADR-0242 DR drill. Measures whether controls survive when a dependency is dead or lying: Keycloak down must mean 401/503 never 200 (fail-open = release blocker), Falco/Loki/ruler absence must itself alert, audit anchoring must never silently skip.
- **Runbook 0021 — purple-team exercise (#22):** extends the 0018 tabletop with the machine half. Hard rule: the attack must traverse the **real** alert pipeline (rule pack → Alertmanager → on-call). Promotion criterion is a live known-positive: a `HoneyEndpointHit` must page within 5 minutes before any scenario starts; if it doesn't, the exercise is cancelled and the pipeline itself becomes the incident.
- **Runbook 0022 — VDP readiness (#25):** SLA table for the public reporting channel, private-advisory flow, quarterly channel-alive tests, and explicit activation criteria before any bug-bounty spend (2 quarters of met SLAs, triage median ≤ 3 days, no stale `needs-permanent-control`).
- **SECURITY.md (#19):** maintainer authentication hardening — WebAuthn/passkeys required, two keys per maintainer, re-auth for privileged actions, quarterly roster attestation.

## Verification

Docs-only. Cross-references verified against the repo: ADR-0242/0279 exist, `HoneyEndpointHit` exists in `loki-rules-security-signals.yaml`, runbook numbers 0019–0022 were free, SECURITY.md section placed after the controls list it extends.

Refs #8590
