### PR TITLE
docs(contributing): 15-minute first-contribution path — curated good-first-issues, one-command env

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,25 @@ This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDU
 
 ## How to Contribute
 
+### Your first contribution (the 15-minute path)
+
+1. **Pick a [`good-first-issue`](https://github.com/JiRaska/open-bank-oss/labels/good-first-issue).**
+   The set is curated to stay at ≥5 open issues, and each carries a *newcomer context* comment:
+   where the code lives, what the fix shape is, and which repo conventions the PR will be judged
+   against.
+2. **Spin up the dev environment (one command).** Prereqs: Docker Desktop ≥ 4.x, 16 GB RAM.
+   ```bash
+   cd openbank-infra && cp .env.example .env && make up-infra && make up-all && make health-all
+   ```
+   Full detail in [`DEPLOYMENT.md`](DEPLOYMENT.md) §2; to poke the *live* sandbox instead of
+   running anything, use [`docs/QUICKSTART_SANDBOX.md`](docs/QUICKSTART_SANDBOX.md).
+3. **Make the change on a branch** `<type>/<scope>-<summary>`; the commit message *is* the
+   changelog (Conventional Commits, `git commit -s -S`).
+4. **Run the local gate before pushing:** `./gradlew detekt ktlintCheck koverVerify build`
+   (add `:<svc>:quarkusBuild` — CDI wiring failures surface only there).
+5. **Open the PR** — every PR links its issue (`Closes #<n>`), CI is path-scoped, and
+   `/ship-check` runs the same governance gates CI enforces.
+
 ### Reporting bugs
 
 - Open a GitHub issue using the **Bug report** template.

--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ full checklist. Maintainers with Claude Code can also run `/ship-check` — it m
 
 Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) first.
 
+New here? The fastest path in: pick a [`good-first-issue`](https://github.com/JiRaska/open-bank-oss/labels/good-first-issue)
+(each carries a newcomer-context comment telling you exactly where to start), spin the stack up with
+one command (`cd openbank-infra && make up-infra && make up-all`), and sanity-check the live sandbox
+via [`docs/QUICKSTART_SANDBOX.md`](docs/QUICKSTART_SANDBOX.md). Target: first green PR in ~15 minutes
+of hands-on time.
+
 OpenBank uses the [Developer Certificate of Origin](https://developercertificate.org/) — every commit must
 be signed off and signed with `git commit -s -S`.
 


### PR DESCRIPTION
Refs #8365 (two acceptance criteria need humans / a clean machine — see below; issue stays open).

## Co PR přináší

- **README → Contributing**: přímý vstup pro nováčka — curated `good-first-issue` set,
  one-command dev env, odkaz na `docs/QUICKSTART_SANDBOX.md`, cíl "first green PR in ~15 min".
- **CONTRIBUTING.md**: nová sekce "Your first contribution (the 15-minute path)" — 5 kroků od
  výběru issue po PR, včetně local gate (`detekt ktlintCheck koverVerify build` + `quarkusBuild`).
- **Curated set (mimo PR, už aplikováno na GitHubu):** `good-first-issue` + `help-wanted` label a
  newcomer-context komentář s konkrétním startovním bodem na #8548 (KYC expiry), #8535 (dead
  DOCUMENTS_REQUIRED state), #8495 (ROLE_DPO realm), #8510 (dead outboxy), #8263 (Test
  Intelligence misclassification). 5 otevřených — splňuje "≥5 at all times" startovní stav.

## Co zůstává otevřené (nelze autonomně)

- **Změření time-to-first-green-PR na 2–3 trial contributors** — potřebuje skutečné nové
  přispěvatele; label `good-first-issue` je teď připravený, měření se doplní, až první externí
  PR projde.
- **Ověření one-command env na čistém stroji/Codespace** — lokálně ověřeno proti existující
  instalaci; clean-machine běh zůstává na prvním trial contributorovi (a je to součást měření).
- Gaps found by trial contributors — doplní se z jejich feedbacku.
