### PR TITLE
test(account): prove outbox atomicity by transaction id in account, sdd and fraud

### DIFF
--- a/openbank-account-service/src/test/kotlin/com/openbank/account/integration/AccountOutboxAtomicityIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/integration/AccountOutboxAtomicityIT.kt
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.account.integration
+
+import com.openbank.account.it.PostgresRedpandaRedisTestResource
+import com.openbank.account.it.StubScaChallengeClient
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import io.smallrye.reactive.messaging.memory.InMemorySource
+import jakarta.enterprise.inject.Any
+import jakarta.inject.Inject
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import javax.sql.DataSource
+
+/**
+ * Issue #8353 — proves that `WithdrawalProposalRepositoryImpl.save(proposal, event)` commits the
+ * `savings_withdrawal_proposals` row and its `account_outbox` row in **one** database transaction,
+ * so neither can exist without the other.
+ *
+ * The subject is the owner's SCA-bound APPROVAL of a delegate's savings-withdrawal proposal
+ * (`POST .../proposals/{id}/decide` with `approve: true`) — the only call site in this service that
+ * writes the aggregate and an outbox event together. The sibling REJECT branch deliberately writes
+ * no outbox row at all: `save(proposal)` without an event, which this test uses as a control.
+ *
+ * ### Why presence is not the property
+ *
+ * The house pattern (`LendingOutboxWriteIT`, `ConsentRevocationOutboxIT`) drives the flow through
+ * the real REST endpoint and asserts the outbox row landed. That is necessary — a mocked repository
+ * commits nothing, and a reactive Panache repo cannot be called from a bare `@QuarkusTest` thread
+ * ("No current Vertx context found"), so only a real HTTP request can exercise the write — but it
+ * is **not sufficient**: an implementation that persisted the aggregate in one transaction and the
+ * outbox row in a second would satisfy every presence assertion while having lost the property.
+ * The sibling [SavingsProposalIT] is in exactly that position — it asserts the decision returned
+ * `APPROVED`, which a two-transaction save answers identically.
+ *
+ * ### What makes it falsifiable
+ *
+ * Postgres stamps every row version with `xmin`, the id of the transaction that wrote it. Two rows
+ * written by one transaction carry the *same* `xmin`; two rows written by two transactions cannot.
+ * Comparing the two `xmin`s is a direct read of the property rather than of its happy-path shadow —
+ * splitting `save`'s single `Panache.withTransaction` in two turns this test red, where a presence
+ * assertion stays green.
+ *
+ * The scheduled outbox dispatcher is switched off for this class: it UPDATEs claimed rows, and an
+ * UPDATE writes a new row version with a *new* `xmin`, which would race the assertion. (This
+ * service correctly ships `openbank.outbox.dispatch-enabled: true` in `application.yaml` — the
+ * fleet default is `false`, under which a service dispatches nothing and reports no error — which
+ * is precisely why it has to be disabled here rather than merely left alone.)
+ *
+ * That switch lives in a [QuarkusTestProfile] and NOT in the test resource, deliberately: a
+ * `@QuarkusTestResource` is applied to every test class in the module, so a resource carrying
+ * `dispatch-enabled=false` would silently disable dispatch for the module's other ITs too —
+ * measured in the sdd half of this change, where doing so turned that module's dispatch IT red. A
+ * profile is per-class and forces this class its own Quarkus boot, which is exactly the scope
+ * wanted.
+ */
+@QuarkusTest
+@TestProfile(AccountOutboxAtomicityIT.NoDispatchProfile::class)
+@QuarkusTestResource(PostgresRedpandaRedisTestResource::class)
+@QuarkusTestResource(AccountOutboxAtomicityIT.DelegationChannel::class)
+class AccountOutboxAtomicityIT {
+
+    class NoDispatchProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf("openbank.outbox.dispatch-enabled" to "false")
+    }
+
+    class DelegationChannel : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> =
+            InMemoryConnector.switchIncomingChannelsToInMemory("delegation-events-in")
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    @Any
+    @Inject
+    lateinit var connector: InMemoryConnector
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    private val ownerParty: UUID = UUID.randomUUID()
+    private val delegateParty: UUID = UUID.randomUUID()
+
+    @Test
+    @TestSecurity(user = ACTOR_ID, roles = ["ROLE_OPERATOR"])
+    fun `approving a proposal commits the proposal row and its outbox row in one transaction`(): Unit = runBlocking {
+        val accountId = openAccount()
+        grantSavingsDelegation(accountId)
+
+        val approved = approve(accountId, propose(accountId))
+        val rows = writersOf(approved)
+
+        assertThat(rows)
+            .describedAs("exactly one account_outbox row for proposal %s", approved)
+            .hasSize(1)
+        val (proposalXmin, outboxXmin, eventType) = rows.single()
+        assertThat(eventType).isEqualTo(EVENT_WITHDRAWAL_APPROVED)
+        assertThat(outboxXmin)
+            .describedAs(
+                "the savings_withdrawal_proposals row and its outbox row must carry the SAME " +
+                    "Postgres xmin — different values mean two transactions wrote them, so one can " +
+                    "commit without the other (proposal xmin=%s, outbox xmin=%s)",
+                proposalXmin,
+                outboxXmin,
+            )
+            .isEqualTo(proposalXmin)
+
+        // Known-different control, so one run shows the identical comparison both matching and NOT
+        // matching. A second approval on the same account is a second request and therefore a
+        // second transaction; if its outbox row shared a writer with the first, the match above
+        // would be matching everything and could not fail.
+        val second = approve(accountId, propose(accountId))
+        val secondRows = writersOf(second)
+        assertThat(secondRows).hasSize(1)
+        assertThat(secondRows.single().outboxXmin).isEqualTo(secondRows.single().proposalXmin)
+        assertThat(secondRows.single().outboxXmin)
+            .describedAs(
+                "control: two separate approvals cannot share a writing transaction (first=%s, second=%s)",
+                outboxXmin,
+                secondRows.single().outboxXmin,
+            )
+            .isNotEqualTo(outboxXmin)
+    }
+
+    /**
+     * The REJECT branch calls `save(proposal)` — the overload with no event — so it writes no
+     * outbox row. Asserting that here keeps the `hasSize(1)` above honest about *which* write path
+     * produced the row: were the outbox write moved somewhere shared, this case would go red.
+     */
+    @Test
+    @TestSecurity(user = ACTOR_ID, roles = ["ROLE_OPERATOR"])
+    fun `rejecting a proposal writes no outbox row at all`(): Unit = runBlocking {
+        val accountId = openAccount()
+        grantSavingsDelegation(accountId)
+
+        val rejected = decide(accountId, propose(accountId), approve = false, expectedStatus = "REJECTED")
+
+        assertThat(writersOf(rejected)).isEmpty()
+    }
+
+    /**
+     * Guards the assertions above against reading their own success from an empty set: a proposal
+     * id that was never written must produce no pair at all, so `hasSize(1)` is a claim the query
+     * is capable of failing.
+     */
+    @Test
+    fun `the atomicity query returns nothing for a proposal that was never written`() {
+        assertThat(writersOf(UUID.randomUUID())).isEmpty()
+    }
+
+    private data class WriterPair(val proposalXmin: String, val outboxXmin: String, val eventType: String)
+
+    /** The transaction ids (`xmin`) that wrote the aggregate row and each of its outbox rows. */
+    private fun writersOf(proposalId: UUID): List<WriterPair> = dataSource.connection.use { connection ->
+        connection.prepareStatement(
+            """
+            SELECT p.xmin::text AS proposal_xmin, o.xmin::text AS outbox_xmin, o.event_type
+            FROM savings_withdrawal_proposals p
+            JOIN account_outbox o ON o.aggregate_id = p.id
+            WHERE p.id = ?
+            ORDER BY o.id
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setObject(1, proposalId)
+            statement.executeQuery().use { rows ->
+                generateSequence { if (rows.next()) rows else null }
+                    .map { WriterPair(it.getString(1), it.getString(2), it.getString(3)) }
+                    .toList()
+            }
+        }
+    }
+
+    private fun openAccount(): String {
+        val opened = Given {
+            contentType("application/json")
+            header("Idempotency-Key", UUID.randomUUID().toString())
+            body(
+                """
+                {
+                  "partyId": "$ownerParty",
+                  "productId": "00000000-2222-0000-0000-000000000001",
+                  "accountType": "SAVINGS",
+                  "currencyCode": "CZK",
+                  "legalName": "Outbox Atomicity IT"
+                }
+                """.trimIndent(),
+            )
+        } When {
+            post("/api/v1/accounts")
+        } Then {
+            statusCode(201)
+        }
+        return opened.extract().path("id")
+    }
+
+    /**
+     * The proposal endpoint is reachable only for a delegate holding a SAVINGS_PROPOSE_WITHDRAW
+     * grant, which this service learns from `delegation-events-in`. Same arrangement as
+     * [SavingsProposalIT]; the poll below is on the service's own check endpoint, so it observes
+     * the projection rather than assuming a delay is enough.
+     */
+    private suspend fun grantSavingsDelegation(accountId: String) {
+        val source: InMemorySource<String> = connector.source("delegation-events-in")
+        source.runOnVertxContext(true)
+        source.send(
+            """
+            {
+              "eventType": "DelegationActivated",
+              "lifecycleRevision": 1,
+              "aggregateId": "${UUID.randomUUID()}",
+              "grantorPartyId": "$ownerParty",
+              "granteePartyId": "$delegateParty",
+              "resourceType": "SAVINGS_GOAL",
+              "resourceId": "$accountId",
+              "capabilities": ["SAVINGS_PROPOSE_WITHDRAW"],
+              "validFrom": "2026-01-01T00:00:00Z",
+              "occurredAt": "2026-08-01T12:00:00Z"
+            }
+            """.trimIndent(),
+        )
+        repeat(GRANT_POLL_ATTEMPTS) {
+            val checked = Given { this } When {
+                get(
+                    "/api/v1/accounts/$accountId/savings-goal/delegation/check" +
+                        "?partyId=$delegateParty&intent=PROPOSE_WITHDRAW",
+                )
+            } Then {
+                statusCode(200)
+            }
+            if (checked.extract().path<Boolean>("authorized")) return
+            delay(GRANT_POLL_INTERVAL_MS)
+        }
+        error("savings grant never became visible")
+    }
+
+    private fun propose(accountId: String): String {
+        val proposed = Given {
+            contentType("application/json")
+            header("X-Customer-Party-Id", delegateParty.toString())
+            body("""{"amountMinor": 150000, "currency": "CZK", "note": "kolo"}""")
+        } When {
+            post("/api/v1/accounts/$accountId/savings-goal/delegation/proposals")
+        } Then {
+            statusCode(202)
+        }
+        return proposed.extract().path("proposal.id")
+    }
+
+    private fun approve(accountId: String, proposalId: String): UUID =
+        decide(accountId, proposalId, approve = true, expectedStatus = "APPROVED")
+
+    private fun decide(accountId: String, proposalId: String, approve: Boolean, expectedStatus: String): UUID {
+        StubScaChallengeClient.party.set(ownerParty)
+        val decided = Given {
+            contentType("application/json")
+            header("X-Customer-Party-Id", ownerParty.toString())
+            body("""{"approve": $approve, "scaSessionId": "${UUID.randomUUID()}"}""")
+        } When {
+            post("/api/v1/accounts/$accountId/savings-goal/delegation/proposals/$proposalId/decide")
+        } Then {
+            statusCode(200)
+        }
+        // Arrangement assertion: only the APPROVE branch reaches `save(proposal, event)`. A change
+        // that routed this request elsewhere would otherwise leave the test silently asserting over
+        // an empty outbox.
+        assertThat(decided.extract().path<String>("status")).isEqualTo(expectedStatus)
+        return UUID.fromString(proposalId)
+    }
+
+    private companion object {
+        const val ACTOR_ID = "00000000-0000-0000-0000-000000000099"
+        const val GRANT_POLL_ATTEMPTS = 40
+        const val GRANT_POLL_INTERVAL_MS = 250L
+
+        /** `SavingsWithdrawalApproved.eventType` — the wire value is the subject. */
+        const val EVENT_WITHDRAWAL_APPROVED = "SavingsWithdrawalApproved"
+    }
+}

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/integration/FraudOutboxAtomicityIT.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/integration/FraudOutboxAtomicityIT.kt
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.fraud.integration
+
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import javax.sql.DataSource
+
+/**
+ * Issue #8353 — proves that `FraudHoldService.maybeRaise` commits the `fraud_hold` row and its
+ * `fraud_outbox` row in **one** database transaction, so neither can exist without the other.
+ *
+ * The hold is the service's only durable write besides the immutable score audit row, and the
+ * `fraud.hold_changed` event is how every downstream consumer learns a party is held — a hold that
+ * committed without its event is a party restricted with nothing told, and an event without its
+ * hold is the reverse.
+ *
+ * ### Why presence is not the property
+ *
+ * The house pattern (`LendingOutboxWriteIT`, `ConsentRevocationOutboxIT`) drives the flow through
+ * the real REST endpoint and asserts the outbox row landed. That is necessary — a mocked repository
+ * commits nothing, and a reactive Panache repo cannot be called from a bare `@QuarkusTest` thread
+ * ("No current Vertx context found") — but it is **not sufficient**: an implementation that
+ * persisted the aggregate in one transaction and the outbox row in a second would satisfy every
+ * presence assertion while having lost the property. The sibling [FraudHoldServiceIT] is in exactly
+ * that position: it asserts `outboxCountFor("fraud.hold_changed") >= 1`, which a two-transaction
+ * write answers identically. It also calls `holdService.maybeRaise` directly rather than through
+ * HTTP, so it cannot see a defect that only the real request path reaches.
+ *
+ * ### What makes it falsifiable
+ *
+ * Postgres stamps every row version with `xmin`, the id of the transaction that wrote it. Two rows
+ * written by one transaction carry the *same* `xmin`; two rows written by two transactions cannot.
+ * Splitting `maybeRaise`'s single `Panache.withTransaction` in two turns this test red, where a
+ * presence assertion stays green.
+ *
+ * The scheduled outbox dispatcher is switched off for this class: it UPDATEs claimed rows, and an
+ * UPDATE writes a new row version with a *new* `xmin`, which would race the assertion. (This
+ * service correctly ships `openbank.outbox.dispatch-enabled: true` in `application.yaml` — the
+ * fleet default is `false`, under which a service dispatches nothing and reports no error — which
+ * is precisely why it has to be disabled here rather than merely left alone.) That switch lives in
+ * a [QuarkusTestProfile] and NOT in a test resource, deliberately: a `@QuarkusTestResource` is
+ * applied to every test class in the module, so a resource carrying `dispatch-enabled=false` would
+ * silently disable dispatch for the module's other ITs too — measured in the sdd half of this
+ * change, where doing so turned that module's dispatch IT red. A profile is per-class and forces
+ * this class its own Quarkus boot, which is exactly the scope wanted.
+ *
+ * `AccountPartyLookupPort` is the one collaborator that decides whether the write path runs at all:
+ * `maybeRaise` returns early when the account maps to no party, so with no account-service
+ * reachable the test would assert nothing while looking like it had. [StubAccountPartyLookupPort]
+ * (`@Alternative @Priority(1)`, declared alongside [FraudHoldServiceIT]) already replaces it for
+ * this module's tests; this class only sets which party it answers with.
+ */
+@QuarkusTest
+@TestProfile(FraudOutboxAtomicityIT.NoDispatchProfile::class)
+@QuarkusTestResource(com.openbank.fraud.it.PostgresRedisTestResource::class)
+class FraudOutboxAtomicityIT {
+
+    class NoDispatchProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf("openbank.outbox.dispatch-enabled" to "false")
+    }
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    @Test
+    @TestSecurity(user = ACTOR_ID, roles = ["ROLE_API"])
+    fun `raising a hold commits the hold row and its outbox row in one transaction`() {
+        val firstParty = UUID.randomUUID()
+        val firstAccount = raiseHoldFor(firstParty)
+
+        val rows = writersOf(firstParty)
+        assertThat(rows)
+            .describedAs("exactly one fraud_outbox row for party %s (account %s)", firstParty, firstAccount)
+            .hasSize(1)
+        val (holdXmin, outboxXmin, eventType) = rows.single()
+        assertThat(eventType).isEqualTo(EVENT_HOLD_CHANGED)
+        assertThat(outboxXmin)
+            .describedAs(
+                "the fraud_hold row and its outbox row must carry the SAME Postgres xmin — " +
+                    "different values mean two transactions wrote them, so one can commit without " +
+                    "the other (hold xmin=%s, outbox xmin=%s)",
+                holdXmin,
+                outboxXmin,
+            )
+            .isEqualTo(holdXmin)
+
+        // Known-different control, so one run shows the identical comparison both matching and NOT
+        // matching. A hold for a second party is a second request and therefore a second
+        // transaction; if its outbox row shared a writer with the first, the match above would be
+        // matching everything and could not fail.
+        val secondParty = UUID.randomUUID()
+        raiseHoldFor(secondParty)
+        val secondRows = writersOf(secondParty)
+        assertThat(secondRows).hasSize(1)
+        assertThat(secondRows.single().outboxXmin).isEqualTo(secondRows.single().holdXmin)
+        assertThat(secondRows.single().outboxXmin)
+            .describedAs(
+                "control: two separate holds cannot share a writing transaction (first=%s, second=%s)",
+                outboxXmin,
+                secondRows.single().outboxXmin,
+            )
+            .isNotEqualTo(outboxXmin)
+    }
+
+    /**
+     * Guards the assertions above against reading their own success from an empty set: a party id
+     * that was never held must produce no pair at all, so `hasSize(1)` is a claim the query is
+     * capable of failing.
+     */
+    @Test
+    fun `the atomicity query returns nothing for a party that was never held`() {
+        assertThat(writersOf(UUID.randomUUID())).isEmpty()
+    }
+
+    private data class WriterPair(val holdXmin: String, val outboxXmin: String, val eventType: String)
+
+    /** The transaction ids (`xmin`) that wrote the aggregate row and each of its outbox rows. */
+    private fun writersOf(partyId: UUID): List<WriterPair> = dataSource.connection.use { connection ->
+        connection.prepareStatement(
+            """
+            SELECT h.xmin::text AS hold_xmin, o.xmin::text AS outbox_xmin, o.event_type
+            FROM fraud_hold h
+            JOIN fraud_outbox o ON o.aggregate_id = h.party_id
+            WHERE h.party_id = ?
+            ORDER BY o.id
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setObject(1, partyId)
+            statement.executeQuery().use { rows ->
+                generateSequence { if (rows.next()) rows else null }
+                    .map { WriterPair(it.getString(1), it.getString(2), it.getString(3)) }
+                    .toList()
+            }
+        }
+    }
+
+    /**
+     * Drives `POST /api/v1/fraud/score` until the repeated-REVIEW rule fires. A CZK amount over
+     * `LargeSingleTransactionReviewRule`'s 500 000 threshold makes every call a REVIEW, and
+     * `openbank.fraud-hold.review-threshold` is 3 — so the third request is the one whose
+     * `maybeRaise` writes the hold. `score` awaits `maybeRaise`, so the write has committed by the
+     * time the third response returns; nothing here polls.
+     */
+    private fun raiseHoldFor(partyId: UUID): UUID {
+        val accountId = UUID.randomUUID()
+        StubAccountPartyLookupPort.partyId = partyId
+        repeat(REVIEW_THRESHOLD) {
+            val scored = Given {
+                contentType("application/json")
+                body(
+                    """
+                    {
+                      "amount": "600000.00",
+                      "currency": "CZK",
+                      "rail": "SEPA",
+                      "accountId": "$accountId",
+                      "counterpartyId": "${UUID.randomUUID()}"
+                    }
+                    """.trimIndent(),
+                )
+            } When {
+                post("/api/v1/fraud/score")
+            } Then {
+                statusCode(200)
+            }
+            // Arrangement assertion: only a REVIEW verdict counts towards the hold threshold. A
+            // rule-engine change that made this amount ALLOW would otherwise leave the test
+            // silently asserting over an empty outbox.
+            assertThat(scored.extract().path<String>("verdict")).isEqualTo("REVIEW")
+        }
+        return accountId
+    }
+
+    private companion object {
+        const val ACTOR_ID = "00000000-0000-0000-0000-000000000099"
+
+        /** `openbank.fraud-hold.review-threshold` in `application.yaml`. */
+        const val REVIEW_THRESHOLD = 3
+
+        /** `FraudHoldService.emitHoldChanged` — the wire value is the subject. */
+        const val EVENT_HOLD_CHANGED = "fraud.hold_changed"
+    }
+}

--- a/openbank-sdd-service/build.gradle.kts
+++ b/openbank-sdd-service/build.gradle.kts
@@ -41,6 +41,10 @@ dependencies {
     implementation(project(":openbank-libs-runtime"))
     testImplementation(libs.quarkus.junit5)
     testImplementation(libs.rest.assured.kotlin)
+    // @TestSecurity: SddOutboxAtomicityIT (#8353) drives POST /mandates and POST /mandates/{id}/suspend,
+    // both behind @RolesAllowed on SddResource. The module's existing ITs only hit unsecured routes
+    // (health, /api/v1/info) and the dispatcher directly, so nothing pulled this in before.
+    testImplementation(libs.quarkus.test.security)
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.smallrye.reactive.messaging.inmemory)

--- a/openbank-sdd-service/src/test/kotlin/com/openbank/sdd/integration/SddOutboxAtomicityIT.kt
+++ b/openbank-sdd-service/src/test/kotlin/com/openbank/sdd/integration/SddOutboxAtomicityIT.kt
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.sdd.integration
+
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import javax.sql.DataSource
+
+/**
+ * Issue #8353 — proves that `SddMandateService`'s two write paths commit the `sdd_mandate` row and
+ * its `sdd_outbox` row in **one** database transaction, so neither can exist without the other:
+ * `register` (`POST /api/v1/sdd/mandates`, the birth of a debtor mandate) and the lifecycle
+ * `transition` helper behind `suspend`/`resume`/`cancel`/`confirm`
+ * (`POST /api/v1/sdd/mandates/{id}/suspend`).
+ *
+ * A mandate is the standing authority under which `SddCollectionDebitConsumer` posts a real debit,
+ * so a mandate whose state change committed without its event — or the reverse — is a divergence on
+ * the money path itself.
+ *
+ * ### Why presence is not the property
+ *
+ * The house pattern (`LendingOutboxWriteIT`, `ConsentRevocationOutboxIT`) drives the flow through
+ * the real REST endpoint and asserts the outbox row landed. That is necessary — a mocked repository
+ * commits nothing, and a reactive Hibernate repo cannot be driven from a bare `@QuarkusTest` thread
+ * ("No current Vertx context found"), so only a real HTTP request can exercise the write — but it
+ * is **not sufficient**: an implementation that persisted the aggregate in one transaction and the
+ * outbox row in a second would satisfy every presence assertion while having lost the property.
+ * The sibling [SddOutboxDispatchIT] seeds outbox rows directly and tests claim/dispatch semantics,
+ * so it is silent about the write.
+ *
+ * ### What makes it falsifiable
+ *
+ * Postgres stamps every row version with `xmin`, the id of the transaction that wrote it. Two rows
+ * written by one transaction carry the *same* `xmin`; two rows written by two transactions cannot.
+ * Here the single transaction is the resource method's own `@WithTransaction`, which
+ * `SddMandateRepositoryImpl.save`'s `sf.withTransaction` and `SddOutboxRepositoryImpl.append`'s
+ * bare `persist` both join; splitting either out of it turns this test red, where a presence
+ * assertion stays green.
+ *
+ * The scheduled outbox dispatcher is switched off for this class: it UPDATEs claimed rows, and an
+ * UPDATE writes a new row version with a *new* `xmin`, which would race the assertion. sdd ships
+ * `openbank.outbox.dispatch-enabled: true` in BOTH its default and its `%test` profile (the latter
+ * so [SddOutboxDispatchIT] can drive `dispatch()` directly), so leaving it alone here would not do.
+ *
+ * That switch lives in a [QuarkusTestProfile] and NOT in the test resource, deliberately: a
+ * `@QuarkusTestResource` is applied to every test class in the module, so putting
+ * `dispatch-enabled=false` there turned [SddOutboxDispatchIT] red — measured, not assumed. A
+ * profile is per-class and forces this class its own Quarkus boot, which is exactly the scope
+ * wanted.
+ */
+@QuarkusTest
+@TestProfile(SddOutboxAtomicityIT.NoDispatchProfile::class)
+@QuarkusTestResource(SddOutboxAtomicityIT.InMemoryKafkaResource::class)
+@QuarkusTestResource(com.openbank.sdd.it.PostgresTestResource::class)
+class SddOutboxAtomicityIT {
+
+    /**
+     * `authz.enforce` is the second override and is not incidental: sdd is one of the few services
+     * shipping `AUTHZ_ENFORCE` defaulted to **true** (account and fraud both default it to false),
+     * and with no OPA sidecar reachable the interceptor fails closed — every write endpoint here
+     * answers **503**, not 403, so without this the test would be red for a reason that has nothing
+     * to do with the outbox.
+     */
+    class NoDispatchProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf(
+            "openbank.outbox.dispatch-enabled" to "false",
+            "authz.enforce" to "false",
+        )
+    }
+
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> {
+            val props = InMemoryConnector.switchOutgoingChannelsToInMemory("sdd-events-out").toMutableMap()
+            props.putAll(InMemoryConnector.switchIncomingChannelsToInMemory("sdd-collection-authorised-in"))
+            props["quarkus.kafka.devservices.enabled"] = "false"
+            return props
+        }
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    @Test
+    @TestSecurity(user = ACTOR_ID, roles = ["ROLE_OPERATOR"])
+    fun `both mandate write paths commit the mandate row and its outbox row in one transaction`() {
+        val mandateId = registerCoreMandate()
+
+        // --- write path 1: register ---------------------------------------------------------
+        val afterRegister = writersOf(mandateId)
+        assertThat(afterRegister)
+            .describedAs("exactly one sdd_outbox row for mandate %s after registration", mandateId)
+            .hasSize(1)
+        val registered = afterRegister.single()
+        assertThat(registered.eventType).isEqualTo(EVENT_REGISTERED)
+        assertThat(registered.outboxXmin)
+            .describedAs(
+                "the sdd_mandate row and its outbox row must carry the SAME Postgres xmin — " +
+                    "different values mean two transactions wrote them, so one can commit without " +
+                    "the other (mandate xmin=%s, outbox xmin=%s)",
+                registered.mandateXmin,
+                registered.outboxXmin,
+            )
+            .isEqualTo(registered.mandateXmin)
+
+        // --- write path 2: the lifecycle transition helper ------------------------------------
+        suspendMandate(mandateId)
+        val afterSuspend = writersOf(mandateId)
+        assertThat(afterSuspend).hasSize(2)
+        val suspended = afterSuspend.single { it.eventType == EVENT_SUSPENDED }
+        assertThat(suspended.outboxXmin)
+            .describedAs(
+                "suspend must also write the mandate row and its outbox row in one transaction " +
+                    "(mandate xmin=%s, outbox xmin=%s)",
+                suspended.mandateXmin,
+                suspended.outboxXmin,
+            )
+            .isEqualTo(suspended.mandateXmin)
+
+        // Known-different control, so one run shows the identical comparison both matching and NOT
+        // matching. The suspend UPDATEd the mandate row, giving it a new version whose xmin is the
+        // suspending transaction's; the REGISTRATION outbox row was written by an earlier
+        // transaction and therefore must NOT match the current mandate row. Were the comparison
+        // matching everything, this would fail.
+        val staleRegistration = afterSuspend.single { it.eventType == EVENT_REGISTERED }
+        assertThat(staleRegistration.outboxXmin)
+            .describedAs(
+                "control: the registration outbox row was written by an earlier transaction than " +
+                    "the current mandate row version (registration outbox xmin=%s, mandate xmin=%s)",
+                staleRegistration.outboxXmin,
+                staleRegistration.mandateXmin,
+            )
+            .isNotEqualTo(staleRegistration.mandateXmin)
+    }
+
+    /**
+     * Guards the assertions above against reading their own success from an empty set: a mandate id
+     * that was never written must produce no pair at all, so `hasSize(1)` is a claim the query is
+     * capable of failing.
+     */
+    @Test
+    fun `the atomicity query returns nothing for a mandate that was never written`() {
+        assertThat(writersOf(UUID.randomUUID())).isEmpty()
+    }
+
+    private data class WriterPair(val mandateXmin: String, val outboxXmin: String, val eventType: String)
+
+    /** The transaction ids (`xmin`) that wrote the aggregate row and each of its outbox rows. */
+    private fun writersOf(mandateId: UUID): List<WriterPair> = dataSource.connection.use { connection ->
+        connection.prepareStatement(
+            """
+            SELECT m.xmin::text AS mandate_xmin, o.xmin::text AS outbox_xmin, o.event_type
+            FROM sdd_mandate m
+            JOIN sdd_outbox o ON o.aggregate_id = m.id
+            WHERE m.id = ?
+            ORDER BY o.id
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setObject(1, mandateId)
+            statement.executeQuery().use { rows ->
+                generateSequence { if (rows.next()) rows else null }
+                    .map { WriterPair(it.getString(1), it.getString(2), it.getString(3)) }
+                    .toList()
+            }
+        }
+    }
+
+    private fun registerCoreMandate(): UUID {
+        val registered = Given {
+            contentType("application/json")
+            body(
+                """
+                {
+                  "accountId": "${UUID.randomUUID()}",
+                  "debtorIban": "CZ6508000000192000145399",
+                  "creditorIdentifier": "CZ98ZZZ${UUID.randomUUID().toString().take(8)}",
+                  "umr": "UMR-${UUID.randomUUID().toString().take(UMR_SUFFIX_LENGTH)}",
+                  "scheme": "CORE",
+                  "sequenceType": "FRST",
+                  "creditorName": "Energie a.s.",
+                  "debtorName": "Jan Novak",
+                  "signatureDate": "2026-01-15"
+                }
+                """.trimIndent(),
+            )
+        } When {
+            post("/api/v1/sdd/mandates")
+        } Then {
+            statusCode(201)
+        }
+        val body = registered.extract()
+        // Arrangement assertion: only a CORE mandate is born ACTIVE, and only an ACTIVE mandate can
+        // then be suspended. A change that routed this to PENDING_CONFIRMATION would otherwise
+        // leave the second half of the test asserting over a failed request.
+        assertThat(body.path<String>("status")).isEqualTo("ACTIVE")
+        return UUID.fromString(body.path("id"))
+    }
+
+    private fun suspendMandate(mandateId: UUID) {
+        val suspended = Given {
+            contentType("application/json")
+        } When {
+            post("/api/v1/sdd/mandates/$mandateId/suspend")
+        } Then {
+            statusCode(200)
+        }
+        assertThat(suspended.extract().path<String>("status")).isEqualTo("SUSPENDED")
+    }
+
+    private companion object {
+        const val ACTOR_ID = "00000000-0000-0000-0000-000000000099"
+
+        /** `sdd_mandate.umr` is `varchar(35)`; a full UUID after the `UMR-` prefix overflows it. */
+        const val UMR_SUFFIX_LENGTH = 20
+
+        /** The wire values `SddMandateService` stamps on the outbox row — the subject. */
+        const val EVENT_REGISTERED = "sdd.mandate.registered.v1"
+        const val EVENT_SUSPENDED = "sdd.mandate.suspended.v1"
+    }
+}


### PR DESCRIPTION
## What

The third tranche of #8353 — an outbox-atomicity integration test for three more money-path
services: **account**, **sdd**, **fraud**. Follows the oracle #8496 established and #8507 repeated,
verbatim: compare the Postgres `xmin` of the aggregate row and its outbox row instead of asserting
the outbox row is merely present.

## How these three were chosen

Same criteria as #8496/#8507, applied to the remainder #8507 named
(`account`, `swift`, `sdd`, `interest`, `sca`, `fraud`, `billing`):

- **money-path weight.** All three are in `rules.yaml: money_path_services`. `account` holds the
  balances themselves; `sdd` is the standing authority under which `SddCollectionDebitConsumer`
  posts a real debit for every authorised collection (#1478); `fraud`'s hold is the signal every
  downstream consumer acts on when a party is restricted.
- **the write path is genuinely co-transactional with a state change.** Established by reading
  every outbox-write call site in each candidate, not by naming — which is also how the `sca`
  finding below fell out.
- **a proven-green REST-driven `@QuarkusTest` already exists in the module**, so a boot failure
  cannot masquerade as a pass: `SavingsProposalIT` (RestAssured + `@TestSecurity`, and the exact
  delegation arrangement this test needs), `SddBootSmokeIT`, `FraudApiIT`.

## Verified by effect, not by a green run

Each write path was run against a **deliberately broken** build — its single transaction split in
two — and goes red naming the two transaction ids:

| service | write path | REST entry | broken-build failure |
|---|---|---|---|
| account | `WithdrawalProposalRepositoryImpl.save(proposal, event)` | `POST .../proposals/{id}/decide` | proposal xmin=784, outbox xmin=785 |
| sdd | `register` | `POST /api/v1/sdd/mandates` | mandate xmin=741, outbox xmin=742 |
| sdd | `transition` (suspend/resume/cancel/confirm) | `POST /api/v1/sdd/mandates/{id}/suspend` | mandate xmin=742, outbox xmin=743 |
| fraud | `FraudHoldService.maybeRaise` | `POST /api/v1/fraud/score` | hold xmin=750, outbox xmin=751 |

The source was restored after each run (`git checkout --`) and the tests re-run green. This PR
contains **test files only**, plus one `build.gradle.kts` test-scope dependency explained below.

Module runs, reading the **SKIPPED** count and not just failures — a service that cannot boot
reports its tests as SKIPPED, and a skip count scans as a pass:

| module | tests | skipped | failures |
|---|---|---|---|
| `openbank-account-service` | 271 | 1 | 0 |
| `openbank-sdd-service` | 63 | 0 | 0 |
| `openbank-fraud-service` | 187 | 1 | 0 |

Both skips are the broker-sourced Pact provider classes (`AccountEventPactProviderVerificationTest`,
`FraudPactProviderVerificationTest` — `@PactBroker` + `@EnabledIfSystemProperty(pactbroker.url)`),
pre-existing and expected on a PR lane. `ktlintCheck` + `detekt` were run as a **separate** Gradle
invocation after `test` — Gradle stops at the first failing task, so a green-looking task list is
not a list that ran — clean on all three. No module OOM'd, and `find pacts -size 0` is empty.

One run in this session did fail with `QuarkusBindException: Port already bound: 8081` from a
parallel Gradle build on the same machine; it was re-run before being believed, per the repo's own
note that that failure is indistinguishable from a real one at a glance.

## The dispatcher, and why the switch is in a PROFILE and not a test resource

`xmin` belongs to a row *version*, so any later UPDATE replaces it. The scheduled outbox dispatcher
claims rows and marks them DISPATCHING/SENT, so it is switched **off** per class. All three services
correctly ship `openbank.outbox.dispatch-enabled: true` in `application.yaml` — the fleet default is
`false`, under which a service dispatches nothing and reports no error — which is precisely why it
has to be disabled here rather than merely left alone.

Where #8496 and #8507 folded that switch into the `@QuarkusTestResource`, this PR puts it in a
`QuarkusTestProfile`. That is not a style preference: a `@QuarkusTestResource` is applied to **every**
test class in the module, and doing it that way turned `SddOutboxDispatchIT` red — that IT drives
`dispatcher.dispatch()` explicitly, and `dispatch()` is a no-op when the flag is false, so the whole
class stopped testing anything. Measured, then fixed; a profile is per-class and forces this class
its own Quarkus boot, which is exactly the scope wanted. Worth knowing before the next tranche
copies the resource form into a module that has a dispatch IT.

sdd's profile carries a second override, `authz.enforce=false`, and it is not incidental: **sdd is
one of the few services shipping `AUTHZ_ENFORCE` defaulted to `true`** (account and fraud both
default it to `false`). With no OPA sidecar reachable the interceptor fails closed, so every write
endpoint answers **503** — not 403 — and without the override the test would be red for a reason
that has nothing to do with the outbox. That is also why sdd had no `@TestSecurity` dependency
before: its existing ITs only ever hit unsecured routes.

## Controls, so the assertions cannot pass vacuously

- **Known-negative** in all three classes: an id that was never written must return no pair at all,
  so `hasSize(1)` is a claim the query is capable of failing.
- **Known-different**, so one run shows the identical comparison both matching and not:
  - *sdd* gets it for free — the suspend UPDATEs the mandate row, so the **registration** outbox row
    was genuinely written by an earlier transaction and must NOT match the current mandate version.
  - *account* and *fraud* drive the write twice (a second proposal / a second party) and require the
    identical comparison to fail across them.
- **A second, structural control in account**: the REJECT branch calls `save(proposal)` — the
  overload with no event — so it must write **no** outbox row. That keeps `hasSize(1)` honest about
  *which* write path produced the row.
- **Arrangement assertions**, so a change that moves the test onto a different write path fails here
  rather than silently asserting over an empty outbox: account asserts the decision came back
  `APPROVED`/`REJECTED`, sdd asserts `ACTIVE` then `SUSPENDED` (only a CORE mandate is born ACTIVE,
  and only an ACTIVE one can be suspended), fraud asserts every scoring call returned `REVIEW` (only
  a REVIEW counts towards `review-threshold: 3`, and only the third call reaches the write).

## One collaborator that had to be pinned, and one that did not

`fraud`'s `maybeRaise` returns early when the account maps to no party, so with no account-service
reachable the test would assert nothing while looking like it had. `StubAccountPartyLookupPort`
(`@Alternative @Priority(1)`, declared alongside `FraudHoldServiceIT`) already replaces that port
for the module; this class only sets which party it answers with. The ML shadow model, by contrast,
runs after the write and fails open by design, so it needs no stub — its "model card verification
FAILED" lines in the log are the designed behaviour, not a defect.

## Finding, reported and NOT fixed here

**`openbank-sca-service` is NOT atomic — measured, not inferred.** `ScaService.enroll` awaits
`enrolledDeviceRepository.save(...)`, whose `EnrolledDeviceRepositoryImpl.save` opens and commits
its **own** `Panache.withTransaction`, and then calls `outboxRepository.save(...)`, whose
`ScaOutboxRepositoryImpl.save` opens a **second** one. Nothing wraps the pair: `ScaResource` carries
no `@WithTransaction` anywhere, and `enroll` is a `suspend fun`, so there is no ambient transaction
for either to join. A throwaway copy of this PR's test, run against unmodified `main`, answered
`device xmin=751, outbox xmin=752` — two transactions.

So a crash between the two commits leaves a device enrolled with `sca.device_enrolled` never
emitted, permanently, and every presence-based assertion stays green about it. That event already
has history: onboarding-service discarded it for months (#4353), so a silently-lost one is not
hypothetical. It is `sca`'s **only** outbox write — `outboxRepository` has exactly one call site in
`src/main` — so the service's whole outbox is on this path.

A test for it is deliberately **not** in this PR: it would be red on `main`. Same shape as #8509
(clearing) and a sibling of #8510 (balance/psd2's outbox with no producer).

## Remaining scope for #8353

Money-path, has an outbox entity, still only a `*OutboxClaimIT`: `balance`, `clearing`, `swift`,
`interest`, `sca`, `billing`, `psd2` — of which `balance`/`psd2` are the dead-outbox finding
(#8510), and `clearing`/`sca` are blocked on the atomicity defects above (#8509 and this PR).
`swift`, `interest` and `billing` remain genuinely testable and were passed over here only for the
stubbing/four-eyes reasons #8507 already recorded.

Refs #8353

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without
      justification (state it in this PR).
- [x] No new third-party dependency, OR: dependency review attached
      (license, CVE, source). `testImplementation(libs.quarkus.test.security)` in sdd-service's
      `build.gradle.kts` is an existing catalog entry already used by other services' test suites
      (e.g. account-service) — not a new dependency to the tree.
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. Test-only PR:
      3 new integration tests asserting outbox-row atomicity by transaction id across
      account/fraud/sdd. No production code touched.
- [x] PII path changed? → tag `gdpr-review-required`. No.
- [x] Cardholder data path changed? → tag `pci-review-required`. No.
