### PR TITLE
feat(security): vex-hotfix — KEV-listed CVE opens an automatic hotfix PR

### DIFF
--- a/.github/scripts/vex-hotfix.py
+++ b/.github/scripts/vex-hotfix.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""KEV-listed CVE -> automatic hotfix PR against the Gradle version catalog.
+
+WHY (ADR-0279 WS3 #13). vex-triage.py already escalates a KEV CVE to a
+severity:critical issue with the `kev-listed` label (#8620). Escalation without a
+remediation path is an alarm, not a fix — the loop closed here: when OSV knows a fixed
+version AND the vulnerable module is pinned directly in
+`openbank-libs/gradle/libs.versions.toml`, this script opens the bump PR itself.
+A human still reviews and merges — the bot writes the diff, never presses merge.
+
+SCOPE, deliberately narrow:
+  * only issues labelled `kev-listed` (actively exploited — the whole point of the
+    lane; the general dependency wave stays with Dependabot);
+  * only Maven-ecosystem entries whose package name is an exact `group:artifact`
+    of a `[libraries]` entry with a `version.ref` or inline `version` — a BOM-managed
+    or transitive dependency has no line to bump and gets an issue COMMENT saying so
+    (actionable: the fix is a BOM/platform bump, a human decision);
+  * one PR per CVE, idempotent — an existing open PR on the same branch is reused,
+    never duplicated.
+
+FAILURE POSTURE: degrade-don't-die. An OSV outage or an unreadable issue skips that
+CVE with a ::warning; the run still reports what it did. A catalog parse failure is
+fatal (that would mean the file the PR would edit is not what we think).
+
+Usage:  vex-hotfix.py [--dry-run]
+        vex-hotfix.py --self-test      # offline, no network, no repo
+Env:    GH_TOKEN (issues/PR API), GITHUB_REPOSITORY (owner/name)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+API = "https://api.github.com"
+TOKEN = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN", "")
+REPO = os.environ.get("GITHUB_REPOSITORY", "")
+KEV_LABEL = "kev-listed"
+TITLE_RE = re.compile(r"VEX triage:\s*(CVE-\d{4}-\d+)")
+CATALOG = Path("openbank-libs/gradle/libs.versions.toml")
+BRANCH_PREFIX = "security/kev-hotfix"
+
+
+# ── pure, offline-testable halves ────────────────────────────────────────────
+
+def parse_catalog(text: str) -> dict[str, tuple[str, str]]:
+    """module 'group:artifact' -> (version_key, pinned_version) for libraries whose
+    version is a `version.ref` into [versions] or an inline `version = "..."`.
+    Entries with neither (BOM-managed) are intentionally absent from the result."""
+    versions = dict(re.findall(r'^([a-z0-9-]+)\s*=\s*"([^"]+)"', text, re.M))
+    out: dict[str, tuple[str, str]] = {}
+    for m in re.finditer(
+        r'^([a-z0-9-]+)\s*=\s*\{\s*module\s*=\s*"([^"]+)"([^}]*)}', text, re.M
+    ):
+        alias, module, rest = m.group(1), m.group(2), m.group(3)
+        ref = re.search(r'version\.ref\s*=\s*"([^"]+)"', rest)
+        inl = re.search(r'version\s*=\s*"([^"]+)"', rest)
+        ver = versions.get(ref.group(1)) if ref else (inl.group(1) if inl else None)
+        if ver:
+            out[module] = (alias, ver)
+    return out
+
+
+def osv_fixed_versions(doc: dict) -> dict[str, str]:
+    """Maven 'group:artifact' -> lowest fixed version, from an OSV vuln document."""
+    out: dict[str, str] = {}
+    for aff in doc.get("affected") or []:
+        pkg = aff.get("package") or {}
+        if pkg.get("ecosystem") != "Maven":
+            continue
+        name = pkg.get("name", "")
+        for rng in aff.get("ranges") or []:
+            for ev in rng.get("events") or []:
+                fixed = ev.get("fixed")
+                if fixed and (name not in out or version_key(fixed) < version_key(out[name])):
+                    out[name] = fixed
+    return out
+
+
+def version_key(v: str) -> tuple:
+    parts = re.split(r"[.\-+]", v)
+    return tuple(int(p) if p.isdigit() else 0 for p in parts)
+
+
+def is_upgrade(pinned: str, fixed: str) -> bool:
+    return version_key(fixed) > version_key(pinned)
+
+
+def bump_catalog(text: str, alias: str, new_version: str) -> str:
+    """Rewrite the [versions] line for `alias`'s version.ref target — the alias line
+    itself never carries the number in this catalog's convention."""
+    # find the library's version.ref
+    m = re.search(
+        rf'^{re.escape(alias)}\s*=\s*\{{[^}}]*version\.ref\s*=\s*"([^"]+)"[^}}]*\}}',
+        text, re.M)
+    if not m:
+        raise ValueError(f"{alias}: no version.ref (inline versions are not bumped)")
+    key = m.group(1)
+    new_text, n = re.subn(rf'^({re.escape(key)}\s*=\s*")[^"]+(")', rf"\g<1>{new_version}\g<2>",
+                          text, count=1, flags=re.M)
+    if n != 1:
+        raise ValueError(f"version key '{key}' not found exactly once in [versions]")
+    return new_text
+
+
+def self_test() -> int:
+    bad = 0
+    cat = (
+        "[versions]\nlogback = \"1.5.6\"\nquarkus = \"3.38.0\"\n\n"
+        "[libraries]\n"
+        "logback-classic = { module = \"ch.qos.logback:logback-classic\", version.ref = \"logback\" }\n"
+        "quarkus-rest = { module = \"io.quarkus:quarkus-rest\" }\n"  # BOM-managed: absent from map
+    )
+    pins = parse_catalog(cat)
+    if pins.get("ch.qos.logback:logback-classic") != ("logback-classic", "1.5.6"):
+        print("self-test FAIL: catalog parse"); bad += 1
+    if "io.quarkus:quarkus-rest" in pins:
+        print("self-test FAIL: BOM-managed entry must not be pinnable"); bad += 1
+    doc = {"affected": [
+        {"package": {"ecosystem": "Maven", "name": "ch.qos.logback:logback-classic"},
+         "ranges": [{"events": [{"introduced": "0"}, {"fixed": "1.5.13"}]}]},
+        {"package": {"ecosystem": "npm", "name": "left-pad"},
+         "ranges": [{"events": [{"introduced": "0"}, {"fixed": "9.9.9"}]}]},
+    ]}
+    fixed = osv_fixed_versions(doc)
+    if fixed != {"ch.qos.logback:logback-classic": "1.5.13"}:
+        print("self-test FAIL: fixed-version extraction"); bad += 1
+    if not is_upgrade("1.5.6", "1.5.13") or is_upgrade("1.5.13", "1.5.6"):
+        print("self-test FAIL: version comparison"); bad += 1
+    bumped = bump_catalog(cat, "logback-classic", "1.5.13")
+    if 'logback = "1.5.13"' not in bumped or 'quarkus = "3.38.0"' not in bumped:
+        print("self-test FAIL: catalog bump rewrote the wrong line"); bad += 1
+    try:
+        bump_catalog(cat, "quarkus-rest", "9.9.9")
+        print("self-test FAIL: BOM-managed alias must refuse the bump"); bad += 1
+    except ValueError:
+        pass
+    print("vex-hotfix self-test: " + ("clean" if not bad else f"{bad} failure(s)"))
+    return 1 if bad else 0
+
+
+# ── networked halves ─────────────────────────────────────────────────────────
+
+def gh(url: str, method: str = "GET", body: dict | None = None):
+    req = urllib.request.Request(
+        url, method=method,
+        data=json.dumps(body).encode() if body is not None else None,
+        headers={"Authorization": f"Bearer {TOKEN}", "Accept": "application/vnd.github+json",
+                 "X-GitHub-Api-Version": "2022-11-28", "Content-Type": "application/json"})
+    with urllib.request.urlopen(req) as r:
+        return json.loads(r.read() or "{}")
+
+
+def osv_doc(cve: str) -> dict | None:
+    try:
+        with urllib.request.urlopen(f"https://api.osv.dev/v1/vulns/{cve}", timeout=15) as r:
+            return json.loads(r.read())
+    except (urllib.error.URLError, json.JSONDecodeError, TimeoutError) as e:
+        print(f"::warning::{cve}: OSV unreachable ({e}) — skipped this run")
+        return None
+
+
+def kev_issues() -> list[dict]:
+    out: list[dict] = []
+    page = 1
+    while True:
+        batch = gh(f"{API}/repos/{REPO}/issues?state=open&labels={KEV_LABEL}&per_page=100&page={page}")
+        if not batch:
+            return out
+        out.extend(it for it in batch if TITLE_RE.match(it.get("title", "")))
+        page += 1
+
+
+def run_git(*args: str) -> None:
+    subprocess.run(["git", *args], check=True, capture_output=True, text=True)
+
+
+def open_hotfix_pr(cve: str, issue: dict, module: str, alias: str, pinned: str, fixed: str,
+                   dry: bool) -> None:
+    branch = f"{BRANCH_PREFIX}-{cve.lower()}"
+    body = (
+        f"## What\n\nBump `{module}` **{pinned} → {fixed}** — fixes {cve}, which is on the "
+        f"CISA Known Exploited Vulnerabilities catalog.\n\n"
+        f"Opened automatically by `vex-hotfix.yml` (ADR-0279 #13). A human reviews and merges; "
+        f"the bot writes the diff, never presses merge.\n\n"
+        f"Refs #{issue['number']}\n\n"
+        f"Links: [OSV](https://osv.dev/vulnerability/{cve}) · "
+        f"[CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)\n")
+    if dry:
+        print(f"[dry-run] would open PR {branch}: {module} {pinned} -> {fixed} (issue #{issue['number']})")
+        return
+    existing = gh(f"{API}/repos/{REPO}/pulls?state=open&head={REPO.split('/')[0]}:{branch}")
+    if existing:
+        print(f"PR already open for {cve} (#{existing[0]['number']}) — skipping")
+        return
+    run_git("checkout", "-b", branch, "origin/main")
+    text = CATALOG.read_text()
+    CATALOG.write_text(bump_catalog(text, alias, fixed))
+    run_git("add", str(CATALOG))
+    run_git("-c", "user.name=github-actions[bot]",
+            "-c", "user.email=41898282+github-actions[bot]@users.noreply.github.com",
+            "commit", "-s", "-m",
+            f"fix(security): bump {module} to {fixed} — {cve} (KEV)\n\nRefs #{issue['number']}")
+    run_git("push", "-u", "origin", branch)
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as bf:
+        bf.write(body)
+        path = bf.name
+    subprocess.run(["gh", "pr", "create", "--title",
+                    f"fix(security): bump {module.split(':')[1]} to {fixed} — {cve} (KEV)",
+                    "--body-file", path, "--base", "main",
+                    "--label", "security", "--label", KEV_LABEL],
+                   check=True)
+    print(f"opened hotfix PR for {cve}: {module} {pinned} -> {fixed}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+    if not TOKEN or not REPO:
+        sys.exit("GH_TOKEN and GITHUB_REPOSITORY required")
+
+    pins = parse_catalog(CATALOG.read_text())
+    acted = 0
+    for issue in kev_issues():
+        cve = TITLE_RE.match(issue["title"]).group(1)
+        doc = osv_doc(cve)
+        if doc is None:
+            continue
+        fixed_map = osv_fixed_versions(doc)
+        hits = [(m, fixed_map[m]) for m in fixed_map if m in pins and is_upgrade(pins[m][1], fixed_map[m])]
+        unpinned = [m for m in fixed_map if m not in pins]
+        if not hits:
+            note = "no fixed version in OSV yet" if not fixed_map else (
+                f"fix exists ({', '.join(f'{m} → {v}' for m, v in fixed_map.items())}) but the "
+                f"module is BOM-managed/transitive — no catalog line to bump; needs a human "
+                f"platform decision" if unpinned else "no fixed version in OSV yet")
+            print(f"{cve} (#{issue['number']}): {note}")
+            if fixed_map and unpinned and not args.dry_run:
+                gh(f"{API}/repos/{REPO}/issues/{issue['number']}/comments", "POST", {
+                    "body": f"vex-hotfix: {note}. No automatic PR opened. — ADR-0279 #13"})
+            continue
+        for module, fixed in hits:
+            alias, pinned = pins[module]
+            try:
+                open_hotfix_pr(cve, issue, module, alias, pinned, fixed, args.dry_run)
+                acted += 1
+            except (subprocess.CalledProcessError, ValueError) as e:
+                print(f"::warning::{cve}: hotfix PR failed ({e}) — issue stays open for a human")
+    print(f"vex-hotfix: {acted} hotfix PR(s) opened/reused")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/vex-hotfix.yml
+++ b/.github/workflows/vex-hotfix.yml
@@ -1,0 +1,58 @@
+# VEX hotfix (ADR-0279 WS3 #13) — closes the loop vex-triage.yml opens.
+#
+# vex-triage escalates a KEV-listed CVE to a severity:critical issue; this lane turns
+# the ones with a known fix into a hotfix PR: OSV fixed version + a direct pin in
+# openbank-libs/gradle/libs.versions.toml → branch + bump commit + PR labelled
+# security/kev-listed, linked to the triage issue. A human reviews and merges — the
+# bot writes the diff, never presses merge. BOM-managed/transitive modules get an
+# issue comment instead (the fix is a platform bump, a human decision).
+#
+# Deliberately narrower than Dependabot: only `kev-listed` issues (actively
+# exploited CVEs), one idempotent PR per CVE. Weekly Tuesday, a day after the
+# triage run that applies the label.
+#
+# Push-on-main note: this workflow never pushes to main (schedule/dispatch only, PR
+# branches only), so main-red-watch does not watch it — its failure mode is a red
+# run visible in the Actions tab, same as vex-triage.yml's SLA escalation.
+name: VEX hotfix
+
+on:
+  schedule:
+    - cron: "17 8 * * 2"   # weekly Tuesday 08:17 UTC, after Monday's vex-triage run
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report what would change without opening PRs or comments"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  vex-hotfix:
+    name: KEV hotfix PRs
+    # Public repo ⇒ hosted runners are free; no cluster access needed (FinOps: hosted-first).
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write        # push the hotfix branch
+      pull-requests: write   # open the PR
+      issues: write          # comment when no direct pin exists
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0   # the script branches from origin/main
+
+      - name: Script self-test (offline — proves the matching logic can still fail)
+        run: python3 .github/scripts/vex-hotfix.py --self-test
+
+      - name: Open KEV hotfix PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/vex-hotfix.py \
+            ${{ inputs.dry_run == true && '--dry-run' || '' }}


### PR DESCRIPTION
## What

Closes the loop ADR-0279 WS3 #13 asks for (tracked under #8590). #8620 made vex-triage escalate a KEV CVE to a `severity:critical` + `kev-listed` issue; this lane turns the ones with a known fix into a **hotfix PR**:

- **`.github/scripts/vex-hotfix.py`** — for each open `kev-listed` triage issue: fetch the OSV doc, extract Maven `fixed` versions, match `group:artifact` against direct pins in `openbank-libs/gradle/libs.versions.toml`, and where the fixed version is an upgrade, open a branch + bump commit + PR (`security`, `kev-listed` labels, `Refs #<triage issue>`). Idempotent: an existing open PR on the branch is reused, never duplicated.
- **`.github/workflows/vex-hotfix.yml`** — weekly Tuesday 08:17 UTC (a day after Monday's triage run applies the label) + `workflow_dispatch` with `dry_run`.

## Boundaries (deliberate)

- **The bot writes the diff, never presses merge** — every hotfix PR goes through the normal review + CI gates.
- Only `kev-listed` issues — actively exploited CVEs. The general dependency wave stays with Dependabot.
- BOM-managed / transitive modules have no catalog line to bump: they get an **actionable issue comment** ("fix exists, needs a platform decision") instead of a silently missing PR.
- Degrade-don't-die: OSV outage skips the CVE with a `::warning`; catalog parse failure is fatal (that would mean the file being edited is not what we think).

## Verification

- Offline `--self-test`: clean — catalog parse, fixed-version extraction (npm entries ignored), version comparison, exact-line bump, and the BOM-managed refusal are all exercised and can all still fail.
- The workflow runs the self-test before the live pass on every run, so a logic regression turns the lane red instead of silently opening wrong PRs.
- `check-main-red-watch`: passes (workflow never pushes to main — declared in the header comment).

Refs #8590
