### PR TITLE
perf(ci): lower gate-health detail runs 5 → 3 (and correct my own overstated saving)

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -495,6 +495,12 @@ jobs:
           set -u
           api() { curl -sf -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" "$@"; }
           mkdir -p openbank-admin-ui/test-run-history
+          # Measured 2026-09-04: only 54 non-expired main-branch `test-intelligence-run-*`
+          # artifacts exist repo-wide, so this cap does not bind and lowering it saves ~4
+          # requests, not ~50. Left at 100 deliberately. What those 54 buy is the number
+          # that matters and it is not this one: 21 components across 10 CI runs spanning
+          # 0.6 HOURS, median 2 envelopes per component — a snapshot, not the per-test-case
+          # history it feeds. The binding constraint is artifact retention (see #8690).
           MAX_ENVELOPES=100
           # The workflow-runs endpoint is dominated by deploy-only Services CI runs, which
           # produce no per-service envelope.  Even a 100-run scan can therefore find zero

--- a/openbank-admin-ui/scripts/collect-gate-health.mjs
+++ b/openbank-admin-ui/scripts/collect-gate-health.mjs
@@ -16,10 +16,15 @@
 //   * Per-GATE detail (id-level status, subjects, self-test, budget) — requires
 //     downloading and unzipping the `gate-results-<group>` artifact `run-gates.py
 //     --json` writes and ci.yml uploads. Bounded to `--gate-detail-runs` (default
-//     5): artifacts expire (this repo has not overridden GitHub's 90-day default,
-//     but 5 runs is enough for "current state + is this flaky right now" without
-//     paying for a long backfill on every deploy). Missing/expired artifacts
-//     degrade that run to shard-only data, never a crash.
+//     3): artifacts expire (this repo has not overridden GitHub's 90-day default,
+//     but a few runs are enough for "current state + is this flaky right now"
+//     without paying for a long backfill on every deploy). Missing/expired
+//     artifacts degrade that run to shard-only data, never a crash.
+//     Lowered 5 -> 3 on 2026-09-04. Each detail run costs 1 artifact listing plus
+//     one download per shard, and the shard count went 8 -> 3 (#6257), so 5 runs
+//     is 20 requests where 3 is 12. The installation API quota — 1000/hour, shared
+//     by every workflow — was exhausted at 08:01 on 2026-09-03 and took Trivy's
+//     SARIF upload and dependency-review down fleet-wide, including on main.
 //
 // Honest by construction, like every other collector in this directory: outside
 // a token, or on any API failure, this writes `available:false` and a reason —
@@ -40,7 +45,7 @@ const getArg = (flag, dflt) => {
 }
 const OUT = getArg('--out', 'gate-health.json')
 const RUNS = parseInt(getArg('--runs', '20'), 10)
-const GATE_DETAIL_RUNS = parseInt(getArg('--gate-detail-runs', '5'), 10)
+const GATE_DETAIL_RUNS = parseInt(getArg('--gate-detail-runs', '3'), 10)
 // A build-time observability collector must degrade, never strand a deployment
 // behind one unavailable GitHub API connection. Keep this bounded and allow a
 // runner-specific override for diagnosed transient network conditions.


### PR DESCRIPTION
## Correction first

**My first push claimed ~62 requests saved and −18%. Both were wrong by roughly 4×.** I used `MAX_ENVELOPES=100` as the download count while having measured, in the same session, that only **54** such artifacts exist. The cap never bound.

Corrected: a build is **~299** requests (not ~345), and this PR takes it to **~291 — about −3%**.

## What changes

| parameter | from | to | saving | evidence |
|---|---|---|---|---|
| `--gate-detail-runs` (`collect-gate-health.mjs`) | 5 | **3** | **8 requests/build** | each detail run = 1 listing + 1 download per shard; shards went 8→3 in #6257. Verified live: **3 runs still yields 206 distinct gates**, identical to 5 |

That is the whole change.

## What I withdrew

- **`MAX_ENVELOPES` 100 → 50.** Saves 4 requests, not 50. Withdrawn as noise.
- **History paging 5 pages → 2.** Worth 3 requests, and it fails `test-intelligence-ecosystem`, which asserts the literal string `"for page in 1 2 3 4 5; do"`. That gate checks a **string** where it means a **property** — a known trap here — but the honest response is not to edit a guard so my change fits it, for three requests. Reverted.

## What is documented in place

The cap stays at 100, with a comment recording what those 54 envelopes actually buy:

```
21 distinct components | 10 distinct CI runs | 0.6 HOURS of span
median 2 envelopes per component
```

They feed `testCaseHistory()` — per-test-case state over time, i.e. the flakiness view. **Two points per service across 36 minutes is a snapshot, not a trend.** The binding constraint is artifact **retention**, not the cap.

## Why this matters at all, given −3%

`admin-ui-deploy` is the largest consumer of the **installation** API quota — 1000/hour, shared by every workflow — at ~299 requests/build and ~4 builds/hour, i.e. **~1200/hour on its own**. That quota was exhausted at **2026-09-03 08:01Z** and took Trivy's SARIF upload and `dependency-review` down fleet-wide including on `main`; Code Scanning silently stopped updating for ~20 minutes.

−3% does not fix that. The two structural options, with their numbers, are in **#8690**.

## Linked issues

Refs #8690 — retention, and not rebuilding the history every build.
Refs #6853 — the same installation rate limit from the spot-kill-retry side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
