### PR TITLE
fix(party): define ROLE_DPO in the realm templates (#8495)

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -3971,10 +3971,10 @@ gates:
   # a test written from the annotation matches the annotation and passes against a resource
   # that 403s in production — exactly how finrep's stayed green.
   - id: rolesallowed-realm-parity
-    name: "@RolesAllowed ⇒ realm parity (issue #2404, enforced)"
+    name: "@RolesAllowed + hasRole ⇒ realm parity (issues #2404, #8495, enforced)"
     group: security
     mode: enforced
-    min_subjects: 200   # 419 @RolesAllowed sites today (2026-08-09)
+    min_subjects: 200   # 491 role-reference sites today (2026-09-04): 419 @RolesAllowed + hasRole probes (#8495)
     selftest: python3 .github/scripts/check-roles-allowed-realm.py --self-test
     selftest_expect: pass
     selftest_inputs: [".github/scripts/check-roles-allowed-realm.py"]

--- a/.github/scripts/check-realm-role-parity.py
+++ b/.github/scripts/check-realm-role-parity.py
@@ -147,7 +147,7 @@ def annotation_roles(root: pathlib.Path) -> dict:
     spec.loader.exec_module(mod)
     consts = mod.role_constants(root)
     sites = {}
-    for rel, line, names, _dead in mod.scan(root, set(), consts):
+    for rel, line, names, _dead, _form in mod.scan(root, set(), consts):
         for n in names:
             sites.setdefault(n, []).append(f"{rel}:{line}")
     return sites

--- a/.github/scripts/check-roles-allowed-realm.py
+++ b/.github/scripts/check-roles-allowed-realm.py
@@ -2,7 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 #
-# Guard: every @RolesAllowed role name must exist in a Keycloak realm (issue #2404).
+# Guard: every @RolesAllowed role name must exist in a Keycloak realm (issue #2404), and
+# every literal role probed via hasRole("...") must have an issuer too (issue #8495 — the
+# same dead-name defect one layer down, where it reads as a working endpoint with a
+# silently unreachable branch).
 #
 # WHY THIS EXISTS
 #   `@RolesAllowed` takes a compile-time string, and nothing checked that the string names a role
@@ -55,6 +58,14 @@ ROLES_KT = "openbank-libs-domain/src/main/kotlin/com/openbank/libs/security/Role
 CATALOG_ROLES_KT = "openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/security/CatalogScopeIdentityAugmentor.kt"
 
 ANNOTATION_RE = re.compile(r"@RolesAllowed\s*\(([^)]*)\)", re.S)
+# The same dead-role defect one layer down (#8495): `hasRole("ROLE_X")` is a runtime probe of
+# the same string. A role no realm issues makes the branch it guards unreachable forever, and
+# worse than the annotation case, it fails CLOSED-looking: the endpoint answers 200 through its
+# other caller shapes, so nothing anywhere notices the branch is dead. ROLE_DPO sat in exactly
+# that state for the life of the GDPR export endpoints — the DPO branch was dead code and the
+# only test mentioning it stubbed the probe to `false`. Literal-argument calls only; a
+# `hasRole(Roles.X)` constant is resolved through `consts` the same way the annotation form is.
+HASROLE_RE = re.compile(r'hasRole\s*\(\s*(?:"([^"]+)"|(?:(Roles|CatalogRoles)\.(\w+)))\s*\)')
 ARG_RE = re.compile(r'"([^"]+)"|(?:(Roles|CatalogRoles)\.(\w+))')
 CONST_RE = re.compile(r'const\s+val\s+(\w+)\s*[:=][^"]*"([^"]+)"')
 
@@ -152,19 +163,31 @@ def role_constants(root: pathlib.Path):
 
 
 def scan(root: pathlib.Path, known, consts):
-    """Yield (path, line, all_names, dead_names) for every @RolesAllowed in service main sources."""
+    """Yield (path, line, all_names, dead_names) for every role reference in service main sources.
+
+    Covers both reference shapes: `@RolesAllowed(...)` annotations and `hasRole(...)` probes
+    (the same dead-name defect one layer down, #8495). A hasRole call names exactly one role,
+    so for it `names` is always a one-element list. The fifth element is the reference form
+    ("annotation" or "probe") so the finding names what was actually read.
+    """
     for f in sorted(root.glob("openbank-*/src/main/kotlin/**/*.kt")):
         src = strip_comments(f.read_text())
-        for m in ANNOTATION_RE.finditer(src):
-            names = []
-            for literal, qualifier, const in ARG_RE.findall(m.group(1)):
-                key = f"{qualifier}.{const}" if qualifier else ""
-                names.append(literal or consts.get(key, key))
-            if not names:
-                continue
-            line = src[: m.start()].count("\n") + 1
-            dead = [n for n in names if n not in known]
-            yield f.relative_to(root), line, names, dead
+        for pattern, form in ((ANNOTATION_RE, "annotation"), (HASROLE_RE, "probe")):
+            for m in pattern.finditer(src):
+                # The annotation captures its whole argument list in group 1; the probe
+                # captures either the literal (1) or the qualifier.constant (2, 3).
+                argtext = m.group(1) if form == "annotation" else (
+                    f'"{m.group(1)}"' if m.group(1) is not None else f"{m.group(2)}.{m.group(3)}"
+                )
+                names = []
+                for literal, qualifier, const in ARG_RE.findall(argtext):
+                    key = f"{qualifier}.{const}" if qualifier else ""
+                    names.append(literal or consts.get(key, key))
+                if not names:
+                    continue
+                line = src[: m.start()].count("\n") + 1
+                dead = [n for n in names if n not in known]
+                yield f.relative_to(root), line, names, dead, form
 
 
 def self_test() -> int:
@@ -214,6 +237,10 @@ def self_test() -> int:
             '@RolesAllowed(CatalogRoles.AUTHOR)\nfun g() {}\n\n'                  # catalog constant
             '@RolesAllowed("ROLE_DERIVED_AT_RUNTIME")\nfun h() {}\n\n'            # augmentor-issued
             '// @RolesAllowed("ROLE_IN_A_COMMENT")\nfun f() {}\n'                   # prose
+            'fun i() { id.hasRole("ROLE_OPERATOR") }\n\n'                        # probe, known
+            'fun j() { id.hasRole("ROLE_TYPO3") }\n\n'                           # THE PROBE DEFECT (#8495)
+            'fun k() { id.hasRole(Roles.GHOST) }\n\n'                            # probe via constant
+            '// id.hasRole("ROLE_PROBE_IN_A_COMMENT")\n'                          # probe prose
         )
 
         # A real augmentor: implements SecurityIdentityAugmentor AND calls addRoles, so the role
@@ -248,12 +275,12 @@ def self_test() -> int:
         if consts != expected_consts:
             fails.append(f"role constants wrong: {consts}")
 
-        found = {str(rel) + ":" + str(line): (names, dead) for rel, line, names, dead in scan(root, known, consts)}
+        found = {str(rel) + ":" + str(line): (names, dead) for rel, line, names, dead, _ in scan(root, known, consts)}
         allnames = [n for names, _ in found.values() for n in names]
         alldead = sorted({d for _, dead in found.values() for d in dead})
 
-        # THE DEFECT and its constant-valued twin must both be dead.
-        for want in ("ROLE_TYPO", "ROLE_NEVER_DEFINED", "ROLE_TYPO2", "ROLE_CATALOG_AUTHOR"):
+        # THE DEFECT, its constant-valued twin, and the probe-shape twin must all be dead.
+        for want in ("ROLE_TYPO", "ROLE_NEVER_DEFINED", "ROLE_TYPO2", "ROLE_CATALOG_AUTHOR", "ROLE_TYPO3"):
             if want not in alldead:
                 fails.append(f"{want} should be reported as not in the realm; dead={alldead}")
         # Known roles must NOT be — a gate that flags valid roles is one nobody keeps.
@@ -272,6 +299,8 @@ def self_test() -> int:
         # Prose must not be read as code.
         if "ROLE_IN_A_COMMENT" in allnames:
             fails.append("an annotation inside a // comment was read as code")
+        if "ROLE_PROBE_IN_A_COMMENT" in allnames:
+            fails.append("a hasRole probe inside a // comment was read as code")
 
     # --- the comment stripper, which is where nesting bites (Kotlin block comments NEST) ---
     if "X" in strip_comments("/* a /* b */ X */"):
@@ -294,7 +323,7 @@ def self_test() -> int:
             sys.stderr.write(f"::error::self-test: {f}\n")
         sys.stderr.write(f"self-test FAILED ({len(fails)} case(s))\n")
         return 1
-    print("self-test ok: @RolesAllowed realm parity is falsifiable (16 cases)")
+    print("self-test ok: @RolesAllowed + hasRole realm parity is falsifiable (20 cases)")
     return 0
 
 
@@ -314,9 +343,13 @@ def main() -> int:
     known |= derived
     consts = role_constants(root)
 
-    unreachable, partial, checked = [], [], 0
-    for rel, line, names, dead in scan(root, known, consts):
+    unreachable, partial, dead_probes, checked = [], [], [], 0
+    for rel, line, names, dead, form in scan(root, known, consts):
         checked += 1
+        if form == "probe":
+            if dead:
+                dead_probes.append((rel, line, names[0]))
+            continue
         if dead and len(dead) == len(names):
             unreachable.append((rel, line, names))
         elif dead:
@@ -336,20 +369,28 @@ def main() -> int:
             f"Keycloak or delete it from the annotation.",
         )
 
+    for rel, line, role in dead_probes:
+        errors.append(
+            f"{rel}:{line} — hasRole(\"{role}\") probes a role no realm issues, so the branch it "
+            f"guards is unreachable forever while the endpoint answers through its other caller "
+            f"shapes — nothing anywhere says so (#8495: ROLE_DPO sat exactly like this on the "
+            f"GDPR export endpoints). Define the role in the realm template or delete the branch.",
+        )
+
     # Before the verdict, so a gate that found its corpus and then failed on it is not also
     # reported as having lost the corpus.
-    gatelib.subjects(checked, "@RolesAllowed sites")
+    gatelib.subjects(checked, "role-reference sites")
 
     if errors:
         for e in errors:
             sys.stderr.write(f"::error title=RolesAllowed realm parity::{e}\n")
-        sys.stderr.write(f"::error::check-roles-allowed-realm: {len(errors)} @RolesAllowed name(s) no realm issues.\n")
+        sys.stderr.write(f"::error::check-roles-allowed-realm: {len(errors)} role name(s) no realm issues.\n")
         return 1
 
     print(
-        f"roles-allowed parity: {checked} @RolesAllowed site(s) checked against "
-        f"{len(known)} role(s) — {len(known) - len(derived)} from {', '.join(realm_files)} and "
-        f"{len(derived)} synthesised by a SecurityIdentityAugmentor "
+        f"roles-allowed parity: {checked} role-reference site(s) (@RolesAllowed + hasRole) checked "
+        f"against {len(known)} role(s) — {len(known) - len(derived)} from "
+        f"{', '.join(realm_files)} and {len(derived)} synthesised by a SecurityIdentityAugmentor "
         f"({', '.join(sorted(derived)) or 'none'}); every named role has an issuer.",
     )
     return 0

--- a/openbank-infra/docker/keycloak/realm/openbank-realm.json
+++ b/openbank-infra/docker/keycloak/realm/openbank-realm.json
@@ -30,6 +30,10 @@
         "description": "Read-only access"
       },
       {
+        "name": "ROLE_DPO",
+        "description": "Data Protection Officer — GDPR Art. 15/20 export endpoints (ADR-0204); no write actions"
+      },
+      {
         "name": "ROLE_API",
         "description": "Machine-to-machine API access"
       },

--- a/openbank-infra/gitops/components/keycloak/realm-template.json
+++ b/openbank-infra/gitops/components/keycloak/realm-template.json
@@ -63,6 +63,10 @@
         "description": "Read-only access to audit trail (SOX/DORA evidence)"
       },
       {
+        "name": "ROLE_DPO",
+        "description": "Data Protection Officer — GDPR Art. 15/20 export endpoints (ADR-0204); no write actions"
+      },
+      {
         "name": "ROLE_SUPERVISOR",
         "description": "Approves limit overrides, large payments, board-level escalations"
       },

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/rest/PartyResourceAuditTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/rest/PartyResourceAuditTest.kt
@@ -119,6 +119,33 @@ class PartyResourceAuditTest {
     }
 
     @Test
+    fun `exportPartyGdpr admits a DPO caller and audits the access`(): Unit = runBlocking {
+        // #8495: ROLE_DPO is now a real realm role, so pin the branch the other way than the
+        // fixture above — a caller holding ONLY ROLE_DPO (no ROLE_ADMIN, no self-JWT) must be
+        // admitted. Before the role was defined in the realm this branch was unreachable and
+        // the suite stayed green precisely because nothing could hold it.
+        val events = mutableListOf<AuditEvent>()
+        val res = resource(events).apply {
+            securityIdentity = mockk<io.quarkus.security.identity.SecurityIdentity>().also {
+                every { it.hasRole("ROLE_ADMIN") } returns false
+                every { it.hasRole("ROLE_DPO") } returns true
+            }
+        }
+        coEvery { res.partyUseCase.getPartyKeycloakSub(partyId) } returns "somebody-else"
+        coEvery { res.partyUseCase.exportPartyData(partyId) } returns
+            PartyGdprExport(sampleParty(), emptyList(), now)
+
+        val response = res.exportPartyGdpr(partyId)
+
+        assertThat(response.status).isEqualTo(200)
+        assertThat(events).singleElement().satisfies({ e ->
+            assertThat(e.operation).isEqualTo("party.gdpr-export")
+            assertThat(e.result).isEqualTo(AuditResult.SUCCESS)
+            assertThat(e.payload["gdpr_article"]).isEqualTo("15")
+        })
+    }
+
+    @Test
     fun `exportPartyGdpr does not emit an audit event when the subject fetch fails`(): Unit = runBlocking {
         val events = mutableListOf<AuditEvent>()
         val res = resource(events)


### PR DESCRIPTION
## Summary

`ROLE_DPO` was granted by nothing — zero hits across every realm JSON — so the `hasRole("ROLE_DPO")` branch of both GDPR export handlers was dead code. Of the three caller shapes ADR-0204 documents for a GDPR export (`ROLE_ADMIN` / `ROLE_DPO` / self-JWT), exactly one worked: the broadest staff role in the fleet, which is the opposite of what a data-protection role is for.

The issue asks to decide whether the role is real. It is: ADR-0204 D5 names the DPO as the operator of record for Art. 15/20 exports, and the alternative (deleting the branch) would leave `ROLE_ADMIN` as the only working shape.

**What changed:**

- `ROLE_DPO` defined in the gitops realm template and the docker dev realm ("no write actions" in the description, so the admin console tells the next operator what the role is for).
- `check-roles-allowed-realm.py` now also scans `hasRole("...")` probes — the acceptance criterion's "test that fails when a documented role is granted by no realm, the general shape". The annotation gate could never see this defect class: a dead `hasRole` branch does not 403, it just never runs, and the suite stays green because the only test stubbed the probe to `false`. Now hard: 491 role-reference sites checked, zero dead names. Self-test extended to 20 cases (literal probe, constant probe, probe-in-comment).
- `PartyResourceAuditTest` pins the branch the other way: a caller holding **only** `ROLE_DPO` is admitted and the access is audited — before this, nothing proved the branch could ever fire.

**Acceptance-criterion deviation, stated plainly:** the issue's criterion 2 asks for an `opa eval` must-ALLOW on the two export actions. Those endpoints are not OPA-gated — they are `@Authenticated` with the three-shape check in the method body (`PartyResource.kt:290-298`), and adding `@Authorize` would break the self-JWT shape (OPA has no subject-equality input for it, #8421 owns that half). So there is no rego grant to eval; the proof here is the unit test plus the gate.

**Not in scope:** the self-JWT shape stays broken — #8421/#8487.

Refs #8495

## Test plan

- [x] `check-roles-allowed-realm.py --self-test` — 20 cases green
- [x] `check-roles-allowed-realm.py` — 491 sites, every named role has an issuer
- [x] `check-realm-template-importable.py`, `check-realm-devci-artifact-parity.py` — green/advisory-unchanged
- [x] `:openbank-party-service:test` + `ktlintCheck detekt` — green locally
- [ ] CI

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` — none added.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? → A role is *defined*; nothing is granted to any principal, and no endpoint's effective access widens (the DPO branch was unreachable before).
- [x] PII path changed? → No behaviour change on the PII path; the export payloads are untouched.
- [x] Cardholder data path changed? → No.
