### PR TITLE
fix(account): map screening outcomes to 503/422 without leaking the match (#8512)

### DIFF
--- a/docs/threat-models/openbank-account-service.md
+++ b/docs/threat-models/openbank-account-service.md
@@ -96,6 +96,23 @@ not change any existing request's outcome until explicitly flipped.
 
 ## 6. Change log
 
+- **2026-09-04** — **Inbound REST error surface on account opening**, no new route, caller, edge
+  or privilege. Two sanctions-screening outcomes rendered 500 INTERNAL_ERROR through the generic
+  mapper: an unreachable screening service (the gate fails closed, ADR-0032 §C) and a policy
+  refusal (HIT/REVIEW). They now answer 503 with `Retry-After: 30` and 422 respectively, via two
+  dedicated mappers in `ExceptionMappers.kt`; the routine policy refusal also stops logging at
+  ERROR with a full stack (WARN, no stack), so it no longer consumes this money-path service's
+  5xx error budget. **Security-relevant half — the disclosure the naive fix would have shipped:**
+  re-parenting `AccountOpeningBlockedByScreeningException` to `IllegalStateException` would have
+  fixed the status and put the matched sanctions name plus partyId into the response body
+  (libs-runtime's 422 mapper echoes `exception.message`), handing the caller a sanctions-list
+  oracle. The mapper bodies are fixed strings naming neither; a unit test asserts the matched
+  name and partyId appear nowhere in the body, and that a refusal with a match is
+  indistinguishable from one without. RBAC, OPA and the screening call itself are untouched.
+  **Risk class:** availability/observability plus disclosure hardening; no money mutation and no
+  new principal. Rollback: delete the two mappers and both types fall back to the generic 500
+  mapper. (#8512)
+
 - **2026-09-03** — **Inbound REST error surface on the authorization routes**, no new route, caller,
   edge or privilege. Revoking an authorization that does not exist answered 500 INTERNAL_ERROR; it now
   answers 404, via two service-local mappers (`AuthorizationNotFoundExceptionMapper`,

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AccountService.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AccountService.kt
@@ -538,7 +538,10 @@ class AccountOpeningBlockedByScreeningException(partyId: UUID, matchedName: Stri
  * that fails open (see [ProductCatalogPort]). Extends [IllegalStateException] deliberately (not
  * a bare [RuntimeException] like [AccountOpeningBlockedByScreeningException]) so it resolves to
  * the libs-runtime `IllegalStateExceptionMapper` (422 BUSINESS_RULE_VIOLATION) instead of falling
- * through to the generic 500 mapper.
+ * through to the generic 500 mapper. The screening exception above must NEVER copy this pattern
+ * (#8512): its message carries the matched sanctions name, and the IllegalStateException mapper
+ * echoes `message` on the wire — a free sanctions-list oracle. It has a dedicated mapper in
+ * ExceptionMappers.kt that answers 422 with a fixed body and keeps the detail in a WARN log.
  */
 class ProductNotEligibleException(productId: UUID, reason: String) :
     IllegalStateException("Cannot open account against product $productId: $reason")

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/ExceptionMappers.kt
@@ -4,8 +4,10 @@
 
 package com.openbank.account.infrastructure.rest
 
+import com.openbank.account.application.port.out.AccountScreeningUnavailableException
 import com.openbank.account.application.usecase.AccountNotEmptyException
 import com.openbank.account.application.usecase.AccountNotFoundException
+import com.openbank.account.application.usecase.AccountOpeningBlockedByScreeningException
 import com.openbank.account.application.usecase.AccountUpdateConflictException
 import com.openbank.account.application.usecase.AuthorizationNotFoundException
 import com.openbank.account.application.usecase.AuthorizationNotOnAccountException
@@ -138,5 +140,68 @@ class AuthorizationNotOnAccountExceptionMapper : ExceptionMapper<AuthorizationNo
 // SelfApprovalNotAllowedMapper / InvalidApprovalStateMapper (403/409) moved to
 // openbank-libs-runtime's CommonExceptionMappers (issue #1394) — a service-local copy of the
 // same exact type would collide non-deterministically with the shared one (issue #526).
+
+// --- Sanctions-screening outcomes (#8512) -----------------------------------------------------
+//
+// Both screening exceptions previously extended a bare RuntimeException with no mapper, so
+// both rendered 500 INTERNAL_ERROR through GenericExceptionMapper. Neither is a server fault:
+// one is an upstream-dependency outage (the gate fails closed, ADR-0032 §C), the other a
+// well-formed request correctly refused by policy. The 500 also logged every routine refusal
+// at ERROR with a full stack trace, inflating a money-path service's error budget.
+//
+// THE TRAP THE ISSUE NAMES, and why these are dedicated mappers rather than a one-word
+// re-parenting to IllegalStateException: libs-runtime's IllegalStateExceptionMapper answers
+// 422 with `message = exception.message`, and AccountOpeningBlockedByScreeningException's
+// message carries the MATCHED SANCTIONS NAME and the partyId. Correct status, free
+// sanctions-list oracle on the wire. These bodies therefore name neither the matched name nor
+// the party; the distinguishing detail goes to WARN (no stack), where compliance already
+// reads it today.
+
+private const val SCREENING_REFUSED_MESSAGE = "Account opening refused by screening policy"
+
+@Provider
+class AccountOpeningBlockedByScreeningExceptionMapper : ExceptionMapper<AccountOpeningBlockedByScreeningException> {
+    private val log = Logger.getLogger(AccountOpeningBlockedByScreeningExceptionMapper::class.java)
+
+    override fun toResponse(exception: AccountOpeningBlockedByScreeningException): Response {
+        // The matched name stays server-side. A caller who could vary the submitted name and
+        // read back whether it matched would have a free sanctions-list oracle (#8512).
+        log.warnf("account opening blocked by screening: %s", exception.message)
+        return Response.status(UNPROCESSABLE_ENTITY)
+            .entity(
+                ApiError(
+                    traceId = Ids.randomId().toString(),
+                    status = UNPROCESSABLE_ENTITY,
+                    code = "ACCOUNT_OPENING_BLOCKED",
+                    message = SCREENING_REFUSED_MESSAGE,
+                    timestamp = Instant.now(),
+                ),
+            )
+            .build()
+    }
+}
+
+@Provider
+class AccountScreeningUnavailableExceptionMapper : ExceptionMapper<AccountScreeningUnavailableException> {
+    private val log = Logger.getLogger(AccountScreeningUnavailableExceptionMapper::class.java)
+
+    override fun toResponse(exception: AccountScreeningUnavailableException): Response {
+        // WARN, not ERROR: an upstream outage is an availability fact the caller can retry,
+        // not a defect in this service. No stack trace — the cause is a connection failure.
+        log.warnf("sanctions screening unavailable, account opening blocked: %s", exception.cause?.message)
+        return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+            .header("Retry-After", "30")
+            .entity(
+                ApiError(
+                    traceId = Ids.randomId().toString(),
+                    status = Response.Status.SERVICE_UNAVAILABLE.statusCode,
+                    code = "SCREENING_UNAVAILABLE",
+                    message = "Sanctions screening is temporarily unavailable; retry later",
+                    timestamp = Instant.now(),
+                ),
+            )
+            .build()
+    }
+}
 
 private const val UNPROCESSABLE_ENTITY = 422

--- a/openbank-account-service/src/main/resources/openapi.yaml
+++ b/openbank-account-service/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Account Service API
   # API-contract axis (ADR-0048) — bumps are classified from the OpenAPI diff,
   # independently of the release version in version.txt.
-  version: 1.13.0
+  version: 1.14.0
   description: BIAN-aligned account lifecycle management — open, query, freeze, close accounts.
   contact:
     name: OpenBank Platform
@@ -62,6 +62,23 @@ paths:
                 enum: ['true']
         '422':
           $ref: '#/components/responses/UnprocessableEntity'
+          description: >
+            Well-formed request refused by policy — e.g. product not eligible
+            (BUSINESS_RULE_VIOLATION) or sanctions screening refused the opening
+            (ACCOUNT_OPENING_BLOCKED). The screening-refusal body deliberately names
+            neither the matched name nor the party (#8512).
+        '503':
+          description: >
+            Sanctions screening temporarily unavailable; the opening gate fails
+            closed (ADR-0032 §C). Safe to retry after the Retry-After interval.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
     get:
       tags: [Accounts]
       summary: List accounts for a party

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/rest/ScreeningExceptionMapperTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/rest/ScreeningExceptionMapperTest.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.account.infrastructure.rest
+
+import com.openbank.account.application.port.out.AccountScreeningUnavailableException
+import com.openbank.account.application.usecase.AccountOpeningBlockedByScreeningException
+import com.openbank.libs.api.error.ApiError
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.util.UUID
+
+/**
+ * Unit cover for the two mappers added in #8512. Asserts the SHAPE — and above all what the
+ * body must NOT carry: the matched sanctions name and the partyId stay server-side, or the
+ * endpoint is a free sanctions-list oracle. That the status is actually reached over HTTP is
+ * the half a mocked test cannot see; it is asserted by driving the real endpoint (schemathesis
+ * lane and the account-opening ITs).
+ */
+class ScreeningExceptionMapperTest {
+
+    private val partyId = UUID.fromString("22222222-2222-2222-2222-222222222222")
+    private val matchedName = "A. Sanctioned Person"
+
+    @Test
+    fun `maps a screening refusal to 422 with a body that names neither the match nor the party`() {
+        val response = AccountOpeningBlockedByScreeningExceptionMapper()
+            .toResponse(AccountOpeningBlockedByScreeningException(partyId, matchedName))
+
+        assertThat(response.status).isEqualTo(422)
+        val error = response.entity as ApiError
+        assertThat(error.status).isEqualTo(422)
+        assertThat(error.code).isEqualTo("ACCOUNT_OPENING_BLOCKED")
+        assertThat(error.traceId).isNotBlank()
+        // The disclosure guard — the reason this is a dedicated mapper and not a re-parenting
+        // to IllegalStateException, whose 422 mapper echoes exception.message on the wire.
+        assertThat(error.message).doesNotContain(matchedName)
+        assertThat(error.message).doesNotContain(partyId.toString())
+        assertThat(error.details?.toString() ?: "").doesNotContain(matchedName)
+    }
+
+    @Test
+    fun `maps screening unavailability to 503 with Retry-After and no upstream detail`() {
+        val response = AccountScreeningUnavailableExceptionMapper()
+            .toResponse(AccountScreeningUnavailableException(IOException("connection refused")))
+
+        assertThat(response.status).isEqualTo(503)
+        assertThat(response.getHeaderString("Retry-After")).isEqualTo("30")
+        val error = response.entity as ApiError
+        assertThat(error.status).isEqualTo(503)
+        assertThat(error.code).isEqualTo("SCREENING_UNAVAILABLE")
+        assertThat(error.message).doesNotContain("connection refused")
+    }
+
+    @Test
+    fun `a refusal with no matched name is indistinguishable from one with`() {
+        val withMatch = AccountOpeningBlockedByScreeningExceptionMapper()
+            .toResponse(AccountOpeningBlockedByScreeningException(partyId, matchedName)).entity as ApiError
+        val withoutMatch = AccountOpeningBlockedByScreeningExceptionMapper()
+            .toResponse(AccountOpeningBlockedByScreeningException(partyId, null)).entity as ApiError
+
+        assertThat(withMatch.status).isEqualTo(withoutMatch.status)
+        assertThat(withMatch.code).isEqualTo(withoutMatch.code)
+        assertThat(withMatch.message).isEqualTo(withoutMatch.message)
+        assertThat(withMatch.details).isEqualTo(withoutMatch.details)
+    }
+}


### PR DESCRIPTION
## Summary

Both sanctions-screening exceptions in account opening fell through to `GenericExceptionMapper`, so an upstream outage and a routine policy refusal both rendered **500 INTERNAL_ERROR** — and every refusal logged at ERROR with a full stack trace, inflating a money-path service's error budget with policy outcomes.

The issue names the trap and this PR steps around it exactly as specified: the obvious one-word fix (re-parenting to `IllegalStateException` for the libs 422 mapper) would have put `matched: <name>` and the partyId into the response body — that mapper echoes `exception.message`. **The status bug and the disclosure were the same edit.** So:

- `AccountScreeningUnavailableExceptionMapper` → **503** + `Retry-After: 30`, generic body, WARN without stack (the cause is a connection failure, not a defect here).
- `AccountOpeningBlockedByScreeningExceptionMapper` → **422** with a fixed body (`ACCOUNT_OPENING_BLOCKED`) naming neither the matched name nor the party; the detail goes to WARN, where compliance already reads it today. Pattern copied from #8466's byte-identical-body mappers in this same file.
- `ProductNotEligibleException`'s KDoc — which pointed at the screening exception as its counter-example — now warns against the copy instead of inviting it.
- `openapi.yaml`: `openAccount` gains the `503` response (Retry-After documented); the `422` description now names both refusals. `info.version` 1.13.0 → 1.14.0 (additive; ADR-0048 axis independent of the release version).
- Threat model change-logged (money-path, ADR-0030 D2). No new route, caller, topic or privilege — only status and body of an already-refused/already-failed request change.

**Secondary finding fixed:** the WARN-without-stack logging drops the routine refusal out of ERROR, so genuine faults are no longer buried in policy outcomes.

Refs #8512

## Test plan

- [x] New `ScreeningExceptionMapperTest` — pins the no-disclosure shape: the matched name and partyId appear nowhere in the 422 body, and a refusal with a match is wire-indistinguishable from one without
- [x] `:openbank-account-service:test` green on rerun (one Testcontainers IT flaked on a parallel local build — the `QuarkusBindException` class from AGENTS.md; green standalone)
- [x] `ktlintCheck detekt compileKotlin compileTestKotlin` green
- [ ] CI (incl. oasdiff classification of the additive 503)

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs — the whole point: the matched name no longer risks the wire.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")`.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? → Error mapping on a money-path route only; screening call, RBAC and OPA untouched. Threat model updated in this diff.
- [x] PII path changed? → Narrowed, not widened: partyId/matched-name removed from a response body.
- [x] Cardholder data path changed? → No.
