### PR TITLE
ci(gates): new enforced gate — class-level @Path must not be stolen by a top-level function

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -2483,6 +2483,7 @@ gates:
     name: "class-level @Path is not stolen by a top-level function (#3371, enforced)"
     group: kotlin
     mode: enforced
+    budget_seconds: 15   # whole-corpus Kotlin scan, measured well under 1s locally
     rationale: >-
       Kotlin binds an annotation to the next declaration, so a top-level function placed
       between @Path and its class steals the annotation; RESTEasy then never registers the

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -2473,6 +2473,28 @@ gates:
     run: |
       python3 .github/scripts/check-no-runblocking-in-scheduled.py
 
+  # Kotlin binds an annotation to the NEXT declaration — a top-level function between
+  # `@Path` and its class silently steals it. RESTEasy then never registers the
+  # resource and every call 404s on a running pod while the bean, the unit tests and
+  # the siblings all look healthy (McpEndpoint, #3371 — admin-ui rendered the healthy
+  # service as "not deployed"). A unit test cannot see a route that was never served,
+  # so this is a gate, not a doc. ENFORCED; clean at introduction.
+  - id: jaxrs-path-not-hijacked-by-toplevel-fun
+    name: "class-level @Path is not stolen by a top-level function (#3371, enforced)"
+    group: kotlin
+    mode: enforced
+    rationale: >-
+      Kotlin binds an annotation to the next declaration, so a top-level function placed
+      between @Path and its class steals the annotation; RESTEasy then never registers the
+      resource and the endpoint 404s on a healthy pod, invisible to unit tests (#3371).
+    review_after: 2027-03-05
+    min_subjects: 1080   # 2187 Kotlin main sources measured 2026-09-04; half, so the fleet can shrink without a red
+    selftest: python3 .github/scripts/check-jaxrs-path-hijack.py --self-test
+    selftest_expect: pass
+    selftest_inputs: [".github/scripts/check-jaxrs-path-hijack.py"]
+    run: |
+      python3 .github/scripts/check-jaxrs-path-hijack.py
+
   # Guard the silent Kotlin+JUnit5 footgun: `fun x() = runBlocking { assert }`
   # without `: Unit` infers a non-Unit return → JUnit5 silently skips the test.
   # Bans the bare expression-body form in src/test (the whole fleet is clean as

--- a/.github/scripts/check-jaxrs-path-hijack.py
+++ b/.github/scripts/check-jaxrs-path-hijack.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Guard: a JAX-RS `@Path` class annotation must not be hijacked by a top-level function.
+
+WHY THIS EXISTS: Kotlin binds an annotation to the NEXT declaration. A top-level
+function placed between `@Path` and its class steals the annotation:
+
+    @Path("/mcp")
+    private fun String?.sanitizeForLog(): String = ...
+
+    class McpEndpoint { ... }
+
+The `@Path` binds to the *function*; the class carries none, RESTEasy never registers
+the resource, and every call to the endpoint answers 404 on a running pod — while
+everything else looks healthy: it compiles, the bean is still in the CDI graph, unit
+tests that call the class directly stay green, and sibling endpoints serve normally.
+This is not hypothetical: `McpEndpoint` answered 404 for the whole life of the
+endpoint (#3371), and admin-ui rendered the healthy service as "not deployed".
+
+A unit test cannot see it (calling a resource class cannot tell a served route from
+an unserved one — only real HTTP can), so this is a guard, not a lesson in a doc.
+
+WHAT IT CHECKS: every `openbank-*/src/main/kotlin/**.kt`. Walking top-level
+(column-0) declarations only, a `@Path` annotation line opens a pending block that
+annotations, blank lines and comments extend. If the declaration that CLOSES the
+block is a top-level `fun` (any modifiers), that is a finding: the annotation is
+bound to the function and the resource class below it is unregistered. A block
+closed by `class` / `object` / `interface` is fine, as is a top-level function that
+comes AFTER the class. Method-level `@Path` is indented, so it never enters the
+scan; `@ApplicationScoped`-style stacked annotations between `@Path` and its class
+are the normal case and stay silent.
+
+ENFORCED: findings are ::error:: annotations and exit 1.
+
+Usage: check-jaxrs-path-hijack.py [--root .]
+       check-jaxrs-path-hijack.py --self-test   # prove the gate can fail
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import gatelib
+
+REPO = Path(__file__).resolve().parents[2]
+
+PATH_ANN = re.compile(r"^@Path\b")
+TOPLEVEL_FUN = re.compile(r"^(?:[a-z]+\s+)*fun\b")
+TOPLEVEL_TYPE = re.compile(r"^(?:[a-z]+\s+)*(?:class|object|interface)\b")
+ANNOTATION = re.compile(r"^@\w")
+COMMENT = re.compile(r"^(//|/\*|\*)")
+
+
+def audit(root: Path) -> tuple[list[str], int]:
+    findings: list[str] = []
+    examined = 0
+    for kt in gatelib.rglob(root, "openbank-*/src/main/kotlin/**/*.kt"):
+        examined += 1
+        pending_path_line: int | None = None
+        for lineno, line in enumerate(gatelib.read_text(kt).splitlines(), start=1):
+            if line.startswith((" ", "\t")):
+                continue  # inside a declaration — never the annotation's target line
+            if PATH_ANN.match(line):
+                pending_path_line = lineno
+                continue
+            if not line.strip() or ANNOTATION.match(line) or COMMENT.match(line):
+                continue  # the pending block extends through these
+            if TOPLEVEL_FUN.match(line):
+                if pending_path_line is not None:
+                    findings.append(
+                        f"{kt.relative_to(root)}:{pending_path_line}: @Path is followed by the "
+                        f"top-level function on line {lineno}, so it binds to the FUNCTION and "
+                        f"the resource class below is never registered (the endpoint 404s on a "
+                        f"running pod — #3371). Move the function below the class or into it."
+                    )
+                pending_path_line = None
+                continue
+            # Any other top-level declaration closes the block.
+            pending_path_line = None
+    return findings, examined
+
+
+DEFECT = """package com.openbank.probe
+
+import jakarta.ws.rs.Path
+
+@Path("/mcp")
+private fun String?.sanitizeForLog(): String = this ?: ""
+
+class McpEndpoint
+"""
+
+CORRECT = """package com.openbank.probe
+
+import jakarta.ws.rs.Path
+
+@Path("/mcp")
+class McpEndpoint
+
+private fun String?.sanitizeForLog(): String = this ?: ""
+"""
+
+STACKED = """package com.openbank.probe
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.Path
+
+@ApplicationScoped
+@Path("/things")
+class ThingsResource
+"""
+
+METHOD_LEVEL = """package com.openbank.probe
+
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+
+@Path("/things")
+class ThingsResource {
+    @GET
+    @Path("/{id}")
+    fun get() = Unit
+}
+"""
+
+
+def self_test() -> int:
+    cases = [
+        ("@Path stolen by a top-level fun -> MUST fire", DEFECT, True),
+        ("fun AFTER the class -> silent", CORRECT, False),
+        ("stacked annotations before the class -> silent", STACKED, False),
+        ("method-level @Path inside the class -> silent", METHOD_LEVEL, False),
+    ]
+    failures = 0
+    for label, source, want_finding in cases:
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "openbank-probe-service" / "src" / "main" / "kotlin"
+            src.mkdir(parents=True)
+            (src / "Endpoint.kt").write_text(source)
+            got, examined = audit(Path(tmp))
+            ok = bool(got) == want_finding and examined == 1
+            print(f"  {'ok  ' if ok else 'FAIL'}  {label}")
+            if not ok:
+                failures += 1
+                for g in got:
+                    print(f"        got: {g}")
+    if failures:
+        print(f"SELF-TEST FAILED: {failures} case(s)", file=sys.stderr)
+        return 1
+    print("self-test: PASS — the gate fires on the hijack and is silent on the correct shapes")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+
+    findings, examined = audit(REPO)
+    gatelib.subjects(examined, "Kotlin main source files")
+    if findings:
+        print("JAX-RS @Path annotations bound to a top-level function instead of their class:\n",
+              file=sys.stderr)
+        for f in findings:
+            print(f"::error::{f}", file=sys.stderr)
+        print(f"\n{len(findings)} finding(s).", file=sys.stderr)
+        return 1
+    print("OK: every class-level @Path binds to its class, not to a top-level function.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Co a proč

Audit-top50 F49: parity audit AGENTS.md gotchas vs CI gates. Gotcha „Kotlin annotation binds to
the NEXT declaration — a top-level function between `@Path` and its class silently steals it"
(#3371, `McpEndpoint` 404oval celý svůj život na zdravém podu) neměla gate. Unit test to
nepochytí (zavolat resource class ≠ obsloužit route), takže z poučky v doc se stává gate.

**Nový enforced gate `jaxrs-path-not-hijacked-by-toplevel-fun`:**
- `.github/scripts/check-jaxrs-path-hijack.py` — prochází jen top-level (column-0) deklarace;
  `@Path` blok uzavřený top-level `fun` = finding. Method-level `@Path` (indentovaný) a stacked
  anotace (`@ApplicationScoped` nad `@Path`) jsou správně silent.
- Self-test dokazuje oba směry (fires on defect, silent on 3 correct shapes).
- Reálný běh: **2187 Kotlin main sources, 0 findings** — čisté při zavedení, ratchet.
- Registrace v `gates.yaml` s rationale + review_after (2027-03-05); všechny meta-gates
  (script-registration, invocation-reachability, lifecycle-metadata, selftest-declaration,
  observability-declarations) zelené.

Refs #3371
