### PR TITLE
test(security): enforce PIT mutation floor on the authz decision path

### DIFF
--- a/.github/scripts/check-gradle-cache-writers.py
+++ b/.github/scripts/check-gradle-cache-writers.py
@@ -162,6 +162,12 @@ DECLARED: dict[str, tuple[str, str]] = {
         "weekly scheduled sweep — but it is still a pure consumer, so reading the entry "
         "fleet-lint already maintains costs the pool nothing and cannot churn it.",
     ),
+    "pitest.yml::pitest-authz": (
+        "read-only",
+        "Consumer; restores fleet-lint's home. Targeted authz mutation lane (ADR-0279 #7) "
+        "riding the same weekly schedule and cache posture as the matrix job above — a "
+        "pure consumer with no reason to store a per-run entry.",
+    ),
     "pact-drift-check.yml::drift-check": (
         "read-only",
         "Demoted from setup-java. Consumer; regenerates consumer pacts and diffs them, and "

--- a/.github/scripts/pitest-authz.init.gradle
+++ b/.github/scripts/pitest-authz.init.gradle
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Targeted authz mutation testing (ADR-0279 #7) — init-script application.
+// The plugins DSL cannot add ANY external versioned plugin to openbank-libs-runtime:
+// it splits the plugin classloaders and kordamp jandex then loads twice
+// (Banner$Inject_ ClassCastException, measured 2026-09-05 across plugin choices and
+// jandex 2.0.0/2.3.0). An init script carries its own classpath, so pitest loads
+// without touching the module's plugin resolution.
+initscript {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.19.0'
+    }
+}
+
+gradle.projectsLoaded { g ->
+    g.rootProject { root ->
+        def target = root.findProject(':openbank-libs-runtime')
+        if (target == null) {
+            return  // included builds (e.g. build-logic) don't have the module
+        }
+        target.with { p ->
+            p.afterEvaluate { proj ->
+                proj.apply(plugin: info.solidsoft.gradle.pitest.PitestPlugin)
+                def ext = proj.extensions.getByName('pitest')
+                ext.junit5PluginVersion = '1.2.3'
+                ext.targetClasses = ['com.openbank.libs.authz.*'] as Set
+                ext.targetTests = ['com.openbank.libs.authz.*'] as Set
+                // 0 = advisory locally; the pitest.yml pitest-authz job enforces its ratchet
+                // via -Ppitest.mutationThreshold=<n>. Read it explicitly — the plugin's own
+                // project-property resolution loses to an explicitly set extension value.
+                def thresholdProp = proj.findProperty('pitest.mutationThreshold')
+                ext.mutationThreshold = thresholdProp != null ? thresholdProp.toString().toInteger() : 0
+                ext.outputFormats = ['XML', 'HTML'] as Set
+                ext.timestampedReports = false
+                ext.threads = 4
+                ext.excludedClasses = ['com.openbank.libs.authz.*Kt'] as Set
+            }
+        }
+    }
+}

--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -137,3 +137,84 @@ jobs:
           else
             echo "::notice::Mutation score ${SCORE}% — OK"
           fi
+
+  # Targeted mutation testing of the authorization decision path (ADR-0279 item #7).
+  # Unlike the advisory domain lanes above this job is ENFORCED: com.openbank.libs.authz
+  # (AuthorizeInterceptor scope derivation + OPA PDP call) is the fleet's security-critical
+  # decision code — a surviving mutant there is an authorization check no test could tell
+  # from its negation. The package is small (3 files, ~40s), so a blocking lane costs
+  # nothing. Threshold 63 = measured baseline (2026-09-05: 174 mutations, 109 killed);
+  # raise it as surviving mutants get killed — the lane is a ratchet, never lowered.
+  # pitest is applied by init script, NOT the plugins DSL: any external versioned plugin
+  # in openbank-libs-runtime's plugins{} block splits the classloaders and kordamp jandex
+  # loads twice (Banner$Inject_ ClassCastException) — see the init script header.
+  pitest-authz:
+    name: pitest / authz decision path (enforced)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          java-version: "25"
+          distribution: temurin
+
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          # READ-ONLY — same cache-pool reasoning as the matrix job above (#3299).
+          cache-read-only: true
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+
+      - name: Run pitest on the authz package (threshold 63 enforced)
+        run: |
+          ./gradlew -I .github/scripts/pitest-authz.init.gradle \
+            :openbank-libs-runtime:pitest \
+            -Ppitest.mutationThreshold=63
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false -Xmx2g"
+
+      - name: Build mutation Test Intelligence envelope
+        if: always()
+        continue-on-error: true
+        run: |
+          python3 .github/scripts/collect-test-run-evidence.py \
+            --service "openbank-libs-runtime-authz" \
+            --mutation-report openbank-libs-runtime/build/reports/pitest/mutations.xml \
+            --mutation-threshold 63 \
+            --out openbank-libs-runtime/build/reports/pitest/test-intelligence-run.json
+
+      - name: Upload pitest XML report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pitest-authz
+          path: openbank-libs-runtime/build/reports/pitest/
+          retention-days: 30
+
+      # Reporting mirror of the Gradle-enforced threshold (single-quote XML note as above).
+      - name: Report mutation score
+        if: always()
+        run: |
+          XML="openbank-libs-runtime/build/reports/pitest/mutations.xml"
+          if [ ! -f "$XML" ]; then
+            echo "::error file=$XML::pitest XML report not found — the enforced lane cannot score a run without it"
+            exit 1
+          fi
+          TOTAL=$(grep -o '<mutation ' "$XML" | wc -l | tr -d ' ')
+          KILLED=$(grep -oE "status=['\"]KILLED['\"]" "$XML" | wc -l | tr -d ' ')
+          if [ "$TOTAL" -eq "0" ]; then
+            echo "::error::No mutations generated for the authz package — check targetClasses in pitest-authz.init.gradle"
+            exit 1
+          fi
+          SCORE=$(( KILLED * 100 / TOTAL ))
+          echo "Mutation score: ${SCORE}% (${KILLED}/${TOTAL} killed)"
+          if [ "$SCORE" -lt "63" ]; then
+            echo "::error::Mutation score ${SCORE}% is below the 63% enforced threshold for the authz decision path"
+            exit 1
+          fi
+          echo "::notice::Mutation score ${SCORE}% — OK (enforced floor 63%)"


### PR DESCRIPTION
## Co a proč

ADR-0279 bod **#7 — Mutation testing authz kódu (PIT, cíleně)** (tracking #8590).

Doménové PIT lanes běží advisory už od ADR-0063, ale authz rozhodovací kód — `AuthorizeInterceptor` (derivace a vynucení scope na každém `@Authorize` endpointu) a `OpaSidecarPolicyDecisionPoint` (volání OPA PDP) — pokrytý nebyl. Přitom právě tady přežívající mutant znamená autorizační check, který žádný test neodliší od své negace.

## Řešení

- **`.github/scripts/pitest-authz.init.gradle`** — pitest 1.19.0 aplikovaný init skriptem, cíleně na `com.openbank.libs.authz.*`. Init skript proto, že plugins DSL v `openbank-libs-runtime` **nemůže** přidat žádný externí verzovaný plugin: rozdělí plugin classloadery a kordamp jandex se načte dvakrát (`Banner$Inject_` ClassCastException — změřeno 2026-09-05 napříč volbami pluginu i jandex 2.0.0/2.3.0).
- **`pitest.yml`: nový job `pitest-authz`** — na rozdíl od advisory doménových lanes **enforced**: threshold 63 = změřený baseline (174 mutací, 109 killed, 52 testů, ~40 s), ratchet-only. Číselně ověřeno lokálně: `-Ppitest.mutationThreshold=64` → BUILD FAILED („Mutation score of 63 is below threshold of 64"), 63 → zelená.

## Baseline (2026-09-05, lokálně)

- 174 mutací, 109 zabitých (**63 %**), 30 bez coverage, line coverage 91 %, test strength 76 %
- Nejvíc přežívajících: `AuthorizeInterceptor` (20 SURVIVED + 18 NO_COVERAGE) — killing těchto mutantů je follow-up práce, ratchet je připravený

## Testování

- Lokální run reprodukuje CI kroky 1:1 (stejný init skript, stejná gradle příkazová řádka, daemon off)
- actionlint čistý
- Yaml validní

Refs #8590
