### PR TITLE
docs(libs-domain): correct a false claim in the SettlementScope KDoc

### DIFF
--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/domain/payment/SettlementScope.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/domain/payment/SettlementScope.kt
@@ -18,10 +18,14 @@ package com.openbank.libs.domain.payment
  * an account of ours to credit — domestic-payment resolves it for in-house transfers and leaves it
  * null when "the money genuinely leaves the bank" (its own words), and sepa-payment, swift-service
  * and sepa-instant never set it at all. Rail is deliberately *not* trusted here: it arrives as a
- * free-form string parsed with `PaymentRail.valueOf(...)` inside a swallowing `runCatching`, and
- * three services currently send values that are not members (`SCT_INST`, `SEPA`, `FX`) and land as
- * null. A guard keyed on `rail == null` would therefore hand same-day booking to genuinely external
- * SEPA payments.
+ * free-form string parsed with `PaymentRail.valueOf(...)` inside a swallowing `runCatching`, so an
+ * unparseable value lands as null and is from then on indistinguishable from "no rail supplied".
+ * Every sender today does send a real member (sepa-payment `SEPA_CT`, sepa-instant `SEPA_INST`,
+ * each from its own `SettlementAdapter`), so that is latent rather than live — but a guard keyed
+ * on `rail == null` would hand same-day booking to genuinely external SEPA payments the day one
+ * stops. `SCT_INST`, `SEPA` and `FX` do occur in those services and are *not* members: they are
+ * fraud-scoring labels on `FraudScoreCommand.rail`, a deliberately free-form field that
+ * fraud-service stores as `String` and never parses. #8699 carries the trace.
  */
 object SettlementScope {
 


### PR DESCRIPTION
## What

Corrects one false sentence in `SettlementScope`'s KDoc. Comment-only, no behaviour change.

The KDoc justified not trusting `rail` like this:

> three services currently send values that are not members (`SCT_INST`, `SEPA`, `FX`) and land as null. A guard keyed on `rail == null` would therefore hand same-day booking to genuinely external SEPA payments.

Traced to the calls that actually reach `transaction-service`, that is wrong. Those three strings are **fraud-scoring labels**, on a different field, going to a service that never parses them.

| service | the string the KDoc cites | where it really is | **rail sent to transaction-service** |
|---|---|---|---|
| sepa-payment | `"SEPA"` | `SepaPaymentActivitiesImpl.kt:173`, inside `FraudScoreCommand` | **`"SEPA_CT"`** — `SettlementAdapter.kt:62`, a valid member |
| sepa-instant | `"SCT_INST"` | `SctInstPaymentService.kt:125`, inside `FraudScoreCommand` | **`"SEPA_INST"`** — `SettlementAdapter.kt:58`, a valid member |
| fx-service | `"FX"` | `FxService.kt:342`, `FxActivitiesImpl.kt:129`, both `FraudScoreCommand` | none — **fx-service has no `TransactionServiceClient`** |

And the receiving end treats the label as free text on purpose: `fraud-service` declares `val rail: String` in `FraudScoreRepository`, `FraudModel` and `FraudResource`, and never calls `PaymentRail.valueOf` —

```
git grep "rail" -- 'openbank-fraud-service/src/main/**/*.kt' | grep -iE "valueOf|PaymentRail|runCatching"   # empty
```

So there are two vocabularies by design: a closed `PaymentRail` enum for bookings, and a free-form label for fraud telemetry.

## What does not change

The **decision** the KDoc documents — that the payee leg and not the rail is the discriminator — stands untouched. It rests on the #4869 story (an own-account transfer silently refused for weeks) and on `targetAccountId` being the field that actually says "there is an account of ours to credit", neither of which involves the non-member-rail claim.

What changes is the *supporting reason*. The real hazard in a `rail == null` guard is that `runCatching { PaymentRail.valueOf(s) }.getOrNull()` makes an unparseable value indistinguishable from an absent one — **latent today**, because every current sender sends a real member, rather than live as the KDoc said.

## Why it mattered

I believed the sentence and built a severity-2 claim on it in #8699 — that three money-path services send unparseable rails today, so the senders would have to be aligned before the boundary could be tightened. That was wrong in both halves, and I have [withdrawn it there](https://github.com/JiRaska/open-bank-oss/issues/8699#issuecomment-5547658177). Leaving the KDoc as-is would keep re-teaching it: it is the most authoritative-looking statement about rail vocabulary in the tree, and it sits in `openbank-libs-domain` where every service reads it.

It also inverts a remedy. Under the old text, tightening `TransactionResource.kt:169` to reject an unparseable rail "would break three senders". It breaks none.

## Verification

- `./gradlew :openbank-libs-domain:ktlintCheck` — exit 0
- comment-only diff; `git diff --stat` is one file, KDoc lines only

Refs #8699
