### PR TITLE
feat(security): DAST fuzz coverage KPI end to end — nightly cadence, aggregate record, console domain

### DIFF
--- a/.github/scripts/fuzz-coverage-aggregate.py
+++ b/.github/scripts/fuzz-coverage-aggregate.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
-import glob
 import json
 import sys
 from pathlib import Path

--- a/.github/scripts/fuzz-coverage-aggregate.py
+++ b/.github/scripts/fuzz-coverage-aggregate.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""Aggregate one api-fuzz run's per-service artifacts into fuzz-coverage.json.
+
+WHY (ADR-0279 #2). A fuzz/DAST job list showing a service is NOT evidence the service
+was tested (#6492, the 2026-08-18 run where 6 of 7 "failures" never sent a request).
+The durable evidence is the per-service `*-ops*.json` the harness writes
+(fuzz-services.sh: selected / auth_blocked / exercised). This job merges those records
+plus the prepare step's scope file into ONE machine-readable verdict:
+
+  * inScope   — services the derivation selected for this run
+  * excluded  — services skipped OUT LOUD, with the reason (never silently dropped)
+  * tested    — in-scope services with a real exercised-surface record (selected > 0)
+  * per-service exercised/authBlocked so the console can say what a green is worth
+
+A matrix leg that failed before writing an ops record shows up as `no-evidence` —
+that is a harness/infra finding, not an HTTP-surface finding, and it must not count
+as tested.
+
+Usage:  fuzz-coverage-aggregate.py --artifacts <dir> --scope <fuzz-scope.json> \
+            --run-url <url> --out <fuzz-coverage.json>
+        fuzz-coverage-aggregate.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import glob
+import json
+import sys
+from pathlib import Path
+
+
+def aggregate(artifacts: Path, scope_file: Path, run_url: str) -> dict:
+    scope = json.loads(scope_file.read_text()) if scope_file.exists() else {"keep": [], "skipped": []}
+    services = []
+    for ops in sorted(artifacts.rglob("*-ops*.json")):
+        try:
+            rec = json.loads(ops.read_text())
+        except json.JSONDecodeError:
+            continue
+        svc = rec.get("service")
+        lane = rec.get("lane", "")
+        if lane != "authz ON":  # the ON pass is the production-shaped one; OFF is the control
+            continue
+        selected = int(rec.get("selected") or 0)
+        services.append({
+            "service": svc,
+            "status": "tested" if selected > 0 else "no-evidence",
+            "exercised": int(rec.get("exercised") or 0),
+            "authBlocked": int(rec.get("auth_blocked") or 0),
+        })
+    seen = {s["service"] for s in services}
+    for svc in scope.get("keep", []):
+        if svc not in seen:
+            # In scope for this run but left no ops record — boot failure, harness error,
+            # or a leg killed before the fuzz pass. NOT evidence about the HTTP surface.
+            services.append({"service": svc, "status": "no-evidence",
+                             "exercised": 0, "authBlocked": 0})
+    tested = sum(1 for s in services if s["status"] == "tested")
+    return {
+        "generatedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "run": run_url,
+        "inScope": len(scope.get("keep", [])),
+        "excluded": scope.get("skipped", []),
+        "tested": tested,
+        "coveragePct": round(100 * tested / len(services)) if services else 0,
+        "totalExercised": sum(s["exercised"] for s in services),
+        "services": sorted(services, key=lambda s: s["service"] or ""),
+    }
+
+
+def self_test() -> int:
+    import tempfile
+    bad = 0
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        (root / "scope.json").write_text(json.dumps({
+            "keep": ["openbank-ledger-service", "openbank-balance-service", "openbank-fx-service"],
+            "skipped": [["openbank-vop-service", "no postgresql:// URL"]],
+        }))
+        (root / "a").mkdir()
+        (root / "a" / "openbank-ledger-service-ops.json").write_text(json.dumps({
+            "service": "openbank-ledger-service", "lane": "authz ON",
+            "selected": 40, "auth_blocked": 12, "exercised": 28}))
+        (root / "a" / "openbank-ledger-service-ops-authz-off.json").write_text(json.dumps({
+            "service": "openbank-ledger-service", "lane": "authz OFF",
+            "selected": 40, "auth_blocked": 0, "exercised": 40}))
+        (root / "a" / "openbank-balance-service-ops.json").write_text(json.dumps({
+            "service": "openbank-balance-service", "lane": "authz ON",
+            "selected": 0, "auth_blocked": 0, "exercised": 0}))
+        cov = aggregate(root, root / "scope.json", "https://example.test/run/1")
+        if cov["inScope"] != 3 or cov["tested"] != 1:
+            print(f"self-test FAIL: inScope/tested = {cov['inScope']}/{cov['tested']}, want 3/1")
+            bad += 1
+        # fx never wrote an ops record -> must surface as no-evidence, not silently vanish
+        fx = [s for s in cov["services"] if s["service"] == "openbank-fx-service"]
+        if not fx or fx[0]["status"] != "no-evidence":
+            print("self-test FAIL: missing ops record must surface as no-evidence"); bad += 1
+        # the authz-OFF control pass must not double-count the service
+        led = [s for s in cov["services"] if s["service"] == "openbank-ledger-service"]
+        if len(led) != 1 or led[0]["exercised"] != 28:
+            print("self-test FAIL: authz-OFF pass leaked into the coverage record"); bad += 1
+        if cov["excluded"] != [["openbank-vop-service", "no postgresql:// URL"]]:
+            print("self-test FAIL: excluded services must carry their reason"); bad += 1
+    print("fuzz-coverage-aggregate self-test: " + ("clean" if not bad else f"{bad} failure(s)"))
+    return 1 if bad else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--artifacts", type=Path)
+    ap.add_argument("--scope", type=Path)
+    ap.add_argument("--run-url", default="")
+    ap.add_argument("--out", type=Path, default=Path("fuzz-coverage.json"))
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+    cov = aggregate(args.artifacts, args.scope, args.run_url)
+    args.out.write_text(json.dumps(cov, indent=2) + "\n")
+    print(f"fuzz-coverage: {cov['tested']}/{cov['inScope']} services tested "
+          f"({cov['coveragePct']}%), {cov['totalExercised']} operations exercised, "
+          f"{len(cov['excluded'])} excluded -> {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/security-kpis.py
+++ b/.github/scripts/security-kpis.py
@@ -73,6 +73,55 @@ def collect_credentials() -> dict:
             "overdueFound": rc != 0}
 
 
+def collect_fuzz() -> dict:
+    """DAST coverage from the latest api-fuzz run's fuzz-coverage artifact (ADR-0279 #2).
+
+    Reads the artifact the aggregate job uploads — NEVER the job list: a listed leg is
+    not evidence the service was tested (#6492). Degrades to unavailable without a token
+    or when no run has produced the artifact yet (pre-merge of the aggregate job), never
+    invents a number.
+    """
+    import io
+    import os
+    import urllib.request
+    import zipfile
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    repo = os.environ.get("GITHUB_REPOSITORY", "JiRaska/open-bank-oss")
+    if not token:
+        return {"available": False, "reason": "no GH token"}
+
+    def gh(path: str) -> bytes:
+        req = urllib.request.Request(
+            f"https://api.github.com/repos/{repo}/{path}",
+            headers={"Authorization": f"Bearer {token}",
+                     "Accept": "application/vnd.github+json"})
+        return urllib.request.urlopen(req, timeout=30).read()
+
+    try:
+        runs = json.loads(gh("actions/workflows/api-fuzz.yml/runs?status=completed&per_page=10"))
+        artifacts = []
+        for run in runs.get("workflow_runs", []):
+            arts = json.loads(gh(f"actions/runs/{run['id']}/artifacts?per_page=100"))
+            hit = [a for a in arts.get("artifacts", [])
+                   if a["name"] == "fuzz-coverage" and not a.get("expired")]
+            if hit:
+                artifacts = hit
+                break
+        if not artifacts:
+            return {"available": False, "reason": "no fuzz-coverage artifact yet"}
+        req = urllib.request.Request(
+            artifacts[0]["archive_download_url"],
+            headers={"Authorization": f"Bearer {token}",
+                     "Accept": "application/vnd.github+json"})
+        blob = urllib.request.urlopen(req, timeout=30).read()
+        cov = json.loads(zipfile.ZipFile(io.BytesIO(blob)).read("fuzz-coverage.json"))
+        return {"available": True, "inScope": cov["inScope"], "tested": cov["tested"],
+                "coveragePct": cov["coveragePct"], "totalExercised": cov["totalExercised"],
+                "excludedCount": len(cov.get("excluded", [])),
+                "run": cov.get("run", ""), "runDate": cov.get("generatedAt", "")[:10]}
+    except Exception as exc:  # network/API degradation must not kill the other collectors
+        return {"available": False, "reason": f"fuzz artifact fetch failed: {exc.__class__.__name__}"}
 def self_test() -> int:
     bad = 0
     # The parse regexes must survive the real scripts' output shape — pin them on the
@@ -110,12 +159,13 @@ def main() -> int:
             "netpol": collect_netpol(),
             "freshness": freshness,
             "credentials": collect_credentials(),
+            "fuzz": collect_fuzz(),
         }
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(snapshot, indent=2) + "\n")
-    avail = sum(1 for k in ("netpol", "freshness", "credentials") if snapshot[k]["available"])
-    print(f"security-kpis: {avail}/3 collectors available -> {out}")
+    avail = sum(1 for k in ("netpol", "freshness", "credentials", "fuzz") if snapshot[k]["available"])
+    print(f"security-kpis: {avail}/4 collectors available -> {out}")
     return 0
 
 

--- a/.github/workflows/api-fuzz.yml
+++ b/.github/workflows/api-fuzz.yml
@@ -28,11 +28,14 @@
 # reports itself instead of consuming the budget of everything after it in the list, which the
 # shared `OVERALL=1` used to hide.
 #
-# Batch lane (openbank-batch): weekly + manual, never a PR gate (ADR-0053).
+# Batch lane (openbank-batch): nightly + manual, never a PR gate (ADR-0053). Nightly since
+# ADR-0279 #2 — a weekly cadence meant a money-path endpoint regression could sit unfuzzed
+# for three days; hosted runners on a public repo make the nightly pass free.
 name: API fuzz
 
 on:
   schedule:
+    - cron: "17 4 * * *"   # nightly 04:17 UTC (ADR-0279 #2)
     - cron: "30 5 * * 2"   # weekly Tue 05:30 UTC — after the Monday dep bumps
     - cron: "30 5 * * 4"   # weekly Thu 05:30 UTC
   workflow_dispatch:
@@ -112,7 +115,18 @@ jobs:
           print(f"fuzzing {len(keep)} service(s); {len(skipped)} excluded")
           with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
               fh.write("services=" + json.dumps(keep) + "\n")
+          # Durable scope record for the aggregate step: the job list alone is NOT
+          # evidence of what was in scope (#2) — keep and skipped-with-reason both.
+          with open("fuzz-scope.json", "w") as fh:
+              json.dump({"keep": keep, "skipped": skipped}, fh, indent=2)
           PY
+
+      - name: Upload derived scope
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-scope
+          path: fuzz-scope.json
+          retention-days: 30
 
   fuzz:
     name: "schemathesis (${{ matrix.service }})"
@@ -178,3 +192,51 @@ jobs:
           name: api-fuzz-reports-${{ matrix.service }}
           path: fuzz-reports/
           retention-days: 30
+
+  # ADR-0279 #2: merge the per-service exercised-surface records into ONE fuzz-coverage.json
+  # (uploaded as the `fuzz-coverage` artifact). The security-kpis snapshot publisher reads
+  # the latest run's artifact into the excellence console, so "what did DAST actually test"
+  # is a durable number, not a job list. if: always() — a failed leg is exactly what this
+  # record must capture (as no-evidence), so the aggregate runs on red runs too.
+  aggregate:
+    name: fuzz coverage record
+    needs: [prepare, fuzz]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Self-test the aggregator
+        run: python3 .github/scripts/fuzz-coverage-aggregate.py --self-test
+
+      - name: Download all fuzz reports
+        uses: actions/download-artifact@9dbf31a64cf2a9f7b784a4c24c203321ddd843e0 # v7.0.1
+        with:
+          pattern: api-fuzz-reports-*
+          path: fuzz-artifacts
+          merge-multiple: true
+
+      - name: Download the derived scope
+        uses: actions/download-artifact@9dbf31a64cf2a9f7b784a4c24c203321ddd843e0 # v7.0.1
+        with:
+          name: fuzz-scope
+          path: fuzz-scope-dir
+
+      - name: Build fuzz-coverage.json
+        run: |
+          python3 .github/scripts/fuzz-coverage-aggregate.py \
+            --artifacts fuzz-artifacts \
+            --scope fuzz-scope-dir/fuzz-scope.json \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --out fuzz-coverage.json
+
+      - name: Upload fuzz-coverage
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-coverage
+          path: fuzz-coverage.json
+          retention-days: 90   # the KPI publisher reads the latest run's artifact; 90d
+                               # covers a long stretch of red fuzz runs without losing it

--- a/.github/workflows/security-kpis.yml
+++ b/.github/workflows/security-kpis.yml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       contents: write        # push the refresh branch
       pull-requests: write   # open the refresh PR
+      actions: read          # fuzz collector reads the latest api-fuzz run's artifact
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -38,6 +39,8 @@ jobs:
         run: python3 .github/scripts/security-kpis.py --self-test
 
       - name: Recompute the snapshot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 .github/scripts/security-kpis.py
 
       - name: Open a refresh PR when the snapshot moved

--- a/docs/runbooks/0016-security-excellence-console.md
+++ b/docs/runbooks/0016-security-excellence-console.md
@@ -23,8 +23,9 @@ obrazovky, které zůstávají autoritativním zdrojem detailu.
 | Segmentace sítě | `/api/security/kpis` → `netpol` (gate `netpol-coverage-kpi`, ADR-0279 #17) | tato stránka |
 | Čerstvost závislostí | `/api/security/kpis` → `freshness` (`deps-freshness.yml`, ADR-0279 #15) | tato stránka |
 | Dlouhožijící credentials | `/api/security/kpis` → `credentials` (`credential-inventory.yml`, ADR-0279 #18) | tato stránka |
+| DAST pokrytí | `/api/security/kpis` → `fuzz` (`api-fuzz.yml` aggregate → `fuzz-coverage` artifact, ADR-0279 #2) | tato stránka |
 
-## KPI snapshot — kde se berou tři nové domény
+## KPI snapshot — kde se berou čtyři nové domény
 
 `/api/security/kpis` servíruje `openbank-admin-ui/security-kpis.json`, CI-generovaný
 snapshot z workflow `security-kpis.yml` (weekly pátek 09:23 UTC, refresh PR při změně),
@@ -32,7 +33,14 @@ který přepočítává čísla **ze stejných gate skriptů** (`check-netpol-co
 `deps-freshness.py`, `credential-inventory.py`) — nikdy z reimplementace, aby se
 konzole a gaty nemohly rozejít. Soubor se vpeče do image buildu (`COPY
 openbank-admin-ui/ ./`); chybějící soubor = `not_deployed`, nikdy falešné OK.
-Každý kolektor degraduje nezávisle — jedna nedostupná doména neshodí ostatní dvě.
+Každý kolektor degraduje nezávisle — jedna nedostupná doména neshodí ostatní tři.
+
+Doména **DAST pokrytí** se nepočítá ze skriptu, ale z artefaktu `fuzz-coverage`
+posledního dokončeného běhu `api-fuzz.yml` (nightly 04:17 UTC od ADR-0279 #2):
+agregační job slepí per-service exercised-surface záznamy (`*-ops.json`) se scope
+záznamem z prepare kroku. Služba v job listu se NIKDY nepočítá jako otestovaná —
+počítá se jen ta se skutečným záznamem `selected > 0`; leg, který zkolaboval před
+fuzzingem, figuruje jako `no-evidence`. Excluded služby nesou důvod, ne ticho.
 
 ## Jak číst skóre
 

--- a/openbank-admin-ui/src/app/security/excellence/page.tsx
+++ b/openbank-admin-ui/src/app/security/excellence/page.tsx
@@ -24,7 +24,7 @@ import Link from 'next/link'
 import {
   Shield, ScanLine, AlertTriangle, ShieldAlert, AlertOctagon, ClipboardCheck,
   ScrollText, Fingerprint, RefreshCw, ArrowRight, Scale, Package,
-  Network, TrendingUp, KeyRound,
+  Network, TrendingUp, KeyRound, Bug,
 } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { PageHeader } from '@/components/ui/PageHeader'
@@ -231,6 +231,7 @@ interface KpisSnapshot {
   netpol?: { available?: boolean; coveragePct?: number; covered?: number; total?: number }
   freshness?: { available?: boolean; fleetScore?: number; unknownModules?: number }
   credentials?: { available?: boolean; staticSecrets?: number; withDeadline?: number; overdue?: number }
+  fuzz?: { available?: boolean; inScope?: number; tested?: number; coveragePct?: number; totalExercised?: number; excludedCount?: number; runDate?: string }
 }
 
 async function fetchKpis(): Promise<KpisSnapshot | null> {
@@ -282,6 +283,20 @@ async function fetchCredentials(): Promise<Patch> {
   }
 }
 
+async function fetchFuzz(): Promise<Patch> {
+  // DAST coverage (ADR-0279 #2): podíl in-scope služeb, které poslední api-fuzz běh
+  // skutečně profuzzoval (exercised-surface záznam), ne jen zobrazil v job listu.
+  const snap = await fetchKpis()
+  const z = snap?.fuzz
+  if (!z?.available || z.coveragePct == null) return unavailable('not_deployed')
+  return {
+    status: z.coveragePct < 100 ? 'degraded' : 'ok',
+    score: z.coveragePct,
+    metricCs: `${z.tested}/${z.inScope} služeb profuzzováno · ${z.totalExercised} operací${z.excludedCount ? ` · ${z.excludedCount} vyjmuto` : ''}${z.runDate ? ` · ${z.runDate}` : ''}`,
+    metricEn: `${z.tested}/${z.inScope} services fuzzed · ${z.totalExercised} ops${z.excludedCount ? ` · ${z.excludedCount} excluded` : ''}${z.runDate ? ` · ${z.runDate}` : ''}`,
+  }
+}
+
 // ── Stránka ──────────────────────────────────────────────────────────────────
 
 const DOMAIN_DEFS: Array<Omit<Domain, 'status'>> = [
@@ -321,6 +336,9 @@ const DOMAIN_DEFS: Array<Omit<Domain, 'status'>> = [
   { id: 'credentials', icon: KeyRound,     href: '/security/excellence',
     nameCs: 'Dlouhožijící credentials', nameEn: 'Long-lived Credentials',
     descCs: 'Statické ExternalSecrets s rotačním deadlinem', descEn: 'Static ExternalSecrets carrying a rotation deadline' },
+  { id: 'fuzz', icon: Bug,                 href: '/security/excellence',
+    nameCs: 'DAST pokrytí', nameEn: 'DAST Coverage',
+    descCs: 'Schemathesis nightly — skutečně profuzzované služby, ne job list', descEn: 'Schemathesis nightly — services actually fuzzed, not the job list' },
 ]
 
 export default function SecurityExcellencePage() {
@@ -336,7 +354,7 @@ export default function SecurityExcellencePage() {
       posture: fetchPosture, incidents: fetchIncidents, fraud: fetchFraud, aml: fetchAml,
       sanctions: fetchSanctions, approvals: fetchApprovals, audit: fetchAudit, identity: fetchIdentity,
       sbom: fetchSbom, segmentation: fetchSegmentation, freshness: fetchFreshness,
-      credentials: fetchCredentials,
+      credentials: fetchCredentials, fuzz: fetchFuzz,
     }
     // Fan-out paralelně; každá doména se doplní jakmile odpoví (progressive render).
     await Promise.all(Object.entries(fetchers).map(async ([id, fn]) => {


### PR DESCRIPTION
## ADR-0279 #2 — Continuous DAST matice + fuzz coverage metrika

Matice už existovala (derivovaná z `rules.yaml: money_path_services` + legacy set), ale chybělo to podstatné: **důkaz, co se skutečně profuzzovalo, a metrika na hubu**.

## Co přidává

1. **Nightly kadence** — `17 4 * * *` (doposud Tue/Thu; money-path endpoint regression mohla čekat 3 dny). Hosted runners na public repo = zdarma.
2. **`fuzz-coverage-aggregate.py`** (+ aggregate job v api-fuzz.yml, `if: always()`) — slepí per-service `*-ops.json` exercised-surface záznamy (authz-ON pass) se scope záznamem `fuzz-scope.json` z prepare kroku do jednoho **`fuzz-coverage.json`** artefaktu (retence 90 dní). Leg bez ops záznamu = `no-evidence` (nezapočítá se jako tested), vyjmuté služby nesou důvod. Self-test pokrývá double-count authz-OFF passu i chybějící záznam.
3. **`security-kpis.py` čtvrtý kolektor `fuzz`** — čte `fuzz-coverage` artefakt posledního dokončeného běhu přes GH API (`actions: read`), degraduje nezávisle na ostatních.
4. **Konzole: nová doména „DAST pokrytí"** (ikona Bug) — tested/in-scope %, exercised operace, excluded count, datum běhu.
5. Runbook 0016: řádek + jak se doména počítá.

## Ověření

- `fuzz-coverage-aggregate.py --self-test` clean (fixtures: no-evidence leg, OFF-pass double-count, excluded reason)
- `security-kpis.py --self-test` clean; tsc 0 chyb v excellence page; eslint 0 errors
- actionlint čistý (1 pre-existing SC2016 info na security-kpis.yml, je i na main)

Zbývá po merge: dispatch api-fuzz → security-kpis refresh PR naplní doménu daty (do pátku jinak `not_deployed`, což je správný degraded stav).

Refs #8590
