### PR TITLE
test(party): main does not compile — the third exportPartyGdpr call site is missing its argument

### DIFF
--- a/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/rest/PartyResourceAuditTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/rest/PartyResourceAuditTest.kt
@@ -138,7 +138,7 @@ class PartyResourceAuditTest {
         coEvery { res.partyUseCase.exportPartyData(partyId) } returns
             PartyGdprExport(sampleParty(), emptyList(), now)
 
-        val response = res.exportPartyGdpr(partyId)
+        val response = res.exportPartyGdpr(partyId, null)
 
         assertThat(response.status).isEqualTo(200)
         assertThat(events).singleElement().satisfies({ e ->


### PR DESCRIPTION
## `main` does not compile

`:openbank-party-service:compileTestKotlin` fails on current `origin/main`:

```
e: PartyResourceAuditTest.kt:141:44 No value passed for parameter 'partyHeader'
```

#8487 (`2ba4787544`, merged 2026-09-05T01:34Z) gave `PartyResource.exportPartyGdpr` a second parameter —

```kotlin
suspend fun exportPartyGdpr(
    @PathParam("id") id: UUID,
    @HeaderParam(CUSTOMER_PARTY_HEADER) partyHeader: String?,   // no default
): Response
```

— and updated **two of the three** call sites in the same commit. Lines 108 and 157 pass `(partyId, null)`; line 141 still passes `(partyId)`.

## Why `null`, specifically

The parameter is read in exactly one place:

```kotlin
val viaEdge = !byStaffOrSubject && edgeActsForSubject(partyHeader, id)
```

The test at line 141 asserts the **DPO** path, so `isDpo` is true, `byStaffOrSubject` is true, and `viaEdge` is short-circuited to `false` before `partyHeader` is ever read. `null` is both what the sibling call sites pass and behaviourally the right value here — the assertion is unaffected either way, which the passing test confirms.

## Why nothing caught it

CI is path-scoped. #8487 landed as a customer-edge + party change and its own run predates the merge; nothing since has rebuilt this module's tests. `main`'s check-runs read **green**, because the job that would fail was never scheduled.

It surfaces only on unrelated PRs whose diff happens to pull a party-service build into scope — **#8665, #8676, #8697** are all red on `Submit fleet dependency graph` for this reason, where it reads as *their* failure. I went looking for a rate-limit cause there (there was a real installation-quota incident tonight, #8690) and found a compile error instead.

This is the failure mode the repo already documents: *"a module CI never rebuilt stays red on `main` unseen"* — the #5844 shape, one step milder because it breaks at compile time rather than at boot.

## Verified by effect, not by a green run

| tree | `:openbank-party-service:compileTestKotlin` |
|---|---|
| fix in place | **exit 0** |
| reverted | **exit 1**, naming `PartyResourceAuditTest.kt:141:44` |
| restored | **exit 0** |

And the class actually runs, read from the JUnit XML rather than the console:

```
PartyResourceAuditTest — tests=6 failures=0 errors=0 skipped=0
```

The skipped count matters here: a `@QuarkusTest` class that cannot boot reports its tests as SKIPPED, and a skip count scans as a pass.

## Scope

One line, in `src/test`. `openbank-party-service` is not in `rules.yaml: money_path_services`. `src/test` is in the package's `exclude-paths`, and `test` is a hidden commit type, so this releases nothing on either axis.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without
      justification (state it in this PR).
- [x] No new third-party dependency, OR: dependency review attached
      (license, CVE, source).
- [x] Auth / crypto / payment code changed? → tag `security-review-required`.
- [x] PII path changed? → tag `gdpr-review-required`.
- [x] Cardholder data path changed? → tag `pci-review-required`.

The diff is one argument added to one existing test call — no production code, no dependency, no `@Suppress`, no secret-shaped line. It touches a test *of* a GDPR export path but changes no PII handling: the argument it supplies is the one the compiler already required and the two sibling call sites already pass.
