### PR TITLE
fix(party): pass partyHeader to exportPartyGdpr in DPO test

### DIFF
--- a/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/rest/PartyResourceAuditTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/rest/PartyResourceAuditTest.kt
@@ -138,7 +138,7 @@ class PartyResourceAuditTest {
         coEvery { res.partyUseCase.exportPartyData(partyId) } returns
             PartyGdprExport(sampleParty(), emptyList(), now)
 
-        val response = res.exportPartyGdpr(partyId)
+        val response = res.exportPartyGdpr(partyId, null)
 
         assertThat(response.status).isEqualTo(200)
         assertThat(events).singleElement().satisfies({ e ->


### PR DESCRIPTION
## Summary
`PartyResource.exportPartyGdpr(id, partyHeader)` has no default value for `partyHeader`.
The DPO-caller test in `PartyResourceAuditTest` calls it with a single argument, so
`compileTestKotlin` for `openbank-party-service` has been failing to compile on `main`,
blocking every PR that touches the module — including unrelated ones (e.g. #8749).

The sibling test 20 lines above already calls it correctly as `exportPartyGdpr(partyId, null)`.

## Test plan
- [x] `./gradlew :openbank-party-service:compileTestKotlin` — BUILD SUCCESSFUL
