### PR TITLE
feat(security): threat-model freshness and CVE MTTR on the excellence hub

### DIFF
--- a/.github/scripts/security-kpis.py
+++ b/.github/scripts/security-kpis.py
@@ -73,6 +73,87 @@ def collect_credentials() -> dict:
             "overdueFound": rc != 0}
 
 
+def collect_threat_models() -> dict:
+    """Threat-model freshness over money-path services (ADR-0279 #23 hub signal).
+
+    Age = days since the model's last git change (the publisher checks out with
+    fetch-depth: 0, so the history is real). A model untouched for > 90 days counts as
+    stale — the fleet rule is that a trust-boundary change must touch it (gate
+    threat-model-updated-on-trust-boundary-change), and a year-old money-path model is
+    prose nobody has re-derived from the code.
+    """
+    # rules.yaml money_path_services is a flat dash list under one top-level key — BUT the
+    # entries carry multi-line trailing comments (issue #1478 assessments), so capture up to
+    # the next top-level key and take only `  - ` lines. A two-regex parse avoids a PyYAML
+    # install in the publisher job (and the hash-pinning Scorecard would demand of it).
+    raw = Path("openbank-libs/governance/rules.yaml").read_text()
+    block = re.search(r"^money_path_services:\n(.*?)(?=^\S)", raw, re.M | re.S)
+    if not block:
+        return {"available": False, "reason": "money_path_services block unparsable"}
+    money = re.findall(r"^  - (\S+)", block.group(1), re.M)
+    now = dt.datetime.now(dt.timezone.utc).timestamp()
+    ages, missing = [], []
+    for svc in money:
+        f = Path("docs/threat-models") / f"{svc}.md"
+        if not f.is_file():
+            missing.append(svc)
+            continue
+        rc, out = run_json(["git", "log", "-1", "--format=%ct", "--", str(f)])
+        if rc != 0 or not out.strip():
+            missing.append(svc)
+            continue
+        ages.append((svc, int((now - int(out.strip())) / 86400)))
+    if not ages and missing:
+        return {"available": False, "reason": "no money-path threat model resolved"}
+    stale = sum(1 for _, a in ages if a > 90)
+    return {"available": True, "moneyPathTotal": len(money),
+            "withModel": len(ages), "missing": missing,
+            "staleCount": stale, "oldestDays": max((a for _, a in ages), default=0)}
+
+
+def collect_mttr() -> dict:
+    """Vulnerability remediation time from Dependabot alerts (SLO S1 proxy, ADR-0279 #23).
+
+    The release-SBOM diff the SLO table names as S1's final source is not wired yet; the
+    Dependabot alert stream is the computable proxy that exists TODAY: fixed alerts carry
+    created_at→fixed_at, open Critical/High carry age. Median, never a mean — one quarter-
+    old alert must not hide behind fifty same-day fixes.
+    """
+    import os
+    import statistics
+    import urllib.request
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    repo = os.environ.get("GITHUB_REPOSITORY", "JiRaska/open-bank-oss")
+    if not token:
+        return {"available": False, "reason": "no GH token"}
+    try:
+        req = urllib.request.Request(
+            f"https://api.github.com/repos/{repo}/dependabot/alerts?per_page=100&state=all",
+            headers={"Authorization": f"Bearer {token}",
+                     "Accept": "application/vnd.github+json"})
+        alerts = json.loads(urllib.request.urlopen(req, timeout=30).read())
+        now = dt.datetime.now(dt.timezone.utc)
+        fixed_days, open_crit = [], []
+        for a in alerts:
+            sev = (a.get("security_advisory") or {}).get("severity", "")
+            if sev not in ("critical", "high"):
+                continue
+            created = dt.datetime.fromisoformat(a["created_at"].replace("Z", "+00:00"))
+            if a.get("state") == "fixed" and a.get("fixed_at"):
+                fixed = dt.datetime.fromisoformat(a["fixed_at"].replace("Z", "+00:00"))
+                fixed_days.append((fixed - created).total_seconds() / 86400)
+            elif a.get("state") == "open":
+                open_crit.append((now - created).total_seconds() / 86400)
+        return {"available": True, "severityScope": "critical+high",
+                "fixedCount": len(fixed_days),
+                "medianFixDays": round(statistics.median(fixed_days), 1) if fixed_days else None,
+                "openCount": len(open_crit),
+                "oldestOpenDays": round(max(open_crit)) if open_crit else 0}
+    except Exception as exc:  # API degradation must not kill the other collectors
+        return {"available": False, "reason": f"dependabot fetch failed: {exc.__class__.__name__}"}
+
+
 def collect_fuzz() -> dict:
     """DAST coverage from the latest api-fuzz run's fuzz-coverage artifact (ADR-0279 #2).
 
@@ -160,12 +241,15 @@ def main() -> int:
             "freshness": freshness,
             "credentials": collect_credentials(),
             "fuzz": collect_fuzz(),
+            "threatModels": collect_threat_models(),
+            "mttr": collect_mttr(),
         }
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(snapshot, indent=2) + "\n")
-    avail = sum(1 for k in ("netpol", "freshness", "credentials", "fuzz") if snapshot[k]["available"])
-    print(f"security-kpis: {avail}/4 collectors available -> {out}")
+    avail = sum(1 for k in ("netpol", "freshness", "credentials", "fuzz",
+                            "threatModels", "mttr") if snapshot[k]["available"])
+    print(f"security-kpis: {avail}/6 collectors available -> {out}")
     return 0
 
 

--- a/docs/runbooks/0016-security-excellence-console.md
+++ b/docs/runbooks/0016-security-excellence-console.md
@@ -24,8 +24,10 @@ obrazovky, které zůstávají autoritativním zdrojem detailu.
 | Čerstvost závislostí | `/api/security/kpis` → `freshness` (`deps-freshness.yml`, ADR-0279 #15) | tato stránka |
 | Dlouhožijící credentials | `/api/security/kpis` → `credentials` (`credential-inventory.yml`, ADR-0279 #18) | tato stránka |
 | DAST pokrytí | `/api/security/kpis` → `fuzz` (`api-fuzz.yml` aggregate → `fuzz-coverage` artifact, ADR-0279 #2) | tato stránka |
+| Čerstvost threat modelů | `/api/security/kpis` → `threatModels` (git historie `docs/threat-models/`, money-path z rules.yaml, ADR-0279 #23) | tato stránka |
+| CVE remediation | `/api/security/kpis` → `mttr` (Dependabot alerts critical+high: open count, oldest age, median fix — SLO S1 proxy, ADR-0279 #23) | tato stránka |
 
-## KPI snapshot — kde se berou čtyři nové domény
+## KPI snapshot — kde se berou nové domény
 
 `/api/security/kpis` servíruje `openbank-admin-ui/security-kpis.json`, CI-generovaný
 snapshot z workflow `security-kpis.yml` (weekly pátek 09:23 UTC, refresh PR při změně),
@@ -33,7 +35,7 @@ který přepočítává čísla **ze stejných gate skriptů** (`check-netpol-co
 `deps-freshness.py`, `credential-inventory.py`) — nikdy z reimplementace, aby se
 konzole a gaty nemohly rozejít. Soubor se vpeče do image buildu (`COPY
 openbank-admin-ui/ ./`); chybějící soubor = `not_deployed`, nikdy falešné OK.
-Každý kolektor degraduje nezávisle — jedna nedostupná doména neshodí ostatní tři.
+Každý kolektor degraduje nezávisle — jedna nedostupná doména neshodí ostatních pět.
 
 Doména **DAST pokrytí** se nepočítá ze skriptu, ale z artefaktu `fuzz-coverage`
 posledního dokončeného běhu `api-fuzz.yml` (nightly 04:17 UTC od ADR-0279 #2):

--- a/openbank-admin-ui/src/app/security/excellence/page.tsx
+++ b/openbank-admin-ui/src/app/security/excellence/page.tsx
@@ -24,7 +24,7 @@ import Link from 'next/link'
 import {
   Shield, ScanLine, AlertTriangle, ShieldAlert, AlertOctagon, ClipboardCheck,
   ScrollText, Fingerprint, RefreshCw, ArrowRight, Scale, Package,
-  Network, TrendingUp, KeyRound, Bug,
+  Network, TrendingUp, KeyRound, Bug, FileClock, Timer,
 } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { PageHeader } from '@/components/ui/PageHeader'
@@ -232,6 +232,8 @@ interface KpisSnapshot {
   freshness?: { available?: boolean; fleetScore?: number; unknownModules?: number }
   credentials?: { available?: boolean; staticSecrets?: number; withDeadline?: number; overdue?: number }
   fuzz?: { available?: boolean; inScope?: number; tested?: number; coveragePct?: number; totalExercised?: number; excludedCount?: number; runDate?: string }
+  threatModels?: { available?: boolean; moneyPathTotal?: number; withModel?: number; staleCount?: number; oldestDays?: number }
+  mttr?: { available?: boolean; fixedCount?: number; medianFixDays?: number | null; openCount?: number; oldestOpenDays?: number }
 }
 
 async function fetchKpis(): Promise<KpisSnapshot | null> {
@@ -297,6 +299,43 @@ async function fetchFuzz(): Promise<Patch> {
   }
 }
 
+
+async function fetchThreatModels(): Promise<Patch> {
+  // Threat-model stáří (ADR-0279 #23): money-path služba bez modelu je critical
+  // (governance pravidlo), model > 90 dní bez změny je stale — prose, které nikdo
+  // nepřepočítal proti kódu.
+  const snap = await fetchKpis()
+  const m = snap?.threatModels
+  if (!m?.available || m.moneyPathTotal == null) return unavailable('not_deployed')
+  const pct = Math.round(100 * (m.withModel ?? 0) / m.moneyPathTotal)
+  const missing = (m.withModel ?? 0) < m.moneyPathTotal
+  return {
+    status: missing ? 'critical' : (m.staleCount ?? 0) > 0 ? 'degraded' : 'ok',
+    score: pct,
+    metricCs: `${m.withModel}/${m.moneyPathTotal} money-path s modelem · nejstarší ${m.oldestDays} d${m.staleCount ? ` · ${m.staleCount} zastaralých` : ''}`,
+    metricEn: `${m.withModel}/${m.moneyPathTotal} money-path with a model · oldest ${m.oldestDays}d${m.staleCount ? ` · ${m.staleCount} stale` : ''}`,
+  }
+}
+
+async function fetchMttr(): Promise<Patch> {
+  // CVE remediation (SLO S1 proxy přes Dependabot alerts, critical+high): otevřená
+  // kritická zranitelnost > 14 dní je critical postoj; median fix čas se ukáže,
+  // jakmile historie existuje.
+  const snap = await fetchKpis()
+  const v = snap?.mttr
+  if (!v?.available) return unavailable('not_deployed')
+  const open = v.openCount ?? 0
+  const oldest = v.oldestOpenDays ?? 0
+  const median = v.medianFixDays != null ? `median fix ${v.medianFixDays} d` : 'zatím bez fix dat'
+  const medianEn = v.medianFixDays != null ? `median fix ${v.medianFixDays}d` : 'no fix history yet'
+  return {
+    status: open > 0 ? (oldest > 14 ? 'critical' : 'degraded') : 'ok',
+    score: open > 0 ? Math.max(0, 100 - oldest) : 100,
+    metricCs: `${open} otevřených krit/vysokých${open ? ` · nejstarší ${oldest} d` : ''} · ${median}`,
+    metricEn: `${open} open crit/high${open ? ` · oldest ${oldest}d` : ''} · ${medianEn}`,
+  }
+}
+
 // ── Stránka ──────────────────────────────────────────────────────────────────
 
 const DOMAIN_DEFS: Array<Omit<Domain, 'status'>> = [
@@ -339,6 +378,12 @@ const DOMAIN_DEFS: Array<Omit<Domain, 'status'>> = [
   { id: 'fuzz', icon: Bug,                 href: '/security/excellence',
     nameCs: 'DAST pokrytí', nameEn: 'DAST Coverage',
     descCs: 'Schemathesis nightly — skutečně profuzzované služby, ne job list', descEn: 'Schemathesis nightly — services actually fuzzed, not the job list' },
+  { id: 'threatmodels', icon: FileClock,   href: '/security/excellence',
+    nameCs: 'Čerstvost threat modelů', nameEn: 'Threat-model Freshness',
+    descCs: 'Money-path pokrytí a stáří modelů — stale model je prose, ne kontrola', descEn: 'Money-path coverage and model age — a stale model is prose, not a control' },
+  { id: 'mttr', icon: Timer,               href: '/security/excellence',
+    nameCs: 'CVE remediation', nameEn: 'CVE Remediation',
+    descCs: 'SLO S1 proxy: otevřené kritické zranitelnosti a median čas opravy', descEn: 'SLO S1 proxy: open critical vulns and median time to fix' },
 ]
 
 export default function SecurityExcellencePage() {
@@ -355,6 +400,7 @@ export default function SecurityExcellencePage() {
       sanctions: fetchSanctions, approvals: fetchApprovals, audit: fetchAudit, identity: fetchIdentity,
       sbom: fetchSbom, segmentation: fetchSegmentation, freshness: fetchFreshness,
       credentials: fetchCredentials, fuzz: fetchFuzz,
+      threatmodels: fetchThreatModels, mttr: fetchMttr,
     }
     // Fan-out paralelně; každá doména se doplní jakmile odpoví (progressive render).
     await Promise.all(Object.entries(fetchers).map(async ([id, fn]) => {


### PR DESCRIPTION
## ADR-0279 #23 — security hub: další dvě per-service metriky na excellence konzoli

Navazuje na #8708 (KPI snapshot infrastruktura) a #8750 (DAST coverage). Hub teď agreguje **6 domén** z jednoho CI snapshotu.

## Nové kolektory (`security-kpis.py`)

- **`threatModels`** — money-path pokrytí (23/23) + stáří modelů z git historie. Model > 90 dní bez změny = stale (prose, ne kontrola — gate `threat-model-updated-on-trust-boundary-change` vynucuje dopad při změně boundary, ale stáří nikdo neměřil). rules.yaml parsuje regexem záměrně bez PyYAML (publisher job nemá pip krok; Scorecard pinning).
- **`mttr`** — SLO S1 proxy z Dependabot alerts (critical+high): open count, oldest age, median fix days. Finální zdroj S1 (release-SBOM diff) ještě není napojen — sbírka na Dependabot streamu je computable proxy, který existuje DNES, a dokumentace to tak říká. Dnešní stav: 0 open krit/high.

## Konzole

Dvě nové karty: **Čerstvost threat modelů** (FileClock; missing money-path model = critical, stale = degraded) a **CVE remediation** (Timer; open crit/high > 14 d = critical). Runbook 0016 aktualizován.

## Ověření

- Oba kolektory lokálně proti reálným datům: `threatModels 23/23, oldest 26 d`, `mttr 0 open`
- `security-kpis.py --self-test` clean; ruff v gate konfiguraci clean; tsc/eslint clean

Refs #8590
