### PR TITLE
fix(psd2): declare the enforced Idempotency-Key on all four v2 PIS endpoints

### DIFF
--- a/openbank-psd2-service/src/main/resources/openapi.yaml
+++ b/openbank-psd2-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: PSD2 Open Banking API
-  version: 2.5.0
+  version: 2.6.0
   description: |
     PSD2-compliant open banking — Account Information Service (AIS) and
     Payment Initiation Service (PIS) for Third Party Providers.
@@ -255,7 +255,7 @@ paths:
           required: true
           schema:
             type: string
-        - name: X-Idempotency-Key
+        - name: Idempotency-Key
           in: header
           required: true
           schema:
@@ -281,7 +281,7 @@ paths:
           required: true
           schema:
             type: string
-        - name: X-Idempotency-Key
+        - name: Idempotency-Key
           in: header
           required: true
           schema:
@@ -307,6 +307,11 @@ paths:
           required: true
           schema:
             type: string
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -324,6 +329,11 @@ paths:
       operationId: pisInitiateSipo
       parameters:
         - name: X-TPP-ID
+          in: header
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
           in: header
           required: true
           schema:


### PR DESCRIPTION
## Co a proč

Spec-vs-code drift odhalený inventářem pro #8351: `PisResource` čte
`@HeaderParam("Idempotency-Key")` na všech čtyřech v2 PIS endpointech a chybějící klíč odmítá 400,
ale openapi.yaml ho deklaroval jen u `sepa-credit-transfers` a `instant-sepa-credit-transfers` —
a pod jménem `X-Idempotency-Key`, které kód nikdy nečte. TPP jednající podle specu poslal header,
který dedup store nikdy neviděl → idempotence tiše nefungovala; u `domestic-cz` a `sipo` spec
nedeklaroval nic, přestože kód klíč vyžaduje.

Změna je dokumentační (spec-only, `correction` dle ADR-0048 D5): server je byte-identický,
minor bump `info.version` 2.5.0 → 2.6.0.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? → spec-only, žádná změna kódu.
- [x] PII path changed? → ne.
- [x] Cardholder data path changed? → ne.

Refs #8351
