### PR TITLE
fix(party): pass partyHeader to exportPartyGdpr in the DPO-caller audit test

### DIFF
--- a/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/rest/PartyResourceAuditTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/rest/PartyResourceAuditTest.kt
@@ -138,7 +138,7 @@ class PartyResourceAuditTest {
         coEvery { res.partyUseCase.exportPartyData(partyId) } returns
             PartyGdprExport(sampleParty(), emptyList(), now)
 
-        val response = res.exportPartyGdpr(partyId)
+        val response = res.exportPartyGdpr(partyId, null)
 
         assertThat(response.status).isEqualTo(200)
         assertThat(events).singleElement().satisfies({ e ->


### PR DESCRIPTION
## What

#8487 added a `partyHeader: String?` parameter to `PartyResource.exportPartyGdpr` (the `CUSTOMER_PARTY_HEADER`, for GDPR Art. 15/20 reachability by the data subject) and updated two of the three call sites in `PartyResourceAuditTest.kt`, but missed the DPO-caller test added alongside #8495 the same day.

That left `origin/main` itself with a broken `:openbank-party-service:compileTestKotlin` — confirmed directly on a fresh `origin/main` checkout:

```
e: .../PartyResourceAuditTest.kt:141:44 No value passed for parameter 'partyHeader'.
> Task :openbank-party-service:compileTestKotlin FAILED
```

This fails the "Submit fleet dependency graph" job (and any job that compiles the whole test tree against a merge with main) on every open PR, regardless of what that PR touches — observed on #8507 and #8640, neither of which touches party-service.

## Fix

One line: `res.exportPartyGdpr(partyId)` → `res.exportPartyGdpr(partyId, null)`, matching the other two call sites in the same file (lines 108 and 157) which already pass `null` for an unauthenticated/non-self-service caller.

## Type of change

- [x] fix

## Compliance impact

- [x] None — test-only, restores the previously-intended coverage (a DPO-only caller is admitted and audited); no production code changed.

## Rollout / Rollback

- Deployment strategy: n/a (test-only)
- Rollback plan: revert
- Data migration reversible: N/A