### PR TITLE
docs(governance): mp_messaging_dotted_keys — 171 occurrences not 16, and both cited issues are closed

### DIFF
--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -568,12 +568,27 @@ change_requirements:
     gate: dotted-mp-messaging-keys
     enforced: advisory
     target_enforce_date: "2026-09-30"   # ADR-0144
-    blocked_on: "16 findings fleet-wide as of 2026-08-08 (#3931), across kyc/sdd/psd2/ledger/
-      onboarding/anacredit — NOT the 1 this line claimed while carrying no date; the claim was never
-      re-measured because an advisory gate's own justification note is not itself gated. The script
-      supports --enforce, so graduating is a one-word change once the findings are cleared — and
-      the right sequencing is #3928 first: widen the ENFORCED check-kafka-dotted-keys.py to the
-      whole class and retire this advisory duplicate, rather than graduating two overlapping gates."
+    # RE-MEASURED 2026-09-05, and this note had gone stale in exactly the way it warns about.
+    # Both issues it sequences on are CLOSED (#3928, #3931), and the count is not 16:
+    # `check-dotted-mp-messaging-keys.sh --enforce` reports 171 occurrences today.
+    #
+    # 171 is not "the debt grew 10x" — the two gates count different things, which IS the point:
+    #   * kafka-dotted-key-ratchet (ENFORCED) baselines today's set as an operational decision
+    #     (#2945) and fails only on a NEW occurrence. It reports clean: 11 baselined, 0 new.
+    #   * dotted-mp-messaging-key-guard (ADVISORY, this rule) has NO baseline at all and counts
+    #     every occurrence, including the ones its enforced sibling deliberately accepted.
+    #
+    # So graduating this on 2026-09-30 would fail the build on 171 occurrences the enforced gate
+    # has already decided to keep. The previous note's recommendation — retire the advisory
+    # duplicate rather than graduate two overlapping gates — is therefore confirmed by
+    # measurement. What is NOT established here is how many of the 171 are genuine defects
+    # rather than the accepted set; that needs a ruling on the Kafka semantics and is the real
+    # work behind this date.
+    blocked_on: "graduating would fail the build on 171 occurrences (measured 2026-09-05) that the
+      ENFORCED sibling kafka-dotted-key-ratchet deliberately baselines (11 entries, 0 new, #2945);
+      this advisory gate has no baseline. #3928 and #3931, which the previous note sequenced on,
+      are both closed. The action is to retire this duplicate, not to flip it — how many of the 171
+      are genuine defects rather than the accepted set is unsettled."
     # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
     # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
     # itself gated by .github/scripts/check-advisory-gate-registration.py.


### PR DESCRIPTION
## The note warned about itself, then became the example

`mp_messaging_dotted_keys`'s `blocked_on` said:

> the claim was never re-measured because **an advisory gate's own justification note is not itself gated**

Re-measured 2026-09-05:

| | claimed | measured today |
|---|---|---|
| findings | 16 (as of 2026-08-08) | **171** |
| #3928, #3931 — the issues it sequenced on | pending | **both CLOSED** |
| `kafka-dotted-key-ratchet` (the enforced sibling) | — | **clean: 11 baselined, 0 new** |

## 171 is not "the debt grew 10×" — and that is the finding

The two gates count different things:

- **`kafka-dotted-key-ratchet` (enforced)** baselines today's set as an *operational decision* (#2945) and fails only on a **new** occurrence.
- **`dotted-mp-messaging-key-guard` (advisory, this rule's producer)** has **no baseline at all** and counts every occurrence — including the ones its enforced sibling deliberately accepted.

So flipping this rule on **2026-09-30** would fail the build on 171 occurrences the enforced gate has already decided to keep.

The previous note's recommendation — **retire the advisory duplicate rather than graduate two overlapping gates** — is therefore confirmed by measurement rather than by argument.

## What this deliberately does not settle

**How many of the 171 are genuine defects rather than the accepted set.** That needs a ruling on the Kafka semantics — `key.serializer` and `client.id` appear in the advisory output, and whether those are broken or normal is not something my measurement establishes. It is the real work behind this date, and it is stated in the record rather than guessed at.

**I did not touch either gate.**

## Scope

No behaviour change — `blocked_on` is prose no checker reads.

- `gate-graduation-guard`, `advisory-gate-registration`, `gate-lifecycle-metadata`, `yamllint`: all pass.
- `gen-rules-opa-data.py`: no diff.

Fourth stale governance record this week, all found the same way: reading a record against the thing it describes rather than trusting either alone.

## Linked issues

Refs #8690.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
